### PR TITLE
BET-60: M0.2 Network Refactor — ConnectionManager core (standalone)

### DIFF
--- a/src/shared/net/connectionManager.test.ts
+++ b/src/shared/net/connectionManager.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ConnectionManager } from "./connectionManager";
+import type { Transport, TimerHandle } from "./connectionManager";
+import { ExponentialBackoff } from "./backoff";
+import type { ConnectionState, ConnectionStateName } from "./state";
+
+// --- Deterministic fake clock + timer scheduler ------------------------------
+//
+// A minimal virtual scheduler: timers are stored with their absolute fire time
+// and only fire when `advance(ms)` crosses them. `now()` tracks virtual ms.
+// No real wall-clock is ever consulted, so tests are fully deterministic.
+
+interface Scheduled {
+  id: number;
+  fireAt: number;
+  fn: () => void;
+  cancelled: boolean;
+}
+
+class FakeClock {
+  private current = 0;
+  private nextId = 1;
+  private timers: Scheduled[] = [];
+
+  now = (): number => this.current;
+
+  setTimeout = (fn: () => void, ms: number): TimerHandle => {
+    const t: Scheduled = { id: this.nextId++, fireAt: this.current + ms, fn, cancelled: false };
+    this.timers.push(t);
+    return t.id;
+  };
+
+  clearTimeout = (handle: TimerHandle): void => {
+    const t = this.timers.find((x) => x.id === handle);
+    if (t) t.cancelled = true;
+  };
+
+  /**
+   * Advance virtual time by `ms`, firing every timer whose deadline is crossed
+   * in chronological order. Also drains microtasks between fires so awaited
+   * promises inside callbacks settle deterministically.
+   */
+  async advance(ms: number): Promise<void> {
+    const target = this.current + ms;
+    // Keep firing due timers (including ones scheduled by earlier fires) until
+    // we reach the target time and no due timers remain.
+    for (;;) {
+      const due = this.timers
+        .filter((t) => !t.cancelled && t.fireAt <= target)
+        .sort((a, b) => a.fireAt - b.fireAt);
+      if (due.length === 0) break;
+      const next = due[0];
+      next.cancelled = true;
+      this.current = next.fireAt;
+      next.fn();
+      // Let any promises the callback awaited resolve before the next timer.
+      await flushMicrotasks();
+    }
+    this.current = target;
+    await flushMicrotasks();
+  }
+
+  pendingCount(): number {
+    return this.timers.filter((t) => !t.cancelled).length;
+  }
+}
+
+/** Drain the microtask queue a few times so chained awaits settle. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+// --- Configurable fake transport --------------------------------------------
+
+class FakeTransport implements Transport {
+  openCalls = 0;
+  closeCalls = 0;
+  pingCalls = 0;
+
+  /** Number of leading `open()` calls that should reject (then succeed). */
+  failOpens = 0;
+  /** When true, `ping()` returns a promise that never resolves (simulates a dead peer). */
+  pingHangs = false;
+
+  private pingResolvers: Array<() => void> = [];
+
+  async open(): Promise<void> {
+    this.openCalls++;
+    if (this.failOpens > 0) {
+      this.failOpens--;
+      throw new Error("open failed");
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++;
+  }
+
+  ping(): Promise<void> {
+    this.pingCalls++;
+    if (this.pingHangs) {
+      return new Promise<void>((resolve) => this.pingResolvers.push(resolve));
+    }
+    return Promise.resolve();
+  }
+}
+
+function makeManager(
+  transport: Transport,
+  clock: FakeClock,
+  states: ConnectionState[],
+  overrides: Partial<ConstructorParameters<typeof ConnectionManager>[0]> = {},
+) {
+  return new ConnectionManager({
+    transport,
+    onState: (s) => states.push(s),
+    now: clock.now,
+    setTimeoutFn: clock.setTimeout,
+    clearTimeoutFn: clock.clearTimeout,
+    // Jitter off so backoff delays are exact and assertable.
+    backoff: new ExponentialBackoff({ base: 1000, max: 30000, jitter: false }),
+    pingIntervalMs: 30000,
+    pongTimeoutMs: 5000,
+    stallHealAfterMs: 10000,
+    ...overrides,
+  });
+}
+
+const names = (states: ConnectionState[]): ConnectionStateName[] => states.map((s) => s.state);
+
+describe("ConnectionManager", () => {
+  let clock: FakeClock;
+  let transport: FakeTransport;
+  let states: ConnectionState[];
+
+  beforeEach(() => {
+    clock = new FakeClock();
+    transport = new FakeTransport();
+    states = [];
+  });
+
+  it("idle → connecting → connected happy path emits the right sequence", async () => {
+    const cm = makeManager(transport, clock, states);
+    expect(cm.getState().state).toBe("idle");
+
+    await cm.connect();
+    await flushMicrotasks();
+
+    expect(names(states)).toEqual(["connecting", "connected"]);
+    expect(cm.getState().state).toBe("connected");
+    expect(transport.openCalls).toBe(1);
+  });
+
+  it("open() failure → reconnecting with growing backoff → eventual connected → backoff reset", async () => {
+    // Fail the first two opens, succeed on the third.
+    transport.failOpens = 2;
+    const cm = makeManager(transport, clock, states);
+
+    await cm.connect();
+    await flushMicrotasks();
+
+    // First open failed → reconnecting with backoff 1000 (base * 2^0).
+    let last = states[states.length - 1];
+    expect(last.state).toBe("reconnecting");
+    expect(last).toMatchObject({ state: "reconnecting", backoffMs: 1000 });
+    expect(transport.openCalls).toBe(1);
+
+    // Advance past the first backoff → second open attempt (also fails) →
+    // reconnecting with backoff 2000 (base * 2^1).
+    await clock.advance(1000);
+    last = states[states.length - 1];
+    expect(last).toMatchObject({ state: "reconnecting", backoffMs: 2000 });
+    expect(transport.openCalls).toBe(2);
+
+    // Advance past the second backoff → third open attempt (succeeds) → connected.
+    await clock.advance(2000);
+    expect(transport.openCalls).toBe(3);
+    expect(cm.getState().state).toBe("connected");
+    expect(names(states)).toContain("connected");
+
+    // Backoff was reset on success: a subsequent stall-reconnect starts at 1000.
+    // (Fail the next open to observe the fresh backoff value.)
+    transport.failOpens = 1;
+    transport.pingHangs = true;
+    await clock.advance(30000); // trigger a ping
+    await clock.advance(5000); // pong times out → stalled
+    expect(cm.getState().state).toBe("stalled");
+    await clock.advance(10000); // stall-heal → reconnect
+    const reconnecting = states.filter((s) => s.state === "reconnecting");
+    // The reconnect after reset starts at backoff 1000 again.
+    expect(reconnecting[reconnecting.length - 1]).toMatchObject({ backoffMs: 1000 });
+  });
+
+  it("ping timeout → stalled → (past stallHealAfterMs) → reconnect", async () => {
+    transport.pingHangs = true;
+    const cm = makeManager(transport, clock, states);
+
+    await cm.connect();
+    await flushMicrotasks();
+    expect(cm.getState().state).toBe("connected");
+
+    // Advance to the first ping.
+    await clock.advance(30000);
+    expect(transport.pingCalls).toBe(1);
+    // Still connected until the pong deadline elapses.
+    expect(cm.getState().state).toBe("connected");
+
+    // Advance past the pong timeout → stalled.
+    await clock.advance(5000);
+    expect(cm.getState().state).toBe("stalled");
+    const stalled = states.find((s) => s.state === "stalled");
+    expect(stalled).toBeDefined();
+    expect((stalled as { since: Date }).since).toBeInstanceOf(Date);
+
+    // Stop hanging so the reconnect can succeed.
+    transport.pingHangs = false;
+
+    // Advance past the stall-heal window → close + reconnect.
+    await clock.advance(10000);
+    // Reconnect path closes the old transport then re-opens.
+    expect(transport.closeCalls).toBeGreaterThanOrEqual(1);
+    // After the backoff delay it should reconnect.
+    await clock.advance(30000);
+    expect(cm.getState().state).toBe("connected");
+    expect(transport.openCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("disconnect() → closed, loops stopped, transport.close() called once, idempotent", async () => {
+    const cm = makeManager(transport, clock, states);
+    await cm.connect();
+    await flushMicrotasks();
+    expect(cm.getState().state).toBe("connected");
+    // Health-check ping is armed.
+    expect(clock.pendingCount()).toBeGreaterThan(0);
+
+    await cm.disconnect("bye");
+    expect(cm.getState().state).toBe("closed");
+    expect(cm.getState()).toMatchObject({ state: "closed", reason: "bye" });
+    expect(transport.closeCalls).toBe(1);
+    // All timers cancelled → no pending work.
+    expect(clock.pendingCount()).toBe(0);
+
+    // Idempotent: second call is a no-op, does not re-close.
+    await cm.disconnect("again");
+    expect(transport.closeCalls).toBe(1);
+    expect(cm.getState()).toMatchObject({ state: "closed", reason: "bye" });
+
+    // Advancing time must not fire any stale ping / reconnect callbacks.
+    const openBefore = transport.openCalls;
+    const pingBefore = transport.pingCalls;
+    await clock.advance(100000);
+    expect(transport.openCalls).toBe(openBefore);
+    expect(transport.pingCalls).toBe(pingBefore);
+  });
+
+  it("disconnect() from reconnecting state → closed, no further reconnect attempts", async () => {
+    transport.failOpens = 100; // never succeeds
+    const cm = makeManager(transport, clock, states);
+
+    await cm.connect();
+    await flushMicrotasks();
+    expect(cm.getState().state).toBe("reconnecting");
+
+    await cm.disconnect();
+    expect(cm.getState().state).toBe("closed");
+
+    // Pending reconnect timer must not fire.
+    const openBefore = transport.openCalls;
+    await clock.advance(100000);
+    expect(transport.openCalls).toBe(openBefore);
+  });
+
+  it("uses no real wall-clock — a hanging ping never resolves on its own", async () => {
+    transport.pingHangs = true;
+    const cm = makeManager(transport, clock, states);
+    await cm.connect();
+    await flushMicrotasks();
+
+    // Without advancing the injected clock, no ping fires and state is stable.
+    await flushMicrotasks();
+    expect(transport.pingCalls).toBe(0);
+    expect(cm.getState().state).toBe("connected");
+  });
+
+  it("connect() is a no-op when already connecting/connected", async () => {
+    const cm = makeManager(transport, clock, states);
+    await cm.connect();
+    await flushMicrotasks();
+    expect(transport.openCalls).toBe(1);
+
+    // Second connect while connected does nothing.
+    await cm.connect();
+    await flushMicrotasks();
+    expect(transport.openCalls).toBe(1);
+  });
+
+  it("connect() after disconnect reuses the manager (closed → idle → connecting)", async () => {
+    const cm = makeManager(transport, clock, states);
+    await cm.connect();
+    await flushMicrotasks();
+    await cm.disconnect();
+    expect(cm.getState().state).toBe("closed");
+
+    states.length = 0;
+    await cm.connect();
+    await flushMicrotasks();
+    expect(cm.getState().state).toBe("connected");
+    // idle transition is internal; observed sequence is connecting → connected.
+    expect(names(states)).toEqual(["idle", "connecting", "connected"]);
+  });
+});

--- a/src/shared/net/connectionManager.ts
+++ b/src/shared/net/connectionManager.ts
@@ -1,0 +1,310 @@
+// Transport-agnostic connection orchestrator for the unified network layer.
+//
+// Composes the stage-1 primitives (`ExponentialBackoff`, `ConnectionState` +
+// `canTransition`) into a single state machine that drives connect / health
+// check / reconnect / disconnect against an INJECTED `Transport`. It performs
+// no I/O itself — no `child_process`, no `EventSource`, no `WebSocket`. The real
+// SSH and SSE/WS transports get wired in stages 3 (BET-46.3) and 4 (BET-46.4).
+//
+// All time and timer access goes through injectable `now` / `setTimeoutFn` /
+// `clearTimeoutFn` hooks so tests are fully deterministic (no real sleeps).
+
+import { ExponentialBackoff } from "./backoff";
+import { canTransition, describe as describeState } from "./state";
+import type { ConnectionState, ConnectionStateName } from "./state";
+
+/**
+ * The underlying connection this manager orchestrates. Implementations are
+ * injected (SSH ControlMaster, EventSource, WebSocket, or a test fake) — the
+ * manager never constructs one itself.
+ */
+export interface Transport {
+  /** Establish the underlying connection. Rejects/throws on failure. */
+  open(): Promise<void>;
+  /** Tear the underlying connection down. Should not throw in normal use. */
+  close(): Promise<void>;
+  /** Resolve on pong; reject/throw (or never resolve) when the peer is dead. */
+  ping(): Promise<void>;
+}
+
+/** Opaque timer handle — a number (browser) or NodeJS.Timeout. Never inspected. */
+export type TimerHandle = unknown;
+
+export type SetTimeoutFn = (fn: () => void, ms: number) => TimerHandle;
+export type ClearTimeoutFn = (handle: TimerHandle) => void;
+
+export interface ConnectionManagerOpts {
+  /** The injected transport to drive. Required. */
+  transport: Transport;
+  /**
+   * Shared exponential backoff used for reconnect delays. Defaults to
+   * `new ExponentialBackoff({ base: 1000, max: 30000 })`. Reset on every
+   * successful (re)connect.
+   */
+  backoff?: ExponentialBackoff;
+  /** Interval between health-check pings while connected. Defaults to 30000ms. */
+  pingIntervalMs?: number;
+  /** How long to wait for a pong before marking the link stalled. Defaults to 5000ms. */
+  pongTimeoutMs?: number;
+  /** How long the link may stay stalled before we force a reconnect. Defaults to 10000ms. */
+  stallHealAfterMs?: number;
+  /** Emitted on every state transition. */
+  onState?: (s: ConnectionState) => void;
+  /** Injectable clock (ms). Defaults to `Date.now`. */
+  now?: () => number;
+  /** Injectable timer scheduler. Defaults to global `setTimeout`. */
+  setTimeoutFn?: SetTimeoutFn;
+  /** Injectable timer canceller. Defaults to global `clearTimeout`. */
+  clearTimeoutFn?: ClearTimeoutFn;
+}
+
+/**
+ * Orchestrates a single transport through the connection lifecycle:
+ *
+ *   idle → connecting → connected ⇄ stalled → reconnecting → connected …
+ *                                                → closed
+ *
+ * - `connect()` opens the transport, retrying with exponential backoff on
+ *   failure, and starts a health-check loop once connected.
+ * - The health-check loop pings every `pingIntervalMs`; a ping that doesn't
+ *   resolve within `pongTimeoutMs` marks the link `stalled`. Once it has been
+ *   stalled for `stallHealAfterMs`, a reconnect is triggered.
+ * - `disconnect()` stops all loops, closes the transport once, and lands in
+ *   `closed`. It is idempotent.
+ */
+export class ConnectionManager {
+  private readonly transport: Transport;
+  private readonly backoff: ExponentialBackoff;
+  private readonly pingIntervalMs: number;
+  private readonly pongTimeoutMs: number;
+  private readonly stallHealAfterMs: number;
+  private readonly onState?: (s: ConnectionState) => void;
+  private readonly now: () => number;
+  private readonly setTimeoutFn: SetTimeoutFn;
+  private readonly clearTimeoutFn: ClearTimeoutFn;
+
+  private state: ConnectionState = { state: "idle" };
+
+  /** Pending scheduled timers we own, so `disconnect()` can cancel them. */
+  private pingTimer: TimerHandle | null = null;
+  private reconnectTimer: TimerHandle | null = null;
+  /** Monotonic epoch bumped on every teardown so stale async callbacks no-op. */
+  private epoch = 0;
+
+  constructor(opts: ConnectionManagerOpts) {
+    this.transport = opts.transport;
+    this.backoff = opts.backoff ?? new ExponentialBackoff({ base: 1000, max: 30000 });
+    this.pingIntervalMs = opts.pingIntervalMs ?? 30000;
+    this.pongTimeoutMs = opts.pongTimeoutMs ?? 5000;
+    this.stallHealAfterMs = opts.stallHealAfterMs ?? 10000;
+    this.onState = opts.onState;
+    this.now = opts.now ?? (() => Date.now());
+    this.setTimeoutFn =
+      opts.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms) as unknown as TimerHandle);
+    this.clearTimeoutFn =
+      opts.clearTimeoutFn ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  }
+
+  /** Current connection state (the live object, not a copy). */
+  getState(): ConnectionState {
+    return this.state;
+  }
+
+  /**
+   * Begin connecting. Transitions idle→connecting and attempts `open()`. On
+   * success → connected and the health loop starts; on failure → reconnecting
+   * with a backoff delay, then retries. No-op if already past `idle`/`closed`.
+   */
+  async connect(): Promise<void> {
+    if (this.state.state !== "idle") {
+      // Only a fresh (idle) or previously-closed→idle manager may connect.
+      // `connecting`/`connected`/etc. are already in-flight; ignore.
+      if (this.state.state === "closed") {
+        // closed → idle is a legal edge; allow a caller to reuse the manager.
+        this.transition({ state: "idle" });
+      } else {
+        return;
+      }
+    }
+    await this.attemptOpen(1);
+  }
+
+  /**
+   * Stop all activity and close the transport exactly once. Lands in
+   * `closed{reason}`. Idempotent — a second call while already closed is a
+   * no-op that does NOT re-close the transport.
+   */
+  async disconnect(reason = "disconnect"): Promise<void> {
+    if (this.state.state === "closed") return;
+    this.teardownTimers();
+    // Bump epoch so any in-flight open/ping callback recognises it is stale.
+    this.epoch += 1;
+    this.transition({ state: "closed", reason });
+    await this.safeClose();
+  }
+
+  // --- internal ---------------------------------------------------------
+
+  /**
+   * Attempt to open the transport. On failure, schedule a backoff-delayed
+   * retry via the reconnecting state. `attempt` is 1-indexed for reporting.
+   */
+  private async attemptOpen(attempt: number): Promise<void> {
+    this.transition({ state: "connecting", attempt });
+    const myEpoch = this.epoch;
+    try {
+      await this.transport.open();
+    } catch {
+      if (this.isStale(myEpoch)) return;
+      this.scheduleReconnect(attempt);
+      return;
+    }
+    if (this.isStale(myEpoch)) return;
+    this.onConnected();
+  }
+
+  /** Land in `connected`, reset backoff, and (re)arm the health-check loop. */
+  private onConnected(): void {
+    this.backoff.reset();
+    this.transition({ state: "connected" });
+    this.armPing();
+  }
+
+  /**
+   * Schedule the next reconnect attempt after a backoff delay. Enters
+   * `reconnecting` immediately (so observers see it), then waits `backoffMs`
+   * before the next `open()`.
+   */
+  private scheduleReconnect(prevAttempt: number): void {
+    const backoffMs = this.backoff.next();
+    const nextAttempt = prevAttempt + 1;
+    this.transition({ state: "reconnecting", attempt: nextAttempt, backoffMs });
+    const myEpoch = this.epoch;
+    this.reconnectTimer = this.setTimeoutFn(() => {
+      this.reconnectTimer = null;
+      if (this.isStale(myEpoch)) return;
+      void this.attemptOpen(nextAttempt);
+    }, backoffMs);
+  }
+
+  /** Arm the next health-check ping `pingIntervalMs` from now. */
+  private armPing(): void {
+    const myEpoch = this.epoch;
+    this.pingTimer = this.setTimeoutFn(() => {
+      this.pingTimer = null;
+      if (this.isStale(myEpoch)) return;
+      void this.runHealthCheck();
+    }, this.pingIntervalMs);
+  }
+
+  /**
+   * Ping the transport with a `pongTimeoutMs` deadline. A timely pong re-arms
+   * the loop; a timeout marks the link stalled and starts the stall-heal timer.
+   */
+  private async runHealthCheck(): Promise<void> {
+    if (this.state.state !== "connected") return;
+    const myEpoch = this.epoch;
+
+    let timedOut = false;
+    const timeout = new Promise<"timeout">((resolve) => {
+      const h = this.setTimeoutFn(() => {
+        timedOut = true;
+        resolve("timeout");
+      }, this.pongTimeoutMs);
+      // Store on the ping slot so a disconnect cancels the pong deadline too.
+      this.pingTimer = h;
+    });
+
+    let outcome: "ok" | "timeout";
+    try {
+      outcome = await Promise.race([
+        this.transport.ping().then(() => "ok" as const),
+        timeout,
+      ]);
+    } catch {
+      outcome = "timeout";
+    }
+
+    if (this.isStale(myEpoch)) return;
+    // If the pong won the race, cancel the still-pending timeout timer.
+    if (!timedOut && this.pingTimer !== null) {
+      this.clearTimeoutFn(this.pingTimer);
+      this.pingTimer = null;
+    }
+
+    if (outcome === "ok") {
+      // Healthy: schedule the next ping.
+      this.armPing();
+      return;
+    }
+    this.onStalled();
+  }
+
+  /** Enter `stalled`, recording `since`, and arm the stall-heal timer. */
+  private onStalled(): void {
+    const since = new Date(this.now());
+    this.transition({ state: "stalled", since });
+    const myEpoch = this.epoch;
+    this.pingTimer = this.setTimeoutFn(() => {
+      this.pingTimer = null;
+      if (this.isStale(myEpoch)) return;
+      if (this.state.state !== "stalled") return;
+      void this.healViaReconnect();
+    }, this.stallHealAfterMs);
+  }
+
+  /**
+   * Heal a stalled link: close the current transport, then reconnect through
+   * the normal backoff path.
+   */
+  private async healViaReconnect(): Promise<void> {
+    const myEpoch = this.epoch;
+    await this.safeClose();
+    if (this.isStale(myEpoch)) return;
+    // stalled → reconnecting is a legal edge; drive the backoff loop from here.
+    this.scheduleReconnect(this.backoff.attempt());
+  }
+
+  /** Apply a state transition, guarding illegal edges, and notify observers. */
+  private transition(next: ConnectionState): void {
+    const from: ConnectionStateName = this.state.state;
+    if (from !== next.state && !canTransition(from, next.state)) {
+      throw new Error(
+        `illegal connection transition ${from} → ${next.state} ` +
+          `(current: ${describeState(this.state)})`,
+      );
+    }
+    this.state = next;
+    this.onState?.(next);
+  }
+
+  /** Cancel every timer we own. */
+  private teardownTimers(): void {
+    if (this.pingTimer !== null) {
+      this.clearTimeoutFn(this.pingTimer);
+      this.pingTimer = null;
+    }
+    if (this.reconnectTimer !== null) {
+      this.clearTimeoutFn(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  /** Close the transport, swallowing errors (best-effort teardown). */
+  private async safeClose(): Promise<void> {
+    try {
+      await this.transport.close();
+    } catch {
+      // Best-effort; a failing close must not wedge the state machine.
+    }
+  }
+
+  /**
+   * True if the manager has been torn down / re-driven since `capturedEpoch`
+   * was taken, meaning this async continuation is stale and must not mutate
+   * state. Every scheduled callback checks this before acting.
+   */
+  private isStale(capturedEpoch: number): boolean {
+    return capturedEpoch !== this.epoch;
+  }
+}

--- a/src/shared/net/connectionManager.ts
+++ b/src/shared/net/connectionManager.ts
@@ -126,6 +126,7 @@ export class ConnectionManager {
         return;
       }
     }
+    this.transition({ state: "connecting", attempt: 1 });
     await this.attemptOpen(1);
   }
 
@@ -146,11 +147,17 @@ export class ConnectionManager {
   // --- internal ---------------------------------------------------------
 
   /**
-   * Attempt to open the transport. On failure, schedule a backoff-delayed
-   * retry via the reconnecting state. `attempt` is 1-indexed for reporting.
+   * Attempt to open the transport, from whatever state we are currently in
+   * (`connecting` for the first attempt, `reconnecting` for retries — both are
+   * legal edges into `connected`). On failure, schedule a backoff-delayed retry
+   * via the `reconnecting` state. `attempt` is 1-indexed for reporting.
+   *
+   * The state machine has no `reconnecting → connecting` edge on purpose, so a
+   * retry must NOT re-enter `connecting`; the caller sets the entry state
+   * (`connect()` → `connecting`; `scheduleReconnect()` → `reconnecting`) and
+   * this method only handles the open outcome.
    */
   private async attemptOpen(attempt: number): Promise<void> {
-    this.transition({ state: "connecting", attempt });
     const myEpoch = this.epoch;
     try {
       await this.transport.open();


### PR DESCRIPTION
## BET-60 (M0.2) — ConnectionManager core (standalone)

Stage 2 of 4 of the M0 Network Layer Refactor (parent BET-46). Adds the transport-agnostic `ConnectionManager` that composes the stage-1 primitives (`ExponentialBackoff`, `ConnectionState`/`canTransition`) **without wiring any live SSH/SSE/WS code** — that lands in stages 3 (BET-46.3) and 4 (BET-46.4).

**Base:** `origin/main @ 126b51a`

### What's added
- `src/shared/net/connectionManager.ts` — pure TS orchestrator driving an injected `Transport { open, close, ping }`:
  - `connect()`: idle→connecting→connected; on `open()` failure → reconnecting with an `ExponentialBackoff` delay, then retries. Every transition emitted via `onState`.
  - Health loop: pings every `pingIntervalMs`; a pong not resolving within `pongTimeoutMs` → **stalled** (records `since`); stalled longer than `stallHealAfterMs` → close + backoff + reopen. Backoff reset on every successful (re)connect.
  - `disconnect(reason)`: → closed{reason}, stops loops, `close()` once, idempotent.
  - `getState()`. All time/timer access via injected `now`/`setTimeoutFn`/`clearTimeoutFn` (no real sleeps). An epoch guard makes stale scheduled callbacks no-op after teardown.
- `src/shared/net/connectionManager.test.ts` — vitest, fake transport + virtual clock (8 tests): happy path sequence, open-failure → growing backoff → connected → backoff reset, ping-timeout → stalled → reconnect, `disconnect()` idempotency + loop-stop, disconnect-from-reconnecting, no-wall-clock guarantee, connect no-op when active, reuse after disconnect.

### Design note
The stage-1 state machine has **no `reconnecting → connecting` edge** by design, so retries stay in `reconnecting` (legal `reconnecting → connected | reconnecting | closed`) rather than re-entering `connecting`. Only the first attempt uses `idle → connecting`. (This was caught by the tests during implementation.)

### Out of scope (untouched)
No real SSH ControlMaster, no EventSource/WebSocket. No edits to `opencode.ts` / `index.ts` / `forwardHeal.ts` / `httpApi.ts` / `server/opencode.mjs`.

**Files changed:** 2 files, +628 (both new, additive only).

**Verification results:**
- PR branch (`multica/BET-60-connection-manager` @ `47f546d`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`. vitest `648` pass / `0` fail / `0` skip (33 files, incl. 8 new ConnectionManager tests); node:test `226` pass / `0` fail. Failures: none. log sha256: `cb4991bf0cf0ac0591e455b91dd82cd3fb35648bdb91004dff5622b1bbf38d75`
- Base (`main` @ `126b51a`): not re-run — this PR is **purely additive** (2 new files under `src/shared/net/`, no edits to existing modules), so it cannot change existing test outcomes.
- **Conclusion:** 0 new failures, 0 pre-existing failures observed on the PR branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
