### PR TITLE
BET-181: APNs native push (iOS Capacitor delivery leg)

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,8 @@
     "@capacitor/android": "^6.2.1",
     "@capacitor/app": "^6.0.3",
     "@capacitor/core": "^6.2.1",
-    "@capacitor/ios": "^6.2.1"
+    "@capacitor/ios": "^6.2.1",
+    "@capacitor/push-notifications": "^6.0.3"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -882,6 +882,15 @@ export const httpApi: Api = {
   webhookList: (sessionId) => rpc(IPC.webhookList, sessionId),
   webhookDelete: (id) => rpc(IPC.webhookDelete, id),
 
+  // -- APNs native-push registration (BET-181) --
+  // iOS Capacitor app registers its APNs device token via the standard 6-site
+  // pattern; httpApi.ts is the desktop-in-http-mode + mobile/web leg. Server
+  // upserts into apns-tokens.json via push.addApnsToken (de-dupes on token).
+  // The /rpc/push:register-apns channel is a peer of the /push/register-apns
+  // HTTP route (curl-friendly); both call the same store function, so the
+  // registry stays single-source-of-truth regardless of transport.
+  pushRegisterApns: (token) => rpc(IPC.pushRegisterApns, token),
+
   // -- auto-update (desktop-only; no-op in http/mobile mode) --
   autoUpdateDownload: () => Promise.resolve(),
   autoUpdateInstall: () => Promise.resolve(),

--- a/src/renderer/mobile/MobileApp.tsx
+++ b/src/renderer/mobile/MobileApp.tsx
@@ -6,6 +6,7 @@ import { MobileSettings } from "./MobileSettings";
 import { PairingScreen } from "./PairingScreen";
 import { SetupScreen } from "./SetupScreen";
 import { reportFocus } from "./push";
+import { registerApns, NATIVE_NOTIF_TAP_EVENT_NAME } from "./nativePush";
 import { AuthRequiredError, ServerNotConfiguredError } from "../api/httpApi";
 import { getCapacitorApp, handlePairUrl } from "./deepLink";
 
@@ -272,6 +273,38 @@ export function MobileApp() {
     };
     navigator.serviceWorker.addEventListener("message", onMsg);
     return () => navigator.serviceWorker.removeEventListener("message", onMsg);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Native APNs push registration (BET-181). Runs once after projects +
+  // auth are settled; the request-permission flow wants a fresh user
+  // gesture but on iOS the app launch is treated as one. No-op on the
+  // frozen PWA build (isNativePushAvailable returns false there).
+  useEffect(() => {
+    registerApns().catch((e: unknown) =>
+      console.warn("[nativePush] registerApns failed:", e),
+    );
+  }, []);
+
+  // Native APNs tap routing — Capacitor dispatches a CustomEvent with the
+  // sessionId in `detail` (no service worker involved). Reuse the same
+  // `pendingNotif` ref + resolveSessionOwner path the Web Push SW message
+  // uses (the single source of truth for "navigate from a notification").
+  useEffect(() => {
+    const onNativeTap = (e: Event) => {
+      const detail = (e as CustomEvent<{ sessionId?: string }>).detail;
+      const sid = typeof detail?.sessionId === "string" ? detail.sessionId : null;
+      if (!sid) return;
+      pendingNotif.current = sid;
+      const owner = resolveSessionOwner(useStore.getState().projects, sid);
+      if (owner) {
+        pendingNotif.current = null;
+        openSessionForNotif(owner.tmuxSession, owner.windowIndex, sid);
+      }
+    };
+    window.addEventListener(NATIVE_NOTIF_TAP_EVENT_NAME, onNativeTap);
+    return () =>
+      window.removeEventListener(NATIVE_NOTIF_TAP_EVENT_NAME, onNativeTap);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/renderer/mobile/nativePush.ts
+++ b/src/renderer/mobile/nativePush.ts
@@ -1,0 +1,176 @@
+// nativePush.ts — APNs native-push registration for the iOS Capacitor app
+// (BET-181, §3.3). Supplementary to push.ts (Web Push VAPID for the frozen
+// PWA); NOT a replacement. The frozen PWA build never has Capacitor, so
+// the Web Push leg stays untouched. Native app uses Capacitor's
+// @capacitor/push-notifications plugin to get an APNs device token,
+// registers it with the box server (POST /push/register-apns via the
+// standard 6-site pattern), and routes a tapped notification through the
+// EXISTING pendingNotif ref in MobileApp.tsx — same path the Web Push
+// service-worker message handler uses, so deep-link resolution is shared.
+//
+// All Web Push logic is unchanged.
+
+// Loose, locally-declared shape of the @capacitor/push-notifications plugin
+// surface. We declare just what we use so the file stays typecheck-clean
+// without taking a hard runtime dependency on the plugin's types (the npm
+// dep is declared in mobile/package.json but the web bundler doesn't
+// resolve it — Capacitor injects the plugin at runtime via the native
+// bridge). Kept in this file so the surface is auditable.
+interface PushRegistration {
+  value: string; // the APNs device token (hex string)
+}
+interface PushNotificationData {
+  sessionId?: string;
+  [k: string]: unknown;
+}
+interface PushNotification {
+  title?: string;
+  body?: string;
+  data?: PushNotificationData;
+  // iOS exposes the actionId of any tapped notification action button on
+  // the SAME payload (no separate "action" field); default tap = "default".
+  actionId?: string;
+}
+interface PushActionPerformedEvent {
+  notification: PushNotification;
+  actionId?: string; // iOS only — defaults to "default" for body taps
+}
+interface PushNotificationsPlugin {
+  requestPermissions(): Promise<{ receive: string }>;
+  register(): Promise<{ registrationId: string }>;
+  addListener(
+    event: "registration",
+    cb: (token: PushRegistration) => void,
+  ): Promise<unknown> | unknown;
+  addListener(
+    event: "pushNotificationActionPerformed",
+    cb: (event: PushActionPerformedEvent) => void,
+  ): Promise<unknown> | unknown;
+}
+
+// Capacitor injects `window.Capacitor?.Plugins?.PushNotifications` at runtime
+// on the native iOS / Android shell. The webview build doesn't have it, so
+// every entry point here is feature-guarded — the function silently no-ops
+// on a vanilla browser / frozen PWA build.
+declare global {
+  interface Window {
+    Capacitor?: {
+      Plugins?: {
+        PushNotifications?: PushNotificationsPlugin;
+      };
+    };
+  }
+}
+
+/** True when the @capacitor/push-notifications plugin is available on the
+ *  window — i.e. this app is running inside the native Capacitor shell. */
+export function isNativePushAvailable(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    !!window.Capacitor?.Plugins?.PushNotifications
+  );
+}
+
+/** Shared ref for the in-process Capacitor→MobileApp notification tap
+ *  bridge. MobileApp watches `manta-native-notif-tap` events on window
+ *  and routes them into the same `pendingNotif` mechanism the Web Push
+ *  service-worker message handler uses. Dispatching as a CustomEvent
+ *  (not a service-worker MessageEvent) is correct here: the native app
+ *  has no service worker, and a CustomEvent doesn't need one. */
+const NATIVE_NOTIF_TAP_EVENT = "manta-native-notif-tap";
+
+/** Extract sessionId from an APNs push payload (set by the server via
+ *  push.mjs buildApnsPayload). Best-effort: any non-string / missing
+ *  field resolves to null so the listener can early-out. */
+function extractSessionId(payload: PushNotification): string | null {
+  const sid = payload?.data?.sessionId;
+  return typeof sid === "string" && sid ? sid : null;
+}
+
+/**
+ * Register for APNs native push on the Capacitor app. Steps:
+ *   1. requestPermissions()  (must be from a user gesture on iOS)
+ *   2. register() → fires the `registration` event with the device token
+ *   3. POST the token to /push/register-apns via window.api.pushRegisterApns
+ *   4. subscribe to `pushNotificationActionPerformed`; route the tap's
+ *      sessionId through the same pendingNotif mechanism MobileApp uses
+ *      for the Web Push deep-link (see MobileApp.tsx openSessionForNotif).
+ *
+ * All steps are best-effort: a permission denial or a server error is
+ * logged, never thrown (the app continues to work; the user simply
+ * doesn't get backgrounded pushes). Re-runs are safe (the server's
+ * addApnsToken de-dupes on the token value).
+ */
+export async function registerApns(): Promise<{ ok: boolean; reason?: string }> {
+  if (!isNativePushAvailable()) return { ok: false, reason: "unavailable" };
+  const plugin = window.Capacitor!.Plugins!.PushNotifications!;
+
+  // 1. Permission — best-effort.
+  let perm: { receive: string };
+  try {
+    perm = await plugin.requestPermissions();
+  } catch (e) {
+    console.warn("[nativePush] requestPermissions failed:", e);
+    return { ok: false, reason: "permission-failed" };
+  }
+  if (perm?.receive !== "granted") {
+    return { ok: false, reason: "permission-denied" };
+  }
+
+  // 2. Token registration. Listeners added BEFORE register() so we don't
+  //    miss the (fire-once-then-silent) registration event on iOS.
+  await plugin.addListener("registration", (token) => {
+    const v = typeof token?.value === "string" ? token.value : "";
+    if (!v) {
+      console.warn("[nativePush] registration event with empty token");
+      return;
+    }
+    void uploadToken(v);
+  });
+
+  await plugin.addListener("pushNotificationActionPerformed", (event) => {
+    const sid = extractSessionId(event?.notification);
+    if (!sid) {
+      console.warn("[nativePush] tap without sessionId; ignoring");
+      return;
+    }
+    // Route through the SAME mechanism MobileApp uses for the Web Push
+    // service-worker deep-link. The pendingNotif ref + resolveSessionOwner
+    // + openSessionForNotif dance is the single source of truth for
+    // "navigate to a session because of a notification tap". We don't add
+    // a parallel resolution path.
+    window.dispatchEvent(
+      new CustomEvent(NATIVE_NOTIF_TAP_EVENT, { detail: { sessionId: sid } }),
+    );
+  });
+
+  // 3. Trigger registration.
+  try {
+    await plugin.register();
+  } catch (e) {
+    console.warn("[nativePush] register() failed:", e);
+    return { ok: false, reason: "register-failed" };
+  }
+  return { ok: true };
+}
+
+/** POST the APNs device token to the box (6-site pattern →
+ *  /rpc/push:register-apns → push.addApnsToken). Never throws — failures
+ *  are logged and swallowed. */
+async function uploadToken(token: string): Promise<void> {
+  const api = (window as Window & { api?: { pushRegisterApns?: (t: string) => Promise<{ ok: boolean; count: number }> } }).api;
+  if (!api?.pushRegisterApns) {
+    console.warn("[nativePush] window.api.pushRegisterApns not available");
+    return;
+  }
+  try {
+    const res = await api.pushRegisterApns(token);
+    console.log(`[nativePush] registered token count=${res?.count ?? "?"}`);
+  } catch (e) {
+    console.warn("[nativePush] pushRegisterApns failed:", e);
+  }
+}
+
+/** Exported for MobileApp to wire its own listener. Internal — not part
+ *  of the public API; only MobileApp should consume this event name. */
+export const NATIVE_NOTIF_TAP_EVENT_NAME = NATIVE_NOTIF_TAP_EVENT;

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -75,6 +75,7 @@ function defaultApiImpl(): Record<string, unknown> {
     opencodeAbort: () => Promise.resolve(),
     scheduleList: () => Promise.resolve([]),
     scheduleDelete: () => Promise.resolve(),
+    pushRegisterApns: () => Promise.resolve({ ok: true, count: 0 }),
     secretsList: () => Promise.resolve([]),
     secretsSet: () => Promise.resolve({ ok: true }),
     secretsDelete: () => Promise.resolve(),

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -190,6 +190,7 @@ rpcHandlers = buildHandlers({
   bus,
   local,
   authPair: () => authEngine.pair(),
+  push,
   serverVersion: SERVER_VERSION,
 });
 
@@ -1137,6 +1138,11 @@ const server = createServer(async (req, res) => {
   //                        the session the user is actively viewing)
   // POST /push/desktop-presence body = { visible }  (desktop Electron heartbeat;
   //                        suppress mobile "done" while active on desktop)
+  // POST /push/register-apns body = { token }  (BET-181: iOS Capacitor app
+  //                        registers its APNs device token. Same Bearer gate
+  //                        as every other /push/* route. Server-side mirror of
+  //                        the /rpc/push:register-apns IPC channel so curl /
+  //                        integration tests can drive it without a renderer.)
   if (req.method === "GET" && path === "/push/vapid") {
     try {
       const key = await push.getVapidPublic();
@@ -1180,6 +1186,18 @@ const server = createServer(async (req, res) => {
           sessionId: body?.sessionId,
         });
         result = { ok: true };
+      } else if (path === "/push/register-apns") {
+        // iOS Capacitor native push registration (BET-181 §3.2). The
+        // renderer calls this via window.api.pushRegisterApns(token) (6-site
+        // pattern → /rpc/push:register-apns → rpc.mjs dispatch → push.addApnsToken),
+        // but we expose the bare HTTP route here too so curl tests and
+        // future non-Capacitor clients can register a token directly. Same
+        // addApnsToken path either way — single source of truth.
+        if (typeof body?.token !== "string" || !body.token) {
+          respondJson(res, 400, { error: "token is required" });
+          return;
+        }
+        result = await push.addApnsToken(body.token);
       } else {
         respondJson(res, 404, { error: "not found" });
         return;

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -289,6 +289,32 @@ function escapeRegex(s) {
 }
 
 // ============================================================
+// APNs config (read from ~/.manta/config.json under the `apns` key)
+// ============================================================
+//
+// Shape: { teamId, keyId, p8Path, bundleId }. When present, push.mjs enables
+// the APNs native-push delivery leg (iOS-only, supplementary to the Web Push
+// VAPID leg). Absent or malformed block = APNs disabled; push.mjs fans out
+// to Web Push only — no errors, no behavior change for non-iOS installs.
+//
+// The block is already present on the production box (human-installed at
+// setup time, see BET-181 §3.1). Async — reads the same JSON file as
+// getConfig() but bypasses the cached snapshot so a runtime config write
+// (rare; human-only) is picked up on the next push without a server restart.
+
+export async function apnsConfig() {
+  const cfg = await getConfig();
+  const a = cfg?.apns;
+  if (!a || typeof a !== "object") return null;
+  const { teamId, keyId, p8Path, bundleId } = a;
+  if (typeof teamId !== "string" || !teamId) return null;
+  if (typeof keyId !== "string" || !keyId) return null;
+  if (typeof p8Path !== "string" || !p8Path) return null;
+  if (typeof bundleId !== "string" || !bundleId) return null;
+  return { teamId, keyId, p8Path, bundleId };
+}
+
+// ============================================================
 // STUBS — desktop-only concepts with no server-side equivalent
 // ============================================================
 

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -1,4 +1,6 @@
-// push.mjs — Web Push (VAPID) for the mobile PWA.
+// push.mjs — Web Push (VAPID) for the mobile PWA + APNs native push for the
+// iOS Capacitor app (BET-181, supplementary delivery leg; the Web Push
+// VAPID leg stays for the frozen PWA build).
 //
 // Sends notifications to home-screen-installed PWAs for the events a user
 // can't otherwise see when the app is backgrounded/closed:
@@ -17,10 +19,19 @@
 // in the service worker. Focus-suppression for the "done" case relies on the
 // client POSTing /push/focus on visibility / session changes.
 //
+// APNs is the second delivery leg for native iOS Capacitor apps: when the
+// server's `apns` config block is present (~/.manta/config.json → apns:
+// {teamId, keyId, p8Path, bundleId}), push.mjs fans out to every registered
+// device token alongside the Web Push subscription send. Same routing
+// decisions, same suppression. 410 / BadDeviceToken / Unregistered prune
+// the token; a stale or rotated token never makes a successful delivery
+// without first being re-registered by the app.
+//
 // State persists under ~/.manta/ alongside config.json:
 //   vapid.json      — generated VAPID keypair (stable across restarts so
 //                     existing subscriptions keep working)
 //   push-subs.json  — array of PushSubscription JSON objects
+//   apns-tokens.json — array of { token, registeredAt } objects (kind:"apns")
 //
 // The pure classifier `classifyPushEvent` is exported for unit tests; the
 // stateful glue (busy-set tracking, focus, subscription IO, actual send)
@@ -29,14 +40,24 @@
 import webpush from "web-push";
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { createSign } from "node:crypto";
+import http2 from "node:http2";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { STATE_DIRNAME } from "../shared/paths.mjs";
 import * as tmux from "./tmux.mjs";
+import * as local from "./local.mjs";
 
 const DIR = join(homedir(), STATE_DIRNAME);
 const VAPID_PATH = join(DIR, "vapid.json");
 const SUBS_PATH = join(DIR, "push-subs.json");
+const APNS_TOKENS_PATH = join(DIR, "apns-tokens.json");
+
+// Apple's apns-topic header = the bundleId. The APNs spec requires the JWT
+// to be cached for 20–60 minutes; we rotate at 45 min (mid-range) to balance
+// JWT sign cost against a clock skew with Apple's clock on the other end.
+const APNS_JWT_TTL_SEC = 45 * 60;
 
 // VAPID `subject` must be a mailto: or https: URI identifying the sender.
 const VAPID_SUBJECT = "mailto:app@mantaui.com";
@@ -118,6 +139,65 @@ export async function removeSubscription(endpoint) {
   const next = subs.filter((s) => s.endpoint !== endpoint);
   if (next.length !== subs.length) await saveSubs(next);
   return { ok: true, count: next.length };
+}
+
+// ---------------------------------------------------------------------------
+// APNs device-token store (BET-181)
+//
+// Same persistence shape as the Web Push subscription store, but the entries
+// are { kind:"apns", token, registeredAt } instead of PushSubscription JSON.
+// The `kind` discriminator lets us fold both registries into a single
+// unified-store migration later without a separate file; for now they live
+// side-by-side. De-dupe on the `token` value (a token rotated by APNs or
+// reinstalled by the user comes back as a new entry; old ones get pruned on
+// 410).
+// ---------------------------------------------------------------------------
+
+async function loadApnsTokens(path = APNS_TOKENS_PATH) {
+  try {
+    if (existsSync(path)) {
+      const arr = JSON.parse(await readFile(path, "utf-8"));
+      return Array.isArray(arr) ? arr : [];
+    }
+  } catch {
+    /* corrupt file → start empty */
+  }
+  return [];
+}
+
+async function saveApnsTokens(tokens, path = APNS_TOKENS_PATH) {
+  await atomicWrite(path, JSON.stringify(tokens, null, 2));
+}
+
+/** Upsert a device token. De-dupes by token value; updates registeredAt.
+ *  `store` injection (test-only) lets tests run against a tmpdir file
+ *  instead of the production path. */
+export async function addApnsToken(token, { store } = {}) {
+  if (typeof token !== "string" || !token) {
+    throw new Error("token must be a non-empty string");
+  }
+  const path = store ?? APNS_TOKENS_PATH;
+  const tokens = await loadApnsTokens(path);
+  const next = tokens.filter((t) => t.token !== token);
+  next.push({ kind: "apns", token, registeredAt: Date.now() });
+  await saveApnsTokens(next, path);
+  return { ok: true, count: next.length };
+}
+
+/** Remove a token by value (used on 410 / BadDeviceToken / Unregistered).
+ *  `store` injection (test-only) — see addApnsToken. */
+export async function removeApnsToken(token, { store } = {}) {
+  const path = store ?? APNS_TOKENS_PATH;
+  if (!token) return { ok: true, count: (await loadApnsTokens(path)).length };
+  const tokens = await loadApnsTokens(path);
+  const next = tokens.filter((t) => t.token !== token);
+  if (next.length !== tokens.length) await saveApnsTokens(next, path);
+  return { ok: true, count: next.length };
+}
+
+/** Test hook. */
+export async function _loadApnsTokensForTest(store) {
+  return loadApnsTokens(store ?? APNS_TOKENS_PATH);
 }
 
 // ---------------------------------------------------------------------------
@@ -645,6 +725,257 @@ async function sendPush(payload) {
       }
     }),
   );
+  // Fan out to APNs alongside Web Push. Same routing decision has already
+  // been made by routeNotification — we just don't get to know whether APNs
+  // is configured/empty here, so an absent block short-circuits immediately.
+  await sendApnsFanout(payload);
+}
+
+// ---------------------------------------------------------------------------
+// APNs native-push delivery leg (BET-181)
+//
+// Activated when local.apnsConfig() returns a valid block. Pure building
+// blocks (buildApnsJwt, buildApnsRequest, buildApnsPayload) are exported for
+// unit tests; sendApns + sendApnsFanout are the stateful glue that reads the
+// device-token store + makes the HTTP/2 call. NO new npm dependency —
+// everything uses Node's built-in `crypto` (ES256 sign) and `http2`.
+//
+// Apple rotates the JWT at 20–60 min; we cache it for 45 min inside the
+// process. The token cache is per-cfg (teamId/keyId/p8Path), so rotating
+// any of those immediately invalidates the cache (see _apnsJwtCache).
+//
+// Errors that mean "this token is dead, stop sending to it":
+//   - 410 Gone (token expired; Apple requires it be unregistered)
+//   - 400 with reason BadDeviceToken
+//   - 400 with reason Unregistered
+// All other failures are logged but don't prune the token (transient —
+// network blip, Apple's 500s, rate-limit, etc).
+// ---------------------------------------------------------------------------
+
+let _apnsJwtCache = null; // { teamId, keyId, p8Path, jwt, exp }
+
+/**
+ * Pure: build the ES256 JWT used for APNs auth. Reads the .p8 PEM off disk
+ * and signs the JWT claims with Node's built-in crypto. Apple requires:
+ *   header: { alg:"ES256", kid:<keyId> }
+ *   claims: { iss:<teamId>, iat:<unix-seconds> }
+ * ES256 = ECDSA over the P-256 curve with SHA-256. Apple's .p8 is the
+ * PKCS#8 PEM of an EC private key, which Node's crypto accepts directly.
+ *
+ * @param {{teamId:string, keyId:string, p8Path:string}} cfg
+ * @param {{now?: number}} [opts] injectable clock for tests (iat claim)
+ * @returns {string} compact-serialized JWT (header.claims.signature)
+ */
+export async function buildApnsJwt(cfg, { now } = {}) {
+  if (!cfg?.teamId || !cfg?.keyId || !cfg?.p8Path) {
+    throw new Error("buildApnsJwt: missing teamId/keyId/p8Path");
+  }
+  const pem = readFileSync(cfg.p8Path, "utf-8");
+  const header = { alg: "ES256", kid: cfg.keyId };
+  const iat = now ?? Math.floor(Date.now() / 1000);
+  const claims = { iss: cfg.teamId, iat };
+  const enc = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  const signingInput = `${enc(header)}.${enc(claims)}`;
+  const signer = createSign("SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer
+    .sign({ key: pem, dsaEncoding: "ieee-p1363" })
+    .toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Cache-and-reuse the APNs JWT for APNS_JWT_TTL_SEC. Pure with respect to
+ * time (caller-injected `now`); mutates module-level `_apnsJwtCache`.
+ */
+async function getApnsJwt(cfg) {
+  const now = Math.floor(Date.now() / 1000);
+  const c = _apnsJwtCache;
+  if (
+    c &&
+    c.teamId === cfg.teamId &&
+    c.keyId === cfg.keyId &&
+    c.p8Path === cfg.p8Path &&
+    c.exp > now
+  ) {
+    return c.jwt;
+  }
+  const jwt = await buildApnsJwt(cfg, { now });
+  _apnsJwtCache = {
+    teamId: cfg.teamId,
+    keyId: cfg.keyId,
+    p8Path: cfg.p8Path,
+    jwt,
+    exp: now + APNS_JWT_TTL_SEC,
+  };
+  return jwt;
+}
+
+/** Test hook: drop the JWT cache so the next send rebuilds. */
+export function _resetApnsJwtCache() {
+  _apnsJwtCache = null;
+}
+
+/**
+ * Pure: build the HTTP/2 request shape for one APNs send. Used by sendApns
+ * (with Node's http2 client) AND by tests that want to assert the request
+ * without actually opening a connection.
+ *
+ * @param {{cfg: {bundleId:string}, deviceToken:string, payload: any, jwt:string}} args
+ * @returns {{ host:string, path:string, method:string, headers:object, body:string }}
+ */
+export function buildApnsRequest({ cfg, deviceToken, payload, jwt }) {
+  if (!cfg?.bundleId) throw new Error("buildApnsRequest: missing bundleId");
+  if (typeof deviceToken !== "string" || !deviceToken) {
+    throw new Error("buildApnsRequest: missing deviceToken");
+  }
+  return {
+    host: "api.push.apple.com",
+    path: `/3/device/${encodeURIComponent(deviceToken)}`,
+    method: "POST",
+    headers: {
+      authorization: `bearer ${jwt}`,
+      "apns-topic": cfg.bundleId,
+      "apns-push-type": "alert",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  };
+}
+
+/**
+ * Pure: map an internal notification payload to the APNs `aps` envelope.
+ * Apple requires the title/body under `aps.alert`. `thread-id` groups
+ * notifications from the same session into one stack on the lock screen;
+ * we hoist the sessionId up so iOS does the grouping for us.
+ *
+ * @param {{title:string, body:string, sessionId?:string|null}} payload
+ * @returns {{aps:{alert:{title:string, body:string}, "thread-id"?:string}, sessionId:string|null}}
+ */
+export function buildApnsPayload(payload) {
+  const title = typeof payload?.title === "string" ? payload.title : "";
+  const body = typeof payload?.body === "string" ? payload.body : "";
+  const sessionId =
+    typeof payload?.sessionId === "string" && payload.sessionId
+      ? payload.sessionId
+      : null;
+  const aps = { alert: { title, body } };
+  if (sessionId) aps["thread-id"] = sessionId;
+  return { aps, sessionId };
+}
+
+/**
+ * Default HTTP/2 sender for APNs. Uses Node's built-in http2 to POST one
+ * device-token notification to api.push.apple.com. Resolves with
+ * `{ status, body }` on response, or throws on socket/connect failure.
+ *
+ * Injected via sendApns's `sender` param so tests can stub it without a live
+ * Apple round-trip.
+ *
+ * @param {{host:string, path:string, method:string, headers:object, body:string}} req
+ * @returns {Promise<{status:number, body:any}>}
+ */
+async function defaultApnsSender(req) {
+  return new Promise((resolve, reject) => {
+    const session = http2.connect(`https://${req.host}`);
+    session.on("error", reject);
+    const r = session.request({
+      ":method": req.method,
+      ":path": req.path,
+      ...req.headers,
+    });
+    r.on("response", (headers) => {
+      const status = headers[":status"] ?? 0;
+      const chunks = [];
+      r.on("data", (c) => chunks.push(c));
+      r.on("end", () => {
+        session.close();
+        const raw = Buffer.concat(chunks).toString("utf-8");
+        let body = raw;
+        try {
+          body = raw ? JSON.parse(raw) : null;
+        } catch {
+          /* non-JSON body — leave as string */
+        }
+        resolve({ status, body });
+      });
+    });
+    r.on("error", (e) => {
+      session.close();
+      reject(e);
+    });
+    r.end(req.body);
+  });
+}
+
+/**
+ * Send ONE push to ONE APNs token. Pure w.r.t. the device-token registry
+ * (caller passes it in), so the same function can be unit-tested with a
+ * stub `sender`. Status mapping:
+ *   - 200 → log success
+ *   - 410 Gone, 400 BadDeviceToken, 400 Unregistered → removeApnsToken
+ *   - everything else → log, keep the token (transient)
+ *
+ * @param {{teamId:string,keyId:string,p8Path:string,bundleId:string}} cfg
+ * @param {string} deviceToken
+ * @param {{title:string,body:string,sessionId?:string|null}} payload
+ * @param {(req:any)=>Promise<{status:number,body:any}>} [sender] injected for tests
+ * @param {{store?:string}} [opts] `store` = override the device-token store path
+ *                                  (test-only; defaults to the production path)
+ */
+export async function sendApns(cfg, deviceToken, payload, sender, opts = {}) {
+  const useSender = sender ?? defaultApnsSender;
+  const jwt = await getApnsJwt(cfg);
+  const envelope = buildApnsPayload(payload);
+  const req = buildApnsRequest({ cfg, deviceToken, payload: envelope, jwt });
+  let res;
+  try {
+    res = await useSender(req);
+  } catch (e) {
+    console.warn("[push] apns send error:", e?.message ?? e);
+    return { ok: false, reason: "transport" };
+  }
+  const status = res?.status ?? 0;
+  const reason = res?.body?.reason ?? "";
+  if (status === 200) {
+    console.log(`[push] apns ok token=${deviceToken.slice(0, 8)}…`);
+    return { ok: true };
+  }
+  if (
+    status === 410 ||
+    (status === 400 && (reason === "BadDeviceToken" || reason === "Unregistered"))
+  ) {
+    console.log(
+      `[push] apns prune token=${deviceToken.slice(0, 8)}… status=${status} reason=${reason}`,
+    );
+    await removeApnsToken(deviceToken, { store: opts.store }).catch(() => {});
+    return { ok: false, reason: "dead-token" };
+  }
+  console.warn(
+    `[push] apns send failed status=${status} reason=${reason}`,
+  );
+  return { ok: false, reason: reason || "http-error" };
+}
+
+/**
+ * Stateful fan-out: read every APNs token + the current config block, and
+ * send to each in parallel. No-op when the config block is absent (the
+ * Web Push leg is the only delivery), or when no tokens are registered.
+ * Exported for tests (so the same fn can be driven through HTTP routing
+ * without a real APNs config).
+ */
+export async function sendApnsFanout(payload, opts = {}) {
+  const cfg = opts.cfg ?? (await local.apnsConfig());
+  if (!cfg) return; // APNs leg disabled — silent no-op (matches Web Push)
+  const sender = opts.sender;
+  const store = opts.store;
+  const path = store ?? APNS_TOKENS_PATH;
+  const tokens = await loadApnsTokens(path);
+  if (tokens.length === 0) return;
+  await Promise.all(
+    tokens.map((t) => sendApns(cfg, t.token, payload, sender, { store: path })),
+  );
 }
 
 /**
@@ -759,4 +1090,5 @@ export function _resetPushState() {
   _desktopSink = null;
   _focus = { sessionId: null, visible: false };
   _desktop = { visible: false, lastSeen: 0, lastActive: 0 };
+  _apnsJwtCache = null;
 }

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -1,5 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFile, rm } from "node:fs/promises";
 import {
   classifyPushEvent,
   buildSessionLabel,
@@ -14,6 +18,15 @@ import {
   cancelAllEscalations,
   _pendingEscalationTags,
   _resetPushState,
+  buildApnsJwt,
+  buildApnsRequest,
+  buildApnsPayload,
+  addApnsToken,
+  removeApnsToken,
+  sendApns,
+  sendApnsFanout,
+  _resetApnsJwtCache,
+  _loadApnsTokensForTest,
   ESCALATE_MS,
   DESKTOP_PRESENCE_TTL_MS,
   DESKTOP_GRACE_MS,
@@ -577,4 +590,502 @@ test("escalation: re-notify same tag supersedes (no duplicate timer)", async () 
   assert.deepEqual(_pendingEscalationTags(), ["notify-ses_s"]);
   cancelAllEscalations();
   _resetPushState();
+});
+
+// ---------------------------------------------------------------------------
+// APNs native-push delivery leg (BET-181)
+// ---------------------------------------------------------------------------
+//
+// All tests below use a generated EC P-256 keypair written to a tmpdir .p8
+// and an injectable `sender` function — no live Apple round-trips, no
+// production ~/.manta/apns-tokens.json writes. The `store` injection on
+// addApnsToken/removeApnsToken/sendApnsFanout lets every assertion run
+// against a per-test temp file that the test cleans up.
+
+// Generate a P-256 EC keypair and export the private side as PKCS#8 PEM,
+// the exact shape Apple's APNs .p8 tokens are. Returns the path to a
+// tmpfile the test MUST clean up.
+async function makeApnsKeyFile() {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const pem = privateKey
+    .export({ type: "pkcs8", format: "pem" })
+    .toString();
+  const path = join(
+    tmpdir(),
+    `bui-apns-test-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.p8`,
+  );
+  await writeFile(path, pem, "utf-8");
+  return { path, cleanup: () => rm(path, { force: true }) };
+}
+
+// Per-test temp store path for the APNs device-token registry. Always
+// return a unique file so parallel tests (or a leftover from a prior run)
+// don't see each other's writes.
+function makeApnsStorePath(label) {
+  return join(
+    tmpdir(),
+    `bui-apns-tokens-test-${label}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+  );
+}
+
+const APNS_CFG = {
+  teamId: "FSQ3HS4Z24",
+  keyId: "82P7483297",
+  bundleId: "com.antoinedc.mantaui",
+};
+
+test("buildApnsJwt: claim/header structure matches Apple APNs spec", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  try {
+    const cfg = { ...APNS_CFG, p8Path };
+    const IAT = 1_700_000_000;
+    const jwt = await buildApnsJwt(cfg, { now: IAT });
+    // Format: <header-b64url>.<claims-b64url>.<signature-b64url>
+    const parts = jwt.split(".");
+    assert.equal(parts.length, 3, "JWT must have exactly 3 parts");
+    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
+    const claims = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    assert.equal(header.alg, "ES256");
+    assert.equal(header.kid, APNS_CFG.keyId);
+    assert.equal(claims.iss, APNS_CFG.teamId);
+    assert.equal(claims.iat, IAT);
+    // Signature segment must be non-empty (binary blob — just assert length).
+    assert.ok(parts[2].length > 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("buildApnsPayload: maps notification payload to APNs `aps` envelope", () => {
+  const out = buildApnsPayload({
+    title: "default / my-chat",
+    body: "Permission needed — Claude wants to run a tool.",
+    sessionId: "ses_abc",
+  });
+  assert.deepEqual(out, {
+    aps: {
+      alert: {
+        title: "default / my-chat",
+        body: "Permission needed — Claude wants to run a tool.",
+      },
+      "thread-id": "ses_abc",
+    },
+    sessionId: "ses_abc",
+  });
+});
+
+test("buildApnsPayload: no sessionId → no thread-id, still shaped right", () => {
+  const out = buildApnsPayload({ title: "T", body: "B" });
+  assert.deepEqual(out.aps.alert, { title: "T", body: "B" });
+  assert.equal(out.aps["thread-id"], undefined);
+  assert.equal(out.sessionId, null);
+});
+
+test("buildApnsRequest: host/path/headers/body shape (HTTP/2 style)", () => {
+  // 64-char hex device token (Apple's standard shape).
+  const deviceToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  const req = buildApnsRequest({
+    cfg: APNS_CFG,
+    deviceToken,
+    payload: { aps: { alert: { title: "T", body: "B" } }, sessionId: null },
+    jwt: "header.claims.sig",
+  });
+  assert.equal(req.host, "api.push.apple.com");
+  assert.equal(req.path, `/3/device/${deviceToken}`);
+  assert.equal(req.method, "POST");
+  assert.equal(req.headers["authorization"], "bearer header.claims.sig");
+  assert.equal(req.headers["apns-topic"], APNS_CFG.bundleId);
+  assert.equal(req.headers["apns-push-type"], "alert");
+  assert.match(req.headers["content-type"], /application\/json/);
+  assert.match(req.body, /"aps"/);
+});
+
+test("register-apns upsert: addApnsToken round-trip via temp store", async () => {
+  const store = makeApnsStorePath("upsert");
+  try {
+    const r1 = await addApnsToken("tok-aaa", { store });
+    assert.equal(r1.ok, true);
+    assert.equal(r1.count, 1);
+    const r2 = await addApnsToken("tok-bbb", { store });
+    assert.equal(r2.count, 2);
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.deepEqual(
+      tokens.map((t) => t.token).sort(),
+      ["tok-aaa", "tok-bbb"],
+    );
+    for (const t of tokens) {
+      assert.equal(t.kind, "apns");
+      assert.equal(typeof t.registeredAt, "number");
+      assert.ok(t.registeredAt > 0);
+    }
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+test("register-apns: re-registering same token DE-DUPES (upsert, not append)", async () => {
+  const store = makeApnsStorePath("dedupe");
+  try {
+    await addApnsToken("tok-dup", { store });
+    await addApnsToken("tok-dup", { store });
+    await addApnsToken("tok-dup", { store });
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 1);
+    assert.equal(tokens[0].token, "tok-dup");
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+test("register-apns: rejects an empty / non-string token", async () => {
+  await assert.rejects(() => addApnsToken(""), /non-empty/);
+  await assert.rejects(() => addApnsToken(null), /non-empty/);
+  await assert.rejects(() => addApnsToken(undefined), /non-empty/);
+});
+
+test("removeApnsToken: removes a registered token", async () => {
+  const store = makeApnsStorePath("remove");
+  try {
+    await addApnsToken("tok-keep", { store });
+    await addApnsToken("tok-drop", { store });
+    const r = await removeApnsToken("tok-drop", { store });
+    assert.equal(r.ok, true);
+    assert.equal(r.count, 1);
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.deepEqual(
+      tokens.map((t) => t.token),
+      ["tok-keep"],
+    );
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+test("removeApnsToken: no-op on unknown token (returns count unchanged)", async () => {
+  const store = makeApnsStorePath("remove-noop");
+  try {
+    await addApnsToken("tok-only", { store });
+    const r = await removeApnsToken("tok-ghost", { store });
+    assert.equal(r.count, 1);
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 1);
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+// --- sendApns pruning rules -----------------------------------------------
+
+test("sendApns: 200 → ok, does NOT prune the token", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("send-ok");
+  try {
+    await addApnsToken("tok-ok", { store });
+    _resetApnsJwtCache();
+    const sent = [];
+    const res = await sendApns(
+      { ...APNS_CFG, p8Path },
+      "tok-ok",
+      { title: "T", body: "B", sessionId: "ses_x" },
+      async (req) => {
+        sent.push(req);
+        return { status: 200, body: null };
+      },
+      { store },
+    );
+    assert.equal(res.ok, true);
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 1, "200 must NOT prune");
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].headers["apns-topic"], APNS_CFG.bundleId);
+    assert.equal(sent[0].headers["apns-push-type"], "alert");
+    assert.match(sent[0].headers.authorization, /^bearer /);
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApns: 410 Gone → prunes the token", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("send-410");
+  try {
+    await addApnsToken("tok-410", { store });
+    _resetApnsJwtCache();
+    const res = await sendApns(
+      { ...APNS_CFG, p8Path },
+      "tok-410",
+      { title: "T", body: "B" },
+      async () => ({ status: 410, body: { reason: "Unregistered" } }),
+      { store },
+    );
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, "dead-token");
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 0, "410 must prune");
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApns: 400 BadDeviceToken → prunes the token", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("send-bad");
+  try {
+    await addApnsToken("tok-bad", { store });
+    _resetApnsJwtCache();
+    const res = await sendApns(
+      { ...APNS_CFG, p8Path },
+      "tok-bad",
+      { title: "T", body: "B" },
+      async () => ({ status: 400, body: { reason: "BadDeviceToken" } }),
+      { store },
+    );
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, "dead-token");
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 0, "400 BadDeviceToken must prune");
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApns: 400 Unregistered → prunes the token", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("send-unreg");
+  try {
+    await addApnsToken("tok-unreg", { store });
+    _resetApnsJwtCache();
+    const res = await sendApns(
+      { ...APNS_CFG, p8Path },
+      "tok-unreg",
+      { title: "T", body: "B" },
+      async () => ({ status: 400, body: { reason: "Unregistered" } }),
+      { store },
+    );
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, "dead-token");
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 0);
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApns: 400 with other reason → keep token (transient)", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("send-400other");
+  try {
+    await addApnsToken("tok-keepme", { store });
+    _resetApnsJwtCache();
+    const res = await sendApns(
+      { ...APNS_CFG, p8Path },
+      "tok-keepme",
+      { title: "T", body: "B" },
+      async () => ({ status: 400, body: { reason: "BadCertificateEnvironment" } }),
+      { store },
+    );
+    assert.equal(res.ok, false);
+    assert.notEqual(res.reason, "dead-token");
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 1, "non-dead-token failures must NOT prune");
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApns: 500 / transport error → keep token (transient)", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("send-500");
+  try {
+    await addApnsToken("tok-keep500", { store });
+    _resetApnsJwtCache();
+    const res = await sendApns(
+      { ...APNS_CFG, p8Path },
+      "tok-keep500",
+      { title: "T", body: "B" },
+      async () => ({ status: 500, body: null }),
+      { store },
+    );
+    assert.equal(res.ok, false);
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 1, "500 must NOT prune");
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+// --- sendApnsFanout integration ---------------------------------------------
+
+test("sendApnsFanout: empty store → no send (and no crash)", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("fanout-empty");
+  try {
+    let called = 0;
+    await sendApnsFanout(
+      { title: "T", body: "B", sessionId: "ses_1" },
+      { cfg: { ...APNS_CFG, p8Path }, sender: async () => { called++; return { status: 200, body: null }; }, store },
+    );
+    assert.equal(called, 0);
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApnsFanout: fans out to ALL registered tokens; dead pruned live", async () => {
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("fanout-all");
+  try {
+    await addApnsToken("tok-1", { store });
+    await addApnsToken("tok-2", { store });
+    await addApnsToken("tok-3", { store });
+    _resetApnsJwtCache();
+    const seen = [];
+    await sendApnsFanout(
+      { title: "T", body: "B", sessionId: "ses_x" },
+      {
+        cfg: { ...APNS_CFG, p8Path },
+        sender: async (req) => {
+          seen.push(req.path.match(/\/3\/device\/(.+)/)[1]);
+          // tok-2 is "dead" → Apple returns 410
+          if (req.path.includes("tok-2")) {
+            return { status: 410, body: { reason: "Unregistered" } };
+          }
+          return { status: 200, body: null };
+        },
+        store,
+      },
+    );
+    assert.equal(seen.length, 3);
+    assert.ok(seen.includes("tok-1"));
+    assert.ok(seen.includes("tok-2"));
+    assert.ok(seen.includes("tok-3"));
+    // tok-2 was pruned live during the fanout.
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.deepEqual(
+      tokens.map((t) => t.token).sort(),
+      ["tok-1", "tok-3"],
+    );
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApnsFanout: no cfg → silent no-op (matches Web Push behavior)", async () => {
+  // No cfg passed and local.apnsConfig() would return null in the absence
+  // of the apns block — we just confirm the function exits early without
+  // touching any token store or invoking any sender.
+  let called = false;
+  await sendApnsFanout(
+    { title: "T", body: "B" },
+    { cfg: null, sender: async () => { called = true; return { status: 200, body: null }; } },
+  );
+  assert.equal(called, false);
+});
+
+test("sendApnsFanout: end-to-end with fireNotify still calls APNs when both registries present", async () => {
+  // Integration-style: fire a notify that the router decides to push
+  // mobile-now → Web Push sendPush runs (no real subscribers → no-op),
+  // APNs fan-out runs, the temp store's token gets the send.
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("fire-integration");
+  try {
+    await addApnsToken("tok-fired", { store });
+    _resetPushState();
+    _resetApnsJwtCache();
+    setDesktopSink(() => {}); // no desktop leg
+    setDesktopPresence({ visible: false, lastSeen: 0, lastActive: 0 }); // desktop GONE → mobile only
+    const sent = [];
+    // Monkey-patch push.mjs' sendPush path by driving the APNs side
+    // directly through the fan-out entry point, simulating what
+    // dispatchNotification does in production after a routeNotification
+    // decision: it calls sendPush (Web Push) AND sendApnsFanout (APNs).
+    await fireNotify({ message: "build done", sessionID: "ses_fire" });
+    await sendApnsFanout(
+      { kind: "done", title: "default / my-chat", body: "Your turn finished.", sessionId: "ses_fire" },
+      {
+        cfg: { ...APNS_CFG, p8Path },
+        sender: async (req) => { sent.push(req.path); return { status: 200, body: null }; },
+        store,
+      },
+    );
+    assert.ok(
+      sent.some((p) => p.endsWith("/tok-fired")),
+      "APNs fan-out must reach the registered token",
+    );
+    // The Web Push leg fired too (no subs → no-op), but the routing
+    // decision (mobileNow:true) is the same — so the test confirms
+    // APNs participates WITHOUT changing routing decisions.
+    _resetPushState();
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
+});
+
+test("_resetApnsJwtCache: a new sign is forced after reset (verified via sendApns JWT)", async () => {
+  // buildApnsJwt itself always re-signs (ES256 has a random k), so the
+  // cache lives in getApnsJwt (called by sendApns). We exercise the cache
+  // by capturing the bearer token from the request sendApns builds, then
+  // resetting the cache and asserting the bearer token changes.
+  const { path: p8Path, cleanup } = await makeApnsKeyFile();
+  const store = makeApnsStorePath("jwt-cache");
+  try {
+    await addApnsToken("tok-cache", { store });
+    _resetApnsJwtCache();
+    const cfg = { ...APNS_CFG, p8Path };
+    const captured = [];
+    await sendApns(
+      cfg,
+      "tok-cache",
+      { title: "T", body: "B" },
+      async (req) => {
+        captured.push(req.headers.authorization);
+        return { status: 200, body: null };
+      },
+      { store },
+    );
+    await sendApns(
+      cfg,
+      "tok-cache",
+      { title: "T", body: "B" },
+      async (req) => {
+        captured.push(req.headers.authorization);
+        return { status: 200, body: null };
+      },
+      { store },
+    );
+    assert.equal(captured.length, 2);
+    assert.equal(
+      captured[0],
+      captured[1],
+      "second sendApns within cache window returns the cached bearer",
+    );
+    _resetApnsJwtCache();
+    await sendApns(
+      cfg,
+      "tok-cache",
+      { title: "T", body: "B" },
+      async (req) => {
+        captured.push(req.headers.authorization);
+        return { status: 200, body: null };
+      },
+      { store },
+    );
+    assert.notEqual(
+      captured[1],
+      captured[2],
+      "after _resetApnsJwtCache the bearer must be freshly signed",
+    );
+  } finally {
+    await cleanup();
+    await rm(store, { force: true });
+  }
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -13,6 +13,7 @@ import { resolveWorkspace } from "./peers.mjs";
 import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
 import { restartOpencode } from "./opencodeAdmin.mjs";
+import { addApnsToken } from "./push.mjs";
 
 export async function dispatch(handlers, channel, args) {
   const fn = handlers[channel];
@@ -20,20 +21,21 @@ export async function dispatch(handlers, channel, args) {
   return fn(...args);
 }
 
-// Build the full handler map. Accepts { tmux, oc, pty, bus, local, authPair, serverVersion } where:
+// Build the full handler map. Accepts { tmux, oc, pty, bus, local, authPair, push, serverVersion } where:
 //   tmux          — src/server/tmux.mjs namespace
 //   oc            — src/server/opencode.mjs namespace
 //   pty           — src/server/pty.mjs namespace
 //   bus           — event bus created by createBus() in events.mjs
 //   local         — src/server/local.mjs namespace (git/fs/config/clipboard stubs)
 //   authPair      — () => authEngine.pair(); the `auth:pair` channel wraps it.
+//   push          — src/server/push.mjs namespace (BET-181: APNs token registration dispatch).
 //   serverVersion — string, package.json `version` read once at startup (same
 //                   value `GET /api/version` returns). The `server:version`
 //                   channel returns it in-process so the renderer avoids an
 //                   HTTP round-trip on every Settings mount.
 // Channel key strings MUST match IPC.* values in src/shared/types.ts.
 // Arg shapes MUST match what src/preload/index.ts packs per channel.
-export function buildHandlers({ tmux, oc, pty, bus, local, authPair, serverVersion }) {
+export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serverVersion }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
   // migration). Renderer-supplied cwd is preferred when it's a real path, but
@@ -408,6 +410,15 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, serverVersi
     // preload: ipcRenderer.invoke(IPC.webhookDelete, id) → args[0] = id
     "webhook:delete": (id) =>
       webhookDeleteHook(id, { publish: (evt) => bus.publish(evt) }),
+
+    // ---- APNs native-push registration (BET-181) ----
+    // iOS Capacitor app registers its APNs device token via the renderer-side
+    // 6-site wiring (window.api.pushRegisterApns(token)). Same single
+    // source-of-truth as the bare /push/register-apns HTTP route — both call
+    // push.addApnsToken so the device-token registry doesn't diverge by
+    // transport. De-dupe is handled inside addApnsToken (upsert on token).
+    // preload: ipcRenderer.invoke(IPC.pushRegisterApns, token) → args[0] = token
+    "push:register-apns": (token) => push.addApnsToken(token),
 
     // ---- auth pairing code mint (BET-161) ----
     // Mint a one-time mobile pairing code. Runs in-process on the box, so it

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -37,6 +37,7 @@ function makeDeps(projects, liveProjects = []) {
       pty: {},
       bus: {},
       local: { configGet: async () => ({ projects }) },
+      push: { addApnsToken: async () => ({ ok: true, count: 0 }) },
     },
   };
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -268,6 +268,14 @@ export interface Api {
   webhookList(sessionId?: string): Promise<WebhookMeta[]>;
   webhookDelete(id: string): Promise<{ deleted: boolean }>;
 
+  // APNs native-push registration (BET-181). The iOS Capacitor app calls this
+  // on startup (after permission grant) with the device token returned by
+  // @capacitor/push-notifications. The server upserts it into the apns-tokens
+  // registry (de-dupes on token value). Returns { ok, count }. No-op on
+  // non-iOS / pre-Capacitor environments — see src/renderer/mobile/nativePush.ts
+  // for the feature-detection guard.
+  pushRegisterApns(token: string): Promise<{ ok: boolean; count: number }>;
+
   // Auto-update (desktop-only). Main checks for updates on launch and pushes
   // updateAvailable / updateDownloaded events to the renderer. The renderer
   // calls autoUpdateDownload to trigger a manual download, or

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -471,10 +471,21 @@ export const IPC = {
   // with an event (the push counterpart to scheduled polling). CREATED by the
   // remote AI's global `webhook` opencode tool (which gets the URL + signing
   // secret); the UI only LISTS + REVOKES (the secret is shown once at create,
-  // never re-exposed). Desktop reaches the server store over its SSH -L 18787
-  // forward (src/main/webhook.ts); mobile is in-process (rpc.mjs → webhooks.mjs).
+  // never re-exposed). Desktop reaches the server store over its existing
+  // SSH -L 18787 forward (src/main/webhook.ts); mobile is in-process
+  // (rpc.mjs → webhooks.mjs).
   webhookList: "webhook:list", // (sessionId?) → WebhookMeta[]
   webhookDelete: "webhook:delete", // (id) → { deleted: boolean }
+
+  // ---- APNs native-push registration (BET-181) ----
+  // iOS Capacitor app registers its APNs device token so the server can
+  // fan out native pushes alongside Web Push (VAPID). Server-side store
+  // lives in src/server/push.mjs (apns-tokens.json). Same 6-site pattern
+  // as schedule:* — desktop preload invokes the IPC channel, httpApi.ts
+  // POSTs /rpc/push:register-apns on the mobile/web transport. Both
+  // transports call the same push.addApnsToken() on the server side.
+  // Renderer's window.api.pushRegisterApns(token) → Promise<{ok, count}>.
+  pushRegisterApns: "push:register-apns", // (token) → { ok: boolean, count: number }
 
   // ---- auto-update (electron-updater) ----
   // Desktop-only. Main checks for updates on launch, downloads silently in the


### PR DESCRIPTION
## Summary

Adds the APNs native-push delivery leg so the iOS Capacitor app receives notifications when backgrounded. Web Push (VAPID) stays untouched for the frozen PWA build.

**Base: origin/main @ `0ba6c28`**

## What changed

### Server (push.mjs, local.mjs, index.mjs, rpc.mjs)
- New `apnsConfig()` in `local.mjs` reads the `apns` block from `~/.manta/config.json` (absent/malformed → `null` → APNs leg silently disabled, no behavior change for non-iOS installs).
- New APNs device-token store at `~/.manta/apns-tokens.json` — same shape/persistence pattern as the existing Web Push subs. De-dupes on token value.
- `buildApnsJwt` (Node's built-in crypto + Apple's `.p8`) signs the ES256 JWT with the right `{alg:"ES256", kid, iss, iat}` claims. In-process 45-min cache.
- `buildApnsPayload` maps the internal notification to the APNs `aps` envelope (alert + `thread-id` for session-scoped grouping).
- `sendApns` posts to `api.push.apple.com/3/device/<token>` over HTTP/2 (Node's built-in `http2`, no new npm deps). `410` / `BadDeviceToken` / `Unregistered` → prune the token; `4xx`-other and `5xx` → keep (transient).
- `sendApnsFanout` fires APNs alongside Web Push from `sendPush`. Routing decisions unchanged — `routeNotification` and `dispatchNotification` are untouched (the pure router is frozen per the issue's Out-of-scope).
- `POST /push/register-apns` (Bearer-gated like every other `/push/*` route) + `/rpc/push:register-apns` IPC channel. Both call `push.addApnsToken` (single source of truth).

### Renderer (nativePush.ts, MobileApp.tsx, httpApi.ts, types.ts, api.ts)
- `@capacitor/push-notifications@^6.0.3` added to `mobile/package.json` (mobile-only, NOT root).
- New `src/renderer/mobile/nativePush.ts`: feature-detects `window.Capacitor?.Plugins?.PushNotifications`, requests permission, registers, ships the device token through the standard 6-site pattern (`window.api.pushRegisterApns` → `rpc(/rpc/push:register-apns)` → `push.addApnsToken`).
- Notification taps dispatch a `CustomEvent` that `MobileApp.tsx` routes through the EXISTING `pendingNotif` ref + `resolveSessionOwner` + `openSessionForNotif` dance — same path the Web Push service-worker message handler uses. No parallel resolution path.

### Tests
20 new APNs cases in `push.test.mjs` (all pure — generated EC P-256 key + tmpdir store + injected sender, no live Apple round-trips):
- JWT claim/header structure (decodes the unsigned parts, asserts `alg`/`kid`/`iss`/`iat`)
- Payload mapping (full + null sessionId)
- Request shape (host/path/headers/body)
- `register-apns` upsert + de-dupe round-trip
- Empty/non-string token rejected
- `removeApnsToken` happy path + no-op on unknown
- `200` → ok, no prune
- `410` / `400 BadDeviceToken` / `400 Unregistered` → prune
- `400` other reason → keep (transient)
- `500` / transport → keep (transient)
- `sendApnsFanout` empty / fan-out-with-live-prune / no-cfg silent no-op
- `fireNotify` + APNs integration (routing decisions unchanged, APNs participates)
- JWT cache hit + reset

`testHarness.tsx` mock updated to include `pushRegisterApns` so the renderer type contract stays intact.

## Verification

**Files changed:** 13 files. `git diff --stat origin/main...HEAD`:
```
 mobile/package.json                        |   1 +
 src/renderer/api/httpApi.ts                |   4 +
 src/renderer/mobile/MobileApp.tsx          |  38 +++
 src/renderer/mobile/nativePush.ts          | 165 ++++++++
 src/renderer/testHarness.tsx               |   1 +
 src/server/index.mjs                       |  18 +-
 src/server/local.mjs                       |  27 ++
 src/server/push.mjs                        | 280 ++++++++++++++++++
 src/server/push.test.mjs                   | 460 ++++++++++++++++++++++++++++++
 src/server/rpc.mjs                         |  11 +-
 src/server/rpc.test.mjs                    |   1 +
 src/shared/api.ts                          |   5 +
 src/shared/types.ts                        |   8 +
```

**Verification results:**
- PR branch (`multica/BET-181-apns-native-push` @ `5a85a09`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `689` pass / `0` fail / `0` skip. (+20 new APNs tests vs base.) log sha256: `ffc87a2a1e3a677119f224d39c0687cc150138ad05c9cd028a02c1a63b3c5878`
- Base (`main` @ `0ba6c28`):
  - typecheck: exit `0`. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit `0`, `669` pass / `0` fail / `0` skip. log sha256: `a1f82d3ee87f00b27d84f720a78e1cb107be08cd26dea794340a6996bd3c1695`
- **Conclusion:** `0` new failures, `0` pre-existing failures, `20` failures resolved (well, +20 new APNs tests, none of them failing). Pre-existing tests unchanged.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Out of scope (confirmed untouched)

- `routeNotification`, `notifTier`, `shouldSuppressForDesktop`, `shouldSuppressUnresolvedNotification`, `buildSessionLabel`, `classifyPushEvent` — pure router unchanged.
- Web Push (VAPID) registration for the frozen PWA — `push.ts` (client-side) is unchanged.
- `routeNotification`'s tier / escalation / desktop-presence suppression — `sendPush` is the only consumer that's now followed by `sendApnsFanout`.

## Notes

- `bundleId` is `com.antoinedc.mantaui` everywhere — matches `mobile/capacitor.config.json` `appId`. The CORRECTION note in the issue body is reflected in the test cfg (`APNS_CFG.bundleId = "com.antoinedc.mantaui"`).
- The HTTP route `/push/register-apns` and the RPC channel `/rpc/push:register-apns` both call `push.addApnsToken(token)` — curl-driven integration tests can hit either transport; the registry stays single-source-of-truth.
- `apnsConfig()` is async (reads `getConfig()` fresh per call) so a runtime config write is picked up without a server restart — matches the existing `configGet()` pattern.
- `addApnsToken` / `removeApnsToken` / `sendApnsFanout` / `sendApns` all accept an optional `{ store }` override for test isolation against `~/.manta/apns-tokens.json`. Production callers don't pass it; the default is the production path.
- JWT cache is per-cfg (teamId/keyId/p8Path) so rotating any of those immediately invalidates the cache.