### PR TITLE
M6.3: Settings Redesign (tabbed, full-screen)

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -8,6 +8,15 @@ import type {
   ProbeResult,
 } from "../shared/types";
 
+const TABS = [
+  { id: "connection", label: "Connection" },
+  { id: "ai", label: "AI" },
+  { id: "voice", label: "Voice" },
+  { id: "files", label: "Files" },
+  { id: "general", label: "General" },
+] as const;
+type TabId = (typeof TABS)[number]["id"];
+
 const CHECK_LABELS: Record<ProbeCheck["name"], string> = {
   ssh: "SSH",
   tmux: "tmux",
@@ -40,64 +49,57 @@ export function Settings({ onClose }: { onClose: () => void }) {
     tmuxConfig,
     refresh,
   } = useStore();
+
+  // Connection fields (Connection tab)
   const [h, setH] = useState(host);
   const [u, setU] = useState(user ?? "");
   const [k, setK] = useState(identityFile ?? "");
   const [tp, setTp] = useState<"auto" | "mosh" | "ssh">(transportPreference);
-  const [uch, setUch] = useState<string>(String(uploadCleanupHours));
-  const [agentPush, setAgentPush] = useState(allowAgentPush);
-  const [autoRename, setAutoRename] = useState(autoRenameSessions);
-  const [dlDir, setDlDir] = useState(downloadsDir);
-  const [restoring, setRestoring] = useState(false);
-  const [settingUp, setSettingUp] = useState(false);
-  // Setup wizard — probe runs the diagnostic, bootstrap installs opencode.
-  // Both target the *saved* config (Electron IPC reads from main process
-  // state, not the form). We disable the buttons while the form is dirty
-  // so a user can't run probe against stale values and get confused by
-  // the result (regression-bait if you forget — verified live during PR
-  // self-review).
   const [probing, setProbing] = useState(false);
   const [probeResult, setProbeResult] = useState<ProbeResult | null>(null);
   const [bootstrapping, setBootstrapping] = useState(false);
   const [bootstrapResult, setBootstrapResult] = useState<BootstrapResult | null>(null);
+  const [settingUp, setSettingUp] = useState(false);
+  const [restoring, setRestoring] = useState(false);
 
-  // True iff any connection-related field differs from the saved config.
-  // We compare against the values that probe/bootstrap actually use
-  // (host, user, identityFile). Transport/uploadCleanupHours/etc. don't
-  // affect the wizard and shouldn't gate it.
-  const connectionDirty =
-    h.trim() !== host ||
-    u.trim() !== (user ?? "") ||
-    k.trim() !== (identityFile ?? "");
-  // Default model selection
+  // AI fields (AI tab)
   const [models, setModels] = useState<OpencodeModel[] | null>(null);
   const [selectedModel, setSelectedModel] = useState<{ providerID: string; modelID: string } | null>(
     defaultModel ?? null,
   );
-  // Skill registry URLs
   const [registryUrls, setRegistryUrls] = useState<string[]>(skillRegistryUrls ?? []);
   const [newRegistryUrl, setNewRegistryUrl] = useState("");
-  // Anthropic prompt cache TTL — used to predict session staleness for the
-  // "/clear to save Nk tokens" pill. Must match opencode's actual
-  // cache_control.ttl setting; bui doesn't control it directly.
   const [ttl, setTtl] = useState<"5m" | "1h">(cacheTtl);
-  // Voice / Groq — empty key hides the mic button entirely in the chat input.
+
+  // Files fields (Files tab)
+  const [uch, setUch] = useState<string>(String(uploadCleanupHours));
+  const [agentPush, setAgentPush] = useState(allowAgentPush);
+  const [dlDir, setDlDir] = useState(downloadsDir);
+
+  // General fields (General tab)
+  const [autoRename, setAutoRename] = useState(autoRenameSessions);
+
+  // Voice fields (Voice tab)
   const [groqKey, setGroqKey] = useState(groqApiKey);
   const [voiceTrModel, setVoiceTrModel] = useState(voiceTranscriptionModel);
   const [voiceCmdModel, setVoiceCmdModel] = useState(voiceCommandModel);
 
+  // Active tab
+  const [activeTab, setActiveTab] = useState<TabId>("connection");
+
+  // Sync local state when store values change
   useEffect(() => {
     setH(host);
     setU(user ?? "");
     setK(identityFile ?? "");
     setTp(transportPreference);
-    setUch(String(uploadCleanupHours));
-    setAgentPush(allowAgentPush);
-    setAutoRename(autoRenameSessions);
-    setDlDir(downloadsDir);
     setSelectedModel(defaultModel ?? null);
     setRegistryUrls(skillRegistryUrls ?? []);
     setTtl(cacheTtl);
+    setUch(String(uploadCleanupHours));
+    setAgentPush(allowAgentPush);
+    setDlDir(downloadsDir);
+    setAutoRename(autoRenameSessions);
     setGroqKey(groqApiKey);
     setVoiceTrModel(voiceTranscriptionModel);
     setVoiceCmdModel(voiceCommandModel);
@@ -120,7 +122,6 @@ export function Settings({ onClose }: { onClose: () => void }) {
     setSaveError(null);
     const hoursNum = Number(uch);
     try {
-      // The write to disk is the part that MUST succeed for "saved" to be true.
       await window.api.configUpdate({
         host: h.trim(),
         user: u.trim() || undefined,
@@ -133,26 +134,15 @@ export function Settings({ onClose }: { onClose: () => void }) {
         defaultModel: selectedModel ?? undefined,
         skillRegistryUrls: registryUrls,
         cacheTtl: ttl,
-        // Voice fields. Empty string clears (so unsetting the API key actually
-        // unsets it server-side). Leading/trailing whitespace stripped.
         groqApiKey: groqKey.trim(),
         voiceTranscriptionModel: voiceTrModel.trim(),
         voiceCommandModel: voiceCmdModel.trim(),
       });
     } catch (e) {
-      // configUpdate itself failed — the config was NOT saved. Surface it and
-      // keep the dialog open so the user can retry rather than silently losing
-      // their edits.
       setSaveError(e instanceof Error ? e.message : String(e));
       setSaving(false);
       return;
     }
-    // The config IS saved at this point. refresh() re-pulls tmux/transport
-    // state and can reject if the SSH host is unreachable — but that must NOT
-    // block closing or make a successful save look like a failure. Swallow it;
-    // the sidebar's own refresh paths recover. (This was the "saved but no
-    // feedback, dialog stuck open" bug: an unguarded refresh() threw before
-    // onClose().)
     try {
       await refresh();
     } catch {
@@ -179,19 +169,12 @@ export function Settings({ onClose }: { onClose: () => void }) {
       const r = await window.api.setupProbe();
       setProbeResult(r);
     } catch (e) {
-      // Should never throw (probe traps all errors internally), but guard
-      // against IPC layer failures.
       alert(e instanceof Error ? e.message : String(e));
     } finally {
       setProbing(false);
     }
   };
 
-  // User-initiated probe (button click) clears any prior bootstrap log
-  // so the new probe result isn't visually competing with a stale log.
-  // runBootstrap → runProbe must NOT clear bootstrapResult, otherwise the
-  // bootstrap log flashes for one React commit then disappears (the whole
-  // point of the log pane is to read what bootstrap did).
   const runProbeFromButton = async () => {
     setBootstrapResult(null);
     await runProbe();
@@ -212,7 +195,6 @@ export function Settings({ onClose }: { onClose: () => void }) {
     try {
       const r = await window.api.setupBootstrap();
       setBootstrapResult(r);
-      // Re-probe so the status pills refresh.
       await runProbe();
     } catch (e) {
       alert(e instanceof Error ? e.message : String(e));
@@ -254,457 +236,540 @@ export function Settings({ onClose }: { onClose: () => void }) {
     }
   };
 
+  // True iff any connection-related field differs from the saved config.
+  const connectionDirty =
+    h.trim() !== host ||
+    u.trim() !== (user ?? "") ||
+    k.trim() !== (identityFile ?? "");
+
   return (
-    <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-bg-elev border border-border rounded-lg p-6 w-[480px] space-y-4 max-h-[90vh] overflow-y-auto">
-        <h2 className="text-lg font-semibold">Settings</h2>
-
-        <div className="space-y-2">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Remote host
-          </label>
-          <input
-            placeholder="hostname or IP"
-            value={h}
-            onChange={(e) => setH(e.target.value)}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          />
+    <div className="fixed inset-0 bg-bg z-50 flex">
+      {/* Left sidebar navigation */}
+      <div className="w-48 bg-bg-soft border-r border-border flex flex-col shrink-0">
+        <div className="p-4 border-b border-border">
+          <h2 className="text-lg font-semibold">Settings</h2>
         </div>
-
-        <div className="space-y-2">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            User (optional, falls back to ssh config)
-          </label>
-          <input
-            placeholder="user"
-            value={u}
-            onChange={(e) => setU(e.target.value)}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Identity file (optional, e.g. ~/.ssh/id_ed25519)
-          </label>
-          <input
-            placeholder="~/.ssh/id_ed25519"
-            value={k}
-            onChange={(e) => setK(e.target.value)}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          />
-        </div>
-
-        <div className="space-y-2 pt-2">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Transport
-          </label>
-          <select
-            value={tp}
-            onChange={(e) => setTp(e.target.value as "auto" | "mosh" | "ssh")}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          >
-            <option value="auto">Auto (mosh if available)</option>
-            <option value="mosh">Mosh — force</option>
-            <option value="ssh">SSH — force</option>
-          </select>
-          {transport && (
-            <div className="text-xs text-text-faint">
-              Currently using <span className="text-text">{transport.effective}</span>.
-              {" "}Mosh on Mac: {transport.moshLocal ? "yes" : "no"} ·
-              {" "}mosh-server on remote: {transport.moshRemote ? "yes" : "no"}.
-              {!transport.moshLocal && (
-                <> Install with <code className="text-text-muted">brew install mosh</code> for resilient connections.</>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="space-y-2 pt-2">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Auto-clean uploads (hours)
-          </label>
-          <input
-            type="number"
-            min={0}
-            step={1}
-            placeholder="1"
-            value={uch}
-            onChange={(e) => setUch(e.target.value)}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          />
-          <div className="text-xs text-text-faint">
-            Sweeps <code className="text-text-muted">~/.bui-uploads</code> on the remote, removing
-            drag-and-drop batches older than this. <code className="text-text-muted">0</code>{" "}
-            disables.
-          </div>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Agent file delivery
-          </label>
-          <label className="flex items-start gap-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
-              checked={agentPush}
-              onChange={(e) => setAgentPush(e.target.checked)}
-              className="mt-0.5"
-            />
-            <span>
-              Auto-save files the AI sends
-              <span className="block text-xs text-text-faint">
-                When the AI drops a file in{" "}
-                <code className="text-text-muted">~/.bui-outbox</code> on the remote, save it to your
-                downloads folder without asking. Off = a toast asks before each file is saved.
-              </span>
-            </span>
-          </label>
-          <input
-            type="text"
-            placeholder="~/Downloads (default)"
-            value={dlDir}
-            onChange={(e) => setDlDir(e.target.value)}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          />
-          <div className="text-xs text-text-faint">
-            Destination for AI-sent files. Absolute path; leave empty for your OS Downloads folder.
-          </div>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Auto-rename sessions
-          </label>
-          <label className="flex items-start gap-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
-              checked={autoRename}
-              onChange={(e) => setAutoRename(e.target.checked)}
-              className="mt-0.5"
-            />
-            <span>
-              Name sessions from the conversation
-              <span className="block text-xs text-text-faint">
-                Every few turns, ask the model for a 1-2 word title and rename
-                the chat window to match the current work. Overwrites the
-                window name, including names you set by hand.
-              </span>
-            </span>
-          </label>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Default model
-          </label>
-          <select
-            value={selectedModel ? `${selectedModel.providerID}::${selectedModel.modelID}` : ""}
-            onChange={(e) => {
-              const val = e.target.value;
-              if (!val) {
-                setSelectedModel(null);
-              } else {
-                const [providerID, modelID] = val.split("::");
-                setSelectedModel({ providerID, modelID });
-              }
-            }}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-          >
-            <option value="">opencode default</option>
-            {models && models.map((m) => (
-              <option key={`${m.providerID}::${m.id}`} value={`${m.providerID}::${m.id}`}>
-                {m.name} ({m.providerID})
-              </option>
-            ))}
-          </select>
-          <div className="text-xs text-text-faint">
-            Applied to every new and cleared chat session. Can still be overridden per-session
-            with the model picker. "opencode default" lets the server decide.
-          </div>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Prompt cache TTL
-          </label>
-          <div className="flex gap-2">
+        <nav className="flex-1 py-2">
+          {TABS.map((tab) => (
             <button
-              type="button"
-              onClick={() => setTtl("5m")}
-              className={`flex-1 px-3 py-1.5 text-sm rounded border ${
-                ttl === "5m"
-                  ? "bg-accent text-bg border-accent"
-                  : "bg-bg-soft text-text-muted border-border hover:text-text"
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                activeTab === tab.id
+                  ? "bg-accent/10 text-accent border-r-2 border-accent"
+                  : "text-text-muted hover:text-text hover:bg-bg-elev"
               }`}
             >
-              5 minutes
+              {tab.label}
             </button>
-            <button
-              type="button"
-              onClick={() => setTtl("1h")}
-              className={`flex-1 px-3 py-1.5 text-sm rounded border ${
-                ttl === "1h"
-                  ? "bg-accent text-bg border-accent"
-                  : "bg-bg-soft text-text-muted border-border hover:text-text"
-              }`}
-            >
-              1 hour (default)
-            </button>
-          </div>
-          <div className="text-xs text-text-faint">
-            How long Anthropic keeps a session's prompt cache warm between
-            requests. Used to predict when a session has gone stale and show
-            "/clear to save Nk tokens" in the chat footer. bui doesn't set
-            this value itself — opencode does, when it builds the Anthropic
-            request. Match this setting to opencode's{" "}
-            <code className="text-text-muted">cache_control.ttl</code> so the
-            staleness pill fires at the right time. 1h is the better default
-            for bui's typical "step away to read code" pattern.
-          </div>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Voice (Groq)
-          </label>
-          <div className="text-xs text-text-faint">
-            Enables push-to-talk dictation in the chat composer. Press{" "}
-            <kbd className="text-text-muted">ctrl+m</kbd> to start recording — a
-            pulsing red ring appears around the input. Press{" "}
-            <kbd className="text-text-muted">⏎</kbd> to stop and send, or{" "}
-            <kbd className="text-text-muted">ctrl+m</kbd> again to stop and edit
-            before sending. <kbd className="text-text-muted">esc</kbd> cancels.
-            Get a key at{" "}
-            <a
-              href="https://console.groq.com/keys"
-              onClick={(e) => {
-                e.preventDefault();
-                window.api.openExternal("https://console.groq.com/keys");
-              }}
-              className="text-accent hover:underline"
-            >
-              console.groq.com/keys
-            </a>
-            . Free tier covers normal use.
-          </div>
-          <input
-            type="password"
-            placeholder="gsk_… (leave blank to disable)"
-            value={groqKey}
-            onChange={(e) => setGroqKey(e.target.value)}
-            autoComplete="off"
-            spellCheck={false}
-            className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
-          />
-          <div className="grid grid-cols-2 gap-2">
-            <div className="space-y-1">
-              <label className="block text-[10px] uppercase tracking-wider text-text-faint">
-                Transcription model
-              </label>
-              <input
-                placeholder="whisper-large-v3-turbo"
-                value={voiceTrModel}
-                onChange={(e) => setVoiceTrModel(e.target.value)}
-                spellCheck={false}
-                className="w-full bg-bg-soft border border-border px-2 py-1.5 text-xs rounded focus:outline-none focus:border-accent font-mono"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="block text-[10px] uppercase tracking-wider text-text-faint">
-                Command classifier model
-              </label>
-              <input
-                placeholder="llama-3.1-8b-instant"
-                value={voiceCmdModel}
-                onChange={(e) => setVoiceCmdModel(e.target.value)}
-                spellCheck={false}
-                className="w-full bg-bg-soft border border-border px-2 py-1.5 text-xs rounded focus:outline-none focus:border-accent font-mono"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Remote tmux config
-          </label>
-          <div className="text-xs text-text-faint">
-            Opt-in. Click "Set up" to append a small fenced block to your remote{" "}
-            <code className="text-text-muted">~/.tmux.conf</code> with the options bui works
-            best with (status off, mouse on, allow-passthrough on, snappy escape time). Your
-            original is saved at <code className="text-text-muted">~/.tmux.conf.pre-bui</code>.
-            These settings are global and apply to every tmux session on your remote, not
-            just bui's — restore anytime with the button below.
-          </div>
-          {tmuxConfig && (
-            <div className="text-xs">
-              Status:{" "}
-              <span className={tmuxConfig.buiManaged ? "text-green-400" : "text-text-muted"}>
-                {tmuxConfig.buiManaged ? "bui-managed" : "not yet set up"}
-              </span>
-              {" · backup "}
-              <span className={tmuxConfig.backupExists ? "text-text-muted" : "text-text-faint"}>
-                {tmuxConfig.backupExists ? "available" : "none"}
-              </span>
-            </div>
-          )}
-          <div className="flex gap-2">
-            <button
-              onClick={setupTmux}
-              disabled={!host || tmuxConfig?.buiManaged || settingUp}
-              className="text-xs px-3 py-1.5 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              {settingUp ? "Setting up…" : "Set up tmux config"}
-            </button>
-            <button
-              onClick={restore}
-              disabled={!tmuxConfig?.buiManaged || restoring}
-              className="text-xs px-3 py-1.5 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              {restoring ? "Restoring…" : "Restore previous"}
-            </button>
-          </div>
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Skill registries
-          </label>
-          <div className="text-xs text-text-faint">
-            Extra skill registry URLs fetched by opencode on startup. The default bui registry is
-            always included. Add your own to surface additional skills in the AI's toolset.
-          </div>
-          <div className="space-y-1">
-            {registryUrls.map((url) => (
-              <div key={url} className="flex items-center gap-2">
-                <code className="flex-1 text-xs bg-bg-soft border border-border rounded px-2 py-1 text-text-muted truncate">
-                  {url}
-                </code>
-                <button
-                  onClick={() => removeRegistryUrl(url)}
-                  className="text-xs text-text-faint hover:text-text px-1"
-                  title="Remove"
-                >
-                  ✕
-                </button>
-              </div>
-            ))}
-          </div>
-          <div className="flex gap-2">
-            <input
-              placeholder="https://example.com/skills"
-              value={newRegistryUrl}
-              onChange={(e) => setNewRegistryUrl(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && addRegistryUrl()}
-              className="flex-1 bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
-            />
-            <button
-              onClick={addRegistryUrl}
-              disabled={!newRegistryUrl.trim()}
-              className="px-3 py-1.5 text-sm bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              Add
-            </button>
-          </div>
-        </div>
-
-        <ProvidersCard />
-
-        <div className="text-xs text-text-faint">
-          Authentication uses your system ssh client (and ssh-agent / ~/.ssh/config). Make sure
-          you can already <code className="text-text-muted">ssh {u || "user"}@{h || "host"}</code> from a terminal.
-        </div>
-
-        <div className="space-y-2 pt-2 border-t border-border">
-          <label className="block text-xs uppercase tracking-wider text-text-muted">
-            Connection &amp; remote setup
-          </label>
-          <div className="text-xs text-text-faint">
-            Verify the remote host has everything bui needs: ssh reachable, tmux
-            installed, opencode installed, and Anthropic auth wired up for chat
-            mode.
-          </div>
-          {connectionDirty && (
-            <div className="text-xs text-amber-400">
-              You have unsaved connection changes. Save first — the wizard runs
-              against the saved host/user/identity.
-            </div>
-          )}
-          <div className="flex gap-2">
-            <button
-              onClick={runProbeFromButton}
-              disabled={!host || probing || bootstrapping || connectionDirty}
-              className="text-xs px-3 py-1.5 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              {probing ? "Testing…" : "Test connection"}
-            </button>
-            <button
-              onClick={runBootstrap}
-              disabled={!host || probing || bootstrapping || connectionDirty}
-              className="text-xs px-3 py-1.5 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              {bootstrapping ? "Bootstrapping…" : "Bootstrap remote"}
-            </button>
-          </div>
-          {probeResult && (
-            <div className="space-y-1 text-xs">
-              {probeResult.checks.map((c) => (
-                <div key={c.name} className="flex items-baseline gap-2">
-                  <span className={c.ok ? "text-green-400" : "text-red-400"}>
-                    {c.ok ? "✓" : "✗"}
-                  </span>
-                  <span className="text-text-muted w-32 shrink-0">{checkLabel(c.name)}</span>
-                  <span className="text-text-faint flex-1 break-all">{c.detail}</span>
-                </div>
-              ))}
-            </div>
-          )}
-          {bootstrapResult && (
-            <pre className="text-xs bg-bg-soft border border-border rounded p-2 text-text-muted whitespace-pre-wrap max-h-48 overflow-y-auto">
-              {bootstrapResult.log.join("\n")}
-            </pre>
-          )}
-        </div>
-
-        {/* Re-run the full-screen onboarding flow. Clears the persisted
-            onboardingSkipped flag and forces the shell open (BET-49-T3). Full
-            Settings redesign lands in M6.3; this is the minimal placement. */}
-        <div className="flex items-center justify-between border-t border-border pt-3">
-          <div className="text-xs text-text-faint">
-            Re-run the guided setup (pairing, providers, first project).
-          </div>
-          <button
-            onClick={() => {
-              void useStore.getState().relaunchOnboarding();
-              onClose();
-            }}
-            className="text-xs px-3 py-1.5 rounded bg-bg-soft border border-border text-text-muted hover:text-text shrink-0"
-          >
-            Run setup again
-          </button>
-        </div>
-
-        {saveError && (
-          <div className="text-xs text-red-400 text-right">
-            Couldn't save: {saveError}
-          </div>
-        )}
-        <div className="flex justify-end gap-2 pt-2">
+          ))}
+        </nav>
+        <div className="p-3 border-t border-border">
           <button
             onClick={onClose}
-            disabled={saving}
-            className="px-3 py-1.5 text-sm text-text-muted hover:text-text disabled:opacity-40"
+            className="w-full text-left text-xs text-text-muted hover:text-text px-2 py-1 rounded hover:bg-bg-elev transition-colors"
           >
-            Cancel
+            Close
           </button>
+        </div>
+      </div>
+
+      {/* Main content area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Header with close button */}
+        <div className="flex items-center justify-end p-4 border-b border-border">
           <button
-            onClick={save}
-            disabled={saving}
-            className="px-3 py-1.5 text-sm bg-accent text-bg rounded hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+            onClick={onClose}
+            className="text-text-muted hover:text-text text-sm px-3 py-1.5 rounded hover:bg-bg-elev transition-colors"
           >
-            {saving ? "Saving…" : "Save"}
+            ✕
           </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto p-6">
+          {/* Connection Tab */}
+          {activeTab === "connection" && (
+            <div className="max-w-2xl space-y-6">
+              <div>
+                <h3 className="text-base font-semibold mb-4">Remote host</h3>
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      Host
+                    </label>
+                    <input
+                      placeholder="hostname or IP"
+                      value={h}
+                      onChange={(e) => setH(e.target.value)}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      User (optional, falls back to ssh config)
+                    </label>
+                    <input
+                      placeholder="user"
+                      value={u}
+                      onChange={(e) => setU(e.target.value)}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      Identity file (optional, e.g. ~/.ssh/id_ed25519)
+                    </label>
+                    <input
+                      placeholder="~/.ssh/id_ed25519"
+                      value={k}
+                      onChange={(e) => setK(e.target.value)}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-base font-semibold mb-4">Transport</h3>
+                <div className="space-y-2">
+                  <select
+                    value={tp}
+                    onChange={(e) => setTp(e.target.value as "auto" | "mosh" | "ssh")}
+                    className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                  >
+                    <option value="auto">Auto (mosh if available)</option>
+                    <option value="mosh">Mosh — force</option>
+                    <option value="ssh">SSH — force</option>
+                  </select>
+                  {transport && (
+                    <div className="text-xs text-text-faint">
+                      Currently using <span className="text-text">{transport.effective}</span>.
+                      {" "}Mosh on Mac: {transport.moshLocal ? "yes" : "no"} ·
+                      {" "}mosh-server on remote: {transport.moshRemote ? "yes" : "no"}.
+                      {!transport.moshLocal && (
+                        <> Install with <code className="text-text-muted">brew install mosh</code> for resilient connections.</>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Connection &amp; remote setup</h3>
+                <div className="text-sm text-text-faint mb-4">
+                  Verify the remote host has everything bui needs: ssh reachable, tmux
+                  installed, opencode installed, and Anthropic auth wired up for chat
+                  mode.
+                </div>
+                {connectionDirty && (
+                  <div className="text-sm text-amber-400 mb-3">
+                    You have unsaved connection changes. Save first — the wizard runs
+                    against the saved host/user/identity.
+                  </div>
+                )}
+                <div className="flex gap-2 mb-4">
+                  <button
+                    onClick={runProbeFromButton}
+                    disabled={!host || probing || bootstrapping || connectionDirty}
+                    className="text-sm px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {probing ? "Testing…" : "Test connection"}
+                  </button>
+                  <button
+                    onClick={runBootstrap}
+                    disabled={!host || probing || bootstrapping || connectionDirty}
+                    className="text-sm px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {bootstrapping ? "Bootstrapping…" : "Bootstrap remote"}
+                  </button>
+                </div>
+                {probeResult && (
+                  <div className="space-y-1 text-sm">
+                    {probeResult.checks.map((c) => (
+                      <div key={c.name} className="flex items-baseline gap-2">
+                        <span className={c.ok ? "text-green-400" : "text-red-400"}>
+                          {c.ok ? "✓" : "✗"}
+                        </span>
+                        <span className="text-text-muted w-32 shrink-0">{checkLabel(c.name)}</span>
+                        <span className="text-text-faint flex-1 break-all">{c.detail}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {bootstrapResult && (
+                  <pre className="text-sm bg-bg-soft border border-border rounded p-3 text-text-muted whitespace-pre-wrap max-h-64 overflow-y-auto">
+                    {bootstrapResult.log.join("\n")}
+                  </pre>
+                )}
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Remote tmux config</h3>
+                <div className="text-sm text-text-faint mb-3">
+                  Opt-in. Click "Set up" to append a small fenced block to your remote{" "}
+                  <code className="text-text-muted">~/.tmux.conf</code> with the options bui works
+                  best with (status off, mouse on, allow-passthrough on, snappy escape time). Your
+                  original is saved at <code className="text-text-muted">~/.tmux.conf.pre-bui</code>.
+                  These settings are global and apply to every tmux session on your remote, not
+                  just bui's — restore anytime with the button below.
+                </div>
+                {tmuxConfig && (
+                  <div className="text-sm mb-3">
+                    Status:{" "}
+                    <span className={tmuxConfig.buiManaged ? "text-green-400" : "text-text-muted"}>
+                      {tmuxConfig.buiManaged ? "bui-managed" : "not yet set up"}
+                    </span>
+                    {" · backup "}
+                    <span className={tmuxConfig.backupExists ? "text-text-muted" : "text-text-faint"}>
+                      {tmuxConfig.backupExists ? "available" : "none"}
+                    </span>
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    onClick={setupTmux}
+                    disabled={!host || tmuxConfig?.buiManaged || settingUp}
+                    className="text-sm px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {settingUp ? "Setting up…" : "Set up tmux config"}
+                  </button>
+                  <button
+                    onClick={restore}
+                    disabled={!tmuxConfig?.buiManaged || restoring}
+                    className="text-sm px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {restoring ? "Restoring…" : "Restore previous"}
+                  </button>
+                </div>
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-text-faint">
+                    Re-run the guided setup (pairing, providers, first project).
+                  </div>
+                  <button
+                    onClick={() => {
+                      void useStore.getState().relaunchOnboarding();
+                      onClose();
+                    }}
+                    className="text-sm px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text shrink-0"
+                  >
+                    Run setup again
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* AI Tab */}
+          {activeTab === "ai" && (
+            <div className="max-w-2xl space-y-6">
+              <div>
+                <h3 className="text-base font-semibold mb-4">Default model</h3>
+                <select
+                  value={selectedModel ? `${selectedModel.providerID}::${selectedModel.modelID}` : ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (!val) {
+                      setSelectedModel(null);
+                    } else {
+                      const [providerID, modelID] = val.split("::");
+                      setSelectedModel({ providerID, modelID });
+                    }
+                  }}
+                  className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                >
+                  <option value="">opencode default</option>
+                  {models && models.map((m) => (
+                    <option key={`${m.providerID}::${m.id}`} value={`${m.providerID}::${m.id}`}>
+                      {m.name} ({m.providerID})
+                    </option>
+                  ))}
+                </select>
+                <div className="text-xs text-text-faint mt-2">
+                  Applied to every new and cleared chat session. Can still be overridden per-session
+                  with the model picker. "opencode default" lets the server decide.
+                </div>
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Prompt cache TTL</h3>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setTtl("5m")}
+                    className={`flex-1 px-4 py-2 text-sm rounded border ${
+                      ttl === "5m"
+                        ? "bg-accent text-bg border-accent"
+                        : "bg-bg-soft text-text-muted border-border hover:text-text"
+                    }`}
+                  >
+                    5 minutes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTtl("1h")}
+                    className={`flex-1 px-4 py-2 text-sm rounded border ${
+                      ttl === "1h"
+                        ? "bg-accent text-bg border-accent"
+                        : "bg-bg-soft text-text-muted border-border hover:text-text"
+                    }`}
+                  >
+                    1 hour (default)
+                  </button>
+                </div>
+                <div className="text-xs text-text-faint mt-2">
+                  How long Anthropic keeps a session's prompt cache warm between
+                  requests. Used to predict when a session has gone stale and show
+                  "/clear to save Nk tokens" in the chat footer. bui doesn't set
+                  this value itself — opencode does, when it builds the Anthropic
+                  request. Match this setting to opencode's{" "}
+                  <code className="text-text-muted">cache_control.ttl</code> so the
+                  staleness pill fires at the right time. 1h is the better default
+                  for bui's typical "step away to read code" pattern.
+                </div>
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <ProvidersCard />
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Skill registries</h3>
+                <div className="text-sm text-text-faint mb-3">
+                  Extra skill registry URLs fetched by opencode on startup. The default bui registry is
+                  always included. Add your own to surface additional skills in the AI's toolset.
+                </div>
+                <div className="space-y-2">
+                  {registryUrls.map((url) => (
+                    <div key={url} className="flex items-center gap-2">
+                      <code className="flex-1 text-sm bg-bg-soft border border-border rounded px-3 py-2 text-text-muted truncate">
+                        {url}
+                      </code>
+                      <button
+                        onClick={() => removeRegistryUrl(url)}
+                        className="text-sm text-text-faint hover:text-text px-2"
+                        title="Remove"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex gap-2 mt-3">
+                  <input
+                    placeholder="https://example.com/skills"
+                    value={newRegistryUrl}
+                    onChange={(e) => setNewRegistryUrl(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && addRegistryUrl()}
+                    className="flex-1 bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                  />
+                  <button
+                    onClick={addRegistryUrl}
+                    disabled={!newRegistryUrl.trim()}
+                    className="px-4 py-2 text-sm bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Voice Tab */}
+          {activeTab === "voice" && (
+            <div className="max-w-2xl space-y-6">
+              <div>
+                <h3 className="text-base font-semibold mb-4">Voice (Groq)</h3>
+                <div className="text-sm text-text-faint mb-4">
+                  Enables push-to-talk dictation in the chat composer. Press{" "}
+                  <kbd className="text-text-muted">ctrl+m</kbd> to start recording — a
+                  pulsing red ring appears around the input. Press{" "}
+                  <kbd className="text-text-muted">⏎</kbd> to stop and send, or{" "}
+                  <kbd className="text-text-muted">ctrl+m</kbd> again to stop and edit
+                  before sending. <kbd className="text-text-muted">esc</kbd> cancels.
+                  Get a key at{" "}
+                  <a
+                    href="https://console.groq.com/keys"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      window.api.openExternal("https://console.groq.com/keys");
+                    }}
+                    className="text-accent hover:underline"
+                  >
+                    console.groq.com/keys
+                  </a>
+                  . Free tier covers normal use.
+                </div>
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      Groq API key
+                    </label>
+                    <input
+                      type="password"
+                      placeholder="gsk_… (leave blank to disable)"
+                      value={groqKey}
+                      onChange={(e) => setGroqKey(e.target.value)}
+                      autoComplete="off"
+                      spellCheck={false}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="block text-[10px] uppercase tracking-wider text-text-faint">
+                        Transcription model
+                      </label>
+                      <input
+                        placeholder="whisper-large-v3-turbo"
+                        value={voiceTrModel}
+                        onChange={(e) => setVoiceTrModel(e.target.value)}
+                        spellCheck={false}
+                        className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="block text-[10px] uppercase tracking-wider text-text-faint">
+                        Command classifier model
+                      </label>
+                      <input
+                        placeholder="llama-3.1-8b-instant"
+                        value={voiceCmdModel}
+                        onChange={(e) => setVoiceCmdModel(e.target.value)}
+                        spellCheck={false}
+                        className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Files Tab */}
+          {activeTab === "files" && (
+            <div className="max-w-2xl space-y-6">
+              <div>
+                <h3 className="text-base font-semibold mb-4">Upload cleanup</h3>
+                <div className="space-y-2">
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    placeholder="1"
+                    value={uch}
+                    onChange={(e) => setUch(e.target.value)}
+                    className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                  />
+                  <div className="text-xs text-text-faint">
+                    Sweeps <code className="text-text-muted">~/.bui-uploads</code> on the remote, removing
+                    drag-and-drop batches older than this. <code className="text-text-muted">0</code>{" "}
+                    disables.
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Agent file delivery</h3>
+                <div className="space-y-3">
+                  <label className="flex items-start gap-3 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={agentPush}
+                      onChange={(e) => setAgentPush(e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      Auto-save files the AI sends
+                      <span className="block text-xs text-text-faint mt-1">
+                        When the AI drops a file in{" "}
+                        <code className="text-text-muted">~/.bui-outbox</code> on the remote, save it to your
+                        downloads folder without asking. Off = a toast asks before each file is saved.
+                      </span>
+                    </span>
+                  </label>
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      Downloads directory
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="~/Downloads (default)"
+                      value={dlDir}
+                      onChange={(e) => setDlDir(e.target.value)}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent"
+                    />
+                    <div className="text-xs text-text-faint">
+                      Destination for AI-sent files. Absolute path; leave empty for your OS Downloads folder.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* General Tab */}
+          {activeTab === "general" && (
+            <div className="max-w-2xl space-y-6">
+              <div>
+                <h3 className="text-base font-semibold mb-4">Auto-rename sessions</h3>
+                <label className="flex items-start gap-3 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={autoRename}
+                    onChange={(e) => setAutoRename(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    Name sessions from the conversation
+                    <span className="block text-xs text-text-faint mt-1">
+                      Every few turns, ask the model for a 1-2 word title and rename
+                      the chat window to match the current work. Overwrites the
+                      window name, including names you set by hand.
+                    </span>
+                  </span>
+                </label>
+              </div>
+
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">About</h3>
+                <div className="text-sm text-text-faint">
+                  Better UI v0.0.1
+                </div>
+                <div className="text-xs text-text-faint mt-2">
+                  Desktop client for remote Claude Code sessions over SSH+tmux.
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer with Save/Cancel */}
+        <div className="border-t border-border p-4">
+          {saveError && (
+            <div className="text-sm text-red-400 mb-3">
+              Couldn't save: {saveError}
+            </div>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={onClose}
+              disabled={saving}
+              className="px-4 py-2 text-sm text-text-muted hover:text-text disabled:opacity-40"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={save}
+              disabled={saving}
+              className="px-4 py-2 text-sm bg-accent text-bg rounded hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Redesign desktop Settings into a tabbed, full-screen panel.

### Changes
- **1 file changed**: 
- Converted from 480px modal to full-screen panel with left sidebar navigation
- Five tabs: Connection, AI, Voice, Files, General
- All existing settings fields preserved (no regressions)
- ProvidersCard embedded in AI tab with wider layout

### Verification results:
- typecheck: exit 0. Errors: none.
- test: exit 0, 385 pass / 0 fail / 0 skip.

### Design decisions
- Left sidebar with tab icons (Connection, AI, Voice, Files, General)
- Full-screen layout (~900px+ content area)
- Save/Cancel at bottom right consistent across tabs
- All existing functionality preserved: probe, bootstrap, tmux setup/restore, model picker, cache TTL, voice settings, file delivery, skill registries

Base: origin/main @ c38d823