### PR TITLE
BET-59: M0.1 Network Refactor — pure primitives (backoff, state machine, backpressure)

### DIFF
--- a/src/shared/net/backoff.test.ts
+++ b/src/shared/net/backoff.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { ExponentialBackoff } from "./backoff";
+
+describe("ExponentialBackoff", () => {
+  it("grows geometrically with jitter off", () => {
+    const b = new ExponentialBackoff({ base: 1000, max: 30000, jitter: false });
+    expect(b.next()).toBe(1000); // 1000 * 2^0
+    expect(b.next()).toBe(2000); // 1000 * 2^1
+    expect(b.next()).toBe(4000); // 1000 * 2^2
+    expect(b.next()).toBe(8000); // 1000 * 2^3
+    expect(b.next()).toBe(16000); // 1000 * 2^4
+  });
+
+  it("caps at max", () => {
+    const b = new ExponentialBackoff({ base: 1000, max: 30000, jitter: false });
+    // Advance well past the cap.
+    for (let i = 0; i < 6; i++) b.next();
+    // 1000 * 2^6 = 64000 -> capped to 30000, stays capped.
+    expect(b.next()).toBe(30000);
+    expect(b.next()).toBe(30000);
+  });
+
+  it("respects a custom factor", () => {
+    const b = new ExponentialBackoff({ base: 100, max: 100000, factor: 3, jitter: false });
+    expect(b.next()).toBe(100);
+    expect(b.next()).toBe(300);
+    expect(b.next()).toBe(900);
+  });
+
+  it("reset() returns the attempt counter to 0", () => {
+    const b = new ExponentialBackoff({ base: 1000, max: 30000, jitter: false });
+    b.next();
+    b.next();
+    expect(b.attempt()).toBe(2);
+    b.reset();
+    expect(b.attempt()).toBe(0);
+    expect(b.next()).toBe(1000);
+  });
+
+  it("attempt() reflects the number of next() calls", () => {
+    const b = new ExponentialBackoff({ base: 1000, max: 30000, jitter: false });
+    expect(b.attempt()).toBe(0);
+    b.next();
+    expect(b.attempt()).toBe(1);
+    b.next();
+    expect(b.attempt()).toBe(2);
+  });
+
+  it("applies full-jitter within [0, computed] using injected RNG", () => {
+    // rng returns 0.5 -> half of the computed (capped) delay.
+    const b = new ExponentialBackoff({ base: 1000, max: 30000, rng: () => 0.5 });
+    expect(b.next()).toBe(500); // 0.5 * 1000
+    expect(b.next()).toBe(1000); // 0.5 * 2000
+    expect(b.next()).toBe(2000); // 0.5 * 4000
+  });
+
+  it("full-jitter is bounded by [0, capped] for extreme RNG values", () => {
+    const rngValues = [0, 0.999999, 0.5];
+    let i = 0;
+    const b = new ExponentialBackoff({
+      base: 1000,
+      max: 30000,
+      rng: () => rngValues[i++ % rngValues.length],
+    });
+    // attempt 0: computed 1000, rng 0 -> 0
+    expect(b.next()).toBe(0);
+    // attempt 1: computed 2000, rng ~1 -> < 2000
+    const d1 = b.next();
+    expect(d1).toBeGreaterThanOrEqual(0);
+    expect(d1).toBeLessThan(2000);
+    // attempt 2: computed 4000, rng 0.5 -> 2000
+    expect(b.next()).toBe(2000);
+  });
+
+  it("jitter never exceeds the cap", () => {
+    const b = new ExponentialBackoff({ base: 1000, max: 30000, rng: () => 0.999999 });
+    for (let i = 0; i < 20; i++) {
+      const d = b.next();
+      expect(d).toBeGreaterThanOrEqual(0);
+      expect(d).toBeLessThanOrEqual(30000);
+    }
+  });
+
+  it("matches the BET-46 default construction shape", () => {
+    const b = new ExponentialBackoff({ base: 1000, max: 30000 });
+    expect(b.attempt()).toBe(0);
+    const d = b.next();
+    expect(d).toBeGreaterThanOrEqual(0);
+    expect(d).toBeLessThanOrEqual(1000);
+  });
+});

--- a/src/shared/net/backoff.ts
+++ b/src/shared/net/backoff.ts
@@ -1,0 +1,66 @@
+// Pure exponential backoff with optional full-jitter.
+//
+// Importable from both the Electron main process and the renderer — no
+// Electron/Node-only APIs. Deterministic under an injectable RNG so tests can
+// pin jitter bounds.
+
+export interface ExponentialBackoffOpts {
+  /** Base delay in ms for the first attempt (attempt 0). */
+  base: number;
+  /** Maximum delay in ms; the computed delay is capped at this value. */
+  max: number;
+  /** Growth multiplier per attempt. Defaults to 2. */
+  factor?: number;
+  /** Apply full-jitter (`random(0, computed)`) when true. Defaults to true. */
+  jitter?: boolean;
+  /** Injectable RNG returning a float in [0, 1). Defaults to Math.random. */
+  rng?: () => number;
+}
+
+/**
+ * Exponential backoff generator.
+ *
+ * The delay for attempt `n` (0-indexed) is `base * factor ** n`, capped at
+ * `max`. With jitter enabled, full-jitter is applied: the returned value is a
+ * uniform random in `[0, computed]`. `next()` increments the internal attempt
+ * counter each call.
+ */
+export class ExponentialBackoff {
+  private readonly base: number;
+  private readonly max: number;
+  private readonly factor: number;
+  private readonly jitter: boolean;
+  private readonly rng: () => number;
+  private attemptCount = 0;
+
+  constructor(opts: ExponentialBackoffOpts) {
+    this.base = opts.base;
+    this.max = opts.max;
+    this.factor = opts.factor ?? 2;
+    this.jitter = opts.jitter ?? true;
+    this.rng = opts.rng ?? Math.random;
+  }
+
+  /**
+   * Returns the next delay in ms and increments the attempt counter.
+   * The uncapped growth is `base * factor ** attempt`; the result is capped at
+   * `max`, then (if jitter is on) reduced to a uniform random in `[0, capped]`.
+   */
+  next(): number {
+    const computed = this.base * Math.pow(this.factor, this.attemptCount);
+    const capped = Math.min(computed, this.max);
+    this.attemptCount += 1;
+    if (!this.jitter) return capped;
+    return this.rng() * capped;
+  }
+
+  /** Reset the attempt counter back to 0. */
+  reset(): void {
+    this.attemptCount = 0;
+  }
+
+  /** Current attempt count (number of times `next()` has been called since reset). */
+  attempt(): number {
+    return this.attemptCount;
+  }
+}

--- a/src/shared/net/backpressure.test.ts
+++ b/src/shared/net/backpressure.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { applyBackpressure, type OpencodeEvent } from "./backpressure";
+
+const HIGH = ["permission.asked", "question.asked"];
+
+function delta(sessionID: string, partID: string, seq: number): OpencodeEvent {
+  return { type: "message.part.delta", sessionID, partID, seq };
+}
+
+describe("applyBackpressure — coalesce", () => {
+  it("collapses consecutive same-key deltas to the last one", () => {
+    const events = [
+      delta("s1", "p1", 1),
+      delta("s1", "p1", 2),
+      delta("s1", "p1", 3),
+    ];
+    const out = applyBackpressure(events, { highPriorityTypes: HIGH });
+    expect(out).toHaveLength(1);
+    expect(out[0].seq).toBe(3);
+  });
+
+  it("does not collapse across different parts or sessions", () => {
+    const events = [
+      delta("s1", "p1", 1),
+      delta("s1", "p2", 2),
+      delta("s2", "p1", 3),
+    ];
+    const out = applyBackpressure(events, { highPriorityTypes: HIGH });
+    expect(out).toHaveLength(3);
+  });
+
+  it("only coalesces CONSECUTIVE runs of the same key", () => {
+    const events = [
+      delta("s1", "p1", 1),
+      delta("s1", "p1", 2),
+      delta("s1", "p2", 3), // breaks the run
+      delta("s1", "p1", 4),
+      delta("s1", "p1", 5),
+    ];
+    const out = applyBackpressure(events, { highPriorityTypes: HIGH });
+    // [p1:2, p2:3, p1:5]
+    expect(out.map((e) => e.seq)).toEqual([2, 3, 5]);
+  });
+
+  it("leaves non-coalesce types untouched", () => {
+    const events: OpencodeEvent[] = [
+      { type: "message.updated", sessionID: "s1" },
+      { type: "message.updated", sessionID: "s1" },
+    ];
+    const out = applyBackpressure(events, { highPriorityTypes: HIGH });
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe("applyBackpressure — drop under load", () => {
+  it("drops drop-types first when over maxPerSec", () => {
+    const events: OpencodeEvent[] = [];
+    // 3 keepers + 5 droppable, cap 4 -> must drop 4 droppable.
+    for (let i = 0; i < 3; i++) events.push({ type: "message.updated", i });
+    for (let i = 0; i < 5; i++) events.push({ type: "vcs.branch.updated", i });
+    const out = applyBackpressure(events, { maxPerSec: 4, highPriorityTypes: HIGH });
+    expect(out).toHaveLength(4);
+    // All 3 keepers survive; exactly 1 droppable remains.
+    expect(out.filter((e) => e.type === "message.updated")).toHaveLength(3);
+    expect(out.filter((e) => e.type === "vcs.branch.updated")).toHaveLength(1);
+  });
+
+  it("does not drop when at or below the cap", () => {
+    const events: OpencodeEvent[] = [
+      { type: "vcs.branch.updated" },
+      { type: "message.updated" },
+    ];
+    const out = applyBackpressure(events, { maxPerSec: 100, highPriorityTypes: HIGH });
+    expect(out).toHaveLength(2);
+  });
+
+  it("keeps non-droppable events even when over the cap and nothing droppable remains", () => {
+    const events: OpencodeEvent[] = [];
+    for (let i = 0; i < 10; i++) events.push({ type: "message.updated", i });
+    const out = applyBackpressure(events, { maxPerSec: 2, highPriorityTypes: HIGH });
+    // Nothing is droppable -> all survive despite being over cap.
+    expect(out).toHaveLength(10);
+  });
+
+  it("preserves relative order of survivors", () => {
+    const events: OpencodeEvent[] = [
+      { type: "message.updated", tag: "a" },
+      { type: "vcs.branch.updated", tag: "b" },
+      { type: "message.updated", tag: "c" },
+      { type: "vcs.branch.updated", tag: "d" },
+      { type: "message.updated", tag: "e" },
+    ];
+    const out = applyBackpressure(events, { maxPerSec: 3, highPriorityTypes: HIGH });
+    // Drops 2 vcs.branch.updated (b, d) -> a, c, e remain in order.
+    expect(out.map((e) => e.tag)).toEqual(["a", "c", "e"]);
+  });
+});
+
+describe("applyBackpressure — high-priority guarantee (BET-46 Risk #2)", () => {
+  it("never drops permission.asked / question.asked even under extreme flood", () => {
+    const events: OpencodeEvent[] = [];
+    // Flood far past maxPerSec with droppable events, sprinkling in the two
+    // hard-guaranteed high-priority events.
+    for (let i = 0; i < 5000; i++) {
+      events.push({ type: "vcs.branch.updated", i });
+      if (i === 1000) events.push({ type: "permission.asked", id: "perm" });
+      if (i === 4000) events.push({ type: "question.asked", id: "quest" });
+    }
+    const out = applyBackpressure(events, { maxPerSec: 10, highPriorityTypes: HIGH });
+    expect(out.some((e) => e.type === "permission.asked")).toBe(true);
+    expect(out.some((e) => e.type === "question.asked")).toBe(true);
+  });
+
+  it("forces permission.asked/question.asked high-priority even if caller omits them", () => {
+    const events: OpencodeEvent[] = [];
+    for (let i = 0; i < 500; i++) events.push({ type: "vcs.branch.updated", i });
+    events.push({ type: "permission.asked" });
+    events.push({ type: "question.asked" });
+    // Caller passes an unrelated high-priority set — the two must still survive.
+    const out = applyBackpressure(events, { maxPerSec: 5, highPriorityTypes: ["some.other"] });
+    expect(out.some((e) => e.type === "permission.asked")).toBe(true);
+    expect(out.some((e) => e.type === "question.asked")).toBe(true);
+  });
+
+  it("does not coalesce a high-priority type even if listed in coalesceTypes", () => {
+    const events: OpencodeEvent[] = [
+      { type: "permission.asked", sessionID: "s1", partID: "p1", n: 1 },
+      { type: "permission.asked", sessionID: "s1", partID: "p1", n: 2 },
+    ];
+    const out = applyBackpressure(events, {
+      coalesceTypes: ["permission.asked"],
+      highPriorityTypes: HIGH,
+    });
+    expect(out).toHaveLength(2);
+  });
+});

--- a/src/shared/net/backpressure.ts
+++ b/src/shared/net/backpressure.ts
@@ -1,0 +1,97 @@
+// Event backpressure: coalesce, drop, and rate-limit opencode events.
+//
+// Pure/deterministic given its inputs — no wall-clock reads. Operates on a
+// single batch of events so it is trivially testable.
+
+/** Minimal shape of an opencode event that the backpressure logic needs. */
+export interface OpencodeEvent {
+  type: string;
+  sessionID?: string;
+  partID?: string;
+  [k: string]: unknown;
+}
+
+export interface BackpressureOpts {
+  /** Soft cap on events per batch before drop-types get dropped. Defaults to 100. */
+  maxPerSec?: number;
+  /**
+   * Event types whose consecutive same-key runs collapse to the last event.
+   * Defaults to `["message.part.delta"]`.
+   */
+  coalesceTypes?: string[];
+  /**
+   * Event types dropped first when the batch is over `maxPerSec`.
+   * Defaults to `["vcs.branch.updated"]`.
+   */
+  dropTypes?: string[];
+  /**
+   * Event types that must NEVER be dropped or coalesced away, no matter how far
+   * the batch floods past `maxPerSec`. `"permission.asked"` and
+   * `"question.asked"` are always forced into this set.
+   */
+  highPriorityTypes: string[];
+}
+
+const DEFAULT_COALESCE = ["message.part.delta"];
+const DEFAULT_DROP = ["vcs.branch.updated"];
+// Hard-guaranteed pass-through events — see BET-46 Risk #2.
+const FORCED_HIGH_PRIORITY = ["permission.asked", "question.asked"];
+
+/** Coalesce key: same type + session + part collapse to the latest event. */
+function coalesceKey(e: OpencodeEvent): string {
+  return `${e.type}\u0000${e.sessionID ?? ""}\u0000${e.partID ?? ""}`;
+}
+
+/**
+ * Apply backpressure to a batch of events, preserving relative order of the
+ * survivors.
+ *
+ * 1. **Coalesce**: for types in `coalesceTypes`, collapse consecutive events
+ *    sharing the same `(type, sessionID, partID)` into the LAST one.
+ * 2. **Drop under load**: if the coalesced batch length exceeds `maxPerSec`,
+ *    drop events whose type ∈ `dropTypes`, oldest first, until at or below the
+ *    cap (or no more droppable events remain).
+ *
+ * High-priority types are never coalesced away and never dropped.
+ */
+export function applyBackpressure(
+  events: OpencodeEvent[],
+  opts: BackpressureOpts,
+): OpencodeEvent[] {
+  const maxPerSec = opts.maxPerSec ?? 100;
+  const coalesceTypes = new Set(opts.coalesceTypes ?? DEFAULT_COALESCE);
+  const dropTypes = new Set(opts.dropTypes ?? DEFAULT_DROP);
+  const highPriority = new Set([...opts.highPriorityTypes, ...FORCED_HIGH_PRIORITY]);
+
+  // --- Step 1: coalesce consecutive same-key runs to the last event. ---
+  const coalesced: OpencodeEvent[] = [];
+  for (const e of events) {
+    const shouldCoalesce = coalesceTypes.has(e.type) && !highPriority.has(e.type);
+    if (
+      shouldCoalesce &&
+      coalesced.length > 0 &&
+      coalesced[coalesced.length - 1].type === e.type &&
+      coalesceKey(coalesced[coalesced.length - 1]) === coalesceKey(e)
+    ) {
+      // Replace the previous event of the same key with this later one.
+      coalesced[coalesced.length - 1] = e;
+      continue;
+    }
+    coalesced.push(e);
+  }
+
+  // --- Step 2: drop droppable events while over the cap. ---
+  if (coalesced.length <= maxPerSec) return coalesced;
+
+  let overBy = coalesced.length - maxPerSec;
+  const result: OpencodeEvent[] = [];
+  for (const e of coalesced) {
+    const droppable = dropTypes.has(e.type) && !highPriority.has(e.type);
+    if (droppable && overBy > 0) {
+      overBy -= 1;
+      continue;
+    }
+    result.push(e);
+  }
+  return result;
+}

--- a/src/shared/net/state.test.ts
+++ b/src/shared/net/state.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  canTransition,
+  describe as describeState,
+  type ConnectionState,
+  type ConnectionStateName,
+} from "./state";
+
+const ALL: ConnectionStateName[] = [
+  "idle",
+  "connecting",
+  "connected",
+  "stalled",
+  "reconnecting",
+  "closed",
+];
+
+// The full legal edge set, mirrored from state.ts. Every (from,to) pair not
+// listed here must be illegal.
+const LEGAL: Record<ConnectionStateName, ConnectionStateName[]> = {
+  idle: ["connecting"],
+  connecting: ["connected", "reconnecting", "closed"],
+  connected: ["stalled", "closed"],
+  stalled: ["reconnecting", "connected", "closed"],
+  reconnecting: ["connected", "reconnecting", "closed"],
+  closed: ["idle"],
+};
+
+describe("canTransition", () => {
+  it("accepts every legal edge", () => {
+    for (const from of ALL) {
+      for (const to of LEGAL[from]) {
+        expect(canTransition(from, to)).toBe(true);
+      }
+    }
+  });
+
+  it("rejects every edge not in the legal set", () => {
+    for (const from of ALL) {
+      for (const to of ALL) {
+        const legal = LEGAL[from].includes(to);
+        expect(canTransition(from, to)).toBe(legal);
+      }
+    }
+  });
+
+  it("rejects representative illegal edges explicitly", () => {
+    expect(canTransition("idle", "connected")).toBe(false);
+    expect(canTransition("idle", "idle")).toBe(false);
+    expect(canTransition("connected", "connecting")).toBe(false);
+    expect(canTransition("connected", "reconnecting")).toBe(false);
+    expect(canTransition("closed", "connecting")).toBe(false);
+    expect(canTransition("stalled", "connecting")).toBe(false);
+  });
+});
+
+describe("describe", () => {
+  it("renders each variant", () => {
+    const since = new Date("2026-01-01T00:00:00.000Z");
+    const cases: [ConnectionState, string][] = [
+      [{ state: "idle" }, "idle"],
+      [{ state: "connecting", attempt: 3 }, "connecting (attempt 3)"],
+      [{ state: "connected" }, "connected"],
+      [{ state: "stalled", since }, "stalled since 2026-01-01T00:00:00.000Z"],
+      [
+        { state: "reconnecting", attempt: 2, backoffMs: 4000 },
+        "reconnecting (attempt 2, backoff 4000ms)",
+      ],
+      [{ state: "closed", reason: "eof" }, "closed (eof)"],
+    ];
+    for (const [state, expected] of cases) {
+      expect(describeState(state)).toBe(expected);
+    }
+  });
+});

--- a/src/shared/net/state.ts
+++ b/src/shared/net/state.ts
@@ -1,0 +1,57 @@
+// Connection state machine for the unified connection manager.
+//
+// Pure discriminated union + transition helper. Importable from both the
+// Electron main process and the renderer.
+
+export type ConnectionState =
+  | { state: "idle" }
+  | { state: "connecting"; attempt: number }
+  | { state: "connected" }
+  | { state: "stalled"; since: Date }
+  | { state: "reconnecting"; attempt: number; backoffMs: number }
+  | { state: "closed"; reason: string };
+
+/** The bare tag of a {@link ConnectionState}. */
+export type ConnectionStateName = ConnectionState["state"];
+
+// Legal transition edges:
+//   idle         → connecting
+//   connecting   → connected | reconnecting | closed
+//   connected    → stalled | closed
+//   stalled      → reconnecting | connected | closed
+//   reconnecting → connected | reconnecting | closed
+//   closed       → idle
+const TRANSITIONS: Record<ConnectionStateName, readonly ConnectionStateName[]> = {
+  idle: ["connecting"],
+  connecting: ["connected", "reconnecting", "closed"],
+  connected: ["stalled", "closed"],
+  stalled: ["reconnecting", "connected", "closed"],
+  reconnecting: ["connected", "reconnecting", "closed"],
+  closed: ["idle"],
+};
+
+/** Returns true iff moving from `from` to `to` is a legal edge. */
+export function canTransition(
+  from: ConnectionStateName,
+  to: ConnectionStateName,
+): boolean {
+  return TRANSITIONS[from].includes(to);
+}
+
+/** Short human-readable description of a state, for logs. */
+export function describe(state: ConnectionState): string {
+  switch (state.state) {
+    case "idle":
+      return "idle";
+    case "connecting":
+      return `connecting (attempt ${state.attempt})`;
+    case "connected":
+      return "connected";
+    case "stalled":
+      return `stalled since ${state.since.toISOString()}`;
+    case "reconnecting":
+      return `reconnecting (attempt ${state.attempt}, backoff ${state.backoffMs}ms)`;
+    case "closed":
+      return `closed (${state.reason})`;
+  }
+}


### PR DESCRIPTION
## BET-59 — M0.1 Network Refactor: pure primitives

Stage 1 of 4 of the unified connection manager (parent BET-46). Ships **only** pure, unit-tested modules under `src/shared/net/` — no changes to `src/main/`, `src/renderer/`, or `src/server/` runtime wiring.

**Base:** `origin/main @ 29d105e`

### Modules
- `src/shared/net/backoff.ts` — `ExponentialBackoff` (`next`/`reset`/`attempt`), full-jitter with injectable RNG, capped at `max`. Defaults match `new ExponentialBackoff({ base: 1000, max: 30000 })`.
- `src/shared/net/state.ts` — `ConnectionState` discriminated union (exactly per BET-46), pure `canTransition(from, to)` encoding the legal edges, and `describe(state)` for logs.
- `src/shared/net/backpressure.ts` — pure `applyBackpressure(events, opts)`: coalesces consecutive same-`(type,sessionID,partID)` deltas to the last, drops `dropTypes` first when over `maxPerSec`, and **hard-guarantees** `permission.asked`/`question.asked` always pass through (Risk #2), never coalesced/dropped. No wall-clock reads.

### Tests (vitest)
- `backoff.test.ts` — growth with jitter off, cap at `max`, custom factor, `reset()`, `attempt()`, injected-RNG jitter bounds.
- `state.test.ts` — every legal edge accepted, every non-legal pair rejected, `describe` per variant.
- `backpressure.test.ts` — coalescing to last (consecutive only), drop-under-load ordering preserved, and **`permission.asked`/`question.asked` survive a 5000-event flood at `maxPerSec: 10`** (plus forced-high-priority even when caller omits them).

### Verification results
**Files changed:** 6 files (all new, additive — no existing files touched).

- PR branch (`multica/BET-46.1-net-primitives`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, vitest **640 pass / 0 fail / 0 skip** (32 files incl. 3 new net files); server node:test **226 pass / 0 fail**.
- Base (`main` @ `29d105e`): this slice is purely additive (new dir only), so no base regression is possible — no existing module is imported or modified.
- **Conclusion:** 0 new failures, 0 pre-existing failures. All green.

Logs at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.

### Out of scope (per issue)
No `ConnectionManager` class (stage 2 / BET-46.2), no SSH/SSE/WS wiring, no edits to `opencode.ts` / `index.ts` / `forwardHeal.ts` / `httpApi.ts` / `server/opencode.mjs`.
