### PR TITLE
fix(server): add /rpc auth:pair handler + remove dead preload IPC path (BET-161)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,20 +17,6 @@ import {
 import { checkForUpdates } from "./autoUpdate.js";
 import { IPC, type AppConfig, type AuthClaimInput } from "../shared/types.js";
 
-// Parse a non-2xx /auth/pair response body into a user-facing error string.
-// The server returns { error: "..." } for 403 (not loopback), 429 (rate limit),
-// and 5xx (server error). We extract the `error` field if present, otherwise
-// fall back to a generic message.
-function tryParsePairError(raw: string): string | null {
-  try {
-    const body = JSON.parse(raw);
-    if (body && typeof body.error === "string") return body.error;
-  } catch {
-    /* not JSON — fall through */
-  }
-  return null;
-}
-
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 let mainWindow: BrowserWindow | null = null;
@@ -271,51 +257,5 @@ function registerHandlers(): void {
   ipcMain.handle(IPC.authClaim, (_e, input: AuthClaimInput) =>
     claimPairing(input, (patch) => commit(patch)),
   );
-
-  // Mobile pairing code mint (BET-80): GET /auth/pair over HTTPS.
-  // Returns { pairingCode, boxId, expiresAt } for the desktop to render as a
-  // QR. The /auth/pair endpoint is exempt from the auth gate, so no Bearer
-  // token is needed.
-  ipcMain.handle(IPC.authPair, async () => {
-    const cfg = config;
-    if (!cfg.serverUrl) return { ok: false as const, error: "not connected" };
-    try {
-      const url = `${cfg.serverUrl.replace(/\/+$/, "")}/auth/pair`;
-      const res = await fetch(url, {
-        method: "GET",
-        signal: AbortSignal.timeout(4000),
-      });
-      let raw = "";
-      try { raw = await res.text(); } catch { /* bodyless */ }
-      if (!res.ok) {
-        const msg = tryParsePairError(raw);
-        return { ok: false, error: msg || `server ${res.status}` };
-      }
-      try {
-        const body = JSON.parse(raw) as {
-          pairing_code?: string;
-          box_id?: string;
-          expiresAt?: string;
-        };
-        if (
-          typeof body.pairing_code === "string" &&
-          typeof body.box_id === "string" &&
-          typeof body.expiresAt === "string"
-        ) {
-          return {
-            ok: true,
-            pairingCode: body.pairing_code,
-            boxId: body.box_id,
-            expiresAt: body.expiresAt,
-          };
-        }
-        return { ok: false, error: "unexpected response shape" };
-      } catch {
-        return { ok: false, error: "bad JSON from server" };
-      }
-    } catch {
-      return { ok: false, error: "server unreachable" };
-    }
-  });
 
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,7 +3,6 @@ import {
   IPC,
   type AppConfig,
   type AuthClaimInput,
-  type AuthPairResult,
   type DesktopNotifyPayload,
 } from "../shared/types.js";
 import type { ClaimOutcome } from "../shared/claim.mjs";
@@ -31,13 +30,6 @@ const api = {
   // { ok:false } result, NOT a rejected promise.
   authClaim: (input: AuthClaimInput): Promise<ClaimOutcome> =>
     ipcRenderer.invoke(IPC.authClaim, input),
-
-  // Mobile pairing code mint (BET-80): GET /auth/pair over the SSH tunnel.
-  // Returns { pairingCode, boxId, expiresAt } for the desktop to render as a
-  // QR. Resolves to an AuthPairResult — a failure is { ok:false, error }, NOT
-  // a rejected promise.
-  authPair: (): Promise<AuthPairResult> =>
-    ipcRenderer.invoke(IPC.authPair),
 
   clipboardWriteText: (text: string): Promise<void> =>
     ipcRenderer.invoke(IPC.clipboardWriteText, text),

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -530,8 +530,10 @@ export const httpApi: Api = {
   // the mobile client authenticates via the localStorage Bearer token.)
   authClaim: (input) => claimAgainst(input.serverUrl, input.code),
 
-  // Mobile pairing code mint (BET-80): GET /auth/pair. Desktop routes through
-  // the SSH tunnel via IPC (window.api.authPair); mobile calls this directly.
+  // Mobile pairing code mint (BET-161): POST /rpc/auth:pair. Both desktop and
+  // mobile go through the same /rpc channel — GET /auth/pair is loopback-only
+  // (cloudflared proxies public traffic from 127.0.0.1), so a remote renderer
+  // can't reach it as HTTP. The /rpc handler calls authEngine.pair() in-process.
   // Returns { pairingCode, boxId, expiresAt } or { error }.
   authPair: () => rpc<AuthPairResult>(IPC.authPair),
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -79,7 +79,11 @@ async function handleApiDelete(req, url, res, deleteFn) {
   respondJson(res, 200, { deleted: result.deleted });
 }
 
-const rpcHandlers = buildHandlers({ tmux, oc, pty, bus, local });
+// rpcHandlers is built further down — after authEngine exists — so the
+// `auth:pair` channel can call authEngine.pair() in-process. The dispatch
+// only fires inside the HTTP request handler below, which runs lazily once
+// the listen() callback returns, so the late binding is safe.
+let rpcHandlers = null;
 
 // Resolve a caller's bui project (tmux session) name from its opencode
 // sessionID and/or cwd, so project-scoped secrets resolve to the right
@@ -164,6 +168,11 @@ if (!authEnforced) {
 } else {
   console.log(`[auth] gate enabled — box_id ${boxAuth.box_id}`);
 }
+
+// Now that authEngine exists, wire the /rpc dispatch — the `auth:pair` channel
+// needs authEngine.pair() (GET /auth/pair is loopback-only, so the renderer can
+// only reach it through this in-process call, not as an HTTP round-trip).
+rpcHandlers = buildHandlers({ tmux, oc, pty, bus, local, authPair: () => authEngine.pair() });
 
 // Relay-agent handle (BET-151 ADR-1). Populated below in the listen() callback
 // when shouldStartRelayAgent(config) returns true. Read by GET /relay/status

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -19,15 +19,16 @@ export async function dispatch(handlers, channel, args) {
   return fn(...args);
 }
 
-// Build the full handler map. Accepts { tmux, oc, pty, bus, local } where:
-//   tmux  — src/server/tmux.mjs namespace
-//   oc    — src/server/opencode.mjs namespace
-//   pty   — src/server/pty.mjs namespace
-//   bus   — event bus created by createBus() in events.mjs
-//   local — src/server/local.mjs namespace (git/fs/config/clipboard stubs)
+// Build the full handler map. Accepts { tmux, oc, pty, bus, local, authPair } where:
+//   tmux     — src/server/tmux.mjs namespace
+//   oc       — src/server/opencode.mjs namespace
+//   pty      — src/server/pty.mjs namespace
+//   bus      — event bus created by createBus() in events.mjs
+//   local    — src/server/local.mjs namespace (git/fs/config/clipboard stubs)
+//   authPair — () => authEngine.pair(); the `auth:pair` channel wraps it.
 // Channel key strings MUST match IPC.* values in src/shared/types.ts.
 // Arg shapes MUST match what src/preload/index.ts packs per channel.
-export function buildHandlers({ tmux, oc, pty, bus, local }) {
+export function buildHandlers({ tmux, oc, pty, bus, local, authPair }) {
   // Mirror of resolveProjectCwd() in src/main/index.ts. Renderer-supplied cwd
   // is preferred when it's a real path, but falls through to the project's
   // stored defaultCwd whenever the renderer sends nothing or the literal "~".
@@ -390,6 +391,21 @@ export function buildHandlers({ tmux, oc, pty, bus, local }) {
     // preload: ipcRenderer.invoke(IPC.webhookDelete, id) → args[0] = id
     "webhook:delete": (id) =>
       webhookDeleteHook(id, { publish: (evt) => bus.publish(evt) }),
+
+    // ---- auth pairing code mint (BET-161) ----
+    // Mint a one-time mobile pairing code. Runs in-process on the box, so it
+    // satisfies the loopback-only minting invariant that the GET /auth/pair
+    // HTTP endpoint enforces (a remote httpApi caller can't hit that endpoint
+    // — it 403s non-loopback). authEngine.pair() returns snake_case;
+    // translate to the camelCase AuthPairResult the renderer expects.
+    "auth:pair": async () => {
+      try {
+        const r = await authPair();
+        return { ok: true, pairingCode: r.pairing_code, boxId: r.box_id, expiresAt: r.expiresAt };
+      } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : String(e) };
+      }
+    },
 
     // ---- pty channels (4 channels) ----
     //

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -214,3 +214,35 @@ test("opencode:discover-models accepts positional (baseURL, apiKey) args", async
     globalThis.fetch = origFetch;
   }
 });
+
+// BET-161: the `auth:pair` /rpc channel. authEngine.pair() returns snake_case
+// ({ pairing_code, box_id, expiresAt }); the handler translates to the
+// camelCase AuthPairResult the renderer expects. Failures must surface as
+// { ok:false, error } — a rejected promise would crash the renderer, which
+// expects the classified result shape (see Settings.tsx).
+test("auth:pair translates snake_case authEngine.pair() output to AuthPairResult", async () => {
+  const { deps } = makeDeps([]);
+  deps.authPair = async () => ({
+    pairing_code: "123456",
+    box_id: "abc",
+    expiresAt: "2026-01-01T00:00:00Z",
+  });
+  const handlers = buildHandlers(deps);
+  const result = await dispatch(handlers, "auth:pair", []);
+  assert.deepEqual(result, {
+    ok: true,
+    pairingCode: "123456",
+    boxId: "abc",
+    expiresAt: "2026-01-01T00:00:00Z",
+  });
+});
+
+test("auth:pair returns { ok:false, error } when authEngine.pair() throws", async () => {
+  const { deps } = makeDeps([]);
+  deps.authPair = async () => {
+    throw new Error("rate limited");
+  };
+  const handlers = buildHandlers(deps);
+  const result = await dispatch(handlers, "auth:pair", []);
+  assert.deepEqual(result, { ok: false, error: "rate limited" });
+});


### PR DESCRIPTION
## Summary

Clicking **Generate pairing code** in desktop Settings was throwing `unknown rpc channel: auth:pair`. On a paired desktop `window.api` is `httpApi`, which routes `authPair()` to `POST /rpc/auth:pair` — a channel the bui-server `/rpc` dispatch did not handle.

Fix: add an `auth:pair` handler to `rpcHandlers` that calls `authEngine.pair()` in-process. `/rpc` runs locally on the box, satisfying the loopback-only minting invariant (the `GET /auth/pair` HTTP endpoint 403s non-loopback, and cloudflared proxies public traffic from `127.0.0.1`, so a remote renderer cannot reach it as HTTP).

**Base: `origin/main` @ `425a89a`** — branched off fresh master.

## Files changed (6 files, +69 / -78)

- `src/server/rpc.mjs` — accept `authPair` in destructured deps; add `"auth:pair"` handler that translates `authEngine.pair()`'s snake_case to the camelCase `AuthPairResult` the renderer expects; failures return `{ ok:false, error }`, never a rejected promise.
- `src/server/index.mjs` — move `buildHandlers(...)` call from line 82 to after `authEngine` is created (was line 153), so the closure can reference `authEngine.pair()`. Verified safe — `rpcHandlers` is only consumed inside the lazy HTTP request handler that fires after `listen()`.
- `src/server/rpc.test.mjs` — two new tests: snake_case → camelCase translation on success, `{ ok:false, error }` on throw.
- `src/main/index.ts` — remove the dead `ipcMain.handle(IPC.authPair, ...)` block (~45 lines including its `fetch` to `<serverUrl>/auth/pair`) and the now-orphaned `tryParsePairError` helper.
- `src/preload/index.ts` — remove the dead `authPair` bridge method (renderer never uses the preload bridge; it's always `httpApi`).
- `src/renderer/api/httpApi.ts` — replace the stale "Desktop routes through the SSH tunnel via IPC" comment with the accurate "Both desktop and mobile go through `POST /rpc/auth:pair`" note.

`IPC.authPair` in `src/shared/types.ts`, the `authPair()` declaration in `src/shared/api.ts`, and the `httpApi.authPair` implementation are intentionally untouched — those are the live contract.

## Verification results

- PR branch (`multica/BET-161-auth-pair-rpc` @ `70e6dca`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `597` pass / `0` fail / `0` skip. New tests: `auth:pair translates snake_case authEngine.pair() output to AuthPairResult`, `auth:pair returns { ok:false, error } when authEngine.pair() throws`.
- Base (`master` @ `425a89a`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `595` pass / `0` fail / `0` skip.
- **Conclusion:** `0` new failures, `0` pre-existing failures, `+2` tests added.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for spot-check.

## Self-check (criteria → score)

1. Channel `"auth:pair"` matches `IPC.authPair` → **10/10**
2. Success shape `{ ok:true, pairingCode, boxId, expiresAt }` matches `AuthPairResult` → **10/10**
3. Failure shape `{ ok:false, error }` on throw (no rejected promise) → **10/10**
4. snake_case → camelCase mapping (`pairing_code → pairingCode`, `box_id → boxId`) → **10/10**
5. `buildHandlers` accepts `authPair`, closure captures `authEngine.pair()` → **10/10**
6. Dead Electron IPC handler removed from `src/main/index.ts` → **10/10**
7. Dead preload bridge method + unused `AuthPairResult` import removed from `src/preload/index.ts` → **10/10**
8. `tryParsePairError` helper removed (no other callers, verified by grep) → **10/10**
9. Stale "SSH tunnel via IPC" comment in `httpApi.ts` updated → **10/10**
10. Live contract kept: `IPC.authPair`, `authPair()` in `api.ts`, `httpApi.authPair` → **10/10**
11. `GET /auth/pair` HTTP endpoint + loopback guard untouched → **10/10**
12. `auth:claim` path untouched → **10/10**

All criteria ≥ 8/10.

## Cross-cutting notes

- No mobile rebuild needed — no CSS / renderer-source change reaches the served mobile bundle.
- The renderer-side `authPair` consumer (`Settings.tsx`) does not change behavior — it already expects `{ ok:true, ... }` or `{ ok:false, error }`; the new `/rpc` handler delivers both shapes.