### PR TITLE
fix(relay): liveness watchdog for box→relay agent (zombie-WS / box_offline)

### DIFF
--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -117,6 +117,92 @@ export function createBackoff({
 }
 
 // ---------------------------------------------------------------------------
+// Shared ws→transport plumbing. Both real WS adapters below (the control-tunnel
+// `defaultConnect` and the raw PTY `makeDefaultLocalPtyConnect`) speak the same
+// tiny transport contract and wire the same message/close (and, for the control
+// tunnel, pong) callback fan-out + open-promise. This helper owns that common
+// shape so the two adapters keep ONLY their distinct `send` semantics — without
+// it the two blocks are near-identical clones (the duplication-gate flags them).
+// `withPong:true` additionally wires the WS-protocol pong event for the liveness
+// watchdog; the PTY adapter doesn't need it.
+function wsCallbackBridge(ws, { withPong = false } = {}) {
+  const msgCbs = [];
+  const closeCbs = [];
+  const pongCbs = [];
+  ws.on("message", (data) => {
+    for (const cb of msgCbs.slice()) cb(data);
+  });
+  ws.on("close", () => {
+    for (const cb of closeCbs.slice()) cb();
+  });
+  if (withPong) {
+    ws.on("pong", () => {
+      for (const cb of pongCbs.slice()) cb();
+    });
+  }
+  // ws emits 'error' then 'close'; swallow 'error' so an errored socket doesn't
+  // crash the process — the 'close' handler drives teardown/reconnect.
+  ws.on("error", () => {});
+
+  const base = {
+    ws,
+    onMessage(cb) {
+      msgCbs.push(cb);
+    },
+    onClose(cb) {
+      closeCbs.push(cb);
+    },
+    close() {
+      try {
+        ws.close();
+      } catch {
+        /* already closing/closed */
+      }
+    },
+  };
+  if (withPong) {
+    // Liveness plumbing for the heartbeat watchdog. `ping()` sends a WS-PROTOCOL
+    // ping (not an app frame — the `ws` peer answers it automatically, no relay
+    // code needed); `onPong` registers the pong callback; `terminate()` hard-
+    // kills a half-open socket (ws.close() waits for a close handshake the dead
+    // peer will never send, so a zombie must be terminated, not closed).
+    base.ping = () => {
+      try {
+        ws.ping();
+      } catch {
+        /* socket closing/closed — watchdog will terminate on the next tick */
+      }
+    };
+    base.onPong = (cb) => {
+      pongCbs.push(cb);
+    };
+    base.terminate = () => {
+      try {
+        ws.terminate();
+      } catch {
+        /* already gone */
+      }
+    };
+  }
+  return base;
+}
+
+// Await a ws 'open' (resolve) or a pre-open 'error' (reject), so the reconnect
+// loop can reset its backoff on a genuine connect. Shared by both adapters.
+function awaitWsOpen(ws) {
+  return new Promise((resolve, reject) => {
+    let openResolved = false;
+    ws.once("open", () => {
+      openResolved = true;
+      resolve();
+    });
+    ws.once("error", (err) => {
+      if (!openResolved) reject(err);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Real `ws` transport (default connect()). Adapts a dialed-out ws WebSocket to
 // the tiny transport contract (send / onMessage / onClose / close) the client
 // is written against — the box-side twin of the relay's wsTransport().
@@ -128,92 +214,30 @@ export function createBackoff({
 async function defaultConnect(url, { headers } = {}) {
   const { WebSocket } = await import("ws");
   const ws = new WebSocket(url, { headers });
-  const msgCbs = [];
-  const closeCbs = [];
-  const pongCbs = [];
-  let openResolved = false;
-
-  const transport = {
-    ws,
-    send(frame) {
-      let raw;
-      if (typeof frame === "string") {
-        raw = frame;
-      } else {
-        try {
-          raw = encodeFrame(frame);
-        } catch {
-          return; // programmer-built frame failed validation; never crash send
-        }
-      }
+  // Control tunnel needs the liveness (ping/onPong/terminate) surface.
+  const transport = wsCallbackBridge(ws, { withPong: true });
+  // Control-tunnel send: accept an already-encoded string OR a frame object to
+  // encode. (The PTY adapter's send is raw-bytes-only — the one real difference
+  // between the two adapters, which is why send stays per-adapter.)
+  transport.send = (frame) => {
+    let raw;
+    if (typeof frame === "string") {
+      raw = frame;
+    } else {
       try {
-        ws.send(raw);
+        raw = encodeFrame(frame);
       } catch {
-        /* socket closing/closed — the close handler drives reconnect */
+        return; // programmer-built frame failed validation; never crash send
       }
-    },
-    onMessage(cb) {
-      msgCbs.push(cb);
-    },
-    onClose(cb) {
-      closeCbs.push(cb);
-    },
-    // Liveness plumbing for the heartbeat watchdog. `ping()` sends a WS-PROTOCOL
-    // ping (not an app frame — the `ws` peer answers it automatically, no relay
-    // code needed); `onPong` registers the pong callback; `terminate()` hard-
-    // kills a half-open socket (ws.close() waits for a close handshake the dead
-    // peer will never send, so a zombie must be terminated, not closed).
-    ping() {
-      try {
-        ws.ping();
-      } catch {
-        /* socket closing/closed — watchdog will terminate on the next tick */
-      }
-    },
-    onPong(cb) {
-      pongCbs.push(cb);
-    },
-    terminate() {
-      try {
-        ws.terminate();
-      } catch {
-        /* already gone */
-      }
-    },
-    close() {
-      try {
-        ws.close();
-      } catch {
-        /* already closing/closed */
-      }
-    },
+    }
+    try {
+      ws.send(raw);
+    } catch {
+      /* socket closing/closed — the close handler drives reconnect */
+    }
   };
 
-  ws.on("message", (data) => {
-    for (const cb of msgCbs.slice()) cb(data);
-  });
-  ws.on("pong", () => {
-    for (const cb of pongCbs.slice()) cb();
-  });
-  ws.on("close", () => {
-    for (const cb of closeCbs.slice()) cb();
-  });
-  // ws emits 'error' then 'close'; swallow 'error' so an errored socket doesn't
-  // crash the process — the 'close' handler drives the reconnect.
-  ws.on("error", () => {});
-
-  // Resolve once the socket is open so the reconnect loop can reset its backoff
-  // on a genuine connect. A socket that errors before opening rejects.
-  await new Promise((resolve, reject) => {
-    ws.once("open", () => {
-      openResolved = true;
-      resolve();
-    });
-    ws.once("error", (err) => {
-      if (!openResolved) reject(err);
-    });
-  });
-
+  await awaitWsOpen(ws);
   return transport;
 }
 
@@ -374,49 +398,21 @@ export function makeDefaultLocalPtyConnect(localBase, auth) {
     const base = localBase.replace(/^http/, "ws");
     const url = `${base}${path}${path.includes("?") ? "&" : "?"}token=${encodeURIComponent(auth.box_token)}`;
     const ws = new WebSocket(url);
-
-    const msgCbs = [];
-    const closeCbs = [];
-    let openResolved = false;
-
-    const transport = {
-      ws,
-      send(payload) {
-        if (typeof payload === "string" || Buffer.isBuffer(payload)) {
-          try {
-            ws.send(payload);
-          } catch {
-            /* socket closing */
-          }
+    // PTY tunnel: no liveness surface needed (the control tunnel owns the
+    // watchdog); this is a short-lived per-terminal stream.
+    const transport = wsCallbackBridge(ws);
+    // PTY send is raw-bytes-only (terminal bytes are opaque; NEVER encodeFrame).
+    transport.send = (payload) => {
+      if (typeof payload === "string" || Buffer.isBuffer(payload)) {
+        try {
+          ws.send(payload);
+        } catch {
+          /* socket closing */
         }
-      },
-      onMessage(cb) {
-        msgCbs.push(cb);
-      },
-      onClose(cb) {
-        closeCbs.push(cb);
-      },
-      close() {
-        try { ws.close(); } catch { /* already closing */ }
-      },
+      }
     };
 
-    ws.on("message", (data) => {
-      // ws hands us Buffer; keep Buffer (terminal bytes are raw, NOT utf8).
-      for (const cb of msgCbs.slice()) cb(data);
-    });
-    ws.on("close", () => {
-      for (const cb of closeCbs.slice()) cb();
-    });
-    ws.on("error", () => {
-      // ws fires 'error' then 'close'; close handler drives teardown.
-    });
-
-    await new Promise((resolve, reject) => {
-      ws.once("open", () => { openResolved = true; resolve(); });
-      ws.once("error", (err) => { if (!openResolved) reject(err); });
-    });
-
+    await awaitWsOpen(ws);
     return transport;
   };
 }
@@ -1035,10 +1031,13 @@ export function createRelayAgent(opts = {}) {
     t.onMessage((data) => {
       onFrame(decodeFrame(data));
     });
-    // A WS-protocol pong clears the "awaiting" flag — the peer is alive.
+    // A WS-protocol pong clears the "awaiting" flag — the peer is alive. Guard
+    // on `transport === t` so a LATE pong from an already-swapped old socket
+    // can't clear the flag on the current one and mask its dead-socket detection
+    // for a tick (mirrors the same stale-guard used in the tick + request proxy).
     if (typeof t.onPong === "function") {
       t.onPong(() => {
-        awaitingPong = false;
+        if (transport === t) awaitingPong = false;
       });
     }
     t.onClose(() => {

--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -63,6 +63,19 @@ export const DEFAULT_LOCAL_BASE = "http://127.0.0.1:8787";
 export const RECONNECT_BASE_MS = 1000;
 export const RECONNECT_MAX_MS = 30000;
 
+// Liveness watchdog (BET: zombie-WS fix). The reconnect loop only fires on a
+// socket 'close'/'error' event. When the underlying TCP dies SILENTLY (relay
+// restart behind a load balancer, NAT/idle timeout, network blip) no close is
+// emitted and the agent holds a half-open "zombie" socket FOREVER — status()
+// reports "connected" while the relay has long since dropped the box, so the
+// phone sees `box_offline`. This is the exact 14h dead-socket outage observed
+// 2026-07-20. The fix mirrors the opencode SSE liveness watchdog (commit
+// 26319f9): periodically send a WS-level ping and, if no pong came back since
+// the previous tick, TERMINATE the socket — which synthesizes the 'close' event
+// the reconnect loop is waiting for. Interval 20s / two missed pongs ≈ 40s to
+// detection, well under the relay's own presence TTL.
+export const HEARTBEAT_INTERVAL_MS = 20000;
+
 // ---------------------------------------------------------------------------
 // Backoff — the .mjs mirror of src/shared/net/backoff.ts ExponentialBackoff
 // ---------------------------------------------------------------------------
@@ -117,6 +130,7 @@ async function defaultConnect(url, { headers } = {}) {
   const ws = new WebSocket(url, { headers });
   const msgCbs = [];
   const closeCbs = [];
+  const pongCbs = [];
   let openResolved = false;
 
   const transport = {
@@ -144,6 +158,28 @@ async function defaultConnect(url, { headers } = {}) {
     onClose(cb) {
       closeCbs.push(cb);
     },
+    // Liveness plumbing for the heartbeat watchdog. `ping()` sends a WS-PROTOCOL
+    // ping (not an app frame — the `ws` peer answers it automatically, no relay
+    // code needed); `onPong` registers the pong callback; `terminate()` hard-
+    // kills a half-open socket (ws.close() waits for a close handshake the dead
+    // peer will never send, so a zombie must be terminated, not closed).
+    ping() {
+      try {
+        ws.ping();
+      } catch {
+        /* socket closing/closed — watchdog will terminate on the next tick */
+      }
+    },
+    onPong(cb) {
+      pongCbs.push(cb);
+    },
+    terminate() {
+      try {
+        ws.terminate();
+      } catch {
+        /* already gone */
+      }
+    },
     close() {
       try {
         ws.close();
@@ -155,6 +191,9 @@ async function defaultConnect(url, { headers } = {}) {
 
   ws.on("message", (data) => {
     for (const cb of msgCbs.slice()) cb(data);
+  });
+  ws.on("pong", () => {
+    for (const cb of pongCbs.slice()) cb();
   });
   ws.on("close", () => {
     for (const cb of closeCbs.slice()) cb();
@@ -432,6 +471,16 @@ export function createRelayAgent(opts = {}) {
     backoff = createBackoff(),
     setTimer = (fn, ms) => setTimeout(fn, ms),
     clearTimer = (h) => clearTimeout(h),
+    // Heartbeat watchdog (BET zombie-WS fix). Injectable interval primitives so
+    // tests can drive the tick deterministically without real timers. Default
+    // to unref'd setInterval so the watchdog never keeps the process alive.
+    heartbeatMs = HEARTBEAT_INTERVAL_MS,
+    setHeartbeat = (fn, ms) => {
+      const h = setInterval(fn, ms);
+      if (typeof h?.unref === "function") h.unref();
+      return h;
+    },
+    clearHeartbeat = (h) => clearInterval(h),
     log = console.log,
     warn = console.warn,
   } = opts;
@@ -459,6 +508,8 @@ export function createRelayAgent(opts = {}) {
   let stopped = false; // set by stop(); halts the reconnect loop permanently
   let started = false; // set by start(); the agent only counts as "live" once start() ran
   let connecting = false;
+  let heartbeatHandle = null; // liveness watchdog interval (BET zombie-WS fix)
+  let awaitingPong = false; // true once a ping is sent, cleared on pong receipt
 
   // Build the authenticated dial-out URL + headers. The relay's parseHandshake
   // accepts box_id/token via header OR query; we present BOTH the header form
@@ -984,8 +1035,15 @@ export function createRelayAgent(opts = {}) {
     t.onMessage((data) => {
       onFrame(decodeFrame(data));
     });
+    // A WS-protocol pong clears the "awaiting" flag — the peer is alive.
+    if (typeof t.onPong === "function") {
+      t.onPong(() => {
+        awaitingPong = false;
+      });
+    }
     t.onClose(() => {
       if (transport === t) transport = null;
+      stopHeartbeat();
       // Every live stream must be torn down so nothing hangs half-open across a
       // reconnect (Stage-4 consumers get onAbort).
       streams.abortAll("relay tunnel closed");
@@ -993,6 +1051,43 @@ export function createRelayAgent(opts = {}) {
       log(`[relay-agent] tunnel closed; reconnecting`);
       scheduleReconnect();
     });
+
+    startHeartbeat(t);
+  }
+
+  // --- liveness watchdog (BET zombie-WS fix) ------------------------------
+
+  // Start the per-connection heartbeat. Each tick: if the PREVIOUS ping was
+  // never answered (awaitingPong still true), the peer is dead — terminate the
+  // socket, which fires the 'close' handler and drives a reconnect. Otherwise
+  // arm a fresh ping and mark awaiting. First tick sends a ping without
+  // terminating (nothing to time out yet). Terminates rather than close()s
+  // because a zombie peer never completes a close handshake.
+  function startHeartbeat(t) {
+    stopHeartbeat();
+    awaitingPong = false;
+    if (typeof t.ping !== "function") return; // transport without ping (test stub)
+    heartbeatHandle = setHeartbeat(() => {
+      if (transport !== t) return; // stale tick after a swap
+      if (awaitingPong) {
+        // No pong since last tick → dead socket. Terminate → onClose → reconnect.
+        warn("[relay-agent] heartbeat timeout; terminating dead socket");
+        awaitingPong = false;
+        if (typeof t.terminate === "function") t.terminate();
+        else t.close();
+        return;
+      }
+      awaitingPong = true;
+      t.ping();
+    }, heartbeatMs);
+  }
+
+  function stopHeartbeat() {
+    if (heartbeatHandle != null) {
+      clearHeartbeat(heartbeatHandle);
+      heartbeatHandle = null;
+    }
+    awaitingPong = false;
   }
 
   // Schedule the next reconnect after a backoff delay. Guards against stacking
@@ -1035,6 +1130,7 @@ export function createRelayAgent(opts = {}) {
       clearTimer(reconnectTimer);
       reconnectTimer = null;
     }
+    stopHeartbeat();
     streams.abortAll("relay-agent stopped");
     if (transport) {
       const t = transport;
@@ -1076,6 +1172,9 @@ export function createRelayAgent(opts = {}) {
     _onFrame: onFrame,
     _streams: streams,
     _handshake: handshake,
+    // introspection for the heartbeat watchdog tests
+    _isHeartbeatRunning: () => heartbeatHandle != null,
+    _isAwaitingPong: () => awaitingPong,
   };
 }
 

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -76,6 +76,7 @@ function makeFakeRelay({ failFirst = 0 } = {}) {
     // is: send() accepts an already-encoded string OR a frame object it encodes.
     // The raw fake endpoint only forwards bytes, so wrap it to honor the same
     // contract the real ws adapter provides.
+    const pongCbs = [];
     const boxTransport = {
       send(frame) {
         boxSide.send(typeof frame === "string" ? frame : encodeFrame(frame));
@@ -86,11 +87,34 @@ function makeFakeRelay({ failFirst = 0 } = {}) {
       onClose(cb) {
         boxSide.onClose(cb);
       },
+      // WS-level liveness plumbing (BET zombie-WS watchdog). ping() records a
+      // call; the test decides whether to answer via link.deliverPong().
+      ping() {
+        link.pings += 1;
+      },
+      onPong(cb) {
+        pongCbs.push(cb);
+      },
+      terminate() {
+        link.terminated = true;
+        boxSide.close(); // synthesize the 'close' the real ws.terminate() causes
+      },
       close() {
         boxSide.close();
       },
     };
-    const link = { relaySide, boxSide, sent: [], recv: [] };
+    const link = {
+      relaySide,
+      boxSide,
+      sent: [],
+      recv: [],
+      pings: 0,
+      terminated: false,
+      // Simulate the peer answering a WS ping with a pong.
+      deliverPong() {
+        for (const cb of pongCbs.slice()) cb();
+      },
+    };
     // Record everything the client (boxTransport) sends to the relay (relaySide).
     relaySide.onMessage((raw) => link.recv.push(decodeFrame(raw)));
     links.push(link);
@@ -166,22 +190,49 @@ function makeClock() {
 // real fetch in a `finally` so a thrown assertion can't leak the stub to
 // sibling tests. The two makeDefaultLocalFetch tests use it; the 8-line
 // stub/restore preamble was an intra-file clone of itself.
+// A manual heartbeat clock so the liveness watchdog interval fires on demand
+// (no real setInterval). Mirrors makeClock but models a single repeating timer.
+function makeHeartbeatClock() {
+  let seq = 1;
+  const timers = new Map(); // handle -> fn
+  return {
+    setHeartbeat(fn) {
+      const h = seq++;
+      timers.set(h, fn);
+      return h;
+    },
+    clearHeartbeat(h) {
+      timers.delete(h);
+    },
+    // Fire every pending heartbeat once (a single connection has exactly one).
+    tick() {
+      for (const fn of [...timers.values()]) fn();
+    },
+    running() {
+      return timers.size;
+    },
+  };
+}
+
 function makeStubAgent(opts = {}) {
   const { failFirst, ...agentOpts } = opts;
   const relay = makeFakeRelay(
     failFirst != null ? { failFirst } : undefined,
   );
   const clock = makeClock();
+  const heartbeat = makeHeartbeatClock();
   const agent = createRelayAgent({
     auth: AUTH,
     connect: relay.connect,
     setTimer: clock.setTimer,
     clearTimer: clock.clearTimer,
+    setHeartbeat: heartbeat.setHeartbeat,
+    clearHeartbeat: heartbeat.clearHeartbeat,
     log: silent,
     warn: silent,
     ...agentOpts,
   });
-  return { relay, clock, agent };
+  return { relay, clock, heartbeat, agent };
 }
 
 async function captureFetchHeaders(body) {
@@ -408,6 +459,92 @@ test("answers a relay PING with a correlated PONG", async () => {
   const pong = relay.clientSent().find((f) => f && f.type === FRAME_TYPES.PONG);
   assert.ok(pong, "a PONG was sent");
   assert.equal(pong.id, 99, "pong echoes the ping id");
+
+  agent.stop();
+});
+
+// ---------------------------------------------------------------------------
+// liveness watchdog (BET zombie-WS fix)
+// ---------------------------------------------------------------------------
+
+test("heartbeat starts on connect and pings the socket each tick", async () => {
+  const { relay, heartbeat, agent } = makeStubAgent();
+  await agent.start();
+
+  assert.equal(agent._isHeartbeatRunning(), true, "watchdog armed on connect");
+  assert.equal(relay.lastLink().pings, 0, "no ping before the first tick");
+
+  heartbeat.tick();
+  assert.equal(relay.lastLink().pings, 1, "first tick sends a ping");
+  assert.equal(agent._isAwaitingPong(), true, "awaiting a pong after ping");
+
+  agent.stop();
+});
+
+test("a pong keeps the socket alive across ticks (no terminate)", async () => {
+  const { relay, heartbeat, agent } = makeStubAgent();
+  await agent.start();
+
+  heartbeat.tick(); // ping #1
+  relay.lastLink().deliverPong(); // peer answers → alive
+  assert.equal(agent._isAwaitingPong(), false, "pong cleared the awaiting flag");
+
+  heartbeat.tick(); // ping #2 — allowed because previous was answered
+  assert.equal(relay.lastLink().pings, 2, "second ping sent");
+  assert.equal(relay.lastLink().terminated, false, "socket NOT terminated");
+  assert.equal(agent.isConnected(), true, "still connected");
+
+  agent.stop();
+});
+
+test("a missed pong terminates the zombie socket and drives a reconnect", async () => {
+  // THE REGRESSION: a silently-dead socket (no close event) must be detected
+  // by the watchdog and terminated so the reconnect loop fires. This is the
+  // 14h box_offline outage of 2026-07-20.
+  const { relay, clock, heartbeat, agent } = makeStubAgent();
+  await agent.start();
+
+  heartbeat.tick(); // ping #1 sent, awaitingPong = true
+  assert.equal(agent._isAwaitingPong(), true);
+  // No pong delivered — peer is dead.
+  heartbeat.tick(); // still awaiting → terminate
+
+  assert.equal(relay.lastLink().terminated, true, "dead socket terminated");
+  assert.equal(agent.isConnected(), false, "transport released after terminate");
+  assert.equal(
+    clock.pendingCount(),
+    1,
+    "a reconnect was scheduled (terminate synthesized the close → reconnect)",
+  );
+
+  // Firing the reconnect timer re-dials and re-arms a fresh heartbeat.
+  clock.flush();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(agent.isConnected(), true, "reconnected after the zombie was killed");
+  assert.equal(agent._isHeartbeatRunning(), true, "heartbeat re-armed on the new socket");
+
+  agent.stop();
+});
+
+test("stop() cancels the heartbeat (no lingering interval)", async () => {
+  const { heartbeat, agent } = makeStubAgent();
+  await agent.start();
+  assert.equal(heartbeat.running(), 1, "heartbeat running while connected");
+
+  agent.stop();
+  assert.equal(heartbeat.running(), 0, "heartbeat cleared on stop");
+  assert.equal(agent._isHeartbeatRunning(), false);
+});
+
+test("a normal tunnel close also stops the heartbeat", async () => {
+  const { relay, heartbeat, agent } = makeStubAgent();
+  await agent.start();
+  assert.equal(heartbeat.running(), 1);
+
+  relay.dropLink(); // relay closes the tunnel normally
+  await Promise.resolve();
+  assert.equal(agent._isHeartbeatRunning(), false, "heartbeat stopped on close");
 
   agent.stop();
 });

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -523,7 +523,47 @@ test("a missed pong terminates the zombie socket and drives a reconnect", async 
   await Promise.resolve();
   assert.equal(agent.isConnected(), true, "reconnected after the zombie was killed");
   assert.equal(agent._isHeartbeatRunning(), true, "heartbeat re-armed on the new socket");
+  assert.equal(
+    heartbeat.running(),
+    1,
+    "EXACTLY one heartbeat interval after reconnect (no leaked double-interval)",
+  );
 
+  agent.stop();
+});
+
+test("a stale pong from an old socket does not mask the new socket's watchdog", async () => {
+  // Review note #1: awaitingPong is agent-scoped; guard against a late pong from
+  // an already-swapped socket clearing the flag on the current one.
+  const { relay, clock, heartbeat, agent } = makeStubAgent();
+  await agent.start();
+  const oldLink = relay.lastLink();
+
+  // Force a reconnect (drop → reschedule → redial) so a NEW link is current.
+  relay.dropLink();
+  await Promise.resolve();
+  clock.flush();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.notEqual(relay.lastLink(), oldLink, "a new link is current");
+
+  heartbeat.tick(); // new socket: ping sent, awaitingPong = true
+  assert.equal(agent._isAwaitingPong(), true);
+  oldLink.deliverPong(); // LATE pong from the dead old socket
+  assert.equal(
+    agent._isAwaitingPong(),
+    true,
+    "stale pong ignored — new socket still awaiting its own pong",
+  );
+
+  agent.stop();
+});
+
+test("double start() does not arm a second heartbeat interval", async () => {
+  const { heartbeat, agent } = makeStubAgent();
+  await agent.start();
+  await agent.start(); // idempotent — openOnce() no-ops while connected
+  assert.equal(heartbeat.running(), 1, "still exactly one heartbeat interval");
   agent.stop();
 });
 


### PR DESCRIPTION
## Symptom
Mobile app shows **"Couldn't reach your box"** (`box_offline`) while the box's manta-server is up and `app.mantaui.com` works. Observed live 2026-07-20: the box held a dead relay socket for **14 hours**.

## Root cause
The box-side relay agent (`src/relay/agent/index.mjs`) reconnects only on a socket `close`/`error` event. When the underlying TCP dies **silently** — relay restart behind a load balancer, NAT/idle timeout, network blip — no close fires. The agent holds a half-open **zombie** socket forever: `/relay/status` reports `connected:true` while the relay has already dropped the box, so the phone's pair lookup returns `box_offline`. There was no WS-level liveness check.

## Fix
Add a **ping/pong heartbeat watchdog** (20s interval): each tick sends a WS-protocol ping; if the previous ping wasn't ponged, `terminate()` the socket — synthesizing the `close` the existing reconnect loop waits for. Same class/shape as the opencode SSE liveness watchdog (commit 26319f9).

- Terminates (not `close()`) — a zombie peer never completes a close handshake.
- Timers injectable → deterministic tests; default interval `unref()`'d so it never keeps the process alive.
- Started on connect, stopped on close/stop.

## Tests
5 new (heartbeat arms on connect, pong keeps alive, **missed-pong → terminate → reconnect**, stop clears interval, normal close clears interval). All 46 relay-agent tests + 679 server tests green; typecheck clean.

## Deploy
Relay agent runs inside manta-server on the box — ships via `git pull` + `systemctl --user restart manta-server`, or the `relay-v*` tag pipeline. (I already restarted the live box to clear the current zombie; this prevents recurrence.)