### PR TITLE
fix(renderer): restore tool-boundary trigger for queued-message drain (BET-131)

### DIFF
--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -7,12 +7,16 @@
 // mount ChatPanel and emit events through the mock bus.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
 import { ChatPanel } from "../ChatPanel";
 import {
   installMockApi,
   resetStore,
   mount,
   emitAndFlush,
+  type MockApi,
+  type MockEventBus,
+  type Harness,
 } from "../testHarness";
 
 const PROPS = {
@@ -366,5 +370,146 @@ describe("useSseBus via ChatPanel", () => {
 
     // Component should still be mounted (event was dropped).
     expect(h.container.querySelector("textarea")).not.toBeNull();
+  });
+});
+
+// ===== Queued-message drain at the next tool boundary (BET-131 regression) =====
+//
+// The deployed opencode build never emits `session.next.step.*`, so the
+// drain trigger on that event is dead in production. The real, primary
+// trigger is a `message.part.updated` event whose part is a tool that just
+// completed/errored (`isToolStepBoundary`). This regression was introduced
+// when the SSE handler moved from ChatPanel.tsx into useSseBus.ts (BET-64)
+// and the tool-boundary call site was dropped. Verify it fires the abort
+// immediately at the next tool completion instead of waiting for full idle.
+describe("useSseBus queued-message drain on tool step boundary", () => {
+  let api: MockApi;
+  let bus: MockEventBus;
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  // Same controlled-input helper as ChatPanel.harness.test.tsx.
+  function typeInto(el: HTMLTextAreaElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  async function queueASecondMessage(container: HTMLElement) {
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    await act(async () => {
+      typeInto(textarea, "second message");
+    });
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+  }
+
+  it("aborts and drains at the next completed tool part, not at full idle", async () => {
+    ({ api, bus } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    // Turn is already running.
+    await emitAndFlush(bus, h, {
+      type: "session.status",
+      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    });
+
+    // User submits a second message mid-turn — it queues instead of sending.
+    await queueASecondMessage(h.container);
+    await h.flush();
+    expect(api.calls.opencodeAbort ?? []).toEqual([]);
+
+    // A tool call completes — this is the ONLY step-boundary event the
+    // deployed opencode build actually emits. It must trigger the drain
+    // immediately, not wait for session.idle.
+    await emitAndFlush(bus, h, {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        part: { type: "tool", state: { status: "completed" } },
+      },
+    });
+
+    expect(api.calls.opencodeAbort).toEqual([["ses_test"]]);
+  });
+
+  it("does not abort on a running (non-boundary) tool part", async () => {
+    ({ api, bus } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    await emitAndFlush(bus, h, {
+      type: "session.status",
+      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    });
+    await queueASecondMessage(h.container);
+    await h.flush();
+
+    await emitAndFlush(bus, h, {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        part: { type: "tool", state: { status: "running" } },
+      },
+    });
+
+    expect(api.calls.opencodeAbort ?? []).toEqual([]);
+  });
+
+  it("does not drain the parent queue on a subagent child's tool completion", async () => {
+    ({ api, bus } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    // Register a subagent child session under the main session.
+    await emitAndFlush(bus, h, {
+      type: "session.created",
+      properties: {
+        sessionID: "ses_test",
+        info: { id: "child_boundary", parentID: "ses_test" },
+      },
+    });
+
+    await emitAndFlush(bus, h, {
+      type: "session.status",
+      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    });
+    await queueASecondMessage(h.container);
+    await h.flush();
+
+    // A tool completes inside the CHILD session — must not drain the
+    // parent's queue.
+    await emitAndFlush(bus, h, {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "child_boundary",
+        messageID: "msg_child_1",
+        part: { type: "tool", state: { status: "completed" } },
+      },
+    });
+
+    expect(api.calls.opencodeAbort ?? []).toEqual([]);
   });
 });

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -60,6 +60,7 @@ import {
   registerChildSessionFromCreated,
   isDrainAbortError,
   shouldAbortForQueuedDrain,
+  isToolStepBoundary,
   collectChildSessionIds,
   applyQuestionEvent,
   hydrateQuestion,
@@ -532,6 +533,15 @@ export function useSseBus(params: {
         const messageID = String(props.messageID ?? "");
         spliceMessage(messageID);
         flushPendingDeltas(false);
+      }
+
+      // Primary drain trigger — the real step boundary the deployed opencode
+      // build actually emits (see module doc + BET-131). Only fires for the
+      // main session: `isChildEvent` above already returned early for
+      // subagent child events, so a completed tool part reaching here always
+      // belongs to the session this hook owns.
+      if (ev.type === "message.part.updated" && isToolStepBoundary(props.part)) {
+        maybeDrainQueuedPrompt();
       }
 
       if (ev.type === "session.compacted") {


### PR DESCRIPTION
## Summary

Fixes BET-131: mid-turn queued messages were only injected at full session idle instead of the next tool-completion boundary, because the BET-64 hook extraction (`ChatPanel.tsx` → `useSseBus.ts`) dropped the primary drain trigger.

## Root cause

`src/renderer/hooks/useSseBus.ts` never imported `isToolStepBoundary` and never checked it on `message.part.updated`. The only surviving drain call site was `session.next.step.ended`, which the deployed opencode build never emits — so the drain fell through to `session.idle`, reproducing the pre-fix bug.

## Fix

- Import `isToolStepBoundary` from `../chatUtils`.
- On `message.part.updated`, if `isToolStepBoundary(props.part)` is true, call `maybeDrainQueuedPrompt()`. This runs after the `isChildEvent` early-return, so it only fires for the main session — subagent tool completions never drain the parent's queue.
- `session.next.step.ended` call site is untouched (harmless idempotent fallback, guarded by `drainAbortRef`).

No server changes — the event pipeline already forwards every `message.part.updated` tool event correctly.

## Tests added (`src/renderer/hooks/useSseBus.test.tsx`)

- Aborts and drains the queue at the next completed tool part (not at idle).
- Does NOT abort on a running (non-boundary) tool part.
- Does NOT drain the parent queue on a subagent child's tool completion (regression guard).

## Verification results

**Files changed:** 2 files — `src/renderer/hooks/useSseBus.ts`, `src/renderer/hooks/useSseBus.test.tsx`

- PR branch (`multica/BET-131-tool-boundary-drain` @ `fbcb588`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0` — vitest 911 pass / 0 fail; node:test 483 pass / 0 fail. log sha256: `0a8b91657488f28dc7a1a4a2fbc971251cb03f53ba07277a42ef74aa6e24560b`
- Base (`main` @ `dfd9571`): not re-run — PR branch is a strict superset of `main` (2 files changed, both new lines, no deletions/edits to shared logic outside the described diff), and the PR-branch run already shows 0 failures across both suites, so there are no new or fixed failures to compare.
- **Conclusion:** 0 failures on the PR branch; net-new tests (3) all pass.

## e2e-smoke (bui-e2e-smoke skill)

Built (`npm run build`) and launched the Electron app via Playwright in this ephemeral test env (no paired box config, so it renders the "Connect to your server" onboarding screen — expected for an unconfigured box, not a regression). Result: window mounts (title "Better UI"), zero console/React errors. Sidebar/main assertions are N/A in onboarding mode by design (see `App.tsx` onboarding gate).

Base: `origin/main @ dfd9571`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
