### PR TITLE
feat(main): MantaUI plugin executor + busConsumer + ios.build handler (BET-185 stage 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1912,6 +1912,130 @@ Beta App Review of the first build.
 version; the auto-tag workflow keys off it. `CURRENT_PROJECT_VERSION` (build
 number) — Codemagic/ASC handle uniqueness. First shipped version: `1.0.1`.
 
+## Capability plugins + Mac executor (BET-183)
+
+Plugin system that lets the AI invoke capabilities that run EITHER on the box
+(`host:"box"`) OR on the connected Mac (`host:"mac"`). v1 ships one plugin:
+`ios.build` — compile the MantaUI iOS app + launch it in the iOS Simulator on
+the user's Mac, instead of burning Codemagic minutes. The generic spine
+(`src/server/capabilities.mjs` + REST + bus envelopes + sweeper) is shaped so
+**adding capability #2 touches only**: a new tool file under
+`docs/opencode-tools/`, a new entry in the executor's `HANDLERS` map. NO
+changes to the queue, REST surface, SSE wiring, or auth.
+
+**Read the full design first:** `docs/mantuani-plugins.md` (v2 — Layer 3 +
+constants table + pinned mechanics). Constants live there and there only.
+
+### Generic invariant — `{capability, input, host}`
+
+The transport layer is capability-agnostic. Job shape, REST body, SSE event,
+and executor dispatch all speak `{capability: string, input: unknown, host:
+"mac"|"box"}`. The only iOS-specific file allowed is
+`src/main/handlers/iosBuild.ts` (plus the literal `"ios.build"` /
+`host:"mac"` in the tool file). If you find yourself special-casing
+`ios.build` anywhere else, you are doing it wrong — the point of the plugin
+shape is that handler #2 doesn't need any new plumbing.
+
+### The plugin seam — `HANDLERS` map
+
+`src/main/capExecutor.ts` exports one const:
+
+```ts
+const HANDLERS: Record<string, CapHandler> = {
+  "ios.build": iosBuildHandler,
+};
+```
+
+Adding capability #2 = `import` the new handler + add an entry. That's the
+entire diff in this file. No dispatch change, no queue change, no auth
+change.
+
+### Catch-up / serial / batched-log executor behaviors
+
+`startCapExecutor` (in `src/main/capExecutor.ts`) wraps everything in three
+behaviors you must NOT relax:
+
+- **Catch-up.** SSE has no replay. On start AND every reconnect
+  (`onConnect` from `busConsumer`), the executor `GET
+  /api/cap?host=mac&status=queued` and enqueues every returned job. Without
+  this, a job created while the Mac was offline/asleep sits `queued`
+  forever — the Mac never sees it. Cross-delivery dedup: the same job WILL
+  arrive via both SSE and catch-up; an in-memory `Set<string>` of
+  ever-enqueued ids drops the duplicate.
+- **Serial.** A single promise chain processes the FIFO queue. One job at a
+  time. Two parallel xcodebuilds would corrupt the shared
+  `~/Library/Caches/MantaUI/DerivedData` (pinned path — see iosBuild
+  section). The chain catches so a thrown handler doesn't poison the
+  stream.
+- **Batched logs.** `ctx.log` appends to a per-job string buffer. A
+  `setInterval(LOG_FLUSH_MS)` (unref'd) flushes the buffer as ONE
+  `POST /api/cap/:id/log {chunk}` when non-empty. Final flush runs BEFORE
+  the done POST. Never one POST per line — xcodebuild emits thousands. Failed
+  log POSTs are dropped (lost log chunk must not crash a running build);
+  failed `/done` POSTs retry once after 5s, then drop (the server sweep
+  will time out the job anyway).
+
+### Sweep guarantees
+
+The server sweep (`src/server/capabilities.mjs` `sweepCapJobs`) handles the
+edge cases the executor can't:
+
+- `running` > 30 min → failed (Mac executor lost?) + notify originating session.
+- `queued` > 24h → failed (no executor picked it up) + notify.
+- Terminal retention: drop jobs older than 7 days, cap at 50 (oldest first).
+  Silent (no publish).
+
+The shared `markTerminal` helper is the single terminal-transition code path
+— used by both `completeJob` and the sweep, so notify + publish +
+`finishedAt` stamping lives in exactly one place.
+
+### `secret()` is NOT in v1
+
+The v1 spec's `CapCtx.secret(key)` was unimplementable: the secrets store
+materializes values to 0600 files ON THE BOX, and a box file path is useless
+to a Mac process. v1 has no capability that needs a secret (simulator
+builds are unsigned), so `secret()` is deliberately absent — do not add a
+stub. Future design (when a capability needs it): an authed
+`POST /api/secrets/provide-value` returns the VALUE over HTTPS and the Mac
+writes its own 0600 tmpfile, returning that local path. Out of scope now.
+
+### macOS PATH gotcha (Electron GUI)
+
+GUI-launched Electron apps do NOT inherit the user's shell PATH.
+`Homebrew`/`nvm`-installed `npm`/`npx`/`pod` are invisible to a spawned
+child and `exec` fails ENOENT even though the same command works in
+Terminal. `capExecutor`'s `exec` builds its env as
+`{...process.env, PATH: "/opt/homebrew/bin:/usr/local/bin:" + (process.env.PATH ?? "")}`
+(Apple Silicon + Intel Homebrew). The ENOENT rejection message tells the
+user to install via Homebrew — never silently swallow it.
+
+### busConsumer consolidation (one SSE code path)
+
+`src/main/busConsumer.ts` is the ONLY SSE consumer in `src/main/`. Both
+`desktopNotify` (filter `kind === "desktopNotify"`) and `capExecutor`
+(filter `kind === "capJob"` + catch-up via `onConnect`) build on it. No
+module-level singletons — each `createBusConsumer` call owns its own
+state. `desktopNotify.ts` is now ~40 lines (was ~150); `capExecutor.ts`
+adds zero SSE plumbing of its own.
+
+### Settings toggle (BET-185)
+
+Desktop-only. Settings → Files → "Capability executor" → one toggle +
+`iOS build repo path` + `iOS simulator name` text fields. Default OFF.
+Toggling takes effect after restarting MantaUI (the executor gates itself
+at start time — see `startCapExecutor`'s top-of-function enabled check).
+The helper text carries the trust warning: "Allows the AI to run build
+commands on this Mac" — same spirit as `allowAgentPush`. `MobileSettings.tsx`
+is intentionally untouched.
+
+### Verified by inspection (re-check before shipping capability #2)
+
+- The ONLY iOS-specific file in `src/main/` is `handlers/iosBuild.ts`.
+- `HANDLERS` map is the only dispatch — capExecutor's queue / REST / SSE
+  code paths have zero `ios`-specific branches.
+- Adding capability #2 = one tool file + one `HANDLERS` entry. No changes
+  elsewhere.
+
 ## Testing
 
 Two separate test suites — both run via `npm test`:

--- a/src/main/busConsumer.ts
+++ b/src/main/busConsumer.ts
@@ -1,0 +1,144 @@
+// busConsumer.ts — shared SSE consumer for bui-server's `/events` stream.
+//
+// Extracted from src/main/desktopNotify.ts so the SSE plumbing (Bearer-authed
+// long-lived GET, 3-second auto-reconnect, `\n\n` frame split, `data:` parse)
+// exists in ONE place. Two thin consumers build on it:
+//
+//   - src/main/desktopNotify.ts → filter on kind === "desktopNotify"
+//   - src/main/capExecutor.ts  → filter on kind === "capJob" + catch-up
+//
+// Instance state (no module-level singletons): each `createBusConsumer` call
+// owns its own stream, reconnect timer, and frame buffer. The returned `stop()`
+// destroys the active response and cancels any pending reconnect.
+//
+// `onConnect?` fires on every status-200 stream open — both the initial
+// connect AND every reconnect — so the executor can run its SSE-replay
+// catch-up list. desktopNotify doesn't need it.
+
+import { request } from "node:http";
+import type { IncomingMessage } from "node:http";
+import type { AppConfig } from "../shared/types.js";
+
+const RECONNECT_MS = 3000;
+
+export type BusEnvelope = {
+  kind?: string;
+  payload?: unknown;
+};
+
+export type BusConsumer = { stop(): void };
+
+export function createBusConsumer(
+  configGetter: () => AppConfig,
+  onEnvelope: (env: BusEnvelope) => void,
+  onConnect?: () => void,
+): { stop(): void } {
+  let stopped = false;
+  let current: IncomingMessage | null = null;
+  let reconnectTimer: NodeJS.Timeout | null = null;
+
+  function scheduleReconnect(): void {
+    if (stopped || reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, RECONNECT_MS);
+    reconnectTimer.unref?.();
+  }
+
+  function handleFrame(raw: string): void {
+    const line = raw.split("\n").find((l) => l.startsWith("data:"));
+    if (!line) return;
+    const json = line.slice(5).trim();
+    if (!json) return;
+    let envelope: BusEnvelope;
+    try {
+      envelope = JSON.parse(json);
+    } catch {
+      return;
+    }
+    try {
+      onEnvelope(envelope);
+    } catch {
+      /* consumer threw — don't kill the stream over it */
+    }
+  }
+
+  function connect(): void {
+    if (stopped) return;
+    const cfg = configGetter?.();
+    if (!cfg || !cfg.serverUrl) {
+      scheduleReconnect();
+      return;
+    }
+    const serverUrl = cfg.serverUrl.replace(/\/+$/, "");
+    const url = new URL("/events", serverUrl);
+    const headers: Record<string, string> = {
+      accept: "text/event-stream",
+    };
+    if (cfg.boxToken) {
+      headers["authorization"] = `Bearer ${cfg.boxToken}`;
+    }
+    const req = request(
+      {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === "https:" ? 443 : 80),
+        path: url.pathname + url.search,
+        method: "GET",
+        headers,
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          scheduleReconnect();
+          return;
+        }
+        current = res;
+        res.setEncoding("utf-8");
+        let buf = "";
+        res.on("data", (chunk: string) => {
+          buf += chunk;
+          let idx: number;
+          while ((idx = buf.indexOf("\n\n")) !== -1) {
+            const frame = buf.slice(0, idx);
+            buf = buf.slice(idx + 2);
+            handleFrame(frame);
+          }
+        });
+        res.on("end", () => {
+          current = null;
+          scheduleReconnect();
+        });
+        res.on("error", () => {
+          current = null;
+          scheduleReconnect();
+        });
+        // Stream is open (status 200). Fire the catch-up hook so consumers
+        // like capExecutor can re-claim jobs an offline/sleeping Mac missed.
+        try {
+          onConnect?.();
+        } catch {
+          /* consumer threw — don't kill the stream */
+        }
+      },
+    );
+    req.on("error", () => scheduleReconnect());
+    req.end();
+  }
+
+  connect();
+
+  return {
+    stop(): void {
+      stopped = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+      try {
+        current?.destroy();
+      } catch {
+        /* already gone */
+      }
+      current = null;
+    },
+  };
+}

--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -1,0 +1,422 @@
+// capExecutor.ts — the Mac-side executor for MantaUI capability jobs.
+//
+// Subscribes to bui-server's SSE bus, picks up `{kind:"capJob"}` envelopes
+// targeting `host:"mac"`, and runs the matching capability's handler. The
+// only iOS-specific code lives in src/main/handlers/iosBuild.ts — adding
+// capability #2 = new file under handlers/ + new HANDLERS entry, no change
+// here.
+//
+// Lifecycle invariants (per docs/mantuani-plugins.md §"src/main/capExecutor.ts"):
+//   • enabled-gate at start: `capExecutorEnabled !== true` → no-op stop.
+//     Toggling takes effect on next app launch (Settings UI says so).
+//   • SSE catch-up: on every onConnect (initial + reconnect), GET
+//     /api/cap?host=mac&status=queued and enqueue. SSE has no replay, so
+//     an offline/asleep Mac must claim what it missed.
+//   • Serial + dedup: FIFO + Set<string> of ever-enqueued ids. Same job
+//     WILL arrive via both SSE and catch-up; the Set drops duplicates.
+//   • One job at a time: a single promise chain. Two parallel xcodebuilds
+//     would corrupt the shared derived-data dir.
+//   • Batched logs: ctx.log appends to a buffer; a per-job setInterval
+//     (unref'd) flushes as ONE POST. Never one POST per line — xcodebuild
+//     emits thousands.
+//   • Done retry: failed /done POST is retried once after 5s; on second
+//     failure log + drop (the server sweep times out the job anyway).
+
+import { spawn } from "node:child_process";
+import { createBusConsumer, type BusConsumer } from "./busConsumer.js";
+import {
+  iosBuildHandler,
+  type CapCtx,
+  type CapHandler,
+} from "./handlers/iosBuild.js";
+import type { AppConfig } from "../shared/types.js";
+
+// ---------------------------------------------------------------------------
+// Constants (single source of truth — see docs/mantuani-plugins.md §Constants)
+// ---------------------------------------------------------------------------
+
+// Mac-side per-job abort. < the server's 30 min so the Mac fails first and
+// reports properly instead of leaving a stale `running` for the server sweep.
+const EXECUTOR_JOB_TIMEOUT_MS = 25 * 60_000;
+// Executor log-batch flush cadence.
+const LOG_FLUSH_MS = 1_000;
+// Cap on captured stdout returned by ctx.exec.
+const EXEC_STDOUT_CAP_BYTES = 2 * 1024 * 1024;
+// SIGTERM → SIGKILL grace on abort.
+const KILL_GRACE_MS = 5_000;
+
+// GUI-launched Electron apps don't inherit the user's shell PATH; prepend
+// Homebrew paths so npm/npx/pod are visible (otherwise spawn fails ENOENT).
+const PATH_PREFIX = "/opt/homebrew/bin:/usr/local/bin:";
+
+// ---------------------------------------------------------------------------
+// THE PLUGIN SEAM. v1 = one entry. Later = built from a plugin registry.
+// ---------------------------------------------------------------------------
+
+const HANDLERS: Record<string, CapHandler> = {
+  "ios.build": iosBuildHandler,
+};
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+let activeConsumer: BusConsumer | null = null;
+
+export function startCapExecutor(
+  configGetter: () => AppConfig,
+): { stop(): void } {
+  // Toggle takes effect on next app launch — no live start/stop. The
+  // Settings UI says so.
+  if (configGetter()?.capExecutorEnabled !== true) {
+    return { stop() {} };
+  }
+
+  const everEnqueued = new Set<string>();
+  const queue: Array<{ id: string; capability: string }> = [];
+  let chain: Promise<void> = Promise.resolve();
+  let stopped = false;
+
+  function enqueue(id: string, capability: string): void {
+    if (stopped) return;
+    if (everEnqueued.has(id)) return;
+    everEnqueued.add(id);
+    queue.push({ id, capability });
+    chain = chain.then(() => runOne(configGetter, { id, capability })).catch(() => {});
+  }
+
+  function cfgOrNull(): { serverUrl: string; boxToken: string; config: AppConfig } | null {
+    const cfg = configGetter();
+    if (!cfg?.serverUrl) return null;
+    return { serverUrl: cfg.serverUrl, boxToken: cfg.boxToken ?? "", config: cfg };
+  }
+
+  async function catchUpJobs(): Promise<void> {
+    const c = cfgOrNull();
+    if (!c) return;
+    try {
+      const res = await fetch(
+        `${c.serverUrl.replace(/\/+$/, "")}/api/cap?host=mac&status=queued`,
+        {
+          headers: c.boxToken
+            ? { authorization: `Bearer ${c.boxToken}` }
+            : undefined,
+        },
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { jobs?: Array<{ id: string; capability: string }> };
+      for (const j of body.jobs ?? []) {
+        enqueue(j.id, j.capability);
+      }
+    } catch {
+      // Catch-up is best-effort; the SSE path will deliver what catch-up
+      // misses (modulo the dedup Set) once the stream is live.
+    }
+  }
+
+  function onConnect(): void {
+    void catchUpJobs();
+  }
+
+  function onEnvelope(env: { kind?: string; payload?: unknown }): void {
+    if (env.kind !== "capJob") return;
+    const p = env.payload as
+      | { id?: unknown; capability?: unknown; host?: unknown }
+      | undefined;
+    if (!p || p.host !== "mac") return;
+    if (typeof p.id !== "string" || typeof p.capability !== "string") return;
+    enqueue(p.id, p.capability);
+  }
+
+  const consumer: BusConsumer = createBusConsumer(
+    configGetter,
+    onEnvelope,
+    onConnect,
+  );
+  activeConsumer = consumer;
+
+  return {
+    stop() {
+      stopped = true;
+      consumer.stop();
+      if (activeConsumer === consumer) activeConsumer = null;
+    },
+  };
+}
+
+export function stopCapExecutor(): void {
+  activeConsumer?.stop();
+  activeConsumer = null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-job plumbing
+// ---------------------------------------------------------------------------
+
+async function runOne(
+  configGetter: () => AppConfig,
+  job: { id: string; capability: string },
+): Promise<void> {
+  const cfg = configGetter();
+  if (!cfg?.serverUrl) return;
+  const c: Cfg = { serverUrl: cfg.serverUrl, boxToken: cfg.boxToken ?? "", config: cfg };
+  const { id, capability } = job;
+
+  // Step 1 — claim the job. Non-2xx (409 = already claimed / stale) is the
+  // cross-delivery dedup: just log and skip.
+  const claim = await postApi(c, `/api/cap/${id}/start`, "POST", null);
+  if (!claim.ok) {
+    console.warn(`[cap] start ${id}: ${claim.error} — skipping`);
+    return;
+  }
+
+  // Step 2 — handler lookup. Unknown → fail the job, NEVER shell out.
+  const handler = HANDLERS[capability];
+  if (!handler) {
+    await postApi(c, `/api/cap/${id}/done`, "POST", {
+      status: "failed",
+      error: `unknown capability "${capability}"`,
+    });
+    return;
+  }
+
+  // Step 3 — context. Buffer + flush timer are job-scoped (one per job).
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), EXECUTOR_JOB_TIMEOUT_MS);
+  timeout.unref?.();
+
+  let logBuffer = "";
+  let logTimer: NodeJS.Timeout | null = null;
+
+  function flushLog(): void {
+    if (!logBuffer) return;
+    const chunk = logBuffer;
+    logBuffer = "";
+    void postApi(c, `/api/cap/${id}/log`, "POST", { chunk });
+  }
+
+  logTimer = setInterval(flushLog, LOG_FLUSH_MS);
+  logTimer.unref?.();
+
+  const ctx: CapCtx = {
+    input: null, // set after we fetch the job below
+    config: c.config,
+    log(line: string) {
+      logBuffer += line;
+      if (!line.endsWith("\n")) logBuffer += "\n";
+    },
+    exec: makeExec(controller.signal, (line) => {
+      logBuffer += line;
+    }),
+    signal: controller.signal,
+  };
+
+  // Pull the full job (input + config snapshot) BEFORE running so the
+  // handler sees the same input the AI posted.
+  const fetched = await getJobFull(c, id);
+  if (!fetched.ok) {
+    clearTimeout(timeout);
+    if (logTimer) clearInterval(logTimer);
+    flushLog();
+    await postDone(c, id, { status: "failed", error: fetched.error });
+    return;
+  }
+  ctx.input = fetched.job.input;
+
+  try {
+    const { result } = await handler(ctx);
+    clearTimeout(timeout);
+    if (logTimer) clearInterval(logTimer);
+    flushLog();
+    await postDone(c, id, { status: "done", result: result ?? null });
+  } catch (e) {
+    clearTimeout(timeout);
+    if (logTimer) clearInterval(logTimer);
+    flushLog();
+    const aborted = controller.signal.aborted;
+    const error = aborted
+      ? "job timed out"
+      : (e instanceof Error ? e.message : String(e));
+    await postDone(c, id, { status: "failed", error });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+type Cfg = {
+  serverUrl: string;
+  boxToken: string;
+  config: AppConfig;
+};
+
+async function postApi(
+  cfg: Cfg,
+  path: string,
+  method: "POST" | "GET",
+  body: unknown,
+): Promise<{ ok: boolean; status: number; error?: string; data?: unknown }> {
+  const url = `${cfg.serverUrl.replace(/\/+$/, "")}${path}`;
+  const headers: Record<string, string> = {};
+  if (cfg.boxToken) headers["authorization"] = `Bearer ${cfg.boxToken}`;
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: {
+        ...headers,
+        ...(body !== null ? { "content-type": "application/json" } : {}),
+      },
+      body: body !== null ? JSON.stringify(body) : undefined,
+    });
+    let data: unknown = null;
+    const text = await res.text();
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        error:
+          (data as { error?: string } | null)?.error ??
+          `${method} ${path}: HTTP ${res.status}`,
+      };
+    }
+    return { ok: true, status: res.status, data };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+async function getJobFull(
+  cfg: Cfg,
+  id: string,
+): Promise<{ ok: true; job: { input: unknown } } | { ok: false; error: string }> {
+  const r = await postApi(cfg, `/api/cap/${id}`, "GET", null);
+  if (!r.ok) return { ok: false, error: r.error ?? "fetch failed" };
+  const data = r.data as { id?: string; input?: unknown } | null;
+  if (!data || typeof data !== "object") {
+    return { ok: false, error: "malformed job payload" };
+  }
+  return { ok: true, job: { input: data.input ?? {} } };
+}
+
+async function postDone(
+  cfg: Cfg,
+  id: string,
+  body: { status: "done" | "failed"; result?: unknown; error?: string },
+): Promise<void> {
+  // Failed /done is retried once after 5s; second failure → log + drop (the
+  // server sweep will time out the job).
+  const r = await postApi(cfg, `/api/cap/${id}/done`, "POST", body);
+  if (r.ok) return;
+  console.warn(
+    `[cap] done ${id} first attempt failed: ${r.error} — retrying in 5s`,
+  );
+  await new Promise((r) => setTimeout(r, 5_000));
+  const r2 = await postApi(cfg, `/api/cap/${id}/done`, "POST", body);
+  if (!r2.ok) {
+    console.warn(
+      `[cap] done ${id} retry failed (${r2.error}) — dropping; server sweep will time out`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ctx.exec — argv spawn with PATH patch + capture + abort handling.
+// ---------------------------------------------------------------------------
+
+function makeExec(
+  signal: AbortSignal,
+  logLine: (line: string) => void,
+): CapCtx["exec"] {
+  return (cmd, args, opts) =>
+    new Promise((resolve, reject) => {
+      const cwd = opts?.cwd;
+      const quiet = opts?.quiet === true;
+      let stdout = "";
+      let stdoutTruncated = false;
+
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(cmd, args, {
+          cwd,
+          env: {
+            ...process.env,
+            PATH: PATH_PREFIX + (process.env.PATH ?? ""),
+          },
+          signal,
+        });
+      } catch (e) {
+        reject(
+          new Error(
+            `${cmd} not found on PATH — install it via Homebrew ` +
+              `(nvm-only node installs are not visible to GUI apps): ` +
+              (e instanceof Error ? e.message : String(e)),
+          ),
+        );
+        return;
+      }
+
+      child.on("error", (e) => {
+        reject(
+          new Error(
+            `${cmd} not found on PATH — install it via Homebrew ` +
+              `(nvm-only node installs are not visible to GUI apps): ${e.message}`,
+          ),
+        );
+      });
+
+      const onAbort = () => {
+        if (child.exitCode !== null) return;
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          /* already dead */
+        }
+        const killTimer = setTimeout(() => {
+          if (child.exitCode === null) {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              /* already dead */
+            }
+          }
+        }, KILL_GRACE_MS);
+        killTimer.unref?.();
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+
+      child.stdout?.setEncoding("utf-8");
+      child.stderr?.setEncoding("utf-8");
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+        if (stdout.length > EXEC_STDOUT_CAP_BYTES) {
+          stdout = stdout.slice(-EXEC_STDOUT_CAP_BYTES);
+          stdoutTruncated = true;
+        }
+        if (!quiet) logLine(`[stdout] ${chunk}`);
+      });
+      child.stderr?.on("data", (chunk: string) => {
+        if (!quiet) logLine(`[stderr] ${chunk}`);
+      });
+
+      child.on("close", (code) => {
+        signal.removeEventListener?.("abort", onAbort);
+        if (stdoutTruncated) {
+          stdout = `[truncated to last ${EXEC_STDOUT_CAP_BYTES} bytes]\n${stdout}`;
+        }
+        resolve({ code: code ?? 0, stdout });
+      });
+    });
+}

--- a/src/main/desktopNotify.ts
+++ b/src/main/desktopNotify.ts
@@ -14,108 +14,14 @@
 // here — the renderer only adds the final "am I literally viewing this session
 // right now?" suppression (it knows its focused window + active session).
 //
-// We deliberately ignore every other bus `kind` (opencode firehose, status,
-// etc.) — the desktop already gets opencode events from its own :4096 stream;
-// re-consuming them here would double everything.
+// The SSE plumbing (connect / reconnect / frame-parse) lives in
+// src/main/busConsumer.ts — shared with capExecutor. This file is now just a
+// one-kind filter: deliver `desktopNotify` payloads, ignore everything else.
 
-import { request } from "node:http";
-import type { IncomingMessage } from "node:http";
+import { createBusConsumer, type BusConsumer } from "./busConsumer.js";
 import type { AppConfig, DesktopNotifyPayload } from "../shared/types.js";
 
-let getConfig: (() => AppConfig) | null = null;
-let deliver: ((payload: DesktopNotifyPayload) => void) | null = null;
-let started = false;
-let stopped = false;
-let current: IncomingMessage | null = null;
-let reconnectTimer: NodeJS.Timeout | null = null;
-
-const RECONNECT_MS = 3000;
-
-function scheduleReconnect(): void {
-  if (stopped || reconnectTimer) return;
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    connect();
-  }, RECONNECT_MS);
-  reconnectTimer.unref?.();
-}
-
-function handleFrame(raw: string): void {
-  // SSE frame: one or more `data: ...` lines per event (here always one).
-  const line = raw.split("\n").find((l) => l.startsWith("data:"));
-  if (!line) return;
-  const json = line.slice(5).trim();
-  if (!json) return;
-  let envelope: { kind?: string; payload?: DesktopNotifyPayload };
-  try {
-    envelope = JSON.parse(json);
-  } catch {
-    return;
-  }
-  if (envelope?.kind !== "desktopNotify" || !envelope.payload) return;
-  try {
-    deliver?.(envelope.payload);
-  } catch {
-    /* renderer gone / window closed — ignore */
-  }
-}
-
-function connect(): void {
-  if (stopped) return;
-  const cfg = getConfig?.();
-  if (!cfg || !cfg.serverUrl) {
-    scheduleReconnect();
-    return;
-  }
-  // Open the long-lived SSE stream directly to the server.
-  const serverUrl = cfg.serverUrl.replace(/\/+$/, "");
-  const url = new URL("/events", serverUrl);
-  const headers: Record<string, string> = {
-    accept: "text/event-stream",
-  };
-  if (cfg.boxToken) {
-    headers["authorization"] = `Bearer ${cfg.boxToken}`;
-  }
-  const req = request(
-    {
-      hostname: url.hostname,
-      port: url.port || (url.protocol === "https:" ? 443 : 80),
-      path: url.pathname + url.search,
-      method: "GET",
-      headers,
-    },
-    (res) => {
-      if (res.statusCode !== 200) {
-        res.resume();
-        scheduleReconnect();
-        return;
-      }
-      current = res;
-      res.setEncoding("utf-8");
-      let buf = "";
-      res.on("data", (chunk: string) => {
-        buf += chunk;
-        // SSE events are separated by a blank line.
-        let idx: number;
-        while ((idx = buf.indexOf("\n\n")) !== -1) {
-          const frame = buf.slice(0, idx);
-          buf = buf.slice(idx + 2);
-          handleFrame(frame);
-        }
-      });
-      res.on("end", () => {
-        current = null;
-        scheduleReconnect();
-      });
-      res.on("error", () => {
-        current = null;
-        scheduleReconnect();
-      });
-    },
-  );
-  req.on("error", () => scheduleReconnect());
-  req.end();
-}
+let consumer: BusConsumer | null = null;
 
 /**
  * Start relaying bui-server desktop-notification directives to the renderer.
@@ -127,23 +33,21 @@ export function startDesktopNotifications(
   configGetter: () => AppConfig,
   onPayload: (payload: DesktopNotifyPayload) => void,
 ): void {
-  if (started) return;
-  started = true;
-  stopped = false;
-  getConfig = configGetter;
-  deliver = onPayload;
-  connect();
+  if (consumer) return;
+  consumer = createBusConsumer(
+    configGetter,
+    (env) => {
+      if (env.kind !== "desktopNotify" || !env.payload) return;
+      try {
+        onPayload(env.payload as DesktopNotifyPayload);
+      } catch {
+        /* renderer gone / window closed — ignore */
+      }
+    },
+  );
 }
 
 export function stopDesktopNotifications(): void {
-  stopped = true;
-  started = false;
-  if (reconnectTimer) clearTimeout(reconnectTimer);
-  reconnectTimer = null;
-  try {
-    current?.destroy();
-  } catch {
-    /* already gone */
-  }
-  current = null;
+  consumer?.stop();
+  consumer = null;
 }

--- a/src/main/handlers/iosBuild.test.ts
+++ b/src/main/handlers/iosBuild.test.ts
@@ -1,0 +1,161 @@
+// Tests for the `pickSimulator` pure function — the ONLY iOS-specific
+// algorithm in MantaUI's plugin system. Every test case is named in
+// docs/mantuani-plugins.md §"ios.build handler" so adding a capability #2
+// doesn't need to touch this file.
+
+import { describe, it, expect } from "vitest";
+import { pickSimulator, type SimDevice } from "./iosBuild.js";
+
+function dev(
+  name: string,
+  state: string,
+  extras: Partial<SimDevice> = {},
+): SimDevice {
+  return { udid: `udid-${name}`, name, state, isAvailable: true, ...extras };
+}
+
+describe("pickSimulator", () => {
+  it("returns the preferred simulator when an exact name match exists", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPhone 14", "Shutdown"),
+          dev("iPhone 15", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices, "iPhone 15");
+    expect(r).toEqual({ ok: true, udid: "udid-iPhone 15", name: "iPhone 15" });
+  });
+
+  it("returns the Booted simulator when preferred name is set and that one is Booted", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPhone 15", "Shutdown"),
+          dev("iPhone 15 Pro", "Booted"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices, "iPhone 15 Pro");
+    expect(r.ok).toBe(true);
+    expect((r as { name: string }).name).toBe("iPhone 15 Pro");
+  });
+
+  it("returns an error listing available names when preferred name is not found", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPhone 14", "Shutdown"),
+          dev("iPhone 15", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices, "iPhone 99");
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain("iPhone 99");
+    expect((r as { error: string }).error).toContain("iPhone 14");
+    expect((r as { error: string }).error).toContain("iPhone 15");
+  });
+
+  it("falls back to the highest-runtime iPhone when no preferred name is set", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-16-4": [
+          dev("iPhone SE", "Shutdown"),
+          dev("iPhone 14", "Shutdown"),
+        ],
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPhone 14", "Shutdown"),
+          dev("iPhone 15", "Shutdown"),
+          dev("iPad Pro", "Shutdown"),
+        ],
+        "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+          dev("iPhone 16", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices);
+    expect(r.ok).toBe(true);
+    expect((r as { name: string }).name).toBe("iPhone 16");
+  });
+
+  it("prefers a Booted simulator over runtime-version sort", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPhone 15", "Shutdown"),
+          dev("iPhone 14", "Booted"),
+        ],
+        "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+          dev("iPhone 16", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices);
+    expect(r.ok).toBe(true);
+    expect((r as { name: string }).name).toBe("iPhone 14");
+  });
+
+  it("returns an actionable error when no iOS simulators are installed", () => {
+    const r = pickSimulator({ devices: {} });
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toMatch(/no iOS simulators/i);
+  });
+
+  it("returns an actionable error when no iOS simulators match (other runtimes present)", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.tvOS-17-0": [dev("Apple TV", "Shutdown")],
+      },
+    };
+    const r = pickSimulator(devices);
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toMatch(/no iOS simulators/i);
+  });
+
+  it("excludes devices with isAvailable === false", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPhone 15", "Shutdown", { isAvailable: false }),
+          dev("iPhone 14", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices);
+    expect(r.ok).toBe(true);
+    expect((r as { name: string }).name).toBe("iPhone 14");
+  });
+
+  it("ignores non-iOS runtime keys entirely", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.watchOS-10-0": [
+          dev("Apple Watch", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices);
+    expect(r.ok).toBe(false);
+  });
+
+  it("handles a null/undefined devicesJson gracefully", () => {
+    expect(pickSimulator(null).ok).toBe(false);
+    expect(pickSimulator(undefined).ok).toBe(false);
+  });
+
+  it("falls back to the first candidate when no Booted and no iPhone-named device exists", () => {
+    const devices = {
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+          dev("iPad Pro", "Shutdown"),
+          dev("iPad Mini", "Shutdown"),
+        ],
+      },
+    };
+    const r = pickSimulator(devices);
+    expect(r.ok).toBe(true);
+    expect((r as { name: string }).name).toBe("iPad Pro");
+  });
+});

--- a/src/main/handlers/iosBuild.ts
+++ b/src/main/handlers/iosBuild.ts
@@ -1,0 +1,309 @@
+// iosBuild.ts — the ONLY iOS-specific file in the MantaUI plugin system.
+//
+// Implements the `ios.build` capability (BET-183 / BET-185 stage 2). Compiles
+// the MantaUI iOS app on the connected Mac and (by default) launches it in the
+// iOS Simulator. Lives under src/main/handlers/ so capExecutor's HANDLERS map
+// dispatches to it — adding capability #2 = new file under handlers/ + new
+// HANDLERS entry, NO core changes.
+//
+// The generic plumbing (queue, SSE, catch-up, auth, batched logs, timeouts)
+// lives in src/main/capExecutor.ts and src/server/capabilities.mjs. This
+// handler ONLY knows how to take an `input.action` / `input.pull` and turn it
+// into xcodebuild output. Node builtins only.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AppConfig } from "../../shared/types.js";
+
+// ---------------------------------------------------------------------------
+// The plugin-seam context this handler receives from capExecutor. Matches the
+// spec EXACTLY — `secret()` is intentionally absent (see doc string on
+// ctx below; v1 capability #1 needs no secrets).
+// ---------------------------------------------------------------------------
+
+export type CapCtx = {
+  input: unknown;
+  config: AppConfig;
+  log(line: string): void;
+  // spawn helper — argv array, never a shell string. PATH is pre-patched by
+  // capExecutor so Homebrew/nvm binaries are visible to this GUI app.
+  exec(
+    cmd: string,
+    args: string[],
+    opts?: { cwd?: string; quiet?: boolean },
+  ): Promise<{ code: number; stdout: string }>;
+  signal: AbortSignal;
+};
+
+export type CapHandler = (ctx: CapCtx) => Promise<{ result?: unknown }>;
+
+// Bundle id used for `simctl launch`. Mirrors the AGENTS.md §"App Store Connect
+// facts" canonical value — keep in sync if the bundle id ever moves.
+const BUNDLE_ID = "com.antoinedc.mantaui";
+
+// Pinned derived-data dir. Hardcoded per spec — sharing one DerivedData dir
+// across parallel xcodebuilds would corrupt it. The Mac executor SERIALIZES
+// jobs (capExecutor is one-at-a-time), so a single pinned path is safe and
+// makes subsequent builds incremental.
+function derivedDataDir(): string {
+  return join(homedir(), "Library", "Caches", "MantaUI", "DerivedData");
+}
+
+function derivedAppPath(): string {
+  return join(
+    derivedDataDir(),
+    "Build",
+    "Products",
+    "Debug-iphonesimulator",
+    "App.app",
+  );
+}
+
+// Expand a leading "~" against os.homedir(). Only used for the user-supplied
+// repo path — keeps the server-side path resolution out of main/.
+function expandTilde(p: string): string {
+  if (!p) return p;
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return join(homedir(), p.slice(2));
+  }
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// `pickSimulator` — pure function implementing the spec's exact algorithm.
+// Exported + tested because every test in the spec (`preferred found / not
+// found`, `Booted preferred`, `highest-runtime iPhone fallback`, `no devices`,
+// `isAvailable:false excluded`) lives here.
+//
+// Input shape: real `xcrun simctl list devices available --json` output,
+// which looks like:
+//
+//   { "devices": {
+//       "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+//         { udid, name, state, isAvailable, ... }
+//       ],
+//       "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [ ... ]
+//   }}
+// ---------------------------------------------------------------------------
+
+export type SimDevice = {
+  udid?: string;
+  name?: string;
+  state?: string;
+  isAvailable?: boolean;
+};
+
+export type SimPickResult =
+  | { ok: true; udid: string; name: string }
+  | { ok: false; error: string };
+
+export function pickSimulator(
+  devicesJson: { devices?: Record<string, SimDevice[] | undefined> } | null | undefined,
+  preferredName?: string,
+): SimPickResult {
+  const devices = devicesJson?.devices ?? {};
+  // Flatten runtime keys containing "SimRuntime.iOS", dropping unavailable.
+  const all: Array<{ runtime: string; device: SimDevice }> = [];
+  for (const [runtime, list] of Object.entries(devices)) {
+    if (!runtime.includes("SimRuntime.iOS")) continue;
+    if (!Array.isArray(list)) continue;
+    for (const d of list) {
+      if (d?.isAvailable === false) continue;
+      all.push({ runtime, device: d });
+    }
+  }
+
+  const candidates = preferredName
+    ? all.filter((c) => c.device.name === preferredName)
+    : all;
+
+  if (preferredName && candidates.length === 0) {
+    const names = Array.from(
+      new Set(all.map((c) => c.device.name).filter(Boolean)),
+    ).sort();
+    return {
+      ok: false,
+      error: `simulator "${preferredName}" not found; available: ${names.join(", ") || "(none)"}`,
+    };
+  }
+
+  if (candidates.length === 0) {
+    return { ok: false, error: "no iOS simulators available — install one in Xcode" };
+  }
+
+  // 1. Booted preferred (or first booted if no preferred).
+  const booted = candidates.find((c) => c.device.state === "Booted");
+  if (booted) {
+    return {
+      ok: true,
+      udid: booted.device.udid ?? "",
+      name: booted.device.name ?? "",
+    };
+  }
+
+  // 2. Highest iOS runtime version, first device whose name starts with "iPhone".
+  const sorted = [...candidates].sort((a, b) => {
+    const va = parseRuntimeVersion(a.runtime);
+    const vb = parseRuntimeVersion(b.runtime);
+    for (let i = 0; i < Math.max(va.length, vb.length); i++) {
+      const ai = va[i] ?? 0;
+      const bi = vb[i] ?? 0;
+      if (ai !== bi) return bi - ai;
+    }
+    return 0;
+  });
+  const iphone = sorted.find((c) => (c.device.name ?? "").startsWith("iPhone"));
+  if (iphone) {
+    return {
+      ok: true,
+      udid: iphone.device.udid ?? "",
+      name: iphone.device.name ?? "",
+    };
+  }
+
+  // 3. First candidate.
+  const first = candidates[0];
+  return {
+    ok: true,
+    udid: first.device.udid ?? "",
+    name: first.device.name ?? "",
+  };
+}
+
+// Parse `iOS-17-5` → [17, 5] from a runtime key like
+// `com.apple.CoreSimulator.SimRuntime.iOS-17-5`. Returns [0] when the key has
+// no `iOS-<digits>` tail.
+function parseRuntimeVersion(runtime: string): number[] {
+  const tail = runtime.split("SimRuntime.iOS-").pop() ?? "";
+  const parts = tail.split("-").filter((s) => /^\d+$/.test(s));
+  return parts.map((p) => Number.parseInt(p, 10));
+}
+
+// ---------------------------------------------------------------------------
+// The handler
+// ---------------------------------------------------------------------------
+
+type IosBuildInput = {
+  action?: "build-and-launch" | "test" | "compile-only";
+  pull?: boolean;
+};
+
+export const iosBuildHandler: CapHandler = async (ctx) => {
+  const input = (ctx.input ?? {}) as IosBuildInput;
+  const action = input.action ?? "build-and-launch";
+
+  // Step 0 — precheck. Failures here propagate with the PATH hint baked in
+  // by capExecutor's exec helper.
+  await ctx.exec("xcodebuild", ["-version"]);
+  await ctx.exec("npm", ["--version"]);
+
+  // Step 1 — repo path. Default ~/projects/better-ui; expand a leading "~"
+  // against os.homedir() locally (no server import).
+  const repo = expandTilde(
+    (ctx.config.iosBuildRepoPath ?? "").trim() || "~/projects/better-ui",
+  );
+
+  // Step 2 — optional pull. Pulls main only (--ff-only); the tool description
+  // carries the warning that this builds the Mac clone on main, not the
+  // session's branch.
+  if (input.pull) {
+    await ctx.exec("git", ["-C", repo, "pull", "--ff-only", "origin", "main"]);
+  }
+
+  // Step 3 — web bundle + cap sync. The mobile/www bundle must exist before
+  // the Capacitor build (see AGENTS.md §"MOBILE CHANGES REACH DEVICES…").
+  await ctx.exec("npm", ["run", "build:mobile"], { cwd: repo });
+  await ctx.exec("npx", ["cap", "sync", "ios"], { cwd: repo });
+
+  // Step 4 — simulator resolution. Run quietly — JSON output would pollute
+  // the user-visible log.
+  const simList = await ctx.exec(
+    "xcrun",
+    ["simctl", "list", "devices", "available", "--json"],
+    { quiet: true },
+  );
+  let parsed: { devices?: Record<string, SimDevice[] | undefined> };
+  try {
+    parsed = JSON.parse(simList.stdout) as typeof parsed;
+  } catch (e) {
+    throw new Error(`failed to parse simctl list JSON: ${(e as Error).message}`);
+  }
+  const picked = pickSimulator(parsed, ctx.config.iosSimulatorName);
+  if (!picked.ok) throw new Error(picked.error);
+  const { udid, name: simName } = picked;
+
+  // Step 5 — build (or test, or compile-only). Simulator SDK = no signing.
+  const derivedData = derivedDataDir();
+  const appPath = derivedAppPath();
+  const xcodeArg =
+    action === "test" ? "test" : "build";
+  const buildRes = await ctx.exec(
+    "xcodebuild",
+    [
+      "-workspace",
+      join(repo, "mobile/ios/App/App.xcworkspace"),
+      "-scheme",
+      "App",
+      "-sdk",
+      "iphonesimulator",
+      "-configuration",
+      "Debug",
+      "-destination",
+      `platform=iOS Simulator,id=${udid}`,
+      "-derivedDataPath",
+      derivedData,
+      xcodeArg,
+    ],
+    { cwd: repo },
+  );
+  if (buildRes.code !== 0) {
+    throw new Error(`xcodebuild ${xcodeArg}: exit ${buildRes.code}`);
+  }
+
+  // Verify the pinned .app actually landed where we expect — `xcodebuild`
+  // exit 0 can still miss the expected output if the workspace path was
+  // wrong, etc.
+  if (!existsSync(appPath)) {
+    throw new Error(`build succeeded but App.app not found at ${appPath}`);
+  }
+
+  // Step 6 — boot + launch (default only).
+  if (action === "build-and-launch") {
+    // "already booted" is non-zero; that's fine.
+    await ctx.exec("xcrun", ["simctl", "boot", udid]).catch(() => {});
+    // Open the Simulator app so the user sees a window. Non-zero needs a
+    // real GUI session; surface it.
+    const openSim = await ctx.exec("open", ["-a", "Simulator"]);
+    if (openSim.code !== 0) {
+      throw new Error(`open -a Simulator: exit ${openSim.code}`);
+    }
+    const install = await ctx.exec("xcrun", [
+      "simctl",
+      "install",
+      udid,
+      appPath,
+    ]);
+    if (install.code !== 0) {
+      throw new Error(`simctl install: exit ${install.code}`);
+    }
+    const launch = await ctx.exec("xcrun", [
+      "simctl",
+      "launch",
+      udid,
+      BUNDLE_ID,
+    ]);
+    if (launch.code !== 0) {
+      throw new Error(`simctl launch: exit ${launch.code}`);
+    }
+    return { result: { appPath, simUdid: udid, simName, launched: true } };
+  }
+
+  if (action === "test") {
+    return { result: { tested: true, simUdid: udid, simName } };
+  }
+
+  // compile-only
+  return { result: { appPath, simUdid: udid, simName, launched: false } };
+};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,10 @@ import {
   startDesktopNotifications,
   stopDesktopNotifications,
 } from "./desktopNotify.js";
+import {
+  startCapExecutor,
+  stopCapExecutor,
+} from "./capExecutor.js";
 import { checkForUpdates } from "./autoUpdate.js";
 import { IPC, type AppConfig, type AuthClaimInput } from "../shared/types.js";
 
@@ -191,6 +195,10 @@ app.whenReady().then(() => {
         }
       },
     );
+    // Capability executor (BET-183 / BET-185): when enabled in Settings, this
+    // Mac subscribes to bui-server's bus and runs plugin handlers (e.g.
+    // ios.build). startCapExecutor is a no-op when capExecutorEnabled is off.
+    startCapExecutor(() => config);
     // Defer update check until after the renderer is ready (avoids blocking startup).
     // electron-updater skips the check in dev mode (unpacked app).
     setTimeout(() => checkForUpdates(), 5000);
@@ -209,6 +217,7 @@ app.on("before-quit", () => {
   stopScreenshotDetector();
   stopDesktopPresence();
   stopDesktopNotifications();
+  stopCapExecutor();
 });
 
 function registerHandlers(): void {

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -32,6 +32,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
     groqApiKey,
     voiceTranscriptionModel,
     voiceCommandModel,
+    capExecutorEnabled,
+    iosBuildRepoPath,
+    iosSimulatorName,
     launcherFlags,
     refresh,
   } = useStore();
@@ -57,6 +60,12 @@ export function Settings({ onClose }: { onClose: () => void }) {
 
   // General fields (General tab)
   const [autoRename, setAutoRename] = useState(autoRenameSessions);
+
+  // Capability executor fields (Files tab — co-located with allowAgentPush
+  // since both gate what the AI can do on this Mac).
+  const [capExecutorOn, setCapExecutorOn] = useState(capExecutorEnabled);
+  const [iosRepoPath, setIosRepoPath] = useState(iosBuildRepoPath);
+  const [iosSimName, setIosSimName] = useState(iosSimulatorName);
 
   // Voice fields (Voice tab)
   const [groqKey, setGroqKey] = useState(groqApiKey);
@@ -88,8 +97,11 @@ export function Settings({ onClose }: { onClose: () => void }) {
     setGroqKey(groqApiKey);
     setVoiceTrModel(voiceTranscriptionModel);
     setVoiceCmdModel(voiceCommandModel);
+    setCapExecutorOn(capExecutorEnabled);
+    setIosRepoPath(iosBuildRepoPath);
+    setIosSimName(iosSimulatorName);
     setLauncherFlagValues(launcherFlags ?? {});
-  }, [defaultModel, skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, launcherFlags]);
+  }, [defaultModel, skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, capExecutorEnabled, iosBuildRepoPath, iosSimulatorName, launcherFlags]);
 
   // Fetch available models once (non-fatal — Settings works even if opencode is unreachable).
   useEffect(() => {
@@ -135,6 +147,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
         groqApiKey: groqKey.trim(),
         voiceTranscriptionModel: voiceTrModel.trim(),
         voiceCommandModel: voiceCmdModel.trim(),
+        capExecutorEnabled: capExecutorOn,
+        iosBuildRepoPath: iosRepoPath.trim(),
+        iosSimulatorName: iosSimName.trim(),
         launcherFlags: launcherFlagValues,
       });
     } catch (e) {
@@ -644,6 +659,70 @@ export function Settings({ onClose }: { onClose: () => void }) {
                     />
                     <div className="text-xs text-text-faint">
                       Destination for AI-sent files. Absolute path; leave empty for your OS Downloads folder.
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Capability executor (BET-183 / BET-185) — co-located with
+                  allowAgentPush because both gate what the AI can do on this
+                  Mac. The toggle is OFF by default; changing it takes effect
+                  after restarting MantaUI (the executor gates itself at start
+                  time — see src/main/capExecutor.ts). */}
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Capability executor</h3>
+                <div className="space-y-3">
+                  <label className="flex items-start gap-3 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={capExecutorOn}
+                      onChange={(e) => setCapExecutorOn(e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      Run plugin commands on this Mac
+                      <span className="block text-xs text-text-faint mt-1">
+                        Allows the AI to run build commands on this Mac (e.g.
+                        <code className="text-text-muted"> ios_build</code>) so you
+                        don&apos;t burn Codemagic minutes. Off by default — takes
+                        effect after restarting MantaUI.
+                      </span>
+                    </span>
+                  </label>
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      iOS build repo path
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="~/projects/better-ui (default)"
+                      value={iosRepoPath}
+                      onChange={(e) => setIosRepoPath(e.target.value)}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                    />
+                    <div className="text-xs text-text-faint">
+                      Absolute path to the MantaUI clone used by{" "}
+                      <code className="text-text-muted">ios_build</code>. Must
+                      track <code className="text-text-muted">origin/main</code>{" "}
+                      — the tool builds the Mac clone on main, not your session
+                      branch.
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      iOS simulator name
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="(auto-pick: highest iOS runtime + iPhone)"
+                      value={iosSimName}
+                      onChange={(e) => setIosSimName(e.target.value)}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                    />
+                    <div className="text-xs text-text-faint">
+                      Exact simulator device name to target (e.g.{" "}
+                      <code className="text-text-muted">iPhone 15</code>). Leave
+                      empty to auto-pick.
                     </div>
                   </div>
                 </div>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -131,6 +131,14 @@ type State = {
   groqApiKey: string;
   voiceTranscriptionModel: string;
   voiceCommandModel: string;
+  // Capability executor (BET-183 / BET-185). When true, this Mac runs plugin
+  // handlers (e.g. ios.build) for jobs the AI queues. Mirrored from
+  // AppConfig.capExecutorEnabled / iosBuildRepoPath / iosSimulatorName.
+  // Mirroring is read-only here — toggling takes effect on next app launch
+  // (the executor gates itself at start time).
+  capExecutorEnabled: boolean;
+  iosBuildRepoPath: string;
+  iosSimulatorName: string;
   projects: Project[];
   activeProjectName: string | null;
   activeWindowByProject: Record<string, number>; // projectName -> windowIndex
@@ -273,6 +281,9 @@ export const useStore = create<State>((set, get) => ({
   groqApiKey: "",
   voiceTranscriptionModel: "",
   voiceCommandModel: "",
+  capExecutorEnabled: false,
+  iosBuildRepoPath: "",
+  iosSimulatorName: "",
   projects: [],
   activeProjectName: null,
   activeWindowByProject: {},
@@ -386,6 +397,9 @@ export const useStore = create<State>((set, get) => ({
       groqApiKey: c.groqApiKey ?? "",
       voiceTranscriptionModel: c.voiceTranscriptionModel ?? "",
       voiceCommandModel: c.voiceCommandModel ?? "",
+      capExecutorEnabled: c.capExecutorEnabled ?? false,
+      iosBuildRepoPath: c.iosBuildRepoPath ?? "",
+      iosSimulatorName: c.iosSimulatorName ?? "",
     }),
 
   applyPairing: (p) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -117,6 +117,23 @@ export type AppConfig = {
   // classifier in chatUtils.ts can't match a command-mode utterance. Default
   // "llama-3.1-8b-instant" — JSON-mode capable, ~$0.0001/call, ~300ms.
   voiceCommandModel?: string;
+  // ----- Capability executor (BET-183 / BET-185) -----
+  // Master switch for the Mac-side capability executor (capExecutor.ts). When
+  // true, this Mac subscribes to bui-server's SSE bus and runs MantaUI plugin
+  // handlers (e.g. ios.build). Default false (OFF) — toggling takes effect on
+  // next app launch. Trust boundary: handlers run arbitrary shell commands
+  // scoped to the allowlist in capExecutor's HANDLERS map.
+  capExecutorEnabled?: boolean;
+  // Absolute path to the MantaUI git clone used by the ios.build handler.
+  // Default `~/projects/better-ui`. Leading `~` is expanded against
+  // os.homedir() in the handler. Must be a clone that tracks origin/main —
+  // the tool description carries the warning that ios.build builds the
+  // Mac's clone (tracking main), NOT this session's branch.
+  iosBuildRepoPath?: string;
+  // Exact simulator device name to target for ios.build (e.g. "iPhone 15").
+  // Absent/empty = auto-pick (highest iOS runtime + iPhone-prefixed name).
+  // See src/main/handlers/iosBuild.ts `pickSimulator` for the algorithm.
+  iosSimulatorName?: string;
 };
 
 // ----- Live tmux state -----


### PR DESCRIPTION
Stage 2 of the MantaUI plugin system — the Mac-side executor that runs plugin handlers (e.g. `ios.build`) for jobs the AI queues via `/api/cap`. Stage 1 (BET-184) landed the box-side queue + REST + sweeper + the `ios_build` AI tool; this stage closes the loop on the user's Mac so that tool actually fires.

**Base:** `origin/main` @ `b74f4f4`

## What ships

The 8 deliverables from the issue:

1. `src/main/busConsumer.ts` (NEW, 144 lines) — shared SSE consumer extracted from `desktopNotify.ts`. Instance state (no module-level singletons), optional `onConnect` hook for catch-up, generic `onEnvelope` receives every well-formed envelope.
2. `src/main/desktopNotify.ts` (REWRITE) — thin one-kind filter over `busConsumer`. Public API unchanged (`startDesktopNotifications` / `stopDesktopNotifications`), same idempotency, same callers in `src/main/index.ts`. **Net: 149 → 53 lines.**
3. `src/main/capExecutor.ts` (NEW, 422 lines) — the Mac executor. `startCapExecutor` is a no-op unless `capExecutorEnabled === true` at start (toggle takes effect on next app launch). Subscribes via `busConsumer`. Filter is `kind:"capJob"` + `payload.host === "mac"`. Catch-up fires from `onConnect` (initial AND every reconnect). Serial FIFO with a `Set<string>` of ever-enqueued ids so SSE+catch-up duplicates collapse. Per job: `POST /start` (non-2xx → skip, this is the cross-delivery dedup), HANDLERS lookup (unknown → `POST /done {failed: unknown capability "…"}`, never shell out), `CapCtx` with `AbortController` armed at `EXECUTOR_JOB_TIMEOUT_MS` (unref'd), `ctx.log` buffered + `setInterval(LOG_FLUSH_MS)` (unref'd) flushing as ONE `POST /log {chunk}` when non-empty, final flush BEFORE the done POST, failed done POST retried once after 5s. `CapCtx` shape EXACTLY `{input, config, log, exec, signal}` — **no `secret()`** (intentionally absent per spec). `exec(cmd, args, {cwd?, quiet?})` spawns argv-array only (never a shell string), env `PATH` prepended with `/opt/homebrew/bin:/usr/local/bin:` so GUI-Electron apps see Homebrew binaries, captures stdout up to `EXEC_STDOUT_CAP_BYTES` (keep newest), resolves `{code, stdout}` on close (does NOT throw on non-zero — handlers decide), rejects on spawn `error` with the Homebrew hint, SIGTERM-then-SIGKILL on `ctx.signal` abort with `KILL_GRACE_MS` grace. The plugin seam is one const: `const HANDLERS: Record<string, CapHandler> = { "ios.build": iosBuildHandler }`.
4. `src/main/handlers/iosBuild.ts` (NEW, 309 lines) — **the ONLY iOS-specific file** in the repo. Precheck (`xcodebuild -version`, `npm --version`); repo path from `ctx.config.iosBuildRepoPath` default `~/projects/better-ui` (local `expandTilde` against `os.homedir()`, no server import); optional `git -C <repo> pull --ff-only origin main`; `npm run build:mobile` + `npx cap sync ios` (cwd repo); simulator resolution via `xcrun simctl list devices available --json` (quiet) + `pickSimulator(parsed, ctx.config.iosSimulatorName)`; xcodebuild with the PINNED `-derivedDataPath ~/Library/Caches/MantaUI/DerivedData` and destination `platform=iOS Simulator,id=<udid>`; verify `App.app` exists at the pinned path; boot (IGNORE exit code — "already booted" is non-zero), `open -a Simulator`, `simctl install`, `simctl launch com.antoinedc.mantaui`. `action: "test"` and `"compile-only"` branches stay INSIDE this file (no leaking action handling into `capExecutor`). Node builtins only — no new deps.
5. `src/main/handlers/iosBuild.test.ts` (NEW, 161 lines) — vitest, 11 cases for `pickSimulator`: preferred found, Booted preferred, preferred-not-found error listing names, highest-runtime iPhone fallback, no devices, `isAvailable:false` excluded, null/undefined input, non-iOS runtime keys ignored, fallback to first candidate when no iPhone-named device.
6. `src/shared/types.ts` — three new optional `AppConfig` fields: `capExecutorEnabled?` (default false), `iosBuildRepoPath?`, `iosSimulatorName?`. Ride the existing `configGet` / `configUpdate` IPC channels — no new channels. Device-local (NOT in `sharedConfig.mjs`).
7. `src/main/index.ts` — `startCapExecutor(() => config)` wired right next to `startDesktopNotifications(...)`, mirroring its start/stop lifecycle exactly. `stopCapExecutor()` in `before-quit`. The enabled-gate lives INSIDE `startCapExecutor` so callers don't need to know.
8. `src/renderer/Settings.tsx` (desktop only — `MobileSettings.tsx` untouched) — Files tab → new "Capability executor" section. One toggle ("Run plugin commands on this Mac") + "iOS build repo path" + "iOS simulator name". Helper text carries the trust warning ("Allows the AI to run build commands on this Mac") AND "takes effect after restarting MantaUI" — same spirit as `allowAgentPush`.
9. `AGENTS.md` — new "Capability plugins + Mac executor (BET-183)" section appended right before the iOS release section. Covers: the generic `{capability, input, host}` invariant; the HANDLERS map as the plugin seam; catch-up/serial/batched-log executor behaviors; sweep guarantees; the no-`secret()`-in-v1 rationale + future design; macOS GUI PATH gotcha with the Homebrew hint; the busConsumer consolidation claim; Settings placement; and the verified-by-inspection "adding capability #2 = one tool file + one HANDLERS entry" invariant.

## Verification results

```
**Files changed:** 10 files. +1299 / -116
  AGENTS.md                        | +124
  src/main/busConsumer.ts          | NEW (+144)
  src/main/capExecutor.ts          | NEW (+422)
  src/main/desktopNotify.ts        | -110 / +53
  src/main/handlers/iosBuild.ts    | NEW (+309)
  src/main/handlers/iosBuild.test.ts | NEW (+161)
  src/main/index.ts                | +9
  src/renderer/Settings.tsx        | +80
  src/renderer/store.ts            | +14
  src/shared/types.ts              | +17

**Verification results:**
- PR branch (`multica/BET-185-mantai-plugins-stage2` @ `0cd4525`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 56 vitest files / 1022 tests pass (was 55/1011, +1 file +11
    cases from iosBuild.test.ts), 743 node:test pass / 0 fail. Failures: none.
- Base (`main` @ `b74f4f4`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 55 vitest files / 1011 tests pass, 743 node:test pass / 0
    fail. Failures: none.
- **Conclusion:** 0 new failures. 11 new passing tests (iosBuild.test.ts).
  No regressions.
```

## Desktop notifications — still arrive after the busConsumer extraction

Verified by inspection (cannot run a live GUI here):
- `startDesktopNotifications` is unchanged at the call site in `src/main/index.ts` (same `configGetter`, same `onPayload` → `IPC.desktopNotify` send).
- The filter (`env.kind === "desktopNotify" && env.payload`) sits at the same boundary as before, just inside a one-line `onEnvelope` callback instead of `handleFrame`'s switch.
- The SSE plumbing moved verbatim into `busConsumer.ts` — same `connect` / `scheduleReconnect` / frame buffer / `handleFrame` logic, same `RECONNECT_MS = 3000`, same headers (`Authorization: Bearer <boxToken>`), same `URL("/events", serverUrl)`. The only addition is the optional `onConnect` hook (desktopNotify doesn't pass one).
- `stopDesktopNotifications` calls `consumer.stop()`, which destroys the active response + cancels the reconnect timer — same effective behavior as the prior `current?.destroy()` + `clearTimeout(reconnectTimer)`.

The next live-Mac run will exercise this end-to-end (a notification from bui-server's `push.mjs` router → SSE envelope → `busConsumer` `onEnvelope` → `desktopNotify` filter → IPC to renderer → Notification API).

## Live Mac verification — pending

The PR comment template's "Live on the Mac with `capExecutorEnabled:true`" run is a Mac-only verification (this PR runs on a Linux box with no Xcode, no `simctl`, no Homebrew-prefixed `PATH`). I will run it on the user's Mac once this lands, per the issue's Definition of done, and update this PR comment with the results:

1. `capExecutorEnabled: true` in Settings → restart → call `ios_build` from a chat session → expect a job id, no polling, completion turn injected into the session, simulator boots with the app launched, `xcodebuild` log streamed to `ios_build_status`.
2. While the Mac app is closed, manually `POST /api/cap` (or have the AI create a job) → launch the app → expect catch-up to claim the job.

Will report both runs + observed results in a follow-up comment before final review.

## Verified by inspection — adding capability #2

Confirmed against `git diff origin/main...HEAD`:
- The ONLY iOS-specific file in `src/main/` is `handlers/iosBuild.ts`. (`grep -r ios src/main/` → `handlers/iosBuild.ts` plus the `"ios.build"` literal in `capExecutor.ts`'s `HANDLERS` map.)
- `capExecutor.ts`'s `HANDLERS` map is the ONLY capability-dispatch site — its queue / REST / SSE code paths have zero `ios`-specific branches. (`grep ios src/main/capExecutor.ts` → only `iosBuildHandler` import + `"ios.build"` key.)
- Adding capability #2 = drop a new file under `src/main/handlers/`, add one entry to `HANDLERS`. No changes to `capExecutor`'s dispatch, the queue, the REST surface, or auth.

## Cross-cutting notes

- New config fields ride the existing `configGet` / `configUpdate` IPC channels — no new IPC/RPC channels added.
- "MantaUI" branding in all NEW text (tool descriptions / AGENTS.md / UI labels). No rename of existing "bui" code.
- `npm run typecheck` and `npm test` are the gates that gate; both pass.
- The `consumer` handle is also tracked at module scope (`activeConsumer`) so `stopCapExecutor()` (called from `before-quit`) is a single `consumer.stop()` — symmetry with `stopDesktopNotifications()`.