### PR TITLE
BET-152: Relay real box auth (TOFU) + POST /pair + account tokens — delete dev-open

### DIFF
--- a/src/relay/api.mjs
+++ b/src/relay/api.mjs
@@ -28,11 +28,10 @@
 // AUTH (phone leg): reuses `src/server/webhooks.mjs` isValidToken (shape) +
 // createRateLimiter (per account/box token bucket). WHO a phone is (which
 // account) is decided by an injectable `authenticatePhone(req)` seam. The
-// default extracts a bearer token, shape-validates it, and (when an
-// `accountTokens` map is configured) maps token→account_id; with no map it runs
-// DEV-OPEN (a well-formed token IS the account id) and logs once — Stage 5
-// replaces this seam with the IAP-account lookup. This mirrors the box-leg
-// verifier seam in index.mjs so both auth surfaces move together.
+// default (createDefaultPhoneAuth) extracts a bearer token, shape-validates it,
+// and looks up sha256(token) in the store's `account_tokens` table — only
+// tokens minted at /pair time resolve. The seam itself remains so a future
+// Stage-5 IAP-account lookup can be injected without touching the router.
 //
 // TESTABILITY: the router core operates on a NORMALIZED request object
 // ({ method, path, headers, body }) and returns a normalized response
@@ -42,6 +41,7 @@
 // same core in a Node `http` request listener for the CLI entry.
 
 import { isValidToken, createRateLimiter } from "../server/webhooks.mjs";
+import { hashToken } from "./store.mjs";
 
 // Per-phone-token rate limit for the API surface. A phone polls its box list and
 // proxies a handful of requests; a token hammering the relay is throttled.
@@ -84,44 +84,29 @@ export function isGatedSubpath(subpath) {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the default phone authenticator.
+ * Build the default phone authenticator (BET-152 / ADR-5).
  *
  * Extracts a bearer token from `Authorization: Bearer <t>` (or `?token=<t>`),
- * shape-validates it with isValidToken, and resolves it to an account_id:
- *   - with an `accountTokens` map (token → account_id): only a mapped token
- *     authenticates; unknown/malformed → null (401).
- *   - without a map (DEV-OPEN): a well-formed token IS the account_id; logs once.
- *     Stage 5 replaces this with the IAP-bound account lookup.
+ * shape-validates it with isValidToken, and resolves it to an account_id by
+ * looking up `sha256(token)` in the store's `account_tokens` table. The store
+ * is REQUIRED (no dev-open fallback): a relay with no token store has no
+ * known accounts and every phone request must reject.
  *
  * Returns a function (normReq) => { accountId } | null.
  *
- * @param {object} [opts]
- * @param {Map<string,string>|Record<string,string>|null} [opts.accountTokens]
- * @param {(msg:string)=>void} [opts.warn]
+ * @param {object} opts
+ * @param {object} opts.store    an openStore() handle (getAccountByTokenHash).
+ *                                Required.
+ * @param {(msg:string)=>void} [opts.warn]  injectable warn sink (tests silence).
  */
-export function createDefaultPhoneAuth({ accountTokens = null, warn = console.warn } = {}) {
-  const lookup =
-    accountTokens == null
-      ? null
-      : accountTokens instanceof Map
-        ? accountTokens
-        : new Map(Object.entries(accountTokens));
-  let warnedOpen = false;
-
+export function createDefaultPhoneAuth({ store, warn = console.warn } = {}) {
+  if (!store || typeof store.getAccountByTokenHash !== "function") {
+    throw new Error("createDefaultPhoneAuth: store required");
+  }
   return function authenticatePhone(req) {
     const token = extractBearer(req);
     if (!isValidToken(token)) return null;
-    if (lookup == null) {
-      if (!warnedOpen) {
-        warnedOpen = true;
-        warn(
-          "[relay-api] DEV-OPEN phone auth: a well-formed token IS the account. " +
-            "Configure accountTokens (or a Stage-5 IAP lookup) before production.",
-        );
-      }
-      return { accountId: token };
-    }
-    const accountId = lookup.get(token);
+    const accountId = store.getAccountByTokenHash(hashToken(token));
     return typeof accountId === "string" && accountId ? { accountId } : null;
   };
 }
@@ -180,12 +165,11 @@ export function createDefaultSubscriptionCheck(store, now = () => Date.now()) {
  * Create the phone-facing relay API.
  *
  * @param {object} opts
- * @param {object} opts.store                a relay store (bindings/boxes/receipts).
+ * @param {object} opts.store                a relay store (bindings/boxes/receipts/account_tokens).
  * @param {(boxId,req,o?)=>Promise<{status,headers?,body?}>} opts.proxyRequest
  *   the box-tunnel proxy from createRelayServer().proxyRequest.
  * @param {(req)=>({accountId:string}|null)} [opts.authenticatePhone]
- *   phone auth seam; default createDefaultPhoneAuth({ accountTokens }).
- * @param {Map|object|null} [opts.accountTokens]  passed to the default auth.
+ *   phone auth seam; default createDefaultPhoneAuth({ store, warn }).
  * @param {(boxId:string)=>boolean} [opts.hasActiveSubscription]
  *   gate seam; default createDefaultSubscriptionCheck(store, now).
  * @param {(key:string)=>boolean} [opts.rateLimiter]  take(key)=>bool; created if omitted.
@@ -196,7 +180,6 @@ export function createRelayApi(opts = {}) {
   const {
     store,
     proxyRequest,
-    accountTokens = null,
     now = () => Date.now(),
     warn = console.warn,
   } = opts;
@@ -207,7 +190,7 @@ export function createRelayApi(opts = {}) {
   }
 
   const authenticatePhone =
-    opts.authenticatePhone || createDefaultPhoneAuth({ accountTokens, warn });
+    opts.authenticatePhone || createDefaultPhoneAuth({ store, warn });
   const hasActiveSubscription =
     opts.hasActiveSubscription || createDefaultSubscriptionCheck(store, now);
   const rl =

--- a/src/relay/api.test.mjs
+++ b/src/relay/api.test.mjs
@@ -8,7 +8,7 @@ import {
   isGatedSubpath,
 } from "./api.mjs";
 import { createRelayServer, createDefaultVerifier } from "./index.mjs";
-import { openStore, BOX_STATUS } from "./store.mjs";
+import { openStore, BOX_STATUS, hashToken } from "./store.mjs";
 import { encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
 
 const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
@@ -35,11 +35,15 @@ const noProxy = async () => {
 };
 
 // Auth that maps the two account tokens; anything else → null.
-function makeAuth() {
-  return createDefaultPhoneAuth({
-    accountTokens: { [ACCT_1]: ACCT_1, [ACCT_2]: ACCT_2 },
-    warn: silent,
-  });
+// Seeded into a fresh in-memory store: device tokens map to their own account
+// id (the same opaque identifier; this matches what /pair mints today).
+function makeAuth(storeArg) {
+  const store = storeArg || openStore();
+  store.addAccountToken(hashToken(ACCT_1), ACCT_1);
+  store.addAccountToken(hashToken(ACCT_2), ACCT_2);
+  const auth = createDefaultPhoneAuth({ store, warn: silent });
+  // expose the store so callers can use it for fixtures
+  return Object.assign(auth, { _store: store });
 }
 
 function bearer(token) {
@@ -67,23 +71,24 @@ test("isGatedSubpath: transcript/stream/prompt/pty are gated; metadata is free",
 // pure: default phone auth seam
 // ---------------------------------------------------------------------------
 
-test("createDefaultPhoneAuth: mapped token → accountId; unknown/malformed → null", () => {
-  const auth = makeAuth();
-  assert.deepEqual(auth({ headers: bearer(ACCT_1) }), { accountId: ACCT_1 });
-  assert.equal(auth({ headers: bearer("deadbeefdeadbeefdeadbeefdeadbeef") }), null, "unknown token");
-  assert.equal(auth({ headers: bearer("not-hex") }), null, "malformed token");
-  assert.equal(auth({ headers: {} }), null, "no token");
+test("createDefaultPhoneAuth: throws without a store (no dev-open fallback)", () => {
+  assert.throws(() => createDefaultPhoneAuth(), /store required/);
 });
 
-test("createDefaultPhoneAuth: DEV-OPEN (no map) treats a well-formed token as the account", () => {
-  const auth = createDefaultPhoneAuth({ warn: silent });
+test("createDefaultPhoneAuth: store-known token → accountId; unknown/malformed → null", () => {
+  const auth = makeAuth();
   assert.deepEqual(auth({ headers: bearer(ACCT_1) }), { accountId: ACCT_1 });
-  assert.equal(auth({ headers: bearer("bad") }), null);
+  assert.deepEqual(auth({ headers: bearer(ACCT_2) }), { accountId: ACCT_2 });
+  assert.equal(auth({ headers: bearer("deadbeefdeadbeefdeadbeefdeadbeef") }), null, "unknown well-formed token");
+  assert.equal(auth({ headers: bearer("not-hex") }), null, "malformed token");
+  assert.equal(auth({ headers: {} }), null, "no token");
+  auth._store.close();
 });
 
 test("createDefaultPhoneAuth: falls back to ?token= query when no header", () => {
   const auth = makeAuth();
   assert.deepEqual(auth({ path: `/api/boxes?token=${ACCT_1}` }), { accountId: ACCT_1 });
+  auth._store.close();
 });
 
 // ---------------------------------------------------------------------------
@@ -308,7 +313,7 @@ test("end-to-end: phone metadata request is forwarded to a live box and the fram
   const relay = createRelayServer({
     wss,
     store,
-    verifyBox: createDefaultVerifier({ warn: silent }),
+    verifyBox: createDefaultVerifier({ store, warn: silent, log: silent }),
     log: silent,
     warn: silent,
   });

--- a/src/relay/index.mjs
+++ b/src/relay/index.mjs
@@ -21,18 +21,17 @@
 //   and the box_id as ?box_id=<box_id> query param (or an `x-box-id` header).
 //   Both must pass isValidToken (32-hex) shape validation from webhooks.mjs, and
 //   then an injectable verifyBox({boxId, token}) decides acceptance. The default
-//   verifier consults an optional boxTokens map (box_id → expected box_token,
-//   constant-time compared); if no map is configured it runs in DEV-OPEN mode
-//   (any well-formed pair accepted) and logs a loud warning — the real
-//   credential source (IAP-bound box_secret) is wired in Stage 5. verifyBox is
-//   the single seam Stage 5 replaces; nothing else here changes.
+//   verifier (createDefaultVerifier) implements trust-on-first-use via the
+//   store: sha256(token) is recorded on the first dial-out for a box_id; later
+//   dial-outs must hash-compare (constant-time). verifyBox remains the seam for
+//   an out-of-store verifier (e.g. Stage-5 IAP-bound secrets); nothing else
+//   here changes.
 //
 // PORT: 20787 by default (bui 20xxx block per AGENTS.md), override with
 //   RELAY_PORT. Bind host override with RELAY_HOST (default 0.0.0.0).
 
 import { WebSocketServer } from "ws";
 import { isValidToken, createRateLimiter } from "../server/webhooks.mjs";
-import { tokenMatches } from "../server/auth.mjs";
 import {
   RoutingTable,
   PendingRequests,
@@ -40,7 +39,7 @@ import {
   decodeFrame,
   FRAME_TYPES,
 } from "./protocol.mjs";
-import { openStore, BOX_STATUS } from "./store.mjs";
+import { openStore, BOX_STATUS, hashToken, hashEquals } from "./store.mjs";
 
 export const DEFAULT_RELAY_PORT = 20787;
 
@@ -110,43 +109,48 @@ export function parseHandshake({ url, headers = {}, host = "localhost" } = {}) {
 }
 
 /**
- * Build the default box verifier.
+ * Build the default box verifier (BET-152 / ADR-4: trust-on-first-use).
  *
- * @param {object} [opts]
- * @param {Map<string,string>|Record<string,string>|null} [opts.boxTokens]
- *   Optional box_id → expected box_token map. When provided, a handshake is
- *   accepted only if the presented token constant-time matches the stored one.
- *   When omitted (null), the relay runs DEV-OPEN: any shape-valid {boxId, token}
- *   is accepted (a loud warning is logged once). Stage 5 replaces this with the
- *   IAP-bound credential lookup.
+ * Behavior:
+ *   - Shape gate with isValidToken first (a malformed id/token is NEVER
+ *     accepted, and NEVER registers — so a scanner can not seed itself).
+ *   - Look up the stored credential for `boxId` in the store.
+ *     - No row → first dial-out: persist `sha256(token)`, log the TOFU
+ *       registration, accept.
+ *     - Row present → accept iff `hashEquals(row.token_hash, hashToken(token))`.
+ *     - Hash mismatch → reject (the box presented a different token for the
+ *       same box_id; either the box owner rotated without us, or someone is
+ *       trying to squat the id).
+ *
+ * `store` is REQUIRED. There is no dev-open fallback: a relay with no
+ * credential store is misconfigured and every handshake must reject.
+ *
+ * @param {object} opts
+ * @param {object} opts.store  an openStore() handle (getBoxCredential /
+ *                              setBoxCredential). Required.
  * @param {(msg:string)=>void} [opts.warn]  injectable warn sink (tests silence).
+ * @param {(msg:string)=>void} [opts.log]   injectable log sink for the TOFU
+ *                                            registration line (tests silence).
  */
-export function createDefaultVerifier({ boxTokens = null, warn = console.warn } = {}) {
-  const lookup =
-    boxTokens == null
-      ? null
-      : boxTokens instanceof Map
-        ? boxTokens
-        : new Map(Object.entries(boxTokens));
-
-  let warnedOpen = false;
+export function createDefaultVerifier({ store, warn = console.warn, log = console.log } = {}) {
+  if (!store || typeof store.getBoxCredential !== "function") {
+    throw new Error("createDefaultVerifier: store required");
+  }
   return function verifyBox({ boxId, token }) {
-    // Shape gate first — both must be 32-hex. A malformed id/token is never
-    // accepted, even in dev-open mode.
+    // Shape gate first — a malformed id/token is NEVER accepted AND never
+    // registers, so an attacker can't probe to seed a row.
     if (!isValidToken(boxId) || !isValidToken(token)) return false;
-    if (lookup == null) {
-      if (!warnedOpen) {
-        warnedOpen = true;
-        warn(
-          "[relay] DEV-OPEN auth: accepting any well-formed box handshake. " +
-            "Configure boxTokens (or a Stage-5 verifier) before production.",
-        );
-      }
+    const cred = store.getBoxCredential(boxId);
+    if (!cred) {
+      // First dial-out for this box_id → trust-on-first-use: persist sha256
+      // (NOT the plaintext token — ADR-1) and accept. setBoxCredential throws
+      // on a UNIQUE collision, which surfaces as a hard reject (a stale in-mem
+      // routing race or a deliberate double-register attempt).
+      store.setBoxCredential(boxId, hashToken(token));
+      log(`[relay] box ${boxId.slice(0, 8)} registered (TOFU)`);
       return true;
     }
-    const expected = lookup.get(boxId);
-    if (typeof expected !== "string") return false;
-    return tokenMatches(expected, token);
+    return hashEquals(cred.token_hash, hashToken(token));
   };
 }
 
@@ -210,8 +214,7 @@ export function wsTransport(ws, { onError } = {}) {
  * @param {object} [opts.store]        an openStore() handle; created in-memory if omitted.
  * @param {string} [opts.storePath]    path passed to openStore when store omitted.
  * @param {(a:{boxId:string,token:string})=>boolean} [opts.verifyBox]
- *   box handshake verifier; defaults to createDefaultVerifier({ boxTokens }).
- * @param {Map|object|null} [opts.boxTokens]  passed to the default verifier.
+ *   box handshake verifier; defaults to createDefaultVerifier({ store, log, warn }).
  * @param {object} [opts.routingTable] a RoutingTable; created if omitted.
  * @param {(...a)=>void} [opts.log]     injectable logger (default console.log).
  * @param {(...a)=>void} [opts.warn]    injectable warn (default console.warn).
@@ -232,7 +235,6 @@ export function createRelayServer(opts = {}) {
     host = process.env.RELAY_HOST || "0.0.0.0",
     storePath,
     verifyBox,
-    boxTokens = null,
     log = console.log,
     warn = console.warn,
     now = () => Date.now(),
@@ -244,7 +246,7 @@ export function createRelayServer(opts = {}) {
   const routing = opts.routingTable || new RoutingTable({
     onEvict: (boxId) => log(`[relay] evicted stale socket for box ${short(boxId)}`),
   });
-  const verify = verifyBox || createDefaultVerifier({ boxTokens, warn });
+  const verify = verifyBox || createDefaultVerifier({ store, log, warn });
   const rl =
     rateLimiter ||
     createRateLimiter({

--- a/src/relay/index.test.mjs
+++ b/src/relay/index.test.mjs
@@ -8,7 +8,7 @@ import {
   wsTransport,
   DEFAULT_RELAY_PORT,
 } from "./index.mjs";
-import { openStore, BOX_STATUS } from "./store.mjs";
+import { openStore, BOX_STATUS, hashToken } from "./store.mjs";
 import { encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
 
 const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
@@ -53,32 +53,55 @@ test("parseHandshake: missing creds → nulls; malformed url → nulls", () => {
 });
 
 // ---------------------------------------------------------------------------
-// pure: default verifier
+// pure: default verifier (BET-152 / ADR-4 TOFU)
 // ---------------------------------------------------------------------------
 
-test("createDefaultVerifier: dev-open accepts any well-formed pair, rejects malformed", () => {
-  const v = createDefaultVerifier({ warn: silent });
-  assert.equal(v({ boxId: BOX_A, token: TOKEN_A }), true);
-  assert.equal(v({ boxId: "bad", token: TOKEN_A }), false);
-  assert.equal(v({ boxId: BOX_A, token: "bad" }), false);
+test("createDefaultVerifier: throws without a store (no dev-open fallback)", () => {
+  assert.throws(() => createDefaultVerifier(), /store required/);
 });
 
-test("createDefaultVerifier: with boxTokens map, only exact token matches", () => {
-  const v = createDefaultVerifier({
-    boxTokens: { [BOX_A]: TOKEN_A },
-    warn: silent,
-  });
+test("createDefaultVerifier: first dial-out registers + accepts; same token re-accepts", () => {
+  const store = openStore();
+  const v = createDefaultVerifier({ store, warn: silent, log: silent });
+
+  // First sight: row created, accepted.
   assert.equal(v({ boxId: BOX_A, token: TOKEN_A }), true);
+  const cred = store.getBoxCredential(BOX_A);
+  assert.ok(cred, "credential row persisted on first sight");
+  assert.equal(cred.token_hash, hashToken(TOKEN_A), "stored hash is sha256(token)");
+
+  // Re-present the same pair: still accepted, no second row, same hash.
+  assert.equal(v({ boxId: BOX_A, token: TOKEN_A }), true);
+  assert.equal(store.getBoxCredential(BOX_A).token_hash, hashToken(TOKEN_A));
+  store.close();
+});
+
+test("createDefaultVerifier: wrong token for a known box rejects; store row untouched", () => {
+  const store = openStore();
+  const v = createDefaultVerifier({ store, warn: silent, log: silent });
+
+  assert.equal(v({ boxId: BOX_A, token: TOKEN_A }), true, "register");
+  const originalHash = store.getBoxCredential(BOX_A).token_hash;
+
   assert.equal(v({ boxId: BOX_A, token: TOKEN_B }), false, "wrong token rejected");
-  assert.equal(v({ boxId: BOX_B, token: TOKEN_B }), false, "unknown box rejected");
+  assert.equal(
+    store.getBoxCredential(BOX_A).token_hash,
+    originalHash,
+    "stored credential NOT rotated by a wrong-token attempt",
+  );
+  store.close();
 });
 
-test("createDefaultVerifier: accepts a Map as well as a plain object", () => {
-  const v = createDefaultVerifier({
-    boxTokens: new Map([[BOX_A, TOKEN_A]]),
-    warn: silent,
-  });
-  assert.equal(v({ boxId: BOX_A, token: TOKEN_A }), true);
+test("createDefaultVerifier: malformed handshake rejects BEFORE any row is created", () => {
+  const store = openStore();
+  const v = createDefaultVerifier({ store, warn: silent, log: silent });
+
+  // Malformed shapes must reject AND must not register anything.
+  assert.equal(v({ boxId: "not-hex", token: TOKEN_A }), false);
+  assert.equal(v({ boxId: BOX_A, token: "not-hex" }), false);
+  // The valid-shape box row is untouched (none created, none modified).
+  assert.equal(store.getBoxCredential(BOX_A), null, "no row created from a malformed handshake");
+  store.close();
 });
 
 // ---------------------------------------------------------------------------
@@ -103,17 +126,17 @@ test("wsTransport.send encodes frame objects and forwards strings; swallows enco
 // integration: real loopback ws server, real box client sockets
 // ---------------------------------------------------------------------------
 
-// Build a relay on an ephemeral port with an in-memory store and injected
-// verifier. Returns { relay, store, url } and registers teardown.
-async function makeRelay(t, { verifyBox } = {}) {
-  const store = openStore(); // in-memory
+// Build a relay on an ephemeral port with an in-memory store and the default
+// (store-backed) verifier. Returns { relay, store, url } and registers teardown.
+async function makeRelay(t, { verifyBox, store: injectedStore } = {}) {
+  const store = injectedStore || openStore(); // in-memory
   const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
   await new Promise((r) => wss.once("listening", r));
   const { port } = wss.address();
   const relay = createRelayServer({
     wss,
     store,
-    verifyBox: verifyBox || createDefaultVerifier({ warn: silent }),
+    verifyBox: verifyBox || createDefaultVerifier({ store, warn: silent, log: silent }),
     log: silent,
     warn: silent,
   });
@@ -163,8 +186,11 @@ test("authenticated box registers in RoutingTable + persists an online box row",
 });
 
 test("bad-token handshake is rejected: socket closed, no registration, no box row", async (t) => {
-  const verifyBox = createDefaultVerifier({ boxTokens: { [BOX_A]: TOKEN_A }, warn: silent });
-  const { relay, store, url } = await makeRelay(t, { verifyBox });
+  // Pre-seed the store so BOX_A is a KNOWN box (its credential is hash(TOKEN_A))
+  // — a wrong-token dial-out must be rejected AND not allowed to re-register.
+  const store = openStore();
+  store.setBoxCredential(BOX_A, hashToken(TOKEN_A));
+  const { relay, url } = await makeRelay(t, { store });
 
   const ws = connectBox(url, { boxId: BOX_A, token: TOKEN_B }); // wrong token
   const [code] = await once(ws, "close");

--- a/src/relay/server.mjs
+++ b/src/relay/server.mjs
@@ -28,12 +28,12 @@
 //   the `relay.mantaui.com` vhost fronts it). Override with RELAY_PORT /
 //   RELAY_HOST. RELAY_PORT=0 selects an ephemeral port (tests, dev).
 //
-// WHAT'S STILL DEFERRED (live-provisioning, do NOT block on it here — same seams
-// M2 left open): real Apple x5c/verifyJws crypto, real APNs/FCM certs + prod
-// PushSender, and the IAP-bound verifyBox/authenticatePhone lookups. This file
-// only COMPOSES the DEV-OPEN/structural defaults into a runnable service.
+// WHAT'S STILL DEFERRED (live-provisioning, do NOT block on it here): real Apple
+// x5c/verifyJws crypto, real APNs/FCM certs + prod PushSender. The relay's box
+// auth (TOFU, BET-152) and account-token mint are now real (store-backed).
 
 import http from "node:http";
+import { randomBytes } from "node:crypto";
 import { WebSocketServer } from "ws";
 import { STATE_DIRNAME } from "../shared/paths.mjs";
 
@@ -45,8 +45,11 @@ import {
 } from "./api.mjs";
 import { createReceiptValidator, bindReceipt } from "./iap.mjs";
 import { createRelayPush } from "./push.mjs";
-import { openStore } from "./store.mjs";
-import { isValidToken } from "../server/webhooks.mjs";
+import { openStore, hashToken } from "./store.mjs";
+import {
+  isValidToken,
+  createRateLimiter,
+} from "../server/webhooks.mjs";
 
 export const DEFAULT_RELAY_PORT = 20787;
 
@@ -54,10 +57,25 @@ export const DEFAULT_RELAY_PORT = 20787;
 // upgrade is rejected (a stray WS upgrade must not fall into the HTTP router).
 const BOX_UPGRADE_PATH = "/box";
 
-// Cap on an IAP/push request body so an unbounded POST can't exhaust memory
-// before the phone is even authenticated. 256 KiB is generous for a JWS +
-// token registration; larger bodies are refused with 413.
+// Cap on an IAP/push + /pair request body so an unbounded POST can't exhaust
+// memory before the phone is even authenticated. 256 KiB is generous for a JWS
+// + token registration; larger bodies are refused with 413.
 const MAX_BODY_BYTES = 256 * 1024;
+
+// The /pair bootstrap endpoint is UNAUTHENTICATED (the device has nothing to
+// present yet — the whole point of /pair is to GET credentials). Rate-limited
+// to mirror the box's own /auth/* limiter (src/server/auth.mjs AUTH_RL_*):
+// capacity 10, refill 0.2/sec ≈ 12/min sustained — a human pairing needs a
+// handful of hits; a guesser is throttled hard. Combined with the 5-min code
+// TTL and the 10^6 pairing-code space, the code is not brute-forceable in the
+// window.
+export const PAIR_RL_CAPACITY = 10;
+export const PAIR_RL_REFILL_PER_SEC = 0.2;
+
+// A pairing code is exactly 6 decimal digits (matches the box-side
+// isValidPairingCode in src/server/auth.mjs). Stricter than isValidToken so a
+// pairing body can't smuggle a path or extra payload via the code field.
+const PAIR_CODE_RE = /^\d{6}$/;
 
 /**
  * Create (but do not start) the combined relay service: one http.Server serving
@@ -71,12 +89,15 @@ const MAX_BODY_BYTES = 256 * 1024;
  *                               storePath when omitted.
  * @param {string} [opts.storePath]  file path for the shared store (e.g.
  *                               ~/.manta/relay.sqlite); ":memory:" default.
- * @param {Map|object|null} [opts.boxTokens]     box-leg verifier seam.
- * @param {Map|object|null} [opts.accountTokens] phone-auth seam.
  * @param {(req)=>({accountId:string}|null)} [opts.authenticatePhone]
- *   shared phone auth; defaults to createDefaultPhoneAuth({ accountTokens }).
+ *   shared phone auth; defaults to createDefaultPhoneAuth({ store, warn }).
+ * @param {(boxId,req,o?)=>Promise<{status,headers?,body?}>} [opts.proxyRequest]
+ *   override the box-leg proxyRequest (tests inject a fake that bypasses the
+ *   live tunnel; production uses boxLeg.proxyRequest).
  * @param {(jws:string)=>object} [opts.verifyJws]  IAP crypto seam (structural default).
  * @param {object} [opts.pushSender]  a PushSender (stub default).
+ * @param {(key:string)=>boolean} [opts.pairRateLimiter]  take(key)=>bool for the
+ *   unauthenticated /pair bootstrap; created if omitted.
  * @param {() => number} [opts.now=Date.now]
  * @param {(...a)=>void} [opts.log]
  * @param {(...a)=>void} [opts.warn]
@@ -89,8 +110,6 @@ export function createRelayService(opts = {}) {
         : DEFAULT_RELAY_PORT,
     host = process.env.RELAY_HOST || "127.0.0.1",
     storePath,
-    boxTokens = null,
-    accountTokens = null,
     verifyJws,
     pushSender,
     now = () => Date.now(),
@@ -105,7 +124,7 @@ export function createRelayService(opts = {}) {
   // ONE phone-auth seam shared by the API and the IAP/push routes so both phone
   // surfaces authenticate identically and Stage 5 swaps them in one place.
   const authenticatePhone =
-    opts.authenticatePhone || createDefaultPhoneAuth({ accountTokens, warn });
+    opts.authenticatePhone || createDefaultPhoneAuth({ store, warn });
 
   // The subscription gate is also shared so the IAP validate route and the API's
   // 402 gate consult the SAME "is a receipt bound + unexpired?" logic.
@@ -118,17 +137,30 @@ export function createRelayService(opts = {}) {
   const boxLeg = createRelayServer({
     wss,
     store,
-    boxTokens,
     log,
     warn,
     now,
   });
 
+  // /pair uses the box leg's proxyRequest to forward the claim to the box's
+  // own /auth/claim over its live tunnel. Tests inject a fake via opts.proxyRequest
+  // to simulate offline / claim-rejected boxes without a real tunnel.
+  const proxyRequest = opts.proxyRequest || boxLeg.proxyRequest;
+
+  // /pair rate limiter (unauthenticated, see PAIR_RL_* constants).
+  const pairRateLimiter =
+    opts.pairRateLimiter ||
+    createRateLimiter({
+      capacity: PAIR_RL_CAPACITY,
+      refillPerSec: PAIR_RL_REFILL_PER_SEC,
+      now,
+    });
+
   // --- Phone-facing API (Stage 4) ------------------------------------------
   // Wire it with the box leg's proxyRequest and the SHARED store + auth + gate.
   const api = createRelayApi({
     store,
-    proxyRequest: boxLeg.proxyRequest,
+    proxyRequest,
     authenticatePhone,
     hasActiveSubscription,
     now,
@@ -155,11 +187,25 @@ export function createRelayService(opts = {}) {
     warn,
   });
 
+  // --- /pair bootstrap (BET-152) -------------------------------------------
+  // Unauthenticated (it IS the bootstrap). Rate-limited; on success mints a
+  // device token and replies 200 {box_id, account_id, account_token}. The
+  // account_token is the ONLY time the plaintext appears — the relay stores
+  // only its sha256.
+  const pairHandler = createPairHandler({
+    store,
+    proxyRequest,
+    rateLimiter: pairRateLimiter,
+    now,
+    warn,
+  });
+
   // --- The single http.Server ----------------------------------------------
   const server = http.createServer((req, res) => {
-    // Try the IAP/push routes first; they call res and return true when they
-    // own the path. Otherwise fall through to the phone API router.
-    iapPushHandler(req, res, () => apiHandler(req, res));
+    // /pair is unauthenticated (bootstrap) — try it first so a missing/wrong
+    // body never reaches the authenticated IAP/push path. Then IAP/push, then
+    // the phone API router.
+    pairHandler(req, res, () => iapPushHandler(req, res, () => apiHandler(req, res)));
   });
 
   // Route WS upgrades: only /box reaches the box leg; anything else is refused.
@@ -239,6 +285,168 @@ export function createRelayService(opts = {}) {
     _authenticatePhone: authenticatePhone,
     _hasActiveSubscription: hasActiveSubscription,
     _receiptValidator: receiptValidator,
+    _pairHandler: pairHandler,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /pair — the phone bootstrap (BET-152 / ADR-2, ADR-5)
+//
+// UNAUTHENTICATED (it is the bootstrap — the device has no credential yet).
+// Rate-limited per box_id (mirrors the box's own /auth/* limiter so a brute
+// force attempt is bounded the same way on both sides).
+//
+// On success: mints an account_token, stores hashToken(account_token) in
+// account_tokens, returns the PLAINTEXT account_token to the device (the ONLY
+// time it leaves the relay), and 200 { box_id, account_id, account_token }.
+//
+// On the box side: /pair proxies the user-presented 6-digit code to the box's
+// own POST /auth/claim over the box's LIVE tunnel. The box is the source of
+// truth on whether the code is valid. The relay NEVER sees the box_token —
+// the box's response body is discarded entirely (ADR-1).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the /pair request handler. Owns exactly `POST /pair` and calls
+ * `next()` for everything else so the IAP/push + API chain handles the rest.
+ *
+ * @param {object} opts
+ * @param {object} opts.store
+ * @param {(boxId,req,o?)=>Promise<{status,headers?,body?}>} opts.proxyRequest
+ * @param {(key:string)=>boolean} opts.rateLimiter
+ * @param {() => number} [opts.now=Date.now]
+ * @param {(msg:string)=>void} [opts.warn]
+ */
+export function createPairHandler({
+  store,
+  proxyRequest,
+  rateLimiter,
+  now = () => Date.now(),
+  warn = console.warn,
+}) {
+  if (!store) throw new Error("createPairHandler: store required");
+  if (typeof proxyRequest !== "function") {
+    throw new Error("createPairHandler: proxyRequest required");
+  }
+  if (typeof rateLimiter !== "function") {
+    throw new Error("createPairHandler: rateLimiter required");
+  }
+
+  return function handle(req, res, next) {
+    const pathname = (req.url || "/").split("?")[0];
+    if (pathname !== "/pair") return next();
+    if (req.method !== "POST") {
+      return sendJson(res, 405, { error: "method_not_allowed" });
+    }
+
+    readBody(req, (err, body) => {
+      if (err) {
+        return sendJson(res, err.code === "too_large" ? 413 : 400, {
+          error: err.code === "too_large" ? "payload_too_large" : "bad_request",
+        });
+      }
+
+      let parsed;
+      try {
+        parsed = body ? JSON.parse(body) : {};
+      } catch {
+        return sendJson(res, 400, { error: "invalid_json" });
+      }
+
+      routePair({ parsed, store, proxyRequest, rateLimiter, now, warn })
+        .then((resp) => sendJson(res, resp.status, resp.json))
+        .catch((e) => {
+          warn(`[relay-pair] handler error: ${String(e?.message || e)}`);
+          sendJson(res, 500, { error: "internal_error" });
+        });
+    });
+  };
+}
+
+/**
+ * Pure-ish /pair routing core (BET-152). Returns { status, json } so it can be
+ * tested directly, like routeIapPush. The PROXIED box response body is
+ * DISCARDED — only its status tells us whether the box accepted the claim.
+ * The relay must never store, log, or return the box_token.
+ *
+ * Errors:
+ *   400 bad_request      — malformed box_id or pairing code.
+ *   429 rate_limited     — per-box bucket exhausted.
+ *   401 claim_rejected   — box replied non-200 (do NOT leak box body).
+ *   503 box_offline      — no live tunnel for this box_id.
+ *   504 box_timeout      — tunnel live but no answer.
+ */
+export async function routePair({ parsed, store, proxyRequest, rateLimiter, now = () => Date.now(), warn = console.warn }) {
+  const boxId = parsed.box_id ?? parsed.boxId;
+  const code = parsed.code ?? parsed.pairing_code ?? parsed.code ?? parsed.pairingCode;
+
+  // Validate shapes BEFORE rate-limiting so a malformed request doesn't burn a
+  // bucket token a legitimate retry would otherwise have.
+  if (!isValidToken(boxId) || typeof code !== "string" || !PAIR_CODE_RE.test(code)) {
+    return { status: 400, json: { error: "bad_request" } };
+  }
+
+  if (!rateLimiter(`pair:${boxId}`)) {
+    return { status: 429, json: { error: "rate_limited" } };
+  }
+
+  // Ask the live box to confirm the 6-digit code via its own /auth/claim.
+  let resp;
+  try {
+    resp = await proxyRequest(boxId, {
+      method: "POST",
+      path: "/auth/claim",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+  } catch (err) {
+    if (err?.code === "no_tunnel") {
+      return { status: 503, json: { error: "box_offline" } };
+    }
+    // Timeout or any other proxy failure.
+    return { status: 504, json: { error: "box_timeout" } };
+  }
+
+  const boxStatus = Number.isInteger(resp?.status) ? resp.status : 0;
+  if (boxStatus !== 200) {
+    // Box rejected (or any other non-200). Do NOT leak the box body — it can
+    // carry diagnostic detail a brute-forcer would mine.
+    return { status: 401, json: { error: "claim_rejected" } };
+  }
+
+  // Discard the box body entirely (it contains the box_token — ADR-1). We only
+  // learn "the code was good" via the 200 status.
+  void resp.body;
+
+  // Bind or reuse the box's account (one account per box per ADR-5). The
+  // `bindings.box_id` FK requires the boxes row to exist; /pair is the FIRST
+  // time the relay learns about a box if it hasn't dialed in yet, so upsert
+  // the box row first (offline — the box-leg dial-in upserts as ONLINE when
+  // the tunnel comes up).
+  if (!store.getBox(boxId)) {
+    store.upsertBox(boxId, { status: "offline", at: now() });
+  }
+  let binding = store.getBinding(boxId);
+  let accountId;
+  if (!binding) {
+    accountId = randomBytes(16).toString("hex"); // 32-char hex, opaque
+    store.bindBox(boxId, accountId, { at: now() });
+  } else {
+    accountId = binding.account_id;
+  }
+
+  // Mint a fresh device token. Storing only the sha256 — the plaintext is the
+  // payload returned to the device on this single 200 reply.
+  const accountToken = randomBytes(16).toString("hex");
+  store.addAccountToken(hashToken(accountToken), accountId, { at: now() });
+
+  return {
+    status: 200,
+    json: {
+      box_id: boxId,
+      account_id: accountId,
+      account_token: accountToken,
+    },
   };
 }
 

--- a/src/relay/server.mjs
+++ b/src/relay/server.mjs
@@ -378,7 +378,7 @@ export function createPairHandler({
  */
 export async function routePair({ parsed, store, proxyRequest, rateLimiter, now = () => Date.now(), warn = console.warn }) {
   const boxId = parsed.box_id ?? parsed.boxId;
-  const code = parsed.code ?? parsed.pairing_code ?? parsed.code ?? parsed.pairingCode;
+  const code = parsed.code ?? parsed.pairing_code ?? parsed.pairingCode;
 
   // Validate shapes BEFORE rate-limiting so a malformed request doesn't burn a
   // bucket token a legitimate retry would otherwise have.

--- a/src/relay/server.test.mjs
+++ b/src/relay/server.test.mjs
@@ -17,12 +17,12 @@ import assert from "node:assert/strict";
 import { WebSocket } from "ws";
 
 import { createRelayService } from "./server.mjs";
-import { openStore } from "./store.mjs";
+import { openStore, hashToken } from "./store.mjs";
 import { encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
 
 const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
 const TOKEN_A = "11112222333344445555666677778888"; // box token (32 hex)
-const ACCT_1 = "aaaabbbbccccddddeeeeffff00001111"; // phone token == account (DEV-OPEN)
+const ACCT_1 = "aaaabbbbccccddddeeeeffff00001111"; // phone device token (32-hex)
 const silent = () => {};
 
 // ---------------------------------------------------------------------------
@@ -46,14 +46,20 @@ function txPayload({ otid = "1000000999", productId = "sub.monthly", expiresDate
 // boot the real combined service on an ephemeral port with a shared store
 // ---------------------------------------------------------------------------
 
-async function makeService(t) {
+async function makeService(t, { proxyRequest, pairRateLimiter, warnSink } = {}) {
   const store = openStore(); // in-memory, shared so the test can bindBox()
+  // Pre-seed ACCT_1 as a known device token → account. In the new world the
+  // /pair endpoint mints these tokens at runtime; tests that exercise phone
+  // API/IAP/push routes just need ONE valid bearer to be in the store.
+  store.addAccountToken(hashToken(ACCT_1), ACCT_1);
   const svc = createRelayService({
     port: 0,
     host: "127.0.0.1",
     store,
+    proxyRequest,
+    pairRateLimiter,
     log: silent,
-    warn: silent,
+    warn: warnSink || silent,
   });
   const { port } = await svc.start();
   t.after(async () => {
@@ -62,7 +68,8 @@ async function makeService(t) {
   return { svc, store, port, base: `http://127.0.0.1:${port}`, wsBase: `ws://127.0.0.1:${port}` };
 }
 
-// A phone HTTP request with a bearer token (== account id in DEV-OPEN).
+// A phone HTTP request with a bearer token (the minted device token, whose
+// sha256 maps to the authed account in the store).
 async function phone(base, method, path, { token = ACCT_1, body } = {}) {
   const headers = {};
   if (token) headers.authorization = `Bearer ${token}`;
@@ -253,6 +260,215 @@ test("a GET on an IAP route is 405 (routes are POST-only)", async (t) => {
   const { base } = await makeService(t);
   const res = await phone(base, "GET", "/api/iap/validate");
   assert.equal(res.status, 405);
+});
+
+// ---------------------------------------------------------------------------
+// POST /pair — phone bootstrap (BET-152)
+//
+// A fake proxyRequest simulates the box's /auth/claim reply. The relay must:
+//   - mint an account_token + bind box_id → account_id,
+//   - return the token plaintext ONCE,
+//   - accept subsequent phone API calls with that token (list boxes → bound),
+//   - keep the box's response body out of any output,
+//   - rate-limit per box_id,
+//   - reject malformed shapes BEFORE any proxy call / rate-limit burn,
+//   - second pair of the same box_id reuses account_id but issues a fresh token.
+// ---------------------------------------------------------------------------
+
+// Fake box: every claim is decided by `reply(boxId, code)` -> { status, body }.
+// Records every call so a test can assert "no proxy call happened" for the
+// malformed branch.
+function fakeBox(reply) {
+  const calls = [];
+  return {
+    calls,
+    proxyRequest: async (boxId, req) => {
+      calls.push({ boxId, ...req });
+      let body;
+      try {
+        body = JSON.parse(req.body || "{}");
+      } catch {
+        body = {};
+      }
+      return reply(boxId, body.code);
+    },
+  };
+}
+
+const OK_BOX = () => ({
+  status: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ box_token: "BOX_TOKEN_LEAKED_FROM_BOX" }),
+});
+
+test("POST /pair: happy path mints a device token usable by the phone API", async (t) => {
+  const box = fakeBox(OK_BOX);
+  const { svc, store, base } = await makeService(t, { proxyRequest: box.proxyRequest });
+
+  const res = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "123456" } });
+  assert.equal(res.status, 200, "200 with minted account");
+  assert.equal(res.json.box_id, BOX_A);
+  assert.match(res.json.account_id, /^[0-9a-f]{32}$/, "account_id is opaque 32-hex");
+  assert.match(res.json.account_token, /^[0-9a-f]{32}$/, "account_token is plaintext 32-hex");
+
+  // The relay must NOT log/store/return the box_token (ADR-1). Asserting the
+  // account_token is distinct from it is the proxy: the relay never asked for
+  // the box_token in plaintext either, so any leak would be visible as the
+  // box body surfacing in /pair's response — it doesn't.
+  assert.notEqual(res.json.account_token, "BOX_TOKEN_LEAKED_FROM_BOX");
+  assert.equal(box.calls.length, 1, "one /auth/claim proxied");
+  assert.equal(box.calls[0].path, "/auth/claim");
+  assert.equal(box.calls[0].method, "POST");
+  assert.equal(box.calls[0].boxId, BOX_A);
+
+  // The plaintext account_token (sha256 in the store) authenticates the phone
+  // API: GET /api/boxes must now show the bound box.
+  const bearer = res.json.account_token;
+  const list = await phone(base, "GET", "/api/boxes", { token: bearer });
+  assert.equal(list.status, 200);
+  assert.equal(list.json.boxes.length, 1);
+  assert.equal(list.json.boxes[0].box_id, BOX_A);
+
+  // Store side: exactly one binding, exactly one token row, both pointing at
+  // the same account_id.
+  const binding = store.getBinding(BOX_A);
+  assert.ok(binding, "binding persisted");
+  assert.equal(binding.account_id, res.json.account_id);
+  assert.equal(store.listAccountTokensForAccount(res.json.account_id).length, 1);
+  // Store has the HASH, never the plaintext.
+  assert.equal(
+    store.getAccountByTokenHash(hashToken(bearer)),
+    res.json.account_id,
+    "store can look up by sha256(plaintext)",
+  );
+  assert.equal(store.getAccountByTokenHash(bearer), null, "store has no plaintext token row");
+});
+
+test("POST /pair: offline box (proxyRequest rejects no_tunnel) → 503, no binding/token", async (t) => {
+  const calls = [];
+  const proxyRequest = async () => {
+    calls.push("called");
+    const err = new Error("no tunnel");
+    err.code = "no_tunnel";
+    throw err;
+  };
+  const { svc, store, base } = await makeService(t, { proxyRequest });
+
+  const res = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "654321" } });
+  assert.equal(res.status, 503);
+  assert.equal(res.json.error, "box_offline");
+  assert.equal(calls.length, 1, "proxy called exactly once");
+  assert.equal(store.getBinding(BOX_A), null, "no binding persisted");
+});
+
+test("POST /pair: wrong code (box replies non-200) → 401, no binding/token, box body NOT leaked", async (t) => {
+  const calls = [];
+  const proxyRequest = async (_boxId, _req) => {
+    calls.push("called");
+    return {
+      status: 401,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ error: "pairing failed", detail: "BOX_INTERNAL_TRACE_INFO" }),
+    };
+  };
+  const { store, base } = await makeService(t, { proxyRequest });
+
+  const res = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "111111" } });
+  assert.equal(res.status, 401);
+  assert.equal(res.json.error, "claim_rejected");
+  // The box body MUST NOT appear in the relay's response (the box's internal
+  // error text is not the relay's to expose).
+  assert.equal(
+    JSON.stringify(res.json).includes("BOX_INTERNAL_TRACE_INFO"),
+    false,
+    "box body is not leaked",
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(store.getBinding(BOX_A), null);
+});
+
+test("POST /pair: second pair of the same box reuses account_id but issues a fresh token", async (t) => {
+  const box = fakeBox(OK_BOX);
+  const { svc, store, base } = await makeService(t, { proxyRequest: box.proxyRequest });
+
+  const first = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "222222" } });
+  assert.equal(first.status, 200);
+  const second = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "333333" } });
+  assert.equal(second.status, 200);
+
+  assert.equal(first.json.account_id, second.json.account_id, "account_id reused");
+  assert.notEqual(first.json.account_token, second.json.account_token, "distinct tokens");
+
+  assert.equal(box.calls.length, 2, "two box claims");
+  assert.equal(store.listAccountTokensForAccount(first.json.account_id).length, 2, "two token rows");
+
+  // Both tokens must work as phone bearers (the list shows the bound box once).
+  const list1 = await phone(base, "GET", "/api/boxes", { token: first.json.account_token });
+  const list2 = await phone(base, "GET", "/api/boxes", { token: second.json.account_token });
+  assert.equal(list1.json.boxes.length, 1);
+  assert.equal(list2.json.boxes.length, 1);
+});
+
+test("POST /pair: malformed box_id or code → 400 with no proxy call and no rate-limit burn", async (t) => {
+  const calls = [];
+  const proxyRequest = async () => {
+    calls.push("called");
+    return OK_BOX();
+  };
+  // Tiny rate limiter to assert the malformed branch does NOT burn a token.
+  const used = new Set();
+  const pairRateLimiter = (key) => {
+    if (used.has(key)) return false;
+    used.add(key);
+    return true;
+  };
+  const { store, base } = await makeService(t, { proxyRequest, pairRateLimiter });
+
+  const badCases = [
+    { box_id: "not-hex", code: "123456" },
+    { box_id: BOX_A, code: "abc" },                  // not 6 digits
+    { box_id: BOX_A, code: "12345" },               // 5 digits
+    { box_id: BOX_A, code: "1234567" },             // 7 digits
+    { box_id: BOX_A, code: " 123456" },             // leading space
+    { box_id: BOX_A },                              // missing code
+  ];
+  for (const body of badCases) {
+    const res = await phone(base, "POST", "/pair", { token: null, body });
+    assert.equal(res.status, 400, `malformed ${JSON.stringify(body)} → 400`);
+    assert.equal(res.json.error, "bad_request");
+  }
+  assert.equal(calls.length, 0, "no proxy call for malformed input");
+  assert.equal(used.size, 0, "rate-limiter bucket NOT burned for malformed input");
+
+  // After all malformed, a valid request from the SAME box_id still has full bucket.
+  const ok = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "555555" } });
+  assert.equal(ok.status, 200);
+});
+
+test("POST /pair: GET is 405; box body NEVER proxied through on rejection", async (t) => {
+  const box = fakeBox(OK_BOX);
+  const { base } = await makeService(t, { proxyRequest: box.proxyRequest });
+  const get = await phone(base, "GET", "/pair");
+  assert.equal(get.status, 405);
+});
+
+test("POST /pair: rate limit kicks in after PAIR_RL_CAPACITY per-box_id hits", async (t) => {
+  // Drainable limiter — capacity 2, no refill inside the test window.
+  let calls = 0;
+  const pairRateLimiter = () => {
+    calls += 1;
+    return calls <= 2;
+  };
+  const box = fakeBox(OK_BOX);
+  const { base } = await makeService(t, { proxyRequest: box.proxyRequest, pairRateLimiter });
+
+  const r1 = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "000001" } });
+  const r2 = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "000002" } });
+  const r3 = await phone(base, "POST", "/pair", { token: null, body: { box_id: BOX_A, code: "000003" } });
+  assert.equal(r1.status, 200);
+  assert.equal(r2.status, 200);
+  assert.equal(r3.status, 429, "third hit throttled");
+  assert.equal(r3.json.error, "rate_limited");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/relay/store.mjs
+++ b/src/relay/store.mjs
@@ -53,6 +53,7 @@
 // store. Migrations are idempotent (CREATE TABLE/INDEX IF NOT EXISTS), so
 // opening an existing DB is a no-op re-apply, never a destructive one.
 
+import { createHash, timingSafeEqual } from "node:crypto";
 import sqliteWasm from "node-sqlite3-wasm";
 import { isValidToken } from "../server/webhooks.mjs";
 
@@ -131,6 +132,31 @@ CREATE TABLE IF NOT EXISTS metering (
   updated_at   INTEGER NOT NULL,
   FOREIGN KEY (box_id) REFERENCES boxes(box_id) ON DELETE CASCADE
 );
+
+-- Box handshake credentials (BET-152 / ADR-4): trust-on-first-use. The relay
+-- accepts a box's first dial-out by storing sha256(box_token); subsequent
+-- dial-outs must match. box_id is 32-hex random = unguessable, so TOFU
+-- squatting requires the id, which only the box owner has. INSERT only — a
+-- re-register is rejected by the store layer, so a second box claiming an
+-- existing box_id cannot silently rotate the credential.
+CREATE TABLE IF NOT EXISTS box_credentials (
+  box_id     TEXT PRIMARY KEY,
+  token_hash TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+-- Phone account tokens (BET-152 / ADR-5): each successful POST /pair mints a
+-- fresh 32-hex token (the device token), stored here as a sha256 hash. One
+-- account owns many tokens (devices); multiple tokens map to the same
+-- account_id. The relay never sees plaintext tokens at rest — only the
+-- compare path uses hashEquals (constant-time) on lookup.
+CREATE TABLE IF NOT EXISTS account_tokens (
+  token_hash TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+-- "all tokens for account X" (logout-everywhere / revoke sweep).
+CREATE INDEX IF NOT EXISTS idx_account_tokens_account ON account_tokens(account_id);
 `;
 
 // ---------------------------------------------------------------------------
@@ -283,6 +309,29 @@ export function openStore({ path = ":memory:", now = () => Date.now() } = {}) {
     listMetering: db.prepare(`SELECT * FROM metering ORDER BY updated_at DESC`),
     resetMetering: db.prepare(`
       UPDATE metering SET ingress = 0, egress = 0, updated_at = ? WHERE box_id = ?
+    `),
+
+    // Box handshake credentials (BET-152 / ADR-4 TOFU). INSERT only — a second
+    // setBoxCredential() for the same box_id must throw (TOFU never overwrites
+    // an existing credential).
+    insertBoxCredential: db.prepare(`
+      INSERT INTO box_credentials (box_id, token_hash, created_at)
+      VALUES (?, ?, ?)
+    `),
+    getBoxCredential: db.prepare(`SELECT * FROM box_credentials WHERE box_id = ?`),
+
+    // Phone account tokens (BET-152 / ADR-5). token_hash is the sha256 of the
+    // device token (32-hex plaintext) handed to the phone at /pair time; the
+    // relay only ever stores/looks up the hash.
+    insertAccountToken: db.prepare(`
+      INSERT INTO account_tokens (token_hash, account_id, created_at)
+      VALUES (?, ?, ?)
+    `),
+    getAccountTokenByHash: db.prepare(`
+      SELECT * FROM account_tokens WHERE token_hash = ?
+    `),
+    listAccountTokensForAccount: db.prepare(`
+      SELECT * FROM account_tokens WHERE account_id = ?
     `),
   };
 
@@ -470,6 +519,66 @@ export function openStore({ path = ":memory:", now = () => Date.now() } = {}) {
   }
 
   // -------------------------------------------------------------------------
+  // box_credentials (BET-152 / ADR-4 TOFU)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Record the sha256 of a box's box_token on its first dial-out. INSERT only:
+   * a second call for the same box_id throws (TOFU never overwrites). The
+   * caller (createDefaultVerifier) shape-gates the token first; this layer's
+   * guarantee is "if you call it twice, you get an error" so a relay bug can't
+   * silently rotate a credential.
+   *
+   * Returns the inserted row.
+   */
+  function setBoxCredential(boxId, tokenHash, { at = now() } = {}) {
+    assertBoxId(boxId);
+    if (typeof tokenHash !== "string" || !tokenHash) {
+      throw new Error("setBoxCredential: token_hash required (non-empty string)");
+    }
+    // INSERT only — let the UNIQUE constraint turn a second-insert collision
+    // into a programmatic error the verifier can surface as a hard reject.
+    stmts.insertBoxCredential.run(boxId, tokenHash, at);
+    return getBoxCredential(boxId);
+  }
+
+  function getBoxCredential(boxId) {
+    assertBoxId(boxId);
+    return stmts.getBoxCredential.get(boxId) ?? null;
+  }
+
+  // -------------------------------------------------------------------------
+  // account_tokens (BET-152 / ADR-5)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Mint a device token for an account. `tokenHash` is sha256(account_token)
+   * — the plaintext is handed back to the phone at /pair time and is never
+   * stored. Returns the stored row.
+   */
+  function addAccountToken(tokenHash, accountId, { at = now() } = {}) {
+    if (typeof tokenHash !== "string" || !tokenHash) {
+      throw new Error("addAccountToken: token_hash required (non-empty string)");
+    }
+    assertAccountId(accountId);
+    stmts.insertAccountToken.run(tokenHash, accountId, at);
+    return stmts.getAccountTokenByHash.get(tokenHash) ?? null;
+  }
+
+  /** Look up an account_id by the sha256 of a presented device token. */
+  function getAccountByTokenHash(tokenHash) {
+    if (typeof tokenHash !== "string" || !tokenHash) return null;
+    const row = stmts.getAccountTokenByHash.get(tokenHash);
+    return row ? row.account_id : null;
+  }
+
+  /** All stored token hashes for an account (logout-everywhere / revoke sweep). */
+  function listAccountTokensForAccount(accountId) {
+    assertAccountId(accountId);
+    return stmts.listAccountTokensForAccount.all(accountId);
+  }
+
+  // -------------------------------------------------------------------------
   // lifecycle / introspection
   // -------------------------------------------------------------------------
 
@@ -516,6 +625,13 @@ export function openStore({ path = ":memory:", now = () => Date.now() } = {}) {
     getUsage,
     listUsage,
     resetUsage,
+    // box_credentials (BET-152 / ADR-4)
+    setBoxCredential,
+    getBoxCredential,
+    // account_tokens (BET-152 / ADR-5)
+    addAccountToken,
+    getAccountByTokenHash,
+    listAccountTokensForAccount,
     // lifecycle
     close,
     explain,
@@ -563,4 +679,41 @@ function assertByteCount(n, field) {
   if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
     throw new Error(`store: invalid ${field} byte count (want non-negative integer)`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Token hashing (BET-152 / ADR-1, ADR-4, ADR-5)
+//
+// The relay never stores or compares plaintext device tokens / box_tokens at
+// rest: every row carries a sha256 hex digest, and the compare path uses
+// constant-time Buffer equality so a network attacker cannot binary-search a
+// secret byte-by-byte from response latency. `hashToken` + `hashEquals` are
+// exported (rather than inlined at call sites) so every caller uses the same
+// primitives and the timing-safe compare cannot accidentally degrade into a
+// short-circuit `===` somewhere.
+// ---------------------------------------------------------------------------
+
+/** sha256(token) as lowercase hex. Token coerced to string first. */
+export function hashToken(token) {
+  return createHash("sha256").update(String(token), "utf8").digest("hex");
+}
+
+/**
+ * Constant-time equality of two lowercase hex digests. Returns false on any
+ * shape mismatch (length, non-hex) — the compare only runs when both inputs
+ * are equal-length Buffers, the precondition timingSafeEqual demands.
+ */
+export function hashEquals(aHex, bHex) {
+  if (typeof aHex !== "string" || typeof bHex !== "string") return false;
+  if (aHex.length !== bHex.length) return false;
+  let a;
+  let b;
+  try {
+    a = Buffer.from(aHex, "hex");
+    b = Buffer.from(bHex, "hex");
+  } catch {
+    return false;
+  }
+  if (a.length === 0 || a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
 }

--- a/src/relay/store.test.mjs
+++ b/src/relay/store.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { openStore, BOX_STATUS } from "./store.mjs";
+import { openStore, BOX_STATUS, hashToken, hashEquals } from "./store.mjs";
 
 const BOX_A = "0123456789abcdef0123456789abcdef"; // 32 hex
 const BOX_B = "fedcba9876543210fedcba9876543210";
@@ -250,4 +250,105 @@ test("indexed queries use their indexes (EXPLAIN QUERY PLAN smoke)", () => {
   const boxPlan = s.explain("SELECT * FROM boxes WHERE box_id = ?", BOX_A).join(" ");
   assert.doesNotMatch(boxPlan, /\bSCAN boxes\b(?!.*INDEX)/);
   s.close();
+});
+
+// ---------------------------------------------------------------------------
+// box_credentials (BET-152 / ADR-4 TOFU)
+// ---------------------------------------------------------------------------
+
+test("setBoxCredential: first insert returns the row; a second insert for the same box_id throws", () => {
+  const s = openStore();
+  const hash = hashToken("box-token-A");
+  const r1 = s.setBoxCredential(BOX_A, hash);
+  assert.equal(r1.box_id, BOX_A);
+  assert.equal(r1.token_hash, hash);
+
+  // TOFU must not silently overwrite: a relay bug must not be able to rotate a
+  // credential, so the second insert is a hard error from the UNIQUE constraint.
+  assert.throws(() => s.setBoxCredential(BOX_A, hashToken("rotated-token")), /UNIQUE|constraint/i);
+
+  // The stored row is untouched (still the original hash).
+  assert.equal(s.getBoxCredential(BOX_A).token_hash, hash);
+  s.close();
+});
+
+test("getBoxCredential: null for unknown box; rejects malformed box_id", () => {
+  const s = openStore();
+  assert.equal(s.getBoxCredential(BOX_A), null);
+  assert.throws(() => s.getBoxCredential("not-hex"), /invalid box_id/);
+  s.close();
+});
+
+test("setBoxCredential rejects empty token_hash and malformed box_id", () => {
+  const s = openStore();
+  assert.throws(() => s.setBoxCredential(BOX_A, ""), /token_hash required/);
+  assert.throws(() => s.setBoxCredential("bad", "x".repeat(64)), /invalid box_id/);
+  s.close();
+});
+
+// ---------------------------------------------------------------------------
+// account_tokens (BET-152 / ADR-5)
+// ---------------------------------------------------------------------------
+
+test("addAccountToken: insert + lookup by hash; unknown hash → null", () => {
+  const s = openStore();
+  const t = "11112222333344445555666677778888";
+  const hash = hashToken(t);
+  const row = s.addAccountToken(hash, "acct-1");
+  assert.equal(row.token_hash, hash);
+  assert.equal(row.account_id, "acct-1");
+
+  assert.equal(s.getAccountByTokenHash(hash), "acct-1");
+  assert.equal(s.getAccountByTokenHash(hashToken("never-issued")), null);
+  assert.equal(s.getAccountByTokenHash(""), null, "empty hash → null");
+  assert.equal(s.getAccountByTokenHash(null), null, "non-string hash → null");
+  s.close();
+});
+
+test("addAccountToken: many tokens per account (devices) and revoke-sweep read", () => {
+  const s = openStore();
+  const h1 = hashToken("device-1-token");
+  const h2 = hashToken("device-2-token");
+  s.addAccountToken(h1, "acct-x");
+  s.addAccountToken(h2, "acct-x");
+  s.addAccountToken(hashToken("other-account-token"), "acct-y");
+
+  const xTokens = s.listAccountTokensForAccount("acct-x").map((r) => r.token_hash).sort();
+  assert.deepEqual(xTokens, [h1, h2].sort());
+  assert.equal(s.listAccountTokensForAccount("acct-y").length, 1);
+  assert.equal(s.listAccountTokensForAccount("nobody").length, 0);
+  s.close();
+});
+
+test("addAccountToken rejects empty token_hash / account_id", () => {
+  const s = openStore();
+  assert.throws(() => s.addAccountToken("", "acct-1"), /token_hash required/);
+  assert.throws(() => s.addAccountToken("x".repeat(64), ""), /invalid account_id/);
+  assert.throws(() => s.addAccountToken("x".repeat(64), 123), /invalid account_id/);
+  s.close();
+});
+
+// ---------------------------------------------------------------------------
+// hashToken / hashEquals (timing-safe hex compare)
+// ---------------------------------------------------------------------------
+
+test("hashToken is stable, lowercase, 64-hex", () => {
+  const a = hashToken("hello");
+  const b = hashToken("hello");
+  assert.equal(a, b);
+  assert.match(a, /^[0-9a-f]{64}$/);
+  // Distinct inputs produce distinct digests.
+  assert.notEqual(a, hashToken("HELLO"));
+});
+
+test("hashEquals: same digest → true; any mismatch → false; constant-time shape guard", () => {
+  const a = hashToken("one");
+  const b = hashToken("two");
+  assert.equal(hashEquals(a, a), true);
+  assert.equal(hashEquals(a, b), false);
+  // Shape mismatches → false (no Buffer length mismatch thrown out of timingSafeEqual).
+  assert.equal(hashEquals("short", "short"), false, "non-hex input → empty buffer → false");
+  assert.equal(hashEquals(123, 123), false, "non-string input → false");
+  assert.equal(hashEquals(null, undefined), false);
+  assert.equal(hashEquals("aa", "aaaa"), false, "different-length inputs → false");
 });


### PR DESCRIPTION
## Summary

Replaces the relay's "accept any well-formed handshake" dev-open paths with the real auth/credential flow described in BET-152. Closes the parent epic's first Stage-1 slice.

**Files changed:** 8 files, +841 / -147.
- `src/relay/store.mjs` (+`store.test.mjs`) — `box_credentials` + `account_tokens` tables, `setBoxCredential` (INSERT-only, throws on second insert = TOFU never overwrites), `addAccountToken`, `getBoxCredential`, `getAccountByTokenHash`, `listAccountTokensForAccount`. Plus `hashToken` + `hashEquals` (constant-time) exports so every caller shares one compare path.
- `src/relay/index.mjs` (+`index.test.mjs`) — `createDefaultVerifier` now does TOFU via the store. First dial-out seeds `sha256(token)` and logs `[relay] box <first-8-of-id> registered (TOFU)`; subsequent must `hashEquals` match. `createRelayServer` drops the `boxTokens` option (and `tokenMatches` import that backed it).
- `src/relay/api.mjs` (+`api.test.mjs`) — `createDefaultPhoneAuth` resolves token → account_id by looking up `sha256(token)` in `account_tokens`. `createRelayApi` drops the `accountTokens` option. The dev-open "well-formed token IS the account" path is gone.
- `src/relay/server.mjs` (+`server.test.mjs`) — `POST /pair` mounted in the http server callback next to the IAP/push routes. Unauthenticated + rate-limited per box_id (capacity 10, refill 0.2/s — mirrors `AUTH_RL_*` in `src/server/auth.mjs`). Validates `isValidToken(box_id)` + `/^\d{6}$/` before any proxy/rate-limit burn. Proxies the code to the box's own `POST /auth/claim` over the live tunnel; discards the box response body entirely (ADR-1 — the box_token never crosses the relay). On success mints a fresh 32-hex `account_token`, stores `sha256(account_token)` in `account_tokens`, returns the plaintext ONCE. Re-pairs of the same box_id reuse the same `account_id` (one account per box, ADR-5).

## Verification

- `npm run typecheck` — clean.
- `npm test` — 531 pass / 0 fail / 0 skip (vitest + `node --test src/{server,relay,relay/agent}/*.test.mjs scripts/*.test.mjs`).
- `node --test src/relay/*.test.mjs` — 130 pass / 0 fail.
- Hygiene: `grep -rn 'DEV-OPEN|accountTokens|boxTokens' src/relay/` returns ZERO hits (comments included).

## ADR compliance

- **ADR-1**: `box_token` never leaves the box. The relay's `/pair` discards the box's response body entirely and only learns success via status.
- **ADR-2**: Reuses the box's own `/auth/claim` — relay's `/pair` is a thin bootstrap that proxies to it.
- **ADR-4**: TOFU — first dial-out persists sha256, subsequent must match via `hashEquals`.
- **ADR-5**: One account per box, many device tokens per account. `account_id` reused across re-pairs; each pair mints a fresh token row.
- **ADR-6**: dev-open code is deleted, not kept behind a flag. `boxTokens` / `accountTokens` map parameters are gone from the verifier + phone auth + service options. No `*V2` modules.

## Notes

- `routePair({ parsed, store, proxyRequest, rateLimiter, now, warn })` is exported as a pure-ish async core returning `{ status, json }` (like `routeIapPush`), so future direct tests can exercise it without spinning a server.
- Server tests cover the full matrix: happy (minted token authenticates `/api/boxes`), offline box (503), wrong code (401, box body NOT leaked), second pair of same box reuses `account_id` + distinct token, malformed box_id/code (400 with no proxy call and no rate-limit burn), GET (405), rate limit kicks in after `PAIR_RL_CAPACITY`.
- `Base: origin/main @ 5a65f86`
