### PR TITLE
feat(onboarding): auth:claim IPC + Step 1 Pair screen (BET-49-T2)

### DIFF
--- a/src/main/auth.test.ts
+++ b/src/main/auth.test.ts
@@ -34,6 +34,27 @@ function stubFetch(res: Response | { throw: true }): {
   return { fetch: fetchImpl, urls, bodies };
 }
 
+// Shared arrange/act/assert for the failure cases: run a claim against the
+// given response stub and assert it produced the expected failure `kind`
+// without persisting. Returns the recorded fetch URLs for callers that also
+// want to assert on request behavior. Extracting this keeps the individual
+// failure cases from each repeating the same ~11-line scaffold.
+async function expectClaimFailure(
+  res: Response | { throw: true },
+  input: { serverUrl: string; code: string },
+  kind: string,
+): Promise<{ urls: string[] }> {
+  const { fetch, urls } = stubFetch(res);
+  const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+  const out = await claimPairing(input, persist, fetch);
+
+  expect(out.ok).toBe(false);
+  if (!out.ok) expect(out.kind).toBe(kind);
+  expect(persist).not.toHaveBeenCalled();
+  return { urls };
+}
+
 describe("claimPairing", () => {
   it("valid code → ok outcome + persists { serverUrl, boxId, boxToken }", async () => {
     const { fetch, urls, bodies } = stubFetch(
@@ -78,82 +99,44 @@ describe("claimPairing", () => {
   });
 
   it("wrong/expired code (403) → wrong_code outcome, does NOT persist", async () => {
-    const { fetch } = stubFetch(fakeResponse(403, { error: "pairing failed" }));
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
+    await expectClaimFailure(
+      fakeResponse(403, { error: "pairing failed" }),
       { serverUrl: "http://box:8787", code: "000000" },
-      persist,
-      fetch,
+      "wrong_code",
     );
-
-    expect(out.ok).toBe(false);
-    if (!out.ok) expect(out.kind).toBe("wrong_code");
-    expect(persist).not.toHaveBeenCalled();
   });
 
   it("rate limited (429) → rate_limited outcome, no persist", async () => {
-    const { fetch } = stubFetch(fakeResponse(429, { error: "slow down" }));
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
+    await expectClaimFailure(
+      fakeResponse(429, { error: "slow down" }),
       { serverUrl: "http://box:8787", code: "847291" },
-      persist,
-      fetch,
+      "rate_limited",
     );
-
-    expect(out.ok).toBe(false);
-    if (!out.ok) expect(out.kind).toBe("rate_limited");
-    expect(persist).not.toHaveBeenCalled();
   });
 
   it("200 with a malformed token → invalid_response, no persist", async () => {
-    const { fetch } = stubFetch(
+    await expectClaimFailure(
       fakeResponse(200, { ok: true, box_token: "nope", box_id: HEX32B }),
-    );
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
       { serverUrl: "http://box:8787", code: "847291" },
-      persist,
-      fetch,
+      "invalid_response",
     );
-
-    expect(out.ok).toBe(false);
-    if (!out.ok) expect(out.kind).toBe("invalid_response");
-    expect(persist).not.toHaveBeenCalled();
   });
 
   it("unreachable server (fetch rejects) → network outcome, no persist", async () => {
-    const { fetch } = stubFetch({ throw: true });
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
+    await expectClaimFailure(
+      { throw: true },
       { serverUrl: "http://nope:9999", code: "847291" },
-      persist,
-      fetch,
+      "network",
     );
-
-    expect(out.ok).toBe(false);
-    if (!out.ok) expect(out.kind).toBe("network");
-    expect(persist).not.toHaveBeenCalled();
   });
 
   it("empty serverUrl → network outcome without ever fetching", async () => {
-    const { fetch, urls } = stubFetch(
+    const { urls } = await expectClaimFailure(
       fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
-    );
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
       { serverUrl: "   ", code: "847291" },
-      persist,
-      fetch,
+      "network",
     );
-
-    expect(out.ok).toBe(false);
-    if (!out.ok) expect(out.kind).toBe("network");
+    // No fetch should have happened for a blank server URL.
     expect(urls).toEqual([]);
-    expect(persist).not.toHaveBeenCalled();
   });
 });

--- a/src/main/auth.test.ts
+++ b/src/main/auth.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from "vitest";
+import { claimPairing } from "./auth.js";
+import type { AppConfig } from "../shared/types.js";
+
+const HEX32 = "0123456789abcdef0123456789abcdef";
+const HEX32B = "fedcba9876543210fedcba9876543210";
+
+// A minimal Response-like stub — claimPairing only reads .status and .json().
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    status,
+    json: async () => {
+      if (body === undefined) throw new Error("no body");
+      return body;
+    },
+  } as unknown as Response;
+}
+
+// Build a fetch stub that records the URL it was called with and returns the
+// given response. Rejects when `throwOn` is set (simulating an unreachable box).
+function stubFetch(res: Response | { throw: true }): {
+  fetch: typeof fetch;
+  urls: string[];
+  bodies: string[];
+} {
+  const urls: string[] = [];
+  const bodies: string[] = [];
+  const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+    urls.push(url);
+    if (init?.body) bodies.push(String(init.body));
+    if ("throw" in res) throw new Error("ECONNREFUSED");
+    return res;
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, urls, bodies };
+}
+
+describe("claimPairing", () => {
+  it("valid code → ok outcome + persists { serverUrl, boxId, boxToken }", async () => {
+    const { fetch, urls, bodies } = stubFetch(
+      fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "http://box:8787", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out).toEqual({ ok: true, boxToken: HEX32, boxId: HEX32B });
+    expect(urls).toEqual(["http://box:8787/auth/claim"]);
+    // POST body carries the pairing_code under the server's expected key.
+    expect(JSON.parse(bodies[0])).toEqual({ pairing_code: "847291" });
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledWith({
+      serverUrl: "http://box:8787",
+      boxId: HEX32B,
+      boxToken: HEX32,
+    });
+  });
+
+  it("trims a trailing slash off serverUrl before the claim + when persisting", async () => {
+    const { fetch, urls } = stubFetch(
+      fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    await claimPairing(
+      { serverUrl: "http://box:8787/", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(urls).toEqual(["http://box:8787/auth/claim"]);
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({ serverUrl: "http://box:8787" }),
+    );
+  });
+
+  it("wrong/expired code (403) → wrong_code outcome, does NOT persist", async () => {
+    const { fetch } = stubFetch(fakeResponse(403, { error: "pairing failed" }));
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "http://box:8787", code: "000000" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("wrong_code");
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("rate limited (429) → rate_limited outcome, no persist", async () => {
+    const { fetch } = stubFetch(fakeResponse(429, { error: "slow down" }));
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "http://box:8787", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("rate_limited");
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("200 with a malformed token → invalid_response, no persist", async () => {
+    const { fetch } = stubFetch(
+      fakeResponse(200, { ok: true, box_token: "nope", box_id: HEX32B }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "http://box:8787", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("invalid_response");
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("unreachable server (fetch rejects) → network outcome, no persist", async () => {
+    const { fetch } = stubFetch({ throw: true });
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "http://nope:9999", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("network");
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("empty serverUrl → network outcome without ever fetching", async () => {
+    const { fetch, urls } = stubFetch(
+      fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "   ", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("network");
+    expect(urls).toEqual([]);
+    expect(persist).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -1,0 +1,78 @@
+// auth.ts (desktop) — the onboarding pairing handshake (BET-49-T2).
+//
+// The desktop onboarding shell's Step 1 (Pair) sends a 6-digit pairing code +
+// the target server URL over the `auth:claim` IPC channel. This module owns the
+// main-process half: POST <serverUrl>/auth/claim, classify the outcome with the
+// SHARED classifier (src/shared/claim.mjs — the same one the mobile client and
+// the pure tests use), and on success persist { serverUrl, boxId, boxToken } to
+// config so resolveTransportMode flips the app into "http" mode on next read.
+//
+// Why main (not the renderer) does the fetch: only main can write config.json.
+// The mobile client authenticates with a localStorage Bearer token instead, so
+// it claims in the renderer (renderer/api/httpApi submitPairingCode). Same wire
+// contract, different persistence — hence the shared classifier keeps the two
+// entry points from drifting.
+
+import { classifyClaimResult, networkFailure } from "../shared/claim.mjs";
+import type { ClaimOutcome } from "../shared/claim.mjs";
+import type { AppConfig, AuthClaimInput } from "../shared/types.js";
+
+/**
+ * Perform a pairing claim and, on success, persist the credentials to config.
+ *
+ * @param input    { serverUrl, code } from the renderer.
+ * @param persist  commit a config patch (main's `commit`); called ONLY on a
+ *                 successful, token-validated claim.
+ * @param fetchImpl  injectable for tests; defaults to the global fetch.
+ * @returns the classified {@link ClaimOutcome}. A wrong/expired code, a rate
+ *          limit, an unreachable server, etc. are all normal `{ ok:false }`
+ *          results — this never throws for an expected auth failure.
+ */
+export async function claimPairing(
+  input: AuthClaimInput,
+  persist: (patch: Partial<AppConfig>) => void,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ClaimOutcome> {
+  const serverUrl = (input?.serverUrl ?? "").trim();
+  const code = input?.code ?? "";
+
+  // An empty / whitespace-only URL can't be fetched — surface it as a network
+  // failure (the UI shows the URL for correction) rather than throwing.
+  if (serverUrl === "") return networkFailure();
+
+  // Trim trailing slashes so "http://box:8787/" and "http://box:8787" behave
+  // identically before appending the claim path.
+  const url = `${serverUrl.replace(/\/+$/, "")}/auth/claim`;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pairing_code: code }),
+    });
+  } catch {
+    // fetch rejected (offline / DNS / TLS / malformed URL) — no HTTP response.
+    return networkFailure();
+  }
+
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* non-JSON body (proxy / HTML error page) — leave null; classify by status */
+  }
+
+  const outcome = classifyClaimResult(res.status, body);
+  if (outcome.ok) {
+    // Single persistence site: serverUrl (where to reach the box) + the two
+    // credentials. Presence of a valid boxToken is what flips transport to
+    // "http" (see src/shared/transport.mjs resolveTransportMode).
+    persist({
+      serverUrl: serverUrl.replace(/\/+$/, ""),
+      boxId: outcome.boxId,
+      boxToken: outcome.boxToken,
+    });
+  }
+  return outcome;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import {
 } from "./pty.js";
 import { info as transportInfo, invalidate as invalidateTransport } from "./transport.js";
 import { probe as setupProbe, bootstrap as setupBootstrap } from "./setup.js";
+import { claimPairing } from "./auth.js";
 import { startStatusPoller, stopStatusPoller } from "./status.js";
 import { noteSessionActivity } from "./transcriptCache.js";
 import {
@@ -125,6 +126,7 @@ import {
   IPC,
   type AppConfig,
   type AgentFileReady,
+  type AuthClaimInput,
   type Project,
   type ProjectMeta,
   type SpawnOptions,
@@ -1200,6 +1202,15 @@ function registerHandlers(): void {
   // persisted).
   ipcMain.handle(IPC.setupProbe, () => setupProbe(config));
   ipcMain.handle(IPC.setupBootstrap, () => setupBootstrap(config));
+
+  // Onboarding pairing (BET-49): POST <serverUrl>/auth/claim, and on success
+  // persist { serverUrl, boxId, boxToken } to config (via commit — which also
+  // saves config.json). Presence of the valid boxToken flips transport to
+  // "http" on the renderer's next config read. Returns a classified outcome;
+  // an auth failure is a normal { ok:false }, not a thrown IPC error.
+  ipcMain.handle(IPC.authClaim, (_e, input: AuthClaimInput) =>
+    claimPairing(input, (patch) => commit(patch)),
+  );
 
   // Voice / speech-to-text via Groq. Audio bytes are captured by the
   // renderer (MediaRecorder) and shipped here so the API key never lives

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   type AgentFileReady,
   type AppConfig,
+  type AuthClaimInput,
   type BootstrapResult,
   type DesktopNotifyPayload,
   type OpencodeAgent,
@@ -34,6 +35,7 @@ import {
   type DiscoverResult,
   type ProviderInput,
 } from "../shared/types.js";
+import type { ClaimOutcome } from "../shared/claim.mjs";
 
 type PromptModel = { providerID: string; modelID: string; variant?: string };
 type PromptAttachment = { remotePath: string; mime: string; filename?: string };
@@ -86,6 +88,14 @@ const api = {
   // structured results the Settings UI renders.
   setupProbe: (): Promise<ProbeResult> => ipcRenderer.invoke(IPC.setupProbe),
   setupBootstrap: (): Promise<BootstrapResult> => ipcRenderer.invoke(IPC.setupBootstrap),
+
+  // Onboarding pairing (BET-49): exchange a 6-digit code for the box's tokens
+  // via POST <serverUrl>/auth/claim. On success main persists
+  // { serverUrl, boxId, boxToken } to config (flipping transport to "http").
+  // Resolves to a classified ClaimOutcome — a wrong/expired code is a normal
+  // { ok:false } result, NOT a rejected promise.
+  authClaim: (input: AuthClaimInput): Promise<ClaimOutcome> =>
+    ipcRenderer.invoke(IPC.authClaim, input),
 
   // Voice (Groq STT + lightweight classifier). Main owns the API key;
   // renderer only ships audio bytes / transcripts.

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -3,7 +3,6 @@ import {
   ONBOARDING_STEPS,
   STEP_LABELS,
   LAST_STEP,
-  canGoBack,
   nextPosition,
   prevPosition,
   resolveInitialStep,
@@ -11,6 +10,7 @@ import {
   type OnboardingStep,
 } from "./onboardingUtils";
 import { useStore } from "./store";
+import { PairStep } from "./PairStep";
 
 // Onboarding.tsx — full-screen M6.2 onboarding shell (BET-49-T3).
 //
@@ -20,13 +20,18 @@ import { useStore } from "./store";
 // escape hatch, and the terminal success screen.
 //
 // Does NOT own the per-step bodies:
-//   - Step 1 (Pair)          → BET-49-T2
+//   - Step 1 (Pair)          → BET-49-T2 (PairStep.tsx — now mounted below)
 //   - Steps 2–3 (Providers/Model) → BET-49-T4
 //   - Step 4 (First project) → BET-49-T5
-// Those land as their own components mounted into the `renderStepBody` slots
-// below; until then each slot shows a labelled placeholder so the shell,
-// navigation, gating, resume, and skip are all reviewable/testable on their
-// own. The step model + resume math live in onboardingUtils.ts (pure, tested).
+// Those land as their own components mounted into the step-body slots below;
+// steps 2–4 still show a labelled placeholder until their tasks land. The step
+// model + resume math live in onboardingUtils.ts (pure, tested).
+//
+// Step 1 is special: PairStep owns its OWN footer (Skip setup + Connect), per
+// docs/onboarding/mockup.html, because "Connect" must run the pairing claim and
+// only advance on success — the shell's generic goNext footer can't express
+// that. So the shell hides its footer on step 1 and lets PairStep drive
+// advancement (onPaired → goNext) and skipping (onSkip → skip).
 //
 // Props:
 //   onDone — called when onboarding completes (success screen "Open bui") OR is
@@ -162,16 +167,11 @@ function StepPlaceholder({
   );
 }
 
-function stepBody(step: OnboardingStep) {
+// Placeholder bodies for steps 2–4 (their own tasks). Step 1 (Pair) is rendered
+// by PairStep in the component below — it needs the shell's goNext/skip
+// callbacks, which module-level stepBody can't see.
+function stepBody(step: Exclude<OnboardingStep, 1>) {
   switch (step) {
-    case 1:
-      return (
-        <StepPlaceholder
-          title="Connect to your server"
-          subtitle="Enter the 6-digit pairing code shown on your VPS terminal to establish a secure connection."
-          note="Pairing (Step 1) is delivered by BET-49-T2 and mounts here."
-        />
-      );
     case 2:
       return (
         <StepPlaceholder
@@ -274,38 +274,36 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                   <ArrowRight />
                 </button>
               </div>
+            ) : pos === 1 ? (
+              // Step 1 (Pair) owns its own footer (Skip setup + Connect), so it
+              // gets goNext/skip directly and the shell footer is suppressed
+              // below. A successful claim advances; skip drops to the app.
+              <PairStep onPaired={goNext} onSkip={skip} />
             ) : (
               stepBody(pos)
             )}
           </div>
         </div>
 
-        {/* Footer nav (hidden on the success screen — it has its own button). */}
-        {!isSuccess && (
+        {/* Footer nav. Hidden on the success screen (own button) AND on step 1
+            (PairStep renders its own Skip setup + Connect footer). */}
+        {!isSuccess && pos !== 1 && (
           <div className="flex items-center justify-between gap-3 mt-8">
-            {canGoBack(pos) ? (
-              <button
-                onClick={goBack}
-                className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
-              >
-                <ArrowLeft />
-                Back
-              </button>
-            ) : (
-              // Step 1: the back slot holds "Skip setup" instead of Back.
-              <button
-                onClick={skip}
-                className="px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
-              >
-                Skip setup
-              </button>
-            )}
+            {/* pos is always 2–4 here (step 1 renders its own footer, success is
+                excluded), so canGoBack is always true — Back is the left slot. */}
+            <button
+              onClick={goBack}
+              className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
+            >
+              <ArrowLeft />
+              Back
+            </button>
             <button
               onClick={goNext}
               className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg"
               style={{ background: ACCENT }}
             >
-              {pos === LAST_STEP ? "Create project" : pos === 1 ? "Connect" : "Continue"}
+              {pos === LAST_STEP ? "Create project" : "Continue"}
               <ArrowRight />
             </button>
           </div>

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,0 +1,198 @@
+import { useRef, useState } from "react";
+import { normalizeCode } from "../shared/claim.mjs";
+import { normalizeServerUrl, isValidServerUrl, canConnect } from "./pairStepLogic";
+import { useStore } from "./store";
+
+// PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2).
+//
+// Mounts into Onboarding.tsx's step-1 slot. Owns the pairing form:
+//   • a server-URL input (prefilled from config if the user has paired before)
+//   • a 6-digit monospace pairing code input (auto-focused)
+//   • inline errors for every claim-failure branch (wrong/expired code,
+//     rate-limited, unreachable server, malformed response)
+//   • its own Connect button (gated by canConnect) + a "Skip setup" link
+//
+// The claim itself runs in the MAIN process over the `auth:claim` IPC channel
+// (window.api.authClaim), which POSTs <serverUrl>/auth/claim and, on success,
+// persists { serverUrl, boxId, boxToken } to config.json. We mirror those into
+// the store (applyPairing) so resolveTransportMode reads "http" immediately,
+// then call onPaired() to let the shell advance to Step 2.
+//
+// All non-React logic (URL normalization, the submit gate, the 6-digit
+// contract, HTTP-outcome classification) is pure + unit-tested in
+// pairStepLogic.ts + src/shared/claim.test.ts — this file is just the wiring.
+//
+// Props:
+//   onPaired — successful claim; the shell advances to the next step.
+//   onSkip   — user chose "Skip setup"; the shell persists onboardingSkipped
+//              and drops to the normal app (handled by the shell's skip()).
+
+const ACCENT = "#7c9cff"; // matches Onboarding.tsx + the app's accent token
+const DANGER = "#f87171"; // inline error text (no dedicated tailwind token)
+
+export function PairStep({
+  onPaired,
+  onSkip,
+}: {
+  onPaired: () => void;
+  onSkip: () => void;
+}) {
+  // Prefill the server URL from config (empty on a fresh install). Read once at
+  // mount — the store's serverUrl is already populated (App gates on `loaded`).
+  const [serverUrl, setServerUrl] = useState(() => useStore.getState().serverUrl ?? "");
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const codeRef = useRef<HTMLInputElement>(null);
+
+  const connectEnabled = canConnect({ serverUrl, code, submitting });
+
+  const connect = async () => {
+    // Mirror the pure gate so an Enter keypress can't fire from a non-ready
+    // state (the button is also disabled, but Enter bypasses that).
+    if (!canConnect({ serverUrl, code, submitting })) return;
+    setSubmitting(true);
+    setError(null);
+    const result = await window.api.authClaim({
+      serverUrl: normalizeServerUrl(serverUrl),
+      code,
+    });
+    if (result.ok) {
+      // main already persisted to config.json; mirror into the store so the
+      // shell + transport resolution see the paired state without a re-read.
+      useStore.getState().applyPairing({
+        serverUrl: normalizeServerUrl(serverUrl),
+        boxId: result.boxId,
+        boxToken: result.boxToken,
+      });
+      setSubmitting(false);
+      onPaired();
+      return;
+    }
+    // Failure: show the classified message, keep the code so the user can fix
+    // it, and re-focus the code input.
+    setSubmitting(false);
+    setError(result.message);
+    codeRef.current?.focus();
+  };
+
+  const onFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void connect();
+  };
+
+  // A bad/empty URL is only flagged once the user has typed something, so a
+  // pristine field doesn't show a scary red border on first paint.
+  const urlLooksBad = serverUrl.trim() !== "" && !isValidServerUrl(serverUrl);
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight text-text mb-1.5">
+        Connect to your server
+      </h2>
+      <p className="text-sm text-text-muted leading-relaxed mb-8 max-w-md">
+        Enter the 6-digit pairing code shown on your VPS terminal to establish a
+        secure connection.
+      </p>
+
+      <form onSubmit={onFormSubmit} className="flex flex-col gap-5">
+        {/* Server URL */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="pair-server-url" className="text-xs font-medium text-text-muted">
+            Server URL
+          </label>
+          <input
+            id="pair-server-url"
+            type="text"
+            inputMode="url"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="http://your-box:8787"
+            disabled={submitting}
+            value={serverUrl}
+            onChange={(e) => {
+              setServerUrl(e.target.value);
+              setError(null);
+            }}
+            aria-invalid={urlLooksBad}
+            className="w-full rounded-md bg-bg-soft border px-3 py-2.5 text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+            style={{ borderColor: urlLooksBad ? DANGER : undefined }}
+          />
+        </div>
+
+        {/* Pairing code */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="pair-code" className="text-xs font-medium text-text-muted">
+            Pairing code
+          </label>
+          <input
+            id="pair-code"
+            ref={codeRef}
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            autoFocus
+            aria-label="Pairing code"
+            aria-invalid={error != null}
+            placeholder="000000"
+            maxLength={6}
+            disabled={submitting}
+            value={code}
+            onChange={(e) => {
+              setCode(normalizeCode(e.target.value));
+              setError(null);
+            }}
+            className="w-full rounded-md bg-bg-soft border border-border px-3 py-2.5 text-center font-mono text-2xl tracking-[0.4em] text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+          />
+          <p className="text-xs text-text-faint">
+            Found in your terminal after running{" "}
+            <code className="rounded bg-bg-soft px-1.5 py-0.5 text-[11px] text-text-muted">
+              bui pair
+            </code>
+          </p>
+        </div>
+
+        {error && (
+          <div role="alert" className="text-sm" style={{ color: DANGER }}>
+            {error}
+          </div>
+        )}
+
+        {/* Footer: Skip setup (left) + Connect (right) — matches the mockup, so
+            the shell hides its own footer for Step 1. */}
+        <div className="flex items-center justify-between gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onSkip}
+            disabled={submitting}
+            className="px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors disabled:opacity-60"
+          >
+            Skip setup
+          </button>
+          <button
+            type="submit"
+            disabled={!connectEnabled}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
+            style={{ background: ACCENT }}
+          >
+            {submitting ? "Connecting…" : "Connect"}
+            {!submitting && (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="w-4 h-4"
+              >
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -147,16 +147,28 @@ export function clearClientToken(): void {
  * owns only the fetch + the transport-level error → networkFailure() mapping.
  */
 export async function submitPairingCode(code: string): Promise<ClaimResult> {
+  return claimAgainst(serverBase(), code);
+}
+
+/**
+ * POST a pairing `code` to `<base>/auth/claim`, classify the outcome via the
+ * shared classifier, and persist the token (mobile token store) on success.
+ * Shared by the mobile pairing screen (base = serverBase()) and the Api
+ * `authClaim` channel (base = the caller-supplied serverUrl). Trailing slashes
+ * on `base` are trimmed so "http://box/" and "http://box" behave identically.
+ */
+async function claimAgainst(base: string, code: string): Promise<ClaimResult> {
+  const url = `${base.replace(/\/+$/, "")}/auth/claim`;
   let res: Response;
   try {
-    res = await fetch(`${serverBase()}/auth/claim`, {
+    res = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ pairing_code: code }),
     });
   } catch {
-    // fetch rejects (offline / DNS / TLS / serverBase() throwing) — no HTTP
-    // response reached us.
+    // fetch rejects (offline / DNS / TLS / bad URL) — no HTTP response reached
+    // us.
     return networkFailure();
   }
   let body: unknown = null;
@@ -450,6 +462,15 @@ export const httpApi: Api = {
   // Desktop wires the real implementation through Electron IPC.
   setupProbe: () => rpc(IPC.setupProbe),
   setupBootstrap: () => rpc(IPC.setupBootstrap),
+
+  // -- onboarding pairing --
+  // The desktop onboarding shell (BET-49) drives this; the mobile/web client
+  // has its own PairingScreen. We still implement it honestly so the Api
+  // contract holds on both transports: POST <serverUrl>/auth/claim, classify
+  // with the shared helper, and on success persist the token to the mobile
+  // token store. (No config.json write here — that's a desktop-main concern;
+  // the mobile client authenticates via the localStorage Bearer token.)
+  authClaim: (input) => claimAgainst(input.serverUrl, input.code),
 
   // -- clipboard --
   clipboardWriteText: (text) => rpc(IPC.clipboardWriteText, text),

--- a/src/renderer/mobile/pairingLogic.ts
+++ b/src/renderer/mobile/pairingLogic.ts
@@ -14,102 +14,25 @@
 //   • pairingReducer                   — the form state machine (idle →
 //                                        submitting → error, and back)
 //
-// The token-shape validation + success-body parsing is delegated to the shared
-// parseClaimResponse (src/shared/transport.mjs) — the single source of truth
-// the desktop onboarding (BET-49) also uses — so a malformed box_token can
-// never be persisted from either entry point.
+// The input contract + HTTP-outcome classification now live in the shared,
+// process-boundary-safe src/shared/claim.mjs (so the desktop main process can
+// classify the same way without importing renderer code). This module
+// re-exports them for the mobile client's existing call sites + tests, and adds
+// the mobile-only form state machine (pairingReducer) on top.
 
-import { parseClaimResponse } from "../../shared/transport.mjs";
+export {
+  normalizeCode,
+  isSubmittableCode,
+  classifyClaimResult,
+  networkFailure,
+} from "../../shared/claim.mjs";
+import { isSubmittableCode, normalizeCode } from "../../shared/claim.mjs";
+import type { ClaimFailureKind, ClaimOutcome } from "../../shared/claim.mjs";
 
-// A pairing code is exactly 6 decimal digits (mirrors the server's
-// isValidPairingCode in src/server/auth.mjs — kept in sync so the client
-// rejects an obviously-wrong code before spending a round-trip + a rate-limit
-// token on it).
-const PAIRING_CODE_RE = /^[0-9]{6}$/;
-
-/**
- * Normalize raw <input> text into a candidate pairing code: strip every
- * non-digit (so spaces / dashes a user types or a paste carries are dropped)
- * and clamp to the first 6 digits. Pure — safe to call on every keystroke.
- */
-export function normalizeCode(raw: string): string {
-  return String(raw ?? "").replace(/\D+/g, "").slice(0, 6);
-}
-
-/** True when `code` is exactly 6 digits — i.e. worth POSTing to /auth/claim. */
-export function isSubmittableCode(code: string): boolean {
-  return PAIRING_CODE_RE.test(code);
-}
-
-// ---------------------------------------------------------------------------
-// Claim-result classification
-// ---------------------------------------------------------------------------
-
-/** Why a claim attempt failed, mapped to a stable UI category. */
-export type ClaimFailureKind =
-  | "wrong_code" // 400/403 — invalid / expired / already-used code
-  | "rate_limited" // 429 — too many attempts
-  | "invalid_response" // 200 but body wasn't a valid { box_token, box_id }
-  | "network" // fetch rejected / server unreachable
-  | "server_error"; // 5xx or any other unexpected status
-
-export type ClaimResult =
-  | { ok: true; boxToken: string; boxId: string }
-  | { ok: false; kind: ClaimFailureKind; message: string };
-
-// User-facing copy for each failure category. Kept short — rendered inline
-// under the code input.
-const FAILURE_MESSAGE: Record<ClaimFailureKind, string> = {
-  wrong_code: "That code didn't work. Check it and try again.",
-  rate_limited: "Too many attempts. Wait a moment and try again.",
-  invalid_response: "Unexpected response from the server. Try again.",
-  network: "Couldn't reach the server. Check your connection.",
-  server_error: "The server had a problem. Try again.",
-};
-
-function fail(kind: ClaimFailureKind): ClaimResult {
-  return { ok: false, kind, message: FAILURE_MESSAGE[kind] };
-}
-
-/**
- * Classify a POST /auth/claim outcome into a typed ClaimResult. Pure: the
- * caller performs the fetch and hands the parsed pieces here.
- *
- * Server contract (src/server/auth.mjs claim() + index.mjs):
- *   200 { box_token, box_id } — success (validated via parseClaimResponse)
- *   400 { error }             — malformed pairing code (shape rejected server-side)
- *   403 { error }             — wrong / expired / already-used code
- *   429 { error }             — rate limited (too many attempts)
- *   5xx                       — server error
- *
- * 400 and 403 collapse to `wrong_code`: the server deliberately returns 403 for
- * every guess (no partial-progress leak), and a 400 here means our own
- * client-side 6-digit guard was bypassed — either way the actionable message
- * for the user is "that code didn't work."
- *
- * @param status  HTTP status code (0 or negative may be used by a caller to
- *                signal a network-level failure; prefer classifyNetworkError).
- * @param body    Parsed JSON body, or null when the body was absent/unparsable.
- */
-export function classifyClaimResult(status: number, body: unknown): ClaimResult {
-  if (status === 200) {
-    const parsed = parseClaimResponse(body);
-    if (parsed.ok) return { ok: true, boxToken: parsed.boxToken, boxId: parsed.boxId };
-    return fail("invalid_response");
-  }
-  if (status === 429) return fail("rate_limited");
-  if (status === 400 || status === 403) return fail("wrong_code");
-  if (status >= 500) return fail("server_error");
-  // Any other status (401/404/…) is an unexpected server state, not a wrong
-  // code — surface it as a generic server error rather than blaming the user's
-  // input.
-  return fail("server_error");
-}
-
-/** Result for a fetch that never produced an HTTP response (offline, DNS, …). */
-export function networkFailure(): ClaimResult {
-  return fail("network");
-}
+// Historical alias: the mobile client + tests refer to the classified outcome
+// as `ClaimResult`. `ClaimOutcome` is the shared name; keep both in sync.
+export type { ClaimFailureKind };
+export type ClaimResult = ClaimOutcome;
 
 // ---------------------------------------------------------------------------
 // Pairing form state machine

--- a/src/renderer/pairStepLogic.test.ts
+++ b/src/renderer/pairStepLogic.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeServerUrl,
+  isValidServerUrl,
+  canConnect,
+} from "./pairStepLogic";
+
+const CODE = "847291";
+
+describe("normalizeServerUrl", () => {
+  it("trims whitespace and trailing slashes", () => {
+    expect(normalizeServerUrl("  http://box:8787/  ")).toBe("http://box:8787");
+    expect(normalizeServerUrl("http://box:8787///")).toBe("http://box:8787");
+    expect(normalizeServerUrl("http://box:8787")).toBe("http://box:8787");
+  });
+
+  it("tolerates nullish", () => {
+    expect(normalizeServerUrl(undefined as unknown as string)).toBe("");
+    expect(normalizeServerUrl("")).toBe("");
+  });
+});
+
+describe("isValidServerUrl", () => {
+  it("accepts http(s) URLs with a host", () => {
+    expect(isValidServerUrl("http://box:8787")).toBe(true);
+    expect(isValidServerUrl("https://relay.example.com")).toBe(true);
+    expect(isValidServerUrl("  http://192.168.1.10:8787/ ")).toBe(true);
+  });
+
+  it("rejects scheme-less / empty / non-http URLs", () => {
+    expect(isValidServerUrl("")).toBe(false);
+    expect(isValidServerUrl("box:8787")).toBe(false);
+    expect(isValidServerUrl("ftp://box")).toBe(false);
+    expect(isValidServerUrl("http://")).toBe(false);
+  });
+});
+
+describe("canConnect", () => {
+  it("true only with valid URL + 6-digit code + not submitting", () => {
+    expect(
+      canConnect({ serverUrl: "http://box:8787", code: CODE, submitting: false }),
+    ).toBe(true);
+  });
+
+  it("false while submitting", () => {
+    expect(
+      canConnect({ serverUrl: "http://box:8787", code: CODE, submitting: true }),
+    ).toBe(false);
+  });
+
+  it("false with a bad URL", () => {
+    expect(
+      canConnect({ serverUrl: "box:8787", code: CODE, submitting: false }),
+    ).toBe(false);
+    expect(
+      canConnect({ serverUrl: "", code: CODE, submitting: false }),
+    ).toBe(false);
+  });
+
+  it("false with an incomplete code", () => {
+    expect(
+      canConnect({ serverUrl: "http://box:8787", code: "1234", submitting: false }),
+    ).toBe(false);
+  });
+});

--- a/src/renderer/pairStepLogic.ts
+++ b/src/renderer/pairStepLogic.ts
@@ -1,0 +1,52 @@
+// pairStepLogic.ts — pure, framework-free core for the desktop onboarding Step 1
+// (Pair) screen (BET-49-T2).
+//
+// The desktop pair screen differs from the mobile one (renderer/mobile/
+// pairingLogic.ts) in one way: the desktop user also types the SERVER URL to
+// pair against (the mobile client already knows its own base from
+// localStorage["bui_server"]). So Step 1's submit gate is "a non-empty server
+// URL AND a 6-digit code", and the claim is performed by the main process over
+// the `auth:claim` IPC channel (which persists config on success).
+//
+// The 6-digit code contract + HTTP-outcome classification are the SHARED ones
+// (src/shared/claim.mjs). This module adds only the desktop-specific URL
+// normalization + the combined submit gate, so the whole non-React surface of
+// the screen is unit-testable without a DOM or a live server.
+
+import { isSubmittableCode } from "../shared/claim.mjs";
+
+/**
+ * Normalize a server URL for submission: trim surrounding whitespace and any
+ * trailing slashes (so "http://box:8787/" and "http://box:8787" are equal).
+ * Does NOT inject a scheme — an empty or scheme-less value is left as-is and
+ * gated by isValidServerUrl below (the user corrects it inline).
+ */
+export function normalizeServerUrl(raw: string): string {
+  return String(raw ?? "").trim().replace(/\/+$/, "");
+}
+
+/**
+ * True when `raw` looks like a fetchable http(s) URL. Kept deliberately loose —
+ * we don't validate the host, only that there's an http(s):// scheme and
+ * something after it. The real reachability check is the claim round-trip
+ * itself (a bad host surfaces as a network failure the UI shows for correction).
+ */
+export function isValidServerUrl(raw: string): boolean {
+  const url = normalizeServerUrl(raw);
+  return /^https?:\/\/.+/i.test(url);
+}
+
+/**
+ * True when the Connect button should be enabled: not mid-request, a valid
+ * server URL, AND a submittable (6-digit) code. Pure — the caller passes the
+ * current field values + in-flight flag.
+ */
+export function canConnect(input: {
+  serverUrl: string;
+  code: string;
+  submitting: boolean;
+}): boolean {
+  if (input.submitting) return false;
+  if (!isValidServerUrl(input.serverUrl)) return false;
+  return isSubmittableCode(input.code);
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -130,6 +130,11 @@ type State = {
   finishOnboarding: () => Promise<void>;
   applyProjects: (projects: Project[]) => void;
   applyConfig: (c: AppConfig) => void;
+  // Reflect a successful onboarding claim (BET-49-T2) into store state so
+  // resolveTransportMode reads "http" immediately. main already persisted these
+  // to config.json via the auth:claim handler; this just mirrors them so the
+  // onboarding shell can advance without a full config re-read.
+  applyPairing: (p: { serverUrl: string; boxId: string; boxToken: string }) => void;
   applyStatusBatch: (batch: WindowStatus[]) => void;
   // Chat-mode running state driven by opencode SSE (session.status /
   // session.idle / session.error). The PTY-pane poller can't see chat
@@ -317,6 +322,9 @@ export const useStore = create<State>((set, get) => ({
       voiceTranscriptionModel: c.voiceTranscriptionModel ?? "",
       voiceCommandModel: c.voiceCommandModel ?? "",
     }),
+
+  applyPairing: (p) =>
+    set({ serverUrl: p.serverUrl, boxId: p.boxId, boxToken: p.boxToken }),
 
   setChatAutoAllow: async (v) => {
     set({ chatAutoAllow: v });

--- a/src/shared/claim.d.mts
+++ b/src/shared/claim.d.mts
@@ -1,0 +1,29 @@
+// Hand-written type declarations for claim.mjs. Implementation is plain JS so
+// both the renderer tsconfig and the main tsconfig import it without crossing
+// the process boundary. Keep in sync with src/shared/claim.mjs.
+
+// Why a claim attempt failed, mapped to a stable UI category.
+export type ClaimFailureKind =
+  | "wrong_code" // 400/403 — invalid / expired / already-used code
+  | "rate_limited" // 429 — too many attempts
+  | "invalid_response" // 200 but body wasn't a valid { box_token, box_id }
+  | "network" // fetch rejected / server unreachable
+  | "server_error"; // 5xx or any other unexpected status
+
+// The outcome of a POST /auth/claim, classified for the UI to render. On
+// success the tokens are validated 32-hex (via parseClaimResponse).
+export type ClaimOutcome =
+  | { ok: true; boxToken: string; boxId: string }
+  | { ok: false; kind: ClaimFailureKind; message: string };
+
+// Strip non-digits and clamp to the first 6 digits.
+export function normalizeCode(raw: string): string;
+
+// True when `code` is exactly 6 digits.
+export function isSubmittableCode(code: string): boolean;
+
+// Map an /auth/claim HTTP outcome (status + parsed body) to a ClaimOutcome.
+export function classifyClaimResult(status: number, body: unknown): ClaimOutcome;
+
+// The ClaimOutcome for a fetch that never produced an HTTP response.
+export function networkFailure(): ClaimOutcome;

--- a/src/shared/claim.mjs
+++ b/src/shared/claim.mjs
@@ -1,0 +1,93 @@
+// claim.mjs — pure, framework-free classification of a POST /auth/claim outcome.
+//
+// The /auth/claim handshake (exchange a 6-digit pairing code for a box_token +
+// box_id) is reached from THREE places that must all agree on how an HTTP
+// outcome maps to a user-facing result:
+//   • the mobile/web client   (src/renderer/mobile/pairingLogic.ts re-exports)
+//   • the desktop onboarding   (src/renderer/onboarding/PairStep.tsx via IPC)
+//   • the desktop main process (src/main/index.ts auth:claim handler — it does
+//                               the fetch, then classifies with these helpers)
+//
+// Keeping the classification here (a shared .mjs, importable from both the
+// renderer tsconfig and the main tsconfig without crossing the process
+// boundary) is the single source of truth: a 403 means "wrong code" and a 429
+// means "rate limited" in exactly one place. Token-shape validation of a 200
+// body is delegated to parseClaimResponse (src/shared/transport.mjs) so a
+// malformed box_token can never be persisted from any entry point.
+//
+// Pure (no fetch, no DOM, no Node built-ins) → unit-tested in
+// src/shared/claim.test.ts.
+
+import { parseClaimResponse } from "./transport.mjs";
+
+// A pairing code is exactly 6 decimal digits (mirrors the server's
+// isValidPairingCode in src/server/auth.mjs — kept in sync so a client rejects
+// an obviously-wrong code before spending a round-trip + a rate-limit token).
+const PAIRING_CODE_RE = /^[0-9]{6}$/;
+
+/**
+ * Normalize raw <input> text into a candidate pairing code: strip every
+ * non-digit (so spaces / dashes a user types or a paste carries are dropped)
+ * and clamp to the first 6 digits. Pure — safe to call on every keystroke.
+ */
+export function normalizeCode(raw) {
+  return String(raw ?? "").replace(/\D+/g, "").slice(0, 6);
+}
+
+/** True when `code` is exactly 6 digits — i.e. worth POSTing to /auth/claim. */
+export function isSubmittableCode(code) {
+  return PAIRING_CODE_RE.test(code);
+}
+
+// User-facing copy for each failure category. Kept short — rendered inline
+// under the code input.
+const FAILURE_MESSAGE = {
+  wrong_code: "That code didn't work. Check it and try again.",
+  rate_limited: "Too many attempts. Wait a moment and try again.",
+  invalid_response: "Unexpected response from the server. Try again.",
+  network: "Couldn't reach the server. Check the URL and try again.",
+  server_error: "The server had a problem. Try again.",
+};
+
+function fail(kind) {
+  return { ok: false, kind, message: FAILURE_MESSAGE[kind] };
+}
+
+/**
+ * Classify a POST /auth/claim outcome into a typed ClaimOutcome. Pure: the
+ * caller performs the fetch and hands the parsed pieces here.
+ *
+ * Server contract (src/server/auth.mjs claim() + index.mjs):
+ *   200 { box_token, box_id } — success (validated via parseClaimResponse)
+ *   400 { error }             — malformed pairing code (shape rejected server-side)
+ *   403 { error }             — wrong / expired / already-used code
+ *   429 { error }             — rate limited (too many attempts)
+ *   5xx                       — server error
+ *
+ * 400 and 403 collapse to `wrong_code`: the server deliberately returns 403 for
+ * every guess (no partial-progress leak), and a 400 here means our own
+ * client-side 6-digit guard was bypassed — either way the actionable message
+ * for the user is "that code didn't work."
+ *
+ * @param {number}  status  HTTP status code.
+ * @param {unknown} body    Parsed JSON body, or null when absent/unparsable.
+ * @returns {ClaimOutcome}
+ */
+export function classifyClaimResult(status, body) {
+  if (status === 200) {
+    const parsed = parseClaimResponse(body);
+    if (parsed.ok) return { ok: true, boxToken: parsed.boxToken, boxId: parsed.boxId };
+    return fail("invalid_response");
+  }
+  if (status === 429) return fail("rate_limited");
+  if (status === 400 || status === 403) return fail("wrong_code");
+  if (status >= 500) return fail("server_error");
+  // Any other status (401/404/…) is an unexpected server state, not a wrong
+  // code — surface it as a generic server error rather than blaming the input.
+  return fail("server_error");
+}
+
+/** Result for a fetch that never produced an HTTP response (offline, DNS, …). */
+export function networkFailure() {
+  return fail("network");
+}

--- a/src/shared/claim.test.ts
+++ b/src/shared/claim.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeCode,
+  isSubmittableCode,
+  classifyClaimResult,
+  networkFailure,
+} from "./claim.mjs";
+
+// A well-formed 32-lowercase-hex box_token/box_id (128 bits) — the shape
+// src/server/auth.mjs isValidToken and transport.mjs isValidBoxToken enforce.
+const HEX32 = "0123456789abcdef0123456789abcdef";
+const HEX32B = "fedcba9876543210fedcba9876543210";
+
+describe("normalizeCode", () => {
+  it("strips non-digits and clamps to 6", () => {
+    expect(normalizeCode("847291")).toBe("847291");
+    expect(normalizeCode("84-72 91")).toBe("847291");
+    expect(normalizeCode("847291999")).toBe("847291");
+    expect(normalizeCode("abc12def34")).toBe("1234");
+    expect(normalizeCode("")).toBe("");
+  });
+
+  it("tolerates nullish input", () => {
+    expect(normalizeCode(undefined as unknown as string)).toBe("");
+    expect(normalizeCode(null as unknown as string)).toBe("");
+  });
+});
+
+describe("isSubmittableCode", () => {
+  it("true only for exactly 6 digits", () => {
+    expect(isSubmittableCode("847291")).toBe(true);
+    expect(isSubmittableCode("12345")).toBe(false);
+    expect(isSubmittableCode("1234567")).toBe(false);
+    expect(isSubmittableCode("12a456")).toBe(false);
+    expect(isSubmittableCode("")).toBe(false);
+  });
+});
+
+describe("classifyClaimResult", () => {
+  it("200 with a valid body → ok + tokens", () => {
+    const r = classifyClaimResult(200, { box_token: HEX32, box_id: HEX32B });
+    expect(r).toEqual({ ok: true, boxToken: HEX32, boxId: HEX32B });
+  });
+
+  it("200 with malformed token → invalid_response", () => {
+    const r = classifyClaimResult(200, { box_token: "nope", box_id: HEX32B });
+    expect(r).toEqual({
+      ok: false,
+      kind: "invalid_response",
+      message: expect.any(String),
+    });
+  });
+
+  it("200 with a null body → invalid_response", () => {
+    const r = classifyClaimResult(200, null);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("invalid_response");
+  });
+
+  it("403 → wrong_code", () => {
+    const r = classifyClaimResult(403, { error: "pairing failed" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("wrong_code");
+  });
+
+  it("400 → wrong_code", () => {
+    const r = classifyClaimResult(400, { error: "invalid pairing code" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("wrong_code");
+  });
+
+  it("429 → rate_limited", () => {
+    const r = classifyClaimResult(429, { error: "rate limited" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("rate_limited");
+  });
+
+  it("5xx → server_error", () => {
+    const r = classifyClaimResult(500, { error: "boom" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("server_error");
+  });
+
+  it("unexpected status (404/401) → server_error, not wrong_code", () => {
+    for (const status of [401, 404, 418]) {
+      const r = classifyClaimResult(status, null);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.kind).toBe("server_error");
+    }
+  });
+});
+
+describe("networkFailure", () => {
+  it("returns a network failure with a message", () => {
+    const r = networkFailure();
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("network");
+      expect(r.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -390,6 +390,16 @@ export const IPC = {
   voiceTranscribe: "voice:transcribe",
   voiceClassifyCommand: "voice:classify-command",
 
+  // ---- onboarding pairing (BET-49) ----
+  // Exchange a 6-digit pairing code for the box's { boxToken, boxId } via
+  // POST <serverUrl>/auth/claim, and on success persist { serverUrl, boxId,
+  // boxToken } to config (which flips transport mode to "http"). Distinct from
+  // the mobile client's own claim (renderer/api/httpApi submitPairingCode →
+  // localStorage): desktop main owns the fetch so it can write config.json.
+  // Input: { serverUrl, code }. Result: the classified ClaimOutcome
+  // (src/shared/claim.mjs) — never throws for a normal auth failure.
+  authClaim: "auth:claim",
+
   // ---- setup wizard ----
   // One-shot diagnostic over SSH: returns the status of every remote
   // prerequisite bui depends on (ssh reachable, tmux installed, opencode
@@ -514,6 +524,19 @@ export type AgentFileReady = {
   autoPulled: boolean;
   // Saved local absolute path — only set when autoPulled is true.
   localPath?: string;
+};
+
+// ----- Onboarding pairing (BET-49) -----
+
+// Input for the desktop auth:claim channel. `serverUrl` is the base URL of the
+// bui-server to pair with (e.g. "http://box.example:8787"); `code` is the
+// 6-digit pairing code minted on the box (`bui pair`). On success main persists
+// { serverUrl, boxId, boxToken } to config. The typed OUTCOME lives in
+// src/shared/claim.mjs (ClaimOutcome) — imported by preload/main directly so
+// types.ts stays dependency-free.
+export type AuthClaimInput = {
+  serverUrl: string;
+  code: string;
 };
 
 // ----- Setup probe / bootstrap -----


### PR DESCRIPTION
## BET-49-T2: `auth:claim` IPC + Step 1 Pair screen

Depends on T1 (config schema + `parseClaimResponse`) and mounts into the T3 onboarding shell (already merged, #24).

**Base:** `origin/main` @ `fdf2f52`

### What landed

**1. Shared claim classification (`src/shared/claim.mjs` + `.d.mts`)**
Extracted `classifyClaimResult` / `networkFailure` / `normalizeCode` / `isSubmittableCode` out of the renderer-only `mobile/pairingLogic.ts` into a process-boundary-safe shared module, so the desktop **main** process can classify a `/auth/claim` outcome the same way without importing renderer code. `pairingLogic.ts` now re-exports these (mobile call sites + tests unchanged). Single source of truth: 403 = wrong_code, 429 = rate_limited, etc., in exactly one place.

**2. `auth:claim` IPC channel** wired across the sites:
- `src/shared/types.ts` — `IPC.authClaim` + `AuthClaimInput`
- `src/preload/index.ts` — `authClaim(input): Promise<ClaimOutcome>`
- `src/renderer/api/httpApi.ts` — mobile shim (`claimAgainst`, shared with the existing `submitPairingCode`)
- `src/main/index.ts` — handler → `claimPairing(input, commit)`
- `src/main/auth.ts` — impl: POST `<serverUrl>/auth/claim`, classify, and on success persist `{ serverUrl, boxId, boxToken }` to config (flips transport to `http`)

  *(No `src/server/rpc.mjs` dispatch entry: the mobile shim claims via a direct `fetch` to the target URL, not through `/rpc` — the mobile client has its own `PairingScreen`. Documented in the shim.)*

**3. Step 1 Pair screen (`src/renderer/PairStep.tsx` + `pairStepLogic.ts`)**
Per `docs/onboarding/mockup.html`: server-URL input (prefilled from config), 6-digit monospace auto-focused code input, `Connect` gated by `canConnect` (valid http(s) URL + 6-digit code), inline errors for every failure branch (wrong/expired, rate-limited, unreachable-shows-URL, malformed response), and a `Skip setup` link. Mounts into the shell's step-1 slot; the shell suppresses its generic footer for step 1 because `Connect` must run the claim and only advance on success. `store.applyPairing` mirrors the claim into state so `resolveTransportMode` reads `http` immediately, then `onPaired()` advances the shell.

### Verification results

**Files changed:** 15 files (`+904 / -134`). Diff vs `origin/main` lists only touched files — no phantom deletions.

- PR branch (`multica/BET-54-auth-claim-pair` @ `afdf720`):
  - **typecheck**: exit `0`. Errors: none.
  - **test** (`npm test`): exit `0`. vitest **577 pass / 0 fail** (27 files) + server `node --test` **226 pass / 0 fail**.
- **E2E smoke** (Playwright `_electron.launch` on the built app, `xvfb-run`): PASS. On a fresh (unpaired) config the renderer mounts the onboarding **Step 1**: heading "Connect to your server", `#pair-server-url` + `#pair-code` inputs, `Connect` + `Skip setup` buttons all present; window title "Better UI"; **0 real console errors**.

**Conclusion:** 0 new test failures; all suites green. New tests added: `src/shared/claim.test.ts`, `src/renderer/pairStepLogic.test.ts`, `src/main/auth.test.ts` (stubbed-fetch: proves valid code → persist called with correct patch; 403/429/invalid/network/empty-URL → no persist).

### Acceptance criteria
- [x] Valid code → config persisted → advances (callback prop) — stubbed-server test + smoke render
- [x] Invalid/expired → inline error, no state change; all error branches rendered
- [x] `npm run typecheck && npm test` green
