### PR TITLE
BET-69: M2.4 Relay — account↔box routing endpoints + phone-facing proxy (gate seam)

### DIFF
--- a/src/relay/api.mjs
+++ b/src/relay/api.mjs
@@ -1,0 +1,435 @@
+// api.mjs — the PHONE-FACING leg of the relay (M2, BET-36 Stage 4).
+//
+// WHAT THIS SLICE IS: the HTTP surface a phone talks to, plus the phone→box
+// proxy. The box-facing leg (Stage 2 `index.mjs`) already accepts box dial-outs
+// and holds each box's live tunnel in the RoutingTable, and exposes a
+// `proxyRequest(boxId, req)` that frames a phone request down that tunnel and
+// resolves with the box's response. THIS slice sits on top of that:
+//
+//   1. Account↔box routing endpoints (phone-authenticated):
+//        GET  /api/boxes                 → the authed account's boxes.
+//        GET  /api/boxes/:box_id         → one box's details (must be owned).
+//        POST /api/boxes/:box_id/revoke  → drop the box↔account binding.
+//   2. Phone→box PROXY: any other /box/:box_id/<subpath> request is forwarded to
+//        the box's live tunnel via proxyRequest and the box response is relayed
+//        back. 503 when the box has no live tunnel; 504 on box timeout.
+//   3. FREE vs GATED split (structure only): metadata subpaths (project list,
+//        session titles/stats) are served free; transcript/stream/prompt/pty
+//        subpaths pass through a requireSubscription seam that, for now, checks
+//        the store for an active receipt bound to the box and returns 402 when
+//        none exists. The actual Apple-receipt VALIDATION is Stage 5 — this
+//        slice provides the gate seam + the 402, not the receipt crypto.
+//
+// WHAT THIS SLICE IS NOT (owned by later slices, do NOT add here):
+//   - Real Apple IAP receipt validation + native push (APNs/FCM) + byte
+//     metering                                                       → Stage 5
+//   - The RN phone app.
+//
+// AUTH (phone leg): reuses `src/server/webhooks.mjs` isValidToken (shape) +
+// createRateLimiter (per account/box token bucket). WHO a phone is (which
+// account) is decided by an injectable `authenticatePhone(req)` seam. The
+// default extracts a bearer token, shape-validates it, and (when an
+// `accountTokens` map is configured) maps token→account_id; with no map it runs
+// DEV-OPEN (a well-formed token IS the account id) and logs once — Stage 5
+// replaces this seam with the IAP-account lookup. This mirrors the box-leg
+// verifier seam in index.mjs so both auth surfaces move together.
+//
+// TESTABILITY: the router core operates on a NORMALIZED request object
+// ({ method, path, headers, body }) and returns a normalized response
+// ({ status, headers, body }), so every endpoint + the proxy + the gate is
+// exercised under node:test with a store fake and a proxyRequest fake — no real
+// HTTP server, no real sockets, no Apple calls. `attach(httpServer)` wraps the
+// same core in a Node `http` request listener for the CLI entry.
+
+import { isValidToken, createRateLimiter } from "../server/webhooks.mjs";
+
+// Per-phone-token rate limit for the API surface. A phone polls its box list and
+// proxies a handful of requests; a token hammering the relay is throttled.
+export const PHONE_RL_CAPACITY = 60;
+export const PHONE_RL_REFILL_PER_SEC = 10;
+
+// ---------------------------------------------------------------------------
+// Free vs gated path classification (structure only; enforcement = Stage 5)
+// ---------------------------------------------------------------------------
+
+// A proxied box subpath is FREE (metadata) or GATED (subscription-only). The
+// classification is deliberately a small, explicit prefix table rather than a
+// scattered per-route check so Stage 5 wires receipt enforcement in ONE place
+// (requireSubscription) against ONE source of truth.
+//
+// FREE (metadata): the pre-subscription preview surface — project/session lists,
+//   titles, running/idle status, token/message/tool counts. These serve real
+//   metadata so the phone can render the free preview.
+// GATED (subscription): the full-capability surface — live transcript streaming,
+//   sending prompts, terminal (PTY) access.
+const GATED_PREFIXES = ["/transcript", "/stream", "/events", "/prompt", "/pty", "/message"];
+
+/**
+ * Classify a proxied box subpath as gated (subscription-only) or free.
+ * `subpath` is the portion AFTER `/box/:box_id` (always begins with `/`).
+ * Pure + exported so a test pins the free/gated boundary directly.
+ */
+export function isGatedSubpath(subpath) {
+  if (typeof subpath !== "string" || !subpath) return false;
+  // Normalize: compare against the first path segment so query strings and
+  // deeper subpaths (`/stream/abc`) classify by their leading segment.
+  const clean = subpath.split("?")[0];
+  return GATED_PREFIXES.some(
+    (p) => clean === p || clean.startsWith(`${p}/`),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Phone authentication seam
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the default phone authenticator.
+ *
+ * Extracts a bearer token from `Authorization: Bearer <t>` (or `?token=<t>`),
+ * shape-validates it with isValidToken, and resolves it to an account_id:
+ *   - with an `accountTokens` map (token → account_id): only a mapped token
+ *     authenticates; unknown/malformed → null (401).
+ *   - without a map (DEV-OPEN): a well-formed token IS the account_id; logs once.
+ *     Stage 5 replaces this with the IAP-bound account lookup.
+ *
+ * Returns a function (normReq) => { accountId } | null.
+ *
+ * @param {object} [opts]
+ * @param {Map<string,string>|Record<string,string>|null} [opts.accountTokens]
+ * @param {(msg:string)=>void} [opts.warn]
+ */
+export function createDefaultPhoneAuth({ accountTokens = null, warn = console.warn } = {}) {
+  const lookup =
+    accountTokens == null
+      ? null
+      : accountTokens instanceof Map
+        ? accountTokens
+        : new Map(Object.entries(accountTokens));
+  let warnedOpen = false;
+
+  return function authenticatePhone(req) {
+    const token = extractBearer(req);
+    if (!isValidToken(token)) return null;
+    if (lookup == null) {
+      if (!warnedOpen) {
+        warnedOpen = true;
+        warn(
+          "[relay-api] DEV-OPEN phone auth: a well-formed token IS the account. " +
+            "Configure accountTokens (or a Stage-5 IAP lookup) before production.",
+        );
+      }
+      return { accountId: token };
+    }
+    const accountId = lookup.get(token);
+    return typeof accountId === "string" && accountId ? { accountId } : null;
+  };
+}
+
+// Pull a bearer token out of a normalized request (Authorization header first,
+// then ?token= fallback — same two forms the box handshake accepts).
+function extractBearer(req) {
+  const headers = req?.headers || {};
+  const authz = headers["authorization"] || headers["Authorization"];
+  if (typeof authz === "string" && authz.trim()) {
+    const m = /^Bearer\s+(.+)$/i.exec(authz.trim());
+    const t = (m ? m[1] : authz).trim();
+    if (t) return t;
+  }
+  const q = parseQuery(req?.path).get("token");
+  return q && q.trim() ? q.trim() : null;
+}
+
+// ---------------------------------------------------------------------------
+// Subscription gate seam (Stage 5 replaces the check body, not the seam)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the default subscription check: a box is entitled iff the store has at
+ * least one receipt bound to it whose entitlement is active. THIS SLICE does NOT
+ * validate the receipt against Apple — it only asks the store "is a receipt
+ * bound and unexpired?". Stage 5 swaps the store's receipt rows for
+ * Apple-validated ones; the seam (and the 402 the router returns) is unchanged.
+ *
+ * @param {object} store  a relay store (listReceiptsForBox).
+ * @param {() => number} [now]
+ * @returns {(boxId:string) => boolean}
+ */
+export function createDefaultSubscriptionCheck(store, now = () => Date.now()) {
+  return function hasActiveSubscription(boxId) {
+    let receipts;
+    try {
+      receipts = store.listReceiptsForBox(boxId);
+    } catch {
+      return false;
+    }
+    if (!Array.isArray(receipts) || receipts.length === 0) return false;
+    const t = now();
+    // Active = at least one receipt with no expiry, or an expiry in the future.
+    return receipts.some(
+      (r) => r.expires_at == null || Number(r.expires_at) > t,
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The relay API — normalized-request router + Node http adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the phone-facing relay API.
+ *
+ * @param {object} opts
+ * @param {object} opts.store                a relay store (bindings/boxes/receipts).
+ * @param {(boxId,req,o?)=>Promise<{status,headers?,body?}>} opts.proxyRequest
+ *   the box-tunnel proxy from createRelayServer().proxyRequest.
+ * @param {(req)=>({accountId:string}|null)} [opts.authenticatePhone]
+ *   phone auth seam; default createDefaultPhoneAuth({ accountTokens }).
+ * @param {Map|object|null} [opts.accountTokens]  passed to the default auth.
+ * @param {(boxId:string)=>boolean} [opts.hasActiveSubscription]
+ *   gate seam; default createDefaultSubscriptionCheck(store, now).
+ * @param {(key:string)=>boolean} [opts.rateLimiter]  take(key)=>bool; created if omitted.
+ * @param {() => number} [opts.now=Date.now]
+ * @param {(...a)=>void} [opts.warn]
+ */
+export function createRelayApi(opts = {}) {
+  const {
+    store,
+    proxyRequest,
+    accountTokens = null,
+    now = () => Date.now(),
+    warn = console.warn,
+  } = opts;
+
+  if (!store) throw new Error("createRelayApi: store required");
+  if (typeof proxyRequest !== "function") {
+    throw new Error("createRelayApi: proxyRequest(boxId, req) required");
+  }
+
+  const authenticatePhone =
+    opts.authenticatePhone || createDefaultPhoneAuth({ accountTokens, warn });
+  const hasActiveSubscription =
+    opts.hasActiveSubscription || createDefaultSubscriptionCheck(store, now);
+  const rl =
+    opts.rateLimiter ||
+    createRateLimiter({
+      capacity: PHONE_RL_CAPACITY,
+      refillPerSec: PHONE_RL_REFILL_PER_SEC,
+      now,
+    });
+
+  // -------------------------------------------------------------------------
+  // Route a single normalized request. Returns a normalized response. Never
+  // throws — a handler fault becomes a 500 so the HTTP layer always has a reply.
+  // -------------------------------------------------------------------------
+  async function route(req) {
+    try {
+      return await dispatch(req);
+    } catch (err) {
+      warn(`[relay-api] handler error: ${String(err?.message || err)}`);
+      return json(500, { error: "internal_error" });
+    }
+  }
+
+  async function dispatch(req) {
+    const method = (req.method || "GET").toUpperCase();
+    const pathname = (req.path || "/").split("?")[0];
+
+    // Auth gate first — every phone-facing route requires an authenticated
+    // account. 401 (not 404) so an unauthenticated caller can't probe route
+    // existence.
+    const auth = authenticatePhone(req);
+    if (!auth || !auth.accountId) {
+      return json(401, { error: "unauthorized" });
+    }
+
+    // Rate-limit per account (the token bucket key). A single account hammering
+    // the surface is throttled; distinct accounts don't starve each other.
+    if (!rl(`acct:${auth.accountId}`)) {
+      return json(429, { error: "rate_limited" });
+    }
+
+    // GET /api/boxes — the authed account's boxes.
+    if (method === "GET" && pathname === "/api/boxes") {
+      const boxes = store.listBoxesForAccount(auth.accountId) || [];
+      return json(200, { boxes: boxes.map((b) => boxView(b)) });
+    }
+
+    // /api/boxes/:box_id  and  /api/boxes/:box_id/revoke
+    const apiMatch = /^\/api\/boxes\/([^/]+)(\/revoke)?$/.exec(pathname);
+    if (apiMatch) {
+      const boxId = apiMatch[1];
+      const isRevoke = !!apiMatch[2];
+
+      if (!isValidToken(boxId)) return json(404, { error: "not_found" });
+
+      // Ownership: the box must be bound to THIS account. An unowned/unknown box
+      // is 404 (don't leak existence of boxes owned by other accounts).
+      const binding = store.getBinding(boxId);
+      if (!binding || binding.account_id !== auth.accountId) {
+        return json(404, { error: "not_found" });
+      }
+
+      if (isRevoke) {
+        if (method !== "POST") return json(405, { error: "method_not_allowed" });
+        const removed = store.unbindBox(boxId);
+        return json(200, { revoked: removed, box_id: boxId });
+      }
+
+      // GET /api/boxes/:box_id — details.
+      if (method !== "GET") return json(405, { error: "method_not_allowed" });
+      const box = store.getBox(boxId);
+      if (!box) return json(404, { error: "not_found" });
+      return json(200, { box: boxView(box) });
+    }
+
+    // Phone→box PROXY:  /box/:box_id/<subpath>
+    const proxyMatch = /^\/box\/([^/]+)(\/.*)?$/.exec(pathname);
+    if (proxyMatch) {
+      const boxId = proxyMatch[1];
+      const subpath = proxyMatch[2] || "/";
+      if (!isValidToken(boxId)) return json(404, { error: "not_found" });
+
+      // Ownership gate — same as the routing endpoints.
+      const binding = store.getBinding(boxId);
+      if (!binding || binding.account_id !== auth.accountId) {
+        return json(404, { error: "not_found" });
+      }
+
+      // Subscription gate seam: gated subpaths require an active receipt bound
+      // to the box. Metadata subpaths are served free. (Stage 5 fills in real
+      // receipt validation behind hasActiveSubscription.)
+      if (isGatedSubpath(subpath) && !hasActiveSubscription(boxId)) {
+        return json(402, { error: "payment_required", box_id: boxId });
+      }
+
+      // Forward to the box's live tunnel. The relay preserves the phone's method
+      // + body and forwards the subpath (not the /box/:box_id prefix) so the box
+      // server sees the request as if made locally.
+      try {
+        const resp = await proxyRequest(boxId, {
+          method,
+          path: subpath,
+          headers: sanitizeForwardHeaders(req.headers),
+          body: req.body,
+        });
+        return {
+          status: Number.isInteger(resp?.status) ? resp.status : 502,
+          headers: resp?.headers || { "content-type": "application/octet-stream" },
+          body: resp?.body,
+        };
+      } catch (err) {
+        if (err?.code === "no_tunnel") {
+          return json(503, { error: "box_offline", box_id: boxId });
+        }
+        // Timeout or any other proxy failure → 504 (the box didn't answer in time).
+        return json(504, { error: "box_timeout", box_id: boxId });
+      }
+    }
+
+    return json(404, { error: "not_found" });
+  }
+
+  // -------------------------------------------------------------------------
+  // Node http adapter — wrap `route` in a request listener.
+  // -------------------------------------------------------------------------
+  function nodeHandler() {
+    return (httpReq, httpRes) => {
+      const chunks = [];
+      httpReq.on("data", (c) => chunks.push(c));
+      httpReq.on("end", () => {
+        const body = chunks.length ? Buffer.concat(chunks).toString("utf8") : undefined;
+        const req = {
+          method: httpReq.method,
+          path: httpReq.url || "/",
+          headers: httpReq.headers || {},
+          body,
+        };
+        route(req).then((resp) => {
+          const headers = { ...(resp.headers || {}) };
+          const payload = resp.body == null ? "" : resp.body;
+          if (!hasHeader(headers, "content-type")) {
+            headers["content-type"] = "application/json";
+          }
+          httpRes.writeHead(resp.status, headers);
+          httpRes.end(payload);
+        });
+      });
+      httpReq.on("error", () => {
+        try {
+          httpRes.writeHead(400);
+          httpRes.end();
+        } catch {
+          /* response may already be sent */
+        }
+      });
+    };
+  }
+
+  return {
+    route,
+    nodeHandler,
+    // exposed for tests / diagnostics
+    _authenticatePhone: authenticatePhone,
+    _hasActiveSubscription: hasActiveSubscription,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// Normalize a stored box row into the phone-facing view. `tunnel_live` is left
+// out here (the store row only knows persisted status/last_seen); the router
+// reports persisted status. A live-tunnel flag would require the RoutingTable,
+// which the API layer doesn't own — status/last_seen is the durable answer.
+function boxView(b) {
+  return {
+    box_id: b.box_id,
+    status: b.status,
+    created_at: b.created_at,
+    last_seen: b.last_seen,
+  };
+}
+
+function json(status, obj) {
+  return {
+    status,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(obj),
+  };
+}
+
+function parseQuery(path) {
+  try {
+    const qs = typeof path === "string" ? path.split("?")[1] : "";
+    return new URLSearchParams(qs || "");
+  } catch {
+    return new URLSearchParams("");
+  }
+}
+
+// Strip hop-by-hop / auth headers before forwarding a phone request to the box.
+// The relay's Authorization is a PHONE↔RELAY credential and must not be leaked
+// to the box; the box tunnel is already authenticated at the socket layer.
+function sanitizeForwardHeaders(headers) {
+  if (!headers || typeof headers !== "object") return undefined;
+  const DROP = new Set([
+    "authorization",
+    "host",
+    "connection",
+    "content-length",
+    "transfer-encoding",
+    "upgrade",
+  ]);
+  const out = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (!DROP.has(k.toLowerCase())) out[k] = v;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+function hasHeader(headers, name) {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((k) => k.toLowerCase() === lower);
+}

--- a/src/relay/api.test.mjs
+++ b/src/relay/api.test.mjs
@@ -1,0 +1,391 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { WebSocketServer, WebSocket } from "ws";
+import {
+  createRelayApi,
+  createDefaultPhoneAuth,
+  createDefaultSubscriptionCheck,
+  isGatedSubpath,
+} from "./api.mjs";
+import { createRelayServer, createDefaultVerifier } from "./index.mjs";
+import { openStore, BOX_STATUS } from "./store.mjs";
+import { encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
+
+const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
+const BOX_B = "fedcba9876543210fedcba9876543210";
+const BOX_TOKEN_A = "aaaa2222333344445555666677778888";
+const ACCT_1 = "1111111111111111aaaaaaaaaaaaaaaa"; // phone account token
+const ACCT_2 = "2222222222222222bbbbbbbbbbbbbbbb";
+
+const silent = () => {};
+
+// A store seeded with box A bound to account 1 and box B bound to account 2.
+function seededStore() {
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.ONLINE, at: 1000 });
+  store.upsertBox(BOX_B, { status: BOX_STATUS.OFFLINE, at: 2000 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1000 });
+  store.bindBox(BOX_B, ACCT_2, { at: 2000 });
+  return store;
+}
+
+// A default proxyRequest fake that never gets called (routing/gate tests).
+const noProxy = async () => {
+  throw new Error("proxyRequest should not have been called");
+};
+
+// Auth that maps the two account tokens; anything else → null.
+function makeAuth() {
+  return createDefaultPhoneAuth({
+    accountTokens: { [ACCT_1]: ACCT_1, [ACCT_2]: ACCT_2 },
+    warn: silent,
+  });
+}
+
+function bearer(token) {
+  return { authorization: `Bearer ${token}` };
+}
+
+async function parseBody(resp) {
+  return typeof resp.body === "string" && resp.body ? JSON.parse(resp.body) : null;
+}
+
+// ---------------------------------------------------------------------------
+// pure: gated-path classification
+// ---------------------------------------------------------------------------
+
+test("isGatedSubpath: transcript/stream/prompt/pty are gated; metadata is free", () => {
+  for (const p of ["/transcript", "/stream", "/stream/abc", "/prompt", "/pty", "/events", "/message"]) {
+    assert.equal(isGatedSubpath(p), true, `${p} should be gated`);
+  }
+  for (const p of ["/", "/projects", "/sessions", "/sessions/x/stats", "/status"]) {
+    assert.equal(isGatedSubpath(p), false, `${p} should be free`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// pure: default phone auth seam
+// ---------------------------------------------------------------------------
+
+test("createDefaultPhoneAuth: mapped token → accountId; unknown/malformed → null", () => {
+  const auth = makeAuth();
+  assert.deepEqual(auth({ headers: bearer(ACCT_1) }), { accountId: ACCT_1 });
+  assert.equal(auth({ headers: bearer("deadbeefdeadbeefdeadbeefdeadbeef") }), null, "unknown token");
+  assert.equal(auth({ headers: bearer("not-hex") }), null, "malformed token");
+  assert.equal(auth({ headers: {} }), null, "no token");
+});
+
+test("createDefaultPhoneAuth: DEV-OPEN (no map) treats a well-formed token as the account", () => {
+  const auth = createDefaultPhoneAuth({ warn: silent });
+  assert.deepEqual(auth({ headers: bearer(ACCT_1) }), { accountId: ACCT_1 });
+  assert.equal(auth({ headers: bearer("bad") }), null);
+});
+
+test("createDefaultPhoneAuth: falls back to ?token= query when no header", () => {
+  const auth = makeAuth();
+  assert.deepEqual(auth({ path: `/api/boxes?token=${ACCT_1}` }), { accountId: ACCT_1 });
+});
+
+// ---------------------------------------------------------------------------
+// pure: default subscription check reads the store
+// ---------------------------------------------------------------------------
+
+test("createDefaultSubscriptionCheck: no receipt → false; active receipt → true; expired → false", () => {
+  const store = seededStore();
+  const now = () => 5000;
+  const check = createDefaultSubscriptionCheck(store, now);
+
+  assert.equal(check(BOX_A), false, "no receipt bound → not subscribed");
+
+  store.upsertReceipt({ originalTransactionId: "t1", boxId: BOX_A, expiresAt: 9999 });
+  assert.equal(check(BOX_A), true, "future-expiry receipt → subscribed");
+
+  store.upsertReceipt({ originalTransactionId: "t1", boxId: BOX_A, expiresAt: 1 });
+  assert.equal(check(BOX_A), false, "expired receipt → not subscribed");
+
+  store.upsertReceipt({ originalTransactionId: "t2", boxId: BOX_A, expiresAt: null });
+  assert.equal(check(BOX_A), true, "no-expiry receipt → subscribed");
+  store.close();
+});
+
+// ---------------------------------------------------------------------------
+// routing endpoints
+// ---------------------------------------------------------------------------
+
+test("GET /api/boxes returns only the authed account's boxes; unauthenticated → 401", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const api = createRelayApi({ store, proxyRequest: noProxy, authenticatePhone: makeAuth(), warn: silent });
+
+  const unauth = await api.route({ method: "GET", path: "/api/boxes" });
+  assert.equal(unauth.status, 401);
+
+  const resp = await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_1) });
+  assert.equal(resp.status, 200);
+  const body = await parseBody(resp);
+  assert.equal(body.boxes.length, 1, "only account 1's box");
+  assert.equal(body.boxes[0].box_id, BOX_A);
+
+  const resp2 = await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_2) });
+  const body2 = await parseBody(resp2);
+  assert.equal(body2.boxes.length, 1);
+  assert.equal(body2.boxes[0].box_id, BOX_B);
+});
+
+test("GET /api/boxes/:id — unknown → 404, unowned → 404, owned → details", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const api = createRelayApi({ store, proxyRequest: noProxy, authenticatePhone: makeAuth(), warn: silent });
+
+  // Unknown box (well-formed id, no binding).
+  const unknown = "cccccccccccccccccccccccccccccccc";
+  const r1 = await api.route({ method: "GET", path: `/api/boxes/${unknown}`, headers: bearer(ACCT_1) });
+  assert.equal(r1.status, 404, "unknown box → 404");
+
+  // Owned by account 2, requested by account 1 → 404 (no existence leak).
+  const r2 = await api.route({ method: "GET", path: `/api/boxes/${BOX_B}`, headers: bearer(ACCT_1) });
+  assert.equal(r2.status, 404, "unowned box → 404");
+
+  // Owned → details.
+  const r3 = await api.route({ method: "GET", path: `/api/boxes/${BOX_A}`, headers: bearer(ACCT_1) });
+  assert.equal(r3.status, 200);
+  const body = await parseBody(r3);
+  assert.equal(body.box.box_id, BOX_A);
+  assert.equal(body.box.status, BOX_STATUS.ONLINE);
+
+  // Malformed box id → 404.
+  const r4 = await api.route({ method: "GET", path: `/api/boxes/not-a-box`, headers: bearer(ACCT_1) });
+  assert.equal(r4.status, 404, "malformed id → 404");
+});
+
+test("POST /api/boxes/:id/revoke removes the binding; subsequent list omits it", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const api = createRelayApi({ store, proxyRequest: noProxy, authenticatePhone: makeAuth(), warn: silent });
+
+  const rev = await api.route({ method: "POST", path: `/api/boxes/${BOX_A}/revoke`, headers: bearer(ACCT_1) });
+  assert.equal(rev.status, 200);
+  const body = await parseBody(rev);
+  assert.equal(body.revoked, true);
+
+  // Now the list is empty for account 1.
+  const list = await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_1) });
+  const lb = await parseBody(list);
+  assert.equal(lb.boxes.length, 0, "revoked box gone from list");
+
+  // And the box is no longer owned → 404 on detail.
+  const det = await api.route({ method: "GET", path: `/api/boxes/${BOX_A}`, headers: bearer(ACCT_1) });
+  assert.equal(det.status, 404);
+
+  // Revoke of an unowned box → 404 (can't revoke someone else's).
+  const cross = await api.route({ method: "POST", path: `/api/boxes/${BOX_B}/revoke`, headers: bearer(ACCT_1) });
+  assert.equal(cross.status, 404);
+});
+
+// ---------------------------------------------------------------------------
+// gate seam (structure only)
+// ---------------------------------------------------------------------------
+
+test("gate seam: gated subpath with no active receipt → 402; metadata subpath → served free", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+
+  // proxyRequest fake records what it was asked to forward and returns a canned
+  // box response for the free/metadata path.
+  const forwarded = [];
+  const proxyRequest = async (boxId, req) => {
+    forwarded.push({ boxId, ...req });
+    return { status: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ ok: true }) };
+  };
+  const api = createRelayApi({ store, proxyRequest, authenticatePhone: makeAuth(), warn: silent });
+
+  // Gated path, no receipt bound → 402, and proxyRequest NOT called.
+  const gated = await api.route({ method: "GET", path: `/box/${BOX_A}/transcript`, headers: bearer(ACCT_1) });
+  assert.equal(gated.status, 402, "gated path without subscription → 402");
+  assert.equal(forwarded.length, 0, "gated request not forwarded to box");
+
+  // Metadata path → forwarded free, box response relayed back.
+  const free = await api.route({ method: "GET", path: `/box/${BOX_A}/projects`, headers: bearer(ACCT_1) });
+  assert.equal(free.status, 200, "metadata path served free");
+  assert.equal(forwarded.length, 1, "metadata request forwarded");
+  assert.equal(forwarded[0].path, "/projects", "subpath forwarded without /box/:id prefix");
+  const body = await parseBody(free);
+  assert.deepEqual(body, { ok: true });
+
+  // With an active receipt bound, the gated path now forwards too.
+  store.upsertReceipt({ originalTransactionId: "t1", boxId: BOX_A, expiresAt: null });
+  const gatedOk = await api.route({ method: "GET", path: `/box/${BOX_A}/transcript`, headers: bearer(ACCT_1) });
+  assert.equal(gatedOk.status, 200, "gated path with active receipt → forwarded");
+  assert.equal(forwarded.length, 2);
+});
+
+test("proxy: unowned box on the proxy path → 404, never forwarded", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const api = createRelayApi({ store, proxyRequest: noProxy, authenticatePhone: makeAuth(), warn: silent });
+  // Account 1 tries to proxy to account 2's box.
+  const r = await api.route({ method: "GET", path: `/box/${BOX_B}/projects`, headers: bearer(ACCT_1) });
+  assert.equal(r.status, 404);
+});
+
+test("proxy: 503 when the box has no live tunnel (proxyRequest rejects no_tunnel)", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const proxyRequest = async () => {
+    const err = new Error("no tunnel");
+    err.code = "no_tunnel";
+    throw err;
+  };
+  const api = createRelayApi({ store, proxyRequest, authenticatePhone: makeAuth(), warn: silent });
+  const r = await api.route({ method: "GET", path: `/box/${BOX_A}/projects`, headers: bearer(ACCT_1) });
+  assert.equal(r.status, 503);
+  const body = await parseBody(r);
+  assert.equal(body.error, "box_offline");
+});
+
+test("proxy: box timeout → 504", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const proxyRequest = async () => {
+    throw new Error("request 1 timed out after 30000ms");
+  };
+  const api = createRelayApi({ store, proxyRequest, authenticatePhone: makeAuth(), warn: silent });
+  const r = await api.route({ method: "GET", path: `/box/${BOX_A}/projects`, headers: bearer(ACCT_1) });
+  assert.equal(r.status, 504);
+});
+
+test("rate limit: exhausting the per-account bucket → 429", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  // Tiny bucket: capacity 2, no meaningful refill within the test.
+  let calls = 0;
+  const rateLimiter = () => {
+    calls += 1;
+    return calls <= 2;
+  };
+  const api = createRelayApi({ store, proxyRequest: noProxy, authenticatePhone: makeAuth(), rateLimiter, warn: silent });
+  const a = await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_1) });
+  const b = await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_1) });
+  const c = await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_1) });
+  assert.equal(a.status, 200);
+  assert.equal(b.status, 200);
+  assert.equal(c.status, 429, "third request throttled");
+});
+
+// ---------------------------------------------------------------------------
+// end-to-end proxy over a REAL relay + REAL box socket (fake box answers)
+// ---------------------------------------------------------------------------
+
+// Wait for a ws event once, with a timeout guard.
+function once(ws, event, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout waiting for ${event}`)), timeoutMs);
+    ws.once(event, (...args) => {
+      clearTimeout(timer);
+      resolve(args);
+    });
+  });
+}
+
+async function waitFor(pred, { timeoutMs = 2000, stepMs = 5 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, stepMs));
+  }
+  if (!pred()) throw new Error("waitFor: predicate never became true");
+}
+
+test("end-to-end: phone metadata request is forwarded to a live box and the framed response returns", async (t) => {
+  // Real relay on an ephemeral port with a store where box A is bound to acct 1.
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.ONLINE, at: 1 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1 });
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((r) => wss.once("listening", r));
+  const { port } = wss.address();
+  const relay = createRelayServer({
+    wss,
+    store,
+    verifyBox: createDefaultVerifier({ warn: silent }),
+    log: silent,
+    warn: silent,
+  });
+
+  // A fake box: dial in, then answer any REQUEST frame with a canned RESPONSE
+  // echoing the requested path (proves the subpath was forwarded correctly).
+  const boxWs = new WebSocket(
+    `ws://127.0.0.1:${port}/box?box_id=${BOX_A}&token=${BOX_TOKEN_A}`,
+  );
+  await once(boxWs, "open");
+  boxWs.on("message", (data) => {
+    const frame = decodeFrame(data);
+    if (frame && frame.type === FRAME_TYPES.REQUEST) {
+      boxWs.send(
+        encodeFrame({
+          type: FRAME_TYPES.RESPONSE,
+          id: frame.id,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ path: frame.path, method: frame.method }),
+        }),
+      );
+    }
+  });
+  await waitFor(() => relay.routing.has(BOX_A));
+
+  t.after(async () => {
+    // Close the box socket and let the relay's close-cleanup run (unregister +
+    // setBoxStatus) WHILE the store is still open, then close the relay/store.
+    boxWs.close();
+    await waitFor(() => !relay.routing.has(BOX_A));
+    await relay.close();
+    await new Promise((r) => wss.close(() => r()));
+  });
+
+  const api = createRelayApi({
+    store,
+    proxyRequest: relay.proxyRequest,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  const resp = await api.route({
+    method: "GET",
+    path: `/box/${BOX_A}/projects`,
+    headers: bearer(ACCT_1),
+  });
+  assert.equal(resp.status, 200);
+  const body = JSON.parse(resp.body);
+  assert.equal(body.path, "/projects", "box saw the forwarded subpath");
+  assert.equal(body.method, "GET");
+});
+
+test("end-to-end: no live tunnel → proxyRequest rejects no_tunnel → 503", async (t) => {
+  // Box A is bound + known to the store but NEVER dials in → no live tunnel.
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.OFFLINE, at: 1 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1 });
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((r) => wss.once("listening", r));
+  const relay = createRelayServer({ wss, store, log: silent, warn: silent });
+  t.after(async () => {
+    await relay.close();
+    await new Promise((r) => wss.close(() => r()));
+  });
+
+  const api = createRelayApi({
+    store,
+    proxyRequest: relay.proxyRequest,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+  const resp = await api.route({
+    method: "GET",
+    path: `/box/${BOX_A}/projects`,
+    headers: bearer(ACCT_1),
+  });
+  assert.equal(resp.status, 503, "offline box → 503");
+});

--- a/src/relay/index.mjs
+++ b/src/relay/index.mjs
@@ -328,7 +328,14 @@ export function createRelayServer(opts = {}) {
       // Only unregister if THIS socket is still the registered one (a fast
       // reconnect may have already replaced us — don't clobber the fresh one).
       routing.unregister(boxId, transport);
-      store.setBoxStatus(boxId, BOX_STATUS.OFFLINE, { at: now() });
+      // Persisting offline status can race relay shutdown (close() terminates
+      // sockets, whose 'close' fires cleanup AFTER store.close()). Swallow a
+      // closed-store throw so a shutdown-time disconnect can't crash the process.
+      try {
+        store.setBoxStatus(boxId, BOX_STATUS.OFFLINE, { at: now() });
+      } catch {
+        /* store already closed during shutdown */
+      }
       log(`[relay] box ${short(boxId)} disconnected (${routing.size} online)`);
     };
     ws.on("close", cleanup);

--- a/src/relay/index.mjs
+++ b/src/relay/index.mjs
@@ -33,10 +33,21 @@
 import { WebSocketServer } from "ws";
 import { isValidToken, createRateLimiter } from "../server/webhooks.mjs";
 import { tokenMatches } from "../server/auth.mjs";
-import { RoutingTable, encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
+import {
+  RoutingTable,
+  PendingRequests,
+  encodeFrame,
+  decodeFrame,
+  FRAME_TYPES,
+} from "./protocol.mjs";
 import { openStore, BOX_STATUS } from "./store.mjs";
 
 export const DEFAULT_RELAY_PORT = 20787;
+
+// Default timeout (ms) for a phone→box proxied request. A box that never
+// answers must not leak a pending entry / hang the phone HTTP response forever;
+// the correlation rejects with a timeout and the proxy maps that to a 504.
+export const PROXY_REQUEST_TIMEOUT_MS = 30000;
 
 // Rate limit for the UNAUTHENTICATED dial-in handshake — the only pre-auth
 // surface a box hits. Keyed by remote IP. A genuine box reconnects a handful of
@@ -251,6 +262,14 @@ export function createRelayServer(opts = {}) {
   // tests can assert no open handles remain.
   const connections = new Set();
 
+  // Per-box request/response correlation. The Stage-4 phone→box proxy sends a
+  // REQUEST frame down a box's tunnel and awaits the matching RESPONSE; this map
+  // holds the PendingRequests instance for each live box so the box socket's
+  // inbound RESPONSE/ERROR frames resolve/reject the right promise. Keyed by the
+  // live transport (not box_id) so a stale socket's late frames can't settle a
+  // fresh reconnect's pending requests.
+  const pendingByTransport = new Map(); // transport -> PendingRequests
+
   /**
    * Handle a single verified/authenticated box connection. Wires the ws into a
    * transport, registers it in the RoutingTable, persists the box row online,
@@ -262,23 +281,50 @@ export function createRelayServer(opts = {}) {
     });
     connections.add(ws);
 
+    // Correlation for phone→box proxied requests routed over THIS socket.
+    const pending = new PendingRequests({ now });
+    pendingByTransport.set(transport, pending);
+
     // Register the live socket (evicts+closes any stale socket for this box).
     routing.register(boxId, transport);
     // Persist: box seen + online.
     store.upsertBox(boxId, { status: BOX_STATUS.ONLINE, at: now() });
     log(`[relay] box ${short(boxId)} connected (${routing.size} online)`);
 
-    // Reply to liveness PINGs so a box can measure the tunnel is alive. This is
-    // the only frame this slice reacts to; REQUEST/STREAM routing is Stage 4.
+    // Route inbound frames from the box:
+    //   - PING     → answer with a PONG (liveness).
+    //   - RESPONSE → resolve the matching proxied phone request.
+    //   - ERROR    → reject the matching proxied phone request (if it carries an
+    //                in-flight id); a bare error is logged, not fatal.
+    // STREAM_* box→phone routing is exercised by the proxy's stream path in a
+    // later slice; a stream frame with no matching consumer is simply ignored
+    // here (never misrouted).
     ws.on("message", (data) => {
       const frame = decodeFrame(data);
-      if (frame && frame.type === FRAME_TYPES.PING) {
-        transport.send({ type: FRAME_TYPES.PONG, id: frame.id });
+      if (!frame) return;
+      switch (frame.type) {
+        case FRAME_TYPES.PING:
+          transport.send({ type: FRAME_TYPES.PONG, id: frame.id });
+          break;
+        case FRAME_TYPES.RESPONSE:
+          pending.resolve(frame);
+          break;
+        case FRAME_TYPES.ERROR:
+          if (!pending.rejectFromError(frame)) {
+            warn(`[relay] box ${short(boxId)} error: ${frame.message || frame.code || "unknown"}`);
+          }
+          break;
+        default:
+          break;
       }
     });
 
     const cleanup = () => {
       connections.delete(ws);
+      // Fail every in-flight proxied request on this socket so no phone HTTP
+      // response hangs across a box disconnect, then drop the correlation map.
+      pending.rejectAll(new Error("box tunnel closed"));
+      pendingByTransport.delete(transport);
       // Only unregister if THIS socket is still the registered one (a fast
       // reconnect may have already replaced us — don't clobber the fresh one).
       routing.unregister(boxId, transport);
@@ -290,6 +336,48 @@ export function createRelayServer(opts = {}) {
       // ws emits 'error' then 'close'; cleanup runs on close. Swallow here so an
       // errored socket doesn't crash the process.
     });
+  }
+
+  /**
+   * Proxy a single phone→box request over the box's live tunnel and resolve with
+   * the box's { status, headers, body } RESPONSE. This is the correlation core
+   * the Stage-4 phone-facing proxy (api.mjs) calls; it owns framing + timeout so
+   * the HTTP layer stays transport-agnostic.
+   *
+   * Rejects with `err.code === "no_tunnel"` when the box has no live socket (the
+   * caller maps that to 503), or with a timeout Error when the box never answers
+   * within `timeoutMs` (caller maps that to 504).
+   *
+   * @param {string} boxId
+   * @param {{method:string,path:string,headers?:object,body?:string}} req
+   * @param {{timeoutMs?:number}} [opts]
+   * @returns {Promise<{status:number,headers?:object,body?:string}>}
+   */
+  function proxyRequest(boxId, req, { timeoutMs = PROXY_REQUEST_TIMEOUT_MS } = {}) {
+    const transport = routing.lookup(boxId);
+    if (!transport) {
+      const err = new Error(`box ${short(boxId)} has no live tunnel`);
+      err.code = "no_tunnel";
+      return Promise.reject(err);
+    }
+    const pending = pendingByTransport.get(transport);
+    if (!pending) {
+      // Shouldn't happen (every live transport gets a PendingRequests), but be
+      // defensive rather than throw synchronously into the HTTP handler.
+      const err = new Error(`box ${short(boxId)} has no correlation channel`);
+      err.code = "no_tunnel";
+      return Promise.reject(err);
+    }
+    const { id, promise } = pending.create({ timeoutMs });
+    transport.send({
+      type: FRAME_TYPES.REQUEST,
+      id,
+      method: req.method,
+      path: req.path,
+      ...(req.headers ? { headers: req.headers } : {}),
+      ...(req.body != null ? { body: req.body } : {}),
+    });
+    return promise;
   }
 
   // The connection handler: runs AFTER the ws handshake completes. We do the
@@ -340,6 +428,15 @@ export function createRelayServer(opts = {}) {
   }
 
   async function close() {
+    // Fail any in-flight proxied requests so nothing hangs, then close sockets.
+    for (const pending of pendingByTransport.values()) {
+      try {
+        pending.rejectAll(new Error("relay shutting down"));
+      } catch {
+        /* ignore */
+      }
+    }
+    pendingByTransport.clear();
     // Close every live box socket, then the server, then the store.
     for (const ws of [...connections]) {
       try {
@@ -370,6 +467,8 @@ export function createRelayServer(opts = {}) {
     host,
     start,
     close,
+    // phone→box request correlation (Stage-4 phone-facing proxy calls this)
+    proxyRequest,
     // exposed for tests / Stage 4 wiring
     _onConnection: onConnection,
     _acceptBox: acceptBox,


### PR DESCRIPTION
## BET-69 — M2.4: Relay account↔box routing endpoints + phone-facing proxy (gate seam)

Parent: BET-36 (M2 Relay MVP), Stage 4 of 6. Builds on merged Stages 1-3 (protocol, relay server + store, box dial-out client).

**Base: origin/main @ 94741f7**

### What this adds

**`src/relay/api.mjs`** (new) — the phone-facing HTTP surface + proxy:
- `GET /api/boxes` → the authed account's boxes (from `store.listBoxesForAccount`).
- `GET /api/boxes/:box_id` → box details (must be owned by the account).
- `POST /api/boxes/:box_id/revoke` → drops the box↔account binding.
- **Phone→box proxy** `/box/:box_id/<subpath>` → forwards to the box's live tunnel via `relay.proxyRequest` and relays the framed response back. **503** when the box has no live tunnel, **504** on box timeout.
- **Free vs gated split (structure only):** metadata subpaths served free; transcript/stream/prompt/pty subpaths pass a `requireSubscription` seam (`hasActiveSubscription`) that checks the `receipts` store and returns **402** when no active receipt is bound. Real Apple-receipt validation is Stage 5 — this is the seam + the 402, not the crypto.
- Phone auth reuses `webhooks.mjs` `isValidToken` + `createRateLimiter` (per-account token bucket → 429). WHO a phone is comes from an injectable `authenticatePhone` seam (mirrors the box-leg verifier seam; DEV-OPEN default logs once, Stage 5 swaps in the IAP-account lookup).
- Router core operates on normalized `{method,path,headers,body}` req/resp so every endpoint is testable without a real HTTP server; `nodeHandler()` wraps it for the CLI entry.

**`src/relay/index.mjs`** (extended) — I reused the Stage-1 `PendingRequests` rather than adding a parallel correlation mechanism:
- Each live box socket gets a `PendingRequests`; inbound `RESPONSE`/`ERROR` frames from the box resolve/reject the matching proxied phone request. Keyed by transport so a stale socket's late frames can't settle a fresh reconnect's requests.
- New `relay.proxyRequest(boxId, req, {timeoutMs})` frames a phone request down the box tunnel and resolves with the box's response; rejects `no_tunnel` (→503) when no live socket, times out (→504) otherwise. In-flight requests are failed on box disconnect / relay shutdown so no phone response hangs.
- Hardened the box-close cleanup to swallow a closed-store throw (a socket close can race `relay.close()` during shutdown).

### Tests — `src/relay/api.test.mjs` (node:test), 15 tests
- `GET /api/boxes`: only the authed account's boxes; unauthenticated → 401.
- `GET /api/boxes/:id`: unknown → 404, unowned → 404 (no existence leak), malformed → 404, owned → details.
- revoke removes the binding (subsequent list omits it; cross-account revoke → 404).
- gate seam: gated path w/o receipt → 402 (not forwarded); metadata path → served free; active receipt unlocks the gated path.
- proxy: unowned → 404; `no_tunnel` → 503; timeout → 504.
- rate limit exhaustion → 429.
- **end-to-end**: real relay on an ephemeral port + a real box WS client that answers `REQUEST` with a framed `RESPONSE` — asserts the subpath is forwarded and the response returns; no-live-tunnel variant → 503.
- Ephemeral ports (`port: 0`); all servers/sockets/stores closed in `t.after`.

### Verification results
**Files changed:** 3 — `src/relay/api.mjs` (new), `src/relay/api.test.mjs` (new), `src/relay/index.mjs`.

- PR branch (`multica/BET-36.4-relay-api` @ 3dad245):
  - typecheck: exit 0. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit 0. vitest 744 pass / 40 files; node:test 343 pass. Failures: none. log sha256: `fe92e130ed0e740f8ee96797be5796cfc2f4a74450a84ef3038aebe7f176a010`
- **Conclusion:** 0 new failures, 0 pre-existing failures — full suite green on the PR branch, so the base re-run is skipped per the workflow.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.

### Out of scope (Stage 5)
Real Apple IAP receipt validation, native push (APNs/FCM), byte metering, and the RN app.
