### PR TITLE
fix(server): discover-models positional args + stored-key recovery

### DIFF
--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -301,6 +301,29 @@ export async function discoverModels(baseURL, apiKey) {
 }
 
 /**
+ * Discovery entrypoint for the ProvidersCard Refresh flow. The renderer sends
+ * an EMPTY apiKey by design ("Refresh never re-sends the secret"), and the
+ * stored key for the endpoint is recovered here from opencode.jsonc via
+ * findStoredApiKey — the secret stays on the box. An explicit apiKey (the
+ * add-endpoint validation path) is used as-is.
+ *
+ * `readConfig` is injectable for tests; defaults to readRemoteConfig. A config
+ * read failure degrades to keyless discovery (the endpoint may be public).
+ */
+export async function discoverModelsForEndpoint(baseURL, apiKey, readConfig = readRemoteConfig) {
+  let key = apiKey ?? "";
+  if (!key) {
+    try {
+      key = findStoredApiKey(await readConfig(), baseURL);
+    } catch (e) {
+      console.warn("[providers] could not read stored api key:", e);
+      key = "";
+    }
+  }
+  return discoverModels(baseURL, key);
+}
+
+/**
  * Apply a set of provider mutations and write opencode.jsonc back.
  * Does NOT restart opencode; the caller decides (prompt-before-restart).
  */

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -12,6 +12,7 @@ import {
   readProviderEndpoints,
   findStoredApiKey,
   discoverModels,
+  discoverModelsForEndpoint,
   setProviders,
   getProviders,
   getProviderEndpoints,
@@ -562,5 +563,89 @@ describe("setProviders", () => {
     // In test env, the write may succeed or fail depending on filesystem
     // permissions. The important thing is it returns { ok, error? }.
     assert.ok("ok" in result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverModelsForEndpoint — the ProvidersCard Refresh entrypoint
+// ---------------------------------------------------------------------------
+
+describe("discoverModelsForEndpoint", () => {
+  const origFetch = globalThis.fetch;
+  const okResponse = () =>
+    new Response(JSON.stringify({ data: [{ id: "m1" }] }), {
+      status: 200, headers: { "content-type": "application/json" },
+    });
+  const cfgWithKey = {
+    provider: {
+      voska: {
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: "https://api.voska.org/v1", apiKey: "stored-secret" },
+        models: {},
+      },
+    },
+  };
+
+  it("recovers the stored api key when the renderer sends an empty key (Refresh contract)", async () => {
+    const seen = [];
+    globalThis.fetch = async (url, opts) => {
+      seen.push({ url: String(url), auth: opts?.headers?.Authorization ?? "" });
+      return okResponse();
+    };
+    try {
+      const result = await discoverModelsForEndpoint(
+        "https://api.voska.org/v1", "", async () => cfgWithKey,
+      );
+      assert.equal(result.ok, true);
+      assert.equal(seen[0].auth, "Bearer stored-secret");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("uses an explicit api key as-is without reading the config", async () => {
+    const seen = [];
+    globalThis.fetch = async (url, opts) => {
+      seen.push({ auth: opts?.headers?.Authorization ?? "" });
+      return okResponse();
+    };
+    try {
+      const result = await discoverModelsForEndpoint(
+        "https://api.voska.org/v1", "explicit",
+        async () => { throw new Error("readConfig must not be called"); },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(seen[0].auth, "Bearer explicit");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("degrades to keyless discovery when the config is unreadable", async () => {
+    const seen = [];
+    globalThis.fetch = async (url, opts) => {
+      seen.push({ auth: opts?.headers?.Authorization ?? "" });
+      return okResponse();
+    };
+    try {
+      const result = await discoverModelsForEndpoint(
+        "https://public.example/v1", "", async () => { throw new Error("boom"); },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(seen[0].auth, "", "no Authorization header sent");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("still rejects an empty baseURL with a clear error (no network)", async () => {
+    globalThis.fetch = async () => { throw new Error("must not fetch"); };
+    try {
+      const result = await discoverModelsForEndpoint("", "", async () => cfgWithKey);
+      assert.equal(result.ok, false);
+      if (!result.ok) assert.equal(result.error, "bad_response");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -218,9 +218,14 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     "opencode:get-providers": () => providers.getProviderEndpoints(),
 
     // discover-models: query an OpenAI-compatible endpoint's /models.
-    // Args: { baseURL, apiKey? } — apiKey may be "" (use stored key).
-    "opencode:discover-models": (input) =>
-      providers.discoverModels(input?.baseURL ?? "", input?.apiKey ?? ""),
+    // POSITIONAL args (baseURL, apiKey) — httpApi/preload both send
+    // `rpc(channel, baseURL, apiKey)` and dispatch() spreads args, so an
+    // object-destructuring handler here reads `.baseURL` off a STRING and
+    // discovery silently ran against "" ("unreachable: could not reach the
+    // endpoint" on every Refresh). apiKey "" = recover the stored key from
+    // opencode.jsonc server-side (Refresh never re-sends the secret).
+    "opencode:discover-models": (baseURL, apiKey) =>
+      providers.discoverModelsForEndpoint(baseURL ?? "", apiKey ?? ""),
 
     // set-providers: apply upsert/remove mutations to opencode.jsonc.
     // Args: { upsert?: ProviderInput[], remove?: string[] }

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -149,3 +149,36 @@ test("tmux:new-session forwards chatMode + oc client and resolves cwd", async ()
   assert.equal(last.cwd, "/home/dev/projects/newproj", "explicit cwd preserved");
   assert.ok(last.oc && typeof last.oc.createSession === "function", "oc client forwarded");
 });
+
+// REGRESSION (Refresh in Settings → "unreachable: could not reach the
+// endpoint"): httpApi + preload both send discover-models as POSITIONAL args
+// — rpc(channel, baseURL, apiKey) — and dispatch() spreads args into the
+// handler. The old handler destructured a single object (`input?.baseURL`),
+// so it read `.baseURL` off the baseURL STRING → undefined → discovery ran
+// against "" for EVERY refresh. This drives the real positional path through
+// dispatch() with fetch mocked, and asserts the request hits
+// <baseURL>/models with the provided key.
+test("opencode:discover-models accepts positional (baseURL, apiKey) args", async () => {
+  const { deps } = makeDeps([]);
+  const handlers = buildHandlers(deps);
+  const seen = [];
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    seen.push({ url: String(url), auth: opts?.headers?.Authorization ?? "" });
+    return new Response(JSON.stringify({ data: [{ id: "m1" }] }), {
+      status: 200, headers: { "content-type": "application/json" },
+    });
+  };
+  try {
+    const result = await dispatch(handlers, "opencode:discover-models", [
+      "https://api.example.com/v1", "explicit-key",
+    ]);
+    assert.equal(seen.length, 1, "exactly one discovery request");
+    assert.equal(seen[0].url, "https://api.example.com/v1/models");
+    assert.equal(seen[0].auth, "Bearer explicit-key");
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.models, [{ id: "m1" }]);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});


### PR DESCRIPTION
## The actual fix for "unreachable: could not reach the endpoint" on Refresh

PR #79 removed the no-baseURL anthropic row (real footgun), but the reported error had a second, primary cause: **every** Refresh failed, including on valid endpoints.

**Root cause:** `httpApi.ts:716` and `preload/index.ts:278` send `rpc(channel, baseURL, apiKey)` **positionally**, and `dispatch()` spreads args into the handler — but `rpc.mjs`'s handler was `(input) => discoverModels(input?.baseURL …)`, reading `.baseURL` off the baseURL *string* → `undefined` → discovery always fetched `"" + "/models"` → `TypeError: Failed to parse URL` → "unreachable" (confirmed in the bui-server journal).

**Also wired:** the documented Refresh contract ("apiKey '' ⇒ server re-reads the stored key — Refresh never re-sends the secret") was unimplemented — `findStoredApiKey` existed but had zero production callers. New `discoverModelsForEndpoint` recovers the stored key from opencode.jsonc when the renderer sends an empty key; explicit keys pass through; unreadable config degrades to keyless discovery.

**Tests:** rpc-level positional-dispatch regression (mocked fetch asserts `<baseURL>/models` + `Bearer <key>`); providers-level stored-key / explicit-key / degraded / empty-baseURL cases.

**Gates:** typecheck ✅ · vitest 863 ✅ · node:test 461 ✅