### PR TITLE
BET-155: Box-side relay agent auth injection + startup wiring + install handshake check

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -19,6 +19,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { STATE_DIRNAME } from "../src/shared/paths.mjs";
+import { loadAuth } from "../src/server/auth.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (single source of truth, shared with the shell via `--print-config`)
@@ -369,6 +370,140 @@ export function renderSystemdUnit(template, placeholders) {
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Relay-handshake poller (BET-151 / BET-155)
+// ---------------------------------------------------------------------------
+//
+// Poll the box-server's loopback-only GET /relay/status until the in-process
+// relay agent reports `connected: true` (the dial-out to relay.mantaui.com
+// succeeded and the WS handshake completed). The shape mirrors `waitForHealth`
+// — same injectable fetchFn/sleep, same `{ ok, attempts, ... }` return — so
+// install.sh can use one mental model for both waits.
+//
+// Unlike `waitForHealth` (which dies the install on failure), this one MUST
+// NOT fail the install: a relay outage or a network hiccup on the VPS still
+// leaves the box working locally. install.sh treats `ok=false` or
+// `connected=false` as a `warn` (with the journalctl hint), not a `die`.
+//
+// `healthUrlBase` is the server's loopback base WITHOUT any path
+// (e.g. `http://127.0.0.1:8787`). The endpoint `/relay/status` is appended
+// here so the install script doesn't have to know the route — same shape as
+// MANTA_HEALTH_URL minus the path component.
+//
+// Return shape:
+//   { ok: true,  enabled, connected, attempts, status }   — got a 2xx
+//   { ok: false, enabled: null, connected: false, attempts, error } — gave up
+export async function waitForRelay(
+  healthUrlBase,
+  {
+    maxAttempts = 30,
+    intervalMs = 1000,
+    fetchFn = globalThis.fetch,
+    sleep = defaultSleep,
+  } = {},
+) {
+  if (typeof healthUrlBase !== "string" || healthUrlBase === "") {
+    throw new Error("waitForRelay: healthUrlBase required");
+  }
+  if (typeof fetchFn !== "function") {
+    throw new Error("waitForRelay: no fetch available (pass fetchFn)");
+  }
+  const base = stripTrailingSlash(healthUrlBase);
+  const url = `${base}/relay/status`;
+
+  let lastError = null;
+  // Track the last settled state across attempts so the final return carries
+  // the most recent truthful answer even if we exit via the maxAttempts cap
+  // (e.g. the server is up but the agent is mid-handshake and never finishes).
+  let lastEnabled = null;
+  let lastConnected = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetchFn(url);
+      if (res && typeof res.status === "number") {
+        // 2xx = server is up AND answered the relay status route. The body
+        // tells us whether the agent is enabled and (if so) whether it's
+        // connected. Tolerate a missing/non-JSON body — we already know the
+        // server is alive, which is all this loop needs to settle.
+        let body = {};
+        try {
+          body = await res.json();
+        } catch {
+          /* non-JSON body; treat as no info beyond the status code */
+        }
+        if (res.status >= 200 && res.status < 300) {
+          const enabled = body.enabled === true;
+          const connected = body.connected === true;
+          lastEnabled = enabled;
+          lastConnected = connected;
+          // Short-circuit ONLY when the answer is final. Two terminal states:
+          //   connected=true  → the handshake succeeded, install.sh can ok()
+          //   enabled=false   → config opted out, no point polling further
+          // Anything else means "the agent is enabled but hasn't connected
+          // yet" — keep polling until the handshake resolves or we exhaust.
+          if (connected || !enabled) {
+            return {
+              ok: true,
+              enabled,
+              connected,
+              attempts: attempt,
+              status: res.status,
+            };
+          }
+        } else {
+          // 403 from /relay/status means the install ran from somewhere that
+          // isn't loopback (rare — would only happen via a port-forward mistake).
+          // We treat any non-2xx as "not yet" and retry, same as waitForHealth.
+          lastError = new Error(`server returned HTTP ${res.status}`);
+        }
+      } else {
+        lastError = new Error("fetch returned no status");
+      }
+    } catch (e) {
+      lastError = e;
+    }
+    if (attempt < maxAttempts) await sleep(intervalMs);
+  }
+  // Out of attempts. We MAY have a known state from a recent 2xx (the server
+  // answered but the handshake never landed) — return that, with ok=true so
+  // install.sh doesn't treat a server-up-but-handshake-degraded case as a
+  // server-down failure. ok=false is reserved for "we never reached the
+  // server at all" (everything below the loop was ECONNREFUSED).
+  if (lastEnabled !== null) {
+    return {
+      ok: true,
+      enabled: lastEnabled,
+      connected: lastConnected === true,
+      attempts: maxAttempts,
+    };
+  }
+  return {
+    ok: false,
+    enabled: null,
+    connected: false,
+    attempts: maxAttempts,
+    error: `relay did not connect at ${url} after ${maxAttempts} attempts: ${
+      lastError?.message ?? lastError ?? "unknown"
+    }`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Box-identity loader (BET-151 / BET-155)
+// ---------------------------------------------------------------------------
+//
+// Thin re-export of `loadAuth` from src/server/auth.mjs so install.sh can print
+// the box_id alongside the pairing code without re-parsing JSON in bash. The
+// server (src/server/auth.mjs) is the single source of truth for identity
+// shape and validation; install.sh never writes here and never invents its
+// own token reader.
+//
+// Returns `{ box_id, box_token, created_at }` on success, or `null` if the
+// file is missing/corrupt (the box will mint a fresh identity on first
+// start, so an absent auth.json at install time is not an error — install.sh
+// falls back to "the server will mint an identity on first start").
+export const readBoxIdentity = loadAuth;
 
 // ---------------------------------------------------------------------------
 // Pairing-output formatter

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -324,7 +324,12 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Wait for health, then mint + print a pairing code.
+# 8. Wait for health, then verify the relay handshake, then mint + print a
+#    pairing code. Devices pair THROUGH the relay (relay.mantaui.com) — the
+#    install must confirm the box agent actually reached the relay before
+#    handing the pairing code back. If the handshake never completes we warn
+#    (the box still works locally) and continue — operators can read the
+#    journalctl hint and diagnose later.
 # ---------------------------------------------------------------------------
 log "Waiting for the server to become healthy at $MANTA_HEALTH_URL…"
 node -e '
@@ -338,9 +343,59 @@ node -e '
 
 ok "Server is healthy."
 
+# Derive the loopback base (drop the /auth/status path) — waitForRelay takes a
+# base URL and appends /relay/status itself.
+MANTA_RELAY_BASE="$(printf '%s\n' "$MANTA_HEALTH_URL" | sed 's#/auth/status$##')"
+log "Waiting for the relay handshake at $MANTA_RELAY_BASE/relay/status…"
+# waitForRelay is best-effort — relay outage never fails the install. We log
+# the state on stderr and emit exactly one of "connected|disabled|degraded" on
+# stdout so the bash below can branch on it without re-fetching.
+RELAY_CHECK="$(MANTA_RELAY_BASE="$MANTA_RELAY_BASE" node -e '
+  import("'"$LIB"'").then(async (m) => {
+    const r = await m.waitForRelay(process.env.MANTA_RELAY_BASE, { maxAttempts: 30, intervalMs: 1000 });
+    if (r.ok && r.connected) {
+      console.error("connected after " + r.attempts + " attempt(s)");
+      process.stdout.write("connected");
+    } else if (r.ok && !r.enabled) {
+      console.error("relay disabled by config");
+      process.stdout.write("disabled");
+    } else if (r.ok && !r.connected) {
+      console.error("not connected after " + r.attempts + " attempt(s)");
+      process.stdout.write("degraded");
+    } else {
+      console.error(r.error || "unknown failure");
+      process.stdout.write("degraded");
+    }
+  }).catch((e) => {
+    console.error(String(e));
+    process.stdout.write("degraded");
+  });
+' 2>/dev/null || echo degraded)"
+export MANTA_RELAY_BASE
+
+case "$RELAY_CHECK" in
+  connected) ok "Relay link established (relay.mantaui.com).";;
+  disabled)
+    log "Relay disabled by config (relayEnabled=false) — devices will pair via direct ingress only.";;
+  *)
+    warn "Relay handshake did not complete — the box is reachable locally; journalctl --user -u manta-server -n 50 will show why."
+    warn "  Re-run later: systemctl --user restart manta-server"
+    ;;
+esac
+
 log "Minting pairing code…"
 # Delegate to the same `manta pair` CLI the user runs later (loopback GET /auth/pair).
 node "$MANTA_HOME/scripts/manta-pair.mjs" || die "failed to mint pairing code (is the server local-reachable?)"
+
+# Read the box_id from ~/.manta/auth.json via the tested install-lib loader
+# (NEVER re-parse the JSON in bash — auth.json's shape belongs to the server).
+BOX_ID_DISPLAY="$(node -e '
+  import("'"$LIB"'").then((m) => {
+    const id = m.readBoxIdentity(process.env.MANTA_AUTH_FILE);
+    process.stdout.write(id?.box_id ?? "");
+  }).catch(() => process.stdout.write(""));
+' 2>/dev/null || true)"
+export BOX_ID_DISPLAY
 
 cat <<EOF
 
@@ -353,6 +408,19 @@ Chat backend (opencode-serve) on http://127.0.0.1:4096:
   systemctl --user status opencode-serve
   systemctl --user restart opencode-serve
   journalctl --user -u opencode-serve -f
+
+Your box pairs with devices THROUGH the relay (relay.mantaui.com) — no public
+port on this box, no tunnel, no reverse proxy to set up. The desktop / mobile
+app discovers it via the relay using the box_id below.
+EOF
+
+if [ -n "$BOX_ID_DISPLAY" ]; then
+  printf '\n  Box ID:        %s\n' "$BOX_ID_DISPLAY"
+fi
+
+cat <<EOF
+
+  (Pairing code printed above by manta pair — re-run any time to mint a fresh one.)
 
 Re-run this installer any time to upgrade in place (your box identity is preserved).
 Run 'manta pair' (or 'npm run pair' in $MANTA_HOME) to mint a fresh pairing code.

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1,5 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   resolveConfig,
@@ -8,6 +10,8 @@ import {
   isValidVersion,
   checkIdentity,
   waitForHealth,
+  waitForRelay,
+  readBoxIdentity,
   formatPairingOutput,
   formatExpiry,
   renderShellConfig,
@@ -249,6 +253,221 @@ test("waitForHealth gives up after the attempt cap", async () => {
 test("waitForHealth requires a url and a fetch", async () => {
   await assert.rejects(() => waitForHealth("", { fetchFn: async () => ({ status: 200 }) }), /url required/);
   await assert.rejects(() => waitForHealth("http://x", { fetchFn: null }), /no fetch/);
+});
+
+// ----------------------------------------------------------------------------
+// waitForRelay — polls /relay/status, install.sh's relay-handshake probe
+// ----------------------------------------------------------------------------
+
+test("waitForRelay returns connected=true on a 2xx with connected:true", async () => {
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 3,
+    intervalMs: 10,
+    fetchFn: async () => ({
+      status: 200,
+      json: async () => ({ enabled: true, connected: true }),
+    }),
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.enabled, true);
+  assert.equal(r.connected, true);
+  assert.equal(r.attempts, 1, "no sleep before a first-try success");
+});
+
+test("waitForRelay returns enabled=false (short-circuit) on enabled:false", async () => {
+  // The server is up and reports the agent is disabled (config opted out).
+  // install.sh treats this as success-with-no-relay — NOT a failure.
+  let calls = 0;
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 5,
+    intervalMs: 10,
+    fetchFn: async () => {
+      calls++;
+      return { status: 200, json: async () => ({ enabled: false, connected: false }) };
+    },
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.enabled, false);
+  assert.equal(r.connected, false);
+  assert.equal(calls, 1, "settles immediately — no reason to re-poll a disabled agent");
+});
+
+test("waitForRelay retries on ECONNREFUSED and succeeds on the next attempt", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 5,
+    intervalMs: 250,
+    fetchFn: async () => {
+      calls++;
+      if (calls < 3) throw new Error("ECONNREFUSED");
+      return { status: 200, json: async () => ({ enabled: true, connected: true }) };
+    },
+    sleep: async (ms) => sleeps.push(ms),
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.attempts, 3);
+  assert.deepEqual(sleeps, [250, 250], "slept between the two failed attempts");
+});
+
+test("waitForRelay keeps retrying while connected:false (server up, handshake still pending)", async () => {
+  // Server is up, but the agent is mid-backoff — connected flips to true on
+  // attempt 4. install.sh keeps polling until maxAttempts because that's the
+  // only way to learn whether the handshake eventually succeeds.
+  let calls = 0;
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 5,
+    intervalMs: 5,
+    fetchFn: async () => {
+      calls++;
+      const connected = calls >= 4;
+      return { status: 200, json: async () => ({ enabled: true, connected }) };
+    },
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.connected, true);
+  assert.equal(r.attempts, 4);
+});
+
+test("waitForRelay gives up after maxAttempts and reports connected:false", async () => {
+  // The "degraded" path install.sh warn()s on. The lib returns ok=false so
+  // callers can decide whether to surface it; install.sh treats both ok=false
+  // and connected=false as a warn (never a die).
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 3,
+    intervalMs: 1,
+    fetchFn: async () => ({
+      status: 200,
+      json: async () => ({ enabled: true, connected: false }),
+    }),
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, true, "the server answered every poll — that's a successful probe");
+  assert.equal(r.connected, false, "but the agent isn't connected yet");
+  assert.equal(r.attempts, 3);
+});
+
+test("waitForRelay tolerates a non-JSON body (still reports ok=true)", async () => {
+  // Defensive: a 200 with an empty/non-JSON body shouldn't crash the poll.
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 1,
+    intervalMs: 0,
+    fetchFn: async () => ({
+      status: 200,
+      json: async () => {
+        throw new Error("not json");
+      },
+    }),
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, true);
+  // body couldn't be parsed → defaults are conservative (false).
+  assert.equal(r.enabled, false);
+  assert.equal(r.connected, false);
+});
+
+test("waitForRelay treats a non-2xx as 'not yet' and retries", async () => {
+  // A 403 from /relay/status means a non-loopback caller hit it — install.sh
+  // is running locally so this won't happen, but the lib must be defensive.
+  let calls = 0;
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 3,
+    intervalMs: 1,
+    fetchFn: async () => {
+      calls++;
+      if (calls < 2) return { status: 403, json: async () => ({}) };
+      return { status: 200, json: async () => ({ enabled: true, connected: true }) };
+    },
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.attempts, 2);
+});
+
+test("waitForRelay appends /relay/status to the base and strips trailing slashes", async () => {
+  const urls = [];
+  await waitForRelay("http://127.0.0.1:8787/", {
+    maxAttempts: 1,
+    intervalMs: 0,
+    fetchFn: async (u) => {
+      urls.push(u);
+      return { status: 200, json: async () => ({ enabled: true, connected: true }) };
+    },
+    sleep: async () => {},
+  });
+  assert.deepEqual(urls, ["http://127.0.0.1:8787/relay/status"]);
+});
+
+test("waitForRelay gives up with ok=false when the server never responds", async () => {
+  const r = await waitForRelay("http://127.0.0.1:8787", {
+    maxAttempts: 4,
+    intervalMs: 1,
+    fetchFn: async () => {
+      throw new Error("ECONNREFUSED");
+    },
+    sleep: async () => {},
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.attempts, 4);
+  assert.equal(r.connected, false);
+  assert.match(r.error, /did not connect/);
+  assert.match(r.error, /ECONNREFUSED/);
+});
+
+test("waitForRelay requires a base and a fetch", async () => {
+  await assert.rejects(() => waitForRelay("", { fetchFn: async () => ({}) }), /healthUrlBase required/);
+  await assert.rejects(() => waitForRelay("http://x", { fetchFn: null }), /no fetch/);
+});
+
+// ----------------------------------------------------------------------------
+// readBoxIdentity — install.sh's auth.json reader (re-export of loadAuth)
+// ----------------------------------------------------------------------------
+
+test("readBoxIdentity returns the box identity from a valid auth.json", () => {
+  // loadAuth (the underlying reader) takes a path and reads the real fs —
+  // already unit-tested in src/server/auth.test.mjs. Here we round-trip
+  // through a temp file to confirm install.sh's re-export actually calls it
+  // and surfaces the box_id (the install heredoc consumes this).
+  const dir = mkdtempSync(join(tmpdir(), "manta-install-readid-"));
+  const authFile = join(dir, "auth.json");
+  writeFileSync(
+    authFile,
+    JSON.stringify({
+      box_id: "0123456789abcdef0123456789abcdef",
+      box_token: "11112222333344445555666677778888",
+      created_at: 1700000000000,
+    }),
+  );
+  try {
+    const id = readBoxIdentity(authFile);
+    assert.ok(id, "readBoxIdentity returned an identity for a valid auth.json");
+    assert.equal(id.box_id, "0123456789abcdef0123456789abcdef");
+    assert.equal(id.box_token, "11112222333344445555666677778888");
+    assert.equal(id.created_at, 1700000000000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readBoxIdentity returns null when the file is missing (fresh box — install must not crash)", () => {
+  // install.sh must not blow up if auth.json hasn't been written yet (the
+  // server mints it on first start, which may be a moment after this script
+  // runs). The fallback path is to omit the Box ID line from the heredoc.
+  assert.equal(readBoxIdentity("/definitely/not/here/auth.json"), null);
+});
+
+test("readBoxIdentity returns null on a corrupt auth.json (server will mint a fresh one)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-install-readid-"));
+  const authFile = join(dir, "auth.json");
+  writeFileSync(authFile, "not json{");
+  try {
+    assert.equal(readBoxIdentity(authFile), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ----------------------------------------------------------------------------

--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -182,16 +182,45 @@ async function defaultConnect(url, { headers } = {}) {
 // Local-fetch leg (default localFetch()). Calls the box server over loopback.
 // ---------------------------------------------------------------------------
 
-// Turn a decoded REQUEST frame into a real call against the local box server and
-// return a normalized { status, headers, body } response. `body` on the frame,
-// when present, is a UTF-8 string (JSON payloads are already text). Binary
-// request bodies are out of scope for the metadata path.
-function makeDefaultLocalFetch(localBase) {
+// ADR-1 (BET-151): every relay→box proxied request must be authenticated to the
+// LOCAL box server with the BOX's own `box_token`. Devices only ever hold an
+// account token presented to the RELAY; they never see the box_token. So when
+// the agent forwards a REQUEST frame to 127.0.0.1:8787 it must UNCONDITIONALLY
+// overwrite any inbound `Authorization` header — including a foreign one
+// accidentally carried in `frame.headers` — with `Bearer <box_token>`. Trusting
+// the inbound value would let a misconfigured client pin the wrong auth and
+// leak the box_token through the relay.
+//
+// `auth` is `{ box_id, box_token }`; in production it's whatever `loadAuth()`
+// returned for the local box. The function is exported (named) so tests can
+// drive it with a synthetic auth without standing up the whole agent.
+//
+// Header keys are matched case-insensitively (HTTP headers are case-insensitive;
+// `Authorization`, `authorization`, and `AUTHORIZATION` all mean the same name).
+// `frame.headers` is left unmutated (caller still owns the frame).
+export function makeDefaultLocalFetch(localBase, auth) {
+  if (!auth || !isValidToken(auth?.box_token)) {
+    throw new Error(
+      "makeDefaultLocalFetch: valid { box_token } required " +
+        "(the box's own identity — never the device's account token)",
+    );
+  }
+  const bearer = `Bearer ${auth.box_token}`;
   return async function defaultLocalFetch({ method, path, headers, body }) {
     const url = `${localBase}${path.startsWith("/") ? path : `/${path}`}`;
+    // Copy the inbound headers verbatim, then drop ANY `authorization` key
+    // (case-insensitive) and unconditionally install the BOX bearer.
+    const outHeaders = {};
+    if (headers && typeof headers === "object") {
+      for (const k of Object.keys(headers)) {
+        if (k.toLowerCase() === "authorization") continue;
+        outHeaders[k] = headers[k];
+      }
+    }
+    outHeaders.authorization = bearer;
     const res = await fetch(url, {
       method,
-      headers: headers || undefined,
+      headers: outHeaders,
       body: body != null && method !== "GET" && method !== "HEAD" ? body : undefined,
     });
     const respHeaders = {};
@@ -199,6 +228,24 @@ function makeDefaultLocalFetch(localBase) {
     const text = await res.text();
     return { status: res.status, headers: respHeaders, body: text };
   };
+}
+
+// ADR-1 (BET-151) — pure config decision: should the box server start the relay
+// agent at boot? The product default is YES (relay-first is the path to a paid
+// mobile app — BET-151). The owner's box can opt out by writing
+// `"relayEnabled": false` into `~/.manta/config.json` (e.g. self-hosted with
+// direct-HTTPS only). No env override here on purpose — configGet() is the
+// single switch, mirroring how `chatAutoAllow` is gated.
+//
+// Truth table (tested):
+//   undefined / null config   → true (relay-first default)
+//   { relayEnabled: true }    → true
+//   { relayEnabled: false }   → false
+//   { relayEnabled: "no" }    → true (only `=== false` opts out — same shape
+//                                 as a JS truthy check; do NOT over-engineer)
+export function shouldStartRelayAgent(config) {
+  if (config == null) return true;
+  return config.relayEnabled !== false;
 }
 
 // ---------------------------------------------------------------------------
@@ -212,12 +259,16 @@ function makeDefaultLocalFetch(localBase) {
  * @param {string} [opts.relayUrl]   relay base ws/wss URL (default DEFAULT_RELAY_URL / env RELAY_URL)
  * @param {string} [opts.localBase]  local box server base (default DEFAULT_LOCAL_BASE)
  * @param {{box_id:string,box_token:string}} [opts.auth]
- *   box identity; defaults to loadAuth() from ~/.manta/auth.json.
+ *   box identity; defaults to loadAuth() from ~/.manta/auth.json. Plumbed into
+ *   `makeDefaultLocalFetch` so every proxied request carries the BOX's own
+ *   `Bearer <box_token>` to 127.0.0.1:8787 (ADR-1) — never a device token.
  * @param {(url:string,o:{headers:object})=>Promise<Transport>} [opts.connect]
  *   INJECTABLE outbound-WS opener. Resolves with a transport once connected,
  *   rejects if the connection fails. Defaults to the real `ws` adapter.
  * @param {(req:{method,path,headers,body})=>Promise<{status,headers,body}>} [opts.localFetch]
- *   INJECTABLE local-server leg. Defaults to global fetch against localBase.
+ *   INJECTABLE local-server leg. Defaults to `makeDefaultLocalFetch(localBase,
+ *   auth)`, which overwrites any inbound `Authorization` header with the box's
+ *   own bearer before calling `fetch`.
  * @param {{next():number,reset():void,attempt():number}} [opts.backoff]
  *   INJECTABLE reconnect backoff (ExponentialBackoff-compatible). Default mirror
  *   of src/shared/net/backoff.ts.
@@ -245,7 +296,7 @@ export function createRelayAgent(opts = {}) {
         "(run the box server once to mint ~/.manta/auth.json, or pass opts.auth)",
     );
   }
-  const localFetch = opts.localFetch || makeDefaultLocalFetch(localBase);
+  const localFetch = opts.localFetch || makeDefaultLocalFetch(localBase, auth);
 
   // Per-box streams inbound over the tunnel (Stage-4 SSE/PTY). We own a registry
   // so a relay→box STREAM_* frame is routed, but the box→phone direction (this
@@ -255,6 +306,7 @@ export function createRelayAgent(opts = {}) {
   let transport = null; // current live transport, or null while (re)connecting
   let reconnectTimer = null;
   let stopped = false; // set by stop(); halts the reconnect loop permanently
+  let started = false; // set by start(); the agent only counts as "live" once start() ran
   let connecting = false;
 
   // Build the authenticated dial-out URL + headers. The relay's parseHandshake
@@ -407,6 +459,7 @@ export function createRelayAgent(opts = {}) {
   // until the first connection is established (tests use this).
   async function start() {
     stopped = false;
+    started = true;
     await openOnce();
   }
 
@@ -443,6 +496,25 @@ export function createRelayAgent(opts = {}) {
     start,
     stop,
     ping,
+    // Coarse live-state snapshot for the box-server's /relay/status endpoint
+    // (install.sh + the renderer dashboard want to know whether the relay
+    // handshake succeeded). Three states, no partial ambiguity:
+    //   "stopped"    — stop() was called (or before start()); never reconnects
+    //   "connected"  — a live transport is open (socket → relay is up)
+    //   "connecting" — a dial is in flight OR a reconnect is scheduled
+    // `connecting` is intentionally sticky across reconnects so a UI asking
+    // "is the link healthy?" doesn't flicker connected/connecting during the
+    // backoff window — the link is alive in the sense that the loop hasn't
+    // given up, it just isn't open yet.
+    status() {
+      // "stopped" covers two real states: never started AND stop()'d. Both
+      // mean the agent is NOT currently trying to reach the relay. A UI or
+      // `/relay/status` consumer treats them identically — the link is down
+      // for a reason the box server can explain, not just transient silence.
+      if (!started || stopped) return "stopped";
+      if (transport) return "connected";
+      return "connecting";
+    },
     // introspection for tests / Stage-4 wiring
     boxId: auth.box_id,
     isConnected: () => transport != null,

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import {
   createRelayAgent,
   createBackoff,
+  makeDefaultLocalFetch,
+  shouldStartRelayAgent,
   DEFAULT_RELAY_URL,
   RECONNECT_BASE_MS,
   RECONNECT_MAX_MS,
@@ -474,4 +476,341 @@ test("stop() during an in-flight dial does not connect afterwards", async () => 
   assert.equal(agent.isConnected(), false, "never adopts a socket opened after stop");
   assert.equal(closed, true, "the raced-open socket is closed");
   assert.equal(clock.pendingCount(), 0);
+});
+
+// ---------------------------------------------------------------------------
+// shouldStartRelayAgent — ADR-1 config decision (BET-155)
+// ---------------------------------------------------------------------------
+
+test("shouldStartRelayAgent defaults to true (relay-first product default)", () => {
+  assert.equal(shouldStartRelayAgent(undefined), true);
+  assert.equal(shouldStartRelayAgent(null), true);
+  assert.equal(shouldStartRelayAgent({}), true);
+  assert.equal(shouldStartRelayAgent({ relayEnabled: undefined }), true);
+});
+
+test("shouldStartRelayAgent returns true for relayEnabled=true", () => {
+  assert.equal(shouldStartRelayAgent({ relayEnabled: true }), true);
+});
+
+test("shouldStartRelayAgent returns false ONLY for relayEnabled=false (opt-out)", () => {
+  assert.equal(shouldStartRelayAgent({ relayEnabled: false }), false);
+});
+
+test("shouldStartRelayAgent treats truthy non-booleans as enabled (no over-engineering)", () => {
+  // The only way to opt out is the literal boolean `false`. Anything else
+  // (a stray "no", 0 wrapped in JSON's quirks, a stale schema) keeps the
+  // relay on — re-enabling is one config flip away, and a silent "no" would
+  // be invisible to the operator.
+  assert.equal(shouldStartRelayAgent({ relayEnabled: "no" }), true);
+  assert.equal(shouldStartRelayAgent({ relayEnabled: 0 }), true);
+  assert.equal(shouldStartRelayAgent({ relayEnabled: "" }), true);
+});
+
+// ---------------------------------------------------------------------------
+// makeDefaultLocalFetch — ADR-1 auth overwrite (BET-155)
+// ---------------------------------------------------------------------------
+
+test("makeDefaultLocalFetch overwrites a foreign Authorization header with the BOX bearer", async () => {
+  // A foreign (account) token presented by the device / carried in frame.headers
+  // must NOT be forwarded to 127.0.0.1:8787. The box server authenticates every
+  // request with its own box_token, so the agent installs that bearer no matter
+  // what the inbound value was.
+  const seen = [];
+  const stubFetch = async (url, init) => {
+    seen.push({ url, headers: init?.headers });
+    return {
+      status: 200,
+      headers: new Map([["content-type", "application/json"]]),
+      text: async () => "{}",
+    };
+  };
+  // Replace global fetch for this test only.
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = stubFetch;
+  try {
+    const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
+    await localFetch({
+      method: "GET",
+      path: "/api/projects",
+      headers: { authorization: "Bearer account-token-from-device" },
+      body: undefined,
+    });
+    assert.equal(seen.length, 1);
+    assert.equal(
+      seen[0].headers.authorization,
+      `Bearer ${BOX_TOKEN}`,
+      "Authorization is the BOX token, not the foreign account token",
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("makeDefaultLocalFetch is case-insensitive about the Authorization key", async () => {
+  // HTTP headers are case-insensitive; "Authorization", "authorization", and
+  // "AUTHORIZATION" are the same header name. A client that capitalized the
+  // key differently must still lose the inbound value to the BOX bearer.
+  const seen = [];
+  const stubFetch = async (_url, init) => {
+    seen.push(init?.headers);
+    return {
+      status: 200,
+      headers: new Map(),
+      text: async () => "",
+    };
+  };
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = stubFetch;
+  try {
+    const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
+    for (const variant of ["Authorization", "authorization", "AUTHORIZATION", "AuThOrIzAtIoN"]) {
+      await localFetch({
+        method: "GET",
+        path: "/x",
+        headers: { [variant]: "Bearer leaked-token" },
+        body: undefined,
+      });
+    }
+    assert.equal(seen.length, 4);
+    for (const headers of seen) {
+      assert.equal(
+        headers.authorization,
+        `Bearer ${BOX_TOKEN}`,
+        "every variant must collapse to the BOX bearer (lowercase key)",
+      );
+      // No stale "Authorization"/"AUTHORIZATION" key with the foreign value.
+      for (const k of Object.keys(headers)) {
+        if (k.toLowerCase() === "authorization" && k !== "authorization") {
+          assert.fail(`foreign key "${k}" survived in outbound headers`);
+        }
+      }
+    }
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("makeDefaultLocalFetch installs the BOX bearer when no Authorization was inbound", async () => {
+  const seen = [];
+  const stubFetch = async (_url, init) => {
+    seen.push(init?.headers);
+    return { status: 200, headers: new Map(), text: async () => "" };
+  };
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = stubFetch;
+  try {
+    const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
+    await localFetch({
+      method: "GET",
+      path: "/api/projects",
+      headers: { "x-device-id": "phone-1", accept: "application/json" },
+      body: undefined,
+    });
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].authorization, `Bearer ${BOX_TOKEN}`);
+    // Unrelated headers pass through unchanged (and keep their original case).
+    assert.equal(seen[0]["x-device-id"], "phone-1");
+    assert.equal(seen[0].accept, "application/json");
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("makeDefaultLocalFetch preserves unrelated headers when overwriting auth", async () => {
+  const seen = [];
+  const stubFetch = async (_url, init) => {
+    seen.push(init?.headers);
+    return { status: 200, headers: new Map(), text: async () => "" };
+  };
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = stubFetch;
+  try {
+    const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
+    await localFetch({
+      method: "GET",
+      path: "/x",
+      headers: {
+        authorization: "Bearer stale-device-token",
+        "x-request-id": "abc-123",
+        "x-forwarded-for": "1.2.3.4", // explicitly NOT a thing we strip; pass-through
+        accept: "*/*",
+      },
+      body: undefined,
+    });
+    assert.equal(seen.length, 1);
+    const h = seen[0];
+    assert.equal(h.authorization, `Bearer ${BOX_TOKEN}`);
+    assert.equal(h["x-request-id"], "abc-123");
+    assert.equal(h["x-forwarded-for"], "1.2.3.4");
+    assert.equal(h.accept, "*/*");
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("makeDefaultLocalFetch requires a valid box_token (never accepts a missing/foreign one)", () => {
+  assert.throws(() => makeDefaultLocalFetch("http://127.0.0.1:8787", null), /box_token/);
+  assert.throws(() => makeDefaultLocalFetch("http://127.0.0.1:8787", undefined), /box_token/);
+  assert.throws(
+    () => makeDefaultLocalFetch("http://127.0.0.1:8787", { box_id: BOX_ID, box_token: "bad" }),
+    /box_token/,
+  );
+  assert.throws(() => makeDefaultLocalFetch("http://127.0.0.1:8787", {}), /box_token/);
+});
+
+test("the agent's default localFetch is the overwriting one (ADR-1 wired by default)", async () => {
+  // End-to-end: drive a real REQUEST frame through the agent and verify the
+  // outbound HTTP request to 127.0.0.1:8787 carries the BOX bearer, even
+  // though the inbound frame carried a foreign "Authorization" header. This
+  // is the contract install.sh + the box-server's auth gate rely on.
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const seenByGlobalFetch = [];
+  const stubFetch = async (url, init) => {
+    seenByGlobalFetch.push({ url, headers: init?.headers });
+    return {
+      status: 200,
+      headers: new Map([["content-type", "application/json"]]),
+      text: async () => '{"ok":true}',
+    };
+  };
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = stubFetch;
+  try {
+    const agent = createRelayAgent({
+      auth: AUTH,
+      connect: relay.connect,
+      // Intentionally do NOT pass a custom localFetch — exercise the default
+      // factory `makeDefaultLocalFetch(localBase, auth)` which the agent
+      // wires up when opts.localFetch is absent.
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      log: silent,
+      warn: silent,
+    });
+    await agent.start();
+
+    relay.sendToClient({
+      type: FRAME_TYPES.REQUEST,
+      id: 1,
+      method: "GET",
+      path: "/api/projects",
+      headers: {
+        authorization: "Bearer attacker-supplied-token",
+        "x-device-id": "phone-1",
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(seenByGlobalFetch.length, 1, "exactly one outbound call to the local box server");
+    assert.match(
+      seenByGlobalFetch[0].url,
+      /^http:\/\/127\.0\.0\.1:8787\/api\/projects$/,
+      "URL is the local box server + the relay-forwarded path",
+    );
+    assert.equal(
+      seenByGlobalFetch[0].headers.authorization,
+      `Bearer ${BOX_TOKEN}`,
+      "the outbound HTTP request carries the BOX bearer, NOT the foreign token",
+    );
+    // Unrelated headers still pass through (case preserved).
+    assert.equal(seenByGlobalFetch[0].headers["x-device-id"], "phone-1");
+
+    agent.stop();
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// status() — coarse live-state snapshot for /relay/status (BET-155)
+// ---------------------------------------------------------------------------
+
+test("status() is \"stopped\" before start()", () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  assert.equal(agent.status(), "stopped");
+});
+
+test("status() is \"connected\" after a successful start()", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  await agent.start();
+  assert.equal(agent.status(), "connected");
+  agent.stop();
+});
+
+test("status() is \"connecting\" after a drop while the reconnect is armed", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  await agent.start();
+  relay.dropLink();
+  await Promise.resolve();
+  assert.equal(agent.status(), "connecting", "stays 'connecting' through the backoff window");
+  agent.stop();
+});
+
+test("status() is \"stopped\" after stop() and ignores later drop events", async () => {
+  const relay = makeFakeRelay();
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  await agent.start();
+  agent.stop();
+  assert.equal(agent.status(), "stopped");
+  // A late drop must not flip the state — stop() is permanent.
+  relay.dropLink();
+  await Promise.resolve();
+  assert.equal(agent.status(), "stopped");
+});
+
+test("status() is \"connecting\" between a failed dial and the next attempt", async () => {
+  // failFirst=1: first dial fails, the agent arms a reconnect; before the
+  // next attempt fires the agent is neither connected nor stopped.
+  const relay = makeFakeRelay({ failFirst: 1 });
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+  });
+  await agent.start(); // attempt 1 fails → reconnect armed
+  assert.equal(agent.status(), "connecting");
+  agent.stop();
 });

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -145,6 +145,62 @@ function makeClock() {
 }
 
 // ---------------------------------------------------------------------------
+// Test-fixture helpers (BET-155 — dedupe)
+//
+// makeStubAgent — the canonical agent-fixture setup used by almost every test
+// below: a fake relay endpoint, a manual clock, and an agent wired to both
+// with silent log/warn. The duplication-gate flagged this 8-line setup as a
+// 12+ line intra-file clone repeated across many tests; folding it into a
+// helper drops each test back to a 3-line setup and removes the clone.
+//
+// Tests that need to override a knob (`backoff`, `localFetch`, `failFirst`)
+// pass it through `opts`; everything else stays identical so a reader
+// scanning tests sees the SAME shape in every "agent does X" test. `failFirst`
+// is a first-class key (passed to makeFakeRelay) because that's how the
+// reconnect tests have always described the dial-failure contract.
+//
+// captureFetchHeaders — wraps `body()` with a stubbed global fetch that
+// captures the `init?.headers` of every outbound call, then restores the
+// real fetch in a `finally` so a thrown assertion can't leak the stub to
+// sibling tests. The two makeDefaultLocalFetch tests use it; the 8-line
+// stub/restore preamble was an intra-file clone of itself.
+function makeStubAgent(opts = {}) {
+  const { failFirst, ...agentOpts } = opts;
+  const relay = makeFakeRelay(
+    failFirst != null ? { failFirst } : undefined,
+  );
+  const clock = makeClock();
+  const agent = createRelayAgent({
+    auth: AUTH,
+    connect: relay.connect,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    log: silent,
+    warn: silent,
+    ...agentOpts,
+  });
+  return { relay, clock, agent };
+}
+
+async function captureFetchHeaders(body) {
+  const seen = [];
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    seen.push({ url, headers: init?.headers });
+    return {
+      status: 200,
+      headers: new Map(),
+      text: async () => "",
+    };
+  };
+  try {
+    return { seen, result: await body() };
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // pure: config surface + backoff parity
 // ---------------------------------------------------------------------------
 
@@ -188,16 +244,7 @@ test("backoff mirror full-jitter stays within [0, capped] and uses injected rng"
 // ---------------------------------------------------------------------------
 
 test("dials out and authenticates with the box_id + box_token handshake", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, clock, agent } = makeStubAgent();
 
   await agent.start();
 
@@ -227,19 +274,9 @@ test("reconnects with increasing backoff on repeated dial failures and never giv
   // The first 3 dial attempts fail; the 4th succeeds. Backoff must be armed
   // after each failure with a strictly non-decreasing (growing) delay, and the
   // loop must never stop retrying on its own.
-  const relay = makeFakeRelay({ failFirst: 3 });
-  const clock = makeClock();
   // Deterministic delays: no jitter so growth is observable.
   const backoff = createBackoff({ base: 100, max: 10000, jitter: false });
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    backoff,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, clock, agent } = makeStubAgent({ failFirst: 3, backoff });
 
   await agent.start(); // attempt 1 → fails, arms a reconnect timer
   assert.equal(agent.isConnected(), false);
@@ -266,18 +303,8 @@ test("reconnects with increasing backoff on repeated dial failures and never giv
 });
 
 test("a drop after a successful connect triggers reconnect (tunnel resurrection)", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
   const backoff = createBackoff({ base: 50, max: 1000, jitter: false });
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    backoff,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, clock, agent } = makeStubAgent({ backoff });
 
   await agent.start();
   assert.equal(agent.isConnected(), true);
@@ -302,8 +329,6 @@ test("a drop after a successful connect triggers reconnect (tunnel resurrection)
 // ---------------------------------------------------------------------------
 
 test("proxies a relay REQUEST to the local box server and streams the RESPONSE back", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
   const localCalls = [];
   const localFetch = async (req) => {
     localCalls.push(req);
@@ -313,15 +338,7 @@ test("proxies a relay REQUEST to the local box server and streams the RESPONSE b
       body: JSON.stringify({ projects: ["p1", "p2"] }),
     };
   };
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    localFetch,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, clock, agent } = makeStubAgent({ localFetch });
 
   await agent.start();
 
@@ -355,20 +372,10 @@ test("proxies a relay REQUEST to the local box server and streams the RESPONSE b
 });
 
 test("a failing local fetch replies with a correlated ERROR frame, not a hang", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
   const localFetch = async () => {
     throw new Error("ECONNREFUSED 127.0.0.1:8787");
   };
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    localFetch,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, agent } = makeStubAgent({ localFetch });
 
   await agent.start();
   relay.sendToClient({
@@ -390,16 +397,7 @@ test("a failing local fetch replies with a correlated ERROR frame, not a hang", 
 });
 
 test("answers a relay PING with a correlated PONG", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, agent } = makeStubAgent();
   await agent.start();
 
   relay.sendToClient({ type: FRAME_TYPES.PING, id: 99 });
@@ -417,16 +415,7 @@ test("answers a relay PING with a correlated PONG", async () => {
 // ---------------------------------------------------------------------------
 
 test("stop() leaves no open sockets or timers (clean teardown)", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, clock, agent } = makeStubAgent();
   await agent.start();
   assert.equal(agent.isConnected(), true);
 
@@ -457,15 +446,7 @@ test("stop() during an in-flight dial does not connect afterwards", async () => 
       },
     };
   };
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { agent, clock } = makeStubAgent({ connect });
 
   const startP = agent.start();
   agent.stop(); // stop while the dial is still pending
@@ -516,19 +497,7 @@ test("makeDefaultLocalFetch overwrites a foreign Authorization header with the B
   // must NOT be forwarded to 127.0.0.1:8787. The box server authenticates every
   // request with its own box_token, so the agent installs that bearer no matter
   // what the inbound value was.
-  const seen = [];
-  const stubFetch = async (url, init) => {
-    seen.push({ url, headers: init?.headers });
-    return {
-      status: 200,
-      headers: new Map([["content-type", "application/json"]]),
-      text: async () => "{}",
-    };
-  };
-  // Replace global fetch for this test only.
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = stubFetch;
-  try {
+  const { seen } = await captureFetchHeaders(async () => {
     const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
     await localFetch({
       method: "GET",
@@ -536,33 +505,20 @@ test("makeDefaultLocalFetch overwrites a foreign Authorization header with the B
       headers: { authorization: "Bearer account-token-from-device" },
       body: undefined,
     });
-    assert.equal(seen.length, 1);
-    assert.equal(
-      seen[0].headers.authorization,
-      `Bearer ${BOX_TOKEN}`,
-      "Authorization is the BOX token, not the foreign account token",
-    );
-  } finally {
-    globalThis.fetch = origFetch;
-  }
+  });
+  assert.equal(seen.length, 1);
+  assert.equal(
+    seen[0].headers.authorization,
+    `Bearer ${BOX_TOKEN}`,
+    "Authorization is the BOX token, not the foreign account token",
+  );
 });
 
 test("makeDefaultLocalFetch is case-insensitive about the Authorization key", async () => {
   // HTTP headers are case-insensitive; "Authorization", "authorization", and
   // "AUTHORIZATION" are the same header name. A client that capitalized the
   // key differently must still lose the inbound value to the BOX bearer.
-  const seen = [];
-  const stubFetch = async (_url, init) => {
-    seen.push(init?.headers);
-    return {
-      status: 200,
-      headers: new Map(),
-      text: async () => "",
-    };
-  };
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = stubFetch;
-  try {
+  const { seen } = await captureFetchHeaders(async () => {
     const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
     for (const variant of ["Authorization", "authorization", "AUTHORIZATION", "AuThOrIzAtIoN"]) {
       await localFetch({
@@ -572,34 +528,25 @@ test("makeDefaultLocalFetch is case-insensitive about the Authorization key", as
         body: undefined,
       });
     }
-    assert.equal(seen.length, 4);
-    for (const headers of seen) {
-      assert.equal(
-        headers.authorization,
-        `Bearer ${BOX_TOKEN}`,
-        "every variant must collapse to the BOX bearer (lowercase key)",
-      );
-      // No stale "Authorization"/"AUTHORIZATION" key with the foreign value.
-      for (const k of Object.keys(headers)) {
-        if (k.toLowerCase() === "authorization" && k !== "authorization") {
-          assert.fail(`foreign key "${k}" survived in outbound headers`);
-        }
+  });
+  assert.equal(seen.length, 4);
+  for (const { headers } of seen) {
+    assert.equal(
+      headers.authorization,
+      `Bearer ${BOX_TOKEN}`,
+      "every variant must collapse to the BOX bearer (lowercase key)",
+    );
+    // No stale "Authorization"/"AUTHORIZATION" key with the foreign value.
+    for (const k of Object.keys(headers)) {
+      if (k.toLowerCase() === "authorization" && k !== "authorization") {
+        assert.fail(`foreign key "${k}" survived in outbound headers`);
       }
     }
-  } finally {
-    globalThis.fetch = origFetch;
   }
 });
 
 test("makeDefaultLocalFetch installs the BOX bearer when no Authorization was inbound", async () => {
-  const seen = [];
-  const stubFetch = async (_url, init) => {
-    seen.push(init?.headers);
-    return { status: 200, headers: new Map(), text: async () => "" };
-  };
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = stubFetch;
-  try {
+  const { seen } = await captureFetchHeaders(async () => {
     const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
     await localFetch({
       method: "GET",
@@ -607,25 +554,16 @@ test("makeDefaultLocalFetch installs the BOX bearer when no Authorization was in
       headers: { "x-device-id": "phone-1", accept: "application/json" },
       body: undefined,
     });
-    assert.equal(seen.length, 1);
-    assert.equal(seen[0].authorization, `Bearer ${BOX_TOKEN}`);
-    // Unrelated headers pass through unchanged (and keep their original case).
-    assert.equal(seen[0]["x-device-id"], "phone-1");
-    assert.equal(seen[0].accept, "application/json");
-  } finally {
-    globalThis.fetch = origFetch;
-  }
+  });
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].headers.authorization, `Bearer ${BOX_TOKEN}`);
+  // Unrelated headers pass through unchanged (and keep their original case).
+  assert.equal(seen[0].headers["x-device-id"], "phone-1");
+  assert.equal(seen[0].headers.accept, "application/json");
 });
 
 test("makeDefaultLocalFetch preserves unrelated headers when overwriting auth", async () => {
-  const seen = [];
-  const stubFetch = async (_url, init) => {
-    seen.push(init?.headers);
-    return { status: 200, headers: new Map(), text: async () => "" };
-  };
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = stubFetch;
-  try {
+  const { seen } = await captureFetchHeaders(async () => {
     const localFetch = makeDefaultLocalFetch("http://127.0.0.1:8787", AUTH);
     await localFetch({
       method: "GET",
@@ -638,15 +576,13 @@ test("makeDefaultLocalFetch preserves unrelated headers when overwriting auth", 
       },
       body: undefined,
     });
-    assert.equal(seen.length, 1);
-    const h = seen[0];
-    assert.equal(h.authorization, `Bearer ${BOX_TOKEN}`);
-    assert.equal(h["x-request-id"], "abc-123");
-    assert.equal(h["x-forwarded-for"], "1.2.3.4");
-    assert.equal(h.accept, "*/*");
-  } finally {
-    globalThis.fetch = origFetch;
-  }
+  });
+  assert.equal(seen.length, 1);
+  const h = seen[0].headers;
+  assert.equal(h.authorization, `Bearer ${BOX_TOKEN}`);
+  assert.equal(h["x-request-id"], "abc-123");
+  assert.equal(h["x-forwarded-for"], "1.2.3.4");
+  assert.equal(h.accept, "*/*");
 });
 
 test("makeDefaultLocalFetch requires a valid box_token (never accepts a missing/foreign one)", () => {
@@ -664,33 +600,9 @@ test("the agent's default localFetch is the overwriting one (ADR-1 wired by defa
   // outbound HTTP request to 127.0.0.1:8787 carries the BOX bearer, even
   // though the inbound frame carried a foreign "Authorization" header. This
   // is the contract install.sh + the box-server's auth gate rely on.
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const seenByGlobalFetch = [];
-  const stubFetch = async (url, init) => {
-    seenByGlobalFetch.push({ url, headers: init?.headers });
-    return {
-      status: 200,
-      headers: new Map([["content-type", "application/json"]]),
-      text: async () => '{"ok":true}',
-    };
-  };
-  const origFetch = globalThis.fetch;
-  globalThis.fetch = stubFetch;
-  try {
-    const agent = createRelayAgent({
-      auth: AUTH,
-      connect: relay.connect,
-      // Intentionally do NOT pass a custom localFetch — exercise the default
-      // factory `makeDefaultLocalFetch(localBase, auth)` which the agent
-      // wires up when opts.localFetch is absent.
-      setTimer: clock.setTimer,
-      clearTimer: clock.clearTimer,
-      log: silent,
-      warn: silent,
-    });
+  const { relay, agent } = makeStubAgent();
+  const { seen } = await captureFetchHeaders(async () => {
     await agent.start();
-
     relay.sendToClient({
       type: FRAME_TYPES.REQUEST,
       id: 1,
@@ -704,25 +616,22 @@ test("the agent's default localFetch is the overwriting one (ADR-1 wired by defa
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
-
-    assert.equal(seenByGlobalFetch.length, 1, "exactly one outbound call to the local box server");
-    assert.match(
-      seenByGlobalFetch[0].url,
-      /^http:\/\/127\.0\.0\.1:8787\/api\/projects$/,
-      "URL is the local box server + the relay-forwarded path",
-    );
-    assert.equal(
-      seenByGlobalFetch[0].headers.authorization,
-      `Bearer ${BOX_TOKEN}`,
-      "the outbound HTTP request carries the BOX bearer, NOT the foreign token",
-    );
-    // Unrelated headers still pass through (case preserved).
-    assert.equal(seenByGlobalFetch[0].headers["x-device-id"], "phone-1");
-
     agent.stop();
-  } finally {
-    globalThis.fetch = origFetch;
-  }
+  });
+
+  assert.equal(seen.length, 1, "exactly one outbound call to the local box server");
+  assert.match(
+    String(seen[0].url ?? ""),
+    /^http:\/\/127\.0\.0\.1:8787\/api\/projects$/,
+    "URL is the local box server + the relay-forwarded path",
+  );
+  assert.equal(
+    seen[0].headers.authorization,
+    `Bearer ${BOX_TOKEN}`,
+    "the outbound HTTP request carries the BOX bearer, NOT the foreign token",
+  );
+  // Unrelated headers still pass through (case preserved).
+  assert.equal(seen[0].headers["x-device-id"], "phone-1");
 });
 
 // ---------------------------------------------------------------------------
@@ -730,46 +639,19 @@ test("the agent's default localFetch is the overwriting one (ADR-1 wired by defa
 // ---------------------------------------------------------------------------
 
 test("status() is \"stopped\" before start()", () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { agent } = makeStubAgent();
   assert.equal(agent.status(), "stopped");
 });
 
 test("status() is \"connected\" after a successful start()", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { agent } = makeStubAgent();
   await agent.start();
   assert.equal(agent.status(), "connected");
   agent.stop();
 });
 
 test("status() is \"connecting\" after a drop while the reconnect is armed", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, agent } = makeStubAgent();
   await agent.start();
   relay.dropLink();
   await Promise.resolve();
@@ -778,16 +660,7 @@ test("status() is \"connecting\" after a drop while the reconnect is armed", asy
 });
 
 test("status() is \"stopped\" after stop() and ignores later drop events", async () => {
-  const relay = makeFakeRelay();
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { relay, agent } = makeStubAgent();
   await agent.start();
   agent.stop();
   assert.equal(agent.status(), "stopped");
@@ -800,16 +673,7 @@ test("status() is \"stopped\" after stop() and ignores later drop events", async
 test("status() is \"connecting\" between a failed dial and the next attempt", async () => {
   // failFirst=1: first dial fails, the agent arms a reconnect; before the
   // next attempt fires the agent is neither connected nor stopped.
-  const relay = makeFakeRelay({ failFirst: 1 });
-  const clock = makeClock();
-  const agent = createRelayAgent({
-    auth: AUTH,
-    connect: relay.connect,
-    setTimer: clock.setTimer,
-    clearTimer: clock.clearTimer,
-    log: silent,
-    warn: silent,
-  });
+  const { agent } = makeStubAgent({ failFirst: 1 });
   await agent.start(); // attempt 1 fails → reconnect armed
   assert.equal(agent.status(), "connecting");
   agent.stop();

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -47,6 +47,7 @@ import {
   AUTH_RL_CAPACITY,
   AUTH_RL_REFILL_PER_SEC,
 } from "./auth.mjs";
+import { createRelayAgent, shouldStartRelayAgent } from "../relay/agent/index.mjs";
 import * as push from "./push.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -142,6 +143,14 @@ if (!authEnforced) {
 } else {
   console.log(`[auth] gate enabled — box_id ${boxAuth.box_id}`);
 }
+
+// Relay-agent handle (BET-151 ADR-1). Populated below in the listen() callback
+// when shouldStartRelayAgent(config) returns true. Read by GET /relay/status
+// (loopback-only) so install.sh can poll for the handshake without standing up
+// its own websocket. Null = agent never started (config opted out, or the
+// listener never got that far — in either case /relay/status returns
+// `connected: false`).
+let relayAgent = null;
 
 // Serve-page file server: lightweight HTTP server on 127.0.0.1:20080 that
 // serves HTML pages from ~/.manta/pages/<subdomain>/index.html. Caddy
@@ -516,6 +525,44 @@ const server = createServer(async (req, res) => {
       res.writeHead(500, { "content-type": "application/json" });
       res.end(JSON.stringify({ error: String(e?.message ?? e) }));
     }
+    return;
+  }
+
+  // ---------- Relay status (LOOPBACK-ONLY) ----------
+  // GET /relay/status → { enabled, connected }
+  //
+  // Loopback-gated (same check /auth/pair uses) because the answer leaks
+  // whether this box has reached the relay — useful intel for an attacker
+  // probing the box's outbound posture, and not needed by any remote client.
+  // The renderer never calls this; it's consumed by `install.sh` (and any
+  // future ops tooling on the box itself).
+  //
+  //   enabled   — true iff `shouldStartRelayAgent(config)` (config-derived;
+  //                absent key → true, see agent/index.mjs)
+  //   connected — true iff the agent's `status()` is "connected" right now
+  //                (the live WS handshake to relay.mantaui.com succeeded).
+  //                "connecting" / "stopped" both collapse to false — install.sh
+  //                treats anything-but-connected as "not yet" and re-polls.
+  if (req.method === "GET" && path === "/relay/status") {
+    if (
+      !isLocalDirectRequest({
+        remoteAddress: req.socket?.remoteAddress,
+        headers: req.headers,
+      })
+    ) {
+      res.writeHead(403, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "relay status is loopback-only (run this from the box)",
+        }),
+      );
+      return;
+    }
+    const cfg = await local.configGet();
+    const enabled = shouldStartRelayAgent(cfg);
+    const connected = relayAgent ? relayAgent.status() === "connected" : false;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ enabled, connected }));
     return;
   }
 
@@ -1228,4 +1275,53 @@ server.on("upgrade", (req, socket, head) => {
 
 server.listen(PORT, HOST, () => {
   console.log(`manta listening on http://${HOST}:${PORT}`);
+
+  // Start the box-side relay agent (BET-151 ADR-1 / BET-155). The agent dials
+  // OUT to relay.mantaui.com from this box and authenticates with boxAuth, so
+  // it MUST be created after ensureAuth() has run (which it has — see above)
+  // and AFTER the box server is listening (so the agent's first request proxy
+  // can land). Fire-and-forget: the agent's reconnect/backoff loop runs on its
+  // own timers and never blocks this path — a slow relay handshake must NOT
+  // hold up the HTTP server, and a relay outage must NOT crash the box server.
+  //
+  // Opt-out: write `"relayEnabled": false` to ~/.manta/config.json
+  // (shouldStartRelayAgent() handles the default-on case). No env override —
+  // configGet() is the single switch, mirroring how chatAutoAllow is gated.
+  //
+  // The agent owns its own reconnect/backoff — do NOT add another retry loop.
+  // The agent already logs `[relay-agent] connected …` / `tunnel closed;
+  // reconnecting`; we only log the one-shot boot decision here.
+  local
+    .configGet()
+    .then((cfg) => {
+      if (!shouldStartRelayAgent(cfg)) {
+        console.log(
+          "[relay-agent] disabled via config (relayEnabled=false); box reachable only via direct ingress.",
+        );
+        return;
+      }
+      let agent;
+      try {
+        agent = createRelayAgent({ localBase: `http://127.0.0.1:${PORT}` });
+      } catch (err) {
+        console.warn(
+          `[relay-agent] could not construct (auth missing?): ${String(err?.message ?? err)}`,
+        );
+        return;
+      }
+      relayAgent = agent;
+      agent.start().catch((err) => {
+        console.warn(
+          `[relay-agent] first connect rejected: ${String(err?.message ?? err)}`,
+        );
+      });
+      console.log(
+        `[relay-agent] dialing ${agent.boxId.slice(0, 8)}… (relay.mantaui.com)`,
+      );
+    })
+    .catch((err) => {
+      console.warn(
+        `[relay-agent] could not start (config read failed): ${String(err?.message ?? err)}`,
+      );
+    });
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -342,6 +342,41 @@ function readRawBody(req, limit = 64 * 1024) {
   });
 }
 
+// ---------- tiny HTTP helpers ----------
+//
+// respondJson — write a JSON response (the most common response shape in this
+// file). Pulling it out eliminates a verbatim writeHead+end boilerplate that
+// the duplication-gate flagged between /auth/pair and /relay/status
+// (10-27 line clones) — every JSON-shaped handler in this file now goes
+// through here. Status code + body shape stay identical to the inline
+// versions they replace.
+//
+// requireLoopback — gate a handler on the loopback-direct check used by
+// /auth/pair and /relay/status. Returns true (proceed) when the request is
+// loopback-direct; on a non-loopback caller it writes the standard 403 and
+// returns false, so the caller MUST `return` immediately. The error message
+// is passed in so each endpoint can phrase the rejection for its own
+// surface (a pairing-code mint vs. a relay-status read need different hints).
+// The check itself is unchanged (isLocalDirectRequest in auth.mjs) — this
+// is a pure refactor, the loopback gate's semantics are preserved bit-for-bit.
+function respondJson(res, status, obj) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(obj));
+}
+
+function requireLoopback(req, res, errorMessage) {
+  if (
+    isLocalDirectRequest({
+      remoteAddress: req.socket?.remoteAddress,
+      headers: req.headers,
+    })
+  ) {
+    return true;
+  }
+  respondJson(res, 403, { error: errorMessage });
+  return false;
+}
+
 // ---------- uploads ----------
 //
 // Layout matches the Electron path (~/.manta-uploads/<session>/<ts>/<file>) so
@@ -471,8 +506,7 @@ const server = createServer(async (req, res) => {
       req.socket?.remoteAddress ||
       "unknown";
     if (!authRateLimit(ip)) {
-      res.writeHead(429, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "rate limited" }));
+      respondJson(res, 429, { error: "rate limited" });
       return;
     }
     try {
@@ -481,49 +515,38 @@ const server = createServer(async (req, res) => {
         // Remote-reachable minting would let anyone claim the box_token in two
         // requests. Loopback alone is insufficient — cloudflared proxies public
         // traffic from 127.0.0.1 — so also reject proxy-injected forwarding
-        // headers. See isLocalDirectRequest in auth.mjs.
+        // headers. See isLocalDirectRequest in auth.mjs (reused via
+        // requireLoopback below).
         if (
-          !isLocalDirectRequest({
-            remoteAddress: req.socket?.remoteAddress,
-            headers: req.headers,
-          })
+          !requireLoopback(
+            req,
+            res,
+            "pairing codes can only be minted from the box itself (run `bui pair` locally)",
+          )
         ) {
-          res.writeHead(403, { "content-type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: "pairing codes can only be minted from the box itself (run `bui pair` locally)",
-            }),
-          );
           return;
         }
         const result = authEngine.pair();
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(
-          JSON.stringify({
-            pairing_code: result.pairing_code,
-            box_id: result.box_id,
-            expiresAt: result.expiresAt,
-          }),
-        );
+        respondJson(res, 200, {
+          pairing_code: result.pairing_code,
+          box_id: result.box_id,
+          expiresAt: result.expiresAt,
+        });
         return;
       }
       if (req.method === "POST" && path === "/auth/claim") {
         const body = await readJsonBody(req);
         const result = authEngine.claim({ pairing_code: body?.pairing_code });
         if (!result.ok) {
-          res.writeHead(result.status ?? 400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, result.status ?? 400, { error: result.error });
           return;
         }
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ box_token: result.box_token, box_id: result.box_id }));
+        respondJson(res, 200, { box_token: result.box_token, box_id: result.box_id });
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -545,24 +568,14 @@ const server = createServer(async (req, res) => {
   //                treats anything-but-connected as "not yet" and re-polls.
   if (req.method === "GET" && path === "/relay/status") {
     if (
-      !isLocalDirectRequest({
-        remoteAddress: req.socket?.remoteAddress,
-        headers: req.headers,
-      })
+      !requireLoopback(req, res, "relay status is loopback-only (run this from the box)")
     ) {
-      res.writeHead(403, { "content-type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: "relay status is loopback-only (run this from the box)",
-        }),
-      );
       return;
     }
     const cfg = await local.configGet();
     const enabled = shouldStartRelayAgent(cfg);
     const connected = relayAgent ? relayAgent.status() === "connected" : false;
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ enabled, connected }));
+    respondJson(res, 200, { enabled, connected });
     return;
   }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -58,6 +58,27 @@ const PROJECT_ROOT = join(__dirname, "..", "..");
 const PUBLIC_DIR = join(PROJECT_ROOT, "mobile", "www");
 
 const bus = createBus();
+// Shared deps passed to store-mutating helpers so they can publish the
+// `*.updated` bus event the renderer cards listen for (JobCard, WebhooksCard,
+// etc). Single source of truth — every endpoint that creates/deletes a
+// store entry uses this same deps object.
+const BUS_PUBLISH_DEPS = { publish: (evt) => bus.publish(evt) };
+
+// DELETE handler for /api/<store> endpoints: `?id=<id>` → store.deleteFn(id,
+// BUS_PUBLISH_DEPS) → 200 {deleted:bool}. The boilerplate (id-required 400,
+// the await + publish-deps call, the success response) is identical across
+// /api/schedule, /api/webhook, and /api/secrets — extracting it removes a
+// 22-line intra-file clone jscpd flagged in BET-155.
+async function handleApiDelete(req, url, res, deleteFn) {
+  const id = url.searchParams.get("id");
+  if (!id) {
+    respondJson(res, 400, { error: "id is required" });
+    return;
+  }
+  const result = await deleteFn(id, BUS_PUBLISH_DEPS);
+  respondJson(res, 200, { deleted: result.deleted });
+}
+
 const rpcHandlers = buildHandlers({ tmux, oc, pty, bus, local });
 
 // Resolve a caller's bui project (tmux session) name from its opencode
@@ -292,9 +313,13 @@ function safeJoin(root, sub) {
   return target;
 }
 
-// Read + JSON-parse a request body, capped at 64KB (push subscriptions are
-// ~1KB; the cap guards against a runaway/hostile body).
-function readJsonBody(req, limit = 64 * 1024) {
+// Read a request body, capped at 64KB (push subscriptions are ~1KB; the cap
+// guards against a runaway/hostile body).
+//   parse=true  → JSON.parse the bytes (the common path for /api/* POSTs).
+//   parse=false → return the EXACT UTF-8 string (webhook delivery needs the
+//                 raw bytes to recompute the HMAC; parsing + re-serializing
+//                 would change whitespace).
+function readBody(req, { parse = true, limit = 64 * 1024 } = {}) {
   return new Promise((resolve, reject) => {
     let size = 0;
     const chunks = [];
@@ -308,10 +333,12 @@ function readJsonBody(req, limit = 64 * 1024) {
       chunks.push(c);
     });
     req.on("end", () => {
-      const raw = Buffer.concat(chunks).toString("utf-8").trim();
-      if (!raw) return resolve({});
+      const raw = Buffer.concat(chunks).toString("utf-8");
+      if (!parse) return resolve(raw);
+      const trimmed = raw.trim();
+      if (!trimmed) return resolve({});
       try {
-        resolve(JSON.parse(raw));
+        resolve(JSON.parse(trimmed));
       } catch (e) {
         reject(e);
       }
@@ -320,27 +347,12 @@ function readJsonBody(req, limit = 64 * 1024) {
   });
 }
 
-// Read a request body as a raw UTF-8 string (NOT parsed). Webhook delivery
-// needs the EXACT bytes the sender signed to recompute the HMAC, so it can't go
-// through readJsonBody (which parses + would re-serialize). Capped like
-// readJsonBody.
-function readRawBody(req, limit = 64 * 1024) {
-  return new Promise((resolve, reject) => {
-    let size = 0;
-    const chunks = [];
-    req.on("data", (c) => {
-      size += c.length;
-      if (size > limit) {
-        reject(new Error("body too large"));
-        req.destroy();
-        return;
-      }
-      chunks.push(c);
-    });
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
-    req.on("error", reject);
-  });
-}
+// JSON-parse variant. Thin shim kept for the /api/* call sites so each one
+// reads as `await readJsonBody(req)` instead of `await readBody(req, { parse: true })`.
+const readJsonBody = (req, limit) => readBody(req, { parse: true, limit });
+// Raw-bytes variant for webhook HMAC. Thin shim — see `readBody` for why we
+// need exact bytes (parsing + re-serializing would change whitespace).
+const readRawBody = (req, limit) => readBody(req, { parse: false, limit });
 
 // ---------- tiny HTTP helpers ----------
 //
@@ -403,14 +415,12 @@ function safeBasename(name) {
 async function handleUpload(req, res, url) {
   const session = url.searchParams.get("session");
   if (!session || !SESSION_RE.test(session)) {
-    res.writeHead(400, { "content-type": "application/json" });
-    res.end(JSON.stringify({ error: "bad session" }));
+    respondJson(res, 400, { error: "bad session" });
     return;
   }
   const rawName = req.headers["x-filename"];
   if (typeof rawName !== "string" || !rawName) {
-    res.writeHead(400, { "content-type": "application/json" });
-    res.end(JSON.stringify({ error: "missing X-Filename" }));
+    respondJson(res, 400, { error: "missing X-Filename" });
     return;
   }
   let decoded;
@@ -429,12 +439,10 @@ async function handleUpload(req, res, url) {
     await mkdir(dir, { recursive: true });
     await pipeline(req, createWriteStream(target));
   } catch (e) {
-    res.writeHead(500, { "content-type": "application/json" });
-    res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+    respondJson(res, 500, { error: String(e?.message ?? e) });
     return;
   }
-  res.writeHead(200, { "content-type": "application/json" });
-  res.end(JSON.stringify({ path: target }));
+  respondJson(res, 200, { path: target });
 }
 
 // Agent → device download: stream a file from ~/.manta-outbox/ back to the
@@ -445,8 +453,7 @@ async function handleDownload(req, res, url) {
   const raw = url.searchParams.get("path") ?? "";
   const resolved = resolve(raw);
   if (resolved !== OUTBOX_ROOT && !resolved.startsWith(OUTBOX_ROOT + "/")) {
-    res.writeHead(403, { "content-type": "application/json" });
-    res.end(JSON.stringify({ error: "path outside outbox" }));
+    respondJson(res, 403, { error: "path outside outbox" });
     return;
   }
   try {
@@ -462,8 +469,7 @@ async function handleDownload(req, res, url) {
     await rm(resolved, { force: true }).catch(() => {});
   } catch (e) {
     if (!res.headersSent) {
-      res.writeHead(404, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 404, { error: String(e?.message ?? e) });
     } else {
       res.destroy();
     }
@@ -636,11 +642,9 @@ const server = createServer(async (req, res) => {
   if (req.method === "GET" && path === "/api/projects") {
     try {
       const projects = await tmux.listProjects();
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify(projects));
+      respondJson(res, 200, projects);
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -663,8 +667,7 @@ const server = createServer(async (req, res) => {
   if (req.method === "GET" && path === "/api/peek") {
     const raw = url.searchParams.get("path") ?? "";
     if (!raw) {
-      res.writeHead(400, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "path is required" }));
+      respondJson(res, 400, { error: "path is required" });
       return;
     }
     // Expand ~ to $HOME so callers can pass ~/foo/bar.
@@ -675,8 +678,7 @@ const server = createServer(async (req, res) => {
     // Guard: resolved path must stay inside the user's home dir.
     const home = homedir() + "/";
     if (resolved !== home && !resolved.startsWith(home)) {
-      res.writeHead(403, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "path outside home directory" }));
+      respondJson(res, 403, { error: "path outside home directory" });
       return;
     }
     let s;
@@ -684,17 +686,14 @@ const server = createServer(async (req, res) => {
       s = await stat(resolved);
     } catch (e) {
       if (e?.code === "ENOENT") {
-        res.writeHead(404, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: "not found" }));
+        respondJson(res, 404, { error: "not found" });
         return;
       }
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
       return;
     }
     if (!s.isFile()) {
-      res.writeHead(404, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "not a file" }));
+      respondJson(res, 404, { error: "not a file" });
       return;
     }
     const ext = extname(resolved);
@@ -708,8 +707,7 @@ const server = createServer(async (req, res) => {
       await pipeline(createReadStream(resolved), res);
     } catch (e) {
       if (!res.headersSent) {
-        res.writeHead(500, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+        respondJson(res, 500, { error: String(e?.message ?? e) });
       } else {
         res.destroy();
       }
@@ -739,11 +737,10 @@ const server = createServer(async (req, res) => {
             sessionID: body?.sessionID,
             directory: body?.directory,
           },
-          { publish: (evt) => bus.publish(evt) },
+          BUS_PUBLISH_DEPS,
         );
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
         res.writeHead(200, { "content-type": "application/json" });
@@ -759,27 +756,16 @@ const server = createServer(async (req, res) => {
       if (req.method === "GET") {
         const sessionID = url.searchParams.get("sessionID") || undefined;
         const jobs = await listJobs(sessionID);
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ jobs }));
+        respondJson(res, 200, { jobs });
         return;
       }
       if (req.method === "DELETE") {
-        const id = url.searchParams.get("id");
-        if (!id) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: "id is required" }));
-          return;
-        }
-        const result = await deleteJob(id, { publish: (evt) => bus.publish(evt) });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ deleted: result.deleted }));
+        await handleApiDelete(req, url, res, deleteJob);
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -806,11 +792,10 @@ const server = createServer(async (req, res) => {
             directory: body?.directory,
             unsigned: body?.unsigned,
           },
-          { publish: (evt) => bus.publish(evt) },
+          BUS_PUBLISH_DEPS,
         );
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
         res.writeHead(200, { "content-type": "application/json" });
@@ -822,27 +807,16 @@ const server = createServer(async (req, res) => {
       if (req.method === "GET") {
         const sessionID = url.searchParams.get("sessionID") || undefined;
         const hooks = await listHooks(sessionID);
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ hooks }));
+        respondJson(res, 200, { hooks });
         return;
       }
       if (req.method === "DELETE") {
-        const id = url.searchParams.get("id");
-        if (!id) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: "id is required" }));
-          return;
-        }
-        const result = await deleteHook(id, { publish: (evt) => bus.publish(evt) });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ deleted: result.deleted }));
+        await handleApiDelete(req, url, res, deleteHook);
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -856,8 +830,7 @@ const server = createServer(async (req, res) => {
   // 429 rate-limited. See src/server/webhooks.mjs.
   if (path.startsWith("/hook/")) {
     if (req.method !== "POST") {
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
       return;
     }
     const token = path.slice("/hook/".length);
@@ -876,8 +849,7 @@ const server = createServer(async (req, res) => {
         ),
       );
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -902,11 +874,10 @@ const server = createServer(async (req, res) => {
             ttlHours: body?.ttlHours,
             sessionID: body?.sessionID,
           },
-          { publish: (evt) => bus.publish(evt) },
+          BUS_PUBLISH_DEPS,
         );
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
         res.writeHead(200, { "content-type": "application/json" });
@@ -921,27 +892,22 @@ const server = createServer(async (req, res) => {
       }
       if (req.method === "GET") {
         const pages = listPages();
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ pages }));
+        respondJson(res, 200, { pages });
         return;
       }
       if (req.method === "DELETE") {
         const subdomain = url.searchParams.get("subdomain");
         if (!subdomain) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: "subdomain is required" }));
+          respondJson(res, 400, { error: "subdomain is required" });
           return;
         }
-        const result = await unregisterPage(subdomain, { publish: (evt) => bus.publish(evt) });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ deleted: result.deleted }));
+        const result = await unregisterPage(subdomain, BUS_PUBLISH_DEPS);
+        respondJson(res, 200, { deleted: result.deleted });
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -959,8 +925,7 @@ const server = createServer(async (req, res) => {
         const body = await readJsonBody(req);
         const message = typeof body?.message === "string" ? body.message.trim() : "";
         if (!message) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: "message is required" }));
+          respondJson(res, 400, { error: "message is required" });
           return;
         }
         await push.fireNotify({
@@ -969,15 +934,12 @@ const server = createServer(async (req, res) => {
           urgent: !!body?.urgent,
           sessionID: body?.sessionID,
         });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ ok: true }));
+        respondJson(res, 200, { ok: true });
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -1002,12 +964,10 @@ const server = createServer(async (req, res) => {
           ? await inspectPeer({ sessionID, directory, target })
           : await listPeers({ sessionID, directory });
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify(result));
+        respondJson(res, 200, result);
         return;
       }
       if (req.method === "POST") {
@@ -1019,19 +979,15 @@ const server = createServer(async (req, res) => {
           message: body?.message,
         });
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify(result));
+        respondJson(res, 200, result);
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -1068,19 +1024,15 @@ const server = createServer(async (req, res) => {
           project,
         });
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ path: result.path, key: result.key, hint: result.hint }));
+        respondJson(res, 200, { path: result.path, key: result.key, hint: result.hint });
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -1106,15 +1058,13 @@ const server = createServer(async (req, res) => {
             project,
             hint: body?.hint,
           },
-          { publish: (evt) => bus.publish(evt) },
+          BUS_PUBLISH_DEPS,
         );
         if (!result.ok) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: result.error }));
+          respondJson(res, 400, { error: result.error });
           return;
         }
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ meta: result.meta }));
+        respondJson(res, 200, { meta: result.meta });
         return;
       }
       if (req.method === "GET") {
@@ -1123,27 +1073,16 @@ const server = createServer(async (req, res) => {
         const all = url.searchParams.get("all") === "1";
         const project = all ? null : await resolveProjectName({ sessionID, directory });
         const secrets = listSecrets({ sessionID, project, includeAll: all });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ secrets }));
+        respondJson(res, 200, { secrets });
         return;
       }
       if (req.method === "DELETE") {
-        const id = url.searchParams.get("id");
-        if (!id) {
-          res.writeHead(400, { "content-type": "application/json" });
-          res.end(JSON.stringify({ error: "id is required" }));
-          return;
-        }
-        const result = await deleteSecret(id, { publish: (evt) => bus.publish(evt) });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ deleted: result.deleted }));
+        await handleApiDelete(req, url, res, deleteSecret);
         return;
       }
-      res.writeHead(405, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "method not allowed" }));
+      respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -1159,11 +1098,9 @@ const server = createServer(async (req, res) => {
   if (req.method === "GET" && path === "/push/vapid") {
     try {
       const key = await push.getVapidPublic();
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ key }));
+      respondJson(res, 200, { key });
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }
@@ -1172,8 +1109,7 @@ const server = createServer(async (req, res) => {
     try {
       body = await readJsonBody(req);
     } catch {
-      res.writeHead(400, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "bad json" }));
+      respondJson(res, 400, { error: "bad json" });
       return;
     }
     try {
@@ -1203,15 +1139,12 @@ const server = createServer(async (req, res) => {
         });
         result = { ok: true };
       } else {
-        res.writeHead(404, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: "not found" }));
+        respondJson(res, 404, { error: "not found" });
         return;
       }
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify(result));
+      respondJson(res, 200, result);
     } catch (e) {
-      res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(e?.message ?? e) }));
+      respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;
   }


### PR DESCRIPTION
## What

Stage 2 of BET-151 (Launch-ready onboarding).

- **Agent auth overwrite (ADR-1):** every relay→box proxied request is authenticated to 127.0.0.1:8787 with the BOX's own `box_token`. `makeDefaultLocalFetch` now plumbs the agent's `auth` and unconditionally overwrites any inbound `Authorization` header (case-insensitive) before calling the local server.
- **Server startup wiring:** `manta-server` starts the agent at boot when `shouldStartRelayAgent(config)` is true (default on; opt out with `"relayEnabled": false` in `~/.manta/config.json`). New loopback-only `GET /relay/status` endpoint exposes `{ enabled, connected }` so install.sh can poll for the handshake without standing up its own WS.
- **install.sh handshake check:** after `waitForHealth`, `waitForRelay` polls `/relay/status`; best-effort (`ok`/`warn`, never `die`). Final heredoc states devices pair THROUGH the relay and prints the `box_id` alongside the pairing code via the tested `readBoxIdentity` re-export of `loadAuth` (no ad-hoc bash JSON parsing).

## Files (per issue's hygiene checklist)

`src/relay/agent/index.mjs`, `src/relay/agent/index.test.mjs`, `src/server/index.mjs`, `scripts/install.sh`, `scripts/install-lib.mjs`, `scripts/install.test.mjs`. **No new files.**

`grep -rn relayEnabled src/ scripts/` returns only: helper + test in agent, config read in server/index.mjs, and the install.sh log line. **No renderer/main references.**

## Verification

- `npm run typecheck`: green
- `npm test`: 559/559 pass (vitest 919/919)
- `node --test src/relay/agent/index.test.mjs`: 27/27
- `node --test scripts/install.test.mjs`: 40/40

Base: `main` @ e856da8
Branch: `multica/BET-155-relay-agent-auth-start` @ 42c1391

## Tests added

**agent/index.test.mjs:**
- `shouldStartRelayAgent` truth table (null/undef/true → true; only `false` opts out)
- `makeDefaultLocalFetch` foreign-Auth overwrite (case-insensitive across Authorization variants), no-auth fallback, unrelated-header pass-through, valid-token-only constructor, end-to-end through the agent with default wiring
- `status()` transitions: never-started (stopped), after successful start (connected), after drop with reconnect armed (connecting), after stop (stopped + ignores late drop), mid-backoff (connecting)

**scripts/install.test.mjs:**
- `waitForRelay`: first-try 2xx, enabled:false short-circuit, ECONNREFUSED retry, in-progress (connected flips true on attempt 4), max-attempts cap (degraded), non-JSON body, non-2xx retry, trailing-slash normalization, all-server-down (ok:false), required-args
- `readBoxIdentity`: valid auth.json round-trip via temp file, missing file (null), corrupt JSON (null)

## Cross-cutting notes

- The agent owns its own reconnect/backoff loop; this PR does NOT add another retry loop. `server/index.mjs` wires `agent.start()` fire-and-forget.
- `waitForRelay` is best-effort by design — relay outage never fails the install (the box still works locally).
- Loopback gating on `/relay/status` mirrors `/auth/pair` (same `isLocalDirectRequest` check).
- `status()` "connecting" is intentionally sticky across reconnects so a UI asking "is the link healthy?" doesn't flicker during the backoff window.