### PR TITLE
feat(ci): GitHub Pages deploy workflow for mantaui.com

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,63 @@
+# pages-deploy — publishes website/ to GitHub Pages on the custom domain
+# mantaui.com. Uses the "Deploy from GitHub Actions" Pages source (no
+# gh-pages branch). See BET-146 for the ticket/decision record.
+#
+# Also copies scripts/install.sh into the published artifact as /install.sh
+# so `curl -fsSL https://mantaui.com/install.sh | bash` serves the real
+# script byte-for-byte. scripts/install.sh itself stays the single source of
+# truth (owned by BET-148) — this is a copy step at deploy time only, never a
+# second copy checked into git.
+#
+# One-time manual owner step (not done by this workflow, see PR description):
+#   1. Repo Settings → Pages → Source → "GitHub Actions".
+#   2. Point mantaui.com's DNS (A/ALIAS, since it's an apex domain) at GitHub
+#      Pages, or use a CNAME-flattening DNS provider.
+
+name: pages-deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - "scripts/install.sh"
+      - ".github/workflows/pages-deploy.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assemble Pages artifact
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/pages-site
+          mkdir -p /tmp/pages-site
+          cp -r website/. /tmp/pages-site/
+          cp scripts/install.sh /tmp/pages-site/install.sh
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: /tmp/pages-site
+
+  deploy:
+    needs: build
+    runs-on: self-hosted
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,0 +1,1 @@
+mantaui.com


### PR DESCRIPTION
## Summary

Deploys `website/` (Manta marketing site, already merged in `9ca2228`) to
GitHub Pages on the custom domain `mantaui.com`, and serves
`scripts/install.sh` at `https://mantaui.com/install.sh`.

**Base:** `origin/main @ 8211f5c`

## Changes

- `.github/workflows/pages-deploy.yml` — new workflow. On push to `main`
  touching `website/**`, `scripts/install.sh`, or the workflow file itself
  (also `workflow_dispatch`), it assembles an artifact from `website/` plus a
  copy of `scripts/install.sh` as `/install.sh`, then publishes via
  `actions/upload-pages-artifact` + `actions/deploy-pages` (Pages
  "deploy from GitHub Actions" source — no `gh-pages` branch).
- `website/CNAME` — pins the custom domain `mantaui.com` so it survives
  redeploys.

`scripts/install.sh` is untouched — it stays the single source of truth
(owned by BET-148); the workflow only copies it into the published site at
deploy time.

## Manual owner step (outside agent scope — not touched by this PR)

- [ ] In repo Settings → Pages, set Source to **"GitHub Actions"**.
- [ ] Point `mantaui.com`'s DNS at GitHub Pages. Since `mantaui.com` is an
      apex domain, use `A`/`ALIAS` records (GitHub Pages IPs) or a
      CNAME-flattening DNS provider — not a plain `CNAME` at the apex.

## Verification results

- PR branch (`multica/BET-146-pages-deploy` @ `ce768d9`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 919 vitest + 466 node:test pass / 0 fail / 0 skip.
- This change only touches CI config + a new static `website/CNAME` file —
  no app code (`src/`, `mobile/`) touched, so no base-branch re-run needed;
  the above numbers are unaffected by this diff.

Logs: `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.