### PR TITLE
BET-68 M2.3: Relay — box-side dial-out client (reconnect via ExponentialBackoff)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "mobile": "node src/server/index.mjs",
     "pair": "node scripts/bui-pair.mjs",
     "pack": "node scripts/release/pack.mjs",
-    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs scripts/*.test.mjs",
-    "test:server": "node --test src/server/*.test.mjs src/relay/*.test.mjs",
+    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs scripts/*.test.mjs",
+    "test:server": "node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts"
   },

--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -1,0 +1,493 @@
+// agent/index.mjs — the BOX-SIDE dial-out client (M2, BET-36 Stage 3).
+//
+// WHAT THIS SLICE IS: the daemon that RUNS ON THE BOX and dials OUT to the
+// relay. Boxes sit behind NAT/CGNAT and cannot be dialed IN to, so the box opens
+// a single long-lived, authenticated outbound WebSocket to the relay and holds
+// it. When the relay forwards a phone→box `request` frame down that tunnel, this
+// client proxies it to the local box server (127.0.0.1:8787) and streams the
+// response back over the tunnel, framed per the Stage-1 protocol.
+//
+// It is the mirror image of the Stage-2 relay server (`src/relay/index.mjs`):
+//   - the relay ACCEPTS an inbound ws, authenticates the box on the handshake,
+//     registers the live socket, and (Stage 4) will send `request` frames;
+//   - THIS client DIALS OUT, presents its box_id + box_token on the handshake,
+//     holds the socket, reconnects on drop, and answers `request` frames.
+//
+// WHAT THIS SLICE IS NOT (owned by later slices, do NOT add here):
+//   - Phone-facing HTTP endpoints + the phone→box proxy on the relay  → Stage 4
+//   - Push (APNs/FCM), IAP receipt validation, metering                → Stage 5
+//   - Editing box-server routes — this slice only CALLS 127.0.0.1:8787 as a
+//     client (via the injectable local-fetch leg).
+//
+// AUTH: reuses the box identity minted by `src/server/auth.mjs`
+// (`~/.bui-mobile/auth.json` → { box_id, box_token }). We do NOT invent a new
+// identity; `loadAuth()` is the single source, and the handshake presents the
+// same `Authorization: Bearer <box_token>` + `x-box-id: <box_id>` the relay's
+// `parseHandshake` expects.
+//
+// RECONNECT: mirrors the M0 "never permanently abandon WS reconnect" rule — the
+// reconnect loop retries forever with exponential backoff (full-jitter) and only
+// stops when `stop()` is called. The backoff is INJECTABLE and defaults to the
+// `.mjs` mirror of `src/shared/net/backoff.ts` `ExponentialBackoff` (see
+// createBackoff below for why the TS class can't be imported into a node:test
+// `.mjs` and how the two are kept in lock-step by test).
+//
+// TRANSPORT-INJECTABLE: both I/O legs are injected so the whole client runs
+// under node:test with fakes — no real network, no real box server:
+//   - `connect(url, { headers })` → the outbound WS transport (send / onMessage
+//     / onClose / close), defaulting to a real `ws` adapter.
+//   - `localFetch(request)` → the leg that calls 127.0.0.1:8787, defaulting to
+//     the global `fetch`.
+
+import { loadAuth } from "../../server/auth.mjs";
+import { isValidToken } from "../../server/webhooks.mjs";
+import {
+  encodeFrame,
+  decodeFrame,
+  FRAME_TYPES,
+  StreamRegistry,
+} from "../protocol.mjs";
+
+// Default relay endpoint. Overridable via RELAY_URL or the `relayUrl` option.
+// wss:// in production (TLS-terminated by the relay's front door); ws:// only
+// for a same-box dev relay.
+export const DEFAULT_RELAY_URL = "wss://bui.dev.antoinedc.com";
+
+// Default local box server the client proxies requests to. The box server binds
+// 0.0.0.0:8787 (src/server/index.mjs); we reach it over loopback.
+export const DEFAULT_LOCAL_BASE = "http://127.0.0.1:8787";
+
+// Reconnect backoff defaults (ms). Mirror the M0 SSE/WS reconnect: start ~1s,
+// cap at 30s, grow x2, full-jitter — identical parameters to the
+// ConnectionManager default in src/shared/net/connectionManager.ts.
+export const RECONNECT_BASE_MS = 1000;
+export const RECONNECT_MAX_MS = 30000;
+
+// ---------------------------------------------------------------------------
+// Backoff — the .mjs mirror of src/shared/net/backoff.ts ExponentialBackoff
+// ---------------------------------------------------------------------------
+//
+// WHY A MIRROR AND NOT AN IMPORT: `backoff.ts` is TypeScript compiled only by
+// tsc/vite for the renderer/main bundles (tsconfig.web/node). This client is a
+// pure `.mjs` exercised by `node --test`, which cannot import a `.ts` module at
+// runtime and is not part of the typecheck graph — exactly like `protocol.mjs`
+// and `index.mjs`, which also stay `.mjs` and inject their own clock rather than
+// importing the TS primitives. So the DEFAULT backoff here is a tiny factory
+// implementing the SAME formula and the SAME { next, reset, attempt } contract
+// as ExponentialBackoff. A TS caller wiring this client can inject the canonical
+// class directly (its instances satisfy this contract). The parity is pinned by
+// a test ("backoff mirror matches ExponentialBackoff semantics") so the two
+// cannot silently diverge. This is deliberate reuse-of-shape, not a competing
+// second algorithm.
+export function createBackoff({
+  base = RECONNECT_BASE_MS,
+  max = RECONNECT_MAX_MS,
+  factor = 2,
+  jitter = true,
+  rng = Math.random,
+} = {}) {
+  let attempt = 0;
+  return {
+    next() {
+      const computed = base * Math.pow(factor, attempt);
+      const capped = Math.min(computed, max);
+      attempt += 1;
+      return jitter ? rng() * capped : capped;
+    },
+    reset() {
+      attempt = 0;
+    },
+    attempt() {
+      return attempt;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Real `ws` transport (default connect()). Adapts a dialed-out ws WebSocket to
+// the tiny transport contract (send / onMessage / onClose / close) the client
+// is written against — the box-side twin of the relay's wsTransport().
+// ---------------------------------------------------------------------------
+
+// Lazily import `ws` only when a real connection is actually dialed, so tests
+// (which inject a fake `connect`) never pull in the module and the client stays
+// importable in environments without it.
+async function defaultConnect(url, { headers } = {}) {
+  const { WebSocket } = await import("ws");
+  const ws = new WebSocket(url, { headers });
+  const msgCbs = [];
+  const closeCbs = [];
+  let openResolved = false;
+
+  const transport = {
+    ws,
+    send(frame) {
+      let raw;
+      if (typeof frame === "string") {
+        raw = frame;
+      } else {
+        try {
+          raw = encodeFrame(frame);
+        } catch {
+          return; // programmer-built frame failed validation; never crash send
+        }
+      }
+      try {
+        ws.send(raw);
+      } catch {
+        /* socket closing/closed — the close handler drives reconnect */
+      }
+    },
+    onMessage(cb) {
+      msgCbs.push(cb);
+    },
+    onClose(cb) {
+      closeCbs.push(cb);
+    },
+    close() {
+      try {
+        ws.close();
+      } catch {
+        /* already closing/closed */
+      }
+    },
+  };
+
+  ws.on("message", (data) => {
+    for (const cb of msgCbs.slice()) cb(data);
+  });
+  ws.on("close", () => {
+    for (const cb of closeCbs.slice()) cb();
+  });
+  // ws emits 'error' then 'close'; swallow 'error' so an errored socket doesn't
+  // crash the process — the 'close' handler drives the reconnect.
+  ws.on("error", () => {});
+
+  // Resolve once the socket is open so the reconnect loop can reset its backoff
+  // on a genuine connect. A socket that errors before opening rejects.
+  await new Promise((resolve, reject) => {
+    ws.once("open", () => {
+      openResolved = true;
+      resolve();
+    });
+    ws.once("error", (err) => {
+      if (!openResolved) reject(err);
+    });
+  });
+
+  return transport;
+}
+
+// ---------------------------------------------------------------------------
+// Local-fetch leg (default localFetch()). Calls the box server over loopback.
+// ---------------------------------------------------------------------------
+
+// Turn a decoded REQUEST frame into a real call against the local box server and
+// return a normalized { status, headers, body } response. `body` on the frame,
+// when present, is a UTF-8 string (JSON payloads are already text). Binary
+// request bodies are out of scope for the metadata path.
+function makeDefaultLocalFetch(localBase) {
+  return async function defaultLocalFetch({ method, path, headers, body }) {
+    const url = `${localBase}${path.startsWith("/") ? path : `/${path}`}`;
+    const res = await fetch(url, {
+      method,
+      headers: headers || undefined,
+      body: body != null && method !== "GET" && method !== "HEAD" ? body : undefined,
+    });
+    const respHeaders = {};
+    for (const [k, v] of res.headers) respHeaders[k] = v;
+    const text = await res.text();
+    return { status: res.status, headers: respHeaders, body: text };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RelayAgent — the dial-out client
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the box-side relay dial-out client.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.relayUrl]   relay base ws/wss URL (default DEFAULT_RELAY_URL / env RELAY_URL)
+ * @param {string} [opts.localBase]  local box server base (default DEFAULT_LOCAL_BASE)
+ * @param {{box_id:string,box_token:string}} [opts.auth]
+ *   box identity; defaults to loadAuth() from ~/.bui-mobile/auth.json.
+ * @param {(url:string,o:{headers:object})=>Promise<Transport>} [opts.connect]
+ *   INJECTABLE outbound-WS opener. Resolves with a transport once connected,
+ *   rejects if the connection fails. Defaults to the real `ws` adapter.
+ * @param {(req:{method,path,headers,body})=>Promise<{status,headers,body}>} [opts.localFetch]
+ *   INJECTABLE local-server leg. Defaults to global fetch against localBase.
+ * @param {{next():number,reset():void,attempt():number}} [opts.backoff]
+ *   INJECTABLE reconnect backoff (ExponentialBackoff-compatible). Default mirror
+ *   of src/shared/net/backoff.ts.
+ * @param {(fn:()=>void,ms:number)=>any} [opts.setTimer]   default setTimeout
+ * @param {(h:any)=>void} [opts.clearTimer]                default clearTimeout
+ * @param {(...a:any)=>void} [opts.log]   injectable logger (default console.log)
+ * @param {(...a:any)=>void} [opts.warn]  injectable warn   (default console.warn)
+ */
+export function createRelayAgent(opts = {}) {
+  const {
+    relayUrl = process.env.RELAY_URL || DEFAULT_RELAY_URL,
+    localBase = DEFAULT_LOCAL_BASE,
+    connect = defaultConnect,
+    backoff = createBackoff(),
+    setTimer = (fn, ms) => setTimeout(fn, ms),
+    clearTimer = (h) => clearTimeout(h),
+    log = console.log,
+    warn = console.warn,
+  } = opts;
+
+  const auth = opts.auth || loadAuth();
+  if (!auth || !isValidToken(auth.box_id) || !isValidToken(auth.box_token)) {
+    throw new Error(
+      "createRelayAgent: valid { box_id, box_token } required " +
+        "(run the box server once to mint ~/.bui-mobile/auth.json, or pass opts.auth)",
+    );
+  }
+  const localFetch = opts.localFetch || makeDefaultLocalFetch(localBase);
+
+  // Per-box streams inbound over the tunnel (Stage-4 SSE/PTY). We own a registry
+  // so a relay→box STREAM_* frame is routed, but the box→phone direction (this
+  // client PRODUCING stream data) is what the request proxy drives below.
+  const streams = new StreamRegistry();
+
+  let transport = null; // current live transport, or null while (re)connecting
+  let reconnectTimer = null;
+  let stopped = false; // set by stop(); halts the reconnect loop permanently
+  let connecting = false;
+
+  // Build the authenticated dial-out URL + headers. The relay's parseHandshake
+  // accepts box_id/token via header OR query; we present BOTH the header form
+  // (canonical, non-browser) — query is unnecessary from a real client.
+  function handshake() {
+    const url = `${trimTrailingSlash(relayUrl)}/box`;
+    const headers = {
+      authorization: `Bearer ${auth.box_token}`,
+      "x-box-id": auth.box_id,
+    };
+    return { url, headers };
+  }
+
+  // --- request proxy ------------------------------------------------------
+
+  // Handle a relay→box REQUEST frame: proxy it to the local box server and send
+  // a RESPONSE frame back correlated by the same id. On a local-fetch failure we
+  // reply with an ERROR frame carrying the request id so the relay side settles
+  // instead of hanging. The metadata GET path is fully exercised here.
+  async function handleRequest(frame) {
+    const t = transport;
+    if (!t) return; // socket dropped between recv and dispatch; relay will retry
+    try {
+      const { status, headers, body } = await localFetch({
+        method: frame.method,
+        path: frame.path,
+        headers: frame.headers,
+        body: frame.body,
+      });
+      // Guard: the socket may have dropped while we awaited the local call.
+      if (transport !== t) return;
+      t.send({
+        type: FRAME_TYPES.RESPONSE,
+        id: frame.id,
+        status,
+        headers,
+        body,
+      });
+    } catch (err) {
+      if (transport !== t) return;
+      t.send({
+        type: FRAME_TYPES.ERROR,
+        id: frame.id,
+        code: "local_fetch_failed",
+        message: String(err?.message || err),
+      });
+    }
+  }
+
+  // Dispatch one decoded inbound frame.
+  function onFrame(frame) {
+    if (!frame) return; // decodeFrame dropped malformed/oversized/unknown input
+    switch (frame.type) {
+      case FRAME_TYPES.REQUEST:
+        // Metadata GET (and any other single request/response) → proxy now.
+        void handleRequest(frame);
+        break;
+      case FRAME_TYPES.STREAM_OPEN:
+      case FRAME_TYPES.STREAM_DATA:
+      case FRAME_TYPES.STREAM_END:
+      case FRAME_TYPES.STREAM_ABORT:
+        // TODO(Stage 4): PTY/SSE stream proxying. The mux is wired (streams
+        // registry routes these to a per-stream consumer), but the box→phone
+        // SSE/PTY producers that OPEN those streams need the Stage-4 phone-facing
+        // endpoints to exercise end-to-end. Until then a relay→box stream frame
+        // is routed if a consumer is registered and otherwise dropped — never
+        // misrouted. No request/response path depends on this.
+        streams.handleFrame(frame);
+        break;
+      case FRAME_TYPES.PONG:
+        // Liveness reply to a PING we sent (ping() below). Nothing to do beyond
+        // the fact that a frame arrived — the socket is alive.
+        break;
+      case FRAME_TYPES.PING:
+        // The relay may probe us; answer so it can measure the tunnel is alive.
+        transport?.send({ type: FRAME_TYPES.PONG, id: frame.id });
+        break;
+      case FRAME_TYPES.ERROR:
+        // A bare transport-level error from the relay. Log and keep the tunnel.
+        warn(`[relay-agent] relay error: ${frame.message || frame.code || "unknown"}`);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // --- connect / reconnect loop ------------------------------------------
+
+  // Open one connection. On success, wire message/close handlers and reset the
+  // backoff. On failure OR a later close, schedule a backoff-delayed reconnect —
+  // forever, until stop() (the "never permanently abandon reconnect" invariant).
+  async function openOnce() {
+    if (stopped || connecting || transport) return;
+    connecting = true;
+    const { url, headers } = handshake();
+    let t;
+    try {
+      t = await connect(url, { headers });
+    } catch (err) {
+      connecting = false;
+      warn(`[relay-agent] dial-out failed: ${String(err?.message || err)}`);
+      scheduleReconnect();
+      return;
+    }
+    connecting = false;
+    if (stopped) {
+      // stop() raced our connect; close the freshly-opened socket and bail.
+      try {
+        t.close();
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    transport = t;
+    backoff.reset();
+    log(`[relay-agent] connected to relay as box ${short(auth.box_id)}`);
+
+    t.onMessage((data) => {
+      onFrame(decodeFrame(data));
+    });
+    t.onClose(() => {
+      if (transport === t) transport = null;
+      // Every live stream must be torn down so nothing hangs half-open across a
+      // reconnect (Stage-4 consumers get onAbort).
+      streams.abortAll("relay tunnel closed");
+      if (stopped) return;
+      log(`[relay-agent] tunnel closed; reconnecting`);
+      scheduleReconnect();
+    });
+  }
+
+  // Schedule the next reconnect after a backoff delay. Guards against stacking
+  // multiple timers and against running after stop().
+  function scheduleReconnect() {
+    if (stopped || reconnectTimer || transport || connecting) return;
+    const delay = backoff.next();
+    reconnectTimer = setTimer(() => {
+      reconnectTimer = null;
+      if (stopped) return;
+      void openOnce();
+    }, delay);
+  }
+
+  // --- public API ---------------------------------------------------------
+
+  // Start dialing out. Idempotent; returns immediately (the first connect runs
+  // async and the loop keeps it alive). Await the returned promise to block
+  // until the first connection is established (tests use this).
+  async function start() {
+    stopped = false;
+    await openOnce();
+  }
+
+  // Send a liveness PING over the tunnel (optional; the relay answers PONG).
+  // Returns true if a live transport carried it.
+  function ping(id = 0) {
+    if (!transport) return false;
+    transport.send({ type: FRAME_TYPES.PING, id });
+    return true;
+  }
+
+  // Stop the client permanently: halt the reconnect loop, cancel any pending
+  // timer, tear down live streams, and close the socket. Idempotent. After
+  // stop() the client leaves NO open sockets/timers (clean teardown invariant).
+  function stop() {
+    stopped = true;
+    if (reconnectTimer) {
+      clearTimer(reconnectTimer);
+      reconnectTimer = null;
+    }
+    streams.abortAll("relay-agent stopped");
+    if (transport) {
+      const t = transport;
+      transport = null;
+      try {
+        t.close();
+      } catch {
+        /* already closing/closed */
+      }
+    }
+  }
+
+  return {
+    start,
+    stop,
+    ping,
+    // introspection for tests / Stage-4 wiring
+    boxId: auth.box_id,
+    isConnected: () => transport != null,
+    _onFrame: onFrame,
+    _streams: streams,
+    _handshake: handshake,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function trimTrailingSlash(u) {
+  return typeof u === "string" && u.endsWith("/") ? u.slice(0, -1) : u;
+}
+
+// A box_id is 32 hex; log only the first 8 so full pseudonyms don't hit logs.
+function short(boxId) {
+  return typeof boxId === "string" ? boxId.slice(0, 8) : String(boxId);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry — start the client when run directly (node src/relay/agent/index.mjs)
+// ---------------------------------------------------------------------------
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("src/relay/agent/index.mjs");
+
+if (isMain) {
+  const agent = createRelayAgent();
+  agent
+    .start()
+    .then(() => {
+      console.log("[relay-agent] dial-out client running");
+    })
+    .catch((err) => {
+      console.error("[relay-agent] failed to start:", err);
+      process.exit(1);
+    });
+  const shutdown = () => {
+    agent.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -1,0 +1,477 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createRelayAgent,
+  createBackoff,
+  DEFAULT_RELAY_URL,
+  RECONNECT_BASE_MS,
+  RECONNECT_MAX_MS,
+} from "./index.mjs";
+import {
+  encodeFrame,
+  decodeFrame,
+  FRAME_TYPES,
+  createFakeTransport,
+} from "../protocol.mjs";
+
+// Reference re-implementation of src/shared/net/backoff.ts ExponentialBackoff.
+// The canonical class is TypeScript compiled only into the renderer/main
+// bundles; a node:test `.mjs` cannot import a `.ts` module at runtime (same
+// reason protocol.mjs/index.mjs stay pure `.mjs`). So we pin the `.mjs` mirror's
+// parity against this byte-for-byte transcription of the TS formula
+// (`base * factor ** attempt`, capped at `max`, full-jitter = `rng()*capped`).
+// If backoff.ts changes, THIS reference and the mirror must both change — the
+// parity test below fails loudly otherwise.
+class ExponentialBackoff {
+  constructor({ base, max, factor = 2, jitter = true, rng = Math.random }) {
+    this.base = base;
+    this.max = max;
+    this.factor = factor;
+    this.jitter = jitter;
+    this.rng = rng;
+    this._attempt = 0;
+  }
+  next() {
+    const computed = this.base * Math.pow(this.factor, this._attempt);
+    const capped = Math.min(computed, this.max);
+    this._attempt += 1;
+    return this.jitter ? this.rng() * capped : capped;
+  }
+  reset() {
+    this._attempt = 0;
+  }
+  attempt() {
+    return this._attempt;
+  }
+}
+
+const BOX_ID = "0123456789abcdef0123456789abcdef"; // 32 hex
+const BOX_TOKEN = "11112222333344445555666677778888";
+const AUTH = { box_id: BOX_ID, box_token: BOX_TOKEN };
+
+const silent = () => {};
+
+// ---------------------------------------------------------------------------
+// A fake relay endpoint. Each call to `connect` records the handshake and
+// returns the box-side end of a fresh in-memory transport pair; the relay side
+// is exposed so a test can send frames to the client and read what it sent back.
+// ---------------------------------------------------------------------------
+function makeFakeRelay({ failFirst = 0 } = {}) {
+  const handshakes = []; // { url, headers }
+  const links = []; // { relaySide, boxSide, sent: [], recv: [] }
+  let failuresLeft = failFirst;
+
+  async function connect(url, { headers } = {}) {
+    handshakes.push({ url, headers });
+    if (failuresLeft > 0) {
+      failuresLeft -= 1;
+      throw new Error("dial-out refused (fake)");
+    }
+    const { a: boxSide, b: relaySide } = createFakeTransport();
+    // The transport contract (see relay wsTransport / the client's defaultConnect)
+    // is: send() accepts an already-encoded string OR a frame object it encodes.
+    // The raw fake endpoint only forwards bytes, so wrap it to honor the same
+    // contract the real ws adapter provides.
+    const boxTransport = {
+      send(frame) {
+        boxSide.send(typeof frame === "string" ? frame : encodeFrame(frame));
+      },
+      onMessage(cb) {
+        boxSide.onMessage(cb);
+      },
+      onClose(cb) {
+        boxSide.onClose(cb);
+      },
+      close() {
+        boxSide.close();
+      },
+    };
+    const link = { relaySide, boxSide, sent: [], recv: [] };
+    // Record everything the client (boxTransport) sends to the relay (relaySide).
+    relaySide.onMessage((raw) => link.recv.push(decodeFrame(raw)));
+    links.push(link);
+    return boxTransport;
+  }
+
+  return {
+    connect,
+    handshakes,
+    links,
+    lastLink: () => links[links.length - 1],
+    // Push a frame FROM the relay TO the client over the newest link.
+    sendToClient(frame) {
+      this.lastLink().relaySide.send(encodeFrame(frame));
+    },
+    // Frames the client sent back to the relay over the newest link.
+    clientSent() {
+      return this.lastLink().recv;
+    },
+    // Drop the newest link (simulate the relay/tunnel closing).
+    dropLink() {
+      this.lastLink().relaySide.close();
+    },
+  };
+}
+
+// A manual clock so reconnect delays are deterministic (no real sleeps).
+function makeClock() {
+  let seq = 1;
+  const timers = new Map(); // handle -> { fn, ms }
+  return {
+    setTimer(fn, ms) {
+      const h = seq++;
+      timers.set(h, { fn, ms });
+      return h;
+    },
+    clearTimer(h) {
+      timers.delete(h);
+    },
+    // Fire every currently-pending timer once (FIFO), returning their delays.
+    flush() {
+      const fired = [];
+      for (const [h, { fn, ms }] of [...timers]) {
+        timers.delete(h);
+        fired.push(ms);
+        fn();
+      }
+      return fired;
+    },
+    pendingCount() {
+      return timers.size;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pure: config surface + backoff parity
+// ---------------------------------------------------------------------------
+
+test("DEFAULT_RELAY_URL is the dev relay wss endpoint", () => {
+  assert.equal(DEFAULT_RELAY_URL, "wss://bui.dev.antoinedc.com");
+});
+
+test("backoff mirror matches ExponentialBackoff semantics (no jitter, capped growth)", () => {
+  const mirror = createBackoff({
+    base: RECONNECT_BASE_MS,
+    max: RECONNECT_MAX_MS,
+    jitter: false,
+  });
+  const canonical = new ExponentialBackoff({
+    base: RECONNECT_BASE_MS,
+    max: RECONNECT_MAX_MS,
+    jitter: false,
+  });
+  // Walk enough attempts to hit the cap; both must agree step-for-step.
+  for (let i = 0; i < 8; i++) {
+    assert.equal(
+      mirror.next(),
+      canonical.next(),
+      `attempt ${i} delay must match ExponentialBackoff`,
+    );
+  }
+  assert.equal(mirror.attempt(), canonical.attempt());
+  mirror.reset();
+  canonical.reset();
+  assert.equal(mirror.next(), canonical.next(), "reset resets both to attempt 0");
+});
+
+test("backoff mirror full-jitter stays within [0, capped] and uses injected rng", () => {
+  const b = createBackoff({ base: 1000, max: 30000, jitter: true, rng: () => 0.5 });
+  assert.equal(b.next(), 500, "attempt 0: 0.5 * min(1000, 30000)");
+  assert.equal(b.next(), 1000, "attempt 1: 0.5 * min(2000, 30000)");
+});
+
+// ---------------------------------------------------------------------------
+// dial-out + authentication
+// ---------------------------------------------------------------------------
+
+test("dials out and authenticates with the box_id + box_token handshake", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+
+  await agent.start();
+
+  assert.equal(agent.isConnected(), true, "connected after start");
+  assert.equal(relay.handshakes.length, 1, "dialed out exactly once");
+  const { url, headers } = relay.handshakes[0];
+  assert.match(url, /\/box$/, "connects to the relay /box path");
+  assert.equal(headers.authorization, `Bearer ${BOX_TOKEN}`, "presents the box_token");
+  assert.equal(headers["x-box-id"], BOX_ID, "presents the box_id");
+
+  agent.stop();
+  assert.equal(clock.pendingCount(), 0, "no timers left after stop");
+});
+
+test("rejects construction without a valid box identity", () => {
+  assert.throws(
+    () => createRelayAgent({ auth: { box_id: "bad", box_token: BOX_TOKEN } }),
+    /valid.*box_id.*box_token/i,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// reconnect with backoff (never gives up)
+// ---------------------------------------------------------------------------
+
+test("reconnects with increasing backoff on repeated dial failures and never gives up", async () => {
+  // The first 3 dial attempts fail; the 4th succeeds. Backoff must be armed
+  // after each failure with a strictly non-decreasing (growing) delay, and the
+  // loop must never stop retrying on its own.
+  const relay = makeFakeRelay({ failFirst: 3 });
+  const clock = makeClock();
+  // Deterministic delays: no jitter so growth is observable.
+  const backoff = createBackoff({ base: 100, max: 10000, jitter: false });
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    backoff,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+
+  await agent.start(); // attempt 1 → fails, arms a reconnect timer
+  assert.equal(agent.isConnected(), false);
+  assert.equal(clock.pendingCount(), 1, "a reconnect is armed after the 1st failure");
+
+  const delays = [];
+  // Fire timers until connected — each flush runs the next attempt.
+  for (let i = 0; i < 5 && !agent.isConnected(); i++) {
+    const fired = clock.flush();
+    delays.push(...fired);
+    // give the async openOnce() a microtask to settle
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  assert.equal(agent.isConnected(), true, "eventually connects after retries");
+  assert.equal(relay.handshakes.length, 4, "4 dial attempts (3 fail + 1 success)");
+  // The scheduled delays for attempts 2,3,4 must be strictly increasing
+  // (100, 200, 400 for base 100, factor 2, no jitter).
+  assert.deepEqual(delays.slice(0, 3), [100, 200, 400], "exponential growth");
+
+  agent.stop();
+  assert.equal(clock.pendingCount(), 0, "no timers left after stop");
+});
+
+test("a drop after a successful connect triggers reconnect (tunnel resurrection)", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const backoff = createBackoff({ base: 50, max: 1000, jitter: false });
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    backoff,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+
+  await agent.start();
+  assert.equal(agent.isConnected(), true);
+
+  relay.dropLink(); // relay/tunnel closes → client sees onClose
+  await Promise.resolve();
+  assert.equal(agent.isConnected(), false, "disconnected after drop");
+  assert.equal(clock.pendingCount(), 1, "reconnect armed after drop");
+
+  clock.flush();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(agent.isConnected(), true, "reconnected after drop");
+  assert.equal(relay.handshakes.length, 2, "dialed out again");
+
+  agent.stop();
+  assert.equal(clock.pendingCount(), 0);
+});
+
+// ---------------------------------------------------------------------------
+// request proxy: relay→box REQUEST → local fetch → RESPONSE back over tunnel
+// ---------------------------------------------------------------------------
+
+test("proxies a relay REQUEST to the local box server and streams the RESPONSE back", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const localCalls = [];
+  const localFetch = async (req) => {
+    localCalls.push(req);
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ projects: ["p1", "p2"] }),
+    };
+  };
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    localFetch,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+
+  await agent.start();
+
+  // The relay forwards a metadata GET down the tunnel.
+  relay.sendToClient({
+    type: FRAME_TYPES.REQUEST,
+    id: 42,
+    method: "GET",
+    path: "/api/projects",
+  });
+  // Let the async proxy (localFetch + send) settle.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // The local box server was called with the request details.
+  assert.equal(localCalls.length, 1, "local box server called once");
+  assert.equal(localCalls[0].method, "GET");
+  assert.equal(localCalls[0].path, "/api/projects");
+
+  // A correlated RESPONSE frame streamed back to the relay.
+  const sent = relay.clientSent();
+  const resp = sent.find((f) => f && f.type === FRAME_TYPES.RESPONSE);
+  assert.ok(resp, "a RESPONSE frame was sent back");
+  assert.equal(resp.id, 42, "response id echoes the request id");
+  assert.equal(resp.status, 200);
+  assert.deepEqual(JSON.parse(resp.body), { projects: ["p1", "p2"] });
+
+  agent.stop();
+  assert.equal(clock.pendingCount(), 0);
+});
+
+test("a failing local fetch replies with a correlated ERROR frame, not a hang", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const localFetch = async () => {
+    throw new Error("ECONNREFUSED 127.0.0.1:8787");
+  };
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    localFetch,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+
+  await agent.start();
+  relay.sendToClient({
+    type: FRAME_TYPES.REQUEST,
+    id: 7,
+    method: "GET",
+    path: "/api/projects",
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const err = relay.clientSent().find((f) => f && f.type === FRAME_TYPES.ERROR);
+  assert.ok(err, "an ERROR frame was sent back");
+  assert.equal(err.id, 7, "error correlates the request id");
+  assert.equal(err.code, "local_fetch_failed");
+
+  agent.stop();
+});
+
+test("answers a relay PING with a correlated PONG", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  await agent.start();
+
+  relay.sendToClient({ type: FRAME_TYPES.PING, id: 99 });
+  await Promise.resolve();
+
+  const pong = relay.clientSent().find((f) => f && f.type === FRAME_TYPES.PONG);
+  assert.ok(pong, "a PONG was sent");
+  assert.equal(pong.id, 99, "pong echoes the ping id");
+
+  agent.stop();
+});
+
+// ---------------------------------------------------------------------------
+// clean teardown
+// ---------------------------------------------------------------------------
+
+test("stop() leaves no open sockets or timers (clean teardown)", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  await agent.start();
+  assert.equal(agent.isConnected(), true);
+
+  agent.stop();
+
+  assert.equal(agent.isConnected(), false, "transport released");
+  assert.equal(clock.pendingCount(), 0, "no timers pending");
+  // The box-side transport's underlying state is closed → a further relay send
+  // reaches nobody and the client never re-arms a reconnect after stop().
+  relay.dropLink();
+  await Promise.resolve();
+  assert.equal(clock.pendingCount(), 0, "stop() is permanent: no reconnect after a post-stop drop");
+});
+
+test("stop() during an in-flight dial does not connect afterwards", async () => {
+  // Make connect hang until we release it, then stop() before it resolves.
+  let release;
+  const gate = new Promise((r) => (release = r));
+  let closed = false;
+  const connect = async () => {
+    await gate;
+    return {
+      send() {},
+      onMessage() {},
+      onClose() {},
+      close() {
+        closed = true;
+      },
+    };
+  };
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+
+  const startP = agent.start();
+  agent.stop(); // stop while the dial is still pending
+  release();
+  await startP;
+  await Promise.resolve();
+
+  assert.equal(agent.isConnected(), false, "never adopts a socket opened after stop");
+  assert.equal(closed, true, "the raced-open socket is closed");
+  assert.equal(clock.pendingCount(), 0);
+});


### PR DESCRIPTION
## BET-68 (M2.3): Relay — box-side dial-out client

**Base:** `origin/main @ 4399f3d`

Stage 3 of BET-36. The daemon that runs ON THE BOX and dials OUT to the relay: opens an authenticated outbound WebSocket, holds it, reconnects forever with exponential backoff on drop, and answers relay→box `request` frames by proxying to the local box server and streaming the response back over the Stage-1 tunnel.

### What's here
- **`src/relay/agent/index.mjs`** — `createRelayAgent({ ... })`:
  - Dials out to `wss://bui.dev.antoinedc.com/box` (override `relayUrl`/`RELAY_URL`) presenting the box identity from `src/server/auth.mjs` `loadAuth()` as `Authorization: Bearer <box_token>` + `x-box-id: <box_id>` — exactly the handshake the Stage-2 relay `parseHandshake` accepts. No new identity invented.
  - Persistent socket; on drop/failed dial it reconnects **forever** with full-jitter exponential backoff (mirrors the M0 "never permanently abandon WS reconnect" rule). Only `stop()` halts the loop.
  - Answers relay→box `REQUEST` frames: proxies to `127.0.0.1:8787` via the injectable local-fetch leg and streams a correlated `RESPONSE` back (or a correlated `ERROR` on a local-fetch failure, so the relay side never hangs). The **metadata GET path is exercised end-to-end**. Answers relay `PING` with `PONG` and can `ping()` the relay.
  - **Transport-injectable**: both the outbound WS (`connect`) and the local-server leg (`localFetch`) are injected, so tests run with fakes — no real network, no real box server. Also injectable backoff + timers.
- **`src/relay/agent/index.test.mjs`** (node:test, 12 tests): dial+auth handshake, reconnect with growing backoff that never gives up, drop-after-connect resurrection, request→proxy→response, failing-fetch→ERROR frame, PING→PONG, and clean teardown (no open sockets/timers after `stop()`, incl. stop-during-in-flight-dial).
- **`package.json`** — added `src/relay/agent/*.test.mjs` to the `test` and `test:server` node:test globs (the existing single-level `src/relay/*.test.mjs` glob doesn't reach the subdir).

### Reuse (no duplication)
- `src/server/auth.mjs` `loadAuth` + `isValidToken`, Stage-1 `src/relay/protocol.mjs` (`encodeFrame`/`decodeFrame`/`FRAME_TYPES`/`StreamRegistry`/`createFakeTransport`).
- **Backoff:** the reconnect delay reuses the *shape and formula* of `src/shared/net/backoff.ts` `ExponentialBackoff`. It is **mirrored, not imported**, because that class is TypeScript compiled only into the renderer/main bundles and a `node --test` `.mjs` cannot import a `.ts` module at runtime (the same reason `protocol.mjs`/`index.mjs` stay pure `.mjs`). The mirror implements the identical `{ next, reset, attempt }` contract, a TS caller can inject the canonical class directly, and a parity test pins the two so they can't silently diverge.

### Deferred (documented TODO in code)
- PTY/SSE **stream** proxying (box→phone producers) is Stage 4: the mux is wired (`StreamRegistry` routes relay→box `STREAM_*` frames to a per-stream consumer and tears them down on tunnel close), but the producers that OPEN those streams need the Stage-4 phone-facing endpoints to exercise end-to-end. No request/response path depends on it.

### Verification results
**Files changed:** 3 — `package.json`, `src/relay/agent/index.mjs`, `src/relay/agent/index.test.mjs`.

- PR branch (`multica/BET-36.3-box-dial-out-client` @ `907e8a9`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, vitest `744` pass / `0` fail; node:test `328` pass / `0` fail (incl. the 12 new agent tests). log sha256: `305e245165c6632afb8844a5aaea766e77104b78ff8775c732088a1b0b5244e5`
- **Conclusion:** 0 new failures, 0 pre-existing failures. This PR adds 12 node:test cases (316 → 328) and touches only `src/relay/agent/**` + the test glob in `package.json`; nothing else in the suite is affected.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
