### PR TITLE
fix(server): suppress error/permission/question pushes for orphan sessions

### DIFF
--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -436,20 +436,30 @@ export function classifyPushEvent(evt, ctx) {
 }
 
 /**
- * Pure: should a "done" push be dropped because its session can't be resolved
- * to a tmux chat window (null label)? Such a session is a SUBAGENT child (it
+ * Pure: should a push be dropped because its session can't be resolved to a
+ * tmux chat window (null label)? Such a session is a SUBAGENT child (it
  * inherited the parent's directory, runs on the same scoped /event stream, but
  * has no `@bui-session-id` of its own) or a stale orphan — there is no chat for
- * the user to land on, and the push would be the nameless "Claude is done" that
- * deep-links nowhere. Only "done" is gated; permission/question/error must
- * still escalate even for an unresolved session.
+ * the user to land on, and the push would be a nameless notification that
+ * deep-links nowhere.
+ *
+ * Covers `done`, `error`, `permission`, and `question`: an orphan session has
+ * no chat window for the user to act in or land on, so a push to any of these
+ * kinds is useless. A `done` would be a nameless "Claude is done"; an `error`
+ * would be a nameless "The turn failed"; a `permission`/`question` would
+ * require user action the user can't take from a push that deep-links to a
+ * sessionId the app can't find.
  *
  * @param {{kind?: string}|null} payload  classifyPushEvent result
  * @param {string|null} label             resolved "workspace / session-name", or null
  * @returns {boolean}
  */
-export function shouldSuppressUnresolvedDone(payload, label) {
-  return payload?.kind === "done" && !label;
+export function shouldSuppressUnresolvedNotification(payload, label) {
+  if (!label) {
+    const k = payload?.kind;
+    return k === "done" || k === "error" || k === "permission" || k === "question";
+  }
+  return false;
 }
 
 /**
@@ -712,20 +722,21 @@ export async function firePush(evt) {
 
     if (!payload) return;
 
-    // Suppress an unresolvable "done": no tmux window stamps this sessionID
-    // (label is null), so it's a SUBAGENT child session (it inherited the
-    // parent's directory and runs on the same scoped /event stream) or a stale
-    // orphan — NOT a chat the user opened. Such a push has no workspace/name
-    // (generic "Claude is done") and deep-links to a sessionId the app can't
+    // Suppress an unresolvable notification: no tmux window stamps this
+    // sessionID (label is null), so it's a SUBAGENT child session (it inherited
+    // the parent's directory and runs on the same scoped /event stream) or a
+    // stale orphan — NOT a chat the user opened. Such a push has no workspace/
+    // name (generic "Claude is done" / "The turn failed" / "Permission needed"
+    // / "Claude has a question") and deep-links to a sessionId the app can't
     // find, dumping the user on the session list. The desktop renderer hides
     // subagent idles via its childSessionIds allowlist; the server pump has no
     // parent/child awareness, so the null-label test is our proxy: if we can't
-    // name the chat, the user has nothing actionable to land on. Permission /
-    // question / error stay un-gated below — those are blocking and must
-    // escalate even for an unresolved session.
-    if (shouldSuppressUnresolvedDone(payload, label)) {
+    // name the chat, the user has nothing actionable to land on. This applies
+    // to done/error/permission/question — all are useless without a resolvable
+    // session label.
+    if (shouldSuppressUnresolvedNotification(payload, label)) {
       console.log(
-        `[push] done sid=${sid} suppressed=unresolvable-session ` +
+        `[push] ${payload.kind} sid=${sid} suppressed=unresolvable-session ` +
           `(no tmux @bui-session-id → subagent/orphan)`,
       );
       return;

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -4,7 +4,7 @@ import {
   classifyPushEvent,
   buildSessionLabel,
   shouldSuppressForDesktop,
-  shouldSuppressUnresolvedDone,
+  shouldSuppressUnresolvedNotification,
   routeNotification,
   notifTier,
   fireNotify,
@@ -246,7 +246,7 @@ test("REGRESSION: a nameless 'done' (subagent/orphan, null label) is suppressed"
     { focusSessionId: null, focusVisible: false, wasBusy: true, label: null },
   );
   assert.equal(done?.kind, "done");
-  assert.equal(shouldSuppressUnresolvedDone(done, null), true);
+  assert.equal(shouldSuppressUnresolvedNotification(done, null), true);
 });
 
 test("a named 'done' (resolvable session) is NOT suppressed", () => {
@@ -254,16 +254,76 @@ test("a named 'done' (resolvable session) is NOT suppressed", () => {
     { type: "session.idle", properties: { sessionID: "ses_real" } },
     { focusSessionId: null, focusVisible: false, wasBusy: true, label: "default / my-chat" },
   );
-  assert.equal(shouldSuppressUnresolvedDone(done, "default / my-chat"), false);
+  assert.equal(shouldSuppressUnresolvedNotification(done, "default / my-chat"), false);
 });
 
-test("permission/question/error are NEVER suppressed by the unresolved gate", () => {
-  // These are blocking and must escalate even when the session can't be named.
-  for (const type of ["permission", "question", "error"]) {
-    assert.equal(shouldSuppressUnresolvedDone({ kind: type }, null), false);
-  }
-  // Null payload is a no-op too.
-  assert.equal(shouldSuppressUnresolvedDone(null, null), false);
+test("unresolved 'error' (null label) is suppressed — fixes BET-107 orphan spam", () => {
+  // An orphan session errors: no tmux window stamps it, so the push would be
+  // a nameless "The turn failed." that deep-links nowhere. Suppress it.
+  const err = classifyPushEvent(
+    { type: "session.error", properties: { sessionID: "ses_orphan" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: null },
+  );
+  assert.equal(err?.kind, "error");
+  assert.equal(shouldSuppressUnresolvedNotification(err, null), true);
+});
+
+test("resolvable 'error' (with label) is NOT suppressed", () => {
+  const err = classifyPushEvent(
+    { type: "session.error", properties: { sessionID: "ses_real", message: "boom" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: "default / my-chat" },
+  );
+  assert.equal(err?.kind, "error");
+  assert.equal(shouldSuppressUnresolvedNotification(err, "default / my-chat"), false);
+});
+
+test("unresolved 'permission' (null label) is suppressed", () => {
+  // An orphan session asks permission: no chat window for the user to act in,
+  // so the push is useless even though it's "blocking".
+  const perm = classifyPushEvent(
+    { type: "permission.asked", properties: { sessionID: "ses_orphan_perm", id: "per_x" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: null },
+  );
+  assert.equal(perm?.kind, "permission");
+  assert.equal(shouldSuppressUnresolvedNotification(perm, null), true);
+});
+
+test("resolvable 'permission' (with label) is NOT suppressed", () => {
+  const perm = classifyPushEvent(
+    { type: "permission.asked", properties: { sessionID: "ses_real_perm", id: "per_y" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: "default / my-chat" },
+  );
+  assert.equal(perm?.kind, "permission");
+  assert.equal(shouldSuppressUnresolvedNotification(perm, "default / my-chat"), false);
+});
+
+test("unresolved 'question' (null label) is suppressed", () => {
+  // An orphan session asks a question: no chat window for the user to answer
+  // from, so the push is useless.
+  const q = classifyPushEvent(
+    { type: "question.asked", properties: { sessionID: "ses_orphan_q" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: null },
+  );
+  assert.equal(q?.kind, "question");
+  assert.equal(shouldSuppressUnresolvedNotification(q, null), true);
+});
+
+test("resolvable 'question' (with label) is NOT suppressed", () => {
+  const q = classifyPushEvent(
+    { type: "question.asked", properties: { sessionID: "ses_real_q" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: "default / my-chat" },
+  );
+  assert.equal(q?.kind, "question");
+  assert.equal(shouldSuppressUnresolvedNotification(q, "default / my-chat"), false);
+});
+
+test("null payload → no suppression (no-op)", () => {
+  assert.equal(shouldSuppressUnresolvedNotification(null, null), false);
+});
+
+test("non-notifying kind with null label → no suppression", () => {
+  // Other kinds (e.g. "notify") should not be suppressed even with null label.
+  assert.equal(shouldSuppressUnresolvedNotification({ kind: "notify" }, null), false);
 });
 
 const LBL = { ...NOFOCUS, label: "default / my-chat" };


### PR DESCRIPTION
## BET-107 - Suppress error/permission/question pushes for orphan (unresolvable) sessions

**Base:** origin/main @ 9e4b902

### Problem

When a scheduled prompt (or any activity) fires into an opencode session whose tmux window no longer exists (deleted cwd / orphan / subagent child), a `session.error` produces a mobile Web Push titled "Claude hit an error - The turn failed." with no session label. These deep-link nowhere and flood the phone.

The existing `shouldSuppressUnresolvedDone` only gated `kind === "done"` when the session label can't be resolved from tmux. `error` (and by extension `permission` / `question`) were exempt, so an error from a session with no `@bui-session-id` window still pushed - a nameless notification that deep-links to a sessionId the app can't find.

### Fix

Generalized `shouldSuppressUnresolvedDone` to `shouldSuppressUnresolvedNotification(payload, label)` to cover all four notifying kinds (`done`, `error`, `permission`, `question`) when the session label is null.

**Rationale for suppressing all four:** an orphan/subagent session has no chat window for the user to act in or land on, so a push to any of these kinds is useless:
- `done` - nameless "Claude is done"
- `error` - nameless "The turn failed"
- `permission` - requires user approval the user can't give from a push that deep-links nowhere
- `question` - requires user answer the user can't give from a push that deep-links nowhere

### Files changed

- `src/server/push.mjs` - renamed function, extended logic, updated comment + log line
- `src/server/push.test.mjs` - updated existing tests, added 8 new tests

### Verification results:
- typecheck: exit 0. Errors: none.
- test: exit 0, 401 pass / 0 fail / 0 skip (node:test server/relay). Vitest: 849 pass (1 pre-existing `window is not defined` error in `useTranscriptState.test.tsx`, unrelated).
