### PR TITLE
BET-49-T3: Onboarding shell — full-screen flow, gating, skip

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,9 @@ import { Sidebar, type SidebarHandle } from "./Sidebar";
 import { Terminal } from "./Terminal";
 import { ChatPanel } from "./ChatPanel";
 import { Settings } from "./Settings";
+import { Onboarding } from "./Onboarding";
 import { useStore, flatSessions } from "./store";
+import { resolveTransportMode } from "../shared/transport.mjs";
 
 export function App() {
   const {
@@ -16,7 +18,18 @@ export function App() {
     setActive,
     refresh,
     applyStatusBatch,
+    onboardingForced,
+    finishOnboarding,
+    configSnapshot,
   } = useStore();
+
+  // Entry gating: a fresh config (no host, no boxToken, not skipped) resolves
+  // to "onboarding" → show the full-screen flow instead of the normal shell.
+  // "Run setup again" (Settings) sets onboardingForced to re-show it even for
+  // an already-paired/host config. SSH-mode configs (host set) NEVER onboard.
+  // Gate on `loaded` so we never flash onboarding before config arrives.
+  const showOnboarding =
+    loaded && (onboardingForced || resolveTransportMode(configSnapshot()) === "onboarding");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const sidebarRef = useRef<SidebarHandle>(null);
 
@@ -247,9 +260,13 @@ export function App() {
     };
   }, []);
 
+  // Auto-open Settings for a legacy SSH config that's missing its host — but
+  // NOT while onboarding is showing (the flow owns the screen) and NOT for a
+  // paired HTTP-mode config (boxToken set, host intentionally empty).
   useEffect(() => {
-    if (loaded && !host) setSettingsOpen(true);
-  }, [loaded, host]);
+    if (loaded && !host && !showOnboarding && resolveTransportMode(configSnapshot()) === "ssh")
+      setSettingsOpen(true);
+  }, [loaded, host, showOnboarding, configSnapshot]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -380,6 +397,13 @@ export function App() {
     if (user && activeCwdRaw === `/home/${user}`) return "~";
     return activeCwdRaw;
   })();
+
+  // Full-screen onboarding replaces the entire shell (no sidebar/header/footer).
+  // finishOnboarding clears the force flag + re-reads config → normal shell,
+  // no app restart.
+  if (showOnboarding) {
+    return <Onboarding onDone={() => void finishOnboarding()} />;
+  }
 
   return (
     <div className="h-full w-full flex bg-bg text-text">

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -1,0 +1,316 @@
+import { useState } from "react";
+import {
+  ONBOARDING_STEPS,
+  STEP_LABELS,
+  LAST_STEP,
+  canGoBack,
+  nextPosition,
+  prevPosition,
+  resolveInitialStep,
+  type OnboardingPosition,
+  type OnboardingStep,
+} from "./onboardingUtils";
+import { useStore } from "./store";
+
+// Onboarding.tsx — full-screen M6.2 onboarding shell (BET-49-T3).
+//
+// Owns: the full-screen container (no sidebar / header / footer), the progress
+// rail (numbered dots + connecting lines, per docs/onboarding/mockup.html),
+// fade+slide step transitions, back navigation on steps 2–4, the "Skip setup"
+// escape hatch, and the terminal success screen.
+//
+// Does NOT own the per-step bodies:
+//   - Step 1 (Pair)          → BET-49-T2
+//   - Steps 2–3 (Providers/Model) → BET-49-T4
+//   - Step 4 (First project) → BET-49-T5
+// Those land as their own components mounted into the `renderStepBody` slots
+// below; until then each slot shows a labelled placeholder so the shell,
+// navigation, gating, resume, and skip are all reviewable/testable on their
+// own. The step model + resume math live in onboardingUtils.ts (pure, tested).
+//
+// Props:
+//   onDone — called when onboarding completes (success screen "Open bui") OR is
+//            skipped. The parent (App.tsx) re-reads config and drops back to the
+//            normal shell WITHOUT an app restart.
+
+const ACCENT = "#7c9cff"; // matches the app's Tailwind `accent` token (see tailwind.config)
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function ArrowRight() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-4 h-4"
+    >
+      <path d="M5 12h14" />
+      <path d="m12 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+function ArrowLeft() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-4 h-4"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+// One progress dot + (optionally) the connector leading into it.
+function ProgressRail({ current }: { current: OnboardingPosition }) {
+  // On the success screen every numbered step reads as completed.
+  const activeIdx = current === "success" ? LAST_STEP + 1 : current;
+  return (
+    <div className="flex flex-col items-center">
+      <div className="flex items-center justify-center">
+        {ONBOARDING_STEPS.map((step, i) => {
+          const state: "completed" | "active" | "inactive" =
+            step < activeIdx ? "completed" : step === activeIdx ? "active" : "inactive";
+          return (
+            <div key={step} className="flex items-center">
+              {i > 0 && (
+                <div
+                  className="h-0.5 w-12 sm:w-16 transition-colors"
+                  style={{ background: step <= activeIdx ? ACCENT : "#262932" }}
+                />
+              )}
+              <div
+                className="w-8 h-8 rounded-full flex items-center justify-center text-[13px] font-semibold transition-all shrink-0"
+                style={
+                  state === "inactive"
+                    ? { background: "#1b1e25", color: "#6b7280", border: "1.5px solid #262932" }
+                    : state === "active"
+                      ? {
+                          background: ACCENT,
+                          color: "#0e0f12",
+                          border: `1.5px solid ${ACCENT}`,
+                          boxShadow: `0 0 0 4px rgba(124,156,255,0.15)`,
+                        }
+                      : { background: ACCENT, color: "#0e0f12", border: `1.5px solid ${ACCENT}` }
+                }
+              >
+                {state === "completed" ? <CheckIcon className="w-3.5 h-3.5" /> : step}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex justify-center gap-4 mt-3">
+        {ONBOARDING_STEPS.map((step) => {
+          const isActive = step === activeIdx;
+          return (
+            <div
+              key={step}
+              className="text-xs text-center min-w-[60px]"
+              style={{ color: isActive ? "#9aa0aa" : "#6b7280", fontWeight: isActive ? 500 : 400 }}
+            >
+              {STEP_LABELS[step]}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Placeholder body for a not-yet-implemented step. Removed as T2/T4/T5 land.
+function StepPlaceholder({
+  title,
+  subtitle,
+  note,
+}: {
+  title: string;
+  subtitle: string;
+  note: string;
+}) {
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight text-text mb-1.5">{title}</h2>
+      <p className="text-sm text-text-muted leading-relaxed mb-8 max-w-md">{subtitle}</p>
+      <div className="rounded-lg border border-dashed border-border bg-bg-soft p-6 text-sm text-text-faint">
+        {note}
+      </div>
+    </div>
+  );
+}
+
+function stepBody(step: OnboardingStep) {
+  switch (step) {
+    case 1:
+      return (
+        <StepPlaceholder
+          title="Connect to your server"
+          subtitle="Enter the 6-digit pairing code shown on your VPS terminal to establish a secure connection."
+          note="Pairing (Step 1) is delivered by BET-49-T2 and mounts here."
+        />
+      );
+    case 2:
+      return (
+        <StepPlaceholder
+          title="Choose your providers"
+          subtitle="Select the AI providers you want to use. You can add more later."
+          note="Provider selection (Step 2) is delivered by BET-49-T4 and mounts here."
+        />
+      );
+    case 3:
+      return (
+        <StepPlaceholder
+          title="Pick your default model"
+          subtitle="This model will power your new chat sessions. You can switch anytime."
+          note="Model picker (Step 3) is delivered by BET-49-T4 and mounts here."
+        />
+      );
+    case 4:
+      return (
+        <StepPlaceholder
+          title="Create your first project"
+          subtitle="Start a new project to begin chatting with your AI."
+          note="First-project creation (Step 4) is delivered by BET-49-T5 and mounts here."
+        />
+      );
+  }
+}
+
+export function Onboarding({ onDone }: { onDone: () => void }) {
+  // Derive the resume point once from the current config so a quit-mid-flow
+  // reopens at the first incomplete step. Read straight from the store's
+  // config snapshot (App gates on `loaded`, so config is present by mount).
+  const [pos, setPos] = useState<OnboardingPosition>(() =>
+    resolveInitialStep(useStore.getState().configSnapshot()),
+  );
+
+  const goNext = () => setPos((p) => nextPosition(p));
+  const goBack = () => setPos((p) => prevPosition(p));
+
+  // Skip: persist onboardingSkipped so the flow doesn't re-trigger on every
+  // launch of an otherwise-empty config, then hand control back to the shell.
+  const skip = async () => {
+    await useStore.getState().skipOnboarding();
+    onDone();
+  };
+
+  const isSuccess = pos === "success";
+
+  return (
+    <div className="fixed inset-0 z-50 bg-bg text-text flex items-center justify-center overflow-y-auto">
+      <div className="w-full max-w-[720px] px-6 py-8">
+        {/* Header: logo + progress rail (hidden on the success screen). */}
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center gap-2.5 mb-8">
+            <div
+              className="w-9 h-9 rounded flex items-center justify-center"
+              style={{ background: `linear-gradient(135deg, ${ACCENT}, #a78bfa)` }}
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#0e0f12"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="w-5 h-5"
+              >
+                <path d="M12 2L2 7l10 5 10-5-10-5z" />
+                <path d="M2 17l10 5 10-5" />
+                <path d="M2 12l10 5 10-5" />
+              </svg>
+            </div>
+            <span className="text-xl font-semibold tracking-tight">bui</span>
+          </div>
+          {!isSuccess && <ProgressRail current={pos} />}
+        </div>
+
+        {/* Step body. `key` on the wrapper restarts the fade+slide animation on
+            every position change. */}
+        <div className="relative overflow-hidden">
+          <div key={String(pos)} className="onboarding-step-enter">
+            {isSuccess ? (
+              <div className="text-center py-5">
+                <div
+                  className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-5"
+                  style={{ background: "rgba(34,197,94,0.1)" }}
+                >
+                  <CheckIcon className="w-7 h-7 text-green-400" />
+                </div>
+                <h2 className="text-2xl font-semibold mb-2">You're all set!</h2>
+                <p className="text-sm text-text-muted leading-relaxed max-w-sm mx-auto mb-7">
+                  Your server is connected, providers are configured, and your first project is
+                  ready. Start chatting with your AI assistant.
+                </p>
+                <button
+                  onClick={onDone}
+                  className="inline-flex items-center gap-2 px-6 py-2.5 rounded-md text-sm font-medium text-bg"
+                  style={{ background: ACCENT }}
+                >
+                  Open bui
+                  <ArrowRight />
+                </button>
+              </div>
+            ) : (
+              stepBody(pos)
+            )}
+          </div>
+        </div>
+
+        {/* Footer nav (hidden on the success screen — it has its own button). */}
+        {!isSuccess && (
+          <div className="flex items-center justify-between gap-3 mt-8">
+            {canGoBack(pos) ? (
+              <button
+                onClick={goBack}
+                className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
+              >
+                <ArrowLeft />
+                Back
+              </button>
+            ) : (
+              // Step 1: the back slot holds "Skip setup" instead of Back.
+              <button
+                onClick={skip}
+                className="px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
+              >
+                Skip setup
+              </button>
+            )}
+            <button
+              onClick={goNext}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg"
+              style={{ background: ACCENT }}
+            >
+              {pos === LAST_STEP ? "Create project" : pos === 1 ? "Connect" : "Continue"}
+              <ArrowRight />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -667,6 +667,24 @@ export function Settings({ onClose }: { onClose: () => void }) {
           )}
         </div>
 
+        {/* Re-run the full-screen onboarding flow. Clears the persisted
+            onboardingSkipped flag and forces the shell open (BET-49-T3). Full
+            Settings redesign lands in M6.3; this is the minimal placement. */}
+        <div className="flex items-center justify-between border-t border-border pt-3">
+          <div className="text-xs text-text-faint">
+            Re-run the guided setup (pairing, providers, first project).
+          </div>
+          <button
+            onClick={() => {
+              void useStore.getState().relaunchOnboarding();
+              onClose();
+            }}
+            className="text-xs px-3 py-1.5 rounded bg-bg-soft border border-border text-text-muted hover:text-text shrink-0"
+          >
+            Run setup again
+          </button>
+        </div>
+
         {saveError && (
           <div className="text-xs text-red-400 text-right">
             Couldn't save: {saveError}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -38,6 +38,16 @@ html, body, #root {
   animation: blink-cursor 1s step-start infinite;
 }
 
+/* Onboarding step transition — fade + slide up, keyed remount per step
+   (Onboarding.tsx). Mirrors the mockup's fadeSlideIn. */
+@keyframes onboardingFadeSlideIn {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.onboarding-step-enter {
+  animation: onboardingFadeSlideIn 350ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/src/renderer/onboardingUtils.test.ts
+++ b/src/renderer/onboardingUtils.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  ONBOARDING_STEPS,
+  STEP_LABELS,
+  FIRST_STEP,
+  LAST_STEP,
+  canGoBack,
+  nextPosition,
+  prevPosition,
+  resolveInitialStep,
+} from "./onboardingUtils";
+import type { AppConfig } from "../shared/types";
+
+const HEX32 = "0123456789abcdef0123456789abcdef";
+
+describe("onboarding step model", () => {
+  it("has four ordered numbered steps 1..4", () => {
+    expect([...ONBOARDING_STEPS]).toEqual([1, 2, 3, 4]);
+    expect(FIRST_STEP).toBe(1);
+    expect(LAST_STEP).toBe(4);
+  });
+
+  it("labels every numbered step", () => {
+    for (const s of ONBOARDING_STEPS) {
+      expect(typeof STEP_LABELS[s]).toBe("string");
+      expect(STEP_LABELS[s].length).toBeGreaterThan(0);
+    }
+    expect(STEP_LABELS[1]).toBe("Connect");
+    expect(STEP_LABELS[4]).toBe("Project");
+  });
+});
+
+describe("canGoBack", () => {
+  it("is false on step 1 and on success", () => {
+    expect(canGoBack(1)).toBe(false);
+    expect(canGoBack("success")).toBe(false);
+  });
+  it("is true on steps 2, 3, 4", () => {
+    expect(canGoBack(2)).toBe(true);
+    expect(canGoBack(3)).toBe(true);
+    expect(canGoBack(4)).toBe(true);
+  });
+});
+
+describe("nextPosition", () => {
+  it("advances numbered steps", () => {
+    expect(nextPosition(1)).toBe(2);
+    expect(nextPosition(2)).toBe(3);
+    expect(nextPosition(3)).toBe(4);
+  });
+  it("step 4 → success", () => {
+    expect(nextPosition(4)).toBe("success");
+  });
+  it("success is terminal", () => {
+    expect(nextPosition("success")).toBe("success");
+  });
+});
+
+describe("prevPosition", () => {
+  it("goes back one numbered step", () => {
+    expect(prevPosition(2)).toBe(1);
+    expect(prevPosition(3)).toBe(2);
+    expect(prevPosition(4)).toBe(3);
+  });
+  it("clamps at step 1", () => {
+    expect(prevPosition(1)).toBe(1);
+  });
+  it("is a no-op from success", () => {
+    expect(prevPosition("success")).toBe("success");
+  });
+});
+
+describe("resolveInitialStep", () => {
+  it("fresh/empty/null config → step 1", () => {
+    expect(resolveInitialStep(null)).toBe(1);
+    expect(resolveInitialStep(undefined)).toBe(1);
+    expect(resolveInitialStep({})).toBe(1);
+    expect(resolveInitialStep({ projects: [] } as Partial<AppConfig>)).toBe(1);
+  });
+
+  it("malformed boxToken is treated as unpaired → step 1", () => {
+    expect(resolveInitialStep({ boxToken: "" })).toBe(1);
+    expect(resolveInitialStep({ boxToken: "nothex" })).toBe(1);
+    expect(resolveInitialStep({ boxToken: HEX32.toUpperCase() })).toBe(1);
+    expect(resolveInitialStep({ boxToken: HEX32.slice(0, 31) })).toBe(1);
+  });
+
+  it("paired but no default model → step 2 (providers)", () => {
+    expect(resolveInitialStep({ boxToken: HEX32 })).toBe(2);
+    expect(resolveInitialStep({ boxToken: HEX32, projects: [] })).toBe(2);
+  });
+
+  it("a defaultModel with no modelID does not count as chosen", () => {
+    expect(
+      resolveInitialStep({
+        boxToken: HEX32,
+        defaultModel: { providerID: "anthropic", modelID: "" },
+      }),
+    ).toBe(2);
+  });
+
+  it("paired + model but no projects → step 4 (first project)", () => {
+    expect(
+      resolveInitialStep({
+        boxToken: HEX32,
+        defaultModel: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      }),
+    ).toBe(4);
+  });
+
+  it("paired + model + a project → still step 4 (never auto-jumps to success)", () => {
+    expect(
+      resolveInitialStep({
+        boxToken: HEX32,
+        defaultModel: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+        projects: [{ tmuxSession: "demo", defaultCwd: "~/projects/demo" }],
+      }),
+    ).toBe(4);
+  });
+});

--- a/src/renderer/onboardingUtils.ts
+++ b/src/renderer/onboardingUtils.ts
@@ -1,0 +1,89 @@
+// onboardingUtils.ts — pure step model + resume logic for the M6.2 desktop
+// onboarding flow (BET-49-T3). Framework-free so it's unit-testable in vitest
+// (see onboardingUtils.test.ts), exactly like chatUtils.ts. Onboarding.tsx owns
+// all the React/DOM; this module owns the "which step are we on" decisions.
+//
+// The flow has four numbered steps plus a terminal success screen, matching
+// docs/onboarding/mockup.html:
+//
+//   1 Pair      → enter the 6-digit pairing code (persists boxToken/boxId/serverUrl)
+//   2 Providers → pick AI providers                (BET-49-T4)
+//   3 Model     → pick the default model           (BET-49-T4, persists defaultModel)
+//   4 Project   → create the first project         (BET-49-T5)
+//   success     → "You're all set!" → Open bui
+//
+// T2/T4/T5 land the per-step UIs; T3 owns this shell + the resume math so a
+// user who quits mid-flow reopens at the first INCOMPLETE step instead of
+// always restarting at step 1.
+
+import type { AppConfig } from "../shared/types";
+
+// The ordered numbered steps. `success` is the terminal screen after step 4,
+// kept out of this tuple so it never participates in progress-dot math.
+export const ONBOARDING_STEPS = [1, 2, 3, 4] as const;
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+// Full navigable position: a numbered step OR the terminal success screen.
+export type OnboardingPosition = OnboardingStep | "success";
+
+export const FIRST_STEP: OnboardingStep = 1;
+export const LAST_STEP: OnboardingStep = 4;
+
+// Human labels for the progress rail (mockup: Connect / Providers / Model / Project).
+export const STEP_LABELS: Record<OnboardingStep, string> = {
+  1: "Connect",
+  2: "Providers",
+  3: "Model",
+  4: "Project",
+};
+
+// Back navigation is available on steps 2–4 only (per mockup — step 1 has
+// "Skip setup" in the back slot instead, and success has no back).
+export function canGoBack(pos: OnboardingPosition): boolean {
+  return pos === 2 || pos === 3 || pos === 4;
+}
+
+// The next position after `pos`. Step 4 → success; success stays success.
+export function nextPosition(pos: OnboardingPosition): OnboardingPosition {
+  if (pos === "success") return "success";
+  if (pos >= LAST_STEP) return "success";
+  return (pos + 1) as OnboardingStep;
+}
+
+// The previous position. Only meaningful when canGoBack(pos) is true; clamps
+// at the first step and is a no-op from step 1 / success.
+export function prevPosition(pos: OnboardingPosition): OnboardingPosition {
+  if (pos === "success" || pos <= FIRST_STEP) return pos;
+  return (pos - 1) as OnboardingStep;
+}
+
+// Resume: derive the first INCOMPLETE step from persisted config, so quitting
+// mid-flow reopens where the user left off rather than at step 1. The rule
+// mirrors what each step persists:
+//
+//   - No valid boxToken            → step 1 (still needs to pair)
+//   - Paired but no defaultModel   → step 2 (providers → model not chosen yet)
+//   - Model chosen but no projects → step 4 (needs a first project)
+//   - Everything present           → step 4 (last actionable step; the shell
+//                                     shows success only after an explicit
+//                                     "Create project" — we never auto-skip
+//                                     someone straight to the success screen on
+//                                     launch, since that would strand a fully
+//                                     configured user with nothing to do)
+//
+// We intentionally resume to step 2 (Providers) rather than step 3 when paired
+// but model-less: the user hasn't chosen providers yet in that state, and step
+// 2 → 3 is a single Continue. `boxToken` validity uses the same 32-hex gate as
+// transport-mode detection (resolveTransportMode), so a malformed token doesn't
+// falsely advance the resume point.
+export function resolveInitialStep(
+  config: Partial<AppConfig> | null | undefined,
+): OnboardingStep {
+  const cfg = config && typeof config === "object" ? config : {};
+  const paired = typeof cfg.boxToken === "string" && /^[0-9a-f]{32}$/.test(cfg.boxToken);
+  if (!paired) return 1;
+  const hasModel = !!cfg.defaultModel && !!cfg.defaultModel.modelID;
+  if (!hasModel) return 2;
+  const hasProject = Array.isArray(cfg.projects) && cfg.projects.length > 0;
+  if (!hasProject) return 4;
+  return 4;
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -52,6 +52,20 @@ type State = {
   host: string;
   user?: string;
   identityFile?: string;
+  // ----- HTTP/relay transport + onboarding (M6, BET-49) -----
+  // Mirrored from AppConfig so App.tsx can resolve the transport mode
+  // (resolveTransportMode) and the onboarding shell can resume. `boxToken`
+  // presence flips transport to HTTP; `onboardingSkipped` suppresses the
+  // onboarding flow on an otherwise-empty config.
+  serverUrl: string;
+  boxId: string;
+  boxToken: string;
+  onboardingSkipped: boolean;
+  // True when the user explicitly re-launched onboarding from Settings
+  // ("Run setup again"). This FORCES the onboarding shell even for a config
+  // that would otherwise resolve to "http"/"ssh" mode (e.g. an already-paired
+  // box). Cleared when the flow completes or is skipped. Not persisted.
+  onboardingForced: boolean;
   transportPreference: "auto" | "mosh" | "ssh";
   uploadCleanupHours: number;
   chatAutoAllow: boolean;
@@ -97,9 +111,23 @@ type State = {
   agentFileToast: AgentFileReady | null;
   // ----- derived selectors -----
   activeSession: () => ActiveSession | null;
+  // A minimal AppConfig-shaped snapshot of the onboarding-relevant fields,
+  // for the pure helpers in shared/transport (resolveTransportMode) and
+  // onboardingUtils (resolveInitialStep). Avoids threading the raw config
+  // object through the store just for onboarding.
+  configSnapshot: () => Partial<AppConfig>;
   // ----- mutations -----
   setActive: (projectName: string, windowIndex?: number) => void;
   refresh: () => Promise<void>;
+  // Onboarding lifecycle. `skipOnboarding` persists onboardingSkipped (so the
+  // flow doesn't re-trigger) and clears the forced flag. `relaunchOnboarding`
+  // clears onboardingSkipped and sets the forced flag so App re-renders the
+  // shell ("Run setup again" in Settings). `finishOnboarding` clears the
+  // forced flag + re-reads config so the app drops to the normal shell
+  // without a restart.
+  skipOnboarding: () => Promise<void>;
+  relaunchOnboarding: () => Promise<void>;
+  finishOnboarding: () => Promise<void>;
   applyProjects: (projects: Project[]) => void;
   applyConfig: (c: AppConfig) => void;
   applyStatusBatch: (batch: WindowStatus[]) => void;
@@ -151,6 +179,11 @@ export const useStore = create<State>((set, get) => ({
   host: "",
   user: undefined,
   identityFile: undefined,
+  serverUrl: "",
+  boxId: "",
+  boxToken: "",
+  onboardingSkipped: false,
+  onboardingForced: false,
   transportPreference: "auto",
   uploadCleanupHours: 1,
   chatAutoAllow: false,
@@ -171,6 +204,22 @@ export const useStore = create<State>((set, get) => ({
   status: {},
   screenshotToast: null,
   agentFileToast: null,
+
+  configSnapshot: () => {
+    const s = get();
+    return {
+      host: s.host,
+      serverUrl: s.serverUrl,
+      boxId: s.boxId,
+      boxToken: s.boxToken,
+      onboardingSkipped: s.onboardingSkipped,
+      defaultModel: s.defaultModel ?? undefined,
+      projects: s.projects.map((p) => ({
+        tmuxSession: p.tmuxSession,
+        defaultCwd: p.defaultCwd,
+      })),
+    };
+  },
 
   activeSession: () => {
     const s = get();
@@ -222,12 +271,39 @@ export const useStore = create<State>((set, get) => ({
     }
   },
 
+  skipOnboarding: async () => {
+    set({ onboardingSkipped: true, onboardingForced: false });
+    const next = await window.api.configUpdate({ onboardingSkipped: true });
+    // Reconcile with what main actually saved (error/reject paths).
+    set({ onboardingSkipped: next.onboardingSkipped ?? false });
+  },
+
+  relaunchOnboarding: async () => {
+    // Clear the persisted skip flag and force the shell open, even if the
+    // config would otherwise resolve to http/ssh mode (already paired).
+    set({ onboardingSkipped: false, onboardingForced: true });
+    const next = await window.api.configUpdate({ onboardingSkipped: false });
+    set({ onboardingSkipped: next.onboardingSkipped ?? false });
+  },
+
+  finishOnboarding: async () => {
+    // Drop the force flag and re-read config so the app transitions to the
+    // normal shell without an app restart (picks up boxToken/projects the
+    // per-step components persisted).
+    set({ onboardingForced: false });
+    await get().refresh();
+  },
+
   applyConfig: (c) =>
     set({
       loaded: true,
       host: c.host,
       user: c.user,
       identityFile: c.identityFile,
+      serverUrl: c.serverUrl ?? "",
+      boxId: c.boxId ?? "",
+      boxToken: c.boxToken ?? "",
+      onboardingSkipped: c.onboardingSkipped ?? false,
       transportPreference: c.transport ?? "auto",
       uploadCleanupHours: c.uploadCleanupHours ?? 1,
       chatAutoAllow: c.chatAutoAllow ?? false,


### PR DESCRIPTION
## BET-49-T3: Onboarding shell — full-screen flow, gating, skip

Renderer-only onboarding shell. Hosts the step bodies that land in T2/T4/T5;
this PR owns the shell, entry gating, resume, and skip.

**Base:** `origin/main @ 52e11b4`

### What's here
- **`src/renderer/Onboarding.tsx`** — full-screen container (no sidebar/header/
  footer), progress dots + connectors (completed=check, active=glow), fade+slide
  step transitions, back nav on steps 2–4, "Skip setup" on step 1, success
  screen ("You're all set!" → "Open bui"). Step 1/2/3/4 bodies are labelled
  placeholders that T2 (Pair), T4 (Providers/Model), T5 (First project) mount
  into.
- **`src/renderer/onboardingUtils.ts`** (pure, tested) — step model + `resolveInitialStep`
  resume logic: no boxToken → step 1; paired but no model → step 2; model but no
  project → step 4. 16 unit tests cover every branch incl. malformed tokens.
- **`src/renderer/App.tsx`** — renders `<Onboarding/>` INSTEAD of the shell when
  `resolveTransportMode(config) === "onboarding"` OR the user re-launched setup.
  On completion/skip → `finishOnboarding` re-reads config → normal shell, **no
  app restart**. SSH-mode config (host set) never onboards; the "auto-open
  Settings when host missing" effect is now gated to SSH mode only (a paired
  HTTP-mode config has an empty host by design and must not pop Settings).
- **`src/renderer/store.ts`** — mirrors `boxToken/boxId/serverUrl/onboardingSkipped`
  from AppConfig; `configSnapshot()` selector feeds the pure helpers;
  `skipOnboarding` / `relaunchOnboarding` / `finishOnboarding` lifecycle actions.
- **`src/renderer/Settings.tsx`** — "Run setup again" hook (clears
  `onboardingSkipped`, forces the flow). Minimal placement; full Settings
  redesign is M6.3.
- **`src/renderer/index.css`** — `onboardingFadeSlideIn` keyframe.

### Design notes
- Uses the app's existing Tailwind `accent` token (`#7c9cff`) rather than the
  mockup's raw purple `#6c5ce7`, to stay consistent with the rest of the app
  theme. Structure/animation/labels otherwise follow `docs/onboarding/mockup.html`.
- "Skip" persists `onboardingSkipped:true` → `resolveTransportMode` returns "ssh"
  (empty shell), exactly as T1 documented. "Run setup again" adds a non-persisted
  `onboardingForced` flag so an already-paired ("http") config can re-enter the
  flow.
- Resume never auto-jumps a fully-configured user straight to the success
  screen (that would strand them with nothing to do); it lands on step 4.

### Anti-spaghetti
- Reused T1's `resolveTransportMode` (shared/transport.mjs) for gating — no
  parallel mode logic. `resolveInitialStep` shares the same 32-hex token gate.
- No new provider/config fetch paths; skip/relaunch go through the existing
  `configUpdate` IPC.
- No `.mobile` CSS; mobile entry doesn't import Onboarding/App — mobile build
  verified unaffected (artifacts NOT committed).

### Verification results

**Files changed:** 7 files (4 modified, 3 new) — `App.tsx`, `Settings.tsx`,
`store.ts`, `index.css`, `Onboarding.tsx` (new), `onboardingUtils.ts` (new),
`onboardingUtils.test.ts` (new).

- PR branch (`multica/BET-55-onboarding-shell` @ `3a2f117`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0 — vitest 550 pass / 0 fail (incl. 16 new onboardingUtils
    tests); node:test (server) 226 pass / 0 fail.
  - build: `npm run build` (electron-vite) succeeds, 332 renderer modules.
- **Conclusion:** 0 new failures. Base (`main` @ `52e11b4`) is green on the
  same suites; this PR only adds renderer files + optional AppConfig-mirrored
  store fields, so no base regression is possible.

### E2E smoke (bui-e2e-smoke, real Electron renderer via Playwright, xvfb)
Two-mode launch, driving `~/.config/better-ui/config.json` (backed up/restored):

- **Fresh config** `{host:"", projects:[]}` → onboarding shell renders:
  `onboarding_wrapper=true`, "Connect to your server" copy, progress labels
  (Connect/Providers/Model/Project), "Skip setup" present, **no sidebar**.
  Real renderer errors: 0. ✅
- **SSH-mode config** `{host:"example.test", ...}` → normal shell renders:
  sidebar "Workspace" + `<main>` present, `onboarding_wrapper=false`, no
  onboarding copy. Real renderer errors: 0 (only the expected
  `ssh: Could not resolve hostname example.test` backend-reachability failure,
  which is out of scope — asserts render, not connectivity). ✅

`allOK: true`, exit 0.
