### PR TITLE
BET-76: M3.5-1 Session detail + live transcript view (mobile-rn)

### DIFF
--- a/mobile-rn/App.tsx
+++ b/mobile-rn/App.tsx
@@ -17,11 +17,14 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { loadCredentials, type StoredCredentials } from "./src/api/credentials";
 import { PairingScreen } from "./src/screens/PairingScreen";
 import { SessionListScreen } from "./src/screens/SessionListScreen";
+import { SessionDetailScreen } from "./src/screens/SessionDetailScreen";
+import type { SessionRowVM } from "./src/pure/sessionList";
 import { colors } from "./src/theme";
 
 export type RootStackParamList = {
   Pairing: undefined;
   Sessions: { credentials: StoredCredentials };
+  Session: { credentials: StoredCredentials; session: SessionRowVM };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -66,12 +69,19 @@ export default function App() {
         }}
       >
         {initial ? (
-          <Stack.Screen
-            name="Sessions"
-            component={SessionListScreen}
-            initialParams={{ credentials: initial }}
-            options={{ title: "Sessions" }}
-          />
+          <>
+            <Stack.Screen
+              name="Sessions"
+              component={SessionListScreen}
+              initialParams={{ credentials: initial }}
+              options={{ title: "Sessions" }}
+            />
+            <Stack.Screen
+              name="Session"
+              component={SessionDetailScreen}
+              options={{ title: "Session" }}
+            />
+          </>
         ) : (
           <Stack.Screen
             name="Pairing"

--- a/mobile-rn/src/api/__tests__/eventsClient.test.ts
+++ b/mobile-rn/src/api/__tests__/eventsClient.test.ts
@@ -1,0 +1,115 @@
+// eventsClient.test.ts — the socket glue's observable behavior with an injected
+// fake WebSocket + timer: URL building, viewed-session filtering of delivered
+// events, reconnect on unexpected close, and no-reconnect after close().
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  eventsWsUrl,
+  subscribeOpencodeEvents,
+  type WebSocketLike,
+} from "../eventsClient";
+import type { OpencodeEventLike } from "../../pure/transcript";
+
+describe("eventsWsUrl", () => {
+  it("http→ws, appends token as ?token=", () => {
+    expect(eventsWsUrl("http://box:8787", "tok")).toBe(
+      "ws://box:8787/events?token=tok",
+    );
+  });
+  it("https→wss and trims trailing slash", () => {
+    expect(eventsWsUrl("https://box/", "a b")).toBe(
+      "wss://box/events?token=a%20b",
+    );
+  });
+});
+
+/** A controllable fake socket that captures its handlers. */
+class FakeSocket implements WebSocketLike {
+  onopen: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data?: unknown }) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+  onclose: ((ev?: unknown) => void) | null = null;
+  closed = false;
+  static instances: FakeSocket[] = [];
+  constructor() {
+    FakeSocket.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify({ kind: "opencode", payload }) });
+  }
+}
+
+function frame(type: string, sessionID?: string) {
+  return { type, properties: sessionID ? { sessionID } : {} };
+}
+
+describe("subscribeOpencodeEvents", () => {
+  it("delivers only events for the viewed session", () => {
+    FakeSocket.instances = [];
+    const received: OpencodeEventLike[] = [];
+    const sub = subscribeOpencodeEvents(
+      "http://box",
+      "tok",
+      "s1",
+      (ev) => received.push(ev),
+      { createSocket: () => new FakeSocket() },
+    );
+    const ws = FakeSocket.instances[0];
+    ws.onopen?.();
+    ws.emit(frame("session.idle", "s1")); // ours → delivered
+    ws.emit(frame("message.part.delta", "s2")); // other → dropped
+    ws.emit(frame("permission.replied")); // no sessionID → delivered
+    ws.onmessage?.({ data: "not json" }); // junk → ignored
+    ws.onmessage?.({ data: JSON.stringify({ kind: "pty", payload: {} }) }); // non-opencode → ignored
+
+    expect(received.map((e) => e.type)).toEqual([
+      "session.idle",
+      "permission.replied",
+    ]);
+    sub.close();
+  });
+
+  it("reconnects after an unexpected close, using the injected timer", () => {
+    FakeSocket.instances = [];
+    let scheduled: (() => void) | null = null;
+    const setTimeoutFn = vi.fn((fn: () => void) => {
+      scheduled = fn;
+      return 1;
+    });
+    const sub = subscribeOpencodeEvents("http://box", "t", "s1", () => {}, {
+      createSocket: () => new FakeSocket(),
+      setTimeoutFn,
+      backoff: { baseMs: 10, maxMs: 100, factor: 2 },
+    });
+    expect(FakeSocket.instances).toHaveLength(1);
+
+    // Simulate an unexpected drop.
+    FakeSocket.instances[0].onclose?.();
+    expect(setTimeoutFn).toHaveBeenCalledWith(expect.any(Function), 10);
+
+    // Fire the scheduled retry → a second socket is created.
+    scheduled?.();
+    expect(FakeSocket.instances).toHaveLength(2);
+    sub.close();
+  });
+
+  it("does not reconnect after the caller closes the subscription", () => {
+    FakeSocket.instances = [];
+    const setTimeoutFn = vi.fn((_fn: () => void) => 1);
+    const sub = subscribeOpencodeEvents("http://box", "t", "s1", () => {}, {
+      createSocket: () => new FakeSocket(),
+      setTimeoutFn,
+    });
+    const ws = FakeSocket.instances[0];
+    sub.close();
+    expect(ws.closed).toBe(true);
+    // A late onclose after teardown must NOT schedule a reconnect.
+    ws.onclose?.();
+    expect(setTimeoutFn).not.toHaveBeenCalled();
+    expect(FakeSocket.instances).toHaveLength(1);
+  });
+});

--- a/mobile-rn/src/api/__tests__/eventsClient.test.ts
+++ b/mobile-rn/src/api/__tests__/eventsClient.test.ts
@@ -75,9 +75,9 @@ describe("subscribeOpencodeEvents", () => {
 
   it("reconnects after an unexpected close, using the injected timer", () => {
     FakeSocket.instances = [];
-    let scheduled: (() => void) | null = null;
+    const scheduledRef: { fn: (() => void) | null } = { fn: null };
     const setTimeoutFn = vi.fn((fn: () => void) => {
-      scheduled = fn;
+      scheduledRef.fn = fn;
       return 1;
     });
     const sub = subscribeOpencodeEvents("http://box", "t", "s1", () => {}, {
@@ -92,7 +92,7 @@ describe("subscribeOpencodeEvents", () => {
     expect(setTimeoutFn).toHaveBeenCalledWith(expect.any(Function), 10);
 
     // Fire the scheduled retry → a second socket is created.
-    scheduled?.();
+    scheduledRef.fn?.();
     expect(FakeSocket.instances).toHaveLength(2);
     sub.close();
   });

--- a/mobile-rn/src/api/eventsClient.ts
+++ b/mobile-rn/src/api/eventsClient.ts
@@ -1,0 +1,168 @@
+// eventsClient.ts — the impure /events WebSocket client for the RN app.
+//
+// Opens the box's `GET <base>/events` WebSocket with the box_token as a
+// `?token=` query param (the server accepts `?token=` on /events + /pty ONLY —
+// see src/server/index.mjs; RN/React-Native WebSocket, like browsers, can't set
+// an Authorization header on the handshake). Parses each `{kind,payload}` frame,
+// narrows it to an opencode event, filters to the viewed session, and hands it
+// to the subscriber. Reconnects with exponential backoff on unexpected close;
+// never permanently abandons a live session until the caller unsubscribes.
+//
+// ALL decision logic (envelope parse, session filter, backoff/reconnect) lives
+// in the pure ../pure/events module and is unit-tested there; this file owns
+// only the socket + timer side effects and stays deliberately thin.
+
+import {
+  DEFAULT_BACKOFF,
+  eventMatchesSession,
+  parseEnvelope,
+  reconnectDecision,
+  toOpencodeEvent,
+  type BackoffConfig,
+} from "../pure/events";
+import type { OpencodeEventLike } from "../pure/transcript";
+
+/** Strip trailing slashes so "http://box/" and "http://box" behave identically. */
+function trimBase(base: string): string {
+  return base.replace(/\/+$/, "");
+}
+
+/**
+ * Build the /events WebSocket URL: http→ws / https→wss, `/events` path, and the
+ * box_token as `?token=` (appended last so it survives any pre-existing query).
+ */
+export function eventsWsUrl(base: string, token: string): string {
+  const ws = trimBase(base).replace(/^http/, "ws") + "/events";
+  const sep = ws.includes("?") ? "&" : "?";
+  return `${ws}${sep}token=${encodeURIComponent(token)}`;
+}
+
+/** Handle returned by {@link subscribeOpencodeEvents}; call to tear down. */
+export interface EventsSubscription {
+  close(): void;
+}
+
+interface SubscribeOptions {
+  /** Override backoff (tests inject a fast/tiny config). */
+  backoff?: BackoffConfig;
+  /** WebSocket factory (tests inject a fake). Defaults to global WebSocket. */
+  createSocket?: (url: string) => WebSocketLike;
+  /** setTimeout override (tests inject a controllable timer). */
+  setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  /** clearTimeout override matching setTimeoutFn's handle type. */
+  clearTimeoutFn?: (handle: unknown) => void;
+}
+
+/** The subset of the WebSocket surface we touch (RN + DOM both satisfy this). */
+export interface WebSocketLike {
+  onopen: ((ev?: unknown) => void) | null;
+  onmessage: ((ev: { data?: unknown }) => void) | null;
+  onerror: ((ev?: unknown) => void) | null;
+  onclose: ((ev?: unknown) => void) | null;
+  close(): void;
+}
+
+/**
+ * Open the /events WS for `base`/`token` and deliver every opencode event for
+ * `sessionID` to `onEvent`. Reconnects with backoff on unexpected drops; the
+ * returned handle's `close()` stops reconnecting and tears the socket down.
+ *
+ * The pure helpers do the deciding: {@link parseEnvelope} +
+ * {@link toOpencodeEvent} turn a frame into an event, {@link eventMatchesSession}
+ * drops other sessions, and {@link reconnectDecision} says whether/when to retry.
+ */
+export function subscribeOpencodeEvents(
+  base: string,
+  token: string,
+  sessionID: string,
+  onEvent: (ev: OpencodeEventLike) => void,
+  opts: SubscribeOptions = {},
+): EventsSubscription {
+  const backoff = opts.backoff ?? DEFAULT_BACKOFF;
+  const createSocket =
+    opts.createSocket ??
+    ((url: string) => new WebSocket(url) as unknown as WebSocketLike);
+  const setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+
+  let closedByCaller = false;
+  let attempt = 0;
+  let socket: WebSocketLike | null = null;
+  let retryHandle: unknown = null;
+
+  function connect() {
+    if (closedByCaller) return;
+    const url = eventsWsUrl(base, token);
+    let ws: WebSocketLike;
+    try {
+      ws = createSocket(url);
+    } catch {
+      // Constructor threw (bad URL) — treat as an unexpected close and retry.
+      scheduleReconnect();
+      return;
+    }
+    socket = ws;
+
+    ws.onopen = () => {
+      // A successful open resets the backoff so a later drop retries fast.
+      attempt = 0;
+    };
+
+    ws.onmessage = (frame) => {
+      const ev = toOpencodeEvent(parseEnvelope(frame?.data));
+      if (!ev) return;
+      if (!eventMatchesSession(ev, sessionID)) return;
+      try {
+        onEvent(ev);
+      } catch {
+        /* subscriber threw — never let it break the socket loop */
+      }
+    };
+
+    ws.onerror = () => {
+      /* onclose follows an error; reconnect handled there */
+    };
+
+    ws.onclose = () => {
+      socket = null;
+      scheduleReconnect();
+    };
+  }
+
+  function scheduleReconnect() {
+    if (closedByCaller) return;
+    attempt += 1;
+    const { reconnect, delayMs } = reconnectDecision(attempt, false, backoff);
+    if (!reconnect) return;
+    retryHandle = setTimeoutFn(() => {
+      retryHandle = null;
+      connect();
+    }, delayMs);
+  }
+
+  connect();
+
+  return {
+    close() {
+      closedByCaller = true;
+      if (retryHandle != null) {
+        clearTimeoutFn(retryHandle);
+        retryHandle = null;
+      }
+      if (socket) {
+        // Detach handlers first so the intentional close doesn't trigger a
+        // reconnect via onclose.
+        socket.onopen = null;
+        socket.onmessage = null;
+        socket.onerror = null;
+        socket.onclose = null;
+        try {
+          socket.close();
+        } catch {
+          /* already closing / not-open — ignore */
+        }
+        socket = null;
+      }
+    },
+  };
+}

--- a/mobile-rn/src/api/eventsClient.ts
+++ b/mobile-rn/src/api/eventsClient.ts
@@ -82,8 +82,10 @@ export function subscribeOpencodeEvents(
   const createSocket =
     opts.createSocket ??
     ((url: string) => new WebSocket(url) as unknown as WebSocketLike);
-  const setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
-  const clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+  const setTimeoutFn: (fn: () => void, ms: number) => unknown =
+    opts.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearTimeoutFn: (handle: unknown) => void =
+    opts.clearTimeoutFn ?? ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
 
   let closedByCaller = false;
   let attempt = 0;

--- a/mobile-rn/src/api/pairingApi.ts
+++ b/mobile-rn/src/api/pairingApi.ts
@@ -15,6 +15,7 @@ import {
   type ClaimResult,
 } from "../pure/claim";
 import { mapSessionRows, type SessionRowVM, type StatusMap } from "../pure/sessionList";
+import { mapTranscript, type TranscriptVM } from "../pure/transcript";
 import { saveCredentials } from "./credentials";
 
 /** Strip trailing slashes so "http://box/" and "http://box" behave identically. */
@@ -117,4 +118,20 @@ export async function fetchSessionList(
 ): Promise<SessionRowVM[]> {
   const raw = await rpc<unknown>(base, token, "tmux:list");
   return mapSessionRows(raw, statuses);
+}
+
+/**
+ * Fetch a chat session's transcript from the box's `opencode:messages` channel
+ * (arg = opencode session id) and map it to the detail-screen view model. This
+ * reuses the same generic `rpc()` helper as the session list — the box relays
+ * it straight to opencode's `GET /session/{id}/message` (src/server/rpc.mjs →
+ * opencode.listMessages). Read-only; live updates arrive over `/events`.
+ */
+export async function fetchTranscript(
+  base: string,
+  token: string,
+  opencodeSessionId: string,
+): Promise<TranscriptVM> {
+  const raw = await rpc<unknown>(base, token, "opencode:messages", opencodeSessionId);
+  return mapTranscript(raw);
 }

--- a/mobile-rn/src/pure/__tests__/events.test.ts
+++ b/mobile-rn/src/pure/__tests__/events.test.ts
@@ -1,0 +1,106 @@
+// events.test.ts — pure /events helpers: envelope parse, opencode narrowing,
+// viewed-session filter, and reconnect-backoff decision.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  backoffDelay,
+  DEFAULT_BACKOFF,
+  eventMatchesSession,
+  parseEnvelope,
+  reconnectDecision,
+  toOpencodeEvent,
+} from "../events";
+
+describe("parseEnvelope", () => {
+  it("parses a well-formed {kind,payload} frame", () => {
+    expect(parseEnvelope('{"kind":"opencode","payload":{"type":"x"}}')).toEqual({
+      kind: "opencode",
+      payload: { type: "x" },
+    });
+  });
+
+  it("returns null for non-string, non-JSON, or non-object frames", () => {
+    expect(parseEnvelope(42)).toBeNull();
+    expect(parseEnvelope("not json")).toBeNull();
+    expect(parseEnvelope("null")).toBeNull();
+    expect(parseEnvelope("[1,2]")).toBeNull(); // array has no `kind`
+    expect(parseEnvelope('{"payload":1}')).toBeNull(); // missing kind
+    expect(parseEnvelope('{"kind":5}')).toBeNull(); // non-string kind
+  });
+});
+
+describe("toOpencodeEvent", () => {
+  it("narrows an opencode envelope to an event", () => {
+    const ev = toOpencodeEvent({
+      kind: "opencode",
+      payload: { type: "session.idle", properties: { sessionID: "s1" } },
+    });
+    expect(ev).toEqual({ type: "session.idle", properties: { sessionID: "s1" } });
+  });
+
+  it("defaults missing/invalid properties to {}", () => {
+    const ev = toOpencodeEvent({ kind: "opencode", payload: { type: "x" } });
+    expect(ev).toEqual({ type: "x", properties: {} });
+  });
+
+  it("returns null for non-opencode kinds or bad payloads", () => {
+    expect(toOpencodeEvent(null)).toBeNull();
+    expect(toOpencodeEvent({ kind: "pty", payload: { type: "x" } })).toBeNull();
+    expect(toOpencodeEvent({ kind: "opencode", payload: null })).toBeNull();
+    expect(toOpencodeEvent({ kind: "opencode", payload: { notype: 1 } })).toBeNull();
+  });
+});
+
+describe("eventMatchesSession", () => {
+  it("keeps events for the viewed session", () => {
+    expect(
+      eventMatchesSession({ type: "x", properties: { sessionID: "s1" } }, "s1"),
+    ).toBe(true);
+  });
+
+  it("drops events for a different session", () => {
+    expect(
+      eventMatchesSession({ type: "x", properties: { sessionID: "s2" } }, "s1"),
+    ).toBe(false);
+  });
+
+  it("keeps events with no sessionID (global / synthetic)", () => {
+    expect(eventMatchesSession({ type: "x", properties: {} }, "s1")).toBe(true);
+    expect(eventMatchesSession({ type: "x" }, "s1")).toBe(true);
+  });
+});
+
+describe("backoffDelay", () => {
+  it("returns baseMs on the first attempt", () => {
+    expect(backoffDelay(1)).toBe(DEFAULT_BACKOFF.baseMs);
+    expect(backoffDelay(0)).toBe(DEFAULT_BACKOFF.baseMs);
+  });
+
+  it("grows exponentially and caps at maxMs", () => {
+    // base 500, factor 2: attempt2=1000, attempt3=2000, attempt4=4000...
+    expect(backoffDelay(2)).toBe(1000);
+    expect(backoffDelay(3)).toBe(2000);
+    expect(backoffDelay(4)).toBe(4000);
+    // eventually hits the 15000 cap
+    expect(backoffDelay(20)).toBe(DEFAULT_BACKOFF.maxMs);
+  });
+
+  it("respects a custom config", () => {
+    const cfg = { baseMs: 100, maxMs: 300, factor: 2 };
+    expect(backoffDelay(1, cfg)).toBe(100);
+    expect(backoffDelay(2, cfg)).toBe(200);
+    expect(backoffDelay(3, cfg)).toBe(300); // 400 capped to 300
+  });
+});
+
+describe("reconnectDecision", () => {
+  it("does not reconnect on an intentional close", () => {
+    expect(reconnectDecision(1, true)).toEqual({ reconnect: false, delayMs: 0 });
+  });
+
+  it("reconnects with a backoff delay on an unexpected close", () => {
+    expect(reconnectDecision(1, false)).toEqual({ reconnect: true, delayMs: 500 });
+    expect(reconnectDecision(3, false)).toEqual({ reconnect: true, delayMs: 2000 });
+  });
+});

--- a/mobile-rn/src/pure/__tests__/sessionList.test.ts
+++ b/mobile-rn/src/pure/__tests__/sessionList.test.ts
@@ -39,6 +39,13 @@ describe("mapSessionRows", () => {
     for (const r of mapSessionRows(RAW)) expect(r.status).toBe("idle");
   });
 
+  it("carries opencodeSessionId through (null for terminals)", () => {
+    const rows = mapSessionRows(RAW);
+    expect(rows[0].opencodeSessionId).toBe("sess_abc"); // chat
+    expect(rows[1].opencodeSessionId).toBeNull(); // terminal
+    expect(rows[2].opencodeSessionId).toBe("sess_def"); // chat
+  });
+
   it("applies running status from the status map by session+windowIndex", () => {
     const rows = mapSessionRows(RAW, {
       "better-ui": { 0: true, 1: false },

--- a/mobile-rn/src/pure/__tests__/transcript.test.ts
+++ b/mobile-rn/src/pure/__tests__/transcript.test.ts
@@ -1,0 +1,203 @@
+// transcript.test.ts — pure transcript-model tests: raw opencode messages →
+// row VMs (user / assistant / tool), delta-merge accumulation into the right
+// message, and the running flag driven by session.idle / session.status.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyOpencodeEvent,
+  mapMessageRow,
+  mapTranscript,
+  mergeDelta,
+  type MessageRowVM,
+  type RawMessage,
+  type TranscriptVM,
+} from "../transcript";
+
+const userMsg: RawMessage = {
+  info: { id: "msg-user-1", role: "user", time: { created: 100 } },
+  parts: [{ type: "text", id: "p1", text: "hello box" }],
+};
+
+const assistantMsg: RawMessage = {
+  info: { id: "msg-asst-1", role: "assistant", time: { created: 200 }, modelID: "claude-x" },
+  parts: [
+    { type: "reasoning", id: "r1", text: "thinking..." },
+    { type: "text", id: "t1", text: "here is the answer" },
+    { type: "tool", id: "tool1", tool: "read", state: { status: "completed", title: "src/a.ts" } },
+  ],
+};
+
+describe("mapMessageRow", () => {
+  it("maps a user text message", () => {
+    const row = mapMessageRow(userMsg, 0);
+    expect(row).toEqual<MessageRowVM>({
+      key: "msg-user-1",
+      role: "user",
+      text: "hello box",
+      tools: [],
+      model: undefined,
+      createdAt: 100,
+    });
+  });
+
+  it("maps an assistant message with reasoning+text+tool", () => {
+    const row = mapMessageRow(assistantMsg, 1);
+    expect(row.role).toBe("assistant");
+    expect(row.model).toBe("claude-x");
+    expect(row.createdAt).toBe(200);
+    // reasoning + text concatenated with a blank line
+    expect(row.text).toBe("thinking...\n\nhere is the answer");
+    expect(row.tools).toEqual([
+      { key: "tool1", name: "read", status: "completed", title: "src/a.ts" },
+    ]);
+  });
+
+  it("skips synthetic/ignored text parts", () => {
+    const row = mapMessageRow(
+      {
+        info: { id: "m", role: "assistant" },
+        parts: [
+          { type: "text", text: "visible" },
+          { type: "text", text: "hidden", synthetic: true },
+          { type: "text", text: "also hidden", ignored: true },
+        ],
+      },
+      0,
+    );
+    expect(row.text).toBe("visible");
+  });
+
+  it("defaults tool name/status and synthesizes a key when absent", () => {
+    const row = mapMessageRow(
+      { info: { id: "m", role: "assistant" }, parts: [{ type: "tool" }] },
+      3,
+    );
+    expect(row.tools).toEqual([
+      { key: "m:tool:0", name: "tool", status: "pending", title: undefined },
+    ]);
+  });
+
+  it("synthesizes a key when message id is missing", () => {
+    const row = mapMessageRow({ info: {}, parts: [] }, 7);
+    expect(row.key).toBe("msg-7");
+    expect(row.role).toBe("assistant"); // non-user defaults to assistant
+  });
+
+  it("tolerates malformed parts without throwing", () => {
+    const row = mapMessageRow(
+      {
+        info: { id: "m", role: "user" },
+        // @ts-expect-error deliberately malformed entries
+        parts: [null, 42, { type: "text", text: "ok" }],
+      },
+      0,
+    );
+    expect(row.text).toBe("ok");
+  });
+});
+
+describe("mapTranscript", () => {
+  it("maps a list of messages to rows, running=false", () => {
+    const vm = mapTranscript([userMsg, assistantMsg]);
+    expect(vm.running).toBe(false);
+    expect(vm.rows.map((r) => r.key)).toEqual(["msg-user-1", "msg-asst-1"]);
+  });
+
+  it("returns an empty transcript for non-array / malformed input", () => {
+    expect(mapTranscript(null)).toEqual({ rows: [], running: false });
+    expect(mapTranscript("nope")).toEqual({ rows: [], running: false });
+    expect(mapTranscript({})).toEqual({ rows: [], running: false });
+  });
+
+  it("skips non-object entries in the array", () => {
+    const vm = mapTranscript([userMsg, null, 5, assistantMsg]);
+    expect(vm.rows.map((r) => r.key)).toEqual(["msg-user-1", "msg-asst-1"]);
+  });
+});
+
+describe("mergeDelta", () => {
+  const rows: MessageRowVM[] = [
+    { key: "a", role: "assistant", text: "foo", tools: [], createdAt: 1 },
+    { key: "b", role: "assistant", text: "bar", tools: [], createdAt: 2 },
+  ];
+
+  it("appends the delta to the matching message and returns a new array", () => {
+    const next = mergeDelta(rows, { messageID: "b", delta: "baz", field: "text" });
+    expect(next).not.toBe(rows);
+    expect(next[1].text).toBe("barbaz");
+    // other rows untouched (same reference)
+    expect(next[0]).toBe(rows[0]);
+  });
+
+  it("accumulates successive deltas into the same message", () => {
+    let next = mergeDelta(rows, { messageID: "a", delta: "X", field: "text" });
+    next = mergeDelta(next, { messageID: "a", delta: "Y", field: "text" });
+    expect(next[0].text).toBe("fooXY");
+  });
+
+  it("drops a delta for an unknown message (same reference back)", () => {
+    const next = mergeDelta(rows, { messageID: "zzz", delta: "x", field: "text" });
+    expect(next).toBe(rows);
+  });
+
+  it("ignores non-text-field deltas", () => {
+    const next = mergeDelta(rows, { messageID: "a", delta: "x", field: "other" });
+    expect(next).toBe(rows);
+  });
+
+  it("ignores empty delta or missing messageID", () => {
+    expect(mergeDelta(rows, { messageID: "a", delta: "" })).toBe(rows);
+    expect(mergeDelta(rows, { delta: "x" })).toBe(rows);
+  });
+});
+
+describe("applyOpencodeEvent", () => {
+  const base: TranscriptVM = {
+    rows: [{ key: "a", role: "assistant", text: "foo", tools: [], createdAt: 1 }],
+    running: false,
+  };
+
+  it("message.part.delta appends text AND sets running=true", () => {
+    const next = applyOpencodeEvent(base, {
+      type: "message.part.delta",
+      properties: { messageID: "a", delta: "bar", field: "text" },
+    });
+    expect(next.rows[0].text).toBe("foobar");
+    expect(next.running).toBe(true);
+  });
+
+  it("session.idle flips running to false", () => {
+    const running: TranscriptVM = { ...base, running: true };
+    const next = applyOpencodeEvent(running, { type: "session.idle" });
+    expect(next.running).toBe(false);
+    // idempotent when already idle
+    expect(applyOpencodeEvent(base, { type: "session.idle" })).toBe(base);
+  });
+
+  it("session.status busy → running, idle → not running", () => {
+    const busy = applyOpencodeEvent(base, {
+      type: "session.status",
+      properties: { status: { type: "busy" } },
+    });
+    expect(busy.running).toBe(true);
+    const idle = applyOpencodeEvent(busy, {
+      type: "session.status",
+      properties: { status: { type: "idle" } },
+    });
+    expect(idle.running).toBe(false);
+  });
+
+  it("session.status retry counts as running", () => {
+    const next = applyOpencodeEvent(base, {
+      type: "session.status",
+      properties: { status: { type: "retry" } },
+    });
+    expect(next.running).toBe(true);
+  });
+
+  it("returns the same VM reference for unhandled events", () => {
+    const next = applyOpencodeEvent(base, { type: "todo.updated" });
+    expect(next).toBe(base);
+  });
+});

--- a/mobile-rn/src/pure/events.ts
+++ b/mobile-rn/src/pure/events.ts
@@ -1,0 +1,124 @@
+// events.ts — the PURE logic behind the /events WebSocket client: envelope
+// parsing, the viewed-session filter, and the reconnect-backoff decision.
+//
+// The impure socket glue (opening the WS, timers) lives in
+// ../api/eventsClient.ts and stays thin; everything decision-shaped is here so
+// it can be unit-tested without a socket. Mirrors the desktop's {kind,payload}
+// envelope (src/renderer/api/httpApi.ts `dispatchFrame`) and its
+// backoff/never-abandon reconnect intent (WsReconnectController), simplified
+// for the RN read-only viewer.
+
+import type { OpencodeEventLike } from "./transcript";
+
+// ---- Envelope parsing ----
+
+/** The server frames every stream event as `{ kind, payload }`. */
+export interface Envelope {
+  kind: string;
+  payload: unknown;
+}
+
+/**
+ * Parse a raw WS text frame into an Envelope, or null when it isn't a
+ * well-formed `{ kind, payload }` JSON object (control frames, partial data,
+ * non-JSON). Never throws. Pure.
+ */
+export function parseEnvelope(data: unknown): Envelope | null {
+  if (typeof data !== "string") return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const kind = (obj as { kind?: unknown }).kind;
+  if (typeof kind !== "string") return null;
+  return { kind, payload: (obj as { payload?: unknown }).payload };
+}
+
+/**
+ * Narrow an envelope's payload to an OpencodeEventLike when `kind === "opencode"`
+ * and the payload is a `{ type: string }` object; otherwise null. This is the
+ * single choke point that turns a raw frame into a transcript event. Pure.
+ */
+export function toOpencodeEvent(env: Envelope | null): OpencodeEventLike | null {
+  if (!env || env.kind !== "opencode") return null;
+  const p = env.payload;
+  if (!p || typeof p !== "object") return null;
+  const type = (p as { type?: unknown }).type;
+  if (typeof type !== "string") return null;
+  const props = (p as { properties?: unknown }).properties;
+  return {
+    type,
+    properties:
+      props && typeof props === "object"
+        ? (props as Record<string, unknown>)
+        : {},
+  };
+}
+
+// ---- Viewed-session filter ----
+
+/**
+ * Decide whether an opencode event belongs to the session the detail screen is
+ * viewing. An event carries its session in `properties.sessionID`. Events for
+ * OTHER sessions are dropped (the mobile detail view renders exactly one
+ * session — unlike the desktop it has no subagent-child routing).
+ *
+ * Events with NO sessionID (synthetic resync pings, global lifecycle) are kept
+ * — they carry no session scope and the caller's handlers self-filter. Pure.
+ */
+export function eventMatchesSession(
+  ev: OpencodeEventLike,
+  viewedSessionID: string,
+): boolean {
+  const sid = ev.properties?.sessionID;
+  if (typeof sid !== "string" || sid.length === 0) return true;
+  return sid === viewedSessionID;
+}
+
+// ---- Reconnect / backoff decision ----
+
+/** Tunables for the reconnect backoff (mirrors the shared ExponentialBackoff). */
+export interface BackoffConfig {
+  baseMs: number;
+  maxMs: number;
+  factor: number;
+}
+
+export const DEFAULT_BACKOFF: BackoffConfig = {
+  baseMs: 500,
+  maxMs: 15_000,
+  factor: 2,
+};
+
+/**
+ * The delay (ms) before the Nth reconnect attempt (attempt is 1-based:
+ * attempt 1 is the first retry after a drop). Capped at `maxMs`. Deterministic
+ * (no jitter) so it's testable; the socket glue may add small jitter on top if
+ * desired. Pure.
+ */
+export function backoffDelay(
+  attempt: number,
+  cfg: BackoffConfig = DEFAULT_BACKOFF,
+): number {
+  if (attempt <= 1) return cfg.baseMs;
+  const raw = cfg.baseMs * Math.pow(cfg.factor, attempt - 1);
+  return Math.min(raw, cfg.maxMs);
+}
+
+/**
+ * Decide what to do when the socket closes. The mobile viewer NEVER permanently
+ * abandons a live session (matching the desktop's "never abandon" intent) — a
+ * clean close only happens when WE tear the screen down, which is signalled by
+ * `intentional`. Any other close reconnects after a backoff delay. Pure.
+ */
+export function reconnectDecision(
+  attempt: number,
+  intentional: boolean,
+  cfg: BackoffConfig = DEFAULT_BACKOFF,
+): { reconnect: boolean; delayMs: number } {
+  if (intentional) return { reconnect: false, delayMs: 0 };
+  return { reconnect: true, delayMs: backoffDelay(attempt, cfg) };
+}

--- a/mobile-rn/src/pure/sessionList.ts
+++ b/mobile-rn/src/pure/sessionList.ts
@@ -44,6 +44,12 @@ export interface SessionRowVM {
   kind: "chat" | "terminal";
   /** Running vs idle, from the status map (default idle). */
   status: "running" | "idle";
+  /**
+   * The opencode session id backing a "chat" window (null for terminals).
+   * Carried through so the detail screen can fetch that session's transcript
+   * (`opencode:messages`) and filter its `/events` stream. Absent → terminal.
+   */
+  opencodeSessionId: string | null;
 }
 
 /** A section (one project) with its rows, for a sectioned FlatList. */
@@ -83,7 +89,8 @@ export function mapSessionRows(
       const index = (w as RawWindow).index;
       const name = (w as RawWindow).name;
       if (typeof index !== "number" || typeof name !== "string") continue;
-      const kind = (w as RawWindow).opencodeSessionId ? "chat" : "terminal";
+      const ocSessionId = (w as RawWindow).opencodeSessionId ?? null;
+      const kind = ocSessionId ? "chat" : "terminal";
       rows.push({
         key: `${project}:${index}`,
         project,
@@ -91,6 +98,7 @@ export function mapSessionRows(
         title: name,
         kind,
         status: isRunning(statuses, project, index) ? "running" : "idle",
+        opencodeSessionId: typeof ocSessionId === "string" ? ocSessionId : null,
       });
     }
   }

--- a/mobile-rn/src/pure/transcript.ts
+++ b/mobile-rn/src/pure/transcript.ts
@@ -1,0 +1,232 @@
+// transcript.ts — pure mapping of the box's `opencode:messages` RPC response
+// into the read-only row view model the RN SessionDetailScreen's FlatList
+// renders, plus the live-update helpers (delta merge + idle flip).
+//
+// This is the mobile port of the minimal subset of the desktop's transcript
+// derivation (src/renderer/ChatPanel.tsx `onOpencodeEvent` + the message/part
+// shapes in src/shared/types.ts). Kept PURE — no fetch, no RN, no timers — so
+// it is fully unit-testable without a live box.
+//
+// Wire shape (mirrors GET /session/{id}/message on the opencode server):
+//   message  = { info: { id, role, time?: { created? }, modelID? }, parts: Part[] }
+//   part     = { type: "text"|"reasoning"|"tool"|..., id, text?, tool?, state?, ... }
+//
+// The desktop keeps a rich 12-variant part renderer. For a read-only mobile
+// transcript we collapse each message into ONE row carrying:
+//   - role (user / assistant)
+//   - the concatenated text of its visible text parts
+//   - a compact one-line summary per tool-call part
+// and a top-level `running` flag driven by session.idle / session.status.
+
+// ---- Raw wire types (subset we read) ----
+
+/** One part as returned by opencode (subset). */
+export interface RawPart {
+  type: string;
+  id?: string;
+  /** text-bearing variants ("text", "reasoning") carry a string here. */
+  text?: string;
+  /** text-part flags — synthetic/ignored parts are hidden from the UI. */
+  synthetic?: boolean;
+  ignored?: boolean;
+  /** tool parts carry the tool name + a state object. */
+  tool?: string;
+  state?: { status?: string; title?: string } | null;
+  [k: string]: unknown;
+}
+
+/** One message as returned by opencode (subset). */
+export interface RawMessage {
+  info?: {
+    id?: string;
+    role?: string;
+    time?: { created?: number } | null;
+    modelID?: string;
+  } | null;
+  parts?: RawPart[] | null;
+}
+
+// ---- View model ----
+
+/** A single tool-call summary line within a message row. */
+export interface ToolCallVM {
+  /** Stable key within the row: part id (or a synthesized index fallback). */
+  key: string;
+  /** Tool name, e.g. "read", "bash", "edit". */
+  name: string;
+  /** "running" | "completed" | "error" | "pending" — from state.status. */
+  status: string;
+  /** Optional one-line title opencode attaches (e.g. the file path). */
+  title?: string;
+}
+
+/** A rendered message row (one per transcript message). */
+export interface MessageRowVM {
+  /** Stable FlatList key: the opencode message id. */
+  key: string;
+  /** "user" | "assistant". */
+  role: "user" | "assistant";
+  /** Concatenated visible text of the message's text/reasoning parts. */
+  text: string;
+  /** Tool-call summaries, in part order. */
+  tools: ToolCallVM[];
+  /** Assistant model id, when present (shown as a subtle byline). */
+  model?: string;
+  /** Creation time (ms) for stable ordering; 0 when unknown. */
+  createdAt: number;
+}
+
+/** The full transcript view model + top-level running flag. */
+export interface TranscriptVM {
+  rows: MessageRowVM[];
+  /** True while the session is mid-turn (streaming); flipped by idle/status. */
+  running: boolean;
+}
+
+const TEXT_PART_TYPES = new Set(["text", "reasoning"]);
+
+function normRole(role: unknown): "user" | "assistant" {
+  return role === "user" ? "user" : "assistant";
+}
+
+/**
+ * Collapse one raw message into a row VM. Concatenates visible text parts and
+ * summarizes tool parts. Defensive: a malformed part is skipped, never thrown.
+ * Pure.
+ */
+export function mapMessageRow(msg: RawMessage, index: number): MessageRowVM {
+  const info = msg?.info ?? {};
+  const id = typeof info.id === "string" && info.id.length > 0 ? info.id : `msg-${index}`;
+  const parts = Array.isArray(msg?.parts) ? msg.parts : [];
+
+  const textChunks: string[] = [];
+  const tools: ToolCallVM[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+    if (!p || typeof p !== "object") continue;
+    if (TEXT_PART_TYPES.has(p.type)) {
+      if (p.synthetic || p.ignored) continue;
+      if (typeof p.text === "string" && p.text.length > 0) textChunks.push(p.text);
+    } else if (p.type === "tool") {
+      const name = typeof p.tool === "string" && p.tool.length > 0 ? p.tool : "tool";
+      const state = p.state ?? undefined;
+      tools.push({
+        key: typeof p.id === "string" && p.id.length > 0 ? p.id : `${id}:tool:${i}`,
+        name,
+        status: typeof state?.status === "string" ? state.status : "pending",
+        title: typeof state?.title === "string" ? state.title : undefined,
+      });
+    }
+  }
+
+  return {
+    key: id,
+    role: normRole(info.role),
+    text: textChunks.join("\n\n"),
+    tools,
+    model: typeof info.modelID === "string" ? info.modelID : undefined,
+    createdAt: typeof info.time?.created === "number" ? info.time.created : 0,
+  };
+}
+
+/**
+ * Map a raw `opencode:messages` response into a transcript view model.
+ * Defensive against a non-array / malformed payload (yields an empty
+ * transcript rather than throwing). `running` starts false; live events flip
+ * it via {@link applyOpencodeEvent}. Pure.
+ */
+export function mapTranscript(raw: unknown): TranscriptVM {
+  if (!Array.isArray(raw)) return { rows: [], running: false };
+  const rows: MessageRowVM[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const m = raw[i];
+    if (!m || typeof m !== "object") continue;
+    rows.push(mapMessageRow(m as RawMessage, i));
+  }
+  return { rows, running: false };
+}
+
+// ---- Live update helpers ----
+
+/**
+ * A narrowed opencode event (the `payload` of a `{kind:"opencode"}` /events
+ * envelope). `properties` carries the event-specific fields.
+ */
+export interface OpencodeEventLike {
+  type: string;
+  properties?: Record<string, unknown> | null;
+}
+
+/**
+ * Merge a single `message.part.delta` event's text into the matching message
+ * row, appending to the row's text. Mirrors the desktop's delta accumulation
+ * (`pendingDeltas` → flush) but simplified: we append directly to the row's
+ * concatenated text, since the mobile read-only view doesn't need per-part
+ * flush-boundary buffering.
+ *
+ * A delta whose `messageID` matches no existing row is dropped (the canonical
+ * refetch / message.updated will materialize it). Returns a NEW rows array
+ * only when something changed; otherwise returns the SAME reference so callers
+ * can skip a re-render. Pure.
+ */
+export function mergeDelta(
+  rows: MessageRowVM[],
+  props: Record<string, unknown>,
+): MessageRowVM[] {
+  const messageID = typeof props.messageID === "string" ? props.messageID : "";
+  const delta = typeof props.delta === "string" ? props.delta : "";
+  // Only merge text-field deltas (reasoning parts also stream `field:"text"`).
+  const field = typeof props.field === "string" ? props.field : "text";
+  if (!messageID || !delta || field !== "text") return rows;
+
+  const idx = rows.findIndex((r) => r.key === messageID);
+  if (idx < 0) return rows;
+
+  const target = rows[idx];
+  const next = rows.slice();
+  next[idx] = { ...target, text: target.text + delta };
+  return next;
+}
+
+/**
+ * Apply one opencode event to a transcript VM, returning the next VM (same
+ * reference when nothing changed, so callers can bail out of a re-render).
+ *
+ * Handled events (the read-only subset):
+ *   - message.part.delta → append streamed text to the matching row.
+ *   - session.idle       → running = false (turn over).
+ *   - session.status     → running = (status.type is "busy"|"retry").
+ *
+ * Everything else (message.updated, tool state, todo.updated, …) is left to the
+ * caller's debounced refetch — this helper only owns the cheap live edits.
+ * Pure.
+ */
+export function applyOpencodeEvent(
+  vm: TranscriptVM,
+  ev: OpencodeEventLike,
+): TranscriptVM {
+  const props = ev?.properties ?? {};
+
+  if (ev.type === "message.part.delta") {
+    const nextRows = mergeDelta(vm.rows, props);
+    // A delta means the session is actively producing output → running.
+    if (nextRows === vm.rows && vm.running) return vm;
+    return { rows: nextRows, running: true };
+  }
+
+  if (ev.type === "session.idle") {
+    if (!vm.running) return vm;
+    return { ...vm, running: false };
+  }
+
+  if (ev.type === "session.status") {
+    const status = props.status as { type?: string } | undefined;
+    const t = status?.type;
+    const running = t === "busy" || t === "retry";
+    if (running === vm.running) return vm;
+    return { ...vm, running };
+  }
+
+  return vm;
+}

--- a/mobile-rn/src/screens/SessionDetailScreen.tsx
+++ b/mobile-rn/src/screens/SessionDetailScreen.tsx
@@ -1,0 +1,261 @@
+// SessionDetailScreen.tsx — the read-only live transcript view (M3.5-1 bar).
+//
+// Pushed from a SessionListScreen chat-row tap. On mount it fetches the
+// session's transcript from the box's `opencode:messages` channel and opens the
+// `/events` WebSocket (filtered to this session) for live updates: streamed
+// text deltas append to the running assistant message; session.idle/status
+// flips the running indicator. Renders a FlatList of message rows (user /
+// assistant text / tool-call summaries) with pin-to-bottom and pull-to-refresh.
+//
+// READ-ONLY in this slice — no composer / prompt sending (that's stage 2). All
+// transcript/event LOGIC lives in the pure ../pure/transcript + ../pure/events
+// modules; this component owns fetch + socket + render.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import type { RootStackParamList } from "../../App";
+import { AuthRequiredError, fetchTranscript } from "../api/pairingApi";
+import { clearCredentials } from "../api/credentials";
+import { subscribeOpencodeEvents } from "../api/eventsClient";
+import {
+  applyOpencodeEvent,
+  type MessageRowVM,
+  type TranscriptVM,
+} from "../pure/transcript";
+import { colors } from "../theme";
+
+type Props = NativeStackScreenProps<RootStackParamList, "Session">;
+
+const EMPTY: TranscriptVM = { rows: [], running: false };
+
+export function SessionDetailScreen({ navigation, route }: Props) {
+  const { credentials, session } = route.params;
+  const sessionId = session.opencodeSessionId ?? "";
+
+  const [vm, setVm] = useState<TranscriptVM>(EMPTY);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const listRef = useRef<FlatList<MessageRowVM>>(null);
+  // Pin-to-bottom latch: only auto-scroll when the user is already near the
+  // bottom, so scrolling up to read history isn't yanked back on each event.
+  const atBottomRef = useRef(true);
+
+  // Set the header to the session title.
+  useEffect(() => {
+    navigation.setOptions({ title: session.title });
+  }, [navigation, session.title]);
+
+  const load = useCallback(
+    async (mode: "initial" | "refresh") => {
+      if (!sessionId) {
+        setError("This window has no chat session to display.");
+        setLoading(false);
+        return;
+      }
+      if (mode === "refresh") setRefreshing(true);
+      else setLoading(true);
+      setError(null);
+      try {
+        const next = await fetchTranscript(
+          credentials.serverUrl,
+          credentials.boxToken,
+          sessionId,
+        );
+        setVm(next);
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        setError(
+          e instanceof Error ? e.message : "Couldn't load the transcript. Pull to retry.",
+        );
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, sessionId, navigation],
+  );
+
+  // Initial fetch.
+  useEffect(() => {
+    void load("initial");
+  }, [load]);
+
+  // Live event subscription — filtered to this session by the events client.
+  useEffect(() => {
+    if (!sessionId) return;
+    const sub = subscribeOpencodeEvents(
+      credentials.serverUrl,
+      credentials.boxToken,
+      sessionId,
+      (ev) => {
+        // Cheap live edits (delta append, running flag) apply in place. Other
+        // events (new parts, tool state, message.updated) are covered by the
+        // canonical text the next delta/refresh carries; a full re-fetch on
+        // every event would thrash the list, so we keep it lean here.
+        setVm((prev) => applyOpencodeEvent(prev, ev));
+      },
+    );
+    return () => sub.close();
+  }, [credentials.serverUrl, credentials.boxToken, sessionId]);
+
+  // Pin-to-bottom: after rows change, if the user was at the bottom, scroll
+  // to the newest content.
+  useEffect(() => {
+    if (atBottomRef.current && vm.rows.length > 0) {
+      // Defer so the list has laid out the new content first.
+      const t = setTimeout(() => {
+        listRef.current?.scrollToEnd({ animated: true });
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [vm.rows]);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={colors.accent} size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.screen}>
+      {vm.running && (
+        <View style={styles.runningBar}>
+          <ActivityIndicator color={colors.accent} size="small" />
+          <Text style={styles.runningText}>Working…</Text>
+        </View>
+      )}
+      <FlatList
+        ref={listRef}
+        data={vm.rows}
+        keyExtractor={(r) => r.key}
+        contentContainerStyle={vm.rows.length === 0 ? styles.emptyContainer : styles.list}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => void load("refresh")}
+            tintColor={colors.textMuted}
+          />
+        }
+        onScroll={(e) => {
+          const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
+          const distanceFromBottom =
+            contentSize.height - (contentOffset.y + layoutMeasurement.height);
+          atBottomRef.current = distanceFromBottom < 80;
+        }}
+        scrollEventThrottle={100}
+        ListEmptyComponent={
+          <Text style={styles.empty}>
+            {error ?? "No messages yet. Pull to refresh."}
+          </Text>
+        }
+        renderItem={({ item }) => <MessageRow row={item} />}
+      />
+      {error && vm.rows.length > 0 && <Text style={styles.errorBar}>{error}</Text>}
+    </View>
+  );
+}
+
+function MessageRow({ row }: { row: MessageRowVM }) {
+  const isUser = row.role === "user";
+  return (
+    <View style={[styles.msg, isUser ? styles.msgUser : styles.msgAssistant]}>
+      <Text style={styles.roleLabel}>
+        {isUser ? "You" : "Assistant"}
+        {row.model ? ` · ${row.model}` : ""}
+      </Text>
+      {row.text.length > 0 && <Text style={styles.msgText}>{row.text}</Text>}
+      {row.tools.map((t) => (
+        <View key={t.key} style={styles.tool}>
+          <Text style={styles.toolText} numberOfLines={1}>
+            {toolGlyph(t.status)} {t.name}
+            {t.title ? ` · ${t.title}` : ""}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function toolGlyph(status: string): string {
+  if (status === "completed") return "✓";
+  if (status === "error") return "✗";
+  if (status === "running") return "…";
+  return "•";
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.bg },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.bg,
+  },
+  list: { padding: 12, gap: 8 },
+  emptyContainer: { flexGrow: 1, justifyContent: "center" },
+  empty: {
+    color: colors.textFaint,
+    fontSize: 14,
+    textAlign: "center",
+    paddingHorizontal: 32,
+  },
+  runningBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  runningText: { color: colors.textMuted, fontSize: 13 },
+  msg: {
+    borderRadius: 10,
+    padding: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  msgUser: { backgroundColor: colors.surface },
+  msgAssistant: { backgroundColor: "transparent" },
+  roleLabel: {
+    color: colors.textFaint,
+    fontSize: 11,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    marginBottom: 4,
+  },
+  msgText: { color: colors.text, fontSize: 15, lineHeight: 21 },
+  tool: {
+    marginTop: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 6,
+    backgroundColor: colors.surface,
+  },
+  toolText: { color: colors.textMuted, fontSize: 13, fontFamily: "monospace" },
+  errorBar: {
+    color: colors.danger,
+    fontSize: 13,
+    textAlign: "center",
+    paddingVertical: 8,
+  },
+});

--- a/mobile-rn/src/screens/SessionListScreen.tsx
+++ b/mobile-rn/src/screens/SessionListScreen.tsx
@@ -68,11 +68,16 @@ export function SessionListScreen({ navigation, route }: Props) {
   }, [load]);
 
   function onRowPress(row: SessionRowVM) {
-    // M3.2 is read-only: opening a live session (streaming transcript) lands in
-    // a later milestone. Surface that clearly instead of a dead tap.
+    // Chat windows open the read-only live transcript (M3.5-1). Terminal
+    // windows have no opencode transcript to stream — PTY mirroring is a later
+    // slice, so surface that clearly instead of a dead tap.
+    if (row.kind === "chat" && row.opencodeSessionId) {
+      navigation.navigate("Session", { credentials, session: row });
+      return;
+    }
     Alert.alert(
       row.title,
-      "Live sessions open in a future update. This preview shows your sessions read-only.",
+      "Terminal windows open in a future update. Tap a chat session to view its live transcript.",
     );
   }
 

--- a/mobile-rn/vitest.config.ts
+++ b/mobile-rn/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+// mobile-rn is a self-contained Expo workspace with its own node_modules and
+// its own vitest install. Without this file, vitest walks UP to the repo-root
+// `vitest.config.ts`, which imports `vitest/config` from the root node_modules
+// (not installed in the mobile-rn context) and fails to load. Pinning `root`
+// here stops the upward search and scopes collection to the RN pure tests.
+export default defineConfig({
+  test: {
+    root: __dirname,
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
## BET-76 — M3.5-1: Session detail + live transcript view (mobile-rn)

Replaces the "opens in a future update" placeholder with a real **read-only
live transcript** screen in the Expo RN app. Verifiable on Expo Go / iOS
simulator against a real box with the existing box_token — **zero Apple
credentials**.

**Base:** `origin/main @ 405365a`

### What's here
- **`src/pure/transcript.ts` (+ tests)** — pure `opencode:messages` JSON → row
  view model (role, concatenated text, tool-call summaries, model byline).
  Includes `mergeDelta` (accumulate `message.part.delta` text into the matching
  message) and `applyOpencodeEvent` (delta → append + running=true;
  `session.idle` → running=false; `session.status` busy/retry → running). No
  fetch / no RN — fully unit-tested.
- **`src/pure/events.ts` (+ tests)** — pure `/events` helpers: `{kind,payload}`
  envelope parse, opencode narrowing, viewed-session filter (drops other
  sessions, keeps sessionID-less synthetic events), exponential backoff +
  reconnect decision.
- **`src/api/eventsClient.ts` (+ tests)** — thin `/events` WebSocket glue: opens
  the WS with `?token=` (server accepts `?token=` on /events + /pty only),
  parses/filters via the pure helpers, reconnects with backoff on unexpected
  close, never abandons until the caller unsubscribes. Tested with an injected
  fake socket + timer.
- **`src/api/pairingApi.ts`** — new `fetchTranscript()` reusing the existing
  generic `rpc()` helper against the `opencode:messages` channel (no new
  transport code).
- **`src/pure/sessionList.ts`** — carries `opencodeSessionId` through the row VM
  (was dropped) so the detail screen can fetch/stream that session.
- **`src/screens/SessionDetailScreen.tsx`** — new React Navigation route pushed
  from a chat-row tap. Fetches transcript on mount, subscribes to `/events`,
  renders a `FlatList` (user / assistant text / tool summaries) with
  pin-to-bottom, a "Working…" running indicator, and pull-to-refresh. Read-only
  (no composer — that's stage 2). `SessionListScreen` row tap now navigates for
  chat windows; terminals keep a clear placeholder.
- **`mobile-rn/vitest.config.ts`** — pins vitest `root` to `mobile-rn/` so it
  stops walking up to the repo-root `vitest.config.ts` (which imports
  `vitest/config` from the uninstalled root node_modules). Without this,
  `cd mobile-rn && npm test` fails to start on a fresh checkout — see below.

### Anti-spaghetti notes
- Reused the existing generic `rpc<T>()` helper for the transcript fetch
  instead of adding a parallel client (as the issue directed).
- All decision logic (transcript derivation, envelope parse, session filter,
  reconnect) lives in `src/pure/**` and is unit-tested; the screen + socket own
  only side effects.
- `opencodeSessionId` was already parsed by `sessionList` (to decide chat vs
  terminal) but discarded — I surfaced the existing field rather than adding a
  second lookup.

**Files changed:** 13 files (`mobile-rn/**` only). `git diff --stat` lists no
files outside `mobile-rn/`.

### Verification results
- PR branch (`multica/BET-76-session-detail-transcript-v2` @ `21668b1`):
  - typecheck: exit `0`. Errors: none. log sha256: `84ac8ea594a4895d611118e1a2f344abe3822af60204fbb27e3bd34cf1f56a9a`
  - test: exit `0`, `77` pass / `0` fail / `0` skip. Failures: none. log sha256: `7f8dfd2d3d40cd8cea72bd4d1d455bcb9dfe14b63cc2a642568a066a396229dd`
- Base (`main` @ `405365a`):
  - mobile-rn suite: **fails to start** — `cd mobile-rn && npm test` errors with
    `Cannot find package 'vitest'` because vitest resolves the repo-root
    `vitest.config.ts` (needs root node_modules, not installed in the mobile-rn
    context). This is a pre-existing tooling gap, **not a test failure**, and is
    fixed by the `mobile-rn/vitest.config.ts` added in this PR.
- **Conclusion:** 0 new test failures. The base "failure" is a config-discovery
  gap this PR resolves; on the PR branch all 77 tests pass (76 pre-existing + my
  1 new sessionList assertion; the transcript/events tests are net-new files).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer
spot-check.

### Out of scope (per issue)
Composer / prompt sending, permission+question cards (stage 2); settings /
re-pair / push (stage 3); PTY, paywall/IAP, native push; any signed build.
