### PR TITLE
BET-62: unified SSE/WS reconnect + backpressure wiring (M0.4)

### DIFF
--- a/src/main/eventBatcher.test.ts
+++ b/src/main/eventBatcher.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import { EventBatcher, HIGH_PRIORITY_TYPES, type BusEvent } from "./eventBatcher.js";
+
+// A controllable fake timer so batching is deterministic (no real 50ms waits).
+// setTimeoutFn stashes the callback; advance() fires the pending one.
+function makeFakeTimer() {
+  let pending: (() => void) | null = null;
+  let nextId = 1;
+  return {
+    setTimeoutFn: (fn: () => void, _ms: number) => {
+      pending = fn;
+      return nextId++;
+    },
+    clearTimeoutFn: (_h: unknown) => {
+      pending = null;
+    },
+    /** Fire the currently-armed flush callback, if any. */
+    advance() {
+      const fn = pending;
+      pending = null;
+      if (fn) fn();
+    },
+    hasPending() {
+      return pending !== null;
+    },
+  };
+}
+
+/** Build a bus event `{type, properties:{sessionID, partID}}`. */
+function ev(type: string, sessionID?: string, partID?: string): BusEvent {
+  const properties: Record<string, unknown> = {};
+  if (sessionID !== undefined) properties.sessionID = sessionID;
+  if (partID !== undefined) properties.partID = partID;
+  return { type, properties };
+}
+
+describe("EventBatcher — high-priority pass-through (BET-46 Risk #2)", () => {
+  it("exposes the forced high-priority types", () => {
+    expect([...HIGH_PRIORITY_TYPES]).toEqual(["permission.asked", "question.asked"]);
+  });
+
+  it("emits permission.asked / question.asked immediately, never buffered", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    b.push(ev("permission.asked", "s1"));
+    b.push(ev("question.asked", "s1"));
+
+    // Delivered synchronously — no timer advance needed.
+    expect(out.map((e) => e.type)).toEqual(["permission.asked", "question.asked"]);
+    expect(t.hasPending()).toBe(false);
+  });
+
+  it("flushes buffered events before a high-priority one to preserve order", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    b.push(ev("message.updated", "s1"));
+    b.push(ev("permission.asked", "s1")); // forces a flush of the buffered event first
+
+    expect(out.map((e) => e.type)).toEqual(["message.updated", "permission.asked"]);
+  });
+
+  it("NEVER drops permission.asked / question.asked even when the batch floods past the cap", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      maxPerSec: 5,
+      dropTypes: ["vcs.branch.updated"],
+      // Force permission/question to arrive INSIDE a big batch by not tripping
+      // the immediate path: we push them interleaved and rely on the primitive's
+      // forced high-priority set. (Here they take the immediate path, so also
+      // assert the flooded batch keeps every droppable-cap survivor sane.)
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    // Flood: 50 droppable events, cap 5 → most vcs events get shed.
+    for (let i = 0; i < 50; i++) b.push(ev("vcs.branch.updated"));
+    // A permission.asked mid-flood: immediate path drains the buffer then emits.
+    b.push(ev("permission.asked", "s1"));
+    t.advance(); // (buffer already drained by the high-priority push; no-op)
+
+    const perms = out.filter((e) => e.type === "permission.asked");
+    expect(perms).toHaveLength(1); // always survives
+  });
+});
+
+describe("EventBatcher — batching + rate-limit/coalesce", () => {
+  it("buffers non-priority events and flushes them on the window timer", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    b.push(ev("message.updated", "s1"));
+    b.push(ev("session.status", "s1"));
+    expect(out).toHaveLength(0); // nothing emitted before the window fires
+    expect(t.hasPending()).toBe(true);
+
+    t.advance();
+    expect(out.map((e) => e.type)).toEqual(["message.updated", "session.status"]);
+  });
+
+  it("coalesces consecutive same-part message.part.delta into the last one", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    // Three deltas for the same (session, part) → collapse to the last.
+    const d1 = { ...ev("message.part.delta", "s1", "p1"), seq: 1 } as BusEvent;
+    const d2 = { ...ev("message.part.delta", "s1", "p1"), seq: 2 } as BusEvent;
+    const d3 = { ...ev("message.part.delta", "s1", "p1"), seq: 3 } as BusEvent;
+    b.push(d1);
+    b.push(d2);
+    b.push(d3);
+    t.advance();
+
+    expect(out).toHaveLength(1);
+    expect((out[0] as { seq: number }).seq).toBe(3); // the last event object survives
+  });
+
+  it("does NOT coalesce deltas across different parts/sessions", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    b.push(ev("message.part.delta", "s1", "p1"));
+    b.push(ev("message.part.delta", "s1", "p2")); // different part
+    b.push(ev("message.part.delta", "s2", "p1")); // different session
+    t.advance();
+
+    expect(out).toHaveLength(3); // no cross-key collapse
+  });
+
+  it("drops vcs.branch.updated first when a batch exceeds maxPerSec", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      maxPerSec: 3,
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    // 2 keep events + 4 droppable = 6, cap 3 → shed 3 vcs events.
+    b.push(ev("message.updated", "s1"));
+    b.push(ev("vcs.branch.updated"));
+    b.push(ev("vcs.branch.updated"));
+    b.push(ev("vcs.branch.updated"));
+    b.push(ev("vcs.branch.updated"));
+    b.push(ev("session.status", "s1"));
+    t.advance();
+
+    // The two non-droppable events always survive.
+    expect(out.filter((e) => e.type === "message.updated")).toHaveLength(1);
+    expect(out.filter((e) => e.type === "session.status")).toHaveLength(1);
+    // At most 1 vcs event survives (6 - 3 dropped, minus the 2 keepers = 1).
+    expect(out.filter((e) => e.type === "vcs.branch.updated").length).toBeLessThanOrEqual(1);
+    expect(out.length).toBeLessThanOrEqual(3);
+  });
+
+  it("emits the ORIGINAL event object (no __orig shim leakage)", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+    const original = ev("message.updated", "s1");
+    b.push(original);
+    t.advance();
+    expect(out[0]).toBe(original); // same reference, un-shimmed
+    expect((out[0] as Record<string, unknown>).__orig).toBeUndefined();
+  });
+
+  it("stop() cancels a pending flush and discards the buffer", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+    b.push(ev("message.updated", "s1"));
+    b.stop();
+    t.advance(); // no pending timer → nothing fires
+    expect(out).toHaveLength(0);
+    expect(t.hasPending()).toBe(false);
+  });
+
+  it("flood integration: rate-limits/coalesces bulk while high-priority always passes", () => {
+    const t = makeFakeTimer();
+    const out: BusEvent[] = [];
+    const b = new EventBatcher({
+      emit: (e) => out.push(e),
+      maxPerSec: 10,
+      setTimeoutFn: t.setTimeoutFn,
+      clearTimeoutFn: t.clearTimeoutFn,
+    });
+
+    // Interleave a permission.asked into a delta storm + vcs churn.
+    for (let i = 0; i < 100; i++) b.push(ev("message.part.delta", "s1", "p1"));
+    b.push(ev("permission.asked", "s1")); // immediate — flushes the coalesced storm first
+    for (let i = 0; i < 100; i++) b.push(ev("vcs.branch.updated"));
+    t.advance(); // flush the vcs batch
+
+    // The 100 same-part deltas coalesced to 1; permission survived; vcs got capped.
+    expect(out.filter((e) => e.type === "permission.asked")).toHaveLength(1);
+    expect(out.filter((e) => e.type === "message.part.delta")).toHaveLength(1);
+    expect(out.filter((e) => e.type === "vcs.branch.updated").length).toBeLessThanOrEqual(10);
+  });
+});

--- a/src/main/eventBatcher.test.ts
+++ b/src/main/eventBatcher.test.ts
@@ -135,7 +135,7 @@ describe("EventBatcher — batching + rate-limit/coalesce", () => {
     t.advance();
 
     expect(out).toHaveLength(1);
-    expect((out[0] as { seq: number }).seq).toBe(3); // the last event object survives
+    expect((out[0] as unknown as { seq: number }).seq).toBe(3); // the last event object survives
   });
 
   it("does NOT coalesce deltas across different parts/sessions", () => {

--- a/src/main/eventBatcher.ts
+++ b/src/main/eventBatcher.ts
@@ -1,0 +1,186 @@
+// Main-process backpressure pump for the opencode → renderer event stream.
+//
+// This is the stage-4 (BET-46.4) server/main half of BET-46 Risk #2: opencode
+// can flood the renderer with events (delta storms on a long assistant turn,
+// vcs.branch.updated churn on a busy repo). Left unthrottled, every frame is
+// IPC-forwarded to the renderer one at a time, which under load pins the
+// renderer redraw loop and starves the UI.
+//
+// The pure coalesce/drop/rate-limit policy lives in the shared primitive
+// `applyBackpressure` (src/shared/net/backpressure.ts, BET-46.1). That
+// primitive operates on a BATCH of events; this class is the thin, stateful
+// adapter that turns the main-process one-event-at-a-time stream into batches,
+// runs the policy over each batch, and forwards the survivors — WITHOUT ever
+// delaying a high-priority event.
+//
+// Design (the two guarantees that matter):
+//
+//  1. HIGH-PRIORITY events (permission.asked, question.asked — Risk #2) are
+//     NEVER buffered, coalesced, or dropped. They flush the pending batch and
+//     emit synchronously, so a permission prompt reaches the user with zero
+//     added latency. This is enforced twice: structurally here (immediate
+//     path) AND in the primitive's forced high-priority set (defense in depth).
+//
+//  2. Everything else is buffered for at most `windowMs` (default 50ms) and
+//     flushed as a batch through `applyBackpressure`. Coalescing collapses
+//     consecutive same-part deltas; dropping sheds `dropTypes` only when the
+//     batch exceeds `maxPerSec`. Under normal load the batch is tiny and
+//     nothing is coalesced/dropped — the added latency is one animation frame.
+//
+// Timers are injectable so the batching is unit-testable with fake timers.
+
+import { applyBackpressure } from "../shared/net/backpressure.js";
+
+// The main-process bus event shape: opencode frames are `{id?, type, properties}`
+// (see src/shared/types.ts OpencodeEvent). The coalesce key fields
+// (sessionID / partID) live UNDER `properties`, whereas the shared
+// backpressure primitive reads them at the top level. `push()` accepts this
+// bus shape; the batcher lifts the key fields into the primitive's shape for
+// the policy pass, then emits the ORIGINAL event object unchanged.
+export interface BusEvent {
+  id?: string;
+  type: string;
+  properties?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+/** Events that must bypass batching entirely — see BET-46 Risk #2. */
+export const HIGH_PRIORITY_TYPES = ["permission.asked", "question.asked"] as const;
+
+export type TimerHandle = unknown;
+
+export interface EventBatcherOpts {
+  /**
+   * Forward one survivor event to its sink (the renderer via
+   * `webContents.send`, or the mobile bus). Called in batch order.
+   */
+  emit: (ev: BusEvent) => void;
+  /** Flush window in ms. Buffered events flush after this long. Defaults to 50. */
+  windowMs?: number;
+  /** Soft cap on events per flushed batch before drop-types get shed. Defaults to 100. */
+  maxPerSec?: number;
+  /** Event types whose consecutive same-key runs coalesce. Uses primitive default when omitted. */
+  coalesceTypes?: string[];
+  /** Event types shed first when a batch is over cap. Uses primitive default when omitted. */
+  dropTypes?: string[];
+  /**
+   * Extra never-drop/never-coalesce types on top of the always-forced
+   * permission.asked/question.asked. Defaults to none.
+   */
+  highPriorityTypes?: string[];
+  setTimeoutFn?: (fn: () => void, ms: number) => TimerHandle;
+  clearTimeoutFn?: (h: TimerHandle) => void;
+}
+
+/**
+ * Batching backpressure pump. Push events in with {@link push}; survivors are
+ * delivered to `emit` after the flush window (or immediately, for
+ * high-priority events). Call {@link flush} to drain synchronously (e.g. before
+ * teardown) and {@link stop} to cancel a pending flush.
+ */
+export class EventBatcher {
+  private readonly emit: (ev: BusEvent) => void;
+  private readonly windowMs: number;
+  private readonly maxPerSec: number;
+  private readonly coalesceTypes?: string[];
+  private readonly dropTypes?: string[];
+  private readonly highPriorityTypes: string[];
+  private readonly highPrioritySet: Set<string>;
+  private readonly setTimeoutFn: (fn: () => void, ms: number) => TimerHandle;
+  private readonly clearTimeoutFn: (h: TimerHandle) => void;
+
+  private buffer: BusEvent[] = [];
+  private timer: TimerHandle | null = null;
+
+  constructor(opts: EventBatcherOpts) {
+    this.emit = opts.emit;
+    this.windowMs = opts.windowMs ?? 50;
+    this.maxPerSec = opts.maxPerSec ?? 100;
+    this.coalesceTypes = opts.coalesceTypes;
+    this.dropTypes = opts.dropTypes;
+    this.highPriorityTypes = opts.highPriorityTypes ?? [];
+    // The always-forced set + any caller extras. permission.asked/question.asked
+    // are forced by the primitive too; we mirror them here so the immediate-path
+    // check matches the primitive's guarantee.
+    this.highPrioritySet = new Set([
+      ...HIGH_PRIORITY_TYPES,
+      ...this.highPriorityTypes,
+    ]);
+    this.setTimeoutFn =
+      opts.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms) as unknown as TimerHandle);
+    this.clearTimeoutFn =
+      opts.clearTimeoutFn ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  }
+
+  /**
+   * Ingest one event from the opencode stream.
+   *
+   * - High-priority events flush any pending batch (to preserve ordering) then
+   *   emit immediately — zero added latency, never dropped/coalesced.
+   * - Everything else is buffered; the first buffered event since the last
+   *   flush arms the flush timer.
+   */
+  push(ev: BusEvent): void {
+    if (this.highPrioritySet.has(ev.type)) {
+      // Preserve global ordering: drain whatever is buffered first, then emit
+      // the high-priority event synchronously.
+      this.flush();
+      this.emit(ev);
+      return;
+    }
+    this.buffer.push(ev);
+    if (this.timer === null) {
+      this.timer = this.setTimeoutFn(() => {
+        this.timer = null;
+        this.flush();
+      }, this.windowMs);
+    }
+  }
+
+  /** Drain the pending batch synchronously through the backpressure policy. */
+  flush(): void {
+    if (this.timer !== null) {
+      this.clearTimeoutFn(this.timer);
+      this.timer = null;
+    }
+    if (this.buffer.length === 0) return;
+    const batch = this.buffer;
+    this.buffer = [];
+    // Lift the coalesce-key fields (sessionID/partID) out of `properties` into
+    // the shape the shared primitive reads, keeping a back-reference to the
+    // original bus event so we emit the untouched object. `__orig` is stripped
+    // by the primitive's coalesce (it replaces the whole object, keeping the
+    // later event's __orig) and never reaches `emit`.
+    const shims = batch.map((ev) => {
+      const props = (ev.properties ?? {}) as {
+        sessionID?: unknown;
+        partID?: unknown;
+      };
+      return {
+        type: ev.type,
+        sessionID: typeof props.sessionID === "string" ? props.sessionID : undefined,
+        partID: typeof props.partID === "string" ? props.partID : undefined,
+        __orig: ev,
+      };
+    });
+    const survivors = applyBackpressure(shims, {
+      maxPerSec: this.maxPerSec,
+      coalesceTypes: this.coalesceTypes,
+      dropTypes: this.dropTypes,
+      highPriorityTypes: this.highPriorityTypes,
+    });
+    for (const s of survivors) {
+      const orig = (s as { __orig?: BusEvent }).__orig;
+      if (orig) this.emit(orig);
+    }
+  }
+
+  /** Cancel a pending flush and discard the buffer (teardown; no emit). */
+  stop(): void {
+    if (this.timer !== null) {
+      this.clearTimeoutFn(this.timer);
+      this.timer = null;
+    }
+    this.buffer = [];
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -87,6 +87,7 @@ import {
   isSubstantiveFrame,
   STREAM_STALL_MS,
 } from "./forwardHeal.js";
+import { EventBatcher } from "./eventBatcher.js";
 import { buildRemoteConfigWriteCmd } from "./remoteConfigWrite.js";
 import {
   startDesktopPresence,
@@ -197,6 +198,25 @@ function startPollerIfReady(): void {
 let opencodeBusStopped = true;
 const opencodeStreams = new Map<string, () => void>(); // key: "" (global) or dir
 let unsubscribeDirAdded: (() => void) | null = null;
+
+// Backpressure pump for the opencode → renderer event stream (BET-46.4).
+// opencode can flood the renderer (delta storms, vcs churn); the batcher
+// buffers non-high-priority events for a short window and runs the shared
+// coalesce/drop/rate-limit policy (applyBackpressure, BET-46.1) over each
+// batch before IPC-forwarding survivors. permission.asked / question.asked are
+// NEVER buffered, coalesced, or dropped — they flush the batch and emit
+// immediately (Risk #2). One batcher for the whole bus: the coalesce key
+// includes sessionID, so cross-session deltas never collapse into each other.
+const opencodeEventBatcher = new EventBatcher({
+  emit: (ev) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(IPC.opencodeEvent, ev);
+    }
+  },
+  // permission.asked/question.asked are already forced high-priority by the
+  // primitive; naming them here keeps the immediate-emit path explicit.
+  highPriorityTypes: ["permission.asked", "question.asked"],
+});
 
 // Refcount of open ChatPanels per scoped directory. A scoped stream is kept
 // alive while ≥1 panel for that dir is mounted and is torn down when the last
@@ -317,6 +337,9 @@ function stopOpencodeBus(): void {
   opencodeStreams.clear();
   streamReady.clear();
   activeWorkByDir.clear();
+  // Cancel any pending backpressure flush + discard the buffer — no consumers
+  // once the bus stops.
+  opencodeEventBatcher.stop();
   // Tear down the dedicated event tunnel — no consumers once the bus stops.
   teardownEventTunnel();
 }
@@ -502,9 +525,9 @@ function ensureOpencodeStream(directory: string): void {
                 // Fall back to manual approval: forward the event so the
                 // renderer can render the card (mirrors the mobile pump).
                 // Without this a failed auto-allow silently hangs the turn.
-                if (mainWindow && !mainWindow.isDestroyed()) {
-                  mainWindow.webContents.send(IPC.opencodeEvent, ev);
-                }
+                // permission.asked is high-priority → the batcher emits it
+                // immediately (never buffered/dropped).
+                opencodeEventBatcher.push(ev);
               });
             }
             // Suppress forwarding on the success path — the renderer doesn't
@@ -513,9 +536,11 @@ function ensureOpencodeStream(directory: string): void {
             continue;
           }
 
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send(IPC.opencodeEvent, ev);
-          }
+          // Route through the backpressure batcher: high-priority events
+          // (permission.asked / question.asked) emit immediately; everything
+          // else is coalesced/rate-limited over a short window before the
+          // IPC send to the renderer.
+          opencodeEventBatcher.push(ev);
         }
       } catch (e) {
         // Server might not be up yet — fine, retry. We don't proactively

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -11,6 +11,7 @@ import {
   networkFailure,
   type ClaimResult,
 } from "../mobile/pairingLogic.js";
+import { WsReconnectController, type WsLike } from "../net/wsTransport.js";
 
 // ---------------------------------------------------------------------------
 // Server base URL resolution (3 deployment contexts):
@@ -223,25 +224,16 @@ const listeners: Record<Kind, Set<(p: unknown) => void>> = {
 // PWAs can't reliably receive EventSource, but WebSockets work there (the
 // /pty WS already tunnels fine in the installed PWA). Server exposes the
 // same {kind,payload} envelope on a /events WS.
-let es: WebSocket | null = null;
-// WS has no built-in auto-reconnect (EventSource did). Track a backoff timer
-// and the current backoff delay (ms; doubles per failed attempt, capped,
-// reset to 0 on a healthy onopen).
-let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let _backoff = 0;
+//
+// WS has no built-in auto-reconnect (EventSource did). The reconnect state
+// machine — backoff, "never permanently abandon", resync-on-reconnect — lives
+// in the shared WsReconnectController (src/renderer/net/wsTransport.ts), built
+// on the shared ExponentialBackoff (BET-46.1). This module just wires the live
+// WebSocket + browser timers into it and dispatches parsed frames to listeners.
+let _controller: WsReconnectController | null = null;
 
-// ---------------------------------------------------------------------------
-// Reconnect-resync state.
-// ---------------------------------------------------------------------------
-
-// Set to true after the first onerror so we know the NEXT onopen is a
-// reconnect (not the initial connect).  Reset to false after firing the resync
-// so rapid flapping doesn't spam listeners — the next genuine reconnect after
-// another onerror will set it again.
-let _hadError = false;
-
-// Guard: only fire the resync once per reconnect event even if onopen somehow
-// fires multiple times in quick succession.
+// Guard: only fire the resync once per reconnect event even if onReconnect
+// somehow fires multiple times in quick succession.
 let _resyncing = false;
 
 /**
@@ -295,115 +287,71 @@ function wsUrl(): string {
   return withTokenParam(base, clientToken());
 }
 
-// (Re)create the shared events WebSocket. Idempotent: a socket that is OPEN
-// or CONNECTING is left alone; only a missing/CLOSING/CLOSED one is
-// (re)opened. Listeners live in the module `listeners` map (not bound to the
-// socket), so swapping `es` is transparent to every on() consumer. The
-// {kind,payload} frame is byte-identical to the old SSE envelope, so the
-// dispatch body is unchanged.
-//
-// GOTCHA: serverBase() can throw if localStorage["bui_server"] is unset on
-// a non-localhost page (mobile/web descope — fail-fast intent). This
-// function is called synchronously from on() inside React useEffects, so
-// an uncaught throw white-screens the renderer with no recovery path.
-// Catch the throw here, log once, and let the next openStream() call
-// retry (the user typically fixes it by entering a server URL and
-// reloading). The `bootError` from refresh() carries the user-facing
-// message; we just need to not crash before that surfaces.
-function openStream() {
-  if (es && (es.readyState === WebSocket.OPEN || es.readyState === WebSocket.CONNECTING)) {
-    return;
-  }
-  if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
-  if (es) {
-    try { es.close(); } catch { /* already dead */ }
-  }
-  let url: string;
+// Dispatch one parsed {kind,payload} frame to its listeners. The frame is
+// byte-identical to the old SSE envelope, so this is unchanged from before the
+// controller refactor. Non-JSON / control frames are ignored.
+function dispatchFrame(data: unknown) {
   try {
-    url = wsUrl();
-  } catch (e) {
-    // No server URL configured. Log once for DevTools and bail — refresh()
-    // will produce its own bootError that the UI renders.
-    console.warn(
-      "[bui] events WebSocket not opened:",
-      e instanceof Error ? e.message : String(e),
-    );
-    return;
+    const { kind, payload } = JSON.parse(data as string) as {
+      kind: Kind;
+      payload: unknown;
+    };
+    const set = listeners[kind];
+    if (set) for (const fn of set) fn(payload);
+  } catch {
+    // non-JSON / control frame — ignore
   }
-  es = new WebSocket(url);
-  es.onmessage = (m) => {
-    try {
-      const { kind, payload } = JSON.parse(m.data as string) as {
-        kind: Kind;
-        payload: unknown;
-      };
-      const set = listeners[kind];
-      if (set) for (const fn of set) fn(payload);
-    } catch {
-      // non-JSON / control frame — ignore
-    }
-  };
-  const drop = () => {
-    // WebSocket has NO built-in auto-reconnect (EventSource did). Mark the
-    // drop and ALWAYS schedule an explicit reconnect with bounded backoff.
-    //
-    // We intentionally do NOT bail when `listeners` is momentarily empty.
-    // iOS standalone PWAs kill the first socket within seconds of a cold
-    // launch — frequently BEFORE React mounts and subscribes. An earlier
-    // "no listeners → give up" guard made that race permanent: the socket
-    // died pre-subscription, reconnect was abandoned, and the app stayed
-    // static forever (worked in Safari, which doesn't early-kill sockets).
-    // ensureStream() is only ever called from on() (i.e. while a listener
-    // is being added), so a listener will exist shortly; keep the socket
-    // alive so it's ready. _backoff caps the retry interval; onopen's
-    // _hadError path refetches whatever was missed.
-    _hadError = true;
-    if (_reconnectTimer) return;
-    _backoff = Math.min(_backoff ? _backoff * 2 : 1000, 15000);
-    _reconnectTimer = setTimeout(() => {
-      _reconnectTimer = null;
-      openStream();
-    }, _backoff);
-  };
-  es.onerror = drop;
-  es.onclose = drop;
-  es.onopen = () => {
-    _backoff = 0; // healthy connection — reset backoff for any future drop
-    if (_hadError) {
-      // Reconnect after a drop — refetch state that may have changed while
-      // disconnected (existing resync path, unchanged).
-      _hadError = false;
-      fireResync();
-    }
-    // else: initial connect — initial load already fetches.
-  };
+}
+
+// The shared reconnect controller: backoff, "never permanently abandon", and
+// resync-on-reconnect all live in WsReconnectController now. This module owns
+// only the wiring — the live WebSocket constructor, the frame dispatch, and
+// the resync trigger.
+//
+// GOTCHA: serverBase() (inside wsUrl()) can throw if localStorage["bui_server"]
+// is unset on a non-localhost page (mobile/web descope — fail-fast intent).
+// on() is called synchronously from React useEffects, so an uncaught throw
+// white-screens the renderer. The controller catches url() throws, reports
+// `closed` (no retry loop), and calls onConfigError — we log once there.
+function getController(): WsReconnectController {
+  if (_controller) return _controller;
+  _controller = new WsReconnectController({
+    url: wsUrl,
+    // A real DOM WebSocket structurally satisfies WsLike (readyState + the
+    // on*/close members the controller touches). The onmessage event type
+    // differs (MessageEvent vs {data}), so cast through unknown.
+    create: (url) => new WebSocket(url) as unknown as WsLike,
+    onMessage: dispatchFrame,
+    onReconnect: fireResync,
+    onConfigError: (e) =>
+      console.warn(
+        "[bui] events WebSocket not opened:",
+        e instanceof Error ? e.message : String(e),
+      ),
+  });
+  return _controller;
 }
 
 // iOS suspends an installed standalone PWA when backgrounded / screen-locked.
 // It kills the connection and (in standalone) often fires nothing on resume,
 // leaving the socket dead with no events — app "opens once then goes static".
 // On return to foreground (visibilitychange→visible) or bfcache restore
-// (pageshow), if the socket isn't live, reopen it. _hadError makes the fresh
-// onopen drive fireResync() (single resync trigger — don't also call it here).
+// (pageshow), if the socket isn't live, reopen it and force a resync of state
+// missed while backgrounded (markReconnectAndEnsure).
 let _resumeWatchdogInstalled = false;
 function installResumeWatchdog() {
   if (_resumeWatchdogInstalled) return;
   _resumeWatchdogInstalled = true;
   const recover = () => {
     if (document.visibilityState !== "visible") return;
-    const live =
-      es && (es.readyState === WebSocket.OPEN || es.readyState === WebSocket.CONNECTING);
-    if (!live) {
-      _hadError = true; // make the next onopen fire the resync
-      openStream();
-    }
+    getController().markReconnectAndEnsure();
   };
   document.addEventListener("visibilitychange", recover);
   window.addEventListener("pageshow", recover);
 }
 
 function ensureStream() {
-  openStream();
+  getController().ensure();
   installResumeWatchdog();
 }
 

--- a/src/renderer/net/wsTransport.test.ts
+++ b/src/renderer/net/wsTransport.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from "vitest";
+import {
+  WsReconnectController,
+  WS_OPEN,
+  WS_CONNECTING,
+  WS_CLOSED,
+  type WsLike,
+} from "./wsTransport.js";
+import { ExponentialBackoff } from "../../shared/net/backoff.js";
+
+// A scriptable fake WebSocket. The controller wires onopen/onclose/onerror/
+// onmessage; the test drives them via the helper methods to simulate the
+// socket lifecycle deterministically.
+class FakeWs implements WsLike {
+  readyState = WS_CONNECTING;
+  onopen: ((ev?: unknown) => void) | null = null;
+  onclose: ((ev?: unknown) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  closed = false;
+  readonly url: string;
+  constructor(url: string) {
+    this.url = url;
+  }
+  close() {
+    this.closed = true;
+    this.readyState = WS_CLOSED;
+  }
+  // --- test drivers ---
+  fireOpen() {
+    this.readyState = WS_OPEN;
+    this.onopen?.();
+  }
+  fireClose() {
+    this.readyState = WS_CLOSED;
+    this.onclose?.();
+  }
+  fireError() {
+    this.onerror?.();
+  }
+  fireMessage(data: unknown) {
+    this.onmessage?.({ data });
+  }
+}
+
+// Deterministic timer: queue of {id, fn}. run() fires the earliest pending.
+function makeFakeTimer() {
+  const timers = new Map<number, () => void>();
+  let nextId = 1;
+  return {
+    setTimeoutFn: (fn: () => void, _ms: number) => {
+      const id = nextId++;
+      timers.set(id, fn);
+      return id;
+    },
+    clearTimeoutFn: (h: unknown) => {
+      timers.delete(h as number);
+    },
+    /** Fire the oldest pending timer (FIFO by insertion / id). */
+    run() {
+      const id = [...timers.keys()][0];
+      if (id === undefined) return false;
+      const fn = timers.get(id)!;
+      timers.delete(id);
+      fn();
+      return true;
+    },
+    count() {
+      return timers.size;
+    },
+  };
+}
+
+// Zero-jitter backoff so delays are predictable in assertions.
+function noJitterBackoff() {
+  return new ExponentialBackoff({ base: 1000, max: 15000, jitter: false });
+}
+
+function setup(overrides: Partial<Parameters<typeof buildController>[0]> = {}) {
+  return buildController(overrides);
+}
+
+function buildController(overrides: {
+  urlThrows?: boolean;
+  onReconnect?: () => void;
+} = {}) {
+  const t = makeFakeTimer();
+  const created: FakeWs[] = [];
+  const states: string[] = [];
+  const messages: unknown[] = [];
+  const c = new WsReconnectController({
+    url: () => {
+      if (overrides.urlThrows) throw new Error("no server");
+      return "wss://box/events";
+    },
+    create: (url) => {
+      const ws = new FakeWs(url);
+      created.push(ws);
+      return ws;
+    },
+    onMessage: (d) => messages.push(d),
+    onReconnect: overrides.onReconnect,
+    onState: (s) => states.push(s.state),
+    backoff: noJitterBackoff(),
+    setTimeoutFn: t.setTimeoutFn,
+    clearTimeoutFn: t.clearTimeoutFn,
+  });
+  return { c, t, created, states, messages };
+}
+
+describe("WsReconnectController — connect lifecycle", () => {
+  it("opens a socket and reaches connected on open", () => {
+    const { c, created, states } = setup();
+    c.ensure();
+    expect(created).toHaveLength(1);
+    expect(c.getState().state).toBe("connecting");
+    created[0].fireOpen();
+    expect(c.getState().state).toBe("connected");
+    expect(states).toContain("connecting");
+    expect(states).toContain("connected");
+  });
+
+  it("is idempotent: ensure() while OPEN/CONNECTING does not open a second socket", () => {
+    const { c, created } = setup();
+    c.ensure();
+    c.ensure(); // still CONNECTING → no new socket
+    expect(created).toHaveLength(1);
+    created[0].fireOpen();
+    c.ensure(); // now OPEN → still no new socket
+    expect(created).toHaveLength(1);
+  });
+
+  it("dispatches message frames to onMessage", () => {
+    const { c, created, messages } = setup();
+    c.ensure();
+    created[0].fireOpen();
+    created[0].fireMessage('{"kind":"opencode"}');
+    expect(messages).toEqual(['{"kind":"opencode"}']);
+  });
+});
+
+describe("WsReconnectController — reconnect with shared backoff", () => {
+  it("reconnects after a drop and NEVER permanently abandons", () => {
+    const { c, t, created } = setup();
+    c.ensure();
+    created[0].fireOpen();
+
+    // Drop the socket → controller should schedule a reconnect.
+    created[0].fireClose();
+    expect(c.getState().state).toBe("reconnecting");
+    expect(t.count()).toBe(1); // exactly one reconnect timer armed
+
+    // Fire the backoff timer → a fresh socket is opened. The shared state
+    // machine has no reconnecting→connecting edge, so we stay in "reconnecting"
+    // until the retry's open() succeeds (→ connected).
+    t.run();
+    expect(created).toHaveLength(2);
+    expect(c.getState().state).toBe("reconnecting");
+
+    // Drop again → reconnect again. Prove it doesn't give up.
+    created[1].fireOpen();
+    created[1].fireClose();
+    t.run();
+    expect(created).toHaveLength(3);
+  });
+
+  it("grows the backoff delay per consecutive failure and resets on a healthy open", () => {
+    // Capture the delays the controller asks for.
+    const delays: number[] = [];
+    const t = {
+      timers: new Map<number, () => void>(),
+      nextId: 1,
+      setTimeoutFn(fn: () => void, ms: number) {
+        delays.push(ms);
+        const id = this.nextId++;
+        this.timers.set(id, fn);
+        return id;
+      },
+      clearTimeoutFn(h: unknown) {
+        this.timers.delete(h as number);
+      },
+      run() {
+        const id = [...this.timers.keys()][0];
+        if (id === undefined) return;
+        const fn = this.timers.get(id)!;
+        this.timers.delete(id);
+        fn();
+      },
+    };
+    const created: FakeWs[] = [];
+    const c = new WsReconnectController({
+      url: () => "wss://box/events",
+      create: (u) => {
+        const ws = new FakeWs(u);
+        created.push(ws);
+        return ws;
+      },
+      onMessage: () => {},
+      backoff: noJitterBackoff(), // base 1000, factor 2, no jitter
+      setTimeoutFn: (fn, ms) => t.setTimeoutFn(fn, ms),
+      clearTimeoutFn: (h) => t.clearTimeoutFn(h),
+    });
+
+    c.ensure();
+    created[0].fireOpen();
+    created[0].fireClose(); // 1st backoff → 1000
+    t.run();
+    created[1].fireClose(); // never opened → 2nd backoff → 2000
+    t.run();
+    created[2].fireClose(); // 3rd backoff → 4000
+    expect(delays).toEqual([1000, 2000, 4000]);
+
+    // A healthy open resets the backoff: next drop is 1000 again.
+    t.run();
+    created[3].fireOpen();
+    created[3].fireClose();
+    expect(delays[delays.length - 1]).toBe(1000);
+  });
+
+  it("caps the backoff at max (15000)", () => {
+    const delays: number[] = [];
+    const created: FakeWs[] = [];
+    const timers: Array<() => void> = [];
+    const c = new WsReconnectController({
+      url: () => "wss://box/events",
+      create: (u) => {
+        const ws = new FakeWs(u);
+        created.push(ws);
+        return ws;
+      },
+      onMessage: () => {},
+      backoff: noJitterBackoff(),
+      setTimeoutFn: (fn, ms) => {
+        delays.push(ms);
+        timers.push(fn);
+        return timers.length - 1;
+      },
+      clearTimeoutFn: () => {},
+    });
+    c.ensure();
+    created[0].fireOpen();
+    // Drop 6 times without a successful open: 1000,2000,4000,8000,15000,15000
+    created[0].fireClose();
+    for (let i = 1; i <= 5; i++) {
+      timers[timers.length - 1]();
+      created[i].fireClose();
+    }
+    expect(delays.slice(0, 6)).toEqual([1000, 2000, 4000, 8000, 15000, 15000]);
+  });
+});
+
+describe("WsReconnectController — resync on reconnect", () => {
+  it("fires onReconnect on a re-open after a drop, but NOT on the initial open", () => {
+    let reconnects = 0;
+    const { c, t, created } = setup({ onReconnect: () => reconnects++ });
+    c.ensure();
+    created[0].fireOpen();
+    expect(reconnects).toBe(0); // initial connect → no resync
+
+    created[0].fireClose();
+    t.run();
+    created[1].fireOpen();
+    expect(reconnects).toBe(1); // reconnect → resync fired once
+  });
+
+  it("markReconnectAndEnsure() forces the next open to resync (resume watchdog)", () => {
+    let reconnects = 0;
+    const { c, created } = setup({ onReconnect: () => reconnects++ });
+    c.ensure();
+    created[0].fireOpen();
+    // Simulate the socket silently dead but readyState still OPEN (iOS resume):
+    // markReconnectAndEnsure sets hadDrop, and since it's OPEN, ensure() no-ops
+    // the socket but the flag persists. Force a real reopen by closing first.
+    created[0].readyState = WS_CLOSED;
+    c.markReconnectAndEnsure();
+    expect(created).toHaveLength(2);
+    created[1].fireOpen();
+    expect(reconnects).toBe(1);
+  });
+});
+
+describe("WsReconnectController — teardown + config errors", () => {
+  it("close() cancels timers, closes the socket, and lands in closed", () => {
+    const { c, t, created } = setup();
+    c.ensure();
+    created[0].fireOpen();
+    created[0].fireClose();
+    expect(t.count()).toBe(1); // a reconnect is armed
+    c.close();
+    expect(c.getState().state).toBe("closed");
+    // A late timer fire after close() must not open a new socket (stale epoch).
+    t.run();
+    expect(created).toHaveLength(1);
+  });
+
+  it("a stale socket callback after close() is ignored", () => {
+    const { c, created, messages } = setup();
+    c.ensure();
+    const ws = created[0];
+    ws.fireOpen();
+    c.close();
+    // Detached handler: firing a message on the old socket must be a no-op.
+    ws.fireMessage("late");
+    expect(messages).not.toContain("late");
+  });
+
+  it("url() throwing reports closed and does NOT spin a retry loop", () => {
+    const { c, t } = setup({ urlThrows: true });
+    c.ensure();
+    expect(c.getState().state).toBe("closed");
+    expect(t.count()).toBe(0); // no reconnect scheduled — nothing to retry
+  });
+});

--- a/src/renderer/net/wsTransport.ts
+++ b/src/renderer/net/wsTransport.ts
@@ -1,0 +1,294 @@
+// Renderer WebSocket reconnect controller for the unified network layer.
+//
+// This is the stage-4 (BET-46.4) renderer half of BET-46: it replaces the
+// ad-hoc `_backoff` / `_reconnectTimer` reconnect logic that used to live
+// inline in `src/renderer/api/httpApi.ts` with the SHARED
+// `ExponentialBackoff` primitive (BET-46.1) and surfaces the socket's
+// lifecycle as the shared `ConnectionState` machine (BET-46.1) so stall /
+// reconnect state is unified across the whole app.
+//
+// It is intentionally transport-injectable and DOM-free: the real
+// `WebSocket` constructor and browser timers are passed in, so the whole
+// reconnect state machine is unit-testable with a fake socket and fake
+// timers (no real sockets, no real sleeps). `httpApi.ts` wires in the live
+// `WebSocket` + `setTimeout`/`clearTimeout`.
+//
+// WHY a bespoke controller and not `ConnectionManager` (BET-46.2)?
+//   `ConnectionManager` orchestrates an open/close/PING transport with a
+//   health-check ping loop. The events WebSocket here is a *message-carrying*
+//   socket with no application-level ping/pong protocol — liveness is observed
+//   from the socket's own `onopen`/`onclose`/`onerror`, not from a ping. The
+//   issue (BET-46.4 scope §1) calls for exactly this: "WebSocket: manual
+//   reconnect via the shared `ExponentialBackoff`". So this controller reuses
+//   the shared backoff + state union but drives them off socket events. The
+//   SSH/opencode side (BET-46.2/46.3) is the piece that uses ConnectionManager.
+
+import { ExponentialBackoff } from "../../shared/net/backoff.js";
+import type { ConnectionState } from "../../shared/net/state.js";
+
+/**
+ * The minimal WebSocket surface this controller drives. The real DOM
+ * `WebSocket` satisfies it; tests pass a fake. We only touch the members the
+ * reconnect loop actually needs.
+ */
+export interface WsLike {
+  readyState: number;
+  onopen: ((ev?: unknown) => void) | null;
+  onclose: ((ev?: unknown) => void) | null;
+  onerror: ((ev?: unknown) => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  close(): void;
+}
+
+/** WebSocket readyState constants (DOM `WebSocket.OPEN` etc.), inlined so the
+ *  controller has no DOM dependency and tests can use the same numbers. */
+export const WS_CONNECTING = 0;
+export const WS_OPEN = 1;
+export const WS_CLOSING = 2;
+export const WS_CLOSED = 3;
+
+export type TimerHandle = unknown;
+export type SetTimeoutFn = (fn: () => void, ms: number) => TimerHandle;
+export type ClearTimeoutFn = (handle: TimerHandle) => void;
+
+export interface WsReconnectOpts {
+  /**
+   * Build the WebSocket URL for the *next* connection attempt. Called fresh on
+   * every (re)connect so a rotated token / changed server base is picked up.
+   * May THROW (e.g. no server configured) — the controller catches it, reports
+   * `closed`, and does NOT schedule a retry (there is nothing to retry until
+   * config changes and `connect()` is called again).
+   */
+  url: () => string;
+  /** Construct a socket for `url`. The real impl is `(u) => new WebSocket(u)`. */
+  create: (url: string) => WsLike;
+  /** Deliver a parsed message frame's raw `data` to the consumer. */
+  onMessage: (data: unknown) => void;
+  /**
+   * Fired once per *reconnect* (a successful open that followed a drop, not the
+   * initial connect). The httpApi layer uses this to refetch state that may
+   * have changed while disconnected (the existing "resync" behavior).
+   */
+  onReconnect?: () => void;
+  /** Emitted on every connection-state transition (for observers / debugging). */
+  onState?: (s: ConnectionState) => void;
+  /**
+   * Shared exponential backoff for reconnect delays. Defaults to
+   * `new ExponentialBackoff({ base: 1000, max: 15000 })` — matches the prior
+   * inline cap (1s → 15s) this controller replaces. Reset on every healthy open.
+   */
+  backoff?: ExponentialBackoff;
+  /** Called when `url()` throws (no server configured). Optional; for logging. */
+  onConfigError?: (err: unknown) => void;
+  setTimeoutFn?: SetTimeoutFn;
+  clearTimeoutFn?: ClearTimeoutFn;
+}
+
+/**
+ * Owns a single reconnecting WebSocket. `ensure()` opens the socket if it is
+ * not already live and is idempotent; a drop (`onclose`/`onerror`) schedules a
+ * reconnect through the shared `ExponentialBackoff` and **never permanently
+ * abandons** the socket (the guarantee the old inline code made, now unified).
+ *
+ * Connection lifecycle mapped onto the shared `ConnectionState`:
+ *   idle → connecting → connected            (healthy open)
+ *   connected → stalled → reconnecting → …    (drop → backoff retry)
+ *   * → closed                                (explicit close() / config error)
+ *
+ * NOTE the socket is message-carrying, so "stalled" here means "the socket
+ * dropped" (observed from onclose/onerror), which we surface before entering
+ * `reconnecting`. There is no ping loop — liveness is the socket's own events.
+ */
+export class WsReconnectController {
+  private readonly opts: WsReconnectOpts;
+  private readonly backoff: ExponentialBackoff;
+  private readonly setTimeoutFn: SetTimeoutFn;
+  private readonly clearTimeoutFn: ClearTimeoutFn;
+
+  private ws: WsLike | null = null;
+  private state: ConnectionState = { state: "idle" };
+  private reconnectTimer: TimerHandle | null = null;
+  /** True once we've seen a drop, so the NEXT open is a reconnect (→ onReconnect). */
+  private hadDrop = false;
+  /** Bumped on close()/teardown so stale socket callbacks no-op. */
+  private epoch = 0;
+
+  constructor(opts: WsReconnectOpts) {
+    this.opts = opts;
+    this.backoff =
+      opts.backoff ?? new ExponentialBackoff({ base: 1000, max: 15000 });
+    this.setTimeoutFn =
+      opts.setTimeoutFn ??
+      ((fn, ms) => setTimeout(fn, ms) as unknown as TimerHandle);
+    this.clearTimeoutFn =
+      opts.clearTimeoutFn ??
+      ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  }
+
+  /** Current connection state (live object, not a copy). */
+  getState(): ConnectionState {
+    return this.state;
+  }
+
+  /**
+   * Ensure a live socket exists. Idempotent: an OPEN or CONNECTING socket is
+   * left untouched; a missing / CLOSING / CLOSED one is (re)opened. Safe to
+   * call repeatedly (e.g. from a resume watchdog).
+   */
+  ensure(): void {
+    if (
+      this.ws &&
+      (this.ws.readyState === WS_OPEN || this.ws.readyState === WS_CONNECTING)
+    ) {
+      return;
+    }
+    this.open();
+  }
+
+  /**
+   * Force the controller into a "reconnect on next open" posture and ensure a
+   * socket. Used by the resume watchdog (iOS foreground / bfcache restore):
+   * even if the socket looks alive, we want the next open to trigger a resync
+   * of state missed while backgrounded.
+   */
+  markReconnectAndEnsure(): void {
+    this.hadDrop = true;
+    this.ensure();
+  }
+
+  /** Tear down permanently (app teardown). Cancels timers, closes the socket. */
+  close(reason = "close"): void {
+    this.epoch += 1;
+    this.clearReconnectTimer();
+    this.closeSocket();
+    this.transition({ state: "closed", reason });
+  }
+
+  // --- internal ---------------------------------------------------------
+
+  private open(): void {
+    this.clearReconnectTimer();
+    this.closeSocket();
+
+    let url: string;
+    try {
+      url = this.opts.url();
+    } catch (e) {
+      // No server configured (url() threw). Nothing to retry until config
+      // changes and ensure()/connect() is called again — report closed, no
+      // backoff loop (an infinite retry against a throwing url() would spin).
+      this.opts.onConfigError?.(e);
+      this.transition({ state: "closed", reason: "no server configured" });
+      return;
+    }
+
+    this.enterConnecting();
+    const myEpoch = this.epoch;
+    let ws: WsLike;
+    try {
+      ws = this.opts.create(url);
+    } catch (e) {
+      // Constructor threw (malformed URL) — treat as a drop and back off.
+      this.opts.onConfigError?.(e);
+      this.scheduleReconnect(myEpoch);
+      return;
+    }
+    this.ws = ws;
+
+    ws.onmessage = (m) => {
+      if (this.isStale(myEpoch)) return;
+      this.opts.onMessage(m.data);
+    };
+    ws.onopen = () => {
+      if (this.isStale(myEpoch)) return;
+      this.onOpen();
+    };
+    // A single "drop" handler for both error and close — the old inline code
+    // wired the same `drop` to onerror AND onclose. Reconnect is idempotent
+    // (guarded by the reconnectTimer), so a socket that fires both is fine.
+    const drop = () => {
+      if (this.isStale(myEpoch)) return;
+      this.onDrop(myEpoch);
+    };
+    ws.onerror = drop;
+    ws.onclose = drop;
+  }
+
+  private onOpen(): void {
+    this.backoff.reset();
+    this.transition({ state: "connected" });
+    if (this.hadDrop) {
+      this.hadDrop = false;
+      this.opts.onReconnect?.();
+    }
+  }
+
+  private onDrop(myEpoch: number): void {
+    this.hadDrop = true;
+    // Surface a stalled tick before reconnecting so observers see the drop
+    // distinctly from the reconnect attempt. connected→stalled is a legal edge;
+    // from connecting we skip straight to reconnecting.
+    if (this.state.state === "connected") {
+      this.transition({ state: "stalled", since: new Date() });
+    }
+    this.scheduleReconnect(myEpoch);
+  }
+
+  private scheduleReconnect(myEpoch: number): void {
+    if (this.reconnectTimer !== null) return; // a retry is already armed
+    const backoffMs = this.backoff.next();
+    this.transition({
+      state: "reconnecting",
+      attempt: this.backoff.attempt(),
+      backoffMs,
+    });
+    this.reconnectTimer = this.setTimeoutFn(() => {
+      this.reconnectTimer = null;
+      if (this.isStale(myEpoch)) return;
+      this.open();
+    }, backoffMs);
+  }
+
+  private enterConnecting(): void {
+    // idle/closed → connecting is the fresh-connect edge; reconnecting →
+    // connecting is NOT a legal edge in the shared machine, so when we retry we
+    // are already in `reconnecting` and open() is invoked from the timer — we
+    // must not re-enter connecting there. Guard by only emitting connecting
+    // from a non-reconnecting origin.
+    if (this.state.state === "reconnecting") return;
+    this.transition({ state: "connecting", attempt: this.backoff.attempt() + 1 });
+  }
+
+  private transition(next: ConnectionState): void {
+    this.state = next;
+    this.opts.onState?.(next);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      this.clearTimeoutFn(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private closeSocket(): void {
+    if (this.ws) {
+      // Detach handlers before closing so a late onclose from THIS socket
+      // doesn't drive a reconnect against a controller that's moving on.
+      this.ws.onopen = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      try {
+        this.ws.close();
+      } catch {
+        /* already dead */
+      }
+      this.ws = null;
+    }
+  }
+
+  private isStale(capturedEpoch: number): boolean {
+    return capturedEpoch !== this.epoch;
+  }
+}


### PR DESCRIPTION
## BET-62 (M0.4) — unified SSE/WS reconnect + backpressure wiring

Final slice (stage 4 of 4) of BET-46 network refactor. Puts the renderer WS
client and the main-process opencode event bus onto the shared stage-1/2
primitives (`ExponentialBackoff`, `ConnectionState`, `applyBackpressure`).

**Base: origin/main @ `edef2f7`**

### What changed

1. **Renderer WS reconnect** — new `src/renderer/net/wsTransport.ts`
   (`WsReconnectController`). `httpApi.ts` no longer carries ad-hoc
   `_backoff` / `_reconnectTimer` / `_hadError` inline logic; it wires the live
   `WebSocket` + browser timers into the controller, which drives reconnect via
   the **shared `ExponentialBackoff`** and surfaces socket lifecycle as the
   **shared `ConnectionState`** machine (connecting → connected → stalled →
   reconnecting → closed). Same guarantees as before, unified: idempotent
   `ensure()`, resync-on-reconnect, resume-watchdog, and **never permanently
   abandons** the socket. (The events client is all-WebSocket — iOS PWAs can't
   do EventSource reliably — so there's no separate EventSource path to unify;
   the WS state is what feeds the shared state machine.)

2. **Bus backpressure** — new `src/main/eventBatcher.ts` (`EventBatcher`)
   wraps the shared `applyBackpressure` primitive at the opencode → renderer
   bus in `src/main/index.ts`. Non-priority events are buffered ≤50ms and run
   through coalesce/drop/rate-limit before the IPC send; **`permission.asked`
   and `question.asked` bypass batching entirely** (flush pending, emit
   immediately) and are never coalesced/dropped (Risk #2), enforced both
   structurally here and by the primitive's forced high-priority set.

3. **Preserved behavior** — the "only stream open sessions, not every workspace
   dir" refcount logic and the SSE-stall watchdog (`classifyStreamHealth`) are
   untouched; only the per-event forward call changed from a direct
   `webContents.send` to `batcher.push`.

### Anti-spaghetti notes
- Reused the stage-1 `ExponentialBackoff` / `applyBackpressure` / `ConnectionState`
  primitives rather than adding parallel copies. `WsReconnectController` is a
  distinct piece from `ConnectionManager` (BET-46.2): CM orchestrates an
  open/close/**ping** transport; the events WS is message-carrying with no
  app-level ping, so liveness comes from socket events — the issue's scope §1
  asks for exactly "manual reconnect via the shared ExponentialBackoff".
- Removed the now-dead inline reconnect/backoff branch in `httpApi.ts` (no dead
  code left behind).

### Verification results

**Files changed:** 6 files (see `git diff --stat` below).
```
 src/main/eventBatcher.test.ts        | 236 +++
 src/main/eventBatcher.ts             | 186 +++
 src/main/index.ts                    |  37 +-
 src/renderer/api/httpApi.ts          | 164 +--
 src/renderer/net/wsTransport.test.ts | 313 +++
 src/renderer/net/wsTransport.ts      | 294 +++
```

- PR branch (`multica/BET-46.4-sse-ws-reconnect-backpressure` @ `5de0401`):
  - typecheck: exit `0`. Errors: none.
  - vitest: exit `0`, `692` pass / `0` fail / `0` skip. (670 baseline + 22 new)
  - server (`node --test`): exit `0`, `226` pass / `0` fail.
- Base (`main` @ `edef2f7`):
  - typecheck: exit `0`. Errors: none.
  - vitest: exit `0`, `670` pass / `0` fail. log sha256: `d3cf6c91…`
  - server: exit `0`, `226` pass / `0` fail. log sha256: `01d0a542…`
- **Conclusion:** 0 new failures. The 22 new vitest cases are the added
  `wsTransport` + `eventBatcher` suites; everything else is identical between
  branches.

### E2E smoke (built Electron app, xvfb)
`npm run build` OK → launched via Playwright `_electron`. App alive, title
`Better UI`, **0 renderer console/page errors**, renderer mounted with content.
On a fresh checkout (no `config.json`) the app correctly renders the BET-49
onboarding **"Connect to your server"** full-screen shell (which by design has
no sidebar/titlebar), so the sidebar/main invariants are N/A pre-pairing — not
a regression. Both new modules confirmed present in the shipped bundles
(`WsReconnectController` in the renderer bundle, `EventBatcher` in `out/main`).

### Parent BET-46 success-criteria recheck (last slice)
- ConnectionManager states — ✅ (BET-46.2, merged)
- SSH ControlMaster lifecycle — ✅ (BET-46.3, merged)
- SSE/WebSocket reconnect w/ exponential backoff — ✅ (this PR: renderer WS)
- Backpressure (rate-limit/coalesce/drop) — ✅ (this PR: bus batcher)
- Health checks (ping/pong, stall) — ✅ in `ConnectionManager` (BET-46.2);
  the events WS uses socket-event liveness + the existing `classifyStreamHealth`
  stall watchdog rather than an app-level ping (no ping protocol on that WS).
- All existing tests pass + new tests added — ✅
- **Follow-up note for PM:** the renderer events WebSocket is wired to the
  shared `ExponentialBackoff` + `ConnectionState`, but NOT to the full
  `ConnectionManager` (which is ping-loop oriented and used by the SSH/main
  side). If the PM wants the events WS to also run the CM ping/stall loop
  end-to-end, that's a small follow-up — flagged here rather than silently
  shoehorned.
