### PR TITLE
Fix BET-120: new chat sessions resolve to project defaultCwd instead of ~

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -183,7 +183,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     if (creating) return;
     const name = newProjectName.trim();
     if (!name) return;
-    const cwd = newProjectCwd.trim() || "~";
+    const cwd = newProjectCwd.trim() || "";
 
     if (mode === "auto") {
       setCreating(true);

--- a/src/renderer/mobile/MobileCreateSheet.tsx
+++ b/src/renderer/mobile/MobileCreateSheet.tsx
@@ -159,7 +159,7 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
     if (mode.kind !== "new-project" || creating) return;
     const projectName = name.trim();
     if (!projectName) return;
-    const path = cwd.trim() || "~";
+    const path = cwd.trim() || "";
 
     setError(null);
 

--- a/src/renderer/mobile/SessionScreen.tsx
+++ b/src/renderer/mobile/SessionScreen.tsx
@@ -44,7 +44,7 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
         sessionId: sid,
         sessionName: owner?.tmuxSession ?? projectName,
         windowName,
-        cwd: owner?.cwd || "~",
+        cwd: owner?.cwd ?? "",
       })
       .catch(() => {});
     setSheetOpen(false);


### PR DESCRIPTION
## Issue
BET-120: New chat-mode sessions open with cwd ~ (/home/dev) instead of the project's defaultCwd

## Root Cause
Three renderer locations passed the literal string `"~"` when the cwd input was empty, using `cwd || "~"` instead of `cwd || ""` or `cwd ?? ""`. The server's `resolveProjectCwd` correctly handles empty strings and tildes by falling back to the project's `defaultCwd`, but opencode silently corrupts tilde-prefixed paths by resolving them against its own process cwd.

## Changes
1. **MobileCreateSheet.tsx:162** - Changed `cwd.trim() || "~"` to `cwd.trim() || ""`
2. **SessionScreen.tsx:47** - Changed `owner?.cwd || "~"` to `owner?.cwd ?? ""`
3. **Sidebar.tsx:186** - Changed `newProjectCwd.trim() || "~"` to `newProjectCwd.trim() || ""`

## Verification
- All server tests pass (405/405)
- Pattern matches correct implementation in ChatPanel.tsx (lines 622, 937)
- Renderer now correctly passes empty strings to let server-side `resolveProjectCwd` resolve to project's `defaultCwd`

Closes BET-120