### PR TITLE
feat(release): detect tarball drift + nightly sync check (BET-172)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pair": "node scripts/manta-pair.mjs",
     "pack": "node scripts/release/pack.mjs",
     "pack:desktop": "electron-vite build && electron-builder --config electron-builder.yml",
-    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs scripts/*.test.mjs",
+    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs scripts/*.test.mjs scripts/release/*.test.mjs scripts/prod/*.test.mjs",
     "test:server": "node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts"

--- a/scripts/release/check-tarball-sync.mjs
+++ b/scripts/release/check-tarball-sync.mjs
@@ -1,0 +1,325 @@
+// check-tarball-sync.mjs — assert the served tarball contains the same
+// install.sh + install-lib.mjs that ship in this repo, and POST a signed
+// notify if anything has drifted.
+//
+// Why this exists (BET-172): scripts/release/publish.sh's `200`-only verify
+// silently passed against a stale tarball — a 200 is healthy even when the
+// contents are 6 weeks old. `scripts/release/publish.sh` now content-checks
+// the tarball it just published, but that's only as fresh as the last time
+// the operator ran `bash scripts/release/publish.sh`. This script is the
+// belt-and-braces: it runs nightly from the dev box (off-site relative to
+// prod) and wakes the maintainer when the served tarball diverges from the
+// repo. The notify uses the same MANTA_NOTIFY_URL / MANTA_NOTIFY_SECRET
+// HMAC contract as scripts/prod/backup-relay.sh.
+//
+// INSTALL on the dev box (in this opencode session, per BET-163 §3 pattern):
+//   schedule_create cron "17 4 * * *" running `node /path/check-tarball-sync.mjs`;
+//   on failure the cron turn should call `notify` urgent:true quoting the
+//   drift list. The script itself ALSO POSTs a signed payload to the
+//   webhook, so a separate session listening on that webhook wakes up even
+//   if the cron session is gone.
+//
+// What it checks (every failure is a discrete entry in the returned list):
+//   1. served install.sh  ==  repo scripts/install.sh      (BET-171: deploy drift)
+//   2. tarball's scripts/install.sh  ==  repo scripts/install.sh     (BET-172)
+//   3. tarball's scripts/install-lib.mjs  ==  repo scripts/install-lib.mjs  (BET-172)
+//
+// Override (env):
+//   MANTA_SITE             public URL root (default https://mantaui.com)
+//   MANTA_TARBALL_PATH     path under SITE for the tarball (default /releases/manta-latest.tar.gz)
+//   MANTA_INSTALL_SH_PATH  path under SITE for install.sh (default /install.sh)
+//   MANTA_NOTIFY_URL       webhook URL to POST drift reports to (no-op if unset)
+//   MANTA_NOTIFY_SECRET    HMAC key for the X-Bui-Signature header (no-op if unset)
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { readFile } from "node:fs/promises";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// scripts/release/check-tarball-sync.mjs → repo root is ../..
+const DEFAULT_REPO_ROOT = resolve(HERE, "..", "..");
+
+// ---------------------------------------------------------------------------
+// Default URLs (single source of truth — also used by the test suite).
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TARGETS = {
+  tarballUrl:    "https://mantaui.com/releases/manta-latest.tar.gz",
+  installShUrl:  "https://mantaui.com/install.sh",
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+export function sha256Hex(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Extract the named files from a gzipped tar archive buffer.
+ * Pure: takes bytes in, returns a Map<relPath, bytes>. No filesystem I/O.
+ * Uses `tar` via spawnSync so the tarball never hits disk; equivalent to
+ *   tar -xzf - --to-stdout <each path>
+ * but tar's --to-stdout is one-file-at-a-time, so we stream the whole tar to
+ * a tmpdir instead (still small — the install files are a few KB).
+ *
+ * @param {object} opts
+ * @param {Uint8Array} opts.tarball       gzipped tar bytes
+ * @param {string[]}   opts.paths         relative paths to extract (e.g. ["scripts/install.sh"])
+ * @param {Function}   opts.exec          ({ tarball, paths, cwd }) → Map<path, Uint8Array>
+ *                                        injected for testability.
+ */
+export async function extractTarballPaths({ tarball, paths, exec }) {
+  const fn = exec ?? defaultExecExtract;
+  return fn({ tarball, paths });
+}
+
+async function defaultExecExtract({ tarball, paths }) {
+  const fs = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "manta-tar-"));
+  try {
+    // Pipe the tarball bytes into `tar -xzf - -C <tmp>`. The tarball from
+    // pack.mjs has root `manta-<version>/`; --strip-components=1 makes
+    // `scripts/install.sh` land at tmp/scripts/install.sh (the runtime layout).
+    const r = spawnSync("tar", ["xzf", "-", "--strip-components=1", "-C", tmp], {
+      input: tarball,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (r.status !== 0) {
+      throw new Error(`tar extract failed: ${r.stderr?.toString?.() ?? "(no stderr)"}`);
+    }
+    const out = new Map();
+    for (const p of paths) {
+      const bytes = await fs.readFile(path.join(tmp, p));
+      out.set(p, bytes);
+    }
+    return out;
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Run the drift check. Pure-ish: every I/O surface is injected.
+ * @param {object} opts
+ * @param {string}    opts.repoRoot      absolute path to the repo root
+ * @param {string}    opts.tarballUrl    full URL of the served tarball
+ * @param {string}    opts.installShUrl  full URL of the served install.sh
+ * @param {Function}  opts.fetchFn       fetch(url) → Response
+ * @param {Function}  opts.readRepoFile  (absPath) → Promise<Uint8Array|null>  (null = missing)
+ * @param {Function}  opts.extract       ({ tarball, paths }) → Map<path, Uint8Array>
+ * @param {Function}  opts.log           (line) => void
+ */
+export async function runSyncCheck({
+  repoRoot = DEFAULT_REPO_ROOT,
+  tarballUrl = DEFAULT_TARGETS.tarballUrl,
+  installShUrl = DEFAULT_TARGETS.installShUrl,
+  fetchFn = globalThis.fetch,
+  readRepoFile = defaultReadRepoFile,
+  extract = extractTarballPaths,
+  log = () => {},
+} = {}) {
+  const failures = [];
+  const paths = ["scripts/install.sh", "scripts/install-lib.mjs"];
+
+  // 1. fetch served install.sh and repo install.sh
+  log(`fetch ${installShUrl}`);
+  const servedInstall = await fetchOk(fetchFn, installShUrl, log, "served install.sh");
+  const repoInstall = await readRepoFile(join(repoRoot, "scripts/install.sh"));
+  if (!repoInstall) {
+    failures.push({ kind: "missing", what: "repo scripts/install.sh", url: null });
+  } else {
+    if (!servedInstall) {
+      failures.push({ kind: "fetch-failed", what: "served install.sh", url: installShUrl });
+    } else if (!bytesEq(servedInstall, repoInstall)) {
+      failures.push({
+        kind: "drift",
+        what: "served install.sh ≠ repo scripts/install.sh",
+        servedSha: sha256Hex(servedInstall),
+        repoSha:   sha256Hex(repoInstall),
+        url: installShUrl,
+      });
+    }
+  }
+
+  // 2. fetch tarball, extract paths, compare each against repo
+  log(`fetch ${tarballUrl}`);
+  const tarball = await fetchOk(fetchFn, tarballUrl, log, "served tarball");
+  if (!tarball) {
+    failures.push({ kind: "fetch-failed", what: "served tarball", url: tarballUrl });
+    return { ok: false, failures };
+  }
+
+  let extracted;
+  try {
+    extracted = await extract({ tarball, paths });
+  } catch (e) {
+    failures.push({ kind: "extract-failed", what: `tarball extract: ${e?.message ?? e}`, url: tarballUrl });
+    return { ok: false, failures };
+  }
+
+  for (const p of paths) {
+    const tarFile = extracted.get(p);
+    const repoFile = await readRepoFile(join(repoRoot, p));
+    if (!tarFile) {
+      failures.push({
+        kind: "missing",
+        what: `tarball is missing ${p}`,
+        url: tarballUrl,
+      });
+      continue;
+    }
+    if (!repoFile) {
+      failures.push({
+        kind: "missing",
+        what: `repo is missing ${p} (tarball contains it)`,
+        url: null,
+      });
+      continue;
+    }
+    if (!bytesEq(tarFile, repoFile)) {
+      failures.push({
+        kind: "drift",
+        what: `tarball's ${p} ≠ repo ${p}`,
+        tarballSha: sha256Hex(tarFile),
+        repoSha:    sha256Hex(repoFile),
+        url: tarballUrl,
+      });
+    }
+  }
+
+  log(failures.length === 0
+    ? `OK: served install.sh, tarball install.sh, tarball install-lib.mjs all match repo`
+    : `FAIL: ${failures.length} drift/missing finding(s)`);
+
+  return { ok: failures.length === 0, failures };
+}
+
+async function defaultReadRepoFile(absPath) {
+  try {
+    return new Uint8Array(await readFile(absPath));
+  } catch {
+    return null;
+  }
+}
+
+async function fetchOk(fetchFn, url, log, label) {
+  try {
+    const res = await fetchFn(url);
+    if (res.status !== 200) {
+      log(`${label}: HTTP ${res.status}`);
+      return null;
+    }
+    const buf = new Uint8Array(await res.arrayBuffer());
+    return buf;
+  } catch (e) {
+    log(`${label}: ${e?.message ?? e}`);
+    return null;
+  }
+}
+
+function bytesEq(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Notify — POST a signed JSON body on drift. Reuses the MANTA_NOTIFY_*
+// HMAC contract established by scripts/prod/backup-relay.sh (the webhook
+// handler at src/server/webhooks.mjs `verifySignature` matches).
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign + POST a drift report.
+ * @param {object} opts
+ * @param {Array} opts.failures      drift list from runSyncCheck
+ * @param {object} opts.env          env-like (default process.env)
+ * @param {Function} opts.fetchFn    fetch impl
+ * @param {object} opts.cryptoImpl   { createHmac } — injected for tests
+ * @param {Function} opts.now        () => Date ISO — injected for tests
+ */
+export async function notifyDrift({
+  failures,
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  cryptoImpl = null,
+  now = () => new Date().toISOString(),
+} = {}) {
+  const url    = env.MANTA_NOTIFY_URL;
+  const secret = env.MANTA_NOTIFY_SECRET;
+  if (!url || !secret) return { skipped: true, reason: "MANTA_NOTIFY_URL/SECRET unset" };
+  if (!failures || failures.length === 0) return { skipped: true, reason: "no failures" };
+
+  const body = JSON.stringify({
+    source: "check-tarball-sync",
+    ts: now(),
+    failures,
+  });
+  const crypto = cryptoImpl ?? (await import("node:crypto"));
+  const sig = crypto.createHmac("sha256", secret).update(body).digest("hex");
+  try {
+    const res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Bui-Signature": `sha256=${sig}`,
+      },
+      body,
+    });
+    return { ok: res.status >= 200 && res.status < 300, status: res.status };
+  } catch (e) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry
+// ---------------------------------------------------------------------------
+
+export function envTargets(env) {
+  const site = env.MANTA_SITE ?? "https://mantaui.com";
+  return {
+    tarballUrl:   `${site}${env.MANTA_TARBALL_PATH    ?? "/releases/manta-latest.tar.gz"}`,
+    installShUrl: `${site}${env.MANTA_INSTALL_SH_PATH ?? "/install.sh"}`,
+  };
+}
+
+function cliLog(line) {
+  process.stderr.write(`[check-tarball-sync] ${line}\n`);
+}
+
+async function cliMain() {
+  const targets = envTargets(process.env);
+  const result = await runSyncCheck({
+    tarballUrl:   targets.tarballUrl,
+    installShUrl: targets.installShUrl,
+    log: cliLog,
+  });
+  if (result.ok) {
+    process.stderr.write(`[check-tarball-sync] OK\n`);
+    process.exit(0);
+  }
+  process.stderr.write(`[check-tarball-sync] FAIL: ${result.failures.length} drift/missing finding(s):\n`);
+  for (const f of result.failures) {
+    process.stderr.write(`  - [${f.kind}] ${f.what}` + (f.url ? ` (${f.url})` : "") + "\n");
+  }
+  const notify = await notifyDrift({ failures: result.failures });
+  if (notify.skipped) {
+    process.stderr.write(`[check-tarball-sync] notify skipped: ${notify.reason}\n`);
+  } else if (notify.ok) {
+    process.stderr.write(`[check-tarball-sync] notify POST → ${notify.status}\n`);
+  } else {
+    process.stderr.write(`[check-tarball-sync] notify POST failed: ${notify.error ?? "(no detail)"}\n`);
+  }
+  process.exit(1);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  cliMain();
+}

--- a/scripts/release/check-tarball-sync.test.mjs
+++ b/scripts/release/check-tarball-sync.test.mjs
@@ -1,0 +1,393 @@
+// check-tarball-sync.test.mjs — unit tests for the served-tarball drift check.
+//
+// Pure: every I/O surface (fetch, file reads, tar extract) is injected via
+// `setupScenario`. The only end-to-end exercise is extractTarballPaths's
+// default exec, which shells out to system tar against a real synthetic
+// tarball — that's a smoke test, not a unit, and it skips itself if tar
+// or gzip is unavailable on the test runner.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+
+import {
+  DEFAULT_TARGETS,
+  sha256Hex,
+  extractTarballPaths,
+  runSyncCheck,
+  notifyDrift,
+  envTargets,
+} from "./check-tarball-sync.mjs";
+
+// ---------------------------------------------------------------------------
+// Test fixtures — synthetic repo + tarball contents. Keeps the suite 100%
+// in-memory; no real network or real repo files.
+// ---------------------------------------------------------------------------
+
+const FAKE_REPO_INSTALL_SH = new TextEncoder().encode(
+  "#!/usr/bin/env bash\n# FAKE repo install.sh — version test-fixture\n",
+);
+const FAKE_REPO_INSTALL_LIB = new TextEncoder().encode(
+  "// FAKE repo install-lib.mjs — version test-fixture\nexport const CLI = ['print-config','check-identity','tarball-url'];\n",
+);
+
+// ---------------------------------------------------------------------------
+// Per-URL fake fetch builder.
+// ---------------------------------------------------------------------------
+
+function fakeFetch(perUrl) {
+  return async (url, init = {}) => {
+    const handler = perUrl[url];
+    if (!handler) throw new Error(`fakeFetch: no handler for ${url} (method=${init.method ?? "GET"})`);
+    return handler({ url, method: init.method ?? "GET" });
+  };
+}
+
+function makeRes({ status = 200, body = null } = {}) {
+  const finalBody = body ?? new Uint8Array();
+  return {
+    status,
+    arrayBuffer: async () => finalBody.buffer.slice(
+      finalBody.byteOffset,
+      finalBody.byteOffset + finalBody.byteLength,
+    ),
+  };
+}
+
+// Fake readRepoFile: returns repo bytes for the two paths we ship.
+function fakeReadRepoFile(repoBytes) {
+  return async (absPath) => {
+    if (absPath.endsWith("scripts/install.sh")) return repoBytes.installSh;
+    if (absPath.endsWith("scripts/install-lib.mjs")) return repoBytes.installLib;
+    return null;
+  };
+}
+
+// Fake extract: returns the bytes as-is (no shell-out needed in unit tests).
+function fakeExtract(map) {
+  return async ({ tarball: _tarball, paths }) => {
+    const out = new Map();
+    for (const p of paths) if (map.has(p)) out.set(p, map.get(p));
+    return out;
+  };
+}
+
+/**
+ * Single source of truth for the "happy-path" scenario arguments every test
+ * starts from. Tests override only the specific inputs they want to perturb;
+ * the rest of the wiring (URLs, body decoding, log) stays identical so the
+ * cases below read as "what changed?" not "and now twenty lines of setup".
+ *
+ * User-supplied fetchOverrides win over the defaults — the spread happens
+ * AFTER the defaults so a per-URL override (e.g. a tarball fetch that throws)
+ * is the one that fires.
+ */
+function setupScenario({
+  repoBytes = { installSh: FAKE_REPO_INSTALL_SH, installLib: FAKE_REPO_INSTALL_LIB },
+  tarballMap = new Map([
+    ["scripts/install.sh", FAKE_REPO_INSTALL_SH],
+    ["scripts/install-lib.mjs", FAKE_REPO_INSTALL_LIB],
+  ]),
+  installShBody = FAKE_REPO_INSTALL_SH,
+  tarballBody = new Uint8Array([0x00]),
+  extractOverride = null,
+  fetchOverrides = {},
+} = {}) {
+  const fetchFn = fakeFetch({
+    [DEFAULT_TARGETS.installShUrl]: () => makeRes({ body: installShBody }),
+    [DEFAULT_TARGETS.tarballUrl]: () => makeRes({ body: tarballBody }),
+    ...fetchOverrides,
+  });
+  return {
+    fetchFn,
+    readRepoFile: fakeReadRepoFile(repoBytes),
+    extract: extractOverride ?? fakeExtract(tarballMap),
+    log: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("DEFAULT_TARGETS points at the canonical mantaui.com URLs", () => {
+  assert.equal(DEFAULT_TARGETS.tarballUrl, "https://mantaui.com/releases/manta-latest.tar.gz");
+  assert.equal(DEFAULT_TARGETS.installShUrl, "https://mantaui.com/install.sh");
+});
+
+test("sha256Hex matches node:crypto.createHash reference", () => {
+  const bytes = new TextEncoder().encode("hello");
+  assert.equal(sha256Hex(bytes), createHash("sha256").update(bytes).digest("hex"));
+});
+
+test("runSyncCheck returns ok:true when served install.sh and tarball contents all match repo", async () => {
+  const result = await runSyncCheck(setupScenario());
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("runSyncCheck flags served install.sh drift (BET-171 regression)", async () => {
+  const staleInstall = new TextEncoder().encode("# STALE\n");
+  const result = await runSyncCheck(setupScenario({
+    installShBody: staleInstall,
+    tarballMap: new Map(),
+  }));
+  assert.equal(result.ok, false);
+  const drift = result.failures.find((f) => f.what.includes("served install.sh"));
+  assert.ok(drift, `expected a served-install.sh drift; got ${JSON.stringify(result.failures)}`);
+  assert.equal(drift.kind, "drift");
+  assert.equal(drift.repoSha, sha256Hex(FAKE_REPO_INSTALL_SH));
+  assert.equal(drift.servedSha, sha256Hex(staleInstall));
+});
+
+test("runSyncCheck flags tarball install.sh drift (BET-172)", async () => {
+  const staleTarInstall = new TextEncoder().encode("# STALE in tarball\n");
+  const result = await runSyncCheck(setupScenario({
+    tarballMap: new Map([
+      ["scripts/install.sh", staleTarInstall],
+      ["scripts/install-lib.mjs", FAKE_REPO_INSTALL_LIB],
+    ]),
+  }));
+  assert.equal(result.ok, false);
+  const drift = result.failures.find((f) => f.what.includes("install.sh") && f.what.includes("≠ repo"));
+  assert.ok(drift, `expected a tarball install.sh drift; got ${JSON.stringify(result.failures)}`);
+  assert.equal(drift.repoSha, sha256Hex(FAKE_REPO_INSTALL_SH));
+  assert.equal(drift.tarballSha, sha256Hex(staleTarInstall));
+});
+
+test("runSyncCheck flags tarball install-lib.mjs drift (BET-172, the launch-blocking one)", async () => {
+  // The pre-BET-170 install-lib.mjs subcommand list — exactly what shipped
+  // in the stale tarball that broke the fresh-VPS install.
+  const staleTarLib = new TextEncoder().encode(
+    "export const CLI = ['print-config','check-identity','tarball-url'];\n",
+  );
+  const result = await runSyncCheck(setupScenario({
+    tarballMap: new Map([
+      ["scripts/install.sh", FAKE_REPO_INSTALL_SH],
+      ["scripts/install-lib.mjs", staleTarLib],
+    ]),
+  }));
+  assert.equal(result.ok, false);
+  const drift = result.failures.find((f) => f.what.includes("install-lib.mjs"));
+  assert.ok(drift, `expected a tarball install-lib.mjs drift; got ${JSON.stringify(result.failures)}`);
+  assert.equal(drift.repoSha, sha256Hex(FAKE_REPO_INSTALL_LIB));
+  assert.equal(drift.tarballSha, sha256Hex(staleTarLib));
+});
+
+test("runSyncCheck flags a tarball that lacks install-lib.mjs entirely", async () => {
+  const result = await runSyncCheck(setupScenario({
+    tarballMap: new Map([
+      ["scripts/install.sh", FAKE_REPO_INSTALL_SH],
+      // install-lib.mjs missing on purpose
+    ]),
+  }));
+  assert.equal(result.ok, false);
+  const miss = result.failures.find((f) => f.what.includes("install-lib.mjs"));
+  assert.ok(miss);
+  assert.equal(miss.kind, "missing");
+});
+
+test("runSyncCheck flags a tarball fetch failure (HTTP 500 / network error)", async () => {
+  const result = await runSyncCheck(setupScenario({
+    tarballMap: new Map(),
+    fetchOverrides: {
+      [DEFAULT_TARGETS.tarballUrl]: async () => { throw new Error("ENOTFOUND mantaui.com"); },
+    },
+  }));
+  assert.equal(result.ok, false);
+  const f = result.failures.find((x) => x.what.includes("served tarball"));
+  assert.ok(f);
+  assert.equal(f.kind, "fetch-failed");
+});
+
+test("runSyncCheck flags a tarball that 200s but is not actually a tarball (extract yields 0 files)", async () => {
+  // Each expected path that didn't come out of the tarball is a distinct
+  // "missing" failure — a 200 on a wrong-content body surfaces as two
+  // separate "tarball is missing" findings (one per expected file).
+  const result = await runSyncCheck(setupScenario({
+    tarballBody: new TextEncoder().encode("<!doctype html>not a tarball</html>"),
+    tarballMap: new Map(),
+  }));
+  assert.equal(result.ok, false);
+  const missing = result.failures.filter((f) => f.kind === "missing");
+  assert.equal(missing.length, 2);
+  assert.ok(missing.some((f) => f.what.includes("install.sh")));
+  assert.ok(missing.some((f) => f.what.includes("install-lib.mjs")));
+});
+
+test("runSyncCheck flags a repo file that doesn't exist (tarball contains it, repo doesn't)", async () => {
+  // Repo is missing install-lib.mjs but the tarball DOES ship it — that's a
+  // genuine drift case: the operator published a tarball that carries code
+  // the repo no longer has.
+  const result = await runSyncCheck(setupScenario({
+    repoBytes: { installSh: FAKE_REPO_INSTALL_SH, installLib: null },
+  }));
+  assert.equal(result.ok, false);
+  const f = result.failures.find((x) => x.kind === "missing" && x.what.includes("repo"));
+  assert.ok(f, `expected a repo-missing failure; got ${JSON.stringify(result.failures)}`);
+  assert.match(f.what, /install-lib\.mjs/);
+});
+
+test("runSyncCheck flags a tarball extract failure", async () => {
+  const result = await runSyncCheck(setupScenario({
+    extractOverride: async () => { throw new Error("gzip: not in gzip format"); },
+  }));
+  assert.equal(result.ok, false);
+  const f = result.failures.find((x) => x.kind === "extract-failed");
+  assert.ok(f, `expected an extract-failed; got ${JSON.stringify(result.failures)}`);
+});
+
+test("notifyDrift is a no-op when MANTA_NOTIFY_URL is unset", async () => {
+  const fetchFn = async () => { throw new Error("should not be called"); };
+  const out = await notifyDrift({
+    failures: [{ kind: "drift", what: "test" }],
+    env: {},
+    fetchFn,
+  });
+  assert.equal(out.skipped, true);
+  assert.match(out.reason, /MANTA_NOTIFY_URL\/SECRET unset/);
+});
+
+test("notifyDrift is a no-op when failures list is empty", async () => {
+  const fetchFn = async () => { throw new Error("should not be called"); };
+  const out = await notifyDrift({
+    failures: [],
+    env: { MANTA_NOTIFY_URL: "https://x", MANTA_NOTIFY_SECRET: "s" },
+    fetchFn,
+  });
+  assert.equal(out.skipped, true);
+  assert.equal(out.reason, "no failures");
+});
+
+test("notifyDrift signs the body with HMAC-SHA256 and POSTs it with X-Bui-Signature", async () => {
+  let captured = null;
+  const fetchFn = async (url, init) => {
+    captured = { url, init };
+    return { status: 200 };
+  };
+  const out = await notifyDrift({
+    failures: [{ kind: "drift", what: "tarball install-lib.mjs ≠ repo install-lib.mjs" }],
+    env: { MANTA_NOTIFY_URL: "https://hooks.example/x", MANTA_NOTIFY_SECRET: "shhh" },
+    fetchFn,
+    cryptoImpl: { createHmac },
+    now: () => "2026-07-17T00:00:00.000Z",
+  });
+  assert.equal(out.ok, true);
+  assert.equal(out.status, 200);
+  assert.equal(captured.url, "https://hooks.example/x");
+  assert.equal(captured.init.method, "POST");
+  assert.equal(captured.init.headers["Content-Type"], "application/json");
+  const sigHeader = captured.init.headers["X-Bui-Signature"];
+  assert.match(sigHeader, /^sha256=[a-f0-9]{64}$/);
+  // The signature must equal HMAC-SHA256(secret, body) — independently computed.
+  const expected = createHmac("sha256", "shhh").update(captured.init.body).digest("hex");
+  assert.equal(sigHeader, `sha256=${expected}`);
+  // Body must include the failures list + source + ts.
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.source, "check-tarball-sync");
+  assert.equal(body.ts, "2026-07-17T00:00:00.000Z");
+  assert.deepEqual(body.failures, [{ kind: "drift", what: "tarball install-lib.mjs ≠ repo install-lib.mjs" }]);
+});
+
+test("notifyDrift returns ok:false when the webhook returns non-2xx", async () => {
+  const fetchFn = async () => ({ status: 500 });
+  const out = await notifyDrift({
+    failures: [{ kind: "drift", what: "x" }],
+    env: { MANTA_NOTIFY_URL: "https://hooks.example/x", MANTA_NOTIFY_SECRET: "s" },
+    fetchFn,
+    cryptoImpl: { createHmac },
+  });
+  assert.equal(out.ok, false);
+  assert.equal(out.status, 500);
+});
+
+test("envTargets builds the canonical URLs from MANTA_SITE", () => {
+  assert.deepEqual(envTargets({}), {
+    tarballUrl:   "https://mantaui.com/releases/manta-latest.tar.gz",
+    installShUrl: "https://mantaui.com/install.sh",
+  });
+  assert.deepEqual(
+    envTargets({ MANTA_SITE: "https://staging.mantaui.com" }),
+    {
+      tarballUrl:   "https://staging.mantaui.com/releases/manta-latest.tar.gz",
+      installShUrl: "https://staging.mantaui.com/install.sh",
+    },
+  );
+  assert.deepEqual(
+    envTargets({
+      MANTA_SITE: "https://staging.mantaui.com",
+      MANTA_TARBALL_PATH: "/snapshots/foo.tar.gz",
+      MANTA_INSTALL_SH_PATH: "/scripts/install.sh",
+    }),
+    {
+      tarballUrl:   "https://staging.mantaui.com/snapshots/foo.tar.gz",
+      installShUrl: "https://staging.mantaui.com/scripts/install.sh",
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Smoke test — extractTarballPaths with the real default exec (system tar).
+// Skips if tar or gzip is unavailable on the test runner.
+// ---------------------------------------------------------------------------
+
+function buildFakeTarball(entries) {
+  // entries: [{ name, bytes: Uint8Array }, ...] — built into a USTAR archive
+  // with the same root-prefix shape pack.mjs uses ("manta-<version>/...").
+  const blocks = [];
+  for (const e of entries) {
+    const header = new Uint8Array(512);
+    header.set(new TextEncoder().encode(e.name).slice(0, 100), 0);
+    header.set(new TextEncoder().encode("0000644\0"), 100);
+    header.set(new TextEncoder().encode("0000000\0"), 108);
+    header.set(new TextEncoder().encode("0000000\0"), 116);
+    const sizeOct = e.bytes.length.toString(8).padStart(11, "0") + "\0";
+    header.set(new TextEncoder().encode(sizeOct), 124);
+    header.set(new TextEncoder().encode("00000000000\0"), 136);
+    header.set(new TextEncoder().encode("        "), 148); // checksum placeholder
+    header[156] = 0x30; // type flag = regular file
+    header.set(new TextEncoder().encode("ustar"), 257);
+    header[262] = 0x00;
+    header.set(new TextEncoder().encode("00"), 263);
+    let chk = 0;
+    for (let i = 0; i < 512; i++) chk += header[i];
+    const chkOct = chk.toString(8).padStart(6, "0") + "\0 ";
+    header.set(new TextEncoder().encode(chkOct), 148);
+    blocks.push(header);
+    const padded = new Uint8Array(Math.ceil(e.bytes.length / 512) * 512);
+    padded.set(e.bytes);
+    blocks.push(padded);
+  }
+  blocks.push(new Uint8Array(1024)); // EOF marker (two zero blocks)
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+  const flat = new Uint8Array(total);
+  let off = 0;
+  for (const b of blocks) { flat.set(b, off); off += b.length; }
+  const r = spawnSync("gzip", ["-n"], { input: flat, stdio: ["pipe", "pipe", "pipe"] });
+  if (r.status !== 0) throw new Error("gzip not available — cannot build fake tarball");
+  return r.stdout;
+}
+
+test("extractTarballPaths default exec extracts a real gzipped tar (smoke)", async () => {
+  const probe = spawnSync("tar", ["--version"], { stdio: "ignore" });
+  if (probe.status !== 0) return; // tar missing — skip
+  let tarball;
+  try {
+    tarball = buildFakeTarball([
+      { name: "manta-9.9.9/scripts/install.sh", bytes: FAKE_REPO_INSTALL_SH },
+      { name: "manta-9.9.9/scripts/install-lib.mjs", bytes: FAKE_REPO_INSTALL_LIB },
+    ]);
+  } catch {
+    return; // gzip missing — skip
+  }
+  const out = await extractTarballPaths({
+    tarball,
+    paths: ["scripts/install.sh", "scripts/install-lib.mjs"],
+  });
+  assert.equal(out.size, 2);
+  // fs.readFile returns a Buffer; compare byte-by-byte rather than via
+  // deepStrictEqual (which compares by identity for typed arrays).
+  assert.equal(Buffer.compare(out.get("scripts/install.sh"), FAKE_REPO_INSTALL_SH), 0);
+  assert.equal(Buffer.compare(out.get("scripts/install-lib.mjs"), FAKE_REPO_INSTALL_LIB), 0);
+});

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -30,6 +30,12 @@
 #                  install.sh is ALSO content-verified: the served body must
 #                  byte-match the repo's scripts/install.sh (a 200 alone does
 #                  not prove the deploy took — a stale file also 200s).
+#                  The served tarball is ALSO content-verified: download
+#                  manta-<version>.tar.gz, extract, and cmp its
+#                  scripts/install.sh + scripts/install-lib.mjs against the
+#                  repo's copies — a stale tarball also 200s (BET-172), and
+#                  a fresh VPS running the one-liner silently runs the
+#                  stale installer.
 #                  Fail loudly on any non-200 or content mismatch.
 #   6. tag         git tag v<version> && git push origin v<version> (a tag
 #                  means "published and verified").
@@ -168,6 +174,36 @@ if [ "${LOCAL_INSTALL_SHA}" != "${SERVED_INSTALL_SHA}" ]; then
   die "install.sh mismatch: served=${SERVED_INSTALL_SHA} repo=${LOCAL_INSTALL_SHA} — web-root sync did not take"
 fi
 ok "served install.sh matches repo (${LOCAL_INSTALL_SHA})"
+
+# A 200 on the tarball is NOT enough either — a stale tarball also 200s
+# (BET-172: pre-BET-170 tarball kept serving despite subsequent fix landings).
+# Fetch the served tarball and cmp its install.sh + install-lib.mjs against
+# the repo's copies. Drift here means a fresh VPS would run an installer
+# older than the repo it's built from — re-pack with `npm run pack` and
+# re-publish.
+log "Verifying served tarball contains current install.sh + install-lib.mjs…"
+TARBALL_TMP="$(mktemp -t manta-tarball-XXXXXX.tar.gz)"
+trap 'rm -f "${TARBALL_TMP}" "${TARBALL_EXTRACT_DIR:-}"' EXIT
+if ! curl -fsSL -o "${TARBALL_TMP}" "${SITE}/releases/manta-${VERSION}.tar.gz"; then
+  die "could not download served tarball ${SITE}/releases/manta-${VERSION}.tar.gz"
+fi
+TARBALL_EXTRACT_DIR="$(mktemp -d -t manta-tarball-XXXXXX)"
+# pack.mjs builds the tarball with root `manta-<version>/`; extract with
+# --strip-components=1 so install.sh lands at ${TARBALL_EXTRACT_DIR}/install.sh
+# (matches the runtime layout where scripts/install.sh lives under $MANTA_HOME).
+tar -xzf "${TARBALL_TMP}" -C "${TARBALL_EXTRACT_DIR}" --strip-components=1
+# The pure logic install.sh calls lives in scripts/install-lib.mjs.
+for f in scripts/install.sh scripts/install-lib.mjs; do
+  if [ ! -f "${TARBALL_EXTRACT_DIR}/${f}" ]; then
+    die "served tarball is missing ${f} — republish required (tarball contents do not match the release allowlist in pack.mjs)"
+  fi
+  if ! cmp -s "${f}" "${TARBALL_EXTRACT_DIR}/${f}"; then
+    TARBALL_HASH="$(sha256sum "${TARBALL_EXTRACT_DIR}/${f}" | awk '{print $1}')"
+    LOCAL_HASH="$(sha256sum "${f}" | awk '{print $1}')"
+    die "tarball drift: ${f} in served tarball (sha ${TARBALL_HASH}) ≠ repo (sha ${LOCAL_HASH}) — re-run \`npm run pack\` then re-publish"
+  fi
+done
+ok "served tarball contents match repo (install.sh, install-lib.mjs)"
 
 if [ "${#DMGS[@]}" -gt 0 ]; then
   check_200 "${SITE}/downloads/Manta-latest.dmg"


### PR DESCRIPTION
## BET-172 — installer F4: published tarball is older than install.sh / install-lib.mjs

Closes BET-172. Two guards so the launch-blocking drift (a stale
`manta-latest.tarball` silently undoing every installer fix between
publishes) cannot recur.

**Base:** `origin/main @ aa9edaf`

**Files changed:** 4 files, +755 / -1

- `scripts/release/publish.sh` — extend the verify step: after the
  tarball scp, download the served `manta-<version>.tar.gz`, extract,
  and `cmp -s` its `scripts/install.sh` + `scripts/install-lib.mjs`
  against the repo's copies. `die` loud on drift (a 200 alone passed
  on the stale tarball; the content check cannot).
- `scripts/release/check-tarball-sync.mjs` (new) — nightly drift
  detector for off-site (dev box) execution via `schedule_create`,
  same pattern as `scripts/prod/healthcheck.mjs`. POSTs a
  HMAC-signed webhook payload via the existing
  `MANTA_NOTIFY_URL`/`MANTA_NOTIFY_SECRET` contract when anything
  drifts. Pure-ish I/O: every fetch/extract/read surface is injected.
- `scripts/release/check-tarball-sync.test.mjs` (new) — 17 node:test
  cases covering: ok path, served install.sh drift (BET-171
  regression), tarball install.sh drift (BET-172), tarball
  install-lib.mjs drift (the launch-blocking one, with the exact
  pre-BET-170 subcommand list), missing files, fetch failures,
  non-tarball 200s, extract failures, repo-missing, HMAC sign + POST,
  env-targets parsing, plus a self-skipping smoke test against system
  `tar` + `gzip`.
- `package.json` — extend the `npm test` glob to also run
  `scripts/release/*.test.mjs` and `scripts/prod/*.test.mjs`. This
  also picks up the pre-existing `healthcheck.test.mjs` (BET-163),
  which had been sitting unreached by CI — a small bonus, no behavior
  change.

**Out of scope (per BET-172 + the Hard Rule on prod deploys):**
- The operator-side `bash scripts/release/publish.sh` re-run on prod
  to republish the currently-stale tarball is explicitly off-limits
  to agents (`AGENTS.md` Hard Rule #4). That step belongs to the
  owner after this PR merges; the verify step will then refuse to
  let the operator ship without the tarball contents matching.
- A re-run of the BET-160 §2 launch-gate E2E on a throwaway Hetzner
  VPS to verify the one-liner reaches the opencode-claude-auth seed
  step. That's blocked on (1) the operator republishing the tarball
  (above), and (2) Hetzner ops on the dev box (BET-162/BET-171
  protocol). Filed as the BET-172 "Done when" item, not this PR.

**Verification results:**

- PR branch (`multica/BET-172-tarball-sync-check @ 9008a85`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `680` pass / `0` fail / `0` skip. log sha256: `d1a34b4bd5f79111761fa255663c9f24029f34e2d8d9acd2f47e61a3d9026fd2`
- Base (`main @ aa9edaf`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `655` pass / `0` fail / `0` skip. log sha256: `cee3c9028531760b7a247e8fadfce2d8bc76727a41c4c06b092b86a18d44306c`
- Duplication gate (`scripts/check-duplication-gate.sh origin/main`): PASS — 0 clones.
- Anti-spaghetti advisory: 0 clones among changed files.

**Conclusion:** 0 new failures, 0 pre-existing failures. +25 tests
added (17 new check-tarball-sync + 8 newly-reached healthcheck).
All gates green on the local-runner mirror of CI's
`typecheck-test` + `duplication-gate` jobs.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`,
`/tmp/typecheck-master.log`, `/tmp/test-master.log` for reviewer
spot-check.

**Reviewer checklist (please confirm):**
- publish.sh verify step is consistent with the BET-171 install.sh
  content-check pattern (it is — same sha256/cmp contract, same `die`
  on mismatch, same `ok` on pass).
- check-tarball-sync.mjs I/O injection is sufficient for the test
  suite (it is — every network, file, and tar surface is a named
  parameter with a default; the only end-to-end exercise is the
  system-`tar` smoke test, which self-skips if `tar`/`gzip` are
  missing).
- HMAC sign + POST contract matches `scripts/prod/backup-relay.sh`
  (`X-Bui-Signature: sha256=<hex>` over the JSON body, with
  `Content-Type: application/json`).
- The added package.json test glob is additive — no previously-
  running test is now skipped, and the pre-existing
  `scripts/prod/healthcheck.test.mjs` (BET-163) is now actually
  covered by CI for the first time.
