### PR TITLE
feat(release): AI-assisted install via llms-install.md + MANTA_RELAY=off knob (BET-174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,13 @@ leaves your work running, reopening re-attaches.
 
 ## AI-assisted setup
 
-Setting up with an AI agent (claude code, opencode, …)? Paste this prompt into
-an agent **running on the Linux box** you want to drive:
+Setting up with an AI agent (claude code, opencode, cursor, …)? Paste this
+into an agent that can reach the box:
 
 ```
-Set up this box as a Manta UI box server. Steps:
-1. Run: curl -fsSL https://mantaui.com/install.sh | bash
-   It installs the manta box server (~/manta), a systemd --user unit
-   (manta-server, port 8787 loopback), enables linger, and prints a 6-digit
-   pairing code + the box id. Show me the pairing code and keep the box id.
-2. Verify health: systemctl --user status manta-server should be active;
-   curl -s http://127.0.0.1:8787/auth/pair mints a fresh code if the first
-   one expired (codes are one-time, 5-minute TTL).
-3. Chat mode needs opencode: check `opencode --version`; if missing run
-   curl -fsSL https://opencode.ai/install | bash. Ensure a systemd --user
-   unit runs `opencode serve --port 4096 --hostname 127.0.0.1` (template in
-   scripts/systemd/ of ~/manta), and that ~/.config/opencode/opencode.jsonc
-   lists the "opencode-claude-auth@latest" plugin (merge, don't clobber).
-   I already have claude authenticated on this box (~/.claude), which that
-   plugin reuses. Copy ~/manta/docs/opencode-tools/*.ts (real copies, NOT
-   symlinks) into ~/.config/opencode/tools/ and append
-   ~/manta/docs/opencode-tools/AGENTS.md to ~/.config/opencode/AGENTS.md
-   if not already present. Restart opencode-serve.
-4. Confirm tmux is installed (hard requirement) and tell me:
-   the pairing code, the box id, and whether relay connectivity to
-   wss://relay.mantaui.com is up (journalctl --user -u manta-server).
-Do not regenerate ~/.manta/auth.json if it exists — that would unpair
-every device.
+Set up a Linux box as a Manta UI box server.
+Fetch https://mantaui.com/llms-install.md and follow it exactly.
+Ask me its interview questions before running anything.
 ```
 
 Then install the desktop app from [mantaui.com](https://mantaui.com), enter

--- a/llms-install.md
+++ b/llms-install.md
@@ -1,0 +1,130 @@
+# Manta UI — AI agent install guide
+
+You are an AI coding agent installing Manta UI's box server on behalf of your
+user. Follow this document exactly. Do not improvise install steps: the
+installer script is the single mechanism; your job is the interview, running
+it with the right knobs, verifying, and reporting.
+
+## Safety invariants (never violate)
+
+- NEVER delete or regenerate `~/.manta/auth.json`. It is the box identity;
+  regenerating it unpairs every device the user has.
+- NEVER edit `~/.config/opencode/opencode.jsonc` destructively — the installer
+  merges what it needs; leave it alone.
+- NEVER run the installer as root or with sudo. It is a per-user, user-space
+  install (systemd --user + linger). It never installs system packages. If a
+  prerequisite is missing (e.g. tmux), show the user the exact install command
+  and ask them to run it or approve it — do not run sudo yourself unless the
+  user explicitly approves that command.
+- NEVER install Node.js or build tools — the installer ships its own Node
+  runtime inside the release tarball.
+- Re-running the installer is safe: it upgrades in place and preserves identity.
+
+## Step 1 — interview (ask BEFORE running anything)
+
+Ask the user exactly these two questions:
+
+1. **"Am I running on the Linux box you want to install Manta on, or should I
+   install on a remote box over SSH?"** If remote: ask for `user@host` (and
+   key/port if needed), then run every command below through
+   `ssh user@host '…'`. Verify SSH works with `ssh user@host 'echo ok'` first.
+2. **"How should your devices reach this box?**
+   - **Relay (default, recommended):** zero network setup. The box dials out
+     to relay.mantaui.com; your desktop and phone connect through it.
+   - **Self-hosted / direct:** no Manta infrastructure in the path. You bring
+     your own HTTPS ingress (Cloudflare tunnel, Tailscale, reverse proxy)
+     pointing at the box; devices connect straight to your URL."**
+
+If the user picks self-hosted, also ask what ingress they already have. You
+may help them set one up afterwards if they ask, but it is not part of this
+install: the minimum requirement is an HTTPS URL that reverse-proxies to
+`127.0.0.1:8787` on the box.
+
+Do NOT ask about chat mode (always installed), model providers, or projects —
+the desktop app's onboarding handles those.
+
+## Step 2 — preflight
+
+Run on the target box:
+
+- `uname -m` — must be `x86_64`. Anything else: stop and tell the user only
+  x86_64 Linux is supported today.
+- `for c in curl tar sha256sum tmux git; do command -v $c >/dev/null || echo "missing: $c"; done`
+  — all five are hard requirements the installer does NOT install. For any
+  missing one, give the user the exact command for their distro
+  (`sudo apt-get install -y tmux git` / `sudo dnf install -y tmux git`;
+  `sha256sum` is in coreutils) and wait for them to run or approve it.
+- `test -f ~/.claude/.credentials.json && echo present || echo missing` —
+  chat mode reuses the box's claude login. If missing, tell the user: chat
+  will 401 until they run `claude` once on this box and log in. Offer to
+  pause here while they do (then `systemctl --user restart opencode-serve`
+  after install), or continue and remind them at the end. Continue either way.
+- Do NOT check for or install Node — the installer vendors its own runtime.
+
+## Step 3 — install
+
+Relay mode (default):
+
+    curl -fsSL https://mantaui.com/install.sh | bash
+
+Self-hosted / direct mode:
+
+    curl -fsSL https://mantaui.com/install.sh | MANTA_RELAY=off bash
+
+Watch the output. The installer is idempotent and prints its own diagnostics.
+It downloads a self-contained release (app + Node runtime), verifies its
+checksum, installs to `~/manta`, sets up `manta-server` and `opencode-serve`
+systemd --user units, enables linger, and ends by printing a 6-digit pairing
+code, the box id, and (relay mode) a `manta://pair` link. Capture all of
+those for your final report.
+
+## Step 4 — verify
+
+- `systemctl --user is-active manta-server` → `active`
+- `systemctl --user is-active opencode-serve` → `active`
+- `curl -s http://127.0.0.1:8787/auth/status` → responds (any JSON)
+- Relay mode only: `curl -s http://127.0.0.1:8787/relay/status` → should show
+  connected. If not: `journalctl --user -u manta-server -n 50` and report the
+  error lines to the user.
+- Direct mode only: confirm with the user their ingress URL responds:
+  `curl -sI https://<their-url>/auth/status` from anywhere.
+
+Pairing codes are one-time with a ~5 minute TTL. If the printed code expires
+before the user enters it, mint a fresh one:
+`curl -s http://127.0.0.1:8787/auth/pair` (loopback-only, run on the box).
+
+## Step 5 — failure playbook
+
+- **Installer died at a checksum mismatch** → corrupt download or a release
+  being published right now; re-run once. If it persists, report it to the
+  user verbatim.
+- **Installer died at "server did not become healthy"** →
+  `journalctl --user -u manta-server -n 50`; most common cause is a stale
+  partial install — re-run the installer (safe; the previous install is kept
+  at `~/manta.prev` until a run succeeds).
+- **`systemctl --user` errors with "Failed to connect to bus"** → the user
+  SSH'd in without a session bus; run
+  `export XDG_RUNTIME_DIR=/run/user/$(id -u)` and retry, and make sure
+  `loginctl enable-linger $USER` succeeded (may need sudo).
+- **Relay shows degraded** → box has no outbound access to
+  relay.mantaui.com:443; check firewall/proxy, then
+  `systemctl --user restart manta-server`.
+- **Chat 401s** → `~/.claude/.credentials.json` missing (see preflight); after
+  the user logs in, `systemctl --user restart opencode-serve`.
+- Anything else: re-run the installer first (idempotent), then read the
+  journals of both units before attempting manual fixes.
+
+## Step 6 — report back to the user
+
+Tell the user, in this order:
+
+1. The **pairing code** (and that it expires in ~5 minutes — you can mint a
+   fresh one any time) and the **box id**.
+2. Relay mode: paste the `manta://pair` link into the desktop app, or enter
+   the code. Phone: install the app / open the relay URL and pair the same way.
+   Direct mode: on the desktop enter `https://<their-url>` + the code; on the
+   phone open `https://<their-url>`, add to home screen, pair with a fresh code.
+3. Everything else (providers, first project) happens in the desktop app's
+   onboarding.
+4. If claude login was missing: remind them to run `claude` on the box, then
+   `systemctl --user restart opencode-serve`.

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -318,6 +318,43 @@ export function mergeOpencodeConfig(existingText) {
 }
 
 // ---------------------------------------------------------------------------
+// Relay-disabled merge — pure, used by install.sh when MANTA_RELAY=off (BET-174)
+// ---------------------------------------------------------------------------
+//
+// Sets `relayEnabled: false` in ~/.manta/config.json so the in-process relay
+// agent opts out (only `=== false` opts out — see shouldStartRelayAgent in
+// src/relay/agent/index.mjs). Plain JSON (NOT JSONC) — config.json doesn't
+// allow `//` line comments, so we JSON.parse the raw text directly.
+//
+// Behavior (mirrors mergeOpencodeConfig's safety contract):
+//   * missing/empty/whitespace text → returns {"relayEnabled":false} (pretty)
+//   * valid JSON object → sets relayEnabled:false, preserves ALL other keys,
+//     pretty-prints
+//   * unparseable text or non-object JSON → { ok:false, error }, NO text
+//     (never clobber a config we can't parse — same policy as
+//     mergeOpencodeConfig's `corrupt` path)
+//
+// Returns { ok: true, text } | { ok: false, error }.
+export function mergeRelayDisabled(existingText) {
+  const raw = typeof existingText === "string" ? existingText : "";
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: true, text: JSON.stringify({ relayEnabled: false }, null, 2) + "\n" };
+  }
+  let cfg;
+  try {
+    cfg = JSON.parse(trimmed);
+  } catch (e) {
+    return { ok: false, error: `config.json is not valid JSON: ${e?.message ?? e}` };
+  }
+  if (cfg === null || typeof cfg !== "object" || Array.isArray(cfg)) {
+    return { ok: false, error: "config.json must be a JSON object (got non-object root)" };
+  }
+  const next = { ...cfg, relayEnabled: false };
+  return { ok: true, text: JSON.stringify(next, null, 2) + "\n" };
+}
+
+// ---------------------------------------------------------------------------
 // Systemd unit placeholder substitution — pure, used by install.sh steps E
 // and the existing manta-server step (BET-153).
 // ---------------------------------------------------------------------------
@@ -611,6 +648,43 @@ async function cliMain(argv) {
     process.stdout.write(text);
     return 0;
   }
+  if (cmd === "merge-relay-disabled") {
+    // node install-lib.mjs merge-relay-disabled --file <path>
+    // Reads the existing file (if any), calls mergeRelayDisabled, writes the
+    // merged text atomically (write <path>.tmp then rename). Exits non-zero
+    // with the error on ok:false. Ensures the parent dir exists so a fresh
+    // box that hasn't yet booted the server gets created as needed.
+    const filePath = flags.file;
+    if (!filePath) {
+      process.stderr.write("merge-relay-disabled: --file <path> required\n");
+      return 2;
+    }
+    const { existsSync, readFileSync, mkdirSync, writeFileSync, renameSync } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    let existing = "";
+    if (existsSync(filePath)) {
+      try {
+        existing = readFileSync(filePath, "utf-8");
+      } catch (e) {
+        process.stderr.write(`merge-relay-disabled: read failed: ${e?.message ?? e}\n`);
+        return 1;
+      }
+    }
+    const res = mergeRelayDisabled(existing);
+    if (!res.ok) {
+      process.stderr.write(`merge-relay-disabled: ${res.error}\n`);
+      return 1;
+    }
+    try {
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(`${filePath}.tmp`, res.text);
+      renameSync(`${filePath}.tmp`, filePath);
+    } catch (e) {
+      process.stderr.write(`merge-relay-disabled: write failed: ${e?.message ?? e}\n`);
+      return 1;
+    }
+    return 0;
+  }
   if (cmd === "render-systemd-unit") {
     // node install-lib.mjs render-systemd-unit --template <path> --placeholder K=V [--placeholder K=V ...]
     // Replaces @@K@@ in the template file with V (verbatim, no quoting).
@@ -636,7 +710,7 @@ async function cliMain(argv) {
   }
   process.stderr.write(
     `install-lib: unknown command ${JSON.stringify(cmd)}\n` +
-      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|render-systemd-unit> [--version X]\n",
+      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|merge-relay-disabled|render-systemd-unit> [--version X] [--file P] [--template P] [--placeholder K=V]\n",
   );
   return 2;
 }
@@ -648,6 +722,8 @@ function parseFlags(args) {
       out.version = args[++i];
     } else if (args[i] === "--template") {
       out.template = args[++i];
+    } else if (args[i] === "--file") {
+      out.file = args[++i];
     } else if (args[i] === "--placeholder") {
       // --placeholder KEY=VAL  (value may itself contain `=`; split on FIRST)
       const kv = args[++i] ?? "";

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,6 +34,9 @@
 #   MANTA_HOME          where code is unpacked (default ~/manta)
 #   MANTA_MOBILE_PORT   server port (default 8787)
 #   MANTA_VERSION       version to fetch when MANTA_TARBALL_URL is unset (default: latest)
+#   MANTA_RELAY=off     disables the relay agent — devices connect directly to the box.
+#                       Only the exact value `off` opts in; unset/anything else = relay
+#                       (default). Read directly in bash, not via resolveConfig.
 #
 # The pure logic (URL/home resolution, health-wait, pairing format, idempotency)
 # lives in scripts/install-lib.mjs and is unit-tested (scripts/install.test.mjs).
@@ -382,6 +385,26 @@ main() {
   # ---------------------------------------------------------------------------
   # 7. manta-server systemd --user unit: substitute placeholders and enable.
   # ---------------------------------------------------------------------------
+  # MANTA_RELAY=off opt-out (BET-174): seed ~/.manta/config.json with
+  # {"relayEnabled":false} BEFORE the server first reads it. The merge CLI
+  # preserves any other keys the user may have set (projects, chatAutoAllow,
+  # …) and refuses to clobber an unparseable config (operator can fix by
+  # hand and re-run). WARN, not die — a bad config is not a blocking error
+  # for the install itself.
+  if [ "${MANTA_RELAY:-}" = "off" ]; then
+    log "MANTA_RELAY=off — seeding relayEnabled:false into $MANTA_AUTH_DIR/config.json"
+    if [ ! -d "$MANTA_AUTH_DIR" ]; then
+      mkdir -p "$MANTA_AUTH_DIR" || warn "could not create $MANTA_AUTH_DIR — merge-relay-disabled will try itself"
+    fi
+    if ! "$NODE" "$LIB" merge-relay-disabled --file "$MANTA_AUTH_DIR/config.json" 2>/tmp/manta-relay-merge.err; then
+      warn "could not update $MANTA_AUTH_DIR/config.json (see /tmp/manta-relay-merge.err)"
+      warn "  to finish opting out of the relay, set \"relayEnabled\": false in that file"
+      warn "  and run: systemctl --user restart manta-server"
+    else
+      ok "relay disabled in config (relayEnabled:false)."
+    fi
+  fi
+
   UNIT_SRC="$MANTA_HOME/scripts/systemd/manta-server.service"
   [ -f "$UNIT_SRC" ] || die "missing systemd template: $UNIT_SRC"
 
@@ -407,6 +430,16 @@ main() {
     warn "It will NOT survive reboot — set up your own supervisor for that."
     ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
     SERVER_MANAGED=nohup
+  fi
+
+  # On a re-run with MANTA_RELAY=off, the server is already up with the old
+  # config — `enable --now` won't restart it. One unconditional restart in
+  # the off-branch picks up the freshly-written relayEnabled:false. Fresh
+  # installs pay one cheap restart.
+  if [ "${MANTA_RELAY:-}" = "off" ] && [ "${SERVER_MANAGED:-}" = "systemd" ]; then
+    log "Restarting manta-server to pick up relayEnabled:false…"
+    systemctl --user restart manta-server.service \
+      || warn "systemctl --user restart manta-server failed — run it manually"
   fi
 
   # ---------------------------------------------------------------------------
@@ -506,21 +539,40 @@ Chat backend (opencode-serve) on http://127.0.0.1:4096:
   systemctl --user status opencode-serve
   systemctl --user restart opencode-serve
   journalctl --user -u opencode-serve -f
+EOF
+
+  # Trailing-pairing block is gated on RELAY_CHECK so the disabled mode
+  # doesn't surface a relay-shaped pair link (BET-174). The Box ID line and
+  # the footer are transport-independent and always printed.
+  case "$RELAY_CHECK" in
+    disabled)
+      cat <<EOF
+
+Relay is disabled — devices connect DIRECTLY to this box.
+manta-server listens on 127.0.0.1:8787 (loopback). Expose it over HTTPS
+with your own ingress (cloudflared, Tailscale, reverse proxy), then:
+  Desktop: enter your https URL + the pairing code above.
+  Phone:   open your https URL in the browser, add to home screen, pair.
+EOF
+      ;;
+    *)
+      cat <<EOF
 
 Your box pairs with devices THROUGH the relay (relay.mantaui.com) — no public
 port on this box, no tunnel, no reverse proxy to set up. The desktop / mobile
 app discovers it via the relay using the box_id below.
 EOF
+      ;;
+  esac
 
   if [ -n "$BOX_ID_DISPLAY" ]; then
     printf '\n  Box ID:        %s\n' "$BOX_ID_DISPLAY"
   fi
 
   # Ready-to-paste pair link (BET-156 §1) — the desktop app parses this directly
-  # via parsePairPayload and routes through the relay's /pair endpoint. Both
-  # BOX_ID_DISPLAY and PAIR_CODE are loaded via tested helpers, so this is safe
-  # even if either is missing (we just print the available half, never crash).
-  if [ -n "${BOX_ID_DISPLAY:-}" ] && [ -n "${PAIR_CODE:-}" ]; then
+  # via parsePairPayload and routes through the relay's /pair endpoint. SKIPPED
+  # in disabled mode (the link is relay-shaped and useless without the relay).
+  if [ "$RELAY_CHECK" != "disabled" ] && [ -n "${BOX_ID_DISPLAY:-}" ] && [ -n "${PAIR_CODE:-}" ]; then
     printf '\n  Pair link:     manta://pair?box=%s&code=%s\n' "$BOX_ID_DISPLAY" "$PAIR_CODE"
     printf '                 (paste into the desktop app, or scan as a QR)\n'
   fi

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -18,6 +18,7 @@ import {
   renderShellConfig,
   stripJsoncLineComments,
   mergeOpencodeConfig,
+  mergeRelayDisabled,
   renderSystemdUnit,
   OPENCODE_CLAUDE_AUTH_PLUGIN,
   DEFAULT_PORT,
@@ -687,6 +688,159 @@ test("mergeOpencodeConfig is null/undefined safe (treated as empty)", () => {
 });
 
 // ----------------------------------------------------------------------------
+// mergeRelayDisabled — sets relayEnabled:false on ~/.manta/config.json
+// (BET-174, mirrors mergeOpencodeConfig's safety contract)
+// ----------------------------------------------------------------------------
+
+test("mergeRelayDisabled on empty input seeds only relayEnabled:false", () => {
+  const a = mergeRelayDisabled("");
+  const b = mergeRelayDisabled("   \n  ");
+  const c = mergeRelayDisabled(undefined);
+  const d = mergeRelayDisabled(null);
+  assert.equal(a.ok, true);
+  assert.equal(b.ok, true);
+  assert.equal(c.ok, true);
+  assert.equal(d.ok, true);
+  for (const r of [a, b, c, d]) {
+    const parsed = JSON.parse(r.text);
+    assert.deepEqual(parsed, { relayEnabled: false });
+  }
+});
+
+test("mergeRelayDisabled preserves unrelated keys", () => {
+  const before = JSON.stringify(
+    { projects: [{ name: "foo" }], chatAutoAllow: true },
+    null,
+    2,
+  );
+  const r = mergeRelayDisabled(before);
+  assert.equal(r.ok, true);
+  const after = JSON.parse(r.text);
+  assert.equal(after.relayEnabled, false);
+  assert.deepEqual(after.projects, [{ name: "foo" }]);
+  assert.equal(after.chatAutoAllow, true);
+});
+
+test("mergeRelayDisabled flips relayEnabled:true to false", () => {
+  const before = JSON.stringify({ relayEnabled: true, something: "else" }, null, 2);
+  const r = mergeRelayDisabled(before);
+  assert.equal(r.ok, true);
+  const after = JSON.parse(r.text);
+  assert.equal(after.relayEnabled, false);
+  assert.equal(after.something, "else");
+});
+
+test("mergeRelayDisabled rejects unparseable text (no clobber)", () => {
+  const r = mergeRelayDisabled("{oops");
+  assert.equal(r.ok, false);
+  assert.equal(r.text, undefined);
+  assert.match(r.error, /not valid JSON/);
+});
+
+test("mergeRelayDisabled rejects non-object JSON roots", () => {
+  const a = mergeRelayDisabled("[1,2]");
+  const b = mergeRelayDisabled('"a string"');
+  const c = mergeRelayDisabled("42");
+  const d = mergeRelayDisabled("null");
+  for (const r of [a, b, c, d]) {
+    assert.equal(r.ok, false);
+    assert.equal(r.text, undefined);
+  }
+  assert.match(a.error, /non-object root/);
+  assert.match(b.error, /non-object root/);
+  assert.match(c.error, /non-object root/);
+  assert.match(d.error, /non-object root/);
+});
+
+test("mergeRelayDisabled is idempotent (output fed back in → identical output)", () => {
+  const initial = JSON.stringify({ projects: [1, 2], chatAutoAllow: false }, null, 2);
+  const first = mergeRelayDisabled(initial);
+  assert.equal(first.ok, true);
+  // Pretty-print is canonical: feeding the first output back yields the same text.
+  const second = mergeRelayDisabled(first.text);
+  assert.equal(second.ok, true);
+  assert.equal(second.text, first.text);
+});
+
+// ----------------------------------------------------------------------------
+// merge-relay-disabled CLI subcommand — round-trip through node
+// ----------------------------------------------------------------------------
+
+test("merge-relay-disabled CLI writes a fresh config when the file is missing", () => {
+  // install.sh runs this CLI on a brand-new box where the server hasn't
+  // started yet → ~/.manta/config.json doesn't exist. The CLI must mkdir
+  // the parent dir and write a default {"relayEnabled":false}.
+  const dir = mkdtempSync(join(tmpdir(), "manta-relay-cli-"));
+  const cfg = join(dir, "config.json");
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} merge-relay-disabled --file ${cfg}`,
+      { stdio: "pipe" },
+    );
+    const written = readFileSync(cfg, "utf-8");
+    assert.deepEqual(JSON.parse(written), { relayEnabled: false });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("merge-relay-disabled CLI preserves existing keys and adds relayEnabled:false", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-relay-cli-"));
+  const cfg = join(dir, "config.json");
+  writeFileSync(
+    cfg,
+    JSON.stringify({ projects: [{ name: "alpha" }], chatAutoAllow: true }, null, 2),
+  );
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} merge-relay-disabled --file ${cfg}`,
+      { stdio: "pipe" },
+    );
+    const written = JSON.parse(readFileSync(cfg, "utf-8"));
+    assert.equal(written.relayEnabled, false);
+    assert.deepEqual(written.projects, [{ name: "alpha" }]);
+    assert.equal(written.chatAutoAllow, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("merge-relay-disabled CLI exits non-zero on garbage JSON and leaves the file untouched", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-relay-cli-"));
+  const cfg = join(dir, "config.json");
+  writeFileSync(cfg, "{oops");
+  try {
+    let err = "";
+    try {
+      execSync(
+        `node ${join(__dirname, "install-lib.mjs")} merge-relay-disabled --file ${cfg}`,
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (e) {
+      err = (e.stderr ?? "") + (e.stdout ?? "");
+    }
+    assert.match(err, /not valid JSON/, "stderr explains the failure");
+    // File must remain exactly as it was — never clobber a config we can't parse.
+    assert.equal(readFileSync(cfg, "utf-8"), "{oops");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("merge-relay-disabled CLI requires --file", () => {
+  let err = "";
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} merge-relay-disabled`,
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  } catch (e) {
+    err = (e.stderr ?? "") + (e.stdout ?? "");
+  }
+  assert.match(err, /--file/);
+});
+
+// ----------------------------------------------------------------------------
 // renderSystemdUnit — placeholder substitution used by install.sh
 // ----------------------------------------------------------------------------
 
@@ -783,6 +937,35 @@ test("install.sh is bash-syntax-clean (bash -n)", () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// BET-174: the final summary heredoc is gated on RELAY_CHECK so the disabled
+// mode (MANTA_RELAY=off) replaces the relay paragraph and skips the
+// manta://pair link. We assert on the script's structural shape — the heredoc
+// branches and the pair-link gate — so a regression that re-inlined the relay
+// paragraph or restored the pair link in disabled mode fails here.
+test("install.sh final summary gates on RELAY_CHECK (BET-174)", () => {
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  // The disabled-mode block must exist verbatim.
+  assert.match(src, /Relay is disabled — devices connect DIRECTLY to this box\./);
+  assert.match(src, /manta-server listens on 127\.0\.0\.1:8787 \(loopback\)/);
+  // The relay paragraph (connected mode) must still exist.
+  assert.match(src, /Your box pairs with devices THROUGH the relay \(relay\.mantaui\.com\)/);
+  // The pair-link printf must be guarded by an `if [ "$RELAY_CHECK" != "disabled" ]`
+  // check on the SAME if-block (BET-174 spec: "skip the manta://pair link").
+  // We slice the relevant window and assert both pieces appear within it.
+  const pairLinkIdx = src.indexOf("manta://pair?box=%s&code=%s");
+  assert.notEqual(pairLinkIdx, -1, "pair-link printf is present in install.sh");
+  const guardIdx = src.lastIndexOf('RELAY_CHECK" != "disabled"', pairLinkIdx);
+  assert.notEqual(
+    guardIdx,
+    -1,
+    'pair-link printf is gated behind RELAY_CHECK != "disabled" (BET-174)',
+  );
+  assert.ok(
+    guardIdx < pairLinkIdx && pairLinkIdx - guardIdx < 200,
+    "guard appears immediately before the pair-link printf",
+  );
 });
 
 // ----------------------------------------------------------------------------

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -103,6 +103,7 @@ const INCLUDE = [
   "package.json",
   "package-lock.json",
   "README.md",
+  "llms-install.md",
 ];
 
 // Parse the nodejs.org SHASUMS256.txt into {filename: sha256}. Tolerates the

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -153,13 +153,24 @@ log "Deploying relay on ${PROD_HOST}…"
 ssh "${PROD_HOST}" 'git -C /opt/manta pull && systemctl restart manta-relay && systemctl is-active manta-relay'
 ok "relay deployed"
 
-# Caddy serves install.sh statically from the web root, NOT from the repo
-# checkout. The git pull above updates /opt/manta/scripts/install.sh but leaves
-# the served copy stale — sync it explicitly (BET-171). Caddy re-reads static
-# files per request, so no reload is needed.
-log "Syncing install.sh into web root (${WEBROOT_DIR}/install.sh)…"
-ssh "${PROD_HOST}" "cp -f /opt/manta/scripts/install.sh ${WEBROOT_DIR}/install.sh"
-ok "install.sh synced to web root"
+# Caddy serves both install.sh and llms-install.md statically from the web
+# root, NOT from the repo checkout. The git pull above updates /opt/manta
+# but leaves the served copies stale — sync them explicitly (BET-171 for
+# install.sh; BET-174 for llms-install.md). Caddy re-reads static files
+# per request, so no reload is needed.
+# Pair format: "<src-under-repo>:<dest-on-prod>". Keep the two files in sync
+# so a single cp + verify loop covers both legs (BET-174).
+WEBROOT_DOCS=(
+  "scripts/install.sh:${WEBROOT_DIR}/install.sh"
+  "llms-install.md:${WEBROOT_DIR}/llms-install.md"
+)
+log "Syncing static docs into web root…"
+for pair in "${WEBROOT_DOCS[@]}"; do
+  src="${pair%%:*}"
+  dest="${pair#*:}"
+  ssh "${PROD_HOST}" "cp -f /opt/manta/${src} ${dest}"
+  ok "${dest##*/} synced to web root"
+done
 
 # --- 5. verify --------------------------------------------------------------
 log "Verifying published URLs (${SITE})…"
@@ -173,7 +184,9 @@ check_200() {
 }
 
 check_200 "${SITE}/releases/manta-${VERSION}-linux-x64.tar.gz"
-check_200 "${SITE}/install.sh"
+for pair in "${WEBROOT_DOCS[@]}"; do
+  check_200 "${SITE}/${pair##*:}"
+done
 
 # Manifest + tarball drift check (BET-171 F4 class). The publish script just
 # pushed both files; we re-fetch the manifest over HTTPS and assert that the
@@ -197,16 +210,20 @@ if [ "$ACTUAL_SHA" != "$SERVED_SHA" ]; then
 fi
 ok "served manifest live (version=${VERSION}, sha=${ACTUAL_SHA})"
 
-# A 200 on install.sh is not enough — a stale file also 200s (BET-171). Verify
-# the served body byte-matches the repo's scripts/install.sh so we know the
-# deploy actually took.
-log "Verifying served install.sh matches repo…"
-LOCAL_INSTALL_SHA="$(sha256sum scripts/install.sh | awk '{print $1}')"
-SERVED_INSTALL_SHA="$(curl -fsSL "${SITE}/install.sh" | sha256sum | awk '{print $1}')"
-if [ "${LOCAL_INSTALL_SHA}" != "${SERVED_INSTALL_SHA}" ]; then
-  die "install.sh mismatch: served=${SERVED_INSTALL_SHA} repo=${LOCAL_INSTALL_SHA} — web-root sync did not take"
-fi
-ok "served install.sh matches repo (${LOCAL_INSTALL_SHA})"
+# A 200 is not enough — a stale file also 200s (BET-171). Verify each
+# web-root doc byte-matches the repo so we know the deploy actually took.
+# Same loop as the sync step above: one block, multiple files (BET-174).
+log "Verifying served docs match repo…"
+for pair in "${WEBROOT_DOCS[@]}"; do
+  src="${pair%%:*}"
+  dest="${pair#*:}"
+  LOCAL_SHA="$(sha256sum "${src}" | awk '{print $1}')"
+  SERVED_SHA="$(curl -fsSL "${SITE}/${dest##*/}" | sha256sum | awk '{print $1}')"
+  if [ "${LOCAL_SHA}" != "${SERVED_SHA}" ]; then
+    die "${dest##*/} mismatch: served=${SERVED_SHA} repo=${LOCAL_SHA} — web-root sync did not take"
+  fi
+  ok "served ${dest##*/} matches repo (${LOCAL_SHA})"
+done
 
 if [ "${#DMGS[@]}" -gt 0 ]; then
   check_200 "${SITE}/downloads/Manta-latest.dmg"


### PR DESCRIPTION
# BET-174 — AI-assisted install via llms-install.md + MANTA_RELAY=off knob

Two install entry points, one mechanism:

- **Human path** (existing): `curl -fsSL https://mantaui.com/install.sh | bash`
- **AI path** (new): user pastes a 3-line prompt into any coding agent. The agent fetches https://mantaui.com/llms-install.md (a hosted, versioned doc) and follows it: 2-question interview, runs the SAME one-liner (with `MANTA_RELAY=off` when self-hosted/direct), verifies, reports.

Replaces the inlined README prompt that had already drifted from install.sh.

**Base:** `origin/main @ 30326f0` (BET-173 already merged; the installer this issue edits is the post-BET-173 self-contained-tarball version).

## Files changed (7)

| File | Change |
|---|---|
| `llms-install.md` | NEW — verbatim agent install doc (safety invariants, interview, preflight, install, verify, failure playbook, report) |
| `README.md` | Replaces the inlined AI-setup prompt with a 3-line pointer to https://mantaui.com/llms-install.md. Heading + closing line kept. |
| `scripts/install-lib.mjs` | New `mergeRelayDisabled(existingText)` pure helper + `merge-relay-disabled --file <path>` CLI subcommand (atomic write, mkdir parent, refuses to clobber unparseable JSON) |
| `scripts/install.sh` | `MANTA_RELAY=off` env knob: 3 edits inside `main()` (merge before systemd unit; restart after enable --now; gated heredoc at end) |
| `scripts/install.test.mjs` | +11 tests: 6 unit (empty/preserve/flip/garbage/non-object/idempotent) + 4 CLI round-trips + 1 structural gate |
| `scripts/release/pack.mjs` | `INCLUDE` adds `llms-install.md` so the release tarball ships it (keeps `~/manta` self-describing) |
| `scripts/release/publish.sh` | Loops the `install.sh` webroot sync + sha256 byte-verify over TWO docs (`install.sh`, `llms-install.md`) — one block per step, two entries per loop |

## What the installer does differently now

`MANTA_RELAY=off` (default unset → relay on):

1. Before the manta-server systemd unit, if `MANTA_RELAY=off`, run the new `merge-relay-disabled` CLI to write `{"relayEnabled":false}` into `~/.manta/config.json` (preserving any other keys). On parse failure → warn (do not die), instruct operator to fix by hand.
2. After `systemctl --user enable --now manta-server`, if `MANTA_RELAY=off` AND systemd-managed, one unconditional restart picks up the freshly-written config (re-runs would otherwise leave the old server running with stale config; fresh installs pay one cheap restart).
3. Final summary heredoc gates on the existing `RELAY_CHECK` value: `disabled` swaps the relay paragraph + skips the `manta://pair` link (it's relay-shaped and useless in direct mode). `connected` (and the legacy `degraded`) is byte-identical to before.

## Verification results

- PR branch (`multica/BET-174-llms-install-md` @ `e33078a`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `669` pass / `0` fail / `0` skip. log sha256: `6f526cc2dc3553126b0095fbb581e37abfb10895d48a3d46e28ba0e6eb42221a`
- Base (`main` @ `30326f0`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `658` pass / `0` fail / `0` skip. log sha256: `aca955476d4ca5b0435e26a8432a140aa66802f043567e4e13864a5e27b36462`
- **Conclusion:** 0 pre-existing failures, 0 new failures. 11 new tests added, all green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Acceptance criteria — status

| Criterion | Status |
|---|---|
| Branch based on post-BET-173 main; no sudo / system-node / npm-on-box anywhere | ✅ base=30326f0 (BET-173 merged); installer is byte-for-byte the v2 self-contained shape |
| `npm run typecheck && npm test` pass; 6+ new `mergeRelayDisabled` tests green | ✅ 669 pass; +11 new tests (6 unit + 4 CLI + 1 structural) |
| `bash -n scripts/install.sh` passes | ✅ |
| `MANTA_RELAY=off`: preserves other keys + sets `relayEnabled:false`; garbage JSON warns + leaves file untouched | ✅ covered by 2 CLI round-trip tests |
| `RELAY_CHECK=disabled` heredoc has direct-mode block + no `manta://pair`; `connected` byte-identical | ✅ structural test `install.sh final summary gates on RELAY_CHECK` |
| `llms-install.md` exists at repo root with verbatim content; README block replaced; no other README changes | ✅ `git diff README.md` is scoped to the AI-assisted setup block |
| publish.sh loops over both files; no duplicated sync/verify blocks | ✅ single `WEBROOT_DOCS` array drives both the sync step and the verify step |

## Cross-cutting notes

- The relay-disabled `mergeRelayDisabled` helper deliberately mirrors `mergeOpencodeConfig`'s safety contract (same `{ok, text}` shape; parse failure returns no text; empty input seeds). Reuses the existing JSON-parse code path; no new deps.
- The CLI subcommand writes atomically (`.tmp` + `rename`) and `mkdir -p` the parent dir, so a fresh box that has never booted the server still gets a valid config — `~/.manta/` is created on demand.
- `MANTA_RELAY=off` is read directly in bash (`[ "${MANTA_RELAY:-}" = "off" ]`), NOT routed through `resolveConfig` / `renderShellConfig` — per spec, it's behavior (disable a subsystem), not path/URL config.
- The existing `RELAY_CHECK` cases (`connected|disabled|degraded`) are unchanged; the heredoc just branches on `disabled` for the visible difference. `degraded` keeps the relay paragraph as before.
