### PR TITLE
fix(renderer): route screenshot accept bytes through preload OS bridge (BET-130)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, clipboard, ipcMain, shell } from "electron";
 import { join, basename } from "node:path";
 import { watch as fsWatch } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { loadConfig, saveConfig } from "./config.js";
@@ -327,6 +328,15 @@ function registerHandlers(): void {
   ipcMain.handle(IPC.clipboardReadImage, () => {
     const buf = readClipboardImageBuffer();
     return buf ? buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) : null;
+  });
+
+  // Read an arbitrary local (Mac) file's bytes. Used for Desktop screenshot
+  // detection (screenshotDetected source:"file") — only main can touch the
+  // OS filesystem; the renderer funnels the bytes into uploadBuffer from there.
+  // `path` comes from our own fs.watch on the Desktop dir, not user input.
+  ipcMain.handle(IPC.readLocalFile, async (_e, path: string) => {
+    const buf = await readFile(path);
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
   });
 
   // Reveal a local file in Finder / the OS file manager.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -108,6 +108,8 @@ const api = {
     ipcRenderer.invoke(IPC.clipboardWriteText, text),
   clipboardReadImage: (): Promise<ArrayBuffer | null> =>
     ipcRenderer.invoke(IPC.clipboardReadImage),
+  readLocalFile: (path: string): Promise<ArrayBuffer> =>
+    ipcRenderer.invoke(IPC.readLocalFile, path),
 
   onScreenshotDetected: (
     cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -427,3 +427,125 @@ describe("ChatPanel abort rejects orphaned questions", () => {
     expect(api.calls.opencodeQuestionReject ?? []).toEqual([]);
   });
 });
+
+// ===== Screenshot "Add to chat" → uploadBuffer (BET-130) =====
+//
+// Regression coverage for the HTTP-mode bug where acceptScreenshot dead-ended
+// on window.api.clipboardReadImage / window.api.uploadFiles (both server-side
+// stubs once window.api is httpApi). The fix routes bytes through
+// window.__buiPreload (the real Electron preload, never swapped) and then
+// uploads them via window.api.uploadBuffer — the one primitive that actually
+// works in HTTP mode. These tests assert the chip reaches "ready" with a
+// remotePath, and that the preload OS bridge (not window.api) supplied bytes.
+describe("ChatPanel screenshot accept", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    (window as unknown as { __buiPreload: unknown }).__buiPreload = null;
+  });
+
+  it("clipboard source: reads bytes via preload.clipboardReadImage, uploads via window.api.uploadBuffer", async () => {
+    const fakeBuf = new ArrayBuffer(4);
+    const clipboardReadImage = () => Promise.resolve(fakeBuf);
+    const readLocalFile = () => Promise.reject(new Error("should not be called"));
+    (window as unknown as {
+      __buiPreload: { clipboardReadImage: typeof clipboardReadImage; readLocalFile: typeof readLocalFile };
+    }).__buiPreload = { clipboardReadImage, readLocalFile };
+
+    let uploadedBuffer: ArrayBuffer | null = null;
+    const { api } = installMockApi({
+      uploadBuffer: (input: { buffer: ArrayBuffer }) => {
+        uploadedBuffer = input.buffer;
+        return Promise.resolve("/remote/screenshot-123.png");
+      },
+    });
+    resetStore({
+      screenshotToast: { source: "clipboard" },
+    });
+
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const addBtn = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add to chat",
+    ) as HTMLButtonElement;
+    expect(addBtn).toBeTruthy();
+    await act(async () => {
+      addBtn.click();
+    });
+    await h.flush();
+
+    expect(uploadedBuffer).toBe(fakeBuf);
+    expect(api.calls.uploadBuffer?.[0]?.[0]).toMatchObject({
+      projectName: "proj",
+      buffer: fakeBuf,
+    });
+    // Chip landed in the "ready" state — title attr carries the remotePath.
+    const chip = h.container.querySelector('[title="/remote/screenshot-123.png"]');
+    expect(chip).toBeTruthy();
+  });
+
+  it("file source: reads bytes via preload.readLocalFile, uploads via window.api.uploadBuffer", async () => {
+    const fakeBuf = new ArrayBuffer(8);
+    let requestedPath: string | null = null;
+    const readLocalFile = (path: string) => {
+      requestedPath = path;
+      return Promise.resolve(fakeBuf);
+    };
+    (window as unknown as {
+      __buiPreload: { readLocalFile: typeof readLocalFile };
+    }).__buiPreload = { readLocalFile };
+
+    let uploadedBuffer: ArrayBuffer | null = null;
+    installMockApi({
+      uploadBuffer: (input: { buffer: ArrayBuffer }) => {
+        uploadedBuffer = input.buffer;
+        return Promise.resolve("/remote/shot.png");
+      },
+    });
+    resetStore({
+      screenshotToast: { source: "file", path: "/Users/x/Desktop/shot.png" },
+    });
+
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const addBtn = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add to chat",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      addBtn.click();
+    });
+    await h.flush();
+
+    expect(requestedPath).toBe("/Users/x/Desktop/shot.png");
+    expect(uploadedBuffer).toBe(fakeBuf);
+    const chip = h.container.querySelector('[title="/remote/shot.png"]');
+    expect(chip).toBeTruthy();
+  });
+
+  it("no preload (mobile/web): chip goes to error state instead of silently dropping", async () => {
+    (window as unknown as { __buiPreload: unknown }).__buiPreload = null;
+    installMockApi();
+    resetStore({
+      screenshotToast: { source: "clipboard" },
+    });
+
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const addBtn = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add to chat",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      addBtn.click();
+    });
+    await h.flush();
+
+    // Errored chip renders with title = errorMsg (see AttachmentStrip).
+    const chip = h.container.querySelector('[title="Screenshot capture requires the desktop app"]');
+    expect(chip).toBeTruthy();
+  });
+});

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -63,6 +63,7 @@ import { useVoice } from "./hooks/useVoice";
 import { useTypeahead } from "./hooks/useTypeahead";
 import { Transcript } from "./Transcript";
 import { Composer } from "./Composer";
+import { getBuiPreload } from "./preloadAccess";
 
 // Attachment / AgentMention / TypeaheadState / TypeaheadRow are shared with
 // the extracted composer components and live in ./chatShared.
@@ -1244,24 +1245,30 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     ]);
 
     try {
-      let remotePath: string;
+      // Only Electron main can read the Mac clipboard or a Mac file — both
+      // must come from the preload OS bridge, never window.api (which is
+      // httpApi in HTTP mode and has no OS access; the server IS the box).
+      const preload = getBuiPreload();
+      if (!preload) throw new Error("Screenshot capture requires the desktop app");
+
+      let buf: ArrayBuffer;
       if (toast.source === "file" && toast.path) {
-        // Desktop watcher: we have a local Mac path — use uploadFiles directly.
-        const results = await window.api.uploadFiles({
-          projectName: tmuxSession,
-          localPaths: [toast.path],
-        });
-        remotePath = results[0] ?? "";
+        // Desktop watcher: read the local Mac file's bytes via main.
+        buf = await preload.readLocalFile(toast.path);
       } else {
-        // Clipboard: read bytes from main then uploadBuffer.
-        const buf = await window.api.clipboardReadImage();
-        if (!buf) throw new Error("Clipboard image vanished");
-        remotePath = await window.api.uploadBuffer({
-          projectName: tmuxSession,
-          filename,
-          buffer: buf,
-        });
+        // Clipboard: read bytes from main.
+        const clip = await preload.clipboardReadImage();
+        if (!clip) throw new Error("Clipboard image vanished");
+        buf = clip;
       }
+      // Upload the bytes through the same proven path as paste/drag-drop —
+      // window.api.uploadBuffer POSTs to the server's /api/upload.
+      const remotePath = await window.api.uploadBuffer({
+        projectName: tmuxSession,
+        filename,
+        buffer: buf,
+      });
+      if (!remotePath) throw new Error("Upload failed");
       setAttachments((prev) =>
         prev.map((a) => (a.id === id ? { ...a, status: "ready", remotePath } : a)),
       );

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -481,6 +481,10 @@ function on<T>(kind: Kind, cb: (p: T) => void): () => any {
 //     degrades (the terminal still functions).
 //   • onScreenshotDetected / onDesktopNotify → subscription no-ops (these are
 //     Mac-desktop signals; the http client simply never receives them).
+//   • readLocalFile (arbitrary Mac file bytes, for screenshot "Add to chat")
+//     → rejects. The server IS the box and has no access to the Mac
+//     filesystem; callers (ChatPanel's acceptScreenshot) MUST go through
+//     window.__buiPreload.readLocalFile instead, exactly like clipboardReadImage.
 //
 // None of these throw. If a future feature MUST use the real preload in http
 // mode (e.g. OS clipboard), reach it explicitly via window.__buiPreload rather
@@ -533,6 +537,12 @@ export const httpApi: Api = {
   // -- clipboard --
   clipboardWriteText: (text) => rpc(IPC.clipboardWriteText, text),
   clipboardReadImage: () => rpc(IPC.clipboardReadImage),
+  // Never actually called — the server IS the box, it has no Mac filesystem
+  // access. Callers must use window.__buiPreload.readLocalFile (Electron
+  // main → fs.readFile) instead. Present only to satisfy the full Api type.
+  readLocalFile: async (_path: string): Promise<ArrayBuffer> => {
+    throw new Error("readLocalFile is not available over HTTP — use the preload bridge");
+  },
 
   // -- screenshot detection (SSE push) --
   onScreenshotDetected: (cb) =>

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -17,6 +17,8 @@ function makeFakePreload(): BuiPreload {
       return vi.fn();
     }),
     clipboardWriteText: vi.fn(async () => {}),
+    clipboardReadImage: vi.fn(async () => null),
+    readLocalFile: vi.fn(async () => new ArrayBuffer(0)),
     openExternal: vi.fn(async () => {}),
     revealInFolder: vi.fn(async () => {}),
     getPathForFile: vi.fn((f: File) => f.name),

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -17,6 +17,13 @@ export interface BuiPreload {
     cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
   ): () => void;
   clipboardWriteText(text: string): Promise<void>;
+  // Read the current clipboard image as PNG bytes (null if no image). Only
+  // main can touch the OS clipboard — this must go through the preload, NOT
+  // window.api (which is httpApi in HTTP mode and has no OS access).
+  clipboardReadImage(): Promise<ArrayBuffer | null>;
+  // Read an arbitrary local (Mac) file's bytes — e.g. a Desktop screenshot
+  // detected by main's fs.watch. Only main can touch the OS filesystem.
+  readLocalFile(path: string): Promise<ArrayBuffer>;
   openExternal(url: string): Promise<void>;
   revealInFolder(localPath: string): Promise<void>;
   getPathForFile(file: File): string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -225,6 +225,11 @@ export const IPC = {
   // Read the current clipboard image as PNG ArrayBuffer (null if no image).
   // Called on demand after a screenshotDetected event — not polled.
   clipboardReadImage: "clipboard:read-image",
+  // Read an arbitrary local (Mac) file's raw bytes. Only main can touch the
+  // OS filesystem — this is how the renderer gets bytes for a Desktop
+  // screenshot detection (screenshotDetected source:"file") so it can then
+  // upload them via uploadBuffer. NOT for remote/box files (see peekRemoteFile).
+  readLocalFile: "fs:read-local-file",
 
   // Drag-and-drop file upload to a per-session remote tmp dir
   uploadFiles: "upload:files",


### PR DESCRIPTION
## Bug: chat screenshots detected + "added" but never attached (HTTP-mode regression)

Fixes BET-130.

**Root cause:** `acceptScreenshot` in `ChatPanel.tsx` called `window.api.clipboardReadImage()` / `window.api.uploadFiles()`. In HTTP mode `window.api` is `httpApi` (main.tsx swaps it), whose implementations of those two methods are server-side stubs — the server IS the box and has no access to the Mac clipboard or Mac filesystem. Both screenshot-detection sources (clipboard poller, Desktop file watcher) dead-ended, so the chip never got a real `remotePath` and the prompt went out with no file part.

**Fix:** mirror the proven paste/drag-drop path — get bytes from the real Electron preload (`window.__buiPreload`, never swapped, backed by real `ipcMain.handle`s in main), then upload via `window.api.uploadBuffer` (the one upload primitive that already works over HTTP — POSTs raw bytes to `/api/upload`).

- `clipboard` source → `preload.clipboardReadImage()` (already existed in main, just wasn't being called from the renderer)
- `file` source → new `preload.readLocalFile(path)` bridge (new IPC channel, `fs.readFile` in main) since no bridge previously existed to read an arbitrary Mac file's bytes
- Both → `window.api.uploadBuffer(...)` → ready chip → same downstream FilePart path as paste/drag-drop (unchanged)
- No preload (mobile/web): degrades to an error chip instead of a silent drop

**Files:**
- `src/shared/types.ts` — new `IPC.readLocalFile` channel
- `src/main/index.ts` — `ipcMain.handle(readLocalFile)`
- `src/preload/index.ts` — expose `readLocalFile` on the bridge
- `src/renderer/preloadAccess.ts` — add `clipboardReadImage` + `readLocalFile` to `BuiPreload`
- `src/renderer/api/httpApi.ts` — `readLocalFile` stub (rejects; satisfies the full `Api` type, never actually called — real callers go through the preload)
- `src/renderer/ChatPanel.tsx` — rewrite `acceptScreenshot`
- `src/renderer/ChatPanel.harness.test.tsx` — 3 new tests (clipboard source, file source, no-preload degrade)
- `src/renderer/preloadAccess.test.ts` — mock updated for new `BuiPreload` methods

**Base:** `origin/main` @ `dfd9571`

## Verification results

- PR branch (`multica/BET-130-screenshot-attach` @ `39f9592`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, vitest 911 pass / 0 fail, node:test 483 pass / 0 fail. log sha256: `3c4b9da4625921891059d19dc72ee5345ba663b67ea048f84d1755a14e21dd73`
- Base (`main` @ `dfd9571`):
  - typecheck: exit `0`. Errors: none. log sha256: `e61b15bc704e3af0acd59774629da310150ea94b1d2fdc07998188bd82f601ea`
  - test: exit `0`, vitest 908 pass / 0 fail, node:test 483 pass / 0 fail. log sha256: `ec540c953844047a3e06a6477c7926735381e9deee0f79db7c68d1071d122039`
- **Conclusion:** 0 test failures on either branch. PR adds 3 new tests (908 → 911 vitest), all passing.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.
