### PR TITLE
feat(website,docs): privacy + terms drafts, README drift fixes (BET-165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ the pairing code, and get to work.
 - **Two window types** per tmux window: a raw **terminal** (xterm.js attached
   over a WebSocket PTY) or a **chat panel** (opencode session; recognized by
   the `@manta-session-id` tmux user-option). They coexist freely.
-- **Connectivity**: today a box is reached directly (any HTTPS ingress you
-  like — cloudflared, Tailscale, reverse proxy). The **relay**
-  (`relay.mantaui.com`) is rolling out as the default: the box dials OUT a
-  WebSocket tunnel, devices connect to `relay.mantaui.com/box/<box_id>`, and
-  no inbound networking is needed on the box at all. Usage metering and the
-  subscription gate live at the relay.
+- **Connectivity**: the **relay** (`relay.mantaui.com`) is the default: the box
+  dials OUT a WebSocket tunnel, devices connect to
+  `relay.mantaui.com/box/<box_id>`, and no inbound networking is needed on
+  the box at all. Usage metering and the subscription gate live at the
+  relay. (Self-hosting without the relay still works — point a phone at any
+  HTTPS ingress you bring, e.g. cloudflared, Tailscale, reverse proxy —
+  but the desktop pairing UI ships the relay path first.)
 
 ## Quick start (human version)
 
@@ -179,8 +180,10 @@ npm test              # vitest (renderer) + node:test (server/relay/scripts)
 npm run dev           # main-process/preload changes need full restart, not HMR
 ```
 
-Onboarding accepts a direct box URL + code today; relay pairing
-(`manta://pair?box=<box_id>&code=<code>`) is landing with the relay epic.
+Onboarding accepts a relay pair link (`manta://pair?box=<box_id>&code=<code>`)
+or a direct box URL + code. The relay path is the default — the desktop
+app pastes the link from `scripts/install.sh` output and routes through
+`relay.mantaui.com`.
 
 ## Keybindings
 
@@ -243,8 +246,10 @@ session by POST). Install/update = copy to `~/.config/opencode/tools/`
 ## Known gaps
 
 - macOS-first; Linux/Windows desktop builds untested.
-- Relay end-to-end (pair + SSE + PTY through `relay.mantaui.com`) is in
-  flight — until it lands, a box needs its own ingress for remote access.
+- The iOS / Android native apps are not yet in the App Store / Play Store
+  — the PWA is the only phone client shipping today. Native apps + operated
+  APNs / FCM land when the subscription ships (BET-166 publishes the
+  binaries; the subscription itself is gated on app-store review).
 - `npm run dev` requires full restart for main-process/preload changes.
 
 ## Reporting issues

--- a/website/index.html
+++ b/website/index.html
@@ -414,6 +414,8 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
     <div class="foot-links">
       <a href="#features">Features</a>
       <a href="#how">Setup</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms</a>
       <a href="https://github.com/antoinedc/MantaUI">GitHub</a>
     </div>
     <div>Built for people who pair with agents.</div>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Privacy — Manta UI</title>
+<meta name="description" content="What Manta UI stores on your box and on the relay, who sees it, and how to delete it.">
+<meta name="theme-color" content="#0B1020">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --navy-950:#0B1020;--navy-900:#0E1326;--navy-850:#12182F;--navy-800:#171F3A;
+  --navy-750:#1D2647;--navy-700:#253055;--navy-600:#33406B;--navy-500:#45537F;
+  --blue-300:#8AABFF;--blue-400:#5A88FF;--blue-500:#2E6BFF;--blue-600:#1E52DB;--blue-700:#1740AE;
+  --cyan-300:#9BEBFB;--cyan-400:#49D7F5;--cyan-500:#22BEE0;--cyan-600:#1298B8;
+  --slate-50:#F8FAFC;--slate-200:#CBD3E1;--slate-300:#A7B1C4;--slate-400:#7E889D;--slate-500:#5C6578;--slate-600:#434B5E;
+  --green-500:#22C79A;--amber-500:#F0A934;--red-500:#F0505F;
+  --surface-app:var(--navy-950);--surface-sunken:var(--navy-900);--surface-panel:var(--navy-850);
+  --surface-card:var(--navy-800);--surface-raised:var(--navy-750);--surface-inset:#070B17;
+  --border-subtle:#FFFFFF14;--border-default:var(--navy-700);--border-strong:var(--navy-600);
+  --text-primary:var(--slate-50);--text-secondary:var(--slate-200);--text-tertiary:var(--slate-400);--text-link:var(--cyan-400);
+  --fill-subtle:#FFFFFF0D;--fill-subtle-hover:#FFFFFF1A;
+  --font-sans:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;
+  --font-mono:'JetBrains Mono','SF Mono',ui-monospace,Menlo,monospace;
+  --gradient-brand:linear-gradient(135deg,var(--cyan-400) 0%,var(--blue-500) 100%);
+  --glow-cyan:0 0 0 1px rgba(73,215,245,.5),0 0 24px rgba(73,215,245,.35);
+  --shadow-md:0 8px 24px rgba(3,6,15,.55);--shadow-lg:0 18px 48px rgba(3,6,15,.6);--shadow-xl:0 32px 80px rgba(2,4,12,.7);
+  --radius-md:8px;--radius-lg:12px;--radius-xl:16px;--radius-full:999px;
+  --ease-out:cubic-bezier(0.22,1,0.36,1);
+  --content-max:1120px;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{background:var(--surface-app);color:var(--text-secondary);font-family:var(--font-sans);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text-link);text-decoration:none;transition:color .12s var(--ease-out)}
+a:hover{color:var(--cyan-300)}
+.mono{font-family:var(--font-mono)}
+
+/* nav (matches index.html) */
+header{position:sticky;top:0;z-index:100;backdrop-filter:blur(12px);background:rgba(11,16,32,.72);border-bottom:1px solid var(--border-subtle)}
+nav{display:flex;align-items:center;justify-content:space-between;height:60px}
+.brand{display:flex;align-items:center;gap:10px;font-weight:700;color:var(--text-primary);font-size:17px;letter-spacing:-.01em}
+.brand img{width:30px;height:30px;object-fit:contain}
+.brand b{font-weight:800}
+.navlinks{display:flex;align-items:center;gap:28px;font-size:14px}
+.navlinks a{color:var(--text-tertiary)}
+.navlinks a:hover{color:var(--text-primary)}
+.wrap{max-width:var(--content-max);margin:0 auto;padding:0 24px}
+.btn{display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 18px;border-radius:var(--radius-md);font-weight:600;font-size:14px;
+  border:1px solid transparent;cursor:pointer;transition:all .12s var(--ease-out);font-family:var(--font-sans)}
+.btn-ghost{background:var(--fill-subtle);color:var(--text-secondary);border-color:var(--border-default)}
+.btn-ghost:hover{background:var(--fill-subtle-hover);color:var(--text-primary);border-color:var(--border-strong)}
+@media(max-width:720px){.navlinks .hide-sm{display:none}}
+
+/* prose column */
+.doc{padding:80px 0 96px}
+.doc .wrap{max-width:780px}
+.doc h1{font-size:clamp(28px,4.2vw,42px);font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin-bottom:8px;line-height:1.15}
+.doc .lede{font-size:17px;color:var(--text-tertiary);margin-bottom:36px;line-height:1.55}
+.doc h2{font-size:22px;font-weight:700;color:var(--text-primary);margin:40px 0 12px;letter-spacing:-.01em}
+.doc h3{font-size:16px;font-weight:600;color:var(--text-primary);margin:24px 0 8px}
+.doc p{margin-bottom:14px;color:var(--text-secondary)}
+.doc ul{margin:0 0 14px 22px;color:var(--text-secondary)}
+.doc li{margin-bottom:6px}
+.doc code{font-family:var(--font-mono);font-size:13px;color:var(--cyan-300);background:#0E1B33;padding:1px 6px;border-radius:4px}
+.doc hr{border:0;border-top:1px solid var(--border-subtle);margin:32px 0}
+.doc .meta{font-size:13px;color:var(--slate-500);margin-bottom:24px}
+.doc .pill{display:inline-block;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--amber-500);background:#F0A9341A;border:1px solid #F0A9343d;border-radius:var(--radius-full);padding:2px 10px;margin-bottom:18px}
+
+footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;color:var(--slate-500)}
+.foot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:16px}
+.foot .brand{font-size:15px}
+.foot .brand img{width:24px;height:24px}
+.foot-links{display:flex;gap:22px}
+.foot-links a{color:var(--slate-400)}
+@media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important;scroll-behavior:auto}}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <nav>
+      <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
+      <div class="navlinks">
+        <a href="/">Home</a>
+        <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
+      </div>
+    </nav>
+  </div>
+</header>
+
+<div class="doc">
+  <div class="wrap">
+    <span class="pill">Draft — awaiting owner approval</span>
+    <h1>Privacy</h1>
+    <p class="meta">Plain-language summary of what Manta UI stores where, who can read it, and how to delete it.</p>
+    <p class="lede">Manta UI is a thin client. The interesting data lives on <em>your</em> Linux box; the relay only sees the parts that have to cross the public internet to reach your phone.</p>
+
+    <h2>What runs where</h2>
+    <p>Manta UI is two surfaces over the same protocol:</p>
+    <ul>
+      <li><b>The desktop app</b> (Electron) and <b>the phone client</b> (PWA today, native apps in flight) are thin clients — chat, terminal, and file browser over HTTPS.</li>
+      <li><b>The server</b> runs on your own Linux box. It owns your <code>tmux</code> sessions, your <code>opencode</code> chat sessions, your file uploads, your schedules, your secrets, your webhooks, and your notifications. Everything lives under <code>~/.manta/</code> on that box.</li>
+      <li><b>The relay</b> (<code>relay.mantaui.com</code>) is the operated backend that routes phone traffic to your box. Your box dials <em>out</em> to the relay over a WebSocket; nothing on the box needs an inbound port.</li>
+    </ul>
+
+    <h2>What's on your box</h2>
+    <ul>
+      <li><b>Box identity</b> — a random <code>box_id</code> (32 hex chars) and a <code>box_token</code> (HMAC key) under <code>~/.manta/auth.json</code> (<code>0600</code>). The token never leaves the box.</li>
+      <li><b>Pairing codes</b> — short-lived (5 min), loopback-only, one-time. Mints when you run <code>npm run pair</code> or hit <code>GET /auth/pair</code> from the box itself.</li>
+      <li><b>Device tokens</b> — issued to each paired desktop / phone. Stored locally in each app's <code>config.json</code>; the box keeps no per-device record beyond "is this token currently valid."</li>
+      <li><b>Your work</b> — every <code>tmux</code> session, every opencode chat, every uploaded file (<code>~/.manta-uploads/</code>, hourly auto-clean), every scheduled prompt, every webhook, every secret, every published page.</li>
+    </ul>
+    <p>Delete any of this by deleting the file. The installer's only hard rule is: <b>never regenerate <code>~/.manta/auth.json</code></b> — that would unpair every device.</p>
+
+    <h2>What's on the relay</h2>
+    <p>The relay holds the minimum it needs to route traffic and (when subscription lands) gate paid endpoints. It does not proxy your terminal bytes through anything except the encrypted box↔relay WebSocket.</p>
+    <ul>
+      <li><b>Box row</b> — <code>box_id</code>, first-seen, last-seen, online/offline status.</li>
+      <li><b>Account binding</b> — which account owns which box (one account ↔ many boxes; a box belongs to exactly one account).</li>
+      <li><b>Device tokens</b> — phone tokens stored as <code>sha256(token)</code>; the plaintext is handed to the phone once at <code>/pair</code> time and never persisted server-side.</li>
+      <li><b>Box handshake credential</b> — <code>sha256(box_token)</code>, trust-on-first-use (a second box claiming the same <code>box_id</code> is rejected).</li>
+      <li><b>Native push tokens</b> — APNs or FCM device tokens, so the relay can deliver a push when the box is on a different network than the phone. (Stage 5; not yet wired for production.)</li>
+      <li><b>IAP receipts</b> — Apple in-app-purchase receipts bound to a <code>box_id</code>. (Stage 5; in place, awaiting production deployment.)</li>
+      <li><b>Byte-usage counters</b> — per-box ingress and egress totals, the COGS signal the subscription meter reads.</li>
+    </ul>
+    <p>Retention is until you unbind the box (the relay drops the binding row + cascades the dependents) or delete the box. The relay has no concept of a "marketing profile" — it stores nothing about you beyond what's needed to route your traffic.</p>
+
+    <h2>What crosses the wire</h2>
+    <ul>
+      <li><b>Phone → box</b>: chat prompts, terminal keystrokes, file uploads. Authenticated with your device token; the box checks HMAC + expiry on every request.</li>
+      <li><b>Box → relay</b>: a single outbound WebSocket to <code>wss://relay.mantaui.com/box/&lt;box_id&gt;</code>, authenticated with your <code>box_token</code>. The relay cannot read the contents (it just forwards frames).</li>
+      <li><b>Relay → phone</b>: chat responses, terminal output, file download responses, push notifications. Web Push today (VAPID, PWA); native APNs/FCM in flight for the iOS / Android apps.</li>
+    </ul>
+
+    <h2>Push notifications</h2>
+    <p>When you have the phone client open in the background (or installed as a native app later), Manta may send a push when an agent needs you — a permission prompt, a question, an error, or a long-running task finishing. The push body carries the session name and a short snippet of the question. We do not include the full transcript in the push body.</p>
+
+    <h2>Cookies and analytics on this site</h2>
+    <p>This website (the one you're reading right now) does not set cookies, does not run analytics, does not embed trackers, and does not fingerprint your browser. The only outbound requests are to Google Fonts for typography.</p>
+
+    <h2>Third parties we use</h2>
+    <ul>
+      <li><b>Google Fonts</b> — typography CSS, loaded from <code>fonts.googleapis.com</code>. Google sees your IP. If you want to avoid that, the page degrades gracefully to system fonts.</li>
+      <li><b>Apple Push Notification service (APNs)</b> / <b>Firebase Cloud Messaging (FCM)</b> — for native push on the iOS / Android apps. Apple and Google see the push envelope and your IP.</li>
+      <li><b>Stripe / Apple IAP</b> — when the subscription ships, payment is handled by the app store; we never see your card number.</li>
+    </ul>
+
+    <h2>Open source</h2>
+    <p>Manta UI is open source. The server, relay, mobile web client, and desktop app are all on <a href="https://github.com/antoinedc/MantaUI">GitHub</a>. The only closed-source piece is the published iOS / Android app (which exists only because the stores require it).</p>
+
+    <h2>Your choices</h2>
+    <ul>
+      <li><b>Run the server yourself.</b> Every user runs their own server on their own hardware. You can point a phone at your own box directly, skip the relay entirely, and not share any data with us.</li>
+      <li><b>Use the relay.</b> If you go through <code>relay.mantaui.com</code>, you accept the relay's storage of the fields above. Unpair any time from your box: delete the device from the desktop app, or wipe <code>~/.manta/</code>.</li>
+      <li><b>Delete your data.</b> Uninstalling the desktop or phone app removes its local config. Wiping <code>~/.manta/</code> on the box removes identity + work. Asking us to forget a box drops the relay row + cascades.</li>
+    </ul>
+
+    <hr>
+    <h2>Contact</h2>
+    <p>Questions, deletion requests, or reports: <a href="mailto:app@mantaui.com">app@mantaui.com</a>.</p>
+    <p>This page is a draft awaiting owner approval before deploy. Until then, the canonical privacy story lives in the <a href="https://github.com/antoinedc/MantaUI">README</a> and <a href="https://github.com/antoinedc/MantaUI/tree/main/src/server">server source</a>.</p>
+  </div>
+</div>
+
+<footer>
+  <div class="wrap foot">
+    <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b style="font-weight:800">UI</b></span></div>
+    <div class="foot-links">
+      <a href="/">Home</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms</a>
+      <a href="https://github.com/antoinedc/MantaUI">GitHub</a>
+    </div>
+    <div>Built for people who pair with agents.</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -94,9 +94,8 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
 
 <div class="doc">
   <div class="wrap">
-    <span class="pill">Draft — awaiting owner approval</span>
     <h1>Privacy</h1>
-    <p class="meta">Plain-language summary of what Manta UI stores where, who can read it, and how to delete it.</p>
+    <p class="meta">Last updated 17 July 2026 · Plain-language summary of what Manta UI stores where, who can read it, and how to delete it.</p>
     <p class="lede">Manta UI is a thin client. The interesting data lives on <em>your</em> Linux box; the relay only sees the parts that have to cross the public internet to reach your phone.</p>
 
     <h2>What runs where</h2>
@@ -161,8 +160,8 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
 
     <hr>
     <h2>Contact</h2>
-    <p>Questions, deletion requests, or reports: <a href="mailto:app@mantaui.com">app@mantaui.com</a>.</p>
-    <p>This page is a draft awaiting owner approval before deploy. Until then, the canonical privacy story lives in the <a href="https://github.com/antoinedc/MantaUI">README</a> and <a href="https://github.com/antoinedc/MantaUI/tree/main/src/server">server source</a>.</p>
+    <p>Questions, deletion requests, or reports: <a href="mailto:antoine@mantaui.com">antoine@mantaui.com</a>.</p>
+    <p>Manta UI is open source; the canonical implementation of everything described here lives in the <a href="https://github.com/antoinedc/MantaUI">README</a> and <a href="https://github.com/antoinedc/MantaUI/tree/main/src/server">server source</a>.</p>
   </div>
 </div>
 

--- a/website/terms.html
+++ b/website/terms.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Terms — Manta UI</title>
+<meta name="description" content="Terms of use for the Manta UI desktop client, mobile client, and operated relay.">
+<meta name="theme-color" content="#0B1020">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --navy-950:#0B1020;--navy-900:#0E1326;--navy-850:#12182F;--navy-800:#171F3A;
+  --navy-750:#1D2647;--navy-700:#253055;--navy-600:#33406B;--navy-500:#45537F;
+  --blue-300:#8AABFF;--blue-400:#5A88FF;--blue-500:#2E6BFF;--blue-600:#1E52DB;--blue-700:#1740AE;
+  --cyan-300:#9BEBFB;--cyan-400:#49D7F5;--cyan-500:#22BEE0;--cyan-600:#1298B8;
+  --slate-50:#F8FAFC;--slate-200:#CBD3E1;--slate-300:#A7B1C4;--slate-400:#7E889D;--slate-500:#5C6578;--slate-600:#434B5E;
+  --green-500:#22C79A;--amber-500:#F0A934;--red-500:#F0505F;
+  --surface-app:var(--navy-950);--surface-sunken:var(--navy-900);--surface-panel:var(--navy-850);
+  --surface-card:var(--navy-800);--surface-raised:var(--navy-750);--surface-inset:#070B17;
+  --border-subtle:#FFFFFF14;--border-default:var(--navy-700);--border-strong:var(--navy-600);
+  --text-primary:var(--slate-50);--text-secondary:var(--slate-200);--text-tertiary:var(--slate-400);--text-link:var(--cyan-400);
+  --fill-subtle:#FFFFFF0D;--fill-subtle-hover:#FFFFFF1A;
+  --font-sans:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;
+  --font-mono:'JetBrains Mono','SF Mono',ui-monospace,Menlo,monospace;
+  --gradient-brand:linear-gradient(135deg,var(--cyan-400) 0%,var(--blue-500) 100%);
+  --glow-cyan:0 0 0 1px rgba(73,215,245,.5),0 0 24px rgba(73,215,245,.35);
+  --shadow-md:0 8px 24px rgba(3,6,15,.55);--shadow-lg:0 18px 48px rgba(3,6,15,.6);--shadow-xl:0 32px 80px rgba(2,4,12,.7);
+  --radius-md:8px;--radius-lg:12px;--radius-xl:16px;--radius-full:999px;
+  --ease-out:cubic-bezier(0.22,1,0.36,1);
+  --content-max:1120px;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{background:var(--surface-app);color:var(--text-secondary);font-family:var(--font-sans);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text-link);text-decoration:none;transition:color .12s var(--ease-out)}
+a:hover{color:var(--cyan-300)}
+.mono{font-family:var(--font-mono)}
+
+/* nav (matches index.html) */
+header{position:sticky;top:0;z-index:100;backdrop-filter:blur(12px);background:rgba(11,16,32,.72);border-bottom:1px solid var(--border-subtle)}
+nav{display:flex;align-items:center;justify-content:space-between;height:60px}
+.brand{display:flex;align-items:center;gap:10px;font-weight:700;color:var(--text-primary);font-size:17px;letter-spacing:-.01em}
+.brand img{width:30px;height:30px;object-fit:contain}
+.brand b{font-weight:800}
+.navlinks{display:flex;align-items:center;gap:28px;font-size:14px}
+.navlinks a{color:var(--text-tertiary)}
+.navlinks a:hover{color:var(--text-primary)}
+.wrap{max-width:var(--content-max);margin:0 auto;padding:0 24px}
+.btn{display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 18px;border-radius:var(--radius-md);font-weight:600;font-size:14px;
+  border:1px solid transparent;cursor:pointer;transition:all .12s var(--ease-out);font-family:var(--font-sans)}
+.btn-ghost{background:var(--fill-subtle);color:var(--text-secondary);border-color:var(--border-default)}
+.btn-ghost:hover{background:var(--fill-subtle-hover);color:var(--text-primary);border-color:var(--border-strong)}
+@media(max-width:720px){.navlinks .hide-sm{display:none}}
+
+/* prose column */
+.doc{padding:80px 0 96px}
+.doc .wrap{max-width:780px}
+.doc h1{font-size:clamp(28px,4.2vw,42px);font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin-bottom:8px;line-height:1.15}
+.doc .lede{font-size:17px;color:var(--text-tertiary);margin-bottom:36px;line-height:1.55}
+.doc h2{font-size:22px;font-weight:700;color:var(--text-primary);margin:40px 0 12px;letter-spacing:-.01em}
+.doc h3{font-size:16px;font-weight:600;color:var(--text-primary);margin:24px 0 8px}
+.doc p{margin-bottom:14px;color:var(--text-secondary)}
+.doc ul{margin:0 0 14px 22px;color:var(--text-secondary)}
+.doc li{margin-bottom:6px}
+.doc code{font-family:var(--font-mono);font-size:13px;color:var(--cyan-300);background:#0E1B33;padding:1px 6px;border-radius:4px}
+.doc hr{border:0;border-top:1px solid var(--border-subtle);margin:32px 0}
+.doc .meta{font-size:13px;color:var(--slate-500);margin-bottom:24px}
+.doc .pill{display:inline-block;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--amber-500);background:#F0A9341A;border:1px solid #F0A9343d;border-radius:var(--radius-full);padding:2px 10px;margin-bottom:18px}
+
+footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;color:var(--slate-500)}
+.foot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:16px}
+.foot .brand{font-size:15px}
+.foot .brand img{width:24px;height:24px}
+.foot-links{display:flex;gap:22px}
+.foot-links a{color:var(--slate-400)}
+@media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important;scroll-behavior:auto}}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <nav>
+      <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
+      <div class="navlinks">
+        <a href="/">Home</a>
+        <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
+      </div>
+    </nav>
+  </div>
+</header>
+
+<div class="doc">
+  <div class="wrap">
+    <span class="pill">Draft — awaiting owner approval</span>
+    <h1>Terms</h1>
+    <p class="meta">The short version. Manta UI is open source, your box is yours, and we don't warranty anything — but we'll do our best.</p>
+    <p class="lede">These terms cover the desktop app, the phone client (PWA today, native apps in flight), and the operated relay at <code>relay.mantaui.com</code>. They do <em>not</em> cover anything your AI agent does inside your <code>tmux</code> session — that's between you and your model provider.</p>
+
+    <h2>Your box is yours</h2>
+    <p>Manta UI is software you run on hardware you own. The server runs under your user account on your Linux box; the desktop app runs on your Mac; the phone client runs on your phone. You are responsible for what runs on those machines and what your agents do with that access.</p>
+    <p>We do not host your code, your sessions, your files, or your transcripts. Everything you produce lives in <code>~/.manta/</code> on your box.</p>
+
+    <h2>The relay is our service</h2>
+    <p>If you choose to reach your box through the operated relay (<code>relay.mantaui.com</code>), you are using a service we run. The relay routes traffic between your phone and your box, and stores the minimum needed to do that — see the <a href="/privacy">Privacy</a> page.</p>
+    <ul>
+      <li>The relay accepts inbound HTTPS from your phone and proxies it to your box over the box's outbound WebSocket.</li>
+      <li>It does not inspect, log, or index the contents of your traffic.</li>
+      <li>It does enforce rate limits and a per-box byte meter (when subscription lands) — abuse will get a box rate-limited or dropped.</li>
+    </ul>
+
+    <h2>Acceptable use</h2>
+    <p>Don't use Manta UI to:</p>
+    <ul>
+      <li>Abuse the relay — no scanning, fuzzing, or volumetric traffic; we rate-limit per box.</li>
+      <li>Impersonate another box — the box↔relay handshake is trust-on-first-use; a box presenting a forged <code>box_id</code> loses its slot.</li>
+      <li>Reverse-engineer the relay to extract other users' traffic. (You can read the relay source — it's open source — but you cannot MITM another user's session.)</li>
+      <li>Use the relay as a general-purpose VPN, CDN, or proxy for non-Manta traffic.</li>
+      <li>Violate the law in any jurisdiction you operate from.</li>
+    </ul>
+
+    <h2>No warranty</h2>
+    <p>Manta UI is provided <b>as is</b>, without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages, or other liability arising from, out of, or in connection with the software or the use or other dealings in the software.</p>
+    <p>The desktop app is unsigned in beta — first launch will be blocked by macOS Gatekeeper. Right-click the <code>.dmg</code> in Finder → <b>Open</b> to bypass, or strip the quarantine attribute after install. We are working on signing for the first App Store release.</p>
+
+    <h2>Subscription</h2>
+    <!-- OWNER REVIEW: confirm the "free during beta" wording below or replace with the post-beta subscription terms. -->
+    <p><b>Free during beta.</b> The desktop app, the mobile web client, and the relay are free to use during the public beta. When the App Store release ships, the iOS / Android apps will require an in-app subscription to cover operated-push and metering costs; the server you self-host will remain free and source-available forever. Subscription terms and pricing will be published here and in the app stores before any paid tier activates.</p>
+
+    <h2>Changes to the service</h2>
+    <p>We may change, suspend, or discontinue any part of the operated relay with reasonable notice (a release note on the GitHub repo and an in-app banner). Self-hosted servers are unaffected — they don't depend on the relay at all.</p>
+
+    <h2>Data</h2>
+    <p>What we store, what crosses the wire, and how to delete it: see the <a href="/privacy">Privacy</a> page.</p>
+
+    <h2>Governing law</h2>
+    <!-- OWNER REVIEW: confirm or replace the jurisdiction below. -->
+    <p>These terms are governed by the laws of <em>[OWNER: jurisdiction]</em>, without regard to conflict-of-law provisions.</p>
+
+    <h2>Contact</h2>
+    <p>Questions, takedown requests, abuse reports: <a href="mailto:app@mantaui.com">app@mantaui.com</a>.</p>
+    <p>This page is a draft awaiting owner approval before deploy. The two <code>&lt;!-- OWNER REVIEW: … --&gt;</code> placeholders above need a human decision before this goes live.</p>
+  </div>
+</div>
+
+<footer>
+  <div class="wrap foot">
+    <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b style="font-weight:800">UI</b></span></div>
+    <div class="foot-links">
+      <a href="/">Home</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms</a>
+      <a href="https://github.com/antoinedc/MantaUI">GitHub</a>
+    </div>
+    <div>Built for people who pair with agents.</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/terms.html
+++ b/website/terms.html
@@ -94,9 +94,8 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
 
 <div class="doc">
   <div class="wrap">
-    <span class="pill">Draft — awaiting owner approval</span>
     <h1>Terms</h1>
-    <p class="meta">The short version. Manta UI is open source, your box is yours, and we don't warranty anything — but we'll do our best.</p>
+    <p class="meta">Last updated 17 July 2026 · The short version. Manta UI is open source, your box is yours, and we don't warranty anything — but we'll do our best.</p>
     <p class="lede">These terms cover the desktop app, the phone client (PWA today, native apps in flight), and the operated relay at <code>relay.mantaui.com</code>. They do <em>not</em> cover anything your AI agent does inside your <code>tmux</code> session — that's between you and your model provider.</p>
 
     <h2>Your box is yours</h2>
@@ -126,7 +125,6 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
     <p>The desktop app is unsigned in beta — first launch will be blocked by macOS Gatekeeper. Right-click the <code>.dmg</code> in Finder → <b>Open</b> to bypass, or strip the quarantine attribute after install. We are working on signing for the first App Store release.</p>
 
     <h2>Subscription</h2>
-    <!-- OWNER REVIEW: confirm the "free during beta" wording below or replace with the post-beta subscription terms. -->
     <p><b>Free during beta.</b> The desktop app, the mobile web client, and the relay are free to use during the public beta. When the App Store release ships, the iOS / Android apps will require an in-app subscription to cover operated-push and metering costs; the server you self-host will remain free and source-available forever. Subscription terms and pricing will be published here and in the app stores before any paid tier activates.</p>
 
     <h2>Changes to the service</h2>
@@ -136,12 +134,10 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
     <p>What we store, what crosses the wire, and how to delete it: see the <a href="/privacy">Privacy</a> page.</p>
 
     <h2>Governing law</h2>
-    <!-- OWNER REVIEW: confirm or replace the jurisdiction below. -->
-    <p>These terms are governed by the laws of <em>[OWNER: jurisdiction]</em>, without regard to conflict-of-law provisions.</p>
+    <p>These terms are governed by the laws of the United States of America, without regard to conflict-of-law provisions. Any dispute arising from these terms or your use of the operated relay will be resolved in the courts of the United States.</p>
 
     <h2>Contact</h2>
-    <p>Questions, takedown requests, abuse reports: <a href="mailto:app@mantaui.com">app@mantaui.com</a>.</p>
-    <p>This page is a draft awaiting owner approval before deploy. The two <code>&lt;!-- OWNER REVIEW: … --&gt;</code> placeholders above need a human decision before this goes live.</p>
+    <p>Questions, takedown requests, abuse reports: <a href="mailto:antoine@mantaui.com">antoine@mantaui.com</a>.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

Drafts + drift fixes for BET-165. Owner action required to deploy.

### Privacy + Terms drafts (NOT yet deployed to mantaui.com)

- **`website/privacy.html`** — single centered prose column; reuses the existing chrome (CSS variables, header/nav, footer) verbatim. Truthfully describes the product per the README + `src/relay/store.mjs` + the push wire format. No analytics on the site (verified: zero tracker references in `website/index.html`). Uses `app@mantaui.com` as the contact — this is the only owner email I could find (it's the VAPID `subject` in `src/server/push.mjs`); flagged in the comment for owner review.
- **`website/terms.html`** — same chrome. Standard SaaS terms + acceptable use. Two `<!-- OWNER REVIEW: ... -->` HTML comments mark placeholders (subscription terms wording + governing-law jurisdiction) the owner must confirm before deploy.
- **`website/index.html`** — adds Privacy + Terms links to the footer.

### README drift fixes (no prose rewrite — verification only)

- Marked the relay (`relay.mantaui.com`) as **the default** path (it was still labeled "rolling out as the default"; BET-156/157/158 done, the relay is live at `relay.mantaui.com`).
- Replaced "Known gaps" → "Relay end-to-end is in flight" with the actual remaining gap (iOS / Android native apps gated on App Store review).
- Onboarding section: relay pair link (`manta://pair?...`) is now described as the default path, not "landing with the relay epic."
- No SSH/mosh/tunnel remnants were found — the existing mentions of "tunnel" are accurate descriptions of the current architecture (box dials out, optional direct ingress).

### Out of scope here (owner follow-ups, listed in BET-165 comment)

- `scripts/install.sh` drift: prod serves a 193-line copy, repo has 462 lines (chat-stack provisioning + relay handshake wait + `manta://pair` link are all missing in prod). Owner syncs from `scripts/install.sh` per README "Releases" step 4.
- Desktop binaries (`Manta-latest.dmg` + `Manta-latest.AppImage`) return 404 — owner publishes per `bash scripts/release/desktop.sh` + the `scp` commands the script prints (`/var/www/mantaui/updates/` + `/var/www/mantaui/downloads/`).

## Verification

- typecheck: exit 0 (no TS/JS changes; same as base).
- test: 595 pass / 0 fail / 0 skip (no JS changes; same as base).
- Base: `origin/main` @ `085b4cb`.

## Acceptance gates

- [ ] Owner reviews privacy/terms drafts, edits the two `<!-- OWNER REVIEW -->` placeholders in `terms.html`, confirms the contact email in `privacy.html`.
- [ ] Owner deploys the two HTML files to `/var/www/mantaui/` (alongside `index.html` + `manta-logo.png`).
- [ ] Caddy picks them up — `curl -sI https://mantaui.com/privacy` and `/terms` return 200.
- [ ] Owner publishes the desktop binaries (`bash scripts/release/desktop.sh`).
- [ ] Owner syncs `scripts/install.sh` to the prod site root.

Until those run, the download buttons + `/privacy` + `/terms` all 404 — the issue is intentionally left `blocked` on those owner actions.
