### PR TITLE
chore(ios): bump to 1.0.10 for TestFlight release (BET-187)

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -375,7 +375,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";


### PR DESCRIPTION
Bumps iOS MARKETING_VERSION 1.0.9 -> 1.0.10 to cut a fresh TestFlight build of current main.

Main includes BET-187 (Axiom log shipping, PR #140) plus recent SSE/relay/push fixes. Tagging ios-v1.0.10 after merge triggers Codemagic.

Version-only change; no code/test impact.