### PR TITLE
fix(server): exclude no-baseURL provider blocks from ProvidersCard

### DIFF
--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -164,15 +164,28 @@ export function removeProviderBlock(cfg, id) {
 // Project the config's provider map down to renderer-safe metadata. Never
 // includes the apiKey value — only whether one is present — and scrubs any
 // credential embedded in the baseURL.
+//
+// ONLY blocks with an options.baseURL are projected: the ProvidersCard is the
+// manager for OpenAI-compatible ENDPOINTS, and a baseURL is definitional for
+// those. Plugin-authed providers (e.g. the `anthropic` block used by
+// opencode-claude-auth) have no baseURL and MUST be excluded — rendering them
+// in the card gives them a Refresh button that fetches `"" + "/models"`
+// ("unreachable: could not reach the endpoint"), and worse, a model toggle or
+// ✕ on that row would route the block through upsertProviderBlock /
+// removeProviderBlock, overwriting it with npm:"@ai-sdk/openai-compatible" +
+// empty baseURL and corrupting the plugin auth. They still appear in the model
+// dropdown, which reads the live /provider endpoint instead.
 export function readProviderEndpoints(cfg) {
   const providers = getProviderMap(cfg);
-  return Object.entries(providers).map(([id, block]) => ({
-    id,
-    name: typeof block.name === "string" ? block.name : id,
-    baseURL: block.options?.baseURL ? stripUrlUserinfo(block.options.baseURL) : "",
-    hasApiKey: Boolean(block.options?.apiKey),
-    enabledModels: Object.keys(block.models ?? {}),
-  }));
+  return Object.entries(providers)
+    .filter(([, block]) => Boolean(block.options?.baseURL))
+    .map(([id, block]) => ({
+      id,
+      name: typeof block.name === "string" ? block.name : id,
+      baseURL: stripUrlUserinfo(block.options.baseURL),
+      hasApiKey: Boolean(block.options?.apiKey),
+      enabledModels: Object.keys(block.models ?? {}),
+    }));
 }
 
 // Find the apiKey stored in opencode.jsonc for the provider whose baseURL
@@ -256,6 +269,13 @@ export async function getProviders() {
  * the box's network view.
  */
 export async function discoverModels(baseURL, apiKey) {
+  // Defense-in-depth: an endpoint row without a baseURL can't be discovered
+  // (fetch("/models") throws "Failed to parse URL"). readProviderEndpoints
+  // filters these out of the card, but guard here too so a stale client or
+  // direct rpc call gets a clear error instead of "unreachable".
+  if (!baseURL || !String(baseURL).trim()) {
+    return { ok: false, error: "bad_response", detail: "provider has no baseURL configured" };
+  }
   const url = `${normBaseURL(baseURL)}/models`;
   try {
     const headers = {};

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -300,7 +300,7 @@ describe("readProviderEndpoints", () => {
   it("uses id as name when name is missing", () => {
     const cfg = {
       provider: {
-        bare: { npm: "x", options: {}, models: {} },
+        bare: { npm: "x", options: { baseURL: "https://bare.example/v1" }, models: {} },
       },
     };
     const endpoints = readProviderEndpoints(cfg);
@@ -309,6 +309,31 @@ describe("readProviderEndpoints", () => {
 
   it("returns empty array for config with no providers", () => {
     assert.deepEqual(readProviderEndpoints({}), []);
+  });
+
+  // REGRESSION: plugin-authed provider blocks (e.g. anthropic via
+  // opencode-claude-auth) have no options.baseURL. They must NOT be projected
+  // into the ProvidersCard: the card's Refresh would fetch `"" + "/models"`
+  // ("unreachable: could not reach the endpoint"), and a model toggle / remove
+  // on the row would rewrite the block as an @ai-sdk/openai-compatible
+  // endpoint with an empty baseURL, corrupting the plugin auth.
+  it("excludes plugin-authed blocks without a baseURL (anthropic)", () => {
+    const cfg = {
+      provider: {
+        anthropic: {
+          // Real shape from a claude-auth setup: models but no options.baseURL.
+          models: { "claude-opus-4-8": { id: "claude-opus-4-8" } },
+        },
+        voska: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "VoskaAI",
+          options: { baseURL: "https://api.voska.org/v1", apiKey: "k" },
+          models: { "qwen3.6-27b": {} },
+        },
+      },
+    };
+    const endpoints = readProviderEndpoints(cfg);
+    assert.deepEqual(endpoints.map((e) => e.id), ["voska"]);
   });
 });
 
@@ -409,6 +434,24 @@ describe("discoverModels", () => {
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.equal(result.error, "unreachable");
+    }
+    globalThis.fetch = origFetch;
+  });
+
+  // REGRESSION: an empty baseURL used to reach fetch("/models") and surface as
+  // a misleading "unreachable: could not reach the endpoint". It must return a
+  // clear bad_response without touching the network.
+  it("returns bad_response (not unreachable) for an empty baseURL", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("fetch must not be called for an empty baseURL");
+    };
+    for (const bad of ["", "   ", undefined, null]) {
+      const result = await discoverModels(bad, "");
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.equal(result.error, "bad_response");
+        assert.match(result.detail ?? "", /no baseURL/);
+      }
     }
     globalThis.fetch = origFetch;
   });


### PR DESCRIPTION
## Follow-up to BET-114 (PR #75)

**Reported:** clicking Refresh on a provider row in Settings → "unreachable: could not reach the endpoint".

**Root cause:** BET-114 correctly surfaces all `opencode.jsonc` provider blocks, which now includes the plugin-authed `anthropic` block (opencode-claude-auth) that has **no `options.baseURL`**. Refresh on that row fetched `"" + "/models"` → `TypeError: Failed to parse URL` → misleading "unreachable" (confirmed in bui-server journal). Worse footgun: a model toggle or ✕ on that row routes through `upsertProviderBlock`/`removeProviderBlock`, which would rewrite the anthropic block as an `@ai-sdk/openai-compatible` endpoint with an empty baseURL — corrupting Claude plugin auth.

**Fix:**
- `readProviderEndpoints` projects only blocks with an `options.baseURL` — definitional for the OpenAI-compatible endpoints this card manages. Plugin providers still appear in the model dropdown (live `/provider` path).
- `discoverModels` gains a defense-in-depth guard: empty baseURL → clear `bad_response: provider has no baseURL configured`, no network call.

**Tests:** regression cases for both (anthropic-shaped block excluded; empty/whitespace/null baseURL returns bad_response without calling fetch). Full suite: vitest 863 ✅, node:test 456 ✅, typecheck ✅.