### PR TITLE
BET-77: Send prompts + permission/question cards (mobile-rn)

### DIFF
--- a/mobile-rn/src/api/pairingApi.ts
+++ b/mobile-rn/src/api/pairingApi.ts
@@ -16,6 +16,13 @@ import {
 } from "../pure/claim";
 import { mapSessionRows, type SessionRowVM, type StatusMap } from "../pure/sessionList";
 import { mapTranscript, type TranscriptVM } from "../pure/transcript";
+import {
+  hydratePermission,
+  hydrateQuestion,
+  type PermissionReply,
+  type PermissionVM,
+  type QuestionVM,
+} from "../pure/interaction";
 import { saveCredentials } from "./credentials";
 
 /** Strip trailing slashes so "http://box/" and "http://box" behave identically. */
@@ -134,4 +141,128 @@ export async function fetchTranscript(
 ): Promise<TranscriptVM> {
   const raw = await rpc<unknown>(base, token, "opencode:messages", opencodeSessionId);
   return mapTranscript(raw);
+}
+
+/**
+ * Send a prompt into a session via the box's `opencode:prompt` channel. The box
+ * relays it to opencode's `POST /session/{id}/prompt_async` (src/server/
+ * opencode.mjs sendPrompt), which builds the text part and scopes the turn to
+ * the session's worktree. We pass only `{ sessionId, text }` — the box uses the
+ * session's default model when none is supplied. The caller has already gated
+ * `text` through the pure composer module (trimmed, non-empty, not mid-turn).
+ */
+export async function sendPrompt(
+  base: string,
+  token: string,
+  sessionId: string,
+  text: string,
+): Promise<void> {
+  await rpc<void>(base, token, "opencode:prompt", { sessionId, text });
+}
+
+/**
+ * Abort the running generation for a session via `opencode:abort`. Idempotent
+ * on the box; used by the composer's Stop button while a turn is running.
+ */
+export async function abortSession(
+  base: string,
+  token: string,
+  sessionId: string,
+): Promise<void> {
+  await rpc<void>(base, token, "opencode:abort", sessionId);
+}
+
+/**
+ * Fetch pending tool-approval permissions for a session (`opencode:permissions`,
+ * scoped to the session so non-default-directory sessions return their pending
+ * entries — see the server comment). Maps each raw row to the card VM via the
+ * pure hydrator, dropping any without a usable id.
+ */
+export async function fetchPermissions(
+  base: string,
+  token: string,
+  sessionId: string,
+): Promise<PermissionVM[]> {
+  const raw = await rpc<unknown>(base, token, "opencode:permissions", sessionId);
+  if (!Array.isArray(raw)) return [];
+  const out: PermissionVM[] = [];
+  for (const row of raw) {
+    const vm = hydratePermission((row ?? {}) as Record<string, unknown>);
+    if (vm) out.push(vm);
+  }
+  return out;
+}
+
+/**
+ * Reply to a permission request (`opencode:permission-reply`). `requestId` is
+ * the `per_…` id the opencode reply API requires (carried on the card VM);
+ * `reply` is one of once / always / reject. Scoped by sessionId so the reply
+ * lands on the pending entry's workspace.
+ */
+export async function replyPermission(
+  base: string,
+  token: string,
+  requestId: string,
+  reply: PermissionReply,
+  sessionId: string,
+): Promise<void> {
+  await rpc<void>(base, token, "opencode:permission-reply", {
+    requestId,
+    reply,
+    sessionId,
+  });
+}
+
+/**
+ * Fetch pending Question-tool requests for a session (`opencode:questions`,
+ * session-scoped). Maps each raw row to the card VM via the pure hydrator.
+ */
+export async function fetchQuestions(
+  base: string,
+  token: string,
+  sessionId: string,
+): Promise<QuestionVM[]> {
+  const raw = await rpc<unknown>(base, token, "opencode:questions", sessionId);
+  if (!Array.isArray(raw)) return [];
+  const out: QuestionVM[] = [];
+  for (const row of raw) {
+    const vm = hydrateQuestion((row ?? {}) as Record<string, unknown>);
+    if (vm) out.push(vm);
+  }
+  return out;
+}
+
+/**
+ * Reply to a Question-tool request (`opencode:question-reply`). `requestId` is
+ * the `que_…` id (carried on the card VM); `answers` is one string[] per
+ * question, built by the pure `buildQuestionAnswers`.
+ */
+export async function replyQuestion(
+  base: string,
+  token: string,
+  requestId: string,
+  answers: string[][],
+  sessionId: string,
+): Promise<void> {
+  await rpc<void>(base, token, "opencode:question-reply", {
+    requestId,
+    answers,
+    sessionId,
+  });
+}
+
+/**
+ * Reject (dismiss) a Question-tool request without answering
+ * (`opencode:question-reject`).
+ */
+export async function rejectQuestion(
+  base: string,
+  token: string,
+  requestId: string,
+  sessionId: string,
+): Promise<void> {
+  await rpc<void>(base, token, "opencode:question-reject", {
+    requestId,
+    sessionId,
+  });
 }

--- a/mobile-rn/src/pure/__tests__/composer.test.ts
+++ b/mobile-rn/src/pure/__tests__/composer.test.ts
@@ -1,0 +1,44 @@
+// composer.test.ts — pure send-gate: empty/whitespace blocked, running-state
+// gate, trim normalization.
+
+import { describe, expect, it } from "vitest";
+
+import { canSubmitPrompt, preparePrompt } from "../composer";
+
+describe("canSubmitPrompt", () => {
+  it("allows a non-empty draft when idle", () => {
+    expect(canSubmitPrompt("hello", false)).toBe(true);
+  });
+
+  it("blocks an empty draft", () => {
+    expect(canSubmitPrompt("", false)).toBe(false);
+  });
+
+  it("blocks an all-whitespace draft (spaces, tabs, newlines)", () => {
+    expect(canSubmitPrompt("   ", false)).toBe(false);
+    expect(canSubmitPrompt("\t\n  \n", false)).toBe(false);
+  });
+
+  it("blocks while a turn is running, even with a non-empty draft", () => {
+    expect(canSubmitPrompt("hello", true)).toBe(false);
+  });
+
+  it("blocks an empty draft while running too", () => {
+    expect(canSubmitPrompt("", true)).toBe(false);
+  });
+});
+
+describe("preparePrompt", () => {
+  it("trims surrounding whitespace", () => {
+    expect(preparePrompt("  hi there \n")).toBe("hi there");
+  });
+
+  it("returns null for empty / whitespace-only drafts", () => {
+    expect(preparePrompt("")).toBeNull();
+    expect(preparePrompt("   \t\n ")).toBeNull();
+  });
+
+  it("preserves interior whitespace and newlines", () => {
+    expect(preparePrompt("  line one\nline two  ")).toBe("line one\nline two");
+  });
+});

--- a/mobile-rn/src/pure/__tests__/interaction.test.ts
+++ b/mobile-rn/src/pure/__tests__/interaction.test.ts
@@ -1,0 +1,273 @@
+// interaction.test.ts — pure permission + question card logic ported from the
+// desktop chatUtils/Cards: answer-building, submittability, reply mapping,
+// event upsert/clear, and hydration.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyPermissionEvent,
+  applyQuestionEvent,
+  buildQuestionAnswers,
+  canSubmitQuestion,
+  hydratePermission,
+  hydrateQuestion,
+  permissionReplyValue,
+  toggleQuestionOption,
+  type PermissionVM,
+  type QuestionVM,
+} from "../interaction";
+
+// ---- Permission reply mapping ----
+
+describe("permissionReplyValue", () => {
+  it("maps each card action to the correct API reply enum", () => {
+    expect(permissionReplyValue("once")).toBe("once");
+    expect(permissionReplyValue("always")).toBe("always");
+    expect(permissionReplyValue("reject")).toBe("reject");
+  });
+});
+
+describe("hydratePermission", () => {
+  it("keys on tool.callID and keeps per_ as requestId; pulls filepath detail", () => {
+    const vm = hydratePermission({
+      id: "per_1",
+      sessionID: "s1",
+      permission: "external_directory",
+      always: ["/tmp/*"],
+      metadata: { filepath: "/tmp/x.txt" },
+      tool: { messageID: "m1", callID: "call_9" },
+    });
+    expect(vm).toEqual({
+      id: "call_9",
+      requestId: "per_1",
+      sessionID: "s1",
+      permission: "external_directory",
+      detail: "/tmp/x.txt",
+      alwaysScope: "/tmp/*",
+    });
+  });
+
+  it("falls back to per_ id, command detail, and no alwaysScope", () => {
+    const vm = hydratePermission({
+      id: "per_2",
+      sessionID: "s1",
+      permission: "bash",
+      metadata: { command: "rm -rf /" },
+    });
+    expect(vm?.id).toBe("per_2");
+    expect(vm?.requestId).toBe("per_2");
+    expect(vm?.detail).toBe("rm -rf /");
+    expect(vm?.alwaysScope).toBeUndefined();
+  });
+
+  it("returns null when there is no id", () => {
+    expect(hydratePermission({ sessionID: "s1", permission: "bash" })).toBeNull();
+  });
+});
+
+describe("applyPermissionEvent", () => {
+  const base: PermissionVM[] = [];
+
+  it("upserts on permission.asked for the viewed session", () => {
+    const next = applyPermissionEvent(
+      base,
+      "permission.asked",
+      { id: "per_1", sessionID: "s1", permission: "bash", metadata: {} },
+      "s1",
+    );
+    expect(next).toHaveLength(1);
+    expect(next[0].requestId).toBe("per_1");
+  });
+
+  it("ignores permission.asked for a different session", () => {
+    const next = applyPermissionEvent(
+      base,
+      "permission.asked",
+      { id: "per_1", sessionID: "other", permission: "bash" },
+      "s1",
+    );
+    expect(next).toBe(base);
+  });
+
+  it("dedupes a re-ask by id", () => {
+    const one = applyPermissionEvent(
+      base,
+      "permission.asked",
+      { id: "per_1", sessionID: "s1", permission: "bash", tool: { callID: "c1" } },
+      "s1",
+    );
+    const two = applyPermissionEvent(
+      one,
+      "permission.asked",
+      { id: "per_1", sessionID: "s1", permission: "bash", tool: { callID: "c1" } },
+      "s1",
+    );
+    expect(two).toHaveLength(1);
+  });
+
+  it("clears on permission.replied matching id or requestId", () => {
+    const seeded: PermissionVM[] = [
+      { id: "c1", requestId: "per_1", sessionID: "s1", permission: "bash" },
+    ];
+    expect(applyPermissionEvent(seeded, "permission.replied", { id: "per_1" }, "s1")).toHaveLength(0);
+    expect(
+      applyPermissionEvent(seeded, "permission.rejected", { tool: { callID: "c1" } }, "s1"),
+    ).toHaveLength(0);
+  });
+
+  it("returns same reference when a clear matches nothing", () => {
+    const seeded: PermissionVM[] = [
+      { id: "c1", requestId: "per_1", sessionID: "s1", permission: "bash" },
+    ];
+    expect(applyPermissionEvent(seeded, "permission.replied", { id: "nope" }, "s1")).toBe(seeded);
+  });
+});
+
+// ---- Question hydration + events ----
+
+describe("hydrateQuestion", () => {
+  it("keys on callID, keeps que_ as requestId, normalizes options + multiple", () => {
+    const vm = hydrateQuestion({
+      id: "que_1",
+      sessionID: "s1",
+      tool: { messageID: "m1", callID: "c1" },
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          multiple: true,
+          options: [
+            { label: "a", description: "A" },
+            { label: "b" },
+            { bogus: true },
+          ],
+        },
+      ],
+    });
+    expect(vm?.id).toBe("c1");
+    expect(vm?.requestId).toBe("que_1");
+    expect(vm?.questions[0].multiple).toBe(true);
+    expect(vm?.questions[0].options).toEqual([
+      { label: "a", description: "A" },
+      { label: "b", description: undefined },
+    ]);
+  });
+
+  it("returns null with no id or no questions", () => {
+    expect(hydrateQuestion({ sessionID: "s1", questions: [{ header: "h" }] })).toBeNull();
+    expect(hydrateQuestion({ id: "que_1", sessionID: "s1", questions: [] })).toBeNull();
+  });
+});
+
+describe("applyQuestionEvent", () => {
+  it("upserts asked for the viewed session, clears on replied/rejected", () => {
+    const asked = applyQuestionEvent(
+      [],
+      "question.asked",
+      {
+        id: "que_1",
+        sessionID: "s1",
+        tool: { callID: "c1", messageID: "m1" },
+        questions: [{ header: "h", question: "q", options: [{ label: "x" }] }],
+      },
+      "s1",
+    );
+    expect(asked).toHaveLength(1);
+    expect(asked[0].id).toBe("c1");
+
+    const cleared = applyQuestionEvent(asked, "question.replied", { id: "que_1" }, "s1");
+    expect(cleared).toHaveLength(0);
+  });
+
+  it("ignores asked for another session", () => {
+    const next = applyQuestionEvent(
+      [],
+      "question.asked",
+      { id: "que_1", sessionID: "other", questions: [{ header: "h", question: "q", options: [] }] },
+      "s1",
+    );
+    expect(next).toHaveLength(0);
+  });
+});
+
+// ---- Answer building + submittability (ported contract) ----
+
+describe("buildQuestionAnswers", () => {
+  it("option-only", () => {
+    expect(buildQuestionAnswers([new Set(["a"])], [""])).toEqual([["a"]]);
+  });
+
+  it("typed-only", () => {
+    expect(buildQuestionAnswers([new Set()], ["hello"])).toEqual([["hello"]]);
+  });
+
+  it("option + typed (typed appended after labels)", () => {
+    expect(buildQuestionAnswers([new Set(["a"])], ["extra"])).toEqual([["a", "extra"]]);
+  });
+
+  it("multi-select preserves multiple labels", () => {
+    expect(buildQuestionAnswers([new Set(["a", "b"])], [""])).toEqual([["a", "b"]]);
+  });
+
+  it("trims typed text and drops a blank custom field", () => {
+    expect(buildQuestionAnswers([new Set(["a"])], ["  "])).toEqual([["a"]]);
+    expect(buildQuestionAnswers([new Set()], ["  typed  "])).toEqual([["typed"]]);
+  });
+
+  it("handles multiple questions independently", () => {
+    expect(
+      buildQuestionAnswers([new Set(["a"]), new Set()], ["", "typed"]),
+    ).toEqual([["a"], ["typed"]]);
+  });
+});
+
+describe("canSubmitQuestion", () => {
+  it("true when each question has a selection OR typed text", () => {
+    expect(canSubmitQuestion([new Set(["a"])], [""])).toBe(true);
+    expect(canSubmitQuestion([new Set()], ["typed"])).toBe(true);
+    expect(canSubmitQuestion([new Set(["a"]), new Set()], ["", "t"])).toBe(true);
+  });
+
+  it("false when any question is unanswered (no selection, empty/whitespace text)", () => {
+    expect(canSubmitQuestion([new Set()], [""])).toBe(false);
+    expect(canSubmitQuestion([new Set()], ["   "])).toBe(false);
+    expect(canSubmitQuestion([new Set(["a"]), new Set()], ["", ""])).toBe(false);
+  });
+});
+
+describe("toggleQuestionOption", () => {
+  it("single-select replaces the selection", () => {
+    const s0 = [new Set<string>()];
+    const s1 = toggleQuestionOption(s0, 0, "a", false);
+    expect(Array.from(s1[0])).toEqual(["a"]);
+    const s2 = toggleQuestionOption(s1, 0, "b", false);
+    expect(Array.from(s2[0])).toEqual(["b"]);
+  });
+
+  it("multi-select toggles membership", () => {
+    let s = [new Set<string>()];
+    s = toggleQuestionOption(s, 0, "a", true);
+    s = toggleQuestionOption(s, 0, "b", true);
+    expect(Array.from(s[0]).sort()).toEqual(["a", "b"]);
+    s = toggleQuestionOption(s, 0, "a", true);
+    expect(Array.from(s[0])).toEqual(["b"]);
+  });
+
+  it("never mutates the input array/sets", () => {
+    const s0 = [new Set<string>(["x"])];
+    const s1 = toggleQuestionOption(s0, 0, "y", true);
+    expect(Array.from(s0[0])).toEqual(["x"]); // unchanged
+    expect(s1).not.toBe(s0);
+    expect(s1[0]).not.toBe(s0[0]);
+  });
+
+  it("out-of-range index is a no-op clone", () => {
+    const s0 = [new Set<string>(["x"])];
+    const s1 = toggleQuestionOption(s0, 5, "y", true);
+    expect(Array.from(s1[0])).toEqual(["x"]);
+  });
+});
+
+// Type-only touch so unused QuestionVM import is intentional.
+const _typecheck: QuestionVM | undefined = undefined;
+void _typecheck;

--- a/mobile-rn/src/pure/composer.ts
+++ b/mobile-rn/src/pure/composer.ts
@@ -1,0 +1,39 @@
+// composer.ts — pure send-gate logic for the SessionDetailScreen composer.
+//
+// The composer is the mobile port of the desktop ChatPanel's submit() gate
+// (src/renderer/ChatPanel.tsx). The box `opencode:prompt` RPC expects a
+// non-empty text; sending mid-turn would race the running generation. This
+// module owns the "can I submit, and what text do I send" decision so the
+// component stays a thin TextInput + Send/Stop button with no branching logic.
+//
+// Kept PURE — no RN, no fetch, no state — so the gate is fully unit-tested
+// without a live box, exactly like the other mobile-rn pure modules.
+
+/**
+ * Whether the composer's Send action is allowed right now.
+ *
+ * Rules (mirror of the desktop submit() gate):
+ *  - the trimmed draft must be non-empty (an all-whitespace draft sends nothing);
+ *  - the session must not already be running a turn (sending mid-turn would
+ *    race the in-flight generation — the user aborts first, then sends).
+ *
+ * Pure.
+ */
+export function canSubmitPrompt(draft: string, running: boolean): boolean {
+  if (running) return false;
+  return draft.trim().length > 0;
+}
+
+/**
+ * Normalize a draft into the exact text the box `opencode:prompt` RPC should
+ * receive: outer whitespace trimmed (matching the desktop, which trims before
+ * building the text part). Returns null when the draft is not submittable, so
+ * a caller can `const text = preparePrompt(draft); if (!text) return;` without
+ * re-checking the gate.
+ *
+ * Pure.
+ */
+export function preparePrompt(draft: string): string | null {
+  const text = draft.trim();
+  return text.length > 0 ? text : null;
+}

--- a/mobile-rn/src/pure/interaction.ts
+++ b/mobile-rn/src/pure/interaction.ts
@@ -1,0 +1,332 @@
+// interaction.ts — pure permission + question card logic for the RN app.
+//
+// This is the mobile port of the desktop's permission/question handling:
+//   - question answer-building + submittability  (src/renderer/chatUtils.ts:
+//     buildQuestionAnswers / canSubmitQuestion — ported verbatim in contract)
+//   - question card upsert/clear from live events (chatUtils.ts:
+//     applyQuestionEvent, hydrateQuestion — ported)
+//   - permission reply value mapping             (src/renderer/Cards.tsx:
+//     PermissionCard's once/always/reject enum)
+//
+// The box RPC contracts these feed (see src/server/opencode.mjs):
+//   opencode:permission-reply → { requestId, reply: "once"|"always"|"reject", sessionId }
+//   opencode:question-reply   → { requestId, answers: string[][], sessionId }
+//   opencode:question-reject  → { requestId, sessionId }
+//
+// Kept PURE — no RN, no fetch, no state — so the whole card decision surface is
+// unit-tested without a live box, matching the other mobile-rn pure modules.
+
+// ---- Permission ----
+
+/** Category + scope of a pending tool-approval, as the box returns it. */
+export interface PermissionVM {
+  /** Canonical key: tool.callID when present, else the `per_…` id. */
+  id: string;
+  /** The `per_…` request id opencode's reply API requires. */
+  requestId: string;
+  sessionID: string;
+  /** Category, e.g. "external_directory", "bash". */
+  permission: string;
+  /** filepath / command detail pulled from metadata, when present. */
+  detail?: string;
+  /** The scope "always" would grant (e.g. "/tmp/*"), when present. */
+  alwaysScope?: string;
+}
+
+/** The three reply enum values opencode's /permission/{id}/reply accepts. */
+export type PermissionReply = "once" | "always" | "reject";
+
+/**
+ * Map a card button action to the exact `reply` value the box RPC expects.
+ * A trivial identity today, but centralized + tested so the card can't drift
+ * from the API enum (the desktop hard-codes these three strings inline).
+ * Pure.
+ */
+export function permissionReplyValue(action: PermissionReply): PermissionReply {
+  return action;
+}
+
+/** Raw `/permission` list row / `permission.asked` payload (subset we read). */
+interface RawPermission {
+  id?: string;
+  sessionID?: string;
+  permission?: string;
+  always?: string[];
+  metadata?: Record<string, unknown> | null;
+  tool?: { messageID?: string; callID?: string } | null;
+}
+
+/**
+ * Normalize a raw permission (from `opencode:permissions` GET or a
+ * `permission.asked` event) into the card VM. Dedup key prefers tool.callID
+ * (stable across re-asks) and falls back to the `per_…` id; the `per_…` is
+ * kept separately as `requestId` because opencode's reply API accepts only
+ * that form. Returns null when there's no usable id.
+ *
+ * Mirror of the desktop hydrateQuestion + PermissionCard detail derivation.
+ * Pure.
+ */
+export function hydratePermission(raw: RawPermission): PermissionVM | null {
+  const per = typeof raw?.id === "string" && raw.id.length > 0 ? raw.id : "";
+  const callID =
+    typeof raw?.tool?.callID === "string" && raw.tool.callID.length > 0
+      ? raw.tool.callID
+      : "";
+  const id = callID || per;
+  if (!id || !per) return null;
+  const meta = raw.metadata ?? {};
+  const filepath = typeof meta.filepath === "string" ? meta.filepath : undefined;
+  const command = typeof meta.command === "string" ? meta.command : undefined;
+  const alwaysScope =
+    Array.isArray(raw.always) && raw.always.length > 0
+      ? raw.always.join(", ")
+      : undefined;
+  return {
+    id,
+    requestId: per,
+    sessionID: typeof raw.sessionID === "string" ? raw.sessionID : "",
+    permission: typeof raw.permission === "string" ? raw.permission : "tool",
+    detail: filepath ?? command ?? undefined,
+    alwaysScope,
+  };
+}
+
+/**
+ * Apply one permission.* lifecycle event to the pending list.
+ *   - permission.asked   → upsert the request (dedupe by id)
+ *   - permission.replied → remove it (answered)
+ *   - permission.rejected → remove it (denied)
+ * Filtered to the viewed session on `asked`. Returns the SAME reference when
+ * nothing changed so callers can skip a re-render.
+ *
+ * Mirror of the desktop applyQuestionEvent contract for permissions. Pure.
+ */
+export function applyPermissionEvent(
+  prev: PermissionVM[],
+  eventType: string,
+  properties: Record<string, unknown> | undefined,
+  viewedSessionId: string,
+): PermissionVM[] {
+  const p = properties ?? {};
+
+  if (eventType === "permission.replied" || eventType === "permission.rejected") {
+    const tool = p.tool as { messageID?: string; callID?: string } | undefined;
+    const ids = new Set(
+      [p.id, p.requestID, p.callID, tool?.callID].filter(
+        (x): x is string => typeof x === "string" && x.length > 0,
+      ),
+    );
+    if (ids.size === 0) return prev;
+    const next = prev.filter(
+      (perm) => !ids.has(perm.id) && !ids.has(perm.requestId),
+    );
+    return next.length === prev.length ? prev : next;
+  }
+
+  if (eventType === "permission.asked") {
+    const vm = hydratePermission(p as RawPermission);
+    if (!vm) return prev;
+    if (vm.sessionID !== viewedSessionId) return prev;
+    const without = prev.filter((perm) => perm.id !== vm.id);
+    return [...without, vm];
+  }
+
+  return prev;
+}
+
+// ---- Question ----
+
+/** One selectable option in a question (label + description). */
+export interface QuestionOptionVM {
+  label: string;
+  description?: string;
+}
+
+/** One question within a request. */
+export interface QuestionInfoVM {
+  /** Full question text. */
+  question: string;
+  /** Short header/label. */
+  header: string;
+  options: QuestionOptionVM[];
+  /** Allow multi-select. */
+  multiple: boolean;
+}
+
+/** A pending Question tool request (one card, possibly many questions). */
+export interface QuestionVM {
+  /** Canonical key: tool.callID when present, else the `que_…` id. */
+  id: string;
+  /** The `que_…` id opencode's reply/reject API requires. */
+  requestId: string;
+  sessionID: string;
+  questions: QuestionInfoVM[];
+}
+
+/** Raw `/question` row / `question.asked` payload (subset we read). */
+interface RawQuestion {
+  id?: string;
+  sessionID?: string;
+  questions?: unknown;
+  tool?: { messageID?: string; callID?: string } | null;
+}
+
+function normOptions(raw: unknown): QuestionOptionVM[] {
+  if (!Array.isArray(raw)) return [];
+  const out: QuestionOptionVM[] = [];
+  for (const o of raw) {
+    if (!o || typeof o !== "object") continue;
+    const label = (o as { label?: unknown }).label;
+    if (typeof label !== "string" || label.length === 0) continue;
+    const description = (o as { description?: unknown }).description;
+    out.push({
+      label,
+      description: typeof description === "string" ? description : undefined,
+    });
+  }
+  return out;
+}
+
+function normQuestionInfos(raw: unknown): QuestionInfoVM[] {
+  if (!Array.isArray(raw)) return [];
+  const out: QuestionInfoVM[] = [];
+  for (const q of raw) {
+    if (!q || typeof q !== "object") continue;
+    const question = (q as { question?: unknown }).question;
+    const header = (q as { header?: unknown }).header;
+    out.push({
+      question: typeof question === "string" ? question : "",
+      header: typeof header === "string" ? header : "",
+      options: normOptions((q as { options?: unknown }).options),
+      multiple: (q as { multiple?: unknown }).multiple === true,
+    });
+  }
+  return out;
+}
+
+/**
+ * Normalize a raw question (from `opencode:questions` GET or a `question.asked`
+ * event) into the card VM. Dedup key prefers tool.callID; `que_…` is kept as
+ * `requestId` (the only id the reply/reject API accepts). Returns null when
+ * there's no usable id or no questions.
+ *
+ * Mirror of the desktop hydrateQuestion. Pure.
+ */
+export function hydrateQuestion(raw: RawQuestion): QuestionVM | null {
+  const que = typeof raw?.id === "string" && raw.id.length > 0 ? raw.id : "";
+  const callID =
+    typeof raw?.tool?.callID === "string" && raw.tool.callID.length > 0
+      ? raw.tool.callID
+      : "";
+  const id = callID || que;
+  if (!id || !que) return null;
+  const questions = normQuestionInfos(raw.questions);
+  if (questions.length === 0) return null;
+  return {
+    id,
+    requestId: que,
+    sessionID: typeof raw.sessionID === "string" ? raw.sessionID : "",
+    questions,
+  };
+}
+
+/**
+ * Apply one question.* lifecycle event to the pending list.
+ *   - question.asked    → upsert the request (dedupe by id)
+ *   - question.replied  → remove it (answered)
+ *   - question.rejected → remove it (dismissed)
+ * Filtered to the viewed session on `asked`. Returns the SAME reference when
+ * nothing changed.
+ *
+ * Direct port of the desktop chatUtils.applyQuestionEvent. Pure.
+ */
+export function applyQuestionEvent(
+  prev: QuestionVM[],
+  eventType: string,
+  properties: Record<string, unknown> | undefined,
+  viewedSessionId: string,
+): QuestionVM[] {
+  const p = properties ?? {};
+  const tool = p.tool as { messageID?: string; callID?: string } | undefined;
+
+  if (eventType === "question.replied" || eventType === "question.rejected") {
+    const ids = new Set(
+      [p.id, p.requestID, p.callID, tool?.callID].filter(
+        (x): x is string => typeof x === "string" && x.length > 0,
+      ),
+    );
+    if (ids.size === 0) return prev;
+    const next = prev.filter((q) => !ids.has(q.id) && !ids.has(q.requestId));
+    return next.length === prev.length ? prev : next;
+  }
+
+  if (eventType === "question.asked") {
+    const vm = hydrateQuestion(p as RawQuestion);
+    if (!vm) return prev;
+    if (vm.sessionID !== viewedSessionId) return prev;
+    const without = prev.filter((q) => q.id !== vm.id);
+    return [...without, vm];
+  }
+
+  return prev;
+}
+
+/**
+ * Build the `string[][]` reply payload for a Question tool request from the
+ * per-question selected option labels and per-question free-text input.
+ *
+ * Direct port of the desktop chatUtils.buildQuestionAnswers: custom text is
+ * always honored and appended AFTER any selected option labels for that
+ * question; a blank custom field contributes nothing. Selection-only,
+ * typed-only, and selection+typed all work.
+ *
+ * Pure.
+ */
+export function buildQuestionAnswers(
+  selected: Array<ReadonlySet<string>>,
+  customValues: readonly string[],
+): string[][] {
+  return selected.map((sel, i) => {
+    const labels = Array.from(sel);
+    const custom = (customValues[i] ?? "").trim();
+    return custom ? [...labels, custom] : labels;
+  });
+}
+
+/**
+ * Whether a Question request is submittable: every question must have at least
+ * one selected option OR non-empty typed text.
+ *
+ * Direct port of the desktop chatUtils.canSubmitQuestion. Pure.
+ */
+export function canSubmitQuestion(
+  selected: Array<ReadonlySet<string>>,
+  customValues: readonly string[],
+): boolean {
+  return selected.every(
+    (sel, i) => sel.size > 0 || (customValues[i] ?? "").trim().length > 0,
+  );
+}
+
+/**
+ * Toggle an option's selection for question `qIdx`, honoring single vs
+ * multi-select. Returns a NEW array of NEW Sets (never mutates the input), so
+ * it can drive React state directly. Mirror of the desktop QuestionCard's
+ * toggleOption. Pure.
+ */
+export function toggleQuestionOption(
+  selected: Array<ReadonlySet<string>>,
+  qIdx: number,
+  label: string,
+  multiple: boolean,
+): Array<Set<string>> {
+  const next = selected.map((s) => new Set(s));
+  if (qIdx < 0 || qIdx >= next.length) return next;
+  if (multiple) {
+    if (next[qIdx].has(label)) next[qIdx].delete(label);
+    else next[qIdx].add(label);
+  } else {
+    next[qIdx] = new Set([label]);
+  }
+  return next;
+}

--- a/mobile-rn/src/screens/Composer.tsx
+++ b/mobile-rn/src/screens/Composer.tsx
@@ -1,0 +1,105 @@
+// Composer.tsx — the prompt input at the bottom of SessionDetailScreen.
+//
+// A TextInput + Send button. When a turn is running, the Send button becomes a
+// Stop button (abort). The "can I send / what do I send" decision is delegated
+// to the pure ../pure/composer module; this component owns only the draft
+// state + the onSend / onAbort callbacks and layout.
+
+import { useState } from "react";
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
+
+import { canSubmitPrompt, preparePrompt } from "../pure/composer";
+import { colors } from "../theme";
+
+export function Composer({
+  running,
+  onSend,
+  onAbort,
+}: {
+  running: boolean;
+  /** Called with the trimmed, non-empty prompt text. */
+  onSend: (text: string) => void;
+  /** Called when the user taps Stop while a turn is running. */
+  onAbort: () => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const canSend = canSubmitPrompt(draft, running);
+
+  function send() {
+    const text = preparePrompt(draft);
+    if (!text || running) return;
+    onSend(text);
+    setDraft("");
+  }
+
+  return (
+    <View style={styles.bar}>
+      <TextInput
+        value={draft}
+        onChangeText={setDraft}
+        placeholder="Send a message…"
+        placeholderTextColor={colors.textFaint}
+        style={styles.input}
+        multiline
+        editable={!running}
+      />
+      {running ? (
+        <TouchableOpacity
+          onPress={onAbort}
+          style={[styles.btn, styles.stop]}
+          accessibilityLabel="Stop"
+        >
+          <Text style={styles.stopText}>Stop</Text>
+        </TouchableOpacity>
+      ) : (
+        <TouchableOpacity
+          onPress={send}
+          disabled={!canSend}
+          style={[styles.btn, styles.send, !canSend && styles.btnDisabled]}
+          accessibilityLabel="Send"
+        >
+          <Text style={styles.sendText}>Send</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
+    backgroundColor: colors.bg,
+  },
+  input: {
+    flex: 1,
+    maxHeight: 120,
+    minHeight: 40,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    color: colors.text,
+    fontSize: 15,
+    backgroundColor: colors.surface,
+  },
+  btn: {
+    paddingHorizontal: 16,
+    height: 40,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  btnDisabled: { opacity: 0.4 },
+  send: { backgroundColor: colors.accent },
+  sendText: { color: colors.bg, fontSize: 14, fontWeight: "600" },
+  stop: { backgroundColor: colors.danger },
+  stopText: { color: colors.bg, fontSize: 14, fontWeight: "600" },
+});

--- a/mobile-rn/src/screens/SessionDetailScreen.tsx
+++ b/mobile-rn/src/screens/SessionDetailScreen.tsx
@@ -1,4 +1,4 @@
-// SessionDetailScreen.tsx — the read-only live transcript view (M3.5-1 bar).
+// SessionDetailScreen.tsx — the live transcript + interactive session view.
 //
 // Pushed from a SessionListScreen chat-row tap. On mount it fetches the
 // session's transcript from the box's `opencode:messages` channel and opens the
@@ -7,15 +7,20 @@
 // flips the running indicator. Renders a FlatList of message rows (user /
 // assistant text / tool-call summaries) with pin-to-bottom and pull-to-refresh.
 //
-// READ-ONLY in this slice — no composer / prompt sending (that's stage 2). All
-// transcript/event LOGIC lives in the pure ../pure/transcript + ../pure/events
-// modules; this component owns fetch + socket + render.
+// M3.5-2 adds interactivity: a Composer to send prompts (opencode:prompt) with
+// an optimistic user row + abort, and Permission/Question cards driven by the
+// same /events subscription (permission.asked / question.asked) so a turn that
+// blocks on the box can be answered from the phone. All decision LOGIC lives in
+// the pure ../pure/{transcript,events,composer,interaction} modules; this
+// component owns fetch + socket + render.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import {
   ActivityIndicator,
   FlatList,
+  KeyboardAvoidingView,
+  Platform,
   RefreshControl,
   StyleSheet,
   Text,
@@ -23,7 +28,17 @@ import {
 } from "react-native";
 
 import type { RootStackParamList } from "../../App";
-import { AuthRequiredError, fetchTranscript } from "../api/pairingApi";
+import {
+  AuthRequiredError,
+  abortSession,
+  fetchPermissions,
+  fetchQuestions,
+  fetchTranscript,
+  rejectQuestion,
+  replyPermission,
+  replyQuestion,
+  sendPrompt,
+} from "../api/pairingApi";
 import { clearCredentials } from "../api/credentials";
 import { subscribeOpencodeEvents } from "../api/eventsClient";
 import {
@@ -31,6 +46,16 @@ import {
   type MessageRowVM,
   type TranscriptVM,
 } from "../pure/transcript";
+import {
+  applyPermissionEvent,
+  applyQuestionEvent,
+  type PermissionReply,
+  type PermissionVM,
+  type QuestionVM,
+} from "../pure/interaction";
+import { Composer } from "./Composer";
+import { PermissionCard } from "./cards/PermissionCard";
+import { QuestionCard } from "./cards/QuestionCard";
 import { colors } from "../theme";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Session">;
@@ -45,6 +70,13 @@ export function SessionDetailScreen({ navigation, route }: Props) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Pending interaction cards, driven by the /events subscription + a mount
+  // hydrate (an ask fired before we attached is recoverable via the list RPC).
+  const [permissions, setPermissions] = useState<PermissionVM[]>([]);
+  const [questions, setQuestions] = useState<QuestionVM[]>([]);
+  // A card whose reply is in flight — disables its buttons to prevent a
+  // double-submit while the round-trip is outstanding.
+  const [busyCardId, setBusyCardId] = useState<string | null>(null);
 
   const listRef = useRef<FlatList<MessageRowVM>>(null);
   // Pin-to-bottom latch: only auto-scroll when the user is already near the
@@ -73,6 +105,10 @@ export function SessionDetailScreen({ navigation, route }: Props) {
           sessionId,
         );
         setVm(next);
+        // Recover any interaction cards that fired before we attached. These
+        // are best-effort — a failure here must not blank the transcript, so
+        // they're swallowed (the live event stream is the primary path).
+        void hydrateCards();
       } catch (e) {
         if (e instanceof AuthRequiredError) {
           await clearCredentials();
@@ -90,6 +126,23 @@ export function SessionDetailScreen({ navigation, route }: Props) {
     [credentials.serverUrl, credentials.boxToken, sessionId, navigation],
   );
 
+  // Best-effort hydrate of pending permission/question cards on (re)attach.
+  // Never throws — a live ask that arrived before mount is recovered here; the
+  // live event stream keeps them fresh afterward.
+  const hydrateCards = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      const [perms, qs] = await Promise.all([
+        fetchPermissions(credentials.serverUrl, credentials.boxToken, sessionId),
+        fetchQuestions(credentials.serverUrl, credentials.boxToken, sessionId),
+      ]);
+      setPermissions(perms);
+      setQuestions(qs);
+    } catch {
+      /* card hydrate is non-fatal — the /events stream is the primary path */
+    }
+  }, [credentials.serverUrl, credentials.boxToken, sessionId]);
+
   // Initial fetch.
   useEffect(() => {
     void load("initial");
@@ -103,11 +156,19 @@ export function SessionDetailScreen({ navigation, route }: Props) {
       credentials.boxToken,
       sessionId,
       (ev) => {
-        // Cheap live edits (delta append, running flag) apply in place. Other
-        // events (new parts, tool state, message.updated) are covered by the
-        // canonical text the next delta/refresh carries; a full re-fetch on
-        // every event would thrash the list, so we keep it lean here.
+        // Cheap transcript edits (delta append, running flag) apply in place.
         setVm((prev) => applyOpencodeEvent(prev, ev));
+        // Interaction cards appear/clear live off the same stream.
+        const props = ev.properties ?? undefined;
+        if (ev.type.startsWith("permission.")) {
+          setPermissions((prev) =>
+            applyPermissionEvent(prev, ev.type, props, sessionId),
+          );
+        } else if (ev.type.startsWith("question.")) {
+          setQuestions((prev) =>
+            applyQuestionEvent(prev, ev.type, props, sessionId),
+          );
+        }
       },
     );
     return () => sub.close();
@@ -126,6 +187,134 @@ export function SessionDetailScreen({ navigation, route }: Props) {
     return undefined;
   }, [vm.rows]);
 
+  // ---- Interaction handlers ----
+
+  // Send a prompt. Optimistically append a user row + flip running so the UI
+  // reacts instantly; the canonical rows arrive over the event stream. On a
+  // send failure we surface an error and clear the optimistic running flag (the
+  // optimistic user row is left — it matches what the user typed).
+  const handleSend = useCallback(
+    async (text: string) => {
+      atBottomRef.current = true;
+      setVm((prev) => ({
+        rows: [
+          ...prev.rows,
+          {
+            key: `optimistic-${Date.now()}`,
+            role: "user",
+            text,
+            tools: [],
+            createdAt: Date.now(),
+          },
+        ],
+        running: true,
+      }));
+      try {
+        await sendPrompt(credentials.serverUrl, credentials.boxToken, sessionId, text);
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        setVm((prev) => ({ ...prev, running: false }));
+        setError(e instanceof Error ? e.message : "Couldn't send. Try again.");
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, sessionId, navigation],
+  );
+
+  const handleAbort = useCallback(async () => {
+    try {
+      await abortSession(credentials.serverUrl, credentials.boxToken, sessionId);
+      setVm((prev) => ({ ...prev, running: false }));
+    } catch (e) {
+      if (e instanceof AuthRequiredError) {
+        await clearCredentials();
+        navigation.replace("Pairing");
+      }
+      /* other abort errors are benign — the idle event will settle running */
+    }
+  }, [credentials.serverUrl, credentials.boxToken, sessionId, navigation]);
+
+  const handlePermissionReply = useCallback(
+    async (perm: PermissionVM, reply: PermissionReply) => {
+      setBusyCardId(perm.id);
+      try {
+        await replyPermission(
+          credentials.serverUrl,
+          credentials.boxToken,
+          perm.requestId,
+          reply,
+          sessionId,
+        );
+        // Optimistically clear; the permission.replied event also clears it.
+        setPermissions((prev) => prev.filter((p) => p.id !== perm.id));
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        setError(e instanceof Error ? e.message : "Couldn't send the reply.");
+      } finally {
+        setBusyCardId(null);
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, sessionId, navigation],
+  );
+
+  const handleQuestionReply = useCallback(
+    async (q: QuestionVM, answers: string[][]) => {
+      setBusyCardId(q.id);
+      try {
+        await replyQuestion(
+          credentials.serverUrl,
+          credentials.boxToken,
+          q.requestId,
+          answers,
+          sessionId,
+        );
+        setQuestions((prev) => prev.filter((x) => x.id !== q.id));
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        setError(e instanceof Error ? e.message : "Couldn't send the answer.");
+      } finally {
+        setBusyCardId(null);
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, sessionId, navigation],
+  );
+
+  const handleQuestionReject = useCallback(
+    async (q: QuestionVM) => {
+      setBusyCardId(q.id);
+      try {
+        await rejectQuestion(
+          credentials.serverUrl,
+          credentials.boxToken,
+          q.requestId,
+          sessionId,
+        );
+        setQuestions((prev) => prev.filter((x) => x.id !== q.id));
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        setError(e instanceof Error ? e.message : "Couldn't dismiss the question.");
+      } finally {
+        setBusyCardId(null);
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, sessionId, navigation],
+  );
+
   if (loading) {
     return (
       <View style={styles.center}>
@@ -135,7 +324,10 @@ export function SessionDetailScreen({ navigation, route }: Props) {
   }
 
   return (
-    <View style={styles.screen}>
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
       {vm.running && (
         <View style={styles.runningBar}>
           <ActivityIndicator color={colors.accent} size="small" />
@@ -169,7 +361,35 @@ export function SessionDetailScreen({ navigation, route }: Props) {
         renderItem={({ item }) => <MessageRow row={item} />}
       />
       {error && vm.rows.length > 0 && <Text style={styles.errorBar}>{error}</Text>}
-    </View>
+
+      {/* Interaction cards stack above the composer: permissions first (they
+          block the turn hardest), then questions. */}
+      {permissions.map((perm) => (
+        <PermissionCard
+          key={perm.id}
+          perm={perm}
+          busy={busyCardId === perm.id}
+          onReply={(reply) => void handlePermissionReply(perm, reply)}
+        />
+      ))}
+      {questions.map((q) => (
+        <QuestionCard
+          key={q.id}
+          request={q}
+          busy={busyCardId === q.id}
+          onReply={(answers) => void handleQuestionReply(q, answers)}
+          onReject={() => void handleQuestionReject(q)}
+        />
+      ))}
+
+      {sessionId ? (
+        <Composer
+          running={vm.running}
+          onSend={(text) => void handleSend(text)}
+          onAbort={() => void handleAbort()}
+        />
+      ) : null}
+    </KeyboardAvoidingView>
   );
 }
 

--- a/mobile-rn/src/screens/cards/PermissionCard.tsx
+++ b/mobile-rn/src/screens/cards/PermissionCard.tsx
@@ -1,0 +1,108 @@
+// PermissionCard.tsx — RN port of the desktop Cards.tsx PermissionCard.
+//
+// Rendered above the composer when opencode has paused a tool waiting for
+// approval. Surfaces the category + filepath/command detail and the three
+// reply actions that map to opencode's /permission/{id}/reply enum:
+//   - once   — allow this single execution
+//   - always — allow + save the "always" scope for future auto-approval
+//   - reject — deny; the tool errors out
+//
+// All decision logic (id/detail/scope derivation, reply value) lives in the
+// pure ../../pure/interaction module; this component owns only layout + the
+// onReply callback.
+
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+import {
+  permissionReplyValue,
+  type PermissionReply,
+  type PermissionVM,
+} from "../../pure/interaction";
+import { colors } from "../../theme";
+
+export function PermissionCard({
+  perm,
+  onReply,
+  busy,
+}: {
+  perm: PermissionVM;
+  onReply: (reply: PermissionReply) => void;
+  busy?: boolean;
+}) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.glyph}>✻</Text>
+        <Text style={styles.title}>Permission needed</Text>
+        <Text style={styles.category}>· {perm.permission}</Text>
+      </View>
+      {perm.detail ? (
+        <Text style={styles.detail} numberOfLines={3}>
+          {perm.detail}
+        </Text>
+      ) : null}
+      <View style={styles.actions}>
+        <TouchableOpacity
+          disabled={busy}
+          onPress={() => onReply(permissionReplyValue("once"))}
+          style={[styles.btn, busy && styles.btnDisabled]}
+        >
+          <Text style={styles.btnText}>Allow once</Text>
+        </TouchableOpacity>
+        {perm.alwaysScope ? (
+          <TouchableOpacity
+            disabled={busy}
+            onPress={() => onReply(permissionReplyValue("always"))}
+            style={[styles.btn, styles.btnPrimary, busy && styles.btnDisabled]}
+          >
+            <Text style={styles.btnPrimaryText} numberOfLines={1}>
+              Always allow {perm.alwaysScope}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
+        <TouchableOpacity
+          disabled={busy}
+          onPress={() => onReply(permissionReplyValue("reject"))}
+          style={[styles.btn, styles.btnDanger, busy && styles.btnDisabled]}
+        >
+          <Text style={styles.btnDangerText}>Reject</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.accent,
+    backgroundColor: colors.surface,
+    padding: 12,
+    margin: 12,
+    gap: 6,
+  },
+  headerRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  glyph: { color: colors.accent, fontSize: 14 },
+  title: { color: colors.text, fontSize: 13, fontWeight: "600" },
+  category: { color: colors.textFaint, fontSize: 13 },
+  detail: {
+    color: colors.textMuted,
+    fontSize: 13,
+    fontFamily: "monospace",
+  },
+  actions: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
+  btn: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  btnDisabled: { opacity: 0.4 },
+  btnText: { color: colors.text, fontSize: 13 },
+  btnPrimary: { backgroundColor: colors.accent, borderColor: "transparent" },
+  btnPrimaryText: { color: colors.bg, fontSize: 13, fontWeight: "600" },
+  btnDanger: { borderColor: colors.danger },
+  btnDangerText: { color: colors.danger, fontSize: 13 },
+});

--- a/mobile-rn/src/screens/cards/QuestionCard.tsx
+++ b/mobile-rn/src/screens/cards/QuestionCard.tsx
@@ -1,0 +1,197 @@
+// QuestionCard.tsx — RN port of the desktop Cards.tsx QuestionCard.
+//
+// Rendered above the composer when the Question tool asks the user structured
+// questions mid-turn. Each request may carry multiple questions; we render one
+// block per question with option buttons (single- or multi-select) plus a
+// free-text field, then Submit / Cancel(reject).
+//
+// All answer logic (toggle, build answers, submittability) lives in the pure
+// ../../pure/interaction module; this component owns only local selection state
+// + layout, and calls onReply(answers) / onReject().
+
+import { useState } from "react";
+import {
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import {
+  buildQuestionAnswers,
+  canSubmitQuestion,
+  toggleQuestionOption,
+  type QuestionVM,
+} from "../../pure/interaction";
+import { colors } from "../../theme";
+
+export function QuestionCard({
+  request,
+  onReply,
+  onReject,
+  busy,
+}: {
+  request: QuestionVM;
+  onReply: (answers: string[][]) => void;
+  onReject: () => void;
+  busy?: boolean;
+}) {
+  const [selected, setSelected] = useState<Array<Set<string>>>(() =>
+    request.questions.map(() => new Set<string>()),
+  );
+  const [customValues, setCustomValues] = useState<string[]>(() =>
+    request.questions.map(() => ""),
+  );
+
+  const canSubmit = canSubmitQuestion(selected, customValues) && !busy;
+
+  function toggle(qIdx: number, label: string, multiple: boolean) {
+    setSelected((prev) => toggleQuestionOption(prev, qIdx, label, multiple));
+  }
+
+  function setCustom(qIdx: number, value: string) {
+    setCustomValues((prev) => {
+      const next = [...prev];
+      next[qIdx] = value;
+      return next;
+    });
+  }
+
+  function submit() {
+    if (!canSubmit) return;
+    onReply(buildQuestionAnswers(selected, customValues));
+  }
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.glyph}>?</Text>
+        <Text style={styles.title}>Question</Text>
+        <TouchableOpacity
+          onPress={onReject}
+          disabled={busy}
+          style={styles.dismiss}
+          accessibilityLabel="Reject question"
+        >
+          <Text style={styles.dismissText}>×</Text>
+        </TouchableOpacity>
+      </View>
+
+      {request.questions.map((info, qIdx) => (
+        <View key={qIdx} style={styles.question}>
+          {info.header ? <Text style={styles.qHeader}>{info.header}</Text> : null}
+          {info.question ? <Text style={styles.qBody}>{info.question}</Text> : null}
+
+          {info.options.length > 0 ? (
+            <View style={styles.options}>
+              {info.options.map((opt) => {
+                const isSelected = selected[qIdx]?.has(opt.label);
+                return (
+                  <TouchableOpacity
+                    key={opt.label}
+                    disabled={busy}
+                    onPress={() => toggle(qIdx, opt.label, info.multiple)}
+                    style={[styles.option, isSelected && styles.optionSelected]}
+                  >
+                    <Text
+                      style={[
+                        styles.optionText,
+                        isSelected && styles.optionTextSelected,
+                      ]}
+                    >
+                      {opt.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          ) : null}
+
+          <TextInput
+            value={customValues[qIdx]}
+            onChangeText={(v) => setCustom(qIdx, v)}
+            editable={!busy}
+            placeholder="Or type your own answer…"
+            placeholderTextColor={colors.textFaint}
+            style={styles.custom}
+          />
+        </View>
+      ))}
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          onPress={onReject}
+          disabled={busy}
+          style={[styles.btn, busy && styles.btnDisabled]}
+        >
+          <Text style={styles.btnText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={submit}
+          disabled={!canSubmit}
+          style={[styles.btn, styles.btnPrimary, !canSubmit && styles.btnDisabled]}
+        >
+          <Text style={styles.btnPrimaryText}>Submit</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.accent,
+    backgroundColor: colors.surface,
+    padding: 12,
+    margin: 12,
+    gap: 10,
+  },
+  headerRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  glyph: { color: colors.accent, fontSize: 14, fontWeight: "700" },
+  title: { color: colors.text, fontSize: 13, fontWeight: "600" },
+  dismiss: { marginLeft: "auto", paddingHorizontal: 6 },
+  dismissText: { color: colors.textFaint, fontSize: 18, lineHeight: 18 },
+  question: { gap: 6 },
+  qHeader: { color: colors.textMuted, fontSize: 12, fontWeight: "600" },
+  qBody: { color: colors.text, fontSize: 14, lineHeight: 19 },
+  options: { flexDirection: "row", flexWrap: "wrap", gap: 6 },
+  option: {
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  optionSelected: { backgroundColor: colors.accent, borderColor: "transparent" },
+  optionText: { color: colors.text, fontSize: 13 },
+  optionTextSelected: { color: colors.bg, fontWeight: "600" },
+  custom: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    color: colors.text,
+    fontSize: 13,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+    marginTop: 2,
+  },
+  btn: {
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  btnDisabled: { opacity: 0.4 },
+  btnText: { color: colors.textMuted, fontSize: 13 },
+  btnPrimary: { backgroundColor: colors.accent, borderColor: "transparent" },
+  btnPrimaryText: { color: colors.bg, fontSize: 13, fontWeight: "600" },
+});


### PR DESCRIPTION
## BET-77 — M3.5-2: Send prompts + permission/question cards (mobile-rn)

Stage 2 of the pre-TestFlight mobile prep. Makes the RN app interactive over the
existing box HTTP contract — **zero Apple credentials**, verifiable on Expo Go /
simulator. Builds on the merged stage-1 session detail + live transcript screen.

**Base:** `origin/main @ cf19562`

### What's here

**Pure logic (tested, no RN/fetch):**
- `src/pure/composer.ts` — send gate: `canSubmitPrompt` (empty/whitespace blocked,
  blocked while running) + `preparePrompt` (trim → text | null).
- `src/pure/interaction.ts` — ported from the desktop:
  - `buildQuestionAnswers` / `canSubmitQuestion` — **verbatim contract port** of
    `src/renderer/chatUtils.ts` (option-only / typed-only / option+typed /
    multi-select / unanswered → cannot submit).
  - `toggleQuestionOption` (single vs multi, immutable).
  - `permissionReplyValue` (once/always/reject enum mapping).
  - `hydratePermission` / `hydrateQuestion` + `applyPermissionEvent` /
    `applyQuestionEvent` — card upsert/clear from live events + list-endpoint
    hydration (ported from `applyQuestionEvent`/`hydrateQuestion`).

**API (thin, reuse existing `rpc()`):** `sendPrompt`, `abortSession`,
`fetchPermissions`, `replyPermission`, `fetchQuestions`, `replyQuestion`,
`rejectQuestion` in `src/api/pairingApi.ts` — map to the box channels
`opencode:prompt` / `:abort` / `:permissions` / `:permission-reply` /
`:questions` / `:question-reply` / `:question-reject` (bodies match
`src/server/opencode.mjs`).

**UI:** `Composer` (TextInput + Send, becomes Stop while running),
`cards/PermissionCard`, `cards/QuestionCard`. Wired into
`SessionDetailScreen`: optimistic user row + running flip on send; cards render
above the composer and appear/clear live off the **stage-1 `/events`
subscription** (plus a best-effort mount hydrate to recover an ask fired before
attach); busy-guard prevents double-submit; 401 anywhere routes back to Pairing.

### Anti-spaghetti notes
- Reused the existing `rpc()` helper and the stage-1 `subscribeOpencodeEvents`
  subscription rather than adding parallel transport.
- Question answer logic is a **contract port** of the desktop's single source of
  truth (same input/output), pinned by tests, not re-derived ad hoc.

### Verification results
**Files changed:** 9 files (all under `mobile-rn/**`).

- PR branch (`multica/BET-77-mobile-send-cards` @ `364b29a`):
  - typecheck (`tsc --noEmit`): exit `0`. Errors: none.
  - test (`vitest run`): exit `0`, **110 pass / 0 fail / 0 skip** (9 files).
- **Conclusion:** 0 new failures; typecheck + full RN test suite green.

Logs cached at `/tmp/tc-pr.log`, `/tmp/test-pr.log`.

### Note on e2e-smoke
The `bui-e2e-smoke` gate drives the **desktop Electron** renderer via Playwright's
electron launcher; it is not applicable to the `mobile-rn` Expo workspace (no
Electron surface). Verification here is typecheck + the pure/unit test suite, per
the issue's "verifiable on Expo Go / simulator" bar.

### Out of scope (per issue)
Settings / re-pair / push registration (stage 3); terminal/PTY; paywall/IAP;
native push delivery; signed build.
