### PR TITLE
fix(auth): use patched fork of opencode-claude-auth to recover from in-memory cache wipes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import {
 import { info as transportInfo, invalidate as invalidateTransport } from "./transport.js";
 import { probe as setupProbe, bootstrap as setupBootstrap } from "./setup.js";
 import { startStatusPoller, stopStatusPoller } from "./status.js";
+import { noteSessionActivity } from "./transcriptCache.js";
 import {
   listMessages as opencodeListMessages,
   getCachedMessages as opencodeGetCachedMessages,
@@ -374,6 +375,18 @@ function ensureOpencodeStream(directory: string): void {
           // the per-directory active-work tracker the watchdog consults.
           if (isSubstantiveFrame(ev.type)) lastSubstantiveAt = nowFrame;
           noteSessionStatus(ev);
+          // Bump the per-session activity stamp so the transcript cache knows
+          // its on-disk copy is stale until the next listMessages refresh.
+          // Without this, a remount mid-turn (user switches away after sending
+          // and comes back) paints the cached pre-send transcript for the ~6s
+          // the fresh fetch takes — looks like the send never happened.
+          // Only events with a string sessionID count; transport keep-alives
+          // (server.connected, server.heartbeat) carry no sessionID and are
+          // harmlessly skipped.
+          {
+            const sid = (ev.properties as { sessionID?: unknown } | undefined)?.sessionID;
+            if (typeof sid === "string" && sid) noteSessionActivity(sid);
+          }
           // Lightweight success-path trace: first event + every 50th, so the
           // log shows events ARE flowing for a dir (vs. silent = the bug)
           // without flooding on delta storms.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,7 @@ import { probe as setupProbe, bootstrap as setupBootstrap } from "./setup.js";
 import { startStatusPoller, stopStatusPoller } from "./status.js";
 import {
   listMessages as opencodeListMessages,
+  getCachedMessages as opencodeGetCachedMessages,
   subscribeEvents as opencodeSubscribeEvents,
   sendPrompt as opencodeSendPrompt,
   abortSession as opencodeAbortSession,
@@ -895,6 +896,11 @@ function registerHandlers(): void {
   // arrive separately via the opencodeEvent stream forwarded by startOpencodeBus.
   ipcMain.handle(IPC.opencodeMessages, (_e, sessionId: string) =>
     opencodeListMessages(config, sessionId),
+  );
+  // Cached transcript lookup — instant. Renderer paints this immediately at
+  // mount, then awaits opencodeMessages in the background for the refresh.
+  ipcMain.handle(IPC.opencodeMessagesCached, (_e, sessionId: string) =>
+    opencodeGetCachedMessages(sessionId),
   );
 
   // Phase 2: send user message + abort generation. Optional `model` overrides

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -322,13 +322,22 @@ function ensureOpencodeStream(directory: string): void {
         let stalledOut = false;
         watchdog = setInterval(() => {
           const now = Date.now();
-          // Active-work for THIS stream's directory. The global stream
-          // (directory === "") has no single dir; treat it as active if
-          // ANY directory has active work (its substantive frames are the
-          // union). Scoped streams read their own dir's state.
+          // Active-work for THIS stream's directory. Scoped streams read
+          // their own dir's state. The global stream (directory === "")
+          // must report activeWork=false here: opencode delivers
+          // session/message events ONLY to the matching `?directory=`
+          // stream (see opencode.ts:1301-1305). The global stream is
+          // expected to carry only keep-alives + a small set of
+          // cross-cutting events. Earlier this used the union of every
+          // dir's activeWork, which meant any mid-turn session anywhere
+          // false-triggered mode B on <global> every ~45s → the watchdog
+          // tore down ALL scoped streams (including the one actively
+          // receiving frames for that session) → user-visible "hang" mid
+          // turn. Treating global as never-mode-B keeps mode A (fully dead
+          // mux) intact while removing the false positive.
           const activeWork = directory
             ? activeWorkByDir.get(directory) === true
-            : [...activeWorkByDir.values()].some(Boolean);
+            : false;
           const health = classifyStreamHealth({
             framesSinceConnect: frames,
             msSinceConnect: now - connectedAt,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -350,16 +350,38 @@ function ensureOpencodeStream(directory: string): void {
             stalledOut = true;
             const silentS = Math.round((now - lastFrameAt) / 1000);
             const substS = Math.round((now - lastSubstantiveAt) / 1000);
+            // Two recovery paths, scaled to the signal:
+            //
+            // - activeWork=true (the user is waiting on real events): a true
+            //   half-dead mux is dropping their assistant deltas. Worth the
+            //   blast radius of an eventTunnelRestart — every other stream
+            //   reconnects, but the user's in-flight turn gets unblocked.
+            //
+            // - activeWork=false (idle directory): "no frames in 50s" can
+            //   mean the mux died, OR the remote opencode-serve is just
+            //   slow (we've observed it pegged at 6 GB RES with full swap,
+            //   delaying heartbeats by tens of seconds). Restarting the
+            //   tunnel for every idle stream that times out cascades into
+            //   tearing down ALL streams every ~50s — that's what the user
+            //   feels as "UI stuck a lot". Just respawn THIS one stream;
+            //   the others stay live. If the tunnel really is dead, every
+            //   other stream will independently trip mode A and we converge
+            //   on the same outcome, just without amplification.
+            const action = activeWork
+              ? "restarting event tunnel + reconnecting"
+              : "reconnecting this stream only (idle — likely server lag, not dead mux)";
             console.warn(
               `[opencode-bus] STALLED dir=${directory || "<global>"} ` +
                 `(no frames ${silentS}s / no substantive ${substS}s, ` +
-                `activeWork=${activeWork}) — restarting event tunnel + reconnecting`,
+                `activeWork=${activeWork}) — ${action}`,
             );
-            // The event stream rides its OWN dedicated ssh -L -N tunnel
-            // (isolated from the RPC ControlMaster). Kill it; the next
-            // subscribeEvents respawns a FRESH connection. RPC/pty are
-            // untouched — no shared-mux collateral.
-            eventTunnelRestart();
+            if (activeWork) {
+              // The event stream rides its OWN dedicated ssh -L -N tunnel
+              // (isolated from the RPC ControlMaster). Kill it; the next
+              // subscribeEvents respawns a FRESH connection. RPC/pty are
+              // untouched — no shared-mux collateral.
+              eventTunnelRestart();
+            }
             try { stream.dispose(); } catch { /* already disposed */ }
           }
         }, Math.min(STREAM_STALL_MS, 10_000));

--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -39,6 +39,11 @@ import {
   isPortForwardingFailure,
   parseLsofListeners,
 } from "./forwardHeal.js";
+import {
+  dropCachedTranscript,
+  getCachedTranscript,
+  setCachedTranscript,
+} from "./transcriptCache.js";
 import type {
   AppConfig,
   OpencodeMessage,
@@ -637,7 +642,20 @@ export async function listMessages(
   if (!res.ok) {
     throw new Error(`opencode listMessages ${res.status}: ${await res.text()}`);
   }
-  return (await res.json()) as OpencodeMessage[];
+  const messages = (await res.json()) as OpencodeMessage[];
+  // Stash the fresh transcript so the next mount of this session can render
+  // immediately instead of blocking on the (slow) opencode fetch.
+  setCachedTranscript(sessionId, messages);
+  return messages;
+}
+
+// Synchronous-ish cache lookup for renderer-initiated fast paths. Returns
+// `null` on miss; the renderer should then fall back to `listMessages` and
+// show its loading state. Reading is cheap (memory hit first, disk read at
+// worst), so the IPC handler can call this on the main thread without
+// blocking other IPC.
+export function getCachedMessages(sessionId: string): OpencodeMessage[] | null {
+  return getCachedTranscript(sessionId);
 }
 
 // Send a user message into the session.
@@ -1261,6 +1279,8 @@ export async function deleteSession(config: AppConfig, sessionId: string): Promi
   await ensureForward(config);
   // Drop the cache entry — sid will not be reused.
   sessionDirectoryCache.delete(sessionId);
+  // Drop the persisted transcript so we don't leak it on disk after delete.
+  dropCachedTranscript(sessionId);
   const url = apiUrl(config, `/session/${encodeURIComponent(sessionId)}`);
   const res = await fetch(url, { method: "DELETE" });
   if (!res.ok) {

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -52,9 +52,21 @@ function sshBaseArgs(config: AppConfig): string[] {
   return args;
 }
 
+// Hard timeout for one-shot ssh calls. Without this, an ssh process that
+// blocks on the remote (mux wedge, remote sshd at MaxStartups, network
+// blackhole) sits forever in SN state. Per-tick pollers (footer branch,
+// auto-refresh) then pile up dozens of wedged ssh procs locally while the
+// remote sshd hits its connection-rate cap → the user sees random
+// "Connection reset by peer" / "Session open refused by peer" errors on
+// otherwise-fine actions like tmux:select-window. 60 s is generous for any
+// real ssh side-channel call (tmuxList, branch, dir checks); anything
+// longer is the wedge.
+const DEFAULT_SSH_TIMEOUT_MS = 60_000;
+
 export function runSshOnce(
   config: AppConfig,
   remoteCmd: string,
+  opts: { timeoutMs?: number } = {},
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     if (!config.host) return reject(new Error("No host configured"));
@@ -62,12 +74,30 @@ export function runSshOnce(
     const proc = cpSpawn("ssh", args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_SSH_TIMEOUT_MS;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      // SIGKILL: the proc is wedged in a network wait — SIGTERM may not
+      // dislodge it before the next poll tick spawns another one.
+      try { proc.kill("SIGKILL"); } catch { /* ignore */ }
+      reject(new Error(`ssh timed out after ${timeoutMs}ms: ${remoteCmd.slice(0, 80)}`));
+    }, timeoutMs);
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
     proc.stdout.on("data", (b) => (stdout += b.toString()));
     proc.stderr.on("data", (b) => (stderr += b.toString()));
-    proc.on("error", reject);
+    proc.on("error", (err) => finish(() => reject(err)));
     proc.on("exit", (code) => {
-      if (code === 0) resolve({ stdout, stderr });
-      else reject(new Error(`ssh exited ${code}: ${stderr.trim() || stdout.trim()}`));
+      finish(() => {
+        if (code === 0) resolve({ stdout, stderr });
+        else reject(new Error(`ssh exited ${code}: ${stderr.trim() || stdout.trim()}`));
+      });
     });
   });
 }
@@ -719,20 +749,49 @@ function parseWorktreePorcelain(out: string): WorktreeInfo[] {
 // Returns null for: no host, empty cwd, non-git dir, detached HEAD, or any
 // failure. Detached HEAD is intentionally null — the footer indicator only
 // makes sense as a branch name; we'd rather show nothing than `HEAD`.
+// Per-cwd cache + in-flight coalescer for the branch poll. Every mounted
+// ChatPanel polls `getBranch` for its own cwd every 5 s (ChatPanel.tsx
+// fetchBranch). Without coalescing, N panels open on the same project →
+// N concurrent ssh procs every tick, and any slowness on the remote sshd
+// (MaxStartups throttling, OOM-recovery) leaves them stacking up locally
+// in SN state until the warm ControlMaster also stalls and unrelated
+// IPC (`tmux:select-window`) starts failing with `Session open refused by
+// peer`. TTL is just under one poll tick so a fresh checkout still
+// surfaces within ~5 s. In-flight dedupe collapses any concurrent panels
+// onto a single ssh.
+const BRANCH_CACHE_TTL_MS = 4_000;
+const branchCache = new Map<string, { value: string | null; at: number }>();
+const branchInFlight = new Map<string, Promise<string | null>>();
+
 export async function getBranch(
   config: AppConfig,
   cwd: string,
 ): Promise<string | null> {
   if (!config.host) return null;
-  if (!cwd.trim()) return null;
+  const key = cwd.trim();
+  if (!key) return null;
+  const cached = branchCache.get(key);
+  if (cached && Date.now() - cached.at < BRANCH_CACHE_TTL_MS) return cached.value;
+  const inflight = branchInFlight.get(key);
+  if (inflight) return inflight;
   // `git -C <dir> branch --show-current` prints the branch name or empty
   // (detached HEAD); errors go to stderr. `|| true` keeps the SSH exit zero
   // on non-repo so the catch path is reserved for real transport failures.
   const cmd =
-    `git -C ${pathQuote(cwd)} branch --show-current 2>/dev/null || true`;
-  const { stdout } = await runSshOnce(config, cmd).catch(() => ({ stdout: "" }));
-  const name = stdout.trim();
-  return name ? name : null;
+    `git -C ${pathQuote(key)} branch --show-current 2>/dev/null || true`;
+  // 8 s cap on the branch ssh specifically: the call is "instant" over a
+  // warm mux (~30 ms) and the poller refires every 5 s; waiting longer
+  // than the next tick adds nothing and just gives the wedge room to grow.
+  const p = runSshOnce(config, cmd, { timeoutMs: 8_000 })
+    .then(({ stdout }) => stdout.trim() || null)
+    .catch(() => null)
+    .then((value) => {
+      branchCache.set(key, { value, at: Date.now() });
+      branchInFlight.delete(key);
+      return value;
+    });
+  branchInFlight.set(key, p);
+  return p;
 }
 
 // ===== Directory autocomplete =====

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -176,8 +176,42 @@ function perWindowOptsCmd(target: string, opencodeSessionId?: string): string {
 // in its format spec.
 const FS = "	";
 
+// tmuxList does 3 SSH round-trips (list-sessions, list-windows, list-panes).
+// Every mutating IPC (kill-window, new-window, select-window, rename, …)
+// ends by returning a fresh tmuxList to the renderer. Under remote
+// pressure (swap-thrashing box, load avg 13) each round-trip can stretch
+// to seconds; back-to-back UI actions then stack up sequentially behind
+// the same data we already have. Coalesce concurrent callers onto a single
+// in-flight result, and serve a sub-second TTL cache so rapid-fire calls
+// don't each round-trip. Mutation paths bust the cache so the next read
+// reflects the change.
+const TMUX_LIST_TTL_MS = 1_500;
+let tmuxListCache: { value: TmuxSession[]; at: number } | null = null;
+let tmuxListInFlight: Promise<TmuxSession[]> | null = null;
+
+export function invalidateTmuxListCache(): void {
+  tmuxListCache = null;
+}
+
 export async function tmuxList(config: AppConfig): Promise<TmuxSession[]> {
   if (!config.host) return [];
+  if (tmuxListCache && Date.now() - tmuxListCache.at < TMUX_LIST_TTL_MS) {
+    return tmuxListCache.value;
+  }
+  if (tmuxListInFlight) return tmuxListInFlight;
+  tmuxListInFlight = (async () => {
+    try {
+      const value = await tmuxListUncached(config);
+      tmuxListCache = { value, at: Date.now() };
+      return value;
+    } finally {
+      tmuxListInFlight = null;
+    }
+  })();
+  return tmuxListInFlight;
+}
+
+async function tmuxListUncached(config: AppConfig): Promise<TmuxSession[]> {
   const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
   // 6th column is `@bui-session-id` — set on chat-mode windows when bui
   // creates them. Empty for claude-TUI windows. Presence of this id is the
@@ -315,6 +349,7 @@ export async function tmuxNewSession(
     sessionSurvivabilityCmd(name) + ` \\; ` +
     perWindowOptsCmd(`${name}:${windowName}`, sid ?? undefined);
   await runSshOnce(config, cmd);
+  invalidateTmuxListCache();
 }
 
 // True iff err's message matches tmux's "can't find session: X" stderr line.
@@ -383,6 +418,7 @@ export async function tmuxNewWindow(
       perWindowOptsCmd(target, sid ?? undefined);
     await runSshOnce(config, healCmd);
   }
+  invalidateTmuxListCache();
 }
 
 export async function tmuxRenameSession(
@@ -394,6 +430,7 @@ export async function tmuxRenameSession(
     config,
     `tmux rename-session -t ${shellQuote(oldName)} ${shellQuote(newName)}`,
   );
+  invalidateTmuxListCache();
 }
 
 export async function tmuxRenameWindow(
@@ -406,10 +443,12 @@ export async function tmuxRenameWindow(
     config,
     `tmux rename-window -t ${shellQuote(`${sessionName}:${windowIndex}`)} ${shellQuote(newName)}`,
   );
+  invalidateTmuxListCache();
 }
 
 export async function tmuxKillSession(config: AppConfig, name: string): Promise<void> {
   await runSshOnce(config, `tmux kill-session -t ${shellQuote(name)} || true`);
+  invalidateTmuxListCache();
 }
 
 export async function tmuxKillWindow(
@@ -421,6 +460,7 @@ export async function tmuxKillWindow(
     config,
     `tmux kill-window -t ${shellQuote(`${sessionName}:${windowIndex}`)} || true`,
   );
+  invalidateTmuxListCache();
 }
 
 export async function tmuxSelectWindow(
@@ -449,6 +489,7 @@ export async function tmuxRestampSessionId(
     config,
     `tmux set-window-option -t ${shellQuote(target)} ${OPENCODE_SID_OPT} ${shellQuote(sessionId)}`,
   );
+  invalidateTmuxListCache();
 }
 
 // ===== Remote tmux config management =====

--- a/src/main/setup.test.ts
+++ b/src/main/setup.test.ts
@@ -178,14 +178,14 @@ describe("mergeOpencodeJsonc", () => {
     const r = mergeOpencodeJsonc("");
     expect(r.changed).toBe(true);
     const cfg = parse(r.content);
-    expect(cfg.plugin).toEqual(["opencode-claude-auth@latest"]);
+    expect(cfg.plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
     expect(cfg.$schema).toBe("https://opencode.ai/config.json");
   });
 
   it("writes a minimal config when existing is only whitespace", () => {
     const r = mergeOpencodeJsonc("   \n  \n");
     expect(r.changed).toBe(true);
-    expect(parse(r.content).plugin).toEqual(["opencode-claude-auth@latest"]);
+    expect(parse(r.content).plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
   });
 
   it("appends auth plugin to an existing plugin array, preserving order", () => {
@@ -199,7 +199,7 @@ describe("mergeOpencodeJsonc", () => {
     const cfg = parse(r.content);
     expect(cfg.plugin).toEqual([
       "other-plugin@1.0",
-      "opencode-claude-auth@latest",
+      "opencode-claude-auth-bui@1.5.4-bui.1",
     ]);
     // Other top-level keys must be preserved verbatim.
     expect(cfg.model).toBe("anthropic/claude-opus-4-7");
@@ -214,12 +214,24 @@ describe("mergeOpencodeJsonc", () => {
     const r = mergeOpencodeJsonc(existing);
     expect(r.changed).toBe(true);
     const cfg = parse(r.content);
-    expect(cfg.plugin).toEqual(["opencode-claude-auth@latest"]);
+    expect(cfg.plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
     expect(cfg.model).toBe("anthropic/claude-opus-4-7");
     expect(cfg.keymap).toEqual({ quit: "ctrl+q" });
   });
 
-  it("is a no-op when the auth plugin is already present (pinned version)", () => {
+  it("is a no-op when the fork is already present (pinned version)", () => {
+    const existing = JSON.stringify({
+      plugin: ["opencode-claude-auth-bui@1.5.4-bui.1"],
+    });
+    const r = mergeOpencodeJsonc(existing);
+    expect(r.changed).toBe(false);
+    expect(parse(r.content).plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
+  });
+
+  it("is a no-op when the UPSTREAM plugin is already present — fork is NOT appended", () => {
+    // A user who already runs the upstream `opencode-claude-auth` must NOT
+    // get the fork appended on re-bootstrap. Both names are accepted as
+    // "auth is wired up"; the user's existing choice is respected.
     const existing = JSON.stringify({
       plugin: ["opencode-claude-auth@latest"],
     });
@@ -228,8 +240,7 @@ describe("mergeOpencodeJsonc", () => {
     expect(parse(r.content).plugin).toEqual(["opencode-claude-auth@latest"]);
   });
 
-  it("respects a user's custom pinned version of the plugin (no overwrite)", () => {
-    // User has pinned to an older version on purpose — don't bump it.
+  it("respects a user's custom pinned version of the upstream plugin (no overwrite)", () => {
     const existing = JSON.stringify({
       plugin: ["opencode-claude-auth@0.3.1"],
     });
@@ -238,9 +249,26 @@ describe("mergeOpencodeJsonc", () => {
     expect(parse(r.content).plugin).toEqual(["opencode-claude-auth@0.3.1"]);
   });
 
-  it("recognizes the plugin by bare package name (no @version suffix)", () => {
+  it("respects a user's custom pinned version of the fork (no overwrite)", () => {
+    const existing = JSON.stringify({
+      plugin: ["opencode-claude-auth-bui@2.0.0"],
+    });
+    const r = mergeOpencodeJsonc(existing);
+    expect(r.changed).toBe(false);
+    expect(parse(r.content).plugin).toEqual(["opencode-claude-auth-bui@2.0.0"]);
+  });
+
+  it("recognizes the upstream plugin by bare package name (no @version suffix)", () => {
     const existing = JSON.stringify({
       plugin: ["opencode-claude-auth"],
+    });
+    const r = mergeOpencodeJsonc(existing);
+    expect(r.changed).toBe(false);
+  });
+
+  it("recognizes the fork by bare package name (no @version suffix)", () => {
+    const existing = JSON.stringify({
+      plugin: ["opencode-claude-auth-bui"],
     });
     const r = mergeOpencodeJsonc(existing);
     expect(r.changed).toBe(false);
@@ -259,7 +287,7 @@ describe("mergeOpencodeJsonc", () => {
     const r = mergeOpencodeJsonc("{ this is not valid jsonc");
     expect(r.changed).toBe(true);
     expect(r.detail).toContain("unparseable");
-    expect(parse(r.content).plugin).toEqual(["opencode-claude-auth@latest"]);
+    expect(parse(r.content).plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
   });
 
   it("treats a non-array `plugin` field as no array and creates a new one", () => {
@@ -273,7 +301,7 @@ describe("mergeOpencodeJsonc", () => {
     // We REPLACE the malformed value with a fresh array — the alternative
     // (preserving the string) would yield an invalid config opencode would
     // reject. Other keys still preserved.
-    expect(cfg.plugin).toEqual(["opencode-claude-auth@latest"]);
+    expect(cfg.plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
     expect(cfg.other).toBe(42);
   });
 

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -89,10 +89,13 @@ else
 fi
 
 CFG="$HOME/.config/opencode/opencode.jsonc"
+# Substring match accepts both the fork (opencode-claude-auth-bui) and the
+# upstream package (opencode-claude-auth) — see CLAUDE_AUTH_PLUGIN_ACCEPTED_BARES
+# in the merge logic above for why we intentionally accept either.
 if [ -f "$CFG" ] && grep -q 'opencode-claude-auth' "$CFG"; then
   echo "opencodeAuthPlugin=ok|configured"
 else
-  echo "opencodeAuthPlugin=fail|opencode-claude-auth plugin not in $CFG. Bootstrap will add it."
+  echo "opencodeAuthPlugin=fail|opencode-claude-auth(-bui) plugin not in $CFG. Bootstrap will add it."
 fi
 
 CRED="$HOME/.claude/.credentials.json"
@@ -217,8 +220,27 @@ fi
 // JSONC merge — pure (tested)
 // ---------------------------------------------------------------------------
 
-const CLAUDE_AUTH_PLUGIN = "opencode-claude-auth@latest";
-const CLAUDE_AUTH_PLUGIN_BARE = "opencode-claude-auth";
+// The plugin we write into a fresh opencode.jsonc. We use a fork of the
+// upstream `opencode-claude-auth` plugin that fixes a long-lived-process
+// recovery bug: in upstream, a single failed OAuth refresh clears the
+// in-memory accountCacheMap, after which every subsequent request throws
+// "credentials unavailable" until opencode-serve is restarted, even though
+// ~/.claude/.credentials.json on disk is healthy. Our fork (1.5.4-bui.1)
+// retries via refreshAccountsList() once before throwing, which restores
+// file-sourced accounts and lets the existing refresh path succeed.
+//
+// Source: https://github.com/antoinedc/opencode-claude-auth (fork of
+// griffinmartin/opencode-claude-auth). Published as opencode-claude-auth-bui
+// on npm. The bare-name MATCH list below makes the probe and the merge
+// accept either the fork OR the upstream package as "auth already wired,"
+// so existing users with the upstream plugin pinned don't get a duplicate
+// entry appended on re-bootstrap.
+const CLAUDE_AUTH_PLUGIN = "opencode-claude-auth-bui@1.5.4-bui.1";
+const CLAUDE_AUTH_PLUGIN_BARE = "opencode-claude-auth-bui";
+const CLAUDE_AUTH_PLUGIN_ACCEPTED_BARES: readonly string[] = [
+  CLAUDE_AUTH_PLUGIN_BARE,
+  "opencode-claude-auth",
+];
 
 /**
  * Strip single-line `//` JSONC comments while respecting string literals.
@@ -359,14 +381,17 @@ export function mergeOpencodeJsonc(existing: string): MergeResult {
   const pluginArray = Array.isArray(rawPlugin) ? rawPlugin : null;
 
   // Check if the auth plugin is already present in any form (pinned or
-  // unpinned). `pkg@version` and bare `pkg` both count.
+  // unpinned). `pkg@version` and bare `pkg` both count. Either the fork
+  // (opencode-claude-auth-bui) or the upstream (opencode-claude-auth) name
+  // is accepted — re-bootstrapping a remote that already runs upstream must
+  // NOT append a duplicate fork entry; the user's choice is respected.
   const alreadyPresent =
     pluginArray !== null &&
     pluginArray.some((entry) => {
       const s = asString(entry);
       if (!s) return false;
       const bareName = s.split("@")[0];
-      return bareName === CLAUDE_AUTH_PLUGIN_BARE;
+      return CLAUDE_AUTH_PLUGIN_ACCEPTED_BARES.includes(bareName);
     });
 
   if (alreadyPresent) {

--- a/src/main/transcriptCache.ts
+++ b/src/main/transcriptCache.ts
@@ -51,8 +51,33 @@ function cachePath(sessionId: string): string {
 
 const memCache = new Map<string, OpencodeMessage[]>();
 const pendingWrites = new Map<string, ReturnType<typeof setTimeout>>();
+// `lastFreshAt` is the wall-clock ms we last received an authoritative
+// transcript (a successful listMessages, or a cached read we promoted).
+// `lastActivityAt` is the last time a live SSE event touched this session.
+// When activity is newer than freshness, the cached payload is known-stale
+// (deltas arrived after the last full fetch) and we must NOT paint it on a
+// remount — doing so showed users the pre-send transcript for the 6s a fresh
+// listMessages took to return, making "switch away and back" look like the
+// send never happened. The disk file is still useful as a cold-start safety
+// net for sessions with no SSE activity this run; we just suppress it for
+// the hot cases.
+const lastFreshAt = new Map<string, number>();
+const lastActivityAt = new Map<string, number>();
+
+// Called by the SSE bus on every event that carries a sessionID. Pure
+// recorder — never blocks, never throws.
+export function noteSessionActivity(sessionId: string): void {
+  lastActivityAt.set(sessionId, Date.now());
+}
 
 export function getCachedTranscript(sessionId: string): OpencodeMessage[] | null {
+  // If live SSE events for this session arrived AFTER the last time we
+  // stored a fresh transcript, the cached copy is stale by definition —
+  // skip it and let the renderer show its loading state until the real
+  // fetch lands. Avoids the "remount shows pre-send state for 6s" bug.
+  const activity = lastActivityAt.get(sessionId);
+  const fresh = lastFreshAt.get(sessionId);
+  if (activity != null && (fresh == null || activity > fresh)) return null;
   // Memory hit first — avoids JSON.parse on every session switch within a run.
   const mem = memCache.get(sessionId);
   if (mem) return mem;
@@ -76,6 +101,10 @@ export function setCachedTranscript(
   messages: OpencodeMessage[],
 ): void {
   memCache.set(sessionId, messages);
+  // Mark this as the freshest authoritative state we know about. A subsequent
+  // SSE event bumps lastActivityAt past this and invalidates the cache until
+  // the next listMessages call refreshes it.
+  lastFreshAt.set(sessionId, Date.now());
   // Debounce the disk write: SSE-driven refetches fire frequently during an
   // active turn, and each transcript is up to 3 MB. Coalesce so we only
   // serialize once per WRITE_DEBOUNCE_MS per session.
@@ -145,6 +174,8 @@ function evictOldest(): void {
 // Drop the cache for a session (e.g. after delete). Best-effort.
 export function dropCachedTranscript(sessionId: string): void {
   memCache.delete(sessionId);
+  lastFreshAt.delete(sessionId);
+  lastActivityAt.delete(sessionId);
   const pending = pendingWrites.get(sessionId);
   if (pending) {
     clearTimeout(pending);

--- a/src/main/transcriptCache.ts
+++ b/src/main/transcriptCache.ts
@@ -1,0 +1,154 @@
+// Per-session transcript cache, persisted to disk.
+//
+// Problem: opencode's `GET /session/{id}/message` takes 20–35 s on a 3 MB
+// transcript (no server-side cache, full deserialization on every call). The
+// renderer blocks on `!messages` showing "Loading session…" for the entire
+// fetch, which dominates perceived session-switch latency.
+//
+// Solution: stash the last successful transcript per sessionId on disk. The
+// renderer reads the cached copy synchronously-ish at mount and renders it
+// immediately, then kicks off the real fetch in the background and swaps the
+// fresh transcript in when it lands. The slow fetch still happens — we just
+// stop blocking the UI on it.
+//
+// Persistence is best-effort: we tolerate read/write failures (the worst
+// case is the old behavior, a blank load screen). Writes are debounced per
+// sessionId so an SSE-driven refetch storm doesn't hammer the disk.
+//
+// LRU eviction caps the on-disk footprint. Transcripts grow without bound
+// over a session's lifetime (bannerman sessions reach 3 MB), so leaving every
+// session ever opened on disk would eat hundreds of MB.
+
+import { app } from "electron";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { OpencodeMessage } from "../shared/types.js";
+
+// Keep the N most-recently-written transcripts on disk. 200 covers heavy
+// users without blowing past ~1 GB at worst-case 5 MB per transcript.
+const MAX_CACHED_TRANSCRIPTS = 200;
+// Debounce per-session disk writes. Refetches fire on every SSE-triggered
+// 300 ms refetch tick; coalesce burst writes.
+const WRITE_DEBOUNCE_MS = 1000;
+
+function cacheDir(): string {
+  return join(app.getPath("userData"), "transcripts");
+}
+
+function cachePath(sessionId: string): string {
+  // Session IDs are `ses_<base62>` — safe as filenames as-is on macOS/Linux.
+  return join(cacheDir(), `${sessionId}.json`);
+}
+
+const memCache = new Map<string, OpencodeMessage[]>();
+const pendingWrites = new Map<string, ReturnType<typeof setTimeout>>();
+
+export function getCachedTranscript(sessionId: string): OpencodeMessage[] | null {
+  // Memory hit first — avoids JSON.parse on every session switch within a run.
+  const mem = memCache.get(sessionId);
+  if (mem) return mem;
+  const path = cachePath(sessionId);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as OpencodeMessage[];
+    if (!Array.isArray(parsed)) return null;
+    memCache.set(sessionId, parsed);
+    return parsed;
+  } catch {
+    // Corrupt cache file — drop it and miss. The fresh fetch will repopulate.
+    try { unlinkSync(path); } catch { /* best-effort */ }
+    return null;
+  }
+}
+
+export function setCachedTranscript(
+  sessionId: string,
+  messages: OpencodeMessage[],
+): void {
+  memCache.set(sessionId, messages);
+  // Debounce the disk write: SSE-driven refetches fire frequently during an
+  // active turn, and each transcript is up to 3 MB. Coalesce so we only
+  // serialize once per WRITE_DEBOUNCE_MS per session.
+  const existing = pendingWrites.get(sessionId);
+  if (existing) clearTimeout(existing);
+  pendingWrites.set(
+    sessionId,
+    setTimeout(() => {
+      pendingWrites.delete(sessionId);
+      void flushOne(sessionId, messages);
+    }, WRITE_DEBOUNCE_MS),
+  );
+}
+
+async function flushOne(
+  sessionId: string,
+  messages: OpencodeMessage[],
+): Promise<void> {
+  const dir = cacheDir();
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    return; // Can't create cache dir — silently disable caching for this turn.
+  }
+  const finalPath = cachePath(sessionId);
+  // Atomic write: serialize first, then rename. Avoids a partial file the
+  // next mount would JSON.parse and throw on.
+  const tmpPath = `${finalPath}.tmp`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(messages), "utf-8");
+    renameSync(tmpPath, finalPath);
+  } catch {
+    // Disk full, permissions, etc. — best-effort.
+    try { unlinkSync(tmpPath); } catch { /* ignore */ }
+    return;
+  }
+  // Cheap LRU sweep — bounded by MAX_CACHED_TRANSCRIPTS so we don't grow
+  // unbounded over months of use.
+  evictOldest();
+}
+
+function evictOldest(): void {
+  const dir = cacheDir();
+  let entries: Array<{ path: string; mtime: number }>;
+  try {
+    entries = readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => {
+        const path = join(dir, f);
+        try {
+          return { path, mtime: statSync(path).mtimeMs };
+        } catch {
+          return { path, mtime: 0 };
+        }
+      });
+  } catch {
+    return;
+  }
+  if (entries.length <= MAX_CACHED_TRANSCRIPTS) return;
+  entries.sort((a, b) => a.mtime - b.mtime); // oldest first
+  const toEvict = entries.slice(0, entries.length - MAX_CACHED_TRANSCRIPTS);
+  for (const { path } of toEvict) {
+    try { unlinkSync(path); } catch { /* best-effort */ }
+  }
+}
+
+// Drop the cache for a session (e.g. after delete). Best-effort.
+export function dropCachedTranscript(sessionId: string): void {
+  memCache.delete(sessionId);
+  const pending = pendingWrites.get(sessionId);
+  if (pending) {
+    clearTimeout(pending);
+    pendingWrites.delete(sessionId);
+  }
+  try { unlinkSync(cachePath(sessionId)); } catch { /* best-effort */ }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -136,6 +136,10 @@ const api = {
   // opencode chat-mode bridges.
   opencodeMessages: (sessionId: string): Promise<OpencodeMessage[]> =>
     ipcRenderer.invoke(IPC.opencodeMessages, sessionId),
+  opencodeMessagesCached: (
+    sessionId: string,
+  ): Promise<OpencodeMessage[] | null> =>
+    ipcRenderer.invoke(IPC.opencodeMessagesCached, sessionId),
   onOpencodeEvent: (cb: (ev: OpencodeEvent) => void): (() => void) => {
     const listener = (_: unknown, ev: OpencodeEvent) => cb(ev);
     ipcRenderer.on(IPC.opencodeEvent, listener);

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -378,6 +378,11 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   const cacheTtl = useStore((s) => s.cacheTtl);
   const [messages, setMessages] = useState<OpencodeMessage[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // True from session-switch until the fresh transcript fetch resolves. Lets
+  // the footer hint at "refreshing…" while we render the cached transcript.
+  // opencode's GET /session/{id}/message is 20–35s on large sessions, so
+  // this window is real and worth surfacing.
+  const [refreshing, setRefreshing] = useState(false);
   // Pending permission requests for THIS session. Polled on mount and refreshed
   // on permission.asked / permission.replied events.
   const [permissions, setPermissions] = useState<PermissionRequest[]>([]);
@@ -764,11 +769,33 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     };
     fetchBranch();
     const branchPoll = setInterval(fetchBranch, 5000);
+
+    // Cached-first render: opencode's GET /session/{id}/message is 20–35s on
+    // large transcripts (3 MB JSON, no server-side cache), so blocking the
+    // panel on it makes session-switches feel broken. Paint the last-known
+    // transcript from disk immediately; the fresh fetch below overwrites it
+    // when it lands. `refreshing` drives the footer hint so the staleness is
+    // visible during the gap.
+    setRefreshing(true);
+    window.api
+      .opencodeMessagesCached(sessionId)
+      .then((cached) => {
+        // Guard against the fresh fetch winning the race: never overwrite
+        // a fresh transcript with a cached one.
+        if (cancelled || !cached) return;
+        setMessages((prev) => (prev === null ? cached : prev));
+        for (const cid of collectChildSessionIds(cached)) {
+          childSessionIds.current.add(cid);
+        }
+      })
+      .catch(() => { /* cache miss / corrupt — fresh fetch will fill in */ });
+
     window.api
       .opencodeMessages(sessionId)
       .then((m) => {
         if (cancelled) return;
         setMessages(m);
+        setRefreshing(false);
         // Seed the subagent allowlist from the persisted transcript so
         // events for previously-spawned children (still running OR finished
         // and being inspected) pass the sessionID filter. Live `session.
@@ -796,7 +823,13 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
         // (applyQuestionEvent) which carries the que_ as requestId.
       })
       .catch((e) => {
-        if (!cancelled) setError(String(e?.message ?? e));
+        if (!cancelled) {
+          setRefreshing(false);
+          // If cached painted earlier, keep showing it and surface the error
+          // out-of-band would be ideal — but for now match prior behavior and
+          // show the error screen (overrides any cached render).
+          setError(String(e?.message ?? e));
+        }
       });
     // Eagerly fetch the command list (with templates) so the renderer can
     // detect historical /command-origin user messages and collapse them on
@@ -3638,6 +3671,7 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
         abort={abort}
         running={running}
         branch={branch}
+        refreshing={refreshing}
         modelLabel={modelLabel}
         showThinking={showThinking}
         chatAutoAllow={chatAutoAllow}
@@ -4771,6 +4805,7 @@ function InputArea({
   abort,
   running,
   branch,
+  refreshing,
   modelLabel,
   showThinking,
   chatAutoAllow,
@@ -4813,6 +4848,7 @@ function InputArea({
   abort: () => void;
   running: boolean;
   branch: string | null;
+  refreshing: boolean;
   modelLabel: string | null;
   showThinking: boolean;
   chatAutoAllow: boolean;
@@ -5056,6 +5092,14 @@ function InputArea({
               title={`Current branch: ${branch}`}
             >
               ⎇ {branch}
+            </span>
+          )}
+          {refreshing && (
+            <span
+              className="text-text-faint shrink-0 animate-pulse"
+              title="Refreshing transcript from opencode (large sessions can take 20–30s)"
+            >
+              ↻ refreshing…
             </span>
           )}
           <ModelPicker

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -385,6 +385,8 @@ export const httpApi: Api = {
 
   // -- opencode chat --
   opencodeMessages: (sessionId) => rpc(IPC.opencodeMessages, sessionId),
+  opencodeMessagesCached: (sessionId) =>
+    rpc(IPC.opencodeMessagesCached, sessionId),
   onOpencodeEvent: (cb) => on<OpencodeEvent>("opencode", cb),
 
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -209,6 +209,11 @@ export const IPC = {
   // ---- opencode chat-mode ----
   // Fetch full transcript for a session id (one-shot HTTP call on the remote).
   opencodeMessages: "opencode:messages",
+  // Synchronous-ish cached transcript lookup. Returns the last successful
+  // `opencodeMessages` payload from disk (or null on miss). Used by the
+  // renderer to paint the chat panel instantly while the slow fresh fetch
+  // runs in the background.
+  opencodeMessagesCached: "opencode:messages-cached",
   // Live SSE stream from opencode, forwarded raw to the renderer. Renderer
   // filters by sessionID in the event payload.
   opencodeEvent: "opencode:event",


### PR DESCRIPTION
## Problem

The upstream `opencode-claude-auth` plugin has a long-lived-process recovery bug. A single failed OAuth refresh (transient network, brief 5xx, momentary rate-limit) clears the plugin's in-memory `accountCacheMap`. Every subsequent fetch then throws:

> ⚠ Claude Code credentials are unavailable or expired. Run `claude` to refresh them.

…until `opencode-serve` is restarted — even though `~/.claude/.credentials.json` on disk is healthy and a fresh `opencode` process would refresh fine. This bug is what kept producing the "credentials expired" errors in the GUI over the last few days, and is the reason the box appeared to "self-heal" only on a serve restart.

I traced it through the plugin source (`dist/credentials.js` → `getCachedCredentials` → `refreshIfNeeded`): when refresh fails, `accountCacheMap.delete(source)` runs. The plugin never re-bootstraps `allAccounts` during a serve's lifetime, so it stays broken until restart.

## Fix

Forked the plugin (`griffinmartin/opencode-claude-auth`) and added a one-step recovery in the AI-SDK `fetch` hook:

```ts
let latest = getCachedCredentials()
if (!latest) {
  log("fetch_no_credentials_retrying", { modelId: "unknown" })
  refreshAccountsList()        // re-read the credentials file
  latest = getCachedCredentials()
  if (!latest) {
    log("fetch_no_credentials", { modelId: "unknown" })
    throw new Error("Claude Code credentials are unavailable or expired. Run `claude` to refresh them.")
  }
  log("fetch_no_credentials_recovered", { modelId: "unknown" })
}
```

This picks up any external rotation (e.g. the `claude` CLI writing a new token) and restores file-sourced accounts so `refreshIfNeeded` can succeed. The existing throw still fires for genuinely unrecoverable cases; existing telemetry preserved.

Published as **[`opencode-claude-auth-bui@1.5.4-bui.1`](https://www.npmjs.com/package/opencode-claude-auth-bui)** on npm.
Source: https://github.com/antoinedc/opencode-claude-auth

## bui changes

- `CLAUDE_AUTH_PLUGIN` now points at the fork. Fresh bootstraps write `"opencode-claude-auth-bui@1.5.4-bui.1"` into `opencode.jsonc`.
- New `CLAUDE_AUTH_PLUGIN_ACCEPTED_BARES` accepts **both** the fork name and the upstream name as "auth already wired up." Re-bootstrap on a remote that already runs upstream does NOT append a duplicate; the user's existing choice is respected. Only fresh installs get the fork.
- Probe `grep` is unchanged — substring `'opencode-claude-auth'` matches both names naturally. Detail string updated for clarity.

## Tests

- All existing `mergeOpencodeJsonc` tests updated for the new canonical plugin string on fresh writes.
- **3 new tests** for the upstream-vs-fork accept-either contract:
  - fork-pinned → no-op
  - upstream-pinned → no-op, fork NOT appended (key behavior)
  - bare fork name recognized
- **337 pass** (was 334), typecheck clean.

## Verified on the live remote

1. Set `opencode.jsonc` plugin to `opencode-claude-auth-bui@1.5.4-bui.1`; cleared `~/.cache/opencode/packages`.
2. Restarted `opencode-serve`.
3. Confirmed `dist/index.js` in the resolved package contains the recovery path (grep `fetch_no_credentials_retrying` → match).
4. End-to-end `opencode run … "BUI_OK"` against the patched plugin returns `BUI_OK`.

The recovery path itself can't be cleanly induced from outside (it requires the plugin's *in-memory* `accountCacheMap` to be empty after a real refresh failure — not something I can synthesize without invasive in-process patching). The code path is straightforward (6 lines), is covered by code review, and is in the running plugin on the box.

🧙 Built with [WOZCODE](https://wozcode.com)