### PR TITLE
feat(renderer): Electron HTTP-mode transport + 401 re-pair + degradation audit (BET-58)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -70,7 +70,24 @@ export function App() {
   activeChatRef.current = activeChatSessionId;
 
   useEffect(() => {
-    refresh();
+    // Bootstrap. In HTTP mode (paired to a bui-server) refresh() can reject
+    // with AuthRequiredError when the box answers 401 — a revoked/rotated
+    // box_token mid-session. Route that to the pairing screen (onboarding step
+    // 1) instead of letting the app sit dead with no sessions and no
+    // explanation. relaunchOnboarding() forces the full-screen flow open even
+    // for an otherwise-"http" config; a successful re-claim persists a fresh
+    // token and finishOnboarding() re-runs the bootstrap. SSH mode never throws
+    // this (no Bearer gate), so this is a no-op there.
+    refresh().catch((e: unknown) => {
+      const isAuth =
+        (e as { name?: string })?.name === "AuthRequiredError" ||
+        (e as { status?: number })?.status === 401;
+      if (isAuth) {
+        void useStore.getState().relaunchOnboarding();
+      }
+      // Non-auth bootstrap failures (SSH unreachable, etc.) keep the existing
+      // behavior — the app renders its empty/needs-config state.
+    });
   }, [refresh]);
 
   useEffect(() => {

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -370,6 +370,31 @@ function on<T>(kind: Kind, cb: (p: T) => void): () => any {
 // ---------------------------------------------------------------------------
 // httpApi — implements every method of the Api type.
 // ---------------------------------------------------------------------------
+//
+// DESKTOP HTTP-MODE DEGRADATION AUDIT (BET-58). When the desktop runs in
+// "http" mode this object becomes window.api (the real preload is preserved as
+// window.__buiPreload for Electron-local affordances). Because httpApi
+// implements the FULL Api type (typecheck-enforced), no renderer call can hit
+// an undefined method — the worst case is a documented no-op, never a crash.
+// The scp-dependent / OS-integration features degrade as follows:
+//
+//   • peekRemoteFile        → /rpc (server reads its OWN local file; the server
+//                             IS the box, so no scp hop is needed — WORKS).
+//   • uploadFiles / uploadBuffer (drag-in) → /api/upload over Bearer — WORKS.
+//   • getPathForFile (drag-in path extract) → "" (no Electron webUtils here);
+//                             drag-in still works via uploadBuffer's byte path.
+//   • agentPullFile (outbox) → browser download via /api/download — WORKS;
+//     revealInFolder        → no-op (no OS file manager to reveal into).
+//   • openExternal (chat links) → window.open (the WebView is a browser) — WORKS.
+//   • clipboardWriteText / clipboardReadImage → routed to the server RPC no-ops;
+//     OSC52 desktop-clipboard sync is a preload-only affordance and silently
+//     degrades (the terminal still functions).
+//   • onScreenshotDetected / onDesktopNotify → subscription no-ops (these are
+//     Mac-desktop signals; the http client simply never receives them).
+//
+// None of these throw. If a future feature MUST use the real preload in http
+// mode (e.g. OS clipboard), reach it explicitly via window.__buiPreload rather
+// than assuming window.api is the preload.
 
 export const httpApi: Api = {
   // -- config --

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -51,19 +51,25 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
     const seed = desktopHttpClientSeed(config);
     if (seed) {
       // Seed the two localStorage keys httpApi reads for its base URL + token.
+      let seeded = true;
       try {
         localStorage.setItem("bui_server", seed.bui_server);
         localStorage.setItem("bui_token", seed.bui_token);
       } catch (e) {
         // localStorage unavailable is fatal for http mode (httpApi can't read
         // its base) — fall back to preload rather than a 401-looping client.
+        // Do NOT return here: chooseDesktopTransport must fall through so boot()
+        // still renders. We simply leave window.api as the preload bridge by
+        // skipping the httpApi swap below.
         console.warn("[bui] localStorage seed failed; using preload transport:", e);
-        return;
+        seeded = false;
       }
-      // Preserve the real preload for Electron-local affordances, then install
-      // httpApi as the primary window.api.
-      (window as unknown as { __buiPreload: Api }).__buiPreload = realPreload;
-      (window as unknown as { api: Api }).api = httpApi as unknown as Api;
+      if (seeded) {
+        // Preserve the real preload for Electron-local affordances, then install
+        // httpApi as the primary window.api.
+        (window as unknown as { __buiPreload: Api }).__buiPreload = realPreload;
+        (window as unknown as { api: Api }).api = httpApi as unknown as Api;
+      }
     }
     // If seed is null the config claimed http mode but lacks a usable
     // serverUrl/token — leave the preload bridge in place (safer than a broken

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -5,15 +5,84 @@ import { MobileApp } from "./mobile/MobileApp";
 import "./index.css";
 import "./mobile/mobile.css";
 import { httpApi } from "./api/httpApi";
+import type { Api } from "../preload/index";
+import {
+  selectDesktopTransport,
+  desktopHttpClientSeed,
+} from "../shared/transport.mjs";
 
-// No Electron preload → this is the mobile/web client. Install the HTTP shim
-// and render the mobile-native shell. Electron (preload set window.api) keeps
-// the desktop <App/> exactly as before — desktop cannot reach mobile code.
-const isMobile = !(window as unknown as { api?: unknown }).api;
-if (isMobile) {
-  (window as unknown as { api: unknown }).api = httpApi;
+// Transport selection at renderer entry (BET-58):
+//
+//  1. NO preload (window.api absent) → mobile/web build. Install the httpApi
+//     shim and render the mobile-native <MobileApp/>. (Unchanged.)
+//
+//  2. Preload present (Electron desktop) → the config mode decides:
+//       • SSH / onboarding / skipped → keep the preload bridge as window.api
+//         (legacy SSH+tmux transport). SSH users are completely unaffected.
+//       • "http" (paired to a bui-server) → talk to that server over the SAME
+//         httpApi client the mobile build uses (Bearer token, /rpc, /events WS)
+//         INSTEAD of the SSH bridge. We keep the real preload available as
+//         window.__buiPreload so Electron-LOCAL affordances (clipboard, reveal-
+//         in-folder, OS notifications) still work — the split is: data/tmux/
+//         opencode go over http; OS-integration stays on the preload.
+//
+// Reading config requires the preload's async configGet(), so entry is async.
+// We render the desktop <App/> only after the transport is chosen, so no
+// component ever observes a half-installed window.api.
+
+const preload = (window as unknown as { api?: Api }).api;
+const isMobile = !preload;
+
+async function chooseDesktopTransport(realPreload: Api): Promise<void> {
+  // Read the persisted config to learn the transport mode. A failure here
+  // (IPC error) must NOT white-screen the app — fall back to the preload
+  // bridge (the legacy, always-available transport).
+  let mode: "http" | "preload" = "preload";
+  let config: Awaited<ReturnType<Api["configGet"]>> | null = null;
+  try {
+    config = await realPreload.configGet();
+    mode = selectDesktopTransport(config, true);
+  } catch (e) {
+    console.warn("[bui] configGet failed at entry; using preload transport:", e);
+    mode = "preload";
+  }
+
+  if (mode === "http" && config) {
+    const seed = desktopHttpClientSeed(config);
+    if (seed) {
+      // Seed the two localStorage keys httpApi reads for its base URL + token.
+      try {
+        localStorage.setItem("bui_server", seed.bui_server);
+        localStorage.setItem("bui_token", seed.bui_token);
+      } catch (e) {
+        // localStorage unavailable is fatal for http mode (httpApi can't read
+        // its base) — fall back to preload rather than a 401-looping client.
+        console.warn("[bui] localStorage seed failed; using preload transport:", e);
+        return;
+      }
+      // Preserve the real preload for Electron-local affordances, then install
+      // httpApi as the primary window.api.
+      (window as unknown as { __buiPreload: Api }).__buiPreload = realPreload;
+      (window as unknown as { api: Api }).api = httpApi as unknown as Api;
+    }
+    // If seed is null the config claimed http mode but lacks a usable
+    // serverUrl/token — leave the preload bridge in place (safer than a broken
+    // http client). resolveTransportMode won't report "http" without a valid
+    // boxToken, so this is a defensive belt-and-braces branch.
+  }
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>{isMobile ? <MobileApp /> : <App />}</React.StrictMode>,
-);
+async function boot(): Promise<void> {
+  if (!isMobile && preload) {
+    await chooseDesktopTransport(preload);
+  } else {
+    // Mobile/web: install the shim (no preload to preserve).
+    (window as unknown as { api: unknown }).api = httpApi;
+  }
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>{isMobile ? <MobileApp /> : <App />}</React.StrictMode>,
+  );
+}
+
+void boot();

--- a/src/shared/transport.d.mts
+++ b/src/shared/transport.d.mts
@@ -25,3 +25,20 @@ export function resolveTransportMode(
 
 // Validate + normalize the JSON body of a POST /auth/claim response.
 export function parseClaimResponse(json: unknown): ClaimResult;
+
+// Which client the DESKTOP should install as window.api (BET-58):
+//   "http"    — paired config → the httpApi server client (keep preload for
+//               Electron-local affordances under window.__buiPreload)
+//   "preload" — SSH/onboarding/skipped → the legacy preload bridge
+// `hasPreload` is `!!window.api` (Electron sets it; the mobile build doesn't).
+export function selectDesktopTransport(
+  config: Partial<AppConfig> | null | undefined,
+  hasPreload: boolean,
+): "http" | "preload";
+
+// The localStorage keys httpApi reads (bui_server / bui_token), seeded from a
+// paired desktop config's serverUrl + boxToken. Returns null when the config
+// isn't a usable paired-http config (missing serverUrl or invalid boxToken).
+export function desktopHttpClientSeed(
+  config: Partial<AppConfig> | null | undefined,
+): { bui_server: string; bui_token: string } | null;

--- a/src/shared/transport.mjs
+++ b/src/shared/transport.mjs
@@ -49,6 +49,53 @@ export function resolveTransportMode(config) {
   return "onboarding";
 }
 
+// ---------------------------------------------------------------------------
+// Desktop transport SELECTION (BET-49-T6 / BET-58)
+// ---------------------------------------------------------------------------
+//
+// On the DESKTOP (Electron), the preload bridge always sets window.api — that's
+// the legacy SSH+tmux transport. But once a user pairs to a bui-server, their
+// config resolves to "http" and the desktop should talk to that server over the
+// SAME httpApi client the mobile/web build uses (Bearer token, /rpc, /events
+// WS), NOT the SSH bridge. So the presence of window.api is NOT sufficient to
+// pick the transport — the resolved config mode decides.
+//
+// `selectDesktopTransport` is the single, pure decision:
+//   • "http"    — config is paired (valid boxToken) → install httpApi as
+//                 window.api, keeping the real preload for Electron-local
+//                 affordances (clipboard, reveal-in-folder, OS notifications).
+//   • "preload" — everything else (SSH mode, onboarding, skipped) → keep the
+//                 preload bridge exactly as before. SSH users are unaffected.
+//
+// `hasPreload` is passed in (the caller checks `!!window.api`) so this stays
+// framework-free and unit-testable. When there is NO preload at all (the mobile
+// /web build), the caller never reaches here — main.tsx branches on that first.
+export function selectDesktopTransport(config, hasPreload) {
+  // No preload → not a desktop context; the mobile/web entry path owns this.
+  // Defensive: report "http" so a caller that mis-invokes us still gets the
+  // server-backed client rather than a non-existent preload.
+  if (!hasPreload) return "http";
+  return resolveTransportMode(config) === "http" ? "http" : "preload";
+}
+
+// The two localStorage keys the httpApi client reads for its base URL + token
+// (see src/renderer/api/httpApi.ts serverBase()/clientToken(): "bui_server" and
+// "bui_token"). On the desktop the paired credentials live in config.json
+// (serverUrl + boxToken), not localStorage — so before installing httpApi we
+// SEED these keys from config. Pure: returns the {key,value} pairs to write so
+// the seeding is testable without a DOM. Returns null when the config isn't a
+// valid paired http config (missing serverUrl or an invalid boxToken), so the
+// caller can refuse to install a broken client.
+export function desktopHttpClientSeed(config) {
+  const cfg = config && typeof config === "object" ? config : {};
+  const serverUrl = typeof cfg.serverUrl === "string" ? cfg.serverUrl.trim() : "";
+  if (serverUrl === "" || !isValidBoxToken(cfg.boxToken)) return null;
+  return {
+    bui_server: serverUrl.replace(/\/+$/, ""),
+    bui_token: cfg.boxToken,
+  };
+}
+
 // Validate + normalize the JSON body of a successful POST /auth/claim response.
 // The server returns { ok, box_token, box_id } (see src/server/auth.mjs claim()).
 // We only trust it once BOTH tokens match the 32-hex shape — a wrong shape means

--- a/src/shared/transport.test.ts
+++ b/src/shared/transport.test.ts
@@ -3,6 +3,8 @@ import {
   isValidBoxToken,
   resolveTransportMode,
   parseClaimResponse,
+  selectDesktopTransport,
+  desktopHttpClientSeed,
 } from "./transport.mjs";
 
 // A well-formed 32-lowercase-hex token (128 bits).
@@ -148,5 +150,57 @@ describe("parseClaimResponse", () => {
     expect(parseClaimResponse("string")).toEqual({ ok: false, error: "invalid_response" });
     expect(parseClaimResponse(42)).toEqual({ ok: false, error: "invalid_response" });
     expect(parseClaimResponse([])).toEqual({ ok: false, error: "invalid_response" });
+  });
+});
+
+describe("selectDesktopTransport (BET-58)", () => {
+  const paired = { boxToken: HEX32, serverUrl: "http://box:8787" };
+  const sshCfg = { host: "1.2.3.4", user: "dev" };
+
+  it("returns 'http' for a paired config when preload is present", () => {
+    expect(selectDesktopTransport(paired, true)).toBe("http");
+  });
+  it("returns 'preload' for an SSH-mode config (host set, no token)", () => {
+    expect(selectDesktopTransport(sshCfg, true)).toBe("preload");
+  });
+  it("returns 'preload' for an onboarding config (nothing set)", () => {
+    expect(selectDesktopTransport({}, true)).toBe("preload");
+  });
+  it("returns 'preload' for a skipped-onboarding config", () => {
+    expect(selectDesktopTransport({ onboardingSkipped: true }, true)).toBe("preload");
+  });
+  it("SSH users are unaffected even if a stale serverUrl lingers without a token", () => {
+    expect(selectDesktopTransport({ host: "1.2.3.4", serverUrl: "http://box:8787" }, true)).toBe(
+      "preload",
+    );
+  });
+  it("no preload → 'http' (mobile/web path; defensive)", () => {
+    expect(selectDesktopTransport(paired, false)).toBe("http");
+    expect(selectDesktopTransport({}, false)).toBe("http");
+  });
+});
+
+describe("desktopHttpClientSeed (BET-58)", () => {
+  it("returns the localStorage seed for a valid paired config", () => {
+    expect(
+      desktopHttpClientSeed({ boxToken: HEX32, serverUrl: "http://box:8787" }),
+    ).toEqual({ bui_server: "http://box:8787", bui_token: HEX32 });
+  });
+  it("trims trailing slashes from serverUrl", () => {
+    expect(
+      desktopHttpClientSeed({ boxToken: HEX32, serverUrl: "http://box:8787///" }),
+    ).toEqual({ bui_server: "http://box:8787", bui_token: HEX32 });
+  });
+  it("returns null when boxToken is missing/invalid", () => {
+    expect(desktopHttpClientSeed({ serverUrl: "http://box:8787" })).toBeNull();
+    expect(desktopHttpClientSeed({ serverUrl: "http://box:8787", boxToken: "nope" })).toBeNull();
+  });
+  it("returns null when serverUrl is empty/missing", () => {
+    expect(desktopHttpClientSeed({ boxToken: HEX32 })).toBeNull();
+    expect(desktopHttpClientSeed({ boxToken: HEX32, serverUrl: "   " })).toBeNull();
+  });
+  it("returns null for non-object input", () => {
+    expect(desktopHttpClientSeed(null)).toBeNull();
+    expect(desktopHttpClientSeed("x" as never)).toBeNull();
   });
 });


### PR DESCRIPTION
# BET-58 — Electron HTTP-mode transport: httpApi selection, 401 re-pair, degradation audit

Closes the last child of BET-49 (M6.2 Desktop Onboarding Revamp).

**Base:** `origin/main @ f855396`

## What changed

1. **Transport selection by config mode (scope 1/2).** `main.tsx` no longer keys purely on "is `window.api` present" — it now asks the config. New pure helper `selectDesktopTransport(config, hasPreload)`:
   - paired config (`resolveTransportMode === "http"`) → install the **httpApi** server client (the same one the mobile build uses: Bearer token, `/rpc`, `/events` WS) as `window.api`, seeding `localStorage.bui_server`/`bui_token` from the config's `serverUrl`/`boxToken` via `desktopHttpClientSeed`. The **real preload is preserved as `window.__buiPreload`** for Electron-local affordances.
   - SSH / onboarding / skipped → keep the preload bridge unchanged. **SSH users are completely unaffected** (regression-tested).
   - Entry is now async (`configGet()` is IPC); a configGet failure falls back to preload — never white-screens.

2. **401 mid-session → re-pair (scope 3).** `App.tsx` bootstrap catches `AuthRequiredError`/401 from `refresh()` and forces onboarding step 1 (`relaunchOnboarding`). A revoked/rotated `box_token` routes to the pairing screen instead of a silent dead app. SSH mode never hits the Bearer gate → no-op there. Mirrors the existing mobile `MobileApp` re-pair pattern.

3. **Degradation audit (scope 4)** — documented in `httpApi.ts`. Because `httpApi` implements the full `Api` type (typecheck-enforced), no renderer call can hit an undefined method; worst case is a documented no-op, never a crash:

| scp / OS-integration feature | http-mode behavior |
|---|---|
| `peekRemoteFile` | **works** — server reads its own local file (server IS the box; no scp hop) |
| `uploadFiles` / `uploadBuffer` (drag-in) | **works** — `/api/upload` over Bearer |
| `getPathForFile` | `""` (no Electron webUtils); drag-in still works via the byte path |
| `agentPullFile` (outbox) | **works** — browser download via `/api/download` |
| `revealInFolder` | no-op (no OS file manager) |
| `openExternal` (chat links) | **works** — `window.open` (WebView is a browser) |
| `clipboardWriteText` / OSC52 sync | server RPC no-op; OSC52 desktop-clipboard degrades silently, terminal still functions |
| `onScreenshotDetected` / `onDesktopNotify` | subscription no-ops (Mac-desktop signals) |

Escape hatch documented: a future feature that MUST use the real preload in http mode reaches it via `window.__buiPreload`.

## Verification results

- typecheck: **exit 0**, no errors.
- test: **exit 0** — vitest + server `node:test`. `src/shared/transport.test.ts` now 29 pass (11 new for `selectDesktopTransport` + `desktopHttpClientSeed`). Full server suite 226 pass.
- **e2e-smoke (bui-e2e-smoke, xvfb Electron launch): PASS** — app mounts through the new async `boot()`, onboarding shell renders (`buiLogo:true`, `onboarding:true`), `#root` populated, **0 console errors**. Confirms the main.tsx rewrite doesn't white-screen.

## Acceptance criteria
- [x] HTTP-mode desktop uses httpApi (session list/chat/prompt/terminal all route over bui-server) — transport selection + seed in place; manual box walkthrough is the human-review step
- [x] SSH-mode users unaffected (mode-detection regression tests extended: `selectDesktopTransport` returns `"preload"` for host-set/onboarding/skipped/stale-serverUrl-without-token)
- [x] 401 → re-pair prompt; degradation audit checklist complete
- [x] `npm run typecheck && npm test` green

## Notes for reviewer
- The pure logic (`selectDesktopTransport`, `desktopHttpClientSeed`) is fully unit-tested; the wiring in `main.tsx`/`App.tsx` is thin.
- `.d.mts` hand-declarations for `transport.mjs` were updated to match the two new exports.


## Manual verification (addressing reviewer Question on AC1)

**Automated, run in this session (reproducible):**
- **Transport selection** — `selectDesktopTransport` unit tests assert: paired config → `"http"`; host-set/onboarding/skipped/stale-serverUrl-without-token → `"preload"`. `desktopHttpClientSeed` tests assert the `bui_server`/`bui_token` seed is produced only for a valid paired config (else `null`). 29/29 pass.
- **App mounts through the new async `boot()`** — bui-e2e-smoke launched the built Electron app under xvfb: window alive, renderer mounted (`#root` populated, onboarding shell rendered), **0 console errors**. This is the load-bearing check that the entry rewrite (async config read → transport pick → render) doesn't white-screen — the top regression risk of this change.
- **Server auth path** — verified independently that `/api/schedule` returns **200 with** a valid `Authorization: Bearer <box_token>` and **401 without** (the gate my earlier `schedule.ts`/`secrets.ts` fix targets), confirming the http client's Bearer contract against the live box server.

**Interactive box walkthrough — deferred to human review (legitimate for this issue):**
This issue is Inline-dispatched with approval tier `human`; a full paired-desktop walkthrough (pair → session list loads → send prompt → terminal responds, against a live bui-server from a real desktop client) requires an interactive desktop app paired to the box, which is the human reviewer's environment. The automated coverage above exercises every pure decision + the mount path; the remaining end-to-end interactive confirmation is the human approval step by design.
