### PR TITLE
feat(server,renderer): auto-refresh expired Claude credentials in chat mode (BET-139)

### DIFF
--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -58,6 +58,35 @@ export function RetryCard({
   );
 }
 
+// ===== Credential refresh card =====
+//
+// Rendered while the renderer auto-recovers from a ProviderAuthError (BET-139):
+// a background `claude` refresh runs server-side, and on success the failed
+// turn is auto-resent. Failure is surfaced via the sendError banner instead
+// (see credentialRefreshBannerText in chatUtils.ts) — this card renders
+// nothing for the "error" phase to avoid double-surfacing the message.
+
+export function CredRefreshCard({ state }: { state: "refreshing" | "ok" }) {
+  const isRefreshing = state === "refreshing";
+  return (
+    <div
+      className="rounded-md border bg-bg-elev px-3 py-2 text-[12px]"
+      style={{ borderColor: CLAUDE_ORANGE + "55" }}
+    >
+      <div className="flex items-center gap-2">
+        <span style={{ color: CLAUDE_ORANGE }}>
+          <span className={isRefreshing ? "inline-block animate-pulse" : "inline-block"}>
+            ↻
+          </span>
+        </span>
+        <span className="text-text">
+          {isRefreshing ? "Refreshing Claude credentials…" : "Credentials refreshed — resending."}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 // ===== Compaction card =====
 //
 // Rendered while session.next.compaction.* events stream in. "running" shows

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -36,6 +36,8 @@ import {
   classifyScrollForPin,
   detectCommandFromText,
   formatBytes,
+  credentialRefreshBannerText,
+  lastUserMessageText,
   type StaleCacheResult,
 } from "./chatUtils";
 import {
@@ -53,7 +55,7 @@ import {
   type TokenUsage,
 } from "./chatShared";
 import { RunningIndicator } from "./MessageRow";
-import { CompactionCard, PermissionCard, RetryCard } from "./Cards";
+import { CompactionCard, CredRefreshCard, PermissionCard, RetryCard } from "./Cards";
 import { ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
@@ -172,6 +174,19 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   // Input state must be declared before useSseBus (which needs setInput).
   const [input, setInput] = useState("");
 
+  // ===== Claude credential auto-refresh (BET-139) =====
+  //
+  // Driven by a ProviderAuthError session.error, routed here from useSseBus
+  // via the onProviderAuthError callback. `credRefresh` is a per-session
+  // live-event state, same convention as retryInfo/compactionState.
+  const [credRefresh, setCredRefresh] = useState<null | "refreshing" | "ok" | "error">(null);
+  // Indirection mirrors submitRef: the SSE effect inside useSseBus only
+  // depends on [sessionId], so a plain closure passed as a prop would be
+  // captured once (at mount / session change) and go stale against the
+  // freshest `messages`. Routing the call through a ref that's reassigned
+  // every render keeps it fresh without re-arming the SSE subscription.
+  const onProviderAuthErrorRef = useRef<() => void>(() => {});
+
   // ===== Transcript state (extracted to useTranscriptState) =====
   const {
     messages,
@@ -265,7 +280,39 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     submit: () => {}, // placeholder — ChatPanel's submit is used below
     submitRef,
     setInput,
+    // Indirection to dodge the circular dep: this callback needs setSendError
+    // (returned BY useSseBus) and the freshest `messages` (from
+    // useTranscriptState). onProviderAuthErrorRef.current is assigned below,
+    // after both are in scope — see the comment there.
+    onProviderAuthError: () => onProviderAuthErrorRef.current(),
   });
+
+  // Actual ProviderAuthError handler: refresh credentials server-side, then
+  // either auto-resend the failed turn (success) or surface an actionable
+  // banner (failure). Kept as a plain function (not useCallback) reassigned
+  // to the ref every render — see onProviderAuthErrorRef's declaration for
+  // why the indirection is needed.
+  onProviderAuthErrorRef.current = () => {
+    void (async () => {
+      setCredRefresh("refreshing");
+      const res = await window.api.opencodeRefreshCredentials();
+      if (res.ok) {
+        setCredRefresh("ok");
+        const lastText = lastUserMessageText(messages);
+        if (lastText) {
+          setInput(lastText);
+          setTimeout(() => {
+            submitRef.current?.();
+          }, 0);
+        }
+        setTimeout(() => setCredRefresh(null), 2500);
+      } else {
+        setCredRefresh("error");
+        setSendError(credentialRefreshBannerText(res.reason));
+        setCredRefresh(null);
+      }
+    })();
+  };
 
   // ===== ChatPanel-own state (not extracted to hooks) =====
   const [error, setError] = useState<string | null>(null);
@@ -323,8 +370,8 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   // resets messages/scroll/delta-buffer, useSseBus resets permissions/questions/
   // stepTokens/etc. via its SSE effect cleanup). We only need to reset the
   // ChatPanel-own state here: error, modelOverride, attachments, agentMentions,
-  // systemNotice, dragHover. The SSE stream open/close is also handled by
-  // useSseBus's effect now.
+  // systemNotice, dragHover, credRefresh. The SSE stream open/close is also
+  // handled by useSseBus's effect now.
   useEffect(() => {
     setError(null);
     setModelOverride(readSavedModel(sessionId) ?? configDefaultModel ?? null);
@@ -332,6 +379,7 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     setAgentMentions([]);
     setSystemNotice(null);
     setDragHover(false);
+    setCredRefresh(null);
     // Branch indicator: poll every 5s while this session is mounted.
     const fetchBranch = () => {
       window.api
@@ -1727,6 +1775,15 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       {compactionState && (
         <div className="shrink-0 px-4 pt-2">
           <CompactionCard state={compactionState} />
+        </div>
+      )}
+
+      {/* Claude credential auto-refresh (BET-139). Only "refreshing"/"ok" */}
+      {/* render here — "error" surfaces via the sendError banner instead */}
+      {/* (see onProviderAuthErrorRef above), so it's intentionally excluded. */}
+      {(credRefresh === "refreshing" || credRefresh === "ok") && (
+        <div className="shrink-0 px-4 pt-2">
+          <CredRefreshCard state={credRefresh} />
         </div>
       )}
 

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -784,6 +784,7 @@ export const httpApi: Api = {
   opencodeRestart: () => rpc(IPC.opencodeRestart),
   opencodeDefaultModel: () => rpc(IPC.opencodeDefaultModel),
   opencodeVcsBranch: (directory) => rpc(IPC.opencodeVcsBranch, directory),
+  opencodeRefreshCredentials: () => rpc(IPC.opencodeRefreshCredentials),
 
   // -- session management --
   opencodeListSessions: (directory) => rpc(IPC.opencodeListSessions, directory),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -61,6 +61,8 @@ import {
   reconcileOptimisticUser,
   shouldForceReconnect,
   runWithConcurrency,
+  credentialRefreshBannerText,
+  lastUserMessageText,
 } from "./chatUtils";
 
 // ===== formatTokens =====
@@ -2842,5 +2844,64 @@ describe("runWithConcurrency", () => {
       seen.push(item);
     });
     expect(seen.sort((a, b) => a - b)).toEqual(items);
+  });
+});
+
+// ===== credentialRefreshBannerText =====
+
+describe("credentialRefreshBannerText", () => {
+  it("maps refresh-token-expired to a re-login instruction", () => {
+    expect(credentialRefreshBannerText("refresh-token-expired")).toBe(
+      "Claude login expired — run `opencode auth login anthropic` on the box, then retry.",
+    );
+  });
+
+  it("maps no-credentials to a login instruction", () => {
+    expect(credentialRefreshBannerText("no-credentials")).toBe(
+      "No Claude credentials found — run `opencode auth login anthropic` on the box.",
+    );
+  });
+
+  it("maps failed (and undefined) to a generic manual-fix instruction", () => {
+    const expected =
+      "Couldn't refresh Claude credentials automatically. Run `claude` on the box, then retry.";
+    expect(credentialRefreshBannerText("failed")).toBe(expected);
+    expect(credentialRefreshBannerText(undefined)).toBe(expected);
+  });
+});
+
+// ===== lastUserMessageText =====
+
+describe("lastUserMessageText", () => {
+  it("returns the most recent non-empty user message", () => {
+    const out = lastUserMessageText([
+      { info: { role: "user" }, parts: [{ type: "text", text: "first" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "reply" }] },
+      { info: { role: "user" }, parts: [{ type: "text", text: "second" }] },
+    ]);
+    expect(out).toBe("second");
+  });
+
+  it("skips synthetic/ignored/empty user messages when searching backward", () => {
+    const out = lastUserMessageText([
+      { info: { role: "user" }, parts: [{ type: "text", text: "keep me" }] },
+      {
+        info: { role: "user" },
+        parts: [{ type: "text", text: "dropped", synthetic: true }],
+      },
+    ]);
+    expect(out).toBe("keep me");
+  });
+
+  it("returns null for null/empty transcripts", () => {
+    expect(lastUserMessageText(null)).toBe(null);
+    expect(lastUserMessageText([])).toBe(null);
+  });
+
+  it("returns null when there are no user messages", () => {
+    const out = lastUserMessageText([
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "hi" }] },
+    ]);
+    expect(out).toBe(null);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2012,3 +2012,45 @@ export async function runWithConcurrency<T>(
   });
   await Promise.all(workers);
 }
+
+// ---------------------------------------------------------------------------
+// Claude credential auto-refresh (BET-139)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a failed `opencodeRefreshCredentials()` outcome to the actionable
+ * banner text shown via `setSendError`. Pure so the copy is testable without
+ * exercising the async refresh flow. Keep in sync with the reasons returned
+ * by `refreshClaudeCredentials` in src/server/opencode.mjs.
+ */
+export function credentialRefreshBannerText(
+  reason?: "no-credentials" | "refresh-token-expired" | "failed",
+): string {
+  switch (reason) {
+    case "refresh-token-expired":
+      return "Claude login expired — run `opencode auth login anthropic` on the box, then retry.";
+    case "no-credentials":
+      return "No Claude credentials found — run `opencode auth login anthropic` on the box.";
+    default:
+      return "Couldn't refresh Claude credentials automatically. Run `claude` on the box, then retry.";
+  }
+}
+
+/**
+ * The text of the most recent user-role message with non-empty text —
+ * i.e. the turn that just errored with ProviderAuthError and needs to be
+ * auto-resent once credentials are refreshed. Returns null when there's no
+ * such message (empty/synthetic transcript).
+ */
+export function lastUserMessageText(
+  messages: { info: { role: string }; parts: OpencodePartLike[] }[] | null,
+): string | null {
+  if (!messages) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.info.role !== "user") continue;
+    const text = extractTextFromParts(m.parts).trim();
+    if (text) return text;
+  }
+  return null;
+}

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -135,6 +135,10 @@ export function useSseBus(params: {
   submit: () => void;
   submitRef: React.RefObject<() => void>;
   setInput: (v: string) => void;
+  // Called (fire-and-forget) on a ProviderAuthError session.error. The async
+  // refresh-then-resend logic lives in ChatPanel (with the rest of the panel
+  // logic) — this hook only routes the event to the callback.
+  onProviderAuthError: () => void;
 }): SseBus {
   const {
     sessionId,
@@ -153,6 +157,7 @@ export function useSseBus(params: {
     submit,
     submitRef,
     setInput,
+    onProviderAuthError,
   } = params;
 
   const [running, setRunning] = useState(false);
@@ -433,11 +438,17 @@ export function useSseBus(params: {
           setRunning(false);
           return;
         }
+        // ProviderAuthError is not surfaced as a plain banner — it triggers
+        // the credential auto-refresh flow (owned by ChatPanel) instead.
+        // Skip the generic switch entirely so its `setSendError` call below
+        // doesn't race the refresh's own (better, actionable) messaging.
+        if (err?.name === "ProviderAuthError") {
+          setRunning(false);
+          onProviderAuthError();
+          return;
+        }
         let msg: string;
         switch (err?.name) {
-          case "ProviderAuthError":
-            msg = `Auth error: ${raw}`;
-            break;
           case "ContextOverflowError":
             msg = `Context full — try /compact: ${raw}`;
             break;

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -67,6 +67,7 @@ function defaultApiImpl(): Record<string, unknown> {
     opencodeModels: () => Promise.resolve([]),
     opencodeDefaultModel: () => Promise.resolve(null),
     opencodeVcsBranch: () => Promise.resolve(null),
+    opencodeRefreshCredentials: () => Promise.resolve({ ok: false, reason: "failed" }),
     opencodeCommands: () => Promise.resolve([]),
     opencodeAgents: () => Promise.resolve([]),
     opencodeFindFiles: () => Promise.resolve([]),

--- a/src/server/claudeAuth.mjs
+++ b/src/server/claudeAuth.mjs
@@ -1,0 +1,80 @@
+// Pure helpers for the Claude credential auto-refresh flow (BET-139).
+//
+// Chat mode authenticates to Anthropic via the opencode-claude-auth plugin,
+// which reads/writes ~/.claude/.credentials.json. When the plugin can't
+// refresh a stale access token, opencode emits a ProviderAuthError. The
+// user's manual fix today is to run `claude` once on the box, which re-mints
+// the token; this module supplies the PURE decision logic for automating
+// that fix. All IO (spawn, file read) lives in src/server/opencode.mjs
+// (refreshClaudeCredentials) — this file has no top-level side effects and
+// no imports of node:fs / node:child_process, so it's directly node:test-able
+// with in-memory literals.
+
+import { homedir } from "node:os";
+import path from "node:path";
+
+/** Where the opencode-claude-auth plugin (and the `claude` CLI) persist OAuth
+ *  tokens. Expanded via homedir() so it works regardless of $HOME overrides
+ *  in the spawned child's env. */
+export const CREDENTIALS_PATH = path.join(homedir(), ".claude", ".credentials.json");
+
+/**
+ * Parse the raw text of ~/.claude/.credentials.json into the fields we care
+ * about. Returns null for invalid JSON or a missing `claudeAiOauth` block —
+ * callers treat null as "no usable credentials" rather than throwing.
+ *
+ * @param {string} rawFileText
+ * @returns {{ accessToken?: string, refreshToken?: string, expiresAt?: number, refreshTokenExpiresAt?: number } | null}
+ */
+export function parseCredentials(rawFileText) {
+  let parsed;
+  try {
+    parsed = JSON.parse(rawFileText);
+  } catch {
+    return null;
+  }
+  const oauth = parsed?.claudeAiOauth;
+  if (!oauth || typeof oauth !== "object") return null;
+  return {
+    accessToken: oauth.accessToken,
+    refreshToken: oauth.refreshToken,
+    expiresAt: oauth.expiresAt,
+    refreshTokenExpiresAt: oauth.refreshTokenExpiresAt,
+  };
+}
+
+/**
+ * True when the refresh token itself is expired — i.e. the CLI refresh
+ * cannot possibly succeed and the user must re-run `opencode auth login
+ * anthropic` (or `claude` interactively) to re-authenticate from scratch.
+ * A missing `refreshTokenExpiresAt` is treated as "not expired" (assume
+ * still valid — do not block on missing data).
+ *
+ * @param {{ refreshTokenExpiresAt?: number }} creds
+ * @param {number} now epoch millis
+ * @returns {boolean}
+ */
+export function isRefreshTokenExpired(creds, now) {
+  const exp = creds?.refreshTokenExpiresAt;
+  return typeof exp === "number" && exp <= now;
+}
+
+/**
+ * Classify the outcome of a refresh attempt by comparing the credential
+ * snapshot before and after running the CLI refresh. Pure — no IO, just a
+ * decision over the two snapshots + current time.
+ *
+ * @param {{ credsBefore: ReturnType<typeof parseCredentials>, credsAfter: ReturnType<typeof parseCredentials>, now: number }} args
+ * @returns {"no-credentials" | "refresh-token-expired" | "ok" | "failed"}
+ */
+export function classifyRefreshOutcome({ credsBefore, credsAfter, now }) {
+  if (!credsBefore) return "no-credentials";
+  if (isRefreshTokenExpired(credsBefore, now)) return "refresh-token-expired";
+  // Mirrors the opencode-claude-auth plugin's own freshness check
+  // (expiresAt > now + 60_000, a 60s clock-skew margin) — "ok" means the
+  // token was genuinely advanced past that window, not just present.
+  if (credsAfter && typeof credsAfter.expiresAt === "number" && credsAfter.expiresAt > now + 60_000) {
+    return "ok";
+  }
+  return "failed";
+}

--- a/src/server/claudeAuth.test.mjs
+++ b/src/server/claudeAuth.test.mjs
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseCredentials,
+  isRefreshTokenExpired,
+  classifyRefreshOutcome,
+} from "./claudeAuth.mjs";
+
+// ===== parseCredentials =====
+
+test("parseCredentials extracts claudeAiOauth fields from a valid blob", () => {
+  const raw = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: "at",
+      refreshToken: "rt",
+      expiresAt: 1000,
+      refreshTokenExpiresAt: 2000,
+    },
+  });
+  assert.deepEqual(parseCredentials(raw), {
+    accessToken: "at",
+    refreshToken: "rt",
+    expiresAt: 1000,
+    refreshTokenExpiresAt: 2000,
+  });
+});
+
+test("parseCredentials returns null when claudeAiOauth is missing", () => {
+  assert.equal(parseCredentials(JSON.stringify({ other: "field" })), null);
+});
+
+test("parseCredentials returns null for invalid JSON", () => {
+  assert.equal(parseCredentials("not json{"), null);
+});
+
+// ===== isRefreshTokenExpired =====
+
+test("isRefreshTokenExpired: true when refreshTokenExpiresAt is in the past", () => {
+  assert.equal(isRefreshTokenExpired({ refreshTokenExpiresAt: 1000 }, 2000), true);
+});
+
+test("isRefreshTokenExpired: false when refreshTokenExpiresAt is in the future", () => {
+  assert.equal(isRefreshTokenExpired({ refreshTokenExpiresAt: 3000 }, 2000), false);
+});
+
+test("isRefreshTokenExpired: false when the field is missing (assume still valid)", () => {
+  assert.equal(isRefreshTokenExpired({}, 2000), false);
+});
+
+// ===== classifyRefreshOutcome =====
+
+test("classifyRefreshOutcome: no-credentials when credsBefore is null", () => {
+  assert.equal(
+    classifyRefreshOutcome({ credsBefore: null, credsAfter: null, now: 1000 }),
+    "no-credentials",
+  );
+});
+
+test("classifyRefreshOutcome: refresh-token-expired when the refresh token itself expired", () => {
+  const credsBefore = { expiresAt: 500, refreshTokenExpiresAt: 900 };
+  assert.equal(
+    classifyRefreshOutcome({ credsBefore, credsAfter: null, now: 1000 }),
+    "refresh-token-expired",
+  );
+});
+
+test("classifyRefreshOutcome: ok when the token advanced past now + 60s", () => {
+  const now = 1_000_000;
+  const credsBefore = { expiresAt: 500, refreshTokenExpiresAt: now + 10_000_000 };
+  const credsAfter = { expiresAt: now + 61_000, refreshTokenExpiresAt: now + 10_000_000 };
+  assert.equal(classifyRefreshOutcome({ credsBefore, credsAfter, now }), "ok");
+});
+
+test("classifyRefreshOutcome: failed when the token did not advance (same/no progress)", () => {
+  const now = 1_000_000;
+  const credsBefore = { expiresAt: 500, refreshTokenExpiresAt: now + 10_000_000 };
+  // credsAfter identical to before — refresh ran but nothing changed.
+  const credsAfter = { expiresAt: 500, refreshTokenExpiresAt: now + 10_000_000 };
+  assert.equal(classifyRefreshOutcome({ credsBefore, credsAfter, now }), "failed");
+});
+
+test("classifyRefreshOutcome: failed when credsAfter is null (file unreadable post-refresh)", () => {
+  const now = 1_000_000;
+  const credsBefore = { expiresAt: 500, refreshTokenExpiresAt: now + 10_000_000 };
+  assert.equal(
+    classifyRefreshOutcome({ credsBefore, credsAfter: null, now }),
+    "failed",
+  );
+});

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -9,8 +9,15 @@
 // task comments on each function).
 
 import { spawn as cpSpawn } from "node:child_process";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
 import http from "node:http";
+import {
+  CREDENTIALS_PATH,
+  parseCredentials,
+  isRefreshTokenExpired,
+  classifyRefreshOutcome,
+} from "./claudeAuth.mjs";
 
 const REMOTE_PORT = 4096;
 
@@ -856,6 +863,88 @@ export async function getVcsBranch(directory) {
       resolve(name ? name : null);
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Claude credential auto-refresh (BET-139)
+// ---------------------------------------------------------------------------
+
+// Single-flight guard: concurrent ProviderAuthError events share one
+// in-flight refresh promise instead of racing multiple `claude` spawns.
+let _refreshInFlight = null;
+
+/** Best-effort read + parse of ~/.claude/.credentials.json. Null on any
+ *  read or parse failure (file missing, permissions, malformed JSON). */
+function readCredsSnapshot() {
+  try {
+    return parseCredentials(readFileSync(CREDENTIALS_PATH, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-mint expired Claude OAuth credentials by shelling out to the `claude`
+ * CLI — the exact fix the user performs by hand today. Mirrors getVcsBranch's
+ * cpSpawn-wrapped-in-a-Promise shape.
+ *
+ * Triggered from exactly ONE place: the renderer's ProviderAuthError handler
+ * (via the opencode:refresh-credentials RPC channel). Single-flight guarded
+ * so concurrent auth errors share one refresh instead of duplicate spawns.
+ *
+ * @returns {Promise<{ ok: boolean, reason?: "no-credentials" | "refresh-token-expired" | "failed", expiresAt?: number }>}
+ */
+export async function refreshClaudeCredentials() {
+  if (_refreshInFlight) return _refreshInFlight;
+  _refreshInFlight = doRefresh().finally(() => {
+    _refreshInFlight = null;
+  });
+  return _refreshInFlight;
+}
+
+async function doRefresh() {
+  const credsBefore = readCredsSnapshot();
+
+  // Pre-checks — no point spawning `claude` if we already know it can't work.
+  if (!credsBefore) {
+    return logAndReturn({ ok: false, reason: "no-credentials" });
+  }
+  if (isRefreshTokenExpired(credsBefore, Date.now())) {
+    return logAndReturn({ ok: false, reason: "refresh-token-expired" });
+  }
+
+  // Run the CLI refresh (this is the "run claude" the user does by hand).
+  // Non-zero exit / spawn error (e.g. ENOENT) doesn't short-circuit — we
+  // re-check the actual credentials file afterward, which is the source of
+  // truth regardless of the process's exit code.
+  await new Promise((resolve) => {
+    const proc = cpSpawn("claude", ["-p", ".", "--model", "haiku"], {
+      cwd: tmpdir(),
+      env: { ...process.env, TERM: "dumb" },
+      stdio: "ignore",
+      timeout: 60_000,
+    });
+    proc.on("error", () => resolve());
+    proc.on("exit", () => resolve());
+  });
+
+  const credsAfter = readCredsSnapshot();
+  const now = Date.now();
+  const outcome = classifyRefreshOutcome({ credsBefore, credsAfter, now });
+  if (outcome === "ok") {
+    return logAndReturn({ ok: true, expiresAt: credsAfter.expiresAt });
+  }
+  return logAndReturn({ ok: false, reason: outcome });
+}
+
+function logAndReturn(result) {
+  console.log(
+    "[claude-auth] refresh ok=%s reason=%s expiresAt=%s",
+    result.ok,
+    result.reason ?? "-",
+    result.expiresAt ?? "-",
+  );
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -267,6 +267,9 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     // → args[0] = directory (string | undefined)
     "opencode:vcs-branch": (directory) => oc.getVcsBranch(directory),
 
+    // preload: ipcRenderer.invoke(IPC.opencodeRefreshCredentials)  → no args
+    "opencode:refresh-credentials": () => oc.refreshClaudeCredentials(),
+
     // preload: ipcRenderer.invoke(IPC.opencodeListSessions, directory?)
     // → args[0] = directory (string | undefined)
     "opencode:list-sessions": (directory) => oc.listSessions(directory),

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -216,6 +216,11 @@ export interface Api {
   }): Promise<{ ok: boolean; error?: string }>;
   opencodeRestart(): Promise<void>;
   opencodeVcsBranch(directory?: string): Promise<string | null>;
+  opencodeRefreshCredentials(): Promise<{
+    ok: boolean;
+    reason?: "no-credentials" | "refresh-token-expired" | "failed";
+    expiresAt?: number;
+  }>;
 
   // Session management.
   opencodeListSessions(directory?: string): Promise<OpencodeSessionListItem[]>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -330,6 +330,10 @@ export const IPC = {
   // only fires on change, so the chat footer fetches the initial value on
   // mount via this channel.
   opencodeVcsBranch: "opencode:vcs-branch",
+  // Re-mint expired Claude OAuth credentials (spawns `claude` server-side)
+  // and report the outcome. Triggered by the renderer's ProviderAuthError
+  // handler — see the session.error switch in useSseBus.ts.
+  opencodeRefreshCredentials: "opencode:refresh-credentials",
   // Session management: list/fork/compact/delete.
   opencodeListSessions: "opencode:list-sessions",
   opencodeForkSession: "opencode:fork-session",     // returns new sessionId


### PR DESCRIPTION
## Summary

Implements the v1 (minimal) auto-refresh of expired Claude OAuth credentials in chat mode, per BET-139. On a `ProviderAuthError` session error, the renderer now triggers a server-side credential refresh (`claude -p . --model haiku`, the exact fix a user does by hand) and, on success, auto-resends the failed turn. On failure it shows an actionable banner instead of the old generic `Auth error: <raw>` message.

**Base:** `origin/main` @ `3f0b073`

Note: the issue references `docs/specs/2026-07-12-claude-credential-auto-refresh.md` as mandatory reading — that file does not exist anywhere in git history on this repo. The issue body itself is exhaustively detailed (effectively the spec inline), so I implemented directly from it.

## What changed

**Server (Part A)**
- `src/server/claudeAuth.mjs` (new): pure helpers — `parseCredentials`, `isRefreshTokenExpired`, `classifyRefreshOutcome`. No IO, no top-level side effects.
- `src/server/opencode.mjs`: `refreshClaudeCredentials()` — spawns `claude -p . --model haiku`, single-flight guarded (`_refreshInFlight`), mirrors `getVcsBranch`'s cpSpawn-wrapped-in-a-Promise shape. Logs one `[claude-auth] refresh ok=… reason=… expiresAt=…` line per attempt.
- RPC channel `opencode:refresh-credentials` wired across `src/shared/api.ts`, `src/shared/types.ts`, `src/renderer/api/httpApi.ts`, `src/server/rpc.mjs` — same sites as `opencodeVcsBranch`. Preload untouched (typecheck passed without it).
- `src/server/claudeAuth.test.mjs` (new): 11 node:test cases covering all branches of the 3 pure helpers.

**Renderer (Part B)**
- `src/renderer/hooks/useSseBus.ts`: the `session.error` switch's `ProviderAuthError` case no longer sets the `Auth error: …` banner — it calls a new `onProviderAuthError` callback (passed in from ChatPanel, routed through a ref indirection mirroring the existing `submitRef` pattern, since the handler needs the freshest `messages`/`setSendError` which aren't stable across the hook's `[sessionId]`-scoped SSE effect).
- `src/renderer/ChatPanel.tsx`: new `credRefresh` state (`null | "refreshing" | "ok" | "error"`), reset alongside the other per-session live states. The handler calls `window.api.opencodeRefreshCredentials()`; on success it restores the last user message into `input` and resubmits via the existing `submitRef.current()` deferred-`setTimeout(0)` pattern (same one the queued-message drain uses — no new send path); on failure it sets `sendError` to the mapped banner text.
- `src/renderer/Cards.tsx`: new `CredRefreshCard` (styled after `RetryCard`) — "Refreshing Claude credentials…" / "Credentials refreshed — resending." The "error" state renders nothing here; the `sendError` banner carries that message (no double-surfacing).
- `src/renderer/chatUtils.ts`: `credentialRefreshBannerText(reason)` (the 3 banner strings, pure + tested) and `lastUserMessageText(messages)` (pure selector for the turn to resend).
- `src/renderer/testHarness.tsx`: added a default `opencodeRefreshCredentials` stub for the test harness's `window.api`.

## Scope discipline

Exactly one trigger path (renderer `ProviderAuthError` branch). Single-flight guard server-side. No new npm deps, no new AppConfig, no Settings UI, no mobile-specific CSS (ChatPanel is shared, so this ships to mobile automatically). Preload left untouched per the issue's instruction (typecheck compiles without it).

## Verification results

- PR branch (`multica/BET-139-claude-auth-refresh` @ `b0de0cc`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e`
  - test: exit `0`. Vitest 909/909 pass. node:test 500/500 pass, 0 fail. log sha256: `b4a03710db9fd7f22c30a105d0d2eeee9c9f3ab451f1c847dddda1cbbf7ff5c1`
- Base (`main` @ `3f0b073`):
  - typecheck: exit `0`. Errors: none. log sha256: `b88e8941187928d1e8e83088a2e929d18d4cee2e508cc1d7da96459a4017097e` (identical — no pre-existing errors either branch)
  - test: exit `0`. Vitest 902/902 pass. node:test 489/489 pass, 0 fail. log sha256: `3b53686c91dc2a9d91ad36ffb84253b25c28bef49d755e1794afd34b7c02dde8`
- **Conclusion:** 0 test failures on either branch. The PR branch adds 7 new vitest cases (`credentialRefreshBannerText`, `lastUserMessageText`) and 11 new node:test cases (`claudeAuth.mjs` helpers) — accounting for the 909-902=7 and 500-489=11 deltas. 0 pre-existing failures, 0 new failures, 0 regressions.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

## e2e smoke (bui-e2e-smoke)

Built (`npm run build`) and launched the packaged app via Playwright's Electron launcher (`xvfb-run`, no live `$DISPLAY` in this sandbox). App title "Better UI" rendered, **zero console errors**. This fresh test environment has no `~/.bui-mobile`-style Electron `config.json`, so the app correctly shows the full-screen onboarding "Connect to your server" screen instead of the sidebar/main layout — this is pre-existing, unrelated first-run behavior (confirmed not a regression: this PR touches no onboarding code). No crash, no blank screen.

## Files changed

13 files: `src/server/claudeAuth.mjs` (new), `src/server/claudeAuth.test.mjs` (new), `src/server/opencode.mjs`, `src/server/rpc.mjs`, `src/shared/api.ts`, `src/shared/types.ts`, `src/renderer/api/httpApi.ts`, `src/renderer/hooks/useSseBus.ts`, `src/renderer/ChatPanel.tsx`, `src/renderer/Cards.tsx`, `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts`, `src/renderer/testHarness.tsx`
