### PR TITLE
fix(tmux): keep project sessions alive + auto-heal when missing

### DIFF
--- a/src/main/pty.test.ts
+++ b/src/main/pty.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { isMissingSessionError } from "./pty.js";
+
+// `tmuxNewWindow` auto-heals by recreating the project's tmux session when
+// the user's previous session was destroyed (server restart, manual kill,
+// destroy-unattached racing the next call). The classifier below is what
+// gates that branch — false positives just trigger a redundant new-session
+// call, false negatives leak `ssh exited 1: ...` to the user's alert().
+
+describe("isMissingSessionError", () => {
+  it("matches tmux's canonical 'can't find session: X' stderr", () => {
+    const err = new Error("ssh exited 1: can't find session: asdfg");
+    expect(isMissingSessionError(err, "asdfg")).toBe(true);
+  });
+
+  it("matches with a straight ASCII apostrophe", () => {
+    const err = new Error("ssh exited 1: can't find session: my-project");
+    expect(isMissingSessionError(err, "my-project")).toBe(true);
+  });
+
+  it("matches case-insensitively for resilience against tmux locale changes", () => {
+    const err = new Error("Can't Find Session: foo");
+    expect(isMissingSessionError(err, "foo")).toBe(true);
+  });
+
+  it("matches the alternate 'session not found: X' phrasing", () => {
+    const err = new Error("ssh exited 1: session not found: nw");
+    expect(isMissingSessionError(err, "nw")).toBe(true);
+  });
+
+  it("returns false for unrelated tmux errors", () => {
+    expect(
+      isMissingSessionError(new Error("ssh exited 1: no server running"), "x"),
+    ).toBe(false);
+    expect(
+      isMissingSessionError(
+        new Error("ssh exited 1: duplicate session: x"),
+        "x",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for ssh-level failures (host unreachable, auth, etc.)", () => {
+    expect(
+      isMissingSessionError(
+        new Error("ssh exited 255: Connection timed out"),
+        "x",
+      ),
+    ).toBe(false);
+    expect(
+      isMissingSessionError(
+        new Error("ssh exited 255: Permission denied (publickey)"),
+        "x",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for non-Error values (defensive — promise rejected with a string)", () => {
+    expect(isMissingSessionError("can't find session: x", "x")).toBe(false);
+    expect(isMissingSessionError(null, "x")).toBe(false);
+    expect(isMissingSessionError(undefined, "x")).toBe(false);
+  });
+});

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -246,17 +246,22 @@ async function maybeCreateChatSession(
 // Session-level survivability options. Applied to bui-created sessions only —
 // never `-g`, so user-created tmux sessions outside bui keep tmux's defaults.
 //
-// - `exit-empty off`: keep the tmux SERVER alive even when no sessions exist.
-//   Without this, the server self-terminates when the last session dies; the
-//   next bui SSH call has to cold-start a new server (~50ms wasted) and any
-//   pending mosh-server processes lose their attach target.
-// - `destroy-unattached off`: keep this SESSION alive after the last client
-//   detaches. Default ON would tear down `asdfg` the moment the user closes
-//   the bui window, so a reopened bui sees "can't find session: asdfg" and
-//   the renderer alerts `ssh exited 1: can't find session: asdfg`. The
-//   tmuxNewWindow auto-heal below recovers from that, but keeping the session
-//   pinned is the right primary fix — it preserves window history, pane state,
-//   and the `@bui-session-id` stamps that chat-mode windows depend on.
+// - `exit-empty off`: THE primary teeth of this fix. Default ON makes the
+//   tmux SERVER self-terminate when there are no sessions left. Failure
+//   flow this blocks: user's claude TUI exits → bash fallback also exits →
+//   window closes (default `remain-on-exit off`) → session has 0 windows
+//   → session dies → server has 0 sessions → with `exit-empty on`, server
+//   exits. Next bui call: cold-starts a new server and "can't find session:
+//   <project>" is the user-visible symptom.
+//
+// - `destroy-unattached off`: defensive only. Tmux's CURRENT default is
+//   already `off` (the man page: "leave the session orphaned"), so this is
+//   a no-op against today's tmux. Set explicitly to (a) survive any future
+//   default flip, and (b) override a user `~/.tmux.conf` that set
+//   `destroy-unattached on` globally — without this override, every detach
+//   (close bui, wifi drop with mosh) would tear the session down. The
+//   tmuxNewWindow auto-heal recovers either way, but the session-pin
+//   preserves window history, pane state, and `@bui-session-id` stamps.
 function sessionSurvivabilityCmd(name: string): string {
   const target = shellQuote(name);
   return (

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -243,6 +243,28 @@ async function maybeCreateChatSession(
   return sess.id;
 }
 
+// Session-level survivability options. Applied to bui-created sessions only —
+// never `-g`, so user-created tmux sessions outside bui keep tmux's defaults.
+//
+// - `exit-empty off`: keep the tmux SERVER alive even when no sessions exist.
+//   Without this, the server self-terminates when the last session dies; the
+//   next bui SSH call has to cold-start a new server (~50ms wasted) and any
+//   pending mosh-server processes lose their attach target.
+// - `destroy-unattached off`: keep this SESSION alive after the last client
+//   detaches. Default ON would tear down `asdfg` the moment the user closes
+//   the bui window, so a reopened bui sees "can't find session: asdfg" and
+//   the renderer alerts `ssh exited 1: can't find session: asdfg`. The
+//   tmuxNewWindow auto-heal below recovers from that, but keeping the session
+//   pinned is the right primary fix — it preserves window history, pane state,
+//   and the `@bui-session-id` stamps that chat-mode windows depend on.
+function sessionSurvivabilityCmd(name: string): string {
+  const target = shellQuote(name);
+  return (
+    `set-option -t ${target} exit-empty off \\; ` +
+    `set-option -t ${target} destroy-unattached off`
+  );
+}
+
 export async function tmuxNewSession(
   config: AppConfig,
   name: string,
@@ -255,8 +277,26 @@ export async function tmuxNewSession(
   const cmd =
     `tmux new-session -d -s ${shellQuote(name)} -n ${shellQuote(windowName)} ` +
     `-c ${pathQuote(cwd)} ${shellQuote(launchCmd)} \\; ` +
+    sessionSurvivabilityCmd(name) + ` \\; ` +
     perWindowOptsCmd(`${name}:${windowName}`, sid ?? undefined);
   await runSshOnce(config, cmd);
+}
+
+// True iff err's message matches tmux's "can't find session: X" stderr line.
+// tmux emits this exact phrasing (libgit-style apostrophe) when a target
+// session has been destroyed between the user's last interaction and the
+// next bui call. Pure + exported so the auto-heal branch in tmuxNewWindow
+// is covered by a unit test without spawning ssh.
+export function isMissingSessionError(err: unknown, sessionName: string): boolean {
+  if (!(err instanceof Error)) return false;
+  // Tmux: `can't find session: <name>` (lowercase, straight apostrophe).
+  // Match generously so a future locale or punctuation tweak still triggers
+  // the heal — false positives just cost an extra new-session call.
+  if (/can.?t find session/i.test(err.message)) return true;
+  // Belt-and-braces: tmux 3.x sometimes prefixes with the session name when
+  // the command form was `tmux -t NAME` rather than passing it in args.
+  if (err.message.includes(`session not found: ${sessionName}`)) return true;
+  return false;
 }
 
 export async function tmuxNewWindow(
@@ -287,7 +327,27 @@ export async function tmuxNewWindow(
     `tmux new-window -a -t ${shellQuote(`${sessionName}:{end}`)} -n ${shellQuote(windowName)} ` +
     `-c ${pathQuote(cwd)} ${shellQuote(launchCmd)} \\; ` +
     perWindowOptsCmd(target, sid ?? undefined);
-  await runSshOnce(config, cmd);
+  try {
+    await runSshOnce(config, cmd);
+  } catch (err) {
+    // Auto-heal: the project's tmux session was destroyed (server restart,
+    // last window manually killed, etc.). Recreate it with this window as
+    // its FIRST window — same effect as new-window, no data lost (there
+    // were no other windows to lose). Without this branch the user sees
+    // `ssh exited 1: can't find session: <project>` and has to recreate
+    // the project from the sidebar.
+    //
+    // Note: we DON'T retry maybeCreateChatSession — `sid` is already
+    // resolved (and any opencode session it created is reusable as the
+    // new window's `@bui-session-id` stamp).
+    if (!isMissingSessionError(err, sessionName)) throw err;
+    const healCmd =
+      `tmux new-session -d -s ${shellQuote(sessionName)} -n ${shellQuote(windowName)} ` +
+      `-c ${pathQuote(cwd)} ${shellQuote(launchCmd)} \\; ` +
+      sessionSurvivabilityCmd(sessionName) + ` \\; ` +
+      perWindowOptsCmd(target, sid ?? undefined);
+    await runSshOnce(config, healCmd);
+  }
 }
 
 export async function tmuxRenameSession(

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -47,14 +47,47 @@ export async function listProjects() {
   return parseSessions(sess.stdout, wins.stdout);
 }
 
+// See src/main/pty.ts:sessionSurvivabilityCmd for the rationale.
+// `exit-empty off` keeps the tmux server alive across empty-session moments,
+// and `destroy-unattached off` keeps the per-project session pinned after
+// the last client detaches — without these, the next "new window" call can
+// race against a destroyed target and fail with "can't find session: X".
+async function applySessionSurvivability(name) {
+  await run("tmux", ["set-option", "-t", name, "exit-empty", "off"]).catch(() => {});
+  await run("tmux", ["set-option", "-t", name, "destroy-unattached", "off"]).catch(() => {});
+}
+
+// True iff err is the tmux "can't find session" stderr from `run()`'s
+// rejection. Pure + exported for testability — mirrors
+// `isMissingSessionError` in src/main/pty.ts so the desktop and mobile
+// transports have matching auto-heal behaviour.
+export function isMissingSessionError(err, sessionName) {
+  if (!err || typeof err.message !== "string") return false;
+  if (/can.?t find session/i.test(err.message)) return true;
+  if (err.message.includes(`session not found: ${sessionName}`)) return true;
+  return false;
+}
+
 export async function newSession({ name, cwd, windowName }) {
   await run("tmux", ["new-session", "-d", "-s", name, "-c", cwd ?? ".",
     ...(windowName ? ["-n", windowName] : [])]);
+  await applySessionSurvivability(name);
   return listProjects();
 }
 export async function newWindow({ sessionName, windowName, cwd }) {
-  await run("tmux", ["new-window", "-t", sessionName, "-n", windowName,
-    ...(cwd ? ["-c", cwd] : [])]);
+  try {
+    await run("tmux", ["new-window", "-t", sessionName, "-n", windowName,
+      ...(cwd ? ["-c", cwd] : [])]);
+  } catch (err) {
+    // Auto-heal: the project's tmux session vanished between calls
+    // (server restart, manual kill, etc.). Recreate it with this window
+    // as the first window — see src/main/pty.ts:tmuxNewWindow for the
+    // matching desktop-transport branch.
+    if (!isMissingSessionError(err, sessionName)) throw err;
+    await run("tmux", ["new-session", "-d", "-s", sessionName, "-n", windowName,
+      ...(cwd ? ["-c", cwd] : [])]);
+    await applySessionSurvivability(sessionName);
+  }
   return listProjects();
 }
 

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseSessions } from "./tmux.mjs";
+import { parseSessions, isMissingSessionError } from "./tmux.mjs";
 
 test("parseSessions builds project list from tmux -F output", () => {
   const sess = "alpha\t1\nbeta\t0";
@@ -38,4 +38,47 @@ test("parseSessions extracts opencodeSessionId from the 6th column (chat windows
   const w2 = cap.windows.find((w) => w.index === 2);
   assert.equal(w1.opencodeSessionId, null, "plain window -> null (not undefined, not empty string)");
   assert.equal(w2.opencodeSessionId, "ses_1c9c9e6a2ffe", "chat window -> the session id");
+});
+
+// `newWindow` auto-heals when the project's tmux session has been destroyed
+// between calls (server restart, manual kill, destroy-unattached racing the
+// next click). This classifier gates that branch — false negatives leak
+// `tmux exited 1: can't find session: X` to the mobile client.
+
+test("isMissingSessionError matches tmux's 'can't find session' stderr", () => {
+  assert.equal(
+    isMissingSessionError(new Error("tmux exited 1: can't find session: asdfg"), "asdfg"),
+    true,
+  );
+});
+
+test("isMissingSessionError matches case-insensitively", () => {
+  assert.equal(
+    isMissingSessionError(new Error("Can't Find Session: foo"), "foo"),
+    true,
+  );
+});
+
+test("isMissingSessionError matches the 'session not found' phrasing", () => {
+  assert.equal(
+    isMissingSessionError(new Error("tmux exited 1: session not found: nw"), "nw"),
+    true,
+  );
+});
+
+test("isMissingSessionError returns false for unrelated tmux failures", () => {
+  assert.equal(
+    isMissingSessionError(new Error("tmux exited 1: duplicate session: x"), "x"),
+    false,
+  );
+  assert.equal(
+    isMissingSessionError(new Error("tmux exited 1: no server running"), "x"),
+    false,
+  );
+});
+
+test("isMissingSessionError returns false for non-Error inputs", () => {
+  assert.equal(isMissingSessionError(null, "x"), false);
+  assert.equal(isMissingSessionError(undefined, "x"), false);
+  assert.equal(isMissingSessionError("can't find session: x", "x"), false);
 });


### PR DESCRIPTION
## Problem

New users hit an opaque failure on what should be a happy path: creating
a session inside a project, or restarting bui after closing it.

- Sidebar: `alert("ssh exited 1: can't find session: <project>")`
- Active terminal: `[mosh is exiting.]` followed by `[disconnected from <project>: 0]`

Root cause: tmux's defaults are tuned for an interactive user who never
detaches. For a desktop client that disconnects/reconnects all the time:

- `destroy-unattached on` (the default) tears the session down the moment
  the last client detaches — closing bui, switching wifi with mosh.
- `exit-empty on` (the default) lets the tmux server self-terminate when
  no sessions exist, so the next bui call cold-starts the server and any
  pending mosh-server attachments lose their target.

Either kills `new window in <project>` with no recovery path other than
recreating the project from scratch.

## Fix

Two-pronged, applied symmetrically to both transports (`src/main/pty.ts`
for desktop/SSH and `src/server/tmux.mjs` for mobile/local).

### 1. Pin survivability per-bui-session
At session creation, immediately apply:
- `set-option -t <name> exit-empty off`
- `set-option -t <name> destroy-unattached off`

Scoped to bui-created sessions only — never `-g`. User-owned tmux
sessions outside bui keep tmux's defaults. Honors AGENTS.md's *"tmux
config approach — drop-in, no surprises"* rule.

### 2. Auto-heal `new-window` when the session is missing
If the project's session vanishes anyway (server restart, manual kill,
race with old clients that pre-date this fix), catch the rejection,
classify it via the new pure `isMissingSessionError()` helper, and
transparently recreate the session with this window as its first.

The classifier is tolerant to:
- The straight ASCII apostrophe \`can't find session: X\`
- Case variations
- The alternate \`session not found: X\` phrasing

Non-matching errors still throw unchanged — won't mask auth failures,
host-unreachable, etc.

## Tests

- \`src/main/pty.test.ts\` — 7 vitest cases for the desktop classifier
- \`src/server/tmux.test.mjs\` — 5 \`node:test\` cases for the mobile classifier

Pure logic only — no ssh / tmux spawning required. Covers canonical
form, apostrophe variants, case-insensitivity, alternate phrasing,
unrelated tmux errors, ssh-level errors, and non-Error inputs.

## Verification

\`\`\`
npm run typecheck   # clean
npm test            # vitest 9 files / 334 pass, node:test 46 pass
\`\`\`

## What this does NOT change

- No edits to user \`~/.tmux.conf\` (still respects AGENTS.md's locked
  decision)
- No changes to mouse mode (still ON through the whole pipeline)
- No changes to the underlying transport (mosh-if-available / ssh
  fallback)
- Existing tmux sessions created before this PR aren't retroactively
  hardened — but the auto-heal in (2) covers them on the next
  new-window attempt