### PR TITLE
fix(release): collapse unreachable die recovery hint into single error (BET-169)

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -65,9 +65,7 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
-  die "tag v${VERSION} already exists — a tag means 'published and verified'."
-  die "If you really mean to re-publish the same version (idempotent), delete"
-  die "the tag first: git tag -d v${VERSION} && git push origin :v${VERSION}"
+  die "tag v${VERSION} already exists — a tag means 'published and verified'. To re-publish the same version (idempotent), delete the tag first: git tag -d v${VERSION} && git push origin :v${VERSION}"
 fi
 
 if [ ! -f "${TARBALL}" ]; then


### PR DESCRIPTION
Cosmetic — pure bash text fix flagged in PR #124 review.

The existing-tag preflight had two follow-up `die()` lines that never
reached stdout (the first `die` calls `exit 1`). Merge the recovery
command into the single `die` message so it actually prints.

`bash -n scripts/release/publish.sh` passes.

Refs BET-169.