### PR TITLE
BET-73: QR pairing-payload parser (pure module + tests)

### DIFF
--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePairPayload,
+  buildPairPayload,
+  type PairPayload,
+} from "./pairPayload";
+
+describe("parsePairPayload", () => {
+  it("accepts the primary bui://pair?server=&code= form", () => {
+    expect(
+      parsePairPayload("bui://pair?server=http://box:8787&code=123456"),
+    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  });
+
+  it("accepts the id/token alias and normalizes it to server/code", () => {
+    expect(
+      parsePairPayload("bui://pair?id=http://box:8787&token=123456"),
+    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  });
+
+  it("accepts the https://host/m/... deferred-deeplink form", () => {
+    expect(
+      parsePairPayload(
+        "https://links.example.com/m/abc?server=http://box:8787&code=123456",
+      ),
+    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(
+      parsePairPayload("  bui://pair?server=http://box:8787&code=123456  "),
+    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  });
+
+  it("normalizes a bare-host server via normalizeServerUrl and strips trailing slashes", () => {
+    // bare host:port (no scheme) → http:// prefixed
+    expect(
+      parsePairPayload("bui://pair?server=box:8787&code=123456"),
+    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+    // trailing slashes stripped
+    expect(
+      parsePairPayload(
+        "bui://pair?server=" +
+          encodeURIComponent("http://box:8787///") +
+          "&code=123456",
+      ),
+    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  });
+
+  it("URL-decodes an encoded server value", () => {
+    expect(
+      parsePairPayload(
+        "bui://pair?server=" +
+          encodeURIComponent("http://192.168.1.10:8787") +
+          "&code=654321",
+      ),
+    ).toEqual({ serverUrl: "http://192.168.1.10:8787", code: "654321" });
+  });
+
+  describe("returns null for malformed / foreign input", () => {
+    const bad: Array<[string, string]> = [
+      ["empty string", ""],
+      ["whitespace only", "   "],
+      ["a non-bui https URL", "https://example.com"],
+      ["a non-bui http URL", "http://example.com?server=http://box:8787&code=123456"],
+      ["bui scheme but wrong host", "bui://connect?server=http://box:8787&code=123456"],
+      ["missing code", "bui://pair?server=http://box:8787"],
+      ["missing server", "bui://pair?code=123456"],
+      ["empty server", "bui://pair?server=&code=123456"],
+      ["empty code", "bui://pair?server=http://box:8787&code="],
+      ["5-digit code", "bui://pair?server=http://box:8787&code=12345"],
+      ["7-digit code", "bui://pair?server=http://box:8787&code=1234567"],
+      ["non-numeric code", "bui://pair?server=http://box:8787&code=abcdef"],
+      ["syntactically invalid URL", "::::not a url::::"],
+      ["plain text", "hello world"],
+    ];
+    for (const [label, input] of bad) {
+      it(label, () => {
+        expect(parsePairPayload(input)).toBeNull();
+      });
+    }
+  });
+});
+
+describe("buildPairPayload", () => {
+  it("produces the canonical bui://pair?server=<enc>&code= string", () => {
+    expect(
+      buildPairPayload({ serverUrl: "http://box:8787", code: "123456" }),
+    ).toBe(
+      "bui://pair?server=" +
+        encodeURIComponent("http://box:8787") +
+        "&code=123456",
+    );
+  });
+
+  it("URL-encodes the server value", () => {
+    const out = buildPairPayload({
+      serverUrl: "http://192.168.1.10:8787",
+      code: "654321",
+    });
+    expect(out).toContain(encodeURIComponent("http://192.168.1.10:8787"));
+    expect(out).not.toContain("http://192.168.1.10:8787&");
+  });
+});
+
+describe("round-trip", () => {
+  it("parsePairPayload(buildPairPayload(p)) deep-equals p for a valid canonical p", () => {
+    const cases: PairPayload[] = [
+      { serverUrl: "http://box:8787", code: "123456" },
+      { serverUrl: "http://192.168.1.10:8787", code: "000000" },
+      { serverUrl: "https://relay.example.com", code: "987654" },
+    ];
+    for (const p of cases) {
+      expect(parsePairPayload(buildPairPayload(p))).toEqual(p);
+    }
+  });
+});

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -1,0 +1,109 @@
+// pairPayload.ts — pure parser + builder for the pairing deeplink/QR payload
+// (BET-73, M3.1). No DOM, no fetch, no camera: this is the pure-before-wired
+// foundation that stage 2 (camera → auto-connect) imports.
+//
+// A desktop "Pair phone" panel encodes a payload into a QR; the mobile app
+// scans it (or resolves it from a deferred deeplink) and auto-connects. Two URL
+// shapes carry the SAME two fields (server + code); this module normalizes both
+// into a single { serverUrl, code } and provides the inverse builder used as a
+// round-trip oracle in tests (and later by the desktop QR panel in M6).
+//
+//   1. Custom scheme (primary — what the desktop panel renders):
+//        bui://pair?server=<url>&code=<6-digit>
+//      M6-spec alias, also accepted:
+//        bui://pair?id=<serverUrl-or-boxId>&token=<code>
+//   2. Deferred-deeplink https form (Branch/Firebase style):
+//        https://<host>/m/<payload>?server=<url>&code=<6-digit>
+//
+// The validation contract (server URL shape, 6-digit code) is SINGLE-SOURCED:
+// we delegate to normalizeServerUrl / isValidServerUrl (../pairStepLogic) and
+// normalizeCode (../../shared/claim.mjs) rather than re-implementing it here.
+
+import { normalizeServerUrl, isValidServerUrl } from "../pairStepLogic";
+import { normalizeCode } from "../../shared/claim.mjs";
+
+export type PairPayload = { serverUrl: string; code: string };
+
+/**
+ * Coerce a raw server value into a normalized, valid http(s) URL string, or
+ * null if it can't be. A scheme-less bare host ("box:8787") gets an http://
+ * prefix before validation so QR payloads that carry only host:port still
+ * resolve; trailing slashes are stripped by normalizeServerUrl. Returns null
+ * for empty / unparseable input so the caller can reject the whole payload.
+ */
+function coerceServerUrl(raw: string): string | null {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) return null;
+  // If there's no scheme at all, assume http:// (bare host:port from a QR).
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `http://${trimmed}`;
+  const normalized = normalizeServerUrl(withScheme);
+  return isValidServerUrl(normalized) ? normalized : null;
+}
+
+/**
+ * Parse a raw scanned/deeplinked string into a PairPayload, or null for any
+ * malformed / foreign input: not a bui pair URL, missing server or code, code
+ * not exactly 6 digits, or an unparseable URL. Whitespace is trimmed.
+ *
+ * Accepts either query spelling — `server`/`code` (primary) or the M6 alias
+ * `id`/`token` — and both URL shapes (custom `bui://pair` scheme and the
+ * `https://host/m/...` deferred-deeplink form).
+ */
+export function parsePairPayload(raw: string): PairPayload | null {
+  const input = String(raw ?? "").trim();
+  if (!input) return null;
+
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  // Only two families are pairing payloads:
+  //   • bui://pair?...          (custom scheme; host is "pair")
+  //   • https://<host>/m/...    (deferred deeplink; path starts with /m/ or /m)
+  const isBuiScheme = url.protocol === "bui:";
+  const isHttps = url.protocol === "https:" || url.protocol === "http:";
+  const isDeferredPath = /^\/m(\/|$)/.test(url.pathname);
+
+  if (isBuiScheme) {
+    // bui://pair — the host segment must be "pair" (URL puts it in .hostname).
+    if (url.hostname !== "pair") return null;
+  } else if (isHttps) {
+    if (!isDeferredPath) return null;
+  } else {
+    return null;
+  }
+
+  const q = url.searchParams;
+  // Primary spelling wins; fall back to the id/token alias.
+  const rawServer = q.get("server") ?? q.get("id") ?? "";
+  const rawCode = q.get("code") ?? q.get("token") ?? "";
+
+  const serverUrl = coerceServerUrl(rawServer);
+  if (!serverUrl) return null;
+
+  const code = normalizeCode(rawCode);
+  // normalizeCode strips non-digits and clamps to 6, so a 7-digit input would
+  // pass length-6 but silently drop a digit. Guard against that by requiring
+  // the raw code to contain exactly 6 digits (no more, no fewer).
+  if (!/^\d{6}$/.test(code)) return null;
+  if ((String(rawCode).match(/\d/g) ?? []).length !== 6) return null;
+
+  return { serverUrl, code };
+}
+
+/**
+ * Inverse of parsePairPayload: produce the canonical custom-scheme string
+ *   bui://pair?server=<url-encoded>&code=<code>
+ * Used as a round-trip oracle in tests and later by the desktop QR panel (M6).
+ * The server URL is URL-encoded so reserved characters survive the query.
+ */
+export function buildPairPayload(p: PairPayload): string {
+  const serverUrl = normalizeServerUrl(p.serverUrl);
+  const code = normalizeCode(p.code);
+  return `bui://pair?server=${encodeURIComponent(serverUrl)}&code=${code}`;
+}


### PR DESCRIPTION
## BET-73 — M3.1: QR pairing-payload parser (pure module + tests)

Stage 1 of 3 under BET-37. Adds a **pure, framework-free** parser + builder for the pairing deeplink/QR payload — no DOM, no fetch, no camera. Stage 2 imports it for camera → auto-connect.

### What changed
- `src/renderer/mobile/pairPayload.ts` — `type PairPayload`, `parsePairPayload`, `buildPairPayload`.
  - Accepts custom scheme `bui://pair?server=<url>&code=<6-digit>` (primary) and the M6 alias `bui://pair?id=<...>&token=<...>` (normalized to server/code).
  - Accepts the deferred-deeplink form `https://<host>/m/...?server=&code=`.
  - Validation is **single-sourced**: delegates to `normalizeServerUrl` / `isValidServerUrl` (`../pairStepLogic`) and `normalizeCode` (`../../shared/claim.mjs`) — no re-implementation. Bare-host `box:8787` is coerced to `http://box:8787` before validating.
  - Returns `null` for any malformed/foreign input.
  - `buildPairPayload` produces the canonical URL-encoded string, used as a round-trip oracle.
- `src/renderer/mobile/pairPayload.test.ts` — 23 vitest cases (both spellings, both URL shapes, whitespace, bare-host, encoded server, all null cases, build encoding, round-trip).

Did **not** touch `PairingScreen.tsx`, `httpApi.ts`, `MobileApp.tsx`, or any Capacitor/native file (stage 2/3).

### Verification results
- PR branch (`multica/BET-73-qr-pair-payload-parser`):
  - typecheck: exit 0, errors: none
  - test: exit 0 — vitest 23/23 new pass (full renderer suite green), node suite 374/374 pass, 0 fail
- **Conclusion:** 0 new failures. All green.

Base: origin/main @ ca5abd0
