### PR TITLE
fix(server): chat-mode new session creates a Terminal, not ChatPanel (BET-113)

### DIFF
--- a/src/renderer/mobile/MobileCreateSheet.tsx
+++ b/src/renderer/mobile/MobileCreateSheet.tsx
@@ -44,16 +44,12 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
 
   const [name, setName] = useState("");
   const [cwd, setCwd] = useState("~");
-  // chat-mode toggle: HIDDEN on mobile for now because the mobile server's
-  // `tmux:new-session` / `tmux:new-window` channels (src/server/tmux.mjs)
-  // ignore the chatMode flag — the @bui-session-id stamp and chat-holder
-  // pane that desktop pty.ts:tmuxNewWindow does are missing. Toggling here
-  // would create a plain terminal window labeled "chat mode" → broken UX.
-  // Re-expose once the server gains a `chatMode:true` path (parallel to
-  // desktop maybeCreateChatSession + REMOTE_CHAT_HOLDER_CMD). The variable
-  // stays so the few create-paths that pass it remain typed; it's always
-  // false in this build.
-  const chatMode = false;
+  // chat-mode toggle (re-exposed, BET-113): the mobile server's
+  // `tmux:new-session` / `tmux:new-window` channels now honour chatMode —
+  // src/server/tmux.mjs creates an opencode session, launches the holder pane
+  // (`sleep infinity`), and stamps @bui-session-id — the same path desktop
+  // uses. Default OFF to match the desktop new-session/new-project dialog.
+  const [chatMode, setChatMode] = useState(false);
 
   // cwd autocomplete: debounced fsListDirs query; results in a tappable list.
   const [cwdMatches, setCwdMatches] = useState<string[]>([]);
@@ -373,8 +369,16 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
               </div>
             )}
 
-            {/* chat-mode toggle intentionally hidden — see comment above
-                the `chatMode` declaration. */}
+            {/* chat-mode toggle (BET-113): the server now honours chatMode. */}
+            <label className="flex items-center gap-2 text-sm text-text-muted select-none">
+              <input
+                type="checkbox"
+                checked={chatMode}
+                onChange={(e) => setChatMode(e.target.checked)}
+                className="accent-accent"
+              />
+              chat mode (opencode)
+            </label>
 
             {error && <div className="text-xs text-red-400">{error}</div>}
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -137,15 +137,24 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     // to the server. Mobile attachments use uploadBuffer (/api/upload) instead.
     "upload:files": (input) => local.uploadFiles(input),
 
-    // ---- tmux (8 channels, unchanged) ----
+    // ---- tmux (8 channels) ----
     "tmux:list": () => tmux.listProjects(),
-    "tmux:new-session": (i) => tmux.newSession(i),
+    // chatMode (BET-113): when the new-session dialog's "chat mode (opencode)"
+    // toggle is on, tmux.newSession must create an opencode session, launch a
+    // holder pane, and stamp @bui-session-id — so it needs the `oc` client.
+    // Resolve cwd first (createSession requires an absolute-ish dir; the tilde
+    // is expanded inside oc.createSession). For new-session the project meta
+    // doesn't exist yet, so resolveProjectCwd falls back to the passed cwd.
+    "tmux:new-session": async (i) =>
+      tmux.newSession({ ...i, cwd: await resolveProjectCwd(i.name, i.cwd), oc }),
     // Resolve cwd: prefer explicit cwd in input, then fall back to the
     // project's stored defaultCwd (set when the workspace was created).
     // Without this, new chat windows opened in a workspace silently inherit
     // tmux's default cwd (usually $HOME) instead of the workspace path.
+    // Pass `oc` so a chatMode window creates + stamps an opencode session
+    // (BET-113 regression: this used to silently drop chatMode).
     "tmux:new-window": async (i) =>
-      tmux.newWindow({ ...i, cwd: await resolveProjectCwd(i.sessionName, i.cwd) }),
+      tmux.newWindow({ ...i, cwd: await resolveProjectCwd(i.sessionName, i.cwd), oc }),
     "tmux:rename-session": (i) => tmux.renameSession(i),
     "tmux:rename-window": (i) => tmux.renameWindow(i),
     "tmux:kill-session": (n) => tmux.killSession(n),

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -16,13 +16,14 @@ test("dispatch throws a descriptive error for unknown channel", async () => {
 // Minimal stubs for buildHandlers — only the namespaces touched by the cwd
 // resolution tests need real behavior; everything else can be a no-op.
 function makeDeps(projects) {
-  const calls = { newWindow: [], newWindowGetIndex: [], createSession: [], forkSession: [] };
+  const calls = { newWindow: [], newSession: [], newWindowGetIndex: [], createSession: [], forkSession: [] };
   return {
     calls,
     deps: {
       tmux: {
         listProjects: async () => [],
         newWindow: async (i) => { calls.newWindow.push(i); return []; },
+        newSession: async (i) => { calls.newSession.push(i); return []; },
         newWindowGetIndex: async (sessionName, windowName, cwd) => {
           calls.newWindowGetIndex.push({ sessionName, windowName, cwd });
           return 1;
@@ -103,4 +104,48 @@ test("opencode:fork-session creates the new tmux window in the resolved defaultC
     cwd: "",
   });
   assert.equal(calls.newWindowGetIndex.at(-1).cwd, "/home/dev/projects/better-ui");
+});
+
+// ---- BET-113: chatMode must reach the tmux layer with the oc client -------
+// The regression was the tmux:new-window / tmux:new-session handlers dropping
+// chatMode and never giving the tmux layer an opencode client to create a
+// session with. These assert the handler forwards both.
+
+test("tmux:new-window forwards chatMode + oc client to tmux.newWindow", async () => {
+  const { deps, calls } = makeDeps([{ tmuxSession: "better-ui", defaultCwd: "/home/dev/projects/better-ui" }]);
+  const handlers = buildHandlers(deps);
+  await handlers["tmux:new-window"]({
+    sessionName: "better-ui",
+    windowName: "chat",
+    cwd: "",
+    chatMode: true,
+  });
+  const last = calls.newWindow.at(-1);
+  assert.equal(last.chatMode, true, "chatMode forwarded");
+  assert.equal(last.cwd, "/home/dev/projects/better-ui", "cwd resolved from defaultCwd");
+  assert.ok(last.oc && typeof last.oc.createSession === "function", "oc client forwarded");
+});
+
+test("tmux:new-window forwards oc even for a non-chat window (chatMode falsy)", async () => {
+  const { deps, calls } = makeDeps([{ tmuxSession: "better-ui", defaultCwd: "/home/dev/projects/better-ui" }]);
+  const handlers = buildHandlers(deps);
+  await handlers["tmux:new-window"]({ sessionName: "better-ui", windowName: "term", cwd: "" });
+  const last = calls.newWindow.at(-1);
+  assert.ok(!last.chatMode, "chatMode not set for a plain window");
+  assert.ok(last.oc && typeof last.oc.createSession === "function", "oc client still forwarded");
+});
+
+test("tmux:new-session forwards chatMode + oc client and resolves cwd", async () => {
+  const { deps, calls } = makeDeps([]);
+  const handlers = buildHandlers(deps);
+  await handlers["tmux:new-session"]({
+    name: "newproj",
+    windowName: "chat",
+    cwd: "/home/dev/projects/newproj",
+    chatMode: true,
+  });
+  const last = calls.newSession.at(-1);
+  assert.equal(last.chatMode, true, "chatMode forwarded");
+  assert.equal(last.cwd, "/home/dev/projects/newproj", "explicit cwd preserved");
+  assert.ok(last.oc && typeof last.oc.createSession === "function", "oc client forwarded");
 });

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -17,7 +17,7 @@ export function expandTildePath(p) {
   return p; // ~user form — leave for the shell, not ours to guess
 }
 
-export function run(cmd, args) {
+function spawnRun(cmd, args) {
   return new Promise((resolve, reject) => {
     const p = cpSpawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "", stderr = "";
@@ -28,6 +28,22 @@ export function run(cmd, args) {
       code === 0 ? resolve({ stdout, stderr })
                  : reject(new Error(`${cmd} exited ${code}: ${stderr.trim() || stdout.trim()}`)));
   });
+}
+
+// The transport every tmux command dispatches through. Production = spawnRun
+// (real child_process). Tests swap in a fake `(cmd, args) => Promise<{stdout,
+// stderr}>` via `_setRun` so the chat-mode branch (which calls tmux new-window
+// + set-window-option) is unit-testable without a live tmux server. Mirrors
+// the `_setOcTransport` pattern in src/server/opencode.mjs.
+let runImpl = spawnRun;
+
+export function run(cmd, args) {
+  return runImpl(cmd, args);
+}
+
+/** Test-only: override the tmux command transport. Pass null to restore. */
+export function _setRun(fn) {
+  runImpl = fn ?? spawnRun;
 }
 
 export function parseSessions(sessStdout, winStdout) {
@@ -62,6 +78,13 @@ export async function listProjects() {
   return parseSessions(sess.stdout, wins.stdout);
 }
 
+// Chat-mode windows don't run a TUI — bui renders its own React ChatPanel
+// into the slot. The tmux pane just holds the window alive so the existing
+// project/window model still works. `sleep infinity` exits cleanly when the
+// window is killed (no zombies) and consumes no CPU. Mirrors
+// REMOTE_CHAT_HOLDER_CMD in the (now-deleted) desktop src/main/pty.ts.
+export const CHAT_HOLDER_CMD = "sleep infinity";
+
 // See src/main/pty.ts:sessionSurvivabilityCmd for the rationale.
 // `exit-empty off` keeps the tmux server alive across empty-session moments,
 // and `destroy-unattached off` keeps the per-project session pinned after
@@ -83,7 +106,63 @@ export function isMissingSessionError(err, sessionName) {
   return false;
 }
 
-export async function newSession({ name, cwd, windowName, createDir }) {
+// For chat-mode: create an opencode session in `cwd` and return its id;
+// non-chat is a no-op returning null. Centralised so the new-session and
+// new-window paths stay aligned. Mirrors maybeCreateChatSession in the
+// (now-deleted) desktop src/main/pty.ts. `oc` is the src/server/opencode.mjs
+// namespace, injected by the rpc handler (kept as a param so tmux.mjs stays
+// dependency-injected + unit-testable). opencode is LOCAL to this box — no SSH
+// hop. `oc.createSession` expands a leading `~` itself (see expandTilde in
+// opencode.mjs), so the tilde-corruption chokepoint is already covered there.
+async function maybeCreateChatSession(oc, chatMode, cwd, title) {
+  if (!chatMode) return null;
+  if (!oc || typeof oc.createSession !== "function") {
+    throw new Error("chat mode requires an opencode client (oc.createSession)");
+  }
+  const sess = await oc.createSession({ directory: cwd, title });
+  return sess.id;
+}
+
+// Create the tmux window with an explicit index-returning form. For chat-mode
+// we launch the holder pane (`sleep infinity`) instead of the default shell so
+// the pane is inert under bui's overlaid ChatPanel; for non-chat we launch the
+// default shell (no trailing command).
+async function newWindowGetIndexInternal(sessionName, windowName, cwd, chatMode) {
+  const { stdout } = await run("tmux", [
+    "new-window",
+    "-t", sessionName,
+    "-n", windowName,
+    "-P", "-F", "#{window_index}",
+    ...(cwd ? ["-c", cwd] : []),
+    ...(chatMode ? ["sh", "-c", CHAT_HOLDER_CMD] : []),
+  ]);
+  const idx = Number(stdout.trim());
+  if (!Number.isFinite(idx)) {
+    throw new Error(`tmux new-window returned unexpected index: ${JSON.stringify(stdout.trim())}`);
+  }
+  return idx;
+}
+
+// Create a session and return the index of its initial window.
+async function newSessionGetIndex(name, cwd, windowName, chatMode) {
+  const { stdout } = await run("tmux", [
+    "new-session", "-d", "-s", name, "-c", cwd ?? ".",
+    "-P", "-F", "#{window_index}",
+    ...(windowName ? ["-n", windowName] : []),
+    ...(chatMode ? ["sh", "-c", CHAT_HOLDER_CMD] : []),
+  ]);
+  const idx = Number(stdout.trim());
+  return Number.isFinite(idx) ? idx : 0;
+}
+
+// @param {object} input
+// @param {string} input.name           tmux session (project) name
+// @param {string} [input.cwd]          working directory (absolute/tilde)
+// @param {string} [input.windowName]   initial window name
+// @param {boolean} [input.createDir]   mkdir -p the cwd first (onboarding)
+// @param {boolean} [input.chatMode]    create an opencode chat-mode window
+// @param {object} [input.oc]           opencode client (required when chatMode)
+export async function newSession({ name, cwd, windowName, createDir, chatMode, oc }) {
   // Onboarding's first-project step opts into auto-creation via createDir: a
   // missing ~/projects/<name> should be created, not silently swallowed. tmux
   // new-session -c falls back to $HOME for a non-existent dir, so the mkdir -p
@@ -92,25 +171,36 @@ export async function newSession({ name, cwd, windowName, createDir }) {
   if (createDir && cwd) {
     await mkdir(expandTildePath(cwd), { recursive: true });
   }
-  await run("tmux", ["new-session", "-d", "-s", name, "-c", cwd ?? ".",
-    ...(windowName ? ["-n", windowName] : [])]);
+  // Chat-mode: create the opencode session BEFORE the tmux window so we can
+  // stamp @bui-session-id on it. Without the stamp the renderer sees
+  // opencodeSessionId === null and renders Terminal instead of ChatPanel —
+  // this was the BET-113 regression.
+  const sid = await maybeCreateChatSession(
+    oc, chatMode, cwd ?? ".", `${name} / ${windowName ?? "default"}`,
+  );
+  const idx = await newSessionGetIndex(name, cwd, windowName, !!chatMode);
   await applySessionSurvivability(name);
+  if (sid) await restampSessionId(name, idx, sid);
   return listProjects();
 }
-export async function newWindow({ sessionName, windowName, cwd }) {
+export async function newWindow({ sessionName, windowName, cwd, chatMode, oc }) {
+  const sid = await maybeCreateChatSession(
+    oc, chatMode, cwd ?? ".", `${sessionName} / ${windowName}`,
+  );
+  let idx;
   try {
-    await run("tmux", ["new-window", "-t", sessionName, "-n", windowName,
-      ...(cwd ? ["-c", cwd] : [])]);
+    idx = await newWindowGetIndexInternal(sessionName, windowName, cwd, !!chatMode);
   } catch (err) {
     // Auto-heal: the project's tmux session vanished between calls
     // (server restart, manual kill, etc.). Recreate it with this window
     // as the first window — see src/main/pty.ts:tmuxNewWindow for the
-    // matching desktop-transport branch.
+    // matching desktop-transport branch. We do NOT recreate the opencode
+    // session — `sid` is already resolved and reusable as the stamp.
     if (!isMissingSessionError(err, sessionName)) throw err;
-    await run("tmux", ["new-session", "-d", "-s", sessionName, "-n", windowName,
-      ...(cwd ? ["-c", cwd] : [])]);
+    idx = await newSessionGetIndex(sessionName, cwd, windowName, !!chatMode);
     await applySessionSurvivability(sessionName);
   }
+  if (sid) await restampSessionId(sessionName, idx, sid);
   return listProjects();
 }
 

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -1,6 +1,44 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseSessions, isMissingSessionError } from "./tmux.mjs";
+import {
+  parseSessions,
+  isMissingSessionError,
+  newWindow,
+  newSession,
+  _setRun,
+  CHAT_HOLDER_CMD,
+} from "./tmux.mjs";
+
+// Install a fake tmux transport that records every command and returns a
+// window index of 0 for creation commands (matching `-P -F '#{window_index}'`).
+// Returns the recorder so a test can assert on the commands issued.
+function installFakeTmux() {
+  const cmds = [];
+  _setRun(async (cmd, args) => {
+    cmds.push({ cmd, args });
+    // new-session / new-window with -P -F print the window index on stdout.
+    if (args.includes("new-window") || args.includes("new-session")) {
+      return { stdout: "0\n", stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  });
+  return cmds;
+}
+
+// A fake opencode client that records createSession calls.
+function fakeOc(sessionId = "ses_chat123") {
+  const created = [];
+  return {
+    created,
+    createSession: async (i) => { created.push(i); return { id: sessionId }; },
+  };
+}
+
+function findSetSid(cmds) {
+  return cmds.find(
+    (c) => c.args.includes("set-window-option") && c.args.includes("@bui-session-id"),
+  );
+}
 
 test("parseSessions builds project list from tmux -F output", () => {
   const sess = "alpha\t1\nbeta\t0";
@@ -81,4 +119,114 @@ test("isMissingSessionError returns false for non-Error inputs", () => {
   assert.equal(isMissingSessionError(null, "x"), false);
   assert.equal(isMissingSessionError(undefined, "x"), false);
   assert.equal(isMissingSessionError("can't find session: x", "x"), false);
+});
+
+// ---- chat-mode (BET-113 regression) --------------------------------------
+//
+// The "chat mode (opencode)" toggle in the new-session / new-window dialog
+// must (1) create an opencode session, (2) launch the holder pane instead of
+// a shell, and (3) stamp @bui-session-id on the new window. Without the stamp
+// the renderer sees opencodeSessionId === null and renders Terminal, not
+// ChatPanel — the exact regression from commit 81f5779.
+
+test("newWindow chatMode:true creates an opencode session AND stamps @bui-session-id", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc("ses_abc");
+  try {
+    await newWindow({
+      sessionName: "better-ui",
+      windowName: "chat",
+      cwd: "/home/dev/projects/better-ui",
+      chatMode: true,
+      oc,
+    });
+  } finally {
+    _setRun(null);
+  }
+  // (1) opencode session created in the window's cwd.
+  assert.equal(oc.created.length, 1, "one opencode session created");
+  assert.equal(oc.created[0].directory, "/home/dev/projects/better-ui");
+  // (2) holder pane launched (sleep infinity) rather than the default shell.
+  const newWin = cmds.find((c) => c.args.includes("new-window"));
+  assert.ok(newWin, "new-window issued");
+  assert.ok(newWin.args.includes(CHAT_HOLDER_CMD), "holder cmd passed to new-window");
+  // (3) @bui-session-id stamped with the created session id.
+  const stamp = findSetSid(cmds);
+  assert.ok(stamp, "set-window-option @bui-session-id issued");
+  assert.ok(stamp.args.includes("ses_abc"), "stamp carries the opencode session id");
+});
+
+test("newWindow chatMode:false stays a plain window — no session, no stamp, no holder", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc();
+  try {
+    await newWindow({
+      sessionName: "better-ui",
+      windowName: "term",
+      cwd: "/home/dev/projects/better-ui",
+      chatMode: false,
+      oc,
+    });
+  } finally {
+    _setRun(null);
+  }
+  assert.equal(oc.created.length, 0, "no opencode session created for a plain window");
+  assert.equal(findSetSid(cmds), undefined, "no @bui-session-id stamp for a plain window");
+  const newWin = cmds.find((c) => c.args.includes("new-window"));
+  assert.ok(newWin, "new-window issued");
+  assert.ok(!newWin.args.includes(CHAT_HOLDER_CMD), "no holder cmd for a plain window");
+});
+
+test("newSession chatMode:true creates an opencode session AND stamps @bui-session-id", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc("ses_sess1");
+  try {
+    await newSession({
+      name: "newproj",
+      cwd: "/home/dev/projects/newproj",
+      windowName: "chat",
+      chatMode: true,
+      oc,
+    });
+  } finally {
+    _setRun(null);
+  }
+  assert.equal(oc.created.length, 1, "one opencode session created");
+  assert.equal(oc.created[0].directory, "/home/dev/projects/newproj");
+  const newSess = cmds.find((c) => c.args.includes("new-session"));
+  assert.ok(newSess, "new-session issued");
+  assert.ok(newSess.args.includes(CHAT_HOLDER_CMD), "holder cmd passed to new-session");
+  const stamp = findSetSid(cmds);
+  assert.ok(stamp, "set-window-option @bui-session-id issued");
+  assert.ok(stamp.args.includes("ses_sess1"), "stamp carries the opencode session id");
+});
+
+test("newSession chatMode:false stays a plain session — no session create, no stamp", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc();
+  try {
+    await newSession({
+      name: "newproj",
+      cwd: "/home/dev/projects/newproj",
+      windowName: "main",
+      chatMode: false,
+      oc,
+    });
+  } finally {
+    _setRun(null);
+  }
+  assert.equal(oc.created.length, 0, "no opencode session for a plain session");
+  assert.equal(findSetSid(cmds), undefined, "no @bui-session-id stamp for a plain session");
+});
+
+test("newWindow chatMode:true throws when no opencode client is injected", async () => {
+  installFakeTmux();
+  try {
+    await assert.rejects(
+      () => newWindow({ sessionName: "s", windowName: "chat", cwd: "/tmp", chatMode: true }),
+      /chat mode requires an opencode client/,
+    );
+  } finally {
+    _setRun(null);
+  }
 });


### PR DESCRIPTION
## BET-113 — chat-mode new session/project creates a plain terminal

**Root cause:** the SSH→bui-server refactor (81f5779) dropped `chatMode` at the server. `tmux.mjs` `newWindow`/`newSession` never created an opencode session, launched the holder pane, or stamped `@bui-session-id`, so the renderer saw `opencodeSessionId === null` and rendered `Terminal`.

**Fix:**
- `tmux.mjs`: chat-mode branch — create opencode session via injected `oc`, capture the new window index via `-P -F '#{window_index}'`, launch a `sleep infinity` holder, then `restampSessionId`. Adds a `_setRun` test seam (mirrors `opencode.mjs`'s `_setOcTransport`).
- `rpc.mjs`: forward `oc` + resolved cwd through `tmux:new-window`/`tmux:new-session`.
- `MobileCreateSheet.tsx`: re-expose the chat-mode toggle (default off) now that the server path works.

Tilde cwd is expanded to absolute before `createSession` (via existing `expandTilde`); `newWindow` auto-heal reuses the resolved sid (no duplicate session); `chatMode:false` is behavior-preserving.

**Tests:** 5 new `tmux.test.mjs` + 3 new `rpc.test.mjs` — chatMode:true creates session AND stamps; chatMode:false does neither; missing-`oc` throws.

**Gates:** `npm run typecheck` ✅ · `npm test` ✅ (vitest 860, node:test 450).

Independently reviewed: APPROVE (window-index stamping correct/robust, tilde expansion covered, no duplicate session on retry). Non-blocking follow-up nits: orphan-session rollback if tmux fails after createSession; `newSessionGetIndex` parse-failure symmetry.