### PR TITLE
BET-61: M0.3 Network Refactor — SSH ControlMaster transport + fold forwardHeal

### DIFF
--- a/src/main/forwardHeal.ts
+++ b/src/main/forwardHeal.ts
@@ -1,120 +1,19 @@
-// Self-healing logic for the opencode SSH `-L` forward.
+// SSE stream-stall detection for the opencode event bus.
 //
-// Failure mode this addresses: SSH `ControlPersist` keeps a killed app
-// instance's ControlMaster (and its `-L <localPort>` forward) alive as an
-// orphan. A relaunched instance starts its own master, which passes
-// `ssh -O check`, but `ssh -O forward` for the same local port is rejected
-// ("Port forwarding failed") because the orphaned master still holds it.
-//
-// The recovery: identify the process holding the local port. If it's an `ssh`
-// mux master pointed at one of *our* `bui-cm-*` control sockets that is NOT
-// the live master, it's a stale orphan from a prior run — evict it and retry.
-//
-// This module is pure parsing/decision logic so it can be unit-tested without
-// spawning ssh or binding sockets. The thin spawn glue lives in opencode.ts.
-
-// Our control sockets are `bui-cm-<hash>` under /tmp (matches pty.ts /
-// opencode.ts CONTROL_PATH). Anything else holding the port is foreign and we
-// must NOT touch it.
-const BUI_SOCKET_RE = /\/tmp\/bui-cm-[0-9a-f]+/;
-
-// An ssh `-O forward` failure that means "the local port is already bound".
-// OpenSSH phrases this a few ways across versions; match the stable tokens.
-export function isPortForwardingFailure(stderr: string): boolean {
-  return (
-    /port forwarding failed/i.test(stderr) ||
-    /forwarding request failed/i.test(stderr) ||
-    /bind:\s*address already in use/i.test(stderr) ||
-    /cannot listen to port/i.test(stderr)
-  );
-}
-
-export type PortHolder = {
-  pid: number;
-  command: string;
-};
-
-// Parse `lsof -nP -iTCP:<port> -sTCP:LISTEN -F pcn` output. The `-F pcn`
-// format emits one field per line, record-prefixed: `p<pid>`, `c<command>`,
-// `n<name>`. We only need pid + command of the LISTEN holder(s).
-export function parseLsofListeners(lsofOut: string): PortHolder[] {
-  const holders: PortHolder[] = [];
-  let pid: number | null = null;
-  let command = "";
-  for (const line of lsofOut.split("\n")) {
-    if (line.length === 0) continue;
-    const tag = line[0];
-    const val = line.slice(1);
-    if (tag === "p") {
-      // New process record. Flush the previous one if complete.
-      if (pid !== null) holders.push({ pid, command });
-      pid = Number(val);
-      command = "";
-    } else if (tag === "c") {
-      command = val;
-    }
-    // `n` (name) and `f` (fd) lines are present but unneeded; -sTCP:LISTEN
-    // already filtered to listeners so every emitted process is a holder.
-  }
-  if (pid !== null) holders.push({ pid, command });
-  // Dedup: lsof emits one record per matching fd; a single ssh master listens
-  // on both IPv4 and IPv6, yielding the pid twice.
-  const seen = new Set<number>();
-  return holders.filter((h) => {
-    if (seen.has(h.pid)) return false;
-    seen.add(h.pid);
-    return true;
-  });
-}
-
-export type EvictDecision =
-  | { action: "evict"; socketPath: string; pid: number }
-  | { action: "foreign"; pid: number; command: string }
-  | { action: "none" };
-
-// Decide what to do about whatever holds the local forward port.
-//
-// `holders`     - parsed `lsof` LISTEN holders for the local port
-// `psByPid`     - full `ps`-style command line for each ssh pid, used to read
-//                 its `-o ControlPath=...` (so we learn which socket it masters)
-// `liveSocket`  - resolved control socket of the CURRENT instance's master
-//                 (the `%C` hash expanded). The orphan is, by definition, a
-//                 bui socket that is NOT this one.
-//
-// Returns `evict` only when the holder is unambiguously one of our own stale
-// masters. A non-ssh holder, or an ssh process on a non-bui socket, is
-// `foreign` — surfaced to the user, never killed.
-export function decideEviction(
-  holders: PortHolder[],
-  psByPid: Map<number, string>,
-  liveSocket: string,
-): EvictDecision {
-  if (holders.length === 0) return { action: "none" };
-
-  for (const h of holders) {
-    const cmdline = psByPid.get(h.pid) ?? h.command;
-    const isSsh = /(^|\/)ssh\b/.test(h.command) || /(^|\s)ssh\s/.test(cmdline);
-    if (!isSsh) {
-      return { action: "foreign", pid: h.pid, command: h.command };
-    }
-    const m = cmdline.match(BUI_SOCKET_RE);
-    if (!m) {
-      // An ssh process, but not one of ours (no bui-cm socket on its
-      // command line). Could be a user's own tunnel — do not touch.
-      return { action: "foreign", pid: h.pid, command: h.command };
-    }
-    const holderSocket = m[0];
-    if (holderSocket === liveSocket) {
-      // The live master already holds the port — `-O forward` should have
-      // been idempotent. Nothing to evict; let the caller treat as success.
-      return { action: "none" };
-    }
-    // A bui control socket that is NOT the live one: a stale orphan from a
-    // previous app run kept alive by ControlPersist. Safe to evict.
-    return { action: "evict", socketPath: holderSocket, pid: h.pid };
-  }
-  return { action: "none" };
-}
+// NOTE (BET-46.3): the SSH ControlMaster orphan-eviction decision logic that
+// used to live here (isPortForwardingFailure / parseLsofListeners /
+// decideEviction + their types) moved to ./net/forwardHeal.ts, where the new
+// SSH `Transport` / ConnectionManager owns it. This file keeps ONLY the SSE
+// stream-stall detection because that half is consumed by the index.ts event
+// bus, which is out of scope for this stage (folding the SSE/WS consumer into
+// the ConnectionManager is BET-46.4). To avoid churning importers of the moved
+// symbols, this module re-exports them from their new home — a thin shim.
+export {
+  isPortForwardingFailure,
+  parseLsofListeners,
+  decideEviction,
+} from "./net/forwardHeal.js";
+export type { PortHolder, EvictDecision } from "./net/forwardHeal.js";
 
 // ===== Stalled-stream detection =====
 //

--- a/src/main/net/forwardHeal.test.ts
+++ b/src/main/net/forwardHeal.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideEviction,
+  isPortForwardingFailure,
+  parseLsofListeners,
+} from "./forwardHeal";
+
+// These pure orphan-eviction helpers moved here from src/main/forwardHeal.ts in
+// BET-46.3. src/main/forwardHeal.test.ts still exercises them via the re-export
+// shim; this file pins the behavior at their new home so a future shim removal
+// can't silently drop coverage.
+
+describe("isPortForwardingFailure", () => {
+  it("matches the OpenSSH port-bind phrasings", () => {
+    expect(isPortForwardingFailure("Port forwarding failed.")).toBe(true);
+    expect(isPortForwardingFailure("forwarding request failed")).toBe(true);
+    expect(isPortForwardingFailure("bind: Address already in use")).toBe(true);
+    expect(
+      isPortForwardingFailure(
+        "Could not request local forwarding.\ncannot listen to port: 14096",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated failures", () => {
+    expect(isPortForwardingFailure("Host key verification failed.")).toBe(false);
+    expect(isPortForwardingFailure("")).toBe(false);
+  });
+});
+
+describe("parseLsofListeners", () => {
+  it("parses -F pcn records and dedups a pid seen on v4+v6", () => {
+    const out = "p123\ncssh\nn127.0.0.1:14096\np123\ncssh\nn[::1]:14096\n";
+    expect(parseLsofListeners(out)).toEqual([{ pid: 123, command: "ssh" }]);
+  });
+
+  it("returns [] on empty / whitespace input", () => {
+    expect(parseLsofListeners("")).toEqual([]);
+    expect(parseLsofListeners("\n\n")).toEqual([]);
+  });
+});
+
+describe("decideEviction", () => {
+  const LIVE = "/tmp/bui-cm-abc123";
+
+  it("evicts a stale bui master (different socket than live)", () => {
+    const holders = [{ pid: 42, command: "ssh" }];
+    const ps = new Map([[42, "ssh -o ControlPath=/tmp/bui-cm-abcdef01 -N host"]]);
+    expect(decideEviction(holders, ps, LIVE)).toEqual({
+      action: "evict",
+      socketPath: "/tmp/bui-cm-abcdef01",
+      pid: 42,
+    });
+  });
+
+  it("is a no-op when the live master itself holds the port", () => {
+    const holders = [{ pid: 42, command: "ssh" }];
+    const ps = new Map([[42, `ssh -o ControlPath=${LIVE} -N host`]]);
+    expect(decideEviction(holders, ps, LIVE)).toEqual({ action: "none" });
+  });
+
+  it("treats a non-ssh holder as foreign", () => {
+    const holders = [{ pid: 7, command: "node" }];
+    expect(decideEviction(holders, new Map(), LIVE)).toEqual({
+      action: "foreign",
+      pid: 7,
+      command: "node",
+    });
+  });
+
+  it("treats an ssh holder on a non-bui socket as foreign", () => {
+    const holders = [{ pid: 9, command: "ssh" }];
+    const ps = new Map([[9, "ssh -L 14096:localhost:14096 host"]]);
+    expect(decideEviction(holders, ps, LIVE)).toEqual({
+      action: "foreign",
+      pid: 9,
+      command: "ssh",
+    });
+  });
+
+  it("is a no-op when nothing holds the port", () => {
+    expect(decideEviction([], new Map(), LIVE)).toEqual({ action: "none" });
+  });
+});

--- a/src/main/net/forwardHeal.ts
+++ b/src/main/net/forwardHeal.ts
@@ -1,0 +1,125 @@
+// SSH ControlMaster orphan-eviction decision logic for the unified network
+// layer (BET-46.3). Moved here verbatim from the old src/main/forwardHeal.ts
+// so the SSH `Transport` / ConnectionManager path owns it. Pure parsing /
+// decision functions — no child_process, no sockets — so they unit-test
+// without spawning ssh. The thin spawn glue lives in sshTransport.ts /
+// opencode.ts.
+//
+// Failure mode this addresses: SSH `ControlPersist` keeps a killed app
+// instance's ControlMaster (and its `-L <localPort>` forward) alive as an
+// orphan. A relaunched instance starts its own master, which passes
+// `ssh -O check`, but `ssh -O forward` for the same local port is rejected
+// ("Port forwarding failed") because the orphaned master still holds it.
+//
+// The recovery: identify the process holding the local port. If it's an `ssh`
+// mux master pointed at one of *our* `bui-cm-*` control sockets that is NOT
+// the live master, it's a stale orphan from a prior run — evict it and retry.
+//
+// NOTE: the SSE stream-stall detection (classifyStreamHealth / etc.) that used
+// to live alongside this stays in src/main/forwardHeal.ts because it is
+// consumed by the index.ts SSE bus, which is out of scope for this stage
+// (BET-46.4). src/main/forwardHeal.ts re-exports these symbols so existing
+// importers keep working.
+
+// Our control sockets are `bui-cm-<hash>` under /tmp (matches pty.ts /
+// opencode.ts CONTROL_PATH). Anything else holding the port is foreign and we
+// must NOT touch it.
+const BUI_SOCKET_RE = /\/tmp\/bui-cm-[0-9a-f]+/;
+
+// An ssh `-O forward` failure that means "the local port is already bound".
+// OpenSSH phrases this a few ways across versions; match the stable tokens.
+export function isPortForwardingFailure(stderr: string): boolean {
+  return (
+    /port forwarding failed/i.test(stderr) ||
+    /forwarding request failed/i.test(stderr) ||
+    /bind:\s*address already in use/i.test(stderr) ||
+    /cannot listen to port/i.test(stderr)
+  );
+}
+
+export type PortHolder = {
+  pid: number;
+  command: string;
+};
+
+// Parse `lsof -nP -iTCP:<port> -sTCP:LISTEN -F pcn` output. The `-F pcn`
+// format emits one field per line, record-prefixed: `p<pid>`, `c<command>`,
+// `n<name>`. We only need pid + command of the LISTEN holder(s).
+export function parseLsofListeners(lsofOut: string): PortHolder[] {
+  const holders: PortHolder[] = [];
+  let pid: number | null = null;
+  let command = "";
+  for (const line of lsofOut.split("\n")) {
+    if (line.length === 0) continue;
+    const tag = line[0];
+    const val = line.slice(1);
+    if (tag === "p") {
+      // New process record. Flush the previous one if complete.
+      if (pid !== null) holders.push({ pid, command });
+      pid = Number(val);
+      command = "";
+    } else if (tag === "c") {
+      command = val;
+    }
+    // `n` (name) and `f` (fd) lines are present but unneeded; -sTCP:LISTEN
+    // already filtered to listeners so every emitted process is a holder.
+  }
+  if (pid !== null) holders.push({ pid, command });
+  // Dedup: lsof emits one record per matching fd; a single ssh master listens
+  // on both IPv4 and IPv6, yielding the pid twice.
+  const seen = new Set<number>();
+  return holders.filter((h) => {
+    if (seen.has(h.pid)) return false;
+    seen.add(h.pid);
+    return true;
+  });
+}
+
+export type EvictDecision =
+  | { action: "evict"; socketPath: string; pid: number }
+  | { action: "foreign"; pid: number; command: string }
+  | { action: "none" };
+
+// Decide what to do about whatever holds the local forward port.
+//
+// `holders`     - parsed `lsof` LISTEN holders for the local port
+// `psByPid`     - full `ps`-style command line for each ssh pid, used to read
+//                 its `-o ControlPath=...` (so we learn which socket it masters)
+// `liveSocket`  - resolved control socket of the CURRENT instance's master
+//                 (the `%C` hash expanded). The orphan is, by definition, a
+//                 bui socket that is NOT this one.
+//
+// Returns `evict` only when the holder is unambiguously one of our own stale
+// masters. A non-ssh holder, or an ssh process on a non-bui socket, is
+// `foreign` — surfaced to the user, never killed.
+export function decideEviction(
+  holders: PortHolder[],
+  psByPid: Map<number, string>,
+  liveSocket: string,
+): EvictDecision {
+  if (holders.length === 0) return { action: "none" };
+
+  for (const h of holders) {
+    const cmdline = psByPid.get(h.pid) ?? h.command;
+    const isSsh = /(^|\/)ssh\b/.test(h.command) || /(^|\s)ssh\s/.test(cmdline);
+    if (!isSsh) {
+      return { action: "foreign", pid: h.pid, command: h.command };
+    }
+    const m = cmdline.match(BUI_SOCKET_RE);
+    if (!m) {
+      // An ssh process, but not one of ours (no bui-cm socket on its
+      // command line). Could be a user's own tunnel — do not touch.
+      return { action: "foreign", pid: h.pid, command: h.command };
+    }
+    const holderSocket = m[0];
+    if (holderSocket === liveSocket) {
+      // The live master already holds the port — `-O forward` should have
+      // been idempotent. Nothing to evict; let the caller treat as success.
+      return { action: "none" };
+    }
+    // A bui control socket that is NOT the live one: a stale orphan from a
+    // previous app run kept alive by ControlPersist. Safe to evict.
+    return { action: "evict", socketPath: holderSocket, pid: h.pid };
+  }
+  return { action: "none" };
+}

--- a/src/main/net/sshTransport.test.ts
+++ b/src/main/net/sshTransport.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  SshTransport,
+  evictOrphanForwardHolder,
+  controlArgs,
+  sshTarget,
+} from "./sshTransport";
+import type { SshRunner, SpawnResult } from "./sshTransport";
+import type { AppConfig } from "../../shared/types.js";
+
+// A fully mocked shell so no real ssh/lsof/ps is ever spawned (no SSH in CI).
+// Records every invocation and returns canned results keyed by a matcher.
+
+interface Call {
+  cmd: "ssh" | string;
+  args: string[];
+}
+
+class FakeRunner implements SshRunner {
+  calls: Call[] = [];
+  // ssh handler: inspect args, return a SpawnResult.
+  sshHandler: (args: string[]) => SpawnResult = () => ok();
+  // capture handler keyed by command.
+  captureHandler: (cmd: string, args: string[]) => string = () => "";
+
+  async runSsh(args: string[]): Promise<SpawnResult> {
+    this.calls.push({ cmd: "ssh", args });
+    return this.sshHandler(args);
+  }
+  async capture(cmd: string, args: string[]): Promise<string> {
+    this.calls.push({ cmd, args });
+    return this.captureHandler(cmd, args);
+  }
+
+  /** All ssh calls whose args contain the given `-O <op>`. */
+  controlOps(): string[] {
+    const ops: string[] = [];
+    for (const c of this.calls) {
+      if (c.cmd !== "ssh") continue;
+      const i = c.args.indexOf("-O");
+      if (i >= 0 && c.args[i + 1]) ops.push(c.args[i + 1]);
+    }
+    return ops;
+  }
+}
+
+function ok(stdout = ""): SpawnResult {
+  return { code: 0, stdout, stderr: "" };
+}
+function fail(stderr = "", code = 255): SpawnResult {
+  return { code, stdout: "", stderr };
+}
+
+const CONFIG: AppConfig = {
+  host: "box.example",
+  user: "dev",
+  identityFile: "/home/dev/.ssh/id_ed25519",
+  projects: [],
+};
+
+describe("controlArgs / sshTarget", () => {
+  it("builds the shared ControlMaster args including the identity file", () => {
+    expect(controlArgs(CONFIG)).toEqual([
+      "-o", "ControlMaster=auto",
+      "-o", "ControlPath=/tmp/bui-cm-%C",
+      "-o", "ControlPersist=10m",
+      "-i", "/home/dev/.ssh/id_ed25519",
+    ]);
+    expect(sshTarget(CONFIG)).toBe("dev@box.example");
+    expect(sshTarget({ host: "h", projects: [] })).toBe("h");
+  });
+});
+
+describe("SshTransport.ping", () => {
+  it("resolves when `ssh -O check` reports a live master", async () => {
+    const r = new FakeRunner();
+    r.sshHandler = () => ok();
+    const t = new SshTransport(CONFIG, r);
+    await expect(t.ping()).resolves.toBeUndefined();
+    expect(r.controlOps()).toEqual(["check"]);
+  });
+
+  it("rejects when `ssh -O check` reports no live master", async () => {
+    const r = new FakeRunner();
+    r.sshHandler = () => fail("No ControlPath specified / not running");
+    const t = new SshTransport(CONFIG, r);
+    await expect(t.ping()).rejects.toThrow(/check failed/);
+  });
+});
+
+describe("SshTransport.open", () => {
+  it("is a no-op boot when the master is already live (check passes)", async () => {
+    const r = new FakeRunner();
+    r.sshHandler = (args) => (args.includes("check") ? ok() : ok());
+    const t = new SshTransport(CONFIG, r);
+    await t.open();
+    // Only the `-O check` should have run — no trivial `true` boot needed.
+    expect(r.controlOps()).toEqual(["check"]);
+    const bootRan = r.calls.some((c) => c.args[c.args.length - 1] === "true");
+    expect(bootRan).toBe(false);
+  });
+
+  it("boots the master with a trivial `ssh … true` when check fails", async () => {
+    const r = new FakeRunner();
+    r.sshHandler = (args) => {
+      if (args.includes("-O") && args.includes("check")) return fail("not running");
+      if (args[args.length - 1] === "true") return ok();
+      return ok();
+    };
+    const t = new SshTransport(CONFIG, r);
+    await t.open();
+    const bootRan = r.calls.some((c) => c.args[c.args.length - 1] === "true");
+    expect(bootRan).toBe(true);
+  });
+
+  it("throws when the boot itself fails", async () => {
+    const r = new FakeRunner();
+    r.sshHandler = (args) => {
+      if (args.includes("-O") && args.includes("check")) return fail("not running");
+      return fail("Permission denied", 255);
+    };
+    const t = new SshTransport(CONFIG, r);
+    await expect(t.open()).rejects.toThrow(/master boot exited/);
+  });
+
+  it("throws when no host is configured", async () => {
+    const r = new FakeRunner();
+    const t = new SshTransport({ host: "", projects: [] }, r);
+    await expect(t.open()).rejects.toThrow(/No host configured/);
+  });
+});
+
+describe("SshTransport.close", () => {
+  it("issues `ssh -O exit` on the control path", async () => {
+    const r = new FakeRunner();
+    const t = new SshTransport(CONFIG, r);
+    await t.close();
+    expect(r.controlOps()).toEqual(["exit"]);
+    // Uses the shared control args (targets the live master, not an orphan).
+    const exitCall = r.calls.find((c) => c.args.includes("exit"))!;
+    expect(exitCall.args).toContain("ControlPath=/tmp/bui-cm-%C");
+  });
+
+  it("never throws even if `-O exit` fails", async () => {
+    const r = new FakeRunner();
+    r.sshHandler = () => fail("already gone");
+    const t = new SshTransport(CONFIG, r);
+    await expect(t.close()).resolves.toBeUndefined();
+  });
+});
+
+describe("evictOrphanForwardHolder", () => {
+  const LIVE = "/tmp/bui-cm-ab12cd34";
+
+  function runnerWithHolder(psCmdline: string): FakeRunner {
+    const r = new FakeRunner();
+    r.captureHandler = (cmd) => {
+      if (cmd === "lsof") return "p42\ncssh\nn127.0.0.1:14096\n";
+      if (cmd === "ps") return psCmdline;
+      return "";
+    };
+    // `ssh -G` resolves the live socket; everything else (the orphan `-O exit`) ok.
+    r.sshHandler = (args) => {
+      if (args.includes("-G")) return ok(`host box.example\ncontrolpath ${LIVE}\n`);
+      return ok();
+    };
+    return r;
+  }
+
+  it("evicts a stale orphan master and reports evicted:true", async () => {
+    const r = runnerWithHolder(
+      "ssh -o ControlPath=/tmp/bui-cm-deadbeef -N box.example",
+    );
+    const outcome = await evictOrphanForwardHolder(CONFIG, 14096, r);
+    expect(outcome).toEqual({ evicted: true });
+    // The eviction targets the ORPHAN socket, not the live one.
+    const exitCall = r.calls.find(
+      (c) => c.cmd === "ssh" && c.args.includes("exit"),
+    )!;
+    expect(exitCall.args).toContain("ControlPath=/tmp/bui-cm-deadbeef");
+  });
+
+  it("reports evicted:false when nothing holds the port", async () => {
+    const r = new FakeRunner();
+    r.captureHandler = () => "";
+    const outcome = await evictOrphanForwardHolder(CONFIG, 14096, r);
+    expect(outcome).toEqual({ evicted: false });
+  });
+
+  it("reports foreign for a non-bui ssh holder", async () => {
+    const r = runnerWithHolder("ssh -L 14096:localhost:14096 box.example");
+    const outcome = await evictOrphanForwardHolder(CONFIG, 14096, r);
+    expect(outcome).toMatchObject({ foreign: true, pid: 42 });
+  });
+
+  it("does not evict when the LIVE master holds the port", async () => {
+    const r = runnerWithHolder(`ssh -o ControlPath=${LIVE} -N box.example`);
+    const outcome = await evictOrphanForwardHolder(CONFIG, 14096, r);
+    expect(outcome).toEqual({ evicted: false });
+    expect(r.controlOps()).not.toContain("exit");
+  });
+});

--- a/src/main/net/sshTransport.ts
+++ b/src/main/net/sshTransport.ts
@@ -1,0 +1,225 @@
+// SSH ControlMaster transport for the unified network layer (BET-46.3).
+//
+// Implements the stage-2 `Transport` interface (open / close / ping) on top of
+// the SAME shared SSH ControlMaster that pty.ts and opencode.ts already use
+// (ControlPath=/tmp/bui-cm-%C, ControlPersist=10m). A `ConnectionManager` (see
+// src/shared/net/connectionManager.ts) drives this transport through the
+// connect / health-check / stall→heal lifecycle; this file is the thin,
+// SSH-specific glue that ConnectionManager stays agnostic of.
+//
+//   open()  → ensure a live master exists. `ssh -O check`; if it reports no
+//             live master, (re)establish one with a trivial `ssh … true`
+//             (ControlMaster=auto boots the socket as a side effect, exactly
+//             like runSshOnce does elsewhere).
+//   ping()  → cheap liveness probe: `ssh -O check`. Resolves iff a live master
+//             answers, rejects otherwise — the manager's health loop treats a
+//             rejection as a stall.
+//   close() → `ssh -O exit` on the control path — graceful master shutdown.
+//
+// The heal decision logic for ORPHANED sockets (a prior run's master still
+// holding the -L forward port) lives in ./forwardHeal.ts and is exercised by
+// the forward path in opencode.ts; `evictOrphanForwardHolder` here wires the
+// pure decision to the shell so both the transport and opencode share ONE
+// implementation.
+//
+// Everything that touches the shell goes through an injectable `SshRunner` so
+// the transport unit-tests without spawning a real ssh (no SSH in CI).
+
+import { spawn as cpSpawn } from "node:child_process";
+import { join as pathJoin } from "node:path";
+import type { Transport } from "../../shared/net/connectionManager.js";
+import type { AppConfig } from "../../shared/types.js";
+import { decideEviction, parseLsofListeners } from "./forwardHeal.js";
+
+// Must match pty.ts / opencode.ts CONTROL_PATH exactly so we share the ONE
+// ControlMaster the whole app multiplexes over. `/tmp` (not tmpdir()) because
+// macOS tmpdir() overflows the sun_path limit.
+export const CONTROL_PATH = pathJoin("/tmp", "bui-cm-%C");
+
+export function controlArgs(config: AppConfig): string[] {
+  const args = [
+    "-o", "ControlMaster=auto",
+    "-o", `ControlPath=${CONTROL_PATH}`,
+    "-o", "ControlPersist=10m",
+  ];
+  if (config.identityFile) args.push("-i", config.identityFile);
+  return args;
+}
+
+export function sshTarget(config: AppConfig): string {
+  return config.user ? `${config.user}@${config.host}` : config.host;
+}
+
+export type SpawnResult = { code: number | null; stdout: string; stderr: string };
+
+// Injectable shell surface. The real implementation spawns `ssh` / `lsof` /
+// `ps`; tests substitute a fake that returns canned results, so no process is
+// ever spawned in CI.
+export interface SshRunner {
+  /**
+   * Spawn `ssh <args>` and resolve with its exit code + captured stdout/stderr.
+   * Must NOT reject on a non-zero exit — the caller inspects `code`. Reserve
+   * rejection for spawn-level failures (binary missing, etc.).
+   */
+  runSsh(args: string[]): Promise<SpawnResult>;
+  /** Spawn an arbitrary command (`lsof`, `ps`, …) and resolve its stdout. */
+  capture(cmd: string, args: string[]): Promise<string>;
+}
+
+// Default runner: real child_process spawns. Mirrors the capture helpers that
+// previously lived inline in opencode.ts.
+export const defaultSshRunner: SshRunner = {
+  runSsh(args: string[]): Promise<SpawnResult> {
+    return new Promise((resolve, reject) => {
+      const p = cpSpawn("ssh", args, { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      p.stdout.on("data", (b) => (stdout += b.toString()));
+      p.stderr.on("data", (b) => (stderr += b.toString()));
+      p.on("error", reject);
+      p.on("exit", (code) => resolve({ code, stdout, stderr }));
+    });
+  },
+  capture(cmd: string, args: string[]): Promise<string> {
+    return new Promise((resolve) => {
+      const p = cpSpawn(cmd, args, { stdio: ["ignore", "pipe", "ignore"] });
+      let out = "";
+      p.stdout.on("data", (b) => (out += b.toString()));
+      p.on("error", () => resolve(""));
+      p.on("exit", () => resolve(out));
+    });
+  },
+};
+
+/**
+ * Ask ssh for its *effective* config and read back the expanded ControlPath
+ * (the `%C` token resolved to a concrete /tmp/bui-cm-<hash>). This is the
+ * socket the live master listens on; an orphan is any OTHER bui socket.
+ */
+export async function resolveLiveSocket(
+  config: AppConfig,
+  runner: SshRunner = defaultSshRunner,
+): Promise<string | null> {
+  const { stdout } = await runner
+    .runSsh([...controlArgs(config), "-G", sshTarget(config)])
+    .catch(() => ({ code: null, stdout: "", stderr: "" }));
+  const line = stdout
+    .split("\n")
+    .find((l) => l.toLowerCase().startsWith("controlpath "));
+  return line ? line.slice("controlpath ".length).trim() : null;
+}
+
+export type EvictOutcome =
+  | { evicted: true }
+  | { evicted: false }
+  | { foreign: true; pid: number; command: string };
+
+/**
+ * Evict a stale ControlMaster from a previous app run that is still holding
+ * `localPort` (kept alive by ControlPersist). Pure decision logic lives in
+ * ./forwardHeal.ts (`parseLsofListeners` + `decideEviction`); this wires it to
+ * the shell. Returns whether an eviction happened (so the caller can retry the
+ * forward), or reports a `foreign` holder the user must resolve manually.
+ */
+export async function evictOrphanForwardHolder(
+  config: AppConfig,
+  localPort: number,
+  runner: SshRunner = defaultSshRunner,
+): Promise<EvictOutcome> {
+  const lsofOut = await runner.capture("lsof", [
+    "-nP",
+    `-iTCP:${localPort}`,
+    "-sTCP:LISTEN",
+    "-F",
+    "pcn",
+  ]);
+  const holders = parseLsofListeners(lsofOut);
+  if (holders.length === 0) return { evicted: false };
+
+  // Full command line per pid so decideEviction can read each ssh's
+  // `-o ControlPath=...` and match it against the live socket.
+  const psByPid = new Map<number, string>();
+  for (const h of holders) {
+    const ps = await runner.capture("ps", ["-o", "command=", "-p", String(h.pid)]);
+    psByPid.set(h.pid, ps.trim());
+  }
+
+  const liveSocket = await resolveLiveSocket(config, runner);
+  if (!liveSocket) return { evicted: false };
+
+  const decision = decideEviction(holders, psByPid, liveSocket);
+  if (decision.action === "evict") {
+    // `ssh -O exit` on the ORPHAN's own socket (not our controlArgs path):
+    // graceful master shutdown, which closes its listeners and frees the port.
+    // Target the socket explicitly so we never touch the live master.
+    await runner
+      .runSsh([
+        "-o",
+        `ControlPath=${decision.socketPath}`,
+        "-O",
+        "exit",
+        sshTarget(config),
+      ])
+      .catch(() => ({ code: null, stdout: "", stderr: "" }));
+    return { evicted: true };
+  }
+  if (decision.action === "foreign") {
+    return { foreign: true, pid: decision.pid, command: decision.command };
+  }
+  return { evicted: false };
+}
+
+/**
+ * SSH ControlMaster transport. One per box connection; shares the app-wide
+ * ControlMaster socket. Driven by a ConnectionManager.
+ */
+export class SshTransport implements Transport {
+  private readonly config: AppConfig;
+  private readonly runner: SshRunner;
+
+  constructor(config: AppConfig, runner: SshRunner = defaultSshRunner) {
+    this.config = config;
+    this.runner = runner;
+  }
+
+  /**
+   * Ensure a live ControlMaster exists. If `ssh -O check` fails (no live
+   * master, or the socket went stale after sleep/wifi-change/sshd-restart),
+   * (re)establish one with a trivial remote command — ControlMaster=auto boots
+   * the socket as a side effect, exactly like runSshOnce does elsewhere.
+   */
+  async open(): Promise<void> {
+    if (!this.config.host) throw new Error("No host configured");
+    const alive = await this.checkMaster();
+    if (alive) return;
+    const { code, stderr } = await this.runner.runSsh([
+      ...controlArgs(this.config),
+      sshTarget(this.config),
+      "true",
+    ]);
+    if (code !== 0) {
+      throw new Error(`ssh master boot exited ${code}: ${stderr.trim()}`);
+    }
+  }
+
+  /** Cheap liveness probe: `ssh -O check`. Rejects when no live master. */
+  async ping(): Promise<void> {
+    const alive = await this.checkMaster();
+    if (!alive) throw new Error("ssh ControlMaster check failed");
+  }
+
+  /** `ssh -O exit` — graceful master shutdown. Best-effort; never throws. */
+  async close(): Promise<void> {
+    await this.runner
+      .runSsh([...controlArgs(this.config), "-O", "exit", sshTarget(this.config)])
+      .catch(() => ({ code: null, stdout: "", stderr: "" }));
+  }
+
+  /** `ssh -O check` → true iff the mux reports a live master. */
+  private async checkMaster(): Promise<boolean> {
+    const { code } = await this.runner
+      .runSsh([...controlArgs(this.config), "-O", "check", sshTarget(this.config)])
+      .catch(() => ({ code: null, stdout: "", stderr: "" }));
+    return code === 0;
+  }
+}

--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -28,17 +28,19 @@
 // the wire. No OPENCODE_SERVER_PASSWORD configured.
 
 import { spawn as cpSpawn } from "node:child_process";
-import { join as pathJoin } from "node:path";
 import {
   runSshOnce,
   getBranch as getBranchSsh,
   expandRemotePath,
 } from "./pty.js";
+import { isPortForwardingFailure } from "./net/forwardHeal.js";
 import {
-  decideEviction,
-  isPortForwardingFailure,
-  parseLsofListeners,
-} from "./forwardHeal.js";
+  SshTransport,
+  evictOrphanForwardHolder,
+  controlArgs,
+  sshTarget,
+} from "./net/sshTransport.js";
+import { ConnectionManager } from "../shared/net/connectionManager.js";
 import {
   dropCachedTranscript,
   getCachedTranscript,
@@ -68,9 +70,8 @@ function localPort(config: AppConfig): number {
   return config.opencodePort ?? 14096;
 }
 
-function sshTarget(config: AppConfig): string {
-  return config.user ? `${config.user}@${config.host}` : config.host;
-}
+// `sshTarget` and `controlArgs` are imported from ./net/sshTransport.js — the
+// single source of truth for the shared ControlMaster args (BET-46.3).
 
 // ===== Dedicated event-stream tunnel =====
 //
@@ -249,19 +250,9 @@ export async function restartOpencode(config: AppConfig): Promise<void> {
 // We attach `-L localPort:127.0.0.1:REMOTE_PORT` to the SAME ControlMaster
 // connection pty.ts uses, via `ssh -O forward`. Cancel is symmetric.
 
-// Must match pty.ts's CONTROL_PATH exactly so we share its ControlMaster.
-// `/tmp` (not tmpdir()) because macOS tmpdir() overflows the sun_path limit.
-const CONTROL_PATH = pathJoin("/tmp", "bui-cm-%C");
-
-function controlArgs(config: AppConfig): string[] {
-  const args = [
-    "-o", "ControlMaster=auto",
-    "-o", `ControlPath=${CONTROL_PATH}`,
-    "-o", "ControlPersist=10m",
-  ];
-  if (config.identityFile) args.push("-i", config.identityFile);
-  return args;
-}
+// The shared-ControlMaster args (ControlPath=/tmp/bui-cm-%C, ControlPersist=10m)
+// now live in ./net/sshTransport.js (`controlArgs`) — the single source of
+// truth pty.ts, the SshTransport, and this forward path all use.
 
 type SshControlResult = { code: number | null; stderr: string };
 
@@ -292,91 +283,78 @@ function sshControl(config: AppConfig, op: string, extra: string[] = []): Promis
   });
 }
 
-// Ask ssh for its *effective* config and read back the expanded ControlPath
-// (the `%C` token resolved to a concrete /tmp/bui-cm-<hash>). This is the
-// socket the live master listens on; the orphan is any other bui socket.
-function resolveLiveSocket(config: AppConfig): Promise<string | null> {
-  return new Promise((resolve) => {
-    const args = [...controlArgs(config), "-G", sshTarget(config)];
-    const p = cpSpawn("ssh", args, { stdio: ["ignore", "pipe", "ignore"] });
-    let stdout = "";
-    p.stdout.on("data", (b) => (stdout += b.toString()));
-    p.on("error", () => resolve(null));
-    p.on("exit", () => {
-      const line = stdout
-        .split("\n")
-        .find((l) => l.toLowerCase().startsWith("controlpath "));
-      resolve(line ? line.slice("controlpath ".length).trim() : null);
-    });
-  });
-}
-
-function runCapture(cmd: string, args: string[]): Promise<string> {
-  return new Promise((resolve) => {
-    const p = cpSpawn(cmd, args, { stdio: ["ignore", "pipe", "ignore"] });
-    let out = "";
-    p.stdout.on("data", (b) => (out += b.toString()));
-    p.on("error", () => resolve(""));
-    p.on("exit", () => resolve(out));
-  });
-}
-
 // Evict a stale ControlMaster from a previous app run that is still holding
-// the local forward port (kept alive by ControlPersist). Returns true if it
-// took an action that warrants retrying the forward.
+// the local forward port (kept alive by ControlPersist). The lsof/ps/decision
+// logic now lives in ./net/sshTransport.js (`evictOrphanForwardHolder`), shared
+// with the SshTransport (BET-46.3). Returns true if it took an action that
+// warrants retrying the forward; throws on a foreign (non-bui) holder.
 async function evictStaleForwardHolder(config: AppConfig): Promise<boolean> {
   const port = localPort(config);
-  const lsofOut = await runCapture("lsof", [
-    "-nP",
-    `-iTCP:${port}`,
-    "-sTCP:LISTEN",
-    "-F",
-    "pcn",
-  ]);
-  const holders = parseLsofListeners(lsofOut);
-  if (holders.length === 0) return false;
-
-  // Full command line per pid so decideEviction can read each ssh's
-  // `-o ControlPath=...` and match it against the live socket.
-  const psByPid = new Map<number, string>();
-  for (const h of holders) {
-    const ps = await runCapture("ps", ["-o", "command=", "-p", String(h.pid)]);
-    psByPid.set(h.pid, ps.trim());
-  }
-
-  const liveSocket = await resolveLiveSocket(config);
-  if (!liveSocket) return false;
-
-  const decision = decideEviction(holders, psByPid, liveSocket);
-  if (decision.action === "evict") {
-    // `ssh -O exit` on the ORPHAN's own socket (not our controlArgs path):
-    // graceful master shutdown, which closes its listeners and frees the
-    // port. Target the socket explicitly so we never touch the live master.
-    await new Promise<void>((r) =>
-      cpSpawn(
-        "ssh",
-        [
-          "-o",
-          `ControlPath=${decision.socketPath}`,
-          "-O",
-          "exit",
-          sshTarget(config),
-        ],
-        { stdio: "ignore" },
-      )
-        .on("exit", () => r())
-        .on("error", () => r()),
-    );
-    return true;
-  }
-  if (decision.action === "foreign") {
+  const outcome = await evictOrphanForwardHolder(config, port);
+  if ("foreign" in outcome) {
     throw new Error(
       `opencode local port ${port} is held by another process ` +
-        `(pid ${decision.pid}, ${decision.command}). Close it or set a ` +
+        `(pid ${outcome.pid}, ${outcome.command}). Close it or set a ` +
         `different opencodePort in settings.`,
     );
   }
-  return false;
+  return outcome.evicted;
+}
+
+// ===== ControlMaster via ConnectionManager =====
+//
+// The shared SSH ControlMaster is now owned by a ConnectionManager wrapping an
+// SshTransport (BET-46.3). `ensureForward` asks the manager to (re)open the
+// master before attaching the `-L` forward, replacing the ad-hoc inline
+// `ssh -O check` + `runSshOnce("true")` boot it used to do. This is a plumbing
+// swap: same master, same ControlPath, same reconnect outcomes the user sees.
+//
+// A single manager is kept per host (the app is single-box). `masterConfig`
+// tracks which config the current manager was built for so a host change
+// rebuilds it.
+let master: ConnectionManager | null = null;
+let masterConfig: AppConfig | null = null;
+
+function masterKey(config: AppConfig): string {
+  return `${config.user ?? ""}@${config.host}:${config.identityFile ?? ""}`;
+}
+
+function getMaster(config: AppConfig): ConnectionManager {
+  if (master && masterConfig && masterKey(masterConfig) === masterKey(config)) {
+    return master;
+  }
+  master = new ConnectionManager({ transport: new SshTransport(config) });
+  masterConfig = config;
+  return master;
+}
+
+// Ensure the shared ControlMaster is live, preserving the pre-BET-46.3
+// "probe on EVERY call, boot on failure" contract (a cached "up" flag lies
+// after wifi drops / sleep / remote sshd restart). We keep the cheap
+// `ssh -O check` probe here; only when it reports no live master do we drive
+// the ConnectionManager to (re)open the transport, which boots the socket the
+// same way `runSshOnce("true")` did. Routing the boot through the manager is
+// the plumbing swap; the probe-every-call self-heal is unchanged.
+// Returns true if the master had to be (re)booted (was not already live), so
+// the caller can invalidate its cached forward flag exactly as the old inline
+// path did.
+async function ensureMaster(config: AppConfig): Promise<boolean> {
+  const mgr = getMaster(config);
+  let alive = true;
+  try {
+    await sshControl(config, "check");
+  } catch {
+    alive = false;
+  }
+  if (alive) return false;
+  // Master is gone. If the manager thinks it is still connected, close it so
+  // connect() will legally re-open (connect() is a no-op past `idle`/`closed`).
+  const st = mgr.getState().state;
+  if (st !== "idle" && st !== "closed") {
+    await mgr.disconnect("master-gone");
+  }
+  await mgr.connect();
+  return true;
 }
 
 let forwarded = false;
@@ -388,13 +366,20 @@ let forwarded = false;
 // keep the path self-healing. `-O forward` is idempotent (sshControl treats
 // "already forwarded" as success).
 export async function ensureForward(config: AppConfig): Promise<void> {
+  // Ensure the shared ControlMaster is live via the ConnectionManager, which
+  // wraps the SshTransport. `SshTransport.open()` does the same `ssh -O check`
+  // and, if the master is gone, the same trivial `ssh … true` boot this used to
+  // do inline — a behavior-preserving plumbing swap (BET-46.3). A closed/idle
+  // manager reconnects; an already-connected one is a cheap no-op check.
   try {
-    await sshControl(config, "check");
+    // Rebooted master → the old -L forward is gone with it; invalidate the flag
+    // (matches the pre-BET-46.3 catch block that reset it on a failed check).
+    if (await ensureMaster(config)) forwarded = false;
   } catch {
-    // ControlMaster is gone (or never existed). Boot it via the same path
-    // runSshOnce uses elsewhere.
+    // The manager couldn't open a master (host unreachable, etc). Fall through:
+    // the `-O forward` below fails the same way it did before and surfaces the
+    // real error. Reset the cached flag so a later call re-probes from scratch.
     forwarded = false;
-    await runSshOnce(config, "true");
   }
   const spec = `${localPort(config)}:127.0.0.1:${REMOTE_PORT}`;
   const first = await runSshControl(config, "forward", ["-L", spec]);
@@ -469,14 +454,16 @@ export function invalidateForward(): void {
 // forwardHeal.ts). The only recovery is to tear that master down so the
 // next ensureForward() boots a fresh one.
 //
-// `ssh -O exit` here uses controlArgs() → ControlPath=/tmp/bui-cm-%C, i.e.
-// it targets the master for THIS config's connection (the one we use), not
-// an orphan. Best-effort: if the socket is already gone, the next
-// ensureForward() rebuilds anyway.
+// The teardown routes through the ConnectionManager's disconnect(), which calls
+// SshTransport.close() → `ssh -O exit` on controlArgs() → ControlPath=/tmp/
+// bui-cm-%C, i.e. it targets the master for THIS config's connection (the one
+// we use), not an orphan. Leaving the manager `closed` means the next
+// ensureForward()→ensureMaster() reconnect()s a fresh master. Best-effort: if
+// the socket is already gone, the next ensureForward() rebuilds anyway.
 export async function forceEvictControlMaster(
   config: AppConfig,
 ): Promise<void> {
-  await runSshControl(config, "exit").catch(() => {});
+  await getMaster(config).disconnect("forced-evict").catch(() => {});
   forwarded = false;
 }
 


### PR DESCRIPTION
## BET-61 / BET-46.3 — SSH ControlMaster transport + fold forwardHeal

Stage 3 of 4 of the M0 Network Layer Refactor. First slice to touch live `src/main/` code, kept tight and behavior-preserving.

**Base:** `origin/main @ 77364d4`

### What changed

1. **`src/main/net/sshTransport.ts` (new)** — real SSH `Transport` (per the stage-2 `Transport` interface) managing the shared ControlMaster:
   - `open()` — `ssh -O check`; if no live master, boot one with a trivial `ssh … true` (ControlMaster=auto establishes the socket, exactly as `runSshOnce` did).
   - `ping()` — cheap liveness probe (`ssh -O check`), rejects when the master is dead.
   - `close()` — `ssh -O exit` on the shared control path.
   - `evictOrphanForwardHolder()` — wires the moved orphan-detection decision logic to the shell (lsof/ps/`-O exit` on the orphan socket). Shell access is behind an injectable `SshRunner` so it unit-tests with **no real SSH**.
   - Shares `controlArgs` / `sshTarget` / `CONTROL_PATH` — now the single source of truth (opencode.ts imports them instead of its own copies).

2. **Folded `forwardHeal.ts`** — the SSH orphan-eviction pure logic (`isPortForwardingFailure`, `parseLsofListeners`, `decideEviction` + types) moved to `src/main/net/forwardHeal.ts` where the transport owns it. `src/main/forwardHeal.ts` is now a **thin re-export shim** for those symbols and keeps the SSE stream-stall detection (`classifyStreamHealth` / `isSubstantiveFrame` / `STREAM_STALL_MS`) inline.
   - **Why not delete `forwardHeal.ts`:** the stream-stall half is consumed by the `src/main/index.ts` SSE bus, which is explicitly out of scope for this stage (stage 4 / BET-46.4). Shim left in place per the issue's instruction, noted here.

3. **`src/main/opencode.ts` refactor** — obtains its SSH master through a `ConnectionManager` wrapping `SshTransport` instead of ad-hoc inline calls:
   - `ensureForward()` → `ensureMaster()` drives the `ConnectionManager` to (re)open the transport. The pre-existing "probe on **every** call, boot on failure" self-heal contract is preserved (a cached "up" flag lies after wifi drop / sleep / sshd restart).
   - `forceEvictControlMaster()` → `manager.disconnect()` (which calls `SshTransport.close()` → `ssh -O exit`), leaving the manager `closed` so the next `ensureForward` reconnects.
   - `evictStaleForwardHolder()` now delegates to the shared `evictOrphanForwardHolder`.
   - Removed the now-duplicated `resolveLiveSocket`, `runCapture`, `CONTROL_PATH`, `controlArgs`, local `sshTarget`, and the `pathJoin` import.
   - **Behavior-preserving plumbing swap** — same ControlPath, same forwarded ports, same reconnect outcomes. **Did NOT** touch the SSE/WS consumer (stage 4).

### Out of scope (untouched, per issue)
`src/main/index.ts` SSE bus, `src/main/httpApi.ts`, `src/server/opencode.mjs`.

### Tests
- `src/main/net/sshTransport.test.ts` (new, 13 tests) — heal decision + transport lifecycle with a mocked `SshRunner`: live master → no-op boot; stale/orphaned → orphan socket removed + retry; `close()` → `-O exit`; foreign holder reported; no-host throws; boot-failure throws.
- `src/main/net/forwardHeal.test.ts` (new, 9 tests) — pins the orphan-eviction decision logic at its new home.
- `src/main/forwardHeal.test.ts` (existing, 55 tests) — unchanged, still green via the shim (no coverage regression).

### Verification results

**Files changed:** 6 files (`git diff --stat origin/main...HEAD`): `src/main/forwardHeal.ts`, `src/main/net/forwardHeal.ts` (new), `src/main/net/forwardHeal.test.ts` (new), `src/main/net/sshTransport.ts` (new), `src/main/net/sshTransport.test.ts` (new), `src/main/opencode.ts`.

- PR branch (`multica/BET-46.3-ssh-controlmaster-transport`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`. vitest `670` pass / `0` fail (35 files) + server `226` pass / `0` fail. Failures: none. log sha256: `8d923ab8871fa0c4fc8862018b6fb20fa1bd771c15c7242a2e1922ad5cbcdbd0`
- **Conclusion:** 0 new failures. Both suites fully green on the PR branch; base (`main @ 77364d4`) is a merge commit of the just-landed stage-2 work, so no pre-existing failures expected. Base re-run skippable given 0 failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.
