### PR TITLE
fix(chat): keep ContextBar visible during streaming + latch question/permission attention

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2988,6 +2988,15 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   // session.next.step.ended (item 2) feeds stepTokens on every step boundary
   // and we prefer it here so the footer reflects the latest snapshot without
   // waiting for a re-fetch cycle.
+  //
+  // **GOTCHA — fall through "empty" tokens.** A freshly-streaming assistant
+  // message has `tokens` either absent or all-zeros until the first step
+  // boundary lands. The naive "first assistant from the tail" loop returned
+  // that empty object, which made `ctxTokens === 0` and hid the ContextBar
+  // for the entire streaming turn — the bar only re-appeared after the
+  // step.ended event arrived (sometimes minutes later, after a long tool
+  // call). Skip empty entries and keep walking back to the PRIOR turn's
+  // tokens so the bar shows the last known good value during streaming.
   const latestTokens = useMemo<TokenUsage | null>(() => {
     if (stepTokens) {
       return {
@@ -3000,12 +3009,16 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     if (!messages) return null;
     for (let i = messages.length - 1; i >= 0; i--) {
       const info = messages[i].info;
-      if (info.role === "assistant") {
-        // OpencodeMessageInfo type doesn't surface `tokens` directly — read
-        // it off the underlying record. Shape matches AssistantMessage.tokens
-        // from the OpenAPI doc.
-        return (info as unknown as { tokens?: TokenUsage }).tokens ?? null;
-      }
+      if (info.role !== "assistant") continue;
+      // OpencodeMessageInfo type doesn't surface `tokens` directly — read
+      // it off the underlying record. Shape matches AssistantMessage.tokens
+      // from the OpenAPI doc.
+      const t = (info as unknown as { tokens?: TokenUsage }).tokens;
+      if (!t) continue;
+      const totalInput =
+        (t.input ?? 0) + (t.cache?.read ?? 0) + (t.cache?.write ?? 0);
+      if (totalInput <= 0) continue;
+      return t;
     }
     return null;
   }, [messages, stepTokens]);

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -188,14 +188,41 @@ describe("setChatRunning / setChatAttention", () => {
       expect(win.attentionKind).toBeUndefined();
     });
 
-    it("does NOT set attention when the user IS on the window", () => {
-      // QuestionCard / PermissionCard is right there in front of them —
-      // the sidebar dot would be redundant.
+    it("latches question attention EVEN when the user is on the window", () => {
+      // Blocking kinds ('question' / 'permission') must persist so that
+      // navigating away mid-turn still surfaces the indicator in the
+      // sidebar. The card is also visible inline; the sidebar dot is
+      // redundant-but-harmless while active and gets cleared on the
+      // next setActive() touch.
       useStore.setState({
         activeProjectName: "bui",
         activeWindowByProject: { bui: 0 },
       });
       useStore.getState().setChatAttention("ses_chat", "question");
+      expect(useStore.getState().status.bui[0]?.attention).toBe(true);
+      expect(useStore.getState().status.bui[0]?.attentionKind).toBe("question");
+    });
+
+    it("latches permission attention EVEN when the user is on the window", () => {
+      useStore.setState({
+        activeProjectName: "bui",
+        activeWindowByProject: { bui: 0 },
+      });
+      useStore.getState().setChatAttention("ses_chat", "permission");
+      expect(useStore.getState().status.bui[0]?.attention).toBe(true);
+      expect(useStore.getState().status.bui[0]?.attentionKind).toBe(
+        "permission",
+      );
+    });
+
+    it("does NOT set 'idle' attention when the user IS on the window", () => {
+      // Soft "go check" signal — if they're already looking at the
+      // window, there's nothing to go check.
+      useStore.setState({
+        activeProjectName: "bui",
+        activeWindowByProject: { bui: 0 },
+      });
+      useStore.getState().setChatAttention("ses_chat", "idle");
       expect(useStore.getState().status.bui[0]?.attention ?? false).toBe(false);
     });
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -319,11 +319,22 @@ export const useStore = create<State>((set, get) => ({
       const isActiveHere =
         prev.activeProjectName === owner.tmuxSession &&
         prev.activeWindowByProject[owner.tmuxSession] === owner.windowIndex;
-      // Don't latch attention if the user is already viewing the window
-      // — the QuestionCard / PermissionCard is right there in front of
-      // them. The sidebar dot would be redundant and would auto-clear on
-      // the next setActive anyway.
-      const wantAttention = kind != null && !isActiveHere;
+      // Latch "question" and "permission" unconditionally — these block the
+      // turn and the user MUST act, so the sidebar indicator needs to
+      // persist if they navigate away mid-turn (most common case: user is
+      // typing a follow-up in another window when a permission fires; with
+      // the previous `!isActiveHere` gate, no indicator was ever set
+      // because the chat panel WAS active at that moment, and no later
+      // event re-latched it). For these blocking kinds the indicator
+      // auto-clears via `setActive` once the user actually focuses the
+      // window, so the redundancy when they're already looking at the
+      // card is cosmetic and harmless.
+      //
+      // "idle" (soft "go check" from running→idle while away) is still
+      // gated by `!isActiveHere` — if the user IS on the window when the
+      // turn finishes, there's nothing to go check.
+      const wantAttention =
+        kind != null && (kind === "question" || kind === "permission" || !isActiveHere);
       const nextWin: WindowStatusUI = {
         running: old?.running ?? false,
         subagents: old?.subagents ?? 0,


### PR DESCRIPTION
Three bugs reported, two root causes.

## 1. ContextBar disappears sometimes; never shows while streaming

**Root cause:** `latestTokens` walked the transcript from the tail and returned the first assistant message it found — but a freshly-streaming assistant message has `tokens` absent or all-zeros until the first `session.next.step.ended` event arrives. Result: `ctxTokens === 0`, ContextBar hidden for the entire streaming turn (sometimes minutes when a long tool roundtrip delays the step boundary).

**Fix (`src/renderer/ChatPanel.tsx`):** skip empty entries and keep walking back to the prior turn's tokens so the bar shows the last-known-good value while streaming. `stepTokens` (set on `session.next.step.ended`) is still preferred when present, same as before.

## 2. Question indicator often doesn't trigger

**Root cause:** `setChatAttention` gated all attention kinds on `!isActiveHere`. When a question fired while the user was on the chat panel, no attention was latched. The user then navigated away mid-turn — no later event re-latched it, so the sidebar dot never appeared.

**Fix (`src/renderer/store.ts`):** latch `question` and `permission` unconditionally — these block the turn and the user MUST act, so the indicator needs to persist across window switches. `setActive` still auto-clears on focus, so the dot is redundant-but-harmless while viewing the card. `idle` (soft 'go check' signal) keeps the `!isActiveHere` gate — nothing to go check if they're already there.

## 3. Permission indicator should mirror the question one

Already did in `Sidebar.tsx:806` — both `question` and `permission` render a red pulsing dot, with distinct glyphs (`?` vs `!`) so the user can tell what's blocking without opening the window. The root cause for permissions not appearing was the same bug as (2).

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ (327/327 passed; updated store.test.ts to lock in the new latch-while-active behavior for both blocking kinds + keep the negative case for `idle`)