### PR TITLE
rebrand: migrate public domains bui.* -> mantaui.com

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,8 +268,8 @@ also accept `?token=`. Default bind `127.0.0.1:8787`. Internet access is a
   (`MANTA_MOBILE_HOST=127.0.0.1`, port 8787).
 - `~/.config/systemd/user/bui-tunnel.service` (`Requires=bui-server`) →
   `cloudflared tunnel --config ~/.cloudflared/config.yml run bui`.
-- Permanent URL: **https://bui.useronda.com** (named tunnel
-  `6cdca2ea-…`, zone `useronda.com`). Stable across restarts — the iOS
+- Permanent URL: **https://app.mantaui.com** (named tunnel
+  `6cdca2ea-…`, zone `mantaui.com`). Stable across restarts — the iOS
   PWA install stays valid.
 - Manage: `systemctl --user {status,restart} bui-tunnel bui-server`;
   logs `journalctl --user -u bui-tunnel`.
@@ -356,7 +356,7 @@ IS the box — local execution, no hop.
 **Config schema (post-pairing):**
 ```json
 {
-  "serverUrl": "https://bui.useronda.com",
+  "serverUrl": "https://app.mantaui.com",
   "boxId": "<32-hex-char>",
   "boxToken": "<32-hex-char>",
   "projects": [{ "tmuxSession": "...", "defaultCwd": "..." }]
@@ -518,7 +518,7 @@ generates on the box. Follows the same "bui tools" pattern as the scheduler
   `/tmp` cleanup; updating = re-call `serve_page` with the same subdomain).
 - **In-process file server on `127.0.0.1:20080`** (`createFileServer`/
   `startFileServer`, started in `index.mjs` alongside the schedule poller).
-  Routes by **Host header**: `<sub>.bui.antoinedc.com` → that subdomain's
+  Routes by **Host header**: `<sub>.pages.mantaui.com` → that subdomain's
   `index.html`. `extractSubdomain` (pure, tested) rejects non-matching hosts
   and multi-level subdomains. Re-reads from disk per request with `no-store`,
   so an overwrite of the page file is live immediately.
@@ -528,11 +528,11 @@ generates on the box. Follows the same "bui tools" pattern as the scheduler
   immediately. A request for a subdomain whose dir was deleted externally
   prunes the stale registry entry.
 - **Public path is the system Caddy, NOT the Cloudflare tunnel.** Distinct from
-  bui's own `bui.useronda.com` tunnel. `/etc/caddy/Caddyfile` has a
-  `*.bui.antoinedc.com` block → `reverse_proxy 127.0.0.1:20080` with an **OVH
+  bui's own `app.mantaui.com` tunnel. `/etc/caddy/Caddyfile` has a
+  `*.pages.mantaui.com` block → `reverse_proxy 127.0.0.1:20080` with an **OVH
   DNS-01 wildcard cert** (3-level subdomain, needs its own `tls { dns ovh … }`
-  block — not covered by the `*.dev` single-level wildcard). DNS: `*.bui`
-  A-record → `157.90.224.92` in the OVH `antoinedc.com` zone (OVH creds are
+  block — not covered by the `*.dev` single-level wildcard). DNS: `*.pages`
+  A-record → `157.90.224.92` in the OVH `mantaui.com` zone (OVH creds are
   root-only at `/etc/caddy/ovh.env`; the python `ovh` module + passwordless
   sudo were used to add the record). Caddy reload: `sudo systemctl reload caddy`.
 - **No UI card (v1).** Unlike the scheduler there's no ChatPanel management

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ the onboarding flow:
 
 1. **Pair with your box.** Run the self-install script on your Linux box:
    ```bash
-   curl -fsSL https://bui.useronda.com/install.sh | bash
+   curl -fsSL https://app.mantaui.com/install.sh | bash
    ```
    It installs bui-server, starts it, and prints a 6-digit pairing code.
    Enter the code in the bui onboarding screen (along with your box's URL).
@@ -109,7 +109,7 @@ pairing flow. On a fresh Linux VPS, one command installs and starts it and
 prints a 6-digit pairing code to enter in the desktop app:
 
 ```bash
-curl -fsSL https://bui.useronda.com/install.sh | bash
+curl -fsSL https://app.mantaui.com/install.sh | bash
 ```
 
 The installer downloads a pre-built release tarball (no dev toolchain needed on
@@ -124,7 +124,7 @@ Overrides (env):
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `MANTA_TARBALL_URL` | (built from host+version) | full tarball URL — local testing / mirror |
-| `MANTA_RELEASE_HOST` | `https://bui.useronda.com` | host for the default tarball URL |
+| `MANTA_RELEASE_HOST` | `https://app.mantaui.com` | host for the default tarball URL |
 | `MANTA_HOME` | `~/bui` | where the code is unpacked |
 | `MANTA_MOBILE_PORT` | `8787` | server port |
 

--- a/docs/bui-tools-webhook.md
+++ b/docs/bui-tools-webhook.md
@@ -55,7 +55,7 @@ goes green", "let GitHub notify this chat on a new issue".
   land back in the **same chat session** the user is in.
 - The tool returns the **public delivery URL and the signing secret** so the
   agent can configure the external system:
-  `https://bui.useronda.com/hook/<token>` + `secret: whsec_…`.
+  `https://app.mantaui.com/hook/<token>` + `secret: whsec_…`.
 
 `webhook_list` shows this session's hooks (id, label, url, created, last
 delivery time). `webhook_delete` removes one by id (revokes the token).
@@ -63,7 +63,7 @@ delivery time). `webhook_delete` removes one by id (revokes the token).
 ### What an external actor sends
 
 ```
-POST https://bui.useronda.com/hook/<token>
+POST https://app.mantaui.com/hook/<token>
 X-Bui-Signature: sha256=<hmac>          # required unless the hook is unsigned
 Content-Type: application/json
 { "event": "task.completed", "key": "CAPO-123", "result": "merged", ... }
@@ -103,7 +103,7 @@ defense-in-depth on top of the signature.
 Every prior bui tool endpoint binds to `127.0.0.1` (same box, implicit trust).
 A webhook is **the first endpoint that must be reachable by an external,
 untrusted actor**, so it goes through the public Cloudflare tunnel
-(`bui.useronda.com`). And the payload it carries becomes a prompt in a session
+(`app.mantaui.com`). And the payload it carries becomes a prompt in a session
 that may have **`chatAutoAllow` on** (the dangerously-skip-permissions
 equivalent). Unauthenticated public text → auto-approving agent is a
 prompt-injection → RCE path. This is designed in from line one, not bolted on.
@@ -235,8 +235,8 @@ Two route families, added alongside the existing `/api/*` blocks:
   distinctly and, if desired, apply edge rate-limiting.
 
 **Exposure:** `/hook/*` is served by bui-server (port 8787) and reached through
-the existing `bui.useronda.com` Cloudflare tunnel — no new tunnel, no new Caddy
-block needed (distinct from the `*.bui.antoinedc.com` serve-page path). The
+the existing `app.mantaui.com` Cloudflare tunnel — no new tunnel, no new Caddy
+block needed (distinct from the `*.pages.mantaui.com` serve-page path). The
 management routes stay loopback-only in practice (desktop reaches them over the
 `-L 18787` forward); only `/hook/*` is meant for the internet.
 

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -31,13 +31,13 @@ the bui UI (the ⏰ schedules card), so keep labels short and descriptive.
 You have `serve_page`, `stop_page`, and `list_pages` tools to host standalone
 HTML pages publicly. When you generate a web page (design preview, demo,
 mockup), call `serve_page(subdomain, filePath)` to get a public URL under
-*.bui.antoinedc.com. The page auto-expires after 24h (configurable via
+*.pages.mantaui.com. The page auto-expires after 24h (configurable via
 `ttlHours`, or `0` for no expiry). To update a page, call `serve_page` again
 with the same subdomain and a new file. Call `stop_page(subdomain)` to take
 it down early. `list_pages` shows all active pages.
 
-- `serve_page(subdomain, filePath, ttlHours?)` -> "Page served at https://<sub>.bui.antoinedc.com"
-- `stop_page(subdomain)` -> "Page <sub>.bui.antoinedc.com has been taken down."
+- `serve_page(subdomain, filePath, ttlHours?)` -> "Page served at https://<sub>.pages.mantaui.com"
+- `stop_page(subdomain)` -> "Page <sub>.pages.mantaui.com has been taken down."
 - `list_pages` -> bullet list of active pages with URLs and expiry times
 
 ## bui peer-session awareness
@@ -141,7 +141,7 @@ session when the task finishes instead of checking every 5 minutes", "wake me
 here when CI goes green", "let GitHub notify this chat on a new issue".
 
 - `webhook_create(label, instructions?, unsigned?)` -> returns a public delivery
-  URL (`https://bui.useronda.com/hook/<token>`) and an HMAC signing secret
+  URL (`https://app.mantaui.com/hook/<token>`) and an HMAC signing secret
   (shown ONCE). Give both to the user or configure the external system to POST
   its event JSON to that URL with header
   `X-Bui-Signature: sha256=HMAC_SHA256(secret, rawBody)`. `instructions` is a

--- a/docs/opencode-tools/serve-page.ts
+++ b/docs/opencode-tools/serve-page.ts
@@ -8,7 +8,7 @@
 // This tool is a THIN registrar. It validates the request and POSTs it to
 // manta-server (127.0.0.1:8787, same box — no SSH hop), which copies the page
 // into a stable directory and serves it via an in-process HTTP server. Caddy
-// reverse-proxies *.bui.antoinedc.com to this server. The tool does NOT sleep
+// reverse-proxies *.pages.mantaui.com to this server. The tool does NOT sleep
 // or run the page itself — execute() must return promptly.
 //
 // See docs/bui-tools-scheduler.md for the general "bui tools" pattern.
@@ -69,11 +69,11 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
 
 export const serve_page = tool({
   description: [
-    "Host a standalone HTML webpage publicly under *.bui.antoinedc.com.",
+    "Host a standalone HTML webpage publicly under *.pages.mantaui.com.",
     "Use when you generate a web page (design preview, demo, mockup, interactive",
     "prototype) and want it accessible from anywhere — especially from the",
     "machine where the bui UI is running. The page is served at",
-    "https://<subdomain>.bui.antoinedc.com and auto-expires after 24h by",
+    "https://<subdomain>.pages.mantaui.com and auto-expires after 24h by",
     "default (configurable via ttlHours). To update a page, call this tool",
     "again with the same subdomain and a new file path.",
   ].join(" "),
@@ -84,7 +84,7 @@ export const serve_page = tool({
         "Subdomain for the page (e.g. 'preview', 'my-design'). " +
           "Must be 1-63 lowercase alphanumeric characters or hyphens, no " +
           "leading/trailing hyphens. The page will be served at " +
-          "https://<subdomain>.bui.antoinedc.com",
+          "https://<subdomain>.pages.mantaui.com",
       ),
     filePath: z
       .string()
@@ -133,7 +133,7 @@ export const stop_page = tool({
       `/api/serve-page?subdomain=${encodeURIComponent(args.subdomain)}`,
     );
     return result.deleted
-      ? `Page ${args.subdomain}.bui.antoinedc.com has been taken down.`
+      ? `Page ${args.subdomain}.pages.mantaui.com has been taken down.`
       : `No page found for subdomain "${args.subdomain}".`;
   },
 });

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -33,7 +33,7 @@ export const HEALTH_PATH = "/auth/status";
 // Default release host. The repo is private; CI publishes a versioned tarball
 // the installer downloads (no git clone on the VPS). `MANTA_TARBALL_URL` overrides
 // the whole URL for local testing; otherwise we build it from host + version.
-export const DEFAULT_RELEASE_HOST = "https://bui.useronda.com";
+export const DEFAULT_RELEASE_HOST = "https://app.mantaui.com";
 
 // Where the box lives once installed. `~/.manta/` (auth.json + config.json)
 // is deliberately OUTSIDE this dir so an upgrade that replaces MANTA_HOME never

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # install.sh — one-command VPS self-install for the bui box server.
 #
-#   curl -fsSL https://bui.useronda.com/install.sh | bash
+#   curl -fsSL https://app.mantaui.com/install.sh | bash
 #
 # Gets manta-server running under systemd --user on a fresh Linux box and prints a
 # 6-digit pairing code to enter in the desktop app. Idempotent: re-running
@@ -11,7 +11,7 @@
 #
 # Overrides (env):
 #   MANTA_TARBALL_URL   full URL of the release tarball (skips host+version build)
-#   MANTA_RELEASE_HOST  host for the default tarball URL (default bui.useronda.com)
+#   MANTA_RELEASE_HOST  host for the default tarball URL (default app.mantaui.com)
 #   MANTA_HOME          where code is unpacked (default ~/bui)
 #   MANTA_MOBILE_PORT   server port (default 8787)
 #   MANTA_VERSION       version to fetch when MANTA_TARBALL_URL is unset (default: latest)
@@ -72,7 +72,7 @@ MANTA_VERSION="${MANTA_VERSION:-latest}"
 if [ -n "${MANTA_TARBALL_URL:-}" ]; then
   TARBALL_URL="$MANTA_TARBALL_URL"
 else
-  host="${MANTA_RELEASE_HOST:-https://bui.useronda.com}"
+  host="${MANTA_RELEASE_HOST:-https://app.mantaui.com}"
   host="${host%/}"
   TARBALL_URL="${host}/releases/bui-${MANTA_VERSION}.tar.gz"
 fi

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -95,10 +95,10 @@ test("parsePort accepts valid ports, rejects junk", () => {
 test("resolveTarballUrl builds default URL from host + version", () => {
   const url = resolveTarballUrl({
     tarballUrl: null,
-    releaseHost: "https://bui.useronda.com",
+    releaseHost: "https://app.mantaui.com",
     version: "0.0.1",
   });
-  assert.equal(url, "https://bui.useronda.com/releases/bui-0.0.1.tar.gz");
+  assert.equal(url, "https://app.mantaui.com/releases/bui-0.0.1.tar.gz");
 });
 
 test("resolveTarballUrl uses explicit override verbatim", () => {

--- a/scripts/systemd/manta-relay.service
+++ b/scripts/systemd/manta-relay.service
@@ -3,7 +3,7 @@
 # Mirrors manta-server.service, but runs the COMBINED relay entrypoint
 # (`node src/relay/server.mjs`): one process serving BOTH the box-facing
 # WebSocket dial-out leg and the phone-facing HTTP API (+ IAP/push routes) on a
-# single loopback port. The `bui.dev.antoinedc.com` Caddy vhost reverse-proxies
+# single loopback port. The `relay.mantaui.com` Caddy vhost reverse-proxies
 # 127.0.0.1:20787 to this process, so a live relay resolves at that host.
 #
 # INSTALL (a human on-box step — same pattern as manta-server.service; substitute
@@ -13,7 +13,7 @@
 #   loginctl enable-linger "$USER"    # start at boot without an active login
 #
 # Bind is 127.0.0.1 on purpose: the relay is NOT exposed directly. Caddy fronts
-# it and terminates TLS at bui.dev.antoinedc.com. RELAY_PORT/RELAY_HOST override
+# it and terminates TLS at relay.mantaui.com. RELAY_PORT/RELAY_HOST override
 # the bind; RELAY_STORE_PATH overrides the shared SQLite store location.
 
 [Unit]

--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -51,7 +51,7 @@ import {
 // Default relay endpoint. Overridable via RELAY_URL or the `relayUrl` option.
 // wss:// in production (TLS-terminated by the relay's front door); ws:// only
 // for a same-box dev relay.
-export const DEFAULT_RELAY_URL = "wss://bui.dev.antoinedc.com";
+export const DEFAULT_RELAY_URL = "wss://relay.mantaui.com";
 
 // Default local box server the client proxies requests to. The box server binds
 // 0.0.0.0:8787 (src/server/index.mjs); we reach it over loopback.

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -147,7 +147,7 @@ function makeClock() {
 // ---------------------------------------------------------------------------
 
 test("DEFAULT_RELAY_URL is the dev relay wss endpoint", () => {
-  assert.equal(DEFAULT_RELAY_URL, "wss://bui.dev.antoinedc.com");
+  assert.equal(DEFAULT_RELAY_URL, "wss://relay.mantaui.com");
 });
 
 test("backoff mirror matches ExponentialBackoff semantics (no jitter, capped growth)", () => {

--- a/src/relay/server.mjs
+++ b/src/relay/server.mjs
@@ -25,7 +25,7 @@
 //     both phone surfaces move together (and Stage 5 swaps them in one place).
 //
 // PORT: 127.0.0.1:20787 by default (bui 20xxx block; loopback because Caddy /
-//   the `bui.dev.antoinedc.com` vhost fronts it). Override with RELAY_PORT /
+//   the `relay.mantaui.com` vhost fronts it). Override with RELAY_PORT /
 //   RELAY_HOST. RELAY_PORT=0 selects an ephemeral port (tests, dev).
 //
 // WHAT'S STILL DEFERRED (live-provisioning, do NOT block on it here — same seams

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -145,7 +145,7 @@ if (!authEnforced) {
 
 // Serve-page file server: lightweight HTTP server on 127.0.0.1:20080 that
 // serves HTML pages from ~/.manta/pages/<subdomain>/index.html. Caddy
-// reverse-proxies *.bui.antoinedc.com to this port. Pages are registered by
+// reverse-proxies *.pages.mantaui.com to this port. Pages are registered by
 // the remote AI's global opencode `serve_page` tool → POST /api/serve-page.
 // See src/server/servePage.mjs + docs/.
 // eslint-disable-next-line no-unused-vars
@@ -830,7 +830,7 @@ const server = createServer(async (req, res) => {
   // Created by the remote AI's global opencode `serve_page` tool. Source files
   // are copied into ~/.manta/pages/<subdomain>/index.html and served by the
   // in-process file server on 127.0.0.1:20080. Caddy reverse-proxies
-  // *.bui.antoinedc.com to that port. Pages expire after TTL (default 24h).
+  // *.pages.mantaui.com to that port. Pages expire after TTL (default 24h).
   if (path === "/api/serve-page") {
     try {
       if (req.method === "POST") {

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -39,7 +39,7 @@ const VAPID_PATH = join(DIR, "vapid.json");
 const SUBS_PATH = join(DIR, "push-subs.json");
 
 // VAPID `subject` must be a mailto: or https: URI identifying the sender.
-const VAPID_SUBJECT = "mailto:bui@useronda.com";
+const VAPID_SUBJECT = "mailto:app@mantaui.com";
 
 async function atomicWrite(path, data) {
   await mkdir(dirname(path), { recursive: true });

--- a/src/server/servePage.mjs
+++ b/src/server/servePage.mjs
@@ -4,8 +4,8 @@
 // (docs/opencode-tools/serve-page.ts), which POSTs to bui-server's
 // /api/serve-page. The source file is copied into a stable directory
 // under ~/.manta/pages/<subdomain>/, and an in-process HTTP server
-// on 127.0.0.1:20080 serves it. Caddy reverse-proxies *.bui.antoinedc.com
-// to this port, so the page is accessible at https://<sub>.bui.antoinedc.com.
+// on 127.0.0.1:20080 serves it. Caddy reverse-proxies *.pages.mantaui.com
+// to this port, so the page is accessible at https://<sub>.pages.mantaui.com.
 //
 // Server-owned so pages survive Mac-app-close / session navigation / reboot.
 // Pages expire after a configurable TTL (default 24h). A cleanup sweep
@@ -24,7 +24,7 @@ const PAGES_DIR = join(homedir(), STATE_DIRNAME, "pages");
 const FILE_SERVER_PORT = 20080;
 const FILE_SERVER_HOST = "127.0.0.1";
 const DEFAULT_TTL_HOURS = 24;
-const DOMAIN_SUFFIX = ".bui.antoinedc.com";
+const DOMAIN_SUFFIX = ".pages.mantaui.com";
 
 // Cleanup sweep interval — 5 min. Pages expire at TTL, sweep removes
 // stale entries. 5 min is coarse enough to be cheap, fine enough that
@@ -100,7 +100,7 @@ function resolvePageDir(subdomain) {
 
 // Validate subdomain: 1-63 chars, alphanumeric + hyphen, no leading/trailing
 // hyphen. This prevents injection into the Host header and ensures the
-// subdomain matches the *.bui.antoinedc.com wildcard cert.
+// subdomain matches the *.pages.mantaui.com wildcard cert.
 export function isValidSubdomain(s) {
   return typeof s === "string" && /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(s);
 }
@@ -176,7 +176,7 @@ export async function registerPage(
 
   return {
     ok: true,
-    url: `https://${subdomain}.bui.antoinedc.com`,
+    url: `https://${subdomain}.pages.mantaui.com`,
     subdomain,
     expiresAt,
   };
@@ -206,7 +206,7 @@ export async function unregisterPage(
 export function listPages() {
   return loadPages().map((p) => ({
     subdomain: p.subdomain,
-    url: `https://${p.subdomain}.bui.antoinedc.com`,
+    url: `https://${p.subdomain}.pages.mantaui.com`,
     expiresAt: p.expiresAt,
     createdAt: p.createdAt,
     sessionID: p.sessionID,
@@ -269,7 +269,7 @@ export function startCleanupPoller({ intervalMs = CLEANUP_MS } = {}) {
 export function createFileServer({ host = FILE_SERVER_HOST, port = FILE_SERVER_PORT } = {}) {
   const server = createServer(async (req, res) => {
     // Extract subdomain from Host header.
-    // e.g. "preview.bui.antoinedc.com" → "preview"
+    // e.g. "preview.pages.mantaui.com" → "preview"
     const subdomain = extractSubdomain(req.headers.host ?? "");
     if (!subdomain) {
       res.writeHead(404, { "content-type": "application/json" });

--- a/src/server/servePage.test.mjs
+++ b/src/server/servePage.test.mjs
@@ -37,24 +37,24 @@ test("isValidSubdomain accepts max 63-char name", () => {
 // ---------------------------------------------------------------------------
 
 test("extractSubdomain pulls the page name from a Host header", () => {
-  assert.equal(extractSubdomain("preview.bui.antoinedc.com"), "preview");
-  assert.equal(extractSubdomain("my-design.bui.antoinedc.com"), "my-design");
+  assert.equal(extractSubdomain("preview.pages.mantaui.com"), "preview");
+  assert.equal(extractSubdomain("my-design.pages.mantaui.com"), "my-design");
 });
 
 test("extractSubdomain strips the port and lowercases", () => {
-  assert.equal(extractSubdomain("Preview.bui.antoinedc.com:20080"), "preview");
+  assert.equal(extractSubdomain("Preview.pages.mantaui.com:20080"), "preview");
 });
 
 test("extractSubdomain returns null for non-matching hosts", () => {
   assert.equal(extractSubdomain("example.com"), null);
-  assert.equal(extractSubdomain("bui.antoinedc.com"), null); // no subdomain
+  assert.equal(extractSubdomain("pages.mantaui.com"), null); // no subdomain
   assert.equal(extractSubdomain(""), null);
   assert.equal(extractSubdomain(null), null);
 });
 
 test("extractSubdomain rejects multi-level subdomains", () => {
-  // a.b.bui.antoinedc.com — "a.b" contains a dot, not a valid page name
-  assert.equal(extractSubdomain("a.b.bui.antoinedc.com"), null);
+  // a.b.pages.mantaui.com — "a.b" contains a dot, not a valid page name
+  assert.equal(extractSubdomain("a.b.pages.mantaui.com"), null);
 });
 
 test("extractSubdomain honors a custom suffix", () => {

--- a/src/server/webhooks.mjs
+++ b/src/server/webhooks.mjs
@@ -143,7 +143,7 @@ export function toMeta(hook) {
 
 // Build the public delivery URL for a token. The base is configurable so a
 // future custom domain doesn't require a code change.
-export function deliveryUrl(token, base = process.env.MANTA_PUBLIC_URL || "https://bui.useronda.com") {
+export function deliveryUrl(token, base = process.env.MANTA_PUBLIC_URL || "https://app.mantaui.com") {
   return `${base.replace(/\/+$/, "")}/hook/${token}`;
 }
 

--- a/src/server/webhooks.test.mjs
+++ b/src/server/webhooks.test.mjs
@@ -119,7 +119,7 @@ test("toMeta strips secret and token, keeps url + metadata", () => {
     token: "t".repeat(32),
     secret: "whsec_xyz",
     label: "l",
-    url: "https://bui.useronda.com/hook/" + "t".repeat(32),
+    url: "https://app.mantaui.com/hook/" + "t".repeat(32),
     unsigned: false,
     sessionID: "ses_1",
     deliveries: 4,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -503,7 +503,7 @@ export type SecretInput = {
 export type WebhookMeta = {
   id: string; // 8-char hex store id (used for delete)
   label: string; // human label, e.g. "multica CAPO-123 done"
-  url: string | null; // public delivery URL (https://bui.useronda.com/hook/<token>)
+  url: string | null; // public delivery URL (https://app.mantaui.com/hook/<token>)
   unsigned: boolean; // true = no HMAC signature required (discouraged)
   sessionID: string | null; // the session this hook wakes
   instructions: string; // standing directive prepended to each delivery


### PR DESCRIPTION
## Domain migration: bui.* → mantaui.com (code-string portion)

Part of [BET-149](mention://issue/ce5755a3-6d46-4b17-acbb-7cf4f893f46b). This PR
covers only the pure code-string-edit portion (owner-confirmed hostnames);
DNS/Caddy/Cloudflare cutover + PWA re-install remain owner-manual per the
issue's checklist.

**Base:** `origin/main @ 0136084` (BET-147 code rename, already merged)

### Mapping (owner-locked)
- `bui.useronda.com` → `app.mantaui.com` (tunnel/release/PWA-install host)
- `*.bui.antoinedc.com` → `*.pages.mantaui.com` (serve-page wildcard)
- `bui.dev.antoinedc.com` → `relay.mantaui.com` (relay WS host)

### Files changed (19)
`src/server/{servePage,index,webhooks,push}.mjs` + their `.test.mjs`,
`src/relay/agent/index.mjs` + test, `src/relay/server.mjs`,
`src/shared/types.ts`, `scripts/install.sh`, `scripts/install-lib.mjs`,
`scripts/install.test.mjs`, `scripts/systemd/manta-relay.service`,
`README.md`, `AGENTS.md`, `docs/bui-tools-webhook.md`,
`docs/opencode-tools/{AGENTS.md,serve-page.ts}`.

Also fixed two now-stale infra notes in AGENTS.md (tunnel DNS zone,
serve-page A-record zone) to say `mantaui.com` instead of `useronda.com`/
`antoinedc.com`.

**Intentionally left untouched:** `.multica/workspace-context.md` — a dated
historical decision log (M2 planning notes, expired mockup URLs), not live
code/docs.

### Verification results
- PR branch (`multica/BET-149-domain-rename` @ `1a40995`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, 919 vitest + 515 node:test = 1434 pass / 0 fail / 189 vitest skipped (pre-existing skips). log sha256: `03e4182b8c488439eb4da73e22bf144705162b84424dc40121e88a2627a04095`
- Base (`origin/main` @ `0136084`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba` (identical — no typecheck-relevant change)
  - test: exit `0`, 919 vitest + 515 node:test = 1434 pass / 0 fail / 189 vitest skipped. log sha256: `6ffd473234f77b4cc2a7d7bc86e4575e9b998c21ffe76e9cd8ee5f5c3e6b82a1`
- **Conclusion:** 0 new failures, 0 pre-existing failures. Identical pass counts on both branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`,
`/tmp/test-pr2.log`, `/tmp/test-master.log` for reviewer spot-check.

### Self-check
- CRITERION: no `bui.useronda.com`/`bui.antoinedc.com`/`bui.dev.antoinedc.com` string remains in source/scripts/docs/README/AGENTS → score 9/10 → weakness: `.multica/workspace-context.md` still has old strings, deliberately left (historical log, not code)
- CRITERION: `servePage.test.mjs` + `relay/agent/index.test.mjs` domain expectations updated → score 9/10 → weakness: none found
- CRITERION: typecheck + test green → score 10/10 → weakness: none

DNS/Caddy/Cloudflare live cutover and PWA re-install are owner-manual next
steps per the issue.
