### PR TITLE
fix(events): /events stream silently dies — liveness watchdog + resync + readiness gate (BET-115)

### DIFF
--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -16,6 +16,7 @@ import {
 import { WsReconnectController, type WsLike } from "../net/wsTransport.js";
 import { getBuiPreload } from "../preloadAccess.js";
 import { useStore } from "../store.js";
+import { shouldForceReconnect } from "../chatUtils";
 
 // ---------------------------------------------------------------------------
 // Server base URL resolution (3 deployment contexts):
@@ -275,25 +276,28 @@ let _controller: WsReconnectController | null = null;
 let _resyncing = false;
 
 /**
- * Fire two synthetic, side-effect-free OpencodeEvents so that every active
- * ChatPanel refetches messages, permissions, AND questions after the SSE
- * stream reconnects.
+ * Fire a single synthetic, side-effect-free "server.connected" OpencodeEvent
+ * so that every active ChatPanel does a full resync after the events
+ * WebSocket reconnects (missed a `session.idle`, a permission reply, a new
+ * question, etc. while the socket was down/half-open).
  *
- * Synthetic event 1 — "permission.replied"
- *   ChatPanel handler (lines ~736-741): calls refreshPermissions() (→
- *   opencodePermissions re-fetch) AND scheduleRefetch() (→ opencodeMessages
- *   re-fetch, debounced 300 ms).  No state mutations; purely triggers fetches.
- *
- * Synthetic event 2 — "question.asked"
- *   ChatPanel handler (lines ~745-753): calls refreshQuestions() (→
- *   opencodeQuestions re-fetch).  No state mutations; purely triggers a fetch.
- *
- * Both events have no sessionID in properties so they pass the early
+ * `useSseBus.ts`'s `ev.type === "server.connected"` branch already does
+ * exactly this: `scheduleRefetch()` (→ opencodeMessages re-fetch, debounced)
+ * + `refreshPermissions()` + `refreshQuestions()`, and re-derives `running`
+ * from the refetched transcript. It carries no `sessionID`, so it passes the
  * `if (props.sessionID && props.sessionID !== sessionId) return` guard in
- * every mounted ChatPanel, causing each panel to refetch for its own session.
+ * every mounted ChatPanel — each panel resyncs its own session. An inactive
+ * (unmounted-transcript) panel defers its refetch via the owed-flag path in
+ * useTranscriptState and catches up on reactivation.
  *
- * Neither event type mutates transcript state (no delta/part/id fields are
- * processed for these types) — they only schedule fetch calls.
+ * PRIOR BUG (regression, fixed here): this used to dispatch two DIFFERENT
+ * synthetic events — "permission.replied" and "question.asked" — whose
+ * handlers had since changed underneath it (permission.replied dropped its
+ * scheduleRefetch call; question.asked with empty properties has no `id` and
+ * is a no-op in applyQuestionEvent). Net effect: resync silently did nothing,
+ * so a dropped `session.idle` left `running` stuck true forever and the UI
+ * looked frozen until Cmd+R. Reuse the existing server.connected branch
+ * instead of growing new handler code in useSseBus.
  */
 function fireResync() {
   if (_resyncing) return;
@@ -303,12 +307,8 @@ function fireResync() {
     _resyncing = false;
     const set = listeners.opencode;
     if (set.size === 0) return; // no listeners yet — nothing to do
-    // Synthetic event 1: triggers refreshPermissions() + scheduleRefetch()
-    const ev1: OpencodeEvent = { type: "permission.replied", properties: {} };
-    for (const fn of set) { try { fn(ev1); } catch { /* listener error — ignore, see onmessage */ } }
-    // Synthetic event 2: triggers refreshQuestions()
-    const ev2: OpencodeEvent = { type: "question.asked", properties: {} };
-    for (const fn of set) { try { fn(ev2); } catch { /* listener error — ignore */ } }
+    const ev: OpencodeEvent = { type: "server.connected", properties: {} };
+    for (const fn of set) { try { fn(ev); } catch { /* listener error — ignore, see onmessage */ } }
   }, 0);
 }
 
@@ -325,16 +325,37 @@ function wsUrl(): string {
   return withTokenParam(base, clientToken());
 }
 
+// Liveness watchdog (BET-115 fix A). A half-open WebSocket keeps reporting
+// `readyState === OPEN` even when the underlying path died silently (tunnel
+// restart, sleep/wake, NAT timeout) — the browser never fires
+// onclose/onerror because nothing told it to, so the reconnect controller
+// never retries and the app looks frozen until the user hits Cmd+R.
+//
+// The server sends an app-level `{kind:"heartbeat"}` frame every 15s
+// (src/server/events.mjs, alongside its invisible-to-JS protocol ping).
+// `lastFrameAt` is stamped on EVERY frame we receive — heartbeat or real —
+// so it tracks actual liveness of the path, not just the socket object.
+let lastFrameAt = Date.now();
+
+// 45s = 3 missed 15s heartbeats. Long enough to absorb one dropped frame /
+// GC pause without false-positiving; short enough that a genuinely dead path
+// recovers well within the time a user notices "nothing's happening".
+const HEARTBEAT_STALE_MS = 45_000;
+const WATCHDOG_INTERVAL_MS = 15_000;
+
 // Dispatch one parsed {kind,payload} frame to its listeners. The frame is
 // byte-identical to the old SSE envelope, so this is unchanged from before the
-// controller refactor. Non-JSON / control frames are ignored.
+// controller refactor. Non-JSON / control frames are ignored (but still count
+// as liveness — see lastFrameAt above).
 function dispatchFrame(data: unknown) {
+  lastFrameAt = Date.now();
   try {
     const { kind, payload } = JSON.parse(data as string) as {
-      kind: Kind;
+      kind: Kind | "heartbeat";
       payload: unknown;
     };
-    const set = listeners[kind];
+    if (kind === "heartbeat") return; // liveness ping only — no listener, no demux
+    const set = listeners[kind as Kind];
     if (set) for (const fn of set) fn(payload);
   } catch {
     // non-JSON / control frame — ignore
@@ -361,7 +382,14 @@ function getController(): WsReconnectController {
     create: (url) => new WebSocket(url) as unknown as WsLike,
     onMessage: dispatchFrame,
     onReconnect: fireResync,
-    onState: (s) => useStore.getState().setConnectionState(s),
+    onState: (s) => {
+      useStore.getState().setConnectionState(s);
+      // Fresh connect (initial or reconnect, including a forced one): reset
+      // the liveness clock so the watchdog doesn't immediately re-fire while
+      // the new socket is still warming up (its first heartbeat is up to 15s
+      // away).
+      if (s.state === "connected") lastFrameAt = Date.now();
+    },
     onConfigError: (e) =>
       console.warn(
         "[bui] events WebSocket not opened:",
@@ -369,6 +397,23 @@ function getController(): WsReconnectController {
       ),
   });
   return _controller;
+}
+
+// Watchdog loop: every 15s, ask the pure decision helper (chatUtils.ts) if
+// the controller-reported "connected" state is stale relative to the last
+// frame actually seen. If so, the socket is half-open — force it closed and
+// reopen immediately (forceReconnect resets lastFrameAt on the new connect
+// via the onState hook above, so this can't immediately re-fire).
+let _watchdogInstalled = false;
+function installLivenessWatchdog() {
+  if (_watchdogInstalled) return;
+  _watchdogInstalled = true;
+  setInterval(() => {
+    const state = getController().getState().state;
+    if (shouldForceReconnect(state, lastFrameAt, Date.now(), HEARTBEAT_STALE_MS)) {
+      getController().forceReconnect();
+    }
+  }, WATCHDOG_INTERVAL_MS);
 }
 
 // iOS suspends an installed standalone PWA when backgrounded / screen-locked.
@@ -392,6 +437,7 @@ function installResumeWatchdog() {
 function ensureStream() {
   getController().ensure();
   installResumeWatchdog();
+  installLivenessWatchdog();
 }
 
 // The preload's `onX` methods return `() => Electron.IpcRenderer` because

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -57,6 +57,7 @@ import {
   describeNextRun,
   resolveToolOutput,
   reconcileOptimisticUser,
+  shouldForceReconnect,
 } from "./chatUtils";
 
 // ===== formatTokens =====
@@ -2676,5 +2677,42 @@ describe("reconcileOptimisticUser", () => {
     const incoming: Msg = assistantMsg("msg_real");
     // Assistant incoming → never reconciles, even if optimistic is present.
     expect(reconcileOptimisticUser(prev, incoming)).toBe(prev);
+  });
+});
+
+// ===== shouldForceReconnect =====
+
+describe("shouldForceReconnect", () => {
+  const THRESHOLD = 45_000;
+
+  it("returns true when connected and stale beyond the threshold", () => {
+    const lastFrameAt = 0;
+    const now = THRESHOLD + 1;
+    expect(shouldForceReconnect("connected", lastFrameAt, now, THRESHOLD)).toBe(true);
+  });
+
+  it("returns false when connected and fresh (within the threshold)", () => {
+    const lastFrameAt = 1000;
+    const now = 1000 + THRESHOLD - 1;
+    expect(shouldForceReconnect("connected", lastFrameAt, now, THRESHOLD)).toBe(false);
+  });
+
+  it("returns false exactly at the threshold boundary (strictly greater-than)", () => {
+    const lastFrameAt = 0;
+    expect(shouldForceReconnect("connected", lastFrameAt, THRESHOLD, THRESHOLD)).toBe(false);
+  });
+
+  it("returns false when not connected, no matter how stale", () => {
+    const now = 1_000_000;
+    expect(shouldForceReconnect("connecting", 0, now, THRESHOLD)).toBe(false);
+    expect(shouldForceReconnect("reconnecting", 0, now, THRESHOLD)).toBe(false);
+    expect(shouldForceReconnect("stalled", 0, now, THRESHOLD)).toBe(false);
+    expect(shouldForceReconnect("closed", 0, now, THRESHOLD)).toBe(false);
+    expect(shouldForceReconnect("idle", 0, now, THRESHOLD)).toBe(false);
+  });
+
+  it("respects a custom threshold", () => {
+    expect(shouldForceReconnect("connected", 0, 100, 50)).toBe(true);
+    expect(shouldForceReconnect("connected", 0, 40, 50)).toBe(false);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1,5 +1,10 @@
 // Pure utility functions extracted from ChatPanel for testability.
 
+// Type-only import — erased at compile time, keeps this module dependency-
+// free at runtime (the whole point of chatUtils.ts: pure functions testable
+// without DOM/Electron/network).
+import type { ConnectionStateName } from "../shared/net/state.js";
+
 // Fallback context size used when the active model has no `limit.context`
 // (or no active model is known yet). 200k is the lowest common denominator
 // across Claude Sonnet 4.5 and older — generous enough that the bar
@@ -1894,4 +1899,36 @@ export function resolveToolOutput(state: {
   const meta = state.metadata;
   const live = meta && typeof meta.output === "string" ? meta.output : "";
   return live;
+}
+
+// ---------------------------------------------------------------------------
+// Client liveness watchdog (BET-115 fix A)
+//
+// A half-open WebSocket is undetectable from `readyState` alone — it stays
+// "OPEN" even when the underlying path is dead (tunnel restart, sleep/wake,
+// NAT timeout), so the browser never fires onclose/onerror and the shared
+// reconnect controller never retries. The server sends an app-level
+// `{kind:"heartbeat"}` frame every 15s (src/server/events.mjs); the renderer
+// stamps `lastFrameAt` on every frame it receives (heartbeat or real) and a
+// watchdog interval calls this pure decision function to decide whether the
+// connection is stale enough to force a reconnect even though the socket
+// still LOOKS open.
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether the events WebSocket should be force-reconnected.
+ *
+ * Only fires when the controller believes it's `connected` — a socket that's
+ * already `connecting`/`reconnecting`/`closed` is already on the recovery
+ * path and doesn't need the watchdog to intervene. `thresholdMs` is the
+ * caller's staleness bound (BET-115 spec: 45s = 3 missed 15s heartbeats).
+ */
+export function shouldForceReconnect(
+  state: ConnectionStateName,
+  lastFrameAt: number,
+  now: number,
+  thresholdMs: number,
+): boolean {
+  if (state !== "connected") return false;
+  return now - lastFrameAt > thresholdMs;
 }

--- a/src/renderer/net/wsTransport.ts
+++ b/src/renderer/net/wsTransport.ts
@@ -156,6 +156,27 @@ export class WsReconnectController {
     this.ensure();
   }
 
+  /**
+   * Unconditionally tear down the current socket and open a fresh one RIGHT
+   * NOW, even if `readyState === OPEN`. Used by the liveness watchdog
+   * (httpApi.ts): a half-open socket keeps reporting OPEN even when the
+   * underlying path died silently (tunnel restart, sleep/wake, NAT timeout),
+   * so `ensure()` (which no-ops on an already-open socket) can never recover
+   * it — only an unconditional close does.
+   *
+   * This is a deliberate restart, not a failure retry: the backoff is reset
+   * first so the reconnect is immediate (no exponential delay), and the drop
+   * is marked so the next successful open still fires `onReconnect` (the
+   * resync path), exactly like any other reconnect. `open()` itself closes
+   * whatever socket currently exists (open/connecting/dead) before creating
+   * the new one, so there's no separate close step needed here.
+   */
+  forceReconnect(): void {
+    this.hadDrop = true;
+    this.backoff.reset();
+    this.open();
+  }
+
   /** Tear down permanently (app teardown). Cancels timers, closes the socket. */
   close(reason = "close"): void {
     this.epoch += 1;

--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -48,9 +48,16 @@ export function attachEventsWs(bus, ws) {
     }
   });
   // Heartbeat: keeps intermediaries (Cloudflare tunnel) from idling the
-  // socket and lets the client notice a half-open connection.
+  // socket and lets the client notice a half-open connection. The WS
+  // protocol ping() alone isn't enough — it's answered by the network stack
+  // transparently to JS, so the browser never learns whether frames are
+  // actually still arriving. Also send an app-level frame the client CAN
+  // see; the renderer's liveness watchdog (httpApi.ts) stamps a
+  // last-frame-received timestamp on every frame, including this one, and
+  // force-reconnects if too many heartbeats are missed.
   const ka = setInterval(() => {
     try { ws.ping?.(); } catch { /* closing */ }
+    try { ws.send(JSON.stringify({ kind: "heartbeat", ts: Date.now() })); } catch { /* closing */ }
   }, 15000);
   ka.unref();
   const cleanup = () => { clearInterval(ka); off(); };

--- a/src/server/events.test.mjs
+++ b/src/server/events.test.mjs
@@ -1,6 +1,7 @@
-import { test } from "node:test";
+import { test, mock } from "node:test";
 import assert from "node:assert/strict";
-import { createBus } from "./events.mjs";
+import { EventEmitter } from "node:events";
+import { createBus, attachEventsWs } from "./events.mjs";
 
 test("bus delivers published events to subscribers and stops after unsubscribe", () => {
   const bus = createBus();
@@ -12,4 +13,65 @@ test("bus delivers published events to subscribers and stops after unsubscribe",
   off();
   bus.publish({ kind: "opencode", payload: { type: "y" } });
   assert.equal(got.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// attachEventsWs heartbeat (BET-115 fix A, server side)
+//
+// The WS protocol ping() alone is invisible to browser JS — it's answered by
+// the network stack, not the page. attachEventsWs must ALSO send an
+// app-level `{kind:"heartbeat"}` text frame on its 15s interval so the
+// renderer's liveness watchdog can see frames are still arriving.
+// ---------------------------------------------------------------------------
+
+/** Minimal fake ws satisfying the members attachEventsWs touches:
+ *  readyState, ping(), send(), on("close"/"error"). */
+function fakeWs() {
+  const emitter = new EventEmitter();
+  return {
+    readyState: 1, // OPEN
+    sent: [],
+    pinged: 0,
+    ping() { this.pinged += 1; },
+    send(data) { this.sent.push(data); },
+    on(event, fn) { emitter.on(event, fn); },
+    _emit(event, ...args) { emitter.emit(event, ...args); },
+  };
+}
+
+test("attachEventsWs sends a {kind:heartbeat} frame on the 15s ping interval", () => {
+  mock.timers.enable({ apis: ["setInterval"] });
+  try {
+    const bus = createBus();
+    const ws = fakeWs();
+    attachEventsWs(bus, ws);
+
+    assert.equal(ws.sent.length, 0, "no heartbeat before the interval fires");
+
+    mock.timers.tick(15000);
+    assert.equal(ws.sent.length, 1);
+    const frame = JSON.parse(ws.sent[0]);
+    assert.equal(frame.kind, "heartbeat");
+    assert.equal(typeof frame.ts, "number");
+    assert.equal(ws.pinged, 1, "protocol ping still fires alongside the app frame");
+
+    mock.timers.tick(15000);
+    assert.equal(ws.sent.length, 2);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("attachEventsWs stops sending heartbeats after the socket closes", () => {
+  mock.timers.enable({ apis: ["setInterval"] });
+  try {
+    const bus = createBus();
+    const ws = fakeWs();
+    attachEventsWs(bus, ws);
+    ws._emit("close");
+    mock.timers.tick(30000);
+    assert.equal(ws.sent.length, 0, "interval was cleared on close");
+  } finally {
+    mock.timers.reset();
+  }
 });

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -207,6 +207,72 @@ function cacheSessionDirectoryQuiet(sessionId, directory) {
 // in-use session's events arrive even though the bootstrap didn't pre-open it.
 let ensureStreamForDirectory = null;
 
+// ---------------------------------------------------------------------------
+// Scoped-stream readiness gate (BET-115 fix C)
+//
+// opencode's `/event?directory=` is a fresh subscription every time it opens
+// (fresh session/reconnect), and events emitted BEFORE the subscription
+// registers upstream are lost forever — no replay. `sendPrompt` (and the
+// other session-mutating calls) POST through `getSessionDirectoryQuery`,
+// which fire-and-forgets `ensureStreamForDirectory(dir)`. On a brand-new
+// session that races: the POST can land before the scoped stream is actually
+// listening, so the first turn's events vanish and the UI looks frozen.
+//
+// `streamReadyState` tracks, per directory key ("" = global), a promise that
+// resolves the first time `openEventStream`'s upstream fetch comes back OK
+// (see `onConnect` below). `getSessionDirectoryQuery` awaits it with a 5s
+// bound before returning — long enough for a normal connect, short enough
+// that a wedged opencode degrades to "send anyway" rather than hanging the
+// prompt forever.
+// ---------------------------------------------------------------------------
+const streamReadyState = new Map(); // key -> { promise, resolve }
+
+// Test-only: shrink the 5s readiness bound so tests don't have to sleep for
+// real. Reset to null (→ default 5000) between tests.
+let readinessTimeoutMsOverride = null;
+export function _setReadinessTimeoutMs(ms) {
+  readinessTimeoutMsOverride = ms;
+}
+
+function makePendingReadyEntry() {
+  let resolve;
+  const promise = new Promise((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+function getOrCreateStreamReady(key) {
+  let entry = streamReadyState.get(key);
+  if (!entry) {
+    entry = makePendingReadyEntry();
+    streamReadyState.set(key, entry);
+  }
+  return entry;
+}
+
+/** Called by openEventStream's onConnect: the scoped subscription is live. */
+function markStreamConnected(key) {
+  getOrCreateStreamReady(key).resolve();
+}
+
+/**
+ * Called by openEventStream's onDisconnect: the scoped subscription dropped.
+ * Re-arm with a FRESH pending promise so a prompt sent during the reconnect
+ * window waits for the NEW subscription rather than resolving instantly off
+ * the stale (already-resolved) promise. Callers that already captured the old
+ * promise reference are still bounded by the 5s race in
+ * getSessionDirectoryQuery, so this can't hang a caller indefinitely.
+ */
+function markStreamDisconnected(key) {
+  streamReadyState.set(key, makePendingReadyEntry());
+}
+
+/** Test-only: clear readiness state between scenarios. */
+export function _resetStreamReadyState() {
+  streamReadyState.clear();
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 async function fetchSessionDirectory(sessionId) {
   try {
     const res = await ocFetch(apiUrl(`/session/${encodeURIComponent(sessionId)}`));
@@ -236,8 +302,15 @@ async function getSessionDirectoryQuery(sessionId) {
   // doesn't open a stream). opencode emits this prompt's events only on the
   // scoped channel; without the stream they're lost and the session looks
   // frozen. Idempotent (openFor no-ops if already open).
+  //
+  // Readiness gate: wait (bounded) for the scoped stream's FIRST successful
+  // connect before returning, so a session-mutating call (sendPrompt et al.)
+  // can't race ahead of its own event subscription and lose the reply. Bound
+  // is deliberately short — a wedged opencode must never hang the prompt.
   if (dir && ensureStreamForDirectory) {
     try { ensureStreamForDirectory(dir); } catch { /* non-fatal */ }
+    const ready = getOrCreateStreamReady(dir).promise;
+    await Promise.race([ready, sleep(readinessTimeoutMsOverride ?? 5000)]);
   }
   return dir ? `?directory=${encodeURIComponent(dir)}` : "";
 }
@@ -875,11 +948,33 @@ export async function runCommand({ sessionId, command, arguments: argumentsStr, 
 // SSE event subscription
 // ---------------------------------------------------------------------------
 
+// Transport used by the long-lived SSE stream in openEventStream. Production
+// = the real global `fetch` (undici) — deliberately NOT the pooled ocFetch
+// transport (a keep-alive pool socket would be pinned forever by a streaming
+// body; see the ocAgent comment above). Tests can override this to simulate
+// a controllable SSE response (including WHEN it "connects") without a live
+// opencode server.
+let eventStreamTransport = null;
+/** Test-only: override the transport openEventStream dispatches through.
+ *  Pass null to restore the default (global fetch). */
+export function _setEventStreamTransport(fn) {
+  eventStreamTransport = fn;
+}
+function eventFetch(url, init) {
+  return (eventStreamTransport ?? fetch)(url, init);
+}
+
 // One long-lived SSE connection to opencode's /event endpoint, optionally
 // scoped to a project `?directory=`. Auto-reconnects on drop with 1.5 s
 // delay; returns stop() that flips stopped=true AND aborts the in-flight
 // fetch so reader.read() unblocks immediately.
-function openEventStream(onEvent, directory) {
+//
+// `hooks.onConnect` fires each time the upstream fetch comes back OK, before
+// the parse loop starts — this is what resolves the readiness gate above.
+// `hooks.onDisconnect` fires whenever a (non-teardown) connection ends, so
+// the readiness gate can re-arm for the next connect.
+function openEventStream(onEvent, directory, hooks = {}) {
+  const { onConnect, onDisconnect } = hooks;
   let stopped = false;
   let currentController = null;
   const path = directory
@@ -891,13 +986,14 @@ function openEventStream(onEvent, directory) {
       const controller = new AbortController();
       currentController = controller;
       try {
-        const res = await fetch(apiUrl(path), {
+        const res = await eventFetch(apiUrl(path), {
           signal: controller.signal,
           headers: { accept: "text/event-stream" },
         });
         if (!res.ok || !res.body) {
           throw new Error(`opencode SSE ${res.status}: ${res.statusText}`);
         }
+        onConnect?.();
         const reader = res.body.getReader();
         const dec = new TextDecoder();
         let buf = "";
@@ -933,7 +1029,15 @@ function openEventStream(onEvent, directory) {
       } catch {
         /* reconnect on error or AbortError from stop() */
       }
-      if (!stopped) await new Promise((r) => setTimeout(r, 1500));
+      // The connection just ended (cleanly or via error) and we're about to
+      // retry — a real drop, not an intentional stop(). Re-arm the readiness
+      // gate so a prompt sent during this reconnect window waits for the NEXT
+      // successful connect instead of resolving off a stale "was connected"
+      // promise.
+      if (!stopped) {
+        onDisconnect?.();
+        await sleep(1500);
+      }
     }
   })();
 
@@ -962,7 +1066,13 @@ export function subscribeEvents(onEvent) {
 
   const openFor = (key, dir) => {
     if (streams.has(key)) return;
-    streams.set(key, openEventStream(onEvent, dir));
+    streams.set(
+      key,
+      openEventStream(onEvent, dir, {
+        onConnect: () => markStreamConnected(key),
+        onDisconnect: () => markStreamDisconnected(key),
+      }),
+    );
   };
 
   // Global stream catches non-scoped events (server.heartbeat, vcs.branch.updated,

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -12,9 +12,13 @@ import {
   listPermissions,
   listQuestions,
   replyPermission,
+  subscribeEvents,
   _resetSessionDirectoryCache,
   _onSessionDirectoryAdded,
   _setOcTransport,
+  _setEventStreamTransport,
+  _setReadinessTimeoutMs,
+  _resetStreamReadyState,
   _getOcAgent,
   _pooledOcRequest,
   discardBody,
@@ -675,6 +679,111 @@ test("discardBody swallows errors on an already-consumed body", async () => {
   await res.text(); // consume it
   await discardBody(res); // cancelling a used body would throw — must be swallowed
   assert.ok(true);
+});
+
+// ---------------------------------------------------------------------------
+// Scoped-stream readiness gate (BET-115 fix C)
+//
+// sendPrompt (via getSessionDirectoryQuery) must not POST to opencode before
+// the scoped `/event?directory=` subscription it depends on has actually
+// connected upstream — otherwise events emitted in response to the prompt
+// land on a subscription that isn't listening yet and are lost forever.
+// ---------------------------------------------------------------------------
+
+/** A ReadableStream that never emits or closes — models an SSE body that's
+ *  "connected" but has delivered no frames yet. */
+function openStreamBody() {
+  return new ReadableStream({ start() {} });
+}
+
+test("readiness gate: sendPrompt does not POST before the scoped stream connects", async () => {
+  _resetSessionDirectoryCache();
+  _resetStreamReadyState();
+  let releaseConnect;
+  const connectGate = new Promise((r) => { releaseConnect = r; });
+  _setEventStreamTransport(async (url) => {
+    if (String(url).includes("directory=")) {
+      await connectGate; // hold the scoped stream "connecting" until released
+    }
+    return new Response(openStreamBody(), { status: 200 });
+  });
+
+  const calls = [];
+  const stop = subscribeEvents(() => {});
+  try {
+    await withMockFetch(
+      async (url, opts) => {
+        calls.push({ url: String(url), method: opts?.method ?? "GET" });
+        if (String(url).endsWith("/session/ses_gate")) {
+          return new Response(JSON.stringify({ directory: "/work/gate" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(null, { status: 204 });
+      },
+      async () => {
+        const promptDone = sendPrompt({ sessionId: "ses_gate", text: "hi" }).then(
+          () => { calls.push({ marker: "prompt-resolved" }); },
+        );
+        // Let microtasks/timers run without advancing past the gate — the
+        // scoped stream hasn't connected, so the POST must not have fired.
+        await new Promise((r) => setTimeout(r, 30));
+        assert.ok(
+          !calls.some((c) => c.url?.includes("prompt_async")),
+          "sendPrompt POSTed before the scoped stream connected",
+        );
+        releaseConnect();
+        await promptDone;
+        assert.ok(
+          calls.some((c) => c.url?.includes("prompt_async")),
+          "sendPrompt never POSTed after the scoped stream connected",
+        );
+      },
+    );
+  } finally {
+    stop();
+    _setEventStreamTransport(null);
+    _resetStreamReadyState();
+  }
+});
+
+test("readiness gate: degrades to sending after the bound elapses (wedged stream)", async () => {
+  _resetSessionDirectoryCache();
+  _resetStreamReadyState();
+  _setReadinessTimeoutMs(30); // don't make the test sleep 5s for real
+  // The scoped stream never connects (transport hangs forever) — the gate
+  // must still let the prompt through once the bound elapses.
+  _setEventStreamTransport(() => new Promise(() => {}));
+
+  const calls = [];
+  const stop = subscribeEvents(() => {});
+  try {
+    await withMockFetch(
+      async (url, opts) => {
+        calls.push({ url: String(url), method: opts?.method ?? "GET" });
+        if (String(url).endsWith("/session/ses_wedge")) {
+          return new Response(JSON.stringify({ directory: "/work/wedge" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(null, { status: 204 });
+      },
+      async () => {
+        await sendPrompt({ sessionId: "ses_wedge", text: "hi" });
+      },
+    );
+  } finally {
+    stop();
+    _setEventStreamTransport(null);
+    _setReadinessTimeoutMs(null);
+    _resetStreamReadyState();
+  }
+  assert.ok(
+    calls.some((c) => c.url?.includes("prompt_async")),
+    "sendPrompt never degraded to sending once the readiness bound elapsed",
+  );
 });
 
 test("pooled ocFetch reuses one socket across sequential calls", async () => {


### PR DESCRIPTION
## Summary

Fixes BET-115: the `/events` WebSocket can silently die (half-open connection) leaving the UI frozen until Cmd+R. Three independent gaps, each with a targeted fix:

**A. Client liveness watchdog** — a half-open WebSocket keeps `readyState === OPEN` forever with no browser-visible signal that the path died (tunnel restart, sleep/wake, NAT timeout). The server's existing 15s ping interval now ALSO sends an app-level `{kind:"heartbeat"}` text frame (`src/server/events.mjs`). The renderer stamps `lastFrameAt` on every frame received (`dispatchFrame` in `httpApi.ts`); a new 15s watchdog interval calls a pure decision helper (`chatUtils.shouldForceReconnect`) and, if `connected` but stale beyond 45s (3 missed heartbeats), calls a new `WsReconnectController.forceReconnect()` (`wsTransport.ts`) that unconditionally tears down the socket and reopens immediately (backoff reset — deliberate restart, not a failure retry).

**B. Fixed `fireResync`** — it used to dispatch two synthetic events (`permission.replied`, `question.asked`) whose handlers had drifted underneath it (regression): `permission.replied` lost its `scheduleRefetch()` call, and `question.asked` with empty properties is a no-op in `applyQuestionEvent` (no `id`). Net effect: reconnect resync silently did nothing, so a dropped `session.idle` left `running` stuck `true` forever. Replaced with a single synthetic `server.connected` dispatch — `useSseBus.ts` already treats that as a full resync (refetch transcript + permissions + questions). No new handler code added to `useSseBus`.

**C. Restored the scoped-stream readiness gate (server)** — `openEventStream` now takes optional `onConnect`/`onDisconnect` hooks; a per-directory `Map<dir, Promise<void>>` in `opencode.mjs` tracks each scoped stream's "first successful connect." `getSessionDirectoryQuery` (used by `sendPrompt` and every other session-mutating call) now awaits that promise, bounded to 5s (`Promise.race` with a timeout — a wedged opencode degrades to "send anyway," never blocks the prompt). Re-arms on disconnect so prompts sent during a reconnect window also wait for the new subscription. This closes the "or when starting a new session" race: previously the POST could beat the scoped `/event?directory=` subscription's registration, losing the very events the prompt was expected to produce.

## Tests (new)
- `src/server/events.test.mjs` — `attachEventsWs` sends `{kind:"heartbeat"}` on the ping interval (mock timers); stops after `close`.
- `src/server/opencode.test.mjs` — readiness gate: `sendPrompt` does not POST before the scoped stream's `onConnect` fires (injectable event-stream transport); degrades to sending once the (test-shrunk) bound elapses on a wedged stream.
- `src/renderer/chatUtils.test.ts` — `shouldForceReconnect` pure decision helper: connected+stale → true, connecting/reconnecting/stalled/closed/idle → false regardless of staleness, custom threshold, boundary (`>` not `>=`).

## Verification results
- PR branch (`multica/BET-115-events-liveness` @ `c883420`):
  - typecheck: exit 0. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit 0, 883 vitest + 480 node:test subtests pass, 0 fail, 0 skip. log sha256: `08ec9f8408236d2c557d64f637fa3e61ba384ebd02a1024a4947448e64bf9aba`
- Base (`origin/main` @ `c4e4d13`):
  - typecheck: exit 0. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e` (identical — no baseline errors)
  - test: exit 0, 878 vitest + 476 node:test subtests pass, 0 fail, 0 skip. log sha256: `80fca882e35ad5989b689c39948d96a2efe7d614b94a7511eab984898d655396`
- **Conclusion:** 0 pre-existing failures, 0 new failures. The PR branch adds exactly 5 vitest tests (`shouldForceReconnect`) and 4 node:test subtests (2 `opencode.test.mjs` + 2 `events.test.mjs`), all passing.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

`Base: origin/main @ c4e4d13`

## Scope notes
- No new dependencies.
- Did not touch `src/main/opencode.ts` (stale desktop opencode bus — explicitly out of scope per the issue).
- Base branch is `main` (the repo's actual default branch — the `bui-pr-workflow` skill's "master" references are stale; confirmed via `gh pr list` on recent merged PRs and `git remote show origin`).

🤖 Generated with OpenCode