### PR TITLE
BET-50: M6.1 VPS self-install script + bui pair CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,71 @@ The two coexist: each tmux window is one or the other (recognized by a
     long-running `opencode serve` on `127.0.0.1:4096`, tunneled to the Mac
     over SSH `-L 14096:127.0.0.1:4096`. Survives bui restarts.
 
+## Box server (mobile/web) — self-install
+
+The box server (`src/server/`) powers the mobile/web client and the desktop
+pairing flow. On a fresh Linux VPS, one command installs and starts it and
+prints a 6-digit pairing code to enter in the desktop app:
+
+```bash
+curl -fsSL https://bui.useronda.com/install.sh | bash
+```
+
+The installer downloads a pre-built release tarball (no dev toolchain needed on
+the box), runs `npm ci --omit=dev`, installs a `systemd --user` unit
+(`bui-server.service`), waits for the server to come up on `127.0.0.1:8787`, then
+runs `bui pair` and prints the code. Re-running upgrades in place and **preserves
+your box identity** in `~/.bui-mobile/` — the server owns identity (`ensureAuth`
+in `src/server/auth.mjs`); the installer never regenerates it.
+
+Overrides (env):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `BUI_TARBALL_URL` | (built from host+version) | full tarball URL — local testing / mirror |
+| `BUI_RELEASE_HOST` | `https://bui.useronda.com` | host for the default tarball URL |
+| `BUI_HOME` | `~/bui` | where the code is unpacked |
+| `BUI_MOBILE_PORT` | `8787` | server port |
+
+Manage it: `systemctl --user {status,restart} bui-server`, logs
+`journalctl --user -u bui-server -f`. Mint a fresh pairing code any time with
+`bui pair` (or `npm run pair` from `~/bui`) — each new code supersedes the last.
+
+Exposing the box to your phone/desktop is up to you in v1 (Tailscale/VPN, a
+reverse proxy to `127.0.0.1:8787`, or the documented cloudflared setup). The
+operated relay replaces this later.
+
+### Manual install (fallback — no release tarball)
+
+If you'd rather clone the repo directly (e.g. during development, or before a
+release tarball exists):
+
+```bash
+git clone git@github.com:antoinedc/better-ui.git ~/bui
+cd ~/bui
+npm install
+npm run build:mobile        # build the renderer bundle into mobile/www/
+npm run mobile              # start the server on 0.0.0.0:8787 (BUI_MOBILE_HOST/PORT override)
+```
+
+Then, on the box, mint a pairing code:
+
+```bash
+npm run pair               # GET 127.0.0.1:8787/auth/pair, prints the code
+```
+
+To run it under systemd yourself, copy `scripts/systemd/bui-server.service`,
+substitute the `@@BUI_HOME@@` / `@@NODE_BIN@@` / `@@BUI_PORT@@` placeholders,
+drop it in `~/.config/systemd/user/`, then
+`systemctl --user daemon-reload && systemctl --user enable --now bui-server`
+(and `loginctl enable-linger $USER` so it survives logout).
+
+### Cutting a release tarball
+
+`npm run pack` builds the renderer and produces `dist/bui-<version>.tar.gz`
+(shipping a pre-built `mobile/www/`, so the box needs no renderer toolchain).
+Upload it to `<release-host>/releases/bui-<version>.tar.gz`.
+
 ## Known beta gaps
 
 - No packaged `.app` / `.dmg` — install with `npm install && npm run dev`.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "rename:dev": "bash scripts/rename-dev-app.sh",
     "postinstall": "electron-rebuild -f -w node-pty || true; bash scripts/rename-dev-app.sh || true",
     "mobile": "node src/server/index.mjs",
-    "test": "vitest run && node --test src/server/*.test.mjs",
+    "pair": "node scripts/bui-pair.mjs",
+    "pack": "node scripts/release/pack.mjs",
+    "test": "vitest run && node --test src/server/*.test.mjs scripts/*.test.mjs",
     "test:server": "node --test src/server/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts"

--- a/scripts/bui-pair.mjs
+++ b/scripts/bui-pair.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// bui-pair.mjs — the `bui pair` CLI.
+//
+// Mints a fresh pairing code by hitting the LOOPBACK-only endpoint
+// GET http://127.0.0.1:8787/auth/pair and pretty-printing the
+// {pairing_code, box_id, expiresAt} response. Re-runnable any time: each call
+// supersedes the previous code (auth.mjs keeps a single active code).
+//
+// It is the ONLY intended caller of /auth/pair — the route is loopback-gated in
+// src/server/index.mjs (rejects any request carrying proxy forwarding headers),
+// so this must run ON the box (or over an SSH -L forward that terminates here).
+//
+// Install paths (see package.json + install.sh):
+//   * `npm run pair`            (from the repo)
+//   * `bui pair`                (via ~/.local/bin/bui shim the installer drops)
+//
+// Exit codes: 0 on success, 1 on any failure (server down, non-2xx, 403 because
+// the request wasn't local). Keep the logic thin — all formatting lives in the
+// tested install-lib.mjs.
+
+import { resolveConfig, formatPairingOutput } from "./install-lib.mjs";
+
+async function main() {
+  const cfg = resolveConfig();
+  const url = `http://127.0.0.1:${cfg.port}/auth/pair`;
+
+  let res;
+  try {
+    res = await fetch(url, { method: "GET" });
+  } catch (e) {
+    fail(
+      `Could not reach bui-server at ${url}\n` +
+        `  Is it running?  systemctl --user status bui-server\n` +
+        `  (${e?.message ?? e})`,
+    );
+    return;
+  }
+
+  if (res.status === 403) {
+    fail(
+      "bui-server refused to mint a pairing code: this command must run ON the box.\n" +
+        "  Pairing codes are loopback-only. Run `bui pair` directly on the server\n" +
+        "  (or over an SSH -L 8787 forward that terminates on the box).",
+    );
+    return;
+  }
+
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const body = await res.json();
+      if (body?.error) detail = `: ${body.error}`;
+    } catch {
+      /* non-JSON body — ignore */
+    }
+    fail(`bui-server returned HTTP ${res.status}${detail}`);
+    return;
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch (e) {
+    fail(`bui-server returned an unparseable response (${e?.message ?? e})`);
+    return;
+  }
+
+  try {
+    const block = formatPairingOutput({
+      pairing_code: data?.pairing_code,
+      box_id: data?.box_id,
+      expiresAt: data?.expiresAt,
+    });
+    process.stdout.write(block + "\n");
+  } catch (e) {
+    fail(`unexpected pairing response from bui-server (${e?.message ?? e})`);
+  }
+}
+
+function fail(msg) {
+  process.stderr.write(`bui pair: ${msg}\n`);
+  process.exitCode = 1;
+}
+
+main();

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -1,0 +1,368 @@
+// install-lib.mjs — pure, testable helpers for the VPS self-install flow.
+//
+// The bash entrypoint (scripts/install.sh) and the pairing CLI
+// (scripts/bui-pair.mjs) both stay THIN: all the logic that is worth testing —
+// resolving the tarball URL / install home, waiting for the server health
+// endpoint, formatting the pairing block, and deciding whether an existing box
+// identity must be preserved — lives here as small pure functions with injected
+// I/O (fetch, clock, sleep, env). No side effects at import time.
+//
+// Design rules:
+//   * The script NEVER generates box_id/box_token — src/server/auth.mjs owns
+//     identity (ensureAuth). This module only DETECTS an existing auth.json so
+//     a re-run preserves it (idempotency), it never writes one.
+//   * Overrides come from the environment: BUI_TARBALL_URL and BUI_HOME.
+//     Defaults are applied when unset/empty.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Constants (single source of truth, shared with the shell via `--print-config`)
+// ---------------------------------------------------------------------------
+
+// Loopback health/pairing target. The server binds 127.0.0.1:8787 under the
+// systemd unit we install; the installer + `bui pair` only ever talk to it over
+// loopback (minting a pairing code is loopback-gated — see auth.mjs).
+export const DEFAULT_PORT = 8787;
+export const HEALTH_PATH = "/auth/status";
+
+// Default release host. The repo is private; CI publishes a versioned tarball
+// the installer downloads (no git clone on the VPS). `BUI_TARBALL_URL` overrides
+// the whole URL for local testing; otherwise we build it from host + version.
+export const DEFAULT_RELEASE_HOST = "https://bui.useronda.com";
+
+// Where the box lives once installed. `~/.bui-mobile/` (auth.json + config.json)
+// is deliberately OUTSIDE this dir so an upgrade that replaces BUI_HOME never
+// touches box identity. `BUI_HOME` overrides the code location only.
+export const DEFAULT_HOME_DIRNAME = "bui";
+
+// Persisted box identity — the file ensureAuth() writes on first server run.
+// Its presence is the idempotency signal: "identity already exists, preserve it."
+export const AUTH_DIRNAME = ".bui-mobile";
+export const AUTH_FILENAME = "auth.json";
+
+// ---------------------------------------------------------------------------
+// Config resolution (arg/env parsing)
+// ---------------------------------------------------------------------------
+
+// Read a var from an env-like object, treating "" the same as unset so an
+// exported-but-empty override falls back to the default (a common shell
+// footgun: `BUI_HOME= curl ... | bash`).
+function envVal(env, key) {
+  const v = env?.[key];
+  return typeof v === "string" && v !== "" ? v : undefined;
+}
+
+/**
+ * Resolve the effective install config from the environment.
+ * Injectable `home` for tests (defaults to os.homedir()).
+ *
+ * Returns:
+ *   buiHome      — where the code is unpacked (BUI_HOME || ~/bui)
+ *   authDir      — ~/.bui-mobile (never inside buiHome)
+ *   authFile     — ~/.bui-mobile/auth.json (idempotency probe target)
+ *   tarballUrl   — explicit BUI_TARBALL_URL, else null (resolved per-version)
+ *   releaseHost  — BUI_RELEASE_HOST || DEFAULT_RELEASE_HOST
+ *   port         — BUI_MOBILE_PORT || DEFAULT_PORT
+ *   healthUrl    — http://127.0.0.1:<port>/auth/status
+ */
+export function resolveConfig({ env = process.env, home = homedir() } = {}) {
+  const buiHome = envVal(env, "BUI_HOME") ?? join(home, DEFAULT_HOME_DIRNAME);
+  const authDir = join(home, AUTH_DIRNAME);
+  const authFile = join(authDir, AUTH_FILENAME);
+  const tarballUrl = envVal(env, "BUI_TARBALL_URL") ?? null;
+  const releaseHost = stripTrailingSlash(
+    envVal(env, "BUI_RELEASE_HOST") ?? DEFAULT_RELEASE_HOST,
+  );
+  const port = parsePort(envVal(env, "BUI_MOBILE_PORT")) ?? DEFAULT_PORT;
+  return {
+    buiHome,
+    authDir,
+    authFile,
+    tarballUrl,
+    releaseHost,
+    port,
+    healthUrl: `http://127.0.0.1:${port}${HEALTH_PATH}`,
+  };
+}
+
+function stripTrailingSlash(s) {
+  return typeof s === "string" ? s.replace(/\/+$/, "") : s;
+}
+
+// Accept only a valid TCP port (1-65535); anything else → undefined (fall back).
+export function parsePort(value) {
+  if (value == null || value === "") return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) return undefined;
+  return n;
+}
+
+/**
+ * Resolve the tarball download URL.
+ *   - If BUI_TARBALL_URL is set (via resolveConfig → cfg.tarballUrl), use it
+ *     verbatim. This is the local-test / mirror override.
+ *   - Otherwise build `<releaseHost>/releases/bui-<version>.tar.gz`.
+ *
+ * `version` must be a plain semver-ish string (no slashes / traversal); we
+ * validate it so a bogus package.json version can't smuggle a path.
+ */
+export function resolveTarballUrl({ tarballUrl, releaseHost, version } = {}) {
+  if (typeof tarballUrl === "string" && tarballUrl !== "") return tarballUrl;
+  if (!isValidVersion(version)) {
+    throw new Error(
+      `resolveTarballUrl: invalid version ${JSON.stringify(version)} (expected e.g. "0.0.1")`,
+    );
+  }
+  const host = stripTrailingSlash(releaseHost || DEFAULT_RELEASE_HOST);
+  return `${host}/releases/bui-${version}.tar.gz`;
+}
+
+// A release version is digits/letters/dots/hyphens only — enough for semver +
+// prerelease tags (1.2.3, 1.2.3-rc.1) but no `/` or `..` path escapes.
+export function isValidVersion(version) {
+  return typeof version === "string" && /^[0-9A-Za-z][0-9A-Za-z.-]*$/.test(version);
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency: detect an existing box identity so a re-run preserves it.
+// ---------------------------------------------------------------------------
+
+/**
+ * Given the resolved config, decide whether the box already has an identity.
+ * Injectable `exists` (defaults to fs.existsSync) for tests.
+ *
+ * Returns { preserveIdentity, authFile, reason }:
+ *   preserveIdentity=true  → auth.json present; the server must NOT regenerate
+ *                            it and the installer must not delete ~/.bui-mobile.
+ *   preserveIdentity=false → fresh box; first server start mints identity.
+ *
+ * This function NEVER writes anything — it only reports. The single source of
+ * truth for identity is ensureAuth() in src/server/auth.mjs.
+ */
+export function checkIdentity(cfg, { exists = existsSync } = {}) {
+  const authFile = cfg?.authFile;
+  if (typeof authFile !== "string" || authFile === "") {
+    throw new Error("checkIdentity: cfg.authFile required");
+  }
+  const present = exists(authFile);
+  return {
+    preserveIdentity: present,
+    authFile,
+    reason: present
+      ? "existing box identity found — preserving it (server owns identity, never regenerated)"
+      : "no existing identity — the server will mint one on first start",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Health-wait poller
+// ---------------------------------------------------------------------------
+
+/**
+ * Poll `url` until it returns any HTTP response (server is up), or give up.
+ *
+ * A *connection refused* (fetch throws) means the server hasn't bound yet →
+ * retry. ANY HTTP status (200, 401, 403, ...) means the process is listening,
+ * which is all we need before running `bui pair`; /auth/status is gated so it
+ * legitimately answers 401 without a token, and that still proves liveness.
+ *
+ * Deterministic + testable: inject `fetchFn`, `sleep`, and `now`. No real
+ * timers when those are provided.
+ *
+ * @returns { ok:true, attempts } on success, or { ok:false, attempts, error }
+ *          after `maxAttempts` exhausted.
+ */
+export async function waitForHealth(
+  url,
+  {
+    maxAttempts = 60,
+    intervalMs = 1000,
+    fetchFn = globalThis.fetch,
+    sleep = defaultSleep,
+  } = {},
+) {
+  if (typeof url !== "string" || url === "") {
+    throw new Error("waitForHealth: url required");
+  }
+  if (typeof fetchFn !== "function") {
+    throw new Error("waitForHealth: no fetch available (pass fetchFn)");
+  }
+  let lastError = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetchFn(url);
+      // Any HTTP answer means the socket is bound and serving.
+      if (res && typeof res.status === "number") {
+        return { ok: true, attempts: attempt, status: res.status };
+      }
+      lastError = new Error("fetch returned no status");
+    } catch (e) {
+      lastError = e;
+    }
+    if (attempt < maxAttempts) await sleep(intervalMs);
+  }
+  return {
+    ok: false,
+    attempts: maxAttempts,
+    error: `server did not become healthy at ${url} after ${maxAttempts} attempts: ${
+      lastError?.message ?? lastError ?? "unknown"
+    }`,
+  };
+}
+
+function defaultSleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Pairing-output formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the human-facing pairing block printed at the end of install (and by
+ * `bui pair`). Given the server's { pairing_code, box_id, expiresAt } response,
+ * produce a stable, greppable multi-line string.
+ *
+ * `serverUrl` is the address the DESKTOP should point at (the box's public
+ * ingress the user set up — tailscale/reverse-proxy/cloudflared). We can't know
+ * it, so it's passed in (or omitted, in which case we print a hint line).
+ */
+export function formatPairingOutput({ pairing_code, box_id, expiresAt, serverUrl } = {}) {
+  if (!/^[0-9]{6}$/.test(String(pairing_code ?? ""))) {
+    throw new Error("formatPairingOutput: pairing_code must be 6 digits");
+  }
+  const lines = [];
+  lines.push("");
+  lines.push("  ✓ bui server is running.");
+  lines.push("");
+  lines.push(`  Pairing code:  ${pairing_code}`);
+  if (expiresAt != null) {
+    lines.push(`  Expires:       ${formatExpiry(expiresAt)}`);
+  }
+  if (box_id) {
+    lines.push(`  Box ID:        ${box_id}`);
+  }
+  lines.push("");
+  if (serverUrl) {
+    lines.push(`  Server URL:    ${serverUrl}`);
+    lines.push("");
+  } else {
+    lines.push("  Expose this box to your phone/desktop (pick one):");
+    lines.push("    • Tailscale / VPN  → use the box's tailnet address");
+    lines.push("    • Reverse proxy    → point it at 127.0.0.1:8787");
+    lines.push("    • cloudflared      → see docs (the operated relay replaces this later)");
+    lines.push("");
+  }
+  lines.push("  → Enter the pairing code in the bui desktop app to connect.");
+  lines.push("");
+  return lines.join("\n");
+}
+
+// Render an expiry as an ISO-ish local timestamp. Accepts an epoch-ms number
+// (what auth.mjs returns) or an ISO string; falls back to the raw value.
+export function formatExpiry(expiresAt) {
+  let ms = null;
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+    ms = expiresAt;
+  } else if (typeof expiresAt === "string" && expiresAt !== "") {
+    const parsed = Date.parse(expiresAt);
+    if (!Number.isNaN(parsed)) ms = parsed;
+    else return expiresAt;
+  }
+  if (ms == null) return String(expiresAt ?? "");
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return String(expiresAt);
+  return d.toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC");
+}
+
+// ---------------------------------------------------------------------------
+// Shell bridge — keeps install.sh thin by resolving config here.
+// ---------------------------------------------------------------------------
+//
+// install.sh calls:
+//   eval "$(node scripts/install-lib.mjs print-config --version <v>)"
+// which sets BUI_HOME / BUI_AUTH_FILE / BUI_TARBALL_URL / BUI_PORT in the shell,
+// and:
+//   node scripts/install-lib.mjs check-identity
+// which prints "preserve" or "fresh" (exit 0) so the shell knows whether to
+// keep ~/.bui-mobile untouched.
+
+// Emit KEY=VALUE lines the shell can `eval`. Values are single-quoted so paths
+// with spaces survive; embedded single quotes are escaped the POSIX way.
+export function renderShellConfig(cfg, { version } = {}) {
+  const tarball = resolveTarballUrl({
+    tarballUrl: cfg.tarballUrl,
+    releaseHost: cfg.releaseHost,
+    version,
+  });
+  const kv = {
+    BUI_HOME: cfg.buiHome,
+    BUI_AUTH_DIR: cfg.authDir,
+    BUI_AUTH_FILE: cfg.authFile,
+    BUI_TARBALL_URL: tarball,
+    BUI_PORT: String(cfg.port),
+    BUI_HEALTH_URL: cfg.healthUrl,
+  };
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}=${shellQuote(String(v))}`)
+    .join("\n");
+}
+
+function shellQuote(s) {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+// CLI entrypoint — only runs when executed directly, never on import.
+async function cliMain(argv) {
+  const [cmd, ...rest] = argv;
+  const flags = parseFlags(rest);
+  if (cmd === "print-config") {
+    const cfg = resolveConfig();
+    process.stdout.write(renderShellConfig(cfg, { version: flags.version }) + "\n");
+    return 0;
+  }
+  if (cmd === "check-identity") {
+    const cfg = resolveConfig();
+    const { preserveIdentity, reason } = checkIdentity(cfg);
+    process.stdout.write((preserveIdentity ? "preserve" : "fresh") + "\n");
+    process.stderr.write(reason + "\n");
+    return 0;
+  }
+  if (cmd === "tarball-url") {
+    const cfg = resolveConfig();
+    process.stdout.write(
+      resolveTarballUrl({
+        tarballUrl: cfg.tarballUrl,
+        releaseHost: cfg.releaseHost,
+        version: flags.version,
+      }) + "\n",
+    );
+    return 0;
+  }
+  process.stderr.write(
+    `install-lib: unknown command ${JSON.stringify(cmd)}\n` +
+      "  usage: node install-lib.mjs <print-config|check-identity|tarball-url> [--version X]\n",
+  );
+  return 2;
+}
+
+function parseFlags(args) {
+  const out = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--version") {
+      out.version = args[++i];
+    }
+  }
+  return out;
+}
+
+// Run the CLI only when invoked as `node install-lib.mjs …`, not on import.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  cliMain(process.argv.slice(2)).then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# install.sh — one-command VPS self-install for the bui box server.
+#
+#   curl -fsSL https://bui.useronda.com/install.sh | bash
+#
+# Gets bui-server running under systemd --user on a fresh Linux box and prints a
+# 6-digit pairing code to enter in the desktop app. Idempotent: re-running
+# upgrades the code in place and PRESERVES ~/.bui-mobile/ (box identity + config)
+# — the script never generates box_id/box_token itself; ensureAuth() in
+# src/server/auth.mjs is the single source of truth.
+#
+# Overrides (env):
+#   BUI_TARBALL_URL   full URL of the release tarball (skips host+version build)
+#   BUI_RELEASE_HOST  host for the default tarball URL (default bui.useronda.com)
+#   BUI_HOME          where code is unpacked (default ~/bui)
+#   BUI_MOBILE_PORT   server port (default 8787)
+#   BUI_VERSION       version to fetch when BUI_TARBALL_URL is unset (default: latest)
+#
+# The pure logic (URL/home resolution, health-wait, pairing format, idempotency)
+# lives in scripts/install-lib.mjs and is unit-tested (scripts/install.test.mjs).
+# This shell stays a thin orchestrator.
+
+set -euo pipefail
+
+log()  { printf '\033[36m▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisites — verify; report-and-instruct if missing (never silent sudo).
+# ---------------------------------------------------------------------------
+require_cmd() {
+  local cmd="$1" hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "missing prerequisite: $cmd
+      Install it and re-run. Suggested:
+        $hint"
+  fi
+}
+
+log "Checking prerequisites (node, npm, git, tmux, curl, tar)…"
+require_cmd curl "apt-get install -y curl   # or your distro's package manager"
+require_cmd tar  "apt-get install -y tar"
+require_cmd node "install Node.js LTS: https://nodejs.org  (nvm: 'nvm install --lts')"
+require_cmd npm  "ships with Node.js — reinstall Node if npm is missing"
+require_cmd git  "apt-get install -y git"
+require_cmd tmux "apt-get install -y tmux"
+
+# Node 20+ required (matches the desktop app / server runtime).
+node_major="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$node_major" -lt 20 ]; then
+  die "Node.js 20+ required (found $(node -v)). Upgrade Node and re-run."
+fi
+ok "Prerequisites present ($(node -v), npm $(npm -v))."
+
+# ---------------------------------------------------------------------------
+# 2. Resolve config. Bootstrap install-lib.mjs so we can reuse its pure helpers
+#    even before the tarball is unpacked — download just that one file first.
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bui-install.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Determine version (for the default tarball URL). If BUI_TARBALL_URL is set the
+# version is irrelevant (lib ignores it), so pass a harmless placeholder.
+BUI_VERSION="${BUI_VERSION:-latest}"
+
+# Fetch the release tarball. We need install-lib.mjs to resolve the URL, but
+# install-lib.mjs lives INSIDE the tarball — chicken/egg. Resolve the URL with a
+# tiny inline node expression that mirrors resolveTarballUrl's default shape;
+# once unpacked, all further logic uses the real (tested) lib.
+if [ -n "${BUI_TARBALL_URL:-}" ]; then
+  TARBALL_URL="$BUI_TARBALL_URL"
+else
+  host="${BUI_RELEASE_HOST:-https://bui.useronda.com}"
+  host="${host%/}"
+  TARBALL_URL="${host}/releases/bui-${BUI_VERSION}.tar.gz"
+fi
+log "Release tarball: $TARBALL_URL"
+
+# ---------------------------------------------------------------------------
+# 3. Download + extract the pre-built tarball (ships mobile/www/ prebuilt, so no
+#    renderer toolchain needed on the VPS).
+# ---------------------------------------------------------------------------
+BUI_HOME="${BUI_HOME:-$HOME/bui}"
+AUTH_DIR="$HOME/.bui-mobile"
+
+log "Downloading release…"
+curl -fsSL "$TARBALL_URL" -o "$WORK/bui.tar.gz" \
+  || die "download failed: $TARBALL_URL
+      (set BUI_TARBALL_URL to a reachable tarball, e.g. a local file:// or mirror)"
+
+log "Extracting to $BUI_HOME…"
+mkdir -p "$BUI_HOME"
+# Preserve ~/.bui-mobile no matter what — it lives outside BUI_HOME, but be
+# explicit that we never touch it. Extract stripping the top-level dir.
+tar -xzf "$WORK/bui.tar.gz" -C "$BUI_HOME" --strip-components=1 \
+  || die "extract failed"
+ok "Unpacked bui into $BUI_HOME."
+
+cd "$BUI_HOME"
+
+# Now use the REAL tested lib for everything downstream.
+LIB="$BUI_HOME/scripts/install-lib.mjs"
+[ -f "$LIB" ] || die "tarball is missing scripts/install-lib.mjs — bad release?"
+
+# Resolve the canonical config (exports BUI_HOME, BUI_AUTH_FILE, BUI_PORT,
+# BUI_HEALTH_URL, …). Version comes from package.json when unset.
+pkg_version="$(node -p 'require("./package.json").version' 2>/dev/null || echo "$BUI_VERSION")"
+eval "$(BUI_HOME="$BUI_HOME" node "$LIB" print-config --version "$pkg_version")"
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency: report whether we're preserving an existing box identity.
+# ---------------------------------------------------------------------------
+identity="$(node "$LIB" check-identity 2>/dev/null || echo fresh)"
+if [ "$identity" = "preserve" ]; then
+  ok "Existing box identity found at $BUI_AUTH_FILE — preserving it (never regenerated)."
+else
+  log "No existing identity — the server will mint one on first start."
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Production install (tarball ships mobile/www/ prebuilt → no build step).
+# ---------------------------------------------------------------------------
+log "Installing production dependencies (npm ci --omit=dev)…"
+if [ -f package-lock.json ]; then
+  npm ci --omit=dev --no-audit --no-fund || npm install --omit=dev --no-audit --no-fund
+else
+  npm install --omit=dev --no-audit --no-fund
+fi
+ok "Dependencies installed."
+
+# ---------------------------------------------------------------------------
+# 6. systemd --user unit: substitute placeholders and enable.
+# ---------------------------------------------------------------------------
+NODE_BIN="$(command -v node)"
+UNIT_SRC="$BUI_HOME/scripts/systemd/bui-server.service"
+UNIT_DIR="$HOME/.config/systemd/user"
+[ -f "$UNIT_SRC" ] || die "missing systemd template: $UNIT_SRC"
+
+if command -v systemctl >/dev/null 2>&1; then
+  log "Installing systemd --user unit…"
+  mkdir -p "$UNIT_DIR"
+  sed \
+    -e "s|@@BUI_HOME@@|$BUI_HOME|g" \
+    -e "s|@@NODE_BIN@@|$NODE_BIN|g" \
+    -e "s|@@BUI_PORT@@|$BUI_PORT|g" \
+    "$UNIT_SRC" > "$UNIT_DIR/bui-server.service"
+
+  # Survive logout/reboot without an active session.
+  loginctl enable-linger "$USER" >/dev/null 2>&1 \
+    || warn "could not enable-linger for $USER — the server may stop on logout. Run: sudo loginctl enable-linger $USER"
+
+  systemctl --user daemon-reload
+  systemctl --user enable --now bui-server.service
+  ok "bui-server enabled and started (systemctl --user status bui-server)."
+  SERVER_MANAGED=systemd
+else
+  warn "systemctl not found (not a systemd host?). Starting the server in the background instead."
+  warn "It will NOT survive reboot — set up your own supervisor for that."
+  ( BUI_MOBILE_HOST=127.0.0.1 BUI_MOBILE_PORT="$BUI_PORT" nohup node "$BUI_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
+  SERVER_MANAGED=nohup
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Wait for health, then mint + print a pairing code.
+# ---------------------------------------------------------------------------
+log "Waiting for the server to become healthy at $BUI_HEALTH_URL…"
+node -e '
+  import("'"$LIB"'").then(async (m) => {
+    const r = await m.waitForHealth(process.env.BUI_HEALTH_URL, { maxAttempts: 60, intervalMs: 1000 });
+    if (!r.ok) { console.error(r.error); process.exit(1); }
+    console.error("healthy after " + r.attempts + " attempt(s)");
+  }).catch((e) => { console.error(String(e)); process.exit(1); });
+' || die "server did not become healthy — check logs:
+      systemctl --user status bui-server ; journalctl --user -u bui-server -n 50"
+
+ok "Server is healthy."
+
+log "Minting pairing code…"
+# Delegate to the same `bui pair` CLI the user runs later (loopback GET /auth/pair).
+node "$BUI_HOME/scripts/bui-pair.mjs" || die "failed to mint pairing code (is the server local-reachable?)"
+
+cat <<EOF
+
+Installed. Manage the server with:
+  systemctl --user status bui-server
+  systemctl --user restart bui-server
+  journalctl --user -u bui-server -f
+
+Re-run this installer any time to upgrade in place (your box identity is preserved).
+Run 'bui pair' (or 'npm run pair' in $BUI_HOME) to mint a fresh pairing code.
+EOF

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1,0 +1,312 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import {
+  resolveConfig,
+  parsePort,
+  resolveTarballUrl,
+  isValidVersion,
+  checkIdentity,
+  waitForHealth,
+  formatPairingOutput,
+  formatExpiry,
+  renderShellConfig,
+  DEFAULT_PORT,
+  DEFAULT_RELEASE_HOST,
+} from "./install-lib.mjs";
+
+const HOME = "/home/tester";
+
+// ----------------------------------------------------------------------------
+// resolveConfig — arg/env parsing with BUI_HOME / BUI_TARBALL_URL overrides
+// ----------------------------------------------------------------------------
+
+test("resolveConfig applies defaults when env is empty", () => {
+  const cfg = resolveConfig({ env: {}, home: HOME });
+  assert.equal(cfg.buiHome, join(HOME, "bui"));
+  assert.equal(cfg.authDir, join(HOME, ".bui-mobile"));
+  assert.equal(cfg.authFile, join(HOME, ".bui-mobile", "auth.json"));
+  assert.equal(cfg.tarballUrl, null);
+  assert.equal(cfg.releaseHost, DEFAULT_RELEASE_HOST);
+  assert.equal(cfg.port, DEFAULT_PORT);
+  assert.equal(cfg.healthUrl, `http://127.0.0.1:${DEFAULT_PORT}/auth/status`);
+});
+
+test("resolveConfig honors BUI_HOME override", () => {
+  const cfg = resolveConfig({ env: { BUI_HOME: "/opt/bui" }, home: HOME });
+  assert.equal(cfg.buiHome, "/opt/bui");
+  // auth dir stays under HOME, never inside BUI_HOME — identity survives upgrades
+  assert.equal(cfg.authDir, join(HOME, ".bui-mobile"));
+});
+
+test("resolveConfig honors BUI_TARBALL_URL override", () => {
+  const cfg = resolveConfig({
+    env: { BUI_TARBALL_URL: "file:///tmp/bui-test.tar.gz" },
+    home: HOME,
+  });
+  assert.equal(cfg.tarballUrl, "file:///tmp/bui-test.tar.gz");
+});
+
+test("resolveConfig treats empty-string env vars as unset (shell footgun)", () => {
+  const cfg = resolveConfig({
+    env: { BUI_HOME: "", BUI_TARBALL_URL: "", BUI_MOBILE_PORT: "" },
+    home: HOME,
+  });
+  assert.equal(cfg.buiHome, join(HOME, "bui"));
+  assert.equal(cfg.tarballUrl, null);
+  assert.equal(cfg.port, DEFAULT_PORT);
+});
+
+test("resolveConfig strips trailing slash from BUI_RELEASE_HOST", () => {
+  const cfg = resolveConfig({
+    env: { BUI_RELEASE_HOST: "https://mirror.example.com/" },
+    home: HOME,
+  });
+  assert.equal(cfg.releaseHost, "https://mirror.example.com");
+});
+
+test("resolveConfig honors BUI_MOBILE_PORT and derives healthUrl", () => {
+  const cfg = resolveConfig({ env: { BUI_MOBILE_PORT: "9999" }, home: HOME });
+  assert.equal(cfg.port, 9999);
+  assert.equal(cfg.healthUrl, "http://127.0.0.1:9999/auth/status");
+});
+
+// ----------------------------------------------------------------------------
+// parsePort
+// ----------------------------------------------------------------------------
+
+test("parsePort accepts valid ports, rejects junk", () => {
+  assert.equal(parsePort("8787"), 8787);
+  assert.equal(parsePort("1"), 1);
+  assert.equal(parsePort("65535"), 65535);
+  assert.equal(parsePort("0"), undefined);
+  assert.equal(parsePort("65536"), undefined);
+  assert.equal(parsePort("-1"), undefined);
+  assert.equal(parsePort("abc"), undefined);
+  assert.equal(parsePort(""), undefined);
+  assert.equal(parsePort(null), undefined);
+  assert.equal(parsePort("80.5"), undefined);
+});
+
+// ----------------------------------------------------------------------------
+// resolveTarballUrl / isValidVersion
+// ----------------------------------------------------------------------------
+
+test("resolveTarballUrl builds default URL from host + version", () => {
+  const url = resolveTarballUrl({
+    tarballUrl: null,
+    releaseHost: "https://bui.useronda.com",
+    version: "0.0.1",
+  });
+  assert.equal(url, "https://bui.useronda.com/releases/bui-0.0.1.tar.gz");
+});
+
+test("resolveTarballUrl uses explicit override verbatim", () => {
+  const url = resolveTarballUrl({
+    tarballUrl: "file:///tmp/x.tar.gz",
+    releaseHost: "https://ignored.example.com",
+    version: "9.9.9",
+  });
+  assert.equal(url, "file:///tmp/x.tar.gz");
+});
+
+test("resolveTarballUrl strips trailing slash on host", () => {
+  const url = resolveTarballUrl({
+    tarballUrl: "",
+    releaseHost: "https://mirror.example.com/",
+    version: "1.2.3-rc.1",
+  });
+  assert.equal(url, "https://mirror.example.com/releases/bui-1.2.3-rc.1.tar.gz");
+});
+
+test("resolveTarballUrl rejects a path-traversal version", () => {
+  assert.throws(
+    () =>
+      resolveTarballUrl({
+        tarballUrl: null,
+        releaseHost: "https://x.com",
+        version: "../../etc/passwd",
+      }),
+    /invalid version/,
+  );
+});
+
+test("isValidVersion accepts semver-ish, rejects slashes", () => {
+  assert.equal(isValidVersion("0.0.1"), true);
+  assert.equal(isValidVersion("1.2.3-rc.1"), true);
+  assert.equal(isValidVersion("latest"), true);
+  assert.equal(isValidVersion("../x"), false);
+  assert.equal(isValidVersion("a/b"), false);
+  assert.equal(isValidVersion(""), false);
+  assert.equal(isValidVersion(null), false);
+});
+
+// ----------------------------------------------------------------------------
+// checkIdentity — idempotency: preserve existing box identity
+// ----------------------------------------------------------------------------
+
+test("checkIdentity reports preserve when auth.json exists", () => {
+  const cfg = resolveConfig({ env: {}, home: HOME });
+  const seen = [];
+  const res = checkIdentity(cfg, {
+    exists: (p) => {
+      seen.push(p);
+      return true;
+    },
+  });
+  assert.equal(res.preserveIdentity, true);
+  assert.equal(res.authFile, join(HOME, ".bui-mobile", "auth.json"));
+  assert.match(res.reason, /preserving/);
+  assert.deepEqual(seen, [join(HOME, ".bui-mobile", "auth.json")]);
+});
+
+test("checkIdentity reports fresh when auth.json missing", () => {
+  const cfg = resolveConfig({ env: {}, home: HOME });
+  const res = checkIdentity(cfg, { exists: () => false });
+  assert.equal(res.preserveIdentity, false);
+  assert.match(res.reason, /mint/);
+});
+
+test("checkIdentity requires authFile", () => {
+  assert.throws(() => checkIdentity({}, { exists: () => true }), /authFile required/);
+});
+
+// ----------------------------------------------------------------------------
+// waitForHealth — poller with injected fetch + clock (no real sleeps)
+// ----------------------------------------------------------------------------
+
+test("waitForHealth returns on first 200", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const res = await waitForHealth("http://127.0.0.1:8787/auth/status", {
+    maxAttempts: 5,
+    intervalMs: 1000,
+    fetchFn: async () => {
+      calls++;
+      return { status: 200 };
+    },
+    sleep: async (ms) => sleeps.push(ms),
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.attempts, 1);
+  assert.equal(res.status, 200);
+  assert.equal(calls, 1);
+  assert.equal(sleeps.length, 0, "no sleep before a first-try success");
+});
+
+test("waitForHealth treats a gated 401 as healthy (server is listening)", async () => {
+  const res = await waitForHealth("http://127.0.0.1:8787/auth/status", {
+    maxAttempts: 3,
+    fetchFn: async () => ({ status: 401 }),
+    sleep: async () => {},
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.attempts, 1);
+  assert.equal(res.status, 401);
+});
+
+test("waitForHealth retries on connection-refused then succeeds", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const res = await waitForHealth("http://127.0.0.1:8787/auth/status", {
+    maxAttempts: 5,
+    intervalMs: 250,
+    fetchFn: async () => {
+      calls++;
+      if (calls < 3) throw new Error("ECONNREFUSED");
+      return { status: 200 };
+    },
+    sleep: async (ms) => sleeps.push(ms),
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.attempts, 3);
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [250, 250], "slept between the two failed attempts");
+});
+
+test("waitForHealth gives up after the attempt cap", async () => {
+  let calls = 0;
+  const res = await waitForHealth("http://127.0.0.1:8787/auth/status", {
+    maxAttempts: 4,
+    intervalMs: 10,
+    fetchFn: async () => {
+      calls++;
+      throw new Error("ECONNREFUSED");
+    },
+    sleep: async () => {},
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.attempts, 4);
+  assert.equal(calls, 4);
+  assert.match(res.error, /did not become healthy/);
+  assert.match(res.error, /ECONNREFUSED/);
+});
+
+test("waitForHealth requires a url and a fetch", async () => {
+  await assert.rejects(() => waitForHealth("", { fetchFn: async () => ({ status: 200 }) }), /url required/);
+  await assert.rejects(() => waitForHealth("http://x", { fetchFn: null }), /no fetch/);
+});
+
+// ----------------------------------------------------------------------------
+// formatPairingOutput / formatExpiry
+// ----------------------------------------------------------------------------
+
+test("formatPairingOutput produces a stable human block", () => {
+  const out = formatPairingOutput({
+    pairing_code: "847291",
+    box_id: "0123456789abcdef0123456789abcdef",
+    expiresAt: Date.UTC(2026, 6, 3, 12, 34, 56),
+  });
+  assert.match(out, /Pairing code:  847291/);
+  assert.match(out, /Box ID:        0123456789abcdef0123456789abcdef/);
+  assert.match(out, /Expires:       2026-07-03 12:34:56 UTC/);
+  assert.match(out, /Enter the pairing code in the bui desktop app/);
+});
+
+test("formatPairingOutput prints ingress hint when no serverUrl given", () => {
+  const out = formatPairingOutput({ pairing_code: "000123" });
+  assert.match(out, /Pairing code:  000123/);
+  assert.match(out, /Tailscale/);
+  assert.match(out, /Reverse proxy/);
+});
+
+test("formatPairingOutput includes serverUrl when provided", () => {
+  const out = formatPairingOutput({
+    pairing_code: "111111",
+    serverUrl: "https://box.tailnet.ts.net",
+  });
+  assert.match(out, /Server URL:    https:\/\/box\.tailnet\.ts\.net/);
+  assert.doesNotMatch(out, /Tailscale \/ VPN/);
+});
+
+test("formatPairingOutput rejects a non-6-digit code", () => {
+  assert.throws(() => formatPairingOutput({ pairing_code: "12345" }), /6 digits/);
+  assert.throws(() => formatPairingOutput({ pairing_code: "abcdef" }), /6 digits/);
+  assert.throws(() => formatPairingOutput({}), /6 digits/);
+});
+
+test("formatExpiry handles epoch-ms, ISO string, and junk", () => {
+  assert.equal(formatExpiry(Date.UTC(2026, 0, 2, 3, 4, 5)), "2026-01-02 03:04:05 UTC");
+  assert.equal(formatExpiry("2026-01-02T03:04:05.000Z"), "2026-01-02 03:04:05 UTC");
+  assert.equal(formatExpiry("not-a-date"), "not-a-date");
+});
+
+// ----------------------------------------------------------------------------
+// renderShellConfig — the shell bridge install.sh evals
+// ----------------------------------------------------------------------------
+
+test("renderShellConfig emits eval-able KEY=VALUE lines", () => {
+  const cfg = resolveConfig({ env: {}, home: HOME });
+  const out = renderShellConfig(cfg, { version: "0.0.1" });
+  assert.match(out, new RegExp(`BUI_HOME='${join(HOME, "bui")}'`));
+  assert.match(out, /BUI_AUTH_FILE='.*\.bui-mobile\/auth\.json'/);
+  assert.match(out, /BUI_TARBALL_URL='.*\/releases\/bui-0\.0\.1\.tar\.gz'/);
+  assert.match(out, /BUI_PORT='8787'/);
+  assert.match(out, /BUI_HEALTH_URL='http:\/\/127\.0\.0\.1:8787\/auth\/status'/);
+});
+
+test("renderShellConfig single-quotes values with spaces safely", () => {
+  const cfg = resolveConfig({ env: { BUI_HOME: "/opt/my bui" }, home: HOME });
+  const out = renderShellConfig(cfg, { version: "0.0.1" });
+  assert.match(out, /BUI_HOME='\/opt\/my bui'/);
+});

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// pack.mjs — build a versioned release tarball the VPS installer downloads.
+//
+//   node scripts/release/pack.mjs [--out dist] [--skip-build]
+//
+// Produces `dist/bui-<version>.tar.gz` whose contents unpack into a single
+// top-level `bui-<version>/` directory. The installer downloads this, extracts
+// with --strip-components=1 into ~/bui, runs `npm ci --omit=dev`, and starts the
+// server — NO renderer toolchain needed on the box, because we ship a PRE-BUILT
+// `mobile/www/` here.
+//
+// What goes in (the box's runtime surface only):
+//   src/            — the server (src/server/**) + shared code it imports
+//   scripts/        — install.sh, bui-pair.mjs, install-lib.mjs, systemd unit
+//   mobile/www/     — PRE-BUILT renderer bundle (this is why the box needs no
+//                     Vite/electron toolchain)
+//   package.json    — the "mobile"/"pair" npm scripts + prod deps list
+//   package-lock.json — pins prod deps for `npm ci`
+//   README.md       — manual-install fallback reference
+//
+// What's excluded: the Electron desktop build, node_modules, .git, dist, tests,
+// dev configs — none of it runs on the box.
+
+import { mkdir, rm, writeFile, cp, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+
+function log(msg) {
+  process.stdout.write(`▸ ${msg}\n`);
+}
+function die(msg) {
+  process.stderr.write(`✗ ${msg}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = { outDir: "dist", skipBuild: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") out.outDir = argv[++i];
+    else if (argv[i] === "--skip-build") out.skipBuild = true;
+  }
+  return out;
+}
+
+// The set of paths that make up the box runtime. Kept explicit (allowlist) so a
+// stray dev file never leaks into a public release tarball.
+const INCLUDE = [
+  "src",
+  "scripts",
+  "mobile/www",
+  "package.json",
+  "package-lock.json",
+  "README.md",
+];
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const pkg = JSON.parse(await readFile(join(REPO_ROOT, "package.json"), "utf-8"));
+  const version = pkg.version;
+  if (!/^[0-9A-Za-z][0-9A-Za-z.-]*$/.test(version || "")) {
+    die(`package.json version ${JSON.stringify(version)} is not a valid release version`);
+  }
+
+  const stageRoot = join(REPO_ROOT, args.outDir, ".stage");
+  const stageDir = join(stageRoot, `bui-${version}`);
+  const outFile = join(REPO_ROOT, args.outDir, `bui-${version}.tar.gz`);
+
+  // 1. Build the renderer bundle unless told to skip (CI may pre-build).
+  if (!args.skipBuild) {
+    log("Building renderer bundle (npm run build:mobile)…");
+    const r = spawnSync("npm", ["run", "build:mobile"], {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+    });
+    if (r.status !== 0) die("build:mobile failed");
+  } else {
+    log("Skipping build:mobile (--skip-build).");
+  }
+
+  if (!existsSync(join(REPO_ROOT, "mobile", "www", "index.html"))) {
+    die("mobile/www/index.html missing — the renderer bundle must be built before packing");
+  }
+
+  // 2. Stage the allowlisted paths under bui-<version>/.
+  log(`Staging release into ${stageDir}…`);
+  await rm(stageRoot, { recursive: true, force: true });
+  await mkdir(stageDir, { recursive: true });
+  for (const rel of INCLUDE) {
+    const from = join(REPO_ROOT, rel);
+    if (!existsSync(from)) {
+      // package-lock is optional-ish; everything else is required.
+      if (rel === "package-lock.json") {
+        log(`  (no ${rel} — skipping; installer falls back to npm install)`);
+        continue;
+      }
+      die(`required path missing from repo: ${rel}`);
+    }
+    await cp(from, join(stageDir, rel), { recursive: true });
+  }
+
+  // 3. Drop a manifest so the box can report exactly what it's running.
+  await writeFile(
+    join(stageDir, "RELEASE.json"),
+    JSON.stringify(
+      { name: "bui", version, built_at: new Date().toISOString(), includes: INCLUDE },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  // 4. Tar it up. Tarball root is bui-<version>/ so install.sh strips it.
+  log(`Creating ${outFile}…`);
+  await mkdir(dirname(outFile), { recursive: true });
+  const r = spawnSync(
+    "tar",
+    ["-czf", outFile, "-C", stageRoot, `bui-${version}`],
+    { stdio: "inherit" },
+  );
+  if (r.status !== 0) die("tar failed");
+
+  // 5. Clean up the stage dir; leave the tarball.
+  await rm(stageRoot, { recursive: true, force: true });
+
+  log(`Done: ${outFile}`);
+  log(`Upload it to <release-host>/releases/bui-${version}.tar.gz`);
+}
+
+main().catch((e) => die(String(e?.stack ?? e)));

--- a/scripts/systemd/bui-server.service
+++ b/scripts/systemd/bui-server.service
@@ -1,0 +1,35 @@
+# bui-server.service — systemd --user unit for the bui box server.
+#
+# Mirrors the hand-rolled unit documented in AGENTS.md ("Mobile / web client"):
+# runs `node src/server/index.mjs` bound to loopback, restarted on failure,
+# started at boot via `loginctl enable-linger $USER`.
+#
+# The installer (scripts/install.sh) substitutes the @@…@@ placeholders and
+# writes the result to ~/.config/systemd/user/bui-server.service, then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now bui-server
+#
+# Bind is 127.0.0.1 on purpose: the server is NOT exposed directly. The user
+# fronts it with their own ingress (tailscale / reverse proxy / cloudflared) —
+# the operated relay (M2) replaces that later. Pairing codes are loopback-gated
+# so `bui pair` must run on the box.
+
+[Unit]
+Description=bui box server (mobile/web + relay proxy)
+Documentation=https://github.com/antoinedc/better-ui
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@@BUI_HOME@@
+ExecStart=@@NODE_BIN@@ @@BUI_HOME@@/src/server/index.mjs
+Environment=BUI_MOBILE_HOST=127.0.0.1
+Environment=BUI_MOBILE_PORT=@@BUI_PORT@@
+Restart=on-failure
+RestartSec=2
+# Give the server a moment to flush on stop before SIGKILL.
+TimeoutStopSec=10
+
+[Install]
+WantedBy=default.target

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,9 +2,14 @@ import { defineConfig, configDefaults } from "vitest/config";
 
 export default defineConfig({
   test: {
-    // src/server/** uses node:test (run via `node --test`), not vitest.
-    // .claude/** holds Claude Code worktrees — nested copies of this repo
-    // (incl. their own src/server/*.test.mjs) that vitest must not collect.
-    exclude: [...configDefaults.exclude, "src/server/**", ".claude/**"],
+    // src/server/** and scripts/** use node:test (run via `node --test`), not
+    // vitest. .claude/** holds Claude Code worktrees — nested copies of this
+    // repo (incl. their own *.test.mjs) that vitest must not collect.
+    exclude: [
+      ...configDefaults.exclude,
+      "src/server/**",
+      "scripts/**",
+      ".claude/**",
+    ],
   },
 });


### PR DESCRIPTION
## M6.1: VPS self-install script + `bui pair` CLI (BET-50)

One command on a fresh Linux VPS gets bui-server running under `systemd --user`
and prints a 6-digit pairing code:

```bash
curl -fsSL https://bui.useronda.com/install.sh | bash
```

`Base: origin/main @ 4767a52`

### What's here

- **`scripts/install.sh`** — thin orchestrator: prereq check (node 20+/npm/git/tmux;
  report-and-instruct, never silent sudo), download+extract the pre-built release
  tarball into `~/bui`, `npm ci --omit=dev`, install the `systemd --user` unit +
  `enable-linger`, health-wait on `127.0.0.1:8787`, then run `bui pair`.
  **Idempotent:** re-running upgrades in place and preserves `~/.bui-mobile/`
  (auth + config). It never generates box identity — `ensureAuth()` in
  `src/server/auth.mjs` is the single source of truth.
- **`scripts/install-lib.mjs`** — all the logic worth testing, pure with injected
  I/O: config resolution (`BUI_TARBALL_URL`/`BUI_HOME`/`BUI_MOBILE_PORT` overrides),
  tarball-URL resolution, health-wait poller, pairing-output formatter, idempotency
  probe. Plus a shell bridge (`print-config`/`check-identity`/`tarball-url`) so the
  bash stays thin.
- **`scripts/bui-pair.mjs`** (`npm run pair`) — loopback `GET /auth/pair`,
  pretty-prints `{pairing_code, box_id, expiresAt}`. Re-runnable; each code
  supersedes the last (auth.mjs keeps one active code). Handles server-down (exit 1)
  and the loopback-gate 403 with a clear message.
- **`scripts/release/pack.mjs`** (`npm run pack`) — builds the renderer and produces
  `dist/bui-<version>.tar.gz` shipping a PRE-BUILT `mobile/www/` (allowlisted paths
  only; excludes node_modules/.git/out/Electron build), so the box needs no renderer
  toolchain. Verified: 1 MB tarball, single top-level `bui-<version>/` dir.
- **`scripts/systemd/bui-server.service`** — `systemd --user` unit template mirroring
  the hand-rolled unit in AGENTS.md; `@@BUI_HOME@@`/`@@NODE_BIN@@`/`@@BUI_PORT@@`
  substituted by the installer. Binds loopback on purpose (user fronts their own
  ingress; the operated relay replaces this later).
- **`scripts/install.test.mjs`** — 27 node:test cases.
- **`package.json`** — `pair`/`pack` scripts; `test` now also runs `scripts/*.test.mjs`.
- **`vitest.config.ts`** — exclude `scripts/**` (node:test, not vitest).
- **`README.md`** — box-server self-install section, manual-install fallback
  (git clone + `npm run build:mobile` + `npm run mobile`), and how to cut a release.

### Anti-spaghetti notes

- No new auth logic: the CLI + installer are pure *callers* of the existing
  `/auth/pair` route and `ensureAuth()`. `src/server/auth.mjs` untouched.
- Pure logic centralized in `install-lib.mjs` and reused by both `install.sh`
  (via the shell bridge) and `bui-pair.mjs` — one source of truth, no duplicate
  URL/health/format logic.

### Files changed

`README.md`, `package.json`, `vitest.config.ts`, `scripts/install.sh`,
`scripts/install-lib.mjs`, `scripts/bui-pair.mjs`, `scripts/release/pack.mjs`,
`scripts/systemd/bui-server.service`, `scripts/install.test.mjs` — 9 files.

### Verification results

- PR branch (`multica/BET-50-vps-self-install` @ `b7d8af1`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, vitest `739` pass / node:test `253` pass (incl. 27 new) / 0 fail. log sha256: `d0e5bb93d85598c7fabb355cd77e0cd3973a54e0b34acf3f9e35e4f3c47705b6`
- Base (`main` @ `4767a52`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, vitest `739` pass / node:test `226` pass / 0 fail. log sha256: `1436cd4a48383b017b545946c65481f9b9547b8d3c11bdea5e682c8deee33ee8`
- **Conclusion:** 0 new failures, 0 pre-existing failures. The 27-test delta on the
  node:test count is exactly the new `scripts/install.test.mjs`. This PR is additive.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.

### Decisions / notes (not blockers)

- **Release hosting:** default tarball URL is `https://bui.useronda.com/releases/bui-<version>.tar.gz`;
  `BUI_TARBALL_URL` overrides for local/mirror testing (e.g. a `file://` path). CI upload
  mechanism is left to the release pipeline; `pack.mjs` produces the asset and prints the
  upload target.
- **Ingress:** v1 prints a hint (Tailscale/reverse-proxy/cloudflared) only — no tunnel
  automation. The operated relay (M2, BET-36) replaces this.
- This is a frontend-adjacent but **non-UI** change (scripts only) — no renderer surface
  to smoke-test.
