### PR TITLE
BET-65: pool forwardFetch connections — stop loopback ephemeral-port exhaustion (EADDRNOTAVAIL)

### DIFF
--- a/src/main/opencode.test.ts
+++ b/src/main/opencode.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { repairCorruptDirectory } from "./opencode";
+import {
+  repairCorruptDirectory,
+  _getForwardAgent,
+  discardBody,
+} from "./opencode";
 
 // Regression: opencode persists `/home/<user>/~/...` when a session is created
 // with a tilde directory — it joins its cwd ($HOME) with the literal `~/...`.
@@ -46,5 +50,53 @@ describe("repairCorruptDirectory", () => {
 
   it("handles an empty string", () => {
     expect(repairCorruptDirectory("")).toBe("");
+  });
+});
+
+// BET-65: forwardFetch routes through a shared keep-alive http.Agent so it
+// reuses a bounded socket pool instead of opening a fresh 127.0.0.1 socket per
+// call (each of which lingered in TIME_WAIT and exhausted the loopback
+// ephemeral-port range → EADDRNOTAVAIL). These guard the pool config and the
+// body-drain helper that keeps a pooled socket from being pinned open.
+describe("forwardFetch connection pool", () => {
+  // FORWARD_FETCH_MAX_CONCURRENCY is 16 (the semaphore cap); the pool must stay
+  // aligned with it so the two mechanisms don't fight and the pool can't
+  // silently outgrow the concurrency ceiling.
+  const EXPECTED_MAX = 16;
+
+  it("uses a single module-scope agent instance (referential stability)", () => {
+    expect(_getForwardAgent()).toBe(_getForwardAgent());
+  });
+
+  it("is keep-alive and capped at the semaphore concurrency (16)", () => {
+    const agent = _getForwardAgent();
+    expect(agent.keepAlive).toBe(true);
+    expect(agent.maxSockets).toBe(EXPECTED_MAX);
+    expect(agent.maxFreeSockets).toBe(EXPECTED_MAX);
+  });
+});
+
+describe("discardBody", () => {
+  it("cancels an unread body so the pooled socket is freed", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const res = new Response(body, { status: 500 });
+    await discardBody(res);
+    expect(cancelled).toBe(true);
+  });
+
+  it("is a no-op on a bodyless response (does not throw)", async () => {
+    const res = new Response(null, { status: 204 });
+    await expect(discardBody(res)).resolves.toBeUndefined();
+  });
+
+  it("swallows errors on an already-consumed body", async () => {
+    const res = new Response("read me", { status: 500 });
+    await res.text(); // consume
+    await expect(discardBody(res)).resolves.toBeUndefined();
   });
 });

--- a/src/main/opencode.test.ts
+++ b/src/main/opencode.test.ts
@@ -70,7 +70,10 @@ describe("forwardFetch connection pool", () => {
 
   it("is keep-alive and capped at the semaphore concurrency (16)", () => {
     const agent = _getForwardAgent();
-    expect(agent.keepAlive).toBe(true);
+    // `keepAlive` is a runtime property of http.Agent not reflected in the
+    // installed @types/node Agent type, so read it through a narrow cast.
+    const keepAlive = (agent as unknown as { keepAlive?: boolean }).keepAlive;
+    expect(keepAlive).toBe(true);
     expect(agent.maxSockets).toBe(EXPECTED_MAX);
     expect(agent.maxFreeSockets).toBe(EXPECTED_MAX);
   });

--- a/src/main/opencode.ts
+++ b/src/main/opencode.ts
@@ -28,6 +28,7 @@
 // the wire. No OPENCODE_SERVER_PASSWORD configured.
 
 import { spawn as cpSpawn } from "node:child_process";
+import http from "node:http";
 import {
   runSshOnce,
   getBranch as getBranchSsh,
@@ -534,6 +535,170 @@ function releaseForwardSlot(): void {
 // whichever fires first.
 const FORWARD_FETCH_TIMEOUT_MS = 90_000;
 
+// ===== Loopback connection pooling =====
+//
+// Node's global `fetch` (undici) opens a FRESH TCP socket to
+// 127.0.0.1:<forward-port> for every call and closes it when the response is
+// consumed — each closed socket lingers in TIME_WAIT. A reconcile sweep across
+// many sessions burst-creates tens of thousands of these one-shot sockets and
+// exhausts the loopback ephemeral-port range, after which every new loopback
+// `connect()` fails with EADDRNOTAVAIL (and unrelated network calls surface
+// ERR_ADDRESS_INVALID). The semaphore above caps *concurrency* (mux-channel
+// exhaustion, a different problem) but NOT socket *churn*.
+//
+// Fix: route forwardFetch through a shared keep-alive http.Agent so it reuses a
+// bounded pool of sockets instead of burning one per call. We use node:http
+// (NOT undici) deliberately: on this box `require('undici')` and `node:undici`
+// both fail (undici is bundled inside Node, not a resolvable module), so a
+// pooled undici Agent would mean a new npm dependency + electron-vite external
+// wiring. This is loopback-only plain HTTP, so http.request is clean.
+//
+// maxSockets is kept ALIGNED with FORWARD_FETCH_MAX_CONCURRENCY: the semaphore
+// never lets more than that many requests be in flight, so the pool never needs
+// more sockets, and keeping them equal stops the two mechanisms from fighting.
+const forwardAgent = new http.Agent({
+  keepAlive: true,
+  keepAliveMsecs: 10_000,
+  maxSockets: FORWARD_FETCH_MAX_CONCURRENCY,
+  maxFreeSockets: FORWARD_FETCH_MAX_CONCURRENCY,
+});
+
+// Test-only accessor so the pool config can be asserted without reaching into
+// module internals (regression guard: pool must not silently outgrow the
+// semaphore, and must be a single module-scope instance).
+export function _getForwardAgent(): http.Agent {
+  return forwardAgent;
+}
+
+// Drain-and-discard a response body without caring about its content. With a
+// keep-alive pool, an UNCONSUMED body pins its socket open forever (undici
+// won't return it to the pool until the body is read/cancelled), which defeats
+// reuse and re-introduces the churn/leak this fix removes. Every forwardFetch
+// caller that gets a Response but returns/throws WITHOUT reading the body must
+// call this on the non-consuming exit. Safe to call on an already-consumed or
+// bodyless Response (no throw).
+export async function discardBody(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    /* already consumed / locked / errored — nothing to drain */
+  }
+}
+
+// Issue a loopback HTTP request through the shared keep-alive agent and adapt
+// node:http's IncomingMessage into a WHATWG Response so every existing
+// forwardFetch caller (which reads `.ok` / `.status` / `.json()` / `.text()` /
+// `.body`) keeps working unchanged.
+function pooledRequest(
+  url: string,
+  init: Parameters<typeof fetch>[1] | undefined,
+  signal: AbortSignal,
+): Promise<Response> {
+  return new Promise<Response>((resolve, reject) => {
+    const method = (init?.method ?? "GET").toString();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      // Only plain object / Headers shapes are used on this path today.
+      const h = init.headers as Record<string, string> | Headers;
+      if (typeof (h as Headers).forEach === "function" && !Array.isArray(h)) {
+        (h as Headers).forEach((v, k) => {
+          headers[k] = v;
+        });
+      } else {
+        for (const [k, v] of Object.entries(h as Record<string, string>)) {
+          headers[k] = String(v);
+        }
+      }
+    }
+
+    if (signal.aborted) {
+      reject(signalReason(signal));
+      return;
+    }
+
+    const req = http.request(
+      url,
+      { method, headers, agent: forwardAgent },
+      (msg: http.IncomingMessage) => {
+        // Adapt the streaming IncomingMessage into a WHATWG ReadableStream so
+        // `.json()` / `.text()` / `.body` all work on the returned Response.
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            msg.on("data", (chunk: Buffer) => {
+              controller.enqueue(new Uint8Array(chunk));
+            });
+            msg.on("end", () => {
+              try {
+                controller.close();
+              } catch {
+                /* already closed */
+              }
+            });
+            msg.on("error", (err) => {
+              try {
+                controller.error(err);
+              } catch {
+                /* already errored */
+              }
+            });
+          },
+          cancel() {
+            // Body cancelled (discardBody / caller stopped reading): destroy the
+            // response so the socket returns to the keep-alive pool promptly.
+            msg.destroy();
+          },
+        });
+
+        const status = msg.statusCode ?? 0;
+        const resHeaders = new Headers();
+        for (const [k, v] of Object.entries(msg.headers)) {
+          if (Array.isArray(v)) {
+            for (const one of v) resHeaders.append(k, one);
+          } else if (typeof v === "string") {
+            resHeaders.set(k, v);
+          }
+        }
+        // 204/205/304 must not carry a body per the Response constructor.
+        const nullBody = status === 204 || status === 205 || status === 304;
+        resolve(
+          new Response(nullBody ? null : body, {
+            status,
+            statusText: msg.statusMessage ?? "",
+            headers: resHeaders,
+          }),
+        );
+      },
+    );
+
+    const onAbort = () => {
+      req.destroy(signalReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    req.on("error", (err) => {
+      signal.removeEventListener("abort", onAbort);
+      reject(err);
+    });
+    req.on("close", () => {
+      signal.removeEventListener("abort", onAbort);
+    });
+
+    const bodyInit = init?.body;
+    if (bodyInit != null && method !== "GET" && method !== "HEAD") {
+      // JSON bodies are strings today; Buffer/Uint8Array also pass through.
+      req.write(bodyInit as string | Buffer | Uint8Array);
+    }
+    req.end();
+  });
+}
+
+function signalReason(signal: AbortSignal): Error {
+  const reason = (signal as { reason?: unknown }).reason;
+  if (reason instanceof Error) return reason;
+  const err = new Error("The operation was aborted");
+  err.name = "AbortError";
+  return err;
+}
+
 async function forwardFetch(
   url: string,
   init?: Parameters<typeof fetch>[1],
@@ -544,7 +709,7 @@ async function forwardFetch(
     ? AbortSignal.any([init.signal, timeoutSignal])
     : timeoutSignal;
   try {
-    return await fetch(url, { ...init, signal });
+    return await pooledRequest(url, init, signal);
   } finally {
     releaseForwardSlot();
   }
@@ -643,7 +808,10 @@ async function fetchSessionDirectory(
   await ensureForward(config);
   try {
     const res = await forwardFetch(apiUrl(config, `/session/${encodeURIComponent(sessionId)}`));
-    if (!res.ok) return null;
+    if (!res.ok) {
+      await discardBody(res);
+      return null;
+    }
     const body = (await res.json()) as { directory?: unknown };
     return typeof body.directory === "string" ? body.directory : null;
   } catch {
@@ -802,7 +970,10 @@ export async function getMessage(
       `/session/${encodeURIComponent(sessionId)}/message/${encodeURIComponent(messageId)}`,
     );
     const res = await forwardFetch(url);
-    if (!res.ok) return null;
+    if (!res.ok) {
+      await discardBody(res);
+      return null;
+    }
     return (await res.json()) as OpencodeMessage;
   } catch {
     return null;
@@ -859,7 +1030,10 @@ export async function reconcileMessages(
       `/session/${encodeURIComponent(sessionId)}/message?limit=${RECONCILE_TAIL_LIMIT}`,
     );
     const res = await forwardFetch(url);
-    if (!res.ok) return listMessages(config, sessionId);
+    if (!res.ok) {
+      await discardBody(res);
+      return listMessages(config, sessionId);
+    }
     tail = (await res.json()) as OpencodeMessage[];
   } catch {
     // Tail fetch failed — fall back to full (which itself may throw; let it,
@@ -1198,13 +1372,18 @@ export async function getDefaultModel(
           modelID: cfg.model.slice(slash + 1),
         };
       }
+    } else {
+      await discardBody(cfgRes);
     }
   } catch {
     /* fall through to provider catalog default */
   }
 
   const res = await forwardFetch(apiUrl(config, "/provider"));
-  if (!res.ok) return null;
+  if (!res.ok) {
+    await discardBody(res);
+    return null;
+  }
   type R = { connected?: string[]; default?: Record<string, string> };
   const data = (await res.json()) as R;
   const connected = data.connected ?? [];
@@ -1262,6 +1441,8 @@ export async function listModels(config: AppConfig): Promise<OpencodeModel[]> {
           out.push(normalizeProviderModel(p.id, modelId, (p.models ?? {})[modelId]));
         }
       }
+    } else {
+      await discardBody(res);
     }
   } catch {
     /* non-fatal */

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -10,12 +10,118 @@
 
 import { spawn as cpSpawn } from "node:child_process";
 import { homedir } from "node:os";
+import http from "node:http";
 
 const REMOTE_PORT = 4096;
 
 /** Build the full URL for an opencode API path. */
 export function apiUrl(path) {
   return `http://127.0.0.1:${REMOTE_PORT}${path}`;
+}
+
+// ===== Loopback connection pooling =====
+//
+// Node's global `fetch` (undici) opens a FRESH TCP socket to 127.0.0.1:4096
+// for every call and closes it when the response is consumed — each closed
+// socket lingers in TIME_WAIT. Under load (a reconcile/list sweep across many
+// sessions) this burst-creates thousands of one-shot sockets and can exhaust
+// the loopback ephemeral-port range → new connect() fails with EADDRNOTAVAIL.
+// Same class of bug as the desktop forwardFetch path (src/main/opencode.ts);
+// this side just hits opencode directly on the box instead of over an SSH
+// forward. There's no concurrency semaphore here (mobile fan-out is bounded by
+// a single client), so we just pool the sockets.
+//
+// http.Agent gives fetch a keep-alive pool so it reuses a bounded set of
+// sockets instead of burning one per call. maxSockets 16 matches the desktop
+// FORWARD_FETCH_MAX_CONCURRENCY for consistency. The SSE stream path
+// (openEventStream) deliberately does NOT use this agent — a long-lived
+// streaming body would pin a pool socket forever.
+const ocAgent = new http.Agent({
+  keepAlive: true,
+  keepAliveMsecs: 10_000,
+  maxSockets: 16,
+  maxFreeSockets: 16,
+});
+
+/** Test-only accessor: assert the pool config / single-instance invariant. */
+export function _getOcAgent() {
+  return ocAgent;
+}
+
+// A `fetch` replacement for opencode's NON-STREAMING endpoints that routes the
+// request through the keep-alive pool above via node:http.request.
+//
+// NOTE: undici's global `fetch` does NOT honor the classic `agent` option (nor
+// can we pass a pooled undici `dispatcher` — the Node-bundled undici isn't a
+// resolvable module, so importing it would mean a new npm dependency). Verified
+// on this box: `fetch(url, { agent })` reuses undici's own default pool
+// regardless of the agent passed, so it can't be capped/controlled. So we issue
+// the request via http.request through our own http.Agent and adapt the
+// IncomingMessage into a WHATWG Response — every caller keeps using `.ok` /
+// `.status` / `.json()` / `.text()` unchanged. Same technique as the desktop
+// pooledRequest in src/main/opencode.ts.
+function ocFetch(url, init) {
+  return new Promise((resolve, reject) => {
+    const method = (init?.method ?? "GET").toString();
+    const headers = {};
+    if (init?.headers) {
+      for (const [k, v] of Object.entries(init.headers)) headers[k] = String(v);
+    }
+    const req = http.request(url, { method, headers, agent: ocAgent }, (msg) => {
+      const body = new ReadableStream({
+        start(controller) {
+          msg.on("data", (chunk) => controller.enqueue(new Uint8Array(chunk)));
+          msg.on("end", () => {
+            try { controller.close(); } catch { /* already closed */ }
+          });
+          msg.on("error", (err) => {
+            try { controller.error(err); } catch { /* already errored */ }
+          });
+        },
+        cancel() {
+          // Return the socket to the pool promptly when the body is discarded.
+          msg.destroy();
+        },
+      });
+      const status = msg.statusCode ?? 0;
+      const resHeaders = new Headers();
+      for (const [k, v] of Object.entries(msg.headers)) {
+        if (Array.isArray(v)) {
+          for (const one of v) resHeaders.append(k, one);
+        } else if (typeof v === "string") {
+          resHeaders.set(k, v);
+        }
+      }
+      const nullBody = status === 204 || status === 205 || status === 304;
+      resolve(
+        new Response(nullBody ? null : body, {
+          status,
+          statusText: msg.statusMessage ?? "",
+          headers: resHeaders,
+        }),
+      );
+    });
+    req.on("error", reject);
+    const bodyInit = init?.body;
+    if (bodyInit != null && method !== "GET" && method !== "HEAD") {
+      req.write(bodyInit);
+    }
+    req.end();
+  });
+}
+
+// Drain-and-discard a response body without reading its content. With a
+// keep-alive pool, an UNCONSUMED body pins its socket open (undici won't
+// return it to the pool until read/cancelled), defeating reuse and
+// re-introducing the churn this fix removes. Every ocFetch caller that gets a
+// Response but returns/throws WITHOUT reading the body must call this on the
+// non-consuming exit. Safe on an already-consumed/bodyless Response.
+export async function discardBody(res) {
+  try {
+    await res?.body?.cancel();
+  } catch {
+    /* already consumed / locked / errored */
+  }
 }
 
 /**
@@ -81,8 +187,11 @@ let ensureStreamForDirectory = null;
 
 async function fetchSessionDirectory(sessionId) {
   try {
-    const res = await fetch(apiUrl(`/session/${encodeURIComponent(sessionId)}`));
-    if (!res.ok) return null;
+    const res = await ocFetch(apiUrl(`/session/${encodeURIComponent(sessionId)}`));
+    if (!res.ok) {
+      await discardBody(res);
+      return null;
+    }
     const body = await res.json();
     return typeof body?.directory === "string" ? body.directory : null;
   } catch {
@@ -152,7 +261,7 @@ function expandTilde(p) {
 export async function createSession({ directory, title = "" }) {
   const absDir = expandTilde(directory);
   const url = `/session?directory=${encodeURIComponent(absDir)}`;
-  const res = await fetch(apiUrl(url), {
+  const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ title }),
@@ -177,7 +286,7 @@ export async function listMessages(sessionId) {
   // mount; without it, only sending a prompt would open the stream.
   void getSessionDirectoryQuery(sessionId).catch(() => {});
   const url = `/session/${encodeURIComponent(sessionId)}/message`;
-  const res = await fetch(apiUrl(url));
+  const res = await ocFetch(apiUrl(url));
   if (!res.ok) {
     throw new Error(`opencode listMessages ${res.status}: ${await res.text()}`);
   }
@@ -192,8 +301,11 @@ export async function listMessages(sessionId) {
 export async function getMessage(sessionId, messageId) {
   try {
     const url = `/session/${encodeURIComponent(sessionId)}/message/${encodeURIComponent(messageId)}`;
-    const res = await fetch(apiUrl(url));
-    if (!res.ok) return null;
+    const res = await ocFetch(apiUrl(url));
+    if (!res.ok) {
+      await discardBody(res);
+      return null;
+    }
     return res.json();
   } catch {
     return null;
@@ -250,7 +362,7 @@ export async function sendPrompt({ sessionId, text, model, attachments, mentions
     if (model.variant) body.variant = model.variant;
   }
 
-  const res = await fetch(apiUrl(url), {
+  const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -273,7 +385,7 @@ export async function sendPrompt({ sessionId, text, model, attachments, mentions
 export async function abortSession(sessionId) {
   const dirQ = await getSessionDirectoryQuery(sessionId);
   const url = `/session/${encodeURIComponent(sessionId)}/abort${dirQ}`;
-  const res = await fetch(apiUrl(url), { method: "POST" });
+  const res = await ocFetch(apiUrl(url), { method: "POST" });
   if (!res.ok) {
     throw new Error(`opencode abortSession ${res.status}: ${await res.text()}`);
   }
@@ -284,7 +396,7 @@ export async function abortSession(sessionId) {
  */
 export async function listSessions(directory) {
   const qs = directory ? `?directory=${encodeURIComponent(directory)}` : "";
-  const res = await fetch(apiUrl(`/session${qs}`));
+  const res = await ocFetch(apiUrl(`/session${qs}`));
   if (!res.ok) {
     throw new Error(`opencode listSessions ${res.status}: ${await res.text()}`);
   }
@@ -298,7 +410,7 @@ export async function listSessions(directory) {
 export async function forkSession({ sessionId, messageID }) {
   const dirQ = await getSessionDirectoryQuery(sessionId);
   const url = `/session/${encodeURIComponent(sessionId)}/fork${dirQ}`;
-  const res = await fetch(apiUrl(url), {
+  const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(messageID ? { messageID } : {}),
@@ -317,7 +429,7 @@ export async function forkSession({ sessionId, messageID }) {
 export async function compactSession(sessionId) {
   const dirQ = await getSessionDirectoryQuery(sessionId);
   const url = `/api/session/${encodeURIComponent(sessionId)}/compact${dirQ}`;
-  const res = await fetch(apiUrl(url), { method: "POST" });
+  const res = await ocFetch(apiUrl(url), { method: "POST" });
   if (!res.ok) {
     throw new Error(`opencode compactSession ${res.status}: ${await res.text()}`);
   }
@@ -330,7 +442,7 @@ export async function compactSession(sessionId) {
 export async function deleteSessionRaw(sessionId) {
   sessionDirectoryCache.delete(sessionId);
   const url = `/session/${encodeURIComponent(sessionId)}`;
-  const res = await fetch(apiUrl(url), { method: "DELETE" });
+  const res = await ocFetch(apiUrl(url), { method: "DELETE" });
   if (!res.ok) {
     throw new Error(`opencode deleteSession ${res.status}: ${await res.text()}`);
   }
@@ -353,7 +465,7 @@ export async function generateSessionTitle({ directory, instruction }) {
 
   let sid = null;
   try {
-    const createRes = await fetch(
+    const createRes = await ocFetch(
       apiUrl(`/session?directory=${encodeURIComponent(absDir)}`),
       {
         method: "POST",
@@ -361,14 +473,17 @@ export async function generateSessionTitle({ directory, instruction }) {
         body: JSON.stringify({ title: "bui-auto-title" }),
       },
     );
-    if (!createRes.ok) return "";
+    if (!createRes.ok) {
+      await discardBody(createRes);
+      return "";
+    }
     sid = (await createRes.json()).id;
 
     const promptBody = { parts: [{ type: "text", text: instruction }] };
     if (model) {
       promptBody.model = { providerID: model.providerID, modelID: model.modelID };
     }
-    const promptRes = await fetch(
+    const promptRes = await ocFetch(
       apiUrl(
         `/session/${encodeURIComponent(sid)}/prompt_async?directory=${encodeURIComponent(absDir)}`,
       ),
@@ -378,13 +493,19 @@ export async function generateSessionTitle({ directory, instruction }) {
         body: JSON.stringify(promptBody),
       },
     );
-    if (!promptRes.ok) return "";
+    if (!promptRes.ok) {
+      await discardBody(promptRes);
+      return "";
+    }
 
     const msgUrl = apiUrl(`/session/${encodeURIComponent(sid)}/message`);
     for (let i = 0; i < 30; i++) {
       await new Promise((r) => setTimeout(r, 1000));
-      const r = await fetch(msgUrl);
-      if (!r.ok) continue;
+      const r = await ocFetch(msgUrl);
+      if (!r.ok) {
+        await discardBody(r);
+        continue;
+      }
       const msgs = await r.json();
       const text = extractAssistantText(msgs);
       if (text) return text;
@@ -430,7 +551,7 @@ function extractAssistantText(msgs) {
  */
 export async function listPermissions(sessionId) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
-  const res = await fetch(apiUrl(`/permission${dirQ}`));
+  const res = await ocFetch(apiUrl(`/permission${dirQ}`));
   if (!res.ok) {
     throw new Error(`opencode listPermissions ${res.status}: ${await res.text()}`);
   }
@@ -448,7 +569,7 @@ export async function listPermissions(sessionId) {
 export async function replyPermission({ requestId, reply, sessionId }) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
   const url = `/permission/${encodeURIComponent(requestId)}/reply${dirQ}`;
-  const res = await fetch(apiUrl(url), {
+  const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ reply }),
@@ -472,7 +593,7 @@ export async function replyPermission({ requestId, reply, sessionId }) {
  */
 export async function listQuestions(sessionId) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
-  const res = await fetch(apiUrl(`/question${dirQ}`));
+  const res = await ocFetch(apiUrl(`/question${dirQ}`));
   if (!res.ok) {
     throw new Error(`opencode listQuestions ${res.status}: ${await res.text()}`);
   }
@@ -491,7 +612,7 @@ export async function listQuestions(sessionId) {
 export async function replyQuestion({ requestId, answers, sessionId }) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
   const url = `/question/${encodeURIComponent(requestId)}/reply${dirQ}`;
-  const res = await fetch(apiUrl(url), {
+  const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ answers }),
@@ -507,7 +628,7 @@ export async function replyQuestion({ requestId, answers, sessionId }) {
 export async function rejectQuestion({ requestId, sessionId }) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
   const url = `/question/${encodeURIComponent(requestId)}/reject${dirQ}`;
-  const res = await fetch(apiUrl(url), { method: "POST" });
+  const res = await ocFetch(apiUrl(url), { method: "POST" });
   if (!res.ok) {
     throw new Error(`opencode rejectQuestion ${res.status}: ${await res.text()}`);
   }
@@ -522,8 +643,11 @@ export async function rejectQuestion({ requestId, sessionId }) {
  * @returns {Promise<{ providerID: string, modelID: string }|null>}
  */
 export async function getDefaultModel() {
-  const res = await fetch(apiUrl("/provider"));
-  if (!res.ok) return null;
+  const res = await ocFetch(apiUrl("/provider"));
+  if (!res.ok) {
+    await discardBody(res);
+    return null;
+  }
   const data = await res.json();
   const connected = data.connected ?? [];
   const defaults = data.default ?? {};
@@ -542,7 +666,7 @@ export async function getDefaultModel() {
 export async function listModels() {
   const out = [];
   try {
-    const res = await fetch(apiUrl("/provider"));
+    const res = await ocFetch(apiUrl("/provider"));
     if (res.ok) {
       const data = await res.json();
       const connected = new Set(data.connected ?? []);
@@ -552,6 +676,8 @@ export async function listModels() {
           out.push(_normalizeProviderModel(p.id, modelId, (p.models ?? {})[modelId]));
         }
       }
+    } else {
+      await discardBody(res);
     }
   } catch {
     /* non-fatal */
@@ -625,7 +751,7 @@ export async function getVcsBranch(directory) {
  *  @returns {Promise<Array<{ name: string, description?: string, source?: string, ... }>>}
  */
 export async function listCommands() {
-  const res = await fetch(apiUrl("/command"));
+  const res = await ocFetch(apiUrl("/command"));
   if (!res.ok) {
     throw new Error(`opencode listCommands ${res.status}: ${await res.text()}`);
   }
@@ -645,7 +771,7 @@ export async function listCommands() {
  *  @returns {Promise<Array<{ name: string, description?: string, mode?: string, ... }>>}
  */
 export async function listAgents() {
-  const res = await fetch(apiUrl("/agent"));
+  const res = await ocFetch(apiUrl("/agent"));
   if (!res.ok) {
     throw new Error(`opencode listAgents ${res.status}: ${await res.text()}`);
   }
@@ -666,7 +792,7 @@ export async function listAgents() {
 export async function findFiles({ query, directory }) {
   const qs =
     `?query=${encodeURIComponent(query)}&directory=${encodeURIComponent(directory)}`;
-  const res = await fetch(apiUrl(`/find/file${qs}`));
+  const res = await ocFetch(apiUrl(`/find/file${qs}`));
   if (!res.ok) {
     throw new Error(`opencode findFiles ${res.status}: ${await res.text()}`);
   }
@@ -698,7 +824,7 @@ export async function runCommand({ sessionId, command, arguments: argumentsStr, 
     body.model = `${model.providerID}/${model.modelID}`;
     if (model.variant) body.variant = model.variant;
   }
-  const res = await fetch(apiUrl(url), {
+  const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -48,8 +48,26 @@ export function _getOcAgent() {
   return ocAgent;
 }
 
+// The transport ocFetch uses. Production = the pooled http.request impl below
+// (`pooledOcRequest`). Tests can swap in a `(url, init) => Promise<Response>`
+// stub via `_setOcTransport` so they intercept requests without a live server
+// (the old tests mocked globalThis.fetch, which the pooled path bypasses).
+let ocTransport = null; // lazily set to pooledOcRequest after it's defined
+
+/** Test-only: override the transport ocFetch dispatches through. Pass null to
+ *  restore the default pooled transport. */
+export function _setOcTransport(fn) {
+  ocTransport = fn;
+}
+
+/** Test-only: exercise the real pooled transport directly (bypasses any
+ *  installed test stub) so a socket-reuse test can hit a live local server. */
+export function _pooledOcRequest(url, init) {
+  return pooledOcRequest(url, init);
+}
+
 // A `fetch` replacement for opencode's NON-STREAMING endpoints that routes the
-// request through the keep-alive pool above via node:http.request.
+// request through the keep-alive pool via node:http.request (or a test stub).
 //
 // NOTE: undici's global `fetch` does NOT honor the classic `agent` option (nor
 // can we pass a pooled undici `dispatcher` — the Node-bundled undici isn't a
@@ -61,6 +79,10 @@ export function _getOcAgent() {
 // `.status` / `.json()` / `.text()` unchanged. Same technique as the desktop
 // pooledRequest in src/main/opencode.ts.
 function ocFetch(url, init) {
+  return (ocTransport ?? pooledOcRequest)(url, init);
+}
+
+function pooledOcRequest(url, init) {
   return new Promise((resolve, reject) => {
     const method = (init?.method ?? "GET").toString();
     const headers = {};

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -13,6 +13,10 @@ import {
   replyPermission,
   _resetSessionDirectoryCache,
   _onSessionDirectoryAdded,
+  _setOcTransport,
+  _getOcAgent,
+  _pooledOcRequest,
+  discardBody,
 } from "./opencode.mjs";
 
 test("apiUrl targets local opencode port 4096", () => {
@@ -41,11 +45,14 @@ test("parseSseFrame returns null for comments/keepalive", () => {
 // `GET /session/{id}` on a miss.
 // ---------------------------------------------------------------------------
 
+// The non-streaming opencode calls now route through ocFetch → a pooled
+// node:http transport (NOT globalThis.fetch, which undici won't let us pool).
+// Install the test handler as the ocFetch transport instead. Handler signature
+// is unchanged: (url, init) => Promise<Response>.
 function withMockFetch(handler, fn) {
-  const orig = globalThis.fetch;
-  globalThis.fetch = handler;
+  _setOcTransport(handler);
   return fn().finally(() => {
-    globalThis.fetch = orig;
+    _setOcTransport(null);
   });
 }
 
@@ -492,4 +499,78 @@ test("replyPermission appends ?directory= from cache (auto-allow path)", async (
     replyUrl.includes("directory=%2Fproj%2Fpreply"),
     `replyPermission URL missing scoped directory: ${replyUrl}`,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Loopback connection pooling (BET-65)
+//
+// Global fetch (undici) opened a fresh 127.0.0.1:4096 socket per call that
+// lingered in TIME_WAIT; a list/reconcile sweep exhausted the loopback
+// ephemeral-port range (EADDRNOTAVAIL). ocFetch now routes through a shared
+// keep-alive http.Agent so sockets are reused. These guard the pool config and
+// the body-drain helper that keeps pooled sockets from being pinned open.
+// ---------------------------------------------------------------------------
+
+test("ocFetch keep-alive agent is a single module-scope instance", () => {
+  // Referential stability across calls — the pool must not be re-created per
+  // request (that would defeat reuse and re-introduce socket churn).
+  assert.equal(_getOcAgent(), _getOcAgent());
+});
+
+test("ocFetch agent is keep-alive and capped at 16 sockets", () => {
+  const agent = _getOcAgent();
+  assert.equal(agent.keepAlive, true, "agent must keep sockets alive for reuse");
+  assert.equal(agent.maxSockets, 16, "pool must be capped at 16 sockets");
+  assert.equal(agent.maxFreeSockets, 16, "free-socket cap should match maxSockets");
+});
+
+test("discardBody cancels an unread body (frees the pooled socket)", async () => {
+  let cancelled = false;
+  const body = new ReadableStream({
+    cancel() {
+      cancelled = true;
+    },
+  });
+  const res = new Response(body, { status: 500 });
+  await discardBody(res);
+  assert.equal(cancelled, true, "discardBody must cancel the response body");
+});
+
+test("discardBody is a no-op on a bodyless response (no throw)", async () => {
+  const res = new Response(null, { status: 204 });
+  await discardBody(res); // must not throw
+  assert.ok(true);
+});
+
+test("discardBody swallows errors on an already-consumed body", async () => {
+  const res = new Response("already read", { status: 500 });
+  await res.text(); // consume it
+  await discardBody(res); // cancelling a used body would throw — must be swallowed
+  assert.ok(true);
+});
+
+test("pooled ocFetch reuses one socket across sequential calls", async () => {
+  // A real local server: N sequential ocFetch calls must reuse a bounded
+  // number of sockets (not open N), proving the keep-alive pool works.
+  const { createServer } = await import("node:http");
+  const remotePorts = new Set();
+  const server = createServer((req, res) => {
+    remotePorts.add(req.socket.remotePort);
+    res.end("ok");
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const port = server.address().port;
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    for (let i = 0; i < 25; i++) {
+      const res = await _pooledOcRequest(base + "/x");
+      await res.text();
+    }
+    assert.ok(
+      remotePorts.size <= 2,
+      `expected sequential calls to reuse ~1 socket, saw ${remotePorts.size}`,
+    );
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
## BET-65 — pool loopback fetch connections (stop EADDRNOTAVAIL)

Fixes recurring loopback ephemeral-port exhaustion that required a Mac reboot to
clear (~37.5k sockets in TIME_WAIT to `127.0.0.1`, `EADDRNOTAVAIL`, `fetch failed`
on reconcile, `ERR_ADDRESS_INVALID` on unrelated hosts).

**Root cause:** Node's global `fetch` (undici) opens a fresh TCP socket to
`127.0.0.1:<port>` per call and closes it when the body is consumed — each
lands in TIME_WAIT. A `reconcileMessages` sweep across many sessions
burst-created tens of thousands of one-shot sockets and exhausted the loopback
ephemeral-port range. The existing semaphore caps *concurrency* (SSH mux
exhaustion), not socket *churn*.

**Fix:** route the non-streaming loopback fetches through a shared keep-alive
`http.Agent` (via `node:http.request`, adapted to a WHATWG `Response`) so they
reuse a bounded pool instead of burning one socket per call.

### Changes
- **`src/main/opencode.ts`** — `forwardAgent` (`http.Agent`, keepAlive,
  maxSockets=16 aligned with `FORWARD_FETCH_MAX_CONCURRENCY`). `forwardFetch`
  now issues its request via a `pooledRequest` helper through that agent,
  preserving its exact contract (signature, method/headers/body, abort signal,
  90s timeout, semaphore acquire/release, `.ok`/`.status`/`.json()`/`.text()`/`.body`).
  All 24 call sites unchanged.
- **`discardBody(res)`** helper (both files) — drains/cancels a response body on
  non-OK/early-return paths so a pooled socket isn't pinned open. Applied to:
  `fetchSessionDirectory`, `getMessage`, `reconcileMessages`, `getDefaultModel`
  (`/config` + `/provider`), `listModels` (desktop); the same set + the three
  `generateSessionTitle` early returns (mobile). Error-throw paths already
  consume the body via `await res.text()`.
- **`src/server/opencode.mjs`** — `ocAgent` (`http.Agent`, keepAlive,
  maxSockets=16) + an `ocFetch` wrapper on the same `http.request` technique;
  all non-streaming `fetch(apiUrl(...))` calls routed through it.

### Why `node:http`, not undici
Verified on this box: undici's global `fetch` does **not** honor the classic
`agent` option (a passed `keepAlive:false` agent still reused undici's own
default pool), and the Node-bundled undici isn't a resolvable module — importing
it would add an npm dependency + electron-vite external wiring. So the robust
zero-dependency path is `http.request` through our own `http.Agent`. **No new
npm dependency added.**

### Out of scope (left untouched, per issue constraints)
- **SSE stream paths** (`src/main/opencode.ts` `/event` on `EVENT_LOCAL_PORT`,
  mobile `openEventStream`) stay bare `fetch` — a long-lived streaming body
  through a keep-alive pool would pin a slot forever.
- **The concurrency semaphore** (`FORWARD_FETCH_MAX_CONCURRENCY=16`) — unchanged;
  the pool `maxSockets` is kept aligned with it.

### Tests
- Desktop (`src/main/opencode.test.ts`): `_getForwardAgent` is a single
  module-scope instance, keep-alive, `maxSockets`/`maxFreeSockets` == 16;
  `discardBody` cancels an unread body / no-ops on bodyless / swallows an
  already-consumed body.
- Mobile (`src/server/opencode.test.mjs`): same agent-config + `discardBody`
  guards, plus a live-server test that 25 sequential pooled requests reuse
  ≤2 sockets. The existing `withMockFetch` helper now installs its handler as
  the `ocFetch` transport (the pooled path bypasses `globalThis.fetch`) — all
  15 pre-existing scope tests still pass unchanged.

### Verification results
Base: `origin/main` @ `72e42a3`

**Files changed:** 4 — `src/main/opencode.ts`, `src/main/opencode.test.ts`,
`src/server/opencode.mjs`, `src/server/opencode.test.mjs`.

- PR branch (`multica/BET-65-pool-forwardfetch`):
  - typecheck: exit `0`, errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0` — vitest **744 pass** / 0 fail (40 files), server node:test **259 pass** / 0 fail. log sha256: `2cd81aba78316eb1a33c184d2ecac877e82de773fb1814fc6c6db34dabee0cca`
- Base (`main` @ `72e42a3`):
  - typecheck: exit `0`, errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0` — vitest **739 pass**, server **253 pass**. log sha256: `0c696373923d2d2d6f9994d48f8ee67033b2eaf9f49dba6a13bd3132610ed436`
- **Conclusion:** 0 new failures. The +5 vitest / +6 server tests are the new
  BET-65 tests added by this PR; all pass. No pre-existing failures on either branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.

### Electron boot smoke (main-process change)
Built (`npm run build` OK) + launched under xvfb: app boots, renderer mounts
(`#root` populated), title "Better UI", **0 render/console errors**. Fresh
no-config install correctly shows the onboarding flow (Connect/Providers/Model/
Project). No crash from the transport change.

### Manual verification for the human (on the Mac, after rebuild)
During a multi-session reconcile sweep:
```
netstat -an -p tcp | grep '127.0.0.1.*TIME_WAIT' | awk '{print $5}' | sed 's/.*\.//' | sort | uniq -c | sort -rn | head
```
Counts to ports 14096/14097/14098/18787 should stay in the hundreds, not climb
into the thousands.
