### PR TITLE
BET-178 Phase 1: First-run setup screen (server URL + code entry)

### DIFF
--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   AuthRequiredError,
+  ServerNotConfiguredError,
   authHeaders,
   withTokenParam,
   TOKEN_KEY,
+  serverBase,
   httpApi,
 } from "./httpApi.js";
 
@@ -140,6 +142,106 @@ describe("AuthRequiredError", () => {
   it("accepts a custom message and defaults otherwise", () => {
     expect(new AuthRequiredError().message).toBe("authentication required");
     expect(new AuthRequiredError("stale token").message).toBe("stale token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ServerNotConfiguredError — distinguishable typed "no server URL" thrown by
+// serverBase() on first-run (Capacitor iOS shell, no localStorage["manta_server"]
+// yet). Same shape as AuthRequiredError so MobileApp uses the same defensive
+// `instanceof || name ===` pattern.
+// ---------------------------------------------------------------------------
+
+describe("ServerNotConfiguredError", () => {
+  it("is an Error subclass identifiable via instanceof", () => {
+    const e = new ServerNotConfiguredError();
+    expect(e).toBeInstanceOf(Error);
+    expect(e).toBeInstanceOf(ServerNotConfiguredError);
+  });
+
+  it("carries a stable name for UI routing (cross-realm safe)", () => {
+    const e = new ServerNotConfiguredError();
+    expect(e.name).toBe("ServerNotConfiguredError");
+    expect(e.status).toBe(0);
+  });
+
+  it("accepts a custom message and defaults otherwise", () => {
+    expect(new ServerNotConfiguredError().message).toBe("server not configured");
+    expect(new ServerNotConfiguredError("No server configured.").message).toBe(
+      "No server configured.",
+    );
+  });
+
+  it("is distinguishable from AuthRequiredError", () => {
+    const a = new AuthRequiredError();
+    const s = new ServerNotConfiguredError();
+    expect(s).not.toBeInstanceOf(AuthRequiredError);
+    expect(a).not.toBeInstanceOf(ServerNotConfiguredError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serverBase — resolves the base URL from localStorage / same-origin / throws
+// the typed error when nothing is configured (Capacitor first-run).
+// ---------------------------------------------------------------------------
+
+describe("serverBase", () => {
+  // serverBase() reads `window.location` (not the bare `location` global), so we
+  // re-stub `window` with a `.location` field for these tests. The default
+  // beforeEach mock has no location, which is fine for tests that never reach
+  // the same-origin fallback branch (subscription-only paths).
+  const stubWindowLocation = (loc: { protocol: string; hostname: string; origin: string }) => {
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      location: loc,
+    });
+  };
+
+  it("prefers localStorage[\"manta_server\"] (mobile Settings override)", () => {
+    mockLocalStorage["manta_server"] = "http://my-box.local:8787";
+    expect(serverBase()).toBe("http://my-box.local:8787");
+  });
+
+  it("strips trailing slashes from the localStorage value", () => {
+    mockLocalStorage["manta_server"] = "http://my-box:8787///";
+    expect(serverBase()).toBe("http://my-box:8787");
+  });
+
+  it("falls back to same-origin for an https page on a non-local host", () => {
+    delete mockLocalStorage["manta_server"];
+    stubWindowLocation({
+      protocol: "https:",
+      hostname: "relay.example.com",
+      origin: "https://relay.example.com",
+    });
+    expect(serverBase()).toBe("https://relay.example.com");
+  });
+
+  it("throws ServerNotConfiguredError on Capacitor localhost (no override)", () => {
+    delete mockLocalStorage["manta_server"];
+    stubWindowLocation({
+      protocol: "http:",
+      hostname: "localhost",
+      origin: "http://localhost",
+    });
+    expect(() => serverBase()).toThrow(ServerNotConfiguredError);
+  });
+
+  it("ServerNotConfiguredError carries the default message", () => {
+    delete mockLocalStorage["manta_server"];
+    stubWindowLocation({
+      protocol: "http:",
+      hostname: "localhost",
+      origin: "http://localhost",
+    });
+    try {
+      serverBase();
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toBe("No server configured.");
+      expect((e as Error).name).toBe("ServerNotConfiguredError");
+    }
   });
 });
 

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -28,8 +28,10 @@ import { shouldForceReconnect } from "../chatUtils";
 //      location.origin carries the page's own scheme, so no protocol skew.
 //   3. Otherwise (Capacitor http://localhost, file:) → no fallback. The
 //      mobile/web client is currently descoped from v1; fail fast with a
-//      clear error so a tester knows to set localStorage["manta_server"]
-//      rather than silently hitting some hardcoded box.
+//      typed ServerNotConfiguredError so MobileApp's first-run setup screen
+//      can render and collect serverUrl + pairing code from the user.
+//      (User-facing copy lives in SetupScreen.tsx — the UI owns it now, not
+//      the error itself.)
 // ---------------------------------------------------------------------------
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", ""]);
@@ -41,10 +43,7 @@ export function serverBase(): string {
   if ((protocol === "https:" || protocol === "http:") && !LOCAL_HOSTS.has(hostname)) {
     return origin.replace(/\/+$/, "");
   }
-  throw new Error(
-    "bui mobile/web server not configured. Set localStorage['manta_server'] " +
-    "to your server URL (e.g. http://192.168.1.10:8787) and reload.",
-  );
+  throw new ServerNotConfiguredError("No server configured.");
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +81,23 @@ export class AuthRequiredError extends Error {
     this.name = "AuthRequiredError";
     // Restore prototype chain for `instanceof` under transpiled ES5 targets.
     Object.setPrototypeOf(this, AuthRequiredError.prototype);
+  }
+}
+
+/**
+ * Thrown by serverBase() when no server URL can be resolved: neither
+ * localStorage["manta_server"] nor a same-origin http(s) page. MobileApp
+ * catches this on first-run bootstrap and renders SetupScreen so the user
+ * can supply the URL + pairing code. Same shape as AuthRequiredError so the
+ * UI can use the same defensive `instanceof || name ===` pattern.
+ */
+export class ServerNotConfiguredError extends Error {
+  readonly status = 0 as const;
+  constructor(message = "server not configured") {
+    super(message);
+    this.name = "ServerNotConfiguredError";
+    // Restore prototype chain for `instanceof` under transpiled ES5 targets.
+    Object.setPrototypeOf(this, ServerNotConfiguredError.prototype);
   }
 }
 

--- a/src/renderer/mobile/MobileApp.tsx
+++ b/src/renderer/mobile/MobileApp.tsx
@@ -4,8 +4,9 @@ import { SessionListScreen } from "./SessionListScreen";
 import { SessionScreen } from "./SessionScreen";
 import { MobileSettings } from "./MobileSettings";
 import { PairingScreen } from "./PairingScreen";
+import { SetupScreen } from "./SetupScreen";
 import { reportFocus } from "./push";
-import { AuthRequiredError } from "../api/httpApi";
+import { AuthRequiredError, ServerNotConfiguredError } from "../api/httpApi";
 
 type Nav =
   | { screen: "list" }
@@ -27,6 +28,12 @@ export function MobileApp() {
   // instead of the session list — this IS the re-pair path too, since a rotated
   // token 401s exactly like a fresh browser.
   const [authRequired, setAuthRequired] = useState(false);
+  // True on first-run when serverBase() threw ServerNotConfiguredError — no
+  // localStorage["manta_server"] AND no same-origin http(s) page (the iOS
+  // Capacitor shell's `capacitor://localhost` falls in this branch). Routes
+  // to SetupScreen so the user can supply the URL + pairing code, instead of
+  // hitting the dead-end Retry screen.
+  const [setupRequired, setSetupRequired] = useState(false);
 
   // The opencode session id of the on-screen chat (null on list/settings or a
   // terminal window). Drives push focus-suppression: the server skips the
@@ -44,6 +51,19 @@ export function MobileApp() {
   const doRefresh = () => {
     setBootError(null);
     refresh().catch((e: unknown) => {
+      // First-run: serverBase() couldn't resolve a URL (no localStorage
+      // override AND no same-origin http(s) page). Route to SetupScreen so
+      // the user can supply the URL + pairing code instead of hitting the
+      // dead-end Retry screen. Same defensive `instanceof || name ===` pattern
+      // we use for AuthRequiredError below — `name` covers cross-realm throws
+      // where instanceof can fail.
+      if (
+        e instanceof ServerNotConfiguredError ||
+        (e as { name?: string })?.name === "ServerNotConfiguredError"
+      ) {
+        setSetupRequired(true);
+        return;
+      }
       // A 401 from the box means we're unpaired (or the stored token was
       // revoked/rotated) — route to the pairing screen instead of the generic
       // "could not reach the server" error, which offers only a dead Retry.
@@ -53,6 +73,15 @@ export function MobileApp() {
       }
       setBootError(e instanceof Error ? e.message : "Could not reach the server.");
     });
+  };
+
+  // Called by SetupScreen after a successful claim (serverUrl persisted to
+  // localStorage["manta_server"], token persisted to localStorage["manta_token"]
+  // by claimAgainst). Drop the gate and re-run the bootstrap so the session
+  // list loads with the now-resolved serverBase() + now-valid Bearer credential.
+  const onConnected = () => {
+    setSetupRequired(false);
+    doRefresh();
   };
 
   // Called by PairingScreen after a successful claim (token already persisted).
@@ -287,6 +316,10 @@ export function MobileApp() {
     const t = e.changedTouches[0];
     if (t.clientX - s.x > 60 && Math.abs(t.clientY - s.y) < 50) goList();
   };
+
+  if (setupRequired) {
+    return <SetupScreen onConnected={onConnected} />;
+  }
 
   if (authRequired) {
     return <PairingScreen onPaired={onPaired} />;

--- a/src/renderer/mobile/SetupScreen.tsx
+++ b/src/renderer/mobile/SetupScreen.tsx
@@ -1,0 +1,166 @@
+import { useRef, useState } from "react";
+import { normalizeCode } from "../../shared/claim.mjs";
+import {
+  normalizeServerUrl,
+  isValidServerUrl,
+  canConnect,
+} from "../pairStepLogic";
+
+type Props = {
+  // Called after a successful claim (token already persisted by
+  // httpApi.authClaim). MobileApp clears setupRequired and re-runs its
+  // bootstrap refresh so the session list loads with the now-valid
+  // Bearer credential AND the now-resolved serverBase().
+  onConnected: () => void;
+};
+
+/**
+ * First-run setup screen for the mobile client (BET-177 Phase 1). Shown by
+ * MobileApp when serverBase() throws ServerNotConfiguredError — the production
+ * dead-end on a fresh iOS Capacitor install (the shell can't fall back to
+ * `capacitor://localhost` so the user would otherwise see a Retry loop
+ * forever). Replaces that Retry loop with the URL + pairing-code form so
+ * the user can resolve the server on first launch.
+ *
+ * Mirrors PairingScreen.tsx's wrapper/column/input/button class strings
+ * verbatim (copy, not new) so the two screens look identical once the user
+ * has paired.
+ *
+ * Phase 2 will deliver the QR scan + `manta://` deep-link half of the flow
+ * on top of this stage's screen; this stage's UX copy already references
+ * QR scanning so Phase 2 can land cleanly. There is no "paste a pair link"
+ * field on this screen — that's a desktop-only affordance (BET-156) and
+ * would mislead the mobile user.
+ *
+ * All non-React logic (URL normalization, the submit gate, the 6-digit
+ * contract, HTTP-outcome classification) is pure + unit-tested in
+ * pairStepLogic.ts + src/shared/claim.mjs + pairingLogic.ts — this file is
+ * just the wiring.
+ */
+export function SetupScreen({ onConnected }: Props) {
+  const [serverUrl, setServerUrl] = useState("");
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const codeRef = useRef<HTMLInputElement>(null);
+
+  const submit = async () => {
+    // Mirror the pure gate so an Enter keypress can't fire from a non-ready
+    // state (the button is also disabled, but Enter bypasses that).
+    if (!canConnect({ serverUrl, code, submitting })) return;
+    setSubmitting(true);
+    setError(null);
+    // httpApi.authClaim POSTs <serverUrl>/auth/claim, classifies the outcome
+    // via the shared classifier, and persists the returned box_token to
+    // localStorage["manta_token"] on success (see claimAgainst in httpApi.ts).
+    const result = await window.api.authClaim({
+      serverUrl: normalizeServerUrl(serverUrl),
+      code,
+    });
+    if (result.ok) {
+      // Token is already persisted by claimAgainst — do NOT re-persist here.
+      // Persist the server URL so serverBase() resolves on the next refresh.
+      localStorage.setItem("manta_server", normalizeServerUrl(serverUrl));
+      setSubmitting(false);
+      onConnected();
+      return;
+    }
+    // Failure: show the classified message, keep the fields so the user can
+    // fix them, and re-focus the code input.
+    setSubmitting(false);
+    setError(result.message);
+    codeRef.current?.focus();
+  };
+
+  const onSubmitForm = (e: React.FormEvent) => {
+    e.preventDefault();
+    void submit();
+  };
+
+  const urlLooksBad =
+    serverUrl.trim() !== "" && !isValidServerUrl(serverUrl);
+  const disabled = !canConnect({ serverUrl, code, submitting });
+
+  return (
+    <div className="mobile">
+      <div className="h-full flex flex-col items-center justify-center gap-6 px-8 text-center">
+        <div className="flex flex-col gap-2">
+          <div className="text-text text-lg font-medium">Connect to your server</div>
+          <div className="text-text-muted text-sm">
+            Run <code>bui pair</code> on your server, then scan the QR code with
+            your iPhone camera — or enter the details below.
+          </div>
+        </div>
+
+        <form onSubmit={onSubmitForm} className="flex flex-col items-center gap-4 w-full max-w-xs">
+          <div className="flex flex-col gap-1.5 w-full">
+            <label
+              htmlFor="setup-server-url"
+              className="text-xs font-medium text-text-muted self-start"
+            >
+              Server URL
+            </label>
+            <input
+              id="setup-server-url"
+              type="text"
+              inputMode="url"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="http://your-box:8787"
+              disabled={submitting}
+              value={serverUrl}
+              onChange={(e) => {
+                setServerUrl(e.target.value);
+                setError(null);
+              }}
+              aria-invalid={urlLooksBad}
+              className="w-full rounded-lg bg-bg-soft text-text placeholder:text-text-faint border border-border px-4 py-3 outline-none focus:border-accent disabled:opacity-60"
+              style={{ borderColor: urlLooksBad ? "#FF7A88" : undefined }}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5 w-full">
+            <label
+              htmlFor="setup-code"
+              className="text-xs font-medium text-text-muted self-start"
+            >
+              Pairing code
+            </label>
+            <input
+              id="setup-code"
+              ref={codeRef}
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              aria-label="Pairing code"
+              aria-invalid={error != null}
+              placeholder="000000"
+              maxLength={6}
+              disabled={submitting}
+              value={code}
+              onChange={(e) => {
+                setCode(normalizeCode(e.target.value));
+                setError(null);
+              }}
+              className="w-full text-center tracking-[0.4em] text-2xl rounded-lg bg-bg-soft text-text placeholder:text-text-faint border border-border px-4 py-3 outline-none focus:border-accent disabled:opacity-60"
+            />
+          </div>
+
+          {error && (
+            <div role="alert" className="text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={disabled}
+            className="mobile-tap w-full px-5 rounded-lg bg-accent-soft text-white disabled:opacity-40"
+          >
+            {submitting ? "Connecting…" : "Connect"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 1 of BET-177 (iOS-native app). Fixes the production dead-end: on first launch the iOS Capacitor shell cannot build any request because `serverBase()` cannot fall back to `capacitor://localhost`, so the user sees "Retry" forever. This PR adds a typed `ServerNotConfiguredError` and a setup screen that mirrors desktop `PairStep.tsx`'s form (URL + code) minus the pair-link field.

## Files changed

4 files:
- `src/renderer/api/httpApi.ts` — adds `ServerNotConfiguredError`; `serverBase()` throws it instead of generic `Error`
- `src/renderer/api/httpApi.test.ts` — 9 new tests for the error class + `serverBase()` resolution branches
- `src/renderer/mobile/MobileApp.tsx` — adds `setupRequired` state + render branch (above the existing `authRequired` branch)
- `src/renderer/mobile/SetupScreen.tsx` (NEW) — mirrors `PairingScreen.tsx`'s wrapper/column/button class strings verbatim; reuses `pairStepLogic` + `shared/claim.mjs` helpers; submits via `window.api.authClaim`

## What this PR does NOT do (per scope)

- No QR scan or `manta://` deep-link handling — that's Phase 2.
- No QR emitters in `PairingQR.tsx` / `scripts/install-lib.mjs` — Phase 2.
- No native lifecycle / push / Xcode Cloud work — Phases 3/4/5.
- No "paste a pair link" field on this screen (the desktop-only BET-156 affordance would mislead mobile users).
- No touch on `MobileSettings.tsx` (its existing server-URL field is unrelated).

## Reuse over reimplementation

- `normalizeServerUrl` / `isValidServerUrl` / `canConnect` from `src/renderer/pairStepLogic` (already pure + tested).
- `normalizeCode` from `src/shared/claim.mjs`.
- `httpApi.authClaim` / `claimAgainst` already POSTs `<serverUrl>/auth/claim`, classifies via the shared classifier, and persists the token to `localStorage["manta_token"]` on success. We do NOT reimplement.
- `pairingReducer` is intentionally untouched — it stays single-field for the 401 re-pair screen.

## Verification results

- PR branch (`multica/BET-178-first-run-setup-screen` @ `aa99dcd`):
  - typecheck: exit 0. No errors. (no log captured — clean output)
  - test: 669 pass / 0 fail / 0 skip (full suite incl. `vitest run` + `node --test`)
- Base (`main` @ `9fa1bc2`):
  - typecheck: clean before changes
  - test: clean before changes
- **Conclusion:** 0 new failures, 0 resolved failures — pure additive change.

**Base: origin/main @ 9fa1bc2**