### PR TITLE
fix: honor configured default model + validate remote Claude auth health

### DIFF
--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -929,13 +929,38 @@ export async function rejectQuestion(
 // `connected` is just an array of provider ids; we filter `all` by it and
 // flatten each provider's `models` map.
 // What opencode uses when prompt_async is called without an explicit model.
-// Pulled from `/provider`'s `default` map for the first connected provider.
-// Used by the renderer to show a meaningful label BEFORE the first assistant
-// response (otherwise we'd render an empty/fallback string).
+//
+// PRIMARY source: the user's configured `model` in opencode.jsonc, surfaced by
+// `/config` as `"<providerID>/<modelID>"`. This is what opencode actually uses
+// for a new session, so it's what the picker must show. We deliberately do NOT
+// rely on `/provider`'s `default` map for this — that map is a per-provider
+// CATALOG default (e.g. anthropic → claude-sonnet-4-6) that ignores the user's
+// configured `model`, so reading it made new sessions show the wrong model.
+//
+// FALLBACK (no `model` configured): the catalog default for the first connected
+// provider, so we still render a meaningful label before the first response.
 export async function getDefaultModel(
   config: AppConfig,
 ): Promise<{ providerID: string; modelID: string } | null> {
   await ensureForward(config);
+
+  // Configured default wins. `/config.model` is "<providerID>/<modelID>".
+  try {
+    const cfgRes = await fetch(apiUrl(config, "/config"));
+    if (cfgRes.ok) {
+      const cfg = (await cfgRes.json()) as { model?: string };
+      const slash = cfg.model?.indexOf("/") ?? -1;
+      if (cfg.model && slash > 0) {
+        return {
+          providerID: cfg.model.slice(0, slash),
+          modelID: cfg.model.slice(slash + 1),
+        };
+      }
+    }
+  } catch {
+    /* fall through to provider catalog default */
+  }
+
   const res = await fetch(apiUrl(config, "/provider"));
   if (!res.ok) return null;
   type R = { connected?: string[]; default?: Record<string, string> };

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -95,10 +95,52 @@ else
 fi
 
 CRED="$HOME/.claude/.credentials.json"
-if [ -s "$CRED" ]; then
-  echo "anthropicAuth=ok|credentials present"
+if [ ! -s "$CRED" ]; then
+  echo "anthropicAuth=fail|Not signed in. Run 'opencode auth login anthropic' on the remote to sign in to Claude."
 else
-  echo "anthropicAuth=fail|Run 'opencode auth login anthropic' on the remote to sign in to Claude."
+  # File present — but "present" is not "usable". The token expires ~every 8h;
+  # what keeps the box self-sufficient is a VALID REFRESH TOKEN, which the
+  # opencode-claude-auth plugin uses to mint new access tokens in place. So we
+  # report: valid / expired-but-refreshable (still ok, plugin self-heals) /
+  # expired-and-dead (fail, needs interactive re-auth). Uses python3 if present,
+  # else node (guaranteed by opencode); if neither, falls back to presence-only.
+  CHECK='
+import json,sys,time
+try:
+    d=json.load(open(sys.argv[1]))["claudeAiOauth"]
+except Exception:
+    print("fail|Credentials file is malformed. Re-run: opencode auth login anthropic"); sys.exit()
+acc=d.get("accessToken"); rt=d.get("refreshToken"); exp=d.get("expiresAt") or 0
+now=int(time.time()*1000)
+if not acc:
+    print("fail|No access token. Re-run: opencode auth login anthropic")
+elif exp>now:
+    print("ok|valid (%dm left)"%int((exp-now)/60000))
+elif rt:
+    print("ok|access token expired; auto-refreshes via refresh token")
+else:
+    print("fail|Token expired and no refresh token. Re-run: opencode auth login anthropic")
+'
+  if command -v python3 >/dev/null 2>&1; then
+    echo "anthropicAuth=$(python3 -c "$CHECK" "$CRED" 2>/dev/null || echo 'ok|credentials present')"
+  else
+    OCNODE=""
+    if command -v node >/dev/null 2>&1; then OCNODE=node; fi
+    if [ -n "$OCNODE" ]; then
+      echo "anthropicAuth=$("$OCNODE" -e '
+        const fs=require("fs");let d;
+        try{d=JSON.parse(fs.readFileSync(process.argv[1],"utf8")).claudeAiOauth;}
+        catch(e){console.log("fail|Credentials file is malformed. Re-run: opencode auth login anthropic");process.exit(0);}
+        const now=Date.now(),exp=d.expiresAt||0;
+        if(!d.accessToken)console.log("fail|No access token. Re-run: opencode auth login anthropic");
+        else if(exp>now)console.log("ok|valid ("+Math.round((exp-now)/60000)+"m left)");
+        else if(d.refreshToken)console.log("ok|access token expired; auto-refreshes via refresh token");
+        else console.log("fail|Token expired and no refresh token. Re-run: opencode auth login anthropic");
+      ' "$CRED" 2>/dev/null || echo 'ok|credentials present')"
+    else
+      echo "anthropicAuth=ok|credentials present"
+    fi
+  fi
 fi
 `;
 

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -61,9 +61,10 @@ export function parseProbeOutput(stdout: string): ProbeResult {
  *                         (the installer's default). Reports version.
  *   opencodeAuthPlugin  — checks ~/.config/opencode/opencode.jsonc lists
  *                         `opencode-claude-auth` in the `plugin` array.
- *   anthropicAuth       — checks ~/.claude/.credentials.json exists AND is
- *                         non-empty. Doesn't validate contents (that would
- *                         require running opencode).
+ *   anthropicAuth       — parses ~/.claude/.credentials.json (without running
+ *                         opencode) and reports token health, not mere
+ *                         presence: valid / expired-but-refreshable (ok) vs
+ *                         expired-dead / malformed / unverifiable (fail).
  */
 export const PROBE_SCRIPT = `
 echo "ssh=ok|connected"
@@ -98,12 +99,29 @@ CRED="$HOME/.claude/.credentials.json"
 if [ ! -s "$CRED" ]; then
   echo "anthropicAuth=fail|Not signed in. Run 'opencode auth login anthropic' on the remote to sign in to Claude."
 else
-  # File present — but "present" is not "usable". The token expires ~every 8h;
-  # what keeps the box self-sufficient is a VALID REFRESH TOKEN, which the
-  # opencode-claude-auth plugin uses to mint new access tokens in place. So we
-  # report: valid / expired-but-refreshable (still ok, plugin self-heals) /
-  # expired-and-dead (fail, needs interactive re-auth). Uses python3 if present,
-  # else node (guaranteed by opencode); if neither, falls back to presence-only.
+  # File present — but "present" is not "usable". The access token is short-
+  # lived (observed ~8h on the claude.ai OAuth tier); what keeps the box self-
+  # sufficient is a VALID REFRESH TOKEN. The opencode-claude-auth plugin uses it
+  # to mint a new access token and writes it back to this file in place — this
+  # was verified directly: with the file's expiresAt forced into the past and
+  # the refresh token retained, a single opencode call refreshed the token on
+  # disk with no CLI or external timer involved. So the verdicts are:
+  #   valid                 -> ok
+  #   expired + refresh tok  -> ok (plugin self-heals on next request)
+  #   expired, no refresh    -> fail (needs interactive re-auth)
+  #   malformed / no token   -> fail
+  #
+  # NOTE on the "expired + refresh token" = ok heuristic: we report ok on the
+  # PRESENCE of a refresh token, not proof it still works server-side. A revoked
+  # or rotated-away refresh token reads ok here and only fails on the first real
+  # request. We accept that — confirming it would mean spending the (single-use!)
+  # refresh token, which would burn it for the plugin. Presence is the safe,
+  # non-destructive signal.
+  #
+  # Parsing uses python3 if present, else node (bundled with opencode). If the
+  # interpreter is missing OR exits unexpectedly, we report fail|unverified —
+  # NOT ok. A probe whose job is to detect broken auth must never answer "ok"
+  # when it could not actually validate; false confidence is worse than none.
   CHECK='
 import json,sys,time
 try:
@@ -121,25 +139,31 @@ elif rt:
 else:
     print("fail|Token expired and no refresh token. Re-run: opencode auth login anthropic")
 '
+  # Fallback verdict when we cannot run a validating interpreter. Deliberately
+  # fail, not ok — see NOTE above.
+  UNVERIFIED="fail|Credentials file present but could not be validated (no python3/node on remote). Verify auth manually."
   if command -v python3 >/dev/null 2>&1; then
-    echo "anthropicAuth=$(python3 -c "$CHECK" "$CRED" 2>/dev/null || echo 'ok|credentials present')"
+    echo "anthropicAuth=$(python3 -c "$CHECK" "$CRED" 2>/dev/null || echo "$UNVERIFIED")"
+  elif command -v node >/dev/null 2>&1; then
+    # Mirror the python logic exactly: a valid-JSON file MISSING the
+    # claudeAiOauth block must route to "malformed", same as python's KeyError.
+    # JSON.parse(...).claudeAiOauth yields undefined (no throw), so we throw
+    # explicitly inside the try; otherwise a later field access would throw
+    # OUTSIDE the try, exit non-zero, and the OR-fallback would mask it.
+    echo "anthropicAuth=$(node -e '
+      const fs=require("fs");let d;
+      try{
+        d=JSON.parse(fs.readFileSync(process.argv[1],"utf8")).claudeAiOauth;
+        if(!d) throw new Error("no claudeAiOauth block");
+      }catch(e){console.log("fail|Credentials file is malformed. Re-run: opencode auth login anthropic");process.exit(0);}
+      const now=Date.now(),exp=d.expiresAt||0;
+      if(!d.accessToken)console.log("fail|No access token. Re-run: opencode auth login anthropic");
+      else if(exp>now)console.log("ok|valid ("+Math.round((exp-now)/60000)+"m left)");
+      else if(d.refreshToken)console.log("ok|access token expired; auto-refreshes via refresh token");
+      else console.log("fail|Token expired and no refresh token. Re-run: opencode auth login anthropic");
+    ' "$CRED" 2>/dev/null || echo "$UNVERIFIED")"
   else
-    OCNODE=""
-    if command -v node >/dev/null 2>&1; then OCNODE=node; fi
-    if [ -n "$OCNODE" ]; then
-      echo "anthropicAuth=$("$OCNODE" -e '
-        const fs=require("fs");let d;
-        try{d=JSON.parse(fs.readFileSync(process.argv[1],"utf8")).claudeAiOauth;}
-        catch(e){console.log("fail|Credentials file is malformed. Re-run: opencode auth login anthropic");process.exit(0);}
-        const now=Date.now(),exp=d.expiresAt||0;
-        if(!d.accessToken)console.log("fail|No access token. Re-run: opencode auth login anthropic");
-        else if(exp>now)console.log("ok|valid ("+Math.round((exp-now)/60000)+"m left)");
-        else if(d.refreshToken)console.log("ok|access token expired; auto-refreshes via refresh token");
-        else console.log("fail|Token expired and no refresh token. Re-run: opencode auth login anthropic");
-      ' "$CRED" 2>/dev/null || echo 'ok|credentials present')"
-    else
-      echo "anthropicAuth=ok|credentials present"
-    fi
+    echo "anthropicAuth=$UNVERIFIED"
   fi
 fi
 `;


### PR DESCRIPTION
## Summary

Two independent fixes that came out of debugging recurring "credentials expired / wrong model" issues on the remote opencode-serve setup.

### 1. New sessions honor the configured default model (`src/main/opencode.ts`)
`getDefaultModel()` read `/provider`'s `default` map — a per-provider **catalog** default (`anthropic → claude-sonnet-4-6`) that ignores the user's configured `model` in `opencode.jsonc`. So new sessions opened on the wrong model regardless of config (symptom: pinned `claude-opus-4-8`, sessions showed something else).

Now reads `/config.model` first (the configured `"<providerID>/<modelID>"`), falling back to the provider catalog default only when no model is configured.

### 2. Auth probe validates credential *health*, not just presence (`src/main/setup.ts`)
The `anthropicAuth` probe reported `ok` whenever `~/.claude/.credentials.json` existed and was non-empty. But a present file with an expired/dead token still 401s every request — so the probe gave a false ✓ while chat was broken.

The probe now parses the credential and reports its real usability:

| Credential state | Verdict |
|---|---|
| Valid token | `ok · valid (Nm left)` |
| Expired, has refresh token | `ok · auto-refreshes via refresh token` |
| Expired, no refresh token | `fail · re-run opencode auth login anthropic` |
| Malformed | `fail · re-run login` |

**Why "expired + refresh token" is `ok`:** verified that the `opencode-claude-auth` plugin self-heals — with both stores forced expired (valid refresh token retained), one opencode call refreshed the token in place in both `~/.claude/.credentials.json` and opencode's auth store. So an expired access token with a live refresh token is genuinely fine; the box is self-sufficient.

This is the shippable half of "remote self-auths": each user signs in once on their box, the plugin keeps it alive, and the probe honestly distinguishes "expired but fine" from "needs re-auth." Pure shell + python3/node fallback, no per-user secrets, no host dependency.

## Testing
- `npm run typecheck` — clean
- `npx vitest run` — 334 passed (28 in setup.test.ts)
- Probe shell logic exercised against the live remote for all four credential states (valid / expired+refresh / expired+dead / malformed) — correct verdicts.

🧙 Built with [WOZCODE](https://wozcode.com)