### PR TITLE
feat(mobile-rn): add terminal access via PTY WebSocket (BET-39)

### DIFF
--- a/mobile-rn/App.tsx
+++ b/mobile-rn/App.tsx
@@ -19,6 +19,7 @@ import { PairingScreen } from "./src/screens/PairingScreen";
 import { SessionListScreen } from "./src/screens/SessionListScreen";
 import { SessionDetailScreen } from "./src/screens/SessionDetailScreen";
 import { SettingsScreen } from "./src/screens/SettingsScreen";
+import { TerminalScreen } from "./src/screens/TerminalScreen";
 import type { SessionRowVM } from "./src/pure/sessionList";
 import { colors } from "./src/theme";
 
@@ -26,6 +27,7 @@ export type RootStackParamList = {
   Pairing: undefined;
   Sessions: { credentials: StoredCredentials };
   Session: { credentials: StoredCredentials; session: SessionRowVM };
+  Terminal: { credentials: StoredCredentials; session: SessionRowVM };
   Settings: { credentials: StoredCredentials };
 };
 
@@ -96,6 +98,11 @@ export default function App() {
               name="Session"
               component={SessionDetailScreen}
               options={{ title: "Session" }}
+            />
+            <Stack.Screen
+              name="Terminal"
+              component={TerminalScreen}
+              options={{ title: "Terminal" }}
             />
             <Stack.Screen
               name="Settings"

--- a/mobile-rn/src/api/ptyClient.ts
+++ b/mobile-rn/src/api/ptyClient.ts
@@ -1,0 +1,203 @@
+// ptyClient.ts — the impure /pty WebSocket client for the RN app.
+//
+// Opens the box's `GET <base>/pty?session=NAME&window=INDEX&cols=C&rows=R`
+// WebSocket with the box_token as a `?token=` query param (the server accepts
+// `?token=` on /events + /pty ONLY — see src/server/index.mjs).
+//
+// Client→Server frames are JSON: `{type:"data",data:"..."}` for input,
+// `{type:"resize",cols,C}` for terminal resize.
+// Server→Client frames are raw PTY output (utf-8 strings).
+//
+// The client owns the socket lifecycle (connect, send, close, reconnect on
+// drop) and exposes a simple API: `attach()` to connect, `write(text)` to send
+// input, `resize(cols, rows)` to notify the server of a resize, `onData(cb)` to
+// receive output, and `close()` to tear down.
+
+/** Handle returned by {@link attachPty}; call to tear down. */
+export interface PtyHandle {
+  /** Send raw text to the PTY (user keystrokes). */
+  write(text: string): void;
+  /** Notify the server of a terminal resize. */
+  resize(cols: number, rows: number): void;
+  /** Close the WebSocket. */
+  close(): void;
+  /** Attach a listener for raw PTY output. Returns an unsubscribe function. */
+  onData(cb: (data: string) => void): () => void;
+  /** Attach a listener for close/error events. Returns an unsubscribe function. */
+  onClose(cb: (reason?: string) => void): () => void;
+}
+
+/** Strip trailing slashes so "http://box/" and "http://box" behave identically. */
+function trimBase(base: string): string {
+  return base.replace(/\/+$/, "");
+}
+
+/**
+ * Build the /pty WebSocket URL with session/window/cols/rows/token params.
+ * http→ws / https→wss.
+ */
+export function ptyWsUrl(
+  base: string,
+  token: string,
+  session: string,
+  windowIdx: number,
+  cols: number,
+  rows: number,
+): string {
+  const ws = trimBase(base).replace(/^http/, "ws") + "/pty";
+  const params = new URLSearchParams({
+    session,
+    window: String(windowIdx),
+    cols: String(cols),
+    rows: String(rows),
+    token,
+  });
+  return `${ws}?${params.toString()}`;
+}
+
+/**
+ * Attach to the box's /pty WebSocket for the given session/window. Returns a
+ * handle that can send input, resize, and receive output. The socket reconnects
+ * with exponential backoff on unexpected close (never permanently abandons).
+ *
+ * Default terminal size: 80x24 (matches the server's fallback).
+ */
+export function attachPty(
+  base: string,
+  token: string,
+  session: string,
+  windowIdx: number,
+  opts: { cols?: number; rows?: number; backoff?: BackoffConfig } = {},
+): PtyHandle {
+  const cols = opts.cols ?? 80;
+  const rows = opts.rows ?? 24;
+  const backoff = opts.backoff ?? {
+    initialMs: 1000,
+    maxMs: 30000,
+    factor: 2,
+    maxAttempts: Infinity,
+  };
+
+  let socket: WebSocket | null = null;
+  let closedByCaller = false;
+  let attempt = 0;
+  let retryHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const dataListeners = new Set<(data: string) => void>();
+  const closeListeners = new Set<(reason?: string) => void>();
+
+  function scheduleReconnect() {
+    if (closedByCaller) return;
+    attempt += 1;
+    const delayMs = Math.min(
+      backoff.initialMs * Math.pow(backoff.factor, attempt - 1),
+      backoff.maxMs,
+    );
+    if (attempt > backoff.maxAttempts) return;
+    retryHandle = setTimeout(() => {
+      retryHandle = null;
+      connect();
+    }, delayMs);
+  }
+
+  function connect() {
+    if (closedByCaller) return;
+    const url = ptyWsUrl(base, token, session, windowIdx, cols, rows);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      scheduleReconnect();
+      return;
+    }
+    socket = ws;
+
+    ws.onopen = () => {
+      attempt = 0;
+    };
+
+    ws.onmessage = (ev) => {
+      const data = typeof ev.data === "string" ? ev.data : "";
+      for (const cb of dataListeners) {
+        try {
+          cb(data);
+        } catch {
+          /* listener threw — never let it break the socket loop */
+        }
+      }
+    };
+
+    ws.onerror = () => {
+      /* onclose follows an error; reconnect handled there */
+    };
+
+    ws.onclose = (ev) => {
+      socket = null;
+      const reason = ev?.reason ?? "connection closed";
+      for (const cb of closeListeners) {
+        try {
+          cb(reason);
+        } catch {
+          /* ignore */
+        }
+      }
+      scheduleReconnect();
+    };
+  }
+
+  function send(type: string, payload: Record<string, unknown>) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return;
+    try {
+      socket.send(JSON.stringify({ type, ...payload }));
+    } catch {
+      /* socket may have closed between check and send — reconnect will retry */
+    }
+  }
+
+  return {
+    write(text: string) {
+      send("data", { data: text });
+    },
+    resize(newCols: number, newRows: number) {
+      send("resize", { cols: newCols, rows: newRows });
+    },
+    onData(cb: (data: string) => void) {
+      dataListeners.add(cb);
+      return () => {
+        dataListeners.delete(cb);
+      };
+    },
+    onClose(cb: (reason?: string) => void) {
+      closeListeners.add(cb);
+      return () => {
+        closeListeners.delete(cb);
+      };
+    },
+    close() {
+      closedByCaller = true;
+      if (retryHandle != null) {
+        clearTimeout(retryHandle);
+        retryHandle = null;
+      }
+      if (socket) {
+        socket.onopen = null;
+        socket.onmessage = null;
+        socket.onerror = null;
+        socket.onclose = null;
+        try {
+          socket.close();
+        } catch {
+          /* already closing */
+        }
+        socket = null;
+      }
+    },
+  };
+}
+
+interface BackoffConfig {
+  initialMs: number;
+  maxMs: number;
+  factor: number;
+  maxAttempts: number;
+}

--- a/mobile-rn/src/pure/__tests__/pty.test.ts
+++ b/mobile-rn/src/pure/__tests__/pty.test.ts
@@ -37,11 +37,18 @@ describe("appendToBuffer", () => {
 
   it("handles carriage return", () => {
     const buf = createPtyBuffer(10);
-    // "abc\r" should move cursor to start, but we don't overwrite until \n
+    // "abc\r" — \\r resets currentLine to "" (cursor moves to col 0)
     const next = appendToBuffer(buf, "abc\r");
-    // The line is in currentLine (not yet complete)
-    expect(next.currentLine).toBe("abc");
+    expect(next.currentLine).toBe("");
     expect(next.lines).toEqual([]);
+  });
+
+  it("handles carriage return followed by overwrite", () => {
+    const buf = createPtyBuffer(10);
+    // "abc\rdef\n" should result in "def" (\\r moves cursor to col 0, def overwrites)
+    const next = appendToBuffer(buf, "abc\rdef\n");
+    expect(next.lines).toEqual(["def"]);
+    expect(next.currentLine).toBe("");
   });
 
   it("handles backspace", () => {

--- a/mobile-rn/src/pure/__tests__/pty.test.ts
+++ b/mobile-rn/src/pure/__tests__/pty.test.ts
@@ -1,0 +1,123 @@
+// pty.test.ts — tests for the pure PTY buffer logic.
+
+import { describe, expect, it } from "vitest";
+import {
+  appendToBuffer,
+  clearBuffer,
+  createPtyBuffer,
+  getVisibleLines,
+} from "../pty";
+
+describe("createPtyBuffer", () => {
+  it("creates an empty buffer with default maxLines", () => {
+    const buf = createPtyBuffer();
+    expect(buf.lines).toEqual([]);
+    expect(buf.currentLine).toBe("");
+    expect(buf.maxLines).toBe(1000);
+  });
+
+  it("creates a buffer with custom maxLines", () => {
+    const buf = createPtyBuffer(500);
+    expect(buf.maxLines).toBe(500);
+  });
+});
+
+describe("appendToBuffer", () => {
+  it("appends a simple line", () => {
+    const buf = createPtyBuffer(10);
+    const next = appendToBuffer(buf, "hello\n");
+    expect(next.lines).toEqual(["hello"]);
+  });
+
+  it("handles multiple lines", () => {
+    const buf = createPtyBuffer(10);
+    const next = appendToBuffer(buf, "line1\nline2\n");
+    expect(next.lines).toEqual(["line1", "line2"]);
+  });
+
+  it("handles carriage return", () => {
+    const buf = createPtyBuffer(10);
+    // "abc\r" should move cursor to start, but we don't overwrite until \n
+    const next = appendToBuffer(buf, "abc\r");
+    // The line is in currentLine (not yet complete)
+    expect(next.currentLine).toBe("abc");
+    expect(next.lines).toEqual([]);
+  });
+
+  it("handles backspace", () => {
+    const buf = createPtyBuffer(10);
+    const next = appendToBuffer(buf, "ab\b c\n");
+    // "ab" then backspace removes "b", then " c\n" → "a c"
+    expect(next.lines).toEqual(["a c"]);
+  });
+
+  it("strips ANSI escape sequences", () => {
+    const buf = createPtyBuffer(10);
+    const next = appendToBuffer(buf, "\x1b[32mgreen\x1b[0m\n");
+    expect(next.lines).toEqual(["green"]);
+  });
+
+  it("enforces maxLines", () => {
+    const buf = createPtyBuffer(3);
+    let next = buf;
+    next = appendToBuffer(next, "line1\n");
+    next = appendToBuffer(next, "line2\n");
+    next = appendToBuffer(next, "line3\n");
+    next = appendToBuffer(next, "line4\n");
+    // Should only keep last 3 lines
+    expect(next.lines).toEqual(["line2", "line3", "line4"]);
+  });
+
+  it("handles empty input", () => {
+    const buf = createPtyBuffer(10);
+    const next = appendToBuffer(buf, "");
+    expect(next.lines).toEqual([]);
+  });
+
+  it("handles input without trailing newline", () => {
+    const buf = createPtyBuffer(10);
+    const next = appendToBuffer(buf, "partial");
+    // Incomplete line goes to currentLine
+    expect(next.currentLine).toBe("partial");
+    expect(next.lines).toEqual([]);
+  });
+});
+
+describe("clearBuffer", () => {
+  it("clears all lines", () => {
+    const buf = createPtyBuffer(10);
+    const withLines = appendToBuffer(buf, "line1\nline2\n");
+    const cleared = clearBuffer(withLines);
+    expect(cleared.lines).toEqual([]);
+    // maxLines is preserved
+    expect(cleared.maxLines).toBe(10);
+  });
+});
+
+describe("getVisibleLines", () => {
+  it("returns all lines when fewer than rowCount", () => {
+    const buf = createPtyBuffer(10);
+    const withLines = appendToBuffer(buf, "line1\nline2\n");
+    const visible = getVisibleLines(withLines, 10);
+    expect(visible).toEqual(["line1", "line2"]);
+  });
+
+  it("returns only the last rowCount lines", () => {
+    const buf = createPtyBuffer(100);
+    let next = buf;
+    for (let i = 0; i < 50; i++) {
+      next = appendToBuffer(next, `line${i}\n`);
+    }
+    const visible = getVisibleLines(next, 10);
+    expect(visible.length).toBe(10);
+    // Should be the last 10 lines (line40 through line49)
+    expect(visible[0]).toBe("line40");
+    expect(visible[9]).toBe("line49");
+  });
+
+  it("returns empty array for empty buffer", () => {
+    const buf = createPtyBuffer(10);
+    const visible = getVisibleLines(buf, 10);
+    expect(visible).toEqual([]);
+  });
+});

--- a/mobile-rn/src/pure/pty.ts
+++ b/mobile-rn/src/pure/pty.ts
@@ -1,0 +1,89 @@
+// pty.ts — pure PTY buffer logic for the React Native terminal.
+//
+// Manages a scrollback buffer with ANSI escape sequence handling. The buffer
+// is a simple array of strings (one per line), with a max height. ANSI escape
+// sequences (cursor movement, clear screen, etc.) are stripped for display.
+//
+// ALL logic is pure (no I/O, no React) so it's unit-testable. The TerminalScreen
+// component owns the WebSocket + render.
+
+export interface PtyBuffer {
+  /** Current lines in the buffer (complete lines ended with \n). */
+  lines: string[];
+  /** The current incomplete line (no trailing \n yet). */
+  currentLine: string;
+  /** Maximum number of lines to keep (scrollback). */
+  maxLines: number;
+}
+
+/** Create a new empty PTY buffer. */
+export function createPtyBuffer(maxLines: number = 1000): PtyBuffer {
+  return { lines: [], currentLine: "", maxLines };
+}
+
+/**
+ * Append raw PTY output to the buffer. Strips ANSI escape sequences and handles
+ * basic control characters (newline, carriage return, backspace).
+ *
+ * ANSI sequences are stripped by removing everything matching \x1b\[[0-9;]*[a-zA-Z].
+ * Control characters: \n → new line, \r → carriage return (move to start of line),
+ * \b → backspace (remove last char).
+ */
+export function appendToBuffer(buffer: PtyBuffer, raw: string): PtyBuffer {
+  // Strip ANSI escape sequences
+  const cleaned = raw.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+
+  // Start with the buffer's current incomplete line
+  let currentLine = buffer.currentLine;
+  const newLines: string[] = [];
+
+  for (let i = 0; i < cleaned.length; i++) {
+    const char = cleaned[i];
+    if (char === "\n") {
+      // Newline: push current line (complete) and start a new one
+      newLines.push(currentLine);
+      currentLine = "";
+    } else if (char === "\r") {
+      // Carriage return: move to start of current line (don't push yet)
+      // The line content stays the same, just the cursor moves
+    } else if (char === "\b") {
+      // Backspace: remove last character from current line
+      currentLine = currentLine.slice(0, -1);
+    } else {
+      // Regular character: append to current line
+      currentLine += char;
+    }
+  }
+
+  // Combine existing lines with new complete lines
+  let lines = [...buffer.lines, ...newLines];
+
+  // Enforce maxLines
+  if (lines.length > buffer.maxLines) {
+    lines = lines.slice(lines.length - buffer.maxLines);
+  }
+
+  return { lines, currentLine, maxLines: buffer.maxLines };
+}
+
+/**
+ * Clear the buffer (handle \x1b[2J or \x1b[3J — clear screen / clear entire
+ * scrollback).
+ */
+export function clearBuffer(buffer: PtyBuffer): PtyBuffer {
+  return { lines: [], currentLine: "", maxLines: buffer.maxLines };
+}
+
+/**
+ * Get the visible lines for rendering (last `rowCount` lines, excluding empty currentLine).
+ */
+export function getVisibleLines(buffer: PtyBuffer, rowCount: number): string[] {
+  // Only include currentLine if it has content (otherwise we'd show an extra empty line)
+  const allLines = buffer.currentLine.length > 0
+    ? [...buffer.lines, buffer.currentLine]
+    : [...buffer.lines];
+  if (allLines.length <= rowCount) {
+    return allLines;
+  }
+  return allLines.slice(allLines.length - rowCount);
+}

--- a/mobile-rn/src/pure/pty.ts
+++ b/mobile-rn/src/pure/pty.ts
@@ -44,8 +44,8 @@ export function appendToBuffer(buffer: PtyBuffer, raw: string): PtyBuffer {
       newLines.push(currentLine);
       currentLine = "";
     } else if (char === "\r") {
-      // Carriage return: move to start of current line (don't push yet)
-      // The line content stays the same, just the cursor moves
+      // Carriage return: move cursor to column 0, overwrite from there
+      currentLine = "";
     } else if (char === "\b") {
       // Backspace: remove last character from current line
       currentLine = currentLine.slice(0, -1);

--- a/mobile-rn/src/screens/SessionListScreen.tsx
+++ b/mobile-rn/src/screens/SessionListScreen.tsx
@@ -68,16 +68,24 @@ export function SessionListScreen({ navigation, route }: Props) {
   }, [load]);
 
   function onRowPress(row: SessionRowVM) {
-    // Chat windows open the read-only live transcript (M3.5-1). Terminal
-    // windows have no opencode transcript to stream — PTY mirroring is a later
-    // slice, so surface that clearly instead of a dead tap.
+    // Chat windows open the live transcript view (M3.5-1). Terminal windows
+    // open the PTY terminal (M5).
     if (row.kind === "chat" && row.opencodeSessionId) {
+      navigation.navigate("Session", { credentials, session: row });
+      return;
+    }
+    if (row.kind === "terminal") {
+      navigation.navigate("Terminal", { credentials, session: row });
+      return;
+    }
+    // Fallback: if we don't know the kind, try chat first.
+    if (row.opencodeSessionId) {
       navigation.navigate("Session", { credentials, session: row });
       return;
     }
     Alert.alert(
       row.title,
-      "Terminal windows open in a future update. Tap a chat session to view its live transcript.",
+      "This session type isn't supported yet.",
     );
   }
 

--- a/mobile-rn/src/screens/TerminalScreen.tsx
+++ b/mobile-rn/src/screens/TerminalScreen.tsx
@@ -68,10 +68,7 @@ export function TerminalScreen(_props: Props) {
     handle.onData((data) => {
       if (unmounted) return;
       setBuffer((prev) => appendToBuffer(prev, data));
-      // Auto-scroll to bottom on new output
-      setTimeout(() => {
-        scrollRef.current?.scrollToEnd({ animated: true });
-      }, 50);
+      // Auto-scroll is handled by onContentSizeChange below.
     });
 
     handle.onClose((reason) => {
@@ -100,10 +97,10 @@ export function TerminalScreen(_props: Props) {
   }, [credentials.serverUrl, credentials.boxToken, sessionName, windowIdx]);
 
   const handleSend = () => {
-    const text = input.trimEnd(); // Keep trailing spaces, but remove trailing newline
-    if (!text) return;
-    // Send with a newline so the remote shell sees it as a complete command
-    ptyRef.current?.write(text + "\n");
+    if (!input) return;
+    // Send exactly what the user typed (preserving intentional trailing whitespace)
+    // plus a newline so the remote shell sees it as a complete command.
+    ptyRef.current?.write(input + "\n");
     setInput("");
   };
 

--- a/mobile-rn/src/screens/TerminalScreen.tsx
+++ b/mobile-rn/src/screens/TerminalScreen.tsx
@@ -1,0 +1,288 @@
+// TerminalScreen.tsx — a raw PTY terminal for React Native.
+//
+// Connects to the box's /pty WebSocket, renders output in a scrollable View,
+// and provides a TextInput at the bottom for user input. Input is sent as raw
+// text (no line editing — the remote shell handles that).
+//
+// This is a minimal implementation: no ANSI color, no cursor, no resize handling
+// beyond the initial size. It's enough to interact with tmux, ssh, git, etc.
+// A full xterm.js port would be a future enhancement.
+
+import { useEffect, useRef, useState } from "react";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import type { RootStackParamList } from "../../App";
+import { attachPty } from "../api/ptyClient";
+import {
+  appendToBuffer,
+  createPtyBuffer,
+  getVisibleLines,
+  type PtyBuffer,
+} from "../pure/pty";
+import { colors } from "../theme";
+
+type Props = NativeStackScreenProps<RootStackParamList, "Terminal">;
+
+const INITIAL_COLS = 80;
+const INITIAL_ROWS = 24;
+const MAX_LINES = 1000;
+
+export function TerminalScreen(_props: Props) {
+  const { route } = _props;
+  const { credentials, session } = route.params;
+  const sessionName = session.project;
+  const windowIdx = session.windowIndex ?? 0;
+
+  const [buffer, setBuffer] = useState<PtyBuffer>(() => createPtyBuffer(MAX_LINES));
+  const [input, setInput] = useState("");
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const ptyRef = useRef<ReturnType<typeof attachPty> | null>(null);
+  const scrollRef = useRef<ScrollView | null>(null);
+  const inputRef = useRef<TextInput | null>(null);
+
+  // Attach to the PTY on mount.
+  useEffect(() => {
+    let unmounted = false;
+
+    const handle = attachPty(
+      credentials.serverUrl,
+      credentials.boxToken,
+      sessionName,
+      windowIdx,
+      { cols: INITIAL_COLS, rows: INITIAL_ROWS },
+    );
+
+    ptyRef.current = handle;
+
+    handle.onData((data) => {
+      if (unmounted) return;
+      setBuffer((prev) => appendToBuffer(prev, data));
+      // Auto-scroll to bottom on new output
+      setTimeout(() => {
+        scrollRef.current?.scrollToEnd({ animated: true });
+      }, 50);
+    });
+
+    handle.onClose((reason) => {
+      if (unmounted) return;
+      setConnected(false);
+      if (reason && reason !== "connection closed") {
+        setError(`PTY closed: ${reason}`);
+      }
+    });
+
+    setConnected(true);
+    setError(null);
+
+    // Focus the input after a short delay so the keyboard appears.
+    setTimeout(() => {
+      if (!unmounted) {
+        inputRef.current?.focus();
+      }
+    }, 300);
+
+    return () => {
+      unmounted = true;
+      handle.close();
+      ptyRef.current = null;
+    };
+  }, [credentials.serverUrl, credentials.boxToken, sessionName, windowIdx]);
+
+  const handleSend = () => {
+    const text = input.trimEnd(); // Keep trailing spaces, but remove trailing newline
+    if (!text) return;
+    // Send with a newline so the remote shell sees it as a complete command
+    ptyRef.current?.write(text + "\n");
+    setInput("");
+  };
+
+  const handleClear = () => {
+    setBuffer(createPtyBuffer(MAX_LINES));
+  };
+
+  const visibleLines = getVisibleLines(buffer, 100); // Show last 100 lines
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
+    >
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {session.title}
+        </Text>
+        <View style={styles.headerStatus}>
+          <View
+            style={[
+              styles.statusDot,
+              { backgroundColor: connected ? colors.running : colors.idle },
+            ]}
+          />
+          <Text style={styles.statusText}>{connected ? "Connected" : "Disconnected"}</Text>
+        </View>
+        <Text style={styles.headerAction} onPress={handleClear}>
+          Clear
+        </Text>
+      </View>
+
+      {error && <Text style={styles.errorBar}>{error}</Text>}
+
+      {/* Terminal output */}
+      <ScrollView
+        ref={scrollRef}
+        style={styles.output}
+        contentContainerStyle={styles.outputContent}
+        onContentSizeChange={() => {
+          // Auto-scroll on content change
+          scrollRef.current?.scrollToEnd({ animated: true });
+        }}
+      >
+        {visibleLines.map((line, idx) => (
+          <Text key={idx} style={styles.line} selectable>
+            {line || " "}
+          </Text>
+        ))}
+        {visibleLines.length === 0 && (
+          <Text style={styles.empty}>
+            Connecting to {sessionName}...
+          </Text>
+        )}
+      </ScrollView>
+
+      {/* Input bar */}
+      <View style={styles.inputBar}>
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          value={input}
+          onChangeText={setInput}
+          onSubmitEditing={handleSend}
+          placeholder="Type command..."
+          placeholderTextColor={colors.textFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          spellCheck={false}
+          keyboardType="default"
+          returnKeyType="send"
+          blurOnSubmit={false}
+        />
+        <Text style={styles.sendButton} onPress={handleSend}>
+          Send
+        </Text>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  headerTitle: {
+    flex: 1,
+    color: colors.text,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  headerStatus: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginLeft: 8,
+  },
+  statusDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: 6,
+  },
+  statusText: {
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+  headerAction: {
+    color: colors.accent,
+    fontSize: 14,
+    fontWeight: "600",
+    marginLeft: 8,
+  },
+  errorBar: {
+    backgroundColor: colors.dangerBg,
+    color: colors.danger,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    fontSize: 12,
+  },
+  output: {
+    flex: 1,
+    backgroundColor: colors.terminalBg,
+  },
+  outputContent: {
+    padding: 8,
+  },
+  line: {
+    fontFamily: "Menlo",
+    fontSize: 13,
+    lineHeight: 18,
+    color: colors.terminalText,
+    paddingVertical: 1,
+  },
+  empty: {
+    color: colors.textFaint,
+    fontSize: 14,
+    textAlign: "center",
+    marginTop: 20,
+  },
+  inputBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    color: colors.terminalText,
+    fontFamily: "Menlo",
+    fontSize: 13,
+    maxHeight: 80,
+  },
+  sendButton: {
+    color: colors.accent,
+    fontSize: 14,
+    fontWeight: "600",
+    marginLeft: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+});

--- a/mobile-rn/src/theme.ts
+++ b/mobile-rn/src/theme.ts
@@ -12,6 +12,9 @@ export const colors = {
   accent: "#3b82f6",
   accentText: "#ffffff",
   danger: "#ef4444",
+  dangerBg: "#1a0a0a",
   running: "#22c55e",
   idle: "#6b7280",
+  terminalBg: "#0d1117",
+  terminalText: "#c9d1d9",
 };


### PR DESCRIPTION
## Summary

Implements terminal access for the React Native mobile app (BET-39 / M5).

### What's New

- **PTY WebSocket client** (): Connects to the box's `/pty` endpoint with automatic reconnect and exponential backoff.
- **Pure PTY buffer logic** (): Manages scrollback buffer with ANSI escape sequence stripping and line management. Fully unit-tested.
- **TerminalScreen component** (): React Native terminal UI with scrollable output and input bar.
- **Navigation wiring**: Terminal route added to App.tsx; SessionListScreen navigates to Terminal for terminal-type sessions.
- **Theme updates**: Added `terminalBg`, `terminalText`, and `dangerBg` colors.

### Verification

**mobile-rn:**
- typecheck: exit 0, no errors
- test: 161 passed, 0 failed

**Main project (better-ui):**
- typecheck: exit 0, no errors
- test: 385 passed, 0 failed

### Files Changed

- `mobile-rn/App.tsx`
- `mobile-rn/src/theme.ts`
- `mobile-rn/src/screens/SessionListScreen.tsx`
- `mobile-rn/src/api/ptyClient.ts` (new)
- `mobile-rn/src/pure/pty.ts` (new)
- `mobile-rn/src/pure/__tests__/pty.test.ts` (new)
- `mobile-rn/src/screens/TerminalScreen.tsx` (new)

### Next Steps

- Manual test: connect to a box, open a terminal session, verify input/output works
- Consider adding ANSI color support in a follow-up
- Consider adding xterm.js integration for full terminal features (cursor, colors, etc.)
