### PR TITLE
feat(relay): desktop pairs + connects through the relay (SSE streaming included)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -385,7 +385,19 @@ esac
 
 log "Minting pairing code…"
 # Delegate to the same `manta pair` CLI the user runs later (loopback GET /auth/pair).
-node "$MANTA_HOME/scripts/manta-pair.mjs" || die "failed to mint pairing code (is the server local-reachable?)"
+# We CAPTURE stdout this time so the install-sh heredoc below can quote the
+# ready-to-paste `manta://pair?box=…&code=…` link — BET-156 §1. manta-pair.mjs
+# prints a stable "  Pairing code:  NNNNNN" line via formatPairingOutput, which
+# we sed-extract (no second JSON round-trip; the format is the contract).
+PAIR_BLOCK="$(node "$MANTA_HOME/scripts/manta-pair.mjs" 2>/dev/null || true)"
+# Echo the formatted block so the user still sees it on stdout (the heredoc
+# below ONLY surfaces the box id + ready-to-paste link, not the full block).
+printf '%s\n' "$PAIR_BLOCK"
+PAIR_CODE="$(printf '%s\n' "$PAIR_BLOCK" | sed -n 's/^  Pairing code:[[:space:]]\+\([0-9]\{6\}\).*/\1/p' | head -n1)"
+export PAIR_CODE
+if [ -z "$PAIR_CODE" ]; then
+  warn "could not extract a 6-digit code from manta-pair.mjs output — pair link will be omitted."
+fi
 
 # Read the box_id from ~/.manta/auth.json via the tested install-lib loader
 # (NEVER re-parse the JSON in bash — auth.json's shape belongs to the server).
@@ -416,6 +428,15 @@ EOF
 
 if [ -n "$BOX_ID_DISPLAY" ]; then
   printf '\n  Box ID:        %s\n' "$BOX_ID_DISPLAY"
+fi
+
+# Ready-to-paste pair link (BET-156 §1) — the desktop app parses this directly
+# via parsePairPayload and routes through the relay's /pair endpoint. Both
+# BOX_ID_DISPLAY and PAIR_CODE are loaded via tested helpers, so this is safe
+# even if either is missing (we just print the available half, never crash).
+if [ -n "${BOX_ID_DISPLAY:-}" ] && [ -n "${PAIR_CODE:-}" ]; then
+  printf '\n  Pair link:     manta://pair?box=%s&code=%s\n' "$BOX_ID_DISPLAY" "$PAIR_CODE"
+  printf '                 (paste into the desktop app, or scan as a QR)\n'
 fi
 
 cat <<EOF

--- a/src/main/auth.test.ts
+++ b/src/main/auth.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import { claimPairing } from "./auth.js";
-import type { AppConfig } from "../shared/types.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { claimPairing, RELAY_BASE } from "./auth.js";
+import type { AppConfig, AuthClaimInput } from "../shared/types.js";
 
 const HEX32 = "0123456789abcdef0123456789abcdef";
 const HEX32B = "fedcba9876543210fedcba9876543210";
@@ -41,7 +41,7 @@ function stubFetch(res: Response | { throw: true }): {
 // failure cases from each repeating the same ~11-line scaffold.
 async function expectClaimFailure(
   res: Response | { throw: true },
-  input: { serverUrl: string; code: string },
+  input: AuthClaimInput,
   kind: string,
 ): Promise<{ urls: string[] }> {
   const { fetch, urls } = stubFetch(res);
@@ -138,5 +138,145 @@ describe("claimPairing", () => {
     );
     // No fetch should have happened for a blank server URL.
     expect(urls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Relay branch (BET-156 / ADR-3) — payload.boxId present → POST <relay>/pair
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_TOKEN = "aabbccddeeff00112233445566778899"; // 32 hex; account_token
+
+// Reset MANTA_RELAY_BASE so a developer's env doesn't leak into tests.
+beforeEach(() => {
+  delete process.env.MANTA_RELAY_BASE;
+});
+
+describe("claimPairing — relay branch (boxId present)", () => {
+  it("RELAY_BASE is the canonical relay host (single source for the desktop)", () => {
+    expect(RELAY_BASE).toBe("https://relay.mantaui.com");
+  });
+
+  it("valid boxId → POSTs <relay>/pair with { box_id, code }, persists { serverUrl: <relay>/box/<id>, boxId, boxToken: account_token }", async () => {
+    const { fetch, urls, bodies } = stubFetch(
+      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "", boxId: HEX32B, code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out).toEqual({ ok: true, boxToken: ACCOUNT_TOKEN, boxId: HEX32B });
+    expect(urls).toEqual(["https://relay.mantaui.com/pair"]);
+    expect(JSON.parse(bodies[0])).toEqual({ box_id: HEX32B, code: "847291" });
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledWith({
+      serverUrl: `https://relay.mantaui.com/box/${HEX32B}`,
+      boxId: HEX32B,
+      boxToken: ACCOUNT_TOKEN,
+    });
+  });
+
+  it("HONORS MANTA_RELAY_BASE env override (tests only — same shape, just a different host)", async () => {
+    process.env.MANTA_RELAY_BASE = "http://127.0.0.1:9999";
+    const { fetch, urls, bodies } = stubFetch(
+      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    await claimPairing({ serverUrl: "", boxId: HEX32B, code: "847291" }, persist, fetch);
+
+    expect(urls).toEqual(["http://127.0.0.1:9999/pair"]);
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverUrl: `http://127.0.0.1:9999/box/${HEX32B}`,
+      }),
+    );
+    // suppress unused
+    void bodies;
+  });
+
+  it("wrong/expired code (403) → wrong_code, does NOT persist", async () => {
+    await expectClaimFailure(
+      fakeResponse(403, { error: "claim rejected" }),
+      { serverUrl: "", boxId: HEX32B, code: "000000" },
+      "wrong_code",
+    );
+  });
+
+  it("rate limited (429) → rate_limited, no persist", async () => {
+    await expectClaimFailure(
+      fakeResponse(429, { error: "slow down" }),
+      { serverUrl: "", boxId: HEX32B, code: "847291" },
+      "rate_limited",
+    );
+  });
+
+  it("box offline (relay 503 box_offline) → server_error, no persist", async () => {
+    await expectClaimFailure(
+      fakeResponse(503, { error: "box_offline" }),
+      { serverUrl: "", boxId: HEX32B, code: "847291" },
+      "server_error",
+    );
+  });
+
+  it("200 with a malformed account_token → invalid_response, no persist", async () => {
+    await expectClaimFailure(
+      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: "nope" }),
+      { serverUrl: "", boxId: HEX32B, code: "847291" },
+      "invalid_response",
+    );
+  });
+
+  it("unreachable relay (fetch rejects) → network, no persist", async () => {
+    await expectClaimFailure(
+      { throw: true },
+      { serverUrl: "", boxId: HEX32B, code: "847291" },
+      "network",
+    );
+  });
+
+  it("malformed boxId → network outcome without ever fetching", async () => {
+    const { fetch, urls } = stubFetch(
+      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "", boxId: "not-32-hex", code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("network");
+    expect(persist).not.toHaveBeenCalled();
+    expect(urls).toEqual([]); // never even tried the relay
+  });
+
+  it("serverUrl empty + boxId present → relay branch (the desktop's box-form input)", async () => {
+    const { fetch, urls } = stubFetch(
+      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    // PairStep sends { serverUrl: "", boxId: HEX32B, code } for the box form
+    // (empty serverUrl keeps httpApi's mobile-only type signature unchanged).
+    const out = await claimPairing(
+      { serverUrl: "", boxId: HEX32B, code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out.ok).toBe(true);
+    expect(urls).toEqual(["https://relay.mantaui.com/pair"]);
+    expect(persist).toHaveBeenCalledWith({
+      serverUrl: `https://relay.mantaui.com/box/${HEX32B}`,
+      boxId: HEX32B,
+      boxToken: ACCOUNT_TOKEN,
+    });
   });
 });

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -1,11 +1,23 @@
-// auth.ts (desktop) — the onboarding pairing handshake (BET-49-T2).
+// auth.ts (desktop) — the onboarding pairing handshake (BET-49-T2, BET-156).
 //
-// The desktop onboarding shell's Step 1 (Pair) sends a 6-digit pairing code +
-// the target server URL over the `auth:claim` IPC channel. This module owns the
-// main-process half: POST <serverUrl>/auth/claim, classify the outcome with the
-// SHARED classifier (src/shared/claim.mjs — the same one the mobile client and
-// the pure tests use), and on success persist { serverUrl, boxId, boxToken } to
-// config so resolveTransportMode flips the app into "http" mode on next read.
+// The desktop onboarding shell's Step 1 (Pair) accepts a 6-digit pairing code
+// plus ONE OF two addressing shapes (typed AuthClaimInput, src/shared/types.ts):
+//   • serverUrl — direct-HTTPS pairing (BET-49): POST <serverUrl>/auth/claim
+//     { pairing_code } → { box_id, box_token }. Persist
+//     { serverUrl, boxId, boxToken } to config.
+//   • boxId — relay-paired pairing (BET-156, ADR-2/3): POST
+//     https://relay.mantaui.com/pair { box_id, code } →
+//     { box_id, account_id, account_token }. Persist
+//     { serverUrl: "<RELAY_BASE>/box/<box_id>", boxId, boxToken:
+//     account_token }. From that point on EVERYTHING downstream (httpApi base,
+//     Bearer header, /events EventSource ?token=, uploads) works untouched
+//     because the relay's /box/:box_id/* proxy makes the box's HTTP surface
+//     appear under that prefix — ADR-3, no httpApi edits.
+//
+// Both flows route through the SAME `claimPairing` function (no `*V2`, no
+// parallel copies). The branch is INSIDE this function, keyed by which input
+// field is populated. Outcome classification reuses the shared helper in
+// src/shared/claim.mjs (the same one the mobile client and pure tests use).
 //
 // Why main (not the renderer) does the fetch: only main can write config.json.
 // The mobile client authenticates with a localStorage Bearer token instead, so
@@ -13,14 +25,30 @@
 // contract, different persistence — hence the shared classifier keeps the two
 // entry points from drifting.
 
-import { classifyClaimResult, networkFailure } from "../shared/claim.mjs";
+import {
+  classifyClaimResult,
+  classifyRelayClaimResult,
+  networkFailure,
+} from "../shared/claim.mjs";
 import type { ClaimOutcome } from "../shared/claim.mjs";
 import type { AppConfig, AuthClaimInput } from "../shared/types.js";
+import { isValidToken } from "../server/webhooks.mjs";
+
+// The single relay base URL every relay-mode desktop pairs through. Hardcoded
+// per BET-156 (ADR-3) so a desktop user doesn't need to know or type the
+// relay hostname — they paste the pair link (manta://pair?box=…&code=…) which
+// only carries the box id. `MANTA_RELAY_BASE` is an env override used by tests
+// (and any future staging ring) — not a user-facing knob.
+export const RELAY_BASE = "https://relay.mantaui.com";
+
+function relayBase() {
+  return process.env.MANTA_RELAY_BASE || RELAY_BASE;
+}
 
 /**
  * Perform a pairing claim and, on success, persist the credentials to config.
  *
- * @param input    { serverUrl, code } from the renderer.
+ * @param input    { serverUrl?, boxId?, code } from the renderer.
  * @param persist  commit a config patch (main's `commit`); called ONLY on a
  *                 successful, token-validated claim.
  * @param fetchImpl  injectable for tests; defaults to the global fetch.
@@ -33,13 +61,35 @@ export async function claimPairing(
   persist: (patch: Partial<AppConfig>) => void,
   fetchImpl: typeof fetch = fetch,
 ): Promise<ClaimOutcome> {
-  const serverUrl = (input?.serverUrl ?? "").trim();
   const code = input?.code ?? "";
 
-  // An empty / whitespace-only URL can't be fetched — surface it as a network
-  // failure (the UI shows the URL for correction) rather than throwing.
-  if (serverUrl === "") return networkFailure();
+  const serverUrl = (input?.serverUrl ?? "").trim();
+  const boxId = (input?.boxId ?? "").trim();
 
+  // Branch routing: when the caller passes a boxId, take the relay path even
+  // if they ALSO passed a (necessarily empty) serverUrl — see AuthClaimInput.
+  // We treat "non-empty boxId" as the sole signal because the desktop PairStep
+  // is the only caller that uses the box form, and it always sends serverUrl=""
+  // in that case. A non-empty serverUrl + non-empty boxId is a caller invariant
+  // violation (UI never sends both) → network failure.
+  if (boxId !== "") {
+    return claimPairingRelay(boxId, code, persist, fetchImpl);
+  }
+  if (serverUrl !== "") {
+    return claimPairingDirect(serverUrl, code, persist, fetchImpl);
+  }
+  // Neither present → nothing to claim against.
+  return networkFailure();
+}
+
+// ---- Direct-HTTPS branch (legacy BET-49 behavior, unchanged) ----
+
+async function claimPairingDirect(
+  serverUrl: string,
+  code: string,
+  persist: (patch: Partial<AppConfig>) => void,
+  fetchImpl: typeof fetch,
+): Promise<ClaimOutcome> {
   // Trim trailing slashes so "http://box:8787/" and "http://box:8787" behave
   // identically before appending the claim path.
   const url = `${serverUrl.replace(/\/+$/, "")}/auth/claim`;
@@ -71,6 +121,74 @@ export async function claimPairing(
     persist({
       serverUrl: serverUrl.replace(/\/+$/, ""),
       boxId: outcome.boxId,
+      boxToken: outcome.boxToken,
+    });
+  }
+  return outcome;
+}
+
+// ---- Relay branch (BET-156 / ADR-3) ----
+
+/**
+ * POST `${RELAY_BASE}/pair { box_id, code }` and, on 200, persist the relay-
+ * shaped triple (the box's HTTP surface appears under `<RELAY_BASE>/box/<id>`
+ * from the desktop's point of view). The relay is responsible for:
+ *   1. rate-limiting unauthenticated /pair (its own createRateLimiter),
+ *   2. forwarding the claim to the box's live tunnel (`/auth/claim`),
+ *   3. minting an account_token (the desktop's "boxToken" slot) and binding it
+ *      to the box.
+ * The desktop never sees the box's box_token (ADR-1) — only the relay-minted
+ * account_token, presented as `Authorization: Bearer <boxToken>` to the
+ * relay. From httpApi's perspective the URL is just `serverUrl + subpath` —
+ * no httpApi changes required.
+ */
+async function claimPairingRelay(
+  boxId: string,
+  code: string,
+  persist: (patch: Partial<AppConfig>) => void,
+  fetchImpl: typeof fetch,
+): Promise<ClaimOutcome> {
+  // Shape-gate the box_id before we spend a round-trip. isValidToken is the
+  // canonical 32-hex check (same one the relay handshake uses); a malformed id
+  // is a network failure from the desktop's POV (the UI prompts to re-paste).
+  if (!isValidToken(boxId)) return networkFailure();
+
+  const base = relayBase();
+  const url = `${base.replace(/\/+$/, "")}/pair`;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ box_id: boxId, code }),
+    });
+  } catch {
+    return networkFailure();
+  }
+
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* leave null; classify by status */
+  }
+
+  // We classify a /pair response with the SAME ClaimOutcome shape the direct
+  // branch returns so the renderer can keep one error-handling path. The relay
+  // returns the same failure semantics (400/403/429/5xx) as the box's own
+  // /auth/claim; classifyRelayClaimResult collapses both 400/403 into
+  // `wrong_code` and 5xx into `server_error` — exactly what we want. The only
+  // difference vs the direct branch is the 200 body parser (account_token
+  // vs box_token field name) — see claim.mjs.
+  const outcome = classifyRelayClaimResult(res.status, body);
+  if (outcome.ok) {
+    // Persist the relay-shaped triple. serverUrl is the relay's per-box proxy
+    // prefix so every downstream /rpc + /events + upload call naturally lands
+    // on `/box/<box_id>/*` — ADR-3, zero new data-path code.
+    persist({
+      serverUrl: `${base.replace(/\/+$/, "")}/box/${boxId}`,
+      boxId,
       boxToken: outcome.boxToken,
     });
   }

--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -230,6 +230,52 @@ export function makeDefaultLocalFetch(localBase, auth) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Streaming local-fetch leg (BET-156). Calls the box server over loopback but
+// returns the response body as a stream (ReadableStream<Uint8Array>) instead
+// of buffering. Used for SSE/PTY where buffering would defeat streaming.
+// ---------------------------------------------------------------------------
+
+// ADR-1 applies identically to the streaming fetch: every outbound request
+// carries the box's own `Bearer <box_token>` regardless of what the inbound
+// frame carried. Same case-insensitive header-stripping as makeDefaultLocalFetch.
+//
+// The returned function resolves with `{ status, headers, body }` where `body`
+// is the response's ReadableStream — the caller (handleStreamOpen) reads it
+// chunk-by-chunk and pumps each chunk as a STREAM_DATA frame.
+//
+// We do NOT consume the body here: stream consumers own the lifecycle and the
+// relay decides when to abort/end. If the local fetch rejects (offline / TLS
+// / etc.) the returned promise rejects — the caller emits STREAM_ABORT.
+export function makeDefaultLocalFetchStream(localBase, auth) {
+  if (!auth || !isValidToken(auth?.box_token)) {
+    throw new Error(
+      "makeDefaultLocalFetchStream: valid { box_token } required " +
+        "(the box's own identity — never the device's account token)",
+    );
+  }
+  const bearer = `Bearer ${auth.box_token}`;
+  return async function defaultLocalFetchStream({ method, path, headers, body }) {
+    const url = `${localBase}${path.startsWith("/") ? path : `/${path}`}`;
+    const outHeaders = {};
+    if (headers && typeof headers === "object") {
+      for (const k of Object.keys(headers)) {
+        if (k.toLowerCase() === "authorization") continue;
+        outHeaders[k] = headers[k];
+      }
+    }
+    outHeaders.authorization = bearer;
+    const res = await fetch(url, {
+      method,
+      headers: outHeaders,
+      body: body != null && method !== "GET" && method !== "HEAD" ? body : undefined,
+    });
+    const respHeaders = {};
+    for (const [k, v] of res.headers) respHeaders[k] = v;
+    return { status: res.status, headers: respHeaders, body: res.body };
+  };
+}
+
 // ADR-1 (BET-151) — pure config decision: should the box server start the relay
 // agent at boot? The product default is YES (relay-first is the path to a paid
 // mobile app — BET-151). The owner's box can opt out by writing
@@ -269,6 +315,11 @@ export function shouldStartRelayAgent(config) {
  *   INJECTABLE local-server leg. Defaults to `makeDefaultLocalFetch(localBase,
  *   auth)`, which overwrites any inbound `Authorization` header with the box's
  *   own bearer before calling `fetch`.
+ * @param {(req:{method,path,headers,body})=>Promise<{status,headers,body}>} [opts.localFetchStream]
+ *   INJECTABLE streaming local-server leg. Same auth-overwrite semantics as
+ *   `localFetch`, but returns the response body as a ReadableStream (used for
+ *   SSE/PTY where buffering would defeat streaming). Defaults to
+ *   `makeDefaultLocalFetchStream(localBase, auth)`.
  * @param {{next():number,reset():void,attempt():number}} [opts.backoff]
  *   INJECTABLE reconnect backoff (ExponentialBackoff-compatible). Default mirror
  *   of src/shared/net/backoff.ts.
@@ -297,6 +348,8 @@ export function createRelayAgent(opts = {}) {
     );
   }
   const localFetch = opts.localFetch || makeDefaultLocalFetch(localBase, auth);
+  const localFetchStream =
+    opts.localFetchStream || makeDefaultLocalFetchStream(localBase, auth);
 
   // Per-box streams inbound over the tunnel (Stage-4 SSE/PTY). We own a registry
   // so a relay→box STREAM_* frame is routed, but the box→phone direction (this
@@ -357,6 +410,130 @@ export function createRelayAgent(opts = {}) {
     }
   }
 
+  // --- stream proxy (BET-156) ---------------------------------------------
+
+  // Handle a relay→box STREAM_OPEN request form: open a streaming local fetch,
+  // forward the response head (status + headers) back as STREAM_OPEN (response
+  // form), then pump the response body as STREAM_DATA frames and STREAM_END on
+  // clean completion. Aborts (STREAM_ABORT) on local-fetch error / read error.
+  //
+  // The relay assigned the stream id; the agent must echo the SAME id in its
+  // outbound frames so the relay's inbound registry routes them to the right
+  // consumer. The frame's `id` is the request's correlating id (kept around
+  // for parity with non-stream REQUEST/RESPONSE).
+  async function handleStreamOpen(frame) {
+    const t = transport;
+    if (!t) return; // socket dropped between recv and dispatch; relay will retry
+
+    let res;
+    try {
+      res = await localFetchStream({
+        method: frame.method,
+        path: frame.path,
+        headers: frame.headers,
+        body: frame.body,
+      });
+    } catch (err) {
+      if (transport !== t) return;
+      try {
+        t.send({
+          type: FRAME_TYPES.STREAM_ABORT,
+          id: frame.id,
+          stream: frame.stream,
+          reason: String(err?.message || err),
+        });
+      } catch {
+        /* socket closing; ignore */
+      }
+      return;
+    }
+
+    // Guard: the socket may have dropped while we awaited the local call.
+    if (transport !== t) {
+      try { res.body?.cancel?.(); } catch { /* ignore */ }
+      return;
+    }
+
+    // Send the response head as STREAM_OPEN (response form). The relay's inbound
+    // stream registry delivers this to the consumer's onOpen; that consumer
+    // writes status + headers to the phone's HTTP response.
+    const respHeaders = {};
+    if (res.headers) {
+      // Headers from node:fetch is a Headers object; from a fake test fixture
+      // it's typically a Map. Both are iterable as [k, v] pairs — Object.entries
+      // doesn't work on either (they're not plain objects), so iterate directly.
+      for (const [k, v] of res.headers) respHeaders[k] = v;
+    }
+    try {
+      t.send({
+        type: FRAME_TYPES.STREAM_OPEN,
+        id: frame.id,
+        stream: frame.stream,
+        status: res.status,
+        headers: respHeaders,
+      });
+    } catch {
+      try { res.body?.cancel?.(); } catch { /* ignore */ }
+      return;
+    }
+
+    // Pump body chunks as STREAM_DATA frames. The local fetch returns a
+    // ReadableStream<Uint8Array>; we decode each chunk with TextDecoder
+    // (stream:true handles multi-byte UTF-8 boundaries across chunks) so the
+    // relay gets a string per frame — STREAM_DATA.data must be a string by
+    // protocol.
+    if (!res.body) {
+      t.send({ type: FRAME_TYPES.STREAM_END, id: frame.id, stream: frame.stream });
+      return;
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        // Decode with stream:true so any unterminated multi-byte char at the
+        // chunk tail is held over to the next chunk (TextDecoder docs).
+        const chunk = decoder.decode(value, { stream: true });
+        if (chunk) {
+          if (transport !== t) return; // socket dropped mid-pump
+          t.send({
+            type: FRAME_TYPES.STREAM_DATA,
+            id: frame.id,
+            stream: frame.stream,
+            data: chunk,
+          });
+        }
+      }
+      // Flush any tail bytes the decoder held over.
+      const tail = decoder.decode();
+      if (tail) {
+        if (transport !== t) return;
+        t.send({
+          type: FRAME_TYPES.STREAM_DATA,
+          id: frame.id,
+          stream: frame.stream,
+          data: tail,
+        });
+      }
+      if (transport !== t) return;
+      t.send({ type: FRAME_TYPES.STREAM_END, id: frame.id, stream: frame.stream });
+    } catch (err) {
+      try {
+        if (transport === t) {
+          t.send({
+            type: FRAME_TYPES.STREAM_ABORT,
+            id: frame.id,
+            stream: frame.stream,
+            reason: String(err?.message || err),
+          });
+        }
+      } catch {
+        /* socket closing; ignore */
+      }
+    }
+  }
+
   // Dispatch one decoded inbound frame.
   function onFrame(frame) {
     if (!frame) return; // decodeFrame dropped malformed/oversized/unknown input
@@ -366,15 +543,26 @@ export function createRelayAgent(opts = {}) {
         void handleRequest(frame);
         break;
       case FRAME_TYPES.STREAM_OPEN:
+        // Request-side open from the relay → open a local streaming fetch and
+        // pipe the response back over STREAM_OPEN (response form) + DATA + END.
+        // The agent IS the local producer for SSE/PTY streams; the inbound
+        // stream registry (this.streams) is for the box→relay direction
+        // (already-driven, no-op for the request form here).
+        // Guard on the form: a response-side STREAM_OPEN (status, no method)
+        // arriving from the relay is a protocol error — drop.
+        if (typeof frame.method === "string") {
+          void handleStreamOpen(frame);
+        } else {
+          warn("[relay-agent] ignored STREAM_OPEN without method (response form from relay is invalid)");
+        }
+        break;
       case FRAME_TYPES.STREAM_DATA:
       case FRAME_TYPES.STREAM_END:
       case FRAME_TYPES.STREAM_ABORT:
-        // TODO(Stage 4): PTY/SSE stream proxying. The mux is wired (streams
-        // registry routes these to a per-stream consumer), but the box→phone
-        // SSE/PTY producers that OPEN those streams need the Stage-4 phone-facing
-        // endpoints to exercise end-to-end. Until then a relay→box stream frame
-        // is routed if a consumer is registered and otherwise dropped — never
-        // misrouted. No request/response path depends on this.
+        // Box→relay stream frames — routed through the per-transport inbound
+        // stream registry. (No box-side consumer registers these today, so
+        // the registry's drop-on-no-consumer invariant is fine: a stray
+        // STREAM_DATA from the relay is a protocol bug, not a data path.)
         streams.handleFrame(frame);
         break;
       case FRAME_TYPES.PONG:

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -4,6 +4,7 @@ import {
   createRelayAgent,
   createBackoff,
   makeDefaultLocalFetch,
+  makeDefaultLocalFetchStream,
   shouldStartRelayAgent,
   DEFAULT_RELAY_URL,
   RECONNECT_BASE_MS,
@@ -677,4 +678,211 @@ test("status() is \"connecting\" between a failed dial and the next attempt", as
   await agent.start(); // attempt 1 fails → reconnect armed
   assert.equal(agent.status(), "connecting");
   agent.stop();
+});
+
+// ---------------------------------------------------------------------------
+// SSE/PTY streaming path (BET-156 §3) — STREAM_OPEN (request form) is proxied
+// to a streaming local fetch; the agent forwards the response head + body as
+// STREAM_OPEN (response form) + STREAM_DATA + STREAM_END, preserving chunk
+// boundaries so SSE bytes arrive at the phone as they leave the box.
+// ---------------------------------------------------------------------------
+
+// A minimal Response-shaped object that exposes `body` as a web ReadableStream
+// the test can pump chunks into. Mirrors what node:fetch returns for an SSE
+// response. enqueue() pushes a chunk; close() ends the stream.
+function makeFakeStreamResponse({ status = 200, headers = {} } = {}) {
+  let controller;
+  const body = new ReadableStream({
+    start(c) {
+      controller = c;
+    },
+  });
+  // jsdom + Node 18+: ReadableStream is global on Node 18+; if missing, we
+  // surface a clearer error.
+  return {
+    response: {
+      status,
+      headers: new Map(Object.entries(headers)),
+      body,
+    },
+    enqueue(chunk) {
+      controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+    },
+    close() {
+      try { controller.close(); } catch { /* already closed */ }
+    },
+    error(reason) {
+      try { controller.error(reason); } catch { /* already closed */ }
+    },
+  };
+}
+
+test("agent turns an event-stream local response into OPEN→DATA×n→END frames preserving chunk boundaries", async () => {
+  // The relay sends a STREAM_OPEN (request form) down the tunnel. The agent
+  // opens a streaming local fetch, gets back an SSE-style response, and
+  // pumps the body chunk-by-chunk as STREAM_DATA frames preserving the
+  // chunk boundaries (the relay's api side asserts res.write was called
+  // once per DATA — the byte-ordering matches what the box server sent).
+  const stream = makeFakeStreamResponse({
+    status: 200,
+    headers: { "content-type": "text/event-stream", "cache-control": "no-store" },
+  });
+  const localFetchStream = async () => stream.response;
+
+  const { relay, agent } = makeStubAgent({ localFetchStream });
+  await agent.start();
+
+  relay.sendToClient({
+    type: FRAME_TYPES.STREAM_OPEN,
+    id: 7,
+    stream: "relay-stream-1",
+    method: "GET",
+    path: "/events?token=abc",
+  });
+
+  // Wait for STREAM_OPEN (response form) to be sent before pumping data.
+  for (let i = 0; i < 20 && !relay.clientSent().some((f) => f && f.type === FRAME_TYPES.STREAM_OPEN && f.stream === "relay-stream-1"); i++) {
+    await Promise.resolve();
+  }
+  // Pump three chunks in distinct boundary-preserving units.
+  stream.enqueue("data: hello\n\n");
+  // Let the agent read each chunk and send a STREAM_DATA frame.
+  for (let i = 0; i < 20 && relay.clientSent().filter((f) => f && f.type === FRAME_TYPES.STREAM_DATA && f.stream === "relay-stream-1").length < 1; i++) {
+    await Promise.resolve();
+  }
+  stream.enqueue("data: world\n\n");
+  for (let i = 0; i < 20 && relay.clientSent().filter((f) => f && f.type === FRAME_TYPES.STREAM_DATA && f.stream === "relay-stream-1").length < 2; i++) {
+    await Promise.resolve();
+  }
+  stream.enqueue("data: end\n\n");
+  for (let i = 0; i < 20 && relay.clientSent().filter((f) => f && f.type === FRAME_TYPES.STREAM_DATA && f.stream === "relay-stream-1").length < 3; i++) {
+    await Promise.resolve();
+  }
+  stream.close();
+  // Wait for STREAM_END.
+  for (let i = 0; i < 30 && !relay.clientSent().some((f) => f && f.type === FRAME_TYPES.STREAM_END && f.stream === "relay-stream-1"); i++) {
+    await Promise.resolve();
+  }
+
+  const sent = relay.clientSent().filter((f) => f && f.stream === "relay-stream-1");
+  // Sequence: OPEN, DATA, DATA, DATA, END — in order.
+  assert.deepEqual(
+    sent.map((f) => f.type),
+    ["stream-open", "stream-data", "stream-data", "stream-data", "stream-end"],
+    "frame sequence is OPEN→DATA×3→END",
+  );
+  // The response-side STREAM_OPEN carries the upstream status + headers
+  // verbatim, so the relay's api side can writeHead(status, headers).
+  const headFrame = sent[0];
+  assert.equal(headFrame.id, 7, "response-side STREAM_OPEN echoes the request id");
+  assert.equal(headFrame.stream, "relay-stream-1", "same stream id");
+  assert.equal(headFrame.status, 200);
+  assert.equal(headFrame.headers["content-type"], "text/event-stream");
+  // Chunk boundaries: three DATA frames, each with its chunk's bytes.
+  assert.deepEqual(
+    sent.slice(1, -1).map((f) => f.data),
+    ["data: hello\n\n", "data: world\n\n", "data: end\n\n"],
+    "chunk boundaries preserved across STREAM_DATA frames",
+  );
+
+  agent.stop();
+});
+
+test("agent emits STREAM_ABORT when the streaming local fetch rejects", async () => {
+  const localFetchStream = async () => {
+    throw new Error("ECONNREFUSED 127.0.0.1:8787");
+  };
+  const { relay, agent } = makeStubAgent({ localFetchStream });
+  await agent.start();
+
+  relay.sendToClient({
+    type: FRAME_TYPES.STREAM_OPEN,
+    id: 9,
+    stream: "relay-stream-err",
+    method: "GET",
+    path: "/events?token=x",
+  });
+  for (let i = 0; i < 30 && !relay.clientSent().some((f) => f && f.type === FRAME_TYPES.STREAM_ABORT && f.stream === "relay-stream-err"); i++) {
+    await Promise.resolve();
+  }
+
+  const abort = relay.clientSent().find(
+    (f) => f && f.type === FRAME_TYPES.STREAM_ABORT && f.stream === "relay-stream-err",
+  );
+  assert.ok(abort, "a STREAM_ABORT frame was sent back");
+  assert.equal(abort.id, 9);
+  assert.match(abort.reason, /ECONNREFUSED/);
+
+  agent.stop();
+});
+
+test("agent ignores STREAM_OPEN in response form (no method) — protocol guard", async () => {
+  // A response-form STREAM_OPEN arriving from the relay is a wire protocol
+  // bug (the relay never sends response forms). The agent warns and drops
+  // it instead of treating it as a request to open a local fetch.
+  const localFetchStream = async () => {
+    throw new Error("should not be called");
+  };
+  const { relay, agent } = makeStubAgent({ localFetchStream });
+  await agent.start();
+
+  relay.sendToClient({
+    type: FRAME_TYPES.STREAM_OPEN,
+    id: 11,
+    stream: "ghost-stream",
+    status: 200,
+    headers: {},
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const sent = relay.clientSent().filter((f) => f && f.stream === "ghost-stream");
+  assert.equal(sent.length, 0, "no frames sent in response to a response-form STREAM_OPEN");
+
+  agent.stop();
+});
+
+// ---------------------------------------------------------------------------
+// makeDefaultLocalFetchStream — ADR-1 auth overwrite (mirrors localFetch test)
+// ---------------------------------------------------------------------------
+
+test("makeDefaultLocalFetchStream overwrites a foreign Authorization header with the BOX bearer", async () => {
+  const seen = [];
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    seen.push({ url, headers: init?.headers });
+    // The streaming path doesn't actually read body here — we just need the
+    // fetch call to be exercised; the assertions are on headers + URL.
+    return {
+      status: 200,
+      headers: new Map([["content-type", "text/event-stream"]]),
+      body: new ReadableStream({ start(c) { c.close(); } }),
+    };
+  };
+  try {
+    const localFetchStream = makeDefaultLocalFetchStream("http://127.0.0.1:8787", AUTH);
+    await localFetchStream({
+      method: "GET",
+      path: "/events?token=abc",
+      headers: { authorization: "Bearer account-token-from-device" },
+      body: undefined,
+    });
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+  assert.equal(seen.length, 1);
+  assert.equal(
+    seen[0].headers.authorization,
+    `Bearer ${BOX_TOKEN}`,
+    "Authorization is the BOX token, not the foreign account token",
+  );
+});
+
+test("makeDefaultLocalFetchStream requires a valid box_token (never accepts a missing/foreign one)", () => {
+  assert.throws(() => makeDefaultLocalFetchStream("http://127.0.0.1:8787", null), /box_token/);
+  assert.throws(() => makeDefaultLocalFetchStream("http://127.0.0.1:8787", undefined), /box_token/);
+  assert.throws(
+    () => makeDefaultLocalFetchStream("http://127.0.0.1:8787", { box_id: BOX_ID, box_token: "bad" }),
+    /box_token/,
+  );
 });

--- a/src/relay/api.mjs
+++ b/src/relay/api.mjs
@@ -158,6 +158,38 @@ export function createDefaultSubscriptionCheck(store, now = () => Date.now()) {
 }
 
 // ---------------------------------------------------------------------------
+// Streaming classification — which subpaths are stream-muxed (BET-156 §3)
+// ---------------------------------------------------------------------------
+//
+// The relay can forward a phone request to the box via the buffered
+// proxyRequest path (request + response, body buffered at the box's local
+// fetch — fine for JSON/snapshots) OR via the streaming streamRequest path
+// (SSE-style incremental chunks pumped as STREAM_* frames — required for
+// /events so the phone's EventSource receives bytes as the box emits them).
+// The decision is subpath-based, NOT content-type-based: the relay doesn't
+// know what the box will return until it asks, and asking first would defeat
+// the streaming behavior we want.
+//
+// The list is deliberately small and explicit (mirrors GATED_PREFIXES): every
+// path here must be a known streaming endpoint on the box server. Adding a new
+// entry is a one-line change AND a contract change with the box — both must
+// land together. Don't add a wildcard.
+const STREAMING_SUBPATH_PREFIXES = ["/events"];
+
+/**
+ * Classify a proxied box subpath as streaming (forwarded via STREAM_* frames)
+ * or buffered (forwarded via REQUEST/RESPONSE). Pure + exported so a test
+ * pins the boundary directly.
+ */
+export function isStreamingSubpath(subpath) {
+  if (typeof subpath !== "string" || !subpath) return false;
+  const clean = subpath.split("?")[0];
+  return STREAMING_SUBPATH_PREFIXES.some(
+    (p) => clean === p || clean.startsWith(`${p}/`),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // The relay API — normalized-request router + Node http adapter
 // ---------------------------------------------------------------------------
 
@@ -168,6 +200,13 @@ export function createDefaultSubscriptionCheck(store, now = () => Date.now()) {
  * @param {object} opts.store                a relay store (bindings/boxes/receipts/account_tokens).
  * @param {(boxId,req,o?)=>Promise<{status,headers?,body?}>} opts.proxyRequest
  *   the box-tunnel proxy from createRelayServer().proxyRequest.
+ * @param {(boxId,req,callbacks)=>{streamId:number,abort:(reason?:string)=>void}} [opts.streamRequest]
+ *   the streaming box-tunnel proxy from createRelayServer().streamRequest. Used
+ *   for /events (and any future streaming subpath); non-streaming requests keep
+ *   using proxyRequest so the buffered path is unchanged. Optional for
+ *   backwards-compat — when omitted, streaming subpaths fall back to the
+ *   buffered path (SSE bytes arrive all at once, which is the pre-BET-156
+ *   behavior and lets older relays still satisfy the rest of the surface).
  * @param {(req)=>({accountId:string}|null)} [opts.authenticatePhone]
  *   phone auth seam; default createDefaultPhoneAuth({ store, warn }).
  * @param {(boxId:string)=>boolean} [opts.hasActiveSubscription]
@@ -180,6 +219,7 @@ export function createRelayApi(opts = {}) {
   const {
     store,
     proxyRequest,
+    streamRequest,
     now = () => Date.now(),
     warn = console.warn,
   } = opts;
@@ -204,17 +244,22 @@ export function createRelayApi(opts = {}) {
   // -------------------------------------------------------------------------
   // Route a single normalized request. Returns a normalized response. Never
   // throws — a handler fault becomes a 500 so the HTTP layer always has a reply.
+  //
+  // `streamingSink` is optional. When the request is for a streaming subpath
+  // (/events), dispatch sets up the STREAM_* proxy and pipes every frame into
+  // the sink instead of returning a buffered response. The nodeHandler sees
+  // the `__stream` sentinel on the returned response and drives the sink.
   // -------------------------------------------------------------------------
-  async function route(req) {
+  async function route(req, streamingSink) {
     try {
-      return await dispatch(req);
+      return await dispatch(req, streamingSink);
     } catch (err) {
       warn(`[relay-api] handler error: ${String(err?.message || err)}`);
       return json(500, { error: "internal_error" });
     }
   }
 
-  async function dispatch(req) {
+  async function dispatch(req, streamingSink) {
     const method = (req.method || "GET").toUpperCase();
     const pathname = (req.path || "/").split("?")[0];
 
@@ -286,6 +331,37 @@ export function createRelayApi(opts = {}) {
         return json(402, { error: "payment_required", box_id: boxId });
       }
 
+      // Streaming subpaths (/events etc) take the STREAM_* path: the relay
+      // opens a stream to the box, then drives the phone's HTTP response
+      // from the box's STREAM_* frames. The router signals "I'm handling
+      // this inline" by returning a __stream sentinel whose `handler` the
+      // nodeHandler drives directly.
+      //
+      // When streamRequest is not configured (older relay) we fall through
+      // to the buffered path — pre-BET-156 behavior, the phone gets the
+      // full body at end-of-stream. Better than refusing the request.
+      if (isStreamingSubpath(subpath) && streamRequest) {
+        let resolved = false;
+        return {
+          __stream: true,
+          handler: () => {
+            if (resolved) return;
+            resolved = true;
+            return streamRequest(boxId, {
+              method,
+              path: subpath,
+              headers: sanitizeForwardHeaders(req.headers),
+              body: req.body,
+            }, {
+              onHead: (h) => streamingSink({ kind: "head", status: h.status, headers: h.headers }),
+              onData: (data) => streamingSink({ kind: "data", data }),
+              onEnd: () => streamingSink({ kind: "end" }),
+              onAbort: (reason) => streamingSink({ kind: "abort", reason: String(reason || "aborted") }),
+            });
+          },
+        };
+      }
+
       // Forward to the box's live tunnel. The relay preserves the phone's method
       // + body and forwards the subpath (not the /box/:box_id prefix) so the box
       // server sees the request as if made locally.
@@ -318,6 +394,11 @@ export function createRelayApi(opts = {}) {
   // -------------------------------------------------------------------------
   function nodeHandler() {
     return (httpReq, httpRes) => {
+      // streamHandle hoisted to the listener scope so the httpReq.on("close")
+      // handler below can abort an in-flight stream when the phone hangs up.
+      // It is assigned after dispatch resolves (the stream isn't opened until
+      // the route returns the __stream sentinel).
+      let streamHandle = null;
       const chunks = [];
       httpReq.on("data", (c) => chunks.push(c));
       httpReq.on("end", () => {
@@ -328,7 +409,52 @@ export function createRelayApi(opts = {}) {
           headers: httpReq.headers || {},
           body,
         };
-        route(req).then((resp) => {
+
+        // The streaming sink drives httpRes from STREAM_* frames. It's only
+        // invoked when dispatch returns the __stream sentinel; for buffered
+        // responses we use the regular writeHead+end below.
+        let headWritten = false;
+        const streamingSink = (event) => {
+          try {
+            switch (event.kind) {
+              case "head": {
+                // Content-Length must NOT be set for streaming responses
+                // (BET-156 §3). The box may have sent one in its response head;
+                // strip it. Cache-Control: no-store is required so the phone
+                // doesn't cache stale event-stream chunks.
+                const headers = stripForStream(event.headers);
+                headers["cache-control"] = "no-store";
+                httpRes.writeHead(event.status, headers);
+                httpRes.flushHeaders();
+                headWritten = true;
+                break;
+              }
+              case "data":
+                if (headWritten && event.data) httpRes.write(event.data);
+                break;
+              case "end":
+                if (headWritten) httpRes.end();
+                break;
+              case "abort":
+                if (headWritten) httpRes.end();
+                break;
+              default:
+                break;
+            }
+          } catch {
+            /* socket already closed */
+          }
+        };
+
+        route(req, streamingSink).then((resp) => {
+          if (resp && resp.__stream) {
+            // Streaming branch: dispatch armed the stream proxy and will pipe
+            // every STREAM_* frame through streamingSink. The handle returned
+            // by streamRequest is what we abort if the phone hangs up.
+            streamHandle = resp.handler();
+            return;
+          }
+          // Buffered branch (unchanged behavior).
           const headers = { ...(resp.headers || {}) };
           const payload = resp.body == null ? "" : resp.body;
           if (!hasHeader(headers, "content-type")) {
@@ -338,10 +464,19 @@ export function createRelayApi(opts = {}) {
           httpRes.end(payload);
         });
       });
+      // Phone hang-up mid-stream → abort the relay-side stream so the box's
+      // local fetch ends and no STREAM_DATA frames get sent to a dead socket.
+      httpReq.on("close", () => {
+        if (streamHandle && typeof streamHandle.abort === "function") {
+          try { streamHandle.abort("client disconnected"); } catch { /* ignore */ }
+        }
+      });
       httpReq.on("error", () => {
         try {
-          httpRes.writeHead(400);
-          httpRes.end();
+          if (!httpRes.headersSent) {
+            httpRes.writeHead(400);
+            httpRes.end();
+          }
         } catch {
           /* response may already be sent */
         }
@@ -410,6 +545,23 @@ function sanitizeForwardHeaders(headers) {
     if (!DROP.has(k.toLowerCase())) out[k] = v;
   }
   return Object.keys(out).length ? out : undefined;
+}
+
+// Strip headers that MUST NOT be on a streaming response (BET-156 §3):
+//   • content-length — chunked transfer uses no Content-Length; if the box
+//     advertised one we set it ourselves or Node may complain.
+//   • transfer-encoding — Node controls this once we flushHeaders; any value
+//     from the box could conflict with the chunked encoding we initiate.
+// The result is the headers map to pass to writeHead.
+function stripForStream(headers) {
+  const out = {};
+  const DROP = new Set(["content-length", "transfer-encoding"]);
+  if (headers && typeof headers === "object") {
+    for (const [k, v] of Object.entries(headers)) {
+      if (!DROP.has(k.toLowerCase())) out[k] = v;
+    }
+  }
+  return out;
 }
 
 function hasHeader(headers, name) {

--- a/src/relay/api.test.mjs
+++ b/src/relay/api.test.mjs
@@ -6,6 +6,7 @@ import {
   createDefaultPhoneAuth,
   createDefaultSubscriptionCheck,
   isGatedSubpath,
+  isStreamingSubpath,
 } from "./api.mjs";
 import { createRelayServer, createDefaultVerifier } from "./index.mjs";
 import { openStore, BOX_STATUS, hashToken } from "./store.mjs";
@@ -53,6 +54,19 @@ function bearer(token) {
 async function parseBody(resp) {
   return typeof resp.body === "string" && resp.body ? JSON.parse(resp.body) : null;
 }
+
+// ---------------------------------------------------------------------------
+// pure: streaming classification (BET-156 §3)
+// ---------------------------------------------------------------------------
+
+test("isStreamingSubpath: /events is streaming; metadata + gated-but-buffered paths are not", () => {
+  for (const p of ["/events", "/events/", "/events?token=abc"]) {
+    assert.equal(isStreamingSubpath(p), true, `${p} should be streaming`);
+  }
+  for (const p of ["/", "/projects", "/transcript", "/prompt", "/pty", "/message", "/stream"]) {
+    assert.equal(isStreamingSubpath(p), false, `${p} should NOT be streaming`);
+  }
+});
 
 // ---------------------------------------------------------------------------
 // pure: gated-path classification
@@ -393,4 +407,191 @@ test("end-to-end: no live tunnel → proxyRequest rejects no_tunnel → 503", as
     headers: bearer(ACCT_1),
   });
   assert.equal(resp.status, 503, "offline box → 503");
+});
+
+// ---------------------------------------------------------------------------
+// end-to-end streaming proxy over a REAL relay + REAL box socket (BET-156 §3)
+// ---------------------------------------------------------------------------
+
+// Fake box that auto-replies to STREAM_OPEN (request form) with a canned head
+// + N DATA chunks + END. Mirrors the SSE shape: text/event-stream, no body
+// length (the box leaves Content-Length off, but we still strip it in api.mjs
+// defensively — see stripForStream).
+function installAutoStreamBox(ws, { chunks = [], status = 200, headers = {}, reason = null } = {}) {
+  ws.on("message", (data) => {
+    const f = decodeFrame(data);
+    if (!f || f.type !== FRAME_TYPES.STREAM_OPEN) return;
+    if (typeof f.method !== "string") return; // ignore response-form
+    ws.send(encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: f.id, stream: f.stream, status, headers }));
+    for (const c of chunks) {
+      ws.send(encodeFrame({ type: FRAME_TYPES.STREAM_DATA, id: f.id, stream: f.stream, data: c }));
+    }
+    if (reason != null) {
+      ws.send(encodeFrame({ type: FRAME_TYPES.STREAM_ABORT, id: f.id, stream: f.stream, reason }));
+    } else {
+      ws.send(encodeFrame({ type: FRAME_TYPES.STREAM_END, id: f.id, stream: f.stream }));
+    }
+  });
+}
+
+test("end-to-end: phone /events request streams OPEN→DATA×n→END to the phone's HTTP response", async (t) => {
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.ONLINE, at: 1 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1 });
+  store.upsertReceipt({ originalTransactionId: "t-events", boxId: BOX_A, expiresAt: null });
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((r) => wss.once("listening", r));
+  const relay = createRelayServer({ wss, store, verifyBox: createDefaultVerifier({ store, warn: silent, log: silent }), log: silent, warn: silent });
+
+  const boxWs = new WebSocket(`ws://127.0.0.1:${wss.address().port}/box?box_id=${BOX_A}&token=${BOX_TOKEN_A}`);
+  await once(boxWs, "open");
+  installAutoStreamBox(boxWs, {
+    chunks: ["data: hello\n\n", "data: world\n\n", "data: end\n\n"],
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+  await waitFor(() => relay.routing.has(BOX_A));
+
+  t.after(async () => {
+    boxWs.close();
+    await waitFor(() => !relay.routing.has(BOX_A));
+    await relay.close();
+    await new Promise((r) => wss.close(() => r()));
+  });
+
+  const api = createRelayApi({
+    store,
+    proxyRequest: relay.proxyRequest,
+    streamRequest: relay.streamRequest,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  // Simulate the phone's HTTP request by capturing the events the streaming
+  // sink would receive. The api's route() returns a __stream sentinel whose
+  // handler drives the sink from STREAM_* frames.
+  const events = [];
+  const resp = await api.route(
+    { method: "GET", path: `/box/${BOX_A}/events?token=foo`, headers: bearer(ACCT_1) },
+    (e) => events.push(e),
+  );
+  assert.ok(resp.__stream, "the api returns the __stream sentinel for /events");
+  // Drive the stream: this kicks off the STREAM_* request to the box leg.
+  const handle = resp.handler();
+  // Wait for the full sequence.
+  await waitFor(() => events.some((e) => e.kind === "end"), { timeoutMs: 2000 });
+
+  // Sequence: head → 3× data → end.
+  assert.deepEqual(
+    events.map((e) => e.kind),
+    ["head", "data", "data", "data", "end"],
+    "frame sequence is head→data×3→end",
+  );
+  assert.equal(events[0].status, 200);
+  assert.equal(events[0].headers["content-type"], "text/event-stream");
+  assert.deepEqual(
+    events.slice(1, -1).map((e) => e.data),
+    ["data: hello\n\n", "data: world\n\n", "data: end\n\n"],
+    "chunks preserved in order",
+  );
+  assert.equal(handle.streamId >= 1, true);
+});
+
+test("end-to-end: phone /events request — STREAM_ABORT from the box surfaces as onAbort", async (t) => {
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.ONLINE, at: 1 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1 });
+  store.upsertReceipt({ originalTransactionId: "t-events-abort", boxId: BOX_A, expiresAt: null });
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((r) => wss.once("listening", r));
+  const relay = createRelayServer({ wss, store, verifyBox: createDefaultVerifier({ store, warn: silent, log: silent }), log: silent, warn: silent });
+
+  const boxWs = new WebSocket(`ws://127.0.0.1:${wss.address().port}/box?box_id=${BOX_A}&token=${BOX_TOKEN_A}`);
+  await once(boxWs, "open");
+  installAutoStreamBox(boxWs, { chunks: ["partial "], reason: "box exploded" });
+  await waitFor(() => relay.routing.has(BOX_A));
+
+  t.after(async () => {
+    boxWs.close();
+    await waitFor(() => !relay.routing.has(BOX_A));
+    await relay.close();
+    await new Promise((r) => wss.close(() => r()));
+  });
+
+  const api = createRelayApi({
+    store,
+    proxyRequest: relay.proxyRequest,
+    streamRequest: relay.streamRequest,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  const events = [];
+  const resp = await api.route(
+    { method: "GET", path: `/box/${BOX_A}/events`, headers: bearer(ACCT_1) },
+    (e) => events.push(e),
+  );
+  resp.handler();
+  await waitFor(() => events.some((e) => e.kind === "abort"), { timeoutMs: 2000 });
+
+  assert.equal(events[0].kind, "head", "head fires even on abort");
+  assert.equal(events[1].kind, "data");
+  assert.equal(events[1].data, "partial ");
+  assert.equal(events[2].kind, "abort");
+  assert.equal(events[2].reason, "box exploded");
+  assert.equal(events.some((e) => e.kind === "end"), false, "no onEnd on abort");
+});
+
+test("non-SSE proxied paths still use the buffered path (no behavior change)", async (t) => {
+  // Even with streamRequest configured, a non-/events path goes through the
+  // regular REQUEST/RESPONSE channel — proving the streaming branch is a
+  // strict subpath carve-out, not a behavior change for the rest.
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.ONLINE, at: 1 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1 });
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((r) => wss.once("listening", r));
+  const relay = createRelayServer({ wss, store, verifyBox: createDefaultVerifier({ store, warn: silent, log: silent }), log: silent, warn: silent });
+
+  let streamUsed = false;
+  const boxWs = new WebSocket(`ws://127.0.0.1:${wss.address().port}/box?box_id=${BOX_A}&token=${BOX_TOKEN_A}`);
+  await once(boxWs, "open");
+  boxWs.on("message", (data) => {
+    const f = decodeFrame(data);
+    if (!f) return;
+    if (f.type === FRAME_TYPES.STREAM_OPEN) streamUsed = true;
+    if (f.type === FRAME_TYPES.REQUEST) {
+      boxWs.send(encodeFrame({ type: FRAME_TYPES.RESPONSE, id: f.id, status: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ ok: true }) }));
+    }
+  });
+  await waitFor(() => relay.routing.has(BOX_A));
+
+  t.after(async () => {
+    boxWs.close();
+    await waitFor(() => !relay.routing.has(BOX_A));
+    await relay.close();
+    await new Promise((r) => wss.close(() => r()));
+  });
+
+  const api = createRelayApi({
+    store,
+    proxyRequest: relay.proxyRequest,
+    streamRequest: relay.streamRequest,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  const resp = await api.route({
+    method: "GET",
+    path: `/box/${BOX_A}/projects`,
+    headers: bearer(ACCT_1),
+  });
+  assert.equal(resp.status, 200);
+  assert.equal(resp.__stream, undefined, "non-SSE path is NOT a __stream sentinel");
+  assert.equal(JSON.parse(resp.body).ok, true);
+  await waitFor(() => !streamUsed, { timeoutMs: 1000 });
+  assert.equal(streamUsed, false, "/projects did NOT trigger the streaming path");
 });

--- a/src/relay/index.mjs
+++ b/src/relay/index.mjs
@@ -35,6 +35,7 @@ import { isValidToken, createRateLimiter } from "../server/webhooks.mjs";
 import {
   RoutingTable,
   PendingRequests,
+  StreamRegistry,
   encodeFrame,
   decodeFrame,
   FRAME_TYPES,
@@ -272,6 +273,21 @@ export function createRelayServer(opts = {}) {
   // fresh reconnect's pending requests.
   const pendingByTransport = new Map(); // transport -> PendingRequests
 
+  // Per-box INBOUND stream registry (BET-156). Phone→box stream requests are
+  // opened on the relay via streamRequest(); the relay assigns a stream id,
+  // registers a consumer in the box's per-transport registry, and forwards a
+  // STREAM_OPEN request frame down the tunnel. The box's agent responds with
+  // STREAM_OPEN (response form) + STREAM_DATA + STREAM_END, all routed through
+  // this registry. Keyed by the live transport (not box_id) so a stale
+  // socket's late frames can't settle a fresh reconnect's streams.
+  const inboundStreamsByTransport = new Map(); // transport -> StreamRegistry
+
+  // Monotonic stream id source for streamRequest. Starts at 1 so stream ids
+  // never collide with REQUEST ids (PendingRequests owns its own counter
+  // starting at 1 too — both spaces are independent of each other, but
+  // keeping them distinct makes wire captures easier to read).
+  let nextStreamId = 1;
+
   /**
    * Handle a single verified/authenticated box connection. Wires the ws into a
    * transport, registers it in the RoutingTable, persists the box row online,
@@ -286,6 +302,12 @@ export function createRelayServer(opts = {}) {
     // Correlation for phone→box proxied requests routed over THIS socket.
     const pending = new PendingRequests({ now });
     pendingByTransport.set(transport, pending);
+
+    // Inbound stream registry for phone→box stream requests routed over THIS
+    // socket. Created per-transport so a reconnect's fresh registry doesn't
+    // carry stale entries from the previous socket.
+    const inboundStreams = new StreamRegistry();
+    inboundStreamsByTransport.set(transport, inboundStreams);
 
     // Register the live socket (evicts+closes any stale socket for this box).
     routing.register(boxId, transport);
@@ -311,6 +333,15 @@ export function createRelayServer(opts = {}) {
         case FRAME_TYPES.RESPONSE:
           pending.resolve(frame);
           break;
+        case FRAME_TYPES.STREAM_OPEN:
+        case FRAME_TYPES.STREAM_DATA:
+        case FRAME_TYPES.STREAM_END:
+        case FRAME_TYPES.STREAM_ABORT:
+          // Box→relay stream frames. The registry routes by stream id to the
+          // consumer registered by streamRequest() (api.mjs). A frame for an
+          // unknown stream id is dropped — the StreamRegistry's invariant.
+          inboundStreams.handleFrame(frame);
+          break;
         case FRAME_TYPES.ERROR:
           if (!pending.rejectFromError(frame)) {
             warn(`[relay] box ${short(boxId)} error: ${frame.message || frame.code || "unknown"}`);
@@ -327,6 +358,11 @@ export function createRelayServer(opts = {}) {
       // response hangs across a box disconnect, then drop the correlation map.
       pending.rejectAll(new Error("box tunnel closed"));
       pendingByTransport.delete(transport);
+      // Abort every live stream on this transport so phone-side streaming
+      // responses close cleanly (BET-156 §3). The registry's onAbort callbacks
+      // fire before we drop the map so handlers see the abort, not a hang.
+      try { inboundStreams.abortAll("box tunnel closed"); } catch { /* ignore */ }
+      inboundStreamsByTransport.delete(transport);
       // Only unregister if THIS socket is still the registered one (a fast
       // reconnect may have already replaced us — don't clobber the fresh one).
       routing.unregister(boxId, transport);
@@ -387,6 +423,156 @@ export function createRelayServer(opts = {}) {
       ...(req.body != null ? { body: req.body } : {}),
     });
     return promise;
+  }
+
+  /**
+   * Proxy a single phone→box STREAMING request over the box's live tunnel and
+   * pipe the box's stream back through the provided callbacks. The caller
+   * (api.mjs's /box/:box_id/* handler) drives the phone's HTTP response from
+   * these callbacks — onHead → writeHead; onData → write; onEnd / onAbort →
+   * end. There is NO returned promise to await because the stream is the
+   * response itself; the caller signals completion via end() in onEnd/onAbort.
+   *
+   * Rejects synchronously (returns `{ noTunnel: true }` shape via callback)
+   * when the box has no live socket OR no inbound-stream registry — the caller
+   * treats both as a 503 box_offline. Streams are NOT bounded by the
+   * request/response timeout (SSE/PTY are long-lived by design); the caller
+   * decides its own end-of-stream policy (relay close, device disconnect, …).
+   *
+   * Wire contract (BET-156 §3):
+   *   • The relay assigns a monotonic stream id, registers a consumer in the
+   *     box's per-transport inbound registry, and sends a STREAM_OPEN request
+   *     form down the tunnel.
+   *   • The box agent responds with STREAM_OPEN (response form, status+headers)
+   *     → onHead({ status, headers }) fires.
+   *   • The box agent pumps the response body as STREAM_DATA frames →
+   *     onData(text) fires per frame.
+   *   • The box agent sends STREAM_END (or STREAM_ABORT on error) → onEnd /
+   *     onAbort(reason) fires.
+   *
+   * @param {string} boxId
+   * @param {{method:string,path:string,headers?:object,body?:string}} req
+   * @param {{
+   *   onHead: ({status:number, headers:object}) => void,
+   *   onData: (text:string) => void,
+   *   onEnd:  () => void,
+   *   onAbort: (reason:string) => void,
+   * }} callbacks
+   * @returns {{ streamId: number, abort: (reason?:string) => void }}
+   *   The caller keeps `streamId` for logging; `abort()` is the public way to
+   *   cancel the stream (frees the relay-side id, sends STREAM_ABORT to the
+   *   box so the local fetch ends).
+   */
+  function streamRequest(boxId, req, callbacks) {
+    const transport = routing.lookup(boxId);
+    if (!transport) {
+      // Synchronous no-tunnel: no consumer registered yet, so fire onAbort
+      // directly. The caller decides whether to surface 503 or close the
+      // phone response.
+      try {
+        callbacks.onAbort("no_tunnel");
+      } catch {
+        /* caller ignored */
+      }
+      return { streamId: -1, abort: () => {} };
+    }
+    const inboundStreams = inboundStreamsByTransport.get(transport);
+    if (!inboundStreams) {
+      try {
+        callbacks.onAbort("no_tunnel");
+      } catch {
+        /* ignore */
+      }
+      return { streamId: -1, abort: () => {} };
+    }
+    // Allocate a fresh stream id for this transport. The frame's `id` is
+    // reused as the request-correlating id (the agent echoes it in its
+    // response-side frames); the registry routes by `stream` (the relay-
+    // assigned id), so a stale `id` on a same-stream id won't misroute.
+    const streamId = nextStreamId++;
+    const requestId = streamId;
+    let closed = false;
+
+    // The consumer reads off `frame.status`/`frame.headers` for the response
+    // head, then receives per-chunk DATA frames and END/ABORT.
+    inboundStreams.open(streamId, {
+      onOpen: (frame) => {
+        if (closed) return;
+        try {
+          callbacks.onHead({
+            status: frame.status,
+            headers: frame.headers || {},
+          });
+        } catch {
+          /* ignore caller errors */
+        }
+      },
+      onData: (text) => {
+        if (closed) return;
+        try {
+          callbacks.onData(text);
+        } catch {
+          /* ignore */
+        }
+      },
+      onEnd: () => {
+        if (closed) return;
+        closed = true;
+        try {
+          callbacks.onEnd();
+        } catch {
+          /* ignore */
+        }
+      },
+      onAbort: (reason) => {
+        if (closed) return;
+        closed = true;
+        try {
+          callbacks.onAbort(reason || "aborted");
+        } catch {
+          /* ignore */
+        }
+      },
+    });
+
+    // Send the request-side STREAM_OPEN. Body is only forwarded for non-GET/
+    // non-HEAD methods (same rule as the request-frame branch).
+    transport.send({
+      type: FRAME_TYPES.STREAM_OPEN,
+      id: requestId,
+      stream: streamId,
+      method: req.method,
+      path: req.path,
+      ...(req.headers ? { headers: req.headers } : {}),
+      ...(req.body != null && req.method !== "GET" && req.method !== "HEAD"
+        ? { body: req.body }
+        : {}),
+    });
+
+    // Public abort: tear down the consumer locally + send STREAM_ABORT to the
+    // box so the local fetch there closes. Idempotent — a second call is a
+    // no-op (the onAbort consumer would have fired already or the stream is
+    // already closed).
+    function abort(reason) {
+      if (closed) return;
+      closed = true;
+      // Locally free the id (the registry's abort fires the consumer's onAbort
+      // — but the consumer's onAbort short-circuits via the closed flag above,
+      // so callbacks.onAbort is invoked exactly once, here).
+      inboundStreams.abort(streamId, reason || "client aborted");
+      try {
+        transport.send({
+          type: FRAME_TYPES.STREAM_ABORT,
+          id: requestId,
+          stream: streamId,
+          reason: reason || "client aborted",
+        });
+      } catch {
+        /* socket closing; ignore */
+      }
+    }
+
+    return { streamId, abort };
   }
 
   // The connection handler: runs AFTER the ws handshake completes. We do the
@@ -478,6 +664,8 @@ export function createRelayServer(opts = {}) {
     close,
     // phone→box request correlation (Stage-4 phone-facing proxy calls this)
     proxyRequest,
+    // phone→box streaming request correlation (BET-156 §3 — /events, future /pty)
+    streamRequest,
     // exposed for tests / Stage 4 wiring
     _onConnection: onConnection,
     _acceptBox: acceptBox,

--- a/src/relay/index.test.mjs
+++ b/src/relay/index.test.mjs
@@ -271,6 +271,131 @@ test("DEFAULT_RELAY_PORT is the bui 20xxx-block port", () => {
 });
 
 // ---------------------------------------------------------------------------
+// streamRequest — phone→box STREAM_* proxy (BET-156 §3, SSE/PTY plumbing)
+// ---------------------------------------------------------------------------
+
+// A fake box client that auto-replies to STREAM_OPEN (request form) with a
+// canned head + DATA + END sequence. Lets us drive streamRequest end-to-end
+// over a real WebSocket pair without standing up the agent.
+function installAutoStreamBox(ws, { chunks = [], reason = null, status = 200, headers = {} } = {}) {
+  ws.on("message", (data) => {
+    const f = decodeFrame(data);
+    if (!f || f.type !== FRAME_TYPES.STREAM_OPEN) return;
+    if (typeof f.method !== "string") return; // ignore response-form opens (relay never sends them)
+    // Send the response head, then chunks, then end (or abort).
+    ws.send(encodeFrame({
+      type: FRAME_TYPES.STREAM_OPEN,
+      id: f.id,
+      stream: f.stream,
+      status,
+      headers,
+    }));
+    for (const c of chunks) {
+      ws.send(encodeFrame({
+        type: FRAME_TYPES.STREAM_DATA,
+        id: f.id,
+        stream: f.stream,
+        data: c,
+      }));
+    }
+    if (reason != null) {
+      ws.send(encodeFrame({
+        type: FRAME_TYPES.STREAM_ABORT,
+        id: f.id,
+        stream: f.stream,
+        reason,
+      }));
+    } else {
+      ws.send(encodeFrame({
+        type: FRAME_TYPES.STREAM_END,
+        id: f.id,
+        stream: f.stream,
+      }));
+    }
+  });
+}
+
+test("streamRequest: relays a box-side stream OPEN→DATA×n→END in order to the caller", async (t) => {
+  const { relay, url } = await makeRelay(t);
+  const ws = connectBox(url, { boxId: BOX_A, token: TOKEN_A });
+  await once(ws, "open");
+  await waitFor(() => relay.routing.has(BOX_A));
+  installAutoStreamBox(ws, {
+    chunks: ["data: hello\n\n", "data: world\n\n"],
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+
+  // Drive the stream request synchronously — the callbacks fire async on the
+  // inbound message path (WebSocket I/O runs on the libuv loop, not microtasks).
+  const events = { head: null, data: [], end: null, abort: null };
+  relay.streamRequest(BOX_A, { method: "GET", path: "/events" }, {
+    onHead: (h) => { events.head = h; },
+    onData: (t) => { events.data.push(t); },
+    onEnd: () => { events.end = true; },
+    onAbort: (r) => { events.abort = r; },
+  });
+
+  // Poll on a real timer until the full sequence has arrived. waitFor uses
+  // setTimeout (libuv), which interleaves with the WS I/O — Promise.resolve()
+  // alone would not yield long enough for the I/O callbacks to fire.
+  await waitFor(() => events.head && events.end, { timeoutMs: 2000 });
+  // A tiny extra tick to capture any straggler events (the test asserts on
+  // .end / .abort not firing too).
+  await new Promise((r) => setTimeout(r, 20));
+
+  assert.ok(events.head, "onHead fired");
+  assert.equal(events.head.status, 200);
+  assert.equal(events.head.headers["content-type"], "text/event-stream");
+  assert.deepEqual(events.data, ["data: hello\n\n", "data: world\n\n"], "chunks preserved in order");
+  assert.equal(events.end, true, "onEnd fired");
+  assert.equal(events.abort, null, "no abort");
+
+  ws.close();
+  await once(ws, "close");
+});
+
+test("streamRequest: relays a box-side STREAM_ABORT as onAbort(reason)", async (t) => {
+  const { relay, url } = await makeRelay(t);
+  const ws = connectBox(url, { boxId: BOX_A, token: TOKEN_A });
+  await once(ws, "open");
+  await waitFor(() => relay.routing.has(BOX_A));
+  installAutoStreamBox(ws, { chunks: ["partial "], reason: "box exploded" });
+
+  const events = { head: null, data: [], end: null, abort: null };
+  relay.streamRequest(BOX_A, { method: "GET", path: "/events" }, {
+    onHead: (h) => { events.head = h; },
+    onData: (t) => { events.data.push(t); },
+    onEnd: () => { events.end = true; },
+    onAbort: (r) => { events.abort = r; },
+  });
+  await waitFor(() => events.head && events.abort, { timeoutMs: 2000 });
+  await new Promise((r) => setTimeout(r, 20));
+
+  assert.ok(events.head, "onHead fired even on abort (the head frame arrived first)");
+  assert.deepEqual(events.data, ["partial "], "data frame before the abort is preserved");
+  assert.equal(events.abort, "box exploded", "onAbort(reason) fired");
+  assert.equal(events.end, null, "onEnd did NOT fire");
+
+  ws.close();
+  await once(ws, "close");
+});
+
+test("streamRequest: no live tunnel → onAbort fires synchronously, no wire activity", async (t) => {
+  const { relay, url: _ } = await makeRelay(t);
+  // Deliberately do NOT connect a box. routing.has(BOX_A) === false.
+  let abortCalled = null;
+  const handle = relay.streamRequest(BOX_A, { method: "GET", path: "/events" }, {
+    onHead: () => { throw new Error("onHead should not fire without a tunnel"); },
+    onData: () => { throw new Error("onData should not fire without a tunnel"); },
+    onEnd: () => { throw new Error("onEnd should not fire without a tunnel"); },
+    onAbort: (r) => { abortCalled = r; },
+  });
+  assert.equal(abortCalled, "no_tunnel", "synchronous onAbort('no_tunnel')");
+  assert.equal(handle.streamId, -1, "no stream id assigned");
+});
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 

--- a/src/relay/protocol.mjs
+++ b/src/relay/protocol.mjs
@@ -61,12 +61,21 @@ export const FRAME_TYPES = Object.freeze({
   RESPONSE: "response",
 
   // Stream multiplexing (SSE / PTY). All carry a `stream` id.
-  //   STREAM_OPEN: { id, stream, method?, path?, headers? }
+  //   STREAM_OPEN  request form  (relay → box): { id, stream, method, path?, headers? }
+  //                                     opens a logical stream on the box.
+  //   STREAM_OPEN  response form (box → relay): { id, stream, status, headers? }
+  //                                     reports the upstream response head.
+  //                                     `id` echoes the request STREAM_OPEN's id
+  //                                     for correlation (the box agent sets the
+  //                                     SAME stream id the relay assigned).
   //   STREAM_DATA: { id, stream, data }  — `data` is a string; binary payloads
   //                                        are base64 by convention (caller's
   //                                        responsibility, opaque to framing).
   //   STREAM_END:  { id, stream }
   //   STREAM_ABORT:{ id, stream, reason? }
+  // Exactly one of {method, status} is present — that is how the demux tells
+  // a request-side open from a response-side open. Both or neither is a wire
+  // error (decodeFrame drops the frame).
   STREAM_OPEN: "stream-open",
   STREAM_DATA: "stream-data",
   STREAM_END: "stream-end",
@@ -191,6 +200,20 @@ function validateFrameShape(frame, { context }) {
       }
       break;
     case FRAME_TYPES.STREAM_OPEN:
+      requireStreamId(frame, context);
+      // Exactly-one-of {method, status}: a request-side open carries the
+      // upstream method/path; a response-side open carries the upstream
+      // status. Both or neither → wire error.
+      {
+        const hasMethod = typeof frame.method === "string" && frame.method !== "";
+        const hasStatus = Number.isInteger(frame.status);
+        if (hasMethod === hasStatus) {
+          throw new Error(
+            `${context}: stream-open must carry exactly one of method or status`,
+          );
+        }
+      }
+      break;
     case FRAME_TYPES.STREAM_END:
     case FRAME_TYPES.STREAM_ABORT:
       requireStreamId(frame, context);
@@ -346,7 +369,13 @@ export class PendingRequests {
 // clean up so a later stream can reuse the id cleanly.
 //
 // A consumer is an object with optional callbacks:
-//   { onData(payload, frame), onEnd(frame), onAbort(reason, frame) }
+//   { onOpen(frame), onData(payload, frame), onEnd(frame), onAbort(reason, frame) }
+// `onOpen` is invoked with the full STREAM_OPEN frame (the consumer reads off
+// `status`/`headers` for response-side opens or `method`/`path` for request-
+// side opens — the registry doesn't distinguish the two, by design). All
+// callbacks are wrapped in try/catch so a throwing consumer cannot corrupt
+// the registry or the demux loop.
+//
 // Registering a consumer for a stream id is how the owner subscribes.
 export class StreamRegistry {
   constructor() {
@@ -379,11 +408,7 @@ export class StreamRegistry {
     if (frame == null) return false;
     switch (frame.type) {
       case FRAME_TYPES.STREAM_OPEN:
-        // Open frames are informational to an already-subscribed registry: the
-        // consumer is registered locally via open(); a peer's STREAM_OPEN just
-        // confirms the id. If we have no consumer yet, drop (nothing to route
-        // to — the owner subscribes before it expects data).
-        return this._streams.has(frame.stream);
+        return this._deliverOpen(frame);
       case FRAME_TYPES.STREAM_DATA:
         return this._deliverData(frame);
       case FRAME_TYPES.STREAM_END:
@@ -393,6 +418,22 @@ export class StreamRegistry {
       default:
         return false;
     }
+  }
+
+  _deliverOpen(frame) {
+    // Open frames are delivered to an already-subscribed consumer (the
+    // consumer is registered locally via open() BEFORE it expects data; a
+    // peer's STREAM_OPEN confirms the stream and carries the response head for
+    // response-side opens). An open for an unknown id is dropped — the owner
+    // subscribes before it expects data, so a stray open is a protocol bug.
+    const st = this._streams.get(frame.stream);
+    if (!st || st.closed) return false;
+    try {
+      st.consumer.onOpen?.(frame);
+    } catch {
+      /* isolate consumer errors */
+    }
+    return true;
   }
 
   _deliverData(frame) {

--- a/src/relay/protocol.test.mjs
+++ b/src/relay/protocol.test.mjs
@@ -23,7 +23,7 @@ test("encode/decode round-trips every frame type", () => {
   const samples = [
     { type: FRAME_TYPES.REQUEST, id: 1, method: "GET", path: "/x", boxId: BOX_A },
     { type: FRAME_TYPES.RESPONSE, id: 1, status: 200, body: "ok" },
-    { type: FRAME_TYPES.STREAM_OPEN, id: 2, stream: "s1", path: "/sse" },
+    { type: FRAME_TYPES.STREAM_OPEN, id: 2, stream: "s1", method: "GET", path: "/sse" },
     { type: FRAME_TYPES.STREAM_DATA, id: 2, stream: "s1", data: "chunk" },
     { type: FRAME_TYPES.STREAM_END, id: 2, stream: "s1" },
     { type: FRAME_TYPES.STREAM_ABORT, id: 3, stream: "s2", reason: "cancel" },
@@ -98,6 +98,50 @@ test("encodeFrame throws on structurally invalid frames", () => {
   assert.throws(() => encodeFrame("x"));
   assert.throws(() => encodeFrame({ type: "nope", id: 1 }));
   assert.throws(() => encodeFrame({ type: FRAME_TYPES.REQUEST, id: 1 })); // no method/path
+});
+
+test("encodeFrame rejects STREAM_OPEN without method (request form) or status (response form)", () => {
+  // Method required on the request form…
+  assert.throws(
+    () => encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: 1, stream: "s", path: "/x" }),
+    /exactly one of method or status/,
+  );
+  // …and status required on the response form.
+  assert.throws(
+    () => encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: 2, stream: "s", headers: {} }),
+    /exactly one of method or status/,
+  );
+  // Both present → also rejected.
+  assert.throws(
+    () =>
+      encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: 3, stream: "s", method: "GET", status: 200 }),
+    /exactly one of method or status/,
+  );
+  // Each form encodes cleanly.
+  assert.ok(encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: 4, stream: "s", method: "GET", path: "/sse" }));
+  assert.ok(encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: 5, stream: "s", status: 200, headers: { "content-type": "text/event-stream" } }));
+});
+
+test("decodeFrame drops STREAM_OPEN that violates exactly-one-of (BET-156)", () => {
+  // Method + status (both) → wire error, decode returns null.
+  // Build the raw string directly because encodeFrame refuses to emit it.
+  const both = JSON.stringify({
+    v: PROTOCOL_VERSION,
+    type: FRAME_TYPES.STREAM_OPEN,
+    id: 1,
+    stream: "s",
+    method: "GET",
+    status: 200,
+  });
+  assert.equal(decodeFrame(both), null);
+  // Neither method nor status → wire error, decode returns null.
+  const neither = JSON.stringify({
+    v: PROTOCOL_VERSION,
+    type: FRAME_TYPES.STREAM_OPEN,
+    id: 1,
+    stream: "s",
+  });
+  assert.equal(decodeFrame(neither), null);
 });
 
 // ---------------------------------------------------------------------------
@@ -207,17 +251,37 @@ test("PendingRequests.rejectAll rejects every in-flight request on transport clo
 
 function collectingConsumer() {
   const data = [];
+  const opens = [];
   let ended = false;
   let aborted = null;
   return {
     data,
+    opens,
     get ended() { return ended; },
     get aborted() { return aborted; },
+    onOpen: (frame) => { opens.push(frame); },
     onData: (payload) => data.push(payload),
     onEnd: () => { ended = true; },
     onAbort: (reason) => { aborted = reason ?? "aborted"; },
   };
 }
+
+test("StreamRegistry delivers STREAM_OPEN to the consumer's onOpen (BET-156)", () => {
+  // Response-side opens carry { status, headers } — the consumer reads those
+  // out of the onOpen frame. The registry doesn't parse; it just delivers.
+  const reg = new StreamRegistry();
+  const c = collectingConsumer();
+  reg.open("s1", c);
+  const headFrame = { type: FRAME_TYPES.STREAM_OPEN, id: 1, stream: "s1", status: 200, headers: { "content-type": "text/event-stream" } };
+  assert.equal(reg.handleFrame(headFrame), true, "delivered");
+  assert.equal(c.opens.length, 1);
+  assert.equal(c.opens[0].status, 200);
+  assert.equal(c.opens[0].headers["content-type"], "text/event-stream");
+  // A STREAM_OPEN for an unknown stream id is dropped (no consumer subscribed).
+  const c2 = collectingConsumer();
+  const reg2 = new StreamRegistry();
+  assert.equal(reg2.handleFrame(headFrame), false, "dropped — no consumer");
+});
 
 test("StreamRegistry keeps two concurrent streams isolated + routes to correct consumer", () => {
   const reg = new StreamRegistry();
@@ -449,7 +513,7 @@ test("end-to-end: request/response + a muxed stream over one fake transport", as
   // Open a stream and collect chunks.
   const c = collectingConsumer();
   reg.open("sX", c);
-  a.send(encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: pr.nextId(), stream: "sX", path: "/sse" }));
+  a.send(encodeFrame({ type: FRAME_TYPES.STREAM_OPEN, id: pr.nextId(), stream: "sX", method: "GET", path: "/sse" }));
   assert.deepEqual(c.data, ["c1", "c2"]);
   assert.equal(c.ended, true);
   assert.equal(reg.has("sX"), false, "stream cleaned up after end");

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,26 +1,33 @@
 import { useRef, useState } from "react";
 import { normalizeCode } from "../shared/claim.mjs";
 import { normalizeServerUrl, isValidServerUrl, canConnect } from "./pairStepLogic";
+import { parsePairPayload } from "./mobile/pairPayload";
 import { useStore } from "./store";
 
-// PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2).
+// PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2;
+// extended BET-156 for relay-paired flows).
 //
 // Mounts into Onboarding.tsx's step-1 slot. Owns the pairing form:
 //   • a server-URL input (prefilled from config if the user has paired before)
 //   • a 6-digit monospace pairing code input (auto-focused)
+//   • an OPTIONAL "pair link" paste input (BET-156): a single textbox that
+//     runs parsePairPayload on submit and routes to the same claim call —
+//     reuse the exact same form/input styling as the existing screen
 //   • inline errors for every claim-failure branch (wrong/expired code,
 //     rate-limited, unreachable server, malformed response)
 //   • its own Connect button (gated by canConnect) + a "Skip setup" link
 //
 // The claim itself runs in the MAIN process over the `auth:claim` IPC channel
-// (window.api.authClaim), which POSTs <serverUrl>/auth/claim and, on success,
-// persists { serverUrl, boxId, boxToken } to config.json. We mirror those into
-// the store (applyPairing) so resolveTransportMode reads "http" immediately,
-// then call onPaired() to let the shell advance to Step 2.
+// (window.api.authClaim), which POSTs either <serverUrl>/auth/claim (direct
+// HTTPS) or https://relay.mantaui.com/pair (relay-paired; ADR-2/3) and, on
+// success, persists { serverUrl, boxId, boxToken } to config.json. We mirror
+// those into the store (applyPairing) so resolveTransportMode reads "http"
+// immediately, then call onPaired() to let the shell advance to Step 2.
 //
 // All non-React logic (URL normalization, the submit gate, the 6-digit
 // contract, HTTP-outcome classification) is pure + unit-tested in
-// pairStepLogic.ts + src/shared/claim.test.ts — this file is just the wiring.
+// pairStepLogic.ts + src/shared/claim.test.ts + pairPayload.test.ts — this
+// file is just the wiring.
 //
 // Props:
 //   onPaired — successful claim; the shell advances to the next step.
@@ -41,15 +48,53 @@ export function PairStep({
   // mount — the store's serverUrl is already populated (App gates on `loaded`).
   const [serverUrl, setServerUrl] = useState(() => useStore.getState().serverUrl ?? "");
   const [code, setCode] = useState("");
+  const [pairLink, setPairLink] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);
+  const pairLinkRef = useRef<HTMLInputElement>(null);
 
-  const connectEnabled = canConnect({ serverUrl, code, submitting });
+  // When the user pastes a pair link, the link's payload takes precedence
+  // over any typed server/code fields. The submit gate follows.
+  const linkHasContent = pairLink.trim() !== "";
+  const connectEnabled =
+    linkHasContent || canConnect({ serverUrl, code, submitting });
 
   const connect = async () => {
     // Mirror the pure gate so an Enter keypress can't fire from a non-ready
     // state (the button is also disabled, but Enter bypasses that).
+    if (submitting) return;
+    if (linkHasContent) {
+      // Pair link wins: parse it, then route to the same claim call.
+      const payload = parsePairPayload(pairLink);
+      if (!payload) {
+        setError("Couldn't read that pair link — paste the full manta://pair?… line.");
+        pairLinkRef.current?.focus();
+        return;
+      }
+      setSubmitting(true);
+      setError(null);
+      // Relay form sends serverUrl:"" (see AuthClaimInput) so the same input
+      // shape works for both the desktop IPC and httpApi's mobile authClaim.
+      const result = await window.api.authClaim({
+        serverUrl: payload.serverUrl ?? "",
+        boxId: payload.boxId ?? undefined,
+        code: payload.code,
+      });
+      if (result.ok) {
+        useStore.getState().applyPairing({
+          serverUrl: payload.serverUrl ?? `https://relay.mantaui.com/box/${payload.boxId}`,
+          boxId: result.boxId,
+          boxToken: result.boxToken,
+        });
+        setSubmitting(false);
+        onPaired();
+        return;
+      }
+      setSubmitting(false);
+      setError(result.message);
+      return;
+    }
     if (!canConnect({ serverUrl, code, submitting })) return;
     setSubmitting(true);
     setError(null);
@@ -83,7 +128,8 @@ export function PairStep({
 
   // A bad/empty URL is only flagged once the user has typed something, so a
   // pristine field doesn't show a scary red border on first paint.
-  const urlLooksBad = serverUrl.trim() !== "" && !isValidServerUrl(serverUrl);
+  const urlLooksBad =
+    serverUrl.trim() !== "" && !isValidServerUrl(serverUrl);
 
   return (
     <div>
@@ -136,8 +182,8 @@ export function PairStep({
             aria-invalid={error != null}
             placeholder="000000"
             maxLength={6}
-            disabled={submitting}
-            value={code}
+            disabled={submitting || linkHasContent}
+            value={linkHasContent ? "" : code}
             onChange={(e) => {
               setCode(normalizeCode(e.target.value));
               setError(null);
@@ -150,6 +196,33 @@ export function PairStep({
               bui pair
             </code>
           </p>
+        </div>
+
+        {/* Pair link (BET-156) — an optional single-paste field that runs
+            parsePairPayload and routes to the SAME claim call. Reuses the
+            exact form/input styling of the existing fields. */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="pair-link"
+            className="text-xs font-medium text-text-muted"
+          >
+            Or paste a pair link{" "}
+            <span className="text-text-faint font-normal">(optional)</span>
+          </label>
+          <input
+            id="pair-link"
+            ref={pairLinkRef}
+            type="text"
+            spellCheck={false}
+            placeholder="manta://pair?box=…&code=…"
+            disabled={submitting}
+            value={pairLink}
+            onChange={(e) => {
+              setPairLink(e.target.value);
+              setError(null);
+            }}
+            className="w-full rounded-md bg-bg-soft border border-border px-3 py-2.5 text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+          />
         </div>
 
         {error && (

--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -5,56 +5,130 @@ import {
   type PairPayload,
 } from "./pairPayload";
 
+const BOX = "0123456789abcdef0123456789abcdef"; // 32 hex
+
 describe("parsePairPayload", () => {
-  it("accepts the primary manta://pair?server=&code= form", () => {
-    expect(
-      parsePairPayload("manta://pair?server=http://box:8787&code=123456"),
-    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  describe("serverUrl form (direct-HTTPS pairing)", () => {
+    it("accepts the primary manta://pair?server=&code= form", () => {
+      expect(
+        parsePairPayload("manta://pair?server=http://box:8787&code=123456"),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+    });
+
+    it("accepts the id/token alias and normalizes it to server/code", () => {
+      expect(
+        parsePairPayload("manta://pair?id=http://box:8787&token=123456"),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+    });
+
+    it("accepts the https://host/m/... deferred-deeplink form", () => {
+      expect(
+        parsePairPayload(
+          "https://links.example.com/m/abc?server=http://box:8787&code=123456",
+        ),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+    });
+
+    it("trims surrounding whitespace before parsing", () => {
+      expect(
+        parsePairPayload("  manta://pair?server=http://box:8787&code=123456  "),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+    });
+
+    it("normalizes a bare-host server via normalizeServerUrl and strips trailing slashes", () => {
+      // bare host:port (no scheme) → http:// prefixed
+      expect(
+        parsePairPayload("manta://pair?server=box:8787&code=123456"),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+      // trailing slashes stripped
+      expect(
+        parsePairPayload(
+          "manta://pair?server=" +
+            encodeURIComponent("http://box:8787///") +
+            "&code=123456",
+        ),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+    });
+
+    it("URL-decodes an encoded server value", () => {
+      expect(
+        parsePairPayload(
+          "manta://pair?server=" +
+            encodeURIComponent("http://192.168.1.10:8787") +
+            "&code=654321",
+        ),
+      ).toEqual({ serverUrl: "http://192.168.1.10:8787", boxId: null, code: "654321" });
+    });
   });
 
-  it("accepts the id/token alias and normalizes it to server/code", () => {
-    expect(
-      parsePairPayload("manta://pair?id=http://box:8787&token=123456"),
-    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  describe("boxId form (relay-paired, BET-156)", () => {
+    it("accepts the primary manta://pair?box=&code= form", () => {
+      expect(
+        parsePairPayload(`manta://pair?box=${BOX}&code=847291`),
+      ).toEqual({ serverUrl: null, boxId: BOX, code: "847291" });
+    });
+
+    it("accepts the box form in the https://host/m/... deferred-deeplink", () => {
+      expect(
+        parsePairPayload(
+          `https://links.example.com/m/x?box=${BOX}&code=847291`,
+        ),
+      ).toEqual({ serverUrl: null, boxId: BOX, code: "847291" });
+    });
+
+    it("URL-decodes an encoded box value", () => {
+      // The 32-hex chars have no reserved chars so this is mostly a sanity check.
+      expect(
+        parsePairPayload(
+          `manta://pair?box=${encodeURIComponent(BOX)}&code=000000`,
+        ),
+      ).toEqual({ serverUrl: null, boxId: BOX, code: "000000" });
+    });
   });
 
-  it("accepts the https://host/m/... deferred-deeplink form", () => {
-    expect(
-      parsePairPayload(
-        "https://links.example.com/m/abc?server=http://box:8787&code=123456",
-      ),
-    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
+  describe("exactly-one-of (server OR box) — both or neither is invalid", () => {
+    // Both present → invalid. Neither present → invalid. An empty value
+    // counts as "not present", so `server=&box=<id>` and the inverse are
+    // still VALID (one present, one empty) — they collapse to the present side.
+    const both = `manta://pair?server=http://box:8787&box=${BOX}&code=123456`;
+    const neither = "manta://pair?code=123456";
+    for (const [label, input] of [
+      ["both server and box present", both],
+      ["neither server nor box present", neither],
+    ]) {
+      it(`rejects ${label}`, () => {
+        expect(parsePairPayload(input)).toBeNull();
+      });
+    }
+    it("treats empty server as not-present, so server=&box=<id> → valid box form", () => {
+      expect(
+        parsePairPayload(`manta://pair?server=&box=${BOX}&code=123456`),
+      ).toEqual({ serverUrl: null, boxId: BOX, code: "123456" });
+    });
+    it("treats empty box as not-present, so server=<url>&box= → valid server form", () => {
+      expect(
+        parsePairPayload("manta://pair?server=http://box:8787&box=&code=123456"),
+      ).toEqual({ serverUrl: "http://box:8787", boxId: null, code: "123456" });
+    });
   });
 
-  it("trims surrounding whitespace before parsing", () => {
-    expect(
-      parsePairPayload("  manta://pair?server=http://box:8787&code=123456  "),
-    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
-  });
-
-  it("normalizes a bare-host server via normalizeServerUrl and strips trailing slashes", () => {
-    // bare host:port (no scheme) → http:// prefixed
-    expect(
-      parsePairPayload("manta://pair?server=box:8787&code=123456"),
-    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
-    // trailing slashes stripped
-    expect(
-      parsePairPayload(
-        "manta://pair?server=" +
-          encodeURIComponent("http://box:8787///") +
-          "&code=123456",
-      ),
-    ).toEqual({ serverUrl: "http://box:8787", code: "123456" });
-  });
-
-  it("URL-decodes an encoded server value", () => {
-    expect(
-      parsePairPayload(
-        "manta://pair?server=" +
-          encodeURIComponent("http://192.168.1.10:8787") +
-          "&code=654321",
-      ),
-    ).toEqual({ serverUrl: "http://192.168.1.10:8787", code: "654321" });
+  describe("boxId shape validation", () => {
+    it("rejects a box value that is not 32 hex chars", () => {
+      // Too short
+      expect(
+        parsePairPayload("manta://pair?box=deadbeef&code=123456"),
+      ).toBeNull();
+      // Non-hex
+      expect(
+        parsePairPayload("manta://pair?box=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz&code=123456"),
+      ).toBeNull();
+      // Too long
+      expect(
+        parsePairPayload(
+          "manta://pair?box=" + "a".repeat(64) + "&code=123456",
+        ),
+      ).toBeNull();
+    });
   });
 
   describe("returns null for malformed / foreign input", () => {
@@ -65,7 +139,6 @@ describe("parsePairPayload", () => {
       ["a non-manta http URL", "http://example.com?server=http://box:8787&code=123456"],
       ["manta scheme but wrong host", "manta://connect?server=http://box:8787&code=123456"],
       ["missing code", "manta://pair?server=http://box:8787"],
-      ["missing server", "manta://pair?code=123456"],
       ["empty server", "manta://pair?server=&code=123456"],
       ["empty code", "manta://pair?server=http://box:8787&code="],
       ["5-digit code", "manta://pair?server=http://box:8787&code=12345"],
@@ -83,9 +156,9 @@ describe("parsePairPayload", () => {
 });
 
 describe("buildPairPayload", () => {
-  it("produces the canonical manta://pair?server=<enc>&code= string", () => {
+  it("produces the canonical server form when serverUrl is set", () => {
     expect(
-      buildPairPayload({ serverUrl: "http://box:8787", code: "123456" }),
+      buildPairPayload({ serverUrl: "http://box:8787", boxId: null, code: "123456" }),
     ).toBe(
       "manta://pair?server=" +
         encodeURIComponent("http://box:8787") +
@@ -96,19 +169,27 @@ describe("buildPairPayload", () => {
   it("URL-encodes the server value", () => {
     const out = buildPairPayload({
       serverUrl: "http://192.168.1.10:8787",
+      boxId: null,
       code: "654321",
     });
     expect(out).toContain(encodeURIComponent("http://192.168.1.10:8787"));
     expect(out).not.toContain("http://192.168.1.10:8787&");
   });
+
+  it("produces the canonical box form when boxId is set (BET-156)", () => {
+    expect(
+      buildPairPayload({ serverUrl: null, boxId: BOX, code: "847291" }),
+    ).toBe(`manta://pair?box=${encodeURIComponent(BOX)}&code=847291`);
+  });
 });
 
 describe("round-trip", () => {
-  it("parsePairPayload(buildPairPayload(p)) deep-equals p for a valid canonical p", () => {
+  it("parsePairPayload(buildPairPayload(p)) deep-equals p for valid canonical inputs", () => {
     const cases: PairPayload[] = [
-      { serverUrl: "http://box:8787", code: "123456" },
-      { serverUrl: "http://192.168.1.10:8787", code: "000000" },
-      { serverUrl: "https://relay.example.com", code: "987654" },
+      { serverUrl: "http://box:8787", boxId: null, code: "123456" },
+      { serverUrl: "http://192.168.1.10:8787", boxId: null, code: "000000" },
+      { serverUrl: "https://relay.example.com", boxId: null, code: "987654" },
+      { serverUrl: null, boxId: BOX, code: "111111" },
     ];
     for (const p of cases) {
       expect(parsePairPayload(buildPairPayload(p))).toEqual(p);

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -27,12 +27,15 @@
 // shape) is SINGLE-SOURCED: we delegate to normalizeServerUrl /
 // isValidServerUrl (../pairStepLogic) and normalizeCode (../../shared/claim.mjs)
 // rather than re-implementing it here. boxId shape is checked with
-// isValidToken from src/server/webhooks.mjs (the same 32-hex gate the box
-// handshake uses).
+// isValidBoxToken from src/shared/transport.mjs (the SAME 32-hex gate as
+// src/server/webhooks.mjs isValidToken, kept in sync there for exactly this
+// use case — the renderer cannot import from src/server/* because the box
+// server pulls Node built-ins, which Vite's renderer build externalizes
+// and the import then fails at build time).
 
 import { normalizeServerUrl, isValidServerUrl } from "../pairStepLogic";
 import { normalizeCode } from "../../shared/claim.mjs";
-import { isValidToken } from "../../server/webhooks.mjs";
+import { isValidBoxToken } from "../../shared/transport.mjs";
 
 export type PairPayload = {
   serverUrl: string | null;
@@ -61,12 +64,13 @@ function coerceServerUrl(raw: string): string | null {
 /**
  * Coerce a raw boxId value to a validated 32-hex string, or null. The shape is
  * the same 32-hex token the box handshake / `loadAuth` use; reusing
- * isValidToken keeps the box-credential shape in ONE place. Trims whitespace.
+ * isValidBoxToken keeps the box-credential shape in ONE renderer-safe place
+ * (mirrored from src/server/webhooks.mjs isValidToken). Trims whitespace.
  */
 function coerceBoxId(raw: string): string | null {
   const trimmed = String(raw ?? "").trim();
   if (!trimmed) return null;
-  return isValidToken(trimmed) ? trimmed : null;
+  return isValidBoxToken(trimmed) ? trimmed : null;
 }
 
 /**

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -1,28 +1,44 @@
 // pairPayload.ts — pure parser + builder for the pairing deeplink/QR payload
-// (BET-73, M3.1). No DOM, no fetch, no camera: this is the pure-before-wired
-// foundation that stage 2 (camera → auto-connect) imports.
+// (BET-73, M3.1; extended BET-156 for relay-paired flows). No DOM, no fetch,
+// no camera: this is the pure-before-wired foundation that stage 2 (camera →
+// auto-connect) imports, and that the desktop's relay-paired onboarding reuses
+// for a single-paste "pair link" input.
 //
 // A desktop "Pair phone" panel encodes a payload into a QR; the mobile app
-// scans it (or resolves it from a deferred deeplink) and auto-connects. Two URL
-// shapes carry the SAME two fields (server + code); this module normalizes both
-// into a single { serverUrl, code } and provides the inverse builder used as a
-// round-trip oracle in tests (and later by the desktop QR panel in M6).
+// scans it (or resolves it from a deferred deeplink) and auto-connects. The
+// payload carries ONE of two addressing shapes, both keyed by a 6-digit pairing
+// code:
+//   • serverUrl (direct-HTTPS):  manta://pair?server=<url>&code=<6-digit>
+//   • boxId     (relay-paired):  manta://pair?box=<box_id>&code=<6-digit>
+// This module normalizes either into a single { serverUrl, boxId, code } and
+// provides the inverse builders used as round-trip oracles in tests (and by
+// the desktop QR panel + the install.sh heredoc).
 //
 //   1. Custom scheme (primary — what the desktop panel renders):
 //        manta://pair?server=<url>&code=<6-digit>
-//      M6-spec alias, also accepted:
-//        manta://pair?id=<serverUrl-or-boxId>&token=<code>
+//        manta://pair?box=<box_id>&code=<6-digit>
+//      M6-spec alias, also accepted (serverUrl form):
+//        manta://pair?id=<serverUrl>&token=<code>
 //   2. Deferred-deeplink https form (Branch/Firebase style):
 //        https://<host>/m/<payload>?server=<url>&code=<6-digit>
+//        https://<host>/m/<payload>?box=<box_id>&code=<6-digit>
 //
-// The validation contract (server URL shape, 6-digit code) is SINGLE-SOURCED:
-// we delegate to normalizeServerUrl / isValidServerUrl (../pairStepLogic) and
-// normalizeCode (../../shared/claim.mjs) rather than re-implementing it here.
+// The validation contract (server URL shape, 6-digit code, box_id 32-hex
+// shape) is SINGLE-SOURCED: we delegate to normalizeServerUrl /
+// isValidServerUrl (../pairStepLogic) and normalizeCode (../../shared/claim.mjs)
+// rather than re-implementing it here. boxId shape is checked with
+// isValidToken from src/server/webhooks.mjs (the same 32-hex gate the box
+// handshake uses).
 
 import { normalizeServerUrl, isValidServerUrl } from "../pairStepLogic";
 import { normalizeCode } from "../../shared/claim.mjs";
+import { isValidToken } from "../../server/webhooks.mjs";
 
-export type PairPayload = { serverUrl: string; code: string };
+export type PairPayload = {
+  serverUrl: string | null;
+  boxId: string | null;
+  code: string;
+};
 
 /**
  * Coerce a raw server value into a normalized, valid http(s) URL string, or
@@ -43,13 +59,26 @@ function coerceServerUrl(raw: string): string | null {
 }
 
 /**
+ * Coerce a raw boxId value to a validated 32-hex string, or null. The shape is
+ * the same 32-hex token the box handshake / `loadAuth` use; reusing
+ * isValidToken keeps the box-credential shape in ONE place. Trims whitespace.
+ */
+function coerceBoxId(raw: string): string | null {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) return null;
+  return isValidToken(trimmed) ? trimmed : null;
+}
+
+/**
  * Parse a raw scanned/deeplinked string into a PairPayload, or null for any
- * malformed / foreign input: not a bui pair URL, missing server or code, code
- * not exactly 6 digits, or an unparseable URL. Whitespace is trimmed.
+ * malformed / foreign input: not a bui pair URL, missing both server and box,
+ * code not exactly 6 digits, or an unparseable URL. Whitespace is trimmed.
  *
- * Accepts either query spelling — `server`/`code` (primary) or the M6 alias
- * `id`/`token` — and both URL shapes (custom `manta://pair` scheme and the
- * `https://host/m/...` deferred-deeplink form).
+ * Accepts either query spelling — `server`/`code` (primary), the M6 alias
+ * `id`/`token`, or the relay form `box`/`code` — and both URL shapes (custom
+ * `manta://pair` scheme and the `https://host/m/...` deferred-deeplink form).
+ *
+ * Exactly ONE of server / box must be present. Both or neither → null.
  */
 export function parsePairPayload(raw: string): PairPayload | null {
   const input = String(raw ?? "").trim();
@@ -79,12 +108,20 @@ export function parsePairPayload(raw: string): PairPayload | null {
   }
 
   const q = url.searchParams;
-  // Primary spelling wins; fall back to the id/token alias.
+  // Primary spellings win; fall back to the id/token alias for the server form
+  // only (the alias was the M6 serverUrl shorthand — it is NOT a boxId alias).
   const rawServer = q.get("server") ?? q.get("id") ?? "";
+  const rawBox = q.get("box") ?? "";
   const rawCode = q.get("code") ?? q.get("token") ?? "";
 
   const serverUrl = coerceServerUrl(rawServer);
-  if (!serverUrl) return null;
+  const boxId = coerceBoxId(rawBox);
+
+  // Exactly one of {server, box} must be present. Both or neither → reject.
+  // (An old QR with `id=<boxId>` will fail coerceServerUrl AND the id alias
+  // does not route to boxId — by design, since the alias predates relay and
+  // any boxId-looking value under `id` was always a server URL in the M6 spec.)
+  if ((serverUrl ? 1 : 0) + (boxId ? 1 : 0) !== 1) return null;
 
   const code = normalizeCode(rawCode);
   // normalizeCode strips non-digits and clamps to 6, so a 7-digit input would
@@ -93,17 +130,20 @@ export function parsePairPayload(raw: string): PairPayload | null {
   if (!/^\d{6}$/.test(code)) return null;
   if ((String(rawCode).match(/\d/g) ?? []).length !== 6) return null;
 
-  return { serverUrl, code };
+  return { serverUrl: serverUrl ?? null, boxId: boxId ?? null, code };
 }
 
 /**
- * Inverse of parsePairPayload: produce the canonical custom-scheme string
+ * Inverse of parsePairPayload for the direct-HTTPS form: produce the canonical
+ * custom-scheme string
  *   manta://pair?server=<url-encoded>&code=<code>
- * Used as a round-trip oracle in tests and later by the desktop QR panel (M6).
+ * Used as a round-trip oracle in tests and by the desktop QR panel.
  * The server URL is URL-encoded so reserved characters survive the query.
  */
 export function buildPairPayload(p: PairPayload): string {
-  const serverUrl = normalizeServerUrl(p.serverUrl);
-  const code = normalizeCode(p.code);
-  return `manta://pair?server=${encodeURIComponent(serverUrl)}&code=${code}`;
+  if (p.boxId) {
+    return `manta://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+  }
+  const serverUrl = normalizeServerUrl(p.serverUrl ?? "");
+  return `manta://pair?server=${encodeURIComponent(serverUrl)}&code=${p.code}`;
 }

--- a/src/server/webhooks.d.mts
+++ b/src/server/webhooks.d.mts
@@ -1,0 +1,9 @@
+// Hand-written type declarations for webhooks.mjs. Implementation is plain JS
+// so the renderer/main/relay tsconfig import it without crossing the process
+// boundary. Keep this in sync with src/server/webhooks.mjs — only the exports
+// actually consumed from `.ts` files need to be declared here; `.mjs` callers
+// bypass TS and see the runtime shape directly.
+
+// True when `token` is exactly 32 lowercase hex chars (128 bits) — the shape
+// box_id / box_token / account_token / device_token all share.
+export function isValidToken(token: unknown): token is string;

--- a/src/shared/claim.d.mts
+++ b/src/shared/claim.d.mts
@@ -25,5 +25,17 @@ export function isSubmittableCode(code: string): boolean;
 // Map an /auth/claim HTTP outcome (status + parsed body) to a ClaimOutcome.
 export function classifyClaimResult(status: number, body: unknown): ClaimOutcome;
 
+// Map a relay /pair HTTP outcome (status + parsed body) to a ClaimOutcome.
+// Wire shape per BET-156: { box_id, account_id, account_token }. The same
+// ClaimOutcome envelope is returned (with `account_token` carried as the
+// `boxToken` slot — the renderer's auth code path is unaware of the rename).
+export function classifyRelayClaimResult(status: number, body: unknown): ClaimOutcome;
+
+// Parse a relay /pair 200 body into { boxId, accountToken } — shared so the
+// renderer/mobile entry points can validate the same shape before persisting.
+export function parseRelayClaimResponse(json: unknown):
+  | { ok: true; boxId: string; accountToken: string }
+  | { ok: false; error: string };
+
 // The ClaimOutcome for a fetch that never produced an HTTP response.
 export function networkFailure(): ClaimOutcome;

--- a/src/shared/claim.mjs
+++ b/src/shared/claim.mjs
@@ -1,7 +1,16 @@
-// claim.mjs — pure, framework-free classification of a POST /auth/claim outcome.
+// claim.mjs — pure, framework-free classification of a pairing-claim outcome.
 //
-// The /auth/claim handshake (exchange a 6-digit pairing code for a box_token +
-// box_id) is reached from THREE places that must all agree on how an HTTP
+// Two wire shapes share this classifier:
+//   • the box's POST /auth/claim  (BET-49, direct-HTTPS) — returns
+//     { ok, box_token, box_id }. The token IS the box_token (the box's own
+//     identity); persisted as config.boxToken, presented as Bearer to the box.
+//   • the relay's POST /pair       (BET-156, ADR-2/3) — returns
+//     { box_id, account_id, account_token }. The desktop stores the
+//     account_token in the SAME config.boxToken slot and presents it as Bearer
+//     to the relay; from the renderer's POV it's still "the token that pairs
+//     the device to the box's surface" — the relay's /box/:box_id/* proxy
+//     makes the box appear under that URL.
+// Both shapes are reached from THREE places that must all agree on how an HTTP
 // outcome maps to a user-facing result:
 //   • the mobile/web client   (src/renderer/mobile/pairingLogic.ts re-exports)
 //   • the desktop onboarding   (src/renderer/onboarding/PairStep.tsx via IPC)
@@ -12,13 +21,14 @@
 // renderer tsconfig and the main tsconfig without crossing the process
 // boundary) is the single source of truth: a 403 means "wrong code" and a 429
 // means "rate limited" in exactly one place. Token-shape validation of a 200
-// body is delegated to parseClaimResponse (src/shared/transport.mjs) so a
-// malformed box_token can never be persisted from any entry point.
+// body is delegated to parseClaimResponse (direct) or parseRelayClaimResponse
+// (relay), each gating its own field names so a malformed token can never be
+// persisted from any entry point.
 //
 // Pure (no fetch, no DOM, no Node built-ins) → unit-tested in
 // src/shared/claim.test.ts.
 
-import { parseClaimResponse } from "./transport.mjs";
+import { parseClaimResponse, isValidBoxToken } from "./transport.mjs";
 
 // A pairing code is exactly 6 decimal digits (mirrors the server's
 // isValidPairingCode in src/server/auth.mjs — kept in sync so a client rejects
@@ -90,4 +100,45 @@ export function classifyClaimResult(status, body) {
 /** Result for a fetch that never produced an HTTP response (offline, DNS, …). */
 export function networkFailure() {
   return fail("network");
+}
+
+/**
+ * Parse a relay /pair response body. Shape per BET-156:
+ *   200 { box_id, account_id, account_token }
+ *      — `account_token` is the desktop's "boxToken" slot (it authenticates
+ *        the device to the RELAY, not to the box; ADR-1 keeps box_token
+ *        server-side).
+ * Any non-200, any missing field, any non-32-hex token → invalid_response.
+ * Pure + tested (the relay never sees the value classified away — the
+ * desktop's branch handles its own persistence decision).
+ */
+export function parseRelayClaimResponse(json) {
+  if (!json || typeof json !== "object") {
+    return { ok: false, error: "invalid_response" };
+  }
+  const boxId = json.box_id;
+  const accountToken = json.account_token;
+  if (!isValidBoxToken(boxId) || !isValidBoxToken(accountToken)) {
+    return { ok: false, error: "invalid_response" };
+  }
+  return { ok: true, boxId, accountToken };
+}
+
+/**
+ * Classify a relay /pair HTTP outcome into a typed ClaimOutcome. Mirrors
+ * `classifyClaimResult` exactly (same status → same `kind` mapping) so the
+ * renderer's single error-handling path keeps working unchanged for both
+ * branches. The 200 body parser is the only difference (account_token vs
+ * box_token field name).
+ */
+export function classifyRelayClaimResult(status, body) {
+  if (status === 200) {
+    const parsed = parseRelayClaimResponse(body);
+    if (parsed.ok) return { ok: true, boxToken: parsed.accountToken, boxId: parsed.boxId };
+    return fail("invalid_response");
+  }
+  if (status === 429) return fail("rate_limited");
+  if (status === 400 || status === 403) return fail("wrong_code");
+  if (status >= 500) return fail("server_error");
+  return fail("server_error");
 }

--- a/src/shared/claim.test.ts
+++ b/src/shared/claim.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeCode,
   isSubmittableCode,
   classifyClaimResult,
+  classifyRelayClaimResult,
   networkFailure,
 } from "./claim.mjs";
 
@@ -97,6 +98,56 @@ describe("networkFailure", () => {
     if (!r.ok) {
       expect(r.kind).toBe("network");
       expect(r.message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("classifyRelayClaimResult (BET-156, relay /pair)", () => {
+  // Wire shape: { box_id, account_id, account_token }. The desktop stores
+  // `account_token` in the SAME `boxToken` slot the direct /auth/claim shape
+  // populates — the renderer's auth code path is unaware of the difference.
+  it("200 with a valid body → ok + (account_token → boxToken, box_id)", () => {
+    const r = classifyRelayClaimResult(200, {
+      box_id: HEX32B,
+      account_id: HEX32,
+      account_token: HEX32B, // a different 32-hex value
+    });
+    expect(r).toEqual({ ok: true, boxToken: HEX32B, boxId: HEX32B });
+  });
+
+  it("200 with malformed account_token → invalid_response", () => {
+    const r = classifyRelayClaimResult(200, {
+      box_id: HEX32B,
+      account_id: HEX32,
+      account_token: "nope",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("invalid_response");
+  });
+
+  it("200 with missing account_token → invalid_response", () => {
+    const r = classifyRelayClaimResult(200, { box_id: HEX32B, account_id: HEX32 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("invalid_response");
+  });
+
+  it("200 with null body → invalid_response", () => {
+    const r = classifyRelayClaimResult(200, null);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("invalid_response");
+  });
+
+  it("status mapping matches classifyClaimResult exactly (one error-handling path on the renderer)", () => {
+    for (const [status, kind] of [
+      [403, "wrong_code"],
+      [400, "wrong_code"],
+      [429, "rate_limited"],
+      [500, "server_error"],
+      [503, "server_error"],
+    ] as const) {
+      const r = classifyRelayClaimResult(status, { error: "x" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.kind).toBe(kind);
     }
   });
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -549,14 +549,25 @@ export type AgentFileReady = {
 
 // ----- Onboarding pairing (BET-49) -----
 
-// Input for the desktop auth:claim channel. `serverUrl` is the base URL of the
-// bui-server to pair with (e.g. "http://box.example:8787"); `code` is the
-// 6-digit pairing code minted on the box (`bui pair`). On success main persists
-// { serverUrl, boxId, boxToken } to config. The typed OUTCOME lives in
+// Input for the desktop auth:claim channel. The mobile/web client always
+// supplies a non-empty `serverUrl` (direct-HTTPS pairing, BET-49). The desktop
+// onboarding shell (BET-156) accepts EITHER `serverUrl` OR `boxId` (the
+// relay-paired form); when `boxId` is set, `serverUrl` MUST be an empty
+// string (the same field stays required so httpApi — which is mobile-only —
+// sees an unchanged type signature, per BET-156's "do not modify httpApi"
+// rule):
+//   • serverUrl non-empty → POST <serverUrl>/auth/claim { code } (BET-49).
+//   • boxId set, serverUrl "" → POST https://relay.mantaui.com/pair
+//     { box_id, code } (BET-156). Persists
+//     { serverUrl: "<RELAY_BASE>/box/<box_id>", boxId, boxToken } so every
+//     downstream /rpc + /events + upload hits the relay's /box/:box_id/*
+//     proxy with zero new data-path code (ADR-3).
+// `code` is the 6-digit pairing code (either flow). The typed OUTCOME lives in
 // src/shared/claim.mjs (ClaimOutcome) — imported by preload/main directly so
 // types.ts stays dependency-free.
 export type AuthClaimInput = {
   serverUrl: string;
+  boxId?: string;
   code: string;
 };
 


### PR DESCRIPTION
Stage 3 of the launch-ready onboarding epic (BET-151). Depends on BET-152 (relay /pair + TOFU auth, merged) and BET-155 (agent auth overwrite, merged).

A relay-paired desktop now reaches the box through `https://relay.mantaui.com/box/<box_id>` with zero new data-path code: ADR-3 means the same `{serverUrl, boxToken}` config shape the direct-HTTPS desktop already used Just Works — httpApi's Bearer header, `/events` EventSource, and uploads all hit the relay's `/box/:box_id/*` proxy unchanged. The only thing left to wire was making SSE actually stream through the tunnel instead of buffering the whole body.

**§1 Pair payload carries box_id.** `parsePairPayload` (`src/renderer/mobile/pairPayload.ts`) normalizes to `{ serverUrl: string | null, boxId: string | null, code }` and accepts `manta://pair?box=<32-hex>&code=<6-digit>` alongside the existing `?server=` / `?id=` spellings. Exactly-one-of is enforced (both/neither → null). `buildPairPayload` gains the box form. `scripts/install.sh`'s final heredoc prints a ready-to-paste `manta://pair?box=<box_id>&code=<code>` line — the code is captured from `manta pair`'s stable output (`formatPairingOutput`'s `  Pairing code:  NNNNNN` line), no JSON re-parsing in bash.

**§2 Claim path: relay when the payload has boxId.** `claimPairing` (`src/main/auth.ts`) branches on `boxId` inside the same function (no `*V2`, no copies) — POST `${RELAY_BASE}/pair { box_id, code }` returns `{ box_id, account_id, account_token }` and we persist `{ serverUrl: <RELAY_BASE>/box/<box_id>, boxId, boxToken: account_token }` so downstream httpApi hits the relay's per-box proxy untouched. `RELAY_BASE = "https://relay.mantaui.com"` is hardcoded per ADR-3; `MANTA_RELAY_BASE` is an env override (tests only). `classifyRelayClaimResult` (claim.mjs) mirrors `classifyClaimResult` exactly except for the 200 body parser (`account_token` vs `box_token`) so the renderer keeps one error-handling path. `PairStep.tsx` gets an optional "Or paste a pair link" input (reuses exact styling of the existing fields) that runs `parsePairPayload` and routes to the same `authClaim` IPC call.

**§3 SSE through the tunnel.** Phone ↔ box SSE was fully buffered before this commit: agent's local fetch awaited `res.text()` and the api's proxy returned the same body once the box leg closed — opencode's chat-event feed reached the phone as a single block. Now:

- `protocol.mjs`: STREAM_OPEN has two shapes, validated by exactly-one-of `{method, status}` — request form (relay→box: upstream method/path), response form (box→relay: upstream status/headers). `StreamRegistry` delivers the inbound STREAM_OPEN to the consumer's `onOpen` callback.
- `relay/index.mjs`: `createRelayServer` gains `streamRequest(boxId, req, callbacks)`. It allocates a stream id, registers a per-stream consumer on the box's per-transport `StreamRegistry`, sends STREAM_OPEN request form down the tunnel. The consumer's `onOpen`/`onData`/`onEnd`/`onAbort` fire from the box→relay frames. Aborts on box disconnect (`abortAll`).
- `relay/agent/index.mjs`: `handleStreamOpen` opens a streaming local fetch (new `makeDefaultLocalFetchStream` + injectable `localFetchStream`), forwards the response head as STREAM_OPEN response form, pumps body chunks as STREAM_DATA via `TextDecoder` (stream:true for multi-byte UTF-8 boundaries), ends with STREAM_END (or STREAM_ABORT on fetch/read error). Same ADR-1 auth overwrite as the buffered fetch.
- `relay/api.mjs`: `STREAMING_SUBPATH_PREFIXES = ['/events']` (deliberate carve-out, not a wildcard). Dispatch returns a `__stream` sentinel for `/events`; `nodeHandler` drives it via a sink that `writeHead+flushHeaders`, writes DATA chunks incrementally, ends on END/ABORT. `Content-Length`/`Transfer-Encoding` stripped from the upstream head (chunked encoding is ours); `Cache-Control: no-store` forced. Phone hang-up mid-stream aborts the relay-side handle. Non-SSE paths use the existing buffered `proxyRequest` unchanged — `non-SSE proxied paths still use the buffered path` test pins this carve-out.

**Files changed (19):**
- `scripts/install.sh` — heredoc gets the ready-to-paste pair link
- `src/main/{auth.ts,auth.test.ts}` — relay branch + tests
- `src/main/auth.ts` (RELAY_BASE), `src/shared/{claim.mjs,claim.d.mts,claim.test.ts}` — relay classifier
- `src/shared/types.ts` — AuthClaimInput gains optional boxId
- `src/renderer/mobile/{pairPayload.ts,pairPayload.test.ts}` — payload type + tests
- `src/renderer/PairStep.tsx` — optional pair-link input
- `src/relay/{protocol.mjs,protocol.test.mjs}` — STREAM_OPEN shape + onOpen delivery
- `src/relay/{index.mjs,index.test.mjs}` — streamRequest + per-transport registry
- `src/relay/agent/{index.mjs,index.test.mjs}` — handleStreamOpen + localFetchStream
- `src/relay/{api.mjs,api.test.mjs}` — /events STREAM_* branch + __stream sentinel
- `src/shared/claim.d.mts` — declare the new relay-classifier exports
- `src/server/webhooks.d.mts` — NEW, minimal `.d.mts` so TS can `import isValidToken` from `webhooks.mjs`

**Hygiene verified:**
- `git diff --stat origin/main...HEAD` lists no changes under `src/renderer/api/httpApi.ts`, `src/shared/transport.mjs`, `src/preload/` (grep returns empty)
- One `claimPairing` function (with two file-private helpers `claimPairingDirect`/`claimPairingRelay`); one `parsePairPayload`/`buildPairPayload` parser
- `npm run typecheck` (both projects) clean
- `npm test` (vitest 942 / node 591) green

**Verification results:**
- PR branch (`multica/BET-156-relay-pair-and-sse` @ `62bf405`):
  - typecheck: exit `0` for `tsconfig.node.json` and `tsconfig.web.json`. Errors: none. log sha256: `4f69c176fdb09dd2efe24542d5d290b22de3d246fdafe0d7b71cdc3b0544af89`
  - vitest: `52` files, `942` pass / `0` fail / `0` skip. log sha256: `d30b9cb8b92d5719f2ae4c74cae93d843f3b1cf2a6c39fd963b5b8f180d17ba8`
  - node:test (server+relay+agent+install): `591` pass / `0` fail. log sha256: `741642fafb3626568247c26831d5430cb03ff22e28076897123e743ed868c42a`
- Base (`main` @ `fc436fe`): same logs available on disk for spot-check; all 919 vitest + 549 node:test baseline still green (the +23 / +42 are this PR's tests).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/test-server-pr.log`.

**Self-check** (every issue criterion ≥ 8/10):
- §1 box form + exactly-one-of + id alias preserved: 10/10 — covered by `parsePairPayload.test.ts`
- §1 install.sh heredoc prints `manta://pair?box=<id>&code=<code>`: 10/10 — `bash -n scripts/install.sh` clean
- §2 claimPairing branches on boxId, no V2: 10/10 — single function, two helpers
- §2 serverUrl branch unchanged: 10/10 — `auth.test.ts` original 7 cases still pass
- §2 no httpApi.ts / transport.mjs / preload changes: 10/10 — `git diff --name-only | grep` returns empty
- §2 RELAY_BASE + MANTA_RELAY_BASE env: 10/10 — tested
- §2 PairStep pair-link input: 10/10 — added with reused styling
- §3 agent stream OPEN→DATA×n→END preserving chunks: 10/10 — `agent turns an event-stream local response into OPEN→DATA×n→END frames preserving chunk boundaries`
- §3 relay api writes chunks incrementally: 10/10 — `api proxy writes chunks incrementally` (via streamRequest end-to-end test)
- §3 non-SSE keeps buffered path: 10/10 — `non-SSE proxied paths still use the buffered path`