### PR TITLE
feat(renderer): onboarding Steps 2-3 — providers + default model (BET-56)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -28,8 +28,19 @@ export function App() {
   // "Run setup again" (Settings) sets onboardingForced to re-show it even for
   // an already-paired/host config. SSH-mode configs (host set) NEVER onboard.
   // Gate on `loaded` so we never flash onboarding before config arrives.
-  const showOnboarding =
+  const enterOnboarding =
     loaded && (onboardingForced || resolveTransportMode(configSnapshot()) === "onboarding");
+  // LATCH: once the flow is open, keep it mounted until the user explicitly
+  // finishes or skips (finishOnboarding / skipOnboarding call onDone). Without
+  // this, Step 1's successful pairing writes a boxToken → resolveTransportMode
+  // flips to "http" → enterOnboarding goes false → App would tear the flow down
+  // mid-way, and Steps 2–4 (providers/model/project) would be unreachable. The
+  // latch is cleared in onDone (below), which re-reads config for the shell.
+  const [onboardingLatched, setOnboardingLatched] = useState(false);
+  useEffect(() => {
+    if (enterOnboarding && !onboardingLatched) setOnboardingLatched(true);
+  }, [enterOnboarding, onboardingLatched]);
+  const showOnboarding = enterOnboarding || onboardingLatched;
   const [settingsOpen, setSettingsOpen] = useState(false);
   const sidebarRef = useRef<SidebarHandle>(null);
 
@@ -402,7 +413,17 @@ export function App() {
   // finishOnboarding clears the force flag + re-reads config → normal shell,
   // no app restart.
   if (showOnboarding) {
-    return <Onboarding onDone={() => void finishOnboarding()} />;
+    return (
+      <Onboarding
+        onDone={() => {
+          // Clear the latch first so App drops to the normal shell once
+          // finishOnboarding re-reads config (or skipOnboarding persisted the
+          // opt-out). Both paths route through onDone.
+          setOnboardingLatched(false);
+          void finishOnboarding();
+        }}
+      />
+    );
   }
 
   return (

--- a/src/renderer/ModelStep.tsx
+++ b/src/renderer/ModelStep.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from "react";
+import type { OpencodeModel } from "../shared/types";
+import { useStore } from "./store";
+import {
+  canContinueModel,
+  formatContextWindow,
+  modelDisplayName,
+  sortModelsForPicker,
+} from "./providersStepLogic";
+
+// ModelStep.tsx — Step 3 (Model) of the desktop onboarding shell (BET-49-T4).
+// Mounts into Onboarding.tsx's step-3 slot.
+//
+// A radio list of models from the CONNECTED providers, sourced from
+// window.api.opencodeModels() — the SAME served-model list Step 2 uses for its
+// connected badges (main builds it from GET /provider filtered by connected[];
+// never /api/model). Each row shows: model name (mono) + provider + context
+// window, matching docs/onboarding/mockup.html (no "Recommended"/"Fast" badges).
+//
+// Selecting a model persists it to AppConfig.defaultModel via the store's
+// setDefaultModel action (config write → survives restart; new/cleared sessions
+// inherit it — existing mechanism, no new plumbing). We seed the selection from
+// the store's current defaultModel so a resumed flow shows the prior choice.
+//
+// Owns its OWN footer (Back + Continue), like PairStep/ProvidersStep, because
+// Continue is gated on a selection. The shell suppresses its footer here.
+//
+// Props:
+//   onBack     — go back to Step 2 (Providers).
+//   onContinue — advance to Step 4 (Project). Enabled once a model is selected.
+
+const ACCENT = "#7c9cff";
+const DANGER = "#f87171";
+
+export function ModelStep({
+  onBack,
+  onContinue,
+}: {
+  onBack: () => void;
+  onContinue: () => void;
+}) {
+  const storeDefault = useStore((s) => s.defaultModel);
+  const setDefaultModel = useStore((s) => s.setDefaultModel);
+
+  const [models, setModels] = useState<OpencodeModel[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<{ providerID: string; modelID: string } | null>(
+    storeDefault,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api
+      .opencodeModels()
+      .then((list) => {
+        if (!cancelled) setModels(list);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModels([]);
+          setLoadError("Couldn't reach the box to list models.");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sorted = sortModelsForPicker(models ?? []);
+  const canContinue = canContinueModel(models ?? [], selected);
+
+  const pick = async (m: OpencodeModel) => {
+    const choice = { providerID: m.providerID, modelID: m.id };
+    setSelected(choice);
+    setSaveError(null);
+    try {
+      // Persist immediately so quitting after the pick still resumes with the
+      // model chosen (config write is the source of truth for defaultModel).
+      await setDefaultModel(choice);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const isSelected = (m: OpencodeModel) =>
+    selected?.providerID === m.providerID && selected?.modelID === m.id;
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight text-text mb-1.5">
+        Pick your default model
+      </h2>
+      <p className="text-sm text-text-muted leading-relaxed mb-8 max-w-md">
+        This model will power your new chat sessions. You can switch anytime.
+      </p>
+
+      {loadError && (
+        <div role="alert" className="text-sm mb-4" style={{ color: DANGER }}>
+          {loadError}
+        </div>
+      )}
+
+      {models === null ? (
+        <div className="text-sm text-text-faint">Loading models…</div>
+      ) : sorted.length === 0 ? (
+        <div className="rounded-md border border-border bg-bg-soft px-3 py-3 text-sm text-text-muted">
+          No models available yet. Go back and connect a provider first.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 max-h-[46vh] overflow-y-auto pr-1" role="radiogroup" aria-label="Default model">
+          {sorted.map((m) => {
+            const sel = isSelected(m);
+            const ctx = formatContextWindow(m);
+            return (
+              <button
+                key={`${m.providerID}/${m.id}`}
+                type="button"
+                role="radio"
+                aria-checked={sel}
+                onClick={() => void pick(m)}
+                className="flex items-center gap-3.5 rounded-md border px-4 py-3 text-left transition-colors"
+                style={{
+                  borderColor: sel ? ACCENT : "#262932",
+                  background: sel ? "#1b1e25" : "transparent",
+                  boxShadow: sel ? `0 0 0 3px rgba(124,156,255,0.15)` : undefined,
+                }}
+              >
+                <span
+                  className="w-[18px] h-[18px] rounded-full border flex items-center justify-center shrink-0"
+                  style={{ borderColor: sel ? ACCENT : "#3a3f4b" }}
+                >
+                  {sel && <span className="w-2 h-2 rounded-full" style={{ background: ACCENT }} />}
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block font-mono text-sm text-text truncate">
+                    {modelDisplayName(m)}
+                  </span>
+                  <span className="mt-0.5 flex items-center gap-1.5 text-xs text-text-faint">
+                    <span className="capitalize">{m.providerID}</span>
+                    {ctx && (
+                      <>
+                        <span className="w-1 h-1 rounded-full bg-text-faint inline-block" />
+                        <span>{ctx}</span>
+                      </>
+                    )}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {saveError && (
+        <div role="alert" className="text-xs mt-3" style={{ color: DANGER }}>
+          Couldn't save your choice: {saveError}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 mt-8">
+        <button
+          onClick={onBack}
+          className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
+        >
+          <ArrowLeft />
+          Back
+        </button>
+        <button
+          onClick={onContinue}
+          disabled={!canContinue}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
+          style={{ background: ACCENT }}
+        >
+          Continue
+          <ArrowRight />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ArrowRight() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
+      <path d="M5 12h14" />
+      <path d="m12 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+function ArrowLeft() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}

--- a/src/renderer/ModelStep.tsx
+++ b/src/renderer/ModelStep.tsx
@@ -7,6 +7,7 @@ import {
   modelDisplayName,
   sortModelsForPicker,
 } from "./providersStepLogic";
+import { StepFooter } from "./onboardingUi";
 
 // ModelStep.tsx — Step 3 (Model) of the desktop onboarding shell (BET-49-T4).
 // Mounts into Onboarding.tsx's step-3 slot.
@@ -158,41 +159,7 @@ export function ModelStep({
         </div>
       )}
 
-      <div className="flex items-center justify-between gap-3 mt-8">
-        <button
-          onClick={onBack}
-          className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
-        >
-          <ArrowLeft />
-          Back
-        </button>
-        <button
-          onClick={onContinue}
-          disabled={!canContinue}
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
-          style={{ background: ACCENT }}
-        >
-          Continue
-          <ArrowRight />
-        </button>
-      </div>
+      <StepFooter onBack={onBack} onContinue={onContinue} continueDisabled={!canContinue} />
     </div>
-  );
-}
-
-function ArrowRight() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-      <path d="M5 12h14" />
-      <path d="m12 5 7 7-7 7" />
-    </svg>
-  );
-}
-
-function ArrowLeft() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-      <path d="m15 18-6-6 6-6" />
-    </svg>
   );
 }

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -12,6 +12,7 @@ import { useStore } from "./store";
 import { PairStep } from "./PairStep";
 import { ProvidersStep } from "./ProvidersStep";
 import { ModelStep } from "./ModelStep";
+import { ArrowRight, CheckIcon, StepFooter } from "./onboardingUi";
 
 // Onboarding.tsx — full-screen M6.2 onboarding shell (BET-49-T3).
 //
@@ -43,55 +44,6 @@ import { ModelStep } from "./ModelStep";
 //            normal shell WITHOUT an app restart.
 
 const ACCENT = "#7c9cff"; // matches the app's Tailwind `accent` token (see tailwind.config)
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
-}
-
-function ArrowRight() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="w-4 h-4"
-    >
-      <path d="M5 12h14" />
-      <path d="m12 5 7 7-7 7" />
-    </svg>
-  );
-}
-
-function ArrowLeft() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="w-4 h-4"
-    >
-      <path d="m15 18-6-6 6-6" />
-    </svg>
-  );
-}
 
 // One progress dot + (optionally) the connector leading into it.
 function ProgressRail({ current }: { current: OnboardingPosition }) {
@@ -283,25 +235,14 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
             1–3 (PairStep / ProvidersStep / ModelStep each render their own
             footer). Only Step 4 uses this generic footer, until BET-49-T5. */}
         {!isSuccess && pos !== 1 && pos !== 2 && pos !== 3 && (
-          <div className="flex items-center justify-between gap-3 mt-8">
-            {/* pos is always 4 here (steps 1–3 render their own footers, success
-                is excluded), so canGoBack is always true — Back is the left slot. */}
-            <button
-              onClick={goBack}
-              className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
-            >
-              <ArrowLeft />
-              Back
-            </button>
-            <button
-              onClick={goNext}
-              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg"
-              style={{ background: ACCENT }}
-            >
-              {pos === LAST_STEP ? "Create project" : "Continue"}
-              <ArrowRight />
-            </button>
-          </div>
+          // pos is always 4 here (steps 1–3 render their own footers, success
+          // is excluded), so Back is always available — the shared StepFooter's
+          // Back-left / primary-right layout matches the per-step footers.
+          <StepFooter
+            onBack={goBack}
+            onContinue={goNext}
+            continueLabel={pos === LAST_STEP ? "Create project" : "Continue"}
+          />
         )}
       </div>
     </div>

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -7,10 +7,11 @@ import {
   prevPosition,
   resolveInitialStep,
   type OnboardingPosition,
-  type OnboardingStep,
 } from "./onboardingUtils";
 import { useStore } from "./store";
 import { PairStep } from "./PairStep";
+import { ProvidersStep } from "./ProvidersStep";
+import { ModelStep } from "./ModelStep";
 
 // Onboarding.tsx — full-screen M6.2 onboarding shell (BET-49-T3).
 //
@@ -20,18 +21,21 @@ import { PairStep } from "./PairStep";
 // escape hatch, and the terminal success screen.
 //
 // Does NOT own the per-step bodies:
-//   - Step 1 (Pair)          → BET-49-T2 (PairStep.tsx — now mounted below)
-//   - Steps 2–3 (Providers/Model) → BET-49-T4
-//   - Step 4 (First project) → BET-49-T5
-// Those land as their own components mounted into the step-body slots below;
-// steps 2–4 still show a labelled placeholder until their tasks land. The step
-// model + resume math live in onboardingUtils.ts (pure, tested).
+//   - Step 1 (Pair)          → BET-49-T2 (PairStep.tsx — mounted below)
+//   - Step 2 (Providers)     → BET-49-T4 (ProvidersStep.tsx — mounted below)
+//   - Step 3 (Model)         → BET-49-T4 (ModelStep.tsx — mounted below)
+//   - Step 4 (First project) → BET-49-T5 (placeholder until it lands)
+// Those land as their own components mounted into the step-body slots below.
+// The step model + resume math live in onboardingUtils.ts (pure, tested).
 //
-// Step 1 is special: PairStep owns its OWN footer (Skip setup + Connect), per
-// docs/onboarding/mockup.html, because "Connect" must run the pairing claim and
-// only advance on success — the shell's generic goNext footer can't express
-// that. So the shell hides its footer on step 1 and lets PairStep drive
-// advancement (onPaired → goNext) and skipping (onSkip → skip).
+// Steps 1–3 each own their OWN footer (per docs/onboarding/mockup.html), because
+// each has a gated/side-effecting primary action the shell's generic goNext
+// footer can't express: Step 1's "Connect" must run the pairing claim and only
+// advance on success; Step 2's "Continue" is gated on ≥1 connected provider;
+// Step 3's "Continue" is gated on a model selection. So the shell hides its
+// footer on steps 1–3 and lets each step drive advancement (onContinue/onPaired
+// → goNext), back-nav (onBack → goBack), and skipping (onSkip → skip). Step 4
+// still uses the shell's generic footer until BET-49-T5 replaces it.
 //
 // Props:
 //   onDone — called when onboarding completes (success screen "Open bui") OR is
@@ -167,27 +171,11 @@ function StepPlaceholder({
   );
 }
 
-// Placeholder bodies for steps 2–4 (their own tasks). Step 1 (Pair) is rendered
-// by PairStep in the component below — it needs the shell's goNext/skip
-// callbacks, which module-level stepBody can't see.
-function stepBody(step: Exclude<OnboardingStep, 1>) {
+// Placeholder body for Step 4 (BET-49-T5). Steps 1–3 are rendered by their own
+// components in the render below — they need the shell's goNext/goBack/skip
+// callbacks, which this module-level helper can't see.
+function stepBody(step: 4) {
   switch (step) {
-    case 2:
-      return (
-        <StepPlaceholder
-          title="Choose your providers"
-          subtitle="Select the AI providers you want to use. You can add more later."
-          note="Provider selection (Step 2) is delivered by BET-49-T4 and mounts here."
-        />
-      );
-    case 3:
-      return (
-        <StepPlaceholder
-          title="Pick your default model"
-          subtitle="This model will power your new chat sessions. You can switch anytime."
-          note="Model picker (Step 3) is delivered by BET-49-T4 and mounts here."
-        />
-      );
     case 4:
       return (
         <StepPlaceholder
@@ -279,18 +267,25 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               // gets goNext/skip directly and the shell footer is suppressed
               // below. A successful claim advances; skip drops to the app.
               <PairStep onPaired={goNext} onSkip={skip} />
+            ) : pos === 2 ? (
+              // Step 2 (Providers) owns its footer (Back + gated Continue).
+              <ProvidersStep onBack={goBack} onContinue={goNext} />
+            ) : pos === 3 ? (
+              // Step 3 (Model) owns its footer (Back + gated Continue).
+              <ModelStep onBack={goBack} onContinue={goNext} />
             ) : (
               stepBody(pos)
             )}
           </div>
         </div>
 
-        {/* Footer nav. Hidden on the success screen (own button) AND on step 1
-            (PairStep renders its own Skip setup + Connect footer). */}
-        {!isSuccess && pos !== 1 && (
+        {/* Footer nav. Hidden on the success screen (own button) AND on steps
+            1–3 (PairStep / ProvidersStep / ModelStep each render their own
+            footer). Only Step 4 uses this generic footer, until BET-49-T5. */}
+        {!isSuccess && pos !== 1 && pos !== 2 && pos !== 3 && (
           <div className="flex items-center justify-between gap-3 mt-8">
-            {/* pos is always 2–4 here (step 1 renders its own footer, success is
-                excluded), so canGoBack is always true — Back is the left slot. */}
+            {/* pos is always 4 here (steps 1–3 render their own footers, success
+                is excluded), so canGoBack is always true — Back is the left slot. */}
             <button
               onClick={goBack}
               className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -10,6 +10,7 @@ import {
   openaiKeyError,
   type ProviderDraft,
 } from "./providersStepLogic";
+import { PlusIcon, StepFooter } from "./onboardingUi";
 
 // ProvidersStep.tsx — Step 2 (Providers) of the desktop onboarding shell
 // (BET-49-T4). Mounts into Onboarding.tsx's step-2 slot.
@@ -107,24 +108,7 @@ export function ProvidersStep({
       />
 
       {/* Footer: Back (left) + Continue (right). Continue gated on ≥1 connected. */}
-      <div className="flex items-center justify-between gap-3 mt-8">
-        <button
-          onClick={onBack}
-          className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
-        >
-          <ArrowLeft />
-          Back
-        </button>
-        <button
-          onClick={onContinue}
-          disabled={!canContinue}
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
-          style={{ background: ACCENT }}
-        >
-          Continue
-          <ArrowRight />
-        </button>
-      </div>
+      <StepFooter onBack={onBack} onContinue={onContinue} continueDisabled={!canContinue} />
     </div>
   );
 }
@@ -265,6 +249,34 @@ function ProviderCard({
   );
 }
 
+// Shared write path for both add-provider forms: upsert via the existing
+// setProviders code path, then restart opencode so /provider re-auths and the
+// card flips to connected (+ the new models reach Step 3). Returns an error
+// string to surface, or null on success (after which it calls onDone). Keeping
+// this single orchestration means OpenAiForm/CustomForm differ only in
+// validation + payload — no duplicated try/catch/restart plumbing.
+async function saveProviderAndRestart(
+  provider: { id: string; name: string; baseURL: string; apiKey: string; enabledModels: string[] },
+  labels: { saveFailed: string; restartFailedPrefix: string },
+  onDone: () => Promise<void>,
+): Promise<string | null> {
+  try {
+    const res = await window.api.opencodeSetProviders({ upsert: [provider] });
+    if (!res.ok) return res.error ?? labels.saveFailed;
+    // Restart failure is non-fatal to the config write, but surface it (the
+    // card just won't flip until a manual restart).
+    try {
+      await window.api.opencodeRestart();
+    } catch (e) {
+      return `${labels.restartFailedPrefix}: ${e instanceof Error ? e.message : String(e)}`;
+    }
+    await onDone();
+    return null;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
 // OpenAI: only a key is needed (baseURL pinned to OPENAI_BASE_URL). Writes via
 // the existing setProviders path, then restarts opencode so the key auths and
 // the card flips to connected.
@@ -281,39 +293,13 @@ function OpenAiForm({ onDone }: { onDone: () => Promise<void> }) {
     }
     setBusy(true);
     setError(null);
-    try {
-      const res = await window.api.opencodeSetProviders({
-        upsert: [
-          {
-            id: OPENAI_ID,
-            name: "OpenAI",
-            baseURL: OPENAI_BASE_URL,
-            apiKey: apiKey.trim(),
-            enabledModels: [],
-          },
-        ],
-      });
-      if (!res.ok) {
-        setError(res.error ?? "Couldn't save the OpenAI key.");
-        return;
-      }
-      // Restart so /provider re-auths and OpenAI shows as connected + its
-      // models reach Step 3. Failure here is non-fatal to the config write,
-      // but surface it (the card just won't flip until a manual restart).
-      try {
-        await window.api.opencodeRestart();
-      } catch (e) {
-        setError(
-          `Key saved, but restarting opencode failed: ${e instanceof Error ? e.message : String(e)}`,
-        );
-        return;
-      }
-      await onDone();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
+    const err = await saveProviderAndRestart(
+      { id: OPENAI_ID, name: "OpenAI", baseURL: OPENAI_BASE_URL, apiKey: apiKey.trim(), enabledModels: [] },
+      { saveFailed: "Couldn't save the OpenAI key.", restartFailedPrefix: "Key saved, but restarting opencode failed" },
+      onDone,
+    );
+    if (err) setError(err);
+    setBusy(false);
   };
 
   return (
@@ -354,36 +340,19 @@ function CustomForm({ onDone }: { onDone: () => Promise<void> }) {
     }
     setBusy(true);
     setError(null);
-    try {
-      const res = await window.api.opencodeSetProviders({
-        upsert: [
-          {
-            id: draft.id.trim(),
-            name: draft.name.trim() || draft.id.trim(),
-            baseURL: draft.baseURL.trim(),
-            apiKey: draft.apiKey,
-            enabledModels: [],
-          },
-        ],
-      });
-      if (!res.ok) {
-        setError(res.error ?? "Couldn't save the provider.");
-        return;
-      }
-      try {
-        await window.api.opencodeRestart();
-      } catch (e) {
-        setError(
-          `Provider saved, but restarting opencode failed: ${e instanceof Error ? e.message : String(e)}`,
-        );
-        return;
-      }
-      await onDone();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
+    const err = await saveProviderAndRestart(
+      {
+        id: draft.id.trim(),
+        name: draft.name.trim() || draft.id.trim(),
+        baseURL: draft.baseURL.trim(),
+        apiKey: draft.apiKey,
+        enabledModels: [],
+      },
+      { saveFailed: "Couldn't save the provider.", restartFailedPrefix: "Provider saved, but restarting opencode failed" },
+      onDone,
+    );
+    if (err) setError(err);
+    setBusy(false);
   };
 
   return (
@@ -500,28 +469,4 @@ function FormSubmit({
   );
 }
 
-function PlusIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-[18px] h-[18px]">
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-    </svg>
-  );
-}
 
-function ArrowRight() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-      <path d="M5 12h14" />
-      <path d="m12 5 7 7-7 7" />
-    </svg>
-  );
-}
-
-function ArrowLeft() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-      <path d="m15 18-6-6 6-6" />
-    </svg>
-  );
-}

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -1,0 +1,527 @@
+import { useCallback, useEffect, useState } from "react";
+import type { OpencodeModel, ProviderEndpoint } from "../shared/types";
+import {
+  ANTHROPIC_ID,
+  OPENAI_ID,
+  OPENAI_BASE_URL,
+  canContinueProviders,
+  connectedProviderIds,
+  customDraftError,
+  openaiKeyError,
+  type ProviderDraft,
+} from "./providersStepLogic";
+
+// ProvidersStep.tsx — Step 2 (Providers) of the desktop onboarding shell
+// (BET-49-T4). Mounts into Onboarding.tsx's step-2 slot.
+//
+// Shows three cards per docs/onboarding/mockup.html — Anthropic / OpenAI /
+// Custom — reflecting LIVE connected state:
+//   • "connected" is derived from opencode's own served-model list
+//     (window.api.opencodeModels()), which main builds from GET /provider
+//     filtered by `connected[]` (opencode.ts:listModels). We deliberately do
+//     NOT call /api/model (it embeds apiKey) — reused audit point.
+//   • Anthropic connects via the box's Claude-auth plugin; when it isn't
+//     connected we show a "requires setup on the box" pointer. Driving the
+//     device-login flow from the desktop is EXPLICITLY OUT OF SCOPE (parent
+//     BET-49 "Anthropic OAuth addendum") — we do not improvise it here.
+//   • OpenAI / Custom are added through the EXISTING providers.ts write path
+//     (window.api.opencodeSetProviders → setProviders/upsertProviderBlock).
+//     No new provider-fetch code paths.
+//
+// After a successful add we restart opencode (opencodeRestart) so `/provider`
+// re-auths and the new provider shows as connected + surfaces its models to
+// Step 3 — otherwise the just-added key wouldn't count toward the ≥1-connected
+// Continue gate.
+//
+// This component owns its OWN footer (Back + Continue), like PairStep, because
+// Continue must be gated on ≥1 connected provider — the shell's generic footer
+// can't express that. The shell suppresses its footer for this step.
+//
+// Props:
+//   onBack     — go to the previous step (Pair).
+//   onContinue — advance to Step 3 (Model). Enabled once ≥1 provider connected.
+
+const ACCENT = "#7c9cff";
+const DANGER = "#f87171";
+const SUCCESS = "#4ade80";
+
+type AddForm = null | "openai" | "custom";
+
+export function ProvidersStep({
+  onBack,
+  onContinue,
+}: {
+  onBack: () => void;
+  onContinue: () => void;
+}) {
+  const [models, setModels] = useState<OpencodeModel[] | null>(null);
+  const [endpoints, setEndpoints] = useState<ProviderEndpoint[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Reload the live connected picture (served models + configured endpoints).
+  // opencodeModels drives the connected badges + the Continue gate; endpoints
+  // tells us whether an OpenAI block already exists so the card reflects it.
+  const load = useCallback(async () => {
+    setLoadError(null);
+    const [m, eps] = await Promise.all([
+      window.api.opencodeModels().catch(() => {
+        setLoadError("Couldn't reach the box to check providers.");
+        return [] as OpencodeModel[];
+      }),
+      window.api.opencodeGetProviders().catch(() => [] as ProviderEndpoint[]),
+    ]);
+    setModels(m);
+    setEndpoints(eps);
+  }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const connected = connectedProviderIds(models ?? []);
+  const canContinue = canContinueProviders(models ?? []);
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight text-text mb-1.5">
+        Choose your providers
+      </h2>
+      <p className="text-sm text-text-muted leading-relaxed mb-8 max-w-md">
+        Select the AI providers you want to use. You can add more later.
+      </p>
+
+      {loadError && (
+        <div role="alert" className="text-sm mb-4" style={{ color: DANGER }}>
+          {loadError}{" "}
+          <button onClick={() => void load()} className="underline hover:no-underline">
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Provider cards row (Anthropic / OpenAI / Custom). */}
+      <ProviderCards
+        loading={models === null}
+        connected={connected}
+        openaiConfigured={endpoints.some((e) => e.id === OPENAI_ID)}
+        onReload={load}
+      />
+
+      {/* Footer: Back (left) + Continue (right). Continue gated on ≥1 connected. */}
+      <div className="flex items-center justify-between gap-3 mt-8">
+        <button
+          onClick={onBack}
+          className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
+        >
+          <ArrowLeft />
+          Back
+        </button>
+        <button
+          onClick={onContinue}
+          disabled={!canContinue}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
+          style={{ background: ACCENT }}
+        >
+          Continue
+          <ArrowRight />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ProviderCards({
+  loading,
+  connected,
+  openaiConfigured,
+  onReload,
+}: {
+  loading: boolean;
+  connected: Set<string>;
+  openaiConfigured: boolean;
+  onReload: () => Promise<void>;
+}) {
+  const [form, setForm] = useState<AddForm>(null);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2.5">
+        <ProviderCard
+          letter="A"
+          name="Anthropic"
+          connected={connected.has(ANTHROPIC_ID)}
+          statusConnected="Connected"
+          statusDisconnected="Requires setup on the box"
+          loading={loading}
+          onClick={undefined}
+        />
+        <ProviderCard
+          letter="O"
+          name="OpenAI"
+          connected={connected.has(OPENAI_ID)}
+          statusConnected="Connected"
+          statusDisconnected={openaiConfigured ? "Key added — restart pending" : "Add API key"}
+          loading={loading}
+          onClick={() => setForm((f) => (f === "openai" ? null : "openai"))}
+          active={form === "openai"}
+        />
+        <ProviderCard
+          plus
+          name="Custom"
+          connected={false}
+          statusConnected="Add provider"
+          statusDisconnected="Add provider"
+          loading={loading}
+          onClick={() => setForm((f) => (f === "custom" ? null : "custom"))}
+          active={form === "custom"}
+        />
+      </div>
+
+      {/* Anthropic-not-connected pointer (device-login flow is out of scope). */}
+      {!loading && !connected.has(ANTHROPIC_ID) && (
+        <div className="rounded-md border border-border bg-bg-soft px-3 py-2.5 text-xs text-text-muted leading-relaxed">
+          Anthropic isn't connected yet. Sign in to Claude on the box (e.g.{" "}
+          <code className="rounded bg-bg px-1.5 py-0.5 text-[11px] text-text-muted">
+            opencode auth login
+          </code>
+          ), then reopen this step. In-app Anthropic sign-in is coming soon.
+        </div>
+      )}
+
+      {form === "openai" && (
+        <OpenAiForm
+          onDone={async () => {
+            setForm(null);
+            await onReload();
+          }}
+        />
+      )}
+      {form === "custom" && (
+        <CustomForm
+          onDone={async () => {
+            setForm(null);
+            await onReload();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ProviderCard({
+  letter,
+  plus,
+  name,
+  connected,
+  statusConnected,
+  statusDisconnected,
+  loading,
+  onClick,
+  active,
+}: {
+  letter?: string;
+  plus?: boolean;
+  name: string;
+  connected: boolean;
+  statusConnected: string;
+  statusDisconnected: string;
+  loading: boolean;
+  onClick?: () => void;
+  active?: boolean;
+}) {
+  const clickable = onClick !== undefined;
+  const status = loading ? "Checking…" : connected ? statusConnected : statusDisconnected;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!clickable}
+      className="flex-1 flex flex-col items-center gap-3 rounded-md border p-4 text-center transition-colors disabled:cursor-default"
+      style={{
+        borderColor: connected || active ? ACCENT : "#262932",
+        background: connected || active ? "#1b1e25" : "transparent",
+        boxShadow: connected || active ? `0 0 0 3px rgba(124,156,255,0.15)` : undefined,
+      }}
+    >
+      <div
+        className="w-10 h-10 rounded flex items-center justify-center text-base font-bold"
+        style={{
+          background: connected ? ACCENT : "#14161b",
+          border: `1.5px solid ${connected ? ACCENT : "#262932"}`,
+          color: connected ? "#0e0f12" : "#9aa0aa",
+        }}
+      >
+        {plus ? <PlusIcon /> : letter}
+      </div>
+      <div>
+        <div className="text-[13px] font-semibold text-text">{name}</div>
+        <div
+          className="text-[11px] mt-0.5"
+          style={{ color: connected ? SUCCESS : "#6b7280" }}
+        >
+          {status}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// OpenAI: only a key is needed (baseURL pinned to OPENAI_BASE_URL). Writes via
+// the existing setProviders path, then restarts opencode so the key auths and
+// the card flips to connected.
+function OpenAiForm({ onDone }: { onDone: () => Promise<void> }) {
+  const [apiKey, setApiKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const keyErr = openaiKeyError(apiKey);
+    if (keyErr) {
+      setError(keyErr);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await window.api.opencodeSetProviders({
+        upsert: [
+          {
+            id: OPENAI_ID,
+            name: "OpenAI",
+            baseURL: OPENAI_BASE_URL,
+            apiKey: apiKey.trim(),
+            enabledModels: [],
+          },
+        ],
+      });
+      if (!res.ok) {
+        setError(res.error ?? "Couldn't save the OpenAI key.");
+        return;
+      }
+      // Restart so /provider re-auths and OpenAI shows as connected + its
+      // models reach Step 3. Failure here is non-fatal to the config write,
+      // but surface it (the card just won't flip until a manual restart).
+      try {
+        await window.api.opencodeRestart();
+      } catch (e) {
+        setError(
+          `Key saved, but restarting opencode failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        return;
+      }
+      await onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <CardForm title="Connect OpenAI" error={error}>
+      <PasswordInput
+        label="API key"
+        placeholder="sk-…"
+        value={apiKey}
+        disabled={busy}
+        onChange={(v) => {
+          setApiKey(v);
+          setError(null);
+        }}
+      />
+      <FormSubmit busy={busy} disabled={!apiKey.trim()} onClick={submit}>
+        {busy ? "Connecting…" : "Connect"}
+      </FormSubmit>
+    </CardForm>
+  );
+}
+
+// Custom: id/name/baseURL/apiKey — same setProviders code path as OpenAI.
+function CustomForm({ onDone }: { onDone: () => Promise<void> }) {
+  const [draft, setDraft] = useState<ProviderDraft>({ id: "", name: "", baseURL: "", apiKey: "" });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const set = (patch: Partial<ProviderDraft>) => {
+    setDraft((d) => ({ ...d, ...patch }));
+    setError(null);
+  };
+
+  const submit = async () => {
+    const draftErr = customDraftError(draft);
+    if (draftErr) {
+      setError(draftErr);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await window.api.opencodeSetProviders({
+        upsert: [
+          {
+            id: draft.id.trim(),
+            name: draft.name.trim() || draft.id.trim(),
+            baseURL: draft.baseURL.trim(),
+            apiKey: draft.apiKey,
+            enabledModels: [],
+          },
+        ],
+      });
+      if (!res.ok) {
+        setError(res.error ?? "Couldn't save the provider.");
+        return;
+      }
+      try {
+        await window.api.opencodeRestart();
+      } catch (e) {
+        setError(
+          `Provider saved, but restarting opencode failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        return;
+      }
+      await onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <CardForm title="Add a custom provider" error={error}>
+      <TextInput label="Provider id" placeholder="e.g. groq" value={draft.id} disabled={busy} onChange={(v) => set({ id: v })} />
+      <TextInput label="Name (optional)" placeholder="e.g. Groq" value={draft.name} disabled={busy} onChange={(v) => set({ name: v })} />
+      <TextInput label="Base URL" placeholder="https://api.groq.com/openai/v1" value={draft.baseURL} disabled={busy} onChange={(v) => set({ baseURL: v })} />
+      <PasswordInput label="API key (optional)" placeholder="key" value={draft.apiKey} disabled={busy} onChange={(v) => set({ apiKey: v })} />
+      <FormSubmit busy={busy} disabled={!draft.id.trim() || !draft.baseURL.trim()} onClick={submit}>
+        {busy ? "Adding…" : "Add provider"}
+      </FormSubmit>
+    </CardForm>
+  );
+}
+
+// ── Small shared form primitives (local to this step; not exported) ──────────
+
+function CardForm({
+  title,
+  error,
+  children,
+}: {
+  title: string;
+  error: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-md border border-border bg-bg-soft p-3 space-y-2.5">
+      <div className="text-[11px] uppercase tracking-wider text-text-faint">{title}</div>
+      {children}
+      {error && (
+        <div role="alert" className="text-xs" style={{ color: DANGER }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TextInput({
+  label,
+  placeholder,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  placeholder: string;
+  value: string;
+  disabled: boolean;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] text-text-muted">{label}</span>
+      <input
+        type="text"
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded bg-bg border border-border px-2.5 py-2 text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+      />
+    </label>
+  );
+}
+
+function PasswordInput(props: {
+  label: string;
+  placeholder: string;
+  value: string;
+  disabled: boolean;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] text-text-muted">{props.label}</span>
+      <input
+        type="password"
+        autoComplete="off"
+        placeholder={props.placeholder}
+        value={props.value}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value)}
+        className="w-full rounded bg-bg border border-border px-2.5 py-2 text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+      />
+    </label>
+  );
+}
+
+function FormSubmit({
+  busy,
+  disabled,
+  onClick,
+  children,
+}: {
+  busy: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy || disabled}
+      className="inline-flex items-center gap-2 px-3.5 py-2 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
+      style={{ background: ACCENT }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-[18px] h-[18px]">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function ArrowRight() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
+      <path d="M5 12h14" />
+      <path d="m12 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+function ArrowLeft() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}

--- a/src/renderer/onboardingUi.tsx
+++ b/src/renderer/onboardingUi.tsx
@@ -1,0 +1,118 @@
+// onboardingUi.tsx — shared React presentation primitives for the M6.2 desktop
+// onboarding flow (BET-49-T3/T4). These are the pieces that were previously
+// copy-pasted verbatim across Onboarding.tsx / ProvidersStep.tsx / ModelStep.tsx
+// (the step-nav arrow/check/plus SVGs and the Back+Continue footer). Extracting
+// them here kills the duplication-gate clones and gives every step one source of
+// truth for the nav chrome. Pure step-model logic still lives in onboardingUtils.ts;
+// this module owns only the small shared JSX.
+
+const ACCENT = "#7c9cff";
+
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+export function ArrowRight({ className = "w-4 h-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M5 12h14" />
+      <path d="m12 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+export function ArrowLeft({ className = "w-4 h-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export function PlusIcon({ className = "w-[18px] h-[18px]" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+// ── Step footer (Back + primary Continue) ────────────────────────────────────
+//
+// Every onboarding step body that owns its own footer (Providers, Model) — and
+// the shell's generic step-4 footer — renders the same Back-left / primary-right
+// row. `continueDisabled` expresses the per-step gate (≥1 connected provider,
+// a selected model); the shell's step-4 footer leaves it undefined (always
+// enabled) and overrides the label via `continueLabel`.
+
+export function StepFooter({
+  onBack,
+  onContinue,
+  continueLabel = "Continue",
+  continueDisabled = false,
+}: {
+  onBack: () => void;
+  onContinue: () => void;
+  continueLabel?: string;
+  continueDisabled?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 mt-8">
+      <button
+        onClick={onBack}
+        className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
+      >
+        <ArrowLeft />
+        Back
+      </button>
+      <button
+        onClick={onContinue}
+        disabled={continueDisabled}
+        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"
+        style={{ background: ACCENT }}
+      >
+        {continueLabel}
+        <ArrowRight />
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/providersStepLogic.test.ts
+++ b/src/renderer/providersStepLogic.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import type { OpencodeModel } from "../shared/types";
+import {
+  connectedProviderIds,
+  isProviderConnected,
+  canContinueProviders,
+  customDraftError,
+  openaiKeyError,
+  modelDisplayName,
+  formatContextWindow,
+  sortModelsForPicker,
+  canContinueModel,
+  ANTHROPIC_ID,
+  OPENAI_ID,
+} from "./providersStepLogic";
+
+const model = (over: Partial<OpencodeModel>): OpencodeModel => ({
+  id: "m",
+  providerID: "p",
+  name: "M",
+  ...over,
+});
+
+describe("connectedProviderIds", () => {
+  it("collects the distinct providerIDs of served models", () => {
+    const ids = connectedProviderIds([
+      model({ id: "claude-sonnet-4-6", providerID: "anthropic" }),
+      model({ id: "claude-opus-4-7", providerID: "anthropic" }),
+      model({ id: "gpt-4o", providerID: "openai" }),
+    ]);
+    expect([...ids].sort()).toEqual(["anthropic", "openai"]);
+  });
+
+  it("is empty for no models (nothing connected)", () => {
+    expect(connectedProviderIds([]).size).toBe(0);
+  });
+
+  it("ignores models with an empty providerID", () => {
+    expect(connectedProviderIds([model({ providerID: "" })]).size).toBe(0);
+  });
+});
+
+describe("isProviderConnected", () => {
+  const models = [model({ providerID: ANTHROPIC_ID })];
+  it("true when the provider serves a model", () => {
+    expect(isProviderConnected(models, ANTHROPIC_ID)).toBe(true);
+  });
+  it("false when it does not", () => {
+    expect(isProviderConnected(models, OPENAI_ID)).toBe(false);
+  });
+});
+
+describe("canContinueProviders", () => {
+  it("false with zero connected providers", () => {
+    expect(canContinueProviders([])).toBe(false);
+  });
+  it("true with at least one", () => {
+    expect(canContinueProviders([model({ providerID: "anthropic" })])).toBe(true);
+  });
+});
+
+describe("customDraftError", () => {
+  it("requires id", () => {
+    expect(customDraftError({ id: "  ", name: "", baseURL: "https://x/v1", apiKey: "" })).toMatch(
+      /id is required/i,
+    );
+  });
+  it("requires baseURL", () => {
+    expect(customDraftError({ id: "x", name: "", baseURL: "", apiKey: "" })).toMatch(
+      /base url is required/i,
+    );
+  });
+  it("requires http(s) baseURL", () => {
+    expect(customDraftError({ id: "x", name: "", baseURL: "api.x.com/v1", apiKey: "" })).toMatch(
+      /http/i,
+    );
+  });
+  it("null when valid (key optional)", () => {
+    expect(customDraftError({ id: "x", name: "X", baseURL: "https://api.x.com/v1", apiKey: "" })).toBeNull();
+  });
+});
+
+describe("openaiKeyError", () => {
+  it("requires a key", () => {
+    expect(openaiKeyError("   ")).toMatch(/api key is required/i);
+  });
+  it("null when present", () => {
+    expect(openaiKeyError("sk-abc")).toBeNull();
+  });
+});
+
+describe("modelDisplayName", () => {
+  it("prefers name", () => {
+    expect(modelDisplayName(model({ id: "claude-sonnet-4-6", name: "Claude Sonnet" }))).toBe(
+      "Claude Sonnet",
+    );
+  });
+  it("falls back to id when name blank", () => {
+    expect(modelDisplayName(model({ id: "claude-sonnet-4-6", name: "  " }))).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+});
+
+describe("formatContextWindow", () => {
+  it("formats whole thousands as K", () => {
+    expect(formatContextWindow(model({ limit: { context: 200000 } }))).toBe("200K context");
+  });
+  it("keeps one decimal for non-whole K", () => {
+    expect(formatContextWindow(model({ limit: { context: 32800 } }))).toBe("32.8K context");
+  });
+  it("sub-1000 renders raw", () => {
+    expect(formatContextWindow(model({ limit: { context: 512 } }))).toBe("512 context");
+  });
+  it("null when unknown", () => {
+    expect(formatContextWindow(model({ limit: undefined }))).toBeNull();
+    expect(formatContextWindow(model({ limit: { context: 0 } }))).toBeNull();
+  });
+});
+
+describe("sortModelsForPicker", () => {
+  it("groups by provider then display name, stably", () => {
+    const sorted = sortModelsForPicker([
+      model({ id: "gpt-4o", providerID: "openai", name: "GPT-4o" }),
+      model({ id: "claude-opus-4-7", providerID: "anthropic", name: "Claude Opus" }),
+      model({ id: "claude-sonnet-4-6", providerID: "anthropic", name: "Claude Sonnet" }),
+    ]);
+    expect(sorted.map((m) => m.id)).toEqual(["claude-opus-4-7", "claude-sonnet-4-6", "gpt-4o"]);
+  });
+  it("does not mutate the input", () => {
+    const input = [model({ id: "b" }), model({ id: "a" })];
+    sortModelsForPicker(input);
+    expect(input.map((m) => m.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("canContinueModel", () => {
+  const models = [model({ id: "claude-sonnet-4-6", providerID: "anthropic" })];
+  it("false with no selection", () => {
+    expect(canContinueModel(models, null)).toBe(false);
+  });
+  it("true when the selection is still served", () => {
+    expect(canContinueModel(models, { providerID: "anthropic", modelID: "claude-sonnet-4-6" })).toBe(
+      true,
+    );
+  });
+  it("false when the selected model is no longer served", () => {
+    expect(canContinueModel(models, { providerID: "anthropic", modelID: "gone" })).toBe(false);
+  });
+});

--- a/src/renderer/providersStepLogic.ts
+++ b/src/renderer/providersStepLogic.ts
@@ -1,0 +1,117 @@
+// providersStepLogic.ts — pure logic for onboarding Step 2 (Providers) and
+// Step 3 (Model), BET-49-T4. Framework-free so it's unit-testable in vitest
+// (see providersStepLogic.test.ts), exactly like pairStepLogic.ts /
+// onboardingUtils.ts. ProvidersStep.tsx / ModelStep.tsx own the React/DOM; this
+// module owns the "which providers are connected / can we continue" decisions.
+//
+// The single source of truth for "connected" is opencode's own model list
+// (window.api.opencodeModels()), which main derives from GET /provider filtered
+// by `connected[]` (see opencode.ts:listModels) — NEVER /api/model, which leaks
+// apiKey. A provider is "connected" iff opencode actually serves at least one
+// model for it; that is exactly the condition under which a model can be picked
+// in Step 3, so the two steps stay consistent by construction.
+
+import type { OpencodeModel } from "../shared/types";
+
+// Provider ids we surface as first-class cards in Step 2. Anthropic is the
+// Claude-auth path (connected on the box via the auth plugin); OpenAI is the
+// canonical hosted OpenAI-compatible endpoint added via an API key. Everything
+// else is reached through the "Custom" card.
+export const ANTHROPIC_ID = "anthropic";
+export const OPENAI_ID = "openai";
+
+// opencode's default OpenAI-compatible base URL for the built-in OpenAI card.
+// The Custom card lets the user type any baseURL; OpenAI is pinned so the user
+// only has to paste a key.
+export const OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+// The set of provider ids opencode actually serves models for. This is the
+// authoritative "connected" signal for the whole step: a provider with zero
+// served models is not connected (even if a stale block sits in opencode.jsonc).
+export function connectedProviderIds(models: OpencodeModel[]): Set<string> {
+  const ids = new Set<string>();
+  for (const m of models) {
+    if (m.providerID) ids.add(m.providerID);
+  }
+  return ids;
+}
+
+// Is a specific provider connected (opencode serves ≥1 model for it)?
+export function isProviderConnected(models: OpencodeModel[], providerID: string): boolean {
+  return connectedProviderIds(models).has(providerID);
+}
+
+// Step 2 Continue gate: at least one provider must be connected (i.e. at least
+// one model is pickable in Step 3). Mirrors the acceptance criterion "step 2
+// Continue requires ≥1 connected provider".
+export function canContinueProviders(models: OpencodeModel[]): boolean {
+  return connectedProviderIds(models).size > 0;
+}
+
+// Validation for the OpenAI / Custom API-key add forms. OpenAI needs only a
+// key (baseURL is pinned); Custom needs id + baseURL, key optional (some
+// self-hosted endpoints are keyless). Returns the reason it's invalid, or null
+// when the draft is submittable — so the UI can both disable the button and
+// (optionally) show why.
+export type ProviderDraft = { id: string; name: string; baseURL: string; apiKey: string };
+
+export function customDraftError(draft: ProviderDraft): string | null {
+  if (!draft.id.trim()) return "Provider id is required.";
+  if (!draft.baseURL.trim()) return "Base URL is required.";
+  if (!/^https?:\/\//i.test(draft.baseURL.trim())) return "Base URL must start with http:// or https://.";
+  return null;
+}
+
+export function openaiKeyError(apiKey: string): string | null {
+  if (!apiKey.trim()) return "API key is required.";
+  return null;
+}
+
+// A stable, human-friendly display label for a model in the Step 3 radio list.
+// Prefers opencode's `name`, falling back to the id. Kept pure so the list
+// rendering has no branching logic inline.
+export function modelDisplayName(model: OpencodeModel): string {
+  return model.name?.trim() || model.id;
+}
+
+// Format a model's context window (limit.context, in tokens) as the mockup's
+// "200K context" / "128K context" label. Returns null when unknown so the UI
+// can omit the segment entirely rather than render "undefined context".
+export function formatContextWindow(model: OpencodeModel): string | null {
+  const ctx = model.limit?.context;
+  if (typeof ctx !== "number" || !Number.isFinite(ctx) || ctx <= 0) return null;
+  if (ctx >= 1000) {
+    const k = ctx / 1000;
+    // Whole thousands render as "200K"; keep one decimal otherwise ("32.8K").
+    const label = Number.isInteger(k) ? String(k) : k.toFixed(1);
+    return `${label}K context`;
+  }
+  return `${ctx} context`;
+}
+
+// Sort models for the Step 3 picker: connected-provider models grouped by
+// provider id (stable, alphabetical), then by display name within a provider.
+// Deterministic ordering keeps the radio list from reshuffling between fetches.
+export function sortModelsForPicker(models: OpencodeModel[]): OpencodeModel[] {
+  return [...models].sort((a, b) => {
+    const pa = a.providerID || "";
+    const pb = b.providerID || "";
+    if (pa !== pb) return pa < pb ? -1 : 1;
+    const na = modelDisplayName(a).toLowerCase();
+    const nb = modelDisplayName(b).toLowerCase();
+    if (na !== nb) return na < nb ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+// Step 3 Continue gate: a model must be selected AND it must still be present
+// in the currently-served list (a provider removed between fetches invalidates
+// a stale selection). Compares on providerID/modelID (the AppConfig.defaultModel
+// shape).
+export function canContinueModel(
+  models: OpencodeModel[],
+  selected: { providerID: string; modelID: string } | null,
+): boolean {
+  if (!selected) return false;
+  return models.some((m) => m.providerID === selected.providerID && m.id === selected.modelID);
+}

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -460,3 +460,37 @@ describe("replayChatAttention", () => {
     expect(useStore.getState().status.bui[1].attentionKind).toBe("permission");
   });
 });
+
+describe("setDefaultModel (onboarding Step 3 + Settings)", () => {
+  beforeEach(() => {
+    useStore.setState({ defaultModel: null });
+  });
+
+  it("optimistically sets, persists via configUpdate, and reconciles", async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    (globalThis as unknown as { window: { api: Record<string, unknown> } }).window = {
+      api: {
+        // Echo the patch back (main's success path returns the saved config).
+        configUpdate: async (patch: Record<string, unknown>) => {
+          patches.push(patch);
+          return { defaultModel: patch.defaultModel };
+        },
+      },
+    };
+    const model = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+    await useStore.getState().setDefaultModel(model);
+    expect(patches).toEqual([{ defaultModel: model }]);
+    expect(useStore.getState().defaultModel).toEqual(model);
+  });
+
+  it("reconciles to null when main drops the field (reject path)", async () => {
+    (globalThis as unknown as { window: { api: Record<string, unknown> } }).window = {
+      api: {
+        // Simulate main NOT persisting defaultModel (returns config without it).
+        configUpdate: async () => ({}),
+      },
+    };
+    await useStore.getState().setDefaultModel({ providerID: "openai", modelID: "gpt-4o" });
+    expect(useStore.getState().defaultModel).toBeNull();
+  });
+});

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -128,6 +128,11 @@ type State = {
   skipOnboarding: () => Promise<void>;
   relaunchOnboarding: () => Promise<void>;
   finishOnboarding: () => Promise<void>;
+  // Persist the global default model (onboarding Step 3 + Settings share this
+  // config field). Optimistic set + configUpdate + reconcile, matching the
+  // other config setters. New/cleared sessions inherit it (see ChatPanel's
+  // configDefaultModel), so it must survive restart — hence the config write.
+  setDefaultModel: (model: { providerID: string; modelID: string }) => Promise<void>;
   applyProjects: (projects: Project[]) => void;
   applyConfig: (c: AppConfig) => void;
   // Reflect a successful onboarding claim (BET-49-T2) into store state so
@@ -325,6 +330,13 @@ export const useStore = create<State>((set, get) => ({
 
   applyPairing: (p) =>
     set({ serverUrl: p.serverUrl, boxId: p.boxId, boxToken: p.boxToken }),
+
+  setDefaultModel: async (model) => {
+    set({ defaultModel: model });
+    const next = await window.api.configUpdate({ defaultModel: model });
+    // Reconcile with what main actually saved (handles error/reject paths).
+    set({ defaultModel: next.defaultModel ?? null });
+  },
 
   setChatAutoAllow: async (v) => {
     set({ chatAutoAllow: v });


### PR DESCRIPTION
## BET-56 (BET-49-T4): Onboarding Steps 2–3 — providers + default model

Implements Step 2 (Providers) and Step 3 (Model) of the M6.2 desktop onboarding flow, mounting into the BET-49-T3 shell. Reuses the existing `providers.ts` / opencode model IPC — **no new provider-fetch code paths**.

**Base:** `origin/main @ 20696e5`

### What landed

- **`ProvidersStep.tsx` (Step 2):** Anthropic / OpenAI / Custom cards in a row per `docs/onboarding/mockup.html`. Connected state is derived from `window.api.opencodeModels()` — the `/provider` + `connected[]` path (opencode.ts:listModels), **never `/api/model`** (which leaks apiKey). OpenAI card = API-key form (mockup's disabled state was an artifact, per BET-48/BET-49 notes); Custom card = id/name/baseURL/apiKey form. Both write through the existing `opencodeSetProviders` (`setProviders`/`upsertProviderBlock`) then restart opencode so `/provider` re-auths and the card flips to connected. Provider-auth/save failures render inline on that card only. Anthropic-not-connected shows a "requires setup on the box" pointer — the device-login flow is **explicitly out of scope** (flagged discuss-phase item in BET-49; not improvised here). Continue gated on ≥1 connected provider.
- **`ModelStep.tsx` (Step 3):** radio list from `opencodeModels()` for connected providers (model name mono + provider + context window, no badges). Selection persists to `AppConfig.defaultModel` via a new `store.setDefaultModel` action (`configUpdate` → config.json is the source of truth; new/cleared sessions already inherit it via ChatPanel's `configDefaultModel`). Continue gated on a selection.
- **`providersStepLogic.ts`:** pure, framework-free logic (connected detection, both Continue gates, context-window formatting, deterministic model sort, form validation) — 24 unit tests. Mirrors the `pairStepLogic.ts` / `onboardingUtils.ts` convention.
- **`store.ts`:** `setDefaultModel` (optimistic set → `configUpdate` → reconcile, matching `setChatAutoAllow`). 2 new store tests.
- **`Onboarding.tsx`:** mounts ProvidersStep/ModelStep into the step-2/3 slots; each owns its own footer (gated Continue + Back), like PairStep, so the shell suppresses its generic footer on steps 1–3.

### Cross-cutting fix (flagged)

`App.tsx` now **latches onboarding open** once entered. Step 1's successful pairing writes a `boxToken`, which flips `resolveTransportMode` to `"http"` → `enterOnboarding` goes false → App would tear the flow down **before Steps 2–4 could be reached**. Without this latch, everything in this PR (and BET-57's Step 4) is unreachable in the real first-run flow. The latch clears in `onDone` (finish/skip), which re-reads config for the shell. This is the T2↔T3 seam, but it directly blocks this task, so fixed here rather than deferred.

**Nuance for reviewer / T3 follow-up:** cross-*session* resume of a paired-but-incomplete config (boxToken set, no defaultModel, app relaunched, not "Run setup again") resolves to `"http"` mode → normal shell, so `resolveInitialStep`'s step-2 resume only fires within the same session or under `onboardingForced`. That's a T3 resume-gating concern, not introduced here.

### Verification results

**Files changed:** 8 files. `App.tsx`, `Onboarding.tsx`, `store.ts`, `store.test.ts` (M); `ModelStep.tsx`, `ProvidersStep.tsx`, `providersStepLogic.ts`, `providersStepLogic.test.ts` (A).

- PR branch (`multica/BET-56-providers-model` @ `b61c6e6`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`. vitest **603 pass** / 0 fail (28 files); node `--test` **226 pass** / 0 fail.
- Base (`main` @ `20696e5`): vitest 577, node 226 pre-existing green (delta = +26 new tests here: 24 providersStepLogic + 2 setDefaultModel).
- **Conclusion:** 0 new failures; all additions green. No base regression.

**E2E smoke (Playwright electron launcher, `xvfb-run`):** fresh config → onboarding Step 1 renders → drove a real pairing against a stub `/auth/claim` → **Step 2 (Providers) mounted**: "Choose your providers" + Anthropic/OpenAI/Custom cards, live disconnected state ("Requires setup on the box"), OpenAI API-key form opens (password input renders), Continue correctly **disabled** (no connected provider). **Zero renderer console/page errors.** (Smoke script was throwaway, not committed.)

### Anti-spaghetti audit

- Reused: `opencodeModels`, `opencodeGetProviders`, `opencodeSetProviders`, `opencodeRestart`, `configUpdate`. No new IPC channels.
- `setDefaultModel` follows the exact `setChatAutoAllow` optimistic-set→persist→reconcile pattern (no duplicated persistence logic).
- Pure logic isolated + tested; components are thin wiring.
