### PR TITLE
BET-132: fix httpApi.ts readLocalFile excess property (typecheck-test red on main)

### DIFF
--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -482,9 +482,10 @@ function on<T>(kind: Kind, cb: (p: T) => void): () => any {
 //   • onScreenshotDetected / onDesktopNotify → subscription no-ops (these are
 //     Mac-desktop signals; the http client simply never receives them).
 //   • readLocalFile (arbitrary Mac file bytes, for screenshot "Add to chat")
-//     → rejects. The server IS the box and has no access to the Mac
-//     filesystem; callers (ChatPanel's acceptScreenshot) MUST go through
-//     window.__buiPreload.readLocalFile instead, exactly like clipboardReadImage.
+//     is NOT part of the Api type — the server IS the box and has no access
+//     to the Mac filesystem; callers (ChatPanel's acceptScreenshot) MUST go
+//     through window.__buiPreload.readLocalFile instead, exactly like
+//     clipboardReadImage.
 //
 // None of these throw. If a future feature MUST use the real preload in http
 // mode (e.g. OS clipboard), reach it explicitly via window.__buiPreload rather
@@ -537,12 +538,6 @@ export const httpApi: Api = {
   // -- clipboard --
   clipboardWriteText: (text) => rpc(IPC.clipboardWriteText, text),
   clipboardReadImage: () => rpc(IPC.clipboardReadImage),
-  // Never actually called — the server IS the box, it has no Mac filesystem
-  // access. Callers must use window.__buiPreload.readLocalFile (Electron
-  // main → fs.readFile) instead. Present only to satisfy the full Api type.
-  readLocalFile: async (_path: string): Promise<ArrayBuffer> => {
-    throw new Error("readLocalFile is not available over HTTP — use the preload bridge");
-  },
 
   // -- screenshot detection (SSE push) --
   onScreenshotDetected: (cb) =>


### PR DESCRIPTION
Follow-up to BET-127 (#94), which removed `readLocalFile` from the `Api` interface in `src/shared/api.ts` (screenshot "Add to chat" uses `window.__buiPreload.readLocalFile` via the OS bridge, not `window.api`). `src/renderer/api/httpApi.ts` still implemented `readLocalFile` as a property on the `httpApi: Api` object literal, which TypeScript now flags as an excess property (TS2353), breaking `typecheck-test` on `main` and blocking every subsequent PR's required checks.

## Fix
- Removed the dead `readLocalFile` property from the `httpApi` object literal.
- Updated the stale doc comment above it to reflect that `readLocalFile` is no longer part of the `Api` type.
- Did **not** re-add `readLocalFile` to the `Api` interface — its omission was intentional.

## Verify
- `npm run typecheck` — clean.
- `npm test` — 483/483 passing.

BET-132