### PR TITLE
feat(relay): wire per-box byte metering into the proxy path (BET-157)

### DIFF
--- a/src/relay/api.mjs
+++ b/src/relay/api.mjs
@@ -211,6 +211,13 @@ export function isStreamingSubpath(subpath) {
  *   phone auth seam; default createDefaultPhoneAuth({ store, warn }).
  * @param {(boxId:string)=>boolean} [opts.hasActiveSubscription]
  *   gate seam; default createDefaultSubscriptionCheck(store, now).
+ * @param {object} [opts.meter]  the per-box meter from createBoxMeter({ store, now }).
+ *   When provided, the proxy branch enforces the per-box cap (over-cap → 429
+ *   `quota_exceeded`), records byte counters (ingress once on the request body,
+ *   egress once for buffered responses or per STREAM_DATA chunk for streamed
+ *   responses), and `boxView` exposes `bytes_in`/`bytes_out` from the store.
+ *   Optional so callers (and tests) without a meter still get full routing.
+ *   See BET-157 / metering.mjs for the contract.
  * @param {(key:string)=>boolean} [opts.rateLimiter]  take(key)=>bool; created if omitted.
  * @param {() => number} [opts.now=Date.now]
  * @param {(...a)=>void} [opts.warn]
@@ -220,6 +227,7 @@ export function createRelayApi(opts = {}) {
     store,
     proxyRequest,
     streamRequest,
+    meter = null,
     now = () => Date.now(),
     warn = console.warn,
   } = opts;
@@ -280,7 +288,7 @@ export function createRelayApi(opts = {}) {
     // GET /api/boxes — the authed account's boxes.
     if (method === "GET" && pathname === "/api/boxes") {
       const boxes = store.listBoxesForAccount(auth.accountId) || [];
-      return json(200, { boxes: boxes.map((b) => boxView(b)) });
+      return json(200, { boxes: boxes.map((b) => boxView(b, store.getUsage(b.box_id))) });
     }
 
     // /api/boxes/:box_id  and  /api/boxes/:box_id/revoke
@@ -308,7 +316,7 @@ export function createRelayApi(opts = {}) {
       if (method !== "GET") return json(405, { error: "method_not_allowed" });
       const box = store.getBox(boxId);
       if (!box) return json(404, { error: "not_found" });
-      return json(200, { box: boxView(box) });
+      return json(200, { box: boxView(box, store.getUsage(boxId)) });
     }
 
     // Phone→box PROXY:  /box/:box_id/<subpath>
@@ -341,12 +349,25 @@ export function createRelayApi(opts = {}) {
       // to the buffered path — pre-BET-156 behavior, the phone gets the
       // full body at end-of-stream. Better than refusing the request.
       if (isStreamingSubpath(subpath) && streamRequest) {
+        // Cap check before opening the stream (BET-157 §3): an over-cap
+        // request never frames STREAM_OPEN — we return a buffered 429 JSON
+        // so the phone sees the rejection as a status, not as a silently
+        // closed stream. GATED vs FREE is metered identically — the bucket
+        // selection uses hasActiveSubscription as the `paid` flag.
+        if (meter && !meter.allow(boxId, { paid: hasActiveSubscription(boxId) })) {
+          return json(429, { error: "quota_exceeded", box_id: boxId });
+        }
+        const ingress = Buffer.byteLength(req.body ?? "");
         let resolved = false;
         return {
           __stream: true,
           handler: () => {
             if (resolved) return;
             resolved = true;
+            // Record ingress once when the stream is actually opened (the
+            // box's STREAM_OPEN is being framed). Egress starts at 0 and is
+            // accumulated per STREAM_DATA chunk below.
+            if (meter) meter.record(boxId, { ingress, egress: 0 });
             return streamRequest(boxId, {
               method,
               path: subpath,
@@ -354,13 +375,30 @@ export function createRelayApi(opts = {}) {
               body: req.body,
             }, {
               onHead: (h) => streamingSink({ kind: "head", status: h.status, headers: h.headers }),
-              onData: (data) => streamingSink({ kind: "data", data }),
+              onData: (data) => {
+                // Per-chunk egress metering at the single place chunks are
+                // written (BET-157 §2). record() swallows its own errors so
+                // a metering write never breaks the phone's stream.
+                if (meter && data) {
+                  meter.record(boxId, { ingress: 0, egress: Buffer.byteLength(data) });
+                }
+                streamingSink({ kind: "data", data });
+              },
               onEnd: () => streamingSink({ kind: "end" }),
               onAbort: (reason) => streamingSink({ kind: "abort", reason: String(reason || "aborted") }),
             });
           },
         };
       }
+
+      // Pre-flight cap check on the buffered path (BET-157 §3): the rate-
+      // limit verdict decides whether we burn a tunnel round-trip. Recorded
+      // bytes come AFTER the round-trip succeeds (below) so a rejected or
+      // failed request leaves no usage.
+      if (meter && !meter.allow(boxId, { paid: hasActiveSubscription(boxId) })) {
+        return json(429, { error: "quota_exceeded", box_id: boxId });
+      }
+      const ingress = Buffer.byteLength(req.body ?? "");
 
       // Forward to the box's live tunnel. The relay preserves the phone's method
       // + body and forwards the subpath (not the /box/:box_id prefix) so the box
@@ -372,6 +410,15 @@ export function createRelayApi(opts = {}) {
           headers: sanitizeForwardHeaders(req.headers),
           body: req.body,
         });
+        // Record ingress + egress once the round-trip completes. On any
+        // throw below we intentionally do NOT record (a failed request costs
+        // nothing — the issue's over-cap rejection also avoids recording).
+        if (meter) {
+          meter.record(boxId, {
+            ingress,
+            egress: Buffer.byteLength(resp?.body ?? ""),
+          });
+        }
         return {
           status: Number.isInteger(resp?.status) ? resp.status : 502,
           headers: resp?.headers || { "content-type": "application/octet-stream" },
@@ -501,12 +548,18 @@ export function createRelayApi(opts = {}) {
 // out here (the store row only knows persisted status/last_seen); the router
 // reports persisted status. A live-tunnel flag would require the RoutingTable,
 // which the API layer doesn't own — status/last_seen is the durable answer.
-function boxView(b) {
+//
+// `usage` is the metering row from `store.getUsage(boxId)` (may be null when
+// the box has never been proxied through). When provided, `bytes_in` /
+// `bytes_out` are surfaced so clients see per-box usage with no extra endpoint.
+function boxView(b, usage = null) {
   return {
     box_id: b.box_id,
     status: b.status,
     created_at: b.created_at,
     last_seen: b.last_seen,
+    bytes_in: usage?.ingress ?? 0,
+    bytes_out: usage?.egress ?? 0,
   };
 }
 

--- a/src/relay/api.test.mjs
+++ b/src/relay/api.test.mjs
@@ -9,6 +9,7 @@ import {
   isStreamingSubpath,
 } from "./api.mjs";
 import { createRelayServer, createDefaultVerifier } from "./index.mjs";
+import { createBoxMeter, FREE_RL_CAPACITY } from "./metering.mjs";
 import { openStore, BOX_STATUS, hashToken } from "./store.mjs";
 import { encodeFrame, decodeFrame, FRAME_TYPES } from "./protocol.mjs";
 
@@ -594,4 +595,228 @@ test("non-SSE proxied paths still use the buffered path (no behavior change)", a
   assert.equal(JSON.parse(resp.body).ok, true);
   await waitFor(() => !streamUsed, { timeoutMs: 1000 });
   assert.equal(streamUsed, false, "/projects did NOT trigger the streaming path");
+});
+
+// ---------------------------------------------------------------------------
+// byte metering (BET-157) — meter wired into the api proxy branch + boxView
+// ---------------------------------------------------------------------------
+
+test("metering: proxied request records ingress+egress bytes for the right box_id", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  // The proxy path POSTs to /prompt (gated). Bind an active receipt so the
+  // 402 gate doesn't fire before the proxy branch — metering is what we're
+  // testing here.
+  store.upsertReceipt({ originalTransactionId: "t-meter-prompt", boxId: BOX_A, expiresAt: null });
+  const meter = createBoxMeter({ store, warn: silent });
+
+  // The proxyRequest fake reflects the forwarded body back as JSON so the
+  // response body is non-empty — exercising both ingress and egress.
+  const proxyRequest = async (_boxId, fwd) => ({
+    status: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ echo: fwd.body ?? "" }),
+  });
+  const api = createRelayApi({
+    store,
+    proxyRequest,
+    meter,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  // Pre-flight: BOX_A has no usage row yet.
+  assert.equal(store.getUsage(BOX_A), null);
+
+  // POST a known-size body so ingress is deterministic.
+  const reqBody = '{"hello":"world"}';
+  const resp = await api.route({
+    method: "POST",
+    path: `/box/${BOX_A}/prompt`,
+    headers: { ...bearer(ACCT_1), "content-type": "application/json" },
+    body: reqBody,
+  });
+  assert.equal(resp.status, 200);
+
+  const usage = store.getUsage(BOX_A);
+  assert.ok(usage, "BOX_A has a usage row after one proxied request");
+  // ingress = body bytes (req.body is the JSON above — 17 bytes; headers are
+  // NOT metered per BET-157 §2).
+  assert.equal(usage.ingress, Buffer.byteLength(reqBody), "ingress = body byte length");
+  // egress = body byte length of the buffered response.
+  assert.equal(usage.egress, Buffer.byteLength(resp.body), "egress = response body bytes");
+  assert.equal(usage.egress, Buffer.byteLength('{"echo":"{\\"hello\\":\\"world\\"}"}'));
+
+  // Per-box isolation: BOX_B has no usage (its free bucket is still full).
+  assert.equal(store.getUsage(BOX_B), null, "BOX_B was not proxied through");
+
+  // A second request accumulates (does not overwrite).
+  await api.route({
+    method: "POST",
+    path: `/box/${BOX_A}/prompt`,
+    headers: { ...bearer(ACCT_1), "content-type": "application/json" },
+    body: reqBody,
+  });
+  const after = store.getUsage(BOX_A);
+  assert.equal(after.ingress, usage.ingress * 2, "second request doubles ingress");
+  assert.equal(after.egress, usage.egress * 2, "second request doubles egress");
+});
+
+test("metering: over-cap box → 429 and proxyRequest is NOT called", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  // Freeze the clock so the token bucket never refills during the burst.
+  const meter = createBoxMeter({ store, now: () => 1000, warn: silent });
+
+  // Drain BOX_A's free bucket — every subsequent allow() returns false.
+  for (let i = 0; i < FREE_RL_CAPACITY + 2; i++) {
+    meter.allow(BOX_A, { paid: false });
+  }
+
+  let proxyCalls = 0;
+  const proxyRequest = async () => {
+    proxyCalls += 1;
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true }),
+    };
+  };
+  const api = createRelayApi({
+    store,
+    proxyRequest,
+    meter,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  // Free (metadata) subpath — same gate as gated, BET-157 §3.
+  const resp = await api.route({
+    method: "GET",
+    path: `/box/${BOX_A}/projects`,
+    headers: bearer(ACCT_1),
+  });
+  assert.equal(resp.status, 429, "over-cap free subpath → 429");
+  assert.equal(proxyCalls, 0, "proxyRequest NOT called for over-cap request");
+  const body = await parseBody(resp);
+  assert.equal(body.error, "quota_exceeded");
+  assert.equal(body.box_id, BOX_A);
+
+  // The rejection must NOT have recorded usage.
+  assert.equal(store.getUsage(BOX_A), null, "rejected requests leave no usage row");
+});
+
+test("metering: boxView exposes bytes_in/bytes_out from the store", async (t) => {
+  const store = seededStore();
+  t.after(() => store.close());
+  const meter = createBoxMeter({ store, warn: silent });
+  meter.record(BOX_A, { ingress: 123, egress: 456 });
+
+  const api = createRelayApi({
+    store,
+    proxyRequest: noProxy,
+    meter,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  // /api/boxes/:id detail — bytes_* are surfaced from the metering row.
+  const detail = await api.route({
+    method: "GET",
+    path: `/api/boxes/${BOX_A}`,
+    headers: bearer(ACCT_1),
+  });
+  assert.equal(detail.status, 200);
+  const body = await parseBody(detail);
+  assert.equal(body.box.bytes_in, 123);
+  assert.equal(body.box.bytes_out, 456);
+
+  // /api/boxes list — same fields per box (zero when no usage yet).
+  const list = await api.route({
+    method: "GET",
+    path: "/api/boxes",
+    headers: bearer(ACCT_1),
+  });
+  assert.equal(list.status, 200);
+  const lb = await parseBody(list);
+  const a = lb.boxes.find((x) => x.box_id === BOX_A);
+  assert.ok(a, "BOX_A is in the list");
+  assert.equal(a.bytes_in, 123);
+  assert.equal(a.bytes_out, 456);
+
+  // BOX_B was never metered — its boxView shows zeros.
+  const lb2 = await parseBody(
+    await api.route({ method: "GET", path: "/api/boxes", headers: bearer(ACCT_2) }),
+  );
+  const b = lb2.boxes.find((x) => x.box_id === BOX_B);
+  assert.equal(b.bytes_in, 0);
+  assert.equal(b.bytes_out, 0);
+});
+
+test("metering: streamed /events path records ingress once + per-chunk egress (chunk pump)", async (t) => {
+  const store = openStore();
+  store.upsertBox(BOX_A, { status: BOX_STATUS.ONLINE, at: 1 });
+  store.bindBox(BOX_A, ACCT_1, { at: 1 });
+  store.upsertReceipt({ originalTransactionId: "t-meter-stream", boxId: BOX_A, expiresAt: null });
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((r) => wss.once("listening", r));
+  const relay = createRelayServer({
+    wss,
+    store,
+    verifyBox: createDefaultVerifier({ store, warn: silent, log: silent }),
+    log: silent,
+    warn: silent,
+  });
+
+  // Fake box serves three SSE chunks.
+  const boxWs = new WebSocket(
+    `ws://127.0.0.1:${wss.address().port}/box?box_id=${BOX_A}&token=${BOX_TOKEN_A}`,
+  );
+  await once(boxWs, "open");
+  const chunks = ["data: a\n\n", "data: bb\n\n", "data: ccc\n\n"];
+  installAutoStreamBox(boxWs, { chunks, status: 200, headers: { "content-type": "text/event-stream" } });
+  await waitFor(() => relay.routing.has(BOX_A));
+
+  t.after(async () => {
+    boxWs.close();
+    await waitFor(() => !relay.routing.has(BOX_A));
+    await relay.close();
+    await new Promise((r) => wss.close(() => r()));
+  });
+
+  const meter = createBoxMeter({ store, warn: silent });
+  const api = createRelayApi({
+    store,
+    proxyRequest: relay.proxyRequest,
+    streamRequest: relay.streamRequest,
+    meter,
+    authenticatePhone: makeAuth(),
+    warn: silent,
+  });
+
+  // Send a request with a known body so ingress is exact (the box ignores the
+  // body but metering still counts it).
+  const reqBody = "hi";
+  const events = [];
+  const resp = await api.route(
+    {
+      method: "GET",
+      path: `/box/${BOX_A}/events`,
+      headers: { ...bearer(ACCT_1), "content-type": "text/plain" },
+      body: reqBody,
+    },
+    (e) => events.push(e),
+  );
+  assert.ok(resp.__stream, "/events returns the __stream sentinel");
+  // Drive the stream — the handler records ingress once at this point.
+  resp.handler();
+  await waitFor(() => events.some((e) => e.kind === "end"), { timeoutMs: 2000 });
+
+  // Verify egress recorded per-chunk: each chunk's bytes show up in store.
+  const expectedEgress = chunks.reduce((n, c) => n + Buffer.byteLength(c), 0);
+  const usage = store.getUsage(BOX_A);
+  assert.ok(usage, "BOX_A has a usage row after streamed request");
+  assert.equal(usage.ingress, Buffer.byteLength(reqBody), "ingress recorded once on stream open");
+  assert.equal(usage.egress, expectedEgress, "egress = sum of chunk byte lengths");
 });

--- a/src/relay/server.mjs
+++ b/src/relay/server.mjs
@@ -43,6 +43,7 @@ import {
   createDefaultPhoneAuth,
   createDefaultSubscriptionCheck,
 } from "./api.mjs";
+import { createBoxMeter } from "./metering.mjs";
 import { createReceiptValidator, bindReceipt } from "./iap.mjs";
 import { createRelayPush } from "./push.mjs";
 import { openStore, hashToken } from "./store.mjs";
@@ -158,9 +159,16 @@ export function createRelayService(opts = {}) {
 
   // --- Phone-facing API (Stage 4) ------------------------------------------
   // Wire it with the box leg's proxyRequest and the SHARED store + auth + gate.
+  // The per-box meter (BET-157 §1) is the COGS instrument: every phone→box
+  // request the api proxies is gated by the rate cap and counted into
+  // store.getUsage(boxId) — surfaced as bytes_in/bytes_out on boxView. Built
+  // once here so both the buffered proxy branch and the STREAM_DATA pump
+  // (api.mjs) share the same meter instance.
+  const meter = createBoxMeter({ store, now, warn });
   const api = createRelayApi({
     store,
     proxyRequest,
+    meter,
     authenticatePhone,
     hasActiveSubscription,
     now,
@@ -277,6 +285,7 @@ export function createRelayService(opts = {}) {
     boxLeg,
     api,
     push,
+    meter,
     port,
     host,
     start,


### PR DESCRIPTION
Stage-5 wiring for the COGS instrument. metering.mjs was already a complete, tested module (per-box byte accumulation into the metering table + a per-box token-bucket cap); this PR plugs it into the proxy branch and exposes the counters to clients with no new endpoint.

Files changed: 3 files, +291 / -4.
- src/relay/api.mjs (+61 / -4) — accept meter opt, cap-check before proxyRequest, per-chunk STREAM_DATA metering, boxView exposes bytes_in/bytes_out
- src/relay/api.test.mjs (+225) — 4 new metering tests on the existing proxy fixtures
- src/relay/server.mjs (+9) — build the meter once in createRelayService and pass it into createRelayApi

Base: origin/main @ 7f0b65f

Verification results:
- PR branch (multica/BET-157-relay-metering-wiring @ ed4f5c7):
  - typecheck: exit 0. Errors: none. log sha256: f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba
  - node test (relay/server/agent/scripts): 595 pass / 0 fail / 0 skip
  - vitest (renderer): 942 pass / 0 fail
  - test log sha256: e6ddd3442b4c0ed4c2bcab1d7306ad4cef8a8a4a08be2f42190a15f6fbca4c38
- Base (main @ 7f0b65f):
  - typecheck: exit 0. Errors: none. log sha256: f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba
  - node test: 591 pass / 0 fail / 0 skip
  - vitest: 942 pass / 0 fail
  - test log sha256: 51194b0a3f607186088b21ad5628bd19bc5bb921b7362035227c8edcc0827ee2
- Conclusion: 0 pre-existing failures, 4 new node tests added (the 4 new metering cases in api.test.mjs), 0 new failures introduced. Both typecheck hashes match (no TS-level changes — this is .mjs wiring only).

Logs cached at /tmp/typecheck-pr.log, /tmp/typecheck-master.log, /tmp/test-pr-node-only.log, /tmp/test-master-node-only.log for reviewer spot-check.

## What changed

### src/relay/api.mjs
- New meter opt on createRelayApi({...}). When provided:
  - The proxy branch consults meter.allow(boxId, { paid }) BEFORE proxyRequest — over-cap returns 429 { error: quota_exceeded, box_id } via the same json() helper as the rest. proxyRequest is NOT called on rejection and no usage is recorded.
  - Buffered path records ingress once on the request body and egress once on the response body after the round-trip completes (so a thrown proxy error leaves no usage).
  - Streaming path records ingress once when the stream is opened, then per-chunk egress at the single place STREAM_DATA frames are written (next to streamingSink({ kind: data, data })). meter.record() swallows its own errors — a metering write never breaks the phone stream.
  - GATED vs FREE are metered identically: paid flag for bucket selection comes from hasActiveSubscription(boxId), no classification fork.
- boxView(b, usage) now takes the metering row and surfaces bytes_in / bytes_out on both /api/boxes (list) and /api/boxes/:id (detail). Defaults to 0 when no usage row exists.

### src/relay/server.mjs
- createRelayService builds the meter once via createBoxMeter({ store, now, warn }) next to the other Stage-5 pieces and passes it into createRelayApi. Single instance = same rate-limit state across the buffered and streaming paths. meter is also exposed on the returned service object for tests/diagnostics.

### src/relay/api.test.mjs — 4 new tests
1. proxied request records in+out bytes for the right box_id — POSTs a known body to /prompt, asserts store.getUsage(BOX_A).ingress === Buffer.byteLength(body) (not the headers, per §2), egress === response body bytes, BOX_B has no usage, and a second request accumulates (does not overwrite).
2. over-cap box → 429 + proxyRequest NOT called — freezes the clock, drains BOX_A free bucket, sends a free subpath, asserts 429 with quota_exceeded body, asserts proxyCalls === 0, asserts no usage row was created for the rejected request.
3. boxView exposes bytes_in/bytes_out from the store — seeds a known usage row, asserts both /api/boxes/:id detail and /api/boxes list surface the bytes; asserts zero-default for a box with no usage yet.
4. streamed /events records ingress once + per-chunk egress — full end-to-end with a real relay + fake box serving 3 SSE chunks of varying size; asserts usage.ingress === Buffer.byteLength(reqBody) and usage.egress === sum of chunk byte lengths.

## Hygiene
- Zero changes to metering.mjs or its 8 unit tests — they pass untouched (proves the wiring adapts to the module instead of rewriting it).
- No new auth/transport/RN surfaces touched.