### PR TITLE
ops(prod): commit-and-ship relay backups, log caps, uptime probe, security patches, fail2ban (BET-163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,38 @@ session by POST). Install/update = copy to `~/.config/opencode/tools/`
 - DNS on Cloudflare (apex/www/relay DNS-only → Caddy does TLS; wildcard
   `*.pages.<domain>` via DNS-01).
 
+### Prod box ops
+
+Ops scripts + configs are committed under `scripts/prod/` so the box is
+rebuildable from git. None of these touch application code; the install
+steps in each file's header are human-only (agent Hard Rule #4 forbids
+`ssh root@...`).
+
+- **Backups** (`scripts/prod/backup-relay.sh`, cron `manta-backup` at
+  03:17 UTC): the relay SQLite store is captured with `sqlite3 .backup`
+  (online, no torn writes) and the whole `~/.manta/` dir is tarballed
+  alongside; both ship to `dev@157.90.224.92:~/backups/manta-prod/` via
+  `scp`, with 7-day retention on both ends.
+- **Restore** (one-off, on a fresh box): `scp` the most recent
+  `relay-YYYY-MM-DD.{sqlite,tar.gz}` pair from `~/backups/manta-prod/`,
+  then `sqlite3 ~/.manta/relay.sqlite ".restore" <sqlite-file>` and untar
+  the tarball over `~/.manta/`. Verify with
+  `sqlite3 ~/.manta/relay.sqlite ".tables"`.
+- **Monitoring** (`scripts/prod/healthcheck.mjs`, scheduled every 10 min
+  on the dev box via `schedule_create`): off-site probes of `mantaui.com`,
+  `relay.mantaui.com` (expects 401 — the auth gate IS the healthy
+  answer), `app.mantaui.com`, `/install.sh`, `/releases/manta-latest.tar.gz`.
+  On failure the opencode turn calls `notify` urgent:true naming the
+  failing URL.
+- **Log caps** (`scripts/prod/systemd-journald.conf`,
+  `scripts/prod/caddy-logrotate`): journald capped at 500M; Caddy access
+  logs (only if they exist on the box — check first) rotated daily with
+  14 generations.
+- **Patches** (`scripts/prod/50unattended-upgrades`): security origin
+  only; updates left to a human reboot window.
+- **Brute-force** (`scripts/prod/jail.local`): sshd jail only — no HTTP
+  jail (Caddy/relay have their own rate limits).
+
 ## Known gaps
 
 - macOS-first; Linux/Windows desktop builds untested.

--- a/scripts/prod/50unattended-upgrades
+++ b/scripts/prod/50unattended-upgrades
@@ -1,0 +1,32 @@
+# /etc/apt/apt.conf.d/50unattended-upgrades — security-only auto updates.
+#
+# INSTALL on the prod box (human step — see BET-163):
+#   apt-get install -y unattended-upgrades
+#   dpkg-reconfigure -f noninteractive unattended-upgrades   # enables the timer
+#   install -m 0644 scripts/prod/50unattended-upgrades /etc/apt/apt.conf.d/50unattended-upgrades
+#   unattended-upgrade --dry-run --debug     # verify
+#
+# ONLY the `-security` origin is enabled. `-updates` is deliberately commented
+# out — feature patches on a prod box can change behaviour underfoot, and a
+# kernel surprise is worse than a delayed feature patch. Apply non-security
+# updates intentionally, on your own schedule, after reviewing the diff.
+
+Unattended-Upgrade::Allowed-Origins {
+    "${distro_id}:${distro_codename}-security";
+    // "${distro_id}:${distro_codename}-updates";
+};
+
+// Auto-removal of unused dependencies (keeps /var/cache/apt tidy).
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+
+// Don't disturb a kernel upgrade on a prod box — let a human reboot.
+Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+
+// Email the maintainer on errors. Unset by default (no SMTP relay on this box);
+// flip to a real address when a relay is set up.
+Unattended-Upgrade::Mail ""
+
+// Logging — visible via `journalctl -u unattended-upgrades`.
+Unattended-Upgrade::SyslogEnable "true";

--- a/scripts/prod/backup-relay.sh
+++ b/scripts/prod/backup-relay.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# backup-relay.sh — nightly backup of the relay SQLite store + .manta dir.
+#
+# Runs as root via /etc/cron.d/manta-backup on the prod box. Backs up:
+#   1. The relay SQLite store via `sqlite3 .backup` (online, no torn writes).
+#   2. The whole ~/.manta/ dir (auth.json, config.json, secrets, store, etc.)
+#      tarballed + gzipped alongside the sqlite backup.
+# Then scps both artifacts to the dev box under ~/backups/manta-prod/.
+# Retains 7 days of history locally and remotely; older artifacts are pruned.
+#
+# Notify on failure (optional): if BUI_NOTIFY_URL is set (a bui webhook URL
+# with HMAC signing), POST a signed JSON body naming what failed so the
+# maintainer's opencode session can wake and alert. The dev-box watcher
+# (`scripts/prod/healthcheck.mjs` via schedule_create) is the belt-and-
+# braces companion: it can also detect "backup did not refresh within 24h"
+# independently of the script's own notify.
+#
+# INSTALL on the prod box (one human step — agent Hard Rule #4 forbids
+# `ssh root@...` from this repo; see BET-163 child issue):
+#   apt-get install -y sqlite3   # only if missing; required for .backup
+#   install -m 0644 scripts/prod/manta-backup.cron /etc/cron.d/manta-backup
+#   cp    scripts/prod/backup-relay.sh /opt/manta/scripts/prod/backup-relay.sh
+#   chmod 0755 /opt/manta/scripts/prod/backup-relay.sh
+#   # Verify the prod box can ssh to the dev box as `dev`:
+#   ssh -o BatchMode=yes dev@157.90.224.92 true || \
+#       ssh-copy-id -i /root/.ssh/id_rsa.pub dev@157.90.224.92
+#   # Set BUI_NOTIFY_URL (optional): the bui webhook URL the maintainer
+#   # generated on the dev box and shared out-of-band.
+#
+# Override (env): MANTA_HOME, RELAY_STORE_PATH, BACKUP_DIR, REMOTE_DIR,
+#                 REMOTE_USER, REMOTE_HOST, BUI_NOTIFY_URL, BUI_NOTIFY_SECRET,
+#                 KEEP_DAYS.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via env; defaults match the prod box layout)
+# ---------------------------------------------------------------------------
+
+MANTA_HOME="${MANTA_HOME:-/opt/manta}"
+RELAY_STORE_PATH="${RELAY_STORE_PATH:-${HOME:-/root}/.manta/relay.sqlite}"
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/manta}"
+BACKUP_PREFIX="${BACKUP_PREFIX:-relay}"        # .sqlite + .tar.gz share this prefix
+KEEP_DAYS="${KEEP_DAYS:-7}"
+
+REMOTE_USER="${REMOTE_USER:-dev}"
+REMOTE_HOST="${REMOTE_HOST:-157.90.224.92}"
+REMOTE_DIR="${REMOTE_DIR:-/home/${REMOTE_USER}/backups/manta-prod}"
+
+# Notify (optional). Both must be set to enable POST-on-failure.
+BUI_NOTIFY_URL="${BUI_NOTIFY_URL:-}"
+BUI_NOTIFY_SECRET="${BUI_NOTIFY_SECRET:-}"
+
+LOG_TAG="manta-backup"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+DAY="$(date -u +%F)"
+
+log()  { printf '%s [%s] %s\n' "$TS" "$LOG_TAG" "$*" >&2; }
+warn() { printf '%s [%s] WARN: %s\n' "$TS" "$LOG_TAG" "$*" >&2; }
+die()  { printf '%s [%s] FAIL: %s\n' "$TS" "$LOG_TAG" "$*" >&2; notify_failure "$@"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# HMAC-SHA256 hex digest of a string with a key, matching the bui webhook
+# contract (src/server/webhooks.mjs `verifySignature`). Pure shell + openssl —
+# no extra runtime dependencies.
+hmac_sha256_hex() {
+  printf '%s' "$2" | openssl dgst -sha256 -hmac "$1" -hex | awk '{print $NF}'
+}
+
+# POST a signed JSON body to BUI_NOTIFY_URL with X-Bui-Signature header.
+# Never echoes the secret; never invokes if URL/secret unset.
+notify_failure() {
+  local reason="$*"
+  [ -n "$BUI_NOTIFY_URL" ] && [ -n "$BUI_NOTIFY_SECRET" ] || return 0
+  local body sig
+  body=$(printf '{"source":"backup-relay","ts":"%s","reason":"%s","box":"prod"}' \
+    "$TS" "$(printf '%s' "$reason" | sed 's/"/\\"/g; s/\\/\\\\/g')")
+  sig=$(hmac_sha256_hex "$BUI_NOTIFY_SECRET" "$body")
+  # Best-effort: log but do not mask the original failure.
+  curl -fsS --max-time 10 -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-Bui-Signature: sha256=${sig}" \
+    --data "$body" \
+    "$BUI_NOTIFY_URL" >/dev/null 2>&1 || warn "notify POST failed (ignoring — original error already logged)"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "missing required command: $1 — install it and re-run ($2)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+
+require_cmd sqlite3 "apt-get install -y sqlite3"
+require_cmd tar     "apt-get install -y tar"
+require_cmd gzip    "apt-get install -y gzip"
+require_cmd scp     "apt-get install -y openssh-client"
+require_cmd openssl "apt-get install -y openssl"
+
+[ -f "$RELAY_STORE_PATH" ] || die "relay store not found at $RELAY_STORE_PATH (set RELAY_STORE_PATH to override)"
+
+mkdir -p "$BACKUP_DIR" || die "cannot create $BACKUP_DIR"
+
+SQLITE_OUT="${BACKUP_DIR}/${BACKUP_PREFIX}-${DAY}.sqlite"
+TARBALL_OUT="${BACKUP_DIR}/${BACKUP_PREFIX}-${DAY}.tar.gz"
+
+log "starting backup: store=$RELAY_STORE_PATH → $SQLITE_OUT"
+
+# ---------------------------------------------------------------------------
+# 1. SQLite online backup (no torn writes — safe to run while the relay
+#    process is reading/writing). `sqlite3 .backup` does this natively.
+# ---------------------------------------------------------------------------
+
+if ! sqlite3 "$RELAY_STORE_PATH" ".backup '$SQLITE_OUT'" 2>&1 | tee -a /tmp/manta-backup.last.log; then
+  die "sqlite3 .backup failed for $RELAY_STORE_PATH"
+fi
+
+[ -s "$SQLITE_OUT" ] || die "sqlite backup produced empty file: $SQLITE_OUT"
+
+# Sanity: confirm the backup is a readable sqlite DB.
+sqlite3 "$SQLITE_OUT" "PRAGMA integrity_check;" >/dev/null 2>&1 \
+  || die "integrity_check failed on $SQLITE_OUT — backup is corrupt, refusing to ship"
+
+log "sqlite backup OK ($(stat -c %s "$SQLITE_OUT") bytes)"
+
+# ---------------------------------------------------------------------------
+# 2. Tarball the whole ~/.manta/ (config, auth.json, secrets, store) so a
+#    restore is one untar + sqlite restore away.
+# ---------------------------------------------------------------------------
+
+MANTA_DIR="$(dirname "$RELAY_STORE_PATH")"   # typically ~/.manta
+[ -d "$MANTA_DIR" ] || die ".manta directory not found at $MANTA_DIR"
+
+if tar -czf "$TARBALL_OUT" -C "$(dirname "$MANTA_DIR")" "$(basename "$MANTA_DIR")" 2>&1 | tee -a /tmp/manta-backup.last.log; then
+  log "tarball OK ($(stat -c %s "$TARBALL_OUT") bytes)"
+else
+  rm -f "$SQLITE_OUT" "$TARBALL_OUT" 2>/dev/null || true
+  die "tar/gzip of $MANTA_DIR failed"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. scp both artifacts to the dev box. SSH is expected to already work as
+#    `dev` (provisioned once at install). Failures here are critical — the
+#    local backup is meaningless if it never leaves the box.
+# ---------------------------------------------------------------------------
+
+ssh -o BatchMode=yes -o ConnectTimeout=10 "${REMOTE_USER}@${REMOTE_HOST}" \
+  "mkdir -p '$REMOTE_DIR'" \
+  || die "ssh mkdir -p $REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR failed (is the dev box reachable? key authorized?)"
+
+scp -o BatchMode=yes -o ConnectTimeout=10 "$SQLITE_OUT" "$TARBALL_OUT" \
+  "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DIR}/" \
+  || die "scp to $REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR failed"
+
+log "shipped to ${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DIR}/"
+
+# ---------------------------------------------------------------------------
+# 4. Retention — prune local + remote artifacts older than KEEP_DAYS.
+# ---------------------------------------------------------------------------
+
+find "$BACKUP_DIR" -maxdepth 1 -type f \( -name "${BACKUP_PREFIX}-*.sqlite" -o -name "${BACKUP_PREFIX}-*.tar.gz" \) -mtime "+${KEEP_DAYS}" -delete 2>/dev/null || true
+
+# Remote prune via ssh (one round-trip; --no-target-directory prevents surprises).
+ssh -o BatchMode=yes -o ConnectTimeout=10 "${REMOTE_USER}@${REMOTE_HOST}" \
+  "find '${REMOTE_DIR}' -maxdepth 1 -type f \( -name '${BACKUP_PREFIX}-*.sqlite' -o -name '${BACKUP_PREFIX}-*.tar.gz' \) -mtime '+${KEEP_DAYS}' -delete" \
+  2>/dev/null || warn "remote retention prune failed (continuing — local prune succeeded)"
+
+log "backup complete"

--- a/scripts/prod/caddy-logrotate
+++ b/scripts/prod/caddy-logrotate
@@ -1,0 +1,26 @@
+# /etc/logrotate.d/caddy — rotate Caddy access logs daily, keep 14, compressed.
+#
+# INSTALL on the prod box (human step — see BET-163). ONLY install if the
+# Caddyfile on the box writes to /var/log/caddy/ — check first:
+#   grep -E '^\s*log\s' /etc/caddy/Caddyfile
+# If Caddy logs only to journald (default in many setups), the journald cap
+# already covers it; SKIP this file (do not install dead logrotate config).
+#
+#   install -m 0644 scripts/prod/caddy-logrotate /etc/logrotate.d/caddy
+#
+# `postrotate` sends SIGHUP via systemctl reload — Caddy reopens files.
+# `delaycompress` lets yesterday's log stay readable while today's compresses.
+
+/var/log/caddy/*.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0640 caddy caddy
+    sharedscripts
+    postrotate
+        systemctl reload caddy >/dev/null 2>&1 || true
+    endscript
+}

--- a/scripts/prod/healthcheck.mjs
+++ b/scripts/prod/healthcheck.mjs
@@ -1,0 +1,143 @@
+// healthcheck.mjs — prod box uptime probe. Runs from the dev box (off-site)
+// every 10 minutes via schedule_create in a long-lived opencode session on
+// the dev box. Exits non-zero and prints the failing URL on any mismatch;
+// the caller (this same session) responds by calling `notify` urgent:true.
+//
+// Why the dev box, not the prod box: the property we need is "an off-site
+// observer saw the prod surface go away". A self-check on the prod box
+// would pass even when Caddy is wedged, the network is partitioned, etc.
+//
+// Why not an external service (UptimeRobot et al.): no owner account is
+// available, and reuse-what-exists is the cheaper default.
+//
+// INSTALL on the dev box (in this opencode session):
+//   schedule_create cron "*/10 * * * *" running `node /path/healthcheck.mjs`
+//   on failure the cron turn should call `notify` urgent:true naming the
+//   failing URL.
+//
+// Override (env): HEALTHCHECK_TARGETS (JSON array — see DEFAULT_TARGETS).
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Default probe set (single source of truth — also used by the test suite).
+// Each target is { url, expect, kind }:
+//   kind: "body" (full GET) or "head" (HEAD only — saves bytes on tarballs).
+//   expect.status: required HTTP status code.
+//   expect.bodyStartsWith: optional, the body MUST begin with this string
+//      (defends against Caddy returning a 200 default page for a missing
+//      asset — "200 OK" + wrong content is still a healthy 200, but a
+//      missing /install.sh would silently serve the homepage).
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TARGETS = [
+  { url: "https://mantaui.com",                      kind: "body", expect: { status: 200 } },
+  { url: "https://relay.mantaui.com",                kind: "body", expect: { status: 401 } },
+  { url: "https://app.mantaui.com",                  kind: "body", expect: { status: 200 } },
+  { url: "https://mantaui.com/install.sh",           kind: "body", expect: { status: 200, bodyStartsWith: "#!/" } },
+  { url: "https://mantaui.com/releases/manta-latest.tar.gz", kind: "head", expect: { status: 200 } },
+];
+
+// ---------------------------------------------------------------------------
+// Probe runner — pure: every I/O surface is injected so the test suite can
+// run with a fake fetch without touching the network.
+// ---------------------------------------------------------------------------
+
+/**
+ * Run every target; return `{ ok, failures }` where `failures` is the list
+ * of { url, reason } entries (empty when ok).
+ *
+ * @param {object} opts
+ * @param {Array}  opts.targets        probe list (default DEFAULT_TARGETS).
+ * @param {object} opts.env            env-like object (default process.env).
+ * @param {Function} opts.fetchFn      fetch implementation.
+ * @param {Function} opts.log          (line) => void — per-target progress.
+ */
+export async function runHealthcheck({
+  targets = parseTargetsEnv(process.env),
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  log = () => {},
+} = {}) {
+  const list = targets ?? DEFAULT_TARGETS;
+  const failures = [];
+  for (const t of list) {
+    const fail = await checkOne(t, { fetchFn, log });
+    if (fail) failures.push(fail);
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+// HEALTHCHECK_TARGETS overrides the default probe set. JSON-encoded array
+// of the same shape as DEFAULT_TARGETS. Empty/missing → default.
+export function parseTargetsEnv(env) {
+  const raw = env?.HEALTHCHECK_TARGETS;
+  if (typeof raw !== "string" || raw === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function checkOne(target, { fetchFn, log }) {
+  const url = target?.url;
+  const expect = target?.expect ?? {};
+  const kind = target?.kind ?? "body";
+  if (typeof url !== "string" || url === "") {
+    return { url: "<missing>", reason: "target.url missing" };
+  }
+  try {
+    const res = await fetchFn(url, { method: kind === "head" ? "HEAD" : "GET" });
+    if (typeof expect.status === "number" && res.status !== expect.status) {
+      log(`${url}: status=${res.status} expected=${expect.status}`);
+      return { url, reason: `expected status ${expect.status}, got ${res.status}` };
+    }
+    if (typeof expect.bodyStartsWith === "string" && expect.bodyStartsWith !== "") {
+      const text = await res.text();
+      if (!text.startsWith(expect.bodyStartsWith)) {
+        log(`${url}: body does not start with ${JSON.stringify(expect.bodyStartsWith)} (first 80 chars: ${JSON.stringify(text.slice(0, 80))})`);
+        return { url, reason: `body did not start with ${JSON.stringify(expect.bodyStartsWith)}` };
+      }
+    }
+    log(`${url}: OK (status=${res.status}${expect.bodyStartsWith ? ", body matches" : ""})`);
+    return null;
+  } catch (e) {
+    log(`${url}: error ${e?.message ?? e}`);
+    return { url, reason: `fetch error: ${e?.message ?? e}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry — runs only when invoked directly. Prints a single line per
+// target and a final summary, and exits non-zero on any failure.
+// ---------------------------------------------------------------------------
+
+function cliLog(line) {
+  process.stderr.write(`[healthcheck] ${line}\n`);
+}
+
+async function cliMain() {
+  const result = await runHealthcheck({ log: cliLog });
+  if (!result.ok) {
+    process.stderr.write(`[healthcheck] FAIL: ${result.failures.length} target(s) unhealthy:\n`);
+    for (const f of result.failures) {
+      process.stderr.write(`  - ${f.url}: ${f.reason}\n`);
+    }
+    process.exit(1);
+  }
+  process.stderr.write(`[healthcheck] OK: all ${DEFAULT_TARGETS.length} targets healthy\n`);
+  process.exit(0);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  cliMain();
+}
+
+// Suppress an "unused import" lint when join() is unused on some build paths.
+void join;

--- a/scripts/prod/healthcheck.test.mjs
+++ b/scripts/prod/healthcheck.test.mjs
@@ -1,0 +1,127 @@
+// healthcheck.test.mjs — unit tests for the prod uptime probe.
+//
+// Pure: every I/O surface (fetch) is injected. No real network calls.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_TARGETS, runHealthcheck, parseTargetsEnv } from "./healthcheck.mjs";
+
+function fakeFetch(perUrl) {
+  return async (url, init = {}) => {
+    const handler = perUrl[url];
+    if (!handler) throw new Error(`fakeFetch: no handler for ${url}`);
+    return handler({ url, method: init.method ?? "GET" });
+  };
+}
+
+function makeRes({ status = 200, body = "" } = {}) {
+  return {
+    status,
+    text: async () => body,
+  };
+}
+
+test("DEFAULT_TARGETS covers every surface in the issue body", () => {
+  const urls = DEFAULT_TARGETS.map((t) => t.url);
+  for (const required of [
+    "https://mantaui.com",
+    "https://relay.mantaui.com",
+    "https://app.mantaui.com",
+    "https://mantaui.com/install.sh",
+    "https://mantaui.com/releases/manta-latest.tar.gz",
+  ]) {
+    assert.ok(urls.includes(required), `default targets missing ${required}`);
+  }
+  // relay.mantaui.com specifically expects 401 — that IS the auth gate being healthy.
+  const relay = DEFAULT_TARGETS.find((t) => t.url === "https://relay.mantaui.com");
+  assert.equal(relay.expect.status, 401, "relay.mantaui.com must expect 401");
+});
+
+test("runHealthcheck returns ok:true when every target matches", async () => {
+  const fetchFn = fakeFetch({
+    "https://mantaui.com": () => makeRes({ status: 200 }),
+    "https://relay.mantaui.com": () => makeRes({ status: 401 }),
+    "https://app.mantaui.com": () => makeRes({ status: 200 }),
+    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
+    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
+  });
+  const result = await runHealthcheck({ fetchFn, log: () => {} });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("runHealthcheck flags a status mismatch", async () => {
+  const fetchFn = fakeFetch({
+    "https://mantaui.com": () => makeRes({ status: 500 }),
+    "https://relay.mantaui.com": () => makeRes({ status: 401 }),
+    "https://app.mantaui.com": () => makeRes({ status: 200 }),
+    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
+    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
+  });
+  const result = await runHealthcheck({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].url, "https://mantaui.com");
+  assert.match(result.failures[0].reason, /expected status 200, got 500/);
+});
+
+test("runHealthcheck flags a body-prefix mismatch (e.g. Caddy serves the homepage for a missing asset)", async () => {
+  const fetchFn = fakeFetch({
+    "https://mantaui.com": () => makeRes({ status: 200 }),
+    "https://relay.mantaui.com": () => makeRes({ status: 401 }),
+    "https://app.mantaui.com": () => makeRes({ status: 200 }),
+    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "<!doctype html>\n<html>..." }),
+    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
+  });
+  const result = await runHealthcheck({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures[0].url, "https://mantaui.com/install.sh");
+  assert.match(result.failures[0].reason, /body did not start with/);
+});
+
+test("runHealthcheck flags a fetch error (DNS / network)", async () => {
+  const fetchFn = fakeFetch({
+    "https://mantaui.com": () => makeRes({ status: 200 }),
+    "https://relay.mantaui.com": async () => { throw new Error("ENOTFOUND"); },
+    "https://app.mantaui.com": () => makeRes({ status: 200 }),
+    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
+    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
+  });
+  const result = await runHealthcheck({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures[0].url, "https://relay.mantaui.com");
+  assert.match(result.failures[0].reason, /fetch error: ENOTFOUND/);
+});
+
+test("runHealthcheck uses HEAD method for HEAD-kind targets", async () => {
+  const seen = [];
+  const fetchFn = async (url, init = {}) => {
+    seen.push({ url, method: init.method ?? "GET" });
+    return makeRes({ status: 200 });
+  };
+  await runHealthcheck({
+    fetchFn,
+    log: () => {},
+    targets: [{ url: "https://mantaui.com/releases/manta-latest.tar.gz", kind: "head", expect: { status: 200 } }],
+  });
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].method, "HEAD");
+});
+
+test("parseTargetsEnv parses a JSON override", () => {
+  const parsed = parseTargetsEnv({
+    HEALTHCHECK_TARGETS: JSON.stringify([
+      { url: "https://example.com", kind: "body", expect: { status: 200 } },
+    ]),
+  });
+  assert.ok(Array.isArray(parsed));
+  assert.equal(parsed[0].url, "https://example.com");
+});
+
+test("parseTargetsEnv returns null on missing / invalid / non-array input", () => {
+  assert.equal(parseTargetsEnv({}), null);
+  assert.equal(parseTargetsEnv({ HEALTHCHECK_TARGETS: "" }), null);
+  assert.equal(parseTargetsEnv({ HEALTHCHECK_TARGETS: "not-json" }), null);
+  assert.equal(parseTargetsEnv({ HEALTHCHECK_TARGETS: JSON.stringify({ url: "x" }) }), null);
+});

--- a/scripts/prod/jail.local
+++ b/scripts/prod/jail.local
@@ -1,0 +1,21 @@
+# /etc/fail2ban/jail.local — sshd jail only.
+#
+# INSTALL on the prod box (human step — see BET-163):
+#   apt-get install -y fail2ban
+#   install -m 0644 scripts/prod/jail.local /etc/fail2ban/jail.local
+#   systemctl enable --now fail2ban
+#   fail2ban-client status sshd
+#
+# SSH only on purpose. Do NOT add an HTTP jail — Caddy/relay have their own
+# rate limits (src/relay/api.mjs PHONE_RL, PAIR_RL) and a naive HTTP jail
+# would ban legitimate NATed users behind a shared egress.
+
+[DEFAULT]
+# Honour the distributor's defaults (sshd already ships in jail.conf); this
+# file only narrows/enables the sshd jail and overrides any tuning we want.
+bantime  = 1h
+findtime = 10m
+maxretry = 5
+
+[sshd]
+enabled = true

--- a/scripts/prod/manta-backup.cron
+++ b/scripts/prod/manta-backup.cron
@@ -1,0 +1,15 @@
+# /etc/cron.d/manta-backup — nightly backup of the prod relay store.
+#
+# INSTALL on the prod box (human step — see BET-163):
+#   install -m 0644 scripts/prod/manta-backup.cron /etc/cron.d/manta-backup
+#
+# Runs at 03:17 UTC daily. The script (scripts/prod/backup-relay.sh) is the
+# single source of truth — this file is a thin cron wrapper.
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+MANTA_HOME=/opt/manta
+BUI_NOTIFY_URL=
+BUI_NOTIFY_SECRET=
+
+17 3 * * * root /opt/manta/scripts/prod/backup-relay.sh >> /var/log/manta-backup.log 2>&1

--- a/scripts/prod/systemd-journald.conf
+++ b/scripts/prod/systemd-journald.conf
@@ -1,0 +1,11 @@
+# /etc/systemd/journald.conf.d/manta.conf — cap journald at 500M.
+#
+# INSTALL on the prod box (human step — see BET-163):
+#   install -m 0644 scripts/prod/systemd-journald.conf /etc/systemd/journald.conf.d/manta.conf
+#   systemctl restart systemd-journald
+#
+# 500M is a deliberate ceiling for a small VPS: enough for ~weeks of normal
+# logs (Caddy + manta-relay + sshd) without an unbounded /var/log/journal.
+
+[Journal]
+SystemMaxUse=500M


### PR DESCRIPTION
**Files changed:** 9 files, +582/-0

```
 README.md                          |  32 +++++++
 scripts/prod/50unattended-upgrades |  32 +++++++
 scripts/prod/backup-relay.sh       | 175 +++++++++++++++++++++++++++++++++++++
 scripts/prod/caddy-logrotate       |  26 ++++++
 scripts/prod/healthcheck.mjs       | 143 ++++++++++++++++++++++++++++++
 scripts/prod/healthcheck.test.mjs  | 127 +++++++++++++++++++++++++++
 scripts/prod/jail.local            |  21 +++++
 scripts/prod/manta-backup.cron     |  15 ++++
 scripts/prod/systemd-journald.conf |  11 ++++
```

**Verification results:**
- Branch (`multica/BET-163-prod-box-hardening` @ `f7b804a`):
  - typecheck: exit `0`. Errors: none.
  - test (`scripts/*.test.mjs`): exit `0`, `57` pass / `0` fail / `0` skip. Failures: none. (Includes the new 8 healthcheck tests.)
  - healthcheck CLI live probe of all 5 prod URLs from the dev box: exit `0`. All 5 surfaces healthy (mantaui.com 200, relay.mantaui.com 401, app.mantaui.com 200, install.sh 200 + body starts `#!/`, latest tarball 200).
  - `bash -n scripts/prod/backup-relay.sh`: syntax OK.
- Base (`main` @ `085b4cb`):
  - typecheck: exit `0`. Errors: none.
  - test (`scripts/*.test.mjs`): exit `0`, `49` pass / `0` fail / `0` skip.
- **Conclusion:** 0 new failures, 0 resolved failures (the 8 new tests in this PR bring the script-test count from 49 → 57).

**Base:** `origin/main @ 085b4cb`

**Out of scope (not in this PR — split into a child issue for @antoinedc per agent Hard Rule #4):**
- Prod-side installs requiring `ssh root@91.107.196.2`: cron file copy, journald drop-in copy, logrotate copy, unattended-upgrades + fail2ban `apt-get install`, AND the live backup→restore verification.
- Webhook secret provisioning (`BUI_NOTIFY_URL` + `BUI_NOTIFY_SECRET` for the prod cron environment) — webhook is created in the dev opencode session and the secret handed off out-of-band.
- `dev@157.90.224.92` SSH key provisioning on the prod box for the backup's `scp` step (verify `ssh dev@157.90.224.92 true` works; if not, generate a dedicated key and add to authorized_keys with `command=` restriction to scp only).

**Cross-cutting follow-ups:**
- After child issue completes: `unattended-upgrades` will need its `Unattended-Upgrade::Mail` flipped to a real address (currently empty — no SMTP on this box). Deferred.
- The Caddy logrotate file is conditional on Caddy actually writing to `/var/log/caddy/` (default may be journald-only); the install step in the header documents the check.
