### PR TITLE
fix(log): BET-193 — cache Axiom token so renderer ships when box unreachable

### DIFF
--- a/src/renderer/log.ts
+++ b/src/renderer/log.ts
@@ -31,6 +31,8 @@ let shipper: LogShipper | null = null;
 let flushOnHide: (() => void) | null = null;
 
 const DEVICE_KEY = "manta_log_device";
+const TOKEN_CACHE_KEY = "manta_axiom_token";
+const DATASET_CACHE_KEY = "manta_axiom_dataset";
 
 /**
  * Mint or restore an 8-hex-char device id from localStorage. Stable per
@@ -53,6 +55,31 @@ function getOrMintDevice(): string {
 }
 
 /**
+ * Read a localStorage key without throwing (private mode / quota /
+ * disabled storage). Returns null on any failure — callers must treat
+ * absence as "no cached value".
+ */
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a localStorage key without throwing (private mode / quota).
+ * Mirrors getOrMintDevice's swallow-on-failure pattern.
+ */
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* swallow — private mode / quota */
+  }
+}
+
+/**
  * Initialize renderer logging. Reads AppConfig once (fire-and-forget — the
  * boot path must not block on Axiom). No-ops silently when no token is
  * configured. Safe to call multiple times; subsequent calls are idempotent.
@@ -64,9 +91,25 @@ export async function initRendererLogging(source: "mobile" | "desktop"): Promise
   let config: Parameters<typeof resolveAxiomConfig>[0]["config"] = null;
   try {
     config = await window.api.configGet();
+    const token = config?.axiomToken;
+    if (typeof token === "string" && token.length > 0) {
+      safeSet(TOKEN_CACHE_KEY, token);
+      safeSet(DATASET_CACHE_KEY, config?.axiomDataset ?? "manta");
+    }
   } catch {
-    // configGet failing is non-fatal — render in unconfigured state.
-    config = null;
+    // configGet fails when the box is unreachable — the exact scenario we
+    // need to debug. Fall back to the cached token from a prior successful
+    // boot so the renderer still ships events; if no cache exists yet, this
+    // is a never-connected install and config stays null (unchanged).
+    const cachedToken = safeGet(TOKEN_CACHE_KEY);
+    if (cachedToken) {
+      config = {
+        axiomToken: cachedToken,
+        axiomDataset: safeGet(DATASET_CACHE_KEY) ?? "manta",
+      };
+    } else {
+      config = null;
+    }
   }
   const axiomCfg = resolveAxiomConfig({ env: {}, config });
   if (!axiomCfg) return;

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -29,7 +29,7 @@ import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/
 // any subsequent `console.log` so the existing `[push]` / `[opencode-pump]`
 // / `[relay-agent]` / `[auth]` call sites ship transparently.
 {
-  const axiomCfg = resolveAxiomConfig({ env: process.env, config: local.configGet() });
+  const axiomCfg = resolveAxiomConfig({ env: process.env, config: await local.configGet() });
   if (axiomCfg) {
     captureConsole(createLogShipper({ ...axiomCfg, source: "server", device: hostname() }));
   }


### PR DESCRIPTION
**Base:** `main` @ `4bbc81d`

## Problem
BET-187 renderer log shipping is supposed to let the native app ship logs to Axiom even when the box is unreachable. But the implementation defeated itself:

`src/renderer/log.ts` `initRendererLogging()` reads the Axiom token via `await window.api.configGet()` (line 66). On the native app, `configGet()` is an HTTP call to the box **through the relay**. When the box is unreachable — the exact "Couldn't reach your box" scenario we need to debug — `configGet()` throws, `config` becomes `null`, `resolveAxiomConfig` returns `null`, and the shipper is never installed. The app ships **nothing** precisely when its logs matter most.

## Fix
Two edits, both inside the scope the spec names.

### `src/renderer/log.ts` — persist the token, read it back on failure
Reuse the existing localStorage pattern from `getOrMintDevice`. No new module, no build-time secret, no config UI.

- New keys `manta_axiom_token` / `manta_axiom_dataset`.
- On successful `configGet()`: cache token + dataset via a `safeSet` helper (swallow-on-failure, mirroring `getOrMintDevice`'s pattern).
- On `configGet()` throwing: read the cached token back via `safeGet` and rebuild a minimal `{ axiomToken, axiomDataset }` config object so `resolveAxiomConfig` still resolves. No cached token → `config = null` (unchanged behavior for a never-connected install).
- Idempotency guard at `if (shipper) return` is untouched.

### `src/server/index.mjs:32` — `await` the `configGet()` call
Found in the same investigation. `local.configGet()` is async; the call was passing the Promise into `resolveAxiomConfig`, so `config?.axiomToken` was `undefined` and the server's AppConfig-based token path **never** resolved.

## Verification results

**Files changed:** 2 files. `src/renderer/log.ts`, `src/server/index.mjs`.

- PR branch (`multica/BET-193-renderer-log-token-cache` @ `74ce804`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `771` pass / `0` fail / `0` skip.
- Base (`main` @ `4bbc81d`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `771` pass / `0` fail / `0` skip.
- **Conclusion:** 0 new failures, 0 resolved failures, 0 pre-existing failures. CI green expected.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.

## Out of scope
- No new module, no build-time env/define, no config UI, no server RPC change, no `logShip.mjs` changes, no relay changes, no desktop transport changes.
- No token logging or surfacing.