### PR TITLE
feat(renderer): onboarding Step 4 first-project + success (BET-49-T5)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import {
   killPty,
   listPathCompletions,
   listWorktrees,
+  mkdirRemote,
   remoteDirExists,
   resizePty,
   spawnPty,
@@ -1035,13 +1036,27 @@ function registerHandlers(): void {
 
   ipcMain.handle(
     IPC.tmuxNewSession,
-    async (_e, input: { name: string; cwd: string; windowName?: string; chatMode?: boolean }) => {
+    async (
+      _e,
+      input: { name: string; cwd: string; windowName?: string; chatMode?: boolean; createDir?: boolean },
+    ) => {
       if (!input.name.trim()) throw new Error("Project name is required");
       const cwd = input.cwd.trim() || "~";
       if (!(await remoteDirExists(config, cwd))) {
-        throw new Error(
-          `Directory does not exist on ${config.host}: ${cwd}\n\nCheck the path — tmux silently falls back to $HOME otherwise.`,
-        );
+        // Onboarding's first-project step (BET-49-T5) opts into auto-creation
+        // via createDir: the user is naming a fresh project, so a missing
+        // ~/projects/<name> should be created, not rejected. The Sidebar's
+        // normal create path leaves createDir unset and keeps the strict
+        // "directory must exist" guard that surfaces path typos. tmux's -c
+        // silently falls back to $HOME for a non-existent dir, so we mkdir -p
+        // FIRST (failure → inline error on the caller).
+        if (input.createDir) {
+          await mkdirRemote(config, cwd);
+        } else {
+          throw new Error(
+            `Directory does not exist on ${config.host}: ${cwd}\n\nCheck the path — tmux silently falls back to $HOME otherwise.`,
+          );
+        }
       }
       await tmuxNewSession(config, input.name.trim(), cwd, input.windowName, input.chatMode === true);
       // Persist defaultCwd locally so future sessions in this project get the same.

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -969,6 +969,17 @@ export async function remoteDirExists(config: AppConfig, cwd: string): Promise<b
   }
 }
 
+// mkdir -p the remote directory, expanding a leading ~ against the remote
+// $HOME (pathQuote handles that — a single-quoted tilde would create a literal
+// "~" dir). Used by the onboarding first-project step so a missing
+// ~/projects/<name> is created before tmux new-session -c runs (tmux silently
+// falls back to $HOME for a non-existent -c dir, so the mkdir must happen
+// first). Rejects on mkdir failure (e.g. permission denied) so the caller can
+// render an inline error.
+export async function mkdirRemote(config: AppConfig, cwd: string): Promise<void> {
+  await runSshOnce(config, `mkdir -p ${pathQuote(cwd)}`);
+}
+
 // ===== Long-lived attached PTYs (1 per project) =====
 
 const ptys = new Map<string, IPty>();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -58,7 +58,7 @@ const api = {
 
   // tmux operations on the remote
   tmuxList: (): Promise<Project[]> => ipcRenderer.invoke(IPC.tmuxList),
-  tmuxNewSession: (input: { name: string; cwd: string; windowName?: string; chatMode?: boolean }): Promise<Project[]> =>
+  tmuxNewSession: (input: { name: string; cwd: string; windowName?: string; chatMode?: boolean; createDir?: boolean }): Promise<Project[]> =>
     ipcRenderer.invoke(IPC.tmuxNewSession, input),
   tmuxNewWindow: (input: { sessionName: string; windowName: string; cwd?: string; chatMode?: boolean }): Promise<Project[]> =>
     ipcRenderer.invoke(IPC.tmuxNewWindow, input),

--- a/src/renderer/FirstProjectStep.tsx
+++ b/src/renderer/FirstProjectStep.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import {
+  defaultCwdForName,
+  nextCwdOnNameChange,
+  isManualDirEdit,
+  canCreateProject,
+} from "./firstProjectLogic";
+import { useStore } from "./store";
+import { StepFooter } from "./onboardingUi";
+
+// FirstProjectStep.tsx — Step 4 (First project) of the desktop onboarding shell
+// (BET-49-T5). Mounts into Onboarding.tsx's step-4 slot.
+//
+// A deliberately simple name + working-directory form (per docs/onboarding/
+// mockup.html — NO worktree fan-out, NO path autocomplete; the first project is
+// usually a fresh checkout and power users get the full Sidebar flow later). The
+// directory is prefilled `~/projects/<name>` and keeps tracking the name until
+// the user manually edits it, at which point their path wins. All that
+// name→dir bookkeeping is pure + unit-tested in firstProjectLogic.ts.
+//
+// Creation routes through the EXISTING project-creation path — the same
+// window.api.tmuxNewSession the Sidebar uses (tmux session + first window) — so
+// there is no parallel creation code. We pass `createDir: true` (onboarding
+// opt-in) so a missing ~/projects/<name> is `mkdir -p`'d server-side before
+// tmux new-session runs, instead of the Sidebar's strict "directory must exist"
+// rejection (see the tmuxNewSession handlers in src/main/index.ts + the server
+// tmux.newSession in src/server/tmux.mjs). We pass the raw `cwd` string (never
+// the literal "~") straight through; tilde expansion happens at the single
+// creation chokepoint, per the AGENTS.md "cwd inheritance" gotcha.
+//
+// On success we refresh the projects tree and mark the new session active, so
+// the success screen's "Open bui" drops into the normal shell with this project
+// selected. A creation failure (bad path, mkdir permission denied, tmux error)
+// renders inline and leaves the user on the form — the flow is never lost.
+//
+// Owns its OWN footer (Back + Create project), like PairStep/ProvidersStep/
+// ModelStep, because Create is gated on a name + directory. The shell suppresses
+// its footer here.
+//
+// Props:
+//   onBack    — go back to Step 3 (Model).
+//   onCreated — project created; the shell advances to the success screen.
+
+const DANGER = "#f87171"; // inline error text (matches PairStep/ModelStep)
+
+export function FirstProjectStep({
+  onBack,
+  onCreated,
+}: {
+  onBack: () => void;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  // The directory follows the name until manually edited (dirEdited latch).
+  const [cwd, setCwd] = useState(() => defaultCwdForName(""));
+  const [dirEdited, setDirEdited] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onNameChange = (value: string) => {
+    setName(value);
+    setCwd((prev) => nextCwdOnNameChange(value, prev, dirEdited));
+    setError(null);
+  };
+
+  const onCwdChange = (value: string) => {
+    setCwd(value);
+    // Latch "user owns the dir" the instant they deviate from the auto-fill, so
+    // further name edits stop clobbering their path. Typing the exact auto-fill
+    // value is not a deviation (keeps the field following the name).
+    if (isManualDirEdit(name, value)) setDirEdited(true);
+    setError(null);
+  };
+
+  const canCreate = canCreateProject(name, cwd) && !creating;
+
+  const create = async () => {
+    // Mirror the pure gate so an Enter keypress can't fire from a non-ready
+    // state (the button is also disabled, but Enter bypasses that).
+    if (!canCreateProject(name, cwd) || creating) return;
+    setCreating(true);
+    setError(null);
+    const projectName = name.trim();
+    try {
+      // Existing creation path (tmux session + first window). createDir opts
+      // into server-side mkdir -p for a fresh onboarding project. chatMode:true
+      // opens the window pinned to an opencode chat session using the model the
+      // user just picked in Step 3 — the whole point of onboarding is to land
+      // them chatting.
+      await window.api.tmuxNewSession({
+        name: projectName,
+        cwd: cwd.trim(),
+        windowName: "default",
+        chatMode: true,
+        createDir: true,
+      });
+      // Populate the store's projects tree and select the new session so "Open
+      // bui" lands in the normal shell with this project active.
+      await useStore.getState().refresh();
+      useStore.getState().setActive(projectName);
+      setCreating(false);
+      onCreated();
+    } catch (e) {
+      setCreating(false);
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const onFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void create();
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight text-text mb-1.5">
+        Create your first project
+      </h2>
+      <p className="text-sm text-text-muted leading-relaxed mb-8 max-w-md">
+        Give your project a name and pick where it lives. You can add more
+        projects anytime.
+      </p>
+
+      <form onSubmit={onFormSubmit} className="flex flex-col gap-5">
+        {/* Project name */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="project-name" className="text-xs font-medium text-text-muted">
+            Project name
+          </label>
+          <input
+            id="project-name"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            autoFocus
+            placeholder="my-app"
+            disabled={creating}
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            className="w-full rounded-md bg-bg-soft border border-border px-3 py-2.5 text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+          />
+        </div>
+
+        {/* Working directory */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="project-cwd" className="text-xs font-medium text-text-muted">
+            Working directory
+          </label>
+          <input
+            id="project-cwd"
+            type="text"
+            inputMode="url"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="~/projects/my-app"
+            disabled={creating}
+            value={cwd}
+            onChange={(e) => onCwdChange(e.target.value)}
+            className="w-full rounded-md bg-bg-soft border border-border px-3 py-2.5 font-mono text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+          />
+          <p className="text-xs text-text-faint">
+            If the directory doesn't exist, it will be created automatically.
+          </p>
+        </div>
+
+        {error && (
+          <div role="alert" className="text-sm" style={{ color: DANGER }}>
+            {error}
+          </div>
+        )}
+
+        <StepFooter
+          onBack={onBack}
+          onContinue={() => void create()}
+          continueLabel={creating ? "Creating…" : "Create project"}
+          continueDisabled={!canCreate}
+        />
+      </form>
+    </div>
+  );
+}

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -12,7 +12,8 @@ import { useStore } from "./store";
 import { PairStep } from "./PairStep";
 import { ProvidersStep } from "./ProvidersStep";
 import { ModelStep } from "./ModelStep";
-import { ArrowRight, CheckIcon, StepFooter } from "./onboardingUi";
+import { FirstProjectStep } from "./FirstProjectStep";
+import { ArrowRight, CheckIcon } from "./onboardingUi";
 
 // Onboarding.tsx — full-screen M6.2 onboarding shell (BET-49-T3).
 //
@@ -25,18 +26,19 @@ import { ArrowRight, CheckIcon, StepFooter } from "./onboardingUi";
 //   - Step 1 (Pair)          → BET-49-T2 (PairStep.tsx — mounted below)
 //   - Step 2 (Providers)     → BET-49-T4 (ProvidersStep.tsx — mounted below)
 //   - Step 3 (Model)         → BET-49-T4 (ModelStep.tsx — mounted below)
-//   - Step 4 (First project) → BET-49-T5 (placeholder until it lands)
+//   - Step 4 (First project) → BET-49-T5 (FirstProjectStep.tsx — mounted below)
 // Those land as their own components mounted into the step-body slots below.
 // The step model + resume math live in onboardingUtils.ts (pure, tested).
 //
-// Steps 1–3 each own their OWN footer (per docs/onboarding/mockup.html), because
+// Every step owns its OWN footer (per docs/onboarding/mockup.html), because
 // each has a gated/side-effecting primary action the shell's generic goNext
-// footer can't express: Step 1's "Connect" must run the pairing claim and only
-// advance on success; Step 2's "Continue" is gated on ≥1 connected provider;
-// Step 3's "Continue" is gated on a model selection. So the shell hides its
-// footer on steps 1–3 and lets each step drive advancement (onContinue/onPaired
-// → goNext), back-nav (onBack → goBack), and skipping (onSkip → skip). Step 4
-// still uses the shell's generic footer until BET-49-T5 replaces it.
+// footer can't express: Step 1's "Connect" runs the pairing claim and only
+// advances on success; Step 2's "Continue" is gated on ≥1 connected provider;
+// Step 3's "Continue" is gated on a model selection; Step 4's "Create project"
+// runs project creation and only advances (to success) once it succeeds. So the
+// shell hides its footer entirely and lets each step drive advancement
+// (onContinue/onPaired/onCreated → goNext), back-nav (onBack → goBack), and
+// skipping (onSkip → skip).
 //
 // Props:
 //   onDone — called when onboarding completes (success screen "Open bui") OR is
@@ -100,43 +102,6 @@ function ProgressRail({ current }: { current: OnboardingPosition }) {
       </div>
     </div>
   );
-}
-
-// Placeholder body for a not-yet-implemented step. Removed as T2/T4/T5 land.
-function StepPlaceholder({
-  title,
-  subtitle,
-  note,
-}: {
-  title: string;
-  subtitle: string;
-  note: string;
-}) {
-  return (
-    <div>
-      <h2 className="text-2xl font-semibold tracking-tight text-text mb-1.5">{title}</h2>
-      <p className="text-sm text-text-muted leading-relaxed mb-8 max-w-md">{subtitle}</p>
-      <div className="rounded-lg border border-dashed border-border bg-bg-soft p-6 text-sm text-text-faint">
-        {note}
-      </div>
-    </div>
-  );
-}
-
-// Placeholder body for Step 4 (BET-49-T5). Steps 1–3 are rendered by their own
-// components in the render below — they need the shell's goNext/goBack/skip
-// callbacks, which this module-level helper can't see.
-function stepBody(step: 4) {
-  switch (step) {
-    case 4:
-      return (
-        <StepPlaceholder
-          title="Create your first project"
-          subtitle="Start a new project to begin chatting with your AI."
-          note="First-project creation (Step 4) is delivered by BET-49-T5 and mounts here."
-        />
-      );
-  }
 }
 
 export function Onboarding({ onDone }: { onDone: () => void }) {
@@ -226,24 +191,12 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               // Step 3 (Model) owns its footer (Back + gated Continue).
               <ModelStep onBack={goBack} onContinue={goNext} />
             ) : (
-              stepBody(pos)
+              // Step 4 (First project) owns its footer (Back + gated Create
+              // project). onCreated advances to the success screen.
+              <FirstProjectStep onBack={goBack} onCreated={goNext} />
             )}
           </div>
         </div>
-
-        {/* Footer nav. Hidden on the success screen (own button) AND on steps
-            1–3 (PairStep / ProvidersStep / ModelStep each render their own
-            footer). Only Step 4 uses this generic footer, until BET-49-T5. */}
-        {!isSuccess && pos !== 1 && pos !== 2 && pos !== 3 && (
-          // pos is always 4 here (steps 1–3 render their own footers, success
-          // is excluded), so Back is always available — the shared StepFooter's
-          // Back-left / primary-right layout matches the per-step footers.
-          <StepFooter
-            onBack={goBack}
-            onContinue={goNext}
-            continueLabel={pos === LAST_STEP ? "Create project" : "Continue"}
-          />
-        )}
       </div>
     </div>
   );

--- a/src/renderer/firstProjectLogic.test.ts
+++ b/src/renderer/firstProjectLogic.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROJECT_DIR_PREFIX,
+  slugifyProjectName,
+  defaultCwdForName,
+  nextCwdOnNameChange,
+  isManualDirEdit,
+  canCreateProject,
+} from "./firstProjectLogic";
+
+describe("slugifyProjectName", () => {
+  it("lowercases and hyphenates spaces/punctuation", () => {
+    expect(slugifyProjectName("My Cool App")).toBe("my-cool-app");
+    expect(slugifyProjectName("Foo/Bar Baz")).toBe("foo-bar-baz");
+  });
+
+  it("keeps allowed path chars (dot, underscore, hyphen)", () => {
+    expect(slugifyProjectName("my_app.v2-final")).toBe("my_app.v2-final");
+  });
+
+  it("collapses runs of separators and trims leading/trailing hyphens", () => {
+    expect(slugifyProjectName("  --Hello   World!!  ")).toBe("hello-world");
+    expect(slugifyProjectName("@@@edge@@@")).toBe("edge");
+  });
+
+  it("returns empty string for blank/whitespace-only names", () => {
+    expect(slugifyProjectName("")).toBe("");
+    expect(slugifyProjectName("   ")).toBe("");
+    expect(slugifyProjectName("###")).toBe("");
+  });
+});
+
+describe("defaultCwdForName", () => {
+  it("nests the slug under ~/projects/", () => {
+    expect(defaultCwdForName("My App")).toBe("~/projects/my-app");
+    expect(defaultCwdForName("api")).toBe("~/projects/api");
+  });
+
+  it("yields the bare prefix for an empty name (never a dangling half-path)", () => {
+    expect(defaultCwdForName("")).toBe(PROJECT_DIR_PREFIX);
+    expect(defaultCwdForName("   ")).toBe(PROJECT_DIR_PREFIX);
+  });
+});
+
+describe("nextCwdOnNameChange", () => {
+  it("follows the name while the dir is untouched", () => {
+    expect(nextCwdOnNameChange("api", "~/projects/old", false)).toBe("~/projects/api");
+    expect(nextCwdOnNameChange("New Name", "anything", false)).toBe("~/projects/new-name");
+  });
+
+  it("leaves the user's dir alone once it's been manually edited", () => {
+    expect(nextCwdOnNameChange("api", "/srv/custom", true)).toBe("/srv/custom");
+    expect(nextCwdOnNameChange("", "/srv/custom", true)).toBe("/srv/custom");
+  });
+});
+
+describe("isManualDirEdit", () => {
+  it("is false when the typed dir matches what the name would auto-fill", () => {
+    // Simulates the auto-fill writing the same value — not a deviation.
+    expect(isManualDirEdit("my-app", "~/projects/my-app")).toBe(false);
+  });
+
+  it("is true the instant the dir deviates from the name-derived default", () => {
+    expect(isManualDirEdit("my-app", "~/projects/my-app-2")).toBe(true);
+    expect(isManualDirEdit("my-app", "/srv/x")).toBe(true);
+    expect(isManualDirEdit("my-app", "")).toBe(true);
+  });
+});
+
+describe("canCreateProject", () => {
+  it("requires a non-blank name and a non-blank directory", () => {
+    expect(canCreateProject("api", "~/projects/api")).toBe(true);
+  });
+
+  it("blocks when the name is blank", () => {
+    expect(canCreateProject("", "~/projects/api")).toBe(false);
+    expect(canCreateProject("   ", "~/projects/api")).toBe(false);
+  });
+
+  it("blocks when the directory was cleared (no silent $HOME fallback)", () => {
+    expect(canCreateProject("api", "")).toBe(false);
+    expect(canCreateProject("api", "   ")).toBe(false);
+  });
+});

--- a/src/renderer/firstProjectLogic.ts
+++ b/src/renderer/firstProjectLogic.ts
@@ -1,0 +1,65 @@
+// firstProjectLogic.ts — pure logic for onboarding Step 4 (First project),
+// BET-49-T5. Framework-free so it's unit-testable in vitest (see
+// firstProjectLogic.test.ts), exactly like pairStepLogic.ts / onboardingUtils.ts.
+// FirstProjectStep.tsx owns the React/DOM; this module owns the "what's the
+// prefilled directory" / "can we create yet" decisions.
+//
+// The step is a simple name + working-directory form (per docs/onboarding/
+// mockup.html — no worktree fan-out, no path autocomplete; the first project is
+// usually fresh). The directory is prefilled from the name (`~/projects/<name>`)
+// and keeps tracking the name UNTIL the user manually edits the directory, at
+// which point their explicit path wins and the auto-fill stops. All of that
+// "should the dir follow the name" bookkeeping is pure and lives here.
+
+// The prefix every auto-derived working directory sits under. A fresh onboarding
+// project lands in ~/projects/<name>; power users can retype anything.
+export const PROJECT_DIR_PREFIX = "~/projects/";
+
+// Slugify a raw project name into the trailing path segment of its default
+// working directory. We keep this permissive (the name itself is free-form and
+// used verbatim as the tmux session name) but the *path* segment is sanitized so
+// spaces / punctuation don't produce an awkward directory: lowercase, spaces and
+// runs of non [a-z0-9._-] collapse to a single hyphen, and leading/trailing
+// hyphens are trimmed. An empty/whitespace name yields "" (→ the bare prefix).
+export function slugifyProjectName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// The default working directory derived from a project name: `~/projects/<slug>`.
+// An empty name yields the bare prefix (`~/projects/`) so the field is never a
+// dangling half-path the user has to fix before typing.
+export function defaultCwdForName(name: string): string {
+  return PROJECT_DIR_PREFIX + slugifyProjectName(name);
+}
+
+// While the user hasn't touched the directory field, it should keep mirroring
+// the name. Once they manually edit it, their value is authoritative and we stop
+// auto-filling. `dirEdited` is the latch the component holds; this helper picks
+// the next directory value to show given a name change.
+//
+//   - dirEdited === false → follow the name (defaultCwdForName)
+//   - dirEdited === true  → keep the user's current directory unchanged
+export function nextCwdOnNameChange(name: string, currentCwd: string, dirEdited: boolean): string {
+  return dirEdited ? currentCwd : defaultCwdForName(name);
+}
+
+// Whether a manual directory edit should flip the "user owns the dir" latch.
+// Typing the exact value the name would have auto-filled is NOT a manual edit
+// (so the field keeps following the name); anything else is. This keeps the
+// common "type name, glance at dir, keep typing name" flow auto-filling while
+// still latching the instant the user deviates.
+export function isManualDirEdit(name: string, nextCwd: string): boolean {
+  return nextCwd !== defaultCwdForName(name);
+}
+
+// Gate for the "Create project" button. A project needs a non-blank name and a
+// non-blank working directory. The directory defaults to a real path, so the
+// only way it's blank is if the user cleared it — in which case we block rather
+// than silently fall back to $HOME (tmux's -c does that on a bad path).
+export function canCreateProject(name: string, cwd: string): boolean {
+  return name.trim().length > 0 && cwd.trim().length > 0;
+}

--- a/src/renderer/onboardingUi.tsx
+++ b/src/renderer/onboardingUi.tsx
@@ -98,6 +98,7 @@ export function StepFooter({
   return (
     <div className="flex items-center justify-between gap-3 mt-8">
       <button
+        type="button"
         onClick={onBack}
         className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-md text-sm text-text-muted hover:text-text transition-colors"
       >
@@ -105,6 +106,7 @@ export function StepFooter({
         Back
       </button>
       <button
+        type="button"
         onClick={onContinue}
         disabled={continueDisabled}
         className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium text-bg transition-opacity disabled:opacity-40"

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -1,6 +1,21 @@
 import { spawn as cpSpawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
 
 const FS = "\t";
+
+// Expand a leading ~ against this process's $HOME. The mobile server runs ON
+// the box, so a `~/projects/x` cwd is a real local path here. Without this a
+// literal mkdir("~/projects/x") would create a directory named "~" — the same
+// tilde-corruption chokepoint documented for opencode session.create. Mirrors
+// expandTilde in src/server/opencode.mjs (kept local — that one isn't exported).
+export function expandTildePath(p) {
+  if (typeof p !== "string" || !p.startsWith("~")) return p;
+  const home = homedir();
+  if (p === "~") return home;
+  if (p.startsWith("~/")) return home + "/" + p.slice(2);
+  return p; // ~user form — leave for the shell, not ours to guess
+}
 
 export function run(cmd, args) {
   return new Promise((resolve, reject) => {
@@ -68,7 +83,15 @@ export function isMissingSessionError(err, sessionName) {
   return false;
 }
 
-export async function newSession({ name, cwd, windowName }) {
+export async function newSession({ name, cwd, windowName, createDir }) {
+  // Onboarding's first-project step opts into auto-creation via createDir: a
+  // missing ~/projects/<name> should be created, not silently swallowed. tmux
+  // new-session -c falls back to $HOME for a non-existent dir, so the mkdir -p
+  // must run FIRST. mkdir failure (e.g. permission denied) rejects here so the
+  // caller renders an inline error. The Sidebar path leaves createDir unset.
+  if (createDir && cwd) {
+    await mkdir(expandTildePath(cwd), { recursive: true });
+  }
   await run("tmux", ["new-session", "-d", "-s", name, "-c", cwd ?? ".",
     ...(windowName ? ["-n", windowName] : [])]);
   await applySessionSurvivability(name);


### PR DESCRIPTION
## BET-49-T5: Step 4 — first project + success screen

Delivers the final onboarding step: a simple name + working-directory form that
creates the user's first project through the **existing** creation path (tmux
session + first window), then advances to the success screen ("Open bui").

Base: `origin/main @ 722ce1f`

### What changed

- **`src/renderer/FirstProjectStep.tsx`** (new) — Step 4 UI. Name + working-dir
  form; dir prefilled `~/projects/<slug>` and auto-tracks the name until the
  user manually edits it. Hint "If the directory doesn't exist, it will be
  created automatically." Owns its own footer (Back + gated "Create project"),
  matching PairStep/ProvidersStep/ModelStep. Creation failure renders inline;
  the flow is never lost. On success it refreshes the projects tree and marks
  the new session active, so "Open bui" lands in the normal shell with the
  project selected. Opens in `chatMode` using the model chosen in Step 3.
- **`src/renderer/firstProjectLogic.ts`** (new) + **`.test.ts`** — pure,
  framework-free logic (slugify, `defaultCwdForName`, name→dir auto-fill latch,
  `canCreateProject` gate), unit-tested like the sibling `*StepLogic` modules.
- **`src/renderer/Onboarding.tsx`** — mounts `FirstProjectStep` into the step-4
  slot; removes the placeholder helpers and the now-unused generic step-4
  footer (every step owns its own footer).
- **Auto-create the directory (`mkdir -p` server-side, opt-in via `createDir`):**
  - `src/preload/index.ts` — added `createDir?: boolean` to the
    `tmuxNewSession` input (propagates to the `Api` type + httpApi via inference).
  - `src/main/index.ts` + `src/main/pty.ts` — desktop handler `mkdir -p`'s (new
    `mkdirRemote`, tilde-expanded via `pathQuote`) when `createDir` is set,
    instead of the strict "directory must exist" rejection. Sidebar path leaves
    `createDir` unset → unchanged behavior.
  - `src/server/tmux.mjs` — HTTP-mode `newSession` `mkdir`s the tilde-expanded
    cwd (new exported `expandTildePath`) before `tmux new-session`.
- **`src/renderer/onboardingUi.tsx`** — `StepFooter` buttons now `type="button"`
  so they don't implicitly submit the FirstProjectStep `<form>` (safe for the
  existing callers, which are not inside forms).

### Tilde-corruption safety (acceptance criterion)

The component passes the raw `cwd` string straight through (never the literal
`"~"`). Expansion happens only at the creation chokepoint — desktop via
`pathQuote` (`~/x` → `$HOME/x`), server via `expandTildePath` (`~/x` →
`homedir()/x`) — so `/home/<user>/~/...` is impossible. `mkdir` operates on the
expanded path.

### Verification results

**Files changed:** 9 files (see `git diff --stat` below).

- PR branch (`multica/BET-57-first-project-success` @ `9055393`):
  - typecheck: exit `0`. Errors: none. (`/tmp/typecheck-pr.log`)
  - test: exit `0`, **616 vitest pass / 0 fail** + **226 node pass / 0 fail**.
    (`/tmp/test-pr.log`)
  - Note: a first full-suite run showed a single flaky failure in
    `tests/unit/e2e-smoke.test.ts > "should confirm Playwright is installed"`
    — a one-time Playwright browser-download race on cold cache. It passes in
    isolation on BOTH this branch and `main`, and the clean re-run above is
    0 failures. Not caused by this PR (this PR touches onboarding renderer +
    the tmux create path; the flaky test only checks the Playwright install).
- **Conclusion:** 0 new failures. All 616 vitest + 226 node green.

**Electron render smoke (bui-e2e-smoke, xvfb):** built app launches, onboarding
full-screen shell mounts, progress rail shows the Step-4 "Project" label, **0
page errors / 0 console.error**. (Step 4's own body is reached only after a live
pairing, which the headless smoke can't perform; the shell + import wiring are
proven to render crash-free.)

```
git diff --stat origin/main...HEAD
 src/main/index.ts                      |  23 ++++-
 src/main/pty.ts                        |  11 ++
 src/preload/index.ts                   |   2 +-
 src/renderer/FirstProjectStep.tsx      | 181 +++++++++++++++++++++++
 src/renderer/Onboarding.tsx            |  75 +++-----------
 src/renderer/firstProjectLogic.test.ts |  84 +++++++++++++
 src/renderer/firstProjectLogic.ts      |  65 ++++++++++
 src/renderer/onboardingUi.tsx          |   2 +
 src/server/tmux.mjs                    |  25 ++++-
```
