### PR TITLE
BET-134: Parallelize status poller pane captures (bounded concurrency)

### DIFF
--- a/src/server/status.mjs
+++ b/src/server/status.mjs
@@ -13,6 +13,7 @@ import { run } from "./tmux.mjs";
 
 const POLL_MS = 2000;
 const CAPTURE_LINES = 40;
+const CAPTURE_CONCURRENCY = 8;
 
 // Sentinel that won't appear in captured terminal content (ANSI-stripped text).
 export const MARK = "__BUI_PANE__";
@@ -84,15 +85,16 @@ export function parseStatus(stdout) {
 // Desktop does this in one shell pipeline over SSH; here we can't do that
 // in a single run() call (no shell). Instead:
 //   1. list-windows -a  → "session\twindowIndex" lines
-//   2. For each window, capture-pane -p -S -N
-// The extra round-trips per window are fine at 2s poll; correctness matters
-// more than micro-optimisation here.
+//   2. capture-pane -p -S -N for each window, bounded-concurrency parallel
+//      (CAPTURE_CONCURRENCY workers), results reassembled in `targets` order
+//      so parseStatus's MARK-delimited demux stays stable regardless of
+//      which capture resolves first.
 
-async function collectPanes() {
+export async function collectPanes(runFn = run) {
   // Step 1: list all windows.
   let winStdout;
   try {
-    const r = await run("tmux", [
+    const r = await runFn("tmux", [
       "list-windows", "-a",
       "-F", "#{session_name}:#{window_index}",
     ]);
@@ -109,22 +111,36 @@ async function collectPanes() {
 
   if (targets.length === 0) return "";
 
-  // Step 2: capture each pane in sequence, accumulate MARK-delimited output.
-  const chunks = [];
-  for (const target of targets) {
-    chunks.push(`\n${MARK}${target}${MARK}\n`);
-    try {
-      const r = await run("tmux", [
-        "capture-pane",
-        "-t", target,
-        "-p",
-        "-S", String(-CAPTURE_LINES),
-      ]);
-      chunks.push(r.stdout);
-    } catch {
-      // Window may have been killed between list and capture — skip it.
-      chunks.push("");
+  // Step 2: capture each pane, bounded-concurrency parallel. Results are
+  // written into an index-aligned array, not pushed as promises resolve, so
+  // the final join is always in `targets` order.
+  const captured = new Array(targets.length).fill("");
+  let next = 0;
+  async function worker() {
+    for (;;) {
+      const i = next++;
+      if (i >= targets.length) return;
+      try {
+        const r = await runFn("tmux", [
+          "capture-pane",
+          "-t", targets[i],
+          "-p",
+          "-S", String(-CAPTURE_LINES),
+        ]);
+        captured[i] = r.stdout;
+      } catch {
+        // Window may have been killed between list and capture — skip it.
+        captured[i] = "";
+      }
     }
+  }
+  const poolSize = Math.min(CAPTURE_CONCURRENCY, targets.length);
+  await Promise.all(Array.from({ length: poolSize }, () => worker()));
+
+  const chunks = [];
+  for (let i = 0; i < targets.length; i++) {
+    chunks.push(`\n${MARK}${targets[i]}${MARK}\n`);
+    chunks.push(captured[i]);
   }
   return chunks.join("");
 }

--- a/src/server/status.test.mjs
+++ b/src/server/status.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseStatus, countSubagents, MARK } from "./status.mjs";
+import { parseStatus, countSubagents, collectPanes, MARK } from "./status.mjs";
 
 // ----------------------------------------------------------------------------
 // countSubagents — pure helper
@@ -123,4 +123,88 @@ test("parseStatus includes subagents count", () => {
   const out = parseStatus(stdout);
   assert.equal(out[0].running, true);
   assert.equal(out[0].subagents, 1);
+});
+
+// ----------------------------------------------------------------------------
+// collectPanes — bounded-concurrency parallel pane capture (order-preserving)
+// ----------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test("collectPanes preserves target order regardless of capture-pane resolve order", async () => {
+  const targets = ["a:0", "b:1", "c:2"];
+  // Delays chosen so "a:0" (index 0) resolves LAST despite being first in
+  // target order — proving the output is ordered by target index, not by
+  // which capture-pane call settles first.
+  const delays = { "a:0": 30, "b:1": 10, "c:2": 5 };
+
+  const fakeRun = async (cmd, args) => {
+    if (args[0] === "list-windows") {
+      return { stdout: targets.join("\n") + "\n" };
+    }
+    // args: ["capture-pane", "-t", target, "-p", "-S", ...]
+    const target = args[2];
+    await sleep(delays[target]);
+    return { stdout: `body-${target}\n` };
+  };
+
+  const stdout = await collectPanes(fakeRun);
+  const parsed = parseStatus(stdout);
+
+  assert.equal(parsed.length, 3);
+  assert.deepEqual(
+    parsed.map((w) => `${w.session}:${w.windowIndex}`),
+    targets,
+  );
+
+  // Also verify the raw MARK ordering directly (belt-and-suspenders — parseStatus
+  // could theoretically reorder, though it doesn't).
+  const markPositions = targets.map((t) => stdout.indexOf(`${MARK}${t}${MARK}`));
+  assert.deepEqual(
+    [...markPositions].sort((x, y) => x - y),
+    markPositions,
+  );
+});
+
+test("collectPanes isolates a per-window capture-pane failure without rejecting the whole call", async () => {
+  const targets = ["a:0", "b:1", "c:2"];
+
+  const fakeRun = async (cmd, args) => {
+    if (args[0] === "list-windows") {
+      return { stdout: targets.join("\n") + "\n" };
+    }
+    const target = args[2];
+    if (target === "b:1") {
+      throw new Error("window killed between list and capture");
+    }
+    return { stdout: `body-${target}\n` };
+  };
+
+  const stdout = await collectPanes(fakeRun);
+  const parsed = parseStatus(stdout);
+
+  assert.equal(parsed.length, 3);
+  assert.deepEqual(
+    parsed.map((w) => `${w.session}:${w.windowIndex}`),
+    targets,
+  );
+  // The failed window's body is empty (no captured text), but it still
+  // produced a slot — the whole tick did not reject.
+  assert.equal(parsed[1].running, false);
+  assert.equal(parsed[1].subagents, 0);
+});
+
+test("collectPanes returns empty string when no windows exist", async () => {
+  const fakeRun = async (cmd, args) => {
+    if (args[0] === "list-windows") return { stdout: "" };
+    throw new Error("should not be called");
+  };
+  assert.equal(await collectPanes(fakeRun), "");
+});
+
+test("collectPanes returns empty string when list-windows itself fails", async () => {
+  const fakeRun = async () => {
+    throw new Error("no tmux server running");
+  };
+  assert.equal(await collectPanes(fakeRun), "");
 });


### PR DESCRIPTION
Fixes BET-134: the server-side status poller's `collectPanes()` captured every
tmux pane SERIALLY (one `await` per window) on every 2s tick. With many
windows a single tick couldn't finish before the next was due, so the poller
fell behind and continuously pinned CPU — a contributor to overall BUI
slowness and to the poller starving opencode.

## Change

`src/server/status.mjs`:
- Added `CAPTURE_CONCURRENCY = 8` constant.
- Rewrote the pane-capture loop in `collectPanes()` to use a bounded worker
  pool instead of a serial `for` loop. Results are written into an
  index-aligned array (not pushed as promises resolve), then joined in
  `targets` order — so the MARK-delimited output `parseStatus` depends on is
  byte-identical in ordering to before, regardless of which `capture-pane`
  call resolves first.
- Per-window `try/catch` preserved — a window killed between `list-windows`
  and `capture-pane` still yields an empty slot instead of rejecting the
  whole tick.
- `collectPanes` is now exported with an injectable `runFn` param (defaults
  to the real `run`) so it's testable without live tmux.
- Updated the stale comment block that said "capture each pane in sequence …
  correctness matters more than micro-optimisation" — replaced with a note
  describing the bounded-concurrency parallel approach.

Out of scope (per issue): poll interval, `inFlight` guard, `parseStatus`,
BUSY_RE/subagent regexes, bus payload shape, chat-mode SSE status path — all
untouched.

`src/server/status.test.mjs`:
- New test: `collectPanes` preserves target order under parallelism even
  when captures resolve out of order (deliberately delays the first target
  the longest).
- New test: a rejecting `capture-pane` call for one window yields an empty
  slot for that window without failing the whole call.
- New tests: empty-target and `list-windows`-failure edge cases return `""`.

## Verification results

- PR branch (`multica/BET-134-parallel-status-poller` @ `d4565ec`):
  - typecheck: exit 0. No errors.
  - test: exit 0, 487 pass / 0 fail / 0 skip.
- Base (`main` @ `33201b6`):
  - typecheck: not re-run (no changes to non-test files besides the two
    touched here; PR branch typecheck is clean).
  - test: not re-run — the two changed files are additive (new export, new
    tests); no other test files were touched and the PR-branch full suite
    (487 tests across 15 suites) is green with 0 failures, so there are no
    regressions to reconcile against base.
- **Conclusion:** 0 failures on the PR branch across the full suite (487
  tests); no test file besides `status.test.mjs` was modified, so there is
  no base-branch delta to compare.

Base: origin/main @ 33201b6