### PR TITLE
fix(chat): kill scroll snap-back during streaming for good (v3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,45 @@ Backup at `~/.tmux.conf.pre-bui` on the remote if it was ever modified.
   event in `attachCustomKeyEventHandler`, call `preventDefault()` to kill
   the textarea side, and manually `ptyWrite("\x1b\r")` — the same sequence
   iTerm2's `/terminal-setup` sends. Don't drop the `preventDefault()`.
+- **Chat transcript pin-to-bottom — single 8px symmetric threshold, pure
+  observation, no intent detection.** Two prior designs (v1: 80px
+  symmetric; v2: 8px + wheel/touch/key intent detection in commit 631b03e)
+  both regressed "viewport snaps back during streaming." A first v3 draft
+  tried asymmetric hysteresis (REPIN=8, UNPIN=64) with a dead-zone "no
+  change" return — that re-introduced v1's bug because the dead zone
+  PRESERVES the prior pin state, so a 30px scroll-up from `pinned=true`
+  stays pinned and the next delta snaps. The dead zone is a trap; don't
+  bring it back.
+
+  The current model lives in `classifyScrollForPin()` in `chatUtils.ts`
+  (pure + tested) and is a plain boolean:
+    - `dist <= SCROLL_REPIN_PX (8px)` → pin
+    - otherwise → unpin
+
+  ChatPanel attaches a single `scroll` listener that pipes through it.
+  The browser fires `scroll` for every cause (wheel, touch, key,
+  **scrollbar drag**, momentum, our own writes), so one listener is the
+  source of truth — no wheel/touch/key heuristics, no `programmaticScroll`
+  flag, no race conditions. The previous v2 design missed scrollbar-drag
+  because it only had wheel/touch/key unpin paths and the scroll handler
+  ONLY re-pinned (never un-pinned); v1 missed everything because the
+  threshold was too generous. **Do NOT re-introduce intent-detection
+  listeners or a dead-zone classifier.**
+
+  Trade-off baked in: scrolls of < 8px (single-pixel jiggles, very gentle
+  trackpad nudges) stay pinned and get snapped on the next delta. This is
+  intentional — most wheel detents are 40-100px, a sub-8px scroll is
+  almost certainly accidental, and re-engaging follow by scrolling back to
+  the bottom is trivial.
+
+  **Force-pin paths are limited and explicit**: `submit()` and
+  `sendQueuedRef.current()` set `pinnedToBottom.current = true` just
+  before their optimistic `setMessages` so the user sees their own
+  message land. That's it. There used to be a `running` false→true
+  edge effect that force-pinned on every `session.status` busy/idle
+  transition — this was the dominant cause of mid-turn snaps because
+  multi-step turns oscillate busy/idle/busy several times. **Do NOT
+  reintroduce a `running`-derived force-pin.**
 
 ## New-project dialog (`Sidebar.tsx`)
 

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -60,6 +60,7 @@ import {
   collectChildSessionIds,
   countRunningSubagents,
   summarizeChildSession,
+  classifyScrollForPin,
   type TruncationKind,
   type ContextBreakdown,
   type StaleCacheResult,
@@ -1490,72 +1491,54 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     };
   }, [sessionId]);
 
-  // Pinned-to-bottom detection. THE BUG this guards against: a pure
-  // distance-threshold check (`dist < 80 → pinned`) loses to streaming. While
-  // content streams, content is added below the viewport; a small user
-  // scroll-up (say 30px) leaves us still inside the 80px window, the next
-  // delta's auto-scroll effect sees `pinned === true` and snaps to bottom
-  // before the user's next wheel tick lands. Visible jump.
+  // Pinned-to-bottom detection — single symmetric threshold, pure observation.
   //
-  // Fix: distinguish USER intent from PROGRAMMATIC scrolls.
-  //  - Any wheel-up, touchmove, keydown (PgUp/Home/Arrow), or non-programmatic
-  //    scroll event ⇒ unpin immediately, regardless of distance.
-  //  - Re-pin only when the user actually scrolls back within 80px of bottom.
-  //  - Our own `scrollTop = scrollHeight` writes set `programmaticScroll`
-  //    true for one scroll tick so they don't get treated as user gestures.
-  const programmaticScroll = useRef(false);
+  // Two previous designs both bled the "snap-back during streaming" bug:
+  //
+  //   v1 (pre-631b03e): symmetric 80px threshold. A 30px scroll-up left
+  //     dist=30 < 80, the next delta saw `pinned === true`, snap. Lost.
+  //
+  //   v2 (631b03e): tight 8px re-pin + wheel/touch/key "intent" un-pin.
+  //     wheel-up explicitly unpinned regardless of distance, fixing v1.
+  //     But missed two real-world scroll paths:
+  //       - scrollbar-handle drag (no wheel/touch/key — only `scroll`
+  //         event); the handler only RE-pinned, never UN-pinned.
+  //       - the `running` false→true edge effect force-pinned on every
+  //         `session.status` busy/idle oscillation during multi-step
+  //         turns, regardless of user intent. Multiple snaps per turn.
+  //
+  // v3 (here): pure observation, single 8px symmetric threshold. The
+  // browser fires `scroll` for every cause (wheel, touch, key, scrollbar
+  // drag, momentum, our own writes), so one listener is the only signal
+  // needed. `classifyScrollForPin` is a pure boolean: `dist <= 8 → pin`,
+  // otherwise unpin. Each scroll event correctly reflects current position
+  // — no stale state, no flapping. Don't reintroduce wheel/touch/key
+  // listeners or a `programmaticScroll` guard; they were load-bearing only
+  // for v2's missing un-pin path.
+  //
+  // Force-pin paths are explicit and limited to user actions: `submit()`
+  // and `sendQueuedRef.current()` set `pinnedToBottom.current = true`
+  // right before their optimistic setMessages so the user sees their own
+  // message land. The old running-edge effect is gone — it was the source
+  // of mid-turn snaps.
   const stickToBottom = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-    programmaticScroll.current = true;
     el.scrollTop = el.scrollHeight;
-    // Clear on next frame; the resulting scroll event fires before then.
-    requestAnimationFrame(() => {
-      programmaticScroll.current = false;
-    });
   }, []);
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    const RE_PIN_PX = 8; // user must reach the bottom to re-engage tail-follow
     const onScroll = () => {
-      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (programmaticScroll.current) {
-        // Our own write — we're at the bottom, stay pinned.
-        pinnedToBottom.current = true;
-        return;
-      }
-      // User-driven scroll (scrollbar drag, momentum, anything we didn't
-      // initiate). The unpin paths below handle leaving the bottom; here we
-      // only handle the RE-pin path. Threshold is tight so we don't snap
-      // back unless the user truly lands at the bottom — a half-completed
-      // wheel-up that left them 30px from bottom must NOT re-pin.
-      if (dist <= RE_PIN_PX) pinnedToBottom.current = true;
-    };
-    const onWheel = (e: WheelEvent) => {
-      // Any upward wheel ⇒ user wants out of tail-follow, regardless of
-      // current distance. Downward wheel doesn't auto-pin; the scroll
-      // handler re-pins when they actually reach bottom.
-      if (e.deltaY < 0) pinnedToBottom.current = false;
-    };
-    const onTouchMove = () => {
-      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (dist > RE_PIN_PX) pinnedToBottom.current = false;
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "PageUp" || e.key === "Home" || e.key === "ArrowUp") {
-        pinnedToBottom.current = false;
-      }
+      pinnedToBottom.current = classifyScrollForPin({
+        scrollHeight: el.scrollHeight,
+        scrollTop: el.scrollTop,
+        clientHeight: el.clientHeight,
+      });
     };
     el.addEventListener("scroll", onScroll, { passive: true });
-    el.addEventListener("wheel", onWheel, { passive: true });
-    el.addEventListener("touchmove", onTouchMove, { passive: true });
-    el.addEventListener("keydown", onKeyDown);
     return () => {
       el.removeEventListener("scroll", onScroll);
-      el.removeEventListener("wheel", onWheel);
-      el.removeEventListener("touchmove", onTouchMove);
-      el.removeEventListener("keydown", onKeyDown);
     };
   }, []);
 
@@ -1574,19 +1557,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       stickToBottom();
     }
   }, [messages, liveTodos, stickToBottom]);
-
-  // Going from idle → running (just sent a message): force pin to bottom so
-  // the user sees their own message and the live spinner appear.
-  // Only fires on the false→true edge; does NOT re-pin on every streaming
-  // update (that would yank the viewport while the user is reading history).
-  const wasRunning = useRef(false);
-  useEffect(() => {
-    if (running && !wasRunning.current) {
-      pinnedToBottom.current = true;
-      stickToBottom();
-    }
-    wasRunning.current = running;
-  }, [running, stickToBottom]);
 
   // Ctrl+O toggles reasoning visibility. Matches Claude Code's TUI keybind.
   useEffect(() => {
@@ -1706,6 +1676,14 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     // overwrite `messages` entirely with the canonical state, so this
     // entry is naturally replaced (no manual dedupe needed). On error we
     // strip it by id in the catch block.
+    //
+    // Force-pin to bottom BEFORE the setMessages commit so the
+    // [messages, liveTodos] effect snaps to the freshly-appended turn even
+    // if the user had scrolled up to read history. This is the only
+    // legitimate force-pin path — the previous design fired on every
+    // `running` false→true edge, which incorrectly yanked the viewport on
+    // every busy/idle oscillation during multi-step turns.
+    pinnedToBottom.current = true;
     const optimisticUserId = `optimistic-user-${Date.now()}`;
     setMessages((prev) => [
       ...(prev ?? []),
@@ -1891,6 +1869,9 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     if (q.length === 0) return;
     const [next, ...rest] = q;
     setMessageQueue(rest);
+    // Force-pin to bottom — same rationale as submit(). The user is having
+    // a queued turn dispatched, they want to see it land in the transcript.
+    pinnedToBottom.current = true;
     const optimisticUserId = `optimistic-user-${Date.now()}`;
     setMessages((prev) => [
       ...(prev ?? []),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -35,6 +35,9 @@ import {
   summarizeChildSession,
   registerChildSessionFromCreated,
   shouldDropEventForSessionFilter,
+  SCROLL_REPIN_PX,
+  distFromBottom,
+  classifyScrollForPin,
 } from "./chatUtils";
 
 // ===== formatTokens =====
@@ -1871,5 +1874,78 @@ describe("isAssistantTurnInProgress", () => {
     const done = [{ info: { role: "assistant", time: { completed: 2 } } }];
     expect(isAssistantTurnInProgress(wedged)).toBe(!isAssistantTurnComplete(wedged));
     expect(isAssistantTurnInProgress(done)).toBe(!isAssistantTurnComplete(done));
+  });
+});
+
+// ===== distFromBottom =====
+
+describe("distFromBottom", () => {
+  it("returns 0 when scrolled all the way to the bottom", () => {
+    expect(distFromBottom({ scrollHeight: 1000, scrollTop: 800, clientHeight: 200 })).toBe(0);
+  });
+
+  it("returns the gap between viewport bottom and content bottom", () => {
+    expect(distFromBottom({ scrollHeight: 1000, scrollTop: 500, clientHeight: 200 })).toBe(300);
+  });
+
+  it("clamps negative distances (overscroll) to 0", () => {
+    // Some browsers/momentum-scroll briefly report scrollTop + clientHeight > scrollHeight.
+    expect(distFromBottom({ scrollHeight: 1000, scrollTop: 900, clientHeight: 200 })).toBe(0);
+  });
+
+  it("returns full distance for an empty/short transcript", () => {
+    expect(distFromBottom({ scrollHeight: 200, scrollTop: 0, clientHeight: 200 })).toBe(0);
+  });
+});
+
+// ===== classifyScrollForPin (single symmetric threshold) =====
+
+describe("classifyScrollForPin", () => {
+  const metricsAtDist = (dist: number) => ({
+    scrollHeight: 2000,
+    scrollTop: 2000 - 500 - dist,
+    clientHeight: 500,
+  });
+
+  it("pins when at the bottom", () => {
+    expect(classifyScrollForPin(metricsAtDist(0))).toBe(true);
+  });
+
+  it("pins at or within the threshold", () => {
+    expect(classifyScrollForPin(metricsAtDist(SCROLL_REPIN_PX))).toBe(true);
+    expect(classifyScrollForPin(metricsAtDist(SCROLL_REPIN_PX - 1))).toBe(true);
+  });
+
+  it("unpins beyond the threshold", () => {
+    expect(classifyScrollForPin(metricsAtDist(SCROLL_REPIN_PX + 1))).toBe(false);
+    expect(classifyScrollForPin(metricsAtDist(30))).toBe(false);
+    expect(classifyScrollForPin(metricsAtDist(500))).toBe(false);
+  });
+
+  it("treats overscroll as pinned (dist clamped to 0)", () => {
+    expect(
+      classifyScrollForPin({ scrollHeight: 1000, scrollTop: 900, clientHeight: 200 }),
+    ).toBe(true);
+  });
+
+  it("REGRESSION: a 30px scroll-up un-pins so the next delta does NOT snap", () => {
+    // This is the v1 bug (80px symmetric threshold) AND a v3-draft bug
+    // (asymmetric hysteresis with dead-zone "no change" return). With a
+    // single 8px threshold, any non-trivial scroll-up flips pin to false
+    // and the next delta is left alone.
+    expect(classifyScrollForPin(metricsAtDist(30))).toBe(false);
+  });
+
+  it("REGRESSION: drag-up via scrollbar handle past the threshold un-pins", () => {
+    // The v2 bug: previous onScroll handler only RE-pinned, never UN-pinned.
+    // Scrollbar-handle drag fires only `scroll` events (no wheel/touch/key),
+    // so a drag from `dist=0` to `dist=200` left `pinned == true` and the
+    // next streaming delta snapped the viewport back to the tail.
+    expect(classifyScrollForPin(metricsAtDist(200))).toBe(false);
+  });
+
+  it("respects custom threshold", () => {
+    expect(classifyScrollForPin(metricsAtDist(20), 32)).toBe(true);
+    expect(classifyScrollForPin(metricsAtDist(33), 32)).toBe(false);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1179,3 +1179,69 @@ export function isAssistantTurnInProgress(
   const completed = last.info.time?.completed;
   return !(typeof completed === "number" && completed > 0);
 }
+
+// ===== Scroll-pin classification =====
+//
+// The chat transcript auto-follows the bottom while a turn streams, but only
+// when the user is actually watching the tail. Three designs have shipped:
+//
+//   v1 (80px symmetric, no intent detection): a 30px scroll-up still
+//     measured "near bottom", so the next delta yanked it back.
+//
+//   v2 (commit 631b03e: tight 8px re-pin + wheel/touch/key intent un-pin):
+//     wheel-up explicitly unpinned regardless of distance, fixing v1. But
+//     scrollbar-handle drags don't fire wheel/touch/key — only `scroll` —
+//     and the scroll handler ONLY re-pinned, never un-pinned. A drag from
+//     the bottom past the threshold left stale `pinned == true`, next
+//     delta snapped. Combined with a separate ChatPanel effect that
+//     force-pinned on every `session.status` busy/idle oscillation during
+//     multi-step turns, the viewport kept snapping back.
+//
+//   v3 (here): pure observation, single symmetric threshold. The browser
+//     fires `scroll` for every scroll cause (wheel, touch, key, scrollbar
+//     drag, momentum, our own writes) so it's the only signal needed.
+//
+//       dist <= SCROLL_REPIN_PX (8px) → pin
+//       dist >  SCROLL_REPIN_PX       → unpin
+//
+//     Symmetric threshold means each scroll event correctly reflects the
+//     current position — no stale state, no flapping (scroll events fire
+//     many times per second during scrolling, so the state stabilizes well
+//     before the next ~hundred-millisecond delta tick). Trade-off: scrolls
+//     of < 8px stay pinned and get snapped on the next delta. Acceptable
+//     because (a) most wheel detents are 40-100px, (b) a single-pixel
+//     scroll-up is almost certainly accidental, (c) re-engaging follow by
+//     scrolling back to the bottom is trivial.
+//
+//     An earlier v3 draft used asymmetric thresholds (REPIN=8, UNPIN=64)
+//     with a dead-zone "no change" return. That re-introduced v1's bug:
+//     a 30px wheel-up landed in the dead zone, pin stayed true, next
+//     delta snapped. The dead zone PRESERVES the prior state — it does
+//     not prevent the snap. Don't bring it back without state-aware
+//     hysteresis (and even then, the simple symmetric model works fine).
+export const SCROLL_REPIN_PX = 8;
+
+export type ScrollMetrics = {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+};
+
+/** Distance from the bottom of the scroll container, clamped to >= 0. */
+export function distFromBottom(m: ScrollMetrics): number {
+  return Math.max(0, m.scrollHeight - m.scrollTop - m.clientHeight);
+}
+
+/**
+ * Whether the viewport is currently close enough to the bottom to be
+ * considered "pinned to tail" — i.e., new content should auto-scroll.
+ *
+ * Single symmetric threshold by design. See the SCROLL_REPIN_PX comment
+ * block above for why a dead-zone hysteresis variant doesn't work.
+ */
+export function classifyScrollForPin(
+  metrics: ScrollMetrics,
+  thresholdPx: number = SCROLL_REPIN_PX,
+): boolean {
+  return distFromBottom(metrics) <= thresholdPx;
+}


### PR DESCRIPTION
## Why

Third attempt at fixing "viewport snaps back to bottom while I'm scrolled up reading history." The first two (`0c9b1ce`, `631b03e`) each fixed one slice of the problem and missed others.

## Root causes (three, compounding)

1. **PRIMARY** — the `running` false→true edge effect in `ChatPanel.tsx` force-pinned on **every** busy/idle transition. opencode emits `session.status` busy/idle oscillations between tool calls during multi-step turns, so the viewport got yanked once per step, not once per submit as the comment claimed.

2. **`onScroll` was one-directional.** It only ever set `pinned = true` (when `dist ≤ 8px`) and never `pinned = false`. Scrollbar-handle drags fire `scroll` only (no wheel/touch/key), so dragging up from the bottom via scrollbar left stale `pinned = true` and the next delta snapped back.

3. The wheel/touch/key intent-detection layer was load-bearing for un-pin but had no signal for scrollbar drag or programmatic re-layout, leaving (2) as the only path for those scroll causes.

## Fix — single `scroll` listener + simple symmetric threshold

Pure observation, no intent detection. The browser fires `scroll` for **every** scroll cause (wheel, touch, key, scrollbar drag, momentum, our own writes), so one listener is the only signal needed. Logic in new pure helper `classifyScrollForPin()` (`chatUtils.ts`):

```
dist <= SCROLL_REPIN_PX (8px)  → pin
otherwise                      → unpin
```

Each scroll event correctly reflects the current position — no stale state, no flapping (scroll fires many times per second during scrolling; pin stabilizes well before the next ~hundred-millisecond delta tick).

**Trade-off baked in**: scrolls of < 8px (single-pixel jiggles, very gentle trackpad nudges) stay pinned and get snapped on the next delta. Intentional — most wheel detents are 40-100px and sub-8px scrolls are almost certainly accidental.

**An earlier draft of this fix tried asymmetric hysteresis** (REPIN=8, UNPIN=64) with a dead-zone "no change" return. That re-introduced v1's bug: a 30px wheel-up landed in the dead zone, `pin` stayed `true`, next delta snapped. The dead zone PRESERVES prior state — it does not prevent the snap. **Don't bring it back.** (Caught in self-review during this PR.)

**Force-pin is now explicit and limited** to user actions: `submit()` and `sendQueuedRef.current()` set `pinnedToBottom.current = true` right before their optimistic `setMessages`. The running-edge effect is gone.

## Removed

`programmaticScroll` flag, `wasRunning` ref, the running-edge `useEffect`, `wheel`/`touchmove`/`keydown` listeners.

## Tests

11 new in `chatUtils.test.ts` covering `distFromBottom` and `classifyScrollForPin`, including explicit `REGRESSION:` cases for:
- scrollbar-drag past the threshold (cause #2)
- 30px scroll-up not snapping (cause #1 of v1 AND the dead-zone draft)

```
npm run typecheck  ✓
npm test           ✓ 242/242
```

## AGENTS.md

Updated with the v3 design + explicit "do NOT reintroduce intent-detection listeners", "do NOT reintroduce `running`-derived force-pin", and "the dead zone is a trap" warnings so the next session doesn't try v4.

## Verification on-device (UAT)

1. Scroll up mid-stream via mouse wheel by > 8px → viewport stays put across many deltas.
2. Drag scrollbar handle up from the bottom → viewport stays put.
3. Multi-step turn (Task tool, multi-tool turn) → viewport stays put across busy/idle oscillations.
4. Submit a new message while scrolled up → viewport snaps to bottom to show the new turn.