### PR TITLE
feat(providers): manage model endpoints from bui Settings

### DIFF
--- a/docs/superpowers/plans/2026-06-29-provider-management.md
+++ b/docs/superpowers/plans/2026-06-29-provider-management.md
@@ -1,0 +1,1004 @@
+# Provider Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Providers section to bui Settings (desktop + mobile) to add/remove OpenAI-compatible endpoints, refresh model discovery from each endpoint's `/v1/models`, and toggle which discovered models opencode.jsonc advertises.
+
+**Architecture:** opencode.jsonc on the box stays the single source of truth. New `src/main/providers.ts` does discovery (curl on the box) and the read-merge-write of the `provider` key in opencode.jsonc, reusing the tested `buildRemoteConfigWriteCmd` heredoc writer. Three new IPC channels (`getProviders`, `setProviders`, `discoverModels`) plus a reuse of an existing restart path. UI is a `ProvidersCard` rendered in Settings.tsx with a thin mobile mirror. The model picker is unchanged — it keeps reading opencode `/provider`.
+
+**Tech Stack:** TypeScript, Electron main/preload/renderer, React, vitest, opencode `@ai-sdk/openai-compatible` providers, SSH-over-ControlMaster.
+
+---
+
+## File Structure
+
+- **Create** `src/main/providers.ts` — pure helpers (parse `/v1/models`, merge/remove provider blocks into a parsed config object) + thin SSH-driven functions (discover, get, set). Pure helpers are exported for unit testing.
+- **Create** `src/main/providers.test.ts` — unit tests for the pure helpers.
+- **Modify** `src/shared/types.ts` — add `ProviderEndpoint`, `DiscoverResult` types and three IPC channel constants.
+- **Modify** `src/main/index.ts` — register three `ipcMain.handle` handlers wiring providers.ts to IPC; add an `opencodeRestart` handler.
+- **Modify** `src/main/pty.ts` — export `shellQuote` (currently file-private) so providers.ts can quote the API key.
+- **Modify** `src/preload/index.ts` — expose `opencodeGetProviders`, `opencodeSetProviders`, `opencodeDiscoverModels`, `opencodeRestart` on `window.api`.
+- **Modify** `src/renderer/api/httpApi.ts` — map the new calls to RPC (mobile path).
+- **Modify** `src/server/rpc.mjs` — handle the new RPC method names (mobile in-process path delegates to the same main-side functions is not possible on the server, so these return a "desktop only" stub for v1 — see Task 9).
+- **Create** `src/renderer/ProvidersCard.tsx` — the shared card component (used by both Settings surfaces).
+- **Modify** `src/renderer/Settings.tsx` — render `<ProvidersCard />`.
+- **Modify** `src/renderer/mobile/MobileSettings.tsx` — render `<ProvidersCard />`.
+
+---
+
+## Task 1: Provider types and IPC channel constants
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+- [ ] **Step 1: Add the types**
+
+Add near the other opencode-related types in `src/shared/types.ts`:
+
+```ts
+export type ProviderEndpoint = {
+  id: string;            // opencode provider id, e.g. "voska"
+  name: string;          // display name, e.g. "VoskaAI"
+  baseURL: string;       // e.g. "https://api.voska.org/v1"
+  hasApiKey: boolean;    // true if an apiKey is set; the value never leaves main
+  enabledModels: string[]; // model ids present in this provider's opencode `models` map
+};
+
+export type DiscoverResult =
+  | { ok: true; models: { id: string }[] }
+  | { ok: false; error: "unreachable" | "unauthorized" | "bad_response"; detail?: string };
+
+// Input the renderer sends to set/replace a single provider. apiKey is optional:
+// omitted/undefined means "keep the existing key"; empty string means "no key".
+export type ProviderInput = {
+  id: string;
+  name: string;
+  baseURL: string;
+  apiKey?: string;
+  enabledModels: string[];
+};
+```
+
+- [ ] **Step 2: Add the IPC channel constants**
+
+In the `IPC` object in `src/shared/types.ts`, next to `opencodeModels: "opencode:models",` add:
+
+```ts
+  opencodeGetProviders: "opencode:get-providers",
+  opencodeSetProviders: "opencode:set-providers",
+  opencodeDiscoverModels: "opencode:discover-models",
+  opencodeRestart: "opencode:restart",
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no new errors from these additions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat(providers): types + IPC channels for provider management"
+```
+
+---
+
+## Task 2: Pure helper — parse `/v1/models` response
+
+**Files:**
+- Create: `src/main/providers.ts`
+- Test: `src/main/providers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/main/providers.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseModelsResponse } from "./providers.js";
+
+describe("parseModelsResponse", () => {
+  it("extracts ids from a valid OpenAI /v1/models body", () => {
+    const body = JSON.stringify({
+      object: "list",
+      data: [
+        { id: "qwen3.6-27b", object: "model" },
+        { id: "default", object: "model" },
+        { id: "ornith", object: "model" },
+      ],
+    });
+    expect(parseModelsResponse(body)).toEqual({
+      ok: true,
+      models: [{ id: "qwen3.6-27b" }, { id: "default" }, { id: "ornith" }],
+    });
+  });
+
+  it("returns ok:true with empty list when data is empty", () => {
+    expect(parseModelsResponse(JSON.stringify({ data: [] }))).toEqual({
+      ok: true,
+      models: [],
+    });
+  });
+
+  it("returns bad_response for non-JSON", () => {
+    const r = parseModelsResponse("<html>502 Bad Gateway</html>");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("bad_response");
+  });
+
+  it("returns unauthorized when body looks like an auth error", () => {
+    const body = JSON.stringify({ error: { message: "Invalid API key", code: "invalid_api_key" } });
+    const r = parseModelsResponse(body);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("unauthorized");
+  });
+
+  it("returns bad_response when JSON lacks a data array", () => {
+    const r = parseModelsResponse(JSON.stringify({ object: "list" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("bad_response");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/main/providers.test.ts`
+Expected: FAIL — cannot find module `./providers.js` / `parseModelsResponse is not a function`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/main/providers.ts`:
+
+```ts
+// Provider management: discover models from an OpenAI-compatible endpoint and
+// read/merge/write provider blocks in the box's opencode.jsonc. opencode.jsonc
+// stays the single source of truth; the model picker keeps reading opencode's
+// /provider endpoint (see opencode.ts:listModels) — this file only edits config.
+import type { AppConfig } from "../shared/types.js";
+import type { DiscoverResult, ProviderEndpoint, ProviderInput } from "../shared/types.js";
+
+// Parse the body of GET <baseURL>/models (OpenAI-compatible shape: { data: [{ id }] }).
+// Pure — no I/O — so it is unit-testable against fixture strings.
+export function parseModelsResponse(body: string): DiscoverResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return { ok: false, error: "bad_response", detail: body.slice(0, 200) };
+  }
+  const obj = json as Record<string, unknown>;
+  // Auth errors come back as 200/4xx JSON with an `error` object on many gateways.
+  if (obj && typeof obj === "object" && "error" in obj) {
+    const errObj = obj.error as Record<string, unknown> | undefined;
+    const msg = errObj && typeof errObj.message === "string" ? errObj.message : "";
+    const code = errObj && typeof errObj.code === "string" ? errObj.code : "";
+    if (/api key|unauthor|invalid_api_key|401/i.test(`${msg} ${code}`)) {
+      return { ok: false, error: "unauthorized", detail: msg || code };
+    }
+    return { ok: false, error: "bad_response", detail: msg || code };
+  }
+  const data = obj?.data;
+  if (!Array.isArray(data)) {
+    return { ok: false, error: "bad_response", detail: "no data array" };
+  }
+  const models = data
+    .map((m) => (m && typeof m === "object" ? String((m as Record<string, unknown>).id ?? "") : ""))
+    .filter(Boolean)
+    .map((id) => ({ id }));
+  return { ok: true, models };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/main/providers.test.ts`
+Expected: PASS (all 5 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/providers.ts src/main/providers.test.ts
+git commit -m "feat(providers): parseModelsResponse with unit tests"
+```
+
+---
+
+## Task 3: Pure helpers — merge and remove provider blocks
+
+**Files:**
+- Modify: `src/main/providers.ts`
+- Test: `src/main/providers.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/main/providers.test.ts`:
+
+```ts
+import { upsertProviderBlock, removeProviderBlock, readProviderEndpoints } from "./providers.js";
+
+describe("upsertProviderBlock", () => {
+  const base = {
+    $schema: "https://opencode.ai/config.json",
+    model: "anthropic/claude-opus-4-8",
+    plugin: ["opencode-claude-auth-bui@1.5.4-bui.1"],
+    skills: { urls: [] },
+  };
+
+  it("adds a provider block without touching other keys", () => {
+    const out = upsertProviderBlock(base, {
+      id: "voska",
+      name: "VoskaAI",
+      baseURL: "https://api.voska.org/v1",
+      apiKey: "sk-test",
+      enabledModels: ["qwen3.6-27b", "ornith"],
+    });
+    expect(out.model).toBe("anthropic/claude-opus-4-8");
+    expect(out.plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
+    expect(out.skills).toEqual({ urls: [] });
+    const p = (out.provider as Record<string, any>).voska;
+    expect(p.npm).toBe("@ai-sdk/openai-compatible");
+    expect(p.name).toBe("VoskaAI");
+    expect(p.options).toEqual({ baseURL: "https://api.voska.org/v1", apiKey: "sk-test" });
+    expect(Object.keys(p.models)).toEqual(["qwen3.6-27b", "ornith"]);
+    expect(p.models["ornith"]).toEqual({ id: "ornith", name: "ornith" });
+  });
+
+  it("preserves the existing apiKey when input apiKey is undefined", () => {
+    const withProv = upsertProviderBlock(base, {
+      id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1",
+      apiKey: "sk-old", enabledModels: ["qwen3.6-27b"],
+    });
+    const out = upsertProviderBlock(withProv, {
+      id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1",
+      enabledModels: ["qwen3.6-27b", "default"], // no apiKey field
+    });
+    const p = (out.provider as Record<string, any>).voska;
+    expect(p.options.apiKey).toBe("sk-old");
+    expect(Object.keys(p.models)).toEqual(["qwen3.6-27b", "default"]);
+  });
+});
+
+describe("removeProviderBlock", () => {
+  it("drops only the named provider", () => {
+    const cfg = {
+      model: "anthropic/x",
+      provider: {
+        voska: { npm: "@ai-sdk/openai-compatible", models: {} },
+        other: { npm: "@ai-sdk/openai-compatible", models: {} },
+      },
+    };
+    const out = removeProviderBlock(cfg, "voska");
+    expect((out.provider as Record<string, unknown>).voska).toBeUndefined();
+    expect((out.provider as Record<string, unknown>).other).toBeDefined();
+    expect(out.model).toBe("anthropic/x");
+  });
+});
+
+describe("readProviderEndpoints", () => {
+  it("returns endpoint metadata with hasApiKey and enabledModels, never the key", () => {
+    const cfg = {
+      provider: {
+        voska: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "VoskaAI",
+          options: { baseURL: "https://api.voska.org/v1", apiKey: "sk-secret" },
+          models: { "qwen3.6-27b": { id: "qwen3.6-27b" }, ornith: { id: "ornith" } },
+        },
+      },
+    };
+    const eps = readProviderEndpoints(cfg);
+    expect(eps).toEqual([
+      {
+        id: "voska",
+        name: "VoskaAI",
+        baseURL: "https://api.voska.org/v1",
+        hasApiKey: true,
+        enabledModels: ["qwen3.6-27b", "ornith"],
+      },
+    ]);
+    // Ensure the key is never present anywhere in the serialized output.
+    expect(JSON.stringify(eps)).not.toContain("sk-secret");
+  });
+
+  it("returns [] when there is no provider key", () => {
+    expect(readProviderEndpoints({ model: "anthropic/x" })).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/main/providers.test.ts`
+Expected: FAIL — `upsertProviderBlock`/`removeProviderBlock`/`readProviderEndpoints` not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `src/main/providers.ts`:
+
+```ts
+type Cfg = Record<string, unknown>;
+type ProviderBlock = {
+  npm: string;
+  name?: string;
+  options?: { baseURL?: string; apiKey?: string };
+  models?: Record<string, { id: string; name?: string }>;
+};
+
+function getProviderMap(cfg: Cfg): Record<string, ProviderBlock> {
+  const p = cfg.provider;
+  return p && typeof p === "object" ? ({ ...(p as Record<string, ProviderBlock>) }) : {};
+}
+
+// Insert or replace a single provider block. Only the `provider` key is touched;
+// every other key in `cfg` is preserved by spread. If `input.apiKey` is
+// undefined, the existing key (if any) is kept — so the renderer never has to
+// round-trip the secret.
+export function upsertProviderBlock(cfg: Cfg, input: ProviderInput): Cfg {
+  const providers = getProviderMap(cfg);
+  const prev = providers[input.id];
+  const apiKey =
+    input.apiKey !== undefined ? input.apiKey : prev?.options?.apiKey ?? "";
+  const models: Record<string, { id: string; name: string }> = {};
+  for (const id of input.enabledModels) models[id] = { id, name: id };
+  providers[input.id] = {
+    npm: "@ai-sdk/openai-compatible",
+    name: input.name,
+    options: { baseURL: input.baseURL, apiKey },
+    models,
+  };
+  return { ...cfg, provider: providers };
+}
+
+export function removeProviderBlock(cfg: Cfg, id: string): Cfg {
+  const providers = getProviderMap(cfg);
+  delete providers[id];
+  return { ...cfg, provider: providers };
+}
+
+// Project the config's provider map down to renderer-safe metadata. Never
+// includes the apiKey value — only whether one is present.
+export function readProviderEndpoints(cfg: Cfg): ProviderEndpoint[] {
+  const providers = getProviderMap(cfg);
+  return Object.entries(providers).map(([id, block]) => ({
+    id,
+    name: typeof block.name === "string" ? block.name : id,
+    baseURL: block.options?.baseURL ?? "",
+    hasApiKey: Boolean(block.options?.apiKey),
+    enabledModels: Object.keys(block.models ?? {}),
+  }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/main/providers.test.ts`
+Expected: PASS (all cases including the no-key-leak assertion).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/providers.ts src/main/providers.test.ts
+git commit -m "feat(providers): config merge/remove/read helpers (provider key only)"
+```
+
+---
+
+## Task 4: Export `shellQuote` from pty.ts
+
+**Files:**
+- Modify: `src/main/pty.ts:105-107`
+
+- [ ] **Step 1: Make `shellQuote` exported**
+
+In `src/main/pty.ts`, change:
+
+```ts
+function shellQuote(s: string): string {
+```
+to:
+```ts
+export function shellQuote(s: string): string {
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/pty.ts
+git commit -m "refactor(pty): export shellQuote for reuse"
+```
+
+---
+
+## Task 5: SSH-driven discover/get/set functions in providers.ts
+
+**Files:**
+- Modify: `src/main/providers.ts`
+
+These functions do I/O (SSH to the box). They are thin — the parsing/merging logic they call is already tested in Tasks 2-3. We do not unit-test the SSH round-trip itself (no box in CI); the pure helpers carry the coverage.
+
+- [ ] **Step 1: Add the imports and discover function**
+
+At the top of `src/main/providers.ts`, add to the existing imports:
+
+```ts
+import { runSshOnce, shellQuote } from "./pty.js";
+```
+
+Append these functions:
+
+```ts
+const OPENCODE_JSONC = "~/.config/opencode/opencode.jsonc";
+
+// Query an OpenAI-compatible endpoint's /v1/models FROM THE BOX (not the Mac):
+// the box is where opencode reaches these endpoints, so discovery must reflect
+// the box's network view (honors the "remote box is backend-only" invariant).
+export async function discoverModels(
+  config: AppConfig,
+  baseURL: string,
+  apiKey: string,
+): Promise<DiscoverResult> {
+  // Empty key from the renderer means "use the key already stored on the box"
+  // (Refresh on an existing endpoint never re-sends the secret). Re-read it from
+  // opencode.jsonc by matching the baseURL. New endpoints persist their key via
+  // Add before Refresh, so this same lookup finds it.
+  let key = apiKey;
+  if (!key) {
+    try {
+      const cfg = await readRemoteConfig(config);
+      const providers = getProviderMap(cfg);
+      const match = Object.values(providers).find(
+        (b) => b.options?.baseURL?.replace(/\/$/, "") === baseURL.replace(/\/$/, ""),
+      );
+      key = match?.options?.apiKey ?? "";
+    } catch {
+      /* fall through with empty key — endpoint may legitimately need none */
+    }
+  }
+  const url = `${baseURL.replace(/\/$/, "")}/models`;
+  const cmd =
+    `curl -s --max-time 20 -H ${shellQuote(`Authorization: Bearer ${key}`)} ${shellQuote(url)}`;
+  try {
+    const { stdout } = await runSshOnce(config, cmd, { timeoutMs: 30000 });
+    if (!stdout.trim()) return { ok: false, error: "unreachable", detail: "empty response" };
+    return parseModelsResponse(stdout);
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+// Read opencode.jsonc from the box and parse it (strip // comments, like the
+// skill-URLs path in index.ts). Returns {} if the file is absent. THROWS if the
+// file exists but is unparseable — callers must NOT overwrite an unparseable
+// config (that was the 2026-05-18 corruption failure mode).
+async function readRemoteConfig(config: AppConfig): Promise<Cfg> {
+  const { stdout } = await runSshOnce(
+    config,
+    `cat ${OPENCODE_JSONC} 2>/dev/null || echo '{}'`,
+  );
+  const stripped = stdout.replace(/\/\/[^\n]*/g, "");
+  return JSON.parse(stripped) as Cfg; // intentional throw on malformed JSON
+}
+
+export async function getProviderEndpoints(config: AppConfig): Promise<ProviderEndpoint[]> {
+  const cfg = await readRemoteConfig(config);
+  return readProviderEndpoints(cfg);
+}
+
+// Apply a set of provider mutations and write opencode.jsonc back using the
+// TESTED heredoc writer (no string interpolation of JSON — see remoteConfigWrite.ts).
+// Does NOT restart opencode; the caller decides (prompt-before-restart).
+export async function setProviders(
+  config: AppConfig,
+  ops: { upsert?: ProviderInput[]; remove?: string[] },
+): Promise<{ ok: boolean; error?: string }> {
+  let cfg: Cfg;
+  try {
+    cfg = await readRemoteConfig(config);
+  } catch {
+    return { ok: false, error: "opencode.jsonc on the box is unparseable — refusing to overwrite it. Fix it manually first." };
+  }
+  for (const id of ops.remove ?? []) cfg = removeProviderBlock(cfg, id);
+  for (const input of ops.upsert ?? []) cfg = upsertProviderBlock(cfg, input);
+  const content = JSON.stringify(cfg, null, 2);
+  try {
+    const { buildRemoteConfigWriteCmd } = await import("./remoteConfigWrite.js");
+    await runSshOnce(config, buildRemoteConfigWriteCmd(content, OPENCODE_JSONC));
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Re-run the providers unit tests (ensure no regressions)**
+
+Run: `npx vitest run src/main/providers.test.ts`
+Expected: PASS (the pure helpers still pass; new I/O functions are untested by design).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/providers.ts
+git commit -m "feat(providers): SSH-driven discover/get/set against box opencode.jsonc"
+```
+
+---
+
+## Task 6: Restart helper in opencode.ts
+
+**Files:**
+- Modify: `src/main/opencode.ts`
+
+opencode reloads opencode.jsonc only on (re)start. We expose a restart that tears down the `bui-opencode` tmux session; the existing ensure path respawns it on next use.
+
+- [ ] **Step 1: Add the restart function**
+
+In `src/main/opencode.ts`, after `ensureForward`/the tmux helpers (search for `BUI_OPENCODE_TMUX_SESSION`), add:
+
+```ts
+// Restart opencode so it reloads opencode.jsonc (config changes — e.g. provider
+// edits — only take effect on (re)start). We kill the bui-opencode tmux session;
+// the next ensureForward()/ensureOpencode path respawns a fresh server. Active
+// sessions are briefly interrupted — callers MUST gate this behind explicit user
+// consent (prompt-before-restart).
+export async function restartOpencode(config: AppConfig): Promise<void> {
+  await runSshOnce(
+    config,
+    `tmux kill-session -t ${BUI_OPENCODE_TMUX_SESSION} 2>/dev/null || true`,
+  );
+  await ensureOpencode(config);
+}
+```
+
+If the local respawn function is named differently than `ensureOpencode`, use the actual exported function that this file already calls to (re)spawn the server (grep for `tmux new-session -d -s ${BUI_OPENCODE_TMUX_SESSION}` and call its enclosing function). Confirm `runSshOnce` is already imported in this file; if not, add `import { runSshOnce } from "./pty.js";`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/opencode.ts
+git commit -m "feat(opencode): restartOpencode to reload config on demand"
+```
+
+---
+
+## Task 7: Wire IPC handlers in main
+
+**Files:**
+- Modify: `src/main/index.ts:1356` (next to the existing `opencodeModels` handler)
+
+- [ ] **Step 1: Add imports**
+
+Near the top of `src/main/index.ts` (next to `listModels as opencodeListModels`), add:
+
+```ts
+import {
+  getProviderEndpoints as opencodeGetProviders,
+  setProviders as opencodeSetProviders,
+  discoverModels as opencodeDiscoverModels,
+} from "./providers.js";
+import { restartOpencode } from "./opencode.js";
+```
+
+(If `restartOpencode` should be added to the existing `from "./opencode.js"` import group, add it there instead of a second import line.)
+
+- [ ] **Step 2: Register the handlers**
+
+After `ipcMain.handle(IPC.opencodeModels, () => opencodeListModels(config));`, add:
+
+```ts
+  ipcMain.handle(IPC.opencodeGetProviders, () => opencodeGetProviders(config));
+  ipcMain.handle(
+    IPC.opencodeSetProviders,
+    (_e, ops: { upsert?: ProviderInput[]; remove?: string[] }) =>
+      opencodeSetProviders(config, ops),
+  );
+  ipcMain.handle(
+    IPC.opencodeDiscoverModels,
+    (_e, baseURL: string, apiKey: string) =>
+      opencodeDiscoverModels(config, baseURL, apiKey),
+  );
+  ipcMain.handle(IPC.opencodeRestart, () => restartOpencode(config));
+```
+
+Ensure `ProviderInput` is imported from `../shared/types.js` in index.ts (add to the existing type import if absent).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/index.ts
+git commit -m "feat(providers): register get/set/discover/restart IPC handlers"
+```
+
+---
+
+## Task 8: Expose on preload `window.api`
+
+**Files:**
+- Modify: `src/preload/index.ts:257` (next to `opencodeModels`)
+
+- [ ] **Step 1: Add the bindings**
+
+After the `opencodeModels` binding, add:
+
+```ts
+  opencodeGetProviders: (): Promise<ProviderEndpoint[]> =>
+    ipcRenderer.invoke(IPC.opencodeGetProviders),
+  opencodeSetProviders: (
+    ops: { upsert?: ProviderInput[]; remove?: string[] },
+  ): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke(IPC.opencodeSetProviders, ops),
+  opencodeDiscoverModels: (baseURL: string, apiKey: string): Promise<DiscoverResult> =>
+    ipcRenderer.invoke(IPC.opencodeDiscoverModels, baseURL, apiKey),
+  opencodeRestart: (): Promise<void> => ipcRenderer.invoke(IPC.opencodeRestart),
+```
+
+Add `ProviderEndpoint`, `DiscoverResult`, `ProviderInput` to the type imports at the top of the file (from `../shared/types`).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/preload/index.ts
+git commit -m "feat(providers): expose provider IPC on window.api"
+```
+
+---
+
+## Task 9: Mobile RPC mapping (desktop-only stub for v1)
+
+**Files:**
+- Modify: `src/renderer/api/httpApi.ts:474` (next to `opencodeModels`)
+- Modify: `src/server/rpc.mjs:223` (next to `"opencode:models"`)
+
+The mobile/web server (`src/server/`) does not have the main-side providers.ts (it talks to opencode directly, not over SSH from the Mac). For v1, provider editing is a desktop-only action; the mobile picker still SHOWS whatever opencode serves. So the server returns a clear "desktop only" result rather than silently failing.
+
+- [ ] **Step 1: Add httpApi mappings**
+
+In `src/renderer/api/httpApi.ts`, after `opencodeModels: () => rpc(IPC.opencodeModels),` add:
+
+```ts
+  opencodeGetProviders: () => rpc(IPC.opencodeGetProviders),
+  opencodeSetProviders: (ops) => rpc(IPC.opencodeSetProviders, ops),
+  opencodeDiscoverModels: (baseURL, apiKey) => rpc(IPC.opencodeDiscoverModels, baseURL, apiKey),
+  opencodeRestart: () => rpc(IPC.opencodeRestart),
+```
+
+- [ ] **Step 2: Add server rpc handlers (desktop-only stub)**
+
+In `src/server/rpc.mjs`, after `"opencode:models": () => oc.listModels(),` add:
+
+```js
+    "opencode:get-providers": () => [],
+    "opencode:set-providers": () => ({
+      ok: false,
+      error: "Provider editing is available on the desktop app only.",
+    }),
+    "opencode:discover-models": () => ({
+      ok: false,
+      error: "unreachable",
+      detail: "Provider discovery is available on the desktop app only.",
+    }),
+    "opencode:restart": () => undefined,
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/api/httpApi.ts src/server/rpc.mjs
+git commit -m "feat(providers): mobile RPC mapping (desktop-only stub for editing)"
+```
+
+---
+
+## Task 10: ProvidersCard component
+
+**Files:**
+- Create: `src/renderer/ProvidersCard.tsx`
+
+This is the shared UI. It owns its own data (loads endpoints on mount), discovery state, and the restart prompt. It calls `window.api.*` which both Settings surfaces provide.
+
+- [ ] **Step 1: Create the component**
+
+Create `src/renderer/ProvidersCard.tsx`:
+
+```tsx
+import { useEffect, useState, useCallback } from "react";
+import type { ProviderEndpoint, DiscoverResult } from "../shared/types";
+
+type Draft = { id: string; name: string; baseURL: string; apiKey: string };
+const EMPTY_DRAFT: Draft = { id: "", name: "", baseURL: "", apiKey: "" };
+
+export function ProvidersCard() {
+  const [endpoints, setEndpoints] = useState<ProviderEndpoint[] | null>(null);
+  const [discovered, setDiscovered] = useState<Record<string, { id: string }[]>>({});
+  const [discoverError, setDiscoverError] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<string | null>(null); // endpoint id being mutated
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [restartNeeded, setRestartNeeded] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    window.api.opencodeGetProviders().then(setEndpoints).catch(() => setEndpoints([]));
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const refresh = useCallback(async (ep: ProviderEndpoint) => {
+    setBusy(ep.id);
+    setDiscoverError((e) => ({ ...e, [ep.id]: "" }));
+    // apiKey "" => main keeps the stored key (undefined means keep; but discover
+    // needs a concrete key, so we pass "" and main uses the stored one via re-read).
+    const r: DiscoverResult = await window.api.opencodeDiscoverModels(ep.baseURL, "");
+    if (r.ok) {
+      setDiscovered((d) => ({ ...d, [ep.id]: r.models }));
+    } else {
+      setDiscoverError((e) => ({ ...e, [ep.id]: `${r.error}${r.detail ? `: ${r.detail}` : ""}` }));
+    }
+    setBusy(null);
+  }, []);
+
+  const toggleModel = useCallback(async (ep: ProviderEndpoint, modelId: string) => {
+    const enabled = ep.enabledModels.includes(modelId)
+      ? ep.enabledModels.filter((m) => m !== modelId)
+      : [...ep.enabledModels, modelId];
+    setBusy(ep.id);
+    const res = await window.api.opencodeSetProviders({
+      upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
+    });
+    setBusy(null);
+    if (!res.ok) { setGlobalError(res.error ?? "Save failed"); return; }
+    setRestartNeeded(true);
+    load();
+  }, [load]);
+
+  const addEndpoint = useCallback(async () => {
+    const d = draft;
+    if (!d.id.trim() || !d.baseURL.trim()) return;
+    setBusy(d.id);
+    const res = await window.api.opencodeSetProviders({
+      upsert: [{
+        id: d.id.trim(), name: d.name.trim() || d.id.trim(),
+        baseURL: d.baseURL.trim(), apiKey: d.apiKey, enabledModels: [],
+      }],
+    });
+    setBusy(null);
+    if (!res.ok) { setGlobalError(res.error ?? "Add failed"); return; }
+    setDraft(EMPTY_DRAFT);
+    setRestartNeeded(true);
+    load();
+  }, [draft, load]);
+
+  const removeEndpoint = useCallback(async (ep: ProviderEndpoint) => {
+    setBusy(ep.id);
+    const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
+    setBusy(null);
+    if (!res.ok) { setGlobalError(res.error ?? "Remove failed"); return; }
+    setRestartNeeded(true);
+    load();
+  }, [load]);
+
+  const applyRestart = useCallback(async () => {
+    await window.api.opencodeRestart();
+    setRestartNeeded(false);
+  }, []);
+
+  return (
+    <div className="space-y-2 pt-2 border-t border-border">
+      <label className="block text-xs uppercase tracking-wider text-text-muted">
+        Providers
+      </label>
+      <div className="text-xs text-text-faint">
+        OpenAI-compatible endpoints opencode can serve. Refresh to discover models,
+        then enable the ones you want in the model picker.
+      </div>
+
+      {globalError && <div className="text-xs text-red-400">{globalError}</div>}
+
+      {(endpoints ?? []).map((ep) => (
+        <div key={ep.id} className="border border-border rounded p-2 space-y-1">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm text-text truncate">{ep.name}</div>
+              <code className="text-[10px] text-text-faint truncate block">{ep.baseURL}</code>
+            </div>
+            <button
+              onClick={() => refresh(ep)}
+              disabled={busy === ep.id}
+              className="px-2 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+            >
+              {busy === ep.id ? "…" : "Refresh"}
+            </button>
+            <button
+              onClick={() => removeEndpoint(ep)}
+              disabled={busy === ep.id}
+              className="text-xs text-text-faint hover:text-text px-1"
+              title="Remove endpoint"
+            >
+              ✕
+            </button>
+          </div>
+          {discoverError[ep.id] && (
+            <div className="text-[10px] text-red-400">{discoverError[ep.id]}</div>
+          )}
+          {(discovered[ep.id] ?? ep.enabledModels.map((id) => ({ id }))).map((m) => (
+            <label key={m.id} className="flex items-center gap-2 text-xs cursor-pointer">
+              <input
+                type="checkbox"
+                checked={ep.enabledModels.includes(m.id)}
+                onChange={() => toggleModel(ep, m.id)}
+                disabled={busy === ep.id}
+              />
+              <span className="text-text-muted">{m.id}</span>
+            </label>
+          ))}
+        </div>
+      ))}
+
+      <div className="border border-dashed border-border rounded p-2 space-y-1">
+        <div className="text-[10px] uppercase tracking-wider text-text-faint">Add endpoint</div>
+        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="id (e.g. voska)" value={draft.id}
+          onChange={(e) => setDraft({ ...draft, id: e.target.value })} />
+        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="name (e.g. VoskaAI)" value={draft.name}
+          onChange={(e) => setDraft({ ...draft, name: e.target.value })} />
+        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="baseURL (https://api.voska.org/v1)" value={draft.baseURL}
+          onChange={(e) => setDraft({ ...draft, baseURL: e.target.value })} />
+        <input type="password" className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="API key" value={draft.apiKey}
+          onChange={(e) => setDraft({ ...draft, apiKey: e.target.value })} />
+        <button
+          onClick={addEndpoint}
+          disabled={!draft.id.trim() || !draft.baseURL.trim()}
+          className="px-3 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+        >
+          Add
+        </button>
+      </div>
+
+      {restartNeeded && (
+        <div className="flex items-center gap-2 text-xs bg-bg-soft border border-border rounded p-2">
+          <span className="flex-1 text-text-muted">
+            Restart opencode now to apply? (interrupts active sessions)
+          </span>
+          <button onClick={applyRestart}
+            className="px-2 py-1 bg-accent/20 border border-accent rounded text-text">
+            Apply Now
+          </button>
+          <button onClick={() => setRestartNeeded(false)}
+            className="px-2 py-1 border border-border rounded text-text-muted">
+            Apply Later
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. (If `window.api` is typed via a global interface, you may need to add the four new method signatures to that interface — locate the `Window`/`api` type declaration that lists `opencodeModels` and add `opencodeGetProviders`, `opencodeSetProviders`, `opencodeDiscoverModels`, `opencodeRestart` with the same signatures as in preload. Grep for `opencodeModels:` in `.d.ts`/types files.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/ProvidersCard.tsx
+git commit -m "feat(providers): ProvidersCard UI (discover, toggle, add/remove, restart prompt)"
+```
+
+---
+
+## Task 11: Render ProvidersCard in both Settings surfaces
+
+**Files:**
+- Modify: `src/renderer/Settings.tsx` (after the Skill registries block, around line 609)
+- Modify: `src/renderer/mobile/MobileSettings.tsx` (after its model section)
+
+- [ ] **Step 1: Import and render in desktop Settings**
+
+In `src/renderer/Settings.tsx`, add the import at the top:
+
+```ts
+import { ProvidersCard } from "./ProvidersCard";
+```
+
+After the closing `</div>` of the Skill registries `<div className="space-y-2 pt-2 border-t border-border">` block (the one ending around line 609), add:
+
+```tsx
+        <ProvidersCard />
+```
+
+- [ ] **Step 2: Import and render in MobileSettings**
+
+In `src/renderer/mobile/MobileSettings.tsx`, add the import:
+
+```ts
+import { ProvidersCard } from "../ProvidersCard";
+```
+
+After the model-picker section in that file, add `<ProvidersCard />` in the same place relative to other cards.
+
+- [ ] **Step 3: Typecheck + full test run**
+
+Run: `npx tsc --noEmit && npx vitest run`
+Expected: PASS (all existing tests plus the new providers.test.ts).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/Settings.tsx src/renderer/mobile/MobileSettings.tsx
+git commit -m "feat(providers): render ProvidersCard in desktop + mobile Settings"
+```
+
+---
+
+## Task 12: Manual end-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and launch bui locally**
+
+Run the app per the project's run path (e.g. `npm run dev`). The remote box (alphaclaw) must be the configured host — provider edits write to ITS opencode.jsonc.
+
+- [ ] **Step 2: Verify discovery**
+
+Open Settings → Providers. The `voska` endpoint should be listed (it's already in opencode.jsonc). Click **Refresh**. Expected: three checkboxes appear — `qwen3.6-27b` (checked), `default`, `ornith`.
+
+- [ ] **Step 3: Enable a new model + restart**
+
+Check `ornith`. Expected: the restart prompt appears. Click **Apply Now**. Wait ~5s.
+
+- [ ] **Step 4: Confirm it reached opencode**
+
+Run: `ssh dev@157.90.224.92 "curl -s http://127.0.0.1:4096/provider | python3 -c \"import sys,json; d=json.load(sys.stdin); print([m for p in d['all'] if p.get('id')=='voska' for m in p['models']])\""`
+Expected: the list now includes `ornith` (and `qwen3.6-27b`).
+
+- [ ] **Step 5: Confirm config integrity (no corruption, plugin preserved)**
+
+Run: `ssh dev@157.90.224.92 "python3 -c \"import json,re; s=open('/home/dev/.config/opencode/opencode.jsonc').read(); s=re.sub(r'//[^\n]*','',s); c=json.loads(s); print('plugin:', c.get('plugin')); print('model:', c.get('model')); print('voska models:', list(c['provider']['voska']['models']))\""`
+Expected: `plugin` still lists `opencode-claude-auth-bui...`, `model` unchanged, voska models include `ornith`. Valid JSON parse = no corruption.
+
+- [ ] **Step 6: Add + remove a throwaway endpoint**
+
+In the UI, add a dummy endpoint (id `testrm`, any baseURL), confirm it appears, then remove it and Apply. Re-run Step 5's parse check to confirm `testrm` is gone and the file still parses.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** add endpoint (Task 10/addEndpoint), remove (removeEndpoint), refresh discovery (Task 2 + 5 + refresh), toggle enabled models (Task 3 + toggleModel), prompt-before-restart (Task 6 + restart prompt UI), desktop + mobile (Task 11), opencode.jsonc as source of truth (Task 5 read-merge-write, no second store), corruption mitigation (reuse buildRemoteConfigWriteCmd + abort on unparseable), plugin preservation (Task 3 spread test + Task 12 step 5). All covered.
+- **Refresh-without-re-entering-key:** handled in Task 5 — `discoverModels` re-reads the stored `options.apiKey` from opencode.jsonc (matched by baseURL) when the renderer passes an empty key. New endpoints persist their key via Add before Refresh, so the same lookup finds it. The renderer never round-trips the secret.
+- **Comment loss:** writing back drops hand-written comments in opencode.jsonc — accepted per spec, consistent with the skill-URLs feature.

--- a/docs/superpowers/specs/2026-06-29-provider-management-design.md
+++ b/docs/superpowers/specs/2026-06-29-provider-management-design.md
@@ -1,0 +1,173 @@
+# Provider Management in bui
+
+**Date:** 2026-06-29
+**Branch:** `feat/provider-management`
+**Status:** Approved design, ready for implementation plan
+
+## Problem
+
+bui's model picker is dynamic — it reads opencode's `GET /provider` endpoint,
+filters to connected providers, and flattens each provider's `models` map
+(`src/main/opencode.ts:listModels`). But opencode only advertises models that
+are **hand-listed** in the provider's `models` block in `opencode.jsonc` on the
+box. It does not auto-discover from a provider's real `/v1/models`.
+
+Concrete case: the `voska` provider (`https://api.voska.org/v1`) actually serves
+three models — `qwen3.6-27b`, `default`, `ornith` — but only `qwen3.6-27b` is
+registered in `opencode.jsonc`, so the picker shows only that one. Surfacing the
+others today requires SSHing to alphaclaw, hand-editing `opencode.jsonc`, and
+restarting opencode.
+
+## Goal
+
+A **Providers** section in bui Settings where the user can:
+
+- **Add an endpoint** — name, baseURL, API key (any OpenAI-compatible provider).
+- **Refresh discovery** — query the endpoint's `/v1/models` and list everything
+  it returns.
+- **Toggle enabled models** — checked models are written into that provider's
+  `models` map in `opencode.jsonc`.
+- **Remove an endpoint** — drop the provider block.
+
+The model picker is unchanged: it keeps reading opencode `/provider`. opencode.jsonc
+on the box remains the single source of truth, so any enabled model is actually
+servable for prompts end-to-end.
+
+## Non-goals
+
+- bui does NOT route prompts directly to providers. opencode does all prompting;
+  bui only edits opencode's config and triggers a reload.
+- No second persistent store in bui. The endpoint list lives only in
+  `opencode.jsonc`; bui reads it back to populate the UI.
+- Comment preservation in `opencode.jsonc` is out of scope (see Risks).
+
+## Architecture
+
+Three pieces, each with one clear responsibility.
+
+### 1. Discovery — `src/main/providers.ts` (new)
+
+`discoverModels(config, baseURL, apiKey): Promise<DiscoverResult>`
+
+- Runs **on the box** (not the Mac), via the existing SSH-once path, because the
+  box is where opencode reaches these endpoints (honors the "remote box is
+  backend-only" invariant — discovery must reflect the box's network view).
+- Command shape:
+  `curl -s -H "Authorization: Bearer <key>" <baseURL>/models`
+  (baseURL already ends in `/v1`; append `/models`).
+- Parses `data[].id` into `{ id: string }[]`.
+- Returns a discriminated result:
+  - `{ ok: true, models: { id: string }[] }`
+  - `{ ok: false, error: "unreachable" | "unauthorized" | "bad_response", detail?: string }`
+- API key passed via the SSH command is shell-escaped; never logged.
+
+### 2. Read-merge-write config — `src/main/index.ts` (extend)
+
+New IPC handler `opencode:setProviders` mirrors the proven skill-registry-URLs
+block (`index.ts:958-1004`):
+
+1. `cat ~/.config/opencode/opencode.jsonc 2>/dev/null || echo '{}'`
+2. Strip `//` comments, `JSON.parse`. On parse failure: abort with an error to
+   the renderer (do NOT clobber an unparseable file).
+3. Mutate ONLY the top-level `provider` object — set/remove the named provider
+   blocks. Each block uses the fixed `@ai-sdk/openai-compatible` shape:
+   ```jsonc
+   "<id>": {
+     "npm": "@ai-sdk/openai-compatible",
+     "name": "<display name>",
+     "options": { "baseURL": "<url>", "apiKey": "<key>" },
+     "models": { "<modelId>": { "id": "<modelId>", "name": "<modelId>" } }
+   }
+   ```
+4. `JSON.stringify(merged, null, 2)` → `buildRemoteConfigWriteCmd(content, path)`
+   → `runSshOnce`. Reuses the tested heredoc writer (`remoteConfigWrite.ts`) —
+   no hand-rolled interpolation, no double-encoding.
+
+A separate IPC `opencode:getProviders` reads opencode.jsonc and returns the
+current provider blocks (id, name, baseURL, enabled model ids; apiKey presence
+only, never the value) so the UI can populate without a second store.
+
+A separate IPC `opencode:discoverModels` wraps piece 1 for the renderer.
+
+### Restart handling — **prompt before restart**
+
+Writing config does NOT restart opencode. After a successful write, the renderer
+shows: *"Restart opencode now to apply? (interrupts active sessions)"* with
+**Apply Now** / **Apply Later**. Apply Now calls a new IPC `opencode:restart`
+that tears down the `bui-opencode` tmux session and lets the existing ensure
+path respawn it (`opencode.ts`), then the picker re-fetches. Apply Later leaves
+the new config on disk to take effect on the next natural restart.
+
+### 3. UI — `src/renderer/Settings.tsx` + `src/renderer/mobile/MobileSettings.tsx`
+
+`ProvidersCard` (shared logic, two thin render surfaces):
+
+- List of endpoints. Each row: name + baseURL, expand to show models.
+- Expanded: discovered models as checkboxes (enabled = in opencode `models` map),
+  a **Refresh** button per endpoint (calls discoverModels), **Remove** endpoint.
+- **Add endpoint** form: id, name, baseURL, API key.
+- API keys are write-only: shown masked once present; editing replaces.
+- Save triggers `opencode:setProviders`, then the restart prompt.
+
+## Data flow
+
+```
+opencode.jsonc (box)  ──cat──▶  opencode:getProviders  ──▶  ProvidersCard
+       ▲                                                         │
+       │ buildRemoteConfigWriteCmd                               │ Refresh
+       └────── opencode:setProviders ◀── Save ───────────────────┤
+                                                                 ▼
+endpoint /v1/models  ◀──curl(box)──  opencode:discoverModels ◀── ProvidersCard
+                                                                 │
+   (after restart) opencode /provider ──▶ listModels ──▶ model picker (unchanged)
+```
+
+## Types (`src/shared/types.ts`)
+
+```ts
+export type ProviderEndpoint = {
+  id: string;            // opencode provider id, e.g. "voska"
+  name: string;          // display, e.g. "VoskaAI"
+  baseURL: string;       // e.g. "https://api.voska.org/v1"
+  hasApiKey: boolean;    // never send the key to the renderer
+  enabledModels: string[]; // model ids present in opencode `models` map
+};
+
+export type DiscoverResult =
+  | { ok: true; models: { id: string }[] }
+  | { ok: false; error: "unreachable" | "unauthorized" | "bad_response"; detail?: string };
+```
+
+## Error handling
+
+- Discovery failures surface inline per-endpoint (not a global error); the
+  existing enabled list stays intact.
+- Config read parse failure → abort the write, tell the user opencode.jsonc is
+  unparseable (don't overwrite). This matches the defensive stance already taken
+  for skill URLs.
+- Write failure → surface to renderer; nothing on the box changed (the write is
+  the last step).
+- Restart failure → the ensure path already self-heals stale tmux sessions on
+  next use; surface a warning but don't block.
+
+## Testing
+
+- Unit: `providers.ts` discovery parser — valid `/v1/models` JSON, empty `data`,
+  unauthorized, non-JSON body. Pure function over a response string.
+- Unit: the provider-block merge — given an existing parsed config, setting and
+  removing providers preserves `plugin`, `model`, `skills`, and other keys
+  byte-for-byte (mirror `remoteConfigWrite.test.ts`'s preservation assertions).
+- Reuse existing `remoteConfigWrite.test.ts` coverage for the write byte-safety.
+
+## Risks & mitigations
+
+- **opencode.jsonc corruption** (documented history, 2026-05-18 incident):
+  mitigated by reusing the tested `buildRemoteConfigWriteCmd` heredoc writer and
+  the parse-merge-preserve pattern. No string interpolation of JSON.
+- **Comment loss:** `JSON.parse` after comment-strip drops hand-written comments
+  on write-back. Consistent with the existing skill-URLs behavior; accepted for
+  v1. Called out so it's a known trade-off, not a surprise.
+- **Restart blast radius:** gated behind explicit prompt-before-restart; never
+  automatic.
+- **Don't drop the auth plugin:** the merge only touches the `provider` key, so
+  the `plugin` array (opencode-claude-auth-bui) is preserved untouched.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,10 +70,16 @@ import {
   generateSessionTitle as opencodeGenerateTitle,
   eventTunnelRestart,
   teardownEventTunnel,
+  restartOpencode,
   type PromptModel,
   type PromptAttachment,
   type PromptAgentMention,
 } from "./opencode.js";
+import {
+  getProviderEndpoints as opencodeGetProviders,
+  setProviders as opencodeSetProviders,
+  discoverModels as opencodeDiscoverModels,
+} from "./providers.js";
 import {
   classifyStreamHealth,
   isSubstantiveFrame,
@@ -122,6 +128,7 @@ import {
   type Project,
   type ProjectMeta,
   type SpawnOptions,
+  type ProviderInput,
 } from "../shared/types.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -1355,6 +1362,18 @@ function registerHandlers(): void {
   // response; opencode.listModels redacts before this leaves main.
   ipcMain.handle(IPC.opencodeModels, () => opencodeListModels(config));
   ipcMain.handle(IPC.opencodeDefaultModel, () => opencodeGetDefaultModel(config));
+  ipcMain.handle(IPC.opencodeGetProviders, () => opencodeGetProviders(config));
+  ipcMain.handle(
+    IPC.opencodeSetProviders,
+    (_e, ops: { upsert?: ProviderInput[]; remove?: string[] }) =>
+      opencodeSetProviders(config, ops),
+  );
+  ipcMain.handle(
+    IPC.opencodeDiscoverModels,
+    (_e, baseURL: string, apiKey: string) =>
+      opencodeDiscoverModels(config, baseURL, apiKey),
+  );
+  ipcMain.handle(IPC.opencodeRestart, () => restartOpencode(config));
   ipcMain.handle(IPC.opencodeVcsBranch, (_e, directory?: string) =>
     opencodeGetVcsBranch(config, directory),
   );

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,8 @@ import { noteSessionActivity } from "./transcriptCache.js";
 import {
   listMessages as opencodeListMessages,
   getCachedMessages as opencodeGetCachedMessages,
+  reconcileMessages as opencodeReconcileMessages,
+  getMessage as opencodeGetMessage,
   subscribeEvents as opencodeSubscribeEvents,
   sendPrompt as opencodeSendPrompt,
   abortSession as opencodeAbortSession,
@@ -1233,6 +1235,19 @@ function registerHandlers(): void {
   // mount, then awaits opencodeMessages in the background for the refresh.
   ipcMain.handle(IPC.opencodeMessagesCached, (_e, sessionId: string) =>
     opencodeGetCachedMessages(sessionId),
+  );
+  // Reconcile a transcript via tail-merge (fast) instead of a full re-pull.
+  // Used on session-switch/reconnect: paint cache, then call this to fold in
+  // anything new. Returns the merged full transcript (history never truncated).
+  ipcMain.handle(IPC.opencodeMessagesReconcile, (_e, sessionId: string) =>
+    opencodeReconcileMessages(config, sessionId),
+  );
+  // Fetch a single message by id — used to splice a finalized/changed message
+  // into the renderer's transcript during a live turn (vs a full re-pull).
+  ipcMain.handle(
+    IPC.opencodeMessage,
+    (_e, sessionId: string, messageId: string) =>
+      opencodeGetMessage(config, sessionId, messageId),
   );
 
   // Scoped-stream lifecycle. A ChatPanel calls openStream on mount and

--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -231,6 +231,19 @@ export async function ensureRunning(config: AppConfig): Promise<void> {
   );
 }
 
+// Restart opencode so it reloads opencode.jsonc. Config changes (e.g. provider
+// edits) only take effect on (re)start. We kill the bui-opencode tmux session;
+// ensureRunning() then sees the server as down and spawns a fresh one, waiting
+// for /global/health before returning. Active sessions are briefly interrupted,
+// so callers MUST gate this behind explicit user consent (prompt-before-restart).
+export async function restartOpencode(config: AppConfig): Promise<void> {
+  await runSshOnce(
+    config,
+    `tmux kill-session -t ${BUI_OPENCODE_TMUX_SESSION} 2>/dev/null || true`,
+  );
+  await ensureRunning(config);
+}
+
 // ===== local SSH -L forward =====
 //
 // We attach `-L localPort:127.0.0.1:REMOTE_PORT` to the SAME ControlMaster

--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -785,6 +785,103 @@ export function getCachedMessages(sessionId: string): OpencodeMessage[] | null {
   return getCachedTranscript(sessionId);
 }
 
+// Fetch ONE message by id. ~20–80ms regardless of transcript size (the full
+// list is O(transcript) because opencode re-serializes every part). The
+// renderer uses this to splice a finalized/changed message into its existing
+// transcript during a live turn instead of re-pulling the whole thing.
+// Returns null (never throws) so the caller can fall back to a full refetch.
+export async function getMessage(
+  config: AppConfig,
+  sessionId: string,
+  messageId: string,
+): Promise<OpencodeMessage | null> {
+  try {
+    await ensureForward(config);
+    const url = apiUrl(
+      config,
+      `/session/${encodeURIComponent(sessionId)}/message/${encodeURIComponent(messageId)}`,
+    );
+    const res = await forwardFetch(url);
+    if (!res.ok) return null;
+    return (await res.json()) as OpencodeMessage;
+  } catch {
+    return null;
+  }
+}
+
+// How many recent messages to pull when reconciling on switch/reconnect. Covers
+// "switched away briefly" — a turn or two of new activity. If the gap is larger
+// (no overlap with the cache), we fall back to a full pull so history is never
+// lost.
+const RECONCILE_TAIL_LIMIT = 30;
+
+// Merge `incoming` messages into `base` by id: replace changed, append new,
+// keep base-only messages. Ordered by time.created (id as a stable tiebreaker),
+// matching opencode's own ordering. Pure — no I/O.
+function mergeMessagesById(
+  base: OpencodeMessage[],
+  incoming: OpencodeMessage[],
+): OpencodeMessage[] {
+  const byId = new Map<string, OpencodeMessage>();
+  for (const m of base) byId.set(m.info.id, m);
+  for (const m of incoming) byId.set(m.info.id, m); // incoming wins on conflict
+  return [...byId.values()].sort((a, b) => {
+    const ta = a.info.time?.created ?? 0;
+    const tb = b.info.time?.created ?? 0;
+    if (ta !== tb) return ta - tb;
+    return a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0;
+  });
+}
+
+// Reconcile a session's transcript without re-downloading the whole thing.
+// Strategy:
+//   1. No cache → full pull (cold open; nothing to merge against). Same as today.
+//   2. Cache present → fetch only the recent tail (limit=N, ~16ms). If the tail
+//      OVERLAPS the cache (we already know its oldest message id), the cache is
+//      contiguous with the tail: merge by id and we have the complete history.
+//   3. No overlap (session advanced > N messages while away) → full pull, so
+//      we never show a truncated transcript.
+// Always repopulates the disk cache via listMessages on the full-pull paths.
+export async function reconcileMessages(
+  config: AppConfig,
+  sessionId: string,
+): Promise<OpencodeMessage[]> {
+  const cached = getCachedTranscript(sessionId);
+  if (!cached || cached.length === 0) {
+    // Cold: full pull (also primes the cache via setCachedTranscript inside).
+    return listMessages(config, sessionId);
+  }
+  let tail: OpencodeMessage[];
+  try {
+    await ensureForward(config);
+    const url = apiUrl(
+      config,
+      `/session/${encodeURIComponent(sessionId)}/message?limit=${RECONCILE_TAIL_LIMIT}`,
+    );
+    const res = await forwardFetch(url);
+    if (!res.ok) return listMessages(config, sessionId);
+    tail = (await res.json()) as OpencodeMessage[];
+  } catch {
+    // Tail fetch failed — fall back to full (which itself may throw; let it,
+    // so the renderer surfaces the same error it would today).
+    return listMessages(config, sessionId);
+  }
+  if (!Array.isArray(tail) || tail.length === 0) return cached;
+  // Overlap check: does the tail reach back to something we already have? If
+  // the tail's oldest message is present in the cache (or the tail is shorter
+  // than the limit — meaning it IS the whole session), the cache + tail cover
+  // the full history. Otherwise there's a gap → full pull.
+  const cachedIds = new Set(cached.map((m) => m.info.id));
+  const tailReachesCache =
+    tail.length < RECONCILE_TAIL_LIMIT ||
+    tail.some((m) => cachedIds.has(m.info.id));
+  if (!tailReachesCache) return listMessages(config, sessionId);
+  const merged = mergeMessagesById(cached, tail);
+  // Persist the merged view so the next switch paints the up-to-date transcript.
+  setCachedTranscript(sessionId, merged);
+  return merged;
+}
+
 // Send a user message into the session.
 //
 // We use the v1 `prompt_async` endpoint (returns 204 immediately, the

--- a/src/main/providers.test.ts
+++ b/src/main/providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseModelsResponse } from "./providers.js";
+import { parseModelsResponse, upsertProviderBlock, removeProviderBlock, readProviderEndpoints } from "./providers.js";
 
 describe("parseModelsResponse", () => {
   it("extracts ids from a valid OpenAI /v1/models body", () => {
@@ -41,5 +41,93 @@ describe("parseModelsResponse", () => {
     const r = parseModelsResponse(JSON.stringify({ object: "list" }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toBe("bad_response");
+  });
+});
+
+describe("upsertProviderBlock", () => {
+  const base = {
+    $schema: "https://opencode.ai/config.json",
+    model: "anthropic/claude-opus-4-8",
+    plugin: ["opencode-claude-auth-bui@1.5.4-bui.1"],
+    skills: { urls: [] },
+  };
+
+  it("adds a provider block without touching other keys", () => {
+    const out = upsertProviderBlock(base, {
+      id: "voska",
+      name: "VoskaAI",
+      baseURL: "https://api.voska.org/v1",
+      apiKey: "sk-test",
+      enabledModels: ["qwen3.6-27b", "ornith"],
+    });
+    expect(out.model).toBe("anthropic/claude-opus-4-8");
+    expect(out.plugin).toEqual(["opencode-claude-auth-bui@1.5.4-bui.1"]);
+    expect(out.skills).toEqual({ urls: [] });
+    const p = (out.provider as Record<string, any>).voska;
+    expect(p.npm).toBe("@ai-sdk/openai-compatible");
+    expect(p.name).toBe("VoskaAI");
+    expect(p.options).toEqual({ baseURL: "https://api.voska.org/v1", apiKey: "sk-test" });
+    expect(Object.keys(p.models)).toEqual(["qwen3.6-27b", "ornith"]);
+    expect(p.models["ornith"]).toEqual({ id: "ornith", name: "ornith" });
+  });
+
+  it("preserves the existing apiKey when input apiKey is undefined", () => {
+    const withProv = upsertProviderBlock(base, {
+      id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1",
+      apiKey: "sk-old", enabledModels: ["qwen3.6-27b"],
+    });
+    const out = upsertProviderBlock(withProv, {
+      id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1",
+      enabledModels: ["qwen3.6-27b", "default"], // no apiKey field
+    });
+    const p = (out.provider as Record<string, any>).voska;
+    expect(p.options.apiKey).toBe("sk-old");
+    expect(Object.keys(p.models)).toEqual(["qwen3.6-27b", "default"]);
+  });
+});
+
+describe("removeProviderBlock", () => {
+  it("drops only the named provider", () => {
+    const cfg = {
+      model: "anthropic/x",
+      provider: {
+        voska: { npm: "@ai-sdk/openai-compatible", models: {} },
+        other: { npm: "@ai-sdk/openai-compatible", models: {} },
+      },
+    };
+    const out = removeProviderBlock(cfg, "voska");
+    expect((out.provider as Record<string, unknown>).voska).toBeUndefined();
+    expect((out.provider as Record<string, unknown>).other).toBeDefined();
+    expect(out.model).toBe("anthropic/x");
+  });
+});
+
+describe("readProviderEndpoints", () => {
+  it("returns endpoint metadata with hasApiKey and enabledModels, never the key", () => {
+    const cfg = {
+      provider: {
+        voska: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "VoskaAI",
+          options: { baseURL: "https://api.voska.org/v1", apiKey: "sk-secret" },
+          models: { "qwen3.6-27b": { id: "qwen3.6-27b" }, ornith: { id: "ornith" } },
+        },
+      },
+    };
+    const eps = readProviderEndpoints(cfg);
+    expect(eps).toEqual([
+      {
+        id: "voska",
+        name: "VoskaAI",
+        baseURL: "https://api.voska.org/v1",
+        hasApiKey: true,
+        enabledModels: ["qwen3.6-27b", "ornith"],
+      },
+    ]);
+    expect(JSON.stringify(eps)).not.toContain("sk-secret");
+  });
+
+  it("returns [] when there is no provider key", () => {
+    expect(readProviderEndpoints({ model: "anthropic/x" })).toEqual([]);
   });
 });

--- a/src/main/providers.test.ts
+++ b/src/main/providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseModelsResponse, upsertProviderBlock, removeProviderBlock, readProviderEndpoints } from "./providers.js";
+import { stripLineComments } from "./setup.js";
 
 describe("parseModelsResponse", () => {
   it("extracts ids from a valid OpenAI /v1/models body", () => {
@@ -129,5 +130,44 @@ describe("readProviderEndpoints", () => {
 
   it("returns [] when there is no provider key", () => {
     expect(readProviderEndpoints({ model: "anthropic/x" })).toEqual([]);
+  });
+});
+
+// Regression: readRemoteConfig parses opencode.jsonc by running it through
+// stripLineComments (string-literal-aware) then JSON.parse. A real config has
+// `"$schema": "https://opencode.ai/config.json"` and provider `baseURL`s whose
+// `//` lives INSIDE a string. A naive `//`-to-EOL strip truncates those strings
+// and makes JSON.parse throw on a valid config — which surfaced as an empty
+// providers list and every save failing with "unparseable, refusing to write".
+// This proves the strip used by readRemoteConfig preserves in-string `//`.
+describe("readRemoteConfig comment-strip regression (URLs in strings)", () => {
+  it("parses a realistic JSONC config with https:// URLs and // comments", () => {
+    const jsonc = `{
+  // top-level comment
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-opus-4-8",
+  "plugin": ["opencode-claude-auth-bui@1.5.4-bui.1"],
+  "provider": {
+    "voska": {
+      "npm": "@ai-sdk/openai-compatible", // openai-compatible
+      "name": "VoskaAI",
+      "options": { "baseURL": "https://api.voska.org/v1", "apiKey": "sk-x" },
+      "models": { "qwen3.6-27b": { "id": "qwen3.6-27b" } }
+    }
+  }
+}`;
+    const cfg = JSON.parse(stripLineComments(jsonc)) as Record<string, unknown>;
+    // The $schema URL must survive intact (not truncated to "https:").
+    expect(cfg.$schema).toBe("https://opencode.ai/config.json");
+    const eps = readProviderEndpoints(cfg);
+    expect(eps).toEqual([
+      {
+        id: "voska",
+        name: "VoskaAI",
+        baseURL: "https://api.voska.org/v1",
+        hasApiKey: true,
+        enabledModels: ["qwen3.6-27b"],
+      },
+    ]);
   });
 });

--- a/src/main/providers.test.ts
+++ b/src/main/providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseModelsResponse, upsertProviderBlock, removeProviderBlock, readProviderEndpoints } from "./providers.js";
+import { parseModelsResponse, upsertProviderBlock, removeProviderBlock, readProviderEndpoints, findStoredApiKey } from "./providers.js";
 import { stripLineComments } from "./setup.js";
 
 describe("parseModelsResponse", () => {
@@ -43,6 +43,11 @@ describe("parseModelsResponse", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toBe("bad_response");
   });
+
+  it("treats `error: null` alongside data as success (gateway success shape)", () => {
+    const body = JSON.stringify({ object: "list", error: null, data: [{ id: "m1" }] });
+    expect(parseModelsResponse(body)).toEqual({ ok: true, models: [{ id: "m1" }] });
+  });
 });
 
 describe("upsertProviderBlock", () => {
@@ -84,6 +89,60 @@ describe("upsertProviderBlock", () => {
     const p = (out.provider as Record<string, any>).voska;
     expect(p.options.apiKey).toBe("sk-old");
     expect(Object.keys(p.models)).toEqual(["qwen3.6-27b", "default"]);
+  });
+
+  it("CLEARS the apiKey when input apiKey is an empty string (distinct from undefined)", () => {
+    const withProv = upsertProviderBlock(base, {
+      id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1",
+      apiKey: "sk-old", enabledModels: ["qwen3.6-27b"],
+    });
+    const out = upsertProviderBlock(withProv, {
+      id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1",
+      apiKey: "", enabledModels: ["qwen3.6-27b"], // explicit empty = clear
+    });
+    const p = (out.provider as Record<string, any>).voska;
+    expect(p.options.apiKey).toBe("");
+  });
+});
+
+describe("findStoredApiKey", () => {
+  const cfg = {
+    provider: {
+      voska: {
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: "https://api.voska.org/v1", apiKey: "sk-voska" },
+        models: {},
+      },
+      other: {
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: "https://api.other.com/v1", apiKey: "sk-other" },
+        models: {},
+      },
+    },
+  };
+
+  it("recovers the key for an exact baseURL match", () => {
+    expect(findStoredApiKey(cfg, "https://api.voska.org/v1")).toBe("sk-voska");
+  });
+
+  it("matches trailing-slash-insensitively on either side", () => {
+    // stored without slash, queried with slash
+    expect(findStoredApiKey(cfg, "https://api.voska.org/v1/")).toBe("sk-voska");
+    // stored with slash, queried without
+    const slashCfg = {
+      provider: {
+        voska: { npm: "x", options: { baseURL: "https://api.voska.org/v1/", apiKey: "sk-s" }, models: {} },
+      },
+    };
+    expect(findStoredApiKey(slashCfg, "https://api.voska.org/v1")).toBe("sk-s");
+  });
+
+  it("returns '' when no provider baseURL matches", () => {
+    expect(findStoredApiKey(cfg, "https://api.nope.com/v1")).toBe("");
+  });
+
+  it("returns '' when there is no provider key", () => {
+    expect(findStoredApiKey({ model: "anthropic/x" }, "https://api.voska.org/v1")).toBe("");
   });
 });
 
@@ -130,6 +189,22 @@ describe("readProviderEndpoints", () => {
 
   it("returns [] when there is no provider key", () => {
     expect(readProviderEndpoints({ model: "anthropic/x" })).toEqual([]);
+  });
+
+  it("strips userinfo credentials embedded in baseURL", () => {
+    const cfg = {
+      provider: {
+        p: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "P",
+          options: { baseURL: "https://user:s3cret@api.example.com/v1", apiKey: "k" },
+          models: { m: { id: "m" } },
+        },
+      },
+    };
+    const eps = readProviderEndpoints(cfg);
+    expect(eps[0].baseURL).toBe("https://api.example.com/v1");
+    expect(JSON.stringify(eps)).not.toContain("s3cret");
   });
 });
 

--- a/src/main/providers.test.ts
+++ b/src/main/providers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseModelsResponse } from "./providers.js";
+
+describe("parseModelsResponse", () => {
+  it("extracts ids from a valid OpenAI /v1/models body", () => {
+    const body = JSON.stringify({
+      object: "list",
+      data: [
+        { id: "qwen3.6-27b", object: "model" },
+        { id: "default", object: "model" },
+        { id: "ornith", object: "model" },
+      ],
+    });
+    expect(parseModelsResponse(body)).toEqual({
+      ok: true,
+      models: [{ id: "qwen3.6-27b" }, { id: "default" }, { id: "ornith" }],
+    });
+  });
+
+  it("returns ok:true with empty list when data is empty", () => {
+    expect(parseModelsResponse(JSON.stringify({ data: [] }))).toEqual({
+      ok: true,
+      models: [],
+    });
+  });
+
+  it("returns bad_response for non-JSON", () => {
+    const r = parseModelsResponse("<html>502 Bad Gateway</html>");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("bad_response");
+  });
+
+  it("returns unauthorized when body looks like an auth error", () => {
+    const body = JSON.stringify({ error: { message: "Invalid API key", code: "invalid_api_key" } });
+    const r = parseModelsResponse(body);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("unauthorized");
+  });
+
+  it("returns bad_response when JSON lacks a data array", () => {
+    const r = parseModelsResponse(JSON.stringify({ object: "list" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("bad_response");
+  });
+});

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -1,0 +1,36 @@
+// Provider management: discover models from an OpenAI-compatible endpoint and
+// read/merge/write provider blocks in the box's opencode.jsonc. opencode.jsonc
+// stays the single source of truth; the model picker keeps reading opencode's
+// /provider endpoint (see opencode.ts:listModels) — this file only edits config.
+import type { DiscoverResult } from "../shared/types.js";
+
+// Parse the body of GET <baseURL>/models (OpenAI-compatible shape: { data: [{ id }] }).
+// Pure — no I/O — so it is unit-testable against fixture strings.
+export function parseModelsResponse(body: string): DiscoverResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return { ok: false, error: "bad_response", detail: body.slice(0, 200) };
+  }
+  const obj = json as Record<string, unknown>;
+  // Auth errors come back as 200/4xx JSON with an `error` object on many gateways.
+  if (obj && typeof obj === "object" && "error" in obj) {
+    const errObj = obj.error as Record<string, unknown> | undefined;
+    const msg = errObj && typeof errObj.message === "string" ? errObj.message : "";
+    const code = errObj && typeof errObj.code === "string" ? errObj.code : "";
+    if (/api key|unauthor|invalid_api_key|401/i.test(`${msg} ${code}`)) {
+      return { ok: false, error: "unauthorized", detail: msg || code };
+    }
+    return { ok: false, error: "bad_response", detail: msg || code };
+  }
+  const data = obj?.data;
+  if (!Array.isArray(data)) {
+    return { ok: false, error: "bad_response", detail: "no data array" };
+  }
+  const models = data
+    .map((m) => (m && typeof m === "object" ? String((m as Record<string, unknown>).id ?? "") : ""))
+    .filter(Boolean)
+    .map((id) => ({ id }));
+  return { ok: true, models };
+}

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -17,11 +17,15 @@ export function parseModelsResponse(body: string): DiscoverResult {
     return { ok: false, error: "bad_response", detail: body.slice(0, 200) };
   }
   const obj = json as Record<string, unknown>;
-  // Auth errors come back as 200/4xx JSON with an `error` object on many gateways.
-  if (obj && typeof obj === "object" && "error" in obj) {
-    const errObj = obj.error as Record<string, unknown> | undefined;
-    const msg = errObj && typeof errObj.message === "string" ? errObj.message : "";
-    const code = errObj && typeof errObj.code === "string" ? errObj.code : "";
+  // Auth errors come back as 200/4xx JSON with an `error` object on many
+  // gateways. Gate on a truthy object: some OpenAI-compatible gateways return
+  // `{ data: [...], error: null }` on SUCCESS, and a bare `"error" in obj`
+  // check would mistreat that as a failure and discard the valid `data`.
+  const errObj = obj?.error;
+  if (errObj && typeof errObj === "object") {
+    const e = errObj as Record<string, unknown>;
+    const msg = typeof e.message === "string" ? e.message : "";
+    const code = typeof e.code === "string" ? e.code : "";
     if (/api key|unauthor|invalid_api_key|401/i.test(`${msg} ${code}`)) {
       return { ok: false, error: "unauthorized", detail: msg || code };
     }
@@ -77,20 +81,54 @@ export function removeProviderBlock(cfg: Cfg, id: string): Cfg {
   return { ...cfg, provider: providers };
 }
 
+// Strip any `user:pass@` userinfo from a URL so a credential embedded in the
+// baseURL (e.g. https://user:pass@host/v1) can't ride along to the renderer /
+// mobile client. Falls back to a regex if the URL doesn't parse.
+function stripUrlUserinfo(url: string): string {
+  try {
+    const u = new URL(url);
+    u.username = "";
+    u.password = "";
+    return u.toString();
+  } catch {
+    return url.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/@]*@/i, "$1");
+  }
+}
+
 // Project the config's provider map down to renderer-safe metadata. Never
-// includes the apiKey value — only whether one is present.
+// includes the apiKey value — only whether one is present — and scrubs any
+// credential embedded in the baseURL.
 export function readProviderEndpoints(cfg: Cfg): ProviderEndpoint[] {
   const providers = getProviderMap(cfg);
   return Object.entries(providers).map(([id, block]) => ({
     id,
     name: typeof block.name === "string" ? block.name : id,
-    baseURL: block.options?.baseURL ?? "",
+    baseURL: block.options?.baseURL ? stripUrlUserinfo(block.options.baseURL) : "",
     hasApiKey: Boolean(block.options?.apiKey),
     enabledModels: Object.keys(block.models ?? {}),
   }));
 }
 
 const OPENCODE_JSONC = "~/.config/opencode/opencode.jsonc";
+
+// Normalize a baseURL for equality: drop a trailing slash AND any userinfo, so
+// the value the renderer sends back (which readProviderEndpoints scrubbed of
+// `user:pass@`) still matches the stored, possibly-unscrubbed baseURL.
+const normBaseURL = (u: string): string => stripUrlUserinfo(u).replace(/\/$/, "");
+
+// Find the apiKey stored in opencode.jsonc for the provider whose baseURL
+// matches. Pure — unit-testable. Returns "" when no provider matches or the
+// matched one has no key. Backs the Refresh flow: the renderer sends an empty
+// key (never re-sending the secret), and we recover the stored one here by
+// baseURL.
+export function findStoredApiKey(cfg: Cfg, baseURL: string): string {
+  const providers = getProviderMap(cfg);
+  const target = normBaseURL(baseURL);
+  const match = Object.values(providers).find(
+    (b) => b.options?.baseURL && normBaseURL(b.options.baseURL) === target,
+  );
+  return match?.options?.apiKey ?? "";
+}
 
 // Query an OpenAI-compatible endpoint's /v1/models FROM THE BOX (not the Mac):
 // the box is where opencode reaches these endpoints, so discovery must reflect
@@ -101,31 +139,40 @@ export async function discoverModels(
   apiKey: string,
 ): Promise<DiscoverResult> {
   // Empty key from the renderer means "use the key already stored on the box"
-  // (Refresh on an existing endpoint never re-sends the secret). Re-read it from
-  // opencode.jsonc by matching the baseURL. New endpoints persist their key via
-  // Add before Refresh, so this same lookup finds it.
+  // (Refresh on an existing endpoint never re-sends the secret). New endpoints
+  // persist their key via Add before Refresh, so the lookup finds it.
   let key = apiKey;
   if (!key) {
     try {
-      const cfg = await readRemoteConfig(config);
-      const providers = getProviderMap(cfg);
-      const match = Object.values(providers).find(
-        (b) => b.options?.baseURL?.replace(/\/$/, "") === baseURL.replace(/\/$/, ""),
-      );
-      key = match?.options?.apiKey ?? "";
-    } catch {
-      /* fall through with empty key — endpoint may legitimately need none */
+      key = findStoredApiKey(await readRemoteConfig(config), baseURL);
+    } catch (e) {
+      // Best-effort recovery — an endpoint may legitimately need no key, so a
+      // failed re-read must not abort discovery (the curl below will surface a
+      // real auth/parse error). Log so a spurious `unauthorized` is debuggable.
+      console.warn("[providers] stored-key re-read failed; discovering with empty key:", e);
     }
   }
-  const url = `${baseURL.replace(/\/$/, "")}/models`;
+  const url = `${normBaseURL(baseURL)}/models`;
+  // Pass the key via an environment variable read by curl on the box, NOT inline
+  // in argv. This keeps the secret out of (a) the box's process list (`ps`) and
+  // (b) runSshOnce's error message, which echoes the first 80 chars of the
+  // command on timeout — argv-inlining the `Bearer <key>` header would leak it
+  // into `detail` and then into the UI / mobile RPC. `BUI_PROV_KEY` is exported
+  // for curl's child only; `-H "Authorization: Bearer $BUI_PROV_KEY"` is expanded
+  // by the remote shell, so the command string itself never contains the key.
   const cmd =
-    `curl -s --max-time 20 -H ${shellQuote(`Authorization: Bearer ${key}`)} ${shellQuote(url)}`;
+    `BUI_PROV_KEY=${shellQuote(key)} ` +
+    `curl -s --max-time 20 -H "Authorization: Bearer $BUI_PROV_KEY" ${shellQuote(url)}`;
   try {
     const { stdout } = await runSshOnce(config, cmd, { timeoutMs: 30000 });
     if (!stdout.trim()) return { ok: false, error: "unreachable", detail: "empty response" };
     return parseModelsResponse(stdout);
-  } catch (e) {
-    return { ok: false, error: "unreachable", detail: e instanceof Error ? e.message : String(e) };
+  } catch {
+    // Do NOT surface the raw transport error: runSshOnce echoes a slice of the
+    // command, and even with the key moved to an env var we avoid leaking
+    // internal SSH plumbing strings to the user. Log for diagnosis instead.
+    console.warn("[providers] discovery failed for", url);
+    return { ok: false, error: "unreachable", detail: "could not reach the endpoint" };
   }
 }
 
@@ -147,8 +194,28 @@ async function readRemoteConfig(config: AppConfig): Promise<Cfg> {
   return JSON.parse(stripped) as Cfg; // intentional throw on malformed JSON
 }
 
+// User-facing message for an unparseable on-box config. Shared by the read and
+// write paths so the UI says the same actionable thing either way.
+const UNPARSEABLE_CONFIG_MSG =
+  "opencode.jsonc on the box is unparseable — fix it manually first.";
+
 export async function getProviderEndpoints(config: AppConfig): Promise<ProviderEndpoint[]> {
-  const cfg = await readRemoteConfig(config);
+  let cfg: Cfg;
+  try {
+    cfg = await readRemoteConfig(config);
+  } catch (e) {
+    // Distinguish the two failure classes for the renderer, which otherwise
+    // collapses them into a deceptively-empty provider list:
+    //  - SyntaxError  → the config exists but is malformed (actionable message)
+    //  - anything else → SSH/transport failure (box unreachable)
+    // Re-throw a clear Error in both cases so the renderer can show it.
+    if (e instanceof SyntaxError) {
+      console.warn("[providers] opencode.jsonc unparseable on read:", e.message);
+      throw new Error(UNPARSEABLE_CONFIG_MSG);
+    }
+    console.warn("[providers] failed to read providers from the box:", e);
+    throw new Error("Couldn't reach the box to read providers.");
+  }
   return readProviderEndpoints(cfg);
 }
 
@@ -162,8 +229,11 @@ export async function setProviders(
   let cfg: Cfg;
   try {
     cfg = await readRemoteConfig(config);
-  } catch {
-    return { ok: false, error: "opencode.jsonc on the box is unparseable — refusing to overwrite it. Fix it manually first." };
+  } catch (e) {
+    console.warn("[providers] refusing to write — config unparseable/unreadable:", e);
+    // Refuse to overwrite: an unparseable read could mean a malformed config we
+    // must not clobber (the 2026-05-18 corruption mode).
+    return { ok: false, error: `${UNPARSEABLE_CONFIG_MSG} (refusing to overwrite)` };
   }
   for (const id of ops.remove ?? []) cfg = removeProviderBlock(cfg, id);
   for (const input of ops.upsert ?? []) cfg = upsertProviderBlock(cfg, input);
@@ -172,6 +242,7 @@ export async function setProviders(
     await runSshOnce(config, buildRemoteConfigWriteCmd(content, OPENCODE_JSONC));
     return { ok: true };
   } catch (e) {
+    console.warn("[providers] write failed:", e);
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 }

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -2,7 +2,7 @@
 // read/merge/write provider blocks in the box's opencode.jsonc. opencode.jsonc
 // stays the single source of truth; the model picker keeps reading opencode's
 // /provider endpoint (see opencode.ts:listModels) — this file only edits config.
-import type { DiscoverResult } from "../shared/types.js";
+import type { DiscoverResult, ProviderEndpoint, ProviderInput } from "../shared/types.js";
 
 // Parse the body of GET <baseURL>/models (OpenAI-compatible shape: { data: [{ id }] }).
 // Pure — no I/O — so it is unit-testable against fixture strings.
@@ -33,4 +33,56 @@ export function parseModelsResponse(body: string): DiscoverResult {
     .filter(Boolean)
     .map((id) => ({ id }));
   return { ok: true, models };
+}
+
+type Cfg = Record<string, unknown>;
+type ProviderBlock = {
+  npm: string;
+  name?: string;
+  options?: { baseURL?: string; apiKey?: string };
+  models?: Record<string, { id: string; name?: string }>;
+};
+
+function getProviderMap(cfg: Cfg): Record<string, ProviderBlock> {
+  const p = cfg.provider;
+  return p && typeof p === "object" ? ({ ...(p as Record<string, ProviderBlock>) }) : {};
+}
+
+// Insert or replace a single provider block. Only the `provider` key is touched;
+// every other key in `cfg` is preserved by spread. If `input.apiKey` is
+// undefined, the existing key (if any) is kept — so the renderer never has to
+// round-trip the secret.
+export function upsertProviderBlock(cfg: Cfg, input: ProviderInput): Cfg {
+  const providers = getProviderMap(cfg);
+  const prev = providers[input.id];
+  const apiKey =
+    input.apiKey !== undefined ? input.apiKey : prev?.options?.apiKey ?? "";
+  const models: Record<string, { id: string; name: string }> = {};
+  for (const id of input.enabledModels) models[id] = { id, name: id };
+  providers[input.id] = {
+    npm: "@ai-sdk/openai-compatible",
+    name: input.name,
+    options: { baseURL: input.baseURL, apiKey },
+    models,
+  };
+  return { ...cfg, provider: providers };
+}
+
+export function removeProviderBlock(cfg: Cfg, id: string): Cfg {
+  const providers = getProviderMap(cfg);
+  delete providers[id];
+  return { ...cfg, provider: providers };
+}
+
+// Project the config's provider map down to renderer-safe metadata. Never
+// includes the apiKey value — only whether one is present.
+export function readProviderEndpoints(cfg: Cfg): ProviderEndpoint[] {
+  const providers = getProviderMap(cfg);
+  return Object.entries(providers).map(([id, block]) => ({
+    id,
+    name: typeof block.name === "string" ? block.name : id,
+    baseURL: block.options?.baseURL ?? "",
+    hasApiKey: Boolean(block.options?.apiKey),
+    enabledModels: Object.keys(block.models ?? {}),
+  }));
 }

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -5,6 +5,7 @@
 import type { AppConfig, DiscoverResult, ProviderEndpoint, ProviderInput } from "../shared/types.js";
 import { runSshOnce, shellQuote } from "./pty.js";
 import { buildRemoteConfigWriteCmd } from "./remoteConfigWrite.js";
+import { stripLineComments } from "./setup.js";
 
 // Parse the body of GET <baseURL>/models (OpenAI-compatible shape: { data: [{ id }] }).
 // Pure — no I/O — so it is unit-testable against fixture strings.
@@ -128,16 +129,21 @@ export async function discoverModels(
   }
 }
 
-// Read opencode.jsonc from the box and parse it (strip // comments, like the
-// skill-URLs path in index.ts). Returns {} if the file is absent. THROWS if the
-// file exists but is unparseable — callers must NOT overwrite an unparseable
-// config (that was the 2026-05-18 corruption failure mode).
+// Read opencode.jsonc from the box and parse it. Returns {} if the file is
+// absent. THROWS if the file exists but is unparseable — callers must NOT
+// overwrite an unparseable config (that was the 2026-05-18 corruption mode).
+//
+// We use the string-literal-aware `stripLineComments` (from setup.ts), NOT a
+// naive `//`-to-EOL regex: every opencode.jsonc has `"$schema":
+// "https://opencode.ai/config.json"` (and provider `baseURL`s) whose `//`
+// inside a string would be eaten by the naive strip, truncating the string and
+// making JSON.parse throw on a perfectly valid config.
 async function readRemoteConfig(config: AppConfig): Promise<Cfg> {
   const { stdout } = await runSshOnce(
     config,
     `cat ${OPENCODE_JSONC} 2>/dev/null || echo '{}'`,
   );
-  const stripped = stdout.replace(/\/\/[^\n]*/g, "");
+  const stripped = stripLineComments(stdout);
   return JSON.parse(stripped) as Cfg; // intentional throw on malformed JSON
 }
 

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -167,11 +167,11 @@ export async function discoverModels(
     const { stdout } = await runSshOnce(config, cmd, { timeoutMs: 30000 });
     if (!stdout.trim()) return { ok: false, error: "unreachable", detail: "empty response" };
     return parseModelsResponse(stdout);
-  } catch {
-    // Do NOT surface the raw transport error: runSshOnce echoes a slice of the
-    // command, and even with the key moved to an env var we avoid leaking
-    // internal SSH plumbing strings to the user. Log for diagnosis instead.
-    console.warn("[providers] discovery failed for", url);
+  } catch (e) {
+    // Do NOT surface the raw transport error to the USER: it could include SSH
+    // plumbing strings. But log it main-side for diagnosis — safe now that the
+    // key lives in the BUI_PROV_KEY env var, not in the command string.
+    console.warn("[providers] discovery failed for", url, e);
     return { ok: false, error: "unreachable", detail: "could not reach the endpoint" };
   }
 }

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -4,6 +4,7 @@
 // /provider endpoint (see opencode.ts:listModels) — this file only edits config.
 import type { AppConfig, DiscoverResult, ProviderEndpoint, ProviderInput } from "../shared/types.js";
 import { runSshOnce, shellQuote } from "./pty.js";
+import { buildRemoteConfigWriteCmd } from "./remoteConfigWrite.js";
 
 // Parse the body of GET <baseURL>/models (OpenAI-compatible shape: { data: [{ id }] }).
 // Pure — no I/O — so it is unit-testable against fixture strings.
@@ -162,7 +163,6 @@ export async function setProviders(
   for (const input of ops.upsert ?? []) cfg = upsertProviderBlock(cfg, input);
   const content = JSON.stringify(cfg, null, 2);
   try {
-    const { buildRemoteConfigWriteCmd } = await import("./remoteConfigWrite.js");
     await runSshOnce(config, buildRemoteConfigWriteCmd(content, OPENCODE_JSONC));
     return { ok: true };
   } catch (e) {

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -2,7 +2,8 @@
 // read/merge/write provider blocks in the box's opencode.jsonc. opencode.jsonc
 // stays the single source of truth; the model picker keeps reading opencode's
 // /provider endpoint (see opencode.ts:listModels) — this file only edits config.
-import type { DiscoverResult, ProviderEndpoint, ProviderInput } from "../shared/types.js";
+import type { AppConfig, DiscoverResult, ProviderEndpoint, ProviderInput } from "../shared/types.js";
+import { runSshOnce, shellQuote } from "./pty.js";
 
 // Parse the body of GET <baseURL>/models (OpenAI-compatible shape: { data: [{ id }] }).
 // Pure — no I/O — so it is unit-testable against fixture strings.
@@ -85,4 +86,86 @@ export function readProviderEndpoints(cfg: Cfg): ProviderEndpoint[] {
     hasApiKey: Boolean(block.options?.apiKey),
     enabledModels: Object.keys(block.models ?? {}),
   }));
+}
+
+const OPENCODE_JSONC = "~/.config/opencode/opencode.jsonc";
+
+// Query an OpenAI-compatible endpoint's /v1/models FROM THE BOX (not the Mac):
+// the box is where opencode reaches these endpoints, so discovery must reflect
+// the box's network view (honors the "remote box is backend-only" invariant).
+export async function discoverModels(
+  config: AppConfig,
+  baseURL: string,
+  apiKey: string,
+): Promise<DiscoverResult> {
+  // Empty key from the renderer means "use the key already stored on the box"
+  // (Refresh on an existing endpoint never re-sends the secret). Re-read it from
+  // opencode.jsonc by matching the baseURL. New endpoints persist their key via
+  // Add before Refresh, so this same lookup finds it.
+  let key = apiKey;
+  if (!key) {
+    try {
+      const cfg = await readRemoteConfig(config);
+      const providers = getProviderMap(cfg);
+      const match = Object.values(providers).find(
+        (b) => b.options?.baseURL?.replace(/\/$/, "") === baseURL.replace(/\/$/, ""),
+      );
+      key = match?.options?.apiKey ?? "";
+    } catch {
+      /* fall through with empty key — endpoint may legitimately need none */
+    }
+  }
+  const url = `${baseURL.replace(/\/$/, "")}/models`;
+  const cmd =
+    `curl -s --max-time 20 -H ${shellQuote(`Authorization: Bearer ${key}`)} ${shellQuote(url)}`;
+  try {
+    const { stdout } = await runSshOnce(config, cmd, { timeoutMs: 30000 });
+    if (!stdout.trim()) return { ok: false, error: "unreachable", detail: "empty response" };
+    return parseModelsResponse(stdout);
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+// Read opencode.jsonc from the box and parse it (strip // comments, like the
+// skill-URLs path in index.ts). Returns {} if the file is absent. THROWS if the
+// file exists but is unparseable — callers must NOT overwrite an unparseable
+// config (that was the 2026-05-18 corruption failure mode).
+async function readRemoteConfig(config: AppConfig): Promise<Cfg> {
+  const { stdout } = await runSshOnce(
+    config,
+    `cat ${OPENCODE_JSONC} 2>/dev/null || echo '{}'`,
+  );
+  const stripped = stdout.replace(/\/\/[^\n]*/g, "");
+  return JSON.parse(stripped) as Cfg; // intentional throw on malformed JSON
+}
+
+export async function getProviderEndpoints(config: AppConfig): Promise<ProviderEndpoint[]> {
+  const cfg = await readRemoteConfig(config);
+  return readProviderEndpoints(cfg);
+}
+
+// Apply a set of provider mutations and write opencode.jsonc back using the
+// TESTED heredoc writer (no string interpolation of JSON — see remoteConfigWrite.ts).
+// Does NOT restart opencode; the caller decides (prompt-before-restart).
+export async function setProviders(
+  config: AppConfig,
+  ops: { upsert?: ProviderInput[]; remove?: string[] },
+): Promise<{ ok: boolean; error?: string }> {
+  let cfg: Cfg;
+  try {
+    cfg = await readRemoteConfig(config);
+  } catch {
+    return { ok: false, error: "opencode.jsonc on the box is unparseable — refusing to overwrite it. Fix it manually first." };
+  }
+  for (const id of ops.remove ?? []) cfg = removeProviderBlock(cfg, id);
+  for (const input of ops.upsert ?? []) cfg = upsertProviderBlock(cfg, input);
+  const content = JSON.stringify(cfg, null, 2);
+  try {
+    const { buildRemoteConfigWriteCmd } = await import("./remoteConfigWrite.js");
+    await runSshOnce(config, buildRemoteConfigWriteCmd(content, OPENCODE_JSONC));
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
 }

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -102,7 +102,7 @@ export function runSshOnce(
   });
 }
 
-function shellQuote(s: string): string {
+export function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 

--- a/src/main/transcriptCache.ts
+++ b/src/main/transcriptCache.ts
@@ -71,13 +71,15 @@ export function noteSessionActivity(sessionId: string): void {
 }
 
 export function getCachedTranscript(sessionId: string): OpencodeMessage[] | null {
-  // If live SSE events for this session arrived AFTER the last time we
-  // stored a fresh transcript, the cached copy is stale by definition —
-  // skip it and let the renderer show its loading state until the real
-  // fetch lands. Avoids the "remount shows pre-send state for 6s" bug.
-  const activity = lastActivityAt.get(sessionId);
-  const fresh = lastFreshAt.get(sessionId);
-  if (activity != null && (fresh == null || activity > fresh)) return null;
+  // Historically we returned null here when live SSE activity arrived after
+  // the last stored transcript, to avoid the "remount shows pre-send state for
+  // 6s" bug — but that meant EVERY switch to a session with new events painted
+  // a blank "Loading session…" while a full (up-to-35s) refetch ran. Now the
+  // renderer reconciles via a fast tail-merge (reconcileMessages), so the stale
+  // window is milliseconds: paint the cached transcript immediately regardless
+  // of staleness and let the reconcile fold in new messages. The `lastFreshAt`
+  // / `lastActivityAt` bookkeeping is kept (setCachedTranscript still records
+  // freshness) but no longer gates the read.
   // Memory hit first — avoids JSON.parse on every session switch within a run.
   const mem = memCache.get(sessionId);
   if (mem) return mem;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,6 +30,9 @@ import {
   type VoiceTranscribeResult,
   type WindowStatus,
   type WorktreeInfo,
+  type ProviderEndpoint,
+  type DiscoverResult,
+  type ProviderInput,
 } from "../shared/types.js";
 
 type PromptModel = { providerID: string; modelID: string; variant?: string };
@@ -258,6 +261,15 @@ const api = {
     ipcRenderer.invoke(IPC.opencodeModels),
   opencodeDefaultModel: (): Promise<{ providerID: string; modelID: string } | null> =>
     ipcRenderer.invoke(IPC.opencodeDefaultModel),
+  opencodeGetProviders: (): Promise<ProviderEndpoint[]> =>
+    ipcRenderer.invoke(IPC.opencodeGetProviders),
+  opencodeSetProviders: (
+    ops: { upsert?: ProviderInput[]; remove?: string[] },
+  ): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke(IPC.opencodeSetProviders, ops),
+  opencodeDiscoverModels: (baseURL: string, apiKey: string): Promise<DiscoverResult> =>
+    ipcRenderer.invoke(IPC.opencodeDiscoverModels, baseURL, apiKey),
+  opencodeRestart: (): Promise<void> => ipcRenderer.invoke(IPC.opencodeRestart),
   opencodeVcsBranch: (directory?: string): Promise<string | null> =>
     ipcRenderer.invoke(IPC.opencodeVcsBranch, directory),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -177,6 +177,17 @@ const api = {
     sessionId: string,
   ): Promise<OpencodeMessage[] | null> =>
     ipcRenderer.invoke(IPC.opencodeMessagesCached, sessionId),
+  // Tail-merge reconcile (fast) — returns the merged full transcript.
+  opencodeMessagesReconcile: (
+    sessionId: string,
+  ): Promise<OpencodeMessage[]> =>
+    ipcRenderer.invoke(IPC.opencodeMessagesReconcile, sessionId),
+  // Single-message fetch — returns null on miss so callers can fall back.
+  opencodeMessage: (
+    sessionId: string,
+    messageId: string,
+  ): Promise<OpencodeMessage | null> =>
+    ipcRenderer.invoke(IPC.opencodeMessage, sessionId, messageId),
   // Open/close the scoped SSE stream for a session. ChatPanel calls open on
   // mount and close on unmount so the main process only streams open sessions.
   opencodeOpenStream: (sessionId: string): Promise<void> =>

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -593,7 +593,12 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   // effect wires this on mount; the reactivation catch-up effect reads it.
   // (Shared so a catch-up can fire outside the SSE effect's local scope.)
   const scheduleRefetchRef = useRef<(() => void) | null>(null);
-
+  // Per-messageID debounce timers for the incremental splice path (live-turn
+  // single-message merge instead of a full transcript re-pull). Keyed by
+  // messageID so concurrent messages each coalesce independently.
+  const spliceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
   // ===== Streamed-text delta buffer =====
   //
   // opencode emits `message.part.delta` events ~character-by-character for
@@ -939,7 +944,13 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       .catch(() => { /* cache miss / corrupt — fresh fetch will fill in */ });
 
     window.api
-      .opencodeMessages(sessionId)
+      // Reconcile via tail-merge instead of a full re-pull: on desktop this
+      // fetches only the recent tail (~16ms) and merges it into the disk-cached
+      // transcript, so a switch to a session with new events no longer blocks
+      // on a full (up-to-35s) download. Returns the merged FULL transcript
+      // (history is never truncated — falls back to a full pull on a cache gap).
+      // On mobile/web this is just a full pull (no server-side cache).
+      .opencodeMessagesReconcile(sessionId)
       .then((m) => {
         clearTimeout(refreshWatchdog);
         if (cancelled) return;
@@ -1249,6 +1260,68 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       }, 300);
     };
     scheduleRefetchRef.current = scheduleRefetch;
+
+    // Incremental splice: fetch ONE message by id and merge it into `messages`
+    // by id (replace if present, insert in time order if new), instead of
+    // re-pulling the entire (up-to-3 MB) transcript on every part-finalization
+    // event. This is the live-turn analog of the switch-time tail-merge.
+    //
+    // Per-message fetches are debounced+coalesced per messageID so a chatty
+    // part stream (many message.part.updated for the same message) collapses to
+    // one fetch. On a fetch miss (null) or an unmatched insert we fall back to
+    // the full scheduleRefetch so we can never get permanently out of sync.
+    const spliceMessage = (messageId: string) => {
+      if (!messageId) {
+        scheduleRefetch();
+        return;
+      }
+      // Inactive panels don't render — defer to the reactivation refetch, same
+      // policy as scheduleRefetch (avoids per-event ×K-panels fetch cost).
+      if (!isActiveRef.current) {
+        refetchOwedWhileInactive.current = true;
+        return;
+      }
+      const existing = spliceTimers.current.get(messageId);
+      if (existing) clearTimeout(existing);
+      spliceTimers.current.set(
+        messageId,
+        setTimeout(() => {
+          spliceTimers.current.delete(messageId);
+          window.api
+            .opencodeMessage(sessionId, messageId)
+            .then((msg) => {
+              if (!msg) {
+                // Miss — fall back to a full pull so we don't drop the update.
+                scheduleRefetch();
+                return;
+              }
+              setMessages((prev) => {
+                if (prev === null) return prev;
+                const idx = prev.findIndex((m) => m.info.id === msg.info.id);
+                if (idx >= 0) {
+                  const next = prev.slice();
+                  next[idx] = msg;
+                  return next;
+                }
+                // New message: insert in time order (it's usually the newest,
+                // so this is an append in the common case).
+                const t = msg.info.time?.created ?? 0;
+                const insertAt = prev.findIndex(
+                  (m) => (m.info.time?.created ?? 0) > t,
+                );
+                const next = prev.slice();
+                if (insertAt < 0) next.push(msg);
+                else next.splice(insertAt, 0, msg);
+                return next;
+              });
+              for (const cid of collectChildSessionIds([msg])) {
+                childSessionIds.current.add(cid);
+              }
+            })
+            .catch(() => scheduleRefetch());
+        }, 300),
+      );
+    };
 
     // Per-child debounced refetch — called when a known child's
     // message.part.* event arrives while its TaskBody is expanded. We
@@ -1738,18 +1811,38 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       }
 
       if (
-        ev.type === "session.idle" ||
-        ev.type === "session.status" ||
-        ev.type === "session.compacted" ||
-        ev.type === "session.error" ||
         ev.type === "message.part.updated" ||
         ev.type === "message.updated"
       ) {
-        // Force-flush any buffered text deltas before the refetch
-        // overwrites state. Without this, a still-buffered trailing
-        // paragraph would be discarded when the canonical transcript
-        // arrives (the server-side snapshot has the same content but the
-        // refetch races the buffer's max-age timer).
+        // Force-flush any buffered text deltas before the merge overwrites the
+        // affected message. Without this, a still-buffered trailing paragraph
+        // would be discarded when the canonical message arrives (the server
+        // snapshot has the same content but the fetch races the buffer's
+        // max-age timer).
+        flushPendingDeltas(true);
+        // Incremental: splice just the touched message instead of re-pulling
+        // the whole transcript. messageID lives at props.part.messageID for
+        // part events and props.info.id for message.updated. On an empty id we
+        // fall back to a full refetch inside spliceMessage.
+        const mid =
+          ev.type === "message.part.updated"
+            ? String(
+                (props.part as { messageID?: string } | undefined)?.messageID ??
+                  "",
+              )
+            : String(
+                (props.info as { id?: string } | undefined)?.id ?? "",
+              );
+        spliceMessage(mid);
+      } else if (
+        ev.type === "session.idle" ||
+        ev.type === "session.status" ||
+        ev.type === "session.compacted" ||
+        ev.type === "session.error"
+      ) {
+        // Session-lifecycle events carry no single messageID — a full refetch
+        // is the right tool (and these are infrequent vs part events). It also
+        // runs the isAssistantTurnComplete spinner self-heal.
         flushPendingDeltas(true);
         scheduleRefetch();
       }
@@ -1842,6 +1935,9 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       // effect will fetch fresh on first expand.
       for (const t of childRefetchTimers.current.values()) clearTimeout(t);
       childRefetchTimers.current.clear();
+      // Cancel any pending single-message splices for the same reason.
+      for (const t of spliceTimers.current.values()) clearTimeout(t);
+      spliceTimers.current.clear();
       // Force-flush whatever's still buffered on unmount/session change
       // so the user doesn't lose the final sentence of a turn when they
       // navigate away. (The new session's effect will clear the buffer

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState, useCallback } from "react";
+import type { ProviderEndpoint, DiscoverResult } from "../shared/types";
+
+type Draft = { id: string; name: string; baseURL: string; apiKey: string };
+const EMPTY_DRAFT: Draft = { id: "", name: "", baseURL: "", apiKey: "" };
+
+export function ProvidersCard() {
+  const [endpoints, setEndpoints] = useState<ProviderEndpoint[] | null>(null);
+  const [discovered, setDiscovered] = useState<Record<string, { id: string }[]>>({});
+  const [discoverError, setDiscoverError] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<string | null>(null); // endpoint id being mutated
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [restartNeeded, setRestartNeeded] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    window.api.opencodeGetProviders().then(setEndpoints).catch(() => setEndpoints([]));
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const refresh = useCallback(async (ep: ProviderEndpoint) => {
+    setBusy(ep.id);
+    setDiscoverError((e) => ({ ...e, [ep.id]: "" }));
+    // apiKey "" => main re-reads the stored key for this endpoint (Refresh never
+    // re-sends the secret).
+    const r: DiscoverResult = await window.api.opencodeDiscoverModels(ep.baseURL, "");
+    if (r.ok) {
+      setDiscovered((d) => ({ ...d, [ep.id]: r.models }));
+    } else {
+      setDiscoverError((e) => ({ ...e, [ep.id]: `${r.error}${r.detail ? `: ${r.detail}` : ""}` }));
+    }
+    setBusy(null);
+  }, []);
+
+  const toggleModel = useCallback(async (ep: ProviderEndpoint, modelId: string) => {
+    const enabled = ep.enabledModels.includes(modelId)
+      ? ep.enabledModels.filter((m) => m !== modelId)
+      : [...ep.enabledModels, modelId];
+    setBusy(ep.id);
+    const res = await window.api.opencodeSetProviders({
+      upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
+    });
+    setBusy(null);
+    if (!res.ok) { setGlobalError(res.error ?? "Save failed"); return; }
+    setRestartNeeded(true);
+    load();
+  }, [load]);
+
+  const addEndpoint = useCallback(async () => {
+    const d = draft;
+    if (!d.id.trim() || !d.baseURL.trim()) return;
+    setBusy(d.id);
+    const res = await window.api.opencodeSetProviders({
+      upsert: [{
+        id: d.id.trim(), name: d.name.trim() || d.id.trim(),
+        baseURL: d.baseURL.trim(), apiKey: d.apiKey, enabledModels: [],
+      }],
+    });
+    setBusy(null);
+    if (!res.ok) { setGlobalError(res.error ?? "Add failed"); return; }
+    setDraft(EMPTY_DRAFT);
+    setRestartNeeded(true);
+    load();
+  }, [draft, load]);
+
+  const removeEndpoint = useCallback(async (ep: ProviderEndpoint) => {
+    setBusy(ep.id);
+    const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
+    setBusy(null);
+    if (!res.ok) { setGlobalError(res.error ?? "Remove failed"); return; }
+    setRestartNeeded(true);
+    load();
+  }, [load]);
+
+  const applyRestart = useCallback(async () => {
+    await window.api.opencodeRestart();
+    setRestartNeeded(false);
+  }, []);
+
+  return (
+    <div className="space-y-2 pt-2 border-t border-border">
+      <label className="block text-xs uppercase tracking-wider text-text-muted">
+        Providers
+      </label>
+      <div className="text-xs text-text-faint">
+        OpenAI-compatible endpoints opencode can serve. Refresh to discover models,
+        then enable the ones you want in the model picker.
+      </div>
+
+      {globalError && <div className="text-xs text-red-400">{globalError}</div>}
+
+      {(endpoints ?? []).map((ep) => (
+        <div key={ep.id} className="border border-border rounded p-2 space-y-1">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm text-text truncate">{ep.name}</div>
+              <code className="text-[10px] text-text-faint truncate block">{ep.baseURL}</code>
+            </div>
+            <button
+              onClick={() => refresh(ep)}
+              disabled={busy === ep.id}
+              className="px-2 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+            >
+              {busy === ep.id ? "…" : "Refresh"}
+            </button>
+            <button
+              onClick={() => removeEndpoint(ep)}
+              disabled={busy === ep.id}
+              className="text-xs text-text-faint hover:text-text px-1"
+              title="Remove endpoint"
+            >
+              ✕
+            </button>
+          </div>
+          {discoverError[ep.id] && (
+            <div className="text-[10px] text-red-400">{discoverError[ep.id]}</div>
+          )}
+          {(discovered[ep.id] ?? ep.enabledModels.map((id) => ({ id }))).map((m) => (
+            <label key={m.id} className="flex items-center gap-2 text-xs cursor-pointer">
+              <input
+                type="checkbox"
+                checked={ep.enabledModels.includes(m.id)}
+                onChange={() => toggleModel(ep, m.id)}
+                disabled={busy === ep.id}
+              />
+              <span className="text-text-muted">{m.id}</span>
+            </label>
+          ))}
+        </div>
+      ))}
+
+      <div className="border border-dashed border-border rounded p-2 space-y-1">
+        <div className="text-[10px] uppercase tracking-wider text-text-faint">Add endpoint</div>
+        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="id (e.g. voska)" value={draft.id}
+          onChange={(e) => setDraft({ ...draft, id: e.target.value })} />
+        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="name (e.g. VoskaAI)" value={draft.name}
+          onChange={(e) => setDraft({ ...draft, name: e.target.value })} />
+        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="baseURL (https://api.voska.org/v1)" value={draft.baseURL}
+          onChange={(e) => setDraft({ ...draft, baseURL: e.target.value })} />
+        <input type="password" className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
+          placeholder="API key" value={draft.apiKey}
+          onChange={(e) => setDraft({ ...draft, apiKey: e.target.value })} />
+        <button
+          onClick={addEndpoint}
+          disabled={!draft.id.trim() || !draft.baseURL.trim()}
+          className="px-3 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+        >
+          Add
+        </button>
+      </div>
+
+      {restartNeeded && (
+        <div className="flex items-center gap-2 text-xs bg-bg-soft border border-border rounded p-2">
+          <span className="flex-1 text-text-muted">
+            Restart opencode now to apply? (interrupts active sessions)
+          </span>
+          <button onClick={applyRestart}
+            className="px-2 py-1 bg-accent/20 border border-accent rounded text-text">
+            Apply Now
+          </button>
+          <button onClick={() => setRestartNeeded(false)}
+            className="px-2 py-1 border border-border rounded text-text-muted">
+            Apply Later
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -19,58 +19,87 @@ export function ProvidersCard() {
   useEffect(() => { load(); }, [load]);
 
   const refresh = useCallback(async (ep: ProviderEndpoint) => {
+    if (busy) return;
     setBusy(ep.id);
     setDiscoverError((e) => ({ ...e, [ep.id]: "" }));
     // apiKey "" => main re-reads the stored key for this endpoint (Refresh never
     // re-sends the secret).
-    const r: DiscoverResult = await window.api.opencodeDiscoverModels(ep.baseURL, "");
-    if (r.ok) {
-      setDiscovered((d) => ({ ...d, [ep.id]: r.models }));
-    } else {
-      setDiscoverError((e) => ({ ...e, [ep.id]: `${r.error}${r.detail ? `: ${r.detail}` : ""}` }));
+    try {
+      const r: DiscoverResult = await window.api.opencodeDiscoverModels(ep.baseURL, "");
+      if (r.ok) {
+        setDiscovered((d) => ({ ...d, [ep.id]: r.models }));
+      } else {
+        setDiscoverError((e) => ({ ...e, [ep.id]: `${r.error}${r.detail ? `: ${r.detail}` : ""}` }));
+      }
+    } catch (e) {
+      setDiscoverError((er) => ({ ...er, [ep.id]: e instanceof Error ? e.message : String(e) }));
+    } finally {
+      setBusy(null);
     }
-    setBusy(null);
-  }, []);
+  }, [busy]);
 
   const toggleModel = useCallback(async (ep: ProviderEndpoint, modelId: string) => {
+    if (busy) return;
     const enabled = ep.enabledModels.includes(modelId)
       ? ep.enabledModels.filter((m) => m !== modelId)
       : [...ep.enabledModels, modelId];
     setBusy(ep.id);
-    const res = await window.api.opencodeSetProviders({
-      upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
-    });
-    setBusy(null);
-    if (!res.ok) { setGlobalError(res.error ?? "Save failed"); return; }
-    setRestartNeeded(true);
-    load();
-  }, [load]);
+    setGlobalError(null);
+    try {
+      const res = await window.api.opencodeSetProviders({
+        upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
+      });
+      if (!res.ok) { setGlobalError(res.error ?? "Save failed"); return; }
+      setRestartNeeded(true);
+      load();
+    } catch (e) {
+      setGlobalError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }, [busy, load]);
 
   const addEndpoint = useCallback(async () => {
+    if (busy) return;
     const d = draft;
     if (!d.id.trim() || !d.baseURL.trim()) return;
     setBusy(d.id);
-    const res = await window.api.opencodeSetProviders({
-      upsert: [{
-        id: d.id.trim(), name: d.name.trim() || d.id.trim(),
-        baseURL: d.baseURL.trim(), apiKey: d.apiKey, enabledModels: [],
-      }],
-    });
-    setBusy(null);
-    if (!res.ok) { setGlobalError(res.error ?? "Add failed"); return; }
-    setDraft(EMPTY_DRAFT);
-    setRestartNeeded(true);
-    load();
-  }, [draft, load]);
+    setGlobalError(null);
+    try {
+      const res = await window.api.opencodeSetProviders({
+        upsert: [{
+          id: d.id.trim(), name: d.name.trim() || d.id.trim(),
+          baseURL: d.baseURL.trim(), apiKey: d.apiKey, enabledModels: [],
+        }],
+      });
+      if (!res.ok) { setGlobalError(res.error ?? "Add failed"); return; }
+      setDraft(EMPTY_DRAFT);
+      setRestartNeeded(true);
+      load();
+    } catch (e) {
+      setGlobalError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }, [busy, draft, load]);
 
   const removeEndpoint = useCallback(async (ep: ProviderEndpoint) => {
+    if (busy) return;
     setBusy(ep.id);
-    const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
-    setBusy(null);
-    if (!res.ok) { setGlobalError(res.error ?? "Remove failed"); return; }
-    setRestartNeeded(true);
-    load();
-  }, [load]);
+    setGlobalError(null);
+    try {
+      const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
+      if (!res.ok) { setGlobalError(res.error ?? "Remove failed"); return; }
+      setDiscovered((d) => { const { [ep.id]: _drop, ...rest } = d; return rest; });
+      setDiscoverError((er) => { const { [ep.id]: _drop, ...rest } = er; return rest; });
+      setRestartNeeded(true);
+      load();
+    } catch (e) {
+      setGlobalError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }, [busy, load]);
 
   const applyRestart = useCallback(async () => {
     await window.api.opencodeRestart();
@@ -133,19 +162,19 @@ export function ProvidersCard() {
         <div className="text-[10px] uppercase tracking-wider text-text-faint">Add endpoint</div>
         <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
           placeholder="id (e.g. voska)" value={draft.id}
-          onChange={(e) => setDraft({ ...draft, id: e.target.value })} />
+          onChange={(e) => setDraft((d) => ({ ...d, id: e.target.value }))} />
         <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
           placeholder="name (e.g. VoskaAI)" value={draft.name}
-          onChange={(e) => setDraft({ ...draft, name: e.target.value })} />
+          onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))} />
         <input className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
           placeholder="baseURL (https://api.voska.org/v1)" value={draft.baseURL}
-          onChange={(e) => setDraft({ ...draft, baseURL: e.target.value })} />
+          onChange={(e) => setDraft((d) => ({ ...d, baseURL: e.target.value }))} />
         <input type="password" className="w-full bg-bg-soft border border-border px-2 py-1 text-xs rounded"
           placeholder="API key" value={draft.apiKey}
-          onChange={(e) => setDraft({ ...draft, apiKey: e.target.value })} />
+          onChange={(e) => setDraft((d) => ({ ...d, apiKey: e.target.value }))} />
         <button
           onClick={addEndpoint}
-          disabled={!draft.id.trim() || !draft.baseURL.trim()}
+          disabled={!draft.id.trim() || !draft.baseURL.trim() || busy !== null}
           className="px-3 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
         >
           Add

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -14,7 +14,16 @@ export function ProvidersCard() {
   const [globalError, setGlobalError] = useState<string | null>(null);
 
   const load = useCallback(() => {
-    window.api.opencodeGetProviders().then(setEndpoints).catch(() => setEndpoints([]));
+    window.api
+      .opencodeGetProviders()
+      .then((eps) => { setEndpoints(eps); setGlobalError(null); })
+      .catch((e) => {
+        // Don't collapse a failure into a deceptively-empty list: surface it.
+        // main translates the two cases into clear messages (unparseable config
+        // vs box unreachable); show whichever we got.
+        setEndpoints([]);
+        setGlobalError(e instanceof Error ? e.message : String(e));
+      });
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -101,10 +110,22 @@ export function ProvidersCard() {
     }
   }, [busy, load]);
 
+  const [restarting, setRestarting] = useState(false);
   const applyRestart = useCallback(async () => {
-    await window.api.opencodeRestart();
-    setRestartNeeded(false);
-  }, []);
+    if (restarting) return;
+    setRestarting(true);
+    setGlobalError(null);
+    try {
+      await window.api.opencodeRestart();
+      setRestartNeeded(false);
+    } catch (e) {
+      // A restart that killed the session but failed to bring opencode back is
+      // the worst-perceived outcome — never let it fail silently.
+      setGlobalError(`Restart failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRestarting(false);
+    }
+  }, [restarting]);
 
   return (
     <div className="space-y-2 pt-2 border-t border-border">
@@ -186,12 +207,12 @@ export function ProvidersCard() {
           <span className="flex-1 text-text-muted">
             Restart opencode now to apply? (interrupts active sessions)
           </span>
-          <button onClick={applyRestart}
-            className="px-2 py-1 bg-accent/20 border border-accent rounded text-text">
-            Apply Now
+          <button onClick={applyRestart} disabled={restarting}
+            className="px-2 py-1 bg-accent/20 border border-accent rounded text-text disabled:opacity-40">
+            {restarting ? "Restarting…" : "Apply Now"}
           </button>
-          <button onClick={() => setRestartNeeded(false)}
-            className="px-2 py-1 border border-border rounded text-text-muted">
+          <button onClick={() => setRestartNeeded(false)} disabled={restarting}
+            className="px-2 py-1 border border-border rounded text-text-muted disabled:opacity-40">
             Apply Later
           </button>
         </div>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useStore } from "./store";
+import { ProvidersCard } from "./ProvidersCard";
 import type {
   BootstrapResult,
   OpencodeModel,
@@ -607,6 +608,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
             </button>
           </div>
         </div>
+
+        <ProvidersCard />
 
         <div className="text-xs text-text-faint">
           Authentication uses your system ssh client (and ssh-agent / ~/.ssh/config). Make sure

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -472,6 +472,10 @@ export const httpApi: Api = {
 
   // -- model picker --
   opencodeModels: () => rpc(IPC.opencodeModels),
+  opencodeGetProviders: () => rpc(IPC.opencodeGetProviders),
+  opencodeSetProviders: (ops) => rpc(IPC.opencodeSetProviders, ops),
+  opencodeDiscoverModels: (baseURL, apiKey) => rpc(IPC.opencodeDiscoverModels, baseURL, apiKey),
+  opencodeRestart: () => rpc(IPC.opencodeRestart),
   opencodeDefaultModel: () => rpc(IPC.opencodeDefaultModel),
   opencodeVcsBranch: (directory) => rpc(IPC.opencodeVcsBranch, directory),
 

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -429,6 +429,10 @@ export const httpApi: Api = {
   opencodeMessages: (sessionId) => rpc(IPC.opencodeMessages, sessionId),
   opencodeMessagesCached: (sessionId) =>
     rpc(IPC.opencodeMessagesCached, sessionId),
+  opencodeMessagesReconcile: (sessionId) =>
+    rpc(IPC.opencodeMessagesReconcile, sessionId),
+  opencodeMessage: (sessionId, messageId) =>
+    rpc(IPC.opencodeMessage, sessionId, messageId),
   opencodeOpenStream: (sessionId) => rpc(IPC.opencodeOpenStream, sessionId),
   opencodeCloseStream: (sessionId) => rpc(IPC.opencodeCloseStream, sessionId),
   onOpencodeEvent: (cb) => on<OpencodeEvent>("opencode", cb),

--- a/src/renderer/mobile/MobileSettings.tsx
+++ b/src/renderer/mobile/MobileSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useStore } from "../store";
+import { ProvidersCard } from "../ProvidersCard";
 import type { OpencodeModel } from "../../shared/types";
 import {
   isPushSupported,
@@ -322,6 +323,8 @@ export function MobileSettings({ onClose }: Props) {
             per-session in the chat composer.
           </div>
         </section>
+
+        <ProvidersCard />
 
         {/* Cache TTL — two buttons, not a select, to match desktop affordance. */}
         <section className="space-y-2 pt-1 border-t border-border">

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -184,6 +184,36 @@ export async function listMessages(sessionId) {
   return res.json();
 }
 
+/** Fetch a single message by id (GET /session/{id}/message/{messageID}).
+ *  Returns null on miss/error so the caller can fall back to a full refetch.
+ *  @param {string} sessionId
+ *  @param {string} messageId
+ */
+export async function getMessage(sessionId, messageId) {
+  try {
+    const url = `/session/${encodeURIComponent(sessionId)}/message/${encodeURIComponent(messageId)}`;
+    const res = await fetch(apiUrl(url));
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Reconcile a session's transcript.
+ *
+ *  The desktop main process keeps a per-session transcript cache and does a
+ *  fast tail-merge here. The mobile/web server is a stateless relay with no
+ *  such cache to merge against, so reconcile == a full pull. Mobile thus keeps
+ *  its current behavior (no regression); the incremental win is desktop-only,
+ *  where the cache exists. Kept as a distinct entry point so the renderer can
+ *  call one API on both platforms.
+ *  @param {string} sessionId
+ */
+export async function reconcileMessages(sessionId) {
+  return listMessages(sessionId);
+}
+
 /**
  * Send a user message (prompt_async — returns 204 immediately; response
  * streams via SSE). Model is per-prompt; omit to use opencode's default.

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -222,6 +222,19 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     // preload: ipcRenderer.invoke(IPC.opencodeModels)  → no args
     "opencode:models": () => oc.listModels(),
 
+    // Provider management stubs — editing is desktop-only for v1.
+    "opencode:get-providers": () => [],
+    "opencode:set-providers": () => ({
+      ok: false,
+      error: "Provider editing is available on the desktop app only.",
+    }),
+    "opencode:discover-models": () => ({
+      ok: false,
+      error: "unreachable",
+      detail: "Provider discovery is available on the desktop app only.",
+    }),
+    "opencode:restart": () => undefined,
+
     // preload: ipcRenderer.invoke(IPC.opencodeDefaultModel)  → no args
     "opencode:default-model": () => oc.getDefaultModel(),
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -181,6 +181,15 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     // → args[0] = sessionId (string)
     "opencode:messages": (sessionId) => oc.listMessages(sessionId),
 
+    // Reconcile == full pull on the server (no transcript cache to merge
+    // against; the tail-merge win is desktop-only). Same renderer API on both.
+    "opencode:messages-reconcile": (sessionId) =>
+      oc.reconcileMessages(sessionId),
+
+    // Single-message fetch for live-turn splice (returns null on miss).
+    "opencode:message": (sessionId, messageId) =>
+      oc.getMessage(sessionId, messageId),
+
     // preload: ipcRenderer.invoke(IPC.opencodePrompt, { sessionId, text, model, attachments, mentions })
     // → args[0] = that object; opencode.mjs sendPrompt expects the same shape
     "opencode:prompt": (input) => oc.sendPrompt(input),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -284,6 +284,17 @@ export const IPC = {
   // renderer to paint the chat panel instantly while the slow fresh fetch
   // runs in the background.
   opencodeMessagesCached: "opencode:messages-cached",
+  // Fetch a single message by id (GET /session/{id}/message/{messageID}, ~20–80ms).
+  // Used to splice a finalized/changed message into the renderer's transcript
+  // during a live turn instead of re-pulling the whole (up to 3 MB) transcript.
+  // Returns null on miss/error so the caller can fall back to a full refetch.
+  opencodeMessage: "opencode:message",
+  // Reconcile a session's transcript against the renderer's known message ids
+  // by fetching only the recent tail (GET .../message?limit=N) and merging it
+  // into the cached array. Returns the merged full transcript. Falls back to a
+  // full pull when the tail doesn't overlap the cache (a gap), so history is
+  // never truncated. Replaces the full refetch on session-switch/reconnect.
+  opencodeMessagesReconcile: "opencode:messages-reconcile",
   // Live SSE stream from opencode, forwarded raw to the renderer. Renderer
   // filters by sessionID in the event payload.
   opencodeEvent: "opencode:event",
@@ -313,6 +324,11 @@ export const IPC = {
   // Model picker: list available models on the remote opencode server (with
   // provider secrets stripped before forwarding).
   opencodeModels: "opencode:models",
+  // Provider management: list/set custom providers + discover models.
+  opencodeGetProviders: "opencode:get-providers",
+  opencodeSetProviders: "opencode:set-providers",
+  opencodeDiscoverModels: "opencode:discover-models",
+  opencodeRestart: "opencode:restart",
   // What opencode would use if prompt_async were called without a model.
   opencodeDefaultModel: "opencode:default-model",
   // Current VCS branch for a working directory. SSE `vcs.branch.updated`
@@ -581,6 +597,31 @@ export type OpencodeAgent = {
   mode?: string;          // "primary" | "subagent"
   native?: boolean;
   builtIn?: boolean;
+};
+
+// A custom provider entry as seen by the renderer (API key value is never
+// forwarded — only whether one is set).
+export type ProviderEndpoint = {
+  id: string;            // opencode provider id, e.g. "voska"
+  name: string;          // display name, e.g. "VoskaAI"
+  baseURL: string;       // e.g. "https://api.voska.org/v1"
+  hasApiKey: boolean;    // true if an apiKey is set; the value never leaves main
+  enabledModels: string[]; // model ids present in this provider's opencode `models` map
+};
+
+// Result of probing a provider's baseURL/key for available models.
+export type DiscoverResult =
+  | { ok: true; models: { id: string }[] }
+  | { ok: false; error: "unreachable" | "unauthorized" | "bad_response"; detail?: string };
+
+// Input the renderer sends to set/replace a single provider. apiKey is optional:
+// omitted/undefined means "keep the existing key"; empty string means "no key".
+export type ProviderInput = {
+  id: string;
+  name: string;
+  baseURL: string;
+  apiKey?: string;
+  enabledModels: string[];
 };
 
 // Trimmed view of an opencode model from GET /api/model. The wire format


### PR DESCRIPTION
## Provider management in bui

Adds a **Providers** section to bui Settings (desktop + mobile) to manage OpenAI-compatible model endpoints without SSHing to the box and hand-editing `opencode.jsonc`.

### What it does
- **Add / remove** OpenAI-compatible endpoints (name, baseURL, API key)
- **Refresh discovery** — queries the endpoint's `/v1/models` from the box and lists every model it returns
- **Toggle enabled models** — checked models get written into that provider's `models` map in `opencode.jsonc`, so they appear in the model picker
- **Prompt-before-restart** — config writes don't auto-restart opencode; you get Apply Now / Apply Later

### Design
`opencode.jsonc` on the box stays the single source of truth (no second store). The model picker is unchanged — it keeps reading opencode's `/provider`. Config writes reuse the tested `buildRemoteConfigWriteCmd` heredoc writer and mutate **only** the `provider` key, so the auth plugin / `model` / `skills` are preserved byte-for-byte.

Provider *editing* is desktop-only for v1 (the mobile server talks to opencode directly, not over SSH); the mobile picker still shows whatever opencode serves.

### Architecture
- `src/main/providers.ts` — discovery (`curl /models` on the box) + read-merge-write of the `provider` key (pure helpers unit-tested)
- `src/main/opencode.ts` — `restartOpencode` (kill `bui-opencode` tmux session → `ensureRunning` respawns)
- IPC: `opencode:get-providers` / `set-providers` / `discover-models` / `restart` wired through main → preload → renderer (+ desktop-only RPC stubs for mobile)
- `src/renderer/ProvidersCard.tsx` — shared UI card rendered in both Settings surfaces

### Notable fix
`readRemoteConfig` originally used a naive `//`-to-EOL comment strip that ate the `//` inside `https://...` URLs (`$schema`, provider `baseURL`s), making `JSON.parse` throw on a valid config → empty provider list + every save failing. Fixed by reusing `setup.ts`'s string-literal-aware `stripLineComments` + a regression test. **The pre-existing skill-URLs block in `index.ts` has the same latent bug — worth a follow-up.**

### Verification
- `tsc --noEmit` clean, **444 tests pass**, production build clean (no warnings)
- **Live E2E against the box:** discovery → enabled `ornith` on voska via the real save path → restarted opencode → confirmed `voska/ornith` now served in opencode's `/provider`. Config integrity (plugin/model) preserved throughout.

### Note
This branch also includes one pre-existing WIP commit (`wip: pre-existing message reconcile + transcript changes`, 281 lines) that predated this feature — unrelated to provider management, bundled here per author request.

🧙 Built with [WOZCODE](https://wozcode.com)
