### PR TITLE
BET-170: installer bootstrap-node — fixes one-liner on stock Ubuntu

### DIFF
--- a/docs/launch-e2e.md
+++ b/docs/launch-e2e.md
@@ -178,6 +178,280 @@ Server manta-e2e deleted
 
 $ HCLOUD_TOKEN=$(cat /home/dev/.manta-secrets/projects/BUI/HETZNER_MANTA_BOX) \
     hcloud server list
+ID          NAME    STATUS    IPV4           IPV6   PRIVATE NET   LOCATION   AGE
+151615222   manta   running   91.107.196.2   ...    -             fsn1       26h
+```
+
+Only the production box remains.
+
+## Reproducer (for the engineer picking up F1)
+
+```
+# Fresh Ubuntu 24.04 VPS as a non-root sudoer.
+curl -fsSL https://mantaui.com/install.sh | bash   # exits 1, no work done
+```
+
+---
+
+# Re-run after BET-170 fix — installer bootstrap-node
+
+`scripts/install.sh` was patched (branch `multica/BET-170-installer-installs-node`)
+to add `bootstrap_node` — when `command -v node` is missing on a stock Ubuntu
+24.04 image, the installer now adds the NodeSource 20.x apt repo and runs
+`apt-get install -y nodejs` before the rest of the prereq check. Idempotent:
+a box with node already on PATH is a clean no-op (no apt / curl call).
+
+This document is updated with the unit-test verification of the bootstrap path
+in lieu of a second live Hetzner run (the launch-e2e VPS was deleted at end
+of run per the original hard rule, and a fresh run is the operator's call once
+they cherry-pick the branch onto the production `mantaui.com/install.sh`).
+
+## Bootstrap path — what the patch does
+
+When the one-liner runs on a stock cloud image:
+
+1. The script loads helpers (log/ok/warn/die + `bootstrap_node` + distro
+   installers).
+2. `bootstrap_node` checks `command -v node`. Found → `return 0` (no curl, no
+   apt, no `set -e` propagation).
+3. Missing → check `curl` + `tar` are present (the bootstrap path itself needs
+   them). If either is missing, die with a manual-install hint.
+4. `detect_distro_id` reads `/etc/os-release` in a subshell (no env-var leak).
+5. Branch on distro:
+   - `ubuntu`/`debian` → `install_node_via_apt` (NodeSource 20.x setup +
+     `apt-get install -y nodejs`)
+   - `fedora`/`amzn` → `install_node_via_dnf`
+   - `rhel`/`centos`/`rocky`/`almalinux`/`ol` → try `install_node_via_dnf`,
+     fall back to `install_node_via_yum`
+   - empty (unreadable) → die with hint
+   - anything else → die with `distro '…' is not auto-bootstrapped` hint
+6. Post-install `command -v node` re-check. Still missing → die.
+7. The original `require_cmd curl/git/tmux/node/npm` block now sees a node on
+   PATH and proceeds normally.
+
+The bootstrap mirrors the existing `require_cmd` tone — every failure mode
+exits with a "install manually: https://nodejs.org" hint, never silent sudo.
+
+## Unit-test verification (`scripts/install.test.mjs`)
+
+The fix ships with 9 new tests (66 total in `install.test.mjs`, +9 over
+baseline 57; `npm test` totals 652 vs master 643, +9 tests, 0 fails on both
+branches). Each test runs a tiny bash harness that:
+
+- Sets `MANTA_INSTALL_TEST_MODE=1` so install.sh bails before the install
+  body but the helpers stay loaded.
+- Sources `scripts/install.sh` in test mode.
+- Defines function overrides AFTER the source (latest-definition wins) to
+  mock `install_node_via_apt` / `install_node_via_dnf` / `install_node_via_yum`
+  / `detect_distro_id`, plus a `command()` shadow that pretends node is
+  missing on PATH (the test runner has node installed).
+- Calls `bootstrap_node` and asserts on the captured stdout+stderr + exit
+  marker (`BOOTSTRAP_EXIT=N`).
+
+| Test | Asserts |
+|------|---------|
+| `install.sh is bash-syntax-clean (bash -n)` | script parses (catches stray characters / unclosed quotes) |
+| `bootstrap_node is a no-op when node is already on PATH (idempotent)` | mocks `install_node_via_apt`/`_dnf`/`_yum`; asserts NONE were called; exit 0 |
+| `bootstrap_node calls install_node_via_apt on Debian/Ubuntu when node is missing` | `command` shadow + `detect_distro_id=ubuntu`; mock `_apt` is invoked |
+| `bootstrap_node calls install_node_via_dnf on Fedora when node is missing` | distro=fedora → mock `_dnf` fires |
+| `bootstrap_node calls install_node_via_yum on RHEL when dnf is absent` | distro=rhel; `_dnf` returns 1, `_yum` returns 0 → both fire |
+| `bootstrap_node dies with a clear hint when the distro installer fails` | `_apt` returns 1 → die with `Node.js install via apt failed` + nodejs.org hint |
+| `bootstrap_node dies with a manual-install hint for unknown distros` | distro=`arch` (not in case) → `not auto-bootstrapped` + nodejs.org hint |
+| `bootstrap_node dies with a manual-install hint when /etc/os-release is unreadable` | `detect_distro_id` returns empty → `is unreadable` + nodejs.org hint |
+| `bootstrap_node dies when node + curl are missing together` | `command` shadow pretends node+curl+tar are gone → die WITHOUT calling `_apt` (no silent sudo over a hostile env) |
+
+## Verification results
+
+```
+PR branch (multica/BET-170-installer-installs-node @ current):
+  typecheck: exit 0. Errors: none. log sha256: f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba
+  test:      exit 0, 652 pass / 0 fail.  log sha256: 9bf4b0b22ddf689c9f2943a6dedd07923c39cd4f21febcbe166e9dc1ca348406
+Base (origin/main @ e899bfa):
+  typecheck: exit 0. Errors: none. log sha256: f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba
+  test:      exit 0, 643 pass / 0 fail.  log sha256: 99865b6f7b67d6448a6b7dca3fcc4a8c01e49c70018e32165a6920f37ea36c73
+
+Conclusion: 0 new failures, 0 resolved failures, +9 tests (the new bootstrap
+unit tests). Typecheck output is byte-identical between branches (same hash);
+the only test delta is the 9 new bootstrap cases, all green.
+```
+
+## What's still needed before F1 is fully closed
+
+The patch ships the install-side fix and the unit tests. The live VPS re-run
+(Section 2: a stranger with a fresh VPS + the website → working terminal +
+chat) needs the branch cherry-picked onto the etag-served `install.sh` at
+`mantaui.com/install.sh`. That's a release-side operation outside the scope
+of this branch. The reviewer should:
+
+1. Pull `multica/BET-170-installer-installs-node`, run `npm test` (66 cases
+   in `install.test.mjs`, 652 total) and `npm run typecheck` — both green.
+2. Spot-check the bash syntax via `bash -n scripts/install.sh`.
+3. Approve the merge; once on `main`, an operator can cut a release + flip
+   the etag to validate the full live path.
+
+## Reproducer for the live path (post-merge)
+
+```
+# Fresh Ubuntu 24.04 VPS as a non-root sudoer with curl+tar present
+# (the Hetzner Ubuntu 24.04 cloud image ships both).
+curl -fsSL https://mantaui.com/install.sh | bash
+```
+
+Expected output (key lines):
+
+```
+▸ node is missing — bootstrapping Node.js 20.x via NodeSource.
+▸ Downloading NodeSource 20.x setup script…
+▸ Adding NodeSource 20.x apt repository (mode=sudo)…
+✓ node v20.x.y installed via NodeSource.
+▸ Checking prerequisites (curl, tar, git, tmux, node, npm)…
+✓ Prerequisites present (v20.x.y, npm x.y.z).
+…
+▸ Minting pairing code…
+  Pairing code:  NNNNNN
+  Box ID:        <32-hex>
+  Pair link:     manta://pair?box=…&code=…
+```
+
+`systemctl --user status manta-server` → `active (running)`.
+hcloud server create \
+  --type cpx11 --image ubuntu-24.04 --name manta-e2e \
+  --ssh-key alphaclaw@alphaclaw --location ash
+```
+
+Returned immediately: `Waiting for create_server (server: 152016692, image:
+161547269) ... done`. The token's project had `server_limit = 1` initially
+(only the prod box `manta`/id 151615222 existed); the owner raised the limit
+before this run (see `ace0c8be` on BET-162).
+
+Note: the original spec said `--type cx22`, which is the legacy alias and no
+longer exists; the closest current spec is `cpx11` (the smallest plan still
+orderable). `cpx11` is only available in `ash` and `hil`; all the spec'd EU
+locations (`fsn1`, `nbg1`, `hel1`) reject it as `Server Type unavailable`.
+
+## Step 2 — advertised one-liner (verbatim)
+
+```
+$ curl -fsSL https://mantaui.com/install.sh | bash
+```
+
+### Actual output
+
+```
+▸ Checking prerequisites (node, npm, git, tmux, curl, tar)…
+✗ missing prerequisite: node
+      Install it and re-run. Suggested:
+        install Node.js LTS: https://nodejs.org  (nvm: 'nvm install --lts')
+```
+
+**Installer exit code: 1** (the `die` helper calls `exit 1`).
+
+Wall time: <1 second from `bash` start to `exit 1`. No prompts shown, no
+pairing code printed, no state mutated on the box.
+
+### Post-attempt box state
+
+```
+$ ssh manta@178.156.203.86 '...'
+/home/manta/.config/systemd/user/manta-server.service  →  NOT INSTALLED
+systemctl --user status manta-server                    →  Unit not found
+loginctl show-user manta | grep Linger                  →  Linger=yes (set by user bootstrap, not by installer)
+/home/manta/manta/                                      →  NOT CREATED
+~/.manta/                                                →  NOT CREATED
+```
+
+### Root cause
+
+A stock Hetzner Ubuntu 24.04 cloud image does NOT ship Node.js. Confirmed on
+the box:
+
+```
+$ command -v node  →  not found
+$ command -v npm   →  not found
+```
+
+The installer's `require_cmd node` helper (lines 47–54 of `scripts/install.sh`)
+treats this as fatal and `exit 1`s before doing anything else. The script
+comments describe it as a "one-command VPS self-install" that "Gets
+manta-server running under systemd --user on a fresh Linux box" — neither is
+true on a stock cloud image.
+
+The mantaui.com homepage also advertises this as "one-command install — pair
+once and steer"; there is no prerequisite note visible on the page (grep'd
+for `node|prereq|requirement` — only CSS class names matched).
+
+## Steps 3–6 — not reached
+
+The installer exited before any of these could be observed:
+
+- **Step 3** (health / linger / opencode stack / relay link): no
+  `manta-server` unit, no opencode process, no journal to grep.
+- **Step 4** (desktop pair through relay): no `~/manta/` unpacked, so the
+  `manta pair` CLI doesn't exist on the box. No pairing code was printed.
+- **Step 5** (PWA pair + push): same — requires a pairing code from step 2.
+- **Step 6** (reboot resilience): no systemd unit to verify, no dial-out
+  agent to reconnect.
+
+## Network reachability (verified from the box before tearing down)
+
+Useful for follow-up: the box could reach everything a healthy install would
+need to dial.
+
+| Target | From box | Result |
+|--------|----------|--------|
+| `https://mantaui.com/install.sh` | curl | 200 |
+| `https://mantaui.com/releases/manta-latest.tar.gz` | curl | 200, 1,209,791 B |
+| `https://relay.mantaui.com` | curl | 401 (expected — that IS healthy) |
+| `relay.mantaui.com:443` (TCP for WSS upgrade) | `/dev/tcp` | OK |
+| DNS `mantaui.com`, `relay.mantaui.com`, `app.mantaui.com` | `getent hosts` | OK |
+
+So when the installer IS fixed, it will have a clear network path to do
+its job — there is no second-order network problem hiding behind the node
+prereq.
+
+## Findings
+
+### F1 (launch-blocking) — installer does not install Node.js
+
+**Where**: `scripts/install.sh` lines 47–54 (`require_cmd node …`).
+**Symptom**: on a stock Ubuntu 24.04 image, the one-liner exits 1 in <1s with
+"missing prerequisite: node" and leaves the box unchanged.
+**Why it blocks launch**: BET-160 §2 acceptance criterion is "a stranger with
+a fresh VPS + the website can reach a working terminal+chat session without
+any manual help from us". Any manual `apt-get install -y nodejs` (or nodesource
+setup, or nvm) violates that.
+**Fix shape (suggested, NOT applied — per issue hard rule)**:
+- Either have `install.sh` detect a missing `node` and bootstrap it (cleanest:
+  add the NodeSource setup script + `apt-get install -y nodejs` before the
+  prereq check), or
+- Update `mantaui.com` to display "requires Node.js 20+" alongside the install
+  one-liner (weaker — still requires manual help on the box).
+
+Filed as a follow-up issue linked from BET-162.
+
+### F2 (advisory, no severity) — spec inconsistency on server type
+
+`cx22` is the legacy alias (gone). Current smallest orderable plan is
+`cpx11`, only available in `ash` and `hil`. Spec should be updated. Not
+launch-blocking — the rest of the workflow works once F1 is fixed.
+
+## Hard rules respected
+
+- Did NOT patch around the failure on the test box (no manual node install,
+  no hand-copied files, no apt bootstrap).
+- Did NOT modify installer/relay code.
+- Did NOT touch the production server `manta` (id 151615222, 91.107.196.2).
+- VPS deleted at end of run (see Step 9 below); not left running.
+
+## Step 9 — VPS deletion
+
+```
+$ HCLOUD_TOKEN=$(cat /home/dev/.manta-secrets/projects/BUI/HETZNER_MANTA_BOX) \
+    hcloud server delete manta-e2e
+Server manta-e2e deleted
+
+$ HCLOUD_TOKEN=$(cat /home/dev/.manta-secrets/projects/BUI/HETZNER_MANTA_BOX) \
+    hcloud server list
 ID          NAME    STATUS    IPV4           IPV6    PRIVATE NET   LOCATION   AGE
 151615222   manta   running   91.107.196.2   ...     -             fsn1       26h
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,15 +20,202 @@
 # lives in scripts/install-lib.mjs and is unit-tested (scripts/install.test.mjs).
 # This shell stays a thin orchestrator.
 
-set -euo pipefail
-
+# === Always-defined helpers (test-safe: defined even in test mode) ===========
+# These are defined BEFORE the test-mode guard and the install body so the unit
+# tests in scripts/install.test.mjs can source this script and call bootstrap_node
+# / install_node_via_* / require_cmd without the install body running.
 log()  { printf '\033[36m▸\033[0m %s\n' "$*"; }
 ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
 warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
-# 1. Prerequisites — verify; report-and-instruct if missing (never silent sudo).
+# Prerequisite bootstrap (BET-162 F1 fix) — installs Node.js when missing.
+# Mirrors the "report-and-instruct, never silent sudo" tone of require_cmd,
+# but actually performs the install when missing. Idempotent: re-running with
+# node already on PATH is a no-op (no apt/dnf/yum call, no curl).
+# ---------------------------------------------------------------------------
+
+# Detect distro ID from /etc/os-release. Echoes the ID (without quotes), or
+# empty string if unreadable. Pure: uses a subshell so /etc/os-release's vars
+# do NOT leak into the caller's environment.
+detect_distro_id() {
+  ( . /etc/os-release 2>/dev/null && printf '%s' "${ID:-}" ) || true
+}
+
+# Returns "root" / "sudo" via stdout; returns 1 if neither is available.
+# Tests stub install_node_via_* directly so they don't exercise this, but it's
+# kept simple + side-effect-free for symmetry.
+package_install_mode() {
+  if [ "$(id -u)" -eq 0 ]; then
+    printf 'root'
+    return 0
+  fi
+  if command -v sudo >/dev/null 2>&1; then
+    printf 'sudo'
+    return 0
+  fi
+  return 1
+}
+
+# Install nodejs via apt + NodeSource 20.x repo (Debian/Ubuntu). Exposed so
+# scripts/install.test.mjs can stub it with a mock and verify the call site
+# without hitting the network.
+install_node_via_apt() {
+  local mode
+  mode="$(package_install_mode)" || {
+    die "node is missing and neither root nor sudo is available.
+        Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
+        then re-run the installer."
+  }
+  local ns_script="/tmp/manta-nodesource-setup_20.x.sh"
+  log "Downloading NodeSource 20.x setup script…"
+  curl -fsSL https://deb.nodesource.com/setup_20.x -o "$ns_script" \
+    || { warn "failed to download NodeSource setup script"; return 1; }
+  log "Adding NodeSource 20.x apt repository (mode=$mode)…"
+  if [ "$mode" = "root" ]; then
+    bash "$ns_script" && apt-get install -y nodejs
+  else
+    warn "this installer needs to install Node.js, which requires sudo."
+    warn "you'll be prompted for your sudo password."
+    sudo bash "$ns_script" && sudo apt-get install -y nodejs
+  fi
+  local rc=$?
+  rm -f "$ns_script"
+  return $rc
+}
+
+# Install nodejs via dnf + NodeSource 20.x (Fedora / Amazon Linux / RHEL 8+).
+install_node_via_dnf() {
+  local mode
+  mode="$(package_install_mode)" || {
+    die "node is missing and neither root nor sudo is available.
+        Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
+        then re-run the installer."
+  }
+  local ns_script="/tmp/manta-nodesource-setup_20.x.sh"
+  log "Downloading NodeSource 20.x setup script…"
+  curl -fsSL https://rpm.nodesource.com/setup_20.x -o "$ns_script" \
+    || { warn "failed to download NodeSource setup script"; return 1; }
+  log "Adding NodeSource 20.x dnf repository (mode=$mode)…"
+  if [ "$mode" = "root" ]; then
+    bash "$ns_script" && dnf install -y nodejs
+  else
+    warn "this installer needs to install Node.js, which requires sudo."
+    warn "you'll be prompted for your sudo password."
+    sudo bash "$ns_script" && sudo dnf install -y nodejs
+  fi
+  local rc=$?
+  rm -f "$ns_script"
+  return $rc
+}
+
+# Install nodejs via yum + NodeSource 20.x (older RHEL/CentOS where dnf is absent).
+install_node_via_yum() {
+  local mode
+  mode="$(package_install_mode)" || {
+    die "node is missing and neither root nor sudo is available.
+        Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
+        then re-run the installer."
+  }
+  local ns_script="/tmp/manta-nodesource-setup_20.x.sh"
+  log "Downloading NodeSource 20.x setup script…"
+  curl -fsSL https://rpm.nodesource.com/setup_20.x -o "$ns_script" \
+    || { warn "failed to download NodeSource setup script"; return 1; }
+  log "Adding NodeSource 20.x yum repository (mode=$mode)…"
+  if [ "$mode" = "root" ]; then
+    bash "$ns_script" && yum install -y nodejs
+  else
+    warn "this installer needs to install Node.js, which requires sudo."
+    warn "you'll be prompted for your sudo password."
+    sudo bash "$ns_script" && sudo yum install -y nodejs
+  fi
+  local rc=$?
+  rm -f "$ns_script"
+  return $rc
+}
+
+# Top-level: ensure node is on PATH. Idempotent — early-returns when already
+# present (no curl / apt / dnf / yum call). Distro-specific installer is
+# selected by detect_distro_id; unknown distros die with a manual-install
+# hint (same tone as require_cmd failures).
+bootstrap_node() {
+  if command -v node >/dev/null 2>&1; then
+    return 0  # no-op when node is already on PATH (the common idempotent path)
+  fi
+
+  # The bootstrap path itself needs curl + tar to download the NodeSource
+  # setup script. If those are also missing, we can't auto-fix — bail with a
+  # clear manual-install hint (same tone as the require_cmd failures).
+  local missing=""
+  for cmd in curl tar; do
+    command -v "$cmd" >/dev/null 2>&1 || missing="$missing $cmd"
+  done
+  if [ -n "$missing" ]; then
+    die "node is missing and so are:$missing.
+        Install Node.js 20+ and the missing tools manually, then re-run:
+          apt-get install -y curl tar nodejs   # Debian/Ubuntu
+          dnf install -y curl tar nodejs       # Fedora
+          yum install -y curl tar nodejs       # RHEL/CentOS
+        or use the installer from https://nodejs.org."
+  fi
+
+  log "node is missing — bootstrapping Node.js 20.x via NodeSource."
+  local distro
+  distro="$(detect_distro_id)"
+
+  case "$distro" in
+    ubuntu|debian)
+      install_node_via_apt \
+        || die "Node.js install via apt failed.
+            Install manually: https://nodejs.org  (nvm: 'nvm install --lts')
+            then re-run the installer."
+      ;;
+    fedora|amzn)
+      install_node_via_dnf \
+        || die "Node.js install via dnf failed.
+            Install manually: https://nodejs.org  (nvm: 'nvm install --lts')
+            then re-run the installer."
+      ;;
+    rhel|centos|rocky|almalinux|ol)
+      install_node_via_dnf \
+        || install_node_via_yum \
+        || die "Node.js install via dnf/yum failed.
+            Install manually: https://nodejs.org  (nvm: 'nvm install --lts')
+            then re-run the installer."
+      ;;
+    "")
+      die "node is missing and /etc/os-release is unreadable.
+          Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
+          then re-run the installer."
+      ;;
+    *)
+      die "node is missing and your distro ('$distro') is not auto-bootstrapped.
+          Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
+          then re-run the installer."
+      ;;
+  esac
+
+  if ! command -v node >/dev/null 2>&1; then
+    die "node is still missing after bootstrap. Install manually: https://nodejs.org"
+  fi
+  ok "node $(node --version 2>/dev/null || echo unknown) installed via NodeSource."
+}
+
+# Test mode: when sourced by scripts/install.test.mjs with MANTA_INSTALL_TEST_MODE=1,
+# only the bash helpers (log/ok/warn/die + bootstrap_node + its distro-specific
+# installers + require_cmd) are loaded. The actual install does NOT run. Lets the
+# unit tests exercise bootstrap_node / install_node_via_* without hitting the
+# network. See scripts/install.test.mjs "bootstrap_node" cases.
+if [ "${MANTA_INSTALL_TEST_MODE:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisites — bootstrap node, then verify the rest; report-and-instruct
+#    if missing (never silent sudo).
 # ---------------------------------------------------------------------------
 require_cmd() {
   local cmd="$1" hint="$2"
@@ -39,13 +226,21 @@ require_cmd() {
   fi
 }
 
-log "Checking prerequisites (node, npm, git, tmux, curl, tar)…"
+# Bootstrap node FIRST (idempotent no-op when already present). Doing this
+# before the prereq verify means a fresh cloud image with curl+tar but no
+# node still completes the install end-to-end.
+bootstrap_node
+
+log "Checking prerequisites (curl, tar, git, tmux, node, npm)…"
 require_cmd curl "apt-get install -y curl   # or your distro's package manager"
 require_cmd tar  "apt-get install -y tar"
-require_cmd node "install Node.js LTS: https://nodejs.org  (nvm: 'nvm install --lts')"
-require_cmd npm  "ships with Node.js — reinstall Node if npm is missing"
 require_cmd git  "apt-get install -y git"
 require_cmd tmux "apt-get install -y tmux"
+# Defense-in-depth: bootstrap_node guarantees node on PATH, but require it
+# again so a failure in the bootstrap path still produces a clean error
+# instead of a confusing crash later in the script.
+require_cmd node "install Node.js LTS: https://nodejs.org  (nvm: 'nvm install --lts')"
+require_cmd npm  "ships with Node.js — reinstall Node if npm is missing"
 
 # Node 20+ required (matches the desktop app / server runtime).
 node_major="$(node -p 'process.versions.node.split(".")[0]')"

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1,8 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
 import {
   resolveConfig,
   parsePort,
@@ -24,6 +26,62 @@ import {
 } from "./install-lib.mjs";
 
 const HOME = "/home/tester";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INSTALL_SH = join(__dirname, "install.sh");
+
+/**
+ * Source scripts/install.sh in test mode (MANTA_INSTALL_TEST_MODE=1) after
+ * applying `preBody` (mocks / overrides), then call `bootstrap_node`. Returns
+ * the captured stdout+stderr as a single string. The harness writes a tiny bash
+ * script to a temp file so we don't fight bash quoting rules.
+ *
+ * Mock pattern: define functions AFTER sourcing install.sh. Bash uses the
+ * latest definition, so the test's mocks override install.sh's helpers. The
+ * test mock for `command` is what makes "node missing on PATH" testable in a
+ * sandbox that already has node installed.
+ *
+ * Never throws — bootstrap_node's `die` calls `exit 1`, which would otherwise
+ * propagate via execSync's thrown-on-non-zero-exit behavior. The harness
+ * swallows the error and returns the captured output (with BOOTSTRAP_EXIT=NNN
+ * appended) so the test can assert on the message + exit code together.
+ */
+function runBootstrap({ preBody = "" } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-bootstrap-"));
+  const script = join(dir, "test.sh");
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set +e
+export MANTA_INSTALL_TEST_MODE=1
+source '${INSTALL_SH}'
+${preBody}
+bootstrap_node
+rc=$?
+echo "BOOTSTRAP_EXIT=$rc"
+exit $rc
+`,
+    { mode: 0o755 },
+  );
+  try {
+    try {
+      return execSync(`bash ${script}`, {
+        env: { ...process.env, PATH: process.env.PATH },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (e) {
+      // execSync throws when the child exits non-zero (bootstrap_node calls
+      // `die` → `exit 1` for the failure paths). The stderr/stdout is on
+      // the error object — concatenate and return so callers can assert on
+      // the message AND the BOOTSTRAP_EXIT=N marker.
+      const out = (e.stdout ?? "") + (e.stderr ?? "");
+      // execSync's stdout/stderr are string when encoding is set.
+      return out;
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 // ----------------------------------------------------------------------------
 // resolveConfig — arg/env parsing with MANTA_HOME / MANTA_TARBALL_URL overrides
@@ -745,4 +803,222 @@ test("waitForHealth acceptAnyStatus=true (default) accepts 404 as healthy", asyn
   });
   assert.equal(res.ok, true);
   assert.equal(res.status, 404);
+});
+
+// ----------------------------------------------------------------------------
+// install.sh — bash syntax + bootstrap_node (BET-162 F1 fix)
+// ----------------------------------------------------------------------------
+//
+// These tests shell out to bash because install.sh is bash, not JS. They use
+// the MANTA_INSTALL_TEST_MODE=1 sentinel (added in install.sh) which bails
+// before the install body runs and only loads the bash helpers
+// (log/ok/warn/die + bootstrap_node + install_node_via_* + require_cmd). The
+// unit tests then exercise the helpers with mocked apt/dnf/yum call sites so
+// nothing hits the network.
+
+test("install.sh is bash-syntax-clean (bash -n)", () => {
+  // Sanity check that the script parses. The harness writes it to a temp
+  // file so the bash error message includes a useful path; bash -n itself
+  // doesn't need to write, but the temp-file dance keeps the assertion
+  // independent of where the test runner lives.
+  const dir = mkdtempSync(join(tmpdir(), "manta-install-syntax-"));
+  const script = join(dir, "install.sh");
+  writeFileSync(script, readFileSync(INSTALL_SH));
+  try {
+    execSync(`bash -n ${script}`, { stdio: "pipe" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap_node is a no-op when node is already on PATH (idempotent)", () => {
+  // The harness's bash env has node on PATH (the test runner depends on it).
+  // The mock for install_node_via_apt MUST NOT fire — bootstrap_node should
+  // early-return at the `command -v node` check. This is the re-run path:
+  // a box that already has node should NOT touch apt.
+  const out = runBootstrap({
+    preBody: `
+# Mock the apt installer — if this fires, the no-op guarantee is broken.
+install_node_via_apt() {
+  echo "MOCK_APT_CALLED" >&2
+  return 0
+}
+install_node_via_dnf() {
+  echo "MOCK_DNF_CALLED" >&2
+  return 0
+}
+install_node_via_yum() {
+  echo "MOCK_YUM_CALLED" >&2
+  return 0
+}
+`,
+  });
+  assert.doesNotMatch(out, /MOCK_APT_CALLED/);
+  assert.doesNotMatch(out, /MOCK_DNF_CALLED/);
+  assert.doesNotMatch(out, /MOCK_YUM_CALLED/);
+  assert.doesNotMatch(out, /bootstrap_node|NodeSource/, "no bootstrap log lines when node is on PATH");
+  assert.match(out, /BOOTSTRAP_EXIT=0/);
+});
+
+test("bootstrap_node calls install_node_via_apt on Debian/Ubuntu when node is missing", () => {
+  // Pretend node is missing by shadowing `command -v node`. The bash test
+  // env has node, so without the shadow bootstrap_node would no-op.
+  const out = runBootstrap({
+    preBody: `
+# Pretend \`command -v node\` always fails.
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+
+# Force the Debian/Ubuntu distro branch (no /etc/os-release in some sandboxes).
+detect_distro_id() { echo "ubuntu"; }
+
+# Mock the apt installer — if this fires, the call site is wired right.
+install_node_via_apt() {
+  echo "MOCK_APT_CALLED"
+  return 0
+}
+`,
+  });
+  assert.match(out, /MOCK_APT_CALLED/, "apt installer was called");
+  assert.match(out, /bootstrapping Node\.js 20\.x/);
+  // The mock returns 0, so the install is "successful" — but bootstrap_node
+  // re-checks `command -v node` afterwards and our shadow still says "missing",
+  // so it dies. That's the expected flow when the install doesn't actually
+  // put node on PATH (a real apt install would).
+  assert.match(out, /node is still missing after bootstrap/);
+});
+
+test("bootstrap_node calls install_node_via_dnf on Fedora when node is missing", () => {
+  const out = runBootstrap({
+    preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+detect_distro_id() { echo "fedora"; }
+install_node_via_dnf() {
+  echo "MOCK_DNF_CALLED"
+  return 0
+}
+`,
+  });
+  assert.match(out, /MOCK_DNF_CALLED/);
+  assert.match(out, /node is still missing after bootstrap/);
+});
+
+test("bootstrap_node calls install_node_via_yum on RHEL when dnf is absent", () => {
+  const out = runBootstrap({
+    preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+detect_distro_id() { echo "rhel"; }
+# Make dnf fail so yum is tried as the fallback.
+install_node_via_dnf() {
+  echo "MOCK_DNF_CALLED"
+  return 1
+}
+install_node_via_yum() {
+  echo "MOCK_YUM_CALLED"
+  return 0
+}
+`,
+  });
+  assert.match(out, /MOCK_DNF_CALLED/);
+  assert.match(out, /MOCK_YUM_CALLED/);
+  assert.match(out, /node is still missing after bootstrap/);
+});
+
+test("bootstrap_node dies with a clear hint when the distro installer fails", () => {
+  // The mock returns non-zero — install_node_via_apt fails. The script
+  // MUST surface the failure as a `die` with the manual-install hint, NOT
+  // silently swallow it.
+  const out = runBootstrap({
+    preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+detect_distro_id() { echo "ubuntu"; }
+install_node_via_apt() {
+  echo "MOCK_APT_FAIL"
+  return 1
+}
+`,
+  });
+  assert.match(out, /MOCK_APT_FAIL/);
+  assert.match(out, /Node\.js install via apt failed/);
+  assert.match(out, /Install manually: https:\/\/nodejs\.org/);
+});
+
+test("bootstrap_node dies with a manual-install hint for unknown distros", () => {
+  // distro='arch' isn't in our case statement — the user gets the same
+  // "install manually" hint as the require_cmd failures (BET-162 F1 tone).
+  const out = runBootstrap({
+    preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+detect_distro_id() { echo "arch"; }
+`,
+  });
+  assert.match(out, /not auto-bootstrapped/);
+  assert.match(out, /https:\/\/nodejs\.org/, "manual-install hint points at nodejs.org");
+});
+
+test("bootstrap_node dies with a manual-install hint when /etc/os-release is unreadable", () => {
+  const out = runBootstrap({
+    preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+detect_distro_id() { echo ""; }
+`,
+  });
+  assert.match(out, /\/etc\/os-release is unreadable/);
+  assert.match(out, /https:\/\/nodejs\.org/, "manual-install hint points at nodejs.org");
+});
+
+test("bootstrap_node dies when node + curl are missing together", () => {
+  // The bootstrap path itself depends on curl + tar to fetch the NodeSource
+  // setup script. If those are gone too, we must NOT try to apt-install
+  // curl — that would silently sudo over a hostile environment. The hint
+  // is "install everything manually and re-run" — same tone as require_cmd.
+  const out = runBootstrap({
+    preBody: `
+command() {
+  # Pretend node, curl, AND tar are all missing.
+  case " $2 " in
+    " node "|" curl "|" tar ") return 1 ;;
+  esac
+  builtin command "$@"
+}
+# If we DID call the apt installer, this would catch the bug.
+install_node_via_apt() {
+  echo "MOCK_APT_CALLED" >&2
+  return 0
+}
+`,
+  });
+  assert.doesNotMatch(out, /MOCK_APT_CALLED/);
+  assert.match(out, /node is missing and so are:/);
+  assert.match(out, /curl/);
+  assert.match(out, /tar/);
 });


### PR DESCRIPTION
Fixes BET-170. Closes BET-170.

The advertised one-liner at `https://mantaui.com/install.sh` exits 1 on a
stock Ubuntu 24.04 cloud image because Node.js isn't pre-installed and the
installer doesn't bootstrap it (BET-162 F1, launch-blocking).

## What this does

Adds `bootstrap_node` to `scripts/install.sh`. When `command -v node`
is missing, the installer detects the distro from `/etc/os-release`,
adds the NodeSource 20.x apt repo, and runs the distro's package manager
(`apt` / `dnf` / `yum`) to install nodejs BEFORE the rest of the
prereq check. Mirrors the existing 'report-and-instruct, never silent
sudo' tone of `require_cmd` — every failure mode exits with a
manual-install hint, and a box without curl+tar never silently sudo's
apt over the user's behalf. Idempotent: re-running with node on PATH is
a no-op (no curl, no apt call, no `set -e` propagation).

`scripts/install-lib.mjs` is **untouched**. The install body is unchanged;
only a new bootstrap step runs BEFORE the existing `require_cmd` verify
(defense-in-depth: `require_cmd node` still fires after bootstrap).

## Files changed: 3 files

```
docs/launch-e2e.md       | 274 ++++++++++++++++++++++++++++++++++
scripts/install.sh       | 207 +++++++++++++++++++++-
scripts/install.test.mjs | 280 +++++++++++++++++++++++++++++++++-
```

## Verification results

- PR branch (`multica/BET-170-installer-installs-node` @ `cac2b38`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `652` pass / `0` fail / `0` skip. log sha256: `9bf4b0b22ddf689c9f2943a6dedd07923c39cd4f21febcbe166e9dc1ca348406`
- Base (`origin/main` @ `e899bfa`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `643` pass / `0` fail / `0` skip. log sha256: `99865b6f7b67d6448a6b7dca3fcc4a8c01e49c70018e32165a6920f37ea36c73`
- **Conclusion:** `0` new failures, `0` resolved failures, `+9` tests (the
  bootstrap unit tests). Typecheck output is byte-identical between branches
  (same hash); the only delta is the 9 new bootstrap cases, all green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`,
`/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## What the 9 new tests cover

`scripts/install.test.mjs` uses a `MANTA_INSTALL_TEST_MODE=1` sentinel
that loads the bash helpers (log/ok/warn/die + bootstrap_node + its
distro installers + require_cmd) but bails before the install body runs.
Tests source `scripts/install.sh` in test mode and define function
mocks AFTER the source (latest definition wins in bash) so the mocks
shadow the install-side implementations without hitting the network:

1. `install.sh is bash-syntax-clean (bash -n)` — sanity check.
2. `bootstrap_node is a no-op when node is already on PATH (idempotent)` —
   asserts no install function was called.
3. `bootstrap_node calls install_node_via_apt on Debian/Ubuntu when node is
   missing` — distro=ubuntu branch.
4. `bootstrap_node calls install_node_via_dnf on Fedora when node is missing`
   — distro=fedora branch.
5. `bootstrap_node calls install_node_via_yum on RHEL when dnf is absent` —
   distro=rhel branch; dnf fails, yum fallback fires.
6. `bootstrap_node dies with a clear hint when the distro installer fails`
   — failure path surfaces 'install manually' hint.
7. `bootstrap_node dies with a manual-install hint for unknown distros` —
   distro=arch (not in case) → manual-install hint.
8. `bootstrap_node dies with a manual-install hint when /etc/os-release is
   unreadable` — empty distro → 'is unreadable' hint.
9. `bootstrap_node dies when node + curl are missing together` — asserts
   the script does NOT silently sudo apt-install curl over a hostile env.

## Cross-cutting follow-ups

None. `scripts/install-lib.mjs` is **not modified** — only the bash
`install.sh` and its test file changed. `mantaui.com/install.sh` still
serves the old version; an operator will need to cut a release + flip
the etag to validate the live path (BET-170 acceptance criterion
"a stranger with a fresh VPS + the website → working terminal + chat").

## Base

`Base: origin/main @ e899bfa`