### PR TITLE
feat(desktop): publish to mantaui.com + add download buttons + release script (BET-154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,23 @@ in-tree but descoped from this beta — ignore it.
 
 ## Run
 
+Pre-built installers (from the latest release):
+
+- macOS (arm64 + x64, unsigned): <https://mantaui.com/downloads/Manta-latest.dmg>
+- Linux (x64 AppImage): <https://mantaui.com/downloads/Manta-latest.AppImage>
+
+The macOS build is unsigned — first launch will be blocked by Gatekeeper.
+Right-click the `.dmg` in Finder → **Open** to bypass (or `xattr -d com.apple.quarantine
+/Applications/Manta\ UI.app` after install).
+
+Run from source:
+
 ```bash
 npm install
 npm run dev
 ```
 
-No packaged binary yet — a tester runs from source. First launch opens
-the onboarding flow:
+First launch opens the onboarding flow:
 
 1. **Pair with your box.** Run the self-install script on your Linux box:
    ```bash
@@ -176,13 +186,20 @@ Upload it to `<release-host>/releases/manta-<version>.tar.gz`.
 To build a packaged `.dmg` (macOS) or `.AppImage` (Linux):
 
 ```bash
-npm run pack:desktop
+bash scripts/release/desktop.sh
 ```
 
-This runs `electron-vite build` to bundle the app, then `electron-builder` to
-produce the platform-specific artifact in `dist/desktop/`. Auto-update is
-configured to use GitHub Releases — after a build, `electron-builder` uploads
-the artifact and generates a `latest.yml` for `electron-updater` to consume.
+This runs `electron-vite build` to bundle the app, then `electron-builder
+--mac --linux --publish never` to produce the platform-specific artifacts in
+`dist/desktop/`. The script prints the exact `scp` commands the owner runs to
+publish to the prod box — see the script header for the path layout
+(`/var/www/mantaui/updates/` is the electron-updater feed,
+`/var/www/mantaui/downloads/` is the human-facing binaries).
+
+Auto-update is configured to use the **prod box apex** as the update server
+(`electron-builder.yml` → `publish: { provider: generic, url:
+https://mantaui.com/updates }`). `electron-updater` reads the feed URL from
+`app-update.yml` baked at build time — no code override needed.
 
 Signing identities (macOS code signing + notarization) are read from
 environment variables (`CSC_LINK`, `CSC_KEY_PASSWORD`) and are NOT committed

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -5,7 +5,10 @@
 #   - Linux: .AppImage
 #
 # Auto-update: configured via electron-updater in src/main/autoUpdate.ts.
-# Update server: GitHub Releases (default for OSS projects).
+# Update server: the prod box apex — `https://mantaui.com/updates/` (electron-
+# updater "generic" provider). Upload the whole `dist/desktop/` output
+# (binaries + latest-{mac,linux}.yml) to that path and electron-updater does
+# the rest.
 #
 # Signing identities are read from environment variables:
 #   - CSC_LINK: path to .p12 certificate file (macOS code signing)
@@ -64,15 +67,18 @@ nsis:
   allowToChangeInstallationDirectory: true
 
 # Auto-update configuration (electron-updater)
-# Uses GitHub Releases as the update server. The `publish` field tells
-# electron-builder to upload artifacts + generate a `latest.yml` after build.
-# For self-hosted S3/CloudFront later, swap `provider: github` for `provider: s3`.
+# Uses the prod box apex as the update server. The `publish` field tells
+# electron-builder to (a) generate `latest-mac.yml` / `latest-linux.yml`
+# next to the artifacts and (b) upload when `--publish always` is set.
+# scripts/release/desktop.sh builds with `--publish never` (so the yml is
+# emitted but NOT uploaded); the owner scp's the whole `dist/desktop/`
+# directory to `<prod>:/var/www/mantaui/updates/` (see the script's printed
+# checklist).
 publish:
-  provider: github
-  owner: antoinedc
-  repo: MantaUI
+  provider: generic
+  url: https://mantaui.com/updates
 
-# Build only macOS + Linux (no Windows target for v1)
-only:
-  - mac
-  - linux
+# (Target selection is on the CLI — `scripts/release/desktop.sh` passes
+# `--mac --linux` so we never build the `win:` target above. There used to
+# be an `only:` block here, but `only` is a CLI-only flag in electron-builder
+# 25.x and the config schema rejects it.)

--- a/scripts/release/desktop.sh
+++ b/scripts/release/desktop.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# desktop.sh — build the Manta UI desktop installers and print the owner's
+# publish checklist.
+#
+#   bash scripts/release/desktop.sh [--mac-only|--linux-only]
+#
+# What it does:
+#   1. `npm run build` then `npx electron-builder --mac --linux --publish never`.
+#      `--publish never` tells electron-builder to emit the
+#      `latest-mac.yml` / `latest-linux.yml` files next to the binaries
+#      (electron-updater's "generic" feed) but to NOT upload anything.
+#   2. Print the exact `scp` commands the owner runs to publish to the prod
+#      box. Nothing is uploaded by this script — the owner decides.
+#
+# Where the owner sends artifacts (per BET-154):
+#   - /var/www/mantaui/updates/  — full output dir, includes the latest-*.yml
+#                                  feeds (electron-updater's "generic" provider
+#                                  polls `${url}/latest-mac.yml` and
+#                                  `${url}/latest-linux.yml`).
+#   - /var/www/mantaui/downloads/ — human-facing binaries; the website's
+#                                   "Download" buttons link to the
+#                                   `Manta-latest.{dmg,AppImage}` copies here.
+#
+# Env:
+#   MANTA_PROD_HOST  ssh target (default `root@91.107.196.2`). Override for
+#                    local testing or a staging box — never embed a host.
+#
+# Flags:
+#   --mac-only       only build mac targets (skip linux)
+#   --linux-only     only build linux targets (skip mac)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# --- arg parsing -----------------------------------------------------------
+BUILD_MAC=1
+BUILD_LINUX=1
+for arg in "$@"; do
+  case "$arg" in
+    --mac-only)   BUILD_LINUX=0 ;;
+    --linux-only) BUILD_MAC=0 ;;
+    -h|--help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+PROD_HOST="${MANTA_PROD_HOST:-root@91.107.196.2}"
+OUTPUT_DIR="dist/desktop"
+
+# --- build -----------------------------------------------------------------
+echo "▸ Building renderer + main bundles…"
+npm run build
+
+EB_ARGS=(electron-builder)
+[ "${BUILD_MAC}"   -eq 1 ] && EB_ARGS+=(--mac)
+[ "${BUILD_LINUX}" -eq 1 ] && EB_ARGS+=(--linux)
+EB_ARGS+=(--publish never)
+
+echo "▸ Running: npx ${EB_ARGS[*]}"
+npx "${EB_ARGS[@]}"
+
+# --- enumerate artifacts ---------------------------------------------------
+shopt -s nullglob
+
+DMGS=( "${OUTPUT_DIR}"/*.dmg )
+APPIMAGES=( "${OUTPUT_DIR}"/*.AppImage )
+
+# Pick the canonical "latest" files the website buttons link to. The artifact
+# name is `<productName>-<version>-<arch>.<ext>`; on Apple Silicon hosts the
+# arm64 dmg is the right pick, on linux x64 the AppImage is the only one
+# built today. We pick the highest-arch one we can find and print its name
+# so the owner can sanity-check before publishing.
+pick_latest() {
+  # args: <pattern...> ; prints the lexicographically largest basename.
+  local f
+  for f in "$@"; do echo "$(basename "$f")"; done | sort -V | tail -n 1
+}
+
+LATEST_DMG=""
+LATEST_APPIMAGE=""
+if [ "${#DMGS[@]}" -gt 0 ]; then
+  LATEST_DMG="$(pick_latest "${DMGS[@]}")"
+fi
+if [ "${#APPIMAGES[@]}" -gt 0 ]; then
+  LATEST_APPIMAGE="$(pick_latest "${APPIMAGES[@]}")"
+fi
+
+if [ -z "${LATEST_DMG}" ] && [ "${BUILD_MAC}" -eq 1 ]; then
+  echo "✗ no .dmg in ${OUTPUT_DIR}/ — mac build failed silently?" >&2
+  exit 1
+fi
+if [ -z "${LATEST_APPIMAGE}" ] && [ "${BUILD_LINUX}" -eq 1 ]; then
+  echo "✗ no .AppImage in ${OUTPUT_DIR}/ — linux build failed silently?" >&2
+  exit 1
+fi
+
+ALL_ARTIFACTS=( "${DMGS[@]}" "${APPIMAGES[@]}" )
+FEEDS=()
+[ -f "${OUTPUT_DIR}/latest-mac.yml" ]   && FEEDS+=( "${OUTPUT_DIR}/latest-mac.yml" )
+[ -f "${OUTPUT_DIR}/latest-linux.yml" ] && FEEDS+=( "${OUTPUT_DIR}/latest-linux.yml" )
+
+# --- owner checklist -------------------------------------------------------
+cat <<EOF
+
+✓ Build complete. Artifacts in ${OUTPUT_DIR}/.
+
+Owner publishes by hand (NOT done by this script):
+
+  # 1. Send binaries + feed yml to /var/www/mantaui/updates/ (the
+  #    electron-updater "generic" feed root).
+  scp ${ALL_ARTIFACTS[*]} ${FEEDS[*]} \\
+      ${PROD_HOST}:/var/www/mantaui/updates/
+
+  # 2. Send the human-facing binaries to /var/www/mantaui/downloads/.
+  scp ${ALL_ARTIFACTS[*]} \\
+      ${PROD_HOST}:/var/www/mantaui/downloads/
+
+  # 3. Refresh the stable copies the website's "Download" buttons link to.
+EOF
+if [ -n "${LATEST_DMG}" ]; then
+  cat <<EOF
+  ssh ${PROD_HOST} 'cd /var/www/mantaui/downloads \\
+      && cp "${LATEST_DMG}" Manta-latest.dmg'
+EOF
+fi
+if [ -n "${LATEST_APPIMAGE}" ]; then
+  cat <<EOF
+  ssh ${PROD_HOST} 'cd /var/www/mantaui/downloads \\
+      && cp "${LATEST_APPIMAGE}" Manta-latest.AppImage'
+EOF
+fi
+cat <<EOF
+
+  # 4. Verify (must 200 + version match package.json):
+  #    curl -sI https://mantaui.com/downloads/Manta-latest.dmg
+  #    curl -s  https://mantaui.com/updates/latest-mac.yml
+
+Latest dmg       : ${LATEST_DMG:-"(none — mac skipped)"}
+Latest AppImage  : ${LATEST_APPIMAGE:-"(none — linux skipped)"}
+MANTA_PROD_HOST  : ${PROD_HOST}
+EOF

--- a/src/main/autoUpdate.ts
+++ b/src/main/autoUpdate.ts
@@ -6,7 +6,10 @@
 //   3. Notify the renderer when an update is ready to install (via IPC)
 //   4. Restart the app after the user confirms installation
 //
-// Update server: GitHub Releases (configured in electron-builder.yml).
+// Update server: `https://mantaui.com/updates/` (electron-updater "generic"
+// provider, configured in electron-builder.yml → `publish.url`). electron-
+// updater reads the feed URL from `app-update.yml` baked at build time —
+// no override here on purpose.
 // In production, this is seamless. In dev (unpacked app), checks are skipped
 // because there's no signed artifact to verify against.
 

--- a/website/index.html
+++ b/website/index.html
@@ -243,7 +243,11 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
         <button class="copy-btn" onclick="navigator.clipboard.writeText('curl -fsSL https://mantaui.com/install.sh | bash');this.textContent='Copied';setTimeout(()=>this.textContent='Copy',1400)">Copy</button>
       </div>
     </div>
-    <div class="meta">Free &amp; <a href="https://github.com/antoinedc/MantaUI">open source</a> · runs on hardware you already own</div>
+    <div class="cta">
+      <a class="btn btn-primary" href="https://mantaui.com/downloads/Manta-latest.dmg">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://mantaui.com/downloads/Manta-latest.AppImage">Download for Linux</a>
+    </div>
+    <div class="meta">macOS build is unsigned — first launch: right-click the .dmg → Open. Free &amp; <a href="https://github.com/antoinedc/MantaUI">open source</a>.</div>
 
     <div class="shot">
       <div class="shot-bar">
@@ -396,6 +400,10 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
         <code><span class="prompt">$</span> curl -fsSL <span class="url">https://mantaui.com/install.sh</span> | bash</code>
         <button class="copy-btn" onclick="navigator.clipboard.writeText('curl -fsSL https://mantaui.com/install.sh | bash');this.textContent='Copied';setTimeout(()=>this.textContent='Copy',1400)">Copy</button>
       </div>
+    </div>
+    <div class="cta" style="margin-top:20px">
+      <a class="btn btn-primary" href="https://mantaui.com/downloads/Manta-latest.dmg">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://mantaui.com/downloads/Manta-latest.AppImage">Download for Linux</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
**Files changed:** `5` files. `README.md`, `electron-builder.yml`, `src/main/autoUpdate.ts`, `website/index.html`, `scripts/release/desktop.sh`

**Summary (BET-154):**

- **`electron-builder.yml`**: switched `publish` from the GitHub provider to the
  electron-updater "generic" provider at `https://mantaui.com/updates`.
  electron-builder will now emit `latest-mac.yml` / `latest-linux.yml` next to
  the artifacts at build time; the new release script drops the whole
  `dist/desktop/` directory into `/var/www/mantaui/updates/` on the prod box.
  `src/main/autoUpdate.ts` needs no code change — electron-updater reads the
  feed URL from `app-update.yml` baked at build time. (Confirmed by grep:
  no `setFeedURL` / `updateConfig` / override anywhere in `src/main` or
  `src/preload`.) Comment in `autoUpdate.ts` refreshed to reflect the new
  feed.
- **`scripts/release/desktop.sh`** (new, executable, 145 lines): runs
  `npm run build && npx electron-builder --mac --linux --publish never`,
  enumerates the resulting `dist/desktop/` artifacts, and prints the exact
  `scp` commands the owner runs to publish:
  1. send binaries + `latest-*.yml` to `<prod>:/var/www/mantaui/updates/`
     (electron-updater "generic" feed root)
  2. send binaries to `<prod>:/var/www/mantaui/downloads/` (human-facing)
  3. refresh the `Manta-latest.{dmg,AppImage}` copies the website's
     "Download" buttons link at
  4. verify with `curl -sI` / `curl -s` against `mantaui.com`
  Reads the prod host from `$MANTA_PROD_HOST` (default `root@91.107.196.2`).
  Supports `--mac-only` / `--linux-only`.
- **`website/index.html`**: added a "Download for macOS" + "Download for Linux"
  button pair to the hero and to the bottom CTA band, both pointing at the
  stable `Manta-latest.{dmg,AppImage}` names. Reuses the existing `.btn` /
  `.btn-primary` / `.btn-ghost` / `.cta` classes — no new CSS. Updated the
  hero meta line to note the Gatekeeper caveat (right-click → Open).
- **`README.md`**: prebuilt download URLs + Gatekeeper caveat in the **Run**
  section (replacing the "no packaged binary yet" line); updated **Building
  the desktop app** to point at the new release script and the new feed.

**Drive-by:** removed the root-level `only:` block from `electron-builder.yml`.
It was a pre-existing schema error (`only` is a CLI flag, not a config field,
in electron-builder 25.x — schema rejects it). The new release script passes
`--mac --linux` on the CLI which enforces the same constraint.

**Verification results:**
- PR branch (`multica/BET-154-desktop-distribution` @ `1018fc2`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `515` pass / `0` fail / `0` skip. log sha256: `259c5f9618f8dc21914ca21cf09e2b1bea50688dc2dcbd33d67c2996324124b0`
- Base (`master` @ `5a65f86`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba` (identical)
  - test: exit `0`, `515` pass / `0` fail / `0` skip. log sha256: `5d9b1d8bc9ac429753b170e1dcf8011c56f78565f4a3ba69e71273b33309ce9d`
- **Conclusion:** `0` new failures, `0` resolved failures. Test logs differ only in `duration_ms` (timing). Typecheck logs are bit-identical.
- **Build verification:** `bash scripts/release/desktop.sh --linux-only` completes on this Linux host and emits:
  - `dist/desktop/Manta UI-0.0.1-x86_64.AppImage` (110 MB)
  - `dist/desktop/latest-linux.yml` — version `0.0.1` matches `package.json`
  - mac .dmg build is owner-only (no macOS host here); the yml file is NOT faked — owner runs the same script on macOS to emit `dist/desktop/latest-mac.yml`.

**Owner's publish checklist (run on the prod box or any host with `scp` access):**

```bash
MANTA_PROD_HOST=root@91.107.196.2 bash scripts/release/desktop.sh --linux-only   # on a Linux host
MANTA_PROD_HOST=root@91.107.196.2 bash scripts/release/desktop.sh --mac-only     # on a macOS host
```

…then run the printed `scp` commands verbatim.

**Base: origin/main @ `5a65f86`**
