### PR TITLE
fix(opencode): scope abort POST by ?directory= so backend actually stops

### DIFF
--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -725,9 +725,17 @@ export async function sendPrompt(
 
 // Interrupt the running generation for a session. Idempotent — fine to call
 // when nothing is running (the server just returns success).
+//
+// MUST carry `?directory=<session.directory>` like every other session-
+// mutating POST (prompt_async, command, fork, compact). opencode v2 routes
+// session mutations to the per-directory worker; an unscoped abort lands
+// on the wrong worker so the per-directory worker keeps generating. The
+// renderer's running indicator clears because opencode emits *some* idle
+// signal in response, but the model loop never actually stops.
 export async function abortSession(config: AppConfig, sessionId: string): Promise<void> {
   await ensureForward(config);
-  const url = apiUrl(config, `/session/${encodeURIComponent(sessionId)}/abort`);
+  const dirQ = await getSessionDirectoryQuery(config, sessionId);
+  const url = apiUrl(config, `/session/${encodeURIComponent(sessionId)}/abort${dirQ}`);
   const res = await fetch(url, { method: "POST" });
   if (!res.ok) {
     throw new Error(`opencode abortSession ${res.status}: ${await res.text()}`);

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -205,10 +205,18 @@ export async function sendPrompt({ sessionId, text, model, attachments, mentions
 }
 
 /** Abort the running generation for a session (idempotent).
+ *
+ *  MUST carry `?directory=<session.directory>` like every other session-
+ *  mutating POST (prompt_async, command, fork, compact). opencode v2 routes
+ *  session mutations to the per-directory worker; an unscoped abort lands
+ *  on the wrong worker so the per-directory worker keeps generating. The
+ *  renderer's running indicator clears because opencode emits *some* idle
+ *  signal in response, but the model loop never actually stops.
  *  @param {string} sessionId
  */
 export async function abortSession(sessionId) {
-  const url = `/session/${encodeURIComponent(sessionId)}/abort`;
+  const dirQ = await getSessionDirectoryQuery(sessionId);
+  const url = `/session/${encodeURIComponent(sessionId)}/abort${dirQ}`;
   const res = await fetch(apiUrl(url), { method: "POST" });
   if (!res.ok) {
     throw new Error(`opencode abortSession ${res.status}: ${await res.text()}`);

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -8,6 +8,7 @@ import {
   runCommand,
   forkSession,
   compactSession,
+  abortSession,
   _resetSessionDirectoryCache,
   _onSessionDirectoryAdded,
 } from "./opencode.mjs";
@@ -299,6 +300,65 @@ test("forkSession carries parent ?directory= and caches it for the new session",
   assert.ok(
     childPrompt.url.includes("directory=%2Fproj%2Fa"),
     `child prompt missing scoped directory: ${childPrompt.url}`,
+  );
+});
+
+test("abortSession appends ?directory= from cache", async () => {
+  // Regression: without ?directory= the abort POST lands on the wrong
+  // (un-scoped) worker. opencode emits some idle signal so the UI's
+  // running indicator clears, but the per-directory worker keeps
+  // generating tokens. ESC felt like a no-op server-side.
+  _resetSessionDirectoryCache();
+  let abortUrl = "";
+  await withMockFetch(
+    async (url, opts) => {
+      const u = String(url);
+      if (u.startsWith("http://127.0.0.1:4096/session?directory=")) {
+        return new Response(JSON.stringify({
+          id: "ses_ab",
+          title: "t",
+          directory: "/proj/ab",
+          projectID: "pid",
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u.includes("/abort")) abortUrl = u;
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      await createSession({ directory: "/proj/ab", title: "t" });
+      await abortSession("ses_ab");
+    },
+  );
+  assert.ok(
+    abortUrl.includes("directory=%2Fproj%2Fab"),
+    `abort URL missing scoped directory: ${abortUrl}`,
+  );
+});
+
+test("abortSession lazy-fetches directory via GET /session/{id} on cache miss", async () => {
+  _resetSessionDirectoryCache();
+  const calls = [];
+  await withMockFetch(
+    async (url, opts) => {
+      const u = String(url);
+      calls.push({ url: u, method: opts?.method ?? "GET" });
+      if (u === "http://127.0.0.1:4096/session/ses_amiss" && (opts?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify({ id: "ses_amiss", directory: "/restored/abort" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      await abortSession("ses_amiss");
+    },
+  );
+  const abort = calls.find((c) => c.url.includes("/abort"));
+  assert.ok(abort, "expected /abort call");
+  assert.ok(
+    abort.url.includes("directory=%2Frestored%2Fabort"),
+    `abort URL missing scoped directory after lazy fetch: ${abort.url}`,
   );
 });
 


### PR DESCRIPTION
## Symptom

Pressing ESC (or clicking the running-indicator stop button) in chat-mode cleared the running indicator in the UI but the model loop on the opencode server **kept generating tokens**. The backend was never actually aborted.

## Root cause

`abortSession` was the only session-mutating POST that did NOT carry `?directory=<session.directory>`. Every other write (`prompt_async`, `command`, `fork`, `compact`, `question/reply`) does — opencode v2 routes session mutations to the per-directory worker via that query string. An unscoped abort lands on the wrong (or no) worker.

opencode still emits *some* idle signal in response, which flips the renderer's `running` flag via `session.idle` — that's why the UI looked like it worked. But the per-directory worker, which actually owns the model loop, never received the abort and kept running.

Same scope-drift family as the documented *'SSE broken in existing sessions'* / `rememberSessionDirectory` bug in AGENTS.md.

## Fix

Append `getSessionDirectoryQuery(...)` to the abort URL in **both transports**:

- `src/main/opencode.ts:728` — desktop (Electron main → SSH-tunneled opencode)
- `src/server/opencode.mjs:210` — mobile/web server (Node → local opencode)

Matches the existing pattern used by `prompt_async`, `command`, `fork`, `compact`, `question/reply`.

## Tests

Two regression tests added in `src/server/opencode.test.mjs`:

- `abortSession appends ?directory= from cache` — cached-directory path
- `abortSession lazy-fetches directory via GET /session/{id} on cache miss` — same lazy-fetch behavior as `sendPrompt`

```
npm run typecheck   # clean
npm test            # vitest: 249 pass · node:test: 41 pass
```

## What is NOT changed (intentional)

The renderer's `abort()` callback (`ChatPanel.tsx:1909`) still does NOT optimistically clear `running`. It waits for opencode's `session.idle` event — which is the correct pattern, because with this fix that event now corresponds to the worker actually stopping. Adding an optimistic clear would paper over future scope-drift bugs.

## Deploy notes

- Desktop: main-process change → full restart required (`Ctrl+C` + `npm run dev`), per AGENTS.md.
- Mobile server: `systemctl --user restart bui-server` on the box.