### PR TITLE
fix(http-mode): writable window.api + restore local pairing (no false onboarding)

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -383,6 +383,14 @@ const api = {
     ipcRenderer.invoke(IPC.opencodeGenerateTitle, input),
 };
 
-contextBridge.exposeInMainWorld("api", api);
+// Expose the real preload bridge under a STABLE, dedicated name — NOT "api".
+// contextBridge.exposeInMainWorld makes the property read-only + non-
+// configurable, so whatever name it's given can never be reassigned. The
+// renderer entry (main.tsx) needs to install `window.api` itself and, in
+// http/paired mode, SWAP it for the httpApi client — a swap that throws
+// "Cannot assign to read only property 'api'" if `api` is the contextBridge
+// property. So we bridge under `__buiPreload` (immutable, always the genuine
+// Electron preload) and let main.tsx define a writable `window.api` from it.
+contextBridge.exposeInMainWorld("__buiPreload", api);
 
 export type Api = typeof api;

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -210,6 +210,33 @@ async function rpc<T>(channel: string, ...args: unknown[]): Promise<T> {
   return json.result as T;
 }
 
+/**
+ * Like {@link rpc}, but for channels that may not exist on the server (desktop-
+ * only optimizations the bui-server doesn't implement, or a channel added after
+ * the box was last updated). When the server answers 500 "unknown rpc channel:
+ * <ch>" — the exact string src/server/rpc.mjs throws — we treat it as a benign
+ * "not supported here" and resolve to `fallback` instead of surfacing a red 500
+ * in the console. Any OTHER failure (real 500, network error) still throws, and
+ * a 401 still routes to AuthRequiredError via rpc(). This keeps the HTTP-mode
+ * desktop client resilient to server-surface drift without silently masking
+ * genuine errors.
+ */
+async function rpcOptional<T>(
+  channel: string,
+  fallback: T,
+  ...args: unknown[]
+): Promise<T> {
+  try {
+    return await rpc<T>(channel, ...args);
+  } catch (e) {
+    // Never swallow an auth failure — the UI must still route to re-pair.
+    if (e instanceof AuthRequiredError) throw e;
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("unknown rpc channel")) return fallback;
+    throw e;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // SSE stream — one shared EventSource, lazily created.
 // ---------------------------------------------------------------------------
@@ -625,14 +652,28 @@ export const httpApi: Api = {
 
   // -- opencode chat --
   opencodeMessages: (sessionId) => rpc(IPC.opencodeMessages, sessionId),
+  // These three are DESKTOP-ONLY optimizations with no server-side handler:
+  //   • messages-cached — reads main's in-process transcript cache for an
+  //     instant first paint. The bui-server keeps no such cache, so there's
+  //     nothing to serve; returning null is the documented "cache miss" and the
+  //     ChatPanel falls through to its background opencodeMessages() fetch.
+  //   • open-/close-stream — main refcounts a per-directory opencode SSE stream.
+  //     The server's event bus already streams ALL open sessions globally, so
+  //     these are no-ops here.
+  // The server's rpc registry doesn't define these channels, so calling them
+  // returns 500 "unknown rpc channel". rpcOptional() swallows exactly that
+  // (a stale/older box also 500s the same way) and yields the graceful
+  // fallback, instead of a red console 500 on every ChatPanel mount/unmount.
   opencodeMessagesCached: (sessionId) =>
-    rpc(IPC.opencodeMessagesCached, sessionId),
+    rpcOptional(IPC.opencodeMessagesCached, null, sessionId),
   opencodeMessagesReconcile: (sessionId) =>
     rpc(IPC.opencodeMessagesReconcile, sessionId),
   opencodeMessage: (sessionId, messageId) =>
     rpc(IPC.opencodeMessage, sessionId, messageId),
-  opencodeOpenStream: (sessionId) => rpc(IPC.opencodeOpenStream, sessionId),
-  opencodeCloseStream: (sessionId) => rpc(IPC.opencodeCloseStream, sessionId),
+  opencodeOpenStream: (sessionId) =>
+    rpcOptional(IPC.opencodeOpenStream, undefined, sessionId),
+  opencodeCloseStream: (sessionId) =>
+    rpcOptional(IPC.opencodeCloseStream, undefined, sessionId),
   onOpencodeEvent: (cb) => on<OpencodeEvent>("opencode", cb),
 
   /**

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -25,27 +25,61 @@ import {
 // We render the desktop <App/> only after the transport is chosen, so no
 // component ever observes a half-installed window.api.
 
-const preload = (window as unknown as { api?: Api }).api;
+// The genuine Electron preload bridge is exposed by src/preload/index.ts under
+// `__buiPreload` (a read-only contextBridge property). We NEVER write to that
+// name; instead we install our own writable `window.api` below, so http mode
+// can swap it for the httpApi client. On the mobile/web build there is no
+// preload at all → `__buiPreload` is undefined → mobile path.
+const preload = (window as unknown as { __buiPreload?: Api }).__buiPreload;
 const isMobile = !preload;
+
+// Install `window.api` as a WRITABLE, configurable property. contextBridge
+// properties are read-only, which is why main.tsx (not the preload) owns
+// `window.api` — this makes the http-mode swap at boot a legal assignment
+// rather than a "Cannot assign to read only property 'api'" TypeError.
+function setWindowApi(next: unknown): void {
+  Object.defineProperty(window, "api", {
+    value: next,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}
 
 async function chooseDesktopTransport(realPreload: Api): Promise<void> {
   // Desktop always uses httpApi (BET-82: SSH main path gone).
-  // Preserve the real preload for Electron-local affordances, then install
-  // httpApi as the primary window.api.
-  window.__buiPreload = realPreload as unknown as NonNullable<
-    typeof window.__buiPreload
-  >;
-  (window as unknown as { api: Api }).api = httpApi as unknown as Api;
+  // The real preload already lives at window.__buiPreload (exposed read-only by
+  // the preload's contextBridge) — we NEVER write to that name. Here we only
+  // decide whether to swap the primary window.api over to httpApi.
 
   // Try to seed localStorage with paired credentials so httpApi has a base
-  // URL + token. Non-fatal if configGet fails or seed is null — httpApi is
-  // already installed and will show "Not configured" until pairing completes.
+  // URL + token. Non-fatal if configGet fails or seed is null — window.api
+  // stays on the preload bridge and will show "Not configured" until pairing
+  // completes.
   try {
     const config = await realPreload.configGet();
     const seed = desktopHttpClientSeed(config);
     if (seed) {
-      localStorage.setItem("bui_server", seed.bui_server);
-      localStorage.setItem("bui_token", seed.bui_token);
+      // Seed the two localStorage keys httpApi reads for its base URL + token.
+      let seeded = true;
+      try {
+        localStorage.setItem("bui_server", seed.bui_server);
+        localStorage.setItem("bui_token", seed.bui_token);
+      } catch (e) {
+        // localStorage unavailable is fatal for http mode (httpApi can't read
+        // its base) — fall back to preload rather than a 401-looping client.
+        // Do NOT return here: chooseDesktopTransport must fall through so boot()
+        // still renders. We simply leave window.api as the preload bridge by
+        // skipping the httpApi swap below.
+        console.warn("[bui] localStorage seed failed; using preload transport:", e);
+        seeded = false;
+      }
+      if (seeded) {
+        // The real preload already lives at window.__buiPreload (contextBridge)
+        // for Electron-local affordances (clipboard, reveal, OS notifications).
+        // Install httpApi as the primary window.api.
+        setWindowApi(httpApi);
+      }
     }
   } catch (e) {
     console.warn("[bui] configGet failed at entry:", e);
@@ -54,12 +88,16 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
 
 async function boot(): Promise<void> {
   if (!isMobile && preload) {
+    // Desktop: default window.api to the real preload bridge, then let the
+    // transport chooser swap it to httpApi if the config is paired (http mode).
+    // Because `window.api` is now main-owned (not the contextBridge property),
+    // this default install + the http-mode swap are both legal assignments.
+    setWindowApi(preload);
     await chooseDesktopTransport(preload);
     // chooseDesktopTransport already assigned window.__buiPreload.
   } else {
     // Mobile/web: install the shim (no preload to preserve).
-    (window as unknown as { api: unknown }).api = httpApi;
-    window.__buiPreload = null;
+    setWindowApi(httpApi);
   }
 
   ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -7,6 +7,30 @@ import type {
   WindowStatus,
 } from "../shared/types";
 import type { ConnectionState } from "../shared/net/state.js";
+import { clientToken } from "./api/httpApi";
+
+// Overlay the desktop-local pairing secrets (serverUrl/boxToken) onto a config
+// snapshot. In http mode window.api.configGet() returns the bui-server's config,
+// which never carries these — they live only on this desktop, mirrored into
+// localStorage by main.tsx (bui_server/bui_token) at boot. Reading them here
+// keeps resolveTransportMode() from seeing an empty boxToken and forcing
+// onboarding on an already-paired install. A missing/blank local value leaves
+// the incoming config field untouched, so this is a no-op on mobile/web and on
+// a genuinely-unpaired fresh install.
+function mergeLocalPairing(cfg: AppConfig): AppConfig {
+  let serverUrl = "";
+  try {
+    serverUrl = localStorage.getItem("bui_server") ?? "";
+  } catch {
+    /* localStorage unavailable (private mode / SSR) — treat as no override */
+  }
+  const boxToken = clientToken() ?? "";
+  return {
+    ...cfg,
+    serverUrl: serverUrl || cfg.serverUrl,
+    boxToken: boxToken || cfg.boxToken,
+  };
+}
 
 // "Active session" in our UI = (projectName, windowIndex) tuple
 export type ActiveSession = {
@@ -267,7 +291,13 @@ export const useStore = create<State>((set, get) => ({
 
   refresh: async () => {
     const cfg = await window.api.configGet();
-    get().applyConfig(cfg);
+    // In http mode window.api.configGet() returns the bui-SERVER's config,
+    // which structurally lacks the desktop-local pairing secrets
+    // (serverUrl/boxId/boxToken). Those live only on this desktop — mirrored
+    // into localStorage["bui_server"]/["bui_token"] by main.tsx at boot (and by
+    // the pairing step via applyPairing). Overlay them so applyConfig doesn't
+    // blank the pairing and flip the app back into onboarding on every refresh.
+    get().applyConfig(mergeLocalPairing(cfg));
     // Un-gated: always fetch projects via httpApi (SSH main path gone, BET-82).
     const projects = await window.api.tmuxList();
     get().applyProjects(projects);


### PR DESCRIPTION
## Summary

Two related HTTP/paired-mode fixes that together let a paired desktop boot into its normal shell instead of crashing or being forced through onboarding.

### 1. Make `window.api` writable (cherry-picked from `fix/http-mode-window-api-swap`)
`contextBridge.exposeInMainWorld("api", …)` makes `window.api` read-only, so `main.tsx` swapping it to the httpApi client at boot threw:

> `Uncaught (in promise) TypeError: Cannot assign to read only property 'api'`

The preload now exposes itself as read-only `__buiPreload`; `main.tsx` owns a **writable** `window.api` via `Object.defineProperty`, so the http-mode swap is a legal assignment. Also adds `rpcOptional()` for desktop-only RPC channels the bui-server doesn't implement (graceful fallback instead of a red console error).

### 2. Restore desktop-local pairing after server `configGet`
With the swap working, `window.api.configGet()` goes to the **bui-server**, which returns the *server's* config — structurally missing the desktop-local pairing secrets (`serverUrl`/`boxId`/`boxToken`). Those live only on this desktop. Result: `applyConfig()` set `boxToken: ""` → `resolveTransportMode()` returned `"onboarding"` → an already-paired install was forced through onboarding on every refresh.

Fix: `mergeLocalPairing()` in the store's `refresh()` overlays the local pairing fields from `localStorage` (`bui_server`/`bui_token`, already seeded at boot by `main.tsx`) onto the server config. Server owns server settings; the desktop owns pairing. A blank local value leaves the incoming field untouched — no-op on mobile/web and on a genuinely-unpaired fresh install.

## Testing
- `npm run typecheck` clean
- `npm run build` clean
- Store tests pass (34/34)
- Manually verified end-to-end: confirmed the bui-server's `config:get` response carries no `boxToken`, and the app now boots to the normal shell instead of onboarding.

🧙 Built with [WOZCODE](https://wozcode.com)