### PR TITLE
docs(peers): make peer tools cost-aware + anti-reflex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -557,6 +557,17 @@ schedule/serve-page (`docs/bui-tools-scheduler.md`). Key facts:
 - **No UI card, no durable store, no bus event** — purely a live AI-facing
   read + message tool (v1). No `peers:*` window.api channels; the desktop
   renderer doesn't consume it.
+- **Tool descriptions + the AGENTS.md blurb are deliberately cost-aware and
+  anti-reflex** (rewritten after a session called `peers_list` at task start and
+  needlessly woke an unrelated peer). Each `execute` is a read/wake with a token
+  cost — `peers_inspect` reads a transcript, `peers_message` WAKES a peer and
+  warms its (possibly stale) context. The guidance therefore forbids reflexive /
+  "situational awareness" use and requires CONCRETE present evidence of a
+  file-level collision (or an explicit user ask) before calling; questions
+  answerable from `git`/`gh`/CI/fs ("is main green?", "what shipped today?") must
+  NOT trigger a peer call. If you regenerate these descriptions, KEEP the cost
+  warning + the anti-pattern list — the naive "run peers_list first" framing is
+  what caused the waste.
 - Tests: `src/server/peers.test.mjs` (resolveWorkspace, selectPeers,
   parseGitStatus, summarizeTranscript, classifyChatStatus, describeChatActivity,
   recentTurns, formatPeerMessage, sendPeerMessage — 20). Pure logic only.

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -44,25 +44,40 @@ it down early. `list_pages` shows all active pages.
 
 You have `peers_list`, `peers_inspect`, and `peers_message` tools to see what
 OTHER agent sessions in the same workspace (the sibling windows of your tmux
-session) are doing, and to message them. Reach for them when you notice files
-changing under you, `git status` shifting, or otherwise suspect another agent
-is working alongside you and you want to know who, and on what — so you don't
-collide — or when you want to coordinate / hand off work to a peer.
+session) are doing, and to message them.
+
+**These tools are NOT free and NOT a default first step.** Inspecting a peer
+reads its transcript (tokens); messaging one WAKES it and warms a possibly-stale
+context (its tokens, and stale context can produce wrong answers). So do NOT
+call them reflexively at the start of a task or as a "situational awareness"
+habit.
+
+**Only reach for them when there is CONCRETE, PRESENT evidence you must
+coordinate with a specific peer to avoid a collision**, e.g.:
+
+- `git status` shows changes you did not make, or a file changed under you
+  mid-edit → `peers_list` (and maybe `peers_inspect`) to find who owns it.
+- You are about to change an API/file and need to warn whoever is editing it.
+- The user explicitly asks who else is working in this workspace, or asks you to
+  hand off / relay something to another session.
+
+**Do NOT use them to answer questions you can resolve yourself** from `git`,
+`gh`, CI, or the filesystem — "is main green?", "did the build pass?", "what was
+done today?" are answered by the source of truth, not by a peer's stale opinion.
+When in doubt, don't call them.
 
 - `peers_list` -> each peer's window name, type (chat/tui), branch, number of
   uncommitted files, status (working/idle/blocked), and current activity.
 - `peers_inspect(target)` -> deep dive on one peer (by window name, index, or
   session id): full `git status`, branch, and its recent transcript + todos
-  (chat sessions) or terminal tail (claude-TUI sessions).
+  (chat sessions) or terminal tail (claude-TUI sessions). Use only after
+  `peers_list` flagged a peer touching files you care about.
 - `peers_message(target, message)` -> inject a message into a peer's chat as a
-  new turn (chat-mode peers only). Use to coordinate, hand off, ask a question,
-  or share a finding — e.g. "I just changed the API in src/x.ts, rebase before
-  you continue". The message is auto-prefixed with your session name + workspace
-  so the receiver knows it came from you.
-
-Typical flow: run `peers_list` first; if a peer is touching files you care
-about, `peers_inspect` it to see exactly what it's changing before you proceed,
-or `peers_message` it to coordinate.
+  new turn (chat-mode peers only). Send only when the peer genuinely NEEDS it: a
+  real coordination/hand-off, a warning that you touched a file it's editing, or
+  a direct answer it asked you for — NOT a status check or an unsolicited FYI.
+  Auto-prefixed with your session name + workspace so the receiver knows it came
+  from you.
 
 **You can also RECEIVE messages from peers.** A peer's message arrives as an
 ordinary user turn prefixed with `[Message from peer agent session "<name>" in

--- a/docs/opencode-tools/peers.ts
+++ b/docs/opencode-tools/peers.ts
@@ -82,13 +82,20 @@ function q(context: any): string {
 
 export const list = tool({
   description: [
-    "List the OTHER agent sessions working in the same workspace (the sibling",
-    "windows of the same tmux session) and a one-line summary of what each is",
-    "doing. Use when you notice files changing, git status shifting, or",
-    "otherwise suspect another agent is working alongside you and you want to",
-    "know who and on what. Shows each peer's branch, number of uncommitted",
-    "files, status (working/idle/blocked), and current activity. Call",
-    "peers_inspect for a detailed look at one peer.",
+    "List the OTHER agent sessions in the same workspace and a one-line summary",
+    "of each. COSTS TOKENS AND HAS SIDE EFFECTS: inspecting a peer reads its",
+    "transcript and a message WAKES it, warming a possibly-stale context — so",
+    "this is NOT a free 'situational awareness' check and must not be called",
+    "reflexively at the start of a task.",
+    "ONLY call it when there is CONCRETE EVIDENCE another agent is editing the",
+    "SAME files right now AND you must coordinate to avoid a collision:",
+    "e.g. `git status` shows changes you did not make, a file changed under you",
+    "mid-edit, or the user explicitly asks who else is working here.",
+    "DO NOT use it to answer questions you can resolve yourself from git / gh /",
+    "CI / the filesystem (e.g. 'is main green?', 'did the build pass?', 'what",
+    "was done today?') — a peer's opinion is stale and worse than the source of",
+    "truth. If in doubt, don't call it. Shows each peer's branch, uncommitted-",
+    "file count, status, and current activity; call peers_inspect for detail.",
   ].join(" "),
   args: {},
   async execute(_args, context) {
@@ -108,12 +115,14 @@ export const list = tool({
 
 export const inspect = tool({
   description: [
-    "Inspect ONE peer session in your workspace in detail: its full git status",
-    "(which files it's changing), branch, and — for chat sessions — its recent",
-    "transcript turns and active todo list, or — for terminal sessions — the",
-    "tail of its terminal pane. Use after peers_list to dig into what a specific",
-    "agent is doing. Identify the peer by its window name, window index, or",
-    "opencode session id (all shown by peers_list).",
+    "Inspect ONE peer session in detail: its full git status (which files it's",
+    "changing), branch, and — for chat sessions — recent transcript turns +",
+    "todos, or — for terminal sessions — the terminal-pane tail. Use ONLY after",
+    "peers_list has already shown a peer is actively touching files you care",
+    "about and you need to see exactly what, to avoid a collision. Reading a",
+    "peer's transcript costs tokens; do not inspect out of curiosity or to",
+    "gather facts you can get from git / gh / CI yourself. Identify the peer by",
+    "its window name, window index, or opencode session id (from peers_list).",
   ].join(" "),
   args: {
     target: z
@@ -166,14 +175,17 @@ export const inspect = tool({
 export const message = tool({
   description: [
     "Send a message to ANOTHER agent session in your workspace (a sibling tmux",
-    "window). The message is injected into that peer's chat as a new turn,",
-    "prefixed with context about who sent it (your session name + workspace) so",
-    "the receiving agent knows it came from a peer, not its user. Use to",
-    "coordinate, hand off work, ask a question, or share a finding with another",
-    "agent — e.g. 'I just changed the API in src/x.ts, rebase before you",
-    "continue'. Identify the peer by its window name, window index, or opencode",
-    "session id (all shown by peers_list). Only chat-mode peers can receive a",
-    "message; terminal (claude-TUI) peers cannot.",
+    "window). WAKES the target: it runs a fresh turn, warming its context and",
+    "spending its tokens — so only send when you have something the peer",
+    "genuinely NEEDS and cannot get otherwise: a real coordination/hand-off, a",
+    "warning that you changed a file it's editing, or a direct answer it asked",
+    "you for. Do NOT ping a peer for status you can read yourself, to 'check in',",
+    "or to share an FYI it didn't request. The message is injected as a new turn",
+    "prefixed with your session name + workspace so the receiver knows it came",
+    "from a peer, not its user — e.g. 'I just changed the API in src/x.ts, rebase",
+    "before you continue'. Identify the peer by window name, index, or session id",
+    "(from peers_list). Only chat-mode peers can receive a message; terminal",
+    "(claude-TUI) peers cannot.",
   ].join(" "),
   args: {
     target: z


### PR DESCRIPTION
Rescues commit `382445e` that was stranded on `multica/BET-101-delete-ssh-tunnel` (the rest of that branch merged long ago; this docs commit never did).

Rewrites the `peers_list`/`peers_inspect`/`peers_message` tool descriptions + AGENTS.md guidance to stop reflexive peer-tool use (lead with token/wake cost, require concrete collision evidence, forbid answering git/gh/CI questions via a peer). Note: this content is **already deployed** to `~/.config/opencode/` on the box — this PR just lands the source of truth in main.

Docs-only: `AGENTS.md`, `docs/opencode-tools/AGENTS.md`, `docs/opencode-tools/peers.ts`. Typecheck clean.

After merge: delete `multica/BET-101-delete-ssh-tunnel` (fully merged at that point).