### PR TITLE
BET-132: Fix typecheck-test red on main — httpApi.ts readLocalFile excess property

### DIFF
--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -481,10 +481,6 @@ function on<T>(kind: Kind, cb: (p: T) => void): () => any {
 //     degrades (the terminal still functions).
 //   • onScreenshotDetected / onDesktopNotify → subscription no-ops (these are
 //     Mac-desktop signals; the http client simply never receives them).
-//   • readLocalFile (arbitrary Mac file bytes, for screenshot "Add to chat")
-//     → rejects. The server IS the box and has no access to the Mac
-//     filesystem; callers (ChatPanel's acceptScreenshot) MUST go through
-//     window.__buiPreload.readLocalFile instead, exactly like clipboardReadImage.
 //
 // None of these throw. If a future feature MUST use the real preload in http
 // mode (e.g. OS clipboard), reach it explicitly via window.__buiPreload rather
@@ -537,12 +533,6 @@ export const httpApi: Api = {
   // -- clipboard --
   clipboardWriteText: (text) => rpc(IPC.clipboardWriteText, text),
   clipboardReadImage: () => rpc(IPC.clipboardReadImage),
-  // Never actually called — the server IS the box, it has no Mac filesystem
-  // access. Callers must use window.__buiPreload.readLocalFile (Electron
-  // main → fs.readFile) instead. Present only to satisfy the full Api type.
-  readLocalFile: async (_path: string): Promise<ArrayBuffer> => {
-    throw new Error("readLocalFile is not available over HTTP — use the preload bridge");
-  },
 
   // -- screenshot detection (SSE push) --
   onScreenshotDetected: (cb) =>


### PR DESCRIPTION
## Summary

BET-127 (PR #94) extracted the `Api` type contract into `src/shared/api.ts` and correctly omitted `readLocalFile` from the interface (screenshot "Add to chat" uses `window.__buiPreload.readLocalFile` via the OS bridge, not `window.api`). But `src/renderer/api/httpApi.ts` still implemented `readLocalFile` as a property on the `httpApi: Api` object literal — TypeScript flags this as an excess property, which broke `npm run typecheck` on `main` and is blocking the `typecheck-test` required CI check for every PR (including BET-128 / PR #95).

## Fix

Deleted the dead `readLocalFile` property from the `httpApi` object literal in `src/renderer/api/httpApi.ts`, plus its now-stale comment block. Did **not** re-add `readLocalFile` to `src/shared/api.ts`'s `Api` interface — the omission was intentional.

Base: `origin/main @ 177eb0d`

## Verification results

- PR branch (`multica/BET-132-fix-httpapi-readlocalfile-typecheck` @ `ab38e03`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, `483` pass / `0` fail / `0` skip. log sha256: `2f86bc3a3da56dc5c13db00d30711bb6fe4dfdeb63d154e9464e0612a03e8865`
- Base (`main` @ `177eb0d`):
  - typecheck: exit `2`. Errors: `src/renderer/api/httpApi.ts(543,3): error TS2353: Object literal may only specify known properties, and 'readLocalFile' does not exist in type 'Api'.` log sha256: `e7a5152dae5422027fbe4ce404a295519d6d1f2f6522389d7e342b5f12cfe9bb`
  - test: exit `0`, `483` pass / `0` fail / `0` skip (node:test suite is independent of `tsc`). log sha256: `5064895b1c5c784dee3c71945cd226f3dfcaf96905d43e63e739e91da8b2b466`
- **Conclusion:** 1 typecheck failure on `main`, resolved by this PR. 0 new test failures introduced. 0 pre-existing test failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Files changed

1 file: `src/renderer/api/httpApi.ts` (10 deletions, 0 additions)
