### PR TITLE
BET-75: M3.3 EAS build config + TestFlight run docs

### DIFF
--- a/mobile-rn/README.md
+++ b/mobile-rn/README.md
@@ -36,9 +36,81 @@ Then:
   URL (e.g. `http://192.168.1.10:8787`) and the 6-digit code from
   `npm run pair` on the box.
 
-A signed device build (EAS profiles / TestFlight) is **stage 3 (BET-75)** and is
-intentionally out of scope here — everything above runs without an Apple
+## Device / TestFlight builds (EAS)
+
+This box is Linux and can't compile iOS, so device builds run on **Expo
+Application Services (EAS Build)** — cloud macOS builders. The build/submit
+config lives in [`eas.json`](./eas.json) with three profiles:
+
+| Profile | Purpose | iOS output | Apple account needed? |
+|---|---|---|---|
+| `development` | Dev client, hot reload | **simulator** `.app` | No |
+| `preview` | Internal QA / demo | **simulator** `.app` | No |
+| `production` | Store / TestFlight | signed device `.ipa` | **Yes** |
+
+The `development` and `preview` profiles set `ios.simulator: true`, so they build
+a simulator `.app` that needs **no Apple credentials** — that's the CI-friendly
+sanity build. Only `production` (a signed device binary) requires an Apple
 Developer account.
+
+### One-time setup
+
+```bash
+cd mobile-rn
+npm install
+npm install -g eas-cli          # or: npx eas-cli@latest ...
+eas login                       # interactive; or export EXPO_TOKEN=<token> for CI
+eas init                        # links this app to an Expo project (writes extra.eas.projectId into app.json)
+```
+
+`EXPO_TOKEN` (an Expo access token, created at https://expo.dev under Account →
+Access Tokens) lets `eas` run **non-interactively** from this box — set it
+instead of `eas login` for scripted/CI runs.
+
+### Build
+
+```bash
+# No Apple account — simulator build (runs on the iOS simulator):
+eas build --platform ios --profile preview
+
+# Signed device / TestFlight build (requires Apple Developer membership):
+eas build --platform ios --profile production
+```
+
+The first `production` build prompts EAS to create the iOS Distribution
+certificate + provisioning profile for you (EAS-managed credentials); it needs
+you to be logged into an Apple account with an active **Apple Developer Program**
+membership.
+
+### Submit to TestFlight
+
+```bash
+eas submit -p ios --profile production --latest
+```
+
+`eas submit` uploads the built `.ipa` to App Store Connect / TestFlight. The
+`submit.production.ios` block in `eas.json` reads the **App Store Connect API
+key** from env (never committed) — set these before submitting:
+
+| Env var | What | Where it comes from |
+|---|---|---|
+| `ASC_API_KEY_PATH` | Path to the `.p8` API key file | App Store Connect → Users and Access → Integrations → App Store Connect API |
+| `ASC_API_KEY_ID` | Key ID for that `.p8` | same page |
+| `ASC_API_KEY_ISSUER_ID` | Issuer ID for your ASC account | same page |
+
+Store the `.p8` and IDs as **EAS secrets** (`eas secret:create`) or export them
+in the shell for a one-off submit — do **not** commit them to the repo.
+
+### EAS free tier
+
+EAS Build's free tier uses a **shared build queue** (builds wait behind paid
+users) and caps **builds per month**. That's fine for the occasional TestFlight
+build here — `eas.json` intentionally does **not** request paid priority builds.
+Expect a queue wait on free-tier builds.
+
+A signed `production` build/submit is **human-blocked** on the Apple artifacts
+above (Developer membership, `EXPO_TOKEN`, ASC API key). This slice ships the
+config + docs; the actual signed run is an operator step.
 
 ## Verify without a simulator (this repo's CI path)
 

--- a/mobile-rn/eas.json
+++ b/mobile-rn/eas.json
@@ -1,0 +1,33 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "ascApiKeyPath": "$ASC_API_KEY_PATH",
+        "ascApiKeyId": "$ASC_API_KEY_ID",
+        "ascApiKeyIssuerId": "$ASC_API_KEY_ISSUER_ID"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## BET-75 — M3.3: EAS build config + TestFlight run docs

Adds the Expo EAS build configuration for the `mobile-rn/` app and documents the exact human commands for a signed TestFlight build. Config + docs only — **no signed build is run** (human-blocked on Apple credentials, see escalation on the issue).

**Base:** `origin/main @ c8f2ad0`

### Changes
- **`mobile-rn/eas.json`** — three build profiles:
  - `development` — dev client, `ios.simulator: true` (no Apple creds)
  - `preview` — internal, `ios.simulator: true` (no Apple creds)
  - `production` — signed store/device build (`autoIncrement`)
  - `submit.production.ios` reads the ASC API key from env (`$ASC_API_KEY_PATH`, `$ASC_API_KEY_ID`, `$ASC_API_KEY_ISSUER_ID`) — **no secrets committed**.
- **`mobile-rn/README.md`** — EAS section: one-time setup (`eas login` / `EXPO_TOKEN`, `eas init`), `eas build -p ios --profile preview|production`, `eas submit -p ios`, the ASC env-var table, and a free-tier note (shared queue / monthly cap, no paid priority).

### Confirmed (no change needed)
- `app.json` already carries `ios.bundleIdentifier` = `android.package` = `com.antoinedc.bui`, app name `bui`, camera perms.

### Anti-spaghetti
- No new source modules; extended BET-74's existing `mobile-rn/README.md` rather than adding a parallel doc. No Apple Team ID / ASC key / secrets in the repo (all `$ENV` placeholders).

### Verification results
**Files changed:** 2 files — `mobile-rn/eas.json`, `mobile-rn/README.md` (config/docs only).

- PR branch (`multica/BET-75-eas-build-config`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0` — vitest **806 pass** / 0 fail, node:test **385 pass** / 0 fail.
- **Conclusion:** 0 new failures. Changes are JSON + markdown only and cannot affect compilation or the test suite.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.
