### PR TITLE
BET-72: Relay — combined HTTP+WS entrypoint + systemd service

### DIFF
--- a/scripts/systemd/bui-relay.service
+++ b/scripts/systemd/bui-relay.service
@@ -1,0 +1,37 @@
+# bui-relay.service — systemd --user unit for the combined bui relay (M2.7, BET-72).
+#
+# Mirrors bui-server.service, but runs the COMBINED relay entrypoint
+# (`node src/relay/server.mjs`): one process serving BOTH the box-facing
+# WebSocket dial-out leg and the phone-facing HTTP API (+ IAP/push routes) on a
+# single loopback port. The `bui.dev.antoinedc.com` Caddy vhost reverse-proxies
+# 127.0.0.1:20787 to this process, so a live relay resolves at that host.
+#
+# INSTALL (a human on-box step — same pattern as bui-server.service; substitute
+# the @@…@@ placeholders and drop into ~/.config/systemd/user/):
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now bui-relay
+#   loginctl enable-linger "$USER"    # start at boot without an active login
+#
+# Bind is 127.0.0.1 on purpose: the relay is NOT exposed directly. Caddy fronts
+# it and terminates TLS at bui.dev.antoinedc.com. RELAY_PORT/RELAY_HOST override
+# the bind; RELAY_STORE_PATH overrides the shared SQLite store location.
+
+[Unit]
+Description=bui relay (box WS dial-out + phone HTTP API)
+Documentation=https://github.com/antoinedc/better-ui
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@@BUI_HOME@@
+ExecStart=@@NODE_BIN@@ @@BUI_HOME@@/src/relay/server.mjs
+Environment=RELAY_HOST=127.0.0.1
+Environment=RELAY_PORT=20787
+Restart=on-failure
+RestartSec=2
+# Give the relay a moment to flush + close sockets/store on stop before SIGKILL.
+TimeoutStopSec=10
+
+[Install]
+WantedBy=default.target

--- a/src/relay/server.mjs
+++ b/src/relay/server.mjs
@@ -1,0 +1,516 @@
+// server.mjs — the COMBINED relay entrypoint (M2.7, BET-72).
+//
+// WHAT THIS SLICE IS: the shippable process that finally joins the two relay
+// halves M2 built but never wired together. Before this file:
+//   - `index.mjs` (Stage 2) started ONLY the box-facing WebSocket leg — a bare
+//     WebSocketServer, no HTTP server.
+//   - `api.mjs` (Stage 4) was a router core with no listener — nothing bound
+//     `.nodeHandler()` to a port or handed it the box leg's `proxyRequest`.
+//   - `iap.mjs` / `push.mjs` (Stage 5) were libraries with no HTTP routes
+//     mounted at all.
+// The BET-71 device check could only verify the composition via a throwaway
+// in-process harness. This file makes that harness permanent, tested product
+// code: ONE `http.Server` that serves BOTH legs on ONE port, sharing ONE store.
+//
+// COMPOSITION (mirrors the BET-71 harness shape):
+//   - A single `http.Server`.
+//   - WS `upgrade` on `/box`  → the Stage-2 box leg (`createRelayServer`), which
+//     is created with an injected `noServer` WebSocketServer so it does NOT own
+//     its own listener; we drive `handleUpgrade` from the shared server.
+//   - All other HTTP → first the IAP + push routes mounted here, then (fallthrough)
+//     the Stage-4 phone API (`createRelayApi().nodeHandler()`), wired with the
+//     box leg's `proxyRequest`.
+//   - ONE `openStore({ path })` shared by box leg, api, iap binding, and push.
+//   - ONE `authenticatePhone` seam shared by the api AND the iap/push routes, so
+//     both phone surfaces move together (and Stage 5 swaps them in one place).
+//
+// PORT: 127.0.0.1:20787 by default (bui 20xxx block; loopback because Caddy /
+//   the `bui.dev.antoinedc.com` vhost fronts it). Override with RELAY_PORT /
+//   RELAY_HOST. RELAY_PORT=0 selects an ephemeral port (tests, dev).
+//
+// WHAT'S STILL DEFERRED (live-provisioning, do NOT block on it here — same seams
+// M2 left open): real Apple x5c/verifyJws crypto, real APNs/FCM certs + prod
+// PushSender, and the IAP-bound verifyBox/authenticatePhone lookups. This file
+// only COMPOSES the DEV-OPEN/structural defaults into a runnable service.
+
+import http from "node:http";
+import { WebSocketServer } from "ws";
+
+import { createRelayServer } from "./index.mjs";
+import {
+  createRelayApi,
+  createDefaultPhoneAuth,
+  createDefaultSubscriptionCheck,
+} from "./api.mjs";
+import { createReceiptValidator, bindReceipt } from "./iap.mjs";
+import { createRelayPush } from "./push.mjs";
+import { openStore } from "./store.mjs";
+import { isValidToken } from "../server/webhooks.mjs";
+
+export const DEFAULT_RELAY_PORT = 20787;
+
+// The WS upgrade path the box dials out to. Anything else that arrives as an
+// upgrade is rejected (a stray WS upgrade must not fall into the HTTP router).
+const BOX_UPGRADE_PATH = "/box";
+
+// Cap on an IAP/push request body so an unbounded POST can't exhaust memory
+// before the phone is even authenticated. 256 KiB is generous for a JWS +
+// token registration; larger bodies are refused with 413.
+const MAX_BODY_BYTES = 256 * 1024;
+
+/**
+ * Create (but do not start) the combined relay service: one http.Server serving
+ * both the box WS leg and the phone HTTP API (+ IAP/push routes) on one port,
+ * over one shared store.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.port]   defaults to RELAY_PORT env, else DEFAULT_RELAY_PORT.
+ * @param {string} [opts.host]   defaults to RELAY_HOST env, else 127.0.0.1.
+ * @param {object} [opts.store]  a shared openStore() handle; created from
+ *                               storePath when omitted.
+ * @param {string} [opts.storePath]  file path for the shared store (e.g.
+ *                               ~/.bui-mobile/relay.sqlite); ":memory:" default.
+ * @param {Map|object|null} [opts.boxTokens]     box-leg verifier seam.
+ * @param {Map|object|null} [opts.accountTokens] phone-auth seam.
+ * @param {(req)=>({accountId:string}|null)} [opts.authenticatePhone]
+ *   shared phone auth; defaults to createDefaultPhoneAuth({ accountTokens }).
+ * @param {(jws:string)=>object} [opts.verifyJws]  IAP crypto seam (structural default).
+ * @param {object} [opts.pushSender]  a PushSender (stub default).
+ * @param {() => number} [opts.now=Date.now]
+ * @param {(...a)=>void} [opts.log]
+ * @param {(...a)=>void} [opts.warn]
+ */
+export function createRelayService(opts = {}) {
+  const {
+    port =
+      process.env.RELAY_PORT !== undefined && process.env.RELAY_PORT !== ""
+        ? Number(process.env.RELAY_PORT)
+        : DEFAULT_RELAY_PORT,
+    host = process.env.RELAY_HOST || "127.0.0.1",
+    storePath,
+    boxTokens = null,
+    accountTokens = null,
+    verifyJws,
+    pushSender,
+    now = () => Date.now(),
+    log = console.log,
+    warn = console.warn,
+  } = opts;
+
+  // ONE store shared by every leg. Created here (not by the box leg) so the
+  // http.Server owns its lifecycle and close() tears it down exactly once.
+  const store = opts.store || openStore({ path: storePath, now });
+
+  // ONE phone-auth seam shared by the API and the IAP/push routes so both phone
+  // surfaces authenticate identically and Stage 5 swaps them in one place.
+  const authenticatePhone =
+    opts.authenticatePhone || createDefaultPhoneAuth({ accountTokens, warn });
+
+  // The subscription gate is also shared so the IAP validate route and the API's
+  // 402 gate consult the SAME "is a receipt bound + unexpired?" logic.
+  const hasActiveSubscription = createDefaultSubscriptionCheck(store, now);
+
+  // --- Box-facing leg (Stage 2) --------------------------------------------
+  // Build it with a noServer WebSocketServer so it does NOT open its own
+  // listener; we drive handleUpgrade from the shared http.Server below.
+  const wss = new WebSocketServer({ noServer: true });
+  const boxLeg = createRelayServer({
+    wss,
+    store,
+    boxTokens,
+    log,
+    warn,
+    now,
+  });
+
+  // --- Phone-facing API (Stage 4) ------------------------------------------
+  // Wire it with the box leg's proxyRequest and the SHARED store + auth + gate.
+  const api = createRelayApi({
+    store,
+    proxyRequest: boxLeg.proxyRequest,
+    authenticatePhone,
+    hasActiveSubscription,
+    now,
+    warn,
+  });
+  const apiHandler = api.nodeHandler();
+
+  // --- IAP + push routes (Stage 5, mounted HERE) ---------------------------
+  const receiptValidator = createReceiptValidator({ verifyJws, now, warn });
+  const push = createRelayPush({
+    store,
+    sender: pushSender,
+    now,
+    log,
+    warn,
+  });
+
+  const iapPushHandler = createIapPushHandler({
+    store,
+    authenticatePhone,
+    receiptValidator,
+    push,
+    now,
+    warn,
+  });
+
+  // --- The single http.Server ----------------------------------------------
+  const server = http.createServer((req, res) => {
+    // Try the IAP/push routes first; they call res and return true when they
+    // own the path. Otherwise fall through to the phone API router.
+    iapPushHandler(req, res, () => apiHandler(req, res));
+  });
+
+  // Route WS upgrades: only /box reaches the box leg; anything else is refused.
+  server.on("upgrade", (req, socket, head) => {
+    let pathname = "/";
+    try {
+      pathname = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`).pathname;
+    } catch {
+      pathname = "/";
+    }
+    if (pathname !== BOX_UPGRADE_PATH) {
+      // Not a box dial-out; reject cleanly so a stray upgrade can't hang.
+      socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      // Feed the accepted socket into the box leg's own 'connection' handler,
+      // which does the credential parse + verify + acceptBox.
+      wss.emit("connection", ws, req);
+    });
+  });
+
+  function start() {
+    return new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, host, () => {
+        server.off("error", reject);
+        const addr = server.address();
+        const boundPort = addr && typeof addr === "object" ? addr.port : port;
+        log(`[relay] listening on http://${host}:${boundPort} (box WS + phone API)`);
+        resolve({ host, port: boundPort });
+      });
+    });
+  }
+
+  async function close() {
+    // Detach the box leg's listener + fail in-flight proxied requests. The box
+    // leg was built with an injected wss, so its close() only detaches its
+    // 'connection' handler and closes the store — but we own the store here, so
+    // we tolerate a double close (store.close swallows re-close).
+    try {
+      await boxLeg.close();
+    } catch {
+      /* box leg cleanup best-effort */
+    }
+    await new Promise((resolve) => {
+      try {
+        server.close(() => resolve());
+      } catch {
+        resolve();
+      }
+    });
+    try {
+      wss.close();
+    } catch {
+      /* already closed */
+    }
+    try {
+      store.close();
+    } catch {
+      /* already closed by boxLeg.close() */
+    }
+  }
+
+  return {
+    server,
+    store,
+    boxLeg,
+    api,
+    push,
+    port,
+    host,
+    start,
+    close,
+    // exposed for tests / diagnostics
+    _authenticatePhone: authenticatePhone,
+    _hasActiveSubscription: hasActiveSubscription,
+    _receiptValidator: receiptValidator,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// IAP + push HTTP routes
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the IAP + push request handler. It owns exactly these routes and calls
+ * `next()` for everything else so the phone API router handles the rest:
+ *
+ *   POST /api/iap/validate   { box_id, jws }
+ *     Validate a StoreKit 2 transaction JWS and bind receipt → box. Opens the
+ *     subscription gate for that box. 200 { bound, verified }, 400/402/404.
+ *   POST /api/iap/renewed    { box_id, signedPayload }
+ *     App Store Server Notification v2 renewal/expiry. Same binding path via
+ *     validateNotification. (DEV: box_id supplied in body; live Apple webhooks
+ *     carry no bearer — a separate live-provisioning issue swaps the auth.)
+ *   POST /api/push/register  { platform, token }
+ *     Register the authed account's native APNs/FCM device token.
+ *   POST /api/push/unregister { platform }
+ *     Drop the authed account's token for a platform.
+ *   POST /api/push/send      { box_id, payload }
+ *     Trigger a push fan-out to the box owner's registered devices. Returns the
+ *     routeNotification decision + delivered tokens (stub sender in DEV).
+ *
+ * Ownership: every route that names a box requires the authed account to own it
+ * (binding.account_id === accountId), returning 404 otherwise so an unowned box
+ * is indistinguishable from a missing one.
+ */
+export function createIapPushHandler({
+  store,
+  authenticatePhone,
+  receiptValidator,
+  push,
+  now = () => Date.now(),
+  warn = console.warn,
+}) {
+  if (!store) throw new Error("createIapPushHandler: store required");
+  if (typeof authenticatePhone !== "function") {
+    throw new Error("createIapPushHandler: authenticatePhone required");
+  }
+
+  const ROUTES = new Set([
+    "/api/iap/validate",
+    "/api/iap/renewed",
+    "/api/push/register",
+    "/api/push/unregister",
+    "/api/push/send",
+  ]);
+
+  return function handle(req, res, next) {
+    const pathname = (req.url || "/").split("?")[0];
+    if (!ROUTES.has(pathname)) {
+      return next();
+    }
+    if (req.method !== "POST") {
+      return sendJson(res, 405, { error: "method_not_allowed" });
+    }
+
+    readBody(req, (err, body) => {
+      if (err) {
+        return sendJson(res, err.code === "too_large" ? 413 : 400, {
+          error: err.code === "too_large" ? "payload_too_large" : "bad_request",
+        });
+      }
+
+      // Authenticate the phone using the SAME seam the API uses. The IAP/push
+      // routes read the bearer from headers, so build a normalized req view.
+      const normReq = { method: req.method, path: req.url || "/", headers: req.headers || {} };
+      const auth = authenticatePhone(normReq);
+      if (!auth || !auth.accountId) {
+        return sendJson(res, 401, { error: "unauthorized" });
+      }
+
+      let parsed;
+      try {
+        parsed = body ? JSON.parse(body) : {};
+      } catch {
+        return sendJson(res, 400, { error: "invalid_json" });
+      }
+
+      try {
+        routeIapPush({ pathname, parsed, auth, store, receiptValidator, push, now })
+          .then((resp) => sendJson(res, resp.status, resp.json))
+          .catch((e) => {
+            warn(`[relay-iap-push] handler error: ${String(e?.message || e)}`);
+            sendJson(res, 500, { error: "internal_error" });
+          });
+      } catch (e) {
+        warn(`[relay-iap-push] handler error: ${String(e?.message || e)}`);
+        sendJson(res, 500, { error: "internal_error" });
+      }
+    });
+  };
+}
+
+// The pure-ish routing core (async because push.deliver is async). Returns
+// { status, json }. Ownership + validation live here so it's directly testable.
+async function routeIapPush({ pathname, parsed, auth, store, receiptValidator, push, now }) {
+  const accountId = auth.accountId;
+
+  // Helper: assert the account owns box_id; returns the boxId or a 404 response.
+  function ownedBox(boxId) {
+    if (!isValidToken(boxId)) return { error: { status: 404, json: { error: "not_found" } } };
+    const binding = store.getBinding(boxId);
+    if (!binding || binding.account_id !== accountId) {
+      return { error: { status: 404, json: { error: "not_found" } } };
+    }
+    return { boxId };
+  }
+
+  switch (pathname) {
+    case "/api/iap/validate": {
+      const boxId = parsed.box_id ?? parsed.boxId;
+      const jws = parsed.jws ?? parsed.signedTransactionInfo;
+      if (typeof jws !== "string" || !jws) {
+        return { status: 400, json: { error: "jws_required" } };
+      }
+      const owned = ownedBox(boxId);
+      if (owned.error) return owned.error;
+      const result = receiptValidator.validate(jws);
+      if (!result.ok) {
+        // A structurally/crypto-invalid or expired receipt does not open the
+        // gate. 402 so the phone knows it is still unpaid.
+        return { status: 402, json: { error: "receipt_invalid", reason: result.reason } };
+      }
+      bindReceipt(store, { boxId: owned.boxId, transaction: result.transaction, raw: jws }, { now });
+      return {
+        status: 200,
+        json: {
+          bound: true,
+          box_id: owned.boxId,
+          verified: !!result.verified,
+          original_transaction_id: result.transaction.originalTransactionId,
+          expires_at: result.transaction.expiresAt ?? null,
+        },
+      };
+    }
+
+    case "/api/iap/renewed": {
+      const boxId = parsed.box_id ?? parsed.boxId;
+      const signedPayload = parsed.signedPayload ?? parsed.signed_payload;
+      if (typeof signedPayload !== "string" || !signedPayload) {
+        return { status: 400, json: { error: "signed_payload_required" } };
+      }
+      const owned = ownedBox(boxId);
+      if (owned.error) return owned.error;
+      const result = receiptValidator.validateNotification(signedPayload);
+      if (!result.ok) {
+        return { status: 402, json: { error: "receipt_invalid", reason: result.reason } };
+      }
+      bindReceipt(
+        store,
+        { boxId: owned.boxId, transaction: result.transaction, raw: signedPayload },
+        { now },
+      );
+      return {
+        status: 200,
+        json: {
+          bound: true,
+          box_id: owned.boxId,
+          verified: !!result.verified,
+          notification_type: result.notificationType ?? null,
+          expires_at: result.transaction.expiresAt ?? null,
+        },
+      };
+    }
+
+    case "/api/push/register": {
+      const platform = parsed.platform;
+      const token = parsed.token;
+      if (typeof token !== "string" || !token) {
+        return { status: 400, json: { error: "token_required" } };
+      }
+      try {
+        push.register({ accountId, platform, token });
+      } catch (e) {
+        // A bad platform (not apns|fcm) trips the store's assertPlatform.
+        return { status: 400, json: { error: "invalid_registration", reason: String(e?.message || e) } };
+      }
+      return { status: 200, json: { registered: true, platform } };
+    }
+
+    case "/api/push/unregister": {
+      const platform = parsed.platform;
+      try {
+        const removed = push.unregister(accountId, platform);
+        return { status: 200, json: { unregistered: removed !== false } };
+      } catch (e) {
+        return { status: 400, json: { error: "invalid_registration", reason: String(e?.message || e) } };
+      }
+    }
+
+    case "/api/push/send": {
+      const boxId = parsed.box_id ?? parsed.boxId;
+      const payload = parsed.payload;
+      if (!payload || typeof payload !== "object") {
+        return { status: 400, json: { error: "payload_required" } };
+      }
+      const owned = ownedBox(boxId);
+      if (owned.error) return owned.error;
+      const summary = await push.deliver({ accountId, payload, presence: parsed.presence });
+      return { status: 200, json: { ...summary } };
+    }
+
+    default:
+      return { status: 404, json: { error: "not_found" } };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// Read a request body up to MAX_BODY_BYTES; err.code === "too_large" past cap.
+function readBody(req, cb) {
+  const chunks = [];
+  let total = 0;
+  let done = false;
+  const finish = (err, body) => {
+    if (done) return;
+    done = true;
+    cb(err, body);
+  };
+  req.on("data", (c) => {
+    total += c.length;
+    if (total > MAX_BODY_BYTES) {
+      const err = new Error("payload too large");
+      err.code = "too_large";
+      req.destroy();
+      finish(err);
+      return;
+    }
+    chunks.push(c);
+  });
+  req.on("end", () => finish(null, chunks.length ? Buffer.concat(chunks).toString("utf8") : ""));
+  req.on("error", () => finish(Object.assign(new Error("read error"), { code: "read" })));
+}
+
+function sendJson(res, status, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(body);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry — start the combined relay when run directly
+// ---------------------------------------------------------------------------
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("src/relay/server.mjs");
+
+if (isMain) {
+  // Default the shared store to a file under ~/.bui-mobile so a restart keeps
+  // box bindings + receipts. RELAY_STORE_PATH overrides.
+  const storePath =
+    process.env.RELAY_STORE_PATH ||
+    (process.env.HOME ? `${process.env.HOME}/.bui-mobile/relay.sqlite` : undefined);
+  const svc = createRelayService({ storePath });
+  svc
+    .start()
+    .then(({ host, port }) => {
+      console.log(`[relay] combined entrypoint up on http://${host}:${port}`);
+    })
+    .catch((err) => {
+      console.error("[relay] failed to start:", err);
+      process.exit(1);
+    });
+  const shutdown = () => {
+    svc.close().finally(() => process.exit(0));
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}

--- a/src/relay/server.test.mjs
+++ b/src/relay/server.test.mjs
@@ -1,0 +1,279 @@
+// server.test.mjs — the combined relay entrypoint, booted as a REAL process.
+//
+// This is the permanent, CI-guarded version of the throwaway BET-71 harness: it
+// boots `createRelayService` on an ephemeral port and asserts the full BET-71
+// matrix against the RUNNING service (real http.Server, real WS box dial-out,
+// real phone HTTP requests) — not a hand-composed in-process harness. It proves
+// the two relay halves finally meet in shippable code:
+//   1. a box dials OUT over WS on /box and registers (box leg + shared store),
+//   2. GET /api/boxes is phone-authenticated (401 without / 200 with),
+//   3. a FREE metadata subpath proxies through to the box,
+//   4. a GATED subpath returns 402 until a receipt is bound,
+//   5. POST /api/iap/validate binds a receipt and OPENS the gate,
+//   6. the push register + send routes are mounted and fan out.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { WebSocket } from "ws";
+
+import { createRelayService } from "./server.mjs";
+import { openStore } from "./store.mjs";
+import { encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
+
+const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
+const TOKEN_A = "11112222333344445555666677778888"; // box token (32 hex)
+const ACCT_1 = "aaaabbbbccccddddeeeeffff00001111"; // phone token == account (DEV-OPEN)
+const silent = () => {};
+
+// ---------------------------------------------------------------------------
+// JWS fixture builders (mirrors iap.test.mjs; structural verifier accepts these)
+// ---------------------------------------------------------------------------
+
+function b64url(obj) {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+function makeJws(payload, { withX5c = true, sig = "sigbytes" } = {}) {
+  const header = { alg: "ES256", ...(withX5c ? { x5c: ["leaf", "intermediate", "root"] } : {}) };
+  return `${b64url(header)}.${b64url(payload)}.${sig}`;
+}
+function txPayload({ otid = "1000000999", productId = "sub.monthly", expiresDate = null } = {}) {
+  const p = { originalTransactionId: otid, productId };
+  if (expiresDate != null) p.expiresDate = expiresDate;
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// boot the real combined service on an ephemeral port with a shared store
+// ---------------------------------------------------------------------------
+
+async function makeService(t) {
+  const store = openStore(); // in-memory, shared so the test can bindBox()
+  const svc = createRelayService({
+    port: 0,
+    host: "127.0.0.1",
+    store,
+    log: silent,
+    warn: silent,
+  });
+  const { port } = await svc.start();
+  t.after(async () => {
+    await svc.close();
+  });
+  return { svc, store, port, base: `http://127.0.0.1:${port}`, wsBase: `ws://127.0.0.1:${port}` };
+}
+
+// A phone HTTP request with a bearer token (== account id in DEV-OPEN).
+async function phone(base, method, path, { token = ACCT_1, body } = {}) {
+  const headers = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (body !== undefined) headers["content-type"] = "application/json";
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  const text = await res.text();
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = text;
+  }
+  return { status: res.status, json };
+}
+
+// Dial a box OUT over WS and resolve once it's registered in the box leg.
+async function connectBox(svc, wsBase, { boxId = BOX_A, token = TOKEN_A } = {}) {
+  const qs = new URLSearchParams({ box_id: boxId, token });
+  const ws = new WebSocket(`${wsBase}/box?${qs.toString()}`);
+  await once(ws, "open");
+  await waitFor(() => svc.boxLeg.routing.has(boxId));
+  return ws;
+}
+
+// Make the box socket answer proxied REQUEST frames with a canned RESPONSE so
+// the phone→box proxy path is exercised end to end.
+function autoRespondBox(ws, { status = 200, body = '{"ok":true}' } = {}) {
+  ws.on("message", (data) => {
+    const frame = decodeFrame(data);
+    if (frame?.type === FRAME_TYPES.REQUEST) {
+      ws.send(
+        encodeFrame({
+          type: FRAME_TYPES.RESPONSE,
+          id: frame.id,
+          status,
+          headers: { "content-type": "application/json" },
+          body,
+        }),
+      );
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// the matrix
+// ---------------------------------------------------------------------------
+
+test("box dials out over WS on /box and registers in the box leg", async (t) => {
+  const { svc, store, port, wsBase } = await makeService(t);
+  assert.ok(Number.isInteger(port) && port > 0, "bound an ephemeral port");
+  const ws = await connectBox(svc, wsBase);
+  assert.equal(svc.boxLeg.routing.has(BOX_A), true, "box registered live");
+  assert.ok(store.getBox(BOX_A), "box row persisted in shared store");
+  ws.close();
+});
+
+test("a non-/box WS upgrade is refused (only the box leg gets upgrades)", async (t) => {
+  const { wsBase } = await makeService(t);
+  const ws = new WebSocket(`${wsBase}/nope`);
+  const [errOrClose] = await Promise.race([
+    once(ws, "error").then((a) => ["error", ...a]),
+    once(ws, "unexpected-response").then((a) => ["unexpected", ...a]),
+  ]).then((r) => [r[0]]);
+  assert.ok(errOrClose === "error" || errOrClose === "unexpected", "upgrade rejected");
+});
+
+test("GET /api/boxes: 401 without auth, 200 with a bearer token", async (t) => {
+  const { store, base } = await makeService(t);
+  store.upsertBox(BOX_A);
+  store.bindBox(BOX_A, ACCT_1);
+
+  const noAuth = await phone(base, "GET", "/api/boxes", { token: null });
+  assert.equal(noAuth.status, 401, "unauthenticated → 401");
+
+  const authed = await phone(base, "GET", "/api/boxes");
+  assert.equal(authed.status, 200);
+  assert.equal(authed.json.boxes.length, 1);
+  assert.equal(authed.json.boxes[0].box_id, BOX_A);
+});
+
+test("FREE metadata subpath proxies through to the box", async (t) => {
+  const { svc, store, base, wsBase } = await makeService(t);
+  store.upsertBox(BOX_A);
+  store.bindBox(BOX_A, ACCT_1);
+  const ws = await connectBox(svc, wsBase);
+  autoRespondBox(ws, { status: 200, body: '{"projects":[]}' });
+
+  const res = await phone(base, "GET", `/box/${BOX_A}/projects`);
+  assert.equal(res.status, 200, "free subpath forwarded (no 402)");
+  assert.deepEqual(res.json, { projects: [] });
+  ws.close();
+});
+
+test("GATED subpath returns 402 until a receipt is bound, then opens", async (t) => {
+  const { svc, store, base, wsBase } = await makeService(t);
+  store.upsertBox(BOX_A);
+  store.bindBox(BOX_A, ACCT_1);
+  const ws = await connectBox(svc, wsBase);
+  autoRespondBox(ws, { status: 200, body: '{"stream":"ok"}' });
+
+  // Before any receipt: gated subpath is payment-required.
+  const gated = await phone(base, "GET", `/box/${BOX_A}/transcript`);
+  assert.equal(gated.status, 402, "gated subpath 402 pre-subscription");
+
+  // Bind a receipt via the IAP validate route (structural verifier accepts the
+  // x5c fixture; DEV crypto is not enforced but the gate flips).
+  const jws = makeJws(txPayload({ expiresDate: Date.now() + 86_400_000 }));
+  const iap = await phone(base, "POST", "/api/iap/validate", { body: { box_id: BOX_A, jws } });
+  assert.equal(iap.status, 200, "receipt bound");
+  assert.equal(iap.json.bound, true);
+
+  // Now the gated subpath proxies through.
+  const opened = await phone(base, "GET", `/box/${BOX_A}/transcript`);
+  assert.equal(opened.status, 200, "gate opened after receipt bound");
+  assert.deepEqual(opened.json, { stream: "ok" });
+  ws.close();
+});
+
+test("IAP validate rejects a receipt for a box the account does not own (404)", async (t) => {
+  const { store, base } = await makeService(t);
+  store.upsertBox(BOX_A);
+  store.bindBox(BOX_A, "ffffffffffffffffffffffffffffffff"); // owned by someone else
+  const jws = makeJws(txPayload());
+  const res = await phone(base, "POST", "/api/iap/validate", { body: { box_id: BOX_A, jws } });
+  assert.equal(res.status, 404, "unowned box → 404");
+});
+
+test("IAP renewed binds via an App Store notification JWS", async (t) => {
+  const { store, base } = await makeService(t);
+  store.upsertBox(BOX_A);
+  store.bindBox(BOX_A, ACCT_1);
+  const innerJws = makeJws(txPayload({ otid: "renew-1", expiresDate: Date.now() + 86_400_000 }));
+  const outer = { notificationType: "DID_RENEW", data: { signedTransactionInfo: innerJws } };
+  const signedPayload = makeJws(outer);
+  const res = await phone(base, "POST", "/api/iap/renewed", {
+    body: { box_id: BOX_A, signedPayload },
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.json.bound, true);
+  assert.equal(res.json.notification_type, "DID_RENEW");
+  assert.equal(store.listReceiptsForBox(BOX_A).length, 1);
+});
+
+test("push register + send routes are mounted and fan out to the stub sender", async (t) => {
+  const { svc, store, base } = await makeService(t);
+  store.upsertBox(BOX_A);
+  store.bindBox(BOX_A, ACCT_1);
+
+  const reg = await phone(base, "POST", "/api/push/register", {
+    body: { platform: "apns", token: "device-token-abc" },
+  });
+  assert.equal(reg.status, 200);
+  assert.equal(reg.json.registered, true);
+  assert.equal(store.listPushTokensForAccount(ACCT_1).length, 1);
+
+  // A mobile-now payload fans out to the registered device via the stub sender.
+  const send = await phone(base, "POST", "/api/push/send", {
+    body: { box_id: BOX_A, payload: { kind: "agent_message", urgent: true, body: "hi" } },
+  });
+  assert.equal(send.status, 200);
+  assert.ok(send.json.route, "route decision reported");
+  assert.ok(Array.isArray(send.json.delivered), "delivered list returned");
+  assert.equal(svc.push._sender.sent.length, 1, "stub sender received the delivery");
+});
+
+test("push register rejects an invalid platform (400)", async (t) => {
+  const { base } = await makeService(t);
+  const res = await phone(base, "POST", "/api/push/register", {
+    body: { platform: "carrier-pigeon", token: "t" },
+  });
+  assert.equal(res.status, 400);
+});
+
+test("IAP/push routes require phone auth (401 without a bearer)", async (t) => {
+  const { base } = await makeService(t);
+  const res = await phone(base, "POST", "/api/push/register", {
+    token: null,
+    body: { platform: "apns", token: "t" },
+  });
+  assert.equal(res.status, 401);
+});
+
+test("a GET on an IAP route is 405 (routes are POST-only)", async (t) => {
+  const { base } = await makeService(t);
+  const res = await phone(base, "GET", "/api/iap/validate");
+  assert.equal(res.status, 405);
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function once(ws, event, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout waiting for ${event}`)), timeoutMs);
+    ws.once(event, (...args) => {
+      clearTimeout(timer);
+      resolve(args);
+    });
+  });
+}
+
+async function waitFor(pred, { timeoutMs = 3000, stepMs = 5 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, stepMs));
+  }
+  if (!pred()) throw new Error("waitFor: predicate never became true");
+}


### PR DESCRIPTION
## BET-72 — Relay: combined HTTP+WS entrypoint + systemd service

Makes the relay actually deployable. M2 built every relay piece but never wired
them into one runnable process; this joins the box WS leg and the phone HTTP API
in shippable, tested code.

**Base:** `origin/main @ ca5abd0`

### What's added (additive only — 3 new files, no deletions)
- **`src/relay/server.mjs`** — `createRelayService()`: ONE `http.Server` that
  - routes WS `upgrade` on `/box` → the Stage-2 box leg (`createRelayServer`
    built with a `noServer` `WebSocketServer`, driven via `handleUpgrade`);
  - routes all other HTTP → IAP/push routes, then falls through to
    `createRelayApi().nodeHandler()` wired with the box leg's `proxyRequest`;
  - shares ONE `openStore({ path })` across box leg, api, iap binding, push;
  - shares ONE `authenticatePhone` seam between the api and the iap/push routes;
  - listens `127.0.0.1:20787` (`RELAY_PORT`/`RELAY_HOST` overrides; `=0` ephemeral).
  - CLI entry defaults the store to `~/.bui-mobile/relay.sqlite` (`RELAY_STORE_PATH` override).
- **IAP + push routes** (`createIapPushHandler`): `POST /api/iap/validate`,
  `POST /api/iap/renewed`, `POST /api/push/register`, `POST /api/push/unregister`,
  `POST /api/push/send`. All phone-authenticated + box-ownership gated. Reuses
  the existing `createReceiptValidator` / `bindReceipt` (iap.mjs) and
  `createRelayPush` (push.mjs) — no duplication. DEV-OPEN/structural seams kept.
- **`scripts/systemd/bui-relay.service`** — `--user` unit mirroring
  `bui-server.service`, runs `node src/relay/server.mjs` on loopback:20787 so
  `bui.dev.antoinedc.com` (Caddy → 127.0.0.1:20787) resolves to a live relay.
- **`src/relay/server.test.mjs`** — boots the real service on an ephemeral port
  and asserts the full BET-71 matrix against the RUNNING service (not a harness):
  box dial-out registers; `/api/boxes` 401→200 auth; FREE subpath proxies;
  GATED subpath 402 → receipt bind opens it; IAP renewed; push register+send
  fan-out; ownership 404; auth 401; method 405.

### Out of scope (unchanged live-provisioning seams, per the issue)
Apple Root CA-G3 + real `verifyJws`; real APNs/FCM certs + prod `PushSender`;
IAP-bound `verifyBox`/`authenticatePhone`; the PROD relay host/domain. Installing
the systemd unit + Caddy vhost are on-box human deploy steps, not in-repo paths.

### Anti-spaghetti
No new store/auth/validator/push code — the entrypoint COMPOSES the existing
Stage-2/4/5 modules. `createRelayServer` already accepted an injected `wss`, so
the combined server drives it `noServer`-style with zero changes to `index.mjs`.

### Verification results
**Files changed:** 3 files (`src/relay/server.mjs`, `src/relay/server.test.mjs`, `scripts/systemd/bui-relay.service`), all new (+832 / -0).

- PR branch (`multica/BET-72-relay-combined-entrypoint` @ `d7ebbfa`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`. vitest `744 pass / 0 fail`; node:test `385 pass / 0 fail / 0 skip`. Failures: none. log sha256: `c0fd9871345d6bd7ffcbb51f7f54c94c22e848169e3cde481ce8727274f971ce`
- **Conclusion:** 0 new failures. Change is purely additive (3 new files, no
  edits to existing modules), so no existing test can regress; base-branch
  re-run omitted on that basis. New `server.test.mjs` adds 11 node:test cases.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for spot-check.
