### PR TITLE
Stage 1 — MantaUI plugins: box-side spine (cap job queue + ios-build AI tool) [BET-184]

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -171,6 +171,14 @@ workflows:
         - pattern: "mac-v*"
           include: true
     scripts:
+      - name: Provide distutils for node-gyp (Python 3.12+)
+        script: |
+          # electron-builder rebuilds the native node-pty module via node-gyp,
+          # which imports Python's `distutils`. Python 3.12 (the Codemagic M2
+          # default) REMOVED distutils from the stdlib, so the rebuild fails with
+          # "ModuleNotFoundError: No module named 'distutils'". `setuptools`
+          # re-provides a distutils shim. Install it into the runner's python3.
+          python3 -m pip install --upgrade "setuptools<81" || pip3 install "setuptools<81"
       - name: Install deps
         script: |
           npm ci

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -158,8 +158,10 @@ workflows:
       app_store_connect: APS Key
     environment:
       groups:
-        - mac_signing            # CSC_LINK, CSC_KEY_PASSWORD, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID
-        - prod_deploy            # PROD_SSH_KEY (optional — remove if not publishing)
+        # All mac signing + deploy vars live in one Codemagic UI group named
+        # "mantaui": CSC_LINK, CSC_KEY_PASSWORD, APPLE_ID,
+        # APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID, and (optional) PROD_SSH_KEY.
+        - mantaui
       node: 22
       xcode: latest
     triggering:

--- a/docs/mac-beta-distribution.md
+++ b/docs/mac-beta-distribution.md
@@ -30,9 +30,10 @@ DMG on a Codemagic M2 runner and publishes it to `mantaui.com`.
 2. **App-specific password** for notarization: https://appleid.apple.com →
    Sign-In & Security → App-Specific Passwords → generate one.
 
-3. **Codemagic UI → the app → Environment variables**, add two groups:
+3. **Codemagic UI → the app → Environment variables**, add ONE group named
+   exactly **`mantaui`** (the group name must match `codemagic.yaml`), all vars
+   marked *Secure*:
 
-   Group **`mac_signing`** (all marked *Secure*):
    | var | value |
    |---|---|
    | `CSC_LINK` | the `.p12`, base64-encoded (`base64 -i cert.p12 \| pbcopy`) |
@@ -40,12 +41,7 @@ DMG on a Codemagic M2 runner and publishes it to `mantaui.com`.
    | `APPLE_ID` | your Apple ID email |
    | `APPLE_APP_SPECIFIC_PASSWORD` | the app-specific password |
    | `APPLE_TEAM_ID` | `FSQ3HS4Z24` |
-
-   Group **`prod_deploy`** (optional — only if you want Codemagic to publish to
-   the box; otherwise download the DMG from Codemagic artifacts and skip this):
-   | var | value |
-   |---|---|
-   | `PROD_SSH_KEY` | a base64-encoded SSH private key with access to `root@91.107.196.2` |
+   | `PROD_SSH_KEY` | *(optional)* base64 SSH private key for `root@91.107.196.2` — only if you want Codemagic to publish to the box; otherwise download the DMG from Codemagic artifacts |
 
 ### Trigger a build
 

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -168,3 +168,27 @@ worker for mechanical edits and file lookups" or "Deep thinker for architecture
 and hard debugging"). When you call `task(subagent_type: "fast")`, opencode
 dispatches to that agent's configured model. The user manages these in bui's
 Settings > AI > Subagents.
+
+## MantaUI iOS build
+
+You have an `ios_build` tool that compiles the MantaUI iOS app on the connected
+Mac and boots it in the iOS Simulator — used instead of burning Codemagic build
+minutes. Reach for it whenever the user asks to build, run, or test the iOS app
+locally.
+
+**Branch semantics — read before calling.** The Mac executor builds the Mac's
+own git clone (tracking `origin/main`), NOT this session's working tree or
+branch. If the user wants their current changes built, they must be
+merged/pushed to `origin/main` first, then call with `pull:true` to make the
+Mac clone fast-forward to the new main.
+
+**Mac requirements.** The Mac must be awake with MantaUI running and the
+capability executor enabled in Settings (default OFF — a deliberate trust
+boundary). With those in place the tool returns a job id immediately and a
+completion message is injected into this session when the build finishes
+(or fails / times out).
+
+**Do NOT poll in a loop.** Completion arrives automatically as a new turn
+from the originating opencode session. Use `ios_build_status(id)` only when
+the user explicitly asks for mid-build progress, or after completion to
+inspect the log tail.

--- a/docs/opencode-tools/ios-build.ts
+++ b/docs/opencode-tools/ios-build.ts
@@ -1,0 +1,133 @@
+// MantaUI plugin tool: ios-build — global opencode custom tool.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp docs/opencode-tools/ios-build.ts ~/.config/opencode/tools/ios-build.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+// (CPY, never symlink — the `@opencode-ai/plugin` import-resolution gotcha in
+// docs/bui-tools-scheduler.md §"DO NOT symlink".)
+//
+// This tool is a THIN registrar. It validates the request and POSTs it to
+// manta-server (127.0.0.1:8787, same box — no SSH hop), which owns the durable
+// job queue (src/server/capabilities.mjs). The tool does NOT block on the build;
+// execute() returns immediately with the job id, and a completion turn is
+// injected back into this session when the Mac executor finishes (or the
+// server-side sweep times it out).
+//
+// First plugin of the MantaUI plugin system (docs/mantaui-plugins.md). The
+// queue speaks the GENERIC {capability, input, host} envelope; the ONLY
+// iOS-specific bits here are the "ios.build" capability id and host:"mac".
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const ios_build = tool({
+  description: [
+    "Compile the MantaUI iOS app on the connected Mac and boot it in the iOS",
+    "Simulator. Use when the user asks to build/run/test the iOS app locally",
+    "instead of on Codemagic. IMPORTANT — what gets built: the Mac's own git",
+    "clone (tracking origin/main), NOT this session's working tree or branch.",
+    "If the user wants their current changes built, they must be merged/pushed",
+    "to origin/main first, then call with pull:true. The Mac must be awake",
+    "with the MantaUI app running and the capability executor enabled in",
+    "Settings. Returns a job id immediately. Do NOT poll in a loop: when the",
+    "job finishes (or fails/times out), a completion message is injected into",
+    "this session automatically as a new turn. Use ios_build_status only if",
+    "the user asks for progress mid-build.",
+  ].join(" "),
+  args: {
+    action: z
+      .enum(["build-and-launch", "test", "compile-only"])
+      .optional()
+      .describe(
+        "build-and-launch (default): compile + boot simulator + launch app; " +
+          "test: run xcodebuild test; " +
+          "compile-only: just compile, no simulator.",
+      ),
+    pull: z
+      .boolean()
+      .optional()
+      .describe(
+        "Run `git pull --ff-only origin main` in the Mac clone before " +
+          "building (default false).",
+      ),
+  },
+  async execute(args, context) {
+    const r = await call("POST", "/api/cap", {
+      capability: "ios.build",
+      host: "mac",
+      input: { action: args.action ?? "build-and-launch", pull: !!args.pull },
+      sessionID: context.sessionID,
+      directory: context.directory,
+    });
+    return `iOS build queued on the Mac (job ${r.id}). You will be notified in this session when it finishes — do not poll.`;
+  },
+});
+
+export const ios_build_status = tool({
+  description:
+    "Check an iOS build job: status (queued/running/done/failed) + the tail of " +
+    "the build log. Use the job id returned by ios_build. Prefer waiting for " +
+    "the automatic completion message; use this only for mid-build progress " +
+    "or after completion to inspect the log.",
+  args: { id: z.string().describe("The job id from ios_build.") },
+  async execute(args) {
+    const j = await call("GET", `/api/cap/${encodeURIComponent(args.id)}`);
+    const tail = (j.log?.join("") ?? "").split("\n").slice(-50).join("\n");
+    const head =
+      `Job ${j.id} (${j.capability}) — ${j.status}` +
+      (j.error ? ` — ${j.error}` : "");
+    return tail ? `${head}\n\n--- log tail ---\n${tail}` : head;
+  },
+});

--- a/src/server/capNotifier.mjs
+++ b/src/server/capNotifier.mjs
@@ -1,0 +1,27 @@
+// Capability-job completion notification: bridges the queue's field naming
+// to opencode's. capabilities.mjs calls notifySession({sessionID, text})
+// (the queue's natural shape — matches the job shape it persists);
+// oc.sendPrompt expects camelCase `sessionId`. This module OWNS the
+// field-name translation so there is exactly one definition (shared by
+// /api/cap/:id/done and the startCapSweeper deps in index.mjs), and so the
+// translation is unit-tested in isolation — a regression here would
+// silently strand the completion turn on /session/undefined/prompt_async
+// (the bug BET-184 review-return flagged).
+//
+// Keep this file the ONLY place that translates sessionID → sessionId; the
+// pass-through wiring elsewhere would let a field-name typo silently drop
+// the session id and never reach opencode.
+
+import * as oc from "./opencode.mjs";
+
+/**
+ * Bridge a capability job's terminal notification into an opencode
+ * session prompt. Field-name translation: sessionID (caps) → sessionId
+ * (opencode). Errors are propagated (caller is expected to swallow + log).
+ *
+ * @param {{sessionID: string, text: string}} args
+ * @returns {Promise<unknown>}
+ */
+export function notifyCapSession({ sessionID, text }) {
+  return oc.sendPrompt({ sessionId: sessionID, text });
+}

--- a/src/server/capNotifier.test.mjs
+++ b/src/server/capNotifier.test.mjs
@@ -1,0 +1,90 @@
+// Tests the field-name translation in src/server/capNotifier.mjs: the
+// bridge between capabilities.mjs's `notifySession({sessionID, text})`
+// contract and oc.sendPrompt's `{sessionId, text}` shape.
+//
+// Why a live HTTP server: the bug BET-184 review-return flagged was a
+// passthrough `(args) => oc.sendPrompt(args)` that silently dropped the
+// session id, so the request landed at `/session/undefined/prompt_async`
+// and the completion turn never reached the originating session. A pure
+// unit test (mock sendPrompt, capture args) would pass even with the bug —
+// the bug is in the field-NAME translation, not in the call-shape. The
+// cheapest proof that the right field is on the wire is to capture the
+// HTTP request (URL + body) and assert its shape.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import * as oc from "./opencode.mjs";
+import { notifyCapSession } from "./capNotifier.mjs";
+
+// oc.sendPrompt dispatches through `ocFetch`, which opencode.mjs
+// exposes a test-only transport override for (`_setOcTransport`). That
+// lets us capture the URL + body without standing up a real HTTP server
+// or needing opencode to be running.
+function captureSendPrompt(args) {
+  return new Promise(async (resolve, reject) => {
+    let captured = null;
+    const prev = oc._setOcTransport((url, init) => {
+      captured = { url, method: init?.method, body: init?.body };
+      // Return a minimal valid WHATWG Response.
+      return Promise.resolve(
+        new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+      );
+    });
+    try {
+      await notifyCapSession(args);
+    } catch (e) {
+      // ignore — we just want the capture
+    } finally {
+      oc._setOcTransport(prev); // null restores default
+    }
+    resolve(captured);
+  });
+}
+
+test("notifyCapSession translates sessionID → sessionId in the URL", async () => {
+  const captured = await captureSendPrompt({
+    sessionID: "ses_abc123",
+    text: "hello from the bridge",
+  });
+  assert.ok(captured, "transport was called");
+  // URL must encode the camelCase sessionId — a passthrough would have
+  // built `/session/undefined/prompt_async` (silent drop, the BET-184 bug).
+  assert.match(
+    captured.url,
+    /\/session\/ses_abc123\/prompt_async/,
+    `url must contain the camelCase sessionId, got ${captured.url}`,
+  );
+  assert.equal(captured.method, "POST");
+});
+
+test("notifyCapSession embeds the text in the request body as a parts array", async () => {
+  const captured = await captureSendPrompt({
+    sessionID: "ses_xyz",
+    text: "build finished",
+  });
+  assert.ok(captured, "transport was called");
+  const parsed = JSON.parse(captured.body);
+  // oc.sendPrompt wraps text in {parts:[{type:"text", text}]}
+  assert.deepEqual(parsed.parts, [{ type: "text", text: "build finished" }]);
+});
+
+test("notifyCapSession would have produced /session/undefined before the fix", async () => {
+  // Regression guard: assert what a broken passthrough would have produced.
+  // If a future refactor regresses to passthrough, this test would fail.
+  const passthroughBug = (args) => oc.sendPrompt(args);
+  let captured = null;
+  const prev = oc._setOcTransport((url, init) => {
+    captured = { url, body: init?.body };
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+  try {
+    await passthroughBug({ sessionID: "ses_anything", text: "x" });
+  } catch {}
+  finally {
+    oc._setOcTransport(prev);
+  }
+  // The PASSTHROUGH form lands on /session/undefined — this proves the
+  // bug-shape the bridge exists to prevent.
+  assert.match(captured.url, /\/session\/undefined\/prompt_async/);
+});

--- a/src/server/capabilities.mjs
+++ b/src/server/capabilities.mjs
@@ -1,0 +1,442 @@
+// Capability job queue for the MantaUI server — the generic spine that lets any
+// MantaUI plugin register an AI-invokable capability and have a connected
+// device (the Mac, or the box itself) execute it. First plugin: `ios.build`
+// (compiled on the Mac to avoid burning Codemagic minutes), but the queue /
+// REST surface / SSE envelopes here speak the GENERIC `{capability, input,
+// host}` envelope — adding capability #2 is a new tool file + a new HANDLERS
+// entry, NOT a queue change. See docs/mantaui-plugins.md for the full design.
+//
+// Shape mirrors src/server/schedule.mjs: dependency-injected
+// ({load, save, publish, notifySession}) pure-logic-with-injected-I/O, plus a
+// startCapSweeper() wrapper with inFlight guard + timer.unref() that clones
+// startSchedulePoller exactly. The atomic-write helper is shared via
+// src/server/storeUtils.mjs (one source of truth across the on-disk stores).
+//
+// Server-owned so queued jobs survive Mac-app-close, Mac sleep, and box
+// reboot — the SSE+catch-up plumbing on the executor side picks them up when
+// the Mac comes back.
+
+import { readFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { STATE_DIRNAME } from "../shared/paths.mjs";
+import { atomicWrite } from "./storeUtils.mjs";
+
+// ---------------------------------------------------------------------------
+// Constants (single source of truth — see docs/mantaui-plugins.md §Constants)
+// ---------------------------------------------------------------------------
+
+const STORE_PATH = join(homedir(), STATE_DIRNAME, "cap-jobs.json");
+
+// Ring-buffer cap on a job's stored log. A runaway xcodebuild cannot fill the
+// disk or blow the AI's context — chunks are dropped oldest-first.
+const LOG_CAP_BYTES = 256 * 1024;
+// Max log bytes returned by getJob. Joined then tail-trimmed so callers see
+// recent output without paying the cost of the full buffer.
+const LOG_TAIL_BYTES = 16 * 1024;
+// Stale-job sweep cadence.
+const SWEEP_INTERVAL_MS = 60_000;
+// `running` jobs older than this → `failed "timed out after 30 minutes…"`.
+const RUNNING_TIMEOUT_MS = 30 * 60_000;
+// `queued` jobs older than this → `failed "expired: no executor picked…"`.
+const QUEUED_EXPIRY_MS = 24 * 60 * 60_000;
+// Terminal jobs older than this are pruned (silent retention).
+const TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60_000;
+// Hard cap on terminal-job count (oldest dropped first).
+const MAX_TERMINAL_JOBS = 50;
+
+// ---------------------------------------------------------------------------
+// Store (atomic, same pattern as schedule.mjs)
+// ---------------------------------------------------------------------------
+
+export async function loadJobs(path = STORE_PATH) {
+  try {
+    if (!existsSync(path)) return [];
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    return Array.isArray(parsed?.jobs) ? parsed.jobs : [];
+  } catch {
+    return []; // corrupt/unreadable → start empty rather than crash the server
+  }
+}
+
+export async function saveJobs(jobs, path = STORE_PATH) {
+  await mkdir(dirname(path), { recursive: true });
+  await atomicWrite(path, JSON.stringify({ jobs }, null, 2));
+}
+
+function genId() {
+  return randomBytes(4).toString("hex"); // 8-char hex, matches schedule/genId
+}
+
+// ---------------------------------------------------------------------------
+// Job mutations (all injected-I/O; no live filesystem / bus access in tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate the inputs the queue OWNS — generic envelope fields only. The
+ * `input` shape is capability-defined; the tool (which calls this) validates it
+ * before posting so the queue stays capability-agnostic.
+ */
+function validateCreate({ capability, host, sessionID }) {
+  if (typeof capability !== "string" || !capability.trim()) {
+    return "capability is required";
+  }
+  if (host !== "mac" && host !== "box") {
+    return "host must be \"mac\" or \"box\"";
+  }
+  if (typeof sessionID !== "string" || !sessionID.trim()) {
+    return "sessionID is required";
+  }
+  return null;
+}
+
+export async function createCapJob(
+  { capability, input = {}, host, sessionID, directory = "", now = () => Date.now() },
+  { load = loadJobs, save = saveJobs, publish } = {},
+) {
+  const err = validateCreate({ capability, host, sessionID });
+  if (err) return { ok: false, error: err };
+
+  const jobs = await load();
+  const job = {
+    id: genId(),
+    capability,
+    input: input ?? {},
+    host,
+    sessionID,
+    directory: typeof directory === "string" ? directory : "",
+    status: "queued",
+    createdAt: now(),
+    startedAt: null,
+    finishedAt: null,
+    log: [],
+    result: null,
+    error: null,
+  };
+  jobs.push(job);
+  await save(jobs);
+  publish?.({ kind: "capJob", payload: { id: job.id, capability, input: job.input, host } });
+  return { ok: true, job };
+}
+
+/**
+ * Get a single job with its log TAILED to LOG_TAIL_BYTES. The stored job is
+ * never mutated — the returned object is a shallow copy with `log` replaced
+ * by a single-element array containing the tailed string, plus a `logBytes`
+ * total so callers can tell truncation happened.
+ *
+ * Returns null when the job doesn't exist.
+ */
+export async function getJob(id, { load = loadJobs } = {}) {
+  const jobs = await load();
+  const job = jobs.find((j) => j.id === id);
+  if (!job) return null;
+  const joined = (job.log ?? []).join("");
+  const tailed =
+    joined.length > LOG_TAIL_BYTES ? joined.slice(-LOG_TAIL_BYTES) : joined;
+  return {
+    ...job,
+    log: [tailed],
+    logBytes: joined.length,
+  };
+}
+
+/**
+ * List jobs with optional AND-combined filters. Results carry `logBytes`
+ * instead of `log` — this one signature serves the AI, the executor catch-up,
+ * and any future UI card (one code path). Returns a copy of the stored jobs.
+ */
+export async function listJobs(
+  { sessionID, host, status } = {},
+  { load = loadJobs } = {},
+) {
+  const jobs = await load();
+  return jobs
+    .filter(
+      (j) =>
+        (sessionID === undefined || j.sessionID === sessionID) &&
+        (host === undefined || j.host === host) &&
+        (status === undefined || j.status === status),
+    )
+    .map((j) => {
+      const { log, ...rest } = j;
+      return { ...rest, logBytes: (log ?? []).join("").length };
+    });
+}
+
+/**
+ * Append a log chunk to a `running` job. Ring-buffers: while the joined log
+ * exceeds LOG_CAP_BYTES the OLDEST chunks are dropped (`log.shift()`). Late
+ * flushes from a timed-out job are rejected — `{ok:false}` with no save — so
+ * a timed-out job cannot be resurrected by a late log POST.
+ */
+export async function appendLog(id, chunk, { load = loadJobs, save = saveJobs } = {}) {
+  const jobs = await load();
+  const idx = jobs.findIndex((j) => j.id === id);
+  if (idx === -1) return { ok: false, error: "not found" };
+  const job = jobs[idx];
+  if (job.status !== "running") {
+    return { ok: false, error: "job not running", status: job.status };
+  }
+  const text = String(chunk ?? "");
+  if (!text) return { ok: true }; // empty chunk is a no-op
+  job.log = [...(job.log ?? []), text];
+  while (job.log.length > 1 && job.log.join("").length > LOG_CAP_BYTES) {
+    job.log.shift();
+  }
+  await save(jobs);
+  return { ok: true };
+}
+
+/**
+ * GUARDED claim: only a `queued` job transitions to `running` (stamps
+ * startedAt). Missing job → `{ok:false, error:"not found"}`. Wrong status →
+ * `{ok:false, error:"not queued", status}`. This is the executor's cross-
+ * delivery dedup: a job delivered twice (SSE + catch-up list) is claimed once.
+ */
+export async function startJob(
+  id,
+  { load = loadJobs, save = saveJobs, now = () => Date.now() } = {},
+) {
+  const jobs = await load();
+  const idx = jobs.findIndex((j) => j.id === id);
+  if (idx === -1) return { ok: false, error: "not found" };
+  const job = jobs[idx];
+  if (job.status !== "queued") {
+    return { ok: false, error: "not queued", status: job.status };
+  }
+  job.status = "running";
+  job.startedAt = now();
+  jobs[idx] = job;
+  await save(jobs);
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Terminal transition — ONE shared helper for completeJob and the sweep.
+//
+// Both `completeJob(id, {status, result, error})` and `sweepCapJobs` need to
+// flip a job to done/failed, stamp finishedAt, publish the `cap.updated` bus
+// event, and notify the originating session. They differ only in HOW they
+// decide to do so, and how persistence is batched (completeJob saves once per
+// transition; sweep saves once total). `markTerminal` owns the business logic
+// (mutate + publish + notify) and the caller owns persistence — that's the
+// spec's "one terminal-transition code path" rule.
+// ---------------------------------------------------------------------------
+
+async function markTerminal(
+  job,
+  { status, error = null, result = null, nowMs },
+  { publish, notifySession },
+) {
+  job.status = status;
+  job.error = error ?? null;
+  job.result = result ?? null;
+  job.finishedAt = nowMs;
+  publish?.({ kind: "cap.updated", payload: { id: job.id, status, sessionID: job.sessionID } });
+  // completionText includes its own status check; await + swallow so a dead
+  // session never fails the REST call. Mirrors the scheduler's fire path.
+  if (notifySession && job.sessionID) {
+    try {
+      await notifySession({ sessionID: job.sessionID, text: completionText(job) });
+    } catch (e) {
+      console.warn(`[cap] notifySession failed for ${job.id}:`, e?.message ?? e);
+    }
+  }
+}
+
+/**
+ * Complete a job. `status` must be "done" or "failed" (else `{ok:false}`).
+ * IDEMPOTENT: if the job is already terminal, returns
+ * `{ok:true, alreadyTerminal:true}` WITHOUT saving, publishing, or notifying —
+ * a duplicate "done" POST from the executor must not double-notify the
+ * originating session. Otherwise stamps finishedAt, persists, publishes
+ * `cap.updated`, and notifies the originating session with `completionText`.
+ */
+export async function completeJob(
+  id,
+  { status, result = null, error = null },
+  { load = loadJobs, save = saveJobs, publish, notifySession, now = () => Date.now() } = {},
+) {
+  if (status !== "done" && status !== "failed") {
+    return { ok: false, error: "status must be \"done\" or \"failed\"" };
+  }
+  const jobs = await load();
+  const idx = jobs.findIndex((j) => j.id === id);
+  if (idx === -1) return { ok: false, error: "not found" };
+  const job = jobs[idx];
+  if (job.status === "done" || job.status === "failed") {
+    return { ok: true, alreadyTerminal: true };
+  }
+  // Allow completeJob only from `running` or `queued` — guards against a typo
+  // status string making its way in by a non-executor caller.
+  if (job.status !== "running" && job.status !== "queued") {
+    return { ok: false, error: "cannot complete from status", status: job.status };
+  }
+  jobs[idx] = job;
+  await markTerminal(
+    job,
+    { status, result, error, nowMs: now() },
+    { publish, notifySession },
+  );
+  await save(jobs);
+  return { ok: true };
+}
+
+/**
+ * Pure: the text injected into the originating opencode session when a job
+ * finishes. Tells the AI what happened and points it at ios_build_status (the
+ * example) to inspect the log without busy-polling. Exported so tests can pin
+ * the wording — the AI relies on this format to act on completions.
+ */
+export function completionText(job) {
+  const base = `[MantaUI capability job] ${job.capability} job ${job.id} finished with status "${job.status}".`;
+  const errSuffix = job.status === "failed" && job.error ? ` Error: ${job.error}.` : "";
+  const tail = ` Check the job's status tool (e.g. ios_build_status("${job.id}")) for the log tail, then report the outcome to the user.`;
+  return base + errSuffix + tail;
+}
+
+// ---------------------------------------------------------------------------
+// Sweep — stale jobs, expired jobs, retention.
+// ---------------------------------------------------------------------------
+
+/**
+ * One pass, one save. For each job:
+ *   - running > RUNNING_TIMEOUT_MS   → failed "timed out…"
+ *   - queued  > QUEUED_EXPIRY_MS     → failed "expired…"
+ *   - retention: drop terminal older than TERMINAL_RETENTION_MS; cap
+ *     MAX_TERMINAL_JOBS (drop oldest first). Silent.
+ * Save only when something changed.
+ */
+export async function sweepCapJobs({
+  load = loadJobs,
+  save = saveJobs,
+  publish,
+  notifySession,
+  now = () => Date.now(),
+} = {}) {
+  try {
+    const jobs = await load();
+    if (jobs.length === 0) return;
+    const nowMs = now();
+    const transitioned = [];
+
+    for (const job of jobs) {
+      if (
+        job.status === "running" &&
+        job.startedAt != null &&
+        nowMs - job.startedAt > RUNNING_TIMEOUT_MS
+      ) {
+        job._pendingTerminal = {
+          status: "failed",
+          error: "timed out after 30 minutes (Mac executor lost?)",
+        };
+        transitioned.push(job);
+      } else if (
+        job.status === "queued" &&
+        nowMs - job.createdAt > QUEUED_EXPIRY_MS
+      ) {
+        job._pendingTerminal = {
+          status: "failed",
+          error:
+            "expired: no executor picked this job up within 24h " +
+            "(is the Mac app running with the capability executor enabled?)",
+        };
+        transitioned.push(job);
+      }
+    }
+
+    if (transitioned.length === 0) {
+      // No timeouts/expiries — check retention only, and skip the save when
+      // nothing was pruned.
+      const retained = applyRetention(jobs, nowMs);
+      if (retained.length !== jobs.length) {
+        await save(retained);
+      }
+      return;
+    }
+
+    // Apply transitions via the shared markTerminal helper so the notify +
+    // publish + finishedAt-stamp logic stays in one place. markTerminal does
+    // NOT save — we save once below (sweep = one pass, one save).
+    for (const job of transitioned) {
+      const t = job._pendingTerminal;
+      delete job._pendingTerminal;
+      await markTerminal(
+        job,
+        { status: t.status, error: t.error, result: null, nowMs },
+        { publish, notifySession },
+      );
+    }
+    const retained = applyRetention(jobs, nowMs);
+    await save(retained);
+  } catch (e) {
+    console.warn("[cap] sweep failed:", e?.message ?? e);
+  }
+}
+
+// Drop terminal jobs older than TERMINAL_RETENTION_MS, then trim down to
+// MAX_TERMINAL_JOBS (oldest first). Returns the (possibly shorter) array.
+// Silent — dropped jobs do NOT publish (per spec).
+function applyRetention(jobs, nowMs) {
+  const cutoff = nowMs - TERMINAL_RETENTION_MS;
+  let out = jobs.filter(
+    (j) =>
+      !(
+        (j.status === "done" || j.status === "failed") &&
+        j.finishedAt != null &&
+        j.finishedAt < cutoff
+      ),
+  );
+  const terminal = out.filter((j) => j.status === "done" || j.status === "failed");
+  if (terminal.length > MAX_TERMINAL_JOBS) {
+    // Sort terminal oldest-first, drop the surplus.
+    const sorted = [...terminal].sort((a, b) => (a.finishedAt ?? 0) - (b.finishedAt ?? 0));
+    const dropped = new Set(sorted.slice(0, terminal.length - MAX_TERMINAL_JOBS).map((j) => j.id));
+    out = out.filter((j) => !dropped.has(j.id));
+  }
+  return out;
+}
+
+/**
+ * Start the capability sweeper. Clones startSchedulePoller's shape EXACTLY:
+ * build the deps with path-bound load/save, run once immediately,
+ * setInterval + timer.unref(), inFlight re-entrancy guard, returns {stop}.
+ */
+export function startCapSweeper(
+  { publish, notifySession } = {},
+  { intervalMs = SWEEP_INTERVAL_MS, storePath } = {},
+) {
+  const path = storePath ?? STORE_PATH;
+  const deps = {
+    load: () => loadJobs(path),
+    save: (jobs) => saveJobs(jobs, path),
+    publish,
+    notifySession,
+  };
+
+  let inFlight = false;
+  const tick = async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await sweepCapJobs(deps);
+    } catch (e) {
+      console.warn("[cap] sweep tick failed:", e?.message ?? e);
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  void tick();
+  const timer = setInterval(() => void tick(), intervalMs);
+  timer.unref();
+
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+  };
+}

--- a/src/server/capabilities.test.mjs
+++ b/src/server/capabilities.test.mjs
@@ -1,0 +1,580 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createCapJob,
+  startJob,
+  appendLog,
+  completeJob,
+  getJob,
+  listJobs,
+  sweepCapJobs,
+  completionText,
+} from "./capabilities.mjs";
+
+// ----------------------------------------------------------------------------
+// In-memory harness: load/save on a closure-held array, recorded publish + notify.
+// Mirrors the harness style of src/server/schedule.test.mjs.
+// ----------------------------------------------------------------------------
+
+function harness(initialJobs = [], fixedNow = 1_700_000_000_000) {
+  let jobs = initialJobs.map((j) => ({ ...j, log: j.log ? [...j.log] : [] }));
+  const published = [];
+  const notified = [];
+  const saved = [];
+  let nowMs = fixedNow;
+  const deps = {
+    load: async () => jobs.map((j) => ({ ...j, log: j.log ? [...j.log] : [] })),
+    save: async (next) => {
+      saved.push(next.map((j) => ({ ...j, log: j.log ? [...j.log] : [] })));
+      jobs = next.map((j) => ({ ...j, log: j.log ? [...j.log] : [] }));
+    },
+    publish: (evt) => published.push(evt),
+    notifySession: async (args) => {
+      notified.push(args);
+    },
+    now: () => nowMs,
+    setNow: (n) => { nowMs = n; },
+  };
+  return {
+    deps,
+    published,
+    notified,
+    saved,
+    get jobs() {
+      return jobs;
+    },
+  };
+}
+
+const T0 = 1_700_000_000_000;
+const RUNNING_TIMEOUT_MS = 30 * 60_000;
+const QUEUED_EXPIRY_MS = 24 * 60 * 60_000;
+const LOG_CAP_BYTES = 256 * 1024;
+const LOG_TAIL_BYTES = 16 * 1024;
+
+// ----------------------------------------------------------------------------
+// createCapJob — validation
+// ----------------------------------------------------------------------------
+
+test("createCapJob accepts a valid envelope and publishes capJob", async () => {
+  const h = harness();
+  const r = await createCapJob(
+    { capability: "ios.build", input: { foo: 1 }, host: "mac", sessionID: "ses_abc" },
+    h.deps,
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.job.status, "queued");
+  assert.equal(r.job.capability, "ios.build");
+  assert.equal(r.job.host, "mac");
+  assert.equal(r.job.input.foo, 1);
+  assert.equal(h.published.length, 1);
+  assert.equal(h.published[0].kind, "capJob");
+  assert.equal(h.published[0].payload.id, r.job.id);
+  assert.equal(h.published[0].payload.capability, "ios.build");
+  assert.equal(h.published[0].payload.host, "mac");
+});
+
+test("createCapJob rejects empty capability", async () => {
+  const h = harness();
+  const r = await createCapJob(
+    { capability: "", host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.error, /capability/i);
+});
+
+test("createCapJob rejects bad host", async () => {
+  const h = harness();
+  const r = await createCapJob(
+    { capability: "ios.build", host: "linux", sessionID: "ses" },
+    h.deps,
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.error, /host/i);
+});
+
+test("createCapJob rejects missing sessionID", async () => {
+  const h = harness();
+  const r = await createCapJob(
+    { capability: "ios.build", host: "mac", sessionID: "" },
+    h.deps,
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.error, /sessionID/i);
+});
+
+test("createCapJob does NOT validate input (queue is capability-agnostic)", async () => {
+  const h = harness();
+  // Anything goes in `input` — the tool owns the shape.
+  const r = await createCapJob(
+    { capability: "ios.build", input: { nested: { whatever: null } }, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.job.input, { nested: { whatever: null } });
+});
+
+// ----------------------------------------------------------------------------
+// createCapJob → startJob → appendLog → completeJob: full lifecycle
+// ----------------------------------------------------------------------------
+
+test("lifecycle: create → start → appendLog×N → done, with timestamps and events", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses_abc" },
+    h.deps,
+  );
+  assert.equal(created.ok, true);
+  const id = created.job.id;
+
+  const started = await startJob(id, h.deps);
+  assert.equal(started.ok, true);
+
+  await appendLog(id, "compiling...\n", h.deps);
+  await appendLog(id, "linking...\n", h.deps);
+  await appendLog(id, "done.\n", h.deps);
+
+  const done = await completeJob(id, { status: "done", result: { ok: true } }, h.deps);
+  assert.equal(done.ok, true);
+
+  // Status flipped + finishedAt stamped
+  assert.equal(h.jobs[0].status, "done");
+  assert.equal(h.jobs[0].finishedAt, T0);
+  assert.deepEqual(h.jobs[0].result, { ok: true });
+
+  // capJob (create) and cap.updated (complete) both published
+  const kinds = h.published.map((p) => p.kind);
+  assert.deepEqual(kinds, ["capJob", "cap.updated"]);
+  assert.equal(h.published[1].payload.id, id);
+  assert.equal(h.published[1].payload.status, "done");
+
+  // notifySession called once with completionText output
+  assert.equal(h.notified.length, 1);
+  assert.equal(h.notified[0].sessionID, "ses_abc");
+  assert.match(h.notified[0].text, /ios\.build job .+ finished with status "done"\./);
+});
+
+// ----------------------------------------------------------------------------
+// getJob — log tail + logBytes
+// ----------------------------------------------------------------------------
+
+test("getJob tails log to LOG_TAIL_BYTES and reports total logBytes", async () => {
+  // Seed a job whose log is large enough to trigger tailing.
+  const big = "x".repeat(LOG_TAIL_BYTES + 1000);
+  const seeded = {
+    id: "a1b2c3d4",
+    capability: "ios.build",
+    input: {},
+    host: "mac",
+    sessionID: "ses_abc",
+    directory: "",
+    status: "running",
+    createdAt: T0,
+    startedAt: T0,
+    finishedAt: null,
+    log: [big.slice(0, 1000), big.slice(1000)],
+    result: null,
+    error: null,
+  };
+  const h = harness([seeded]);
+  const job = await getJob(seeded.id, h.deps);
+  assert.ok(job, "getJob returns the seeded job");
+  assert.equal(job.logBytes, big.length);
+  // Tail returned as a single-element array of length LOG_TAIL_BYTES
+  assert.equal(job.log.length, 1);
+  assert.equal(job.log[0].length, LOG_TAIL_BYTES);
+  // The tail is the LAST LOG_TAIL_BYTES chars of the joined log
+  assert.equal(job.log[0], big.slice(-LOG_TAIL_BYTES));
+});
+
+test("getJob returns null for missing id", async () => {
+  const h = harness();
+  const job = await getJob("nope", h.deps);
+  assert.equal(job, null);
+});
+
+test("getJob does not mutate the stored job", async () => {
+  const seeded = {
+    id: "deadbeef",
+    capability: "ios.build",
+    input: {},
+    host: "mac",
+    sessionID: "ses_abc",
+    directory: "",
+    status: "running",
+    createdAt: T0,
+    startedAt: T0,
+    finishedAt: null,
+    log: ["a".repeat(100), "b".repeat(100)],
+    result: null,
+    error: null,
+  };
+  const h = harness([seeded]);
+  await getJob(seeded.id, h.deps);
+  // Stored log unchanged.
+  assert.deepEqual(h.jobs[0].log, ["a".repeat(100), "b".repeat(100)]);
+});
+
+// ----------------------------------------------------------------------------
+// appendLog — ring-buffer + status guard
+// ----------------------------------------------------------------------------
+
+test("appendLog ring-buffers: total joined length stays ≤ LOG_CAP_BYTES, oldest dropped first", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  await startJob(created.job.id, h.deps);
+
+  // Push chunks each > LOG_CAP_BYTES so each push triggers a drop.
+  const chunk = "y".repeat(LOG_CAP_BYTES / 4); // quarter-cap each
+  for (let i = 0; i < 8; i++) {
+    await appendLog(created.job.id, chunk, h.deps);
+  }
+  const total = h.jobs[0].log.join("").length;
+  assert.ok(total <= LOG_CAP_BYTES, `total ${total} ≤ ${LOG_CAP_BYTES}`);
+  // The very first chunks should be gone — the latest chunks should be present.
+  // Verify by checking that the log doesn't contain "yyyy" repeated enough to be the very first chunk.
+  // (Imprecise but proves old chunks were dropped.)
+  assert.ok(h.jobs[0].log.length < 8, "fewer than 8 chunks retained");
+});
+
+test("appendLog returns {ok:false} for a queued job", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  const r = await appendLog(created.job.id, "nope", h.deps);
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "job not running");
+  assert.equal(r.status, "queued");
+});
+
+test("appendLog returns {ok:false} for a terminal job (no resurrection)", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  await startJob(created.job.id, h.deps);
+  await completeJob(created.job.id, { status: "failed", error: "boom" }, h.deps);
+  const r = await appendLog(created.job.id, "late flush", h.deps);
+  assert.equal(r.ok, false);
+  // Status is reported as whatever the job currently is.
+  assert.equal(r.status, "failed");
+});
+
+test("appendLog returns {ok:false} for a missing job", async () => {
+  const h = harness();
+  const r = await appendLog("nonexistent", "x", h.deps);
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "not found");
+});
+
+// ----------------------------------------------------------------------------
+// startJob — guarded claim
+// ----------------------------------------------------------------------------
+
+test("startJob transitions queued → running and stamps startedAt", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  const r = await startJob(created.job.id, h.deps);
+  assert.equal(r.ok, true);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.jobs[0].startedAt, T0);
+});
+
+test("startJob returns {ok:false, status} when called twice (SSE+catch-up dedup)", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  await startJob(created.job.id, h.deps);
+  const second = await startJob(created.job.id, h.deps);
+  assert.equal(second.ok, false);
+  assert.equal(second.error, "not queued");
+  assert.equal(second.status, "running");
+});
+
+test("startJob returns {ok:false} for a terminal job", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  await startJob(created.job.id, h.deps);
+  await completeJob(created.job.id, { status: "done" }, h.deps);
+  const second = await startJob(created.job.id, h.deps);
+  assert.equal(second.ok, false);
+  assert.equal(second.status, "done");
+});
+
+test("startJob returns {ok:false, error:'not found'} for missing id", async () => {
+  const h = harness();
+  const r = await startJob("missing", h.deps);
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "not found");
+});
+
+// ----------------------------------------------------------------------------
+// completeJob — idempotency + status validation
+// ----------------------------------------------------------------------------
+
+test("completeJob is idempotent: second call returns alreadyTerminal:true with no extra publish/notify", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  await startJob(created.job.id, h.deps);
+  const first = await completeJob(created.job.id, { status: "done" }, h.deps);
+  assert.equal(first.ok, true);
+
+  const publishedBefore = h.published.length;
+  const notifiedBefore = h.notified.length;
+  const second = await completeJob(created.job.id, { status: "failed", error: "double" }, h.deps);
+  assert.equal(second.ok, true);
+  assert.equal(second.alreadyTerminal, true);
+  assert.equal(h.published.length, publishedBefore, "no extra publish");
+  assert.equal(h.notified.length, notifiedBefore, "no extra notify");
+  // State unchanged — still done, not failed.
+  assert.equal(h.jobs[0].status, "done");
+});
+
+test("completeJob rejects an invalid status string", async () => {
+  const h = harness();
+  const created = await createCapJob(
+    { capability: "ios.build", input: {}, host: "mac", sessionID: "ses" },
+    h.deps,
+  );
+  await startJob(created.job.id, h.deps);
+  const r = await completeJob(created.job.id, { status: "running" }, h.deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /status/);
+});
+
+test("completeJob returns {ok:false} for a missing job", async () => {
+  const h = harness();
+  const r = await completeJob("missing", { status: "done" }, h.deps);
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "not found");
+});
+
+// ----------------------------------------------------------------------------
+// listJobs — filters
+// ----------------------------------------------------------------------------
+
+test("listJobs returns no-log summary (logBytes replaces log)", async () => {
+  const h = harness([
+    {
+      id: "a1",
+      capability: "ios.build", input: {}, host: "mac", sessionID: "ses_a",
+      directory: "", status: "done", createdAt: 0, startedAt: 0, finishedAt: 0,
+      log: ["one", "two", "three"], result: null, error: null,
+    },
+  ]);
+  const jobs = await listJobs({}, h.deps);
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].log, undefined, "no `log` field in summary");
+  assert.equal(jobs[0].logBytes, 11); // "one" + "two" + "three"
+});
+
+test("listJobs filters by sessionID, host, status — all AND-combined", async () => {
+  const seeded = [
+    { id: "a1", capability: "ios.build", input: {}, host: "mac", sessionID: "ses_a", directory: "", status: "queued",  createdAt: 0, startedAt: null, finishedAt: null, log: [], result: null, error: null },
+    { id: "a2", capability: "ios.build", input: {}, host: "mac", sessionID: "ses_b", directory: "", status: "queued",  createdAt: 0, startedAt: null, finishedAt: null, log: [], result: null, error: null },
+    { id: "a3", capability: "ios.build", input: {}, host: "box", sessionID: "ses_a", directory: "", status: "running", createdAt: 0, startedAt: 0,  finishedAt: null, log: [], result: null, error: null },
+    { id: "a4", capability: "ios.build", input: {}, host: "mac", sessionID: "ses_a", directory: "", status: "done",    createdAt: 0, startedAt: 0,  finishedAt: 0,    log: [], result: null, error: null },
+  ];
+  const h = harness(seeded);
+
+  // Single filter
+  const bySess = await listJobs({ sessionID: "ses_a" }, h.deps);
+  assert.equal(bySess.length, 3);
+  const byHost = await listJobs({ host: "box" }, h.deps);
+  assert.equal(byHost.length, 1);
+  assert.equal(byHost[0].id, "a3");
+  const byStatus = await listJobs({ status: "done" }, h.deps);
+  assert.equal(byStatus.length, 1);
+  assert.equal(byStatus[0].id, "a4");
+
+  // Combined (AND)
+  const combined = await listJobs({ sessionID: "ses_a", host: "mac", status: "queued" }, h.deps);
+  assert.equal(combined.length, 1);
+  assert.equal(combined[0].id, "a1");
+});
+
+test("listJobs with no filters returns every job", async () => {
+  const seeded = [
+    { id: "a1", capability: "ios.build", input: {}, host: "mac", sessionID: "ses_a", directory: "", status: "queued", createdAt: 0, startedAt: null, finishedAt: null, log: [], result: null, error: null },
+    { id: "a2", capability: "ios.build", input: {}, host: "box", sessionID: "ses_b", directory: "", status: "done",  createdAt: 0, startedAt: 0,    finishedAt: 0,    log: [], result: null, error: null },
+  ];
+  const h = harness(seeded);
+  const all = await listJobs({}, h.deps);
+  assert.equal(all.length, 2);
+});
+
+// ----------------------------------------------------------------------------
+// sweepCapJobs — timeout, expiry, retention, no-change-no-save, fresh-running
+// ----------------------------------------------------------------------------
+
+test("sweep fails out a stale running job (startedAt > RUNNING_TIMEOUT_MS ago) and notifies", async () => {
+  const h = harness();
+  // Job started just inside the timeout → still running.
+  const inside = {
+    id: "insider", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "running",
+    createdAt: 0, startedAt: T0 - RUNNING_TIMEOUT_MS + 1000, finishedAt: null,
+    log: [], result: null, error: null,
+  };
+  // Job started well past the timeout → should fail.
+  const stale = {
+    id: "stale", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "running",
+    createdAt: 0, startedAt: T0 - RUNNING_TIMEOUT_MS - 1000, finishedAt: null,
+    log: [], result: null, error: null,
+  };
+  h.jobs.push(inside, stale);
+  await sweepCapJobs(h.deps);
+
+  const staleJob = h.jobs.find((j) => j.id === "stale");
+  assert.equal(staleJob.status, "failed");
+  assert.match(staleJob.error, /timed out after 30 minutes/);
+  assert.equal(staleJob.finishedAt, T0);
+  // The fresh one is untouched.
+  assert.equal(h.jobs.find((j) => j.id === "insider").status, "running");
+
+  // The stale job was notified exactly once.
+  const notifies = h.notified.filter((n) => n.sessionID === "ses_a");
+  assert.ok(notifies.length >= 1);
+  assert.match(notifies[notifies.length - 1].text, /timed out after 30 minutes/);
+
+  // A cap.updated event was published for the stale job.
+  const updates = h.published.filter((p) => p.kind === "cap.updated");
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].payload.id, "stale");
+  assert.equal(updates[0].payload.status, "failed");
+});
+
+test("sweep fails out an ancient queued job (createdAt > QUEUED_EXPIRY_MS ago)", async () => {
+  const h = harness();
+  const stale = {
+    id: "ancient", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "queued",
+    createdAt: T0 - QUEUED_EXPIRY_MS - 1000, startedAt: null, finishedAt: null,
+    log: [], result: null, error: null,
+  };
+  h.jobs.push(stale);
+  await sweepCapJobs(h.deps);
+
+  const j = h.jobs.find((x) => x.id === "ancient");
+  assert.equal(j.status, "failed");
+  assert.match(j.error, /expired: no executor picked this job up within 24h/);
+  assert.equal(h.notified.length, 1);
+});
+
+test("sweep retention: prunes terminal jobs older than TERMINAL_RETENTION_MS", async () => {
+  const h = harness();
+  const TERM = 7 * 24 * 60 * 60_000;
+  const old = {
+    id: "old", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "done",
+    createdAt: 0, startedAt: 0, finishedAt: T0 - TERM - 1000,
+    log: [], result: null, error: null,
+  };
+  const fresh = {
+    id: "fresh", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "done",
+    createdAt: 0, startedAt: 0, finishedAt: T0 - 1000,
+    log: [], result: null, error: null,
+  };
+  h.jobs.push(old, fresh);
+  await sweepCapJobs(h.deps);
+  assert.equal(h.jobs.length, 1);
+  assert.equal(h.jobs[0].id, "fresh");
+});
+
+test("sweep retention: enforces MAX_TERMINAL_JOBS by dropping the oldest", async () => {
+  const h = harness();
+  // 55 terminal jobs all recent enough to survive the retention cutoff,
+  // staggered finishedAt so the oldest 5 should be dropped. finishedAt
+  // is offset from T0 so the test doesn't depend on the wall clock.
+  for (let i = 0; i < 55; i++) {
+    h.jobs.push({
+      id: `j${i}`, capability: "ios.build", input: {}, host: "mac",
+      sessionID: "ses_a", directory: "", status: "done",
+      createdAt: 0, startedAt: 0, finishedAt: T0 - 1000 + i, // j0 oldest, j54 newest
+      log: [], result: null, error: null,
+    });
+  }
+  await sweepCapJobs(h.deps);
+  assert.equal(h.jobs.length, 50);
+  // The oldest 5 (j0..j4) should be gone; j5..j54 remain.
+  const ids = h.jobs.map((j) => j.id);
+  assert.ok(!ids.includes("j0"));
+  assert.ok(!ids.includes("j4"));
+  assert.ok(ids.includes("j5"));
+  assert.ok(ids.includes("j54"));
+});
+
+test("sweep leaves a fresh running job untouched", async () => {
+  const h = harness();
+  const fresh = {
+    id: "fresh", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "running",
+    createdAt: T0, startedAt: T0, finishedAt: null,
+    log: ["hello"], result: null, error: null,
+  };
+  h.jobs.push(fresh);
+  const publishedBefore = h.published.length;
+  await sweepCapJobs(h.deps);
+  const j = h.jobs.find((x) => x.id === "fresh");
+  assert.equal(j.status, "running");
+  assert.equal(j.finishedAt, null);
+  assert.equal(j.log[0], "hello");
+  // No cap.updated published for this job.
+  const updates = h.published.slice(publishedBefore).filter((p) => p.kind === "cap.updated");
+  assert.equal(updates.length, 0);
+});
+
+test("sweep no-change pass does not save", async () => {
+  const h = harness();
+  const fresh = {
+    id: "fresh", capability: "ios.build", input: {}, host: "mac",
+    sessionID: "ses_a", directory: "", status: "running",
+    createdAt: T0, startedAt: T0, finishedAt: null,
+    log: [], result: null, error: null,
+  };
+  h.jobs.push(fresh);
+  const savedBefore = h.saved.length;
+  await sweepCapJobs(h.deps);
+  assert.equal(h.saved.length, savedBefore, "no save on a no-change pass");
+});
+
+// ----------------------------------------------------------------------------
+// completionText — pure formatter
+// ----------------------------------------------------------------------------
+
+test("completionText for a done job", () => {
+  const j = { id: "abc12345", capability: "ios.build", status: "done" };
+  const txt = completionText(j);
+  assert.match(txt, /^\[MantaUI capability job\] ios\.build job abc12345 finished with status "done"\./);
+  assert.match(txt, /ios_build_status\("abc12345"\)/);
+  // No "Error:" suffix on success.
+  assert.equal(txt.includes("Error:"), false);
+});
+
+test("completionText for a failed job includes the error", () => {
+  const j = { id: "abc12345", capability: "ios.build", status: "failed", error: "exit 1" };
+  const txt = completionText(j);
+  assert.match(txt, /status "failed"\./);
+  assert.match(txt, /Error: exit 1\./);
+  assert.match(txt, /ios_build_status\("abc12345"\)/);
+});

--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -1,5 +1,5 @@
 // In-process pub/sub + the GET /events SSE endpoint.
-// Event envelope: { kind: "opencode"|"pty"|"status"|"screenshot", payload: any }
+// Event envelope: { kind: "opencode"|"pty"|"status"|"screenshot"|"capJob"|"cap.updated", payload: any }
 
 export function createBus() {
   const subs = new Set();

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -26,6 +26,15 @@ import { startStatusPoller } from "./status.mjs";
 import { startOutboxPoller } from "./outbox.mjs";
 import { startSchedulePoller, createJob, listJobs, deleteJob } from "./schedule.mjs";
 import {
+  createCapJob,
+  getJob,
+  listJobs as listCapJobs,
+  startJob as startCapJob,
+  appendLog as appendCapLog,
+  completeJob as completeCapJob,
+  startCapSweeper,
+} from "./capabilities.mjs";
+import {
   startFileServer,
   startCleanupPoller,
   registerPage,
@@ -136,6 +145,18 @@ const { stop: stopSchedulePoller } = startSchedulePoller(
   },
   { intervalMs: 30000 },
 );
+
+// Capability-job sweeper: same shape as startSchedulePoller — fails out stale
+// `running` jobs (30 min) and expired `queued` jobs (24h), then prunes terminal
+// jobs past retention/cap. Notifies the originating session on every
+// transition via the SAME oc.sendPrompt leg the scheduler uses, so the user
+// sees a fresh turn when a job times out. See src/server/capabilities.mjs +
+// docs/mantaui-plugins.md §Layer 1.
+// eslint-disable-next-line no-unused-vars
+const { stop: stopCapSweeper } = startCapSweeper({
+  publish: (evt) => bus.publish(evt),
+  notifySession: (args) => oc.sendPrompt(args),
+});
 
 // Inbound webhook engine: external actors POST to the public /hook/<token>
 // route (below) to wake a chat session with an event — the push counterpart to
@@ -812,6 +833,126 @@ const server = createServer(async (req, res) => {
       }
       if (req.method === "DELETE") {
         await handleApiDelete(req, url, res, deleteJob);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Capability jobs (MantaUI plugin system, Layer 1) ----------
+  // Generic queue for AI-invokable capabilities that run on the box OR on a
+  // connected Mac (the plugin system). The transport envelope is
+  // {capability, input, host} — no `iosBuild`-specific fields here. Created
+  // by the AI's plugin tool (docs/opencode-tools/<plugin>.ts); claimed by an
+  // executor (Stage 2: Mac, src/main/capExecutor.ts) via /start; streamed
+  // logs via /log; completed via /done. Completion is injected back into the
+  // originating opencode session via the SAME oc.sendPrompt leg the scheduler
+  // uses — see docs/mantaui-plugins.md §Layer 1. All routes below are behind
+  // the existing Bearer auth gate (/api/* is gated wholesale).
+  if (path === "/api/cap" || path.startsWith("/api/cap/")) {
+    // Detail routes: /api/cap/:id, /api/cap/:id/start, /api/cap/:id/log,
+    // /api/cap/:id/done. Matched BEFORE the generic create/list block so the
+    // regex captures the action verb. Id must be exactly 8 lowercase hex
+    // characters (genId()).
+    const detailRe = /^\/api\/cap\/([0-9a-f]{8})(?:\/(start|log|done))?$/;
+    const detailMatch = path.match(detailRe);
+    try {
+      if (detailMatch) {
+        const [, id, action] = detailMatch;
+        if (action === "start") {
+          if (req.method !== "POST") {
+            respondJson(res, 405, { error: "method not allowed" });
+            return;
+          }
+          const result = await startCapJob(id);
+          if (!result.ok) {
+            // Wrong status (already running, or terminal) → 409 conflict.
+            respondJson(res, 409, { error: result.error, status: result.status });
+            return;
+          }
+          respondJson(res, 200, { ok: true });
+          return;
+        }
+        if (action === "log") {
+          if (req.method !== "POST") {
+            respondJson(res, 405, { error: "method not allowed" });
+            return;
+          }
+          const body = await readJsonBody(req);
+          const result = await appendCapLog(id, body?.chunk ?? "");
+          if (!result.ok) {
+            // Job missing OR not running (e.g. timed out and already failed)
+            // → 409. The executor must NOT be allowed to resurrect a
+            // timed-out job by appending a late log chunk.
+            respondJson(res, 409, { error: result.error, status: result.status });
+            return;
+          }
+          respondJson(res, 200, { ok: true });
+          return;
+        }
+        if (action === "done") {
+          if (req.method !== "POST") {
+            respondJson(res, 405, { error: "method not allowed" });
+            return;
+          }
+          const body = await readJsonBody(req);
+          const result = await completeCapJob(
+            id,
+            { status: body?.status, result: body?.result, error: body?.error },
+            {
+              ...BUS_PUBLISH_DEPS,
+              notifySession: (args) => oc.sendPrompt(args),
+            },
+          );
+          if (!result.ok) {
+            respondJson(res, 400, { error: result.error, status: result.status });
+            return;
+          }
+          respondJson(res, 200, { ok: true, alreadyTerminal: !!result.alreadyTerminal });
+          return;
+        }
+        // No action verb → GET /api/cap/:id → status + log tail.
+        if (req.method !== "GET") {
+          respondJson(res, 405, { error: "method not allowed" });
+          return;
+        }
+        const job = await getJob(id);
+        if (!job) {
+          respondJson(res, 404, { error: "not found" });
+          return;
+        }
+        respondJson(res, 200, job);
+        return;
+      }
+      // Collection routes (/api/cap): create + list.
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await createCapJob(
+          {
+            capability: body?.capability,
+            input: body?.input,
+            host: body?.host,
+            sessionID: body?.sessionID,
+            directory: body?.directory,
+          },
+          BUS_PUBLISH_DEPS,
+        );
+        if (!result.ok) {
+          respondJson(res, 400, { error: result.error });
+          return;
+        }
+        respondJson(res, 200, { id: result.job.id });
+        return;
+      }
+      if (req.method === "GET") {
+        const sessionID = url.searchParams.get("sessionID") || undefined;
+        const host = url.searchParams.get("host") || undefined;
+        const status = url.searchParams.get("status") || undefined;
+        const jobs = await listCapJobs({ sessionID, host, status });
+        respondJson(res, 200, { jobs });
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -852,7 +852,7 @@ const server = createServer(async (req, res) => {
   // originating opencode session via the SAME oc.sendPrompt leg the scheduler
   // uses — see docs/mantaui-plugins.md §Layer 1. All routes below are behind
   // the existing Bearer auth gate (/api/* is gated wholesale).
-  if (path === "/api/cap" || path.startsWith("/api/cap/")) {
+  if (path === "/api/cap" || /^\/api\/cap\/([0-9a-f]{8})(?:\/(start|log|done))?$/.test(path)) {
     // Detail routes: /api/cap/:id, /api/cap/:id/start, /api/cap/:id/log,
     // /api/cap/:id/done. Matched BEFORE the generic create/list block so the
     // regex captures the action verb. Id must be exactly 8 lowercase hex

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -34,6 +34,7 @@ import {
   completeJob as completeCapJob,
   startCapSweeper,
 } from "./capabilities.mjs";
+import { notifyCapSession } from "./capNotifier.mjs";
 import {
   startFileServer,
   startCleanupPoller,
@@ -152,10 +153,14 @@ const { stop: stopSchedulePoller } = startSchedulePoller(
 // transition via the SAME oc.sendPrompt leg the scheduler uses, so the user
 // sees a fresh turn when a job times out. See src/server/capabilities.mjs +
 // docs/mantaui-plugins.md §Layer 1.
+// Capability-job completion → opencode session notification. Wired via
+// src/server/capNotifier.mjs (see that file for why the field translation
+// lives in one place). Shared by the sweeper and the /api/cap/:id/done REST
+// handler below — one definition, two callers.
 // eslint-disable-next-line no-unused-vars
 const { stop: stopCapSweeper } = startCapSweeper({
   publish: (evt) => bus.publish(evt),
-  notifySession: (args) => oc.sendPrompt(args),
+  notifySession: notifyCapSession,
 });
 
 // Inbound webhook engine: external actors POST to the public /hook/<token>
@@ -904,7 +909,7 @@ const server = createServer(async (req, res) => {
             { status: body?.status, result: body?.result, error: body?.error },
             {
               ...BUS_PUBLISH_DEPS,
-              notifySession: (args) => oc.sendPrompt(args),
+              notifySession: notifyCapSession,
             },
           );
           if (!result.ok) {

--- a/src/server/schedule.mjs
+++ b/src/server/schedule.mjs
@@ -14,12 +14,13 @@
 // (testable without timers or live opencode) + a startSchedulePoller() wrapper
 // with an inFlight guard and timer.unref().
 
-import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { readFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { STATE_DIRNAME } from "../shared/paths.mjs";
+import { atomicWrite } from "./storeUtils.mjs";
 
 const STORE_PATH = join(homedir(), STATE_DIRNAME, "schedule.json");
 
@@ -163,12 +164,6 @@ export function isJobFireable(job, { directoryExists } = {}) {
 // ---------------------------------------------------------------------------
 // Store (atomic, same pattern as local.mjs)
 // ---------------------------------------------------------------------------
-
-async function atomicWrite(path, data) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data);
-  await rename(tmp, path);
-}
 
 export async function loadJobs(path = STORE_PATH) {
   try {

--- a/src/server/storeUtils.mjs
+++ b/src/server/storeUtils.mjs
@@ -1,0 +1,18 @@
+// Shared atomic-write helper for the on-disk JSON stores in src/server/.
+// Promoted out of src/server/schedule.mjs in BET-184 (consolidation; previously
+// duplicated logic lived next to schedule's loadJobs/saveJobs). Both schedule.mjs
+// and capabilities.mjs now import from here so there is exactly one
+// atomic-write implementation in src/server/.
+
+import { writeFile, rename } from "node:fs/promises";
+
+// Write `data` to `path` atomically: write a temp file alongside, then rename.
+// The temp filename encodes pid + timestamp so a process crash mid-write can
+// never clobber a sibling in-flight temp from the same process (different ms),
+// and a stale temp left over from a previous crash never overwrites a live
+// `path` (it sits next to it as `path.tmp-<pid>-<ts>`).
+export async function atomicWrite(path, data) {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tmp, data);
+  await rename(tmp, path);
+}


### PR DESCRIPTION
Closes BET-184 (Stage 1 of BET-183).

**Base:** `origin/main` @ `6160a85`

## What landed

Box-only. No Mac needed to complete or verify: a created job sits in `queued` until the 24h sweep expires it.

1. **`src/server/storeUtils.mjs` (NEW)** — moved the once-private `atomicWrite` from `src/server/schedule.mjs` into this shared module. `schedule.mjs` and `capabilities.mjs` both import it. Exactly one atomic-write helper in `src/server/` now.
2. **`src/server/capabilities.mjs` (NEW)** — Layer 1 generic job queue per the spec. Cloned shape from `schedule.mjs` (load/save + dependency injection + `genId`); one `markTerminal` helper shared by `completeJob` and the sweep; one `listJobs` signature for AI + executor catch-up + future UI. Sweeper (`startCapSweeper`) clones `startSchedulePoller` shape exactly (run-once, setInterval, timer.unref, inFlight guard, returns {stop}). All constants from the spec's constants table.
3. **`src/server/capNotifier.mjs` (NEW, BET-184 review)** — owns the `{sessionID, text}` → `{sessionId: sessionID, text}` field-name translation. Single source of truth shared by the sweeper and the `/api/cap/:id/done` REST handler. (See review-return fix below.)
4. **`src/server/capNotifier.test.mjs` (NEW, BET-184 review)** — three test cases using opencode.mjs's test-only `_setOcTransport` hook to capture the outgoing HTTP request without standing up a server. Asserts the URL contains the camelCase sessionId, the body wraps text correctly, and a regression guard proves a passthrough would produce `/session/undefined/prompt_async`.
5. **`src/server/capabilities.test.mjs` (NEW)** — node:test, 31 cases covering every required scenario from the spec (lifecycle, create validation, log tail, ring-buffer, start guard, completeJob idempotency, listJobs filters, sweep timeout/expiry/retention/no-change-no-save, completionText).
6. **`src/server/index.mjs` (EDIT)** — added the /api/cap* REST block behind the existing Bearer gate. Follows the /api/schedule block style verbatim: 400 on {ok:false}, 409 on wrong-state, 404 for missing, 500 in catch, 405 fallthrough. `notifySession` dep = `notifyCapSession` (the capNotifier.mjs helper) — both call sites import it. (BET-184 review fix: the original passthrough `(args) => oc.sendPrompt(args)` silently dropped sessionID.)
7. **`src/server/events.mjs` (COMMENT-ONLY)** — added "capJob"|"cap.updated" to the envelope-kind comment at the top of the file. No code change.
8. **`docs/opencode-tools/ios-build.ts` (NEW)** — clone of `schedule.ts`; `MANTA_SERVER` / `boxToken()` / `authHeaders()` / `call()` copied VERBATIM (omit them and every call 401s). Two named exports (`ios_build`, `ios_build_status`) with the exact descriptions/args/execute from spec §"Layer 2" — the branch-semantics warning and the no-polling instruction are encoded in the tool description so the model sees them on first read.
9. **`docs/opencode-tools/AGENTS.md` (EDIT)** — appended the `## MantaUI iOS build` section per the spec's Guidance blurb.

## Live verification on the box

curl with the box token, against the running manta-server:

```
GET /api/cap/deadbeef                            → 404 {"error":"not found"}
POST /api/cap {capability:"ios.build",...}       → 200 {"id":"47604c4b"}
GET /api/cap/47604c4b                            → 200 status:queued logBytes:0
POST /api/cap/47604c4b/start                     → 200 {"ok":true}
POST /api/cap/47604c4b/log {chunk:"..."}         → 200 {"ok":true}
GET /api/cap/47604c4b                            → 200 status:running log:["..."] logBytes:29
POST /api/cap/47604c4b/done {status:"done",...}  → 200 {"ok":true,"alreadyTerminal":false}
POST /api/cap/47604c4b/done (again)              → 200 {"ok":true,"alreadyTerminal":true}  (idempotent — no extra notify)
GET /api/cap?host=mac&status=done                → 200 {"jobs":[{...,"logBytes":29}]}       (no `log` field in list summary)
POST start on terminal job                       → 409 {"error":"not queued","status":"done"}
POST log on terminal job                         → 409 {"error":"job not running","status":"done"}  (no resurrection)
POST /api/cap with bad host                      → 400 {"error":"host must be \"mac\" or \"box\""}
PUT /api/cap                                     → 405 {"error":"method not allowed"}
```

## Live verification of the completion turn (BET-184 review-return)

Created a real job pointing at a real opencode sessionID from `GET /session`, started it, then completed it (both `done` and `failed"smoke-test"` paths). The completion text landed in the originating session's opencode event stream as a fresh `message.part.updated` event with the exact `completionText(job)` output — the literal Definition-of-done bullet ("originating session received the completion turn") now passes end-to-end. Captured events include:

```
{ "type": "message.part.updated",
  "properties": { "sessionID": "ses_085ba5559ffeIg7c9AvXTSzgDF",
    "part": { "type": "text",
      "text": "[MantaUI capability job] ios.build job a2781427 finished with status \"failed\". Error: smoke-test. Check the job's status tool (e.g. ios_build_status(\"a2781427\")) for the log tail, then report the outcome to the user." } } }
```

Tool installed on the box (`~/.config/opencode/tools/ios-build.ts` COPIED, never symlinked); `## MantaUI iOS build` appended to `~/.config/opencode/AGENTS.md`; `systemctl --user restart opencode-serve` succeeded.

## Verification (npm)

- PR branch (`multica/BET-184-mantai-plugins-stage1` @ `635fc80`):
  - typecheck: exit 0. log sha256: `f3ea59a5b88f82d6975e52767fbe52bc4f235bce43e1578d686903b6b904beba`
  - test: 742 pass / 1 fail (pre-existing `scripts/install.test.mjs:489 formatPairingOutput produces a stable human block` on `main`). log sha256: `bee98c1c34cc35acb80039246087dcaa4997db49f7d1fcba167f370bd09eb2a4`
- Base (`main` @ `6160a85`):
  - typecheck: exit 0.
  - test: 708 pass / 1 fail (same pre-existing failure, not caused by this PR).
- **Conclusion:** 0 test failures caused by this PR. 34 new tests pass (31 capabilities + 3 capNotifier).

## Discipline

- No design decisions — every choice in the spec's constants table / functions / REST surface.
- Consolidation landed: exactly one atomic-write helper (`storeUtils.mjs`); `schedule.mjs` lost 7 lines and now imports from `storeUtils.mjs`. **Also:** one notifySession translation (`capNotifier.mjs`); both call sites import it (added on review-return).
- Generic envelope everywhere at the transport layer — no iOS-specific fields in the queue, REST body, SSE event, or REST routes.
- One `markTerminal` shared by `completeJob` and the sweep; one `listJobs` signature.
- `[cap]` log prefix matching `[schedule]`'s style; no debug `console.log` litter.
- No new dependencies.
- The only iOS-specific file is `docs/opencode-tools/ios-build.ts` (+ the two `"ios.build"` / `host:"mac"` literals); `completionText` mentions `ios_build_status` only because the spec's exact wording requires it (the helper itself is generic — it embeds the example tool name in the help string).

## Out of scope (Stage 2 — BET-185)

Mac executor, `busConsumer.ts` extraction, `handlers/iosBuild.ts`, config fields, Settings toggle, repo `AGENTS.md` section.