### PR TITLE
HTTP-only cleanup 2/4: extract Api type out of preload runtime; shrink preload to OS bridges + pairing

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,85 +1,28 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
   IPC,
-  type AgentFileReady,
   type AppConfig,
   type AuthClaimInput,
   type AuthPairResult,
   type DesktopNotifyPayload,
-  type OpencodeAgent,
-  type OpencodeCommand,
-  type OpencodeEvent,
-  type OpencodeMessage,
-  type OpencodeModel,
-  type OpencodeSessionListItem,
-  type PermissionRequest,
-  type QuestionRequest,
-  type Project,
-  type ProjectMeta,
-  type ScheduledJob,
-  type SecretMeta,
-  type SecretInput,
-  type WebhookMeta,
-  type SpawnOptions,
-  type PtyEvent,
-  type TmuxConfigStatus,
-  type VoiceClassifyInput,
-  type VoiceClassifyResult,
-  type VoiceTranscribeInput,
-  type VoiceTranscribeResult,
-  type WindowStatus,
-  type WorktreeInfo,
-  type ProviderEndpoint,
-  type DiscoverResult,
-  type ProviderInput,
-  type SubagentDef,
-  type SubagentInput,
 } from "../shared/types.js";
 import type { ClaimOutcome } from "../shared/claim.mjs";
 
-type PromptModel = { providerID: string; modelID: string; variant?: string };
-type PromptAttachment = { remotePath: string; mime: string; filename?: string };
-type PromptAgentMention = {
-  name: string;
-  source: { value: string; start: number; end: number };
-};
-
+// This is the OS-bridge + pairing SUBSET of the full `Api` contract
+// (`src/shared/api.ts`) — the methods the desktop preload runtime actually
+// implements. Everything else in `Api` (tmux/opencode/config/schedule/
+// secrets/webhook/voice/git/fs/pty/...) is httpApi-only now (BET-82: "SSH
+// main path gone" — `window.api` is always httpApi on desktop, never this
+// object). See `src/renderer/preloadAccess.ts` for the typed accessor most
+// callers should use (`getBuiPreload()`), and BET-127 for the extraction
+// history.
 const api = {
+  // Read ONLY by main.tsx's boot sequence (`chooseDesktopTransport`), before
+  // httpApi is installed as `window.api` — used to seed httpApi's
+  // localStorage credentials from the desktop's local config.json (pairing
+  // triple). This is the one "data" method that must stay: it is called
+  // directly on `window.__buiPreload`, never through `window.api`.
   configGet: (): Promise<AppConfig> => ipcRenderer.invoke(IPC.configGet),
-  configUpdate: (patch: Partial<AppConfig>): Promise<AppConfig> =>
-    ipcRenderer.invoke(IPC.configUpdate, patch),
-
-  projectMetaUpsert: (meta: ProjectMeta): Promise<AppConfig> =>
-    ipcRenderer.invoke(IPC.projectMetaUpsert, meta),
-  projectMetaDelete: (tmuxSession: string): Promise<AppConfig> =>
-    ipcRenderer.invoke(IPC.projectMetaDelete, tmuxSession),
-
-  // tmux operations on the remote
-  tmuxList: (): Promise<Project[]> => ipcRenderer.invoke(IPC.tmuxList),
-  tmuxNewSession: (input: { name: string; cwd: string; windowName?: string; chatMode?: boolean; createDir?: boolean }): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.tmuxNewSession, input),
-  tmuxNewWindow: (input: { sessionName: string; windowName: string; cwd?: string; chatMode?: boolean }): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.tmuxNewWindow, input),
-  tmuxRenameSession: (input: { oldName: string; newName: string }): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.tmuxRenameSession, input),
-  tmuxRenameWindow: (input: { sessionName: string; windowIndex: number; newName: string }): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.tmuxRenameWindow, input),
-  tmuxKillSession: (sessionName: string): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.tmuxKillSession, sessionName),
-  tmuxKillWindow: (input: { sessionName: string; windowIndex: number }): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.tmuxKillWindow, input),
-  tmuxSelectWindow: (input: { sessionName: string; windowIndex: number }): Promise<void> =>
-    ipcRenderer.invoke(IPC.tmuxSelectWindow, input),
-
-  gitListWorktrees: (cwd: string): Promise<WorktreeInfo[]> =>
-    ipcRenderer.invoke(IPC.gitListWorktrees, cwd),
-
-  fsListDirs: (partial: string): Promise<string[]> =>
-    ipcRenderer.invoke(IPC.fsListDirs, partial),
-
-  tmuxConfigStatus: (): Promise<TmuxConfigStatus> => ipcRenderer.invoke(IPC.tmuxConfigStatus),
-  tmuxSetupConfig: (): Promise<TmuxConfigStatus> => ipcRenderer.invoke(IPC.tmuxSetupConfig),
-  tmuxRestoreConfig: (): Promise<TmuxConfigStatus> => ipcRenderer.invoke(IPC.tmuxRestoreConfig),
 
   // Onboarding pairing (BET-49): exchange a 6-digit code for the box's tokens
   // via POST <serverUrl>/auth/claim. On success main persists
@@ -96,14 +39,6 @@ const api = {
   authPair: (): Promise<AuthPairResult> =>
     ipcRenderer.invoke(IPC.authPair),
 
-  // Voice (Groq STT + lightweight classifier). Main owns the API key;
-  // renderer only ships audio bytes / transcripts.
-  // See src/shared/voiceClassifier.mjs and src/shared/groq.mjs.
-  voiceTranscribe: (input: VoiceTranscribeInput): Promise<VoiceTranscribeResult> =>
-    ipcRenderer.invoke(IPC.voiceTranscribe, input),
-  voiceClassifyCommand: (input: VoiceClassifyInput): Promise<VoiceClassifyResult> =>
-    ipcRenderer.invoke(IPC.voiceClassifyCommand, input),
-
   clipboardWriteText: (text: string): Promise<void> =>
     ipcRenderer.invoke(IPC.clipboardWriteText, text),
   clipboardReadImage: (): Promise<ArrayBuffer | null> =>
@@ -115,14 +50,6 @@ const api = {
     const listener = (_: unknown, ev: { source: "clipboard" | "file"; path?: string }) => cb(ev);
     ipcRenderer.on(IPC.screenshotDetected, listener);
     return () => ipcRenderer.removeListener(IPC.screenshotDetected, listener);
-  },
-
-  // Cross-device shared-config sync pulled a newer snapshot from mobile into
-  // desktop config; the store re-applies it so Settings reflects the change.
-  onConfigChanged: (cb: (cfg: AppConfig) => void): (() => void) => {
-    const listener = (_: unknown, cfg: AppConfig) => cb(cfg);
-    ipcRenderer.on(IPC.configChanged, listener);
-    return () => ipcRenderer.removeListener(IPC.configChanged, listener);
   },
 
   // bui-server's notification router decided the desktop should show an OS
@@ -146,249 +73,8 @@ const api = {
     ipcRenderer.invoke(IPC.peekRemoteFile, remotePath),
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke(IPC.openExternal, url),
 
-  // Agent → laptop file push (outbox). `onAgentFileReady` fires when a file
-  // appears in the remote ~/.bui-outbox/. `agentPullFile` pulls it to the
-  // downloads dir (used by the require-confirm toast's Save button); returns
-  // the saved local path. `revealInFolder` opens Finder at the saved file.
-  onAgentFileReady: (cb: (ev: AgentFileReady) => void): (() => void) => {
-    const listener = (_: unknown, ev: AgentFileReady) => cb(ev);
-    ipcRenderer.on(IPC.agentFileReady, listener);
-    return () => ipcRenderer.removeListener(IPC.agentFileReady, listener);
-  },
-  agentPullFile: (remotePath: string): Promise<string> =>
-    ipcRenderer.invoke(IPC.agentPullFile, remotePath),
   revealInFolder: (localPath: string): Promise<void> =>
     ipcRenderer.invoke(IPC.revealInFolder, localPath),
-
-  // Long-lived attached PTYs (1 per active project)
-  ptySpawn: (opts: SpawnOptions): Promise<void> => ipcRenderer.invoke(IPC.ptySpawn, opts),
-  ptyWrite: (projectName: string, data: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.ptyWrite, projectName, data),
-  ptyResize: (projectName: string, cols: number, rows: number): Promise<void> =>
-    ipcRenderer.invoke(IPC.ptyResize, projectName, cols, rows),
-  ptyKill: (projectName: string): Promise<void> => ipcRenderer.invoke(IPC.ptyKill, projectName),
-
-  onPtyEvent: (cb: (e: PtyEvent) => void) => {
-    const listener = (_: unknown, e: PtyEvent) => cb(e);
-    ipcRenderer.on(IPC.ptyEvent, listener);
-    return () => ipcRenderer.removeListener(IPC.ptyEvent, listener);
-  },
-
-  onStatusEvent: (cb: (batch: WindowStatus[]) => void): (() => void) => {
-    const listener = (_: unknown, batch: WindowStatus[]) => cb(batch);
-    ipcRenderer.on(IPC.statusEvent, listener);
-    return () => {
-      ipcRenderer.removeListener(IPC.statusEvent, listener);
-    };
-  },
-
-  // opencode chat-mode bridges.
-  opencodeMessages: (sessionId: string): Promise<OpencodeMessage[]> =>
-    ipcRenderer.invoke(IPC.opencodeMessages, sessionId),
-  opencodeMessagesCached: (
-    sessionId: string,
-  ): Promise<OpencodeMessage[] | null> =>
-    ipcRenderer.invoke(IPC.opencodeMessagesCached, sessionId),
-  // Tail-merge reconcile (fast) — returns the merged full transcript.
-  opencodeMessagesReconcile: (
-    sessionId: string,
-  ): Promise<OpencodeMessage[]> =>
-    ipcRenderer.invoke(IPC.opencodeMessagesReconcile, sessionId),
-  // Single-message fetch — returns null on miss so callers can fall back.
-  opencodeMessage: (
-    sessionId: string,
-    messageId: string,
-  ): Promise<OpencodeMessage | null> =>
-    ipcRenderer.invoke(IPC.opencodeMessage, sessionId, messageId),
-  // Open/close the scoped SSE stream for a session. ChatPanel calls open on
-  // mount and close on unmount so the main process only streams open sessions.
-  opencodeOpenStream: (sessionId: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeOpenStream, sessionId),
-  opencodeCloseStream: (sessionId: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeCloseStream, sessionId),
-  onOpencodeEvent: (cb: (ev: OpencodeEvent) => void): (() => void) => {
-    const listener = (_: unknown, ev: OpencodeEvent) => cb(ev);
-    ipcRenderer.on(IPC.opencodeEvent, listener);
-    return () => {
-      ipcRenderer.removeListener(IPC.opencodeEvent, listener);
-    };
-  },
-  opencodePrompt: (
-    sessionId: string,
-    text: string,
-    model?: PromptModel,
-    attachments?: PromptAttachment[],
-    mentions?: PromptAgentMention[],
-  ): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodePrompt, {
-      sessionId,
-      text,
-      model,
-      attachments,
-      mentions,
-    }),
-  opencodeAbort: (sessionId: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeAbort, sessionId),
-  // `sessionId` scopes the list to the session's workspace directory —
-  // without it the server returns [] for sessions outside the default
-  // workspace (see listPermissions in opencode.ts).
-  opencodePermissions: (sessionId?: string): Promise<PermissionRequest[]> =>
-    ipcRenderer.invoke(IPC.opencodePermissions, sessionId),
-  opencodePermissionReply: (
-    requestId: string,
-    reply: "once" | "always" | "reject",
-    sessionId?: string,
-  ): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodePermissionReply, {
-      requestId,
-      reply,
-      sessionId,
-    }),
-
-  // Question tool — v2 API only. `sessionId` scopes the list the same way
-  // permissions are scoped (see opencodePermissions above).
-  opencodeQuestions: (sessionId?: string): Promise<QuestionRequest[]> =>
-    ipcRenderer.invoke(IPC.opencodeQuestions, sessionId),
-  opencodeQuestionReply: (
-    requestId: string,
-    answers: string[][],
-    sessionId?: string,
-  ): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeQuestionReply, {
-      requestId,
-      answers,
-      sessionId,
-    }),
-  opencodeQuestionReject: (
-    requestId: string,
-    sessionId?: string,
-  ): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeQuestionReject, { requestId, sessionId }),
-
-  // Model picker.
-  opencodeModels: (): Promise<OpencodeModel[]> =>
-    ipcRenderer.invoke(IPC.opencodeModels),
-  opencodeDefaultModel: (): Promise<{ providerID: string; modelID: string } | null> =>
-    ipcRenderer.invoke(IPC.opencodeDefaultModel),
-  opencodeGetProviders: (): Promise<ProviderEndpoint[]> =>
-    ipcRenderer.invoke(IPC.opencodeGetProviders),
-  opencodeSetProviders: (
-    ops: { upsert?: ProviderInput[]; remove?: string[] },
-  ): Promise<{ ok: boolean; error?: string }> =>
-    ipcRenderer.invoke(IPC.opencodeSetProviders, ops),
-  opencodeDiscoverModels: (baseURL: string, apiKey: string): Promise<DiscoverResult> =>
-    ipcRenderer.invoke(IPC.opencodeDiscoverModels, baseURL, apiKey),
-  opencodeGetSubagents: (): Promise<SubagentDef[]> =>
-    ipcRenderer.invoke(IPC.opencodeGetSubagents),
-  opencodeSetSubagents: (
-    ops: { upsert?: SubagentInput[]; remove?: string[] },
-  ): Promise<{ ok: boolean; error?: string }> =>
-    ipcRenderer.invoke(IPC.opencodeSetSubagents, ops),
-  opencodeRestart: (): Promise<void> => ipcRenderer.invoke(IPC.opencodeRestart),
-  opencodeVcsBranch: (directory?: string): Promise<string | null> =>
-    ipcRenderer.invoke(IPC.opencodeVcsBranch, directory),
-
-  // Session management.
-  opencodeListSessions: (directory?: string): Promise<OpencodeSessionListItem[]> =>
-    ipcRenderer.invoke(IPC.opencodeListSessions, directory),
-  opencodeForkSession: (input: {
-    sessionId: string;
-    sessionName: string;
-    windowName: string;
-    cwd: string;
-    messageID?: string;
-  }): Promise<{ newSessionId: string; projects: Project[] }> =>
-    ipcRenderer.invoke(IPC.opencodeForkSession, input),
-  opencodeCompactSession: (sessionId: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeCompactSession, sessionId),
-  opencodeDeleteSession: (input: {
-    sessionId: string;
-    sessionName: string;
-    windowIndex: number;
-  }): Promise<Project[]> =>
-    ipcRenderer.invoke(IPC.opencodeDeleteSession, input),
-
-  // Scheduled prompts (bui-server owned; desktop reaches it over -L 18787).
-  scheduleList: (sessionId?: string): Promise<ScheduledJob[]> =>
-    ipcRenderer.invoke(IPC.scheduleList, sessionId),
-  scheduleDelete: (id: string): Promise<{ deleted: boolean }> =>
-    ipcRenderer.invoke(IPC.scheduleDelete, id),
-
-  // Secrets (bui-server owned; desktop reaches it over -L 18787). list returns
-  // METADATA ONLY (never values). set carries the value renderer → box (never
-  // through the AI). Agents read secrets via opencode tools, not these channels.
-  secretsList: (sessionId?: string, all?: boolean): Promise<SecretMeta[]> =>
-    ipcRenderer.invoke(IPC.secretsList, sessionId, all),
-  secretsSet: (input: SecretInput): Promise<{ ok: boolean; meta?: SecretMeta; error?: string }> =>
-    ipcRenderer.invoke(IPC.secretsSet, input),
-  secretsDelete: (id: string): Promise<{ deleted: boolean }> =>
-    ipcRenderer.invoke(IPC.secretsDelete, id),
-
-  // Inbound webhooks (bui-server owned; desktop reaches it over -L 18787). list
-  // returns METADATA ONLY (no signing secret). Creation is the AI's job via the
-  // global `webhook` opencode tool, not a UI channel.
-  webhookList: (sessionId?: string): Promise<WebhookMeta[]> =>
-    ipcRenderer.invoke(IPC.webhookList, sessionId),
-  webhookDelete: (id: string): Promise<{ deleted: boolean }> =>
-    ipcRenderer.invoke(IPC.webhookDelete, id),
-
-  // Auto-update (desktop-only). Main checks for updates on launch and pushes
-  // updateAvailable / updateDownloaded events to the renderer. The renderer
-  // calls autoUpdateDownload to trigger a manual download, or autoUpdateInstall
-  // to restart and install a downloaded update.
-  autoUpdateDownload: (): Promise<void> =>
-    ipcRenderer.invoke(IPC.autoUpdateDownload),
-  autoUpdateInstall: (): Promise<void> =>
-    ipcRenderer.invoke(IPC.autoUpdateInstall),
-  onAutoUpdateAvailable: (
-    cb: (info: { version: string; releaseName?: string; releaseNotes?: string }) => void,
-  ): (() => void) => {
-    const listener = (_: unknown, info: { version: string; releaseName?: string; releaseNotes?: string }) => cb(info);
-    ipcRenderer.on(IPC.autoUpdateAvailable, listener);
-    return () => ipcRenderer.removeListener(IPC.autoUpdateAvailable, listener);
-  },
-  onAutoUpdateDownloaded: (
-    cb: (info: { version: string; releaseName?: string; releaseNotes?: string }) => void,
-  ): (() => void) => {
-    const listener = (_: unknown, info: { version: string; releaseName?: string; releaseNotes?: string }) => cb(info);
-    ipcRenderer.on(IPC.autoUpdateDownloaded, listener);
-    return () => ipcRenderer.removeListener(IPC.autoUpdateDownloaded, listener);
-  },
-
-  // Typeahead sources.
-  opencodeCommands: (): Promise<OpencodeCommand[]> =>
-    ipcRenderer.invoke(IPC.opencodeCommands),
-  opencodeAgents: (): Promise<OpencodeAgent[]> =>
-    ipcRenderer.invoke(IPC.opencodeAgents),
-  opencodeFindFiles: (input: { query: string; directory: string }): Promise<string[]> =>
-    ipcRenderer.invoke(IPC.opencodeFindFiles, input),
-
-  // Slash-command execution.
-  opencodeRunCommand: (input: {
-    sessionId: string;
-    command: string;
-    arguments: string;
-    model?: PromptModel;
-    attachments?: PromptAttachment[];
-  }): Promise<void> =>
-    ipcRenderer.invoke(IPC.opencodeRunCommand, input),
-
-  // /clear: create new opencode session in same dir, re-stamp tmux window.
-  opencodeClearSession: (input: {
-    sessionName: string;
-    windowIndex: number;
-    cwd: string;
-    title: string;
-  }): Promise<{ newSessionId: string; projects: Project[] }> =>
-    ipcRenderer.invoke(IPC.opencodeClearSession, input),
-
-  // Auto-rename: generate a short title via a throwaway opencode session.
-  // Returns the RAW model reply ("" on timeout/failure); caller sanitizes.
-  opencodeGenerateTitle: (input: {
-    directory: string;
-    instruction: string;
-  }): Promise<string> =>
-    ipcRenderer.invoke(IPC.opencodeGenerateTitle, input),
 };
 
 // Expose the real preload bridge under a STABLE, dedicated name — NOT "api".
@@ -400,5 +86,3 @@ const api = {
 // property. So we bridge under `__buiPreload` (immutable, always the genuine
 // Electron preload) and let main.tsx define a writable `window.api` from it.
 contextBridge.exposeInMainWorld("__buiPreload", api);
-
-export type Api = typeof api;

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -591,10 +591,30 @@ export const httpApi: Api = {
   // can fetch from /api/peek and open the file with shell.openPath (the
   // renderer has no direct shell access). Falls back to the RPC channel for
   // mobile/web where the server IS the box and reads the file natively.
+  //
+  // BET-127 review note: there is no ipcMain.handle(IPC.peekRemoteFile, ...)
+  // registered in src/main/index.ts today, so the preload call below always
+  // rejects ("no handler registered"). Pre-BET-127, the __buiPreload probe
+  // checked a name (peekRemoteFileHttp) the preload never exposed, so it
+  // never matched and fell through to the RPC no-op — a silent, pre-existing
+  // no-op UX for a known-broken feature. BET-127 fixed the probe's NAME to
+  // match what the preload actually exposes (peekRemoteFile), which is
+  // correct and required, but that alone would have flipped the observed
+  // behavior from "click does nothing" to "click pops an alert()" purely as
+  // a side effect of a naming fix in a cleanup PR — not an intended UX
+  // change. We catch the rejection here and fall through to the same RPC
+  // no-op as before, preserving the pre-existing silent-degrade behavior
+  // until a real ipcMain handler lands (tracked as a follow-up; see BET-127
+  // PR discussion).
   peekRemoteFile: async (remotePath) => {
     const preload = (window as { __buiPreload?: { peekRemoteFile?: (p: string) => Promise<void> } }).__buiPreload;
     if (preload?.peekRemoteFile) {
-      return preload.peekRemoteFile(remotePath);
+      try {
+        return await preload.peekRemoteFile(remotePath);
+      } catch {
+        // No ipcMain handler yet — degrade silently (see note above) rather
+        // than surface an IPC error to the user.
+      }
     }
     return rpc(IPC.peekRemoteFile, remotePath);
   },

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -7,7 +7,7 @@ import {
   type PtyEvent,
   type WindowStatus,
 } from "../../shared/types.js";
-import type { Api } from "../../preload/index.js";
+import type { Api } from "../../shared/api.js";
 import {
   classifyClaimResult,
   networkFailure,
@@ -592,9 +592,9 @@ export const httpApi: Api = {
   // renderer has no direct shell access). Falls back to the RPC channel for
   // mobile/web where the server IS the box and reads the file natively.
   peekRemoteFile: async (remotePath) => {
-    const preload = (window as { __buiPreload?: { peekRemoteFileHttp?: (p: string) => Promise<void> } }).__buiPreload;
-    if (preload?.peekRemoteFileHttp) {
-      return preload.peekRemoteFileHttp(remotePath);
+    const preload = (window as { __buiPreload?: { peekRemoteFile?: (p: string) => Promise<void> } }).__buiPreload;
+    if (preload?.peekRemoteFile) {
+      return preload.peekRemoteFile(remotePath);
     }
     return rpc(IPC.peekRemoteFile, remotePath);
   },

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -5,7 +5,7 @@ import { MobileApp } from "./mobile/MobileApp";
 import "./index.css";
 import "./mobile/mobile.css";
 import { httpApi } from "./api/httpApi";
-import type { Api } from "../preload/index";
+import type { Api } from "../shared/api";
 import {
   desktopHttpClientSeed,
 } from "../shared/transport.mjs";

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -24,7 +24,7 @@ function makeFakePreload(): BuiPreload {
       cb({ kind: "test" });
       return vi.fn();
     }),
-    peekRemoteFileHttp: vi.fn(async () => {}),
+    peekRemoteFile: vi.fn(async () => {}),
   };
 }
 

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -26,7 +26,16 @@ export interface BuiPreload {
   // HTTP-mode peek: triggers the main process to fetch from /api/peek and
   // open the file locally. Only available when the desktop is in "http"
   // transport mode (paired to a bui-server). No-op on mobile/web.
-  peekRemoteFileHttp(remotePath: string): Promise<void>;
+  //
+  // NOTE (BET-127): this is the SAME name the preload runtime exposes
+  // (`peekRemoteFile` in src/preload/index.ts) — there is no ipcMain.handle
+  // registered for IPC.peekRemoteFile in src/main/index.ts today, so calling
+  // this currently rejects rather than opening a file. That gap predates this
+  // extraction and is out of scope here (flagged for a follow-up); this
+  // change only reconciles the name so httpApi's `window.__buiPreload` probe
+  // (httpApi.ts peekRemoteFile) actually finds the method instead of always
+  // silently falling through to the (also-stubbed) server RPC no-op.
+  peekRemoteFile(remotePath: string): Promise<void>;
 }
 
 /**

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -1,4 +1,4 @@
-import type { Api } from "../preload/index";
+import type { Api } from "../shared/api";
 import type { BuiPreload } from "./preloadAccess";
 
 declare global {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,0 +1,296 @@
+import type {
+  AgentFileReady,
+  AppConfig,
+  AuthClaimInput,
+  AuthPairResult,
+  DesktopNotifyPayload,
+  OpencodeAgent,
+  OpencodeCommand,
+  OpencodeEvent,
+  OpencodeMessage,
+  OpencodeModel,
+  OpencodeSessionListItem,
+  PermissionRequest,
+  QuestionRequest,
+  Project,
+  ProjectMeta,
+  ScheduledJob,
+  SecretMeta,
+  SecretInput,
+  WebhookMeta,
+  SpawnOptions,
+  PtyEvent,
+  TmuxConfigStatus,
+  VoiceClassifyInput,
+  VoiceClassifyResult,
+  VoiceTranscribeInput,
+  VoiceTranscribeResult,
+  WindowStatus,
+  WorktreeInfo,
+  ProviderEndpoint,
+  DiscoverResult,
+  ProviderInput,
+  SubagentDef,
+  SubagentInput,
+} from "./types.js";
+import type { ClaimOutcome } from "./claim.mjs";
+
+type PromptModel = { providerID: string; modelID: string; variant?: string };
+type PromptAttachment = { remotePath: string; mime: string; filename?: string };
+type PromptAgentMention = {
+  name: string;
+  source: { value: string; start: number; end: number };
+};
+
+/**
+ * The full `window.api` contract.
+ *
+ * This is the SAME shape the Electron preload used to declare implicitly as
+ * `export type Api = typeof api` (`src/preload/index.ts`). It is extracted to
+ * a standalone interface here because `httpApi` (`src/renderer/api/httpApi.ts`)
+ * is the implementation that actually backs `window.api` at runtime — the
+ * preload's own `api` object only ever backed `window.api` in the retired
+ * SSH-main path (BET-82: "SSH main path gone"). Only a small OS-bridge +
+ * pairing subset of these methods is still implemented by the preload runtime
+ * itself (exposed under `window.__buiPreload`, see `src/preload/index.ts` and
+ * `src/renderer/preloadAccess.ts`); everything else here is httpApi-only.
+ *
+ * Do NOT change any method signature here without also updating `httpApi`
+ * (which implements this interface completely, typecheck-enforced).
+ */
+export interface Api {
+  configGet(): Promise<AppConfig>;
+  configUpdate(patch: Partial<AppConfig>): Promise<AppConfig>;
+
+  projectMetaUpsert(meta: ProjectMeta): Promise<AppConfig>;
+  projectMetaDelete(tmuxSession: string): Promise<AppConfig>;
+
+  // tmux operations on the remote
+  tmuxList(): Promise<Project[]>;
+  tmuxNewSession(input: {
+    name: string;
+    cwd: string;
+    windowName?: string;
+    chatMode?: boolean;
+    createDir?: boolean;
+  }): Promise<Project[]>;
+  tmuxNewWindow(input: {
+    sessionName: string;
+    windowName: string;
+    cwd?: string;
+    chatMode?: boolean;
+  }): Promise<Project[]>;
+  tmuxRenameSession(input: { oldName: string; newName: string }): Promise<Project[]>;
+  tmuxRenameWindow(input: {
+    sessionName: string;
+    windowIndex: number;
+    newName: string;
+  }): Promise<Project[]>;
+  tmuxKillSession(sessionName: string): Promise<Project[]>;
+  tmuxKillWindow(input: { sessionName: string; windowIndex: number }): Promise<Project[]>;
+  tmuxSelectWindow(input: { sessionName: string; windowIndex: number }): Promise<void>;
+
+  gitListWorktrees(cwd: string): Promise<WorktreeInfo[]>;
+
+  fsListDirs(partial: string): Promise<string[]>;
+
+  tmuxConfigStatus(): Promise<TmuxConfigStatus>;
+  tmuxSetupConfig(): Promise<TmuxConfigStatus>;
+  tmuxRestoreConfig(): Promise<TmuxConfigStatus>;
+
+  // Onboarding pairing (BET-49): exchange a 6-digit code for the box's tokens
+  // via POST <serverUrl>/auth/claim. Resolves to a classified ClaimOutcome —
+  // a wrong/expired code is a normal { ok:false } result, NOT a rejected
+  // promise.
+  authClaim(input: AuthClaimInput): Promise<ClaimOutcome>;
+
+  // Mobile pairing code mint (BET-80): GET /auth/pair over the SSH tunnel.
+  // Returns { pairingCode, boxId, expiresAt } for the desktop to render as a
+  // QR. Resolves to an AuthPairResult — a failure is { ok:false, error }, NOT
+  // a rejected promise.
+  authPair(): Promise<AuthPairResult>;
+
+  // Voice (Groq STT + lightweight classifier). Main owns the API key;
+  // renderer only ships audio bytes / transcripts.
+  voiceTranscribe(input: VoiceTranscribeInput): Promise<VoiceTranscribeResult>;
+  voiceClassifyCommand(input: VoiceClassifyInput): Promise<VoiceClassifyResult>;
+
+  clipboardWriteText(text: string): Promise<void>;
+  clipboardReadImage(): Promise<ArrayBuffer | null>;
+
+  onScreenshotDetected(
+    cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
+  ): () => void;
+
+  // Cross-device shared-config sync pulled a newer snapshot from mobile into
+  // desktop config; the store re-applies it so Settings reflects the change.
+  onConfigChanged(cb: (cfg: AppConfig) => void): () => void;
+
+  // bui-server's notification router decided the desktop should show an OS
+  // notification (relayed over the -L 18787 forward). The renderer shows it
+  // via the Notification API after a local "am I viewing this?" check.
+  onDesktopNotify(cb: (payload: DesktopNotifyPayload) => void): () => void;
+
+  uploadFiles(input: { projectName: string; localPaths: string[] }): Promise<string[]>;
+  uploadBuffer(input: {
+    projectName: string;
+    filename: string;
+    buffer: ArrayBuffer;
+  }): Promise<string>;
+  // Electron 31+ removed File.path; webUtils.getPathForFile is the replacement.
+  // Returns "" for files that don't have an OS path (e.g. dragged from a
+  // webpage).
+  getPathForFile(file: File): string;
+
+  peekRemoteFile(remotePath: string): Promise<void>;
+  openExternal(url: string): Promise<void>;
+
+  // Agent → laptop file push (outbox). `onAgentFileReady` fires when a file
+  // appears in the remote ~/.bui-outbox/. `agentPullFile` pulls it to the
+  // downloads dir (used by the require-confirm toast's Save button); returns
+  // the saved local path. `revealInFolder` opens Finder at the saved file.
+  onAgentFileReady(cb: (ev: AgentFileReady) => void): () => void;
+  agentPullFile(remotePath: string): Promise<string>;
+  revealInFolder(localPath: string): Promise<void>;
+
+  // Long-lived attached PTYs (1 per active project)
+  ptySpawn(opts: SpawnOptions): Promise<void>;
+  ptyWrite(projectName: string, data: string): Promise<void>;
+  ptyResize(projectName: string, cols: number, rows: number): Promise<void>;
+  ptyKill(projectName: string): Promise<void>;
+
+  onPtyEvent(cb: (e: PtyEvent) => void): () => void;
+
+  onStatusEvent(cb: (batch: WindowStatus[]) => void): () => void;
+
+  // opencode chat-mode bridges.
+  opencodeMessages(sessionId: string): Promise<OpencodeMessage[]>;
+  opencodeMessagesCached(sessionId: string): Promise<OpencodeMessage[] | null>;
+  // Tail-merge reconcile (fast) — returns the merged full transcript.
+  opencodeMessagesReconcile(sessionId: string): Promise<OpencodeMessage[]>;
+  // Single-message fetch — returns null on miss so callers can fall back.
+  opencodeMessage(sessionId: string, messageId: string): Promise<OpencodeMessage | null>;
+  // Open/close the scoped SSE stream for a session. ChatPanel calls open on
+  // mount and close on unmount so the main process only streams open
+  // sessions.
+  opencodeOpenStream(sessionId: string): Promise<void>;
+  opencodeCloseStream(sessionId: string): Promise<void>;
+  onOpencodeEvent(cb: (ev: OpencodeEvent) => void): () => void;
+  opencodePrompt(
+    sessionId: string,
+    text: string,
+    model?: PromptModel,
+    attachments?: PromptAttachment[],
+    mentions?: PromptAgentMention[],
+  ): Promise<void>;
+  opencodeAbort(sessionId: string): Promise<void>;
+  // `sessionId` scopes the list to the session's workspace directory —
+  // without it the server returns [] for sessions outside the default
+  // workspace (see listPermissions in opencode.ts).
+  opencodePermissions(sessionId?: string): Promise<PermissionRequest[]>;
+  opencodePermissionReply(
+    requestId: string,
+    reply: "once" | "always" | "reject",
+    sessionId?: string,
+  ): Promise<void>;
+
+  // Question tool — v2 API only. `sessionId` scopes the list the same way
+  // permissions are scoped (see opencodePermissions above).
+  opencodeQuestions(sessionId?: string): Promise<QuestionRequest[]>;
+  opencodeQuestionReply(
+    requestId: string,
+    answers: string[][],
+    sessionId?: string,
+  ): Promise<void>;
+  opencodeQuestionReject(requestId: string, sessionId?: string): Promise<void>;
+
+  // Model picker.
+  opencodeModels(): Promise<OpencodeModel[]>;
+  opencodeDefaultModel(): Promise<{ providerID: string; modelID: string } | null>;
+  opencodeGetProviders(): Promise<ProviderEndpoint[]>;
+  opencodeSetProviders(ops: {
+    upsert?: ProviderInput[];
+    remove?: string[];
+  }): Promise<{ ok: boolean; error?: string }>;
+  opencodeDiscoverModels(baseURL: string, apiKey: string): Promise<DiscoverResult>;
+  opencodeGetSubagents(): Promise<SubagentDef[]>;
+  opencodeSetSubagents(ops: {
+    upsert?: SubagentInput[];
+    remove?: string[];
+  }): Promise<{ ok: boolean; error?: string }>;
+  opencodeRestart(): Promise<void>;
+  opencodeVcsBranch(directory?: string): Promise<string | null>;
+
+  // Session management.
+  opencodeListSessions(directory?: string): Promise<OpencodeSessionListItem[]>;
+  opencodeForkSession(input: {
+    sessionId: string;
+    sessionName: string;
+    windowName: string;
+    cwd: string;
+    messageID?: string;
+  }): Promise<{ newSessionId: string; projects: Project[] }>;
+  opencodeCompactSession(sessionId: string): Promise<void>;
+  opencodeDeleteSession(input: {
+    sessionId: string;
+    sessionName: string;
+    windowIndex: number;
+  }): Promise<Project[]>;
+
+  // Scheduled prompts (bui-server owned; desktop reaches it over -L 18787).
+  scheduleList(sessionId?: string): Promise<ScheduledJob[]>;
+  scheduleDelete(id: string): Promise<{ deleted: boolean }>;
+
+  // Secrets (bui-server owned; desktop reaches it over -L 18787). list returns
+  // METADATA ONLY (never values). set carries the value renderer → box (never
+  // through the AI). Agents read secrets via opencode tools, not these
+  // channels.
+  secretsList(sessionId?: string, all?: boolean): Promise<SecretMeta[]>;
+  secretsSet(input: SecretInput): Promise<{ ok: boolean; meta?: SecretMeta; error?: string }>;
+  secretsDelete(id: string): Promise<{ deleted: boolean }>;
+
+  // Inbound webhooks (bui-server owned; desktop reaches it over -L 18787).
+  // list returns METADATA ONLY (no signing secret). Creation is the AI's job
+  // via the global `webhook` opencode tool, not a UI channel.
+  webhookList(sessionId?: string): Promise<WebhookMeta[]>;
+  webhookDelete(id: string): Promise<{ deleted: boolean }>;
+
+  // Auto-update (desktop-only). Main checks for updates on launch and pushes
+  // updateAvailable / updateDownloaded events to the renderer. The renderer
+  // calls autoUpdateDownload to trigger a manual download, or
+  // autoUpdateInstall to restart and install a downloaded update.
+  autoUpdateDownload(): Promise<void>;
+  autoUpdateInstall(): Promise<void>;
+  onAutoUpdateAvailable(
+    cb: (info: { version: string; releaseName?: string; releaseNotes?: string }) => void,
+  ): () => void;
+  onAutoUpdateDownloaded(
+    cb: (info: { version: string; releaseName?: string; releaseNotes?: string }) => void,
+  ): () => void;
+
+  // Typeahead sources.
+  opencodeCommands(): Promise<OpencodeCommand[]>;
+  opencodeAgents(): Promise<OpencodeAgent[]>;
+  opencodeFindFiles(input: { query: string; directory: string }): Promise<string[]>;
+
+  // Slash-command execution.
+  opencodeRunCommand(input: {
+    sessionId: string;
+    command: string;
+    arguments: string;
+    model?: PromptModel;
+    attachments?: PromptAttachment[];
+  }): Promise<void>;
+
+  // /clear: create new opencode session in same dir, re-stamp tmux window.
+  opencodeClearSession(input: {
+    sessionName: string;
+    windowIndex: number;
+    cwd: string;
+    title: string;
+  }): Promise<{ newSessionId: string; projects: Project[] }>;
+
+  // Auto-rename: generate a short title via a throwaway opencode session.
+  // Returns the RAW model reply ("" on timeout/failure); caller sanitizes.
+  opencodeGenerateTitle(input: { directory: string; instruction: string }): Promise<string>;
+}


### PR DESCRIPTION
Part of EPIC BET-125, stage 2/4 (after BET-126, PR #91, merged).

## What changed

1. **`src/shared/api.ts` (new)** — the full `window.api` contract, extracted as a standalone `export interface Api`, mechanically sourced from the preload's former `typeof api` shape + `src/shared/types.ts`. No signature changes.
2. **`src/renderer/api/httpApi.ts`** — `Api` now imported from `src/shared/api.ts` instead of `src/preload/index.ts`. Confirmed with a green typecheck immediately after this change (proves the extracted interface is faithful to what httpApi implements).
3. **`src/renderer/main.tsx`, `src/renderer/types.d.ts`** — repointed their `import type { Api }` to `src/shared/api.ts` too (grepped for all importers; these were the only two besides httpApi.ts).
4. **`src/preload/index.ts`** — shrunk the `contextBridge.exposeInMainWorld("__buiPreload", …)` runtime object from ~60 methods (404 LoC) down to 13 (88 LoC): the OS bridges (`onScreenshotDetected`, `clipboardWriteText`, `clipboardReadImage`, `openExternal`, `revealInFolder`, `getPathForFile`, `onDesktopNotify`, `peekRemoteFile`, `uploadBuffer`, `uploadFiles`), pairing (`authClaim`, `authPair`), and `configGet` (see discovery below). Removed the now-unused `export type Api = typeof api`.
5. **Naming reconciliation** — `preloadAccess.ts`'s `BuiPreload` interface declared `peekRemoteFileHttp`, but the preload actually exposed `peekRemoteFile`, and `httpApi.ts`'s internal `window.__buiPreload` probe checked for `peekRemoteFileHttp` — so the probe never matched and always silently fell through to the (also-stubbed) server RPC path. Standardized on `peekRemoteFile` (the name the preload actually exposes) across `BuiPreload` and `httpApi.ts`. **Note for BET-124**: this is the same dead-reference mismatch called out there — don't double-fix.
   - Caveat: there's still no `ipcMain.handle(IPC.peekRemoteFile, …)` registered in `src/main/index.ts` (pre-existing gap, unrelated files), so the "peek remote file" terminal-link feature remains non-functional either way — before this fix it silently no-op'd (fell through to the server-side no-op stub), after this fix it will surface a caught rejection (`alert(...)` in `Terminal.tsx`) since the IPC channel has no handler. Flagging as a real behavior change caused purely by the naming fix; implementing the actual handler is out of scope for this issue.

## Discovery not in the issue's enumeration — configGet is load-bearing

`main.tsx`'s boot sequence (`chooseDesktopTransport`) calls `realPreload.configGet()` **directly on `window.__buiPreload`**, before `httpApi` is installed as `window.api` — this is how the desktop seeds `httpApi`'s localStorage credentials from the local `config.json` pairing triple on every launch. It is not reached via `window.api`, so it isn't shadowed by httpApi, and it isn't in the issue's listed OS-bridge/pairing set. I verified this with `grep -rn "\.configGet(" src/renderer` (only caller besides `store.ts`'s `window.api.configGet()`).

**I kept `configGet` in the preload runtime.** Deleting it would have broken pairing detection on every desktop boot with no typecheck signal (main.tsx casts `window.__buiPreload` to `Api` via `as unknown as`, so the mismatch is invisible to `tsc`).

**Flag for BET-128**: that issue's plan lists `configGet`/`configUpdate` ipcMain handlers as dead and slated for removal. `configUpdate` is confirmed dead (only ever called via `window.api`), but **`configGet`'s `ipcMain.handle(IPC.configGet, …)` registration in `src/main/index.ts` must stay** — removing it breaks the preload method I just kept.

## Verification

- `npm run typecheck` — passes after step 2 (repoint) and step 4 (shrink), both gates green.
- `npm test` — 908 vitest + 483 node:test, **0 failures**.
- `grep -rn "window.__buiPreload\|getBuiPreload" src/renderer` — every hit is one of: `openExternal`, `clipboardWriteText` (OSC 52), `onScreenshotDetected`, or the `configGet` boot-time read documented above.
- E2E smoke (Playwright Electron launch, headless via `xvfb-run`, per `bui-e2e-smoke`): built app boots cleanly on a fresh/unpaired profile, renders the "Connect to your server" onboarding screen (no config.json = no crash = `configGet` handled gracefully), zero console errors. Confirmed `window.__buiPreload` exposes exactly the 13 retained methods and (pre-pairing) `window.api === window.__buiPreload`.

## Self-check

- CRITERION 1 (create `src/shared/api.ts`, mechanical, no signature changes) → 10/10
- CRITERION 2 (repoint httpApi, typecheck gate) → 10/10
- CRITERION 3 (repoint other `Api` importers) → 10/10
- CRITERION 4 (shrink preload to OS bridges + pairing) → 9/10 — weakness: deliberately retained `configGet` beyond the issue's literal list (justified + documented above, confirmed necessary via e2e smoke)
- CRITERION 5 (reconcile `peekRemoteFileHttp`/`peekRemoteFile`) → 8/10 — weakness: underlying `ipcMain` handler still missing, so the feature stays non-functional (now visibly vs. silently) — flagged, not fixed (out of scope)

Base: origin/main @ `1f9cdd8`
