### PR TITLE
fix(docs): correct install URL to apex mantaui.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the onboarding flow:
 
 1. **Pair with your box.** Run the self-install script on your Linux box:
    ```bash
-   curl -fsSL https://app.mantaui.com/install.sh | bash
+   curl -fsSL https://mantaui.com/install.sh | bash
    ```
    It installs bui-server, starts it, and prints a 6-digit pairing code.
    Enter the code in the Manta onboarding screen (along with your box's URL).
@@ -113,7 +113,7 @@ pairing flow. On a fresh Linux VPS, one command installs and starts it and
 prints a 6-digit pairing code to enter in the desktop app:
 
 ```bash
-curl -fsSL https://app.mantaui.com/install.sh | bash
+curl -fsSL https://mantaui.com/install.sh | bash
 ```
 
 The installer downloads a pre-built release tarball (no dev toolchain needed on


### PR DESCRIPTION
## Summary
Fixes README.md's two install one-liners, which currently point at `app.mantaui.com` (wrong — that host is the tarball-hosting release host, set by BET-149's domain migration and mistakenly picked up into the curl commands). Owner reconfirmed the canonical install URL is the apex `https://mantaui.com/install.sh`.

## Changes
- `README.md` line ~51 and ~116: `curl -fsSL https://app.mantaui.com/install.sh | bash` → `curl -fsSL https://mantaui.com/install.sh | bash`

## Explicitly out of scope (per issue instructions)
- `website/index.html` — already correct at apex, owned by BET-146 (PR #112, in_review). Not touched.
- `scripts/install.sh` — stays the single source of truth, untouched. BET-146's GitHub Pages deploy workflow copies it to the Pages artifact root at deploy time (the serving mechanism).
- `MANTA_RELEASE_HOST` / `DEFAULT_RELEASE_HOST` (`https://app.mantaui.com`) — separate, already-settled BET-149 concern (tarball hosting), left untouched.

## Verification
End-to-end verification (`curl -fsSL https://mantaui.com/install.sh`) is blocked on BET-146's PR #112 merging (that's what makes the URL actually resolve). Will follow up with a live curl check once both PRs are on main.

Base: origin/main @ a66a150

**Verification results:**
- PR branch (`multica/BET-148-readme-install-url` @ 657e9d2):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 515 pass / 0 fail / 0 skip.
- No source/behavior code changed (README only) — no base-branch re-run needed; 0 new failures possible.

Logs: /tmp/typecheck-pr.log, /tmp/test-pr.log (cached in the implementer's session).
