### PR TITLE
fix(renderer,server): scope question/permission lists to sessionID

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -791,11 +791,11 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   const replyQuestion = useCallback(
     async (q: QuestionRequest, answers: string[][]) => {
       const que = q.requestId;
+      // No reply token → unanswerable ask (stale/orphan/cross-session leak).
+      // Auto-dismiss instead of surfacing an error the user can't clear.
       if (!que) {
-        setSendError(
-          "This question can't be answered — its reply token was not " +
-            "captured (asked before this session was open).",
-        );
+        setQuestions((prev) => prev.filter((x) => x.id !== q.id));
+        useStore.getState().setChatAttention(q.sessionID, null);
         return;
       }
       setQuestions((prev) => prev.filter((x) => x.id !== q.id));

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -415,7 +415,7 @@ describe("replayChatAttention", () => {
   });
 
   it("latches 'question' for a session with a pending question", async () => {
-    questionsBySid["ses_q"] = [{ id: "q1" }];
+    questionsBySid["ses_q"] = [{ id: "q1", sessionID: "ses_q" }];
     await useStore.getState().replayChatAttention();
     const win = useStore.getState().status.bui[0];
     expect(win.attention).toBe(true);
@@ -423,7 +423,7 @@ describe("replayChatAttention", () => {
   });
 
   it("latches 'permission' for a session with only a pending permission", async () => {
-    permissionsBySid["ses_p"] = [{ id: "p1" }];
+    permissionsBySid["ses_p"] = [{ id: "p1", sessionID: "ses_p" }];
     await useStore.getState().replayChatAttention();
     const win = useStore.getState().status.bui[1];
     expect(win.attention).toBe(true);
@@ -431,8 +431,8 @@ describe("replayChatAttention", () => {
   });
 
   it("question outranks permission when both are pending", async () => {
-    questionsBySid["ses_q"] = [{ id: "q1" }];
-    permissionsBySid["ses_q"] = [{ id: "p1" }];
+    questionsBySid["ses_q"] = [{ id: "q1", sessionID: "ses_q" }];
+    permissionsBySid["ses_q"] = [{ id: "p1", sessionID: "ses_q" }];
     await useStore.getState().replayChatAttention();
     expect(useStore.getState().status.bui[0].attentionKind).toBe("question");
   });
@@ -454,7 +454,7 @@ describe("replayChatAttention", () => {
       if (sid === "ses_q") throw new Error("scoped fetch failed");
       return [];
     };
-    permissionsBySid["ses_p"] = [{ id: "p1" }];
+    permissionsBySid["ses_p"] = [{ id: "p1", sessionID: "ses_p" }];
     await useStore.getState().replayChatAttention();
     // ses_p still latched despite ses_q's question fetch throwing.
     expect(useStore.getState().status.bui[1].attentionKind).toBe("permission");

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -540,14 +540,18 @@ export const useStore = create<State>((set, get) => ({
             window.api.opencodeQuestions?.(sid).catch(() => []) ?? [],
             window.api.opencodePermissions?.(sid).catch(() => []) ?? [],
           ]);
-          // A pending question outranks a pending permission (matches the
-          // StatusIndicator priority — a blocked question is the most
-          // urgent ask). Only latch if something is genuinely pending; do
-          // NOT clear here — absence of a pending request at startup is the
-          // normal case and must not stomp live SSE-driven attention.
-          if (questions.length > 0) {
+          // Belt-and-braces: server-side listQuestions/listPermissions now
+          // filters by sessionId, but defensively scope here too so the
+          // attention latch can't leak if a caller ever bypasses the server
+          // filter (e.g. a future unscoped path). Only latch if something is
+          // genuinely pending for THIS session; do NOT clear — absence of a
+          // pending request at startup is the normal case and must not stomp
+          // live SSE-driven attention.
+          const myQuestions = questions.filter((q) => q.sessionID === sid);
+          const myPermissions = permissions.filter((p) => p.sessionID === sid);
+          if (myQuestions.length > 0) {
             get().setChatAttention(sid, "question");
-          } else if (permissions.length > 0) {
+          } else if (myPermissions.length > 0) {
             get().setChatAttention(sid, "permission");
           }
         } catch {

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -577,7 +577,14 @@ export async function listPermissions(sessionId) {
   if (!res.ok) {
     throw new Error(`opencode listPermissions ${res.status}: ${await res.text()}`);
   }
-  return res.json();
+  const all = await res.json();
+  // opencode's /permission endpoint is `?directory=`-scoped, not session-scoped:
+  // a directory can hold pending permissions from multiple sessions. Filter
+  // down to the requested sessionID so callers never see cross-session leaks.
+  if (sessionId && Array.isArray(all)) {
+    return all.filter((p) => p.sessionID === sessionId);
+  }
+  return all;
 }
 
 /** Approve or deny a permission request.
@@ -619,7 +626,15 @@ export async function listQuestions(sessionId) {
   if (!res.ok) {
     throw new Error(`opencode listQuestions ${res.status}: ${await res.text()}`);
   }
-  return res.json();
+  const all = await res.json();
+  // opencode's /question endpoint is `?directory=`-scoped, not session-scoped:
+  // a directory can hold pending questions from multiple sessions (including
+  // orphan/subagent sessions). Filter down to the requested sessionID so
+  // callers never see cross-session leaks or stale/orphan asks.
+  if (sessionId && Array.isArray(all)) {
+    return all.filter((q) => q.sessionID === sessionId);
+  }
+  return all;
 }
 
 /**

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -10,6 +10,7 @@ import {
   compactSession,
   abortSession,
   listPermissions,
+  listQuestions,
   replyPermission,
   _resetSessionDirectoryCache,
   _onSessionDirectoryAdded,
@@ -498,6 +499,133 @@ test("replyPermission appends ?directory= from cache (auto-allow path)", async (
   assert.ok(
     replyUrl.includes("directory=%2Fproj%2Fpreply"),
     `replyPermission URL missing scoped directory: ${replyUrl}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Session-scoped filtering for listQuestions / listPermissions (BET-110)
+//
+// opencode's /question and /permission endpoints are `?directory=`-scoped, not
+// session-scoped. A directory can hold pending items from multiple sessions
+// (including orphan/subagent sessions). listQuestions/listPermissions must
+// filter the directory-wide response down to the requested sessionId so callers
+// never see cross-session leaks or stale/orphan asks.
+// ---------------------------------------------------------------------------
+
+test("listPermissions filters directory-wide response to the requested sessionId", async () => {
+  _resetSessionDirectoryCache();
+  const calls = [];
+  await withMockFetch(
+    async (url, opts) => {
+      calls.push(String(url));
+      // getSessionDirectoryQuery lazy-fetches the session's directory.
+      if (String(url) === "http://127.0.0.1:4096/session/ses_B") {
+        return new Response(
+          JSON.stringify({ id: "ses_B", directory: "/shared/dir" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (String(url).startsWith("http://127.0.0.1:4096/permission?directory=")) {
+        // Directory-wide response: permissions from THREE different sessions.
+        return new Response(
+          JSON.stringify([
+            { id: "per_a", sessionID: "ses_A", permission: "Bash", reply: null },
+            { id: "per_b", sessionID: "ses_B", permission: "Write", reply: null },
+            { id: "per_c", sessionID: "ses_C", permission: "Bash", reply: null },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listPermissions("ses_B");
+      assert.deepEqual(
+        result,
+        [{ id: "per_b", sessionID: "ses_B", permission: "Write", reply: null }],
+        "must return only the requested session's permissions",
+      );
+    },
+  );
+});
+
+test("listQuestions filters directory-wide response to the requested sessionId", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url, opts) => {
+      // getSessionDirectoryQuery lazy-fetches the session's directory.
+      if (String(url) === "http://127.0.0.1:4096/session/ses_B") {
+        return new Response(
+          JSON.stringify({ id: "ses_B", directory: "/shared/dir" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (String(url).startsWith("http://127.0.0.1:4096/question?directory=")) {
+        // Directory-wide response: questions from THREE different sessions,
+        // plus an orphan session (ses_orphan) that should be dropped.
+        return new Response(
+          JSON.stringify([
+            { id: "que_1", sessionID: "ses_A", questions: [{ question: "OK?", answers: [] }] },
+            { id: "que_2", sessionID: "ses_B", questions: [{ question: "Your move?", answers: [] }] },
+            { id: "que_3", sessionID: "ses_orphan", questions: [{ question: "stale", answers: [] }] },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listQuestions("ses_B");
+      assert.deepEqual(
+        result,
+        [{ id: "que_2", sessionID: "ses_B", questions: [{ question: "Your move?", answers: [] }] }],
+        "must return only the requested session's questions",
+      );
+    },
+  );
+});
+
+test("listPermissions without sessionId returns unfiltered directory-wide list", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).startsWith("http://127.0.0.1:4096/permission")) {
+        return new Response(
+          JSON.stringify([
+            { id: "per_x", sessionID: "ses_X", permission: "Bash", reply: null },
+            { id: "per_y", sessionID: "ses_Y", permission: "Write", reply: null },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listPermissions(null);
+      assert.equal(result.length, 2, "unscoped call returns full list");
+    },
+  );
+});
+
+test("listQuestions without sessionId returns unfiltered directory-wide list", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).startsWith("http://127.0.0.1:4096/question")) {
+        return new Response(
+          JSON.stringify([
+            { id: "que_x", sessionID: "ses_X", questions: [{ question: "q?", answers: [] }] },
+            { id: "que_y", sessionID: "ses_Y", questions: [{ question: "q2?", answers: [] }] },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listQuestions(null);
+      assert.equal(result.length, 2, "unscoped call returns full list");
+    },
   );
 });
 


### PR DESCRIPTION
## Summary

Fixes BET-110: chat questions/permissions/attention leak across sessions on reconnect.

**Root cause:** opencode's `/question` and `/permission` endpoints are `?directory=`-scoped, NOT session-scoped. Multiple chat sessions sharing the same worktree see each other's pending asks, stale/orphan questions, and cross-session `?` dots on reconnect.

## Changes

### Server-side (single source of truth) — `src/server/opencode.mjs`
- `listQuestions(sessionId)` now filters the directory-wide response down to the requested `sessionId`, dropping cross-session and orphan items.
- `listPermissions(sessionId)` same filter applied.

### Belt-and-braces — `src/renderer/store.ts`
- `replayChatAttention` now also filters by `sessionID` before latching attention, so the sidebar dot can't leak even if a future caller bypasses the server filter.

### UI hardening — `src/renderer/ChatPanel.tsx`
- `replyQuestion` now auto-dismisses cards with undefined `requestId` instead of surfacing an un-answerable "reply token was not captured" error the user cannot clear.

### Tests
- 4 new server tests in `src/server/opencode.test.mjs` pinning sessionID filtering for `listQuestions` and `listPermissions` (scoped + unscoped paths).
- Updated 4 existing store tests in `src/renderer/store.test.ts` to include `sessionID` on mock items (required by the belt-and-braces filter).

## Files changed
5 files: `src/renderer/ChatPanel.tsx`, `src/renderer/store.ts`, `src/renderer/store.test.ts`, `src/server/opencode.mjs`, `src/server/opencode.test.mjs`

## Verification results:
- typecheck: exit 0. Errors: none.
- test: exit 0, 442 pass / 0 fail / 0 skip.

Base: origin/main @ 59f4f8b