### PR TITLE
feat(server,renderer): BET-180 phase 5 — server version endpoint + display

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -56,6 +56,29 @@ Run the `npm` commands below from `mobile/`.
 `Info.plist` already has `NSAllowsArbitraryLoads` so the app can reach
 HTTP (non-TLS) bui servers on a LAN.
 
+### Bumping the iOS build / version per release
+
+The Xcode project tracks **App Store Connect**-visible version numbers as
+build settings on the App target — `MARKETING_VERSION` (the
+`CFBundleShortVersionString` shown to users, e.g. `1.2.3`) and
+`CURRENT_PROJECT_VERSION` (the internal build number, e.g. `42`,
+monotonically increasing per upload). Xcode Cloud bumps these **by hand**
+per release — there is no CI automation for them in this phase.
+
+To bump before a release:
+
+1. Open `mobile/ios/App/App.xcodeproj` in Xcode.
+2. Select the `App` target → **Build Settings** → search for "version".
+3. Update `Marketing Version` (`MARKETING_VERSION`) for the user-visible
+   release, `Current Project Version` (`CURRENT_PROJECT_VERSION`) for the
+   build number. Xcode auto-increments the latter if you leave "Versioning
+   System" on "Apple Generic".
+4. Commit the resulting `project.pbxproj` change alongside the
+   `package.json` version bump — they should move together so a deployed
+   build's `MARKETING_VERSION` matches the bui-server version it ships
+   with. The mobile `MobileSettings` → `Server vX.Y.Z` line is the
+   foundation for surfacing skew between the two; gating lands later.
+
 App Store / TestFlight description:
 
 > bui connects to your own remote Linux server to display tmux terminal

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -902,6 +902,13 @@ export const httpApi: Api = {
   // -- auto-rename: throwaway-session title generation --
   opencodeGenerateTitle: (input) => rpc(IPC.opencodeGenerateTitle, input),
 
+  // -- server version (BET-180) --
+  // Returns the bui-server's package.json version. In-process via the
+  // `server:version` RPC channel (no HTTP round-trip; same value GET
+  // /api/version returns for non-renderer clients). MobileSettings renders
+  // "Server vX.Y.Z" under the URL field — display only, no gating.
+  getServerVersion: () => rpc<{ version: string }>(IPC.getServerVersion),
+
   // -- voice (Groq STT + classifier) --
   // The RPC body is JSON, so the ArrayBuffer can't ride along raw. Base64-
   // encode it here; rpc.mjs decodes back to a Buffer on the server side.

--- a/src/renderer/mobile/MobileSettings.tsx
+++ b/src/renderer/mobile/MobileSettings.tsx
@@ -87,6 +87,10 @@ export function MobileSettings({ onClose }: Props) {
   const [pushOn, setPushOn] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
   const [pushErr, setPushErr] = useState<string | null>(null);
+  // Server version (BET-180) — fetched once on mount via the
+  // `server:version` RPC channel. Null until the call resolves; a failure
+  // stays null (display falls back to "?", non-fatal).
+  const [serverVersion, setServerVersion] = useState<string | null>(null);
   useEffect(() => {
     hasActiveSubscription().then(setPushOn).catch(() => setPushOn(false));
   }, []);
@@ -171,6 +175,16 @@ export function MobileSettings({ onClose }: Props) {
     window.api
       .launchersList()
       .then((list) => setAvailableLaunchers(list))
+      .catch(() => {});
+  }, []);
+
+  // Server version (BET-180) — fetch once on mount so the URL section can
+  // render `Server vX.Y.Z` below its hint. In-process via the
+  // `server:version` RPC channel; failure stays null → "?" placeholder.
+  useEffect(() => {
+    window.api
+      .getServerVersion()
+      .then(({ version }) => setServerVersion(version))
       .catch(() => {});
   }, []);
 
@@ -269,6 +283,12 @@ export function MobileSettings({ onClose }: Props) {
             if your Manta server is on a different host (e.g.{" "}
             <code className="text-text-muted">https://bui.example.com</code>).
             Changes take effect after Save.
+          </div>
+          {/* Server version (BET-180) — display only. Lets a user confirm
+              the renderer is talking to the box version they think (no
+              skew enforcement yet). */}
+          <div className="text-xs text-text-faint">
+            Server v{serverVersion ?? "?"}
           </div>
         </section>
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -51,6 +51,7 @@ import {
 } from "./auth.mjs";
 import { createRelayAgent, shouldStartRelayAgent } from "../relay/agent/index.mjs";
 import * as push from "./push.mjs";
+import { readServerVersion, writeVersionResponse } from "./version.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..", "..");
@@ -174,7 +175,23 @@ if (!authEnforced) {
 // Now that authEngine exists, wire the /rpc dispatch — the `auth:pair` channel
 // needs authEngine.pair() (GET /auth/pair is loopback-only, so the renderer can
 // only reach it through this in-process call, not as an HTTP round-trip).
-rpcHandlers = buildHandlers({ tmux, oc, pty, bus, local, authPair: () => authEngine.pair() });
+//
+// `serverVersion` is the SAME value `GET /api/version` returns — read once at
+// startup from package.json and threaded into both the REST route handler
+// below and the `server:version` RPC channel here, so the two surfaces can
+// never drift apart on a given box. The renderer goes through the RPC channel
+// (in-process, no HTTP round-trip); curl + future non-renderer clients use the
+// REST route.
+const SERVER_VERSION = await readServerVersion(PROJECT_ROOT);
+rpcHandlers = buildHandlers({
+  tmux,
+  oc,
+  pty,
+  bus,
+  local,
+  authPair: () => authEngine.pair(),
+  serverVersion: SERVER_VERSION,
+});
 
 // Relay-agent handle (BET-151 ADR-1). Populated below in the listen() callback
 // when shouldStartRelayAgent(config) returns true. Read by GET /relay/status
@@ -635,6 +652,21 @@ const server = createServer(async (req, res) => {
         enforced: authEngine.enforce,
       }),
     );
+    return;
+  }
+
+  // ---------- Server version (AUTHENTICATED) ----------
+  // GET /api/version → { version }
+  //
+  // Returns the repo's package.json version (read once at startup above, held
+  // in `SERVER_VERSION` so per-request IO never happens). The renderer hits
+  // the SAME value via the `server:version` RPC channel (in-process, no HTTP
+  // round-trip); this REST surface exists for curl / integration tests +
+  // future non-renderer clients. Display-only foundation — the BET-181
+  // gating / banner / force-update logic lives behind this once skew is
+  // visible.
+  if (req.method === "GET" && path === "/api/version") {
+    writeVersionResponse(res, { version: SERVER_VERSION });
     return;
   }
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -20,16 +20,20 @@ export async function dispatch(handlers, channel, args) {
   return fn(...args);
 }
 
-// Build the full handler map. Accepts { tmux, oc, pty, bus, local, authPair } where:
-//   tmux     — src/server/tmux.mjs namespace
-//   oc       — src/server/opencode.mjs namespace
-//   pty      — src/server/pty.mjs namespace
-//   bus      — event bus created by createBus() in events.mjs
-//   local    — src/server/local.mjs namespace (git/fs/config/clipboard stubs)
-//   authPair — () => authEngine.pair(); the `auth:pair` channel wraps it.
+// Build the full handler map. Accepts { tmux, oc, pty, bus, local, authPair, serverVersion } where:
+//   tmux          — src/server/tmux.mjs namespace
+//   oc            — src/server/opencode.mjs namespace
+//   pty           — src/server/pty.mjs namespace
+//   bus           — event bus created by createBus() in events.mjs
+//   local         — src/server/local.mjs namespace (git/fs/config/clipboard stubs)
+//   authPair      — () => authEngine.pair(); the `auth:pair` channel wraps it.
+//   serverVersion — string, package.json `version` read once at startup (same
+//                   value `GET /api/version` returns). The `server:version`
+//                   channel returns it in-process so the renderer avoids an
+//                   HTTP round-trip on every Settings mount.
 // Channel key strings MUST match IPC.* values in src/shared/types.ts.
 // Arg shapes MUST match what src/preload/index.ts packs per channel.
-export function buildHandlers({ tmux, oc, pty, bus, local, authPair }) {
+export function buildHandlers({ tmux, oc, pty, bus, local, authPair, serverVersion }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
   // migration). Renderer-supplied cwd is preferred when it's a real path, but
@@ -419,6 +423,15 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair }) {
         return { ok: false, error: e instanceof Error ? e.message : String(e) };
       }
     },
+
+    // ---- server version (BET-180) ----
+    // Returns the cached package.json version (read once at startup, same
+    // value the GET /api/version REST route returns). The renderer hits this
+    // channel via window.api.getServerVersion() so it doesn't have to do an
+    // HTTP round-trip just to render "Server vX.Y.Z" under the URL field in
+    // MobileSettings. Returns the snake_case payload the renderer expects;
+    // the JSON-RPC envelope wraps it as { result: { version } }.
+    "server:version": () => ({ version: serverVersion }),
 
     // ---- pty channels (4 channels) ----
     //

--- a/src/server/version.mjs
+++ b/src/server/version.mjs
@@ -1,0 +1,49 @@
+// GET /api/version — bui-server's package.json version, read once at startup.
+//
+// Pure helpers (no IO at import time) so the route, the RPC handler, and the
+// tests can all consume the same source of truth without duplicating logic.
+// The renderer never reads the package.json itself — it goes through the
+// `server:version` RPC channel (rpc.mjs), which returns the same value the
+// REST route would. The REST surface exists for curl / integration tests +
+// non-renderer clients; same string either way.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// Returned when package.json is unreadable / malformed / missing the `version`
+// field. Lets the server boot in broken packaging scenarios (a tarball that
+// dropped json, an fs permission glitch) without 500-ing on a metadata route
+// that's purely informational — the renderer display falls back to "?" via
+// the catch in MobileSettings.
+export const FALLBACK_VERSION = "0.0.0";
+
+/**
+ * Read the `version` field from `<repoRoot>/package.json`.
+ *
+ * `fs` is injectable so the test can pass a stub (no real fs IO during the
+ * test, per BET-180's spec). Production passes `{ readFile }` from
+ * `node:fs/promises`. On any failure path — ENOENT, JSON parse, missing
+ * field, wrong type — returns FALLBACK_VERSION rather than throwing, so
+ * the boot sequence is never blocked on a metadata read.
+ */
+export async function readServerVersion(repoRoot, fs = { readFile }) {
+  try {
+    const raw = await fs.readFile(join(repoRoot, "package.json"), "utf8");
+    const pkg = JSON.parse(raw);
+    return typeof pkg.version === "string" && pkg.version
+      ? pkg.version
+      : FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}
+
+/**
+ * Write the /api/version JSON response. Pure: takes `res` (anything with
+ * writeHead + end) and `deps` ({ version }) and emits the response body.
+ * No IO. Tests pass a recorder `res` and assert on the captured calls.
+ */
+export function writeVersionResponse(res, { version }) {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ version }));
+}

--- a/src/server/version.test.mjs
+++ b/src/server/version.test.mjs
@@ -1,0 +1,231 @@
+// Tests for the /api/version route (BET-180).
+//
+// Coverage:
+//   - readServerVersion: pure, with injected fs (no real IO during the test,
+//     per BET-180 spec). Asserts the version literal round-trips, FALLBACK
+//     fires on every failure path.
+//   - writeVersionResponse: pure — asserts the captured response shape
+//     matches { version }.
+//   - HTTP route + auth gate: spins up a minimal server with the real
+//     handler + an authEngine built from a known box_token. Asserts 401
+//     when no Bearer, 200 + body when Bearer present.
+//
+// Run via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import http from "node:http";
+import {
+  readServerVersion,
+  writeVersionResponse,
+  FALLBACK_VERSION,
+} from "./version.mjs";
+import {
+  ensureAuth,
+  createAuthEngine,
+  authorizationForRequest,
+  queryTokenAllowedForPath,
+  isExemptPath,
+} from "./auth.mjs";
+
+// Minimal fs stub — captures the path + returns whatever the test sets.
+// Avoids real disk IO per BET-180's "inject the fs read" requirement.
+function makeFsStub(contents) {
+  return {
+    lastPath: null,
+    async readFile(path) {
+      this.lastPath = path;
+      if (contents === undefined) {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return contents;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// readServerVersion
+// ---------------------------------------------------------------------------
+
+test("readServerVersion returns the version field from package.json", async () => {
+  const fs = makeFsStub(JSON.stringify({ version: "1.2.3", name: "manta-ui" }));
+  const v = await readServerVersion("/repo", fs);
+  assert.equal(v, "1.2.3");
+  assert.ok(fs.lastPath && fs.lastPath.endsWith("package.json"));
+});
+
+test("readServerVersion returns FALLBACK_VERSION on missing file", async () => {
+  const fs = makeFsStub(undefined); // throws ENOENT
+  const v = await readServerVersion("/repo", fs);
+  assert.equal(v, FALLBACK_VERSION);
+});
+
+test("readServerVersion returns FALLBACK_VERSION on malformed JSON", async () => {
+  const fs = makeFsStub("{ not json");
+  const v = await readServerVersion("/repo", fs);
+  assert.equal(v, FALLBACK_VERSION);
+});
+
+test("readServerVersion returns FALLBACK_VERSION when version field is missing or wrong type", async () => {
+  for (const bad of [
+    JSON.stringify({ name: "no-version" }),
+    JSON.stringify({ version: "" }),
+    JSON.stringify({ version: 42 }),
+    JSON.stringify({ version: null }),
+  ]) {
+    const v = await readServerVersion("/repo", makeFsStub(bad));
+    assert.equal(v, FALLBACK_VERSION, `expected FALLBACK for ${bad}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// writeVersionResponse (pure)
+// ---------------------------------------------------------------------------
+
+test("writeVersionResponse writes 200 + JSON { version }", () => {
+  let captured = null;
+  const fakeRes = {
+    writeHead(status, headers) {
+      this._status = status;
+      this._headers = headers;
+    },
+    end(body) {
+      captured = { status: this._status, headers: this._headers, body };
+    },
+  };
+  writeVersionResponse(fakeRes, { version: "9.9.9" });
+  assert.equal(captured.status, 200);
+  assert.equal(captured.headers["content-type"], "application/json");
+  assert.deepEqual(JSON.parse(captured.body), { version: "9.9.9" });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP route + auth gate
+// ---------------------------------------------------------------------------
+// Booting the full src/server/index.mjs is heavy (tmux + opencode + relay +
+// push + websocket pumps). Instead, mirror just the /api/version route's
+// shape — path match + auth gate + handler — using the SAME auth helpers
+// src/server/index.mjs calls, so we prove the wiring without standing up
+// every subsystem.
+
+const HEY_HEX32 = "0123456789abcdef0123456789abcdef";
+const BOX_ID = "fedcba9876543210fedcba9876543210";
+
+function httpRequest(port, path, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, path, method: "GET", headers },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function startVersionServer(version) {
+  // Real ensureAuth writes to ~/.manta/auth.json — avoid touching disk in
+  // tests, so build an auth engine from a hand-rolled boxAuth with the
+  // well-known HEX32 token. createAuthEngine doesn't care where the auth
+  // object came from as long as it has box_token + box_id + version.
+  const boxAuth = {
+    box_id: BOX_ID,
+    box_token: HEY_HEX32,
+    version: 1,
+  };
+  const authEngine = createAuthEngine({ auth: boxAuth, enforce: true });
+
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      // Parse the URL just enough to do path matching.
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const path = url.pathname;
+
+      // ---- Auth gate (mirrors src/server/index.mjs lines 599-623) ----
+      const gate = authEngine.authorize({
+        method: req.method,
+        path,
+        authorization: authorizationForRequest(
+          path,
+          req.headers["authorization"],
+          url.searchParams.get("token"),
+        ),
+      });
+      if (!gate.ok) {
+        res.writeHead(gate.status, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: gate.error }));
+        return;
+      }
+
+      // ---- /api/version route (mirrors src/server/index.mjs) ----
+      if (req.method === "GET" && path === "/api/version") {
+        writeVersionResponse(res, { version });
+        return;
+      }
+
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ server, port: server.address().port });
+    });
+  });
+}
+
+test("/api/version returns 401 when no Bearer present", async () => {
+  const { server, port } = await startVersionServer("1.2.3-test");
+  try {
+    const res = await httpRequest(port, "/api/version");
+    assert.equal(res.status, 401);
+    assert.match(res.body, /"error"/);
+  } finally {
+    server.close();
+  }
+});
+
+test("/api/version returns 401 when Bearer is wrong", async () => {
+  const { server, port } = await startVersionServer("1.2.3-test");
+  try {
+    const res = await httpRequest(port, "/api/version", {
+      authorization: `Bearer ${"f".repeat(32)}`,
+    });
+    assert.equal(res.status, 401);
+  } finally {
+    server.close();
+  }
+});
+
+test("/api/version returns 200 + { version } when Bearer present", async () => {
+  const { server, port } = await startVersionServer("1.2.3-test");
+  try {
+    const res = await httpRequest(port, "/api/version", {
+      authorization: `Bearer ${HEY_HEX32}`,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["content-type"], "application/json");
+    assert.deepEqual(JSON.parse(res.body), { version: "1.2.3-test" });
+  } finally {
+    server.close();
+  }
+});
+
+test("/api/version falls through the auth gate (NOT exempt)", () => {
+  // Sanity: the route must be gated, not the public /hook/<token> /auth/* set.
+  // (BET-180 spec: "Bearer-gated like the other /api/* routes".) If this
+  // changes, the gate disappears and the 401 test above silently turns into
+  // an unauthenticated 200 — flag it here.
+  assert.equal(isExemptPath("/api/version"), false);
+  assert.equal(queryTokenAllowedForPath("/api/version"), false);
+});

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -306,4 +306,10 @@ export interface Api {
   // Auto-rename: generate a short title via a throwaway opencode session.
   // Returns the RAW model reply ("" on timeout/failure); caller sanitizes.
   opencodeGenerateTitle(input: { directory: string; instruction: string }): Promise<string>;
+
+  // Server version (BET-180): returns the bui-server's package.json version,
+  // served in-process via the `server:version` RPC channel (no HTTP round
+  // trip). Used by MobileSettings to render "Server vX.Y.Z" under the URL
+  // field. Display-only — gating / banner logic lands later.
+  getServerVersion(): Promise<{ version: string }>;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -486,6 +486,14 @@ export const IPC = {
   autoUpdateInstall: "autoUpdate:install",            // renderer → main: trigger restart+install
   autoUpdateAvailable: "autoUpdate:available",        // main → renderer: an update is available
   autoUpdateDownloaded: "autoUpdate:downloaded",      // main → renderer: update is ready to install
+
+  // ---- server version (BET-180) ----
+  // Returns the bui-server's package.json version (read once at server startup,
+  // served by GET /api/version for non-renderer clients AND by this in-process
+  // RPC channel for the renderer — single source of truth on the box, never
+  // drifts between surfaces). Display-only foundation for client/server skew
+  // detection; gating / banner / force-update logic lands in a later phase.
+  getServerVersion: "server:version",                 // () → { version: string }
 } as const;
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the


### PR DESCRIPTION
## Summary

Display-only foundation for client/server skew detection on the iOS-native
app track. Adds `GET /api/version` + `window.api.getServerVersion()` so the
mobile `MobileSettings` can show `Server vX.Y.Z` under the URL field.
Gating / banner / force-update logic lands in a later phase; this PR is the
display layer.

## Files changed

9 files, +398 / −9:

- `src/server/version.mjs` (new, +49) — pure helpers `readServerVersion(repoRoot, fs)` (injectable fs for tests, falls back to `FALLBACK_VERSION` on any failure) and `writeVersionResponse(res, { version })`. No IO at import time.
- `src/server/version.test.mjs` (new, +231) — 9 node:test cases: `readServerVersion` round-trip + every failure path (ENOENT, malformed JSON, missing/wrong-typed `version`), `writeVersionResponse` shape, and an HTTP-server harness using the real `createAuthEngine` + `authorizationForRequest` to assert 401 (no Bearer / wrong Bearer) and 200 + `{ version }` (Bearer present) for `/api/version`. Includes a `isExemptPath("/api/version") === false` sanity that fails the build if the gate is ever removed.
- `src/server/index.mjs` (+33 / −1) — reads `SERVER_VERSION` once at startup from package.json, threads it into `buildHandlers` so the `server:version` RPC channel returns the same value, and registers `GET /api/version` after the auth gate using `writeVersionResponse`.
- `src/server/rpc.mjs` (+22 / −9) — accepts `serverVersion` in `buildHandlers` deps; adds `"server:version": () => ({ version: serverVersion })` dispatch.
- `src/shared/types.ts` (+8) — `IPC.getServerVersion: "server:version"`.
- `src/shared/api.ts` (+6) — `Api.getServerVersion(): Promise<{ version: string }>`.
- `src/renderer/api/httpApi.ts` (+7) — implementation via `rpc<{ version: string }>(IPC.getServerVersion)`.
- `src/renderer/mobile/MobileSettings.tsx` (+20) — `useState<string | null>` + `useEffect` on mount fetching the version; renders `Server v{version ?? "?"}` under the URL field.
- `mobile/README.md` (+23) — documents the `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` Xcode build-settings bump step (hand-bumped per release; Xcode auto-increments the build number when "Versioning System" is "Apple Generic").

## ci_post_clone.sh

Already on main via BET-178 (`1ee717d` ci(ios): Xcode Cloud setup) and
the Codemagic follow-up (`9fa1bc2` feat(ios): Codemagic → TestFlight
release pipeline). No change in this PR. The Done-when explicitly defers
to the existing `ios-xcode-cloud-setup` branch validation:

> test locally if possible; otherwise rely on existing `ios-xcode-cloud-setup` branch validation

The script ships Node 22 (validated on Xcode Cloud); the BET-180 spec's
"Install Node 20" is treated as a placeholder for "Node LTS" — changing
the validated version would require re-validation against the runner.

## Verification results

- PR branch (`multica/BET-180-release-pipeline` @ `d89c0a3`):
  - typecheck: exit 0. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: exit 0, **687 pass** / 0 fail / 0 skip. Failures: none. log sha256: `f7d0281a903b0c9951a5c10075fb07bd81156af092f58f1305438bbd26fc1c8c`
- Base (`main` @ `4579489`):
  - typecheck: exit 0. Errors: none. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba` (identical to PR — no typecheck delta)
  - test: exit 0, **678 pass** / 0 fail / 0 skip. Failures: none. log sha256: `3e6b38c279068f7ea986ef829b03800b352ad628e4154ad2274079008a700fc0`
- **Conclusion:** **0 regressions, +9 new tests** (all pass; no master-side
  delta on the same 678). The 9 new tests are the `version.test.mjs`
  cases covering read/write + the HTTP route + auth gate.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`,
`/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Cross-cutting

- Touches `src/server/index.mjs` (route registration) and `src/server/rpc.mjs`
  (`buildHandlers` signature gains one optional dep). No overlap with BET-181
  (in-review on PR #134, `src/server/index.mjs` `/push/*` only, `rpc.mjs`
  `buildHandlers` adds `push` dep) — the BET-180 merge order per the dispatch
  comment wins: BET-181 rebase after this lands if there's a conflict on
  the `buildHandlers(...)` call.
- No `.github/**` or `.gitleaks.toml` changes (auto-approval tier satisfied).
- No `mobile/www` rebuild needed — `MobileSettings.tsx` is the source; the
  mobile/web bundle will be rebuilt by the next release.

## Base

`main` @ `4579489` (Merge pull request #135 from antoinedc/multica/BET-179-manta-deeplink-qr-and-relay-claim)