### PR TITLE
fix(main): desktop-presence heartbeat uses HTTPS transport against HTTPS server

### DIFF
--- a/src/main/desktopPresence.ts
+++ b/src/main/desktopPresence.ts
@@ -23,7 +23,8 @@
 // lastSeen fresh (TTL) while active, and lets it lapse once you go idle.
 
 import { app, BrowserWindow, powerMonitor } from "electron";
-import { request } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import type { AppConfig } from "../shared/types.js";
 
 // How often to re-evaluate active-state and refresh the server's lastSeen.
@@ -53,7 +54,8 @@ function sendHeartbeatHttp(cfg: AppConfig, visible: boolean): void {
   if (!serverUrl) return;
   const body = JSON.stringify({ visible });
   const url = new URL("/push/desktop-presence", serverUrl);
-  const req = request(
+  const doRequest = url.protocol === "https:" ? httpsRequest : httpRequest;
+  const req = doRequest(
     {
       hostname: url.hostname,
       port: url.port || (url.protocol === "https:" ? 443 : 80),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -248,7 +248,7 @@ export function App() {
 
   // Desktop OS notifications. bui-server's router (push.mjs) decides WHICH
   // device(s) get a notification (no duplicates) and relays a desktop directive
-  // over the -L 18787 forward → main → IPC here. We add the final local
+  // → main → IPC here. We add the final local
   // suppression — if this window is focused AND already showing that exact
   // session, the user is looking at it, so don't pop an OS notification — then
   // show it via the Notification API and deep-link to the session on click.

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -75,8 +75,8 @@ async function resolveProjectName({ sessionID, directory }) {
 
 // Desktop notification leg: the notification router (push.mjs) publishes a
 // `desktopNotify` bus envelope when it decides the desktop should be notified.
-// The Electron app subscribes to GET /events over its -L 18787 forward and
-// renders it as an OS Notification. push.mjs stays bus-decoupled via this sink.
+// The Electron app subscribes to GET /events and renders it as an OS
+// Notification. push.mjs stays bus-decoupled via this sink.
 push.setDesktopSink((payload) =>
   bus.publish({ kind: "desktopNotify", payload }),
 );
@@ -1128,8 +1128,7 @@ const server = createServer(async (req, res) => {
         });
       } else if (path === "/push/desktop-presence") {
         // Desktop (Electron) heartbeat: suppress mobile "done" pushes while
-        // the user is active on desktop. Posted on focus/blur/system-idle over
-        // the desktop's SSH -L 18787 forward.
+        // the user is active on desktop. Posted on focus/blur/system-idle.
         result = push.setDesktopPresence({ visible: body?.visible });
         console.log(`[push] desktop-presence visible=${!!body?.visible}`);
       } else if (path === "/push/answer") {

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -144,8 +144,7 @@ export function getFocus() {
 // Desktop presence — the Electron app reports "I'm focused" so a mobile "done"
 // push is suppressed when the user is heads-down on the desktop (Discord's
 // "active on desktop ⇒ no mobile push" rule). The desktop reaches this server
-// over an SSH -L 18787:127.0.0.1:8787 forward on the shared ControlMaster and
-// POSTs /push/desktop-presence on focus/blur/system-idle.
+// directly over HTTPS and POSTs /push/desktop-presence on focus/blur/system-idle.
 //
 // Two timers gate suppression so a crashed/asleep desktop can't permanently
 // mute mobile:
@@ -513,8 +512,8 @@ const _pending = new Set();
 // Desktop sink + escalation state
 //
 // `_desktopSink` is injected by index.mjs and publishes a `desktopNotify` bus
-// envelope, which the Electron app consumes over the -L 18787 forward and
-// renders as an OS Notification. push.mjs stays decoupled from the bus (mirrors
+// envelope, which the Electron app consumes and renders as an OS Notification.
+// push.mjs stays decoupled from the bus (mirrors
 // how schedule.mjs takes an injected sendPrompt).
 // ---------------------------------------------------------------------------
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -263,7 +263,7 @@ export const IPC = {
 
   // main → renderer push: the bui-server notification router decided the
   // desktop should show an OS notification. Relayed from the server's
-  // `desktopNotify` bus event over the -L 18787 forward. Payload:
+  // `desktopNotify` bus event. Payload:
   // DesktopNotifyPayload. The renderer suppresses it if it's already viewing
   // that session, else shows it via the Notification API + deep-links on click.
   desktopNotify: "desktop:notify",


### PR DESCRIPTION
Fixes BET-136.

## Root cause
`desktopPresence.ts` sent its heartbeat POST with `node:http` unconditionally. In production `serverUrl` is `https://bui.useronda.com`, so a plaintext HTTP request to an HTTPS endpoint silently fails (the error is swallowed by design — presence is best-effort). The server's desktop presence record never updates, so `routeNotification` in `push.mjs` always treats the desktop as "gone" and never suppresses redundant mobile "done" pushes.

## Fix
Pick the request transport (`node:http` vs `node:https`) based on the target URL's protocol, instead of always using `node:http`. No change to `routeNotification`, `notifTier`, or any suppression/tier logic in `push.mjs` — that logic was already correct and unit-tested.

## Hygiene (comment-only, no behavior change)
Removed stale comments referencing the deleted SSH `-L 18787` transport (bui is direct HTTP/HTTPS now) in `push.mjs`, `index.mjs`, `App.tsx`, and `types.ts`.

## Files changed
5 files: `src/main/desktopPresence.ts`, `src/renderer/App.tsx`, `src/server/index.mjs`, `src/server/push.mjs`, `src/shared/types.ts`

**Base:** `origin/main` @ `2defd3f`

## Verification results
- PR branch (`multica/BET-136-desktop-presence-https` @ `29a3091`):
  - typecheck: exit `0`. Errors: none. log sha256: `f7dbfd435ea3ac52bb6337a7c5fab6a01b676b484c9291902d71fa9b69ca8580`
  - test: exit `0`, `489` pass / `0` fail / `0` skip. log sha256: `eb6afa04b899a148e769c3dbbcfa146287e77ffa321520f190887741fd9cbac0`
- Base (`main` @ `2defd3f`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`, `489` pass / `0` fail / `0` skip. log sha256: `03a94444da817a332853bc10b97e6d9f7937466e0014235b5f7c2ec3d6d3ebee`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. Identical pass counts on both branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.