### PR TITLE
fix(server): prefill custom providers in Settings (BET-114)

### DIFF
--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -209,6 +209,28 @@ async function readRemoteConfig() {
 }
 
 /**
+ * Read opencode.jsonc from the box and project it into the ProviderEndpoint[]
+ * shape the Settings ProvidersCard form expects. This is the config-reading
+ * path (NOT the /provider HTTP endpoint): the card needs the configured
+ * provider blocks (id/name/baseURL/hasApiKey/enabledModels), so a custom
+ * provider like "Voska AI" is prefilled in the form.
+ *
+ * `readConfig` is injectable so the projection can be unit-tested without the
+ * real ~/.config/opencode/opencode.jsonc file; it defaults to readRemoteConfig.
+ * Returns [] if the config is absent or unparseable (the form degrades to an
+ * empty list rather than throwing).
+ */
+export async function getProviderEndpoints(readConfig = readRemoteConfig) {
+  try {
+    const cfg = await readConfig();
+    return readProviderEndpoints(cfg);
+  } catch (e) {
+    console.warn("[providers] could not read provider endpoints:", e);
+    return [];
+  }
+}
+
+/**
  * Fetch the provider list from opencode's /provider endpoint.
  * Returns the raw shape: { all: [...], connected: [...], default: {...} }.
  *

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -14,6 +14,7 @@ import {
   discoverModels,
   setProviders,
   getProviders,
+  getProviderEndpoints,
 } from "./providers.mjs";
 
 // ---------------------------------------------------------------------------
@@ -421,6 +422,64 @@ describe("discoverModels", () => {
       assert.equal(result.error, "bad_response");
     }
     globalThis.fetch = origFetch;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProviderEndpoints — the config-reading path backing "opencode:get-providers"
+// (BET-114). Must return a ProviderEndpoint[] (ARRAY) projected from
+// opencode.jsonc, NOT the raw /provider HTTP object { all, connected, default }.
+// readConfig is injected so we don't touch the real ~/.config/opencode file.
+// ---------------------------------------------------------------------------
+
+describe("getProviderEndpoints", () => {
+  it("returns a ProviderEndpoint[] array (not the raw {all,connected,default} object)", async () => {
+    const cfg = {
+      provider: {
+        voska: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Voska AI",
+          options: { baseURL: "https://api.voska.org/v1", apiKey: "vk-secret" },
+          models: { "voska-large": { id: "voska-large", name: "voska-large" } },
+        },
+      },
+    };
+    const result = await getProviderEndpoints(async () => cfg);
+    // BET-114 regression: the handler must hand the form an ARRAY of endpoints.
+    assert.ok(Array.isArray(result), "expected an array, not the raw provider object");
+    assert.ok(!("all" in result), "must not be the raw /provider { all, connected, default } shape");
+  });
+
+  it("prefills a configured custom provider (Voska AI) with renderer-safe metadata", async () => {
+    const cfg = {
+      provider: {
+        voska: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Voska AI",
+          options: { baseURL: "https://api.voska.org/v1", apiKey: "vk-secret" },
+          models: { "voska-large": { id: "voska-large", name: "voska-large" } },
+        },
+      },
+    };
+    const result = await getProviderEndpoints(async () => cfg);
+    const voska = result.find((e) => e.id === "voska");
+    assert.ok(voska, "Voska AI provider should be surfaced to the form");
+    assert.equal(voska.name, "Voska AI");
+    assert.equal(voska.baseURL, "https://api.voska.org/v1");
+    assert.equal(voska.hasApiKey, true); // presence only — the secret never leaves the box
+    assert.deepEqual(voska.enabledModels, ["voska-large"]);
+  });
+
+  it("returns [] when the config reader throws (unparseable/absent config)", async () => {
+    const result = await getProviderEndpoints(async () => {
+      throw new Error("unparseable");
+    });
+    assert.deepEqual(result, []);
+  });
+
+  it("returns [] for a config with no providers", async () => {
+    const result = await getProviderEndpoints(async () => ({}));
+    assert.deepEqual(result, []);
   });
 });
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -200,9 +200,13 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     "opencode:models": () => oc.listModels(),
 
     // Provider management — now served from the server (BET-82.3).
-    // get-providers: fetch opencode's /provider endpoint (all providers,
-    // connected set, defaults). Returns the raw shape { all, connected, default }.
-    "opencode:get-providers": () => providers.getProviders(),
+    // get-providers: read opencode.jsonc and project the configured provider
+    // blocks into ProviderEndpoint[] (id/name/baseURL/hasApiKey/enabledModels),
+    // which is exactly what the Settings ProvidersCard form consumes. This must
+    // NOT return the raw /provider HTTP shape { all, connected, default } — that
+    // object has no rows for the card to map over, so custom providers (e.g.
+    // "Voska AI") would never be prefilled (BET-114).
+    "opencode:get-providers": () => providers.getProviderEndpoints(),
 
     // discover-models: query an OpenAI-compatible endpoint's /models.
     // Args: { baseURL, apiKey? } — apiKey may be "" (use stored key).


### PR DESCRIPTION
## BET-114 — custom provider not prefilled in Settings ProvidersCard

**Root cause:** `rpc.mjs` `opencode:get-providers` returned the raw opencode `/provider` object `{all,connected,default}` instead of a `ProviderEndpoint[]` array, so `ProvidersCard` found no rows and configured custom providers (e.g. Voska AI) were never prefilled.

**Fix:** new exported `getProviderEndpoints()` in `providers.mjs` = `readProviderEndpoints(readRemoteConfig())`, returns `[]` on read/parse failure; handler dispatches to it. `getProviders()` left intact for other callers.

**Tests:** new `getProviderEndpoints` suite in `providers.test.mjs` asserting an array (not the raw object) containing a configured custom provider, plus empty/throw degradation.

**Gates:** `npm run typecheck` ✅ · `npm test` ✅ (vitest 860, node:test 446).

Independently reviewed: APPROVE (root cause fixed, no regressions; `getProviders` verified dead-only-in-tests, no separate desktop handler needed).