### PR TITLE
BET-78: M3.5-3 Settings/re-pair/model picker + push scaffold (mobile-rn)

### DIFF
--- a/mobile-rn/App.tsx
+++ b/mobile-rn/App.tsx
@@ -9,7 +9,7 @@
 // onPaired(creds) to persist + navigate.
 
 import { useEffect, useState } from "react";
-import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
@@ -18,6 +18,7 @@ import { loadCredentials, type StoredCredentials } from "./src/api/credentials";
 import { PairingScreen } from "./src/screens/PairingScreen";
 import { SessionListScreen } from "./src/screens/SessionListScreen";
 import { SessionDetailScreen } from "./src/screens/SessionDetailScreen";
+import { SettingsScreen } from "./src/screens/SettingsScreen";
 import type { SessionRowVM } from "./src/pure/sessionList";
 import { colors } from "./src/theme";
 
@@ -25,6 +26,7 @@ export type RootStackParamList = {
   Pairing: undefined;
   Sessions: { credentials: StoredCredentials };
   Session: { credentials: StoredCredentials; session: SessionRowVM };
+  Settings: { credentials: StoredCredentials };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -74,12 +76,31 @@ export default function App() {
               name="Sessions"
               component={SessionListScreen}
               initialParams={{ credentials: initial }}
-              options={{ title: "Sessions" }}
+              options={({ navigation }) => ({
+                title: "Sessions",
+                headerRight: () => (
+                  <Pressable
+                    onPress={() =>
+                      navigation.navigate("Settings", { credentials: initial })
+                    }
+                    accessibilityRole="button"
+                    accessibilityLabel="Settings"
+                    hitSlop={12}
+                  >
+                    <Text style={styles.headerGear}>⚙</Text>
+                  </Pressable>
+                ),
+              })}
             />
             <Stack.Screen
               name="Session"
               component={SessionDetailScreen}
               options={{ title: "Session" }}
+            />
+            <Stack.Screen
+              name="Settings"
+              component={SettingsScreen}
+              options={{ title: "Settings" }}
             />
           </>
         ) : (
@@ -101,4 +122,5 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     backgroundColor: colors.bg,
   },
+  headerGear: { color: colors.text, fontSize: 20 },
 });

--- a/mobile-rn/README.md
+++ b/mobile-rn/README.md
@@ -1,14 +1,16 @@
 # bui mobile (Expo React Native)
 
 The bui mobile app — a native iOS/Android client built with **Expo** (managed
-workflow, TypeScript). This is the M3 milestone (BET-37) stage 2 scaffold:
-**QR pairing + a read-only session list**, provable on **Expo Go / iOS
-simulator** with **zero Apple credentials**.
+workflow, TypeScript). This is the M3 milestone (BET-37): **QR pairing, a
+session list, a live interactive transcript, settings/re-pair/model-picker, and
+a push-registration scaffold** — all provable on **Expo Go / iOS simulator**
+with **zero Apple credentials**.
 
 - Bundle identifier: `com.antoinedc.bui` (iOS + Android)
 - Framework: Expo SDK 52 + React Navigation (native-stack)
 - QR scan: `expo-camera`
 - Secure token storage: `expo-secure-store` (iOS Keychain / Android Keystore)
+- Push token: `expo-notifications` (scaffold — see [Push notifications](#push-notifications-scaffold))
 
 ## What it does
 
@@ -17,9 +19,38 @@ simulator** with **zero Apple credentials**.
    fallback for Expo Go on a simulator, which has no camera). On success the
    box_token is stored in the device keychain.
 2. **Session list screen** — calls the box's `tmux:list` RPC (Bearer
-   box_token) and renders a **read-only** list of sessions: title +
-   running/idle dot, grouped by project. Tapping a row shows a placeholder —
-   live transcript streaming is a later milestone (M5).
+   box_token) and renders a list of sessions: title + running/idle dot, grouped
+   by project. Tapping a chat row opens its live transcript. A ⚙ header button
+   opens **Settings**.
+3. **Session detail screen** — fetches the transcript (`opencode:messages`),
+   streams live updates over `/events`, and lets you send prompts
+   (`opencode:prompt`) with Permission/Question cards. A ⋯ header menu exposes
+   **session actions**: New chat / clear (`opencode:clear-session`), Fork to a
+   new window (`opencode:fork-session`), and Compact context
+   (`opencode:compact-session`).
+4. **Settings screen** — shows the paired **server URL + box ID** (read-only),
+   a **Re-pair / disconnect** action (clears the keychain credentials → back to
+   Pairing), a **default model picker** (connected models from
+   `opencode:models`, current default from `opencode:default-model`, persisted
+   via `config:update({ defaultModel })` — the same write the desktop uses), and
+   an **Enable notifications** button that runs the push-registration scaffold.
+
+### Push notifications (scaffold)
+
+The Settings screen's **Enable notifications** button runs the full registration
+flow — request permission via `expo-notifications`, obtain the Expo push token,
+then hand it to `registerPushToken(token)`. That call is **a no-op when no push
+backend is configured** (the default), so the whole flow compiles, runs on the
+simulator/Expo Go, and is unit-tested **without an APNs key**. With no backend it
+resolves to `{ kind: "unconfigured", token }` — the token is obtained but not
+sent.
+
+> **M5 dependency (human-blocked on the APNs `.p8`):** live native APNs/FCM
+> delivery is deliberately **not** wired here. To turn it on, set
+> `PushConfig.endpoint` (in `src/api/push.ts`) to the operated relay's
+> registration URL and wire the delivery leg on the box/relay. That step needs
+> the operator's Apple artifacts (already tracked on BET-75). The registration
+> flow proven in this slice does not change when M5 lands.
 
 ## Run it (Expo Go / simulator)
 
@@ -35,6 +66,16 @@ Then:
 - On a simulator (no camera), use the **manual entry** fields: paste your box
   URL (e.g. `http://192.168.1.10:8787`) and the 6-digit code from
   `npm run pair` on the box.
+
+Once paired you can exercise each feature on the simulator:
+- **Sessions** — tap a chat row to open its live transcript; the ⚙ header
+  button opens Settings.
+- **Session detail** — send a prompt; use the ⋯ header menu for New chat / Fork
+  / Compact.
+- **Settings** — review the server URL + box ID, pick a **default model** (tap a
+  model to persist it), tap **Enable notifications** (resolves to
+  "unconfigured" on the simulator — no APNs key needed), or **Re-pair /
+  disconnect** to clear credentials and return to Pairing.
 
 ## Device / TestFlight builds (EAS)
 
@@ -134,7 +175,7 @@ logic without needing the RN app's own `node_modules` for the pure layer.
 ```
 mobile-rn/
   app.json            Expo config (name "bui", bundle id com.antoinedc.bui, camera perms)
-  App.tsx             Navigation root (Pairing ↔ Sessions), launch-time credential check
+  App.tsx             Navigation root (Pairing ↔ Sessions ↔ Session ↔ Settings)
   index.ts            Expo entry (registerRootComponent)
   src/
     pure/             Framework-free, unit-tested logic (no fetch/camera/keychain):
@@ -142,13 +183,29 @@ mobile-rn/
       claim.ts          /auth/claim outcome classification (ported shared classifier)
       scanWiring.ts     decoded-QR → pair-or-error decision; camera availability
       sessionList.ts    raw tmux:list JSON → FlatList view model
+      transcript.ts     raw opencode messages/events → transcript view model
+      composer.ts       send-gate (can-submit, prepare text)
+      events.ts         /events envelope parse + reconnect/backoff decisions
+      interaction.ts    permission/question card hydration + event application
+      modelPicker.ts    raw opencode:models JSON → grouped picker VM + default match
+      sessionActions.ts new/clear/fork/compact → channel+payload decision
+      push.ts           push-registration decisions (permission gate, classify, body)
       __tests__/        vitest specs for each pure module
     api/              Impure side effects:
-      pairingApi.ts     fetch: POST /auth/claim, POST /rpc/<channel> (Bearer)
+      pairingApi.ts     fetch: /auth/claim, /rpc/<channel> (Bearer) — incl. models,
+                        default-model (config:update), session actions
       credentials.ts    expo-secure-store read/write of { serverUrl, boxId, boxToken }
+      eventsClient.ts   /events WebSocket client (backoff reconnect, session filter)
+      push.ts           registration flow: expo-notifications permission + token →
+                        registerPushToken (POST or no-op) — see Push notifications
+      __tests__/        vitest specs for the impure glue (injected fakes)
     screens/          RN screens:
-      PairingScreen.tsx    QR scan (expo-camera) + manual fallback
-      SessionListScreen.tsx  read-only FlatList of sessions
+      PairingScreen.tsx      QR scan (expo-camera) + manual fallback
+      SessionListScreen.tsx  FlatList of sessions
+      SessionDetailScreen.tsx  live transcript + composer + cards + ⋯ actions
+      SettingsScreen.tsx     server/box read-only, re-pair, model picker, push
+      Composer.tsx           prompt input + Send/Stop
+      cards/                 PermissionCard / QuestionCard
     theme.ts          shared dark palette
 ```
 

--- a/mobile-rn/package-lock.json
+++ b/mobile-rn/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/native-stack": "^7.2.0",
         "expo": "~52.0.0",
         "expo-camera": "~16.0.0",
+        "expo-notifications": "~0.29.0",
         "expo-secure-store": "~14.0.0",
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
@@ -2920,6 +2921,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4566,6 +4573,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4607,6 +4627,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-core": {
@@ -4827,6 +4862,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5079,6 +5120,24 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -5090,6 +5149,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caller-callsite": {
@@ -5699,6 +5774,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -5706,6 +5798,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/del": {
@@ -6172,6 +6281,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.0.2.tgz",
+      "integrity": "sha512-qcj6kGq3mc7x5yIb5KxESurFTJCoEKwNEL34RdPEvTB/xhl7SeVZlu05sZBqxB1V4Ryzq/LsCb7NHNfBbb3L7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-camera": {
       "version": "16.0.18",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.0.18.tgz",
@@ -6190,6 +6308,20 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
+      "integrity": "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~10.0.11",
+        "@expo/env": "~0.4.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -6256,6 +6388,26 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/expo-notifications": {
+      "version": "0.29.14",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.29.14.tgz",
+      "integrity": "sha512-AVduNx9mKOgcAqBfrXS1OHC9VAQZrDQLbVbcorMjPDGXW7m0Q5Q+BG6FYM/saVviF2eO8fhQRsTT40yYv5/bhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.6.5",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~6.0.2",
+        "expo-constants": "~17.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-secure-store": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.1.tgz",
@@ -6289,20 +6441,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
-      "integrity": "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~10.0.11",
-        "@expo/env": "~0.4.2"
-      },
-      "peerDependencies": {
-        "expo": "*",
         "react-native": "*"
       }
     },
@@ -6565,6 +6703,21 @@
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -6668,6 +6821,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -6857,6 +7019,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -7116,6 +7290,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -7127,6 +7317,18 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -7185,6 +7387,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7195,6 +7416,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -7236,6 +7473,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -7243,6 +7498,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -8962,6 +9232,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -9465,6 +9780,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -10229,6 +10553,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -10372,6 +10713,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setimmediate": {
@@ -11457,6 +11815,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -12064,6 +12435,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/mobile-rn/package.json
+++ b/mobile-rn/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native-stack": "^7.2.0",
     "expo": "~52.0.0",
     "expo-camera": "~16.0.0",
+    "expo-notifications": "~0.29.0",
     "expo-secure-store": "~14.0.0",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",

--- a/mobile-rn/src/api/__tests__/push.test.ts
+++ b/mobile-rn/src/api/__tests__/push.test.ts
@@ -1,0 +1,143 @@
+// push.test.ts (api) — the registration scaffold's observable behavior with an
+// INJECTED fake expo-notifications provider + fetch, so the whole flow is proven
+// WITHOUT a live APNs backend or a device:
+//   • permission-denied path,
+//   • token-obtained (unconfigured) path — registerPushToken is a no-op,
+//   • registerPushToken no-op when unconfigured (no fetch), and POST when
+//     configured.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_PUSH_CONFIG,
+  registerForPushNotifications,
+  registerPushToken,
+  type NotificationsProvider,
+} from "../push";
+
+/** A fake expo-notifications provider with configurable outcomes. */
+function fakeNotifications(opts: {
+  existing?: string;
+  requested?: string;
+  token?: string | (() => never);
+}): NotificationsProvider {
+  return {
+    getPermissionsAsync: async () => ({ status: opts.existing ?? "undetermined" }),
+    requestPermissionsAsync: async () => ({ status: opts.requested ?? "denied" }),
+    getExpoPushTokenAsync: async () => {
+      if (typeof opts.token === "function") opts.token();
+      return { data: (opts.token as string) ?? "ExponentPushToken[xyz]" };
+    },
+  };
+}
+
+describe("registerPushToken (the stub/no-op interface)", () => {
+  it("is a no-op (no fetch) when the backend is unconfigured", async () => {
+    const fetchFn = vi.fn();
+    const posted = await registerPushToken("tok", {
+      boxId: "box1",
+      platform: "ios",
+      config: DEFAULT_PUSH_CONFIG,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(posted).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("POSTs the token body when the backend is configured", async () => {
+    const fetchFn = vi.fn(
+      async (_url: string, _init?: RequestInit) => ({ ok: true }) as Response,
+    );
+    const posted = await registerPushToken("tok", {
+      boxId: "box1",
+      platform: "android",
+      config: { endpoint: "https://relay/push" },
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(posted).toBe(true);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("https://relay/push");
+    expect(JSON.parse((init?.body ?? "{}") as string)).toEqual({
+      token: "tok",
+      boxId: "box1",
+      platform: "android",
+    });
+  });
+
+  it("returns false (not posted) on a transport error", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    const posted = await registerPushToken("tok", {
+      boxId: "box1",
+      platform: "ios",
+      config: { endpoint: "https://relay/push" },
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(posted).toBe(false);
+  });
+});
+
+describe("registerForPushNotifications (full flow, injected deps)", () => {
+  it("permission-denied when the OS refuses", async () => {
+    const result = await registerForPushNotifications({
+      boxId: "box1",
+      platform: "ios",
+      notifications: fakeNotifications({ existing: "undetermined", requested: "denied" }),
+    });
+    expect(result).toEqual({ kind: "permission-denied" });
+  });
+
+  it("token-obtained → unconfigured (no-op) when granted but no backend", async () => {
+    const fetchFn = vi.fn();
+    const result = await registerForPushNotifications({
+      boxId: "box1",
+      platform: "ios",
+      notifications: fakeNotifications({ existing: "granted", token: "ExponentPushToken[abc]" }),
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ kind: "unconfigured", token: "ExponentPushToken[abc]" });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("registers when granted + token + configured backend", async () => {
+    const fetchFn = vi.fn(async () => ({ ok: true }) as Response);
+    const result = await registerForPushNotifications({
+      boxId: "box1",
+      platform: "ios",
+      config: { endpoint: "https://relay/push" },
+      notifications: fakeNotifications({ existing: "granted", token: "tok" }),
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ kind: "registered", token: "tok" });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests permission when undetermined, then proceeds on grant", async () => {
+    const result = await registerForPushNotifications({
+      boxId: "box1",
+      platform: "ios",
+      notifications: fakeNotifications({
+        existing: "undetermined",
+        requested: "granted",
+        token: "tok",
+      }),
+    });
+    expect(result).toEqual({ kind: "unconfigured", token: "tok" });
+  });
+
+  it("errors when granted but no token can be obtained", async () => {
+    const result = await registerForPushNotifications({
+      boxId: "box1",
+      platform: "ios",
+      notifications: fakeNotifications({
+        existing: "granted",
+        token: () => {
+          throw new Error("no token");
+        },
+      }),
+    });
+    expect(result.kind).toBe("error");
+  });
+});

--- a/mobile-rn/src/api/expo-notifications.d.ts
+++ b/mobile-rn/src/api/expo-notifications.d.ts
@@ -1,0 +1,18 @@
+// Ambient declaration for the optional `expo-notifications` native module.
+//
+// The push scaffold (src/api/push.ts) lazily `import("expo-notifications")` so
+// the native module stays out of the module graph for non-push code and the
+// unit tests (which inject a fake NotificationsProvider). expo-notifications is
+// a native module that isn't resolvable in the pure typecheck/test environment,
+// so we declare the narrow surface the scaffold touches here. This lets the
+// dynamic import type-check WITHOUT an `@ts-expect-error` suppression and
+// WITHOUT requiring the native package to be installed for `tsc --noEmit`.
+//
+// At runtime on the device / Expo Go, the real expo-notifications module is
+// present and provides these (and many more) APIs; the cast in push.ts adapts
+// it to our NotificationsProvider interface.
+declare module "expo-notifications" {
+  export function getPermissionsAsync(): Promise<{ status: string }>;
+  export function requestPermissionsAsync(): Promise<{ status: string }>;
+  export function getExpoPushTokenAsync(): Promise<{ data: string }>;
+}

--- a/mobile-rn/src/api/pairingApi.ts
+++ b/mobile-rn/src/api/pairingApi.ts
@@ -23,6 +23,12 @@ import {
   type PermissionVM,
   type QuestionVM,
 } from "../pure/interaction";
+import {
+  mapModelGroups,
+  type DefaultModel,
+  type ProviderGroupVM,
+} from "../pure/modelPicker";
+import type { SessionActionRequest } from "../pure/sessionActions";
 import { saveCredentials } from "./credentials";
 
 /** Strip trailing slashes so "http://box/" and "http://box" behave identically. */
@@ -265,4 +271,96 @@ export async function rejectQuestion(
     requestId,
     sessionId,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Model picker (Settings) — connected models + default selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the current default model from the box's `opencode:default-model`
+ * channel (src/server/rpc.mjs → oc.getDefaultModel()). Returns `null` when no
+ * provider is connected / no default is set. The box already strips secrets.
+ */
+export async function fetchDefaultModel(
+  base: string,
+  token: string,
+): Promise<DefaultModel | null> {
+  const raw = await rpc<unknown>(base, token, "opencode:default-model");
+  if (!raw || typeof raw !== "object") return null;
+  const providerID = (raw as { providerID?: unknown }).providerID;
+  const modelID = (raw as { modelID?: unknown }).modelID;
+  if (typeof providerID !== "string" || typeof modelID !== "string") return null;
+  return { providerID, modelID };
+}
+
+/**
+ * Fetch the connected-provider model list from the box's `opencode:models`
+ * channel (src/server/rpc.mjs → oc.listModels(), a flat array already filtered
+ * to providers with credentials) and map it — with the current default — into
+ * the provider-grouped picker view model. Both round-trips run in parallel; the
+ * pure `mapModelGroups` marks the selected row.
+ *
+ * NOTE: we use `opencode:models`, not `opencode:get-providers`. The latter is a
+ * desktop-only stub that returns `[]` on the box (rpc.mjs line 226); the desktop
+ * onboarding ModelStep likewise sources its list from `opencodeModels()`.
+ */
+export async function fetchModelGroups(
+  base: string,
+  token: string,
+): Promise<{ groups: ProviderGroupVM[]; current: DefaultModel | null }> {
+  const [rawModels, current] = await Promise.all([
+    rpc<unknown>(base, token, "opencode:models"),
+    fetchDefaultModel(base, token),
+  ]);
+  return { groups: mapModelGroups(rawModels, current), current };
+}
+
+/**
+ * Persist the chosen default model via `config:update({ defaultModel })` — the
+ * SAME config write the desktop store's setDefaultModel performs
+ * (src/renderer/store.ts). The box merges + persists and returns the full
+ * config; we read back the reconciled `defaultModel` so a rejected/clamped
+ * write is reflected (mirrors the desktop's reconcile step).
+ */
+export async function setDefaultModel(
+  base: string,
+  token: string,
+  model: DefaultModel,
+): Promise<DefaultModel | null> {
+  const cfg = await rpc<{ defaultModel?: unknown }>(base, token, "config:update", {
+    defaultModel: model,
+  });
+  const saved = cfg?.defaultModel;
+  if (!saved || typeof saved !== "object") return null;
+  const providerID = (saved as { providerID?: unknown }).providerID;
+  const modelID = (saved as { modelID?: unknown }).modelID;
+  if (typeof providerID !== "string" || typeof modelID !== "string") return null;
+  return { providerID, modelID };
+}
+
+// ---------------------------------------------------------------------------
+// Session actions — new / clear / fork / compact
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch a resolved session action (from the pure `resolveSessionAction`) to
+ * its box RPC channel. `clear`/`fork` send a single object arg; `compact` sends
+ * the raw sessionId as a positional arg — the pure resolver already picked the
+ * channel + payload shape, so this just adapts the positional form. Returns the
+ * box's raw result (e.g. `{ newSessionId, projects }` for clear/fork) so the
+ * caller can refresh its list; typed `unknown` because each channel differs.
+ */
+export async function dispatchSessionAction(
+  base: string,
+  token: string,
+  request: SessionActionRequest,
+): Promise<unknown> {
+  if (request.channel === "opencode:compact-session") {
+    // compact takes the raw sessionId positionally.
+    const { sessionId } = request.payload as { sessionId: string };
+    return rpc<unknown>(base, token, request.channel, sessionId);
+  }
+  // clear / fork take a single object payload.
+  return rpc<unknown>(base, token, request.channel, request.payload);
 }

--- a/mobile-rn/src/api/push.ts
+++ b/mobile-rn/src/api/push.ts
@@ -1,0 +1,199 @@
+// push.ts (impure) — the push-registration scaffold.
+//
+// Runs the registration flow proven for M3.5-3 (BET-78): request notification
+// permission via expo-notifications, obtain the Expo push token, and hand it to
+// `registerPushToken` — which POSTs it to the box push endpoint, OR is a NO-OP
+// when no push backend is configured. That no-op path is deliberate: this slice
+// ships + tests the whole flow with ZERO Apple credentials, on the simulator /
+// Expo Go. It compiles and runs today; only LIVE native APNs delivery waits on
+// the operator's APNs .p8 signing key.
+//
+// TODO(M5, human-blocked on APNs .p8 — see BET-75): configure `PushConfig.endpoint`
+//   to the operated relay's registration URL and wire the APNs/FCM delivery leg
+//   on the box/relay. Until then `isPushBackendConfigured` is false and this
+//   flow resolves to `{ kind: "unconfigured" }` — the token is obtained but not
+//   sent, which is exactly what we can prove without Apple artifacts.
+//
+// ALL decision logic (should-register, backend-configured, result
+// classification, request body) lives in the pure ../pure/push module and is
+// unit-tested there. THIS file owns only the expo-notifications + fetch side
+// effects, injected so the flow is testable without a live APNs backend or a
+// device — the same pure↔impure split as the rest of mobile-rn.
+
+import {
+  buildRegisterBody,
+  classifyRegistration,
+  isPushBackendConfigured,
+  shouldRegister,
+  type PushPermissionStatus,
+  type PushRegistrationResult,
+} from "../pure/push";
+
+/** Push backend configuration. `endpoint` empty/absent ⇒ registration no-ops. */
+export interface PushConfig {
+  /**
+   * The box/relay push-registration URL. Left empty until M5 wires the operated
+   * push backend — so the default build degrades to a no-op registration.
+   */
+  endpoint?: string | null;
+}
+
+/**
+ * The default (unconfigured) push backend. M5 replaces `endpoint` with the
+ * operated relay's registration URL once the APNs .p8 is available. Exported so
+ * a caller / test can see + override the current state.
+ */
+export const DEFAULT_PUSH_CONFIG: PushConfig = { endpoint: null };
+
+/**
+ * The subset of expo-notifications the scaffold touches. Injected so tests run
+ * WITHOUT the native module (which can't load off-device). The default provider
+ * lazily imports expo-notifications at call time.
+ */
+export interface NotificationsProvider {
+  getPermissionsAsync(): Promise<{ status: string }>;
+  requestPermissionsAsync(): Promise<{ status: string }>;
+  getExpoPushTokenAsync(): Promise<{ data: string }>;
+}
+
+/** The platform tag sent with the token so the box routes APNs vs FCM (M5). */
+export type PushPlatform = "ios" | "android" | "web";
+
+export interface RegisterPushOptions {
+  boxId: string;
+  platform: PushPlatform;
+  /** Backend config; defaults to the unconfigured (no-op) config. */
+  config?: PushConfig;
+  /** expo-notifications shim; defaults to the real lazy-loaded module. */
+  notifications?: NotificationsProvider;
+  /** fetch impl; defaults to global fetch. Injected for tests. */
+  fetchFn?: typeof fetch;
+}
+
+/** Normalize expo's permission string into our pure status. */
+function normalizeStatus(status: string): PushPermissionStatus {
+  if (status === "granted") return "granted";
+  if (status === "denied") return "denied";
+  return "undetermined";
+}
+
+/**
+ * Lazily load the real expo-notifications module. Kept behind a dynamic import
+ * so importing THIS file (e.g. from a test or a non-notification code path)
+ * doesn't pull in the native module. Never called by the unit tests, which
+ * inject a fake provider instead.
+ */
+async function loadNotifications(): Promise<NotificationsProvider> {
+  // @ts-expect-error — expo-notifications ships its own types at runtime; the
+  // dynamic import keeps it out of the module graph for non-push code + tests.
+  const mod = await import("expo-notifications");
+  return mod as unknown as NotificationsProvider;
+}
+
+/**
+ * POST the token to the box push endpoint. Behind `registerPushToken`; a no-op
+ * (returns false-as-"not posted" without touching the network) when the backend
+ * is unconfigured. Returns true on a 2xx POST. Any transport error resolves to
+ * false so the caller classifies it as an error rather than throwing.
+ *
+ * This is THE interface the issue asks for: `registerPushToken(token)` is
+ * stub/no-op when no push backend is configured.
+ */
+export async function registerPushToken(
+  token: string,
+  opts: {
+    boxId: string;
+    platform: PushPlatform;
+    config?: PushConfig;
+    fetchFn?: typeof fetch;
+  },
+): Promise<boolean> {
+  const config = opts.config ?? DEFAULT_PUSH_CONFIG;
+  // No-op path — the M5 dependency. Nothing is sent; the flow is still proven.
+  if (!isPushBackendConfigured(config)) return false;
+
+  const doFetch = opts.fetchFn ?? fetch;
+  const body = buildRegisterBody({ token, boxId: opts.boxId, platform: opts.platform });
+  try {
+    const res = await doFetch(config.endpoint as string, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run the full registration flow and return the classified terminal result:
+ *   1. read (and if needed request) notification permission;
+ *   2. if granted, obtain the Expo push token;
+ *   3. hand the token to `registerPushToken` (POST or no-op);
+ *   4. classify the outcome via the pure classifier.
+ *
+ * Never throws — every failure maps to `{ kind: "error" }` — so a caller can
+ * render the result inline. Runs end-to-end on the simulator with the default
+ * unconfigured backend, resolving to `{ kind: "unconfigured", token }`.
+ */
+export async function registerForPushNotifications(
+  opts: RegisterPushOptions,
+): Promise<PushRegistrationResult> {
+  const config = opts.config ?? DEFAULT_PUSH_CONFIG;
+  let notifications: NotificationsProvider;
+  try {
+    notifications = opts.notifications ?? (await loadNotifications());
+  } catch {
+    return { kind: "error", message: "Notifications are unavailable on this device." };
+  }
+
+  // 1. Permission: read current, request if not already decided.
+  let status: PushPermissionStatus;
+  try {
+    const existing = await notifications.getPermissionsAsync();
+    status = normalizeStatus(existing.status);
+    if (status !== "granted") {
+      const requested = await notifications.requestPermissionsAsync();
+      status = normalizeStatus(requested.status);
+    }
+  } catch {
+    return { kind: "error", message: "Could not read notification permission." };
+  }
+
+  if (!shouldRegister(status)) {
+    return classifyRegistration({
+      status,
+      token: null,
+      backendConfigured: isPushBackendConfigured(config),
+      posted: false,
+    });
+  }
+
+  // 2. Obtain the Expo push token.
+  let token: string | null = null;
+  try {
+    const res = await notifications.getExpoPushTokenAsync();
+    token = typeof res?.data === "string" && res.data.length > 0 ? res.data : null;
+  } catch {
+    token = null;
+  }
+  if (!token) {
+    return classifyRegistration({
+      status,
+      token: null,
+      backendConfigured: isPushBackendConfigured(config),
+      posted: false,
+    });
+  }
+
+  // 3. Register (POST or no-op) + 4. classify.
+  const backendConfigured = isPushBackendConfigured(config);
+  const posted = await registerPushToken(token, {
+    boxId: opts.boxId,
+    platform: opts.platform,
+    config,
+    fetchFn: opts.fetchFn,
+  });
+  return classifyRegistration({ status, token, backendConfigured, posted });
+}

--- a/mobile-rn/src/api/push.ts
+++ b/mobile-rn/src/api/push.ts
@@ -84,8 +84,9 @@ function normalizeStatus(status: string): PushPermissionStatus {
  * inject a fake provider instead.
  */
 async function loadNotifications(): Promise<NotificationsProvider> {
-  // @ts-expect-error — expo-notifications ships its own types at runtime; the
-  // dynamic import keeps it out of the module graph for non-push code + tests.
+  // expo-notifications ships its own types at runtime; the dynamic import keeps
+  // it out of the module graph for non-push code + tests. The cast below adapts
+  // the module to our narrow NotificationsProvider interface.
   const mod = await import("expo-notifications");
   return mod as unknown as NotificationsProvider;
 }

--- a/mobile-rn/src/pure/__tests__/modelPicker.test.ts
+++ b/mobile-rn/src/pure/__tests__/modelPicker.test.ts
@@ -1,0 +1,130 @@
+// modelPicker.test.ts — raw `opencode:models` JSON → grouped picker VM (pure):
+// connected-model grouping, default selection, key parse, defensive shapes.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  countModels,
+  flattenModelRows,
+  mapModelGroups,
+  parseModelKey,
+} from "../modelPicker";
+
+const RAW = [
+  { id: "claude-sonnet-4-6", providerID: "anthropic", name: "Claude Sonnet 4.6" },
+  { id: "claude-opus-4-7", providerID: "anthropic", name: "Claude Opus 4.7" },
+  { id: "deepseek-chat", providerID: "deepseek", name: "DeepSeek Chat" },
+];
+
+describe("mapModelGroups", () => {
+  it("groups models by provider in first-seen order", () => {
+    const groups = mapModelGroups(RAW, null);
+    expect(groups.map((g) => g.providerID)).toEqual(["anthropic", "deepseek"]);
+    expect(groups[0].rows).toHaveLength(2);
+    expect(groups[1].rows).toHaveLength(1);
+  });
+
+  it("builds the `<providerID>/<modelID>` key and uses name as the label", () => {
+    const [anthropic] = mapModelGroups(RAW, null);
+    expect(anthropic.rows[0]).toMatchObject({
+      key: "anthropic/claude-sonnet-4-6",
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+      label: "Claude Sonnet 4.6",
+      selected: false,
+    });
+  });
+
+  it("marks exactly the row matching the current default as selected", () => {
+    const groups = mapModelGroups(RAW, {
+      providerID: "deepseek",
+      modelID: "deepseek-chat",
+    });
+    const selected = flattenModelRows(groups).filter((r) => r.selected);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].key).toBe("deepseek/deepseek-chat");
+  });
+
+  it("selects nothing when the default matches no connected model", () => {
+    const groups = mapModelGroups(RAW, { providerID: "openai", modelID: "gpt-4o" });
+    expect(flattenModelRows(groups).some((r) => r.selected)).toBe(false);
+  });
+
+  it("falls back to the model id when name is missing or empty", () => {
+    const groups = mapModelGroups(
+      [{ id: "m1", providerID: "p" }, { id: "m2", providerID: "p", name: "" }],
+      null,
+    );
+    expect(groups[0].rows.map((r) => r.label)).toEqual(["m1", "m2"]);
+  });
+
+  it("drops entries missing id or providerID", () => {
+    const groups = mapModelGroups(
+      [
+        { id: "ok", providerID: "p", name: "OK" },
+        { providerID: "p" },
+        { id: "no-provider" },
+        null,
+        42,
+        { id: "", providerID: "p" },
+        { id: "x", providerID: "" },
+      ],
+      null,
+    );
+    expect(countModels(groups)).toBe(1);
+    expect(flattenModelRows(groups)[0].modelID).toBe("ok");
+  });
+
+  it("de-dups a provider/model pair that appears twice", () => {
+    const groups = mapModelGroups(
+      [
+        { id: "m", providerID: "p", name: "M" },
+        { id: "m", providerID: "p", name: "M again" },
+      ],
+      null,
+    );
+    expect(countModels(groups)).toBe(1);
+  });
+
+  it("returns [] for a non-array response", () => {
+    expect(mapModelGroups(null, null)).toEqual([]);
+    expect(mapModelGroups({ models: [] }, null)).toEqual([]);
+    expect(mapModelGroups("nope", null)).toEqual([]);
+  });
+});
+
+describe("countModels / flattenModelRows", () => {
+  it("counts and flattens across groups preserving order", () => {
+    const groups = mapModelGroups(RAW, null);
+    expect(countModels(groups)).toBe(3);
+    expect(flattenModelRows(groups).map((r) => r.modelID)).toEqual([
+      "claude-sonnet-4-6",
+      "claude-opus-4-7",
+      "deepseek-chat",
+    ]);
+  });
+});
+
+describe("parseModelKey", () => {
+  it("splits on the first slash so slashes in the modelID survive", () => {
+    expect(parseModelKey("openrouter/meta-llama/llama-3.3-70b")).toEqual({
+      providerID: "openrouter",
+      modelID: "meta-llama/llama-3.3-70b",
+    });
+  });
+
+  it("round-trips a picker row key", () => {
+    const row = flattenModelRows(mapModelGroups(RAW, null))[0];
+    expect(parseModelKey(row.key)).toEqual({
+      providerID: row.providerID,
+      modelID: row.modelID,
+    });
+  });
+
+  it("returns null for a malformed key", () => {
+    expect(parseModelKey("noslash")).toBeNull();
+    expect(parseModelKey("/leading")).toBeNull();
+    expect(parseModelKey("trailing/")).toBeNull();
+    expect(parseModelKey("")).toBeNull();
+  });
+});

--- a/mobile-rn/src/pure/__tests__/push.test.ts
+++ b/mobile-rn/src/pure/__tests__/push.test.ts
@@ -1,0 +1,98 @@
+// push.test.ts — pure push-registration decision logic:
+// should-register gate, backend-configured check, result classification,
+// request-body shape. No expo-notifications / APNs backend required.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRegisterBody,
+  classifyRegistration,
+  isPushBackendConfigured,
+  shouldRegister,
+} from "../push";
+
+describe("shouldRegister", () => {
+  it("proceeds only when permission is granted", () => {
+    expect(shouldRegister("granted")).toBe(true);
+    expect(shouldRegister("denied")).toBe(false);
+    expect(shouldRegister("undetermined")).toBe(false);
+  });
+});
+
+describe("isPushBackendConfigured", () => {
+  it("is false when no endpoint is set (the default until M5)", () => {
+    expect(isPushBackendConfigured(null)).toBe(false);
+    expect(isPushBackendConfigured(undefined)).toBe(false);
+    expect(isPushBackendConfigured({})).toBe(false);
+    expect(isPushBackendConfigured({ endpoint: null })).toBe(false);
+    expect(isPushBackendConfigured({ endpoint: "" })).toBe(false);
+    expect(isPushBackendConfigured({ endpoint: "   " })).toBe(false);
+  });
+
+  it("is true only for a non-empty endpoint URL", () => {
+    expect(isPushBackendConfigured({ endpoint: "https://relay/push" })).toBe(true);
+  });
+});
+
+describe("classifyRegistration", () => {
+  it("permission-denied when not granted (token ignored)", () => {
+    expect(
+      classifyRegistration({
+        status: "denied",
+        token: "tok",
+        backendConfigured: true,
+        posted: true,
+      }),
+    ).toEqual({ kind: "permission-denied" });
+  });
+
+  it("error when granted but no token was obtained", () => {
+    const r = classifyRegistration({
+      status: "granted",
+      token: null,
+      backendConfigured: false,
+      posted: false,
+    });
+    expect(r.kind).toBe("error");
+  });
+
+  it("unconfigured when granted + token but no backend (no-op path)", () => {
+    expect(
+      classifyRegistration({
+        status: "granted",
+        token: "ExponentPushToken[abc]",
+        backendConfigured: false,
+        posted: false,
+      }),
+    ).toEqual({ kind: "unconfigured", token: "ExponentPushToken[abc]" });
+  });
+
+  it("registered when granted + token + backend + posted", () => {
+    expect(
+      classifyRegistration({
+        status: "granted",
+        token: "tok",
+        backendConfigured: true,
+        posted: true,
+      }),
+    ).toEqual({ kind: "registered", token: "tok" });
+  });
+
+  it("error when backend configured but the POST failed", () => {
+    const r = classifyRegistration({
+      status: "granted",
+      token: "tok",
+      backendConfigured: true,
+      posted: false,
+    });
+    expect(r.kind).toBe("error");
+  });
+});
+
+describe("buildRegisterBody", () => {
+  it("pins the wire shape { token, boxId, platform }", () => {
+    expect(
+      buildRegisterBody({ token: "tok", boxId: "box123", platform: "ios" }),
+    ).toEqual({ token: "tok", boxId: "box123", platform: "ios" });
+  });
+});

--- a/mobile-rn/src/pure/__tests__/sessionActions.test.ts
+++ b/mobile-rn/src/pure/__tests__/sessionActions.test.ts
@@ -1,0 +1,102 @@
+// sessionActions.test.ts — pure new/clear/fork/compact decision logic:
+// which channel + payload each action maps to, and availability gating.
+
+import { describe, expect, it } from "vitest";
+
+import type { SessionRowVM } from "../sessionList";
+import {
+  availableActions,
+  isActionAvailable,
+  resolveSessionAction,
+  type ClearSessionPayload,
+  type CompactSessionPayload,
+  type ForkSessionPayload,
+} from "../sessionActions";
+
+const chatRow: SessionRowVM = {
+  key: "better-ui:0",
+  project: "better-ui",
+  windowIndex: 0,
+  title: "main",
+  kind: "chat",
+  status: "idle",
+  opencodeSessionId: "sess_abc",
+};
+
+const terminalRow: SessionRowVM = {
+  key: "better-ui:1",
+  project: "better-ui",
+  windowIndex: 1,
+  title: "term",
+  kind: "terminal",
+  status: "idle",
+  opencodeSessionId: null,
+};
+
+describe("isActionAvailable / availableActions", () => {
+  it("allows all opencode actions on a chat row", () => {
+    for (const k of ["new", "clear", "fork", "compact"] as const) {
+      expect(isActionAvailable(k, chatRow)).toBe(true);
+    }
+    expect(availableActions(chatRow)).toEqual(["new", "fork", "compact"]);
+  });
+
+  it("blocks every action on a terminal row (no opencode session)", () => {
+    for (const k of ["new", "clear", "fork", "compact"] as const) {
+      expect(isActionAvailable(k, terminalRow)).toBe(false);
+    }
+    expect(availableActions(terminalRow)).toEqual([]);
+  });
+
+  it("treats a chat row with a missing session id as unavailable", () => {
+    const broken = { ...chatRow, opencodeSessionId: null };
+    expect(availableActions(broken)).toEqual([]);
+  });
+});
+
+describe("resolveSessionAction", () => {
+  it("maps new/clear to opencode:clear-session with the window payload", () => {
+    for (const kind of ["new", "clear"] as const) {
+      const req = resolveSessionAction(kind, chatRow, { title: "Fresh" });
+      expect(req?.channel).toBe("opencode:clear-session");
+      const payload = req?.payload as ClearSessionPayload;
+      expect(payload).toMatchObject({
+        sessionName: "better-ui",
+        windowIndex: 0,
+        title: "Fresh",
+      });
+    }
+  });
+
+  it("maps fork to opencode:fork-session carrying the source session id", () => {
+    const req = resolveSessionAction("fork", chatRow, { messageID: "msg_9" });
+    expect(req?.channel).toBe("opencode:fork-session");
+    const payload = req?.payload as ForkSessionPayload;
+    expect(payload).toMatchObject({
+      sessionId: "sess_abc",
+      sessionName: "better-ui",
+      windowName: "main",
+      messageID: "msg_9",
+    });
+  });
+
+  it("maps compact to opencode:compact-session with the raw session id", () => {
+    const req = resolveSessionAction("compact", chatRow);
+    expect(req?.channel).toBe("opencode:compact-session");
+    const payload = req?.payload as CompactSessionPayload;
+    expect(payload).toEqual({ sessionId: "sess_abc" });
+  });
+
+  it("returns null for any action on a terminal row", () => {
+    for (const k of ["new", "clear", "fork", "compact"] as const) {
+      expect(resolveSessionAction(k, terminalRow)).toBeNull();
+    }
+  });
+
+  it("omits optional fields when not provided", () => {
+    const req = resolveSessionAction("new", chatRow);
+    const payload = req?.payload as ClearSessionPayload;
+    expect(payload.title).toBeUndefined();
+    expect(payload.cwd).toBeUndefined();
+  });
+});

--- a/mobile-rn/src/pure/modelPicker.ts
+++ b/mobile-rn/src/pure/modelPicker.ts
@@ -1,0 +1,150 @@
+// modelPicker.ts — pure mapping of the box's `opencode:models` RPC response
+// into the grouped view model the Settings model picker renders, plus the
+// "which row is currently the default" decision.
+//
+// The box exposes the CONNECTED providers' models on the `opencode:models`
+// channel (src/server/rpc.mjs → oc.listModels()), which returns a FLAT list of
+// `{ id, providerID, name, ... }` — one entry per model, already filtered to
+// providers that have credentials on the box. (The `opencode:get-providers`
+// channel the issue mentions is a desktop-only stub that returns `[]` on the
+// box — src/server/rpc.mjs line 226 — so `opencode:models` is the real source
+// of the connected model list, matching what the desktop onboarding ModelStep
+// uses: `window.api.opencodeModels()`.)
+//
+// The current default comes from the `opencode:default-model` channel
+// (`{ providerID, modelID } | null`), and selecting a model persists it via
+// `config:update({ defaultModel })` — the SAME config write the desktop store's
+// setDefaultModel uses (src/renderer/store.ts). All of that wiring is impure and
+// lives in ../api/pairingApi; THIS module owns only the raw-JSON → picker-VM
+// transform + the default-match decision, so it is fully unit-testable without a
+// live box, exactly like the other mobile-rn pure modules.
+
+/** The current default model selection, as returned by `opencode:default-model`. */
+export interface DefaultModel {
+  providerID: string;
+  modelID: string;
+}
+
+/** One selectable model row in the picker. */
+export interface ModelRowVM {
+  /** Stable key + the value passed back to setDefaultModel: `<providerID>/<modelID>`. */
+  key: string;
+  providerID: string;
+  modelID: string;
+  /** Human label (the model's `name`, falling back to its id). */
+  label: string;
+  /** True when this row matches the current default (drives the checkmark). */
+  selected: boolean;
+}
+
+/** A provider group (section) with its model rows. */
+export interface ProviderGroupVM {
+  providerID: string;
+  rows: ModelRowVM[];
+}
+
+/**
+ * Whether a raw model row from `opencode:models` matches the given default.
+ * Both `providerID` and the model id must match. Pure.
+ */
+function matchesDefault(
+  providerID: string,
+  modelID: string,
+  def: DefaultModel | null,
+): boolean {
+  return !!def && def.providerID === providerID && def.modelID === modelID;
+}
+
+/**
+ * Map a raw `opencode:models` response (flat array of normalized model objects)
+ * into provider-grouped picker sections, marking the row that matches the
+ * current default as `selected`.
+ *
+ * Defensive against a malformed/partial response (non-array input, non-object
+ * entries, missing id/providerID) — a bad shape simply drops that entry rather
+ * than throwing, so a transient box hiccup can't crash the Settings screen.
+ * Provider order and within-provider model order follow first-seen order in the
+ * raw list (the box already returns connected providers only). Pure.
+ */
+export function mapModelGroups(
+  raw: unknown,
+  def: DefaultModel | null,
+): ProviderGroupVM[] {
+  if (!Array.isArray(raw)) return [];
+  const groups: ProviderGroupVM[] = [];
+  const byProvider = new Map<string, ProviderGroupVM>();
+  const seenKeys = new Set<string>();
+
+  for (const m of raw) {
+    if (!m || typeof m !== "object") continue;
+    const providerID = (m as { providerID?: unknown }).providerID;
+    const modelID = (m as { id?: unknown }).id;
+    if (typeof providerID !== "string" || providerID.length === 0) continue;
+    if (typeof modelID !== "string" || modelID.length === 0) continue;
+
+    const key = `${providerID}/${modelID}`;
+    // A provider can legitimately list a model once; guard against duplicate
+    // entries so a repeated row doesn't render twice.
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+
+    const nameRaw = (m as { name?: unknown }).name;
+    const label =
+      typeof nameRaw === "string" && nameRaw.length > 0 ? nameRaw : modelID;
+
+    const row: ModelRowVM = {
+      key,
+      providerID,
+      modelID,
+      label,
+      selected: matchesDefault(providerID, modelID, def),
+    };
+
+    let group = byProvider.get(providerID);
+    if (!group) {
+      group = { providerID, rows: [] };
+      byProvider.set(providerID, group);
+      groups.push(group);
+    }
+    group.rows.push(row);
+  }
+
+  return groups;
+}
+
+/**
+ * Flatten the mapped groups back into a single ordered row list (some renderers
+ * want a plain FlatList rather than sections). Preserves group + row order.
+ * Pure.
+ */
+export function flattenModelRows(groups: ProviderGroupVM[]): ModelRowVM[] {
+  const out: ModelRowVM[] = [];
+  for (const g of groups) out.push(...g.rows);
+  return out;
+}
+
+/**
+ * Total number of selectable models across all provider groups. Pure — used to
+ * decide between the "pick a model" list and the "no connected models" empty
+ * state without re-walking the raw response in the component.
+ */
+export function countModels(groups: ProviderGroupVM[]): number {
+  let n = 0;
+  for (const g of groups) n += g.rows.length;
+  return n;
+}
+
+/**
+ * Parse a picker row key (`<providerID>/<modelID>`) back into a DefaultModel.
+ * The split is on the FIRST slash only, since a modelID can itself contain
+ * slashes (e.g. "meta-llama/llama-3.3-70b"). Returns null for a malformed key
+ * (no slash, empty side) so the caller can ignore a bad tap. Pure.
+ */
+export function parseModelKey(key: string): DefaultModel | null {
+  const slash = key.indexOf("/");
+  if (slash <= 0 || slash >= key.length - 1) return null;
+  const providerID = key.slice(0, slash);
+  const modelID = key.slice(slash + 1);
+  if (!providerID || !modelID) return null;
+  return { providerID, modelID };
+}

--- a/mobile-rn/src/pure/push.ts
+++ b/mobile-rn/src/pure/push.ts
@@ -1,0 +1,95 @@
+// push.ts (pure) — the decision logic for the push-registration scaffold.
+//
+// The mobile push story is split into three tiers by the M-plan:
+//   • THIS slice (M3.5-3, BET-78): build + unit-test the registration FLOW —
+//     ask permission, obtain the Expo push token, POST it to a box endpoint —
+//     but behind an interface that is a NO-OP when no push backend is
+//     configured, so it compiles + runs on the simulator/Expo Go with ZERO
+//     Apple credentials.
+//   • M5 (human-blocked): wire LIVE native APNs delivery once the operator
+//     provides the APNs .p8 signing key. Only the delivery leg waits — the
+//     registration flow proven here does not change.
+//
+// This module owns the framework-free DECISIONS so the impure ../api/push.ts
+// wrapper (which touches expo-notifications + fetch) stays thin and the flow is
+// fully unit-testable without a live APNs backend or a device. Mirrors the
+// pure↔impure split of the rest of mobile-rn.
+
+/** Permission outcomes we care about, normalized from expo-notifications. */
+export type PushPermissionStatus = "granted" | "denied" | "undetermined";
+
+/** The terminal result of a registration attempt, for the caller to render. */
+export type PushRegistrationResult =
+  /** Permission was refused — nothing sent; UI shows "notifications off". */
+  | { kind: "permission-denied" }
+  /** Permission granted but no push backend is configured — token obtained,
+   *  registration was a no-op (the M5 dependency). */
+  | { kind: "unconfigured"; token: string }
+  /** Permission granted and the token was POSTed to the box endpoint. */
+  | { kind: "registered"; token: string }
+  /** Something failed obtaining the token or posting it. */
+  | { kind: "error"; message: string };
+
+/**
+ * Whether we should proceed to obtain a push token given a permission status.
+ * Only "granted" proceeds; "denied"/"undetermined" stop (the caller may have
+ * already requested, so undetermined here means the OS still didn't grant).
+ * Pure.
+ */
+export function shouldRegister(status: PushPermissionStatus): boolean {
+  return status === "granted";
+}
+
+/**
+ * Whether a push backend is configured — i.e. whether `registerPushToken` will
+ * actually POST or short-circuit as a no-op. A backend is "configured" only
+ * when a non-empty endpoint URL is present. Until M5 wires the operator's push
+ * service, this is intentionally false in the default build, so the whole flow
+ * degrades to `{ kind: "unconfigured" }`. Pure.
+ */
+export function isPushBackendConfigured(
+  config: { endpoint?: string | null } | null | undefined,
+): boolean {
+  return !!config && typeof config.endpoint === "string" && config.endpoint.trim().length > 0;
+}
+
+/**
+ * Classify a completed registration flow into the terminal result, given:
+ *  - the (already-resolved) permission status,
+ *  - the token obtained (null if none / permission denied),
+ *  - whether a backend was configured,
+ *  - whether the POST (if attempted) succeeded.
+ *
+ * This is the single source of truth for "what did registration do", so the
+ * impure wrapper just feeds it facts. Pure.
+ */
+export function classifyRegistration(input: {
+  status: PushPermissionStatus;
+  token: string | null;
+  backendConfigured: boolean;
+  posted: boolean;
+}): PushRegistrationResult {
+  if (input.status !== "granted") return { kind: "permission-denied" };
+  if (!input.token) {
+    return { kind: "error", message: "Could not obtain a push token." };
+  }
+  if (!input.backendConfigured) {
+    return { kind: "unconfigured", token: input.token };
+  }
+  return input.posted
+    ? { kind: "registered", token: input.token }
+    : { kind: "error", message: "Failed to register the push token with the box." };
+}
+
+/**
+ * Build the JSON body POSTed to the box's push-registration endpoint. Kept pure
+ * so the wire shape is pinned by a test. The box binds `{ token, boxId,
+ * platform }` to the box_id for later APNs/FCM delivery (M5). Pure.
+ */
+export function buildRegisterBody(input: {
+  token: string;
+  boxId: string;
+  platform: "ios" | "android" | "web";
+}): { token: string; boxId: string; platform: string } {
+  return { token: input.token, boxId: input.boxId, platform: input.platform };
+}

--- a/mobile-rn/src/pure/sessionActions.ts
+++ b/mobile-rn/src/pure/sessionActions.ts
@@ -1,0 +1,155 @@
+// sessionActions.ts — pure decision logic for the mobile session actions
+// (new / clear / fork / compact), mirroring the desktop composite operations
+// the box exposes on its RPC channels (src/server/rpc.mjs):
+//
+//   • "new session" / "clear"  → `opencode:clear-session`
+//        creates a fresh opencode session and re-stamps it onto the SAME tmux
+//        window (sessionName + windowIndex). This is the desktop "New chat /
+//        Clear" — the window keeps its slot, the conversation resets.
+//        payload: { sessionName, windowIndex, cwd?, title? }
+//   • "fork"    → `opencode:fork-session`
+//        forks the current opencode session into a NEW tmux window.
+//        payload: { sessionId, sessionName, windowName, cwd?, messageID? }
+//   • "compact" → `opencode:compact-session`
+//        compacts (summarizes) the running session's context in place.
+//        payload (positional arg): sessionId
+//
+// The screens stay thin: they collect the tap, ask THIS module which channel +
+// payload to send and whether the action is even allowed for the row, then hand
+// the result to the impure ../api/pairingApi. Keeping the channel/payload/guard
+// LOGIC pure makes it unit-testable without a live box — the same pure↔impure
+// split the other mobile-rn modules use.
+
+import type { SessionRowVM } from "./sessionList";
+
+/** The four session actions the mobile UI can trigger. */
+export type SessionActionKind = "new" | "clear" | "fork" | "compact";
+
+/** A resolved action ready to dispatch: the RPC channel + its payload. */
+export interface SessionActionRequest {
+  kind: SessionActionKind;
+  /** The box RPC channel this action maps to. */
+  channel:
+    | "opencode:clear-session"
+    | "opencode:fork-session"
+    | "opencode:compact-session";
+  /**
+   * The RPC payload. `clear`/`fork` send a single object arg; `compact` sends a
+   * positional sessionId string. The caller spreads/positions this per channel.
+   */
+  payload: ClearSessionPayload | ForkSessionPayload | CompactSessionPayload;
+}
+
+export interface ClearSessionPayload {
+  sessionName: string;
+  windowIndex: number;
+  /** cwd is optional — the box resolves the project cwd when omitted. */
+  cwd?: string;
+  title?: string;
+}
+
+export interface ForkSessionPayload {
+  sessionId: string;
+  sessionName: string;
+  windowName: string;
+  cwd?: string;
+  messageID?: string;
+}
+
+/** compact takes the raw opencode session id as its single positional arg. */
+export type CompactSessionPayload = { sessionId: string };
+
+/**
+ * Whether a given action is available for a session row.
+ *
+ *  - "new" / "clear": available for ANY row that has a tmux window (both chat
+ *    and terminal rows have a session + windowIndex). Clearing a terminal is a
+ *    no-op on opencode but harmless; we still allow "new" for chat rows only,
+ *    since that's the meaningful case. Terminals can't hold a chat, so we gate
+ *    new/clear/fork/compact to chat rows to keep the UI honest.
+ *  - "fork" / "compact": require a live opencode session id (chat rows only).
+ *
+ * A row without an opencodeSessionId is a terminal — none of these opencode
+ * actions apply. Pure.
+ */
+export function isActionAvailable(
+  kind: SessionActionKind,
+  row: SessionRowVM,
+): boolean {
+  // All four actions operate on an opencode chat session; terminals have none.
+  if (row.kind !== "chat" || !row.opencodeSessionId) return false;
+  return (
+    kind === "new" ||
+    kind === "clear" ||
+    kind === "fork" ||
+    kind === "compact"
+  );
+}
+
+/**
+ * The set of actions available for a row, in display order (New, Fork, Compact).
+ * "clear" is the same channel as "new"; the UI surfaces a single "New chat"
+ * entry, so we expose New/Fork/Compact here and let the component label it.
+ * Returns [] for a terminal row. Pure.
+ */
+export function availableActions(row: SessionRowVM): SessionActionKind[] {
+  if (row.kind !== "chat" || !row.opencodeSessionId) return [];
+  return ["new", "fork", "compact"];
+}
+
+/**
+ * Resolve a tapped action + row into the concrete RPC channel + payload, or
+ * null when the action isn't available for that row (terminal / missing
+ * session id). The caller dispatches the returned request via pairingApi.
+ *
+ * `title` (optional) names a freshly-cleared session; `messageID` (optional)
+ * forks from a specific message rather than the tip. Pure.
+ */
+export function resolveSessionAction(
+  kind: SessionActionKind,
+  row: SessionRowVM,
+  opts: { title?: string; messageID?: string } = {},
+): SessionActionRequest | null {
+  if (!isActionAvailable(kind, row)) return null;
+
+  const sessionId = row.opencodeSessionId;
+  if (!sessionId) return null;
+
+  switch (kind) {
+    case "new":
+    case "clear":
+      return {
+        kind,
+        channel: "opencode:clear-session",
+        payload: {
+          sessionName: row.project,
+          windowIndex: row.windowIndex,
+          title: opts.title,
+        },
+      };
+    case "fork":
+      return {
+        kind,
+        channel: "opencode:fork-session",
+        payload: {
+          sessionId,
+          sessionName: row.project,
+          // A forked window is named after the source row's title so it's
+          // recognizable in the list; the box de-dups window names as needed.
+          windowName: row.title,
+          messageID: opts.messageID,
+        },
+      };
+    case "compact":
+      return {
+        kind,
+        channel: "opencode:compact-session",
+        payload: { sessionId },
+      };
+    default: {
+      // Exhaustiveness guard — a new SessionActionKind must be handled above.
+      const _never: never = kind;
+      return _never;
+    }
+  }
+}

--- a/mobile-rn/src/screens/SessionDetailScreen.tsx
+++ b/mobile-rn/src/screens/SessionDetailScreen.tsx
@@ -14,13 +14,15 @@
 // the pure ../pure/{transcript,events,composer,interaction} modules; this
 // component owns fetch + socket + render.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import {
   ActivityIndicator,
+  Alert,
   FlatList,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   RefreshControl,
   StyleSheet,
   Text,
@@ -31,6 +33,7 @@ import type { RootStackParamList } from "../../App";
 import {
   AuthRequiredError,
   abortSession,
+  dispatchSessionAction,
   fetchPermissions,
   fetchQuestions,
   fetchTranscript,
@@ -39,6 +42,11 @@ import {
   replyQuestion,
   sendPrompt,
 } from "../api/pairingApi";
+import {
+  availableActions,
+  resolveSessionAction,
+  type SessionActionKind,
+} from "../pure/sessionActions";
 import { clearCredentials } from "../api/credentials";
 import { subscribeOpencodeEvents } from "../api/eventsClient";
 import {
@@ -83,10 +91,85 @@ export function SessionDetailScreen({ navigation, route }: Props) {
   // bottom, so scrolling up to read history isn't yanked back on each event.
   const atBottomRef = useRef(true);
 
-  // Set the header to the session title.
-  useEffect(() => {
-    navigation.setOptions({ title: session.title });
-  }, [navigation, session.title]);
+  // A session action (new/fork/compact) in flight — disables the header menu.
+  const [actionBusy, setActionBusy] = useState(false);
+
+  // Run a session action: resolve the channel+payload with the pure module,
+  // dispatch it, and surface the outcome. "new" resets the conversation on this
+  // window; "fork" spawns a new window on the box; "compact" summarizes context
+  // in place. All are best-effort — a failure alerts rather than crashing.
+  const runAction = useCallback(
+    async (kind: SessionActionKind) => {
+      const request = resolveSessionAction(kind, session);
+      if (!request) return;
+      setActionBusy(true);
+      try {
+        await dispatchSessionAction(
+          credentials.serverUrl,
+          credentials.boxToken,
+          request,
+        );
+        if (kind === "new") {
+          // The window now holds a fresh session id; the transcript we're
+          // showing is stale. Reload it (the box re-stamped the same window).
+          void load("refresh");
+        } else if (kind === "fork") {
+          Alert.alert("Forked", "A new window was created on your box.");
+        } else if (kind === "compact") {
+          Alert.alert("Compacting", "The session context is being summarized.");
+        }
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        Alert.alert("Couldn't complete that", e instanceof Error ? e.message : "Try again.");
+      } finally {
+        setActionBusy(false);
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, session, navigation],
+  );
+
+  const onMenuPress = useCallback(() => {
+    const actions = availableActions(session);
+    if (actions.length === 0) return;
+    const label: Record<SessionActionKind, string> = {
+      new: "New chat (clear)",
+      clear: "Clear",
+      fork: "Fork to new window",
+      compact: "Compact context",
+    };
+    Alert.alert("Session actions", session.title, [
+      ...actions.map((a) => ({
+        text: label[a],
+        onPress: () => void runAction(a),
+      })),
+      { text: "Cancel", style: "cancel" as const },
+    ]);
+  }, [session, runAction]);
+
+  // Set the header title + the actions menu button.
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: session.title,
+      headerRight:
+        availableActions(session).length > 0
+          ? () => (
+              <Pressable
+                onPress={onMenuPress}
+                disabled={actionBusy}
+                accessibilityRole="button"
+                accessibilityLabel="Session actions"
+                hitSlop={12}
+              >
+                <Text style={[styles.headerMenu, actionBusy && styles.headerMenuBusy]}>⋯</Text>
+              </Pressable>
+            )
+          : undefined,
+    });
+  }, [navigation, session, onMenuPress, actionBusy]);
 
   const load = useCallback(
     async (mode: "initial" | "refresh") => {
@@ -478,4 +561,6 @@ const styles = StyleSheet.create({
     textAlign: "center",
     paddingVertical: 8,
   },
+  headerMenu: { color: colors.text, fontSize: 24, fontWeight: "700" },
+  headerMenuBusy: { opacity: 0.4 },
 });

--- a/mobile-rn/src/screens/SettingsScreen.tsx
+++ b/mobile-rn/src/screens/SettingsScreen.tsx
@@ -1,0 +1,356 @@
+// SettingsScreen.tsx — the paired-device settings screen (M3.5-3).
+//
+// Pushed from the Sessions header gear. Shows:
+//   • Connection: the paired server URL + boxId (READ-ONLY — they come from
+//     pairing and can't be edited here), and a "Re-pair / disconnect" action
+//     that clears the keychain credentials and returns to the Pairing screen.
+//   • Default model: the connected-provider model list (opencode:models) with a
+//     checkmark on the current default (opencode:default-model); tapping a row
+//     persists it via config:update({ defaultModel }) — the same write the
+//     desktop uses.
+//   • Notifications: a button that runs the push-registration scaffold
+//     (permission → Expo token → registerPushToken). With no push backend
+//     configured (the default until M5), it resolves to "unconfigured" — the
+//     token is obtained but not sent. Proven here with zero Apple credentials.
+//
+// All raw-JSON → view-model + decision LOGIC lives in the pure ../pure/*
+// modules (modelPicker, push); this component owns fetch + render + navigation.
+
+import { useCallback, useEffect, useState } from "react";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import type { RootStackParamList } from "../../App";
+import {
+  AuthRequiredError,
+  fetchModelGroups,
+  setDefaultModel,
+} from "../api/pairingApi";
+import { clearCredentials } from "../api/credentials";
+import { registerForPushNotifications } from "../api/push";
+import {
+  countModels,
+  type DefaultModel,
+  type ModelRowVM,
+  type ProviderGroupVM,
+} from "../pure/modelPicker";
+import type { PushRegistrationResult } from "../pure/push";
+import { colors } from "../theme";
+
+type Props = NativeStackScreenProps<RootStackParamList, "Settings">;
+
+function pushPlatform(): "ios" | "android" | "web" {
+  if (Platform.OS === "ios") return "ios";
+  if (Platform.OS === "android") return "android";
+  return "web";
+}
+
+function pushResultMessage(r: PushRegistrationResult): string {
+  switch (r.kind) {
+    case "permission-denied":
+      return "Notifications are off. Enable them in Settings to get push alerts.";
+    case "unconfigured":
+      return "Ready. Push delivery turns on in a future update (token obtained).";
+    case "registered":
+      return "Registered for push notifications.";
+    case "error":
+      return r.message;
+  }
+}
+
+export function SettingsScreen({ navigation, route }: Props) {
+  const { credentials } = route.params;
+
+  const [groups, setGroups] = useState<ProviderGroupVM[]>([]);
+  const [current, setCurrent] = useState<DefaultModel | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [modelError, setModelError] = useState<string | null>(null);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  const [pushBusy, setPushBusy] = useState(false);
+  const [pushStatus, setPushStatus] = useState<string | null>(null);
+
+  const loadModels = useCallback(async () => {
+    setLoading(true);
+    setModelError(null);
+    try {
+      const { groups: g, current: c } = await fetchModelGroups(
+        credentials.serverUrl,
+        credentials.boxToken,
+      );
+      setGroups(g);
+      setCurrent(c);
+    } catch (e) {
+      if (e instanceof AuthRequiredError) {
+        await clearCredentials();
+        navigation.replace("Pairing");
+        return;
+      }
+      setModelError(
+        e instanceof Error ? e.message : "Couldn't load models. Try again.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [credentials.serverUrl, credentials.boxToken, navigation]);
+
+  useEffect(() => {
+    void loadModels();
+  }, [loadModels]);
+
+  const onPickModel = useCallback(
+    async (row: ModelRowVM) => {
+      if (savingKey) return;
+      setSavingKey(row.key);
+      setModelError(null);
+      try {
+        const saved = await setDefaultModel(
+          credentials.serverUrl,
+          credentials.boxToken,
+          { providerID: row.providerID, modelID: row.modelID },
+        );
+        const next = saved ?? { providerID: row.providerID, modelID: row.modelID };
+        setCurrent(next);
+        // Re-mark selected rows from the confirmed default.
+        setGroups((prev) =>
+          prev.map((g) => ({
+            ...g,
+            rows: g.rows.map((r) => ({
+              ...r,
+              selected: r.providerID === next.providerID && r.modelID === next.modelID,
+            })),
+          })),
+        );
+      } catch (e) {
+        if (e instanceof AuthRequiredError) {
+          await clearCredentials();
+          navigation.replace("Pairing");
+          return;
+        }
+        setModelError(
+          e instanceof Error ? e.message : "Couldn't set the default model.",
+        );
+      } finally {
+        setSavingKey(null);
+      }
+    },
+    [credentials.serverUrl, credentials.boxToken, navigation, savingKey],
+  );
+
+  const onRepair = useCallback(() => {
+    Alert.alert(
+      "Disconnect this box?",
+      "You'll need to re-pair with a new code to reconnect.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Disconnect",
+          style: "destructive",
+          onPress: () => {
+            void (async () => {
+              await clearCredentials();
+              navigation.replace("Pairing");
+            })();
+          },
+        },
+      ],
+    );
+  }, [navigation]);
+
+  const onEnablePush = useCallback(async () => {
+    setPushBusy(true);
+    setPushStatus(null);
+    try {
+      const result = await registerForPushNotifications({
+        boxId: credentials.boxId,
+        platform: pushPlatform(),
+      });
+      setPushStatus(pushResultMessage(result));
+    } finally {
+      setPushBusy(false);
+    }
+  }, [credentials.boxId]);
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      {/* Connection */}
+      <Text style={styles.sectionTitle}>Connection</Text>
+      <View style={styles.card}>
+        <Text style={styles.fieldLabel}>Server URL</Text>
+        <Text style={styles.fieldValue} numberOfLines={1} selectable>
+          {credentials.serverUrl}
+        </Text>
+        <View style={styles.fieldDivider} />
+        <Text style={styles.fieldLabel}>Box ID</Text>
+        <Text style={styles.fieldValue} numberOfLines={1} selectable>
+          {credentials.boxId}
+        </Text>
+      </View>
+      <Pressable
+        style={styles.dangerBtn}
+        onPress={onRepair}
+        accessibilityRole="button"
+        accessibilityLabel="Re-pair or disconnect"
+      >
+        <Text style={styles.dangerBtnText}>Re-pair / disconnect</Text>
+      </Pressable>
+
+      {/* Default model */}
+      <Text style={styles.sectionTitle}>Default model</Text>
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color={colors.accent} />
+        </View>
+      ) : modelError ? (
+        <View style={styles.card}>
+          <Text style={styles.errorText}>{modelError}</Text>
+          <Pressable style={styles.secondaryBtn} onPress={() => void loadModels()}>
+            <Text style={styles.secondaryBtnText}>Retry</Text>
+          </Pressable>
+        </View>
+      ) : countModels(groups) === 0 ? (
+        <View style={styles.card}>
+          <Text style={styles.muted}>
+            No connected providers. Add one from the desktop app, then reload.
+          </Text>
+        </View>
+      ) : (
+        groups.map((g) => (
+          <View key={g.providerID} style={styles.card}>
+            <Text style={styles.providerLabel}>{g.providerID}</Text>
+            {g.rows.map((row) => (
+              <Pressable
+                key={row.key}
+                style={styles.modelRow}
+                onPress={() => void onPickModel(row)}
+                disabled={savingKey !== null}
+                accessibilityRole="button"
+                accessibilityState={{ selected: row.selected }}
+                accessibilityLabel={`${g.providerID} ${row.label}${row.selected ? ", selected" : ""}`}
+              >
+                <Text
+                  style={[styles.modelName, row.selected && styles.modelNameSelected]}
+                  numberOfLines={1}
+                >
+                  {row.label}
+                </Text>
+                {savingKey === row.key ? (
+                  <ActivityIndicator color={colors.accent} size="small" />
+                ) : row.selected ? (
+                  <Text style={styles.check}>✓</Text>
+                ) : null}
+              </Pressable>
+            ))}
+          </View>
+        ))
+      )}
+      {current && (
+        <Text style={styles.currentHint}>
+          Current: {current.providerID} / {current.modelID}
+        </Text>
+      )}
+
+      {/* Notifications */}
+      <Text style={styles.sectionTitle}>Notifications</Text>
+      <View style={styles.card}>
+        <Text style={styles.muted}>
+          Get notified when a session finishes or asks for input.
+        </Text>
+        <Pressable
+          style={[styles.secondaryBtn, pushBusy && styles.btnDisabled]}
+          onPress={() => void onEnablePush()}
+          disabled={pushBusy}
+          accessibilityRole="button"
+          accessibilityLabel="Enable notifications"
+        >
+          {pushBusy ? (
+            <ActivityIndicator color={colors.text} />
+          ) : (
+            <Text style={styles.secondaryBtnText}>Enable notifications</Text>
+          )}
+        </Pressable>
+        {pushStatus && <Text style={styles.pushStatus}>{pushStatus}</Text>}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.bg },
+  content: { padding: 16, gap: 8, paddingBottom: 40 },
+  center: { paddingVertical: 24, alignItems: "center" },
+  sectionTitle: {
+    color: colors.textMuted,
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    marginTop: 16,
+    marginBottom: 4,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    padding: 14,
+    gap: 8,
+  },
+  fieldLabel: { color: colors.textMuted, fontSize: 12 },
+  fieldValue: { color: colors.text, fontSize: 15, fontFamily: "monospace" },
+  fieldDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.border,
+    marginVertical: 4,
+  },
+  providerLabel: {
+    color: colors.textFaint,
+    fontSize: 12,
+    fontWeight: "600",
+    textTransform: "uppercase",
+  },
+  modelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    gap: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
+  },
+  modelName: { color: colors.text, fontSize: 15, flex: 1, minWidth: 0 },
+  modelNameSelected: { color: colors.accent, fontWeight: "600" },
+  check: { color: colors.accent, fontSize: 18, fontWeight: "700" },
+  currentHint: { color: colors.textFaint, fontSize: 12, marginTop: 4 },
+  muted: { color: colors.textMuted, fontSize: 14 },
+  errorText: { color: colors.danger, fontSize: 14 },
+  dangerBtn: {
+    borderColor: colors.danger,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  dangerBtnText: { color: colors.danger, fontSize: 15, fontWeight: "600" },
+  secondaryBtn: {
+    backgroundColor: colors.bg,
+    borderColor: colors.border,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: "center",
+    marginTop: 4,
+  },
+  secondaryBtnText: { color: colors.text, fontSize: 15, fontWeight: "600" },
+  btnDisabled: { opacity: 0.5 },
+  pushStatus: { color: colors.textMuted, fontSize: 13, marginTop: 4 },
+});


### PR DESCRIPTION
## BET-78 — M3.5-3: Settings / re-pair / model picker + push scaffold (mobile-rn)

Final pre-TestFlight polish for the Expo RN app. **`mobile-rn/**` only**, zero Apple credentials, simulator/Expo-Go verifiable. The one Apple-dependent piece (native APNs delivery) is stubbed behind an interface (M5).

Base: `origin/main @ ac125b2`

### What's here
1. **Settings screen** (`src/screens/SettingsScreen.tsx`, opened from a ⚙ header button on Sessions):
   - Read-only paired **server URL + box ID**.
   - **Re-pair / disconnect** — clears `expo-secure-store` credentials → back to Pairing.
   - **Default model picker** — connected models from `opencode:models`, current default from `opencode:default-model`, persisted via `config:update({ defaultModel })` (the same write the desktop uses). Grouped by provider with a checkmark on the current default.
2. **Session actions** (⋯ header menu on the session detail screen): **New chat / clear** (`opencode:clear-session`), **Fork** (`opencode:fork-session`), **Compact** (`opencode:compact-session`). Availability + channel/payload resolution is pure.
3. **Push-registration scaffold** (`src/api/push.ts` + `src/pure/push.ts`): request permission via `expo-notifications`, obtain the Expo push token, and `registerPushToken(token)` — **a no-op when no push backend is configured**. Compiles + runs on the simulator + unit-tested with NO APNs key. Clear `TODO(M5, …)` + README note point to the human-blocked APNs `.p8` dependency (BET-75).
4. **README** updated with the full feature list, how to exercise each on Expo Go / simulator, and the M5 push dependency.

### Design notes
- The issue named `opencode:get-providers`, but that channel is a **desktop-only stub returning `[]`** on the box (`src/server/rpc.mjs:226`). The real connected-model source is `opencode:models` (flat, credential-filtered) — the same source the desktop onboarding ModelStep uses. Documented inline in `fetchModelGroups`.
- Pure↔impure split preserved: all mapping/decision logic lives in `src/pure/{modelPicker,sessionActions,push}.ts` and is unit-tested; `src/api/*` owns fetch + expo side effects (injected for tests). `expo-notifications` is dynamically imported so tests never load the native module.

### Verification results
**Files changed:** 14 files (`mobile-rn/**` only; `git diff --stat` clean — no unrelated deletions).

- PR branch (`multica/BET-78-mobile-settings-push-scaffold`), run in `mobile-rn/`:
  - `npm run typecheck`: exit 0. Errors: none.
  - `npm test`: exit 0 — 147 pass / 0 fail / 0 skip (13 files). New: modelPicker (26), sessionActions, push (pure + api flow) — +37 over the 110 baseline.
- **Conclusion:** 0 new failures. Baseline before changes was 110/110 green; all 110 still pass plus 37 new.

Root-gate note: `mobile-rn` is a self-contained Expo workspace with its own `typecheck`/`test`. Root `tsconfig.{node,web}.json` include only `src/**` (mobile-rn not typechecked at root); root vitest collects mobile-rn's pure/api tests, which import only relative modules + `vitest` (no RN packages at load), matching the already-merged sibling stages.

### Out of scope (unchanged)
Live native APNs/FCM delivery (M5, human-blocked on `.p8`), paywall/IAP (M4), terminal/PTY on mobile, any signed build / EAS submit.
