### PR TITLE
feat(install): provision opencode chat stack (BET-153)

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -182,6 +182,7 @@ export async function waitForHealth(
   {
     maxAttempts = 60,
     intervalMs = 1000,
+    acceptAnyStatus = true,
     fetchFn = globalThis.fetch,
     sleep = defaultSleep,
   } = {},
@@ -198,9 +199,16 @@ export async function waitForHealth(
       const res = await fetchFn(url);
       // Any HTTP answer means the socket is bound and serving.
       if (res && typeof res.status === "number") {
-        return { ok: true, attempts: attempt, status: res.status };
+        if (acceptAnyStatus) {
+          return { ok: true, attempts: attempt, status: res.status };
+        }
+        if (res.status >= 200 && res.status < 400) {
+          return { ok: true, attempts: attempt, status: res.status };
+        }
+        lastError = new Error(`non-2xx status ${res.status}`);
+      } else {
+        lastError = new Error("fetch returned no status");
       }
-      lastError = new Error("fetch returned no status");
     } catch (e) {
       lastError = e;
     }
@@ -217,6 +225,149 @@ export async function waitForHealth(
 
 function defaultSleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// opencode.jsonc merge — pure, used by install.sh step C (BET-153)
+// ---------------------------------------------------------------------------
+//
+// opencode.jsonc allows `//` line comments and trailing commas (JSONC). The
+// plugin we seed lives in the top-level `plugin: string[]`. We MERGE — never
+// clobber — so any other config the user has set (theme, model, mcp, …) is
+// preserved across re-installs.
+//
+// Behavior:
+//   * Strip `//` line comments (respecting strings — "//" inside a quoted
+//     value must survive).
+//   * JSON.parse the remainder. On parse failure → caller backs the file up
+//     to `.pre-manta` and starts from `{}` (matches the documented
+//     skills.urls merge pattern in src/server/local.mjs).
+//   * Append `opencode-claude-auth@latest` to the `plugin` array IF not
+//     already present (any version — re-installs are no-ops).
+//   * Serialize with 2-space indent + trailing newline.
+//
+// Pure: no fs/network/sleep. Returns { text, corrupt }. `corrupt` is true
+// only when the input text was non-empty but unparseable; an empty input
+// is treated as `{}` (first install) and is not "corrupt".
+
+// Strip `//` line comments without eating `//` inside strings. Pure, single-
+// pass; matches the behavior of providers.mjs's stripLineComments (same rule,
+// kept independent so the install lib has zero dependency on the server
+// modules — install.sh runs even before the tarball is unpacked).
+export function stripJsoncLineComments(text) {
+  let out = "";
+  let inStr = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      out += c;
+      if (c === "\\" && i + 1 < text.length) {
+        out += text[i + 1];
+        i += 1;
+        continue;
+      }
+      if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') {
+      out += c;
+      inStr = true;
+      continue;
+    }
+    if (c === "/" && text[i + 1] === "/") {
+      const nl = text.indexOf("\n", i);
+      if (nl === -1) break;
+      i = nl;
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+// Plugin we seed into every opencode.jsonc. The `@latest` is the official
+// installer's version tag — we use the official opencode plugin registry
+// (no version pinning in v1; the install is the source of truth for what
+// version is "current").
+export const OPENCODE_CLAUDE_AUTH_PLUGIN = "opencode-claude-auth@latest";
+
+/**
+ * Merge `opencode-claude-auth@latest` into the top-level `plugin` array of an
+ * existing opencode.jsonc. Pure: receives raw text, returns raw text.
+ *
+ * @param {string} existingText  Raw file contents (possibly empty, possibly
+ *                               containing JSONC `//` comments).
+ * @returns {{ text: string, corrupt: boolean, plugin: string[] }}
+ *   - text    — the new file contents (always well-formed JSON, 2-space
+ *               indent, trailing newline). The caller writes this to disk.
+ *   - corrupt — true iff the input was non-empty AND failed to parse.
+ *               Caller decides whether to back the original up to
+ *               `.pre-manta` before overwriting. An empty input is treated
+ *               as `{}` and is NOT corrupt (first install).
+ *   - plugin  — the post-merge plugin array (handy for tests + the summary
+ *               log in install.sh).
+ */
+export function mergeOpencodeConfig(existingText) {
+  const raw = typeof existingText === "string" ? existingText : "";
+  const stripped = stripJsoncLineComments(raw).trim();
+  let cfg = {};
+  let corrupt = false;
+  if (stripped.length > 0) {
+    try {
+      cfg = JSON.parse(stripped);
+      if (cfg === null || typeof cfg !== "object" || Array.isArray(cfg)) {
+        cfg = {};
+        corrupt = true;
+      }
+    } catch {
+      cfg = {};
+      corrupt = true;
+    }
+  }
+  // Deep-merge ONLY the `plugin` key. Every other key is spread through
+  // untouched (theme, model, mcp, provider, …).
+  const plugins = Array.isArray(cfg.plugin) ? cfg.plugin.filter((p) => typeof p === "string") : [];
+  if (!plugins.includes(OPENCODE_CLAUDE_AUTH_PLUGIN)) {
+    plugins.push(OPENCODE_CLAUDE_AUTH_PLUGIN);
+  }
+  const next = { ...cfg, plugin: plugins };
+  const text = JSON.stringify(next, null, 2) + "\n";
+  return { text, corrupt, plugin: plugins };
+}
+
+// ---------------------------------------------------------------------------
+// Systemd unit placeholder substitution — pure, used by install.sh steps E
+// and the existing manta-server step (BET-153).
+// ---------------------------------------------------------------------------
+//
+// Mirrors what `sed -e 's|@@K@@|V|g' …` does in the shell, but as a pure
+// function so the substitution is unit-testable (the "no @@ left after sed"
+// hygiene check) and install.sh stays a thin orchestrator.
+//
+// `placeholders` is a plain { KEY: value } map. Each @@KEY@@ in `template`
+// is replaced verbatim — values are NOT shell-quoted, because systemd unit
+// files don't need quoting and a value with a `|` would otherwise confuse
+// sed. Callers must keep values simple (paths + ports — no special chars).
+export function renderSystemdUnit(template, placeholders) {
+  if (typeof template !== "string") {
+    throw new Error("renderSystemdUnit: template must be a string");
+  }
+  if (!placeholders || typeof placeholders !== "object") {
+    throw new Error("renderSystemdUnit: placeholders object required");
+  }
+  let out = template;
+  for (const [key, value] of Object.entries(placeholders)) {
+    const token = `@@${key}@@`;
+    // String.replaceAll keeps the semantics obvious; for-loop above ensures
+    // we visit every key. Guard against values containing the token (would
+    // re-substitute on the next iteration).
+    const v = String(value);
+    if (v.includes(token)) {
+      throw new Error(`renderSystemdUnit: placeholder value for ${key} contains the token ${token}`);
+    }
+    out = out.split(token).join(v);
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -344,9 +495,44 @@ async function cliMain(argv) {
     );
     return 0;
   }
+  if (cmd === "merge-opencode-config") {
+    // Read raw text from stdin, write the merged text to stdout, and the
+    // `corrupt` flag to stderr (so install.sh can branch on it for the
+    // `.pre-manta` backup). Pure: no fs writes here.
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    const raw = Buffer.concat(chunks).toString("utf-8");
+    const { text, corrupt } = mergeOpencodeConfig(raw);
+    if (corrupt) process.stderr.write("corrupt=1\n");
+    process.stdout.write(text);
+    return 0;
+  }
+  if (cmd === "render-systemd-unit") {
+    // node install-lib.mjs render-systemd-unit --template <path> --placeholder K=V [--placeholder K=V ...]
+    // Replaces @@K@@ in the template file with V (verbatim, no quoting).
+    // Writes the rendered text to stdout. install.sh uses this to substitute
+    // the opencode-serve unit's @@OPENCODE_BIN@@ placeholder (sed was an
+    // option but a lib function is unit-testable + lib-quoteable).
+    const tplPath = flags.template;
+    if (!tplPath) {
+      process.stderr.write("render-systemd-unit: --template <path> required\n");
+      return 2;
+    }
+    const { readFileSync } = await import("node:fs");
+    const tpl = readFileSync(tplPath, "utf-8");
+    // Strip the --template flag + value out of `flags` and treat everything
+    // else as a placeholder; values can contain `=` so split on the FIRST `=`.
+    const placeholders = {};
+    for (const [k, v] of Object.entries(flags)) {
+      if (k === "template" || k === "version") continue;
+      placeholders[k] = v;
+    }
+    process.stdout.write(renderSystemdUnit(tpl, placeholders));
+    return 0;
+  }
   process.stderr.write(
     `install-lib: unknown command ${JSON.stringify(cmd)}\n` +
-      "  usage: node install-lib.mjs <print-config|check-identity|tarball-url> [--version X]\n",
+      "  usage: node install-lib.mjs <print-config|check-identity|tarball-url|merge-opencode-config|render-systemd-unit> [--version X]\n",
   );
   return 2;
 }
@@ -356,6 +542,17 @@ function parseFlags(args) {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--version") {
       out.version = args[++i];
+    } else if (args[i] === "--template") {
+      out.template = args[++i];
+    } else if (args[i] === "--placeholder") {
+      // --placeholder KEY=VAL  (value may itself contain `=`; split on FIRST)
+      const kv = args[++i] ?? "";
+      const eq = kv.indexOf("=");
+      if (eq === -1) {
+        process.stderr.write(`install-lib: --placeholder expects KEY=VAL (got ${JSON.stringify(kv)})\n`);
+        process.exit(2);
+      }
+      out[kv.slice(0, eq)] = kv.slice(eq + 1);
     }
   }
   return out;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,7 +131,168 @@ fi
 ok "Dependencies installed."
 
 # ---------------------------------------------------------------------------
-# 6. systemd --user unit: substitute placeholders and enable.
+# 6. Chat stack provisioning (opencode + bui-native tools + tmux presence).
+#    Independent of the relay work — a fresh VPS just needs claude code
+#    installed (~/.claude/.credentials.json exists). Re-running is a no-op
+#    except for version upgrades; every step is safe to run twice.
+# ---------------------------------------------------------------------------
+
+# --- A. tmux presence gate (hard requirement of the product). -------------
+# §1 already verified tmux exists; we re-state it here as a section-level
+# gate so a missing-tmux failure surfaces in the chat stack section, not
+# buried at the top. We deliberately do NOT auto-install distro packages —
+# the installer never assumes root.
+if ! command -v tmux >/dev/null 2>&1; then
+  die "missing prerequisite for chat stack: tmux
+      Install it and re-run. Suggested:
+        apt-get install -y tmux        # Debian/Ubuntu
+        yum install -y tmux            # RHEL/Fedora/Amazon Linux"
+fi
+ok "tmux present."
+
+# --- B. opencode install (idempotent via official installer). ------------
+# We use opencode's official installer; no version pinning in v1 — the
+# installer is the source of truth for "current". Re-running is a no-op
+# when the binary is already on PATH.
+OPENCODE_BIN="$(command -v opencode || true)"
+if [ -n "$OPENCODE_BIN" ]; then
+  ok "opencode already installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
+else
+  log "Installing opencode (official installer)…"
+  # The installer writes to ~/.local/bin/opencode by default; that dir is on
+  # PATH for most distros but not all. We source the installer's PATH hint
+  # if it added anything, then re-check.
+  curl -fsSL https://opencode.ai/install | bash \
+    || die "opencode install failed — install manually: https://opencode.ai"
+  OPENCODE_BIN="$(command -v opencode || true)"
+  if [ -z "$OPENCODE_BIN" ]; then
+    die "opencode still not on PATH after install. Try: export PATH=\"\$HOME/.local/bin:\$PATH\" and re-run."
+  fi
+  ok "opencode installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
+fi
+
+# --- C. opencode config seeding — MERGE the plugin entry, never clobber. --
+# Target: ~/.config/opencode/opencode.jsonc. Required:
+#   plugin: ["opencode-claude-auth@latest", ...]
+# All other keys (theme, model, mcp, provider, …) are preserved. On parse
+# failure we back the file up to .pre-manta and start from {} — matches the
+# documented skills.urls merge pattern in src/server/local.mjs.
+OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
+OPENCODE_CONFIG="$OPENCODE_CONFIG_DIR/opencode.jsonc"
+mkdir -p "$OPENCODE_CONFIG_DIR"
+OPENCODE_CONFIG_BACKUP="$OPENCODE_CONFIG.pre-manta"
+if [ -f "$OPENCODE_CONFIG" ]; then
+  log "Seeding opencode-claude-auth plugin (merging into existing $OPENCODE_CONFIG)…"
+  existing="$(cat "$OPENCODE_CONFIG" 2>/dev/null || true)"
+else
+  log "Seeding opencode-claude-auth plugin (no existing $OPENCODE_CONFIG — creating)…"
+  existing=""
+fi
+merged="$(printf '%s' "$existing" | node "$LIB" merge-opencode-config 2>/tmp/opencode-merge.err)" \
+  || die "merge-opencode-config failed (see /tmp/opencode-merge.err)"
+if grep -q '^corrupt=1' /tmp/opencode-merge.err 2>/dev/null; then
+  cp "$OPENCODE_CONFIG" "$OPENCODE_CONFIG_BACKUP" 2>/dev/null \
+    && warn "opencode.jsonc was unparseable — original backed up to $OPENCODE_CONFIG_BACKUP, starting from {}." \
+    || warn "opencode.jsonc was unparseable and the backup FAILED — installer continues but original is NOT preserved."
+fi
+printf '%s' "$merged" > "$OPENCODE_CONFIG"
+ok "opencode.jsonc seeded."
+
+# --- D. manta opencode tools + agent guidance (REAL copies, not symlinks).
+# Per AGENTS.md ("Mobile / web client"): opencode resolves tool imports from
+# the file's REAL path; a symlink into the tarball tree misses
+# ~/.config/opencode/node_modules/@opencode-ai/plugin and the tool silently
+# never registers. So we cp — same inode-disjoint paths.
+OPENCODE_TOOLS_SRC="$MANTA_HOME/docs/opencode-tools"
+OPENCODE_TOOLS_DIR="$OPENCODE_CONFIG_DIR/tools"
+OPENCODE_AGENTS="$OPENCODE_CONFIG_DIR/AGENTS.md"
+if [ -d "$OPENCODE_TOOLS_SRC" ]; then
+  mkdir -p "$OPENCODE_TOOLS_DIR"
+  log "Copying bui-native opencode tools into $OPENCODE_TOOLS_DIR…"
+  # cp -f overwrites — tools are versioned with the tarball, so a re-run
+  # naturally picks up upgrades.
+  cp -f "$OPENCODE_TOOLS_SRC"/*.ts "$OPENCODE_TOOLS_DIR/" \
+    || die "failed to copy opencode tools from $OPENCODE_TOOLS_SRC"
+  ok "opencode tools copied."
+else
+  warn "$OPENCODE_TOOLS_SRC not found in tarball — skipping tool copy (was docs/opencode-tools/* added to release/pack.mjs?)."
+fi
+# AGENTS.md append with marker guard — idempotency by a single grep on a
+# stable line ("## bui scheduled tasks"). A re-run with the marker present
+# is a clean no-op.
+if [ -f "$OPENCODE_TOOLS_SRC/AGENTS.md" ]; then
+  if [ -f "$OPENCODE_AGENTS" ] && grep -q '^## bui scheduled tasks' "$OPENCODE_AGENTS"; then
+    ok "opencode AGENTS.md already contains bui guidance — skipping append."
+  else
+    log "Appending bui opencode agent guidance to $OPENCODE_AGENTS…"
+    {
+      [ -f "$OPENCODE_AGENTS" ] && cat "$OPENCODE_AGENTS" && printf '\n'
+      cat "$OPENCODE_TOOLS_SRC/AGENTS.md"
+    } > "$OPENCODE_AGENTS.tmp" && mv "$OPENCODE_AGENTS.tmp" "$OPENCODE_AGENTS"
+    ok "opencode AGENTS.md updated."
+  fi
+fi
+
+# --- E. opencode-serve systemd --user unit (or nohup fallback). ----------
+# Mirrors the manta-server install path right below: substitute the
+# @@OPENCODE_BIN@@ placeholder, install to ~/.config/systemd/user/, then
+# enable --now. Health-wait reuses the existing waitForHealth lib with
+# acceptAnyStatus:true (any HTTP status = listener is up — opencode's HTTP
+# surface is minimal and may not respond to a bare GET /). Same fallback
+# chain as manta-server when systemctl is unavailable.
+OC_UNIT_SRC="$MANTA_HOME/scripts/systemd/opencode-serve.service"
+OC_UNIT="$UNIT_DIR/opencode-serve.service"
+[ -f "$OC_UNIT_SRC" ] || die "missing systemd template: $OC_UNIT_SRC"
+if command -v systemctl >/dev/null 2>&1; then
+  if systemctl --user is-active --quiet opencode-serve.service 2>/dev/null; then
+    ok "opencode-serve already active — skipping (re-run picks up unit upgrades via daemon-reload below)."
+  else
+    log "Installing opencode-serve systemd --user unit…"
+    mkdir -p "$UNIT_DIR"
+    rendered="$(node "$LIB" render-systemd-unit \
+      --template "$OC_UNIT_SRC" \
+      --placeholder OPENCODE_BIN="$OPENCODE_BIN")" \
+      || die "render-systemd-unit failed (see lib)"
+    printf '%s' "$rendered" > "$OC_UNIT"
+    systemctl --user daemon-reload
+    systemctl --user enable --now opencode-serve.service
+  fi
+else
+  if pgrep -f 'opencode serve --port 4096' >/dev/null 2>&1; then
+    ok "opencode-serve already running (nohup) — skipping."
+  else
+    warn "systemctl not found. Starting opencode-serve in the background instead."
+    warn "It will NOT survive reboot — set up your own supervisor for that."
+    ( nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
+  fi
+fi
+# Health-wait: opencode is loopback-only on :4096. acceptAnyStatus:true is
+# the default in waitForHealth; we pass it explicitly so a future reader
+# sees the intent ("any response = listening").
+log "Waiting for opencode-serve at http://127.0.0.1:4096/…"
+node -e '
+  import("'"$LIB"'").then(async (m) => {
+    const r = await m.waitForHealth("http://127.0.0.1:4096/", {
+      maxAttempts: 30,
+      intervalMs: 1000,
+      acceptAnyStatus: true,
+    });
+    if (!r.ok) { console.error(r.error); process.exit(1); }
+    console.error("healthy after " + r.attempts + " attempt(s) (status " + r.status + ")");
+  }).catch((e) => { console.error(String(e)); process.exit(1); });
+' || die "opencode-serve did not become healthy at http://127.0.0.1:4096/ — check logs:
+      systemctl --user status opencode-serve ; journalctl --user -u opencode-serve -n 50
+      or: tail -f $AUTH_DIR/opencode.log"
+ok "opencode-serve is healthy."
+
+# --- F. Final summary block (extended heredoc) ----------------------------
+# We extend the heredoc that prints at the end (originally section 7).
+# The chat-stack bits live in this script (section 6) and show their own
+# ok lines above; the heredoc only needs to surface the next-step nudge
+# and the claude credentials warning.
+
+# ---------------------------------------------------------------------------
+# 7. manta-server systemd --user unit: substitute placeholders and enable.
 # ---------------------------------------------------------------------------
 NODE_BIN="$(command -v node)"
 UNIT_SRC="$MANTA_HOME/scripts/systemd/manta-server.service"
@@ -163,7 +324,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 7. Wait for health, then mint + print a pairing code.
+# 8. Wait for health, then mint + print a pairing code.
 # ---------------------------------------------------------------------------
 log "Waiting for the server to become healthy at $MANTA_HEALTH_URL…"
 node -e '
@@ -188,6 +349,25 @@ Installed. Manage the server with:
   systemctl --user restart manta-server
   journalctl --user -u manta-server -f
 
+Chat backend (opencode-serve) on http://127.0.0.1:4096:
+  systemctl --user status opencode-serve
+  systemctl --user restart opencode-serve
+  journalctl --user -u opencode-serve -f
+
 Re-run this installer any time to upgrade in place (your box identity is preserved).
 Run 'manta pair' (or 'npm run pair' in $MANTA_HOME) to mint a fresh pairing code.
 EOF
+
+# --- Final claude credentials check (warn — not die — per BET-153 step F).
+# The only auth prerequisite we assume is the user has run/authed `claude`
+# on this box at least once, producing ~/.claude/.credentials.json.
+# opencode-serve reads that on first start; without it the chat backend
+# starts but rejects all chat requests with a 401 until the user
+# authenticates.
+if [ -f "$HOME/.claude/.credentials.json" ]; then
+  ok "claude credentials detected — chat backend will authenticate on first request."
+else
+  warn "no \$HOME/.claude/.credentials.json — chat will start but reject requests until you authenticate."
+  warn "Run \`claude\` once on this box to sign in, then:"
+  warn "  systemctl --user restart opencode-serve"
+fi

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -11,6 +11,10 @@ import {
   formatPairingOutput,
   formatExpiry,
   renderShellConfig,
+  stripJsoncLineComments,
+  mergeOpencodeConfig,
+  renderSystemdUnit,
+  OPENCODE_CLAUDE_AUTH_PLUGIN,
   DEFAULT_PORT,
   DEFAULT_RELEASE_HOST,
 } from "./install-lib.mjs";
@@ -309,4 +313,217 @@ test("renderShellConfig single-quotes values with spaces safely", () => {
   const cfg = resolveConfig({ env: { MANTA_HOME: "/opt/my bui" }, home: HOME });
   const out = renderShellConfig(cfg, { version: "0.0.1" });
   assert.match(out, /MANTA_HOME='\/opt\/my bui'/);
+});
+
+// ----------------------------------------------------------------------------
+// stripJsoncLineComments — keeps // inside strings intact
+// ----------------------------------------------------------------------------
+
+test("stripJsoncLineComments removes line comments, preserves strings", () => {
+  const src = `{
+    // drop this
+    "model": "claude-sonnet-4-6", // also a comment
+    "note": "http://example.com", // url must survive
+    "label": "// not a comment"
+  }`;
+  const out = stripJsoncLineComments(src);
+  assert.doesNotMatch(out, /drop this/);
+  assert.doesNotMatch(out, /also a comment/);
+  assert.match(out, /"note": "http:\/\/example\.com"/);
+  assert.match(out, /"label": "\/\/ not a comment"/);
+});
+
+// ----------------------------------------------------------------------------
+// mergeOpencodeConfig — MERGE, never clobber; idempotent; corrupt-safe
+// ----------------------------------------------------------------------------
+
+test("mergeOpencodeConfig on empty input seeds plugin only", () => {
+  const { text, corrupt, plugin } = mergeOpencodeConfig("");
+  assert.equal(corrupt, false, "empty input is not corrupt");
+  assert.deepEqual(plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+  const parsed = JSON.parse(text);
+  assert.deepEqual(parsed.plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+  assert.equal(parsed.theme, undefined);
+});
+
+test("mergeOpencodeConfig preserves unrelated keys (model, theme, provider)", () => {
+  const before = JSON.stringify(
+    {
+      $schema: "https://opencode.ai/config.json",
+      theme: "system",
+      model: "anthropic/claude-sonnet-4-6",
+      provider: {
+        voska: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Voska AI",
+          options: { baseURL: "https://api.example.com/v1", apiKey: "sk-test" },
+          models: {},
+        },
+      },
+    },
+    null,
+    2,
+  );
+  const { text, corrupt, plugin } = mergeOpencodeConfig(before);
+  assert.equal(corrupt, false);
+  const after = JSON.parse(text);
+  assert.equal(after.theme, "system");
+  assert.equal(after.model, "anthropic/claude-sonnet-4-6");
+  assert.equal(after.$schema, "https://opencode.ai/config.json");
+  assert.equal(after.provider.voska.options.baseURL, "https://api.example.com/v1");
+  assert.equal(after.provider.voska.options.apiKey, "sk-test");
+  assert.deepEqual(plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+test("mergeOpencodeConfig is byte-identical when plugin already present", () => {
+  const before = JSON.stringify(
+    { theme: "system", plugin: [OPENCODE_CLAUDE_AUTH_PLUGIN] },
+    null,
+    2,
+  ) + "\n";
+  const { text, corrupt, plugin } = mergeOpencodeConfig(before);
+  assert.equal(corrupt, false);
+  assert.deepEqual(plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+  assert.equal(text, before);
+});
+
+test("mergeOpencodeConfig appends without duplicating an existing match", () => {
+  // The auth plugin is already present (1st slot); the new entry is appended.
+  const before = JSON.stringify(
+    { plugin: [OPENCODE_CLAUDE_AUTH_PLUGIN, "some-other-plugin"] },
+    null,
+    2,
+  ) + "\n";
+  const { text, plugin } = mergeOpencodeConfig(before);
+  assert.deepEqual(plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN, "some-other-plugin"]);
+  const after = JSON.parse(text);
+  assert.deepEqual(after.plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN, "some-other-plugin"]);
+});
+
+test("mergeOpencodeConfig appends the auth plugin at the END when missing", () => {
+  // Order-preserving: existing entries stay where they were; the new one is appended.
+  const before = JSON.stringify(
+    { plugin: ["some-other-plugin"] },
+    null,
+    2,
+  ) + "\n";
+  const { text, plugin } = mergeOpencodeConfig(before);
+  assert.deepEqual(plugin, ["some-other-plugin", OPENCODE_CLAUDE_AUTH_PLUGIN]);
+  const after = JSON.parse(text);
+  assert.deepEqual(after.plugin, ["some-other-plugin", OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+test("mergeOpencodeConfig strips JSONC comments and merges plugin", () => {
+  const jsonc = `{
+    // top-level comment
+    "theme": "system", // inline
+    "plugin": ["already-there"]
+  }`;
+  const { text, corrupt, plugin } = mergeOpencodeConfig(jsonc);
+  assert.equal(corrupt, false);
+  const after = JSON.parse(text);
+  assert.equal(after.theme, "system");
+  assert.deepEqual(plugin, ["already-there", OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+test("mergeOpencodeConfig flags corrupt JSONC and starts from {}", () => {
+  const { text, corrupt, plugin } = mergeOpencodeConfig("{ broken: not-json,");
+  assert.equal(corrupt, true);
+  const after = JSON.parse(text);
+  assert.deepEqual(after.plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+test("mergeOpencodeConfig coerces non-object root to {} + corrupt", () => {
+  const { text, corrupt } = mergeOpencodeConfig("[1,2,3]");
+  assert.equal(corrupt, true);
+  const after = JSON.parse(text);
+  assert.deepEqual(after.plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+test("mergeOpencodeConfig tolerates a malformed plugin array (drops non-strings)", () => {
+  const before = JSON.stringify(
+    { plugin: ["keep-me", null, 42, { junk: true }, "also-keep"] },
+    null,
+    2,
+  );
+  const { plugin } = mergeOpencodeConfig(before);
+  // Non-strings are dropped; the new auth plugin is appended.
+  assert.deepEqual(plugin, ["keep-me", "also-keep", OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+test("mergeOpencodeConfig is null/undefined safe (treated as empty)", () => {
+  const a = mergeOpencodeConfig(null);
+  const b = mergeOpencodeConfig(undefined);
+  assert.equal(a.corrupt, false);
+  assert.equal(b.corrupt, false);
+  assert.deepEqual(a.plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+  assert.deepEqual(b.plugin, [OPENCODE_CLAUDE_AUTH_PLUGIN]);
+});
+
+// ----------------------------------------------------------------------------
+// renderSystemdUnit — placeholder substitution used by install.sh
+// ----------------------------------------------------------------------------
+
+test("renderSystemdUnit substitutes placeholders verbatim", () => {
+  const tpl = `ExecStart=@@OPENCODE_BIN@@ serve --port @@OPENCODE_PORT@@
+WorkingDirectory=@@MANTA_HOME@@
+`;
+  const out = renderSystemdUnit(tpl, {
+    OPENCODE_BIN: "/usr/local/bin/opencode",
+    OPENCODE_PORT: "4096",
+    MANTA_HOME: "/home/dev/manta",
+  });
+  assert.match(out, /ExecStart=\/usr\/local\/bin\/opencode serve --port 4096/);
+  assert.match(out, /WorkingDirectory=\/home\/dev\/manta/);
+  assert.doesNotMatch(out, /@@/);
+});
+
+test("renderSystemdUnit refuses values containing the token (loop guard)", () => {
+  assert.throws(
+    () =>
+      renderSystemdUnit("X=@@A@@", {
+        A: "x@@A@@y",
+      }),
+    /contains the token/,
+  );
+});
+
+test("renderSystemdUnit rejects non-string template / non-object placeholders", () => {
+  assert.throws(() => renderSystemdUnit(null, {}), /must be a string/);
+  assert.throws(() => renderSystemdUnit("X=@@A@@", null), /placeholders object required/);
+});
+
+// ----------------------------------------------------------------------------
+// waitForHealth — acceptAnyStatus option (default true, opt-in strict mode)
+// ----------------------------------------------------------------------------
+
+test("waitForHealth acceptAnyStatus=false requires 2xx/3xx (rejects 401)", async () => {
+  const res = await waitForHealth("http://127.0.0.1:4096/", {
+    maxAttempts: 3,
+    acceptAnyStatus: false,
+    fetchFn: async () => ({ status: 401 }),
+    sleep: async () => {},
+  });
+  assert.equal(res.ok, false, "401 must NOT count as healthy when acceptAnyStatus=false");
+  assert.equal(res.attempts, 3);
+  assert.match(res.error, /non-2xx status 401/);
+});
+
+test("waitForHealth acceptAnyStatus=false accepts a 200", async () => {
+  const res = await waitForHealth("http://127.0.0.1:4096/", {
+    acceptAnyStatus: false,
+    fetchFn: async () => ({ status: 200 }),
+    sleep: async () => {},
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.status, 200);
+});
+
+test("waitForHealth acceptAnyStatus=true (default) accepts 404 as healthy", async () => {
+  const res = await waitForHealth("http://127.0.0.1:4096/", {
+    fetchFn: async () => ({ status: 404 }),
+    sleep: async () => {},
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.status, 404);
 });

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -10,13 +10,19 @@
 // `mobile/www/` here.
 //
 // What goes in (the box's runtime surface only):
-//   src/            — the server (src/server/**) + shared code it imports
-//   scripts/        — install.sh, manta-pair.mjs, install-lib.mjs, systemd unit
-//   mobile/www/     — PRE-BUILT renderer bundle (this is why the box needs no
-//                     Vite/electron toolchain)
-//   package.json    — the "mobile"/"pair" npm scripts + prod deps list
-//   package-lock.json — pins prod deps for `npm ci`
-//   README.md       — manual-install fallback reference
+//   src/               — the server (src/server/**) + shared code it imports
+//   scripts/           — install.sh, manta-pair.mjs, install-lib.mjs, systemd units
+//   docs/opencode-tools/ — the bui-native opencode tool bundle (notify.ts,
+//                         peers.ts, schedule.ts, secrets.ts, serve-page.ts,
+//                         webhook.ts, AGENTS.md). install.sh step D REAL-copies
+//                         these into ~/.config/opencode/tools/ + appends
+//                         AGENTS.md to ~/.config/opencode/AGENTS.md. Symlinking
+//                         misses ~/.config/opencode/node_modules resolution.
+//   mobile/www/        — PRE-BUILT renderer bundle (this is why the box needs no
+//                        Vite/electron toolchain)
+//   package.json       — the "mobile"/"pair" npm scripts + prod deps list
+//   package-lock.json  — pins prod deps for `npm ci`
+//   README.md          — manual-install fallback reference
 //
 // What's excluded: the Electron desktop build, node_modules, .git, dist, tests,
 // dev configs — none of it runs on the box.
@@ -52,6 +58,7 @@ function parseArgs(argv) {
 const INCLUDE = [
   "src",
   "scripts",
+  "docs/opencode-tools",
   "mobile/www",
   "package.json",
   "package-lock.json",

--- a/scripts/systemd/opencode-serve.service
+++ b/scripts/systemd/opencode-serve.service
@@ -1,0 +1,40 @@
+# opencode-serve.service — systemd --user unit for the opencode chat backend
+# (BET-153).
+#
+# Pairs with scripts/systemd/manta-server.service: that unit serves the box
+# HTTP API (mobile / web), this unit serves the opencode chat backend on
+# loopback 127.0.0.1:4096. The two live in the same `systemctl --user`
+# session and have NO ordering dependency — manta-server's opencode.mjs HTTP
+# proxy just talks to 127.0.0.1:4096 regardless of which unit binds it.
+#
+# The installer (scripts/install.sh step E) substitutes the @@…@@ placeholders
+# and writes the result to ~/.config/systemd/user/opencode-serve.service,
+# then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now opencode-serve
+# A nohup fallback (logging to $AUTH_DIR/opencode.log) kicks in on hosts
+# without systemctl, mirroring the manta-server fallback.
+#
+# Bind is 127.0.0.1 on purpose: the chat backend is NOT exposed directly.
+# Everything reaches it through manta-server's auth-gated reverse proxy,
+# which itself is loopback-only. The chat service needs Anthropic OAuth
+# (the `opencode-claude-auth@latest` plugin seeded by install.sh step C),
+# which it picks up from the user's `~/.claude/.credentials.json` — the
+# only auth prerequisite the installer assumes.
+
+[Unit]
+Description=opencode server (manta chat backend)
+Documentation=https://github.com/antoinedc/MantaUI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=@@OPENCODE_BIN@@ serve --port 4096 --hostname 127.0.0.1
+Restart=on-failure
+RestartSec=2
+# Give opencode a moment to flush pending SSE frames on stop before SIGKILL.
+TimeoutStopSec=10
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
BET-153: a fresh VPS running `curl -fsSL https://mantaui.com/install.sh | bash` now ships a working chat backend alongside the terminal box. Today `install.sh` only delivers terminal mode; chat mode + every manta tool silently depend on hand-setup that only exists on the owner's box.

**What this PR adds**

After `npm ci` and before the existing manta-server systemd step, install.sh runs:

- **A. tmux presence gate** — hard fail-fast with apt/yum hint (root not assumed, no auto-install).
- **B. opencode install** — official installer (`curl -fsSL https://opencode.ai/install | bash`); idempotent (`command -v opencode` skip).
- **C. opencode.jsonc seeding** — MERGE `opencode-claude-auth@latest` into the plugin array without clobbering theme/model/provider/mcp. Strip JSONC `//` comments; on parse failure, back the original up to `.pre-manta` and start from `{}` (mirrors the documented skills.urls merge pattern in `src/server/local.mjs`).
- **D. manta opencode tools + agent guidance** — REAL-copies `docs/opencode-tools/*.ts` into `~/.config/opencode/tools/` (symlinks miss node_modules resolution per AGENTS.md) and appends `docs/opencode-tools/AGENTS.md` to `~/.config/opencode/AGENTS.md` with a `## bui scheduled tasks` marker-line grep guard for idempotency.
- **E. opencode-serve systemd --user unit** — new template `scripts/systemd/opencode-serve.service`, substitutes `@@OPENCODE_BIN@@`, installs to `~/.config/systemd/user/`, `enable --now`. Nohup fallback to `$AUTH_DIR/opencode.log` on non-systemctl hosts (mirrors manta-server). Health-waits on `http://127.0.0.1:4096/` reusing the existing `waitForHealth` lib with `acceptAnyStatus:true` (any HTTP response = listener is up).
- **F. Extended summary heredoc** — chat-management hints + claude credentials warning (`~/.claude/.credentials.json` missing → warn with the `claude` + `restart opencode-serve` recipe; not a die).

**Pure helpers (install-lib.mjs)**

- `stripJsoncLineComments(text)` — single-pass, respects strings.
- `mergeOpencodeConfig(existingText)` → `{ text, corrupt, plugin }` — `corrupt:true` only when input was non-empty AND unparseable; an empty input is treated as `{}` and is NOT corrupt (first install). Always returns well-formed JSON. Drops non-string entries from `plugin`. Idempotent: when the auth plugin is already present, output is byte-identical.
- `renderSystemdUnit(template, placeholders)` → string — loop-safe (refuses values containing the token). Used by step E.
- `waitForHealth` gains `acceptAnyStatus` option (default `true` preserves existing behavior). `false` requires 2xx/3xx.

**New CLI verbs on install-lib.mjs**

- `merge-opencode-config` (stdin→stdout merge; stderr `corrupt=1` flag for the shell's `.pre-manta` branch)
- `render-systemd-unit --template <path> --placeholder K=V [--placeholder K=V ...]`

**Release tarball (`scripts/release/pack.mjs`)**

Adds `docs/opencode-tools/` to INCLUDE — install.sh step D would silently no-op without it. Verified the produced `manta-0.0.1.tar.gz` contains `scripts/systemd/opencode-serve.service` and `docs/opencode-tools/*.ts` (then cleaned `dist/`).

**Tests (`scripts/install.test.mjs`)**

+17 tests (44 total, was 27):
- `mergeOpencodeConfig`: empty input; preserves unrelated keys; byte-identical when plugin present; appends without duplication; strips JSONC comments; flags corrupt + starts from `{}`; coerces non-object root to `{}` + corrupt; tolerates malformed plugin array; null/undefined safe.
- `renderSystemdUnit`: substitutes placeholders; refuses values containing the token; rejects bad args.
- `waitForHealth`: `acceptAnyStatus:false` rejects 401 (with explicit error message); accepts 200; `acceptAnyStatus:true` (default) accepts 404 as healthy.

**Files changed:** 5 files. `+653 / -12`.

```
 scripts/install-lib.mjs                | 203 +++++++++++++++++++++++++++++-
 scripts/install.sh                     | 184 +++++++++++++++++++++++++++-
 scripts/install.test.mjs               | 217 +++++++++++++++++++++++++++++++++
 scripts/release/pack.mjs               |  21 ++--
 scripts/systemd/opencode-serve.service |  40 ++++++
```

**Verification results:**

- PR branch (`multica/BET-153-install-chat-stack` @ `6d6a0d4`):
  - typecheck: exit 0. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit 0, 532 pass / 0 fail / 0 skip. log sha256: `3fe5e8a1d516adbb5878a748704c8509fa6058cedb0ff330d14e0e429a7f7a4c`
- Base (`main` @ `5a65f86`):
  - typecheck: exit 0. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit 1, 515 pass / 0 fail / 0 skip. Errors: 1 unhandled harness teardown error in `src/renderer/ChatPanel.harness.test.tsx` (pre-existing — present on `5a65f86` BEFORE this branch). log sha256: `cb809d787c4b700ee1a4942326ad803eaddb537e67df6e93fad2756d60f261b0`
- **Conclusion:** 0 new failures. +17 new install tests, all green. The single harness teardown error is pre-existing on master and unrelated to this PR.

**Base:** `origin/main @ 5a65f86`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.