### PR TITLE
fix(renderer): question cards stacking + stuck submit (BET-112)

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -1311,6 +1311,58 @@ describe("applyQuestionEvent — callID unification & defensive removal", () => 
   });
 });
 
+// ===== BET-112 regression: live path replaces stale GET /question re-poll =====
+//
+// The hook's useSseBus now drives question state via applyQuestionEvent on
+// every question.* event instead of re-polling GET /question (which returns
+// ALL cumulatively-pending workspace questions and dropped both the sessionID
+// filter and the que_ requestId). These cases lock the properties the live
+// path depends on: distinct in-session asks accumulate WITHOUT stacking a
+// cross-session backlog, and every stored card carries a usable requestId so
+// submit can actually POST the reply (the "stuck on loading" root cause).
+describe("applyQuestionEvent — BET-112 live-path stacking/requestId", () => {
+  const SID = "ses_view";
+  const mkAsked = (id: string, callID: string) => ({
+    id,
+    sessionID: SID,
+    questions: [{ question: "q", header: "h", options: [] }],
+    tool: { messageID: `msg_${callID}`, callID },
+  });
+
+  it("two distinct in-session asks yield two cards, each with its own requestId", () => {
+    let state = applyQuestionEvent([], "question.asked", mkAsked("que_1", "toolu_1"), SID);
+    state = applyQuestionEvent(state, "question.asked", mkAsked("que_2", "toolu_2"), SID);
+    expect(state).toHaveLength(2);
+    expect(state.map((q) => q.id)).toEqual(["toolu_1", "toolu_2"]);
+    // Both cards carry the que_ reply token — without this, submit short-circuits
+    // ("reply token was not captured") and the spinner hangs forever.
+    expect(state.map((q) => q.requestId)).toEqual(["que_1", "que_2"]);
+  });
+
+  it("interleaved cross-session asks never stack into the viewed panel", () => {
+    let state = applyQuestionEvent([], "question.asked", mkAsked("que_1", "toolu_1"), SID);
+    // A question fired in ANOTHER session (workspace-wide GET would have
+    // returned it) must not appear in the viewed panel.
+    state = applyQuestionEvent(
+      state,
+      "question.asked",
+      { ...mkAsked("que_9", "toolu_9"), sessionID: "ses_other" },
+      SID,
+    );
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("toolu_1");
+  });
+
+  it("replying one ask leaves the other pending (no backlog re-render)", () => {
+    let state = applyQuestionEvent([], "question.asked", mkAsked("que_1", "toolu_1"), SID);
+    state = applyQuestionEvent(state, "question.asked", mkAsked("que_2", "toolu_2"), SID);
+    state = applyQuestionEvent(state, "question.replied", { requestID: "que_1", sessionID: SID }, SID);
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("toolu_2");
+    expect(state[0].requestId).toBe("que_2");
+  });
+});
+
 // ===== hydrateQuestion =====
 
 describe("hydrateQuestion", () => {

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -61,6 +61,8 @@ import {
   isDrainAbortError,
   shouldAbortForQueuedDrain,
   collectChildSessionIds,
+  applyQuestionEvent,
+  hydrateQuestion,
   type PendingDelta,
 } from "../chatUtils";
 import type { TokenUsage } from "../chatShared";
@@ -201,7 +203,15 @@ export function useSseBus(params: {
     try {
       const qs = await window.api.opencodeQuestions?.(sessionId);
       if (Array.isArray(qs)) {
-        setQuestions(qs);
+        // Mirror ChatPanel's original hydrate + sessionID-filter: hydrateQuestion
+        // copies the server's `que_…` id into `requestId` (required for reply),
+        // and the filter keeps only the viewed session's questions so a
+        // cumulative workspace-wide GET doesn't stack unrelated backlog.
+        setQuestions(
+          qs
+            .filter((q) => q.sessionID === sessionId)
+            .map(hydrateQuestion) as QuestionRequest[],
+        );
       }
     } catch { /* non-fatal */ }
   }, [sessionId]);
@@ -223,9 +233,12 @@ export function useSseBus(params: {
 
   const rejectQuestion = useCallback(
     (q: QuestionRequest) => {
-      void window.api.opencodeQuestionReject?.(sessionId, q.id);
+      // Signature is opencodeQuestionReject(requestId, sessionId?) and the
+      // reply/reject API accepts ONLY the `que_…` requestId, not the callID.
+      if (!q.requestId) return;
+      void window.api.opencodeQuestionReject?.(q.requestId, q.sessionID);
     },
-    [sessionId],
+    [],
   );
 
   // SSE effect
@@ -503,7 +516,18 @@ export function useSseBus(params: {
       }
 
       if (ev.type === "question.asked" || ev.type === "question.replied" || ev.type === "question.rejected") {
-        void refreshQuestions();
+        // Payload-driven live update (restored from BET-64 refactor regression).
+        // Applying the event payload directly (a) hydrates `requestId` from the
+        // asked payload so submit can send the reply, (b) upserts by callID so
+        // re-asks don't stack, and (c) filters to the viewed session — instead
+        // of re-polling GET /question which returns ALL cumulatively-pending
+        // questions for the workspace and dropped the requestId + filter.
+        setQuestions((prev) =>
+          applyQuestionEvent(prev, ev.type, props, sessionId) as QuestionRequest[],
+        );
+        if (ev.type === "question.replied" || ev.type === "question.rejected") {
+          scheduleRefetch();
+        }
       }
     });
 


### PR DESCRIPTION
## BET-112 — Question cards stack across turns + submit hangs on loading

**Root cause:** the BET-64 hook extraction moved `question.*` SSE handling into `useSseBus` and replaced payload-driven `applyQuestionEvent` with a raw `GET /question` re-poll that skipped `hydrateQuestion`. Cards then had `requestId===undefined` → submit short-circuited → reply never sent → opencode stayed blocked → spinner hung. The re-poll also dropped the sessionID filter + callID dedup → every pending question re-stacked each turn.

**Fix (`useSseBus.ts`):**
- live `question.*` handler now applies `applyQuestionEvent(prev, type, props, sessionId)` (hydrates `requestId`, dedups by callID, filters session)
- `refreshQuestions` recovery path now `.filter(sessionID).map(hydrateQuestion)` mirroring ChatPanel
- fixed swapped-arg `opencodeQuestionReject(requestId, sessionId)`

**Tests:** 3 new `chatUtils.test.ts` cases (distinct in-session asks with own requestId; cross-session isolation; reply-one-leaves-other-pending).

**Gates:** `npm run typecheck` ✅ · `npm test` ✅ (vitest 863, node:test 442).

Independently reviewed: APPROVE (both stuck-submit and stacking fixed; cast sound; deps correct).