### PR TITLE
BET-66: M2.1 Relay — tunnel protocol primitives (framing/mux/routing + tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "mobile": "node src/server/index.mjs",
     "pair": "node scripts/bui-pair.mjs",
     "pack": "node scripts/release/pack.mjs",
-    "test": "vitest run && node --test src/server/*.test.mjs scripts/*.test.mjs",
-    "test:server": "node --test src/server/*.test.mjs",
+    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs scripts/*.test.mjs",
+    "test:server": "node --test src/server/*.test.mjs src/relay/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts"
   },

--- a/src/relay/protocol.mjs
+++ b/src/relay/protocol.mjs
@@ -1,0 +1,630 @@
+// protocol.mjs — pure framing / correlation / mux / routing primitives for the
+// box↔relay tunnel (M2, BET-36). This is the "pure-before-wired" foundation
+// slice: everything here is transport-injectable and fully testable with a fake
+// in-memory socket. There is NO real `ws` import, NO SQLite, NO HTTP, NO timers
+// beyond an injectable clock — those belong to later slices (Stages 2–5).
+//
+// ARCHITECTURE (why this shape):
+//   The relay maps `boxId → live WebSocket` and multiplexes many concurrent
+//   phone→box requests (and box→phone stream data) over that one socket. To do
+//   that over a single duplex channel we need four independent, composable
+//   pieces, each of which is a pure function of its inputs + an injected
+//   transport/clock:
+//
+//     1. Framing        — a versioned envelope with encode/decode + validation.
+//     2. Correlation    — PendingRequests: id → Promise, resolve on response,
+//                          reject on timeout / error frame / transport close.
+//     3. Stream mux      — StreamRegistry: route stream-data frames to the right
+//                          consumer, enforce per-stream ordering, clean up on
+//                          end / abort / close, drop late data after end.
+//     4. Routing         — RoutingTable: boxId → transport handle, single live
+//                          socket per box (re-register evicts + closes stale).
+//
+//   The transport contract is deliberately tiny (send / onMessage / onClose /
+//   close) so a fake in-memory socket satisfies it in tests and a real `ws`
+//   socket satisfies it in the wired slice — neither this file nor its tests
+//   ever import `ws`.
+//
+// WIRE FORMAT: frames are UTF-8 JSON strings (WS *text* frames). Rationale:
+//   the payloads we carry (HTTP request/response metadata, SSE lines, control
+//   messages) are already text/JSON-friendly, JSON keeps the envelope
+//   debuggable, and stream-data byte payloads that need to be binary are
+//   base64-encoded in the `data` field (documented on FRAME_TYPES.STREAM_DATA).
+//   A single, uniform text encoding avoids a mixed text/binary demux on the hot
+//   path. `encodeFrame` returns a string; `decodeFrame` accepts a string or a
+//   Buffer/Uint8Array (which it treats as UTF-8) so a transport that hands us
+//   binary WS frames still decodes.
+
+import { isValidToken } from "../server/webhooks.mjs";
+
+// ---------------------------------------------------------------------------
+// Protocol constants
+// ---------------------------------------------------------------------------
+
+// Bump when the envelope shape changes incompatibly. decodeFrame rejects any
+// frame whose `v` !== PROTOCOL_VERSION (unknown-version guard).
+export const PROTOCOL_VERSION = 1;
+
+// Hard cap on a single encoded frame, in bytes (UTF-8). Guards the decoder
+// against a hostile/oversized payload before we JSON.parse it. 1 MiB is
+// comfortably above any control frame or SSE chunk we mux; larger bodies are
+// the job of chunked stream-data, not a single frame.
+export const MAX_FRAME_BYTES = 1024 * 1024;
+
+// The frame taxonomy. Every frame has { v, type, id } at minimum; per-type
+// required/optional fields are documented here and enforced by decodeFrame.
+export const FRAME_TYPES = Object.freeze({
+  // Request/response correlation (phone→box RPC-ish call).
+  //   REQUEST:  { id, method, path, headers?, body?, boxId? }
+  //   RESPONSE: { id, status, headers?, body? }   (id echoes the REQUEST id)
+  REQUEST: "request",
+  RESPONSE: "response",
+
+  // Stream multiplexing (SSE / PTY). All carry a `stream` id.
+  //   STREAM_OPEN: { id, stream, method?, path?, headers? }
+  //   STREAM_DATA: { id, stream, data }  — `data` is a string; binary payloads
+  //                                        are base64 by convention (caller's
+  //                                        responsibility, opaque to framing).
+  //   STREAM_END:  { id, stream }
+  //   STREAM_ABORT:{ id, stream, reason? }
+  STREAM_OPEN: "stream-open",
+  STREAM_DATA: "stream-data",
+  STREAM_END: "stream-end",
+  STREAM_ABORT: "stream-abort",
+
+  // Out-of-band error. When it carries the `id` of an in-flight REQUEST it
+  // rejects that pending request; a bare error (no matching id) is a
+  // transport-level signal the caller may log.
+  //   ERROR: { id?, code?, message? }
+  ERROR: "error",
+
+  // Liveness. PING/PONG carry no payload beyond the envelope; `id` correlates
+  // a PONG to its PING if the caller wants RTT.
+  PING: "ping",
+  PONG: "pong",
+});
+
+const KNOWN_TYPES = new Set(Object.values(FRAME_TYPES));
+
+// ---------------------------------------------------------------------------
+// Framing — encode / decode with validation
+// ---------------------------------------------------------------------------
+
+// Encode a frame object to a UTF-8 JSON string. Injects { v } if absent, so
+// callers only specify { type, id, ... }. Throws on a structurally invalid
+// frame (unknown type, missing id where required, oversize) — the caller is
+// producing the frame, so a throw is the right "programmer error" signal.
+export function encodeFrame(obj) {
+  if (obj == null || typeof obj !== "object") {
+    throw new Error("encodeFrame: frame must be an object");
+  }
+  const frame = { v: PROTOCOL_VERSION, ...obj };
+  validateFrameShape(frame, { context: "encodeFrame" });
+  const raw = JSON.stringify(frame);
+  const bytes = Buffer.byteLength(raw, "utf8");
+  if (bytes > MAX_FRAME_BYTES) {
+    throw new Error(
+      `encodeFrame: frame too large (${bytes} > ${MAX_FRAME_BYTES} bytes)`,
+    );
+  }
+  return raw;
+}
+
+// Decode a raw WS frame (string, Buffer, or Uint8Array) into a validated frame
+// object. Unlike encodeFrame, decode operates on UNTRUSTED input from the wire,
+// so it NEVER throws for bad data — it returns null (malformed / oversized /
+// unknown version / unknown type / failing per-type validation). A null return
+// means "drop this frame"; a non-null return is a fully validated frame.
+export function decodeFrame(raw) {
+  let text;
+  if (typeof raw === "string") {
+    text = raw;
+    // Oversize guard on the string form (byte length, matches encode).
+    if (Buffer.byteLength(text, "utf8") > MAX_FRAME_BYTES) return null;
+  } else if (Buffer.isBuffer(raw) || raw instanceof Uint8Array) {
+    if (raw.length > MAX_FRAME_BYTES) return null;
+    text = Buffer.from(raw).toString("utf8");
+  } else {
+    return null;
+  }
+
+  let frame;
+  try {
+    frame = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (frame == null || typeof frame !== "object" || Array.isArray(frame)) {
+    return null;
+  }
+  // Unknown-version guard: only the current protocol version is accepted.
+  if (frame.v !== PROTOCOL_VERSION) return null;
+
+  try {
+    validateFrameShape(frame, { context: "decodeFrame" });
+  } catch {
+    return null;
+  }
+  return frame;
+}
+
+// Shared structural validator. Throws on failure; encodeFrame lets it bubble
+// (programmer error), decodeFrame catches it (drop malformed wire input).
+function validateFrameShape(frame, { context }) {
+  const { v, type, id } = frame;
+  if (v !== PROTOCOL_VERSION) {
+    throw new Error(`${context}: bad version ${v}`);
+  }
+  if (typeof type !== "string" || !KNOWN_TYPES.has(type)) {
+    throw new Error(`${context}: unknown frame type ${JSON.stringify(type)}`);
+  }
+  // `id` correlates request/response and stream-owning frames. It must be a
+  // finite non-negative integer whenever present. It is REQUIRED for every
+  // type except PING/PONG (a bare PING needs no id — an id makes it RTT-able).
+  const idRequired = type !== FRAME_TYPES.PING && type !== FRAME_TYPES.PONG;
+  if (id !== undefined) {
+    if (!Number.isInteger(id) || id < 0) {
+      throw new Error(`${context}: bad id ${JSON.stringify(id)}`);
+    }
+  } else if (idRequired) {
+    throw new Error(`${context}: missing id for type ${type}`);
+  }
+
+  // boxId, when present, must be the 32-hex box identifier shape. Reuse the
+  // canonical validator from webhooks.mjs rather than re-implementing the regex.
+  if (frame.boxId !== undefined && !isValidToken(frame.boxId)) {
+    throw new Error(`${context}: bad boxId`);
+  }
+
+  switch (type) {
+    case FRAME_TYPES.REQUEST:
+      if (typeof frame.method !== "string" || !frame.method) {
+        throw new Error(`${context}: request missing method`);
+      }
+      if (typeof frame.path !== "string" || !frame.path) {
+        throw new Error(`${context}: request missing path`);
+      }
+      break;
+    case FRAME_TYPES.RESPONSE:
+      if (!Number.isInteger(frame.status)) {
+        throw new Error(`${context}: response missing integer status`);
+      }
+      break;
+    case FRAME_TYPES.STREAM_OPEN:
+    case FRAME_TYPES.STREAM_END:
+    case FRAME_TYPES.STREAM_ABORT:
+      requireStreamId(frame, context);
+      break;
+    case FRAME_TYPES.STREAM_DATA:
+      requireStreamId(frame, context);
+      if (typeof frame.data !== "string") {
+        throw new Error(`${context}: stream-data missing string data`);
+      }
+      break;
+    case FRAME_TYPES.ERROR:
+    case FRAME_TYPES.PING:
+    case FRAME_TYPES.PONG:
+      // No extra required fields.
+      break;
+    default:
+      // Unreachable: KNOWN_TYPES gate above already rejected unknown types.
+      throw new Error(`${context}: unhandled type ${type}`);
+  }
+}
+
+function requireStreamId(frame, context) {
+  const s = frame.stream;
+  const ok =
+    (typeof s === "string" && s.length > 0) ||
+    (Number.isInteger(s) && s >= 0);
+  if (!ok) {
+    throw new Error(`${context}: ${frame.type} missing valid stream id`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PendingRequests — request/response correlation
+// ---------------------------------------------------------------------------
+
+// Assigns a monotonic id to each outbound request, returns a Promise that
+// resolves with the matching response frame, and rejects on timeout, on an
+// error frame carrying the same id, or when the transport closes (rejectAll).
+//
+// The clock is injectable (`now` + `setTimer`/`clearTimer`) so tests drive
+// timeouts deterministically with a fake clock and leave no real timers open.
+export class PendingRequests {
+  // opts:
+  //   now       — () => ms  (default Date.now)
+  //   setTimer  — (fn, ms) => handle   (default setTimeout)
+  //   clearTimer— (handle) => void     (default clearTimeout)
+  constructor({ now = () => Date.now(), setTimer, clearTimer } = {}) {
+    this._now = now;
+    this._setTimer = setTimer || ((fn, ms) => setTimeout(fn, ms));
+    this._clearTimer = clearTimer || ((h) => clearTimeout(h));
+    this._nextId = 1;
+    this._pending = new Map(); // id -> { resolve, reject, timer }
+  }
+
+  // Reserve the next monotonic id without creating a promise. Rarely needed
+  // directly — `create` is the usual entry — but exposed for callers that want
+  // to stamp the id into a frame they build themselves.
+  nextId() {
+    return this._nextId++;
+  }
+
+  // Create a pending entry. Returns { id, promise }. `timeoutMs` (optional)
+  // arms a rejection via the injected timer; omit/<=0 for no timeout.
+  create({ timeoutMs } = {}) {
+    const id = this.nextId();
+    let resolve, reject;
+    const promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    const entry = { resolve, reject, timer: null };
+    if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+      entry.timer = this._setTimer(() => {
+        // Timed out: remove + reject. Guard against a race where the response
+        // already settled and deleted the entry.
+        if (this._pending.get(id) === entry) {
+          this._pending.delete(id);
+          reject(new Error(`request ${id} timed out after ${timeoutMs}ms`));
+        }
+      }, timeoutMs);
+    }
+    this._pending.set(id, entry);
+    return { id, promise };
+  }
+
+  // True if `id` is still awaiting settlement.
+  has(id) {
+    return this._pending.has(id);
+  }
+
+  get size() {
+    return this._pending.size;
+  }
+
+  // Resolve the pending request whose id matches this response frame. Returns
+  // true if a match was found + settled, false otherwise (unknown/late id).
+  resolve(responseFrame) {
+    const id = responseFrame?.id;
+    const entry = this._pending.get(id);
+    if (!entry) return false;
+    this._pending.delete(id);
+    if (entry.timer != null) this._clearTimer(entry.timer);
+    entry.resolve(responseFrame);
+    return true;
+  }
+
+  // Reject the pending request whose id matches this error frame. Returns true
+  // if a match was found + settled. A bare error frame (no matching id) → false
+  // so the caller can treat it as a transport-level signal.
+  rejectFromError(errorFrame) {
+    const id = errorFrame?.id;
+    const entry = this._pending.get(id);
+    if (!entry) return false;
+    this._pending.delete(id);
+    if (entry.timer != null) this._clearTimer(entry.timer);
+    const msg =
+      errorFrame?.message || `request ${id} failed (code ${errorFrame?.code})`;
+    const err = new Error(msg);
+    err.code = errorFrame?.code;
+    entry.reject(err);
+    return true;
+  }
+
+  // Reject a single pending request by id (e.g. an explicit abort).
+  reject(id, err) {
+    const entry = this._pending.get(id);
+    if (!entry) return false;
+    this._pending.delete(id);
+    if (entry.timer != null) this._clearTimer(entry.timer);
+    entry.reject(err instanceof Error ? err : new Error(String(err)));
+    return true;
+  }
+
+  // Reject EVERY in-flight request. Called when the transport closes so no
+  // caller hangs forever. Clears all timers so nothing leaks.
+  rejectAll(err) {
+    const e = err instanceof Error ? err : new Error(String(err ?? "closed"));
+    for (const [, entry] of this._pending) {
+      if (entry.timer != null) this._clearTimer(entry.timer);
+      entry.reject(e);
+    }
+    this._pending.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StreamRegistry — multiplex concurrent streams over one socket
+// ---------------------------------------------------------------------------
+
+// Routes inbound stream frames (open/data/end/abort) to the right per-stream
+// consumer and enforces per-stream lifecycle: data before open is dropped, data
+// after end/abort is dropped (never misrouted to a reused id), and end/abort
+// clean up so a later stream can reuse the id cleanly.
+//
+// A consumer is an object with optional callbacks:
+//   { onData(payload, frame), onEnd(frame), onAbort(reason, frame) }
+// Registering a consumer for a stream id is how the owner subscribes.
+export class StreamRegistry {
+  constructor() {
+    // stream id -> { consumer, open: bool, closed: bool }
+    this._streams = new Map();
+  }
+
+  get size() {
+    return this._streams.size;
+  }
+
+  has(streamId) {
+    return this._streams.has(streamId);
+  }
+
+  // Register (open) a stream with its consumer. Idempotent per id only while
+  // the id is free; re-opening a live id throws (a mux bug — two owners for one
+  // id would misroute). After end/abort the id is free and may be re-opened.
+  open(streamId, consumer = {}) {
+    if (this._streams.has(streamId)) {
+      throw new Error(`StreamRegistry: stream ${streamId} already open`);
+    }
+    this._streams.set(streamId, { consumer, open: true, closed: false });
+  }
+
+  // Route a decoded stream-* frame. Returns true if delivered, false if dropped
+  // (unknown id, or data after close). This is the single inbound entry point
+  // the demux loop calls for every stream frame.
+  handleFrame(frame) {
+    if (frame == null) return false;
+    switch (frame.type) {
+      case FRAME_TYPES.STREAM_OPEN:
+        // Open frames are informational to an already-subscribed registry: the
+        // consumer is registered locally via open(); a peer's STREAM_OPEN just
+        // confirms the id. If we have no consumer yet, drop (nothing to route
+        // to — the owner subscribes before it expects data).
+        return this._streams.has(frame.stream);
+      case FRAME_TYPES.STREAM_DATA:
+        return this._deliverData(frame);
+      case FRAME_TYPES.STREAM_END:
+        return this._deliverEnd(frame);
+      case FRAME_TYPES.STREAM_ABORT:
+        return this._deliverAbort(frame);
+      default:
+        return false;
+    }
+  }
+
+  _deliverData(frame) {
+    const st = this._streams.get(frame.stream);
+    // Drop data for unknown or already-closed streams — this is the "late data
+    // after end is dropped, not misrouted" invariant.
+    if (!st || st.closed || !st.open) return false;
+    try {
+      st.consumer.onData?.(frame.data, frame);
+    } catch {
+      // A consumer callback throwing must not corrupt the registry.
+    }
+    return true;
+  }
+
+  _deliverEnd(frame) {
+    const st = this._streams.get(frame.stream);
+    if (!st || st.closed) return false;
+    st.closed = true;
+    st.open = false;
+    this._streams.delete(frame.stream);
+    try {
+      st.consumer.onEnd?.(frame);
+    } catch {
+      /* isolate consumer errors */
+    }
+    return true;
+  }
+
+  _deliverAbort(frame) {
+    const st = this._streams.get(frame.stream);
+    if (!st || st.closed) return false;
+    st.closed = true;
+    st.open = false;
+    this._streams.delete(frame.stream);
+    try {
+      st.consumer.onAbort?.(frame.reason, frame);
+    } catch {
+      /* isolate consumer errors */
+    }
+    return true;
+  }
+
+  // Locally abort a stream (e.g. the owning request was cancelled). Fires the
+  // consumer's onAbort and frees the id. Returns true if it was live.
+  abort(streamId, reason) {
+    const st = this._streams.get(streamId);
+    if (!st || st.closed) return false;
+    st.closed = true;
+    st.open = false;
+    this._streams.delete(streamId);
+    try {
+      st.consumer.onAbort?.(reason, { type: FRAME_TYPES.STREAM_ABORT, stream: streamId, reason });
+    } catch {
+      /* isolate consumer errors */
+    }
+    return true;
+  }
+
+  // Tear down every live stream (transport close). Each consumer's onAbort is
+  // fired with the given reason so no stream hangs half-open.
+  abortAll(reason = "transport closed") {
+    const entries = [...this._streams.entries()];
+    this._streams.clear();
+    for (const [streamId, st] of entries) {
+      if (st.closed) continue;
+      try {
+        st.consumer.onAbort?.(reason, {
+          type: FRAME_TYPES.STREAM_ABORT,
+          stream: streamId,
+          reason,
+        });
+      } catch {
+        /* isolate consumer errors */
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RoutingTable — boxId → transport handle
+// ---------------------------------------------------------------------------
+
+// Maps each boxId to its single live transport handle. Enforces the
+// single-live-socket-per-box invariant: registering a boxId that already has a
+// live socket EVICTS the stale one — it is removed from the table and its
+// `close()` is called — before the new one is stored. Rationale: a box only
+// ever holds one outbound tunnel; a second register almost always means the box
+// reconnected (its old socket is dead-but-not-yet-reaped), so the freshest
+// socket wins and the stale one is closed to free resources deterministically.
+export class RoutingTable {
+  // opts.onEvict(boxId, staleHandle) — optional hook fired when a live socket
+  // is evicted by a re-register (for logging/metrics). Never throws upward.
+  constructor({ onEvict } = {}) {
+    this._byBox = new Map(); // boxId -> handle
+    this._onEvict = typeof onEvict === "function" ? onEvict : null;
+  }
+
+  get size() {
+    return this._byBox.size;
+  }
+
+  // Register a transport handle for a boxId. Rejects an invalid boxId shape
+  // (defense in depth — the caller authenticated it, but the table is the last
+  // guard before routing). Evicts+closes any existing live handle for the box.
+  // Returns the evicted handle (or null) so the caller can react.
+  register(boxId, handle) {
+    if (!isValidToken(boxId)) {
+      throw new Error("RoutingTable.register: invalid boxId");
+    }
+    if (handle == null || typeof handle.send !== "function") {
+      throw new Error("RoutingTable.register: handle must have send()");
+    }
+    let evicted = null;
+    const existing = this._byBox.get(boxId);
+    if (existing && existing !== handle) {
+      this._byBox.delete(boxId);
+      evicted = existing;
+      if (this._onEvict) {
+        try {
+          this._onEvict(boxId, existing);
+        } catch {
+          /* metrics hook must not break registration */
+        }
+      }
+      try {
+        existing.close?.();
+      } catch {
+        /* stale socket may already be dead */
+      }
+    }
+    this._byBox.set(boxId, handle);
+    return evicted;
+  }
+
+  // Look up the live handle for a boxId, or null.
+  lookup(boxId) {
+    return this._byBox.get(boxId) ?? null;
+  }
+
+  // True if the box has a live registered handle.
+  has(boxId) {
+    return this._byBox.has(boxId);
+  }
+
+  // Remove a boxId's handle. If `handle` is given, only unregister when it is
+  // the currently-registered one (avoids a late close() of a stale socket
+  // clobbering a fresh reconnect that already re-registered). Returns true if
+  // something was removed.
+  unregister(boxId, handle) {
+    const existing = this._byBox.get(boxId);
+    if (existing === undefined) return false;
+    if (handle !== undefined && existing !== handle) return false;
+    this._byBox.delete(boxId);
+    return true;
+  }
+
+  // List all registered boxIds.
+  list() {
+    return [...this._byBox.keys()];
+  }
+
+  // Send a frame to a box by id via its live handle. Returns true if a live
+  // handle existed and send() was invoked, false if the box is not connected.
+  send(boxId, frame) {
+    const handle = this._byBox.get(boxId);
+    if (!handle) return false;
+    handle.send(frame);
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transport contract (documentation + a fake for tests)
+// ---------------------------------------------------------------------------
+
+// The minimal duplex transport every piece above is written against. A real
+// `ws` socket is adapted to this in the wired slice; tests use createFakeTransport.
+//
+//   send(raw)         — send an encoded frame (string) to the peer.
+//   onMessage(cb)     — register a callback invoked with each raw inbound frame.
+//   onClose(cb)       — register a callback invoked once when the transport closes.
+//   close()           — close the transport (idempotent; fires onClose once).
+//
+// createFakeTransport returns a connected PAIR of in-memory transports (a, b):
+// anything a.send()s arrives at b's onMessage callbacks and vice versa, closing
+// either end fires both onClose callbacks exactly once. No real sockets, no
+// timers — deterministic and self-contained for node:test.
+export function createFakeTransport() {
+  const state = { closed: false };
+  const a = makeEndpoint();
+  const b = makeEndpoint();
+  a._peer = b;
+  b._peer = a;
+  a._state = state;
+  b._state = state;
+
+  function makeEndpoint() {
+    const msgCbs = [];
+    const closeCbs = [];
+    const ep = {
+      _peer: null,
+      _state: null,
+      sent: [], // record of everything this endpoint sent (test convenience)
+      send(raw) {
+        if (ep._state.closed) return;
+        ep.sent.push(raw);
+        // Deliver asynchronously? No — synchronous delivery keeps node:test
+        // deterministic without awaiting microtasks. Callers that need async
+        // can wrap. Guard against a callback closing the transport mid-fanout.
+        for (const cb of ep._peer._msgCbs.slice()) {
+          if (ep._state.closed) break;
+          cb(raw);
+        }
+      },
+      onMessage(cb) {
+        msgCbs.push(cb);
+      },
+      onClose(cb) {
+        closeCbs.push(cb);
+      },
+      close() {
+        if (ep._state.closed) return;
+        ep._state.closed = true;
+        for (const cb of a._closeCbs.slice()) cb();
+        for (const cb of b._closeCbs.slice()) cb();
+      },
+      _msgCbs: msgCbs,
+      _closeCbs: closeCbs,
+    };
+    return ep;
+  }
+
+  return { a, b };
+}

--- a/src/relay/protocol.test.mjs
+++ b/src/relay/protocol.test.mjs
@@ -1,0 +1,461 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROTOCOL_VERSION,
+  MAX_FRAME_BYTES,
+  FRAME_TYPES,
+  encodeFrame,
+  decodeFrame,
+  PendingRequests,
+  StreamRegistry,
+  RoutingTable,
+  createFakeTransport,
+} from "./protocol.mjs";
+
+const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
+const BOX_B = "fedcba9876543210fedcba9876543210";
+
+// ---------------------------------------------------------------------------
+// Framing — encode/decode round-trips + validation
+// ---------------------------------------------------------------------------
+
+test("encode/decode round-trips every frame type", () => {
+  const samples = [
+    { type: FRAME_TYPES.REQUEST, id: 1, method: "GET", path: "/x", boxId: BOX_A },
+    { type: FRAME_TYPES.RESPONSE, id: 1, status: 200, body: "ok" },
+    { type: FRAME_TYPES.STREAM_OPEN, id: 2, stream: "s1", path: "/sse" },
+    { type: FRAME_TYPES.STREAM_DATA, id: 2, stream: "s1", data: "chunk" },
+    { type: FRAME_TYPES.STREAM_END, id: 2, stream: "s1" },
+    { type: FRAME_TYPES.STREAM_ABORT, id: 3, stream: "s2", reason: "cancel" },
+    { type: FRAME_TYPES.ERROR, id: 4, code: 500, message: "boom" },
+    { type: FRAME_TYPES.PING },
+    { type: FRAME_TYPES.PONG, id: 7 },
+  ];
+  for (const s of samples) {
+    const raw = encodeFrame(s);
+    assert.equal(typeof raw, "string", `${s.type} encodes to a string`);
+    const back = decodeFrame(raw);
+    assert.notEqual(back, null, `${s.type} decodes`);
+    assert.equal(back.v, PROTOCOL_VERSION);
+    for (const [k, v] of Object.entries(s)) {
+      assert.deepEqual(back[k], v, `${s.type}.${k} round-trips`);
+    }
+  }
+});
+
+test("decodeFrame accepts a Buffer / Uint8Array (binary WS frame)", () => {
+  const raw = encodeFrame({ type: FRAME_TYPES.PING });
+  assert.notEqual(decodeFrame(Buffer.from(raw, "utf8")), null);
+  assert.notEqual(decodeFrame(new TextEncoder().encode(raw)), null);
+});
+
+test("decodeFrame rejects malformed input (returns null, never throws)", () => {
+  for (const bad of [
+    "",
+    "not json",
+    "{",
+    "null",
+    "42",
+    "[]", // array, not object
+    JSON.stringify([1, 2, 3]),
+    JSON.stringify({ v: PROTOCOL_VERSION }), // no type
+    JSON.stringify({ v: PROTOCOL_VERSION, type: "bogus", id: 1 }), // unknown type
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.REQUEST }), // missing id
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.REQUEST, id: 1, method: "GET" }), // no path
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.RESPONSE, id: 1 }), // no status
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s" }), // no data
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.STREAM_DATA, id: 1, data: "x" }), // no stream
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.REQUEST, id: -1, method: "G", path: "/" }), // bad id
+    JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.REQUEST, id: 1, method: "G", path: "/", boxId: "nothex" }), // bad boxId
+    null,
+    undefined,
+    {},
+    12345,
+  ]) {
+    assert.equal(decodeFrame(bad), null, `should reject: ${JSON.stringify(bad)}`);
+  }
+});
+
+test("decodeFrame rejects unknown protocol versions", () => {
+  const future = JSON.stringify({ v: PROTOCOL_VERSION + 1, type: FRAME_TYPES.PING });
+  const past = JSON.stringify({ v: 0, type: FRAME_TYPES.PING });
+  assert.equal(decodeFrame(future), null);
+  assert.equal(decodeFrame(past), null);
+});
+
+test("oversized frames are rejected on encode (throw) and decode (null)", () => {
+  const big = "x".repeat(MAX_FRAME_BYTES + 10);
+  assert.throws(() => encodeFrame({ type: FRAME_TYPES.RESPONSE, id: 1, status: 200, body: big }));
+  // Construct an oversized-but-valid-JSON raw string directly for decode.
+  const rawBig = JSON.stringify({ v: PROTOCOL_VERSION, type: FRAME_TYPES.RESPONSE, id: 1, status: 200, body: big });
+  assert.ok(Buffer.byteLength(rawBig, "utf8") > MAX_FRAME_BYTES);
+  assert.equal(decodeFrame(rawBig), null);
+  assert.equal(decodeFrame(Buffer.from(rawBig, "utf8")), null);
+});
+
+test("encodeFrame throws on structurally invalid frames", () => {
+  assert.throws(() => encodeFrame(null));
+  assert.throws(() => encodeFrame("x"));
+  assert.throws(() => encodeFrame({ type: "nope", id: 1 }));
+  assert.throws(() => encodeFrame({ type: FRAME_TYPES.REQUEST, id: 1 })); // no method/path
+});
+
+// ---------------------------------------------------------------------------
+// PendingRequests — correlation
+// ---------------------------------------------------------------------------
+
+// A tiny controllable fake clock: timers fire only when we call advance().
+function makeFakeClock() {
+  let nowMs = 0;
+  let seq = 1;
+  const timers = new Map(); // handle -> { fn, at }
+  return {
+    now: () => nowMs,
+    setTimer: (fn, ms) => {
+      const h = seq++;
+      timers.set(h, { fn, at: nowMs + ms });
+      return h;
+    },
+    clearTimer: (h) => timers.delete(h),
+    advance: (ms) => {
+      nowMs += ms;
+      for (const [h, t] of [...timers.entries()]) {
+        if (t.at <= nowMs) {
+          timers.delete(h);
+          t.fn();
+        }
+      }
+    },
+    pending: () => timers.size,
+  };
+}
+
+test("PendingRequests resolves on matching response and assigns monotonic ids", async () => {
+  const pr = new PendingRequests();
+  const { id: id1, promise: p1 } = pr.create();
+  const { id: id2, promise: p2 } = pr.create();
+  assert.equal(id2, id1 + 1, "ids are monotonic");
+  assert.equal(pr.size, 2);
+
+  pr.resolve({ type: FRAME_TYPES.RESPONSE, id: id2, status: 200, body: "two" });
+  const r2 = await p2;
+  assert.equal(r2.body, "two");
+  assert.equal(pr.size, 1);
+  assert.equal(pr.has(id1), true);
+
+  pr.resolve({ type: FRAME_TYPES.RESPONSE, id: id1, status: 200, body: "one" });
+  assert.equal((await p1).body, "one");
+  assert.equal(pr.size, 0);
+});
+
+test("PendingRequests.resolve returns false for unknown/late ids", () => {
+  const pr = new PendingRequests();
+  assert.equal(pr.resolve({ id: 999, status: 200 }), false);
+});
+
+test("PendingRequests rejects on timeout via injected fake clock (no real timers)", async () => {
+  const clock = makeFakeClock();
+  const pr = new PendingRequests(clock);
+  const { promise } = pr.create({ timeoutMs: 1000 });
+  assert.equal(clock.pending(), 1);
+
+  clock.advance(999);
+  assert.equal(pr.size, 1, "not yet timed out");
+  clock.advance(1);
+  await assert.rejects(promise, /timed out/);
+  assert.equal(pr.size, 0);
+  assert.equal(clock.pending(), 0, "timer cleaned up");
+});
+
+test("PendingRequests clears the timer when a response arrives first", async () => {
+  const clock = makeFakeClock();
+  const pr = new PendingRequests(clock);
+  const { id, promise } = pr.create({ timeoutMs: 1000 });
+  pr.resolve({ type: FRAME_TYPES.RESPONSE, id, status: 200 });
+  await promise;
+  assert.equal(clock.pending(), 0, "timer was cleared on resolve");
+  clock.advance(5000); // must not reject anything
+});
+
+test("PendingRequests rejects on a matching error frame", async () => {
+  const pr = new PendingRequests();
+  const { id, promise } = pr.create();
+  const matched = pr.rejectFromError({ type: FRAME_TYPES.ERROR, id, code: 502, message: "bad gateway" });
+  assert.equal(matched, true);
+  const err = await promise.then(() => null, (e) => e);
+  assert.equal(err.message, "bad gateway");
+  assert.equal(err.code, 502);
+  // Bare error (no matching id) is not consumed.
+  assert.equal(pr.rejectFromError({ type: FRAME_TYPES.ERROR, code: 1 }), false);
+});
+
+test("PendingRequests.rejectAll rejects every in-flight request on transport close", async () => {
+  const clock = makeFakeClock();
+  const pr = new PendingRequests(clock);
+  const { promise: p1 } = pr.create({ timeoutMs: 1000 });
+  const { promise: p2 } = pr.create({ timeoutMs: 1000 });
+  pr.rejectAll(new Error("transport closed"));
+  await assert.rejects(p1, /transport closed/);
+  await assert.rejects(p2, /transport closed/);
+  assert.equal(pr.size, 0);
+  assert.equal(clock.pending(), 0, "all timers cleared — nothing left open");
+});
+
+// ---------------------------------------------------------------------------
+// StreamRegistry — mux
+// ---------------------------------------------------------------------------
+
+function collectingConsumer() {
+  const data = [];
+  let ended = false;
+  let aborted = null;
+  return {
+    data,
+    get ended() { return ended; },
+    get aborted() { return aborted; },
+    onData: (payload) => data.push(payload),
+    onEnd: () => { ended = true; },
+    onAbort: (reason) => { aborted = reason ?? "aborted"; },
+  };
+}
+
+test("StreamRegistry keeps two concurrent streams isolated + routes to correct consumer", () => {
+  const reg = new StreamRegistry();
+  const c1 = collectingConsumer();
+  const c2 = collectingConsumer();
+  reg.open("s1", c1);
+  reg.open("s2", c2);
+  assert.equal(reg.size, 2);
+
+  reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s1", data: "a1" });
+  reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 2, stream: "s2", data: "b1" });
+  reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s1", data: "a2" });
+
+  assert.deepEqual(c1.data, ["a1", "a2"]);
+  assert.deepEqual(c2.data, ["b1"]);
+});
+
+test("StreamRegistry: end cleans up and frees the id for reuse", () => {
+  const reg = new StreamRegistry();
+  const c1 = collectingConsumer();
+  reg.open("s1", c1);
+  reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s1", data: "x" });
+  assert.equal(reg.handleFrame({ type: FRAME_TYPES.STREAM_END, id: 1, stream: "s1" }), true);
+  assert.equal(c1.ended, true);
+  assert.equal(reg.has("s1"), false, "id freed after end");
+
+  // Reuse the same id with a fresh consumer — must not receive old consumer's data.
+  const c1b = collectingConsumer();
+  reg.open("s1", c1b);
+  reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 9, stream: "s1", data: "fresh" });
+  assert.deepEqual(c1b.data, ["fresh"]);
+  assert.deepEqual(c1.data, ["x"], "old consumer unaffected");
+});
+
+test("StreamRegistry: late data after end is dropped, not misrouted", () => {
+  const reg = new StreamRegistry();
+  const c1 = collectingConsumer();
+  reg.open("s1", c1);
+  reg.handleFrame({ type: FRAME_TYPES.STREAM_END, id: 1, stream: "s1" });
+  const delivered = reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s1", data: "late" });
+  assert.equal(delivered, false, "late data dropped");
+  assert.deepEqual(c1.data, []);
+});
+
+test("StreamRegistry: abort cleans up and fires onAbort", () => {
+  const reg = new StreamRegistry();
+  const c1 = collectingConsumer();
+  reg.open("s1", c1);
+  assert.equal(reg.handleFrame({ type: FRAME_TYPES.STREAM_ABORT, id: 1, stream: "s1", reason: "peer" }), true);
+  assert.equal(c1.aborted, "peer");
+  assert.equal(reg.has("s1"), false);
+  // Data after abort is dropped.
+  assert.equal(reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s1", data: "z" }), false);
+  assert.deepEqual(c1.data, []);
+});
+
+test("StreamRegistry: data for an unknown stream is dropped", () => {
+  const reg = new StreamRegistry();
+  assert.equal(reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "ghost", data: "x" }), false);
+});
+
+test("StreamRegistry: local abort + abortAll tear down live streams", () => {
+  const reg = new StreamRegistry();
+  const c1 = collectingConsumer();
+  const c2 = collectingConsumer();
+  reg.open("s1", c1);
+  reg.open("s2", c2);
+  assert.equal(reg.abort("s1", "cancelled"), true);
+  assert.equal(c1.aborted, "cancelled");
+  reg.abortAll("transport closed");
+  assert.equal(c2.aborted, "transport closed");
+  assert.equal(reg.size, 0);
+});
+
+test("StreamRegistry: opening a live id twice throws (mux bug guard)", () => {
+  const reg = new StreamRegistry();
+  reg.open("s1", collectingConsumer());
+  assert.throws(() => reg.open("s1", collectingConsumer()), /already open/);
+});
+
+test("StreamRegistry isolates a throwing consumer callback", () => {
+  const reg = new StreamRegistry();
+  reg.open("s1", { onData: () => { throw new Error("consumer boom"); } });
+  // Must not throw out of handleFrame.
+  assert.equal(reg.handleFrame({ type: FRAME_TYPES.STREAM_DATA, id: 1, stream: "s1", data: "x" }), true);
+});
+
+// ---------------------------------------------------------------------------
+// RoutingTable — boxId → handle
+// ---------------------------------------------------------------------------
+
+function fakeHandle() {
+  const h = {
+    closed: false,
+    sent: [],
+    send: (f) => h.sent.push(f),
+    close: () => { h.closed = true; },
+  };
+  return h;
+}
+
+test("RoutingTable register/lookup/list/unregister", () => {
+  const rt = new RoutingTable();
+  const ha = fakeHandle();
+  const hb = fakeHandle();
+  assert.equal(rt.register(BOX_A, ha), null, "no eviction on first register");
+  rt.register(BOX_B, hb);
+  assert.equal(rt.size, 2);
+  assert.equal(rt.lookup(BOX_A), ha);
+  assert.equal(rt.has(BOX_B), true);
+  assert.deepEqual(rt.list().sort(), [BOX_A, BOX_B].sort());
+
+  assert.equal(rt.unregister(BOX_A), true);
+  assert.equal(rt.lookup(BOX_A), null);
+  assert.equal(rt.unregister(BOX_A), false, "second unregister is a no-op");
+  assert.equal(rt.size, 1);
+});
+
+test("RoutingTable: re-registering a live boxId evicts + closes the stale socket", () => {
+  const evicts = [];
+  const rt = new RoutingTable({ onEvict: (id, h) => evicts.push([id, h]) });
+  const stale = fakeHandle();
+  const fresh = fakeHandle();
+  rt.register(BOX_A, stale);
+  const evicted = rt.register(BOX_A, fresh);
+
+  assert.equal(evicted, stale, "returns the evicted handle");
+  assert.equal(stale.closed, true, "stale socket closed");
+  assert.equal(fresh.closed, false, "fresh socket stays open");
+  assert.equal(rt.lookup(BOX_A), fresh, "fresh socket is now live");
+  assert.equal(rt.size, 1, "single live socket per box");
+  assert.deepEqual(evicts, [[BOX_A, stale]], "onEvict fired once");
+});
+
+test("RoutingTable.register rejects an invalid boxId or handle", () => {
+  const rt = new RoutingTable();
+  assert.throws(() => rt.register("nothex", fakeHandle()), /invalid boxId/);
+  assert.throws(() => rt.register(BOX_A, {}), /send\(\)/);
+});
+
+test("RoutingTable.unregister(handle) only removes the matching handle", () => {
+  const rt = new RoutingTable();
+  const stale = fakeHandle();
+  const fresh = fakeHandle();
+  rt.register(BOX_A, stale);
+  rt.register(BOX_A, fresh); // evicts stale, fresh is live
+  // A late unregister carrying the stale handle must NOT remove fresh.
+  assert.equal(rt.unregister(BOX_A, stale), false);
+  assert.equal(rt.lookup(BOX_A), fresh);
+  assert.equal(rt.unregister(BOX_A, fresh), true);
+  assert.equal(rt.has(BOX_A), false);
+});
+
+test("RoutingTable.send routes to a live handle and reports connectivity", () => {
+  const rt = new RoutingTable();
+  const ha = fakeHandle();
+  rt.register(BOX_A, ha);
+  assert.equal(rt.send(BOX_A, "frame1"), true);
+  assert.deepEqual(ha.sent, ["frame1"]);
+  assert.equal(rt.send(BOX_B, "frame2"), false, "unknown box → false");
+});
+
+// ---------------------------------------------------------------------------
+// Fake transport + end-to-end integration through the pieces
+// ---------------------------------------------------------------------------
+
+test("createFakeTransport delivers frames both directions and closes once", () => {
+  const { a, b } = createFakeTransport();
+  const gotA = [];
+  const gotB = [];
+  let aClosed = 0;
+  let bClosed = 0;
+  a.onMessage((m) => gotA.push(m));
+  b.onMessage((m) => gotB.push(m));
+  a.onClose(() => aClosed++);
+  b.onClose(() => bClosed++);
+
+  a.send("to-b");
+  b.send("to-a");
+  assert.deepEqual(gotB, ["to-b"]);
+  assert.deepEqual(gotA, ["to-a"]);
+
+  a.close();
+  a.close(); // idempotent
+  b.close();
+  assert.equal(aClosed, 1);
+  assert.equal(bClosed, 1);
+  // Sends after close are dropped.
+  a.send("dropped");
+  assert.deepEqual(gotB, ["to-b"]);
+});
+
+test("end-to-end: request/response + a muxed stream over one fake transport", async () => {
+  const { a, b } = createFakeTransport();
+
+  // Side A: caller. Owns PendingRequests + StreamRegistry, wires demux.
+  const pr = new PendingRequests();
+  const reg = new StreamRegistry();
+  a.onMessage((raw) => {
+    const f = decodeFrame(raw);
+    if (!f) return;
+    if (f.type === FRAME_TYPES.RESPONSE) pr.resolve(f);
+    else if (f.type === FRAME_TYPES.ERROR) pr.rejectFromError(f);
+    else if (f.type.startsWith("stream-")) reg.handleFrame(f);
+  });
+  a.onClose(() => { pr.rejectAll(new Error("closed")); reg.abortAll("closed"); });
+
+  // Side B: responder. Echoes a response and pushes a 2-chunk stream.
+  b.onMessage((raw) => {
+    const f = decodeFrame(raw);
+    if (!f) return;
+    if (f.type === FRAME_TYPES.REQUEST) {
+      b.send(encodeFrame({ type: FRAME_TYPES.RESPONSE, id: f.id, status: 200, body: `re:${f.path}` }));
+    }
+    if (f.type === FRAME_TYPES.STREAM_OPEN) {
+      b.send(encodeFrame({ type: FRAME_TYPES.STREAM_DATA, id: f.id, stream: f.stream, data: "c1" }));
+      b.send(encodeFrame({ type: FRAME_TYPES.STREAM_DATA, id: f.id, stream: f.stream, data: "c2" }));
+      b.send(encodeFrame({ type: FRAME_TYPES.STREAM_END, id: f.id, stream: f.stream }));
+    }
+  });
+
+  // Fire a request.
+  const { id, promise } = pr.create({ timeoutMs: 1000 });
+  a.send(encodeFrame({ type: FRAME_TYPES.REQUEST, id, method: "GET", path: "/hello", boxId: BOX_A }));
+  const resp = await promise;
+  assert.equal(resp.status, 200);
+  assert.equal(resp.body, "re:/hello");
+
+  // Open a stream and collect chunks.
+  const c = collectingConsumer();
+  reg.open("sX", c);
+  a.send(encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: pr.nextId(), stream: "sX", path: "/sse" }));
+  assert.deepEqual(c.data, ["c1", "c2"]);
+  assert.equal(c.ended, true);
+  assert.equal(reg.has("sX"), false, "stream cleaned up after end");
+
+  // Closing the transport rejects any straggler + tears down streams.
+  const { promise: hanging } = pr.create({ timeoutMs: 1000 });
+  a.close();
+  await assert.rejects(hanging, /closed/);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,12 +2,14 @@ import { defineConfig, configDefaults } from "vitest/config";
 
 export default defineConfig({
   test: {
-    // src/server/** and scripts/** use node:test (run via `node --test`), not
-    // vitest. .claude/** holds Claude Code worktrees — nested copies of this
-    // repo (incl. their own *.test.mjs) that vitest must not collect.
+    // src/server/**, src/relay/** and scripts/** use node:test (run via
+    // `node --test`), not vitest. .claude/** holds Claude Code worktrees —
+    // nested copies of this repo (incl. their own *.test.mjs) that vitest must
+    // not collect.
     exclude: [
       ...configDefaults.exclude,
       "src/server/**",
+      "src/relay/**",
       "scripts/**",
       ".claude/**",
     ],


### PR DESCRIPTION
## BET-66 / M2.1 — Relay tunnel protocol primitives

Parent: BET-36 (M2: Relay MVP). **Stage 1 of 6 — pure framing / correlation / mux / routing.**

Pure, transport-injectable foundation slice for the box↔relay tunnel. **Additive-only under `src/relay/`** — zero edits to `src/server/**` (the two other touched files are test-runner globs, below).

**Base:** `origin/main @ 399ddb7`

### What's here — `src/relay/protocol.mjs`

- **Framing** — versioned envelope (`{ v, type, id, ... }`). Wire format = UTF-8 JSON WS *text* frames (documented; binary stream payloads go base64 in `data`). `encodeFrame` throws on programmer error; `decodeFrame` operates on untrusted wire input and **returns `null`** (never throws) for malformed / oversized (>1 MiB) / unknown-version / unknown-type / failing-per-type frames. Frame types: request, response, stream-open/data/end/abort, error, ping/pong.
- **`PendingRequests`** — monotonic `id` → Promise correlation. Resolves on matching response; rejects on error frame, on **injectable-clock** timeout, and rejects ALL in-flight on transport close (`rejectAll`). No real timers in tests.
- **`StreamRegistry`** — multiplexes concurrent streams over one socket. Per-stream lifecycle + ordering; late data after end/abort is **dropped, not misrouted**; id freed + reusable after end/abort; consumer-callback errors isolated.
- **`RoutingTable`** — `boxId → transport handle`, **single-live-socket-per-box** invariant: re-registering a live box evicts + `close()`s the stale socket (documented policy). Reuses `isValidToken` from `src/server/webhooks.mjs` (no duplicated crypto/regex).
- **`createFakeTransport`** — in-memory duplex pair so everything above is testable with **no real `ws`, no sockets, no timers**.

### Tests — `src/relay/protocol.test.mjs` (node:test), 27 tests
Round-trips every frame type; decode rejects malformed/oversized/unknown-version; PendingRequests resolve/timeout(fake clock)/error/close; StreamRegistry isolation/end/abort/late-drop/reuse; RoutingTable register/lookup/list/unregister/evict; plus an end-to-end request+muxed-stream over the fake transport.

### Test-runner wiring (why 2 config files changed)
`src/relay/*.test.mjs` are node:test files, mirroring `src/server/`. Two one-line globs make them run and keep vitest from mis-collecting them:
- `package.json` — `test` / `test:server` scripts now include `src/relay/*.test.mjs` in the `node --test` glob.
- `vitest.config.ts` — added `"src/relay/**"` to the exclude list (same treatment as the existing `"src/server/**"`).

### Verification results

**Files changed:** 4 — `src/relay/protocol.mjs` (new), `src/relay/protocol.test.mjs` (new), `package.json`, `vitest.config.ts`.

- PR branch (`multica/BET-36.1-tunnel-protocol` @ `d99d3f9`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, vitest `744` pass / `0` fail + node:test `286` pass / `0` fail (incl. 27 new relay). log sha256: `00f399442654364531c3d02494a0a5cf6be27cae5fa4b66f04c673a9035a07f1`
- Base (`main` @ `399ddb7`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e` (byte-identical to PR)
  - test: exit `1`, `743` pass / `1` fail. The single failure is `tests/unit/e2e-smoke.test.ts > "should confirm Playwright is installed"` — a first-run Playwright browser-install race, **not related to this PR**. Re-running that file in isolation on `main` passes `3/3`. log sha256: `648585fa946cb0d05e46e81c07f2ef958fa3f2bc6970c4e8dd42e68bb077aa3c`
- **Conclusion:** 0 new failures caused by this PR. The 1 base failure is a pre-existing environment flake (Playwright install timing), confirmed green on isolated re-run. This PR adds 27 passing tests.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.

### Out of scope (later slices)
Real `ws` server, SQLite store, box dial-out client, HTTP endpoints, push, IAP, metering — Stages 2–5. No `src/server/**` behavior changed.
