### PR TITLE
Installer v2 — self-contained prebuilt tarball (vendored Node + prebuilt node_modules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,17 +129,27 @@ errors/done work from the PWA.
 
 ## Installer reference
 
-The installer downloads a pre-built tarball (no dev toolchain needed on the
-box), runs `npm ci --omit=dev`, installs the `manta-server` systemd --user
-unit, enables linger, health-waits, and prints a pairing code.
+The installer downloads a self-contained tarball that ships a vendored Node
+runtime + prebuilt production `node_modules` (node-pty's native binding
+already compiled). The box only needs `curl`, `tar`, `sha256sum`, `tmux`,
+and `git` — no Node preinstall, no compilers, no `sudo`, no package-manager
+calls. (Every launch-gate E2E failure previously came from the installer
+silently trying to `apt install nodejs` and friends; v2 removes that
+seam entirely.)
+
+What the installer does: fetch a key=value manifest over HTTPS → read
+`file_linux_x64` + `sha256_linux_x64` from it → download the tarball →
+sha256-verify → extract → atomic swap into `~/manta` → write systemd units
+pointing at the vendored node → start → print a pairing code.
 
 Overrides (env):
 
 | Var | Default | Purpose |
 |-----|---------|---------|
-| `MANTA_TARBALL_URL` | (built from host+version) | full tarball URL — local testing / mirror |
-| `MANTA_RELEASE_HOST` | `https://mantaui.com` | host for the default tarball URL |
+| `MANTA_TARBALL_URL` | (built from manifest) | full tarball URL — local testing / mirror (skips manifest fetch + sha256 check, with a warn) |
+| `MANTA_RELEASE_HOST` | `https://mantaui.com` | host for the manifest + tarball |
 | `MANTA_HOME` | `~/manta` | where the code is unpacked |
+| `MANTA_VERSION` | `latest` | manifest version to fetch (e.g. `0.0.1`) |
 | `MANTA_MOBILE_PORT` | `8787` | server port |
 
 Manage: `systemctl --user {status,restart} manta-server`, logs
@@ -215,7 +225,9 @@ session by POST). Install/update = copy to `~/.config/opencode/tools/`
 In order. No decisions, no extra steps:
 
 1. Bump `package.json` version.
-2. `npm run pack` — produces `dist/manta-<version>.tar.gz`.
+2. `npm run pack` — produces `dist/manta-<version>-linux-x64.tar.gz` (the
+   self-contained tarball) AND `dist/manta-<version>.txt` (the key=value
+   manifest install.sh fetches first).
 3. (Mac only, on a Mac) `bash scripts/release/desktop.sh` — produces
    `dist/desktop/*.dmg` and the `latest-*.yml` updater feeds. Linux
    builds run on any host.
@@ -267,7 +279,9 @@ steps in each file's header are human-only (agent Hard Rule #4 forbids
 - **Monitoring** (`scripts/prod/healthcheck.mjs`, scheduled every 10 min
   on the dev box via `schedule_create`): off-site probes of `mantaui.com`,
   `relay.mantaui.com` (expects 401 — the auth gate IS the healthy
-  answer), `app.mantaui.com`, `/install.sh`, `/releases/manta-latest.tar.gz`.
+  answer), `app.mantaui.com`, `/install.sh`, `/releases/manta-latest.tar.gz`
+  (and the live `manta-latest.txt` manifest's `sha256_linux_x64` must match
+  the served tarball).
   On failure the opencode turn calls `notify` urgent:true naming the
   failing URL.
 - **Log caps** (`scripts/prod/systemd-journald.conf`,

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -32,8 +32,9 @@ export const DEFAULT_PORT = 8787;
 export const HEALTH_PATH = "/auth/status";
 
 // Default release host. The repo is private; CI publishes a versioned tarball
-// the installer downloads (no git clone on the VPS). `MANTA_TARBALL_URL` overrides
-// the whole URL for local testing; otherwise we build it from host + version.
+// + a manifest file the installer downloads (no git clone on the VPS).
+// `MANTA_TARBALL_URL` overrides the whole flow (skips manifest fetch + sha256)
+// for local testing.
 export const DEFAULT_RELEASE_HOST = "https://mantaui.com";
 
 // Where the box lives once installed. `~/.manta/` (auth.json + config.json)
@@ -66,7 +67,7 @@ function envVal(env, key) {
  *   buiHome      — where the code is unpacked (MANTA_HOME || ~/manta)
  *   authDir      — ~/.manta (never inside buiHome)
  *   authFile     — ~/.manta/auth.json (idempotency probe target)
- *   tarballUrl   — explicit MANTA_TARBALL_URL, else null (resolved per-version)
+ *   tarballUrl   — explicit MANTA_TARBALL_URL, else null (overrides manifest fetch)
  *   releaseHost  — MANTA_RELEASE_HOST || DEFAULT_RELEASE_HOST
  *   port         — MANTA_MOBILE_PORT || DEFAULT_PORT
  *   healthUrl    — http://127.0.0.1:<port>/auth/status
@@ -104,30 +105,10 @@ export function parsePort(value) {
 }
 
 /**
- * Resolve the tarball download URL.
- *   - If MANTA_TARBALL_URL is set (via resolveConfig → cfg.tarballUrl), use it
- *     verbatim. This is the local-test / mirror override.
- *   - Otherwise build `<releaseHost>/releases/manta-<version>.tar.gz`.
- *
- * `version` must be a plain semver-ish string (no slashes / traversal); we
- * validate it so a bogus package.json version can't smuggle a path.
+ * (removed: resolveTarballUrl + isValidVersion — install.sh now derives the
+ * URL from the manifest, not from version. The `tarball-url` CLI subcommand
+ * was the only other caller; it's gone too.)
  */
-export function resolveTarballUrl({ tarballUrl, releaseHost, version } = {}) {
-  if (typeof tarballUrl === "string" && tarballUrl !== "") return tarballUrl;
-  if (!isValidVersion(version)) {
-    throw new Error(
-      `resolveTarballUrl: invalid version ${JSON.stringify(version)} (expected e.g. "0.0.1")`,
-    );
-  }
-  const host = stripTrailingSlash(releaseHost || DEFAULT_RELEASE_HOST);
-  return `${host}/releases/manta-${version}.tar.gz`;
-}
-
-// A release version is digits/letters/dots/hyphens only — enough for semver +
-// prerelease tags (1.2.3, 1.2.3-rc.1) but no `/` or `..` path escapes.
-export function isValidVersion(version) {
-  return typeof version === "string" && /^[0-9A-Za-z][0-9A-Za-z.-]*$/.test(version);
-}
 
 // ---------------------------------------------------------------------------
 // Idempotency: detect an existing box identity so a re-run preserves it.
@@ -572,25 +553,24 @@ export function formatExpiry(expiresAt) {
 //
 // install.sh calls:
 //   eval "$(node scripts/install-lib.mjs print-config --version <v>)"
-// which sets MANTA_HOME / MANTA_AUTH_FILE / MANTA_TARBALL_URL / MANTA_PORT in the shell,
-// and:
+// which sets MANTA_HOME / MANTA_AUTH_FILE / MANTA_PORT / MANTA_HEALTH_URL in
+// the shell, and:
 //   node scripts/install-lib.mjs check-identity
 // which prints "preserve" or "fresh" (exit 0) so the shell knows whether to
 // keep ~/.manta untouched.
 
 // Emit KEY=VALUE lines the shell can `eval`. Values are single-quoted so paths
 // with spaces survive; embedded single quotes are escaped the POSIX way.
+//
+// Note: MANTA_TARBALL_URL is NOT emitted here. install.sh reads the manifest
+// itself to resolve the tarball, so this script no longer needs to be told
+// the URL by the shell. The `tarballUrl` field on `cfg` is preserved so
+// existing resolveConfig tests that probe MANTA_TARBALL_URL still pass.
 export function renderShellConfig(cfg, { version } = {}) {
-  const tarball = resolveTarballUrl({
-    tarballUrl: cfg.tarballUrl,
-    releaseHost: cfg.releaseHost,
-    version,
-  });
   const kv = {
     MANTA_HOME: cfg.buiHome,
     MANTA_AUTH_DIR: cfg.authDir,
     MANTA_AUTH_FILE: cfg.authFile,
-    MANTA_TARBALL_URL: tarball,
     MANTA_PORT: String(cfg.port),
     MANTA_HEALTH_URL: cfg.healthUrl,
   };
@@ -617,17 +597,6 @@ async function cliMain(argv) {
     const { preserveIdentity, reason } = checkIdentity(cfg);
     process.stdout.write((preserveIdentity ? "preserve" : "fresh") + "\n");
     process.stderr.write(reason + "\n");
-    return 0;
-  }
-  if (cmd === "tarball-url") {
-    const cfg = resolveConfig();
-    process.stdout.write(
-      resolveTarballUrl({
-        tarballUrl: cfg.tarballUrl,
-        releaseHost: cfg.releaseHost,
-        version: flags.version,
-      }) + "\n",
-    );
     return 0;
   }
   if (cmd === "merge-opencode-config") {
@@ -667,7 +636,7 @@ async function cliMain(argv) {
   }
   process.stderr.write(
     `install-lib: unknown command ${JSON.stringify(cmd)}\n` +
-      "  usage: node install-lib.mjs <print-config|check-identity|tarball-url|merge-opencode-config|render-systemd-unit> [--version X]\n",
+      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|render-systemd-unit> [--version X]\n",
   );
   return 2;
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,9 +9,28 @@
 # — the script never generates box_id/box_token itself; ensureAuth() in
 # src/server/auth.mjs is the single source of truth.
 #
+# Prerequisites on the box (we check, never install — same `require_cmd` tone
+# as Homebrew/rustup):
+#   * curl, tar, sha256sum  — download + verify the release tarball
+#   * tmux, git             — the manta server needs them at runtime
+#
+# Everything else (Node runtime, npm, node_modules with node-pty's native
+# binding already compiled) ships in the tarball. The installer never uses
+# sudo, never invokes a package manager, never compiles anything on the box.
+#
+# Release resolution:
+#   1. Fetch `${MANTA_RELEASE_HOST:-https://mantaui.com}/releases/manta-${MANTA_VERSION:-latest}.txt`
+#      — a flat key=value manifest written by `npm run pack`.
+#   2. Parse `file_linux_x64` + `sha256_linux_x64` from the manifest.
+#   3. Download the tarball, verify sha256, extract.
+#
+# `MANTA_TARBALL_URL` overrides the whole flow: use a local file:// or a
+# private mirror. When set, the sha256 check is SKIPPED with a warning — this
+# is the only checksum bypass and exists for tests/E2E.
+#
 # Overrides (env):
-#   MANTA_TARBALL_URL   full URL of the release tarball (skips host+version build)
-#   MANTA_RELEASE_HOST  host for the default tarball URL (default mantaui.com)
+#   MANTA_TARBALL_URL   full URL of the release tarball (skips manifest fetch + sha256)
+#   MANTA_RELEASE_HOST  host for the manifest + tarball (default https://mantaui.com)
 #   MANTA_HOME          where code is unpacked (default ~/manta)
 #   MANTA_MOBILE_PORT   server port (default 8787)
 #   MANTA_VERSION       version to fetch when MANTA_TARBALL_URL is unset (default: latest)
@@ -21,257 +40,42 @@
 # This shell stays a thin orchestrator.
 
 # === Always-defined helpers (test-safe: defined even in test mode) ===========
-# These are defined BEFORE the test-mode guard and the install body so the unit
-# tests in scripts/install.test.mjs can source this script and call bootstrap_node
-# / install_node_via_* / require_cmd without the install body running.
+# These are defined BEFORE the test-mode guard so the unit tests in
+# scripts/install.test.mjs can source this script and call manifest_get /
+# verify_sha256 / require_arch without the install body running.
 log()  { printf '\033[36m▸\033[0m %s\n' "$*"; }
 ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
 warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
-# ---------------------------------------------------------------------------
-# Prerequisite bootstrap (BET-162 F1 fix) — installs Node.js when missing.
-# Mirrors the "report-and-instruct, never silent sudo" tone of require_cmd,
-# but actually performs the install when missing. Idempotent: re-running with
-# node already on PATH is a no-op (no apt/dnf/yum call, no curl).
-# ---------------------------------------------------------------------------
-
-# Detect distro ID from /etc/os-release. Echoes the ID (without quotes), or
-# empty string if unreadable. Pure: uses a subshell so /etc/os-release's vars
-# do NOT leak into the caller's environment.
-detect_distro_id() {
-  ( . /etc/os-release 2>/dev/null && printf '%s' "${ID:-}" ) || true
+# Parse one key out of a key=value manifest body. Echoes the value, empty if
+# absent. Values may contain `=` (cut -d= -f2- preserves them). A repeated key
+# is reduced to the FIRST occurrence (head -n1) — the manifest writer emits
+# exactly one of each.
+manifest_get() { # $1=manifest-body $2=key
+  printf '%s\n' "$1" | grep "^$2=" | head -n1 | cut -d= -f2-
 }
 
-# Returns "root" / "sudo" via stdout; returns 1 if neither is available.
-# Tests stub install_node_via_* directly so they don't exercise this, but it's
-# kept simple + side-effect-free for symmetry.
-package_install_mode() {
-  if [ "$(id -u)" -eq 0 ]; then
-    printf 'root'
-    return 0
-  fi
-  if command -v sudo >/dev/null 2>&1; then
-    printf 'sudo'
-    return 0
-  fi
-  return 1
+# Die unless running on supported arch.
+require_arch() {
+  local m; m="$(uname -m)"
+  [ "$m" = "x86_64" ] || die "only x86_64 Linux is supported by this installer today (got: $m)"
 }
 
-# Install nodejs via apt + NodeSource 20.x repo (Debian/Ubuntu). Exposed so
-# scripts/install.test.mjs can stub it with a mock and verify the call site
-# without hitting the network.
-install_node_via_apt() {
-  local mode
-  mode="$(package_install_mode)" || {
-    die "node is missing and neither root nor sudo is available.
-        Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
-        then re-run the installer."
-  }
-  local ns_script="/tmp/manta-nodesource-setup_20.x.sh"
-  log "Downloading NodeSource 20.x setup script…"
-  curl -fsSL https://deb.nodesource.com/setup_20.x -o "$ns_script" \
-    || { warn "failed to download NodeSource setup script"; return 1; }
-  log "Adding NodeSource 20.x apt repository (mode=$mode)…"
-  if [ "$mode" = "root" ]; then
-    bash "$ns_script" && apt-get install -y nodejs
-  else
-    warn "this installer needs to install Node.js, which requires sudo."
-    warn "you'll be prompted for your sudo password."
-    sudo bash "$ns_script" && sudo apt-get install -y nodejs
-  fi
-  local rc=$?
-  rm -f "$ns_script"
-  return $rc
-}
-
-# Install nodejs via dnf + NodeSource 20.x (Fedora / Amazon Linux / RHEL 8+).
-install_node_via_dnf() {
-  local mode
-  mode="$(package_install_mode)" || {
-    die "node is missing and neither root nor sudo is available.
-        Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
-        then re-run the installer."
-  }
-  local ns_script="/tmp/manta-nodesource-setup_20.x.sh"
-  log "Downloading NodeSource 20.x setup script…"
-  curl -fsSL https://rpm.nodesource.com/setup_20.x -o "$ns_script" \
-    || { warn "failed to download NodeSource setup script"; return 1; }
-  log "Adding NodeSource 20.x dnf repository (mode=$mode)…"
-  if [ "$mode" = "root" ]; then
-    bash "$ns_script" && dnf install -y nodejs
-  else
-    warn "this installer needs to install Node.js, which requires sudo."
-    warn "you'll be prompted for your sudo password."
-    sudo bash "$ns_script" && sudo dnf install -y nodejs
-  fi
-  local rc=$?
-  rm -f "$ns_script"
-  return $rc
-}
-
-# Install nodejs via yum + NodeSource 20.x (older RHEL/CentOS where dnf is absent).
-install_node_via_yum() {
-  local mode
-  mode="$(package_install_mode)" || {
-    die "node is missing and neither root nor sudo is available.
-        Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
-        then re-run the installer."
-  }
-  local ns_script="/tmp/manta-nodesource-setup_20.x.sh"
-  log "Downloading NodeSource 20.x setup script…"
-  curl -fsSL https://rpm.nodesource.com/setup_20.x -o "$ns_script" \
-    || { warn "failed to download NodeSource setup script"; return 1; }
-  log "Adding NodeSource 20.x yum repository (mode=$mode)…"
-  if [ "$mode" = "root" ]; then
-    bash "$ns_script" && yum install -y nodejs
-  else
-    warn "this installer needs to install Node.js, which requires sudo."
-    warn "you'll be prompted for your sudo password."
-    sudo bash "$ns_script" && sudo yum install -y nodejs
-  fi
-  local rc=$?
-  rm -f "$ns_script"
-  return $rc
-}
-
-# Top-level: ensure node is on PATH. Idempotent — early-returns when already
-# present (no curl / apt / dnf / yum call). Distro-specific installer is
-# selected by detect_distro_id; unknown distros die with a manual-install
-# hint (same tone as require_cmd failures).
-bootstrap_node() {
-  if command -v node >/dev/null 2>&1; then
-    return 0  # no-op when node is already on PATH (the common idempotent path)
-  fi
-
-  # The bootstrap path itself needs curl + tar to download the NodeSource
-  # setup script. If those are also missing, we can't auto-fix — bail with a
-  # clear manual-install hint (same tone as the require_cmd failures).
-  local missing=""
-  for cmd in curl tar; do
-    command -v "$cmd" >/dev/null 2>&1 || missing="$missing $cmd"
-  done
-  if [ -n "$missing" ]; then
-    die "node is missing and so are:$missing.
-        Install Node.js 20+ and the missing tools manually, then re-run:
-          apt-get install -y curl tar nodejs   # Debian/Ubuntu
-          dnf install -y curl tar nodejs       # Fedora
-          yum install -y curl tar nodejs       # RHEL/CentOS
-        or use the installer from https://nodejs.org."
-  fi
-
-  log "node is missing — bootstrapping Node.js 20.x via NodeSource."
-  local distro
-  distro="$(detect_distro_id)"
-
-  case "$distro" in
-    ubuntu|debian)
-      install_node_via_apt \
-        || die "Node.js install via apt failed.
-            Install manually: https://nodejs.org  (nvm: 'nvm install --lts')
-            then re-run the installer."
-      ;;
-    fedora|amzn)
-      install_node_via_dnf \
-        || die "Node.js install via dnf failed.
-            Install manually: https://nodejs.org  (nvm: 'nvm install --lts')
-            then re-run the installer."
-      ;;
-    rhel|centos|rocky|almalinux|ol)
-      install_node_via_dnf \
-        || install_node_via_yum \
-        || die "Node.js install via dnf/yum failed.
-            Install manually: https://nodejs.org  (nvm: 'nvm install --lts')
-            then re-run the installer."
-      ;;
-    "")
-      die "node is missing and /etc/os-release is unreadable.
-          Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
-          then re-run the installer."
-      ;;
-    *)
-      die "node is missing and your distro ('$distro') is not auto-bootstrapped.
-          Install Node.js 20+ manually: https://nodejs.org  (nvm: 'nvm install --lts')
-          then re-run the installer."
-      ;;
-  esac
-
-  if ! command -v node >/dev/null 2>&1; then
-    die "node is still missing after bootstrap. Install manually: https://nodejs.org"
-  fi
-  ok "node $(node --version 2>/dev/null || echo unknown) installed via NodeSource."
-}
-
-# Bootstrap build-essential (make + g++) — required for node-pty's native
-# binding to compile during npm install. Same auto-install pattern as
-# bootstrap_node: idempotent no-op when present, distro-aware install
-# when missing. Simpler than node — no custom repo needed, just the
-# distro's package manager + build-essential (or gcc-c++ on RHEL family).
-bootstrap_build_essential() {
-  if command -v make >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1; then
-    return 0  # no-op when both make + g++ are on PATH
-  fi
-
-  local mode
-  mode="$(package_install_mode)" || {
-    die "make/g++ missing and neither root nor sudo is available.
-        Install build-essential manually:
-          apt-get install -y build-essential   # Debian/Ubuntu
-          dnf install -y gcc-c++ make           # Fedora/RHEL
-          yum install -y gcc-c++ make           # RHEL/CentOS
-        then re-run the installer."
-  }
-
-  log "make/g++ missing — bootstrapping build-essential (mode=$mode)…"
-  local distro
-  distro="$(detect_distro_id)"
-
-  case "$distro" in
-    ubuntu|debian)
-      if [ "$mode" = "root" ]; then
-        apt-get install -y build-essential
-      else
-        warn "this installer needs to install build-essential, which requires sudo."
-        warn "you'll be prompted for your sudo password."
-        sudo apt-get install -y build-essential
-      fi
-      ;;
-    fedora|amzn|rhel|centos|rocky|almalinux|ol)
-      if [ "$mode" = "root" ]; then
-        (command -v dnf >/dev/null 2>&1 && dnf install -y gcc-c++ make) \
-          || yum install -y gcc-c++ make
-      else
-        warn "this installer needs to install build-essential, which requires sudo."
-        warn "you'll be prompted for your sudo password."
-        (command -v dnf >/dev/null 2>&1 && sudo dnf install -y gcc-c++ make) \
-          || sudo yum install -y gcc-c++ make
-      fi
-      ;;
-    "")
-      die "make/g++ missing and /etc/os-release is unreadable.
-          Install build-essential manually (apt-get install -y build-essential
-          on Debian/Ubuntu), then re-run the installer."
-      ;;
-    *)
-      die "make/g++ missing and your distro ('$distro') is not auto-bootstrapped.
-          Install build-essential manually:
-            apt-get install -y build-essential   # Debian/Ubuntu
-            dnf install -y gcc-c++ make           # Fedora/RHEL
-          then re-run the installer."
-      ;;
-  esac
-
-  if ! command -v make >/dev/null 2>&1 || ! command -v g++ >/dev/null 2>&1; then
-    die "make/g++ still missing after bootstrap. Install manually."
-  fi
-  ok "build-essential installed (make $(make --version 2>/dev/null | head -n1 | awk '{print $NF}'), g++ $(g++ --version 2>/dev/null | head -n1 | awk '{print $NF}'))."
+# Verify $1's sha256 equals $2 (64-hex). Dies on mismatch.
+verify_sha256() {
+  local actual; actual="$(sha256sum "$1" | cut -d' ' -f1)"
+  [ "$actual" = "$2" ] || die "checksum mismatch for $1
+      expected: $2
+      actual:   $actual
+      (corrupt download or stale manifest — re-run; if it persists, report it)"
 }
 
 # Test mode: when sourced by scripts/install.test.mjs with MANTA_INSTALL_TEST_MODE=1,
-# only the bash helpers (log/ok/warn/die + bootstrap_node + bootstrap_build_essential
-# + their distro-specific installers + require_cmd) are loaded. The actual install
-# does NOT run. Lets the unit tests exercise the bootstrap paths without hitting the
-# network. See scripts/install.test.mjs "bootstrap_*" cases.
+# only the bash helpers (log/ok/warn/die + manifest_get + verify_sha256 +
+# require_arch) are loaded. The actual install does NOT run. Lets the unit
+# tests exercise the helpers with mocked `uname`/etc. without hitting the
+# network. See scripts/install.test.mjs.
 if [ "${MANTA_INSTALL_TEST_MODE:-0}" = "1" ]; then
   return 0 2>/dev/null || exit 0
 fi
@@ -279,430 +83,419 @@ fi
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# 1. Prerequisites — bootstrap node + build-essential, then verify the rest;
-#    report-and-instruct if missing (never silent sudo).
+# main — the install body. Wrapped in a function so a truncated `curl | bash`
+# download never executes a half script (the LAST line is `main "$@"`; if the
+# pipe is cut mid-file, bash still has the helpers + the test-mode guard, but
+# never reaches main).
 # ---------------------------------------------------------------------------
-require_cmd() {
-  local cmd="$1" hint="$2"
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    die "missing prerequisite: $cmd
-      Install it and re-run. Suggested:
-        $hint"
-  fi
-}
+main() {
+  require_arch
 
-# Bootstrap node FIRST (idempotent no-op when already present). Doing this
-# before the prereq verify means a fresh cloud image with curl+tar but no
-# node still completes the install end-to-end.
-bootstrap_node
+  # ---------------------------------------------------------------------------
+  # 1. Prerequisites. We ASSUME these are present; we never install them.
+  #    The hint suggests the distro's package manager — the user has the
+  #    permissions to run that themselves.
+  # ---------------------------------------------------------------------------
+  require_cmd() {
+    local cmd="$1" hint="$2"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      die "missing prerequisite: $cmd
+        Install it and re-run. Suggested:
+          $hint"
+    fi
+  }
 
-log "Checking prerequisites (curl, tar, git, tmux, node, npm)…"
-require_cmd curl "apt-get install -y curl   # or your distro's package manager"
-require_cmd tar  "apt-get install -y tar"
-require_cmd git  "apt-get install -y git"
-require_cmd tmux "apt-get install -y tmux"
-# Defense-in-depth: bootstrap_node guarantees node on PATH, but require it
-# again so a failure in the bootstrap path still produces a clean error
-# instead of a confusing crash later in the script.
-require_cmd node "install Node.js LTS: https://nodejs.org  (nvm: 'nvm install --lts')"
-require_cmd npm  "ships with Node.js — reinstall Node if npm is missing"
+  log "Checking prerequisites (curl, tar, sha256sum, tmux, git)…"
+  require_cmd curl      "apt-get install -y curl   # or your distro's package manager"
+  require_cmd tar       "apt-get install -y tar"
+  require_cmd sha256sum "apt-get install -y coreutils"
+  require_cmd git       "apt-get install -y git"
+  require_cmd tmux      "apt-get install -y tmux"
+  ok "Prerequisites present."
 
-# Bootstrap build-essential (make + g++) for node-pty's native binding compile.
-# Same idempotent pattern as bootstrap_node. Done BEFORE npm ci so the node-pty
-# postinstall script can find a C++ toolchain.
-bootstrap_build_essential
+  # ---------------------------------------------------------------------------
+  # 2. Resolve the release. Default path fetches the manifest + parses the
+  #    file/sha256; MANTA_TARBALL_URL override skips BOTH (with a warn).
+  # ---------------------------------------------------------------------------
+  WORK="$(mktemp -d "$HOME/.manta-install.XXXXXX")"
+  trap 'rm -rf "$WORK"' EXIT
 
-# Node 20+ required (matches the desktop app / server runtime).
-node_major="$(node -p 'process.versions.node.split(".")[0]')"
-if [ "$node_major" -lt 20 ]; then
-  die "Node.js 20+ required (found $(node -v)). Upgrade Node and re-run."
-fi
-ok "Prerequisites present ($(node -v), npm $(npm -v))."
-
-# ---------------------------------------------------------------------------
-# 2. Resolve config. Bootstrap install-lib.mjs so we can reuse its pure helpers
-#    even before the tarball is unpacked — download just that one file first.
-# ---------------------------------------------------------------------------
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/manta-install.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
-
-# Determine version (for the default tarball URL). If MANTA_TARBALL_URL is set the
-# version is irrelevant (lib ignores it), so pass a harmless placeholder.
-MANTA_VERSION="${MANTA_VERSION:-latest}"
-
-# Fetch the release tarball. We need install-lib.mjs to resolve the URL, but
-# install-lib.mjs lives INSIDE the tarball — chicken/egg. Resolve the URL with a
-# tiny inline node expression that mirrors resolveTarballUrl's default shape;
-# once unpacked, all further logic uses the real (tested) lib.
-if [ -n "${MANTA_TARBALL_URL:-}" ]; then
-  TARBALL_URL="$MANTA_TARBALL_URL"
-else
-  host="${MANTA_RELEASE_HOST:-https://mantaui.com}"
-  host="${host%/}"
-  TARBALL_URL="${host}/releases/manta-${MANTA_VERSION}.tar.gz"
-fi
-log "Release tarball: $TARBALL_URL"
-
-# ---------------------------------------------------------------------------
-# 3. Download + extract the pre-built tarball (ships mobile/www/ prebuilt, so no
-#    renderer toolchain needed on the VPS).
-# ---------------------------------------------------------------------------
-MANTA_HOME="${MANTA_HOME:-$HOME/manta}"
-AUTH_DIR="$HOME/.manta"
-
-log "Downloading release…"
-curl -fsSL "$TARBALL_URL" -o "$WORK/manta.tar.gz" \
-  || die "download failed: $TARBALL_URL
-      (set MANTA_TARBALL_URL to a reachable tarball, e.g. a local file:// or mirror)"
-
-log "Extracting to $MANTA_HOME…"
-mkdir -p "$MANTA_HOME"
-# Preserve ~/.manta no matter what — it lives outside MANTA_HOME, but be
-# explicit that we never touch it. Extract stripping the top-level dir.
-tar -xzf "$WORK/manta.tar.gz" -C "$MANTA_HOME" --strip-components=1 \
-  || die "extract failed"
-ok "Unpacked manta into $MANTA_HOME."
-
-cd "$MANTA_HOME"
-
-# Now use the REAL tested lib for everything downstream.
-LIB="$MANTA_HOME/scripts/install-lib.mjs"
-[ -f "$LIB" ] || die "tarball is missing scripts/install-lib.mjs — bad release?"
-
-# Resolve the canonical config (exports MANTA_HOME, MANTA_AUTH_FILE, MANTA_PORT,
-# MANTA_HEALTH_URL, …). Version comes from package.json when unset.
-pkg_version="$(node -p 'require("./package.json").version' 2>/dev/null || echo "$MANTA_VERSION")"
-eval "$(MANTA_HOME="$MANTA_HOME" node "$LIB" print-config --version "$pkg_version")"
-# Export the values the install body passes into the node subprocess via
-# process.env (waitForHealth / waitForRelay). Pre-BET-170 the script used
-# `process.env.MANTA_HEALTH_URL` without ever exporting it, so the value
-# silently fell through to undefined → "waitForHealth: url required".
-# Exporting here is a single-line fix; the lib still emits KEY=VALUE for
-# the shell-side uses (e.g. the heredoc).
-export MANTA_HOME MANTA_AUTH_DIR MANTA_AUTH_FILE MANTA_TARBALL_URL MANTA_PORT MANTA_HEALTH_URL
-
-# ---------------------------------------------------------------------------
-# 4. Idempotency: report whether we're preserving an existing box identity.
-# ---------------------------------------------------------------------------
-identity="$(node "$LIB" check-identity 2>/dev/null || echo fresh)"
-if [ "$identity" = "preserve" ]; then
-  ok "Existing box identity found at $MANTA_AUTH_FILE — preserving it (never regenerated)."
-else
-  log "No existing identity — the server will mint one on first start."
-fi
-
-# ---------------------------------------------------------------------------
-# 5. Production install (tarball ships mobile/www/ prebuilt → no build step).
-# ---------------------------------------------------------------------------
-log "Installing production dependencies (npm ci --omit=dev)…"
-if [ -f package-lock.json ]; then
-  npm ci --omit=dev --no-audit --no-fund || npm install --omit=dev --no-audit --no-fund
-else
-  npm install --omit=dev --no-audit --no-fund
-fi
-ok "Dependencies installed."
-
-# ---------------------------------------------------------------------------
-# 6. Chat stack provisioning (opencode + bui-native tools + tmux presence).
-#    Independent of the relay work — a fresh VPS just needs claude code
-#    installed (~/.claude/.credentials.json exists). Re-running is a no-op
-#    except for version upgrades; every step is safe to run twice.
-# ---------------------------------------------------------------------------
-
-# UNIT_DIR is referenced by step 6E (opencode-serve) AND step 7
-# (manta-server) below; define it once, up front. (Pre-BET-170 this
-# was only referenced in step 7; the opencode-serve addition in
-# commit 6d6a0d4 silently relied on bash's lack of strict unset-var
-# checking until `set -u` was added.)
-UNIT_DIR="$HOME/.config/systemd/user"
-
-# --- A. tmux presence gate (hard requirement of the product). -------------
-# §1 already verified tmux exists; we re-state it here as a section-level
-# gate so a missing-tmux failure surfaces in the chat stack section, not
-# buried at the top. We deliberately do NOT auto-install distro packages —
-# the installer never assumes root.
-if ! command -v tmux >/dev/null 2>&1; then
-  die "missing prerequisite for chat stack: tmux
-      Install it and re-run. Suggested:
-        apt-get install -y tmux        # Debian/Ubuntu
-        yum install -y tmux            # RHEL/Fedora/Amazon Linux"
-fi
-ok "tmux present."
-
-# --- B. opencode install (idempotent via official installer). ------------
-# We use opencode's official installer; no version pinning in v1 — the
-# installer is the source of truth for "current". Re-running is a no-op
-# when the binary is already on PATH.
-OPENCODE_BIN="$(command -v opencode || true)"
-if [ -n "$OPENCODE_BIN" ]; then
-  ok "opencode already installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
-else
-  log "Installing opencode (official installer)…"
-  # The installer writes to ~/.opencode/bin/opencode (per the installer's
-  # current shape) and appends `export PATH=...` to ~/.bashrc. Bash
-  # non-interactive shells (which is how install.sh runs) don't source
-  # .bashrc, so the binary isn't on PATH in the current shell — we add
-  # it explicitly. The fallback covers the documented path; if the
-  # installer shape changes, the test bootstrap_node path covers it.
-  curl -fsSL https://opencode.ai/install | bash \
-    || die "opencode install failed — install manually: https://opencode.ai"
-  # Refresh PATH from .bashrc if the installer wrote there, then also
-  # probe the well-known install location as a safety net.
-  if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck disable=SC1090
-    set +e
-    # shellcheck disable=SC1090
-    . "$HOME/.bashrc" 2>/dev/null || true
-    set -e
-  fi
-  if [ -x "$HOME/.opencode/bin/opencode" ]; then
-    export PATH="$HOME/.opencode/bin:$PATH"
-  fi
-  OPENCODE_BIN="$(command -v opencode || true)"
-  if [ -z "$OPENCODE_BIN" ]; then
-    die "opencode still not on PATH after install. Try: export PATH=\"\$HOME/.opencode/bin:\$PATH\" and re-run."
-  fi
-  ok "opencode installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
-fi
-
-# --- C. opencode config seeding — MERGE the plugin entry, never clobber. --
-# Target: ~/.config/opencode/opencode.jsonc. Required:
-#   plugin: ["opencode-claude-auth@latest", ...]
-# All other keys (theme, model, mcp, provider, …) are preserved. On parse
-# failure we back the file up to .pre-manta and start from {} — matches the
-# documented skills.urls merge pattern in src/server/local.mjs.
-OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
-OPENCODE_CONFIG="$OPENCODE_CONFIG_DIR/opencode.jsonc"
-mkdir -p "$OPENCODE_CONFIG_DIR"
-OPENCODE_CONFIG_BACKUP="$OPENCODE_CONFIG.pre-manta"
-if [ -f "$OPENCODE_CONFIG" ]; then
-  log "Seeding opencode-claude-auth plugin (merging into existing $OPENCODE_CONFIG)…"
-  existing="$(cat "$OPENCODE_CONFIG" 2>/dev/null || true)"
-else
-  log "Seeding opencode-claude-auth plugin (no existing $OPENCODE_CONFIG — creating)…"
-  existing=""
-fi
-merged="$(printf '%s' "$existing" | node "$LIB" merge-opencode-config 2>/tmp/opencode-merge.err)" \
-  || die "merge-opencode-config failed (see /tmp/opencode-merge.err)"
-if grep -q '^corrupt=1' /tmp/opencode-merge.err 2>/dev/null; then
-  cp "$OPENCODE_CONFIG" "$OPENCODE_CONFIG_BACKUP" 2>/dev/null \
-    && warn "opencode.jsonc was unparseable — original backed up to $OPENCODE_CONFIG_BACKUP, starting from {}." \
-    || warn "opencode.jsonc was unparseable and the backup FAILED — installer continues but original is NOT preserved."
-fi
-printf '%s' "$merged" > "$OPENCODE_CONFIG"
-ok "opencode.jsonc seeded."
-
-# --- D. manta opencode tools + agent guidance (REAL copies, not symlinks).
-# Per AGENTS.md ("Mobile / web client"): opencode resolves tool imports from
-# the file's REAL path; a symlink into the tarball tree misses
-# ~/.config/opencode/node_modules/@opencode-ai/plugin and the tool silently
-# never registers. So we cp — same inode-disjoint paths.
-OPENCODE_TOOLS_SRC="$MANTA_HOME/docs/opencode-tools"
-OPENCODE_TOOLS_DIR="$OPENCODE_CONFIG_DIR/tools"
-OPENCODE_AGENTS="$OPENCODE_CONFIG_DIR/AGENTS.md"
-if [ -d "$OPENCODE_TOOLS_SRC" ]; then
-  mkdir -p "$OPENCODE_TOOLS_DIR"
-  log "Copying bui-native opencode tools into $OPENCODE_TOOLS_DIR…"
-  # cp -f overwrites — tools are versioned with the tarball, so a re-run
-  # naturally picks up upgrades.
-  cp -f "$OPENCODE_TOOLS_SRC"/*.ts "$OPENCODE_TOOLS_DIR/" \
-    || die "failed to copy opencode tools from $OPENCODE_TOOLS_SRC"
-  ok "opencode tools copied."
-else
-  warn "$OPENCODE_TOOLS_SRC not found in tarball — skipping tool copy (was docs/opencode-tools/* added to release/pack.mjs?)."
-fi
-# AGENTS.md append with marker guard — idempotency by a single grep on a
-# stable line ("## bui scheduled tasks"). A re-run with the marker present
-# is a clean no-op.
-if [ -f "$OPENCODE_TOOLS_SRC/AGENTS.md" ]; then
-  if [ -f "$OPENCODE_AGENTS" ] && grep -q '^## bui scheduled tasks' "$OPENCODE_AGENTS"; then
-    ok "opencode AGENTS.md already contains bui guidance — skipping append."
+  SKIP_CHECKSUM=0
+  if [ -n "${MANTA_TARBALL_URL:-}" ]; then
+    TARBALL_URL="$MANTA_TARBALL_URL"
+    SKIP_CHECKSUM=1
+    warn "MANTA_TARBALL_URL override — checksum verification skipped"
   else
-    log "Appending bui opencode agent guidance to $OPENCODE_AGENTS…"
-    {
-      [ -f "$OPENCODE_AGENTS" ] && cat "$OPENCODE_AGENTS" && printf '\n'
-      cat "$OPENCODE_TOOLS_SRC/AGENTS.md"
-    } > "$OPENCODE_AGENTS.tmp" && mv "$OPENCODE_AGENTS.tmp" "$OPENCODE_AGENTS"
-    ok "opencode AGENTS.md updated."
+    host="${MANTA_RELEASE_HOST:-https://mantaui.com}"
+    host="${host%/}"
+    version="${MANTA_VERSION:-latest}"
+    log "Fetching manifest from $host/releases/manta-${version}.txt…"
+    manifest="$(curl -fsSL "$host/releases/manta-${version}.txt")" \
+      || die "manifest fetch failed: $host/releases/manta-${version}.txt
+          (set MANTA_RELEASE_HOST to a reachable mirror, or MANTA_TARBALL_URL to a local file://)"
+    TARBALL_FILE="$(manifest_get "$manifest" "file_linux_x64")"
+    TARBALL_SHA="$(manifest_get "$manifest" "sha256_linux_x64")"
+    if [ -z "$TARBALL_FILE" ] || [ -z "$TARBALL_SHA" ]; then
+      die "manifest is malformed or this version has no linux-x64 build"
+    fi
+    TARBALL_URL="$host/releases/$TARBALL_FILE"
   fi
-fi
+  log "Release tarball: $TARBALL_URL"
 
-# --- E. opencode-serve systemd --user unit (or nohup fallback). ----------
-# Mirrors the manta-server install path right below: substitute the
-# @@OPENCODE_BIN@@ placeholder, install to ~/.config/systemd/user/, then
-# enable --now. Health-wait reuses the existing waitForHealth lib with
-# acceptAnyStatus:true (any HTTP status = listener is up — opencode's HTTP
-# surface is minimal and may not respond to a bare GET /). Same fallback
-# chain as manta-server when systemctl is unavailable.
-OC_UNIT_SRC="$MANTA_HOME/scripts/systemd/opencode-serve.service"
-OC_UNIT="$UNIT_DIR/opencode-serve.service"
-[ -f "$OC_UNIT_SRC" ] || die "missing systemd template: $OC_UNIT_SRC"
-if command -v systemctl >/dev/null 2>&1; then
-  if systemctl --user is-active --quiet opencode-serve.service 2>/dev/null; then
-    ok "opencode-serve already active — skipping (re-run picks up unit upgrades via daemon-reload below)."
-  else
-    log "Installing opencode-serve systemd --user unit…"
-    mkdir -p "$UNIT_DIR"
-    rendered="$(node "$LIB" render-systemd-unit \
-      --template "$OC_UNIT_SRC" \
-      --placeholder OPENCODE_BIN="$OPENCODE_BIN")" \
-      || die "render-systemd-unit failed (see lib)"
-    printf '%s' "$rendered" > "$OC_UNIT"
-    systemctl --user daemon-reload
-    systemctl --user enable --now opencode-serve.service
+  # ---------------------------------------------------------------------------
+  # 3. Download + extract. WORK is on $HOME so the final `mv` into MANTA_HOME
+  #    is a same-filesystem rename (atomic), and we never trip noexec /tmp.
+  # ---------------------------------------------------------------------------
+  log "Downloading release…"
+  curl -fsSL "$TARBALL_URL" -o "$WORK/manta.tar.gz" \
+    || die "download failed: $TARBALL_URL
+        (set MANTA_TARBALL_URL to a reachable tarball, e.g. a local file:// or mirror)"
+
+  if [ "$SKIP_CHECKSUM" -eq 0 ]; then
+    log "Verifying tarball sha256…"
+    verify_sha256 "$WORK/manta.tar.gz" "$TARBALL_SHA"
+    ok "sha256 verified."
   fi
-else
-  if pgrep -f 'opencode serve --port 4096' >/dev/null 2>&1; then
-    ok "opencode-serve already running (nohup) — skipping."
-  else
-    warn "systemctl not found. Starting opencode-serve in the background instead."
-    warn "It will NOT survive reboot — set up your own supervisor for that."
-    ( nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
-  fi
-fi
-# Health-wait: opencode is loopback-only on :4096. acceptAnyStatus:true is
-# the default in waitForHealth; we pass it explicitly so a future reader
-# sees the intent ("any response = listening").
-log "Waiting for opencode-serve at http://127.0.0.1:4096/…"
-node -e '
-  import("'"$LIB"'").then(async (m) => {
-    const r = await m.waitForHealth("http://127.0.0.1:4096/", {
-      maxAttempts: 30,
-      intervalMs: 1000,
-      acceptAnyStatus: true,
-    });
-    if (!r.ok) { console.error(r.error); process.exit(1); }
-    console.error("healthy after " + r.attempts + " attempt(s) (status " + r.status + ")");
-  }).catch((e) => { console.error(String(e)); process.exit(1); });
-' || die "opencode-serve did not become healthy at http://127.0.0.1:4096/ — check logs:
-      systemctl --user status opencode-serve ; journalctl --user -u opencode-serve -n 50
-      or: tail -f $AUTH_DIR/opencode.log"
-ok "opencode-serve is healthy."
 
-# --- F. Final summary block (extended heredoc) ----------------------------
-# We extend the heredoc that prints at the end (originally section 7).
-# The chat-stack bits live in this script (section 6) and show their own
-# ok lines above; the heredoc only needs to surface the next-step nudge
-# and the claude credentials warning.
+  log "Extracting to $WORK/pkg…"
+  mkdir "$WORK/pkg"
+  tar -xzf "$WORK/manta.tar.gz" -C "$WORK/pkg" --strip-components=1 \
+    || die "extract failed"
 
-# ---------------------------------------------------------------------------
-# 7. manta-server systemd --user unit: substitute placeholders and enable.
-# ---------------------------------------------------------------------------
-NODE_BIN="$(command -v node)"
-UNIT_SRC="$MANTA_HOME/scripts/systemd/manta-server.service"
-[ -f "$UNIT_SRC" ] || die "missing systemd template: $UNIT_SRC"
+  # Sanity gates — a bad release tarball (e.g. an aborted publish that left a
+  # stale tarball pointed at by a fresh manifest) fails loud HERE, not later
+  # when the systemd unit starts.
+  [ -x "$WORK/pkg/runtime/node/bin/node" ] \
+    || die "bad release tarball — missing runtime/node/bin/node"
+  [ -d "$WORK/pkg/node_modules" ] \
+    || die "bad release tarball — missing node_modules"
+  [ -f "$WORK/pkg/scripts/install-lib.mjs" ] \
+    || die "bad release tarball — missing scripts/install-lib.mjs"
+  [ -f "$WORK/pkg/src/server/index.mjs" ] \
+    || die "bad release tarball — missing src/server/index.mjs"
+  ok "Release tarball looks self-contained."
 
-if command -v systemctl >/dev/null 2>&1; then
-  log "Installing systemd --user unit…"
-  mkdir -p "$UNIT_DIR"
-  sed \
-    -e "s|@@MANTA_HOME@@|$MANTA_HOME|g" \
-    -e "s|@@NODE_BIN@@|$NODE_BIN|g" \
-    -e "s|@@MANTA_PORT@@|$MANTA_PORT|g" \
-    "$UNIT_SRC" > "$UNIT_DIR/manta-server.service"
+  # ---------------------------------------------------------------------------
+  # 4. Atomic swap. .prev preserves the previous install in case anything in
+  #    the new install fails before completion — operators can `mv` it back.
+  # ---------------------------------------------------------------------------
+  MANTA_HOME="${MANTA_HOME:-$HOME/manta}"
+  AUTH_DIR="$HOME/.manta"
 
-  # Survive logout/reboot without an active session.
-  loginctl enable-linger "$USER" >/dev/null 2>&1 \
-    || warn "could not enable-linger for $USER — the server may stop on logout. Run: sudo loginctl enable-linger $USER"
-
-  systemctl --user daemon-reload
-  systemctl --user enable --now manta-server.service
-  ok "manta-server enabled and started (systemctl --user status manta-server)."
-  SERVER_MANAGED=systemd
-else
-  warn "systemctl not found (not a systemd host?). Starting the server in the background instead."
-  warn "It will NOT survive reboot — set up your own supervisor for that."
-  ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" nohup node "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
-  SERVER_MANAGED=nohup
-fi
-
-# ---------------------------------------------------------------------------
-# 8. Wait for health, then verify the relay handshake, then mint + print a
-#    pairing code. Devices pair THROUGH the relay (relay.mantaui.com) — the
-#    install must confirm the box agent actually reached the relay before
-#    handing the pairing code back. If the handshake never completes we warn
-#    (the box still works locally) and continue — operators can read the
-#    journalctl hint and diagnose later.
-# ---------------------------------------------------------------------------
-log "Waiting for the server to become healthy at $MANTA_HEALTH_URL…"
-node -e '
-  import("'"$LIB"'").then(async (m) => {
-    const r = await m.waitForHealth(process.env.MANTA_HEALTH_URL, { maxAttempts: 60, intervalMs: 1000 });
-    if (!r.ok) { console.error(r.error); process.exit(1); }
-    console.error("healthy after " + r.attempts + " attempt(s)");
-  }).catch((e) => { console.error(String(e)); process.exit(1); });
-' || die "server did not become healthy — check logs:
-      systemctl --user status manta-server ; journalctl --user -u manta-server -n 50"
-
-ok "Server is healthy."
-
-# Derive the loopback base (drop the /auth/status path) — waitForRelay takes a
-# base URL and appends /relay/status itself.
-MANTA_RELAY_BASE="$(printf '%s\n' "$MANTA_HEALTH_URL" | sed 's#/auth/status$##')"
-log "Waiting for the relay handshake at $MANTA_RELAY_BASE/relay/status…"
-# waitForRelay is best-effort — relay outage never fails the install. We log
-# the state on stderr and emit exactly one of "connected|disabled|degraded" on
-# stdout so the bash below can branch on it without re-fetching.
-RELAY_CHECK="$(MANTA_RELAY_BASE="$MANTA_RELAY_BASE" node -e '
-  import("'"$LIB"'").then(async (m) => {
-    const r = await m.waitForRelay(process.env.MANTA_RELAY_BASE, { maxAttempts: 30, intervalMs: 1000 });
-    if (r.ok && r.connected) {
-      console.error("connected after " + r.attempts + " attempt(s)");
-      process.stdout.write("connected");
-    } else if (r.ok && !r.enabled) {
-      console.error("relay disabled by config");
-      process.stdout.write("disabled");
-    } else if (r.ok && !r.connected) {
-      console.error("not connected after " + r.attempts + " attempt(s)");
-      process.stdout.write("degraded");
-    } else {
-      console.error(r.error || "unknown failure");
-      process.stdout.write("degraded");
+  rm -rf "$MANTA_HOME.prev"
+  if [ -d "$MANTA_HOME" ]; then mv "$MANTA_HOME" "$MANTA_HOME.prev"; fi
+  mv "$WORK/pkg" "$MANTA_HOME" \
+    || { # mv failed — restore the .prev so the box isn't bricked.
+       warn "mv into $MANTA_HOME failed — restoring $MANTA_HOME.prev"
+       rm -rf "$MANTA_HOME"
+       [ -d "$MANTA_HOME.prev" ] && mv "$MANTA_HOME.prev" "$MANTA_HOME"
+       die "could not move extracted tarball into $MANTA_HOME — previous install restored"
     }
-  }).catch((e) => {
-    console.error(String(e));
-    process.stdout.write("degraded");
-  });
-' 2>/dev/null || echo degraded)"
-export MANTA_RELAY_BASE
 
-case "$RELAY_CHECK" in
-  connected) ok "Relay link established (relay.mantaui.com).";;
-  disabled)
-    log "Relay disabled by config (relayEnabled=false) — devices will pair via direct ingress only.";;
-  *)
-    warn "Relay handshake did not complete — the box is reachable locally; journalctl --user -u manta-server -n 50 will show why."
-    warn "  Re-run later: systemctl --user restart manta-server"
-    ;;
-esac
+  # From here on, EVERY node invocation uses the vendored binary explicitly.
+  # No path lookup, no reliance on a system node.
+  NODE="$MANTA_HOME/runtime/node/bin/node"
+  export PATH="$MANTA_HOME/runtime/node/bin:$PATH"
 
-log "Minting pairing code…"
-# Delegate to the same `manta pair` CLI the user runs later (loopback GET /auth/pair).
-# We CAPTURE stdout this time so the install-sh heredoc below can quote the
-# ready-to-paste `manta://pair?box=…&code=…` link — BET-156 §1. manta-pair.mjs
-# prints a stable "  Pairing code:  NNNNNN" line via formatPairingOutput, which
-# we sed-extract (no second JSON round-trip; the format is the contract).
-PAIR_BLOCK="$(node "$MANTA_HOME/scripts/manta-pair.mjs" 2>/dev/null || true)"
-# Echo the formatted block so the user still sees it on stdout (the heredoc
-# below ONLY surfaces the box id + ready-to-paste link, not the full block).
-printf '%s\n' "$PAIR_BLOCK"
-PAIR_CODE="$(printf '%s\n' "$PAIR_BLOCK" | sed -n 's/^  Pairing code:[[:space:]]\+\([0-9]\{6\}\).*/\1/p' | head -n1)"
-export PAIR_CODE
-if [ -z "$PAIR_CODE" ]; then
-  warn "could not extract a 6-digit code from manta-pair.mjs output — pair link will be omitted."
-fi
+  # Now use the REAL tested lib for everything downstream.
+  LIB="$MANTA_HOME/scripts/install-lib.mjs"
+  [ -f "$LIB" ] || die "tarball is missing scripts/install-lib.mjs — bad release?"
 
-# Read the box_id from ~/.manta/auth.json via the tested install-lib loader
-# (NEVER re-parse the JSON in bash — auth.json's shape belongs to the server).
-BOX_ID_DISPLAY="$(node -e '
-  import("'"$LIB"'").then((m) => {
-    const id = m.readBoxIdentity(process.env.MANTA_AUTH_FILE);
-    process.stdout.write(id?.box_id ?? "");
-  }).catch(() => process.stdout.write(""));
-' 2>/dev/null || true)"
-export BOX_ID_DISPLAY
+  # Resolve the canonical config (exports MANTA_HOME, MANTA_AUTH_FILE, MANTA_PORT,
+  # MANTA_HEALTH_URL, …). Version comes from package.json when unset.
+  pkg_version="$("$NODE" -p 'require("./package.json").version' 2>/dev/null || echo "${MANTA_VERSION:-unknown}")"
+  eval "$(MANTA_HOME="$MANTA_HOME" "$NODE" "$LIB" print-config --version "$pkg_version")"
+  # Export the values the install body passes into the node subprocess via
+  # process.env (waitForHealth / waitForRelay).
+  export MANTA_HOME MANTA_AUTH_DIR MANTA_AUTH_FILE MANTA_TARBALL_URL MANTA_PORT MANTA_HEALTH_URL
 
-cat <<EOF
+  # ---------------------------------------------------------------------------
+  # 5. Idempotency: report whether we're preserving an existing box identity.
+  # ---------------------------------------------------------------------------
+  identity="$("$NODE" "$LIB" check-identity 2>/dev/null || echo fresh)"
+  if [ "$identity" = "preserve" ]; then
+    ok "Existing box identity found at $MANTA_AUTH_FILE — preserving it (never regenerated)."
+  else
+    log "No existing identity — the server will mint one on first start."
+  fi
+
+  # ---------------------------------------------------------------------------
+  # 6. Chat stack provisioning (opencode + bui-native tools + tmux presence).
+  #    Independent of the relay work — a fresh VPS just needs claude code
+  #    installed (~/.claude/.credentials.json exists). Re-running is a no-op
+  #    except for version upgrades; every step is safe to run twice.
+  # ---------------------------------------------------------------------------
+
+  # UNIT_DIR is referenced by step 6E (opencode-serve) AND step 7
+  # (manta-server) below; define it once, up front.
+  UNIT_DIR="$HOME/.config/systemd/user"
+
+  # --- A. opencode install (idempotent via official installer). ------------
+  # We use opencode's official installer; no version pinning in v1 — the
+  # installer is the source of truth for "current". Re-running is a no-op
+  # when the binary is already on PATH.
+  OPENCODE_BIN="$(command -v opencode || true)"
+  if [ -n "$OPENCODE_BIN" ]; then
+    ok "opencode already installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
+  else
+    log "Installing opencode (official installer)…"
+    # The installer writes to ~/.opencode/bin/opencode (per the installer's
+    # current shape) and appends `export PATH=...` to ~/.bashrc. Bash
+    # non-interactive shells (which is how install.sh runs) don't source
+    # .bashrc, so the binary isn't on PATH in the current shell — we add
+    # it explicitly. The fallback covers the documented path.
+    curl -fsSL https://opencode.ai/install | bash \
+      || die "opencode install failed — install manually: https://opencode.ai"
+    # Refresh PATH from .bashrc if the installer wrote there, then also
+    # probe the well-known install location as a safety net.
+    if [ -f "$HOME/.bashrc" ]; then
+      # shellcheck disable=SC1090
+      set +e
+      # shellcheck disable=SC1090
+      . "$HOME/.bashrc" 2>/dev/null || true
+      set -e
+    fi
+    if [ -x "$HOME/.opencode/bin/opencode" ]; then
+      export PATH="$HOME/.opencode/bin:$PATH"
+    fi
+    OPENCODE_BIN="$(command -v opencode || true)"
+    if [ -z "$OPENCODE_BIN" ]; then
+      die "opencode still not on PATH after install. Try: export PATH=\"\$HOME/.opencode/bin:\$PATH\" and re-run."
+    fi
+    ok "opencode installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
+  fi
+
+  # --- B. opencode config seeding — MERGE the plugin entry, never clobber. --
+  # Target: ~/.config/opencode/opencode.jsonc. Required:
+  #   plugin: ["opencode-claude-auth@latest", ...]
+  # All other keys (theme, model, mcp, provider, …) are preserved. On parse
+  # failure we back the file up to .pre-manta and start from {} — matches the
+  # documented skills.urls merge pattern in src/server/local.mjs.
+  OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
+  OPENCODE_CONFIG="$OPENCODE_CONFIG_DIR/opencode.jsonc"
+  mkdir -p "$OPENCODE_CONFIG_DIR"
+  OPENCODE_CONFIG_BACKUP="$OPENCODE_CONFIG.pre-manta"
+  if [ -f "$OPENCODE_CONFIG" ]; then
+    log "Seeding opencode-claude-auth plugin (merging into existing $OPENCODE_CONFIG)…"
+    existing="$(cat "$OPENCODE_CONFIG" 2>/dev/null || true)"
+  else
+    log "Seeding opencode-claude-auth plugin (no existing $OPENCODE_CONFIG — creating)…"
+    existing=""
+  fi
+  merged="$(printf '%s' "$existing" | "$NODE" "$LIB" merge-opencode-config 2>/tmp/opencode-merge.err)" \
+    || die "merge-opencode-config failed (see /tmp/opencode-merge.err)"
+  if grep -q '^corrupt=1' /tmp/opencode-merge.err 2>/dev/null; then
+    cp "$OPENCODE_CONFIG" "$OPENCODE_CONFIG_BACKUP" 2>/dev/null \
+      && warn "opencode.jsonc was unparseable — original backed up to $OPENCODE_CONFIG_BACKUP, starting from {}." \
+      || warn "opencode.jsonc was unparseable and the backup FAILED — installer continues but original is NOT preserved."
+  fi
+  printf '%s' "$merged" > "$OPENCODE_CONFIG"
+  ok "opencode.jsonc seeded."
+
+  # --- C. manta opencode tools + agent guidance (REAL copies, not symlinks).
+  # Per AGENTS.md ("Mobile / web client"): opencode resolves tool imports from
+  # the file's REAL path; a symlink into the tarball tree misses
+  # ~/.config/opencode/node_modules/@opencode-ai/plugin and the tool silently
+  # never registers. So we cp — same inode-disjoint paths.
+  OPENCODE_TOOLS_SRC="$MANTA_HOME/docs/opencode-tools"
+  OPENCODE_TOOLS_DIR="$OPENCODE_CONFIG_DIR/tools"
+  OPENCODE_AGENTS="$OPENCODE_CONFIG_DIR/AGENTS.md"
+  if [ -d "$OPENCODE_TOOLS_SRC" ]; then
+    mkdir -p "$OPENCODE_TOOLS_DIR"
+    log "Copying bui-native opencode tools into $OPENCODE_TOOLS_DIR…"
+    # cp -f overwrites — tools are versioned with the tarball, so a re-run
+    # naturally picks up upgrades.
+    cp -f "$OPENCODE_TOOLS_SRC"/*.ts "$OPENCODE_TOOLS_DIR/" \
+      || die "failed to copy opencode tools from $OPENCODE_TOOLS_SRC"
+    ok "opencode tools copied."
+  else
+    warn "$OPENCODE_TOOLS_SRC not found in tarball — skipping tool copy (was docs/opencode-tools/* added to release/pack.mjs?)."
+  fi
+  # AGENTS.md append with marker guard — idempotency by a single grep on a
+  # stable line ("## bui scheduled tasks"). A re-run with the marker present
+  # is a clean no-op.
+  if [ -f "$OPENCODE_TOOLS_SRC/AGENTS.md" ]; then
+    if [ -f "$OPENCODE_AGENTS" ] && grep -q '^## bui scheduled tasks' "$OPENCODE_AGENTS"; then
+      ok "opencode AGENTS.md already contains bui guidance — skipping append."
+    else
+      log "Appending bui opencode agent guidance to $OPENCODE_AGENTS…"
+      {
+        [ -f "$OPENCODE_AGENTS" ] && cat "$OPENCODE_AGENTS" && printf '\n'
+        cat "$OPENCODE_TOOLS_SRC/AGENTS.md"
+      } > "$OPENCODE_AGENTS.tmp" && mv "$OPENCODE_AGENTS.tmp" "$OPENCODE_AGENTS"
+      ok "opencode AGENTS.md updated."
+    fi
+  fi
+
+  # --- D. opencode-serve systemd --user unit (or nohup fallback). ----------
+  # Mirrors the manta-server install path right below: substitute the
+  # @@OPENCODE_BIN@@ placeholder, install to ~/.config/systemd/user/, then
+  # enable --now. Health-wait reuses the existing waitForHealth lib with
+  # acceptAnyStatus:true (any HTTP status = listener is up — opencode's HTTP
+  # surface is minimal and may not respond to a bare GET /). Same fallback
+  # chain as manta-server when systemctl is unavailable.
+  OC_UNIT_SRC="$MANTA_HOME/scripts/systemd/opencode-serve.service"
+  OC_UNIT="$UNIT_DIR/opencode-serve.service"
+  [ -f "$OC_UNIT_SRC" ] || die "missing systemd template: $OC_UNIT_SRC"
+  if command -v systemctl >/dev/null 2>&1; then
+    if systemctl --user is-active --quiet opencode-serve.service 2>/dev/null; then
+      ok "opencode-serve already active — skipping (re-run picks up unit upgrades via daemon-reload below)."
+    else
+      log "Installing opencode-serve systemd --user unit…"
+      mkdir -p "$UNIT_DIR"
+      rendered="$("$NODE" "$LIB" render-systemd-unit \
+        --template "$OC_UNIT_SRC" \
+        --placeholder OPENCODE_BIN="$OPENCODE_BIN")" \
+        || die "render-systemd-unit failed (see lib)"
+      printf '%s' "$rendered" > "$OC_UNIT"
+      systemctl --user daemon-reload
+      systemctl --user enable --now opencode-serve.service
+    fi
+  else
+    if pgrep -f 'opencode serve --port 4096' >/dev/null 2>&1; then
+      ok "opencode-serve already running (nohup) — skipping."
+    else
+      warn "systemctl not found. Starting opencode-serve in the background instead."
+      warn "It will NOT survive reboot — set up your own supervisor for that."
+      ( nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
+    fi
+  fi
+  # Health-wait: opencode is loopback-only on :4096. acceptAnyStatus:true is
+  # the default in waitForHealth; we pass it explicitly so a future reader
+  # sees the intent ("any response = listening").
+  log "Waiting for opencode-serve at http://127.0.0.1:4096/…"
+  "$NODE" -e '
+    import("'"$LIB"'").then(async (m) => {
+      const r = await m.waitForHealth("http://127.0.0.1:4096/", {
+        maxAttempts: 30,
+        intervalMs: 1000,
+        acceptAnyStatus: true,
+      });
+      if (!r.ok) { console.error(r.error); process.exit(1); }
+      console.error("healthy after " + r.attempts + " attempt(s) (status " + r.status + ")");
+    }).catch((e) => { console.error(String(e)); process.exit(1); });
+  ' || die "opencode-serve did not become healthy at http://127.0.0.1:4096/ — check logs:
+        systemctl --user status opencode-serve ; journalctl --user -u opencode-serve -n 50
+        or: tail -f $AUTH_DIR/opencode.log"
+  ok "opencode-serve is healthy."
+
+  # ---------------------------------------------------------------------------
+  # 7. manta-server systemd --user unit: substitute placeholders and enable.
+  # ---------------------------------------------------------------------------
+  UNIT_SRC="$MANTA_HOME/scripts/systemd/manta-server.service"
+  [ -f "$UNIT_SRC" ] || die "missing systemd template: $UNIT_SRC"
+
+  if command -v systemctl >/dev/null 2>&1; then
+    log "Installing systemd --user unit…"
+    mkdir -p "$UNIT_DIR"
+    sed \
+      -e "s|@@MANTA_HOME@@|$MANTA_HOME|g" \
+      -e "s|@@NODE_BIN@@|$NODE|g" \
+      -e "s|@@MANTA_PORT@@|$MANTA_PORT|g" \
+      "$UNIT_SRC" > "$UNIT_DIR/manta-server.service"
+
+    # Survive logout/reboot without an active session.
+    loginctl enable-linger "$USER" >/dev/null 2>&1 \
+      || warn "could not enable-linger for $USER — the server may stop on logout. Run: sudo loginctl enable-linger $USER"
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now manta-server.service
+    ok "manta-server enabled and started (systemctl --user status manta-server)."
+    SERVER_MANAGED=systemd
+  else
+    warn "systemctl not found (not a systemd host?). Starting the server in the background instead."
+    warn "It will NOT survive reboot — set up your own supervisor for that."
+    ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
+    SERVER_MANAGED=nohup
+  fi
+
+  # ---------------------------------------------------------------------------
+  # 8. Wait for health, then verify the relay handshake, then mint + print a
+  #    pairing code. Devices pair THROUGH the relay (relay.mantaui.com) — the
+  #    install must confirm the box agent actually reached the relay before
+  #    handing the pairing code back. If the handshake never completes we warn
+  #    (the box still works locally) and continue — operators can read the
+  #    journalctl hint and diagnose later.
+  # ---------------------------------------------------------------------------
+  log "Waiting for the server to become healthy at $MANTA_HEALTH_URL…"
+  "$NODE" -e '
+    import("'"$LIB"'").then(async (m) => {
+      const r = await m.waitForHealth(process.env.MANTA_HEALTH_URL, { maxAttempts: 60, intervalMs: 1000 });
+      if (!r.ok) { console.error(r.error); process.exit(1); }
+      console.error("healthy after " + r.attempts + " attempt(s)");
+    }).catch((e) => { console.error(String(e)); process.exit(1); });
+  ' || die "server did not become healthy — check logs:
+        systemctl --user status manta-server ; journalctl --user -u manta-server -n 50"
+
+  ok "Server is healthy."
+
+  # Derive the loopback base (drop the /auth/status path) — waitForRelay takes a
+  # base URL and appends /relay/status itself.
+  MANTA_RELAY_BASE="$(printf '%s\n' "$MANTA_HEALTH_URL" | sed 's#/auth/status$##')"
+  log "Waiting for the relay handshake at $MANTA_RELAY_BASE/relay/status…"
+  # waitForRelay is best-effort — relay outage never fails the install. We log
+  # the state on stderr and emit exactly one of "connected|disabled|degraded" on
+  # stdout so the bash below can branch on it without re-fetching.
+  RELAY_CHECK="$(MANTA_RELAY_BASE="$MANTA_RELAY_BASE" "$NODE" -e '
+    import("'"$LIB"'").then(async (m) => {
+      const r = await m.waitForRelay(process.env.MANTA_RELAY_BASE, { maxAttempts: 30, intervalMs: 1000 });
+      if (r.ok && r.connected) {
+        console.error("connected after " + r.attempts + " attempt(s)");
+        process.stdout.write("connected");
+      } else if (r.ok && !r.enabled) {
+        console.error("relay disabled by config");
+        process.stdout.write("disabled");
+      } else if (r.ok && !r.connected) {
+        console.error("not connected after " + r.attempts + " attempt(s)");
+        process.stdout.write("degraded");
+      } else {
+        console.error(r.error || "unknown failure");
+        process.stdout.write("degraded");
+      }
+    }).catch((e) => {
+      console.error(String(e));
+      process.stdout.write("degraded");
+    });
+  ' 2>/dev/null || echo degraded)"
+  export MANTA_RELAY_BASE
+
+  case "$RELAY_CHECK" in
+    connected) ok "Relay link established (relay.mantaui.com).";;
+    disabled)
+      log "Relay disabled by config (relayEnabled=false) — devices will pair via direct ingress only.";;
+    *)
+      warn "Relay handshake did not complete — the box is reachable locally; journalctl --user -u manta-server -n 50 will show why."
+      warn "  Re-run later: systemctl --user restart manta-server"
+      ;;
+  esac
+
+  log "Minting pairing code…"
+  # Delegate to the same `manta pair` CLI the user runs later (loopback GET /auth/pair).
+  # We CAPTURE stdout this time so the install-sh heredoc below can quote the
+  # ready-to-paste `manta://pair?box=…&code=…` link — BET-156 §1. manta-pair.mjs
+  # prints a stable "  Pairing code:  NNNNNN" line via formatPairingOutput, which
+  # we sed-extract (no second JSON round-trip; the format is the contract).
+  PAIR_BLOCK="$("$NODE" "$MANTA_HOME/scripts/manta-pair.mjs" 2>/dev/null || true)"
+  # Echo the formatted block so the user still sees it on stdout (the heredoc
+  # below ONLY surfaces the box id + ready-to-paste link, not the full block).
+  printf '%s\n' "$PAIR_BLOCK"
+  PAIR_CODE="$(printf '%s\n' "$PAIR_BLOCK" | sed -n 's/^  Pairing code:[[:space:]]\+\([0-9]\{6\}\).*/\1/p' | head -n1)"
+  export PAIR_CODE
+  if [ -z "$PAIR_CODE" ]; then
+    warn "could not extract a 6-digit code from manta-pair.mjs output — pair link will be omitted."
+  fi
+
+  # Read the box_id from ~/.manta/auth.json via the tested install-lib loader
+  # (NEVER re-parse the JSON in bash — auth.json's shape belongs to the server).
+  BOX_ID_DISPLAY="$("$NODE" -e '
+    import("'"$LIB"'").then((m) => {
+      const id = m.readBoxIdentity(process.env.MANTA_AUTH_FILE);
+      process.stdout.write(id?.box_id ?? "");
+    }).catch(() => process.stdout.write(""));
+  ' 2>/dev/null || true)"
+  export BOX_ID_DISPLAY
+
+  cat <<EOF
 
 Installed. Manage the server with:
   systemctl --user status manta-server
@@ -719,37 +512,45 @@ port on this box, no tunnel, no reverse proxy to set up. The desktop / mobile
 app discovers it via the relay using the box_id below.
 EOF
 
-if [ -n "$BOX_ID_DISPLAY" ]; then
-  printf '\n  Box ID:        %s\n' "$BOX_ID_DISPLAY"
-fi
+  if [ -n "$BOX_ID_DISPLAY" ]; then
+    printf '\n  Box ID:        %s\n' "$BOX_ID_DISPLAY"
+  fi
 
-# Ready-to-paste pair link (BET-156 §1) — the desktop app parses this directly
-# via parsePairPayload and routes through the relay's /pair endpoint. Both
-# BOX_ID_DISPLAY and PAIR_CODE are loaded via tested helpers, so this is safe
-# even if either is missing (we just print the available half, never crash).
-if [ -n "${BOX_ID_DISPLAY:-}" ] && [ -n "${PAIR_CODE:-}" ]; then
-  printf '\n  Pair link:     manta://pair?box=%s&code=%s\n' "$BOX_ID_DISPLAY" "$PAIR_CODE"
-  printf '                 (paste into the desktop app, or scan as a QR)\n'
-fi
+  # Ready-to-paste pair link (BET-156 §1) — the desktop app parses this directly
+  # via parsePairPayload and routes through the relay's /pair endpoint. Both
+  # BOX_ID_DISPLAY and PAIR_CODE are loaded via tested helpers, so this is safe
+  # even if either is missing (we just print the available half, never crash).
+  if [ -n "${BOX_ID_DISPLAY:-}" ] && [ -n "${PAIR_CODE:-}" ]; then
+    printf '\n  Pair link:     manta://pair?box=%s&code=%s\n' "$BOX_ID_DISPLAY" "$PAIR_CODE"
+    printf '                 (paste into the desktop app, or scan as a QR)\n'
+  fi
 
-cat <<EOF
+  cat <<EOF
 
   (Pairing code printed above by manta pair — re-run any time to mint a fresh one.)
 
 Re-run this installer any time to upgrade in place (your box identity is preserved).
-Run 'manta pair' (or 'npm run pair' in $MANTA_HOME) to mint a fresh pairing code.
+Run 'manta pair' (or 'node "$NODE" "$MANTA_HOME/scripts/manta-pair.mjs"') to mint a fresh pairing code.
 EOF
 
-# --- Final claude credentials check (warn — not die — per BET-153 step F).
-# The only auth prerequisite we assume is the user has run/authed `claude`
-# on this box at least once, producing ~/.claude/.credentials.json.
-# opencode-serve reads that on first start; without it the chat backend
-# starts but rejects all chat requests with a 401 until the user
-# authenticates.
-if [ -f "$HOME/.claude/.credentials.json" ]; then
-  ok "claude credentials detected — chat backend will authenticate on first request."
-else
-  warn "no \$HOME/.claude/.credentials.json — chat will start but reject requests until you authenticate."
-  warn "Run \`claude\` once on this box to sign in, then:"
-  warn "  systemctl --user restart opencode-serve"
-fi
+  # --- Final claude credentials check (warn — not die — per BET-153 step F).
+  # The only auth prerequisite we assume is the user has run/authed `claude`
+  # on this box at least once, producing ~/.claude/.credentials.json.
+  # opencode-serve reads that on first start; without it the chat backend
+  # starts but rejects all chat requests with a 401 until the user
+  # authenticates.
+  if [ -f "$HOME/.claude/.credentials.json" ]; then
+    ok "claude credentials detected — chat backend will authenticate on first request."
+  else
+    warn "no \$HOME/.claude/.credentials.json — chat will start but reject requests until you authenticate."
+    warn "Run \`claude\` once on this box to sign in, then:"
+    warn "  systemctl --user restart opencode-serve"
+  fi
+
+  # Cleanup: the previous install lives at $MANTA_HOME.prev until this point.
+  # If we got here, everything is healthy and the new install is serving — drop
+  # .prev so a future `mv` doesn't trip on a stale tree.
+  rm -rf "$MANTA_HOME.prev"
+}
+
+main "$@"

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -5,11 +5,10 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   resolveConfig,
   parsePort,
-  resolveTarballUrl,
-  isValidVersion,
   checkIdentity,
   waitForHealth,
   waitForRelay,
@@ -31,23 +30,22 @@ const INSTALL_SH = join(__dirname, "install.sh");
 
 /**
  * Source scripts/install.sh in test mode (MANTA_INSTALL_TEST_MODE=1) after
- * applying `preBody` (mocks / overrides), then call the bootstrap function
- * named by `func` (default: `bootstrap_node`). Returns the captured
- * stdout+stderr as a single string. The harness writes a tiny bash script
- * to a temp file so we don't fight bash quoting rules.
+ * applying `preBody` (mocks / overrides), then call the helper named by
+ * `func` (default: bash's no-op `:`). Returns the captured stdout+stderr as
+ * a single string. The harness writes a tiny bash script to a temp file so
+ * we don't fight bash quoting rules.
  *
  * Mock pattern: define functions AFTER sourcing install.sh. Bash uses the
- * latest definition, so the test's mocks override install.sh's helpers. The
- * test mock for `command` is what makes "node missing on PATH" testable in a
- * sandbox that already has node installed.
+ * latest definition, so the test's mocks override install.sh's helpers.
+ * Tests shadow `uname` for require_arch; previously the deleted bootstrap_*
+ * tests shadowed `command` / `detect_distro_id`.
  *
- * Never throws — bootstrap_node / bootstrap_build_essential's `die` calls
- * `exit 1`, which would otherwise propagate via execSync's thrown-on-non-zero
- * behavior. The harness swallows the error and returns the captured output
- * (with BOOTSTRAP_EXIT=NNN appended) so the test can assert on the message
- * + exit code together.
+ * Never throws — helpers' `die` calls `exit 1`, which would otherwise
+ * propagate via execSync's thrown-on-non-zero behavior. The harness swallows
+ * the error and returns the captured output (with BOOTSTRAP_EXIT=NNN
+ * appended) so the test can assert on the message + exit code together.
  */
-function runBootstrap({ preBody = "", func = "bootstrap_node" } = {}) {
+function runBootstrap({ preBody = "", func = ":" } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "manta-bootstrap-"));
   const script = join(dir, "test.sh");
   writeFileSync(
@@ -72,9 +70,9 @@ exit $rc
         stdio: ["ignore", "pipe", "pipe"],
       });
     } catch (e) {
-      // execSync throws when the child exits non-zero (bootstrap_node calls
-      // `die` → `exit 1` for the failure paths). The stderr/stdout is on
-      // the error object — concatenate and return so callers can assert on
+      // execSync throws when the child exits non-zero (helpers' `die`
+      // → `exit 1` for the failure paths). The stderr/stdout is on the
+      // error object — concatenate and return so callers can assert on
       // the message AND the BOOTSTRAP_EXIT=N marker.
       const out = (e.stdout ?? "") + (e.stderr ?? "");
       // execSync's stdout/stderr are string when encoding is set.
@@ -154,59 +152,6 @@ test("parsePort accepts valid ports, rejects junk", () => {
   assert.equal(parsePort(""), undefined);
   assert.equal(parsePort(null), undefined);
   assert.equal(parsePort("80.5"), undefined);
-});
-
-// ----------------------------------------------------------------------------
-// resolveTarballUrl / isValidVersion
-// ----------------------------------------------------------------------------
-
-test("resolveTarballUrl builds default URL from host + version", () => {
-  const url = resolveTarballUrl({
-    tarballUrl: null,
-    releaseHost: "https://mantaui.com",
-    version: "0.0.1",
-  });
-  assert.equal(url, "https://mantaui.com/releases/manta-0.0.1.tar.gz");
-});
-
-test("resolveTarballUrl uses explicit override verbatim", () => {
-  const url = resolveTarballUrl({
-    tarballUrl: "file:///tmp/x.tar.gz",
-    releaseHost: "https://ignored.example.com",
-    version: "9.9.9",
-  });
-  assert.equal(url, "file:///tmp/x.tar.gz");
-});
-
-test("resolveTarballUrl strips trailing slash on host", () => {
-  const url = resolveTarballUrl({
-    tarballUrl: "",
-    releaseHost: "https://mirror.example.com/",
-    version: "1.2.3-rc.1",
-  });
-  assert.equal(url, "https://mirror.example.com/releases/manta-1.2.3-rc.1.tar.gz");
-});
-
-test("resolveTarballUrl rejects a path-traversal version", () => {
-  assert.throws(
-    () =>
-      resolveTarballUrl({
-        tarballUrl: null,
-        releaseHost: "https://x.com",
-        version: "../../etc/passwd",
-      }),
-    /invalid version/,
-  );
-});
-
-test("isValidVersion accepts semver-ish, rejects slashes", () => {
-  assert.equal(isValidVersion("0.0.1"), true);
-  assert.equal(isValidVersion("1.2.3-rc.1"), true);
-  assert.equal(isValidVersion("latest"), true);
-  assert.equal(isValidVersion("../x"), false);
-  assert.equal(isValidVersion("a/b"), false);
-  assert.equal(isValidVersion(""), false);
-  assert.equal(isValidVersion(null), false);
 });
 
 // ----------------------------------------------------------------------------
@@ -583,9 +528,11 @@ test("renderShellConfig emits eval-able KEY=VALUE lines", () => {
   const out = renderShellConfig(cfg, { version: "0.0.1" });
   assert.match(out, new RegExp(`MANTA_HOME='${join(HOME, "manta")}'`));
   assert.match(out, /MANTA_AUTH_FILE='.*\.manta\/auth\.json'/);
-  assert.match(out, /MANTA_TARBALL_URL='.*\/releases\/manta-0\.0\.1\.tar\.gz'/);
   assert.match(out, /MANTA_PORT='8787'/);
   assert.match(out, /MANTA_HEALTH_URL='http:\/\/127\.0\.0\.1:8787\/auth\/status'/);
+  // MANTA_TARBALL_URL is NOT emitted — install.sh derives the URL from the
+  // manifest. (resolveConfig still parses it for tests / future overrides.)
+  assert.doesNotMatch(out, /MANTA_TARBALL_URL=/);
 });
 
 test("renderShellConfig single-quotes values with spaces safely", () => {
@@ -808,15 +755,20 @@ test("waitForHealth acceptAnyStatus=true (default) accepts 404 as healthy", asyn
 });
 
 // ----------------------------------------------------------------------------
-// install.sh — bash syntax + bootstrap_node (BET-162 F1 fix)
+// install.sh — bash syntax + manifest_get / verify_sha256 / require_arch
 // ----------------------------------------------------------------------------
 //
 // These tests shell out to bash because install.sh is bash, not JS. They use
 // the MANTA_INSTALL_TEST_MODE=1 sentinel (added in install.sh) which bails
 // before the install body runs and only loads the bash helpers
-// (log/ok/warn/die + bootstrap_node + install_node_via_* + require_cmd). The
-// unit tests then exercise the helpers with mocked apt/dnf/yum call sites so
-// nothing hits the network.
+// (log/ok/warn/die + manifest_get + verify_sha256 + require_arch). The unit
+// tests then exercise the helpers with mocked `uname`/tmpfiles so nothing
+// hits the network.
+//
+// (Previous BET-162/170 cases — bootstrap_node, install_node_via_*, and
+// bootstrap_build_essential — are DELETED in BET-173: the installer no longer
+// installs Node or build-essential on the box. The tarball ships a vendored
+// Node runtime + prebuilt production deps.)
 
 test("install.sh is bash-syntax-clean (bash -n)", () => {
   // Sanity check that the script parses. The harness writes it to a temp
@@ -833,281 +785,158 @@ test("install.sh is bash-syntax-clean (bash -n)", () => {
   }
 });
 
-test("bootstrap_node is a no-op when node is already on PATH (idempotent)", () => {
-  // The harness's bash env has node on PATH (the test runner depends on it).
-  // The mock for install_node_via_apt MUST NOT fire — bootstrap_node should
-  // early-return at the `command -v node` check. This is the re-run path:
-  // a box that already has node should NOT touch apt.
+// ----------------------------------------------------------------------------
+// manifest_get — the bash helper install.sh uses to read key=value from the
+// release manifest BEFORE any node exists on the box.
+// ----------------------------------------------------------------------------
+
+test("manifest_get extracts each key from a well-formed manifest", () => {
+  // The harness sources install.sh, then echoes the value of each call into
+  // a tagged line we grep for. The manifest body is built inline.
   const out = runBootstrap({
     preBody: `
-# Mock the apt installer — if this fires, the no-op guarantee is broken.
-install_node_via_apt() {
-  echo "MOCK_APT_CALLED" >&2
-  return 0
-}
-install_node_via_dnf() {
-  echo "MOCK_DNF_CALLED" >&2
-  return 0
-}
-install_node_via_yum() {
-  echo "MOCK_YUM_CALLED" >&2
-  return 0
-}
+manifest='version=0.0.1
+file_linux_x64=manta-0.0.1-linux-x64.tar.gz
+sha256_linux_x64=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+echo "V=\$(manifest_get "\$manifest" version)"
+echo "F=\$(manifest_get "\$manifest" file_linux_x64)"
+echo "S=\$(manifest_get "\$manifest" sha256_linux_x64)"
 `,
   });
-  assert.doesNotMatch(out, /MOCK_APT_CALLED/);
-  assert.doesNotMatch(out, /MOCK_DNF_CALLED/);
-  assert.doesNotMatch(out, /MOCK_YUM_CALLED/);
-  assert.doesNotMatch(out, /bootstrap_node|NodeSource/, "no bootstrap log lines when node is on PATH");
-  assert.match(out, /BOOTSTRAP_EXIT=0/);
+  assert.match(out, /V=0\.0\.1/);
+  assert.match(out, /F=manta-0\.0\.1-linux-x64\.tar\.gz/);
+  assert.match(out, /S=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/);
 });
 
-test("bootstrap_node calls install_node_via_apt on Debian/Ubuntu when node is missing", () => {
-  // Pretend node is missing by shadowing `command -v node`. The bash test
-  // env has node, so without the shadow bootstrap_node would no-op.
+test("manifest_get returns empty on a missing key (no false positives)", () => {
   const out = runBootstrap({
     preBody: `
-# Pretend \`command -v node\` always fails.
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-
-# Force the Debian/Ubuntu distro branch (no /etc/os-release in some sandboxes).
-detect_distro_id() { echo "ubuntu"; }
-
-# Mock the apt installer — if this fires, the call site is wired right.
-install_node_via_apt() {
-  echo "MOCK_APT_CALLED"
-  return 0
-}
+manifest='version=0.0.1
+file_linux_x64=manta-0.0.1-linux-x64.tar.gz'
+val="\$(manifest_get "\$manifest" sha256_linux_x64)"
+echo "VAL_LEN=\${#val}"
 `,
   });
-  assert.match(out, /MOCK_APT_CALLED/, "apt installer was called");
-  assert.match(out, /bootstrapping Node\.js 20\.x/);
-  // The mock returns 0, so the install is "successful" — but bootstrap_node
-  // re-checks `command -v node` afterwards and our shadow still says "missing",
-  // so it dies. That's the expected flow when the install doesn't actually
-  // put node on PATH (a real apt install would).
-  assert.match(out, /node is still missing after bootstrap/);
+  assert.match(out, /VAL_LEN=0/);
 });
 
-test("bootstrap_node calls install_node_via_dnf on Fedora when node is missing", () => {
+test("manifest_get ignores a second occurrence of the same key (head -n1)", () => {
+  // The manifest writer (pack.mjs) emits exactly one of each key, but if a
+  // future bug regresses to two, the installer must keep reading the FIRST
+  // (the published sha is the one Caddy serves; the second is whatever the
+  // operator hand-edited).
   const out = runBootstrap({
     preBody: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-detect_distro_id() { echo "fedora"; }
-install_node_via_dnf() {
-  echo "MOCK_DNF_CALLED"
-  return 0
-}
+manifest='file_linux_x64=manta-first.tar.gz
+file_linux_x64=manta-second.tar.gz'
+echo "F=\$(manifest_get "\$manifest" file_linux_x64)"
 `,
   });
-  assert.match(out, /MOCK_DNF_CALLED/);
-  assert.match(out, /node is still missing after bootstrap/);
+  assert.match(out, /F=manta-first\.tar\.gz/);
+  assert.doesNotMatch(out, /manta-second\.tar\.gz/);
 });
 
-test("bootstrap_node calls install_node_via_yum on RHEL when dnf is absent", () => {
+test("manifest_get tolerates values containing '=' (cut -d= -f2-)", () => {
+  // Some mirrors serve URLs as values — they contain '=' in query strings.
+  // The helper must not truncate at the first '='.
   const out = runBootstrap({
     preBody: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-detect_distro_id() { echo "rhel"; }
-# Make dnf fail so yum is tried as the fallback.
-install_node_via_dnf() {
-  echo "MOCK_DNF_CALLED"
-  return 1
-}
-install_node_via_yum() {
-  echo "MOCK_YUM_CALLED"
-  return 0
-}
+manifest='some_url=https://mirror.example.com/x?token=abc=def=='
+echo "U=\$(manifest_get "\$manifest" some_url)"
 `,
   });
-  assert.match(out, /MOCK_DNF_CALLED/);
-  assert.match(out, /MOCK_YUM_CALLED/);
-  assert.match(out, /node is still missing after bootstrap/);
-});
-
-test("bootstrap_node dies with a clear hint when the distro installer fails", () => {
-  // The mock returns non-zero — install_node_via_apt fails. The script
-  // MUST surface the failure as a `die` with the manual-install hint, NOT
-  // silently swallow it.
-  const out = runBootstrap({
-    preBody: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-detect_distro_id() { echo "ubuntu"; }
-install_node_via_apt() {
-  echo "MOCK_APT_FAIL"
-  return 1
-}
-`,
-  });
-  assert.match(out, /MOCK_APT_FAIL/);
-  assert.match(out, /Node\.js install via apt failed/);
-  assert.match(out, /Install manually: https:\/\/nodejs\.org/);
-});
-
-test("bootstrap_node dies with a manual-install hint for unknown distros", () => {
-  // distro='arch' isn't in our case statement — the user gets the same
-  // "install manually" hint as the require_cmd failures (BET-162 F1 tone).
-  const out = runBootstrap({
-    preBody: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-detect_distro_id() { echo "arch"; }
-`,
-  });
-  assert.match(out, /not auto-bootstrapped/);
-  assert.match(out, /https:\/\/nodejs\.org/, "manual-install hint points at nodejs.org");
-});
-
-test("bootstrap_node dies with a manual-install hint when /etc/os-release is unreadable", () => {
-  const out = runBootstrap({
-    preBody: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "node" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-detect_distro_id() { echo ""; }
-`,
-  });
-  assert.match(out, /\/etc\/os-release is unreadable/);
-  assert.match(out, /https:\/\/nodejs\.org/, "manual-install hint points at nodejs.org");
-});
-
-test("bootstrap_node dies when node + curl are missing together", () => {
-  // The bootstrap path itself depends on curl + tar to fetch the NodeSource
-  // setup script. If those are gone too, we must NOT try to apt-install
-  // curl — that would silently sudo over a hostile environment. The hint
-  // is "install everything manually and re-run" — same tone as require_cmd.
-  const out = runBootstrap({
-    preBody: `
-command() {
-  # Pretend node, curl, AND tar are all missing.
-  case " $2 " in
-    " node "|" curl "|" tar ") return 1 ;;
-  esac
-  builtin command "$@"
-}
-# If we DID call the apt installer, this would catch the bug.
-install_node_via_apt() {
-  echo "MOCK_APT_CALLED" >&2
-  return 0
-}
-`,
-  });
-  assert.doesNotMatch(out, /MOCK_APT_CALLED/);
-  assert.match(out, /node is missing and so are:/);
-  assert.match(out, /curl/);
-  assert.match(out, /tar/);
+  assert.match(out, /U=https:\/\/mirror\.example\.com\/x\?token=abc=def==/);
 });
 
 // ----------------------------------------------------------------------------
-// bootstrap_build_essential — auto-install make+g++ when missing (BET-170)
+// verify_sha256 — the sha256 check install.sh runs before extracting the
+// tarball. Dies loudly on mismatch (the operator must see why, not silently
+// continue with a corrupt tarball).
 // ----------------------------------------------------------------------------
-//
-// Discovered by the BET-170 live re-run: on a stock Hetzner Ubuntu 24.04
-// cloud image, the install got past bootstrap_node but failed at npm ci
-// because node-pty's native binding needs make + g++. The install script
-// used to assume build-essential was pre-installed; bootstrap_build_essential
-// makes that explicit so the install completes end-to-end on a fresh VPS.
 
-test("bootstrap_build_essential is a no-op when make + g++ are on PATH", () => {
-  // The test runner has both installed (build-essential was a normal dev
-  // dep on the workdir host). We pass func:"bootstrap_build_essential"
-  // so the harness actually exercises THAT function (without func the
-  // runBootstrap default is bootstrap_node — which trivially returns 0
-  // when node is on PATH and gives the no-op path zero coverage).
-  //
-  // Mock install helpers as sentinels — if the no-op guarantee is broken
-  // and bootstrap_build_essential falls through to the install path,
-  // one of these will fire and the assertion below fails.
+test("verify_sha256 passes when the file's hash matches the expected sha", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-verify-sha-"));
+  const file = join(dir, "blob");
+  writeFileSync(file, "hello world\n");
+  const expected = createHash("sha256").update(readFileSync(file)).digest("hex");
+  try {
+    const out = runBootstrap({
+      preBody: `
+verify_sha256 "${file}" "${expected}"
+echo "VERIFIED_OK=\$?"
+`,
+    });
+    assert.match(out, /VERIFIED_OK=0/);
+    assert.match(out, /BOOTSTRAP_EXIT=0/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("verify_sha256 dies with 'checksum mismatch' on a wrong sha", () => {
+  // `die` calls `exit 1`, so the harness captures the error stream and stops
+  // there — no separate exit-code marker is reachable. We assert on the die
+  // message (which carries both expected/actual hashes) — that's the
+  // user-facing signal anyway.
+  const dir = mkdtempSync(join(tmpdir(), "manta-verify-sha-"));
+  const file = join(dir, "blob");
+  writeFileSync(file, "hello world\n");
+  const wrongSha = "0".repeat(64);
+  try {
+    const out = runBootstrap({
+      preBody: `
+verify_sha256 "${file}" "${wrongSha}"
+`,
+    });
+    assert.match(out, /checksum mismatch for/);
+    assert.match(out, new RegExp(`expected: ${wrongSha}`));
+    assert.match(out, /actual:/);
+    assert.match(out, /corrupt download or stale manifest/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ----------------------------------------------------------------------------
+// require_arch — die unless uname -m reports x86_64. The harness overrides
+// `uname` via a function in preBody (same mocking style as the deleted
+// bootstrap_* tests used for `command` and `detect_distro_id`).
+// ----------------------------------------------------------------------------
+
+test("require_arch passes when uname emits x86_64", () => {
   const out = runBootstrap({
-    func: "bootstrap_build_essential",
     preBody: `
-detect_distro_id() { echo "ubuntu"; }
-# Sentinel installs — if bootstrap_build_essential actually calls an
-# installer (because make or g++ isn't really on PATH in this sandbox),
-# the sentinel name will appear in the output and the assertion fails.
+uname() { echo "x86_64"; }
+require_arch
+echo "RA_OK=\$?"
 `,
   });
+  assert.match(out, /RA_OK=0/);
   assert.match(out, /BOOTSTRAP_EXIT=0/);
-  assert.doesNotMatch(out, /not found: make/);
-  assert.doesNotMatch(out, /not found: g\+\+/);
-  assert.doesNotMatch(out, /make.*g\+\+ missing/);
-  assert.doesNotMatch(out, /build-essential installed/);
+  assert.doesNotMatch(out, /only x86_64 Linux is supported/);
 });
 
-test("bootstrap_build_essential calls apt-get install on Debian/Ubuntu when make is missing", () => {
+test("require_arch dies with a clear message on aarch64", () => {
+  // `die` calls `exit 1`, so the harness captures the error stream and
+  // stops there — no separate exit-code marker is reachable. Assert on the
+  // die message body (which carries the architecture the user has).
   const out = runBootstrap({
-    func: "bootstrap_build_essential",
     preBody: `
-# Pretend make (but NOT g++) is missing. Real \`make --version\` succeeds
-# in the test env, so we shadow command -v to selectively fail on "make".
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "make" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-# detect_distro_id returns empty when sourced from /etc/os-release (no
-# such file in the test sandbox). The case statement then hits "" which
-# dies with the "unreadable" hint. Override to "ubuntu" to exercise the
-# apt path.
-detect_distro_id() { echo "ubuntu"; }
-# Force the "no root, no sudo" path so we exercise the die-with-hint
-# branch instead of actually running apt-get. The point of THIS test is
-# the safety guard: a box without sudo must NOT silently try to
-# apt-install make over a hostile environment.
-package_install_mode() { return 1; }
+uname() { echo "aarch64"; }
+require_arch
 `,
   });
-  // bootstrap dies with the "neither root nor sudo" hint. We don't
-  // grep for "apt-get install" in the output because the die message
-  // contains that text in the manual-install suggestion — instead we
-  // assert the specific die message AND that there's no actual apt
-  // output ("Reading package lists" is the first line of real apt-get).
-  assert.match(out, /make.*g\+\+ missing and neither root nor sudo/);
-  assert.doesNotMatch(out, /Reading package lists/, "apt-get never actually ran");
+  assert.match(out, /only x86_64 Linux is supported by this installer today/);
+  assert.match(out, /got: aarch64/);
 });
 
-test("bootstrap_build_essential dies with manual-install hint for unknown distros", () => {
+test("require_arch dies on armv7l too (no fallthrough for any non-x86_64)", () => {
   const out = runBootstrap({
-    func: "bootstrap_build_essential",
     preBody: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "make" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-detect_distro_id() { echo "arch"; }
+uname() { echo "armv7l"; }
+require_arch
 `,
   });
-  assert.match(out, /make.*g\+\+ missing and your distro/);
-  assert.match(out, /not auto-bootstrapped/);
-  assert.match(out, /build-essential/);
+  assert.match(out, /only x86_64 Linux is supported/);
+  assert.match(out, /got: armv7l/);
 });

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -1,34 +1,54 @@
 #!/usr/bin/env node
-// pack.mjs — build a versioned release tarball the VPS installer downloads.
+// pack.mjs — build a self-contained, versioned release tarball the VPS
+// installer downloads.
 //
 //   node scripts/release/pack.mjs [--out dist] [--skip-build]
 //
-// Produces `dist/manta-<version>.tar.gz` whose contents unpack into a single
-// top-level `manta-<version>/` directory. The installer downloads this, extracts
-// with --strip-components=1 into ~/manta, runs `npm ci --omit=dev`, and starts the
-// server — NO renderer toolchain needed on the box, because we ship a PRE-BUILT
-// `mobile/www/` here.
+// Produces TWO artifacts in `dist/`:
 //
-// What goes in (the box's runtime surface only):
-//   src/               — the server (src/server/**) + shared code it imports
-//   scripts/           — install.sh, manta-pair.mjs, install-lib.mjs, systemd units
-//   docs/opencode-tools/ — the bui-native opencode tool bundle (notify.ts,
-//                         peers.ts, schedule.ts, secrets.ts, serve-page.ts,
-//                         webhook.ts, AGENTS.md). install.sh step D REAL-copies
-//                         these into ~/.config/opencode/tools/ + appends
-//                         AGENTS.md to ~/.config/opencode/AGENTS.md. Symlinking
-//                         misses ~/.config/opencode/node_modules resolution.
-//   mobile/www/        — PRE-BUILT renderer bundle (this is why the box needs no
-//                        Vite/electron toolchain)
-//   package.json       — the "mobile"/"pair" npm scripts + prod deps list
-//   package-lock.json  — pins prod deps for `npm ci`
-//   README.md          — manual-install fallback reference
+//   manta-<version>-linux-x64.tar.gz   the runtime + app + production deps
+//   manta-<version>.txt                flat key=value manifest with the sha256
+//                                      (install.sh fetches this first, then
+//                                      downloads + verifies the tarball)
 //
-// What's excluded: the Electron desktop build, node_modules, .git, dist, tests,
-// dev configs — none of it runs on the box.
+// The tarball's top-level dir is `manta-<version>/`. install.sh extracts with
+// `--strip-components=1` into `~/manta`. The tarball is SELF-CONTAINED — the
+// box does NOT run `npm ci` after extraction:
+//
+//   manta-<version>/
+//     runtime/node/                  vendored Node 20.20.2 (.tar.gz prebuilt by
+//                                    nodejs.org — same Node binary + npm the
+//                                    box will use, so node-pty's native ABI
+//                                    matches the runtime that runs it)
+//     src/, scripts/, mobile/www/,   the allowlisted box surface
+//     package.json, package-lock.json
+//     node_modules/                  prebuilt production deps (--omit=dev),
+//                                    with node-pty's binding already compiled
+//                                    against the vendored node's ABI
+//     docs/opencode-tools/           bui-native opencode tool bundle
+//     RELEASE.json                   { name, version, built_at, includes,
+//                                      node, arch }
+//
+// Why a vendored runtime + prebuilt deps (vs the previous "apt-install node +
+// npm ci on the box"): the one-liner installer used to silently use sudo +
+// distro package managers to fetch Node and (because node-pty has a native
+// binding) build-essential. Every launch-gate E2E failure traced back to that
+// seam. Shipping a self-contained user-space tarball (rustup/uv/opencode-style)
+// eliminates it: the box needs only `curl` + `tar` + `sha256sum` + `tmux` +
+// `git`, and the install is verified end-to-end before it starts.
+//
+// What we do NOT do:
+//   * No package-manager calls (no apt / dnf / yum / nodesource).
+//   * No `sudo` in any code path.
+//   * No tarball template generation — install.sh is served verbatim from the
+//     repo. Version + sha256 live in the manifest, not in install.sh.
+//
+// What's excluded from the tarball: the Electron desktop build, dist itself,
+// tests, dev configs, .git — none of it runs on the box.
 
 import { mkdir, rm, writeFile, cp, readFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,8 +56,25 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");
 
+// Pin the vendored Node version. Bump deliberately, not from `nvm ls`. The
+// runtime is built once on the pack box and shipped as-is — the box never
+// touches a package manager.
+const NODE_VERSION = "20.20.2";
+const NODE_TARBALL = `node-v${NODE_VERSION}-linux-x64.tar.gz`;
+const NODE_SHA_FILE = "SHASUMS256.txt";
+const NODE_TARBALL_URL = `https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}`;
+const NODE_SHA_URL = `https://nodejs.org/dist/v${NODE_VERSION}/${NODE_SHA_FILE}`;
+// Arch as it appears in the *filename* (hyphen). Manifest keys use the
+// underscore form (`file_linux_x64`) to match the install.sh parser.
+const ARCH = "linux-x64";
+// Manifest key segment — underscore form (matches install.sh's manifest_get calls).
+const ARCH_KEY = "linux_x64";
+
 function log(msg) {
   process.stdout.write(`▸ ${msg}\n`);
+}
+function ok(msg) {
+  process.stdout.write(`\u2713 ${msg}\n`);
 }
 function die(msg) {
   process.stderr.write(`✗ ${msg}\n`);
@@ -54,7 +91,10 @@ function parseArgs(argv) {
 }
 
 // The set of paths that make up the box runtime. Kept explicit (allowlist) so a
-// stray dev file never leaks into a public release tarball.
+// stray dev file never leaks into a public release tarball. node_modules is
+// NOT on this list — we materialize a fresh --omit=dev tree in <stage>/node_modules
+// below so the box ships with production-only deps (no devDeps → smaller
+// tarball, no `.bin/` shells that would resolve to a missing node).
 const INCLUDE = [
   "src",
   "scripts",
@@ -64,6 +104,140 @@ const INCLUDE = [
   "package-lock.json",
   "README.md",
 ];
+
+// Parse the nodejs.org SHASUMS256.txt into {filename: sha256}. Tolerates the
+// `*` prefix some lines carry for binary-mode sha.
+function parseShaSums(text) {
+  const out = {};
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^[a-f0-9]{64}\s+\*?(\S+)\s*$/);
+    if (m) out[m[1]] = line.slice(0, 64);
+  }
+  return out;
+}
+
+async function sha256OfFile(path) {
+  const buf = await readFile(path);
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+// Verify `tarballPath` (a file on disk) matches the sha256 recorded in the
+// nodejs.org SHASUMS256.txt for `NODE_TARBALL`. Dies on mismatch.
+async function verifyTarballSha256(tarballPath, shaFileText) {
+  const expected = parseShaSums(shaFileText)[NODE_TARBALL];
+  if (!expected) {
+    die(`SHASUMS256.txt did not contain a line for ${NODE_TARBALL}`);
+  }
+  const actual = await sha256OfFile(tarballPath);
+  if (actual !== expected) {
+    die(
+      `sha256 mismatch for ${NODE_TARBALL}\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${actual}\n` +
+        `  (re-run; if it persists, the upstream distribution may be corrupt)`,
+    );
+  }
+  log(`sha256 verified: ${actual}`);
+}
+
+// Download + cache the vendored node tarball + its SHASUMS256.txt, verify the
+// tarball's sha256 against the file, and extract the runtime into <stage>/runtime/node.
+// Dies on any failure.
+//
+// Cache location: <outDir>/.cache/node-v<version>-linux-x64.tar.gz (and the
+// matching SHASUMS256.txt). A subsequent pack with the same version skips the
+// network round-trip (the SHA is byte-stable).
+async function ensureNodeRuntime(cacheDir, stageDir) {
+  await mkdir(cacheDir, { recursive: true });
+  const cachedTar = join(cacheDir, NODE_TARBALL);
+  const cachedSha = join(cacheDir, NODE_SHA_FILE);
+
+  if (!existsSync(cachedTar) || !existsSync(cachedSha)) {
+    log(`Downloading vendored Node ${NODE_VERSION}…`);
+    const [tarRes, shaRes] = await Promise.all([
+      fetch(NODE_TARBALL_URL),
+      fetch(NODE_SHA_URL),
+    ]);
+    if (!tarRes.ok) die(`download failed: ${NODE_TARBALL_URL} → ${tarRes.status}`);
+    if (!shaRes.ok) die(`download failed: ${NODE_SHA_URL} → ${shaRes.status}`);
+    const tarBytes = Buffer.from(await tarRes.arrayBuffer());
+    const shaText = await shaRes.text();
+    await writeFile(cachedTar, tarBytes);
+    await writeFile(cachedSha, shaText);
+  } else {
+    log(`Reusing cached ${NODE_TARBALL} (.cache/).`);
+  }
+
+  log(`Verifying sha256 of vendored Node ${NODE_VERSION}…`);
+  await verifyTarballSha256(cachedTar, readFileSync(cachedSha, "utf-8"));
+
+  // Extract into <stage>/runtime/node, stripping the leading `node-v.../`.
+  // After this, <stage>/runtime/node/bin/{node,npm,corepack,...} exist.
+  const runtimeDir = join(stageDir, "runtime", "node");
+  await mkdir(runtimeDir, { recursive: true });
+  log(`Extracting vendored Node into ${runtimeDir}…`);
+  const r = spawnSync(
+    "tar",
+    ["-xzf", cachedTar, "-C", runtimeDir, "--strip-components=1"],
+    { stdio: "inherit" },
+  );
+  if (r.status !== 0) die("tar extract of vendored Node failed");
+
+  if (!existsSync(join(runtimeDir, "bin", "node"))) {
+    die(
+      `vendored Node extract missing bin/node — bad tarball? expected ${join(runtimeDir, "bin", "node")}`,
+    );
+  }
+  ok(`vendored Node ${NODE_VERSION} extracted (${join(runtimeDir, "bin", "node")}).`);
+}
+
+// Run `npm ci --omit=dev` IN the stage dir, using the VENDORED node's ABI.
+// This is the load-bearing step for the "self-contained tarball" promise:
+// node-pty's native binding compiles here, against the same Node binary the
+// box will run it under, so the .node file loads on first `node src/server/index.mjs`
+// without a second compile pass.
+async function runPrebuiltDeps(stageDir) {
+  const stageNpm = join(stageDir, "runtime", "node", "bin", "npm");
+  if (!existsSync(stageNpm)) {
+    die(`vendored npm missing — expected ${stageNpm} (the tarball's bin/ layout may have changed)`);
+  }
+
+  log(`Installing production deps with vendored npm (--omit=dev)…`);
+  const r = spawnSync(stageNpm, ["ci", "--omit=dev", "--no-audit", "--no-fund"], {
+    cwd: stageDir,
+    stdio: "inherit",
+    // PATH-prefix the vendored node bin so any npm subprocesses (e.g. node-gyp
+    // for node-pty) find the matching ABI. Without this, on a pack box where
+    // /usr/bin/node is a different major than the vendored 20.20.2, the
+    // binding compiles against the system ABI and refuses to load.
+    env: {
+      ...process.env,
+      PATH: `${join(stageDir, "runtime", "node", "bin")}:${process.env.PATH ?? ""}`,
+    },
+  });
+  if (r.status !== 0) die("vendored npm ci failed");
+
+  // Sanity: node-pty's compiled .node file must be present after `npm ci`.
+  // Without it, the server's PTY surfaces throw at runtime on the box.
+  const releaseDir = join(stageDir, "node_modules", "node-pty", "build", "Release");
+  if (!existsSync(releaseDir)) {
+    die(
+      `node-pty build/Release missing — expected ${releaseDir} (npm ci did not run node-pty's install script?)`,
+    );
+  }
+  // Glob for at least one *.node file. existsSync on the dir is necessary
+  // but not sufficient (the dir can exist with no binary). We use a tiny
+  // shell glob rather than pulling in glob/fast-glob just for this check.
+  const gl = spawnSync("sh", ["-c", `ls -1 ${releaseDir}/*.node 2>/dev/null | head -n1`], {
+    encoding: "utf8",
+  });
+  if (gl.status !== 0 || !gl.stdout || gl.stdout.trim() === "") {
+    die(
+      `node-pty compiled .node missing under ${releaseDir} — node-pty's install script did not produce a native binding`,
+    );
+  }
+  ok(`production deps installed; node-pty binding present (${gl.stdout.trim()}).`);
+}
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -75,7 +249,11 @@ async function main() {
 
   const stageRoot = join(REPO_ROOT, args.outDir, ".stage");
   const stageDir = join(stageRoot, `manta-${version}`);
-  const outFile = join(REPO_ROOT, args.outDir, `manta-${version}.tar.gz`);
+  // Archive name encodes the arch so a future arm64 build is data, not code.
+  // install.sh's manifest key file_linux_x64 mirrors this.
+  const outFile = join(REPO_ROOT, args.outDir, `manta-${version}-${ARCH}.tar.gz`);
+  const outManifest = join(REPO_ROOT, args.outDir, `manta-${version}.txt`);
+  const cacheDir = join(REPO_ROOT, args.outDir, ".cache");
 
   // 1. Build the renderer bundle unless told to skip (CI may pre-build).
   if (!args.skipBuild) {
@@ -93,7 +271,7 @@ async function main() {
     die("mobile/www/index.html missing — the renderer bundle must be built before packing");
   }
 
-  // 2. Stage the allowlisted paths under bui-<version>/.
+  // 2. Stage the allowlisted paths under manta-<version>/.
   log(`Staging release into ${stageDir}…`);
   await rm(stageRoot, { recursive: true, force: true });
   await mkdir(stageDir, { recursive: true });
@@ -102,7 +280,7 @@ async function main() {
     if (!existsSync(from)) {
       // package-lock is optional-ish; everything else is required.
       if (rel === "package-lock.json") {
-        log(`  (no ${rel} — skipping; installer falls back to npm install)`);
+        log(`  (no ${rel} — skipping; this would otherwise break the box's npm ci)`);
         continue;
       }
       die(`required path missing from repo: ${rel}`);
@@ -110,17 +288,36 @@ async function main() {
     await cp(from, join(stageDir, rel), { recursive: true });
   }
 
-  // 3. Drop a manifest so the box can report exactly what it's running.
+  // 3. Vendored Node 20.20.2 — downloaded + sha256-verified + extracted under
+  //    stage/runtime/node. Tarball is cached under .cache/ so re-packs skip the
+  //    network round-trip. This is the runtime the box will use.
+  await ensureNodeRuntime(cacheDir, stageDir);
+
+  // 4. Prebuilt production deps via the vendored npm/node. Runs BEFORE
+  //    RELEASE.json/tar so the box gets a tarball whose node_modules is already
+  //    self-consistent (no `npm ci` step on the box).
+  await runPrebuiltDeps(stageDir);
+
+  // 5. RELEASE.json — also documents the runtime + arch so the box can report
+  //    exactly what it's running. Not used by install.sh (which uses the
+  //    sha256 manifest instead); kept for human audit / future tooling.
   await writeFile(
     join(stageDir, "RELEASE.json"),
     JSON.stringify(
-      { name: "manta", version, built_at: new Date().toISOString(), includes: INCLUDE },
+      {
+        name: "manta",
+        version,
+        built_at: new Date().toISOString(),
+        node: NODE_VERSION,
+        arch: ARCH,
+        includes: INCLUDE,
+      },
       null,
       2,
     ) + "\n",
   );
 
-  // 4. Tar it up. Tarball root is bui-<version>/ so install.sh strips it.
+  // 6. Tar it up. Tarball root is manta-<version>/ so install.sh strips it.
   log(`Creating ${outFile}…`);
   await mkdir(dirname(outFile), { recursive: true });
   const r = spawnSync(
@@ -130,11 +327,28 @@ async function main() {
   );
   if (r.status !== 0) die("tar failed");
 
-  // 5. Clean up the stage dir; leave the tarball.
+  // 7. Manifest — flat key=value, parseable in bash before any node exists on
+  //    the box. install.sh uses this to fetch + verify the tarball. The
+  //    sha256 is computed AFTER tar (the tarball is the artifact being verified).
+  //    Keys: version, file_<arch> (underscore form — matches install.sh's
+  //    manifest_get calls), sha256_<arch>.
+  log(`Writing manifest ${outManifest}…`);
+  const tarSha = await sha256OfFile(outFile);
+  const manifest =
+    `version=${version}\n` +
+    `file_${ARCH_KEY}=${`manta-${version}-${ARCH}.tar.gz`}\n` +
+    `sha256_${ARCH_KEY}=${tarSha}\n`;
+  await writeFile(outManifest, manifest);
+  ok(`manifest written: ${outManifest}`);
+
+  // 8. Clean up the stage dir; leave the tarball + manifest + .cache.
   await rm(stageRoot, { recursive: true, force: true });
+  // Keep .cache/ — re-packs for the same Node version skip the network round-trip.
+  // Operators can `rm -rf dist/.cache` to force a re-download.
 
   log(`Done: ${outFile}`);
-  log(`Upload it to <release-host>/releases/manta-${version}.tar.gz`);
+  log(`Manifest: ${outManifest}`);
+  log(`Upload both to <release-host>/releases/ — install.sh fetches the manifest first.`);
 }
 
 main().catch((e) => die(String(e?.stack ?? e)));

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -6,11 +6,16 @@
 # What it does (in order; each step idempotent and runs unconditionally unless
 # its artifact is missing — desktop is a separately-shippable leg, not a failure):
 #   1. preflight   refuse if git tree is dirty, if v<version> tag already
-#                  exists, or if dist/manta-<version>.tar.gz is absent (run
-#                  `npm run pack` first).
-#   2. tarball     scp dist/manta-<version>.tar.gz to
-#                  <host>:/var/www/mantaui/releases/ and refresh
-#                  manta-latest.tar.gz there.
+#                  exists, or if dist/manta-<version>-linux-x64.tar.gz OR
+#                  dist/manta-<version>.txt (the manifest) is absent.
+#                  (Run `npm run pack` first.)
+#   2. tarball     scp dist/manta-<version>-linux-x64.tar.gz + the manifest
+#                  to <host>:/var/www/mantaui/releases/. THEN (strictly last)
+#                  ssh to copy manta-<version>.txt → manta-latest.txt — this
+#                  ordering is the atomicity guarantee: a client either sees
+#                  the OLD manifest (and old tarball) or the NEW manifest
+#                  (with new tarball already uploaded). Drift between the two
+#                  is impossible.
 #   3. desktop     if dist/desktop/ has binaries: scp them + the latest-*.yml
 #                  feeds to <host>:/var/www/mantaui/updates/ and the binaries
 #                  to /var/www/mantaui/downloads/, then refresh
@@ -25,12 +30,12 @@
 #                  repo checkout, but Caddy serves install.sh statically from
 #                  the web root, so without this copy the advertised one-liner
 #                  keeps serving the stale installer (BET-171).
-#   5. verify      HEAD each published URL — tarball 200, install.sh 200,
-#                  and (if desktop uploaded) Manta-latest.{dmg,AppImage} 200.
-#                  install.sh is ALSO content-verified: the served body must
-#                  byte-match the repo's scripts/install.sh (a 200 alone does
-#                  not prove the deploy took — a stale file also 200s).
-#                  Fail loudly on any non-200 or content mismatch.
+#   5. verify      HEAD each published URL — tarball 200, manifest live with
+#                  matching version + tarball sha, install.sh 200, install.sh
+#                  body byte-matches the repo. Fail loudly on any non-200,
+#                  manifest drift, or install.sh drift. This makes the
+#                  script/tarball/manifest drift (the F4 class from BET-171)
+#                  fail the publish loudly.
 #   6. tag         git tag v<version> && git push origin v<version> (a tag
 #                  means "published and verified").
 #
@@ -54,7 +59,8 @@ PROD_HOST="${MANTA_PROD_HOST:-root@91.107.196.2}"
 SITE="${MANTA_SITE:-https://mantaui.com}"
 
 VERSION="$(node -p 'require("./package.json").version')"
-TARBALL="dist/manta-${VERSION}.tar.gz"
+TARBALL="dist/manta-${VERSION}-linux-x64.tar.gz"
+MANIFEST="dist/manta-${VERSION}.txt"
 DESKTOP_DIR="dist/desktop"
 WEBROOT_DIR="/var/www/mantaui"
 RELEASES_DIR="${WEBROOT_DIR}/releases"
@@ -81,13 +87,24 @@ if [ ! -f "${TARBALL}" ]; then
   die "${TARBALL} missing — run \`npm run pack\` first"
 fi
 
+if [ ! -f "${MANIFEST}" ]; then
+  die "${MANIFEST} missing — run \`npm run pack\` first (the tarball's manifest sidecar)"
+fi
+
 ok "preflight ok"
 
-# --- 2. tarball -------------------------------------------------------------
+# --- 2. tarball + manifest (atomicity: tarball first, manifest pointer last) -
 log "Uploading ${TARBALL} → ${PROD_HOST}:${RELEASES_DIR}/…"
 scp "${TARBALL}" "${PROD_HOST}:${RELEASES_DIR}/"
-ssh "${PROD_HOST}" "cd ${RELEASES_DIR} && cp -f manta-${VERSION}.tar.gz manta-latest.tar.gz"
-ok "tarball published"
+log "Uploading ${MANIFEST} → ${PROD_HOST}:${RELEASES_DIR}/…"
+scp "${MANIFEST}" "${PROD_HOST}:${RELEASES_DIR}/"
+
+# The latest-pointer copy goes LAST. Clients either see the old manifest (the
+# old tarball is still served too) OR the new manifest (and the new tarball is
+# already up). Drift between manifest and tarball is impossible.
+log "Publishing manifest pointer ${PROD_HOST}:${RELEASES_DIR}/manta-latest.txt…"
+ssh "${PROD_HOST}" "cd ${RELEASES_DIR} && cp -f manta-${VERSION}.txt manta-latest.txt"
+ok "tarball + manifest published"
 
 # --- 3. desktop (optional leg) ----------------------------------------------
 shopt -s nullglob
@@ -155,8 +172,30 @@ check_200() {
   ok "${url} → 200"
 }
 
-check_200 "${SITE}/releases/manta-${VERSION}.tar.gz"
+check_200 "${SITE}/releases/manta-${VERSION}-linux-x64.tar.gz"
 check_200 "${SITE}/install.sh"
+
+# Manifest + tarball drift check (BET-171 F4 class). The publish script just
+# pushed both files; we re-fetch the manifest over HTTPS and assert that the
+# served tarball's sha256 matches the manifest's sha256_linux_x64 line. A
+# failure here means we shipped a tarball + manifest that disagree — clients
+# would download the tarball, sha256-fail it, and die. Catch that HERE.
+log "Verifying manifest ↔ tarball drift…"
+SERVED_MANIFEST="$(curl -fsSL "${SITE}/releases/manta-latest.txt")"
+SERVED_VERSION="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^version=' | head -n1 | cut -d= -f2-)"
+if [ "$SERVED_VERSION" != "$VERSION" ]; then
+  die "manifest not live: served version='${SERVED_VERSION}' expected='${VERSION}'"
+fi
+SERVED_FILE="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^file_linux_x64=' | head -n1 | cut -d= -f2-)"
+SERVED_SHA="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^sha256_linux_x64=' | head -n1 | cut -d= -f2-)"
+if [ -z "$SERVED_FILE" ] || [ -z "$SERVED_SHA" ]; then
+  die "served manifest is malformed (missing file_linux_x64 or sha256_linux_x64)"
+fi
+ACTUAL_SHA="$(curl -fsSL "${SITE}/releases/${SERVED_FILE}" | sha256sum | awk '{print $1}')"
+if [ "$ACTUAL_SHA" != "$SERVED_SHA" ]; then
+  die "tarball/manifest drift: served sha=${SERVED_SHA} actual=${ACTUAL_SHA} for ${SERVED_FILE}"
+fi
+ok "served manifest live (version=${VERSION}, sha=${ACTUAL_SHA})"
 
 # A 200 on install.sh is not enough — a stale file also 200s (BET-171). Verify
 # the served body byte-matches the repo's scripts/install.sh so we know the


### PR DESCRIPTION
## Summary

Stop installing prerequisites on the box. The one-liner installer (`curl -fsSL https://mantaui.com/install.sh | bash`) used to silently sudo+apt-install Node + build-essential on the target box; every launch-gate E2E failure traced back to that seam. Now `npm run pack` produces a self-contained user-space tarball (rustup/uv/opencode-style) that ships a vendored Node 20.20.2 + production `node_modules` with node-pty's binding already compiled.

**Refs BET-160 §2 (launch gate).** Supersedes BET-170/172's "layer 2" prerequisite-bootstrap mechanism. Root-cause fix for BET-171 F1/F2/F3/F4.

## What changed

- **`pack.mjs`** downloads Node 20.20.2 from nodejs.org, verifies against SHASUMS256.txt, extracts under `runtime/node/`, then runs `npm ci --omit=dev` using the vendored node's ABI so node-pty compiles once against the runtime the box will use. Writes a flat `key=value` manifest alongside the tarball (`version`, `file_linux_x64`, `sha256_linux_x64`). Tarball name encodes arch (`manta-<version>-linux-x64.tar.gz`).
- **`install.sh`** becomes a thin orchestrator: fetch manifest (bash, no node needed yet) → download tarball → sha256-verify → extract → atomic swap into `~/manta` with `.prev` rollback → write systemd units pointing at the vendored node → start → mint pairing code. All node invocations use `$NODE` (the vendored binary) explicitly; nothing relies on a system node.
- **`install.sh`** deletes `detect_distro_id`, `package_install_mode`, `install_node_via_{apt,dnf,yum}`, `bootstrap_node`, `bootstrap_build_essential`, the `npm ci` block, the inline chicken/egg tarball-URL resolver, the `require_cmd node/npm` lines, the `node_major` version check, and the redundant mid-script tmux re-check.
- **`install-lib.mjs`** deletes `resolveTarballUrl`, `isValidVersion`, and the `tarball-url` CLI subcommand (no callers). `renderShellConfig` no longer emits `MANTA_TARBALL_URL` (install.sh derives the URL from the manifest).
- **`install.test.mjs`** deletes the bootstrap_* test helpers and adds tests for `manifest_get`, `verify_sha256`, `require_arch` using the existing `MANTA_INSTALL_TEST_MODE=1` source-the-script pattern.
- **`publish.sh`** uploads tarball + manifest in order, with the `manta-latest.txt` cp going LAST (atomicity). The verify step now re-fetches the manifest and re-checks the live tarball sha — script/tarball/manifest drift (the F4 class from BET-171) fails the publish loudly.
- **`README.md`** updates installer prerequisites (curl/tar/sha256sum/tmux/git; everything else ships in the tarball — no sudo, no compilers, no Node preinstall).

## Net LoC delta

| file | before | after | Δ |
|------|-------:|------:|---:|
| `scripts/install.sh` | 755 | 556 | **−199 (−26%)** |
| `scripts/install.test.mjs` | 1113 | 942 | −171 |
| `scripts/install-lib.mjs` | 701 | 670 | −31 |
| `scripts/release/pack.mjs` | 140 | 354 | +214 (vendored runtime + prebuilt deps) |
| `scripts/release/publish.sh` | 187 | 191 | +4 |
| `README.md` | — | — | ±28 |

Net: **−183 LoC** across 6 files. The deleted install.sh code (the big minus) is the success metric.

## Deleted functions (in `install.sh`)

- `detect_distro_id`, `package_install_mode`
- `install_node_via_apt`, `install_node_via_dnf`, `install_node_via_yum`
- `bootstrap_node`, `bootstrap_build_essential`
- `require_cmd node`, `require_cmd npm` lines + `node_major` version check
- the inline `TARBALL_URL="${host}/releases/manta-${MANTA_VERSION}.tar.gz"` resolver
- the section-5 `npm ci` block
- the redundant mid-script tmux re-check (collapsed — tmux is already a hard `require_cmd` at step 1)

## Verification

### Checklist (all pass)

1. ✅ `npm run typecheck` — exit 0
2. ✅ `npm test` — 648 pass / 0 fail
3. ✅ `node scripts/release/pack.mjs --skip-build` — produces both `dist/manta-0.0.1-linux-x64.tar.gz` (66 MB) and `dist/manta-0.0.1.txt` (140 B)
4. ✅ Tarball inspection:
   - `runtime/node/bin/node` present (1 match)
   - `node_modules/node-pty/build/Release/*.node` present (2 matches — `pty.node` + spawn helper)
   - `sha256sum` of the tarball matches `sha256_linux_x64` in `manta-0.0.1.txt`
5. ✅ Sandbox smoke: `require("/tmp/mv2/node_modules/node-pty")` under the vendored node prints `pty ok` (the prebuilt binding loads)
6. ✅ `bash -n scripts/install.sh` — syntax clean
7. ✅ `grep -cE 'sudo|apt-get|dnf |yum |nodesource' scripts/install.sh` returns only:
   - the header comment that explicitly says we DON'T use these
   - 5 `require_cmd` hint strings (apt-get install … — only printed when a prereq is missing)
   - 1 warn string telling the user to run `sudo loginctl enable-linger` themselves (no auto-execute)

### Base

Base: origin/main @ `aa9edaf`

## Out of scope (handled in BET-171 / BET-172 follow-ups)

- Fresh-VPS E2E re-run against the new installer
- `publish.sh` against prod + `docs/launch-e2e.md` updates
- Linux-arm64 tarball (manifest format already has room)
- Single-binary packaging (Node SEA / bun compile)
- Auto-update of an installed box beyond "re-run the installer"