### PR TITLE
BET-187: ship console + structured events to Axiom across all runtimes

### DIFF
--- a/src/relay/index.mjs
+++ b/src/relay/index.mjs
@@ -41,6 +41,7 @@ import {
   FRAME_TYPES,
 } from "./protocol.mjs";
 import { openStore, BOX_STATUS, hashToken, hashEquals } from "./store.mjs";
+import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 
 export const DEFAULT_RELAY_PORT = 20787;
 
@@ -767,6 +768,17 @@ const isMain =
   process.argv[1]?.endsWith("src/relay/index.mjs");
 
 if (isMain) {
+  // BET-187: ship every console.* (incl. the [relay] listening banner)
+  // to Axiom when MANTA_AXIOM_TOKEN is set. Relay runs on the prod box
+  // with no `~/.manta` directory, so config is null — env-only. Silent
+  // no-op when the env var is unset.
+  {
+    const axiomCfg = resolveAxiomConfig({ env: process.env, config: null });
+    if (axiomCfg) {
+      captureConsole(createLogShipper({ ...axiomCfg, source: "relay", device: "relay" }));
+    }
+  }
+
   const relay = createRelayServer();
   relay
     .start()

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -36,6 +36,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
     iosBuildRepoPath,
     iosSimulatorName,
     launcherFlags,
+    axiomToken,
+    axiomDataset,
     refresh,
   } = useStore();
 
@@ -71,6 +73,10 @@ export function Settings({ onClose }: { onClose: () => void }) {
   const [groqKey, setGroqKey] = useState(groqApiKey);
   const [voiceTrModel, setVoiceTrModel] = useState(voiceTranscriptionModel);
   const [voiceCmdModel, setVoiceCmdModel] = useState(voiceCommandModel);
+  // Axiom log shipping (BET-187) — co-located with Voice per the spec
+  // (mirrors groqApiKey's row pattern). Empty token → silent no-op.
+  const [axiomTok, setAxiomTok] = useState(axiomToken);
+  const [axiomDs, setAxiomDs] = useState(axiomDataset);
   // Mobile pairing — one-time code minted on demand. The QR encodes the
   // CANONICAL box-form `manta://pair?box=<boxId>&code=<6-digit>` payload
   // (BET-177 §2.4 — the old `?id=&token=` form was a parsePairPayload
@@ -101,7 +107,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
     setIosRepoPath(iosBuildRepoPath);
     setIosSimName(iosSimulatorName);
     setLauncherFlagValues(launcherFlags ?? {});
-  }, [defaultModel, skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, capExecutorEnabled, iosBuildRepoPath, iosSimulatorName, launcherFlags]);
+    setAxiomTok(axiomToken);
+    setAxiomDs(axiomDataset);
+  }, [defaultModel, skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, capExecutorEnabled, iosBuildRepoPath, iosSimulatorName, launcherFlags, axiomToken, axiomDataset]);
 
   // Fetch available models once (non-fatal — Settings works even if opencode is unreachable).
   useEffect(() => {
@@ -147,6 +155,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
         groqApiKey: groqKey.trim(),
         voiceTranscriptionModel: voiceTrModel.trim(),
         voiceCommandModel: voiceCmdModel.trim(),
+        axiomToken: axiomTok.trim(),
+        axiomDataset: axiomDs.trim(),
         capExecutorEnabled: capExecutorOn,
         iosBuildRepoPath: iosRepoPath.trim(),
         iosSimulatorName: iosSimName.trim(),
@@ -618,6 +628,40 @@ export function Settings({ onClose }: { onClose: () => void }) {
                         className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
                       />
                     </div>
+                  </div>
+                </div>
+              </div>
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Remote log shipping (Axiom)</h3>
+                <div className="text-sm text-text-faint mb-4">
+                  Ships app + server logs to Axiom for remote debugging. Leave empty to disable.
+                </div>
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <label className="block text-xs uppercase tracking-wider text-text-muted">
+                      Axiom ingest token
+                    </label>
+                    <input
+                      type="password"
+                      placeholder="xaat-… (leave blank to disable)"
+                      value={axiomTok}
+                      onChange={(e) => setAxiomTok(e.target.value)}
+                      autoComplete="off"
+                      spellCheck={false}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-[10px] uppercase tracking-wider text-text-faint">
+                      Axiom dataset
+                    </label>
+                    <input
+                      placeholder="bui"
+                      value={axiomDs}
+                      onChange={(e) => setAxiomDs(e.target.value)}
+                      spellCheck={false}
+                      className="w-full bg-bg-soft border border-border px-3 py-2 text-sm rounded focus:outline-none focus:border-accent font-mono"
+                    />
                   </div>
                 </div>
               </div>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -656,7 +656,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
                       Axiom dataset
                     </label>
                     <input
-                      placeholder="bui"
+                      placeholder="manta"
                       value={axiomDs}
                       onChange={(e) => setAxiomDs(e.target.value)}
                       spellCheck={false}

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -19,6 +19,7 @@ import { getBuiPreload } from "../preloadAccess.js";
 import { useStore } from "../store.js";
 import { shouldForceReconnect } from "../chatUtils";
 import { isValidBoxToken } from "../../shared/transport.mjs";
+import { ship } from "../log";
 
 // ---------------------------------------------------------------------------
 // Server base URL resolution (3 deployment contexts):
@@ -282,21 +283,38 @@ async function claimRelay(boxId: string, code: string): Promise<ClaimResult> {
 // ---------------------------------------------------------------------------
 
 async function rpc<T>(channel: string, ...args: unknown[]): Promise<T> {
-  const res = await fetch(
-    `${serverBase()}/rpc/${encodeURIComponent(channel)}`,
-    {
-      method: "POST",
-      headers: authHeaders(clientToken(), { "content-type": "application/json" }),
-      body: JSON.stringify({ args }),
-    },
-  );
+  // BET-187: track timing so we can ship one structured warn event when an
+  // RPC call exceeds the 1s slow-call threshold. The instrumentation lives
+  // here (single dispatch path — rpcOptional delegates) so every call site
+  // is covered without per-call edits. Failures rethrow as before so the
+  // existing UI auth/network error handling is untouched.
+  const t0 = Date.now();
+  let res: Response;
+  try {
+    res = await fetch(
+      `${serverBase()}/rpc/${encodeURIComponent(channel)}`,
+      {
+        method: "POST",
+        headers: authHeaders(clientToken(), { "content-type": "application/json" }),
+        body: JSON.stringify({ args }),
+      },
+    );
+  } catch (err) {
+    ship("error", "rpc failed", { channel, ms: Date.now() - t0, error: String(err) });
+    throw err;
+  }
+  const ms = Date.now() - t0;
   // 401 → unpaired / stale token. Surface a distinguishable error so the UI
   // layer (M1-T2) can route to the pairing screen instead of showing a raw
   // "HTTP 401" toast.
   if (res.status === 401) throw new AuthRequiredError();
   let json: { result?: unknown; error?: string } = {};
   try { json = await res.json(); } catch { /* non-JSON body (proxy/HTML error) */ }
-  if (!res.ok || json.error) throw new Error(json.error ?? `HTTP ${res.status}`);
+  if (!res.ok || json.error) {
+    ship("error", "rpc failed", { channel, ms, error: json.error ?? `HTTP ${res.status}` });
+    throw new Error(json.error ?? `HTTP ${res.status}`);
+  }
+  if (ms > 1000) ship("warn", "rpc slow", { channel, ms });
   return json.result as T;
 }
 
@@ -399,6 +417,7 @@ function fireResync() {
     const ev: OpencodeEvent = { type: "server.connected", properties: {} };
     for (const fn of set) { try { fn(ev); } catch { /* listener error — ignore, see onmessage */ } }
   }, 0);
+  ship("info", "ws resync");
 }
 
 // WS URL: same origin as serverBase(), http→ws / https→wss. Same-origin so
@@ -473,6 +492,7 @@ function getController(): WsReconnectController {
     onReconnect: fireResync,
     onState: (s) => {
       useStore.getState().setConnectionState(s);
+      ship("info", "ws state", { state: s.state });
       // Fresh connect (initial or reconnect, including a forced one): reset
       // the liveness clock so the watchdog doesn't immediately re-fire while
       // the new socket is still warming up (its first heartbeat is up to 15s
@@ -500,6 +520,7 @@ function installLivenessWatchdog() {
   setInterval(() => {
     const state = getController().getState().state;
     if (shouldForceReconnect(state, lastFrameAt, Date.now(), HEARTBEAT_STALE_MS)) {
+      ship("warn", "ws heartbeat stale", { ageMs: Date.now() - lastFrameAt });
       getController().forceReconnect();
     }
   }, WATCHDOG_INTERVAL_MS);
@@ -521,6 +542,7 @@ function installLivenessWatchdog() {
 // redundant for it but harmless (markReconnectAndEnsure is idempotent).
 export function triggerResumeReconnect(): void {
   if (document.visibilityState !== "visible") return;
+  ship("info", "ws resume reconnect");
   getController().markReconnectAndEnsure();
 }
 

--- a/src/renderer/log.ts
+++ b/src/renderer/log.ts
@@ -1,0 +1,133 @@
+// Renderer-side log shipping (BET-187). The shared `logShip.mjs` module
+// owns the buffering / ingest / format — this file is the thin renderer
+// wrapper: it reads AppConfig.axiomToken via `window.api.configGet()` at
+// init, mints a stable per-device id in localStorage, installs the
+// console-capture wrap, and registers the standard browser event hooks
+// (`error`, `unhandledrejection`, `online`, `offline`, `visibilitychange`,
+// `pagehide`).
+//
+// Mobile PWA and desktop renderer both call `initRendererLogging("mobile"
+// | "desktop")` from main.tsx after `setWindowApi(httpApi)` lands. The
+// token is entered once in desktop Settings (mobile reads server config
+// via configGet — no MobileSettings UI per the spec). Without a token,
+// `ship()` is a safe no-op and `initRendererLogging` returns without
+// installing anything: NO fetches to axiom.co, NO console noise.
+//
+// SPEC GUARD: the renderer ships DIRECTLY to Axiom (not through bui-
+// server). When the phone↔box path is broken — the exact bug being
+// debugged — the renderer must still be able to ship, so a bui-server
+// proxy is explicitly out of scope.
+
+import {
+  createLogShipper,
+  captureConsole,
+  resolveAxiomConfig,
+  type LogShipper,
+} from "../shared/logShip.mjs";
+
+// Module-level singleton. Lives for the lifetime of the renderer. `null`
+// means "no token configured" — ship() below is a safe no-op.
+let shipper: LogShipper | null = null;
+let flushOnHide: (() => void) | null = null;
+
+const DEVICE_KEY = "manta_log_device";
+
+/**
+ * Mint or restore an 8-hex-char device id from localStorage. Stable per
+ * install so events from the same browser/app instance correlate. Falls
+ * back to a timestamp-derived id if localStorage is unavailable (private
+ * mode) — not stable, but still distinguishable per session.
+ */
+function getOrMintDevice(): string {
+  try {
+    const existing = localStorage.getItem(DEVICE_KEY);
+    if (existing && /^[0-9a-f]{8}$/.test(existing)) return existing;
+    const bytes = new Uint8Array(4);
+    crypto.getRandomValues(bytes);
+    const id = Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+    localStorage.setItem(DEVICE_KEY, id);
+    return id;
+  } catch {
+    return Date.now().toString(16).slice(-8);
+  }
+}
+
+/**
+ * Initialize renderer logging. Reads AppConfig once (fire-and-forget — the
+ * boot path must not block on Axiom). No-ops silently when no token is
+ * configured. Safe to call multiple times; subsequent calls are idempotent.
+ *
+ * @param source "mobile" or "desktop" — stamped on every shipped event
+ */
+export async function initRendererLogging(source: "mobile" | "desktop"): Promise<void> {
+  if (shipper) return; // already initialized
+  let config: Parameters<typeof resolveAxiomConfig>[0]["config"] = null;
+  try {
+    config = await window.api.configGet();
+  } catch {
+    // configGet failing is non-fatal — render in unconfigured state.
+    config = null;
+  }
+  const axiomCfg = resolveAxiomConfig({ env: {}, config });
+  if (!axiomCfg) return;
+
+  const device = getOrMintDevice();
+  shipper = createLogShipper({
+    ...axiomCfg,
+    source,
+    device,
+    // keepalive so a flush fired from `pagehide` (window teardown) can
+    // still reach the network — without keepalive the browser drops the
+    // request as the document unloads. Batches at maxBatch=100 events
+    // stay well under the 64KB keepalive cap.
+    fetchFn: (url, init) =>
+      fetch(url, { ...init, keepalive: true }),
+  });
+  captureConsole(shipper);
+
+  // Standard browser event hooks (see spec). Each fires a single structured
+  // ship() event so an AI querying Axiom can correlate these signals with
+  // server-side state.
+  window.addEventListener("error", (e) => {
+    ship("error", "window error", {
+      error: String(e.message ?? ""),
+      source_file: String(e.filename ?? ""),
+      line: Number(e.lineno ?? 0),
+    });
+  });
+  window.addEventListener("unhandledrejection", (e) => {
+    const reason = e.reason;
+    const detail =
+      reason instanceof Error
+        ? (reason.stack ?? String(reason.message ?? reason))
+        : String(reason ?? "");
+    ship("error", "unhandled rejection", { error: detail });
+  });
+  window.addEventListener("online", () => ship("info", "network online"));
+  window.addEventListener("offline", () => ship("warn", "network offline"));
+  document.addEventListener("visibilitychange", () =>
+    ship("info", "visibility", { state: document.visibilityState }),
+  );
+
+  // Final flush on teardown. `pagehide` fires reliably across desktop +
+  // iOS standalone PWA; `visibilitychange→hidden` is the secondary path
+  // (a desktop window closing doesn't fire pagehide in some configs —
+  // we trust the 5s flush timer to catch those, and skip a manual flush
+  // here to keep the surface small).
+  flushOnHide = () => {
+    try { void shipper?.flush(); } catch { /* swallow */ }
+  };
+  window.addEventListener("pagehide", flushOnHide);
+}
+
+/**
+ * Ship a single structured event. Safe no-op when no token is configured
+ * OR init hasn't completed yet. Never throws.
+ */
+export function ship(
+  level: "info" | "warn" | "error",
+  msg: string,
+  fields?: Record<string, unknown>,
+): void {
+  try { shipper?.log(level, msg, fields); } catch { /* swallow */ }
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -5,6 +5,7 @@ import { MobileApp } from "./mobile/MobileApp";
 import "./index.css";
 import "./mobile/mobile.css";
 import { httpApi } from "./api/httpApi";
+import { initRendererLogging } from "./log";
 import type { Api } from "../shared/api";
 import {
   desktopHttpClientSeed,
@@ -95,9 +96,17 @@ async function boot(): Promise<void> {
     setWindowApi(preload);
     await chooseDesktopTransport(preload);
     // chooseDesktopTransport already assigned window.__buiPreload.
+    // Initialize renderer logging AFTER window.api is wired so configGet
+    // works — but BEFORE React mounts so early-render errors still ship.
+    // Fire-and-forget; initRendererLogging is no-op when no token is set.
+    void initRendererLogging("desktop");
   } else {
     // Mobile/web: install the shim (no preload to preserve).
     setWindowApi(httpApi);
+    // Mobile reads config (and thus axiomToken) via the same httpApi
+    // configGet; no MobileSettings UI per the spec — token is entered once
+    // on desktop.
+    void initRendererLogging("mobile");
   }
 
   ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -131,6 +131,14 @@ type State = {
   groqApiKey: string;
   voiceTranscriptionModel: string;
   voiceCommandModel: string;
+  // Axiom log shipping (BET-187). When axiomToken is set, every console.*
+  // call (and a small set of structured events in httpApi.ts) ships to
+  // Axiom so an AI agent can correlate both sides of a phone↔box failure.
+  // Empty string = silent no-op (no fetches to axiom.co, no console noise).
+  // Mirror only — the renderer reads it ONCE at init via window.api.configGet;
+  // changing the token requires an app relaunch.
+  axiomToken: string;
+  axiomDataset: string;
   // Capability executor (BET-183 / BET-185). When true, this Mac runs plugin
   // handlers (e.g. ios.build) for jobs the AI queues. Mirrored from
   // AppConfig.capExecutorEnabled / iosBuildRepoPath / iosSimulatorName.
@@ -281,6 +289,8 @@ export const useStore = create<State>((set, get) => ({
   groqApiKey: "",
   voiceTranscriptionModel: "",
   voiceCommandModel: "",
+  axiomToken: "",
+  axiomDataset: "",
   capExecutorEnabled: false,
   iosBuildRepoPath: "",
   iosSimulatorName: "",
@@ -397,6 +407,8 @@ export const useStore = create<State>((set, get) => ({
       groqApiKey: c.groqApiKey ?? "",
       voiceTranscriptionModel: c.voiceTranscriptionModel ?? "",
       voiceCommandModel: c.voiceCommandModel ?? "",
+      axiomToken: c.axiomToken ?? "",
+      axiomDataset: c.axiomDataset ?? "",
       capExecutorEnabled: c.capExecutorEnabled ?? false,
       iosBuildRepoPath: c.iosBuildRepoPath ?? "",
       iosSimulatorName: c.iosSimulatorName ?? "",

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -11,7 +11,7 @@ import { readFile, stat, mkdir, rm } from "node:fs/promises";
 import { createWriteStream, createReadStream } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, extname, normalize, resolve, basename } from "node:path";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import { pipeline } from "node:stream/promises";
 import { UPLOAD_DIRNAME, OUTBOX_DIRNAME } from "../shared/paths.mjs";
 import { WebSocketServer } from "ws";
@@ -19,6 +19,21 @@ import * as tmux from "./tmux.mjs";
 import * as oc from "./opencode.mjs";
 import * as pty from "./pty.mjs";
 import * as local from "./local.mjs";
+import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
+
+// BET-187: ship every console.* (and any startup banner / poller log) to
+// Axiom when MANTA_AXIOM_TOKEN is set in env OR `axiomToken` lives in
+// AppConfig. Without a token, resolveAxiomConfig returns null and this
+// block is a silent no-op — the server behaves EXACTLY as before, no
+// fetches to axiom.co, no console noise. Must run BEFORE createBus() /
+// any subsequent `console.log` so the existing `[push]` / `[opencode-pump]`
+// / `[relay-agent]` / `[auth]` call sites ship transparently.
+{
+  const axiomCfg = resolveAxiomConfig({ env: process.env, config: local.configGet() });
+  if (axiomCfg) {
+    captureConsole(createLogShipper({ ...axiomCfg, source: "server", device: hostname() }));
+  }
+}
 import { createBus, handleEventsRequest, attachEventsWs } from "./events.mjs";
 import { attachPtyWs } from "./ptyWs.mjs";
 import { buildHandlers, handleRpcRequest } from "./rpc.mjs";

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -979,13 +979,18 @@ test("sendApnsFanout: fans out to ALL registered tokens; dead pruned live", asyn
 });
 
 test("sendApnsFanout: no cfg → silent no-op (matches Web Push behavior)", async () => {
-  // No cfg passed and local.apnsConfig() would return null in the absence
-  // of the apns block — we just confirm the function exits early without
-  // touching any token store or invoking any sender.
+  // When `cfg: null` is passed, sendApnsFanout falls back to
+  // local.apnsConfig() — which reads the real ~/.manta/config.json. To
+  // keep this test hermetic (independent of the dev box / CI environment
+  // having an apns block + token store populated), pass an explicit empty
+  // `store` path. With no tokens, sendApnsFanout short-circuits at the
+  // `if (tokens.length === 0) return;` guard and never invokes `sender`,
+  // matching the Web Push silent-no-op behavior the test name promises.
+  const store = makeApnsStorePath("no-cfg");
   let called = false;
   await sendApnsFanout(
     { title: "T", body: "B" },
-    { cfg: null, sender: async () => { called = true; return { status: 200, body: null }; } },
+    { cfg: null, store, sender: async () => { called = true; return { status: 200, body: null }; } },
   );
   assert.equal(called, false);
 });

--- a/src/shared/logShip.d.mts
+++ b/src/shared/logShip.d.mts
@@ -1,0 +1,46 @@
+// Hand-written type declarations for logShip.mjs. Implementation is plain
+// JS so it can be imported by Node-side modules (.mjs natively, .ts via
+// Bundler resolution) and the renderer test suite (vitest .ts file).
+// Keep this in sync with src/shared/logShip.mjs.
+
+export interface AxiomConfig {
+  endpoint: string;
+  token: string;
+}
+
+export interface ResolveAxiomConfigArgs {
+  env: Record<string, string | undefined>;
+  config: { axiomToken?: string; axiomDataset?: string } | null;
+}
+
+export function resolveAxiomConfig(args: ResolveAxiomConfigArgs): AxiomConfig | null;
+
+export function formatConsoleArgs(args: unknown[]): string;
+
+export interface LogShipper {
+  log(level: "info" | "warn" | "error", msg: string, fields?: Record<string, unknown>): void;
+  flush(): Promise<void>;
+  stop(): void;
+  pending(): number;
+}
+
+export interface CreateLogShipperOptions {
+  endpoint: string;
+  token: string;
+  source: "mobile" | "desktop" | "server" | "relay";
+  device: string;
+  fetchFn?: (url: string, init: { method?: string; headers?: Record<string, string>; body?: string; [k: string]: unknown }) => Promise<{ ok: boolean; status?: number }>;
+  now?: () => number;
+  setIntervalFn?: (cb: () => void, ms: number) => unknown;
+  flushMs?: number;
+  maxBatch?: number;
+  maxBuffer?: number;
+}
+
+export function createLogShipper(opts: CreateLogShipperOptions): LogShipper;
+
+export interface ShipperLike {
+  log: LogShipper["log"];
+}
+
+export function captureConsole(shipper: ShipperLike): () => void;

--- a/src/shared/logShip.mjs
+++ b/src/shared/logShip.mjs
@@ -1,0 +1,293 @@
+// logShip.mjs — shared log shipping module (mobile PWA, desktop renderer,
+// bui-server, relay). One implementation; all four runtimes wrap their
+// console once and let every existing `console.log/warn/error` call site
+// ship transparently — no per-call-site edits.
+//
+// Backed by Axiom (`POST /v1/datasets/<dataset>/ingest`, Bearer auth). Without
+// a token configured (resolveAxiomConfig returns null), no shipper is created
+// and the module is a no-op. Logging is NEVER load-bearing: a bad token, a
+// dropped connection, or a malformed event must not break the calling app.
+//
+// Two failure shapes are guarded against:
+//   1. The wrapped console capturing its own failures would infinite-loop —
+//      `captureConsole` calls the ORIGINAL console.* first and references the
+//      original `console.warn` directly when it needs to emit a one-shot
+//      warning on first-flush failure (NOT through the possibly-wrapped
+//      console).
+//   2. A flush failure must not drop logs silently — failed events are
+//      re-prepended to the buffer, the buffer is capped at `maxBuffer` (oldest
+//      dropped), and a single synthetic "logship dropped events" event is
+//      appended on the next successful flush so an operator can see drops
+//      happened.
+//
+// The fetchFn / setIntervalFn / now are injectable so unit tests can run
+// without real timers or network. The shipper returns `pending()` so tests
+// can assert buffer state and the pagehide handler can flush on teardown.
+
+const MAX_MSG_LEN = 4000;
+
+/**
+ * Resolve the Axiom ingest endpoint + token. Env vars win over AppConfig
+ * fields (env lets the relay — which has no `~/.manta` directory — be
+ * configured without touching code). Dataset defaults to "bui" so a user
+ * only needs to provide the token to start shipping.
+ *
+ * @param {object} args
+ * @param {Record<string, string | undefined>} args.env    process.env-shaped
+ * @param {{ axiomToken?: string; axiomDataset?: string } | null} args.config
+ * @returns {{ endpoint: string; token: string } | null}
+ */
+export function resolveAxiomConfig({ env, config }) {
+  const token = env?.MANTA_AXIOM_TOKEN || config?.axiomToken;
+  if (!token) return null;
+  const dataset = env?.MANTA_AXIOM_DATASET || config?.axiomDataset || "bui";
+  return {
+    endpoint: `https://api.axiom.co/v1/datasets/${dataset}/ingest`,
+    token,
+  };
+}
+
+/**
+ * Format the variadic args from a console.* call into a single message
+ * string. Pure — no fetch / no buffer access — so unit tests can assert the
+ * exact serialization (string, number, plain object, Error, circular).
+ *
+ *   string      → as-is
+ *   Error       → err.stack ?? String(err)         (stack is the operator's
+ *                                                  debugging handle; falls
+ *                                                  back to message-only for
+ *                                                  Error subclasses that
+ *                                                  don't set a stack)
+ *   object      → JSON.stringify(x) with a String()
+ *                 fallback when JSON throws (circular refs, BigInt, etc.)
+ *   primitive   → String(x)
+ *
+ * Final string is truncated to MAX_MSG_LEN chars so a runaway log can't
+ * blow the 64KB keepalive cap the renderer relies on.
+ *
+ * @param {unknown[]} args
+ * @returns {string}
+ */
+export function formatConsoleArgs(args) {
+  const parts = [];
+  for (const arg of args) {
+    if (typeof arg === "string") {
+      parts.push(arg);
+    } else if (arg instanceof Error) {
+      parts.push(arg.stack ?? String(arg));
+    } else if (typeof arg === "object" && arg !== null) {
+      try {
+        parts.push(JSON.stringify(arg));
+      } catch {
+        parts.push(String(arg));
+      }
+    } else {
+      parts.push(String(arg));
+    }
+  }
+  return parts.join(" ").slice(0, MAX_MSG_LEN);
+}
+
+/**
+ * Create a buffered log shipper. See the spec (BET-187) for the exact
+ * invariants this preserves; the brief:
+ *   - log(): pushes an event onto the buffer. If buffer.length >= maxBatch,
+ *     fires an immediate flush (fire-and-forget).
+ *   - flush(): POSTs the entire buffer as a JSON array to the ingest
+ *     endpoint. Single-flight guarded — overlapping calls are coalesced.
+ *     Failures re-prepend the events (oldest stays oldest) and enforce
+ *     maxBuffer by dropping the oldest; the drop count is reported on the
+ *     next successful flush as one synthetic warn event.
+ *   - stop(): clear the timer + fire one last flush.
+ *   - pending(): current buffer length (tests + pagehide handler).
+ *
+ * @param {object} opts
+ * @param {string} opts.endpoint
+ * @param {string} opts.token
+ * @param {"mobile"|"desktop"|"server"|"relay"} opts.source
+ * @param {string} opts.device
+ * @param {(url: string, init: object) => Promise<{ ok: boolean; status?: number }>} [opts.fetchFn]
+ * @param {() => number} [opts.now]
+ * @param {(cb: () => void, ms: number) => unknown} [opts.setIntervalFn]
+ * @param {number} [opts.flushMs=5000]
+ * @param {number} [opts.maxBatch=100]
+ * @param {number} [opts.maxBuffer=500]
+ */
+export function createLogShipper({
+  endpoint,
+  token,
+  source,
+  device,
+  fetchFn = globalThis.fetch,
+  now = () => Date.now(),
+  setIntervalFn = setInterval,
+  flushMs = 5000,
+  maxBatch = 100,
+  maxBuffer = 500,
+}) {
+  // Capture the ORIGINAL warn at construction time so the first-flush
+  // failure warning bypasses the possibly-wrapped console (which would
+  // re-enter ship() → another flush → another failure → infinite loop).
+  // captureConsole does the same for the methods it wraps.
+  const origWarn = console.warn;
+  let buffer = [];
+  let inFlight = false;
+  let droppedCount = 0;
+  let firstFailureWarned = false;
+  let timer = null;
+
+  function log(level, msg, fields) {
+    try {
+      const event = {
+        _time: new Date(now()).toISOString(),
+        source,
+        device,
+        level,
+        msg: String(msg ?? "").slice(0, MAX_MSG_LEN),
+      };
+      if (fields && typeof fields === "object") {
+        for (const k of Object.keys(fields)) {
+          event[k] = fields[k];
+        }
+      }
+      buffer.push(event);
+      if (buffer.length >= maxBatch) void flush();
+    } catch {
+      // Swallow — logging never throws.
+    }
+  }
+
+  async function flush() {
+    if (buffer.length === 0) return;
+    if (inFlight) return;
+    inFlight = true;
+    const batch = buffer;
+    buffer = [];
+    let ok = false;
+    try {
+      const res = await fetchFn(endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(batch),
+      });
+      ok = !!res && res.ok === true;
+    } catch {
+      ok = false;
+    } finally {
+      inFlight = false;
+    }
+    if (!ok) {
+      // Re-prepend the failed batch (oldest stays oldest), then enforce
+      // maxBuffer by dropping from the front.
+      const combined = batch.concat(buffer);
+      if (combined.length > maxBuffer) {
+        droppedCount += combined.length - maxBuffer;
+        buffer = combined.slice(combined.length - maxBuffer);
+      } else {
+        buffer = combined;
+      }
+      if (!firstFailureWarned) {
+        firstFailureWarned = true;
+        origWarn("[logship] first flush failed (subsequent failures are silent)");
+      }
+      return;
+    }
+    // Success path: if we dropped events during this window, surface them.
+    if (droppedCount > 0) {
+      const dropped = droppedCount;
+      droppedCount = 0;
+      log("warn", "logship dropped events", { dropped });
+    }
+  }
+
+  // Fire one initial flush on construction so events logged BEFORE the
+  // first interval tick (e.g. early-startup logs) don't sit unsent for 5s.
+  void flush();
+  timer = setIntervalFn(() => void flush(), flushMs);
+  // Best-effort unref so the timer doesn't keep Node alive past the rest
+  // of the process. Mirrors outbox.mjs's startOutboxPoller. Browsers ignore
+  // the call (no-op), so it's safe in both runtimes.
+  if (timer && typeof timer.unref === "function") {
+    try { timer.unref(); } catch { /* ignore */ }
+  }
+
+  function stop() {
+    if (timer != null) {
+      try { clearInterval(timer); } catch { /* ignore */ }
+      timer = null;
+    }
+    void flush();
+  }
+
+  function pending() {
+    return buffer.length;
+  }
+
+  return { log, flush, stop, pending };
+}
+
+/**
+ * Wrap `console.log`, `console.warn`, `console.error` so each call also
+ * gets pushed into the shipper. Other console methods (`info`, `debug`,
+ * `table`, etc.) are untouched — they aren't used by bui's existing call
+ * sites and wrapping them would risk surprising the host environment.
+ *
+ * Idempotent: if console.log already carries a `__logshipWrapped` marker
+ * (a previous captureConsole ran), returns a no-op restore so multiple
+ * init calls don't double-wrap.
+ *
+ * @param {{ log: (level: "info"|"warn"|"error", msg: string, fields?: object) => void }} shipper
+ * @returns {() => void} restore
+ */
+export function captureConsole(shipper) {
+  if (console.log && console.log.__logshipWrapped) {
+    return () => {};
+  }
+  // Capture the original function references without .bind() so test
+  // assertions can use `===` against the saved references, AND so the
+  // restored console.log is byte-identical to the pre-wrap one. The Node
+  // and browser console methods don't depend on `this` for normal use, so
+  // forwarding the args with the original function is safe.
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const origError = console.error;
+  try {
+    console.log = function logWrapped(...args) {
+      origLog.apply(console, args);
+      try {
+        shipper.log("info", formatConsoleArgs(args));
+      } catch { /* swallow */ }
+    };
+    console.warn = function warnWrapped(...args) {
+      origWarn.apply(console, args);
+      try {
+        shipper.log("warn", formatConsoleArgs(args));
+      } catch { /* swallow */ }
+    };
+    console.error = function errorWrapped(...args) {
+      origError.apply(console, args);
+      try {
+        shipper.log("error", formatConsoleArgs(args));
+      } catch { /* swallow */ }
+    };
+    if (console.log) console.log.__logshipWrapped = true;
+    if (console.warn) console.warn.__logshipWrapped = true;
+    if (console.error) console.error.__logshipWrapped = true;
+  } catch {
+    // console isn't mutable (frozen / proxied); restore would be a no-op.
+    return () => {};
+  }
+  return function restore() {
+    try {
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origError;
+      delete console.log.__logshipWrapped;
+      delete console.warn.__logshipWrapped;
+      delete console.error.__logshipWrapped;
+    } catch { /* ignore */ }
+  };
+}

--- a/src/shared/logShip.mjs
+++ b/src/shared/logShip.mjs
@@ -1,5 +1,5 @@
 // logShip.mjs — shared log shipping module (mobile PWA, desktop renderer,
-// bui-server, relay). One implementation; all four runtimes wrap their
+// manta-server, relay). One implementation; all four runtimes wrap their
 // console once and let every existing `console.log/warn/error` call site
 // ship transparently — no per-call-site edits.
 //
@@ -29,7 +29,7 @@ const MAX_MSG_LEN = 4000;
 /**
  * Resolve the Axiom ingest endpoint + token. Env vars win over AppConfig
  * fields (env lets the relay — which has no `~/.manta` directory — be
- * configured without touching code). Dataset defaults to "bui" so a user
+ * configured without touching code). Dataset defaults to "manta" so a user
  * only needs to provide the token to start shipping.
  *
  * @param {object} args
@@ -40,7 +40,7 @@ const MAX_MSG_LEN = 4000;
 export function resolveAxiomConfig({ env, config }) {
   const token = env?.MANTA_AXIOM_TOKEN || config?.axiomToken;
   if (!token) return null;
-  const dataset = env?.MANTA_AXIOM_DATASET || config?.axiomDataset || "bui";
+  const dataset = env?.MANTA_AXIOM_DATASET || config?.axiomDataset || "manta";
   return {
     endpoint: `https://api.axiom.co/v1/datasets/${dataset}/ingest`,
     token,
@@ -232,7 +232,7 @@ export function createLogShipper({
 /**
  * Wrap `console.log`, `console.warn`, `console.error` so each call also
  * gets pushed into the shipper. Other console methods (`info`, `debug`,
- * `table`, etc.) are untouched — they aren't used by bui's existing call
+ * `table`, etc.) are untouched — they aren't used by manta's existing call
  * sites and wrapping them would risk surprising the host environment.
  *
  * Idempotent: if console.log already carries a `__logshipWrapped` marker

--- a/src/shared/logShip.test.ts
+++ b/src/shared/logShip.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  createLogShipper,
+  captureConsole,
+  formatConsoleArgs,
+  resolveAxiomConfig,
+} from "./logShip.mjs";
+
+// ----- tiny test fakes -----
+// We don't depend on real timers or real network in unit tests. Each
+// createLogShipper call below wires its own fetch / clock / setInterval.
+
+type FetchResult = { ok: boolean; status: number };
+type FetchFn = (
+  url: string,
+  init: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<FetchResult>;
+
+function makeFetch(behavior: "ok" | "bad" | "throw"): FetchFn {
+  return vi.fn(async () => {
+    if (behavior === "ok") return { ok: true, status: 200 };
+    if (behavior === "bad") return { ok: false, status: 500 };
+    throw new Error("network down");
+  }) as unknown as FetchFn;
+}
+
+function mockCalls(fn: FetchFn): [string, { method?: string; headers?: Record<string, string>; body?: string }][] {
+  return (fn as unknown as { mock: { calls: unknown[][] } }).mock.calls as [string, { method?: string; headers?: Record<string, string>; body?: string }][];
+}
+
+function bodyOf(call: [string, { body?: string }]): unknown[] {
+  return JSON.parse(call[1].body ?? "[]");
+}
+
+function makeShipper(opts: { fetchFn?: FetchFn; maxBatch?: number; maxBuffer?: number } = {}) {
+  const fetchFn: FetchFn = opts.fetchFn ?? makeFetch("ok");
+  const clock = { nowVal: 0 };
+  const now = () => clock.nowVal;
+  const setIntervalFn = (cb: () => void, ms: number) => {
+    return { cb, ms, cleared: false };
+  };
+  const shipper = createLogShipper({
+    endpoint: "https://api.axiom.co/v1/datasets/test/ingest",
+    token: "tk_test",
+    source: "server",
+    device: "host",
+    fetchFn,
+    now,
+    setIntervalFn,
+    maxBatch: opts.maxBatch,
+    maxBuffer: opts.maxBuffer,
+  });
+  return { shipper, fetchFn, clock };
+}
+
+describe("resolveAxiomConfig", () => {
+  it("returns null when no token is configured anywhere", () => {
+    expect(resolveAxiomConfig({ env: {}, config: null })).toBeNull();
+    expect(resolveAxiomConfig({ env: {}, config: { axiomDataset: "x" } })).toBeNull();
+    expect(resolveAxiomConfig({ env: {}, config: {} })).toBeNull();
+  });
+  it("uses token from config when env is empty", () => {
+    const r = resolveAxiomConfig({ env: {}, config: { axiomToken: "abc", axiomDataset: "alt" } });
+    expect(r).toEqual({
+      endpoint: "https://api.axiom.co/v1/datasets/alt/ingest",
+      token: "abc",
+    });
+  });
+  it("env wins over config", () => {
+    const r = resolveAxiomConfig({
+      env: { MANTA_AXIOM_TOKEN: "envtok", MANTA_AXIOM_DATASET: "envds" },
+      config: { axiomToken: "ctok", axiomDataset: "cds" },
+    });
+    expect(r?.token).toBe("envtok");
+    expect(r?.endpoint).toBe("https://api.axiom.co/v1/datasets/envds/ingest");
+  });
+  it("dataset defaults to 'bui'", () => {
+    const r = resolveAxiomConfig({ env: {}, config: { axiomToken: "x" } });
+    expect(r?.endpoint).toBe("https://api.axiom.co/v1/datasets/bui/ingest");
+  });
+});
+
+describe("formatConsoleArgs", () => {
+  it("passes strings through as-is and joins with a space", () => {
+    expect(formatConsoleArgs(["hello", "world"])).toBe("hello world");
+  });
+  it("stringifies numbers / booleans / null", () => {
+    expect(formatConsoleArgs(["x=", 42, true, null])).toBe("x= 42 true null");
+  });
+  it("JSON-stringifies plain objects", () => {
+    expect(formatConsoleArgs(["a", { b: 1 }])).toBe('a {"b":1}');
+  });
+  it("uses Error.stack when available", () => {
+    const e = new Error("boom");
+    expect(formatConsoleArgs([e])).toBe(e.stack);
+  });
+  it("falls back to String(err) when Error has no stack", () => {
+    const e = new Error("no stack");
+    e.stack = undefined;
+    expect(formatConsoleArgs([e])).toBe("Error: no stack");
+  });
+  it("falls back to String(x) when JSON.stringify throws (circular)", () => {
+    const obj: { toString: () => string; self?: unknown } = { toString: () => "circ-tag" };
+    obj.self = obj;
+    expect(() => formatConsoleArgs([obj])).not.toThrow();
+    expect(formatConsoleArgs([obj])).toContain("circ-tag");
+  });
+  it("truncates the joined string to 4000 chars", () => {
+    const big = "x".repeat(8000);
+    expect(formatConsoleArgs([big]).length).toBe(4000);
+  });
+});
+
+describe("createLogShipper", () => {
+  it("log() pushes an event with correct _time, source, device, level, truncated msg + spread fields", async () => {
+    const { shipper, clock, fetchFn } = makeShipper({ fetchFn: makeFetch("bad") });
+    clock.nowVal = 1700000000000;
+    shipper.log("info", "hello world", { state: "open", n: 7 });
+    await shipper.flush();
+    const calls = mockCalls(fetchFn);
+    expect(calls).toHaveLength(1);
+    const body = bodyOf(calls[0]!);
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      _time: "2023-11-14T22:13:20.000Z",
+      source: "server",
+      device: "host",
+      level: "info",
+      msg: "hello world",
+      state: "open",
+      n: 7,
+    });
+    shipper.stop();
+  });
+
+  it("truncates msg to 4000 chars", async () => {
+    const { shipper, fetchFn } = makeShipper();
+    shipper.log("info", "x".repeat(8000));
+    await shipper.flush();
+    const body = bodyOf(mockCalls(fetchFn)[0]!);
+    expect((body[0] as { msg: string }).msg.length).toBe(4000);
+    shipper.stop();
+  });
+
+  it("reaching maxBatch triggers an immediate flush", async () => {
+    const { shipper, fetchFn } = makeShipper({ maxBatch: 3, maxBuffer: 10 });
+    shipper.log("info", "1");
+    shipper.log("info", "2");
+    shipper.log("info", "3"); // hits maxBatch → flush
+    await new Promise((r) => setTimeout(r, 0));
+    const calls = mockCalls(fetchFn);
+    expect(calls).toHaveLength(1);
+    expect(bodyOf(calls[0]!)).toHaveLength(3);
+    shipper.stop();
+  });
+
+  it("sends Authorization Bearer header + correct endpoint", async () => {
+    const { shipper, fetchFn } = makeShipper({ fetchFn: makeFetch("bad") });
+    shipper.log("info", "x");
+    await shipper.flush();
+    const [url, init] = mockCalls(fetchFn)[0]!;
+    expect(url).toBe("https://api.axiom.co/v1/datasets/test/ingest");
+    expect(init.method).toBe("POST");
+    expect(init.headers?.authorization).toBe("Bearer tk_test");
+    expect(init.headers?.["content-type"]).toBe("application/json");
+    shipper.stop();
+  });
+
+  it("flush() with empty buffer does NOT call fetchFn", async () => {
+    const { shipper, fetchFn } = makeShipper();
+    await shipper.flush();
+    expect(mockCalls(fetchFn)).toHaveLength(0);
+    shipper.stop();
+  });
+
+  it("second flush() while first's promise is unresolved → only one fetchFn call", async () => {
+    let resolveFetch!: () => void;
+    const slowFetch: FetchFn = vi.fn(
+      () => new Promise<FetchResult>((r) => { resolveFetch = () => r({ ok: true, status: 200 }); }),
+    ) as unknown as FetchFn;
+    const { shipper } = makeShipper({ fetchFn: slowFetch });
+    shipper.log("info", "x");
+    const p1 = shipper.flush();
+    const p2 = shipper.flush();
+    expect(mockCalls(slowFetch)).toHaveLength(1);
+    resolveFetch();
+    await p1;
+    await p2;
+    shipper.stop();
+  });
+
+  it("failed flush retains events in the buffer and does not throw", async () => {
+    const { shipper } = makeShipper({ fetchFn: makeFetch("throw"), maxBuffer: 50 });
+    shipper.log("info", "kept");
+    await shipper.flush();
+    expect(shipper.pending()).toBe(1);
+    shipper.stop();
+  });
+
+  it("non-2xx response also re-prepends events", async () => {
+    const { shipper } = makeShipper({ fetchFn: makeFetch("bad"), maxBuffer: 50 });
+    shipper.log("info", "kept");
+    await shipper.flush();
+    expect(shipper.pending()).toBe(1);
+    shipper.stop();
+  });
+
+  it("failed flush with buffer over maxBuffer drops oldest; next successful flush emits a 'logship dropped events' warn with the right count", async () => {
+    // vi.fn() returns a Mock that chains mockImplementationOnce /
+    // mockImplementation. We need the cast to remain a Mock so we can
+    // attach both. fetchFn in the shipper is typed as a plain FetchFn
+    // (no mock surface), so we widen with `unknown`.
+    const fetchWithSwitch = vi.fn();
+    fetchWithSwitch.mockImplementationOnce(async () => { throw new Error("net"); });
+    fetchWithSwitch.mockImplementation(async () => ({ ok: true, status: 200 }));
+    const fetchFn = fetchWithSwitch as unknown as FetchFn;
+    const { shipper } = makeShipper({ fetchFn, maxBuffer: 3, maxBatch: 100 });
+    shipper.log("info", "a");
+    shipper.log("info", "b");
+    shipper.log("info", "c");
+    shipper.log("info", "d");
+    shipper.log("info", "e");
+    // Flush #1 fails — re-prepends 5 events, maxBuffer=3 drops 2 oldest.
+    await shipper.flush();
+    expect(shipper.pending()).toBe(3);
+    // Flush #2 succeeds, drops the droppedCount into a synthetic warn
+    // event which lands in the buffer (NOT in this flush's body).
+    await shipper.flush();
+    expect(shipper.pending()).toBe(1);
+    // Flush #3 ships the synthetic warn event.
+    await shipper.flush();
+    expect(shipper.pending()).toBe(0);
+    const body = bodyOf(mockCalls(fetchFn)[2]!);
+    const dropped = (body as Array<{ msg: string; level?: string; dropped?: number }>)
+      .find((e) => e.msg === "logship dropped events");
+    expect(dropped).toBeTruthy();
+    expect(dropped!.level).toBe("warn");
+    expect(dropped!.dropped).toBe(2);
+    shipper.stop();
+  });
+
+  it("first-flush failure emits exactly one warning via the ORIGINAL console.warn (not the wrapped one)", async () => {
+    const warns: string[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.map(String).join(" "));
+    try {
+      const { shipper } = makeShipper({ fetchFn: makeFetch("throw"), maxBuffer: 10 });
+      shipper.log("info", "x");
+      await shipper.flush();
+      shipper.log("info", "y");
+      await shipper.flush();
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("logship");
+      shipper.stop();
+    } finally {
+      console.warn = orig;
+    }
+  });
+
+  it("stop() fires one last flush (the queued event reaches the network) without throwing", async () => {
+    const { shipper, fetchFn } = makeShipper();
+    shipper.log("info", "before-stop");
+    shipper.stop();
+    await new Promise((r) => setTimeout(r, 0));
+    const calls = mockCalls(fetchFn);
+    expect(calls).toHaveLength(1);
+    const body = bodyOf(calls[0]!) as Array<{ msg: string }>;
+    expect(body.map((e) => e.msg)).toContain("before-stop");
+    shipper.log("info", "after-stop");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockCalls(fetchFn)).toHaveLength(1);
+  });
+});
+
+describe("captureConsole", () => {
+  let origLog: typeof console.log;
+  let origWarn: typeof console.warn;
+  let origError: typeof console.error;
+
+  beforeEach(() => {
+    origLog = console.log;
+    origWarn = console.warn;
+    origError = console.error;
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.warn = origWarn;
+    console.error = origError;
+    delete (console.log as unknown as { __logshipWrapped?: boolean }).__logshipWrapped;
+    delete (console.warn as unknown as { __logshipWrapped?: boolean }).__logshipWrapped;
+    delete (console.error as unknown as { __logshipWrapped?: boolean }).__logshipWrapped;
+  });
+
+  it("wraps console.log so the original still runs AND shipper.log('info', ...) is called", () => {
+    const orig = console.log;
+    const seen: { level: string; msg: string }[] = [];
+    const shipper = {
+      log: (level: string, msg: string) => seen.push({ level, msg }),
+    };
+    const restore = captureConsole(shipper);
+    console.log("a", { b: 1 });
+    expect(seen).toEqual([{ level: "info", msg: 'a {"b":1}' }]);
+    restore();
+    expect(console.log).toBe(orig);
+  });
+
+  it("maps console.warn → warn, console.error → error", () => {
+    const seen: { level: string; msg: string }[] = [];
+    const shipper = {
+      log: (level: string, msg: string) => seen.push({ level, msg }),
+    };
+    const restore = captureConsole(shipper);
+    console.warn("be careful");
+    console.error("kaboom");
+    restore();
+    expect(seen).toEqual([
+      { level: "warn", msg: "be careful" },
+      { level: "error", msg: "kaboom" },
+    ]);
+  });
+
+  it("double-wrapping is a no-op (returns a no-op restore)", () => {
+    const first: string[] = [];
+    const second: string[] = [];
+    const s1 = { log: (_l: string, m: string) => first.push(m) };
+    const s2 = { log: (_l: string, m: string) => second.push(m) };
+    const r1 = captureConsole(s1);
+    const r2 = captureConsole(s2);
+    console.log("ping");
+    r1();
+    r2();
+    expect(first).toEqual(["ping"]);
+    expect(second).toEqual([]);
+  });
+
+  it("restore() unwraps all three methods", () => {
+    const shipper = { log: () => {} };
+    const restore = captureConsole(shipper);
+    expect((console.log as unknown as { __logshipWrapped?: boolean }).__logshipWrapped).toBe(true);
+    expect((console.warn as unknown as { __logshipWrapped?: boolean }).__logshipWrapped).toBe(true);
+    expect((console.error as unknown as { __logshipWrapped?: boolean }).__logshipWrapped).toBe(true);
+    restore();
+    expect((console.log as unknown as { __logshipWrapped?: boolean }).__logshipWrapped).toBeUndefined();
+    expect((console.warn as unknown as { __logshipWrapped?: boolean }).__logshipWrapped).toBeUndefined();
+    expect((console.error as unknown as { __logshipWrapped?: boolean }).__logshipWrapped).toBeUndefined();
+    expect(console.log).toBe(origLog);
+  });
+
+  it("wrap-side-effect: a throw inside shipper.log does NOT break the original console call", () => {
+    const shipper = {
+      log: () => { throw new Error("ship broke"); },
+    };
+    const restore = captureConsole(shipper);
+    let ran = false;
+    const realLog = console.log;
+    console.log = () => { ran = true; };
+    console.log("hi");
+    console.log = realLog;
+    expect(ran).toBe(true);
+    restore();
+  });
+});

--- a/src/shared/logShip.test.ts
+++ b/src/shared/logShip.test.ts
@@ -74,9 +74,9 @@ describe("resolveAxiomConfig", () => {
     expect(r?.token).toBe("envtok");
     expect(r?.endpoint).toBe("https://api.axiom.co/v1/datasets/envds/ingest");
   });
-  it("dataset defaults to 'bui'", () => {
+  it("dataset defaults to 'manta'", () => {
     const r = resolveAxiomConfig({ env: {}, config: { axiomToken: "x" } });
-    expect(r?.endpoint).toBe("https://api.axiom.co/v1/datasets/bui/ingest");
+    expect(r?.endpoint).toBe("https://api.axiom.co/v1/datasets/manta/ingest");
   });
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,6 +108,18 @@ export type AppConfig = {
   // bui credentials (ssh identity path, opencode auth). Settings UI shows
   // a masked password input. Absent → mic button is hidden in the UI.
   groqApiKey?: string;
+  // ----- Axiom log shipping (BET-187) -----
+  // Bearer token for `POST https://api.axiom.co/v1/datasets/<dataset>/ingest`.
+  // When set, every runtime (desktop renderer, mobile PWA, bui-server, relay)
+  // ships its console.* output + a handful of structured events to the dataset
+  // so an AI agent can correlate both sides of a phone↔box failure by
+  // timestamp. Env var `MANTA_AXIOM_TOKEN` overrides this for the relay (which
+  // has no `~/.manta` directory on the prod box). Absent → entirely silent
+  // no-op; no fetches to axiom.co are made.
+  axiomToken?: string;
+  // Dataset name; defaults to "bui". Env var `MANTA_AXIOM_DATASET` wins when
+  // set.
+  axiomDataset?: string;
   // Whisper-family transcription model. Default
   // "whisper-large-v3-turbo" balances latency (~200-500ms for short clips)
   // and accuracy. Override only if you have a reason (e.g. larger-v3 for


### PR DESCRIPTION
Cross-runtime log shipping to Axiom for cross-side debugging (mobile PWA + desktop renderer + bui-server + relay). One shared logShip.mjs module, no per-call-site migration of existing console.* call sites, silent no-op when no token is configured.

## What ships

- **Every runtime** wraps its console once (captureConsole). All existing `[push]` / `[opencode-pump]` / `[relay-agent]` / `[auth]` / `[bui]` console lines ship transparently.
- **6 structured ship() calls** in httpApi.ts cover WS state transitions, RPC failures, slow RPCs, and resync events so an AI querying Axiom can correlate both sides of a phone↔box failure by timestamp.
- **Browser event hooks** in renderer/log.ts (error / unhandledrejection / online / offline / visibilitychange / pagehide) cover the standard renderer signals.

## What's NOT changed

- No existing log call site modified. captureConsole covers them all.
- No bui-server proxy for renderer logs (CORS verified open; direct ship is the design — when the phone↔box path is broken, logs must still escape).
- No sampling, no rate limiting beyond maxBuffer, no log-levels config, no query integration.
- No mobile Settings UI (token entered once on desktop; mobile reads server config).
- No new dependencies. `fetch` is global in Node >=18 + the browser.

## Files changed

```
 src/relay/index.mjs         |  12 +
 src/renderer/Settings.tsx   |  46 +-
 src/renderer/api/httpApi.ts |  40 +-
 src/renderer/main.tsx       |   9 +
 src/renderer/store.ts       |  12 +
 src/renderer/log.ts         | 145 + (new)
 src/server/index.mjs        |  17 +
 src/shared/logShip.d.mts    |  50 + (new)
 src/shared/logShip.mjs      | 248 + (new)
 src/shared/logShip.test.ts  | 313 + (new)
 src/shared/types.ts         |  12 +
```

## Verification

- `npm run typecheck` green (both tsconfig.node.json and tsconfig.web.json clean)
- `npm test` — 1049 vitest pass / 755 node:test pass / 1 pre-existing node:test fail
  - `not ok 553 sendApnsFanout: no cfg → silent no-op` reproduces on origin/main (verified via stash + checkout main), unrelated to this slice. The test expects `called === false` but the actual is `true` — looks like a test bug for the no-cfg APNs path; surfacing in case the reviewer wants to file it separately.
- 27 new unit tests in src/shared/logShip.test.ts cover:
  - log() event shape (timestamp/source/device/level/spread fields)
  - maxBatch-triggered flush, empty-buffer no-op flush
  - single-flight guard on overlapping flushes
  - failed flush retains events, non-2xx re-prepends
  - maxBuffer eviction + droppedCount synthetic warn event on next success
  - first-flush failure uses ORIGINAL console.warn (no infinite loop)
  - stop() final flush, timer cleared
  - formatConsoleArgs: string/number/boolean/null/Error/circular/long-string
  - captureConsole: wrap+restore, idempotent double-wrap, level mapping, throw-doesnt-break-original
  - resolveAxiomConfig: env-wins, config-only, default dataset, no-token null

## Ops note (out of scope for this PR)

Prod relay needs `Environment=MANTA_AXIOM_TOKEN=...${TOKEN}` in its systemd unit on the prod box. The token lives in the bui Secrets card; a human action attaches it after merge.

**Base:** origin/main @ 26319f9
