### PR TITLE
BET-82.1: Wire window.__buiPreload typed accessor

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { Settings } from "./Settings";
 import { Onboarding } from "./Onboarding";
 import { useStore, flatSessions } from "./store";
 import { resolveTransportMode } from "../shared/transport.mjs";
+import { getBuiPreload } from "./preloadAccess";
 
 export function App() {
   const {
@@ -119,8 +120,11 @@ export function App() {
   // used to register its own listener, so a single detection fanned out into
   // N toasts (one per mounted chat). Now the toast lives in the store, the
   // active ChatPanel renders it, and accept/dismiss clear it globally.
+  // Routes through the typed preload accessor so it no-ops on mobile/web.
   useEffect(() => {
-    const off = window.api.onScreenshotDetected((ev) => {
+    const preload = getBuiPreload();
+    if (!preload) return;
+    const off = preload.onScreenshotDetected((ev) => {
       useStore.getState().setScreenshotToast(ev);
     });
     return off;

--- a/src/renderer/MarkdownBody.tsx
+++ b/src/renderer/MarkdownBody.tsx
@@ -14,6 +14,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components as MarkdownComponents } from "react-markdown";
 import { CLAUDE_ORANGE } from "./chatShared";
+import { getBuiPreload } from "./preloadAccess";
 
 // Streamed-fence resilience: while a code block is still streaming, the
 // closing ``` hasn't arrived yet. Without a recovery step, remark sees the
@@ -83,9 +84,10 @@ const MD_COMPONENTS: MarkdownComponents = {
         className="underline"
         style={{ color: CLAUDE_ORANGE }}
         onClick={(e) => {
-          if (window.api.openExternal && href) {
+          const preload = getBuiPreload();
+          if (preload && href) {
             e.preventDefault();
-            window.api.openExternal(href);
+            preload.openExternal(href);
           }
         }}
         {...rest}

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useStore } from "./store";
 import { ProvidersCard } from "./ProvidersCard";
 import { PairingQR, PairingCountdown } from "./PairingQR";
+import { getBuiPreload } from "./preloadAccess";
 import type {
   AuthPairResult,
   BootstrapResult,
@@ -686,7 +687,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
                     href="https://console.groq.com/keys"
                     onClick={(e) => {
                       e.preventDefault();
-                      window.api.openExternal("https://console.groq.com/keys");
+                      getBuiPreload()?.openExternal("https://console.groq.com/keys");
                     }}
                     className="text-accent hover:underline"
                   >

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -5,6 +5,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { getBuiPreload } from "./preloadAccess";
 
 type Props = {
   projectName: string;
@@ -66,7 +67,9 @@ export function Terminal({ projectName, active }: Props) {
     // URLs → open in the user's default browser via Electron main.
     term.loadAddon(
       new WebLinksAddon((_event, uri) => {
-        window.api.openExternal(uri).catch((e) => console.warn("openExternal failed:", e));
+        getBuiPreload()?.openExternal(uri).catch((e) =>
+          console.warn("openExternal failed:", e),
+        );
       }),
     );
 
@@ -124,7 +127,7 @@ export function Terminal({ projectName, active }: Props) {
       try {
         const text = atob(payload);
         console.log("[osc52] -> clipboard:", JSON.stringify(text.slice(0, 80)));
-        window.api.clipboardWriteText(text);
+        getBuiPreload()?.clipboardWriteText(text);
         return true;
       } catch (e) {
         console.warn("[osc52] decode failed:", e);

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -67,7 +67,9 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
       if (seeded) {
         // Preserve the real preload for Electron-local affordances, then install
         // httpApi as the primary window.api.
-        (window as unknown as { __buiPreload: Api }).__buiPreload = realPreload;
+        window.__buiPreload = realPreload as unknown as NonNullable<
+          typeof window.__buiPreload
+        >;
         (window as unknown as { api: Api }).api = httpApi as unknown as Api;
       }
     }
@@ -81,9 +83,17 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
 async function boot(): Promise<void> {
   if (!isMobile && preload) {
     await chooseDesktopTransport(preload);
+    // Ensure __buiPreload is always set for the typed accessor. In http mode
+    // chooseDesktopTransport already assigned it; in preload mode window.api
+    // IS the preload so alias it. This guarantees getBuiPreload() returns the
+    // real preload on desktop and null on mobile/web.
+    window.__buiPreload = preload as unknown as NonNullable<
+      typeof window.__buiPreload
+    >;
   } else {
     // Mobile/web: install the shim (no preload to preserve).
     (window as unknown as { api: unknown }).api = httpApi;
+    window.__buiPreload = null;
   }
 
   ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getBuiPreload } from "./preloadAccess";
+import type { BuiPreload } from "./preloadAccess";
+
+// Simulate mobile/web: no preload, no __buiPreload.
+function mockMobileWeb(): void {
+  const w = window as unknown as { __buiPreload: BuiPreload | null };
+  w.__buiPreload = null;
+}
+
+// Build a fake preload with spy callbacks so we can verify forwarding.
+function makeFakePreload(): BuiPreload {
+  return {
+    onScreenshotDetected: vi.fn((cb: (ev: unknown) => void) => {
+      cb({ source: "clipboard" });
+      return vi.fn();
+    }),
+    clipboardWriteText: vi.fn(async () => {}),
+    openExternal: vi.fn(async () => {}),
+    revealInFolder: vi.fn(async () => {}),
+    getPathForFile: vi.fn((f: File) => f.name),
+    onDesktopNotify: vi.fn((cb: (p: unknown) => void) => {
+      cb({ kind: "test" });
+      return vi.fn();
+    }),
+  };
+}
+
+describe("getBuiPreload", () => {
+  beforeEach(() => {
+    mockMobileWeb();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null on mobile/web (no preload)", () => {
+    expect(getBuiPreload()).toBeNull();
+  });
+
+  it("returns the real preload when __buiPreload is set (Electron)", () => {
+    const fake = makeFakePreload();
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = fake;
+
+    expect(getBuiPreload()).toBe(fake);
+  });
+
+  it("forwards onScreenshotDetected to the callback", () => {
+    const cb = vi.fn();
+    let storedOff: (() => void) | null = null;
+    const fake = makeFakePreload();
+    fake.onScreenshotDetected = vi.fn((_fn: (ev: unknown) => void) => {
+      storedOff = () => {};
+      return storedOff;
+    }) as unknown as BuiPreload["onScreenshotDetected"];
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = fake;
+
+    const preload = getBuiPreload();
+    expect(preload).not.toBeNull();
+    const off = preload!.onScreenshotDetected(cb);
+    expect(off).toBe(storedOff);
+    expect(typeof off).toBe("function");
+  });
+
+  it("forwards clipboardWriteText to the preload", async () => {
+    const fake = makeFakePreload();
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = fake;
+
+    const preload = getBuiPreload();
+    expect(preload).not.toBeNull();
+    await preload!.clipboardWriteText("hello");
+    expect(fake.clipboardWriteText).toHaveBeenCalledWith("hello");
+  });
+
+  it("forwards openExternal to the preload", async () => {
+    const fake = makeFakePreload();
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = fake;
+
+    const preload = getBuiPreload();
+    expect(preload).not.toBeNull();
+    await preload!.openExternal("https://example.com");
+    expect(fake.openExternal).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("forwards revealInFolder to the preload", async () => {
+    const fake = makeFakePreload();
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = fake;
+
+    const preload = getBuiPreload();
+    expect(preload).not.toBeNull();
+    await preload!.revealInFolder("/tmp/foo");
+    expect(fake.revealInFolder).toHaveBeenCalledWith("/tmp/foo");
+  });
+
+  it("forwards getPathForFile to the preload", () => {
+    const fake = makeFakePreload();
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = fake;
+
+    const preload = getBuiPreload();
+    expect(preload).not.toBeNull();
+    const file = new File(["x"], "test.txt");
+    const result = preload!.getPathForFile(file);
+    expect(fake.getPathForFile).toHaveBeenCalledWith(file);
+    expect(result).toBe("test.txt");
+  });
+
+  it("returns null when __buiPreload is not set (true mobile/web)", () => {
+    // Ensure __buiPreload is null (simulating mobile/web where no preload ran).
+    const w = window as unknown as { __buiPreload: BuiPreload | null };
+    w.__buiPreload = null;
+    expect(getBuiPreload()).toBeNull();
+  });
+});

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -1,0 +1,41 @@
+import type { DesktopNotifyPayload } from "../shared/types.js";
+
+/**
+ * OS-integration affordances exposed by the Electron preload bridge.
+ *
+ * These are the methods that only work inside Electron — they touch the OS
+ * clipboard, the shell, the file manager, or OS-level notifications. On
+ * mobile/web (no preload) they are unavailable; callers check the accessor
+ * return value and no-op.
+ *
+ * This is a deliberate SUBSET of the full Api type. The full Api (exposed as
+ * `window.api`) includes tmux/opencode/config channels that go over SSH or
+ * HTTP — those are NOT OS-integration and must not live here.
+ */
+export interface BuiPreload {
+  onScreenshotDetected(
+    cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
+  ): () => void;
+  clipboardWriteText(text: string): Promise<void>;
+  openExternal(url: string): Promise<void>;
+  revealInFolder(localPath: string): Promise<void>;
+  getPathForFile(file: File): string;
+  onDesktopNotify(
+    cb: (payload: DesktopNotifyPayload) => void,
+  ): () => void;
+}
+
+/**
+ * Typed accessor for `window.__buiPreload`.
+ *
+ * `main.tsx` always initializes `window.__buiPreload`:
+ *   - Electron http-mode: the real preload (set in chooseDesktopTransport).
+ *   - Electron preload-mode: the real preload (aliased from window.api).
+ *   - Mobile/web: null (no preload ran).
+ *
+ * Callers should treat the return value as `BuiPreload | null` and no-op
+ * when null — never assume it's non-null.
+ */
+export function getBuiPreload(): BuiPreload | null {
+  return window.__buiPreload;
+}

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -1,8 +1,10 @@
 import type { Api } from "../preload/index";
+import type { BuiPreload } from "./preloadAccess";
 
 declare global {
   interface Window {
     api: Api;
+    __buiPreload: BuiPreload | null;
   }
 }
 


### PR DESCRIPTION
## Summary

Wire `window.__buiPreload` with a typed accessor so the renderer can safely read Electron-local affordances (clipboard, shell, screenshot detection, OS notifications) with TypeScript support — and no-op cleanly on mobile/web.

**Files changed:** 8 files.

- `src/renderer/App.tsx` — screenshot detection routed through typed accessor
- `src/renderer/MarkdownBody.tsx` — openExternal routed through typed accessor
- `src/renderer/Settings.tsx` — openExternal routed through typed accessor
- `src/renderer/Terminal.tsx` — clipboardWriteText + openExternal routed through typed accessor
- `src/renderer/main.tsx` — always initializes __buiPreload (null on mobile/web)
- `src/renderer/preloadAccess.ts` — NEW: BuiPreload interface + getBuiPreload() accessor
- `src/renderer/preloadAccess.test.ts` — NEW: 8 tests covering null/real-preload forwarding
- `src/renderer/types.d.ts` — declares __buiPreload: BuiPreload | null on Window

## Verification results:
- typecheck: exit 0. Errors: none.
- test: exit 0, 976 pass / 0 fail / 0 skip.

## Design

- **`BuiPreload`** is a deliberate SUBSET of the full `Api` type — only OS-integration affordances (clipboard, shell, screenshot detection, OS notifications, file manager, file path). Data/transport channels (tmux, opencode, config) stay on `window.api`.
- **`getBuiPreload()`** returns `window.__buiPreload` which is always initialized by `main.tsx`:
  - Electron http-mode: the real preload
  - Electron preload-mode: the real preload (aliased from `window.api`)
  - Mobile/web: `null`
- Callers use optional chaining (`getBuiPreload()?.openExternal(url)`) — no-op on mobile/web, typed on Electron.

## Routing changes

| Affordance | Before | After |
|---|---|---|
| Screenshot detection (App.tsx) | `window.api.onScreenshotDetected(...)` | `getBuiPreload()?.onScreenshotDetected(...)` |
| OSC52 clipboard (Terminal.tsx) | `window.api.clipboardWriteText(...)` | `getBuiPreload()?.clipboardWriteText(...)` |
| Terminal URL links (Terminal.tsx) | `window.api.openExternal(...)` | `getBuiPreload()?.openExternal(...)` |
| Markdown links (MarkdownBody.tsx) | `window.api.openExternal(...)` | `getBuiPreload()?.openExternal(...)` |
| Settings Groq link (Settings.tsx) | `window.api.openExternal(...)` | `getBuiPreload()?.openExternal(...)` |

## openExternal + setWindowOpenHandler

Verified: `src/main/index.ts:862` already installs `setWindowOpenHandler` that calls `shell.openExternal(url)` and returns `{ action: "deny" }`. This means `window.open(url, "_blank")` in the renderer is caught and opened externally — no conflict with routing `openExternal` through the preload IPC path.

Base: origin/main @ 7206613
