### PR TITLE
BET-199: gateway service (APNs moved, register/push/store/dns)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "pair": "node scripts/manta-pair.mjs",
     "pack": "node scripts/release/pack.mjs",
     "pack:desktop": "electron-vite build && electron-builder --config electron-builder.yml",
-    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs scripts/*.test.mjs",
-    "test:server": "node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs",
+    "test": "vitest run && node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs src/gateway/*.test.mjs scripts/*.test.mjs",
+    "test:server": "node --test src/server/*.test.mjs src/relay/*.test.mjs src/relay/agent/*.test.mjs src/gateway/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts"
   },

--- a/shared/ports/registry.md
+++ b/shared/ports/registry.md
@@ -1,0 +1,58 @@
+# Port registry
+
+Single source of truth for ports claimed by MantaUI services. New ports
+MUST be reserved here before being added to a service's listener, so two
+services can never silently collide.
+
+Ports are loopback (`127.0.0.1`) by default; a service that needs a
+public bind states so explicitly.
+
+## MantaUI `10xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `11xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `12xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `13xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `14xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `17xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `18xxx` block
+
+| Port | Service |
+|---|---|
+| _(reserved — claim before use)_ | |
+
+## MantaUI `20xxx` block
+
+| Port | Service |
+|---|---|
+| 20080 | serve-page file server (behind `*.pages.<domain>` vhost) |
+| 20081 | gateway (push relay → APNs + DNS automation, behind `gateway.<domain>` vhost) |
+| 20787 | relay (deprecated — see `src/gateway/`; left listed during deprecation window) |

--- a/src/gateway/apns.mjs
+++ b/src/gateway/apns.mjs
@@ -1,0 +1,254 @@
+// apns.mjs — Apple APNs native push (gateway-side).
+//
+// MOVED from src/server/push.mjs in BET-199. The gateway now holds the
+// `.p8` Apple key (BET-198 §1: "Single push path"). Boxes do not hold APNs
+// credentials anymore — their push.mjs fans out via POST /push on the
+// gateway (BET-201 will swap the box internals).
+//
+// The shape of `sendApns` changed because the gateway is stateless about
+// device tokens: it does NOT maintain an apns-tokens.json (that's box-side
+// state). The new contract returns `{ok, prune}` per token — the gateway's
+// /push handler passes that result back to the box, which owns the actual
+// `removeApnsToken` call.
+//
+// Same crypto + HTTP plumbing as before:
+//   - ES256 JWT (Apple's spec: header {alg:"ES256",kid:<keyId>}, claims
+//     {iss:<teamId>, iat:<unix-seconds>}), cached for 45 min to amortize the
+//     ~5ms P-256 sign cost.
+//   - HTTP/2 to api.push.apple.com:443, path /3/device/<token>.
+//   - 410 Gone / 400 BadDeviceToken / 400 Unregistered → prune:true.
+//
+// Config is loaded once at startup from /etc/manta-gateway/apns.json
+// (same shape as the `apns` block in ~/.manta/config.json on the box:
+// `{ teamId, keyId, p8Path, bundleId }`).
+//
+// Pure helpers (buildApnsJwt, buildApnsRequest, buildApnsPayload) are
+// exported unchanged for unit tests; the module-level JWT cache is exported
+// via `_resetApnsJwtCache` so tests can force a re-sign.
+
+import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { createSign, randomBytes } from "node:crypto";
+import http2 from "node:http2";
+
+const APNS_JWT_TTL_SEC = 45 * 60;
+
+let _apnsJwtCache = null; // { teamId, keyId, p8Path, jwt, exp }
+
+// ---------------------------------------------------------------------------
+// Config — load once at startup
+// ---------------------------------------------------------------------------
+
+// Read `{ teamId, keyId, p8Path, bundleId }` from a JSON file. Same shape as
+// the box's apns config block (src/server/local.mjs apnsConfig). Returns
+// null if the file is missing, malformed, or any required field is empty.
+export async function loadApnsConfig(path) {
+  if (typeof path !== "string" || !path) {
+    throw new Error("loadApnsConfig: path required");
+  }
+  try {
+    const text = await readFile(path, "utf-8");
+    const parsed = JSON.parse(text);
+    const { teamId, keyId, p8Path, bundleId } = parsed ?? {};
+    if (typeof teamId !== "string" || !teamId) return null;
+    if (typeof keyId !== "string" || !keyId) return null;
+    if (typeof p8Path !== "string" || !p8Path) return null;
+    if (typeof bundleId !== "string" || !bundleId) return null;
+    return { teamId, keyId, p8Path, bundleId };
+  } catch {
+    return null;
+  }
+}
+
+// Default config path on prod. systemd places this at
+// /etc/manta-gateway/apns.json (BET-198 WP6 runbook step 1).
+export const DEFAULT_APNS_CONFIG_PATH = "/etc/manta-gateway/apns.json";
+
+// ---------------------------------------------------------------------------
+// Pure JWT / payload / request builders
+// ---------------------------------------------------------------------------
+
+// ES256 JWT used for APNs auth. Apple requires:
+//   header: { alg:"ES256", kid:<keyId> }
+//   claims: { iss:<teamId>, iat:<unix-seconds> }
+// ES256 = ECDSA over the P-256 curve with SHA-256. Apple's .p8 is the
+// PKCS#8 PEM of an EC private key, which Node's crypto accepts directly.
+export async function buildApnsJwt(cfg, { now } = {}) {
+  if (!cfg?.teamId || !cfg?.keyId || !cfg?.p8Path) {
+    throw new Error("buildApnsJwt: missing teamId/keyId/p8Path");
+  }
+  const pem = readFileSync(cfg.p8Path, "utf-8");
+  const header = { alg: "ES256", kid: cfg.keyId };
+  const iat = now ?? Math.floor(Date.now() / 1000);
+  const claims = { iss: cfg.teamId, iat };
+  const enc = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  const signingInput = `${enc(header)}.${enc(claims)}`;
+  const signer = createSign("SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer
+    .sign({ key: pem, dsaEncoding: "ieee-p1363" })
+    .toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+// Cache-and-reuse the APNs JWT for APNS_JWT_TTL_SEC. Pure w.r.t. time
+// (caller-injected `now`); mutates module-level `_apnsJwtCache`.
+async function getApnsJwt(cfg, { now = () => Math.floor(Date.now() / 1000) } = {}) {
+  const t = now();
+  const c = _apnsJwtCache;
+  if (
+    c &&
+    c.teamId === cfg.teamId &&
+    c.keyId === cfg.keyId &&
+    c.p8Path === cfg.p8Path &&
+    c.exp > t
+  ) {
+    return c.jwt;
+  }
+  const jwt = await buildApnsJwt(cfg, { now: t });
+  _apnsJwtCache = {
+    teamId: cfg.teamId,
+    keyId: cfg.keyId,
+    p8Path: cfg.p8Path,
+    jwt,
+    exp: t + APNS_JWT_TTL_SEC,
+  };
+  return jwt;
+}
+
+// Test hook: drop the JWT cache so the next send rebuilds.
+export function _resetApnsJwtCache() {
+  _apnsJwtCache = null;
+}
+
+// Build the HTTP/2 request shape for one APNs send.
+export function buildApnsRequest({ cfg, deviceToken, payload, jwt }) {
+  if (!cfg?.bundleId) throw new Error("buildApnsRequest: missing bundleId");
+  if (typeof deviceToken !== "string" || !deviceToken) {
+    throw new Error("buildApnsRequest: missing deviceToken");
+  }
+  return {
+    host: "api.push.apple.com",
+    path: `/3/device/${encodeURIComponent(deviceToken)}`,
+    method: "POST",
+    headers: {
+      authorization: `bearer ${jwt}`,
+      "apns-topic": cfg.bundleId,
+      "apns-push-type": "alert",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  };
+}
+
+// Map an internal notification payload to the APNs `aps` envelope.
+// Apple requires the title/body under `aps.alert`. `thread-id` groups
+// notifications from the same session into one stack on the lock screen.
+export function buildApnsPayload(payload) {
+  const title = typeof payload?.title === "string" ? payload.title : "";
+  const body = typeof payload?.body === "string" ? payload.body : "";
+  const sessionId =
+    typeof payload?.sessionId === "string" && payload.sessionId
+      ? payload.sessionId
+      : null;
+  const aps = { alert: { title, body } };
+  if (sessionId) aps["thread-id"] = sessionId;
+  return { aps, sessionId };
+}
+
+// ---------------------------------------------------------------------------
+// sendApns — gateway-side, stateless about device tokens
+// ---------------------------------------------------------------------------
+
+/**
+ * Send ONE push to ONE APNs token.
+ *
+ * Returns `{ ok, prune, reason }`:
+ *   - ok=true,  prune=false → delivered (Apple 200)
+ *   - ok=false, prune=true  → dead token (410 Gone, 400 BadDeviceToken, or
+ *                              400 Unregistered) — caller must remove it
+ *                              from its own device-token store
+ *   - ok=false, prune=false → transient error (network blip, Apple 5xx,
+ *                              other 400 reason) — keep the token
+ *
+ * `fetchImpl` is injected for tests. Production uses `defaultApnsSender`
+ * (HTTP/2 to api.push.apple.com). The sender's contract is the same as
+ * the box-side original: take a built `req` object, return
+ * `{status, body}`.
+ *
+ * @param {{token:string, payload:{title:string, body:string, sessionId?:string|null}}} args
+ * @param {{teamId:string, keyId:string, p8Path:string, bundleId:string}} apnsConfig
+ * @param {(req:any)=>Promise<{status:number, body:any}>} [fetchImpl] injected for tests
+ */
+export async function sendApns({ token, payload }, apnsConfig, fetchImpl) {
+  if (typeof token !== "string" || !token) {
+    throw new Error("sendApns: token required");
+  }
+  if (!apnsConfig) throw new Error("sendApns: apnsConfig required");
+
+  const useFetch = fetchImpl ?? defaultApnsSender;
+  const jwt = await getApnsJwt(apnsConfig);
+  const envelope = buildApnsPayload(payload);
+  const req = buildApnsRequest({
+    cfg: apnsConfig,
+    deviceToken: token,
+    payload: envelope,
+    jwt,
+  });
+
+  let res;
+  try {
+    res = await useFetch(req);
+  } catch (e) {
+    console.warn("[gateway-apns] send error:", e?.message ?? e);
+    return { ok: false, prune: false, reason: "transport" };
+  }
+  const status = res?.status ?? 0;
+  const reason = res?.body?.reason ?? "";
+  if (status === 200) {
+    return { ok: true, prune: false, reason: "" };
+  }
+  if (
+    status === 410 ||
+    (status === 400 && (reason === "BadDeviceToken" || reason === "Unregistered"))
+  ) {
+    return { ok: false, prune: true, reason: reason || "dead-token" };
+  }
+  return { ok: false, prune: false, reason: reason || "http-error" };
+}
+
+// Default HTTP/2 sender for APNs (production). Resolves with
+// `{ status, body }` on response, or throws on socket/connect failure.
+async function defaultApnsSender(req) {
+  return new Promise((resolve, reject) => {
+    const session = http2.connect(`https://${req.host}`);
+    session.on("error", reject);
+    const r = session.request({
+      ":method": req.method,
+      ":path": req.path,
+      ...req.headers,
+    });
+    r.on("response", (headers) => {
+      const status = headers[":status"] ?? 0;
+      const chunks = [];
+      r.on("data", (c) => chunks.push(c));
+      r.on("end", () => {
+        session.close();
+        const raw = Buffer.concat(chunks).toString("utf-8");
+        let body = raw;
+        try {
+          body = raw ? JSON.parse(raw) : null;
+        } catch {
+          /* non-JSON body — leave as string */
+        }
+        resolve({ status, body });
+      });
+    });
+    r.on("error", (e) => {
+      session.close();
+      reject(e);
+    });
+    r.end(req.body);
+  });
+}

--- a/src/gateway/apns.test.mjs
+++ b/src/gateway/apns.test.mjs
@@ -1,0 +1,316 @@
+// apns.test.mjs — unit tests for the moved APNs client (gateway-side).
+//
+// The shape of `sendApns` changed because the gateway is stateless about
+// device tokens: it returns `{ok, prune}` per call, and the box owns the
+// actual `removeApnsToken` call. Tests cover the same behavior matrix the
+// box-side tests covered (200 → ok / 410 → prune / 400 BadDeviceToken /
+// 400 Unregistered / 400 other → keep / 500 → keep / transport error →
+// keep) plus the JWT builder, payload, request shape, and loadApnsConfig.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFile, rm, mkdir } from "node:fs/promises";
+import {
+  buildApnsJwt,
+  buildApnsRequest,
+  buildApnsPayload,
+  sendApns,
+  _resetApnsJwtCache,
+  loadApnsConfig,
+  DEFAULT_APNS_CONFIG_PATH,
+} from "./apns.mjs";
+
+const APNS_CFG_BASE = {
+  teamId: "FSQ3HS4Z24",
+  keyId: "82P7483297",
+  bundleId: "com.antoinedc.mantaui",
+};
+
+// Generate a P-256 EC keypair and export the private side as PKCS#8 PEM
+// (the shape Apple's APNs .p8 tokens are). Returns the path; tests MUST
+// clean up.
+async function makeApnsKeyFile() {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  const path = join(
+    tmpdir(),
+    `bui-gw-apns-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.p8`,
+  );
+  await writeFile(path, pem, "utf-8");
+  return { path, cleanup: () => rm(path, { force: true }) };
+}
+
+async function makeApnsKeyConfig() {
+  const k = await makeApnsKeyFile();
+  return { cfg: { ...APNS_CFG_BASE, p8Path: k.path }, cleanup: k.cleanup };
+}
+
+test("buildApnsJwt: header + claims match Apple APNs spec", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    const IAT = 1_700_000_000;
+    const jwt = await buildApnsJwt(cfg, { now: IAT });
+    const parts = jwt.split(".");
+    assert.equal(parts.length, 3);
+    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
+    const claims = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    assert.equal(header.alg, "ES256");
+    assert.equal(header.kid, cfg.keyId);
+    assert.equal(claims.iss, cfg.teamId);
+    assert.equal(claims.iat, IAT);
+    assert.ok(parts[2].length > 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("buildApnsJwt: rejects missing fields", async () => {
+  await assert.rejects(() => buildApnsJwt({ teamId: "T", keyId: "K" }), /p8Path/);
+  await assert.rejects(() => buildApnsJwt({ teamId: "T", p8Path: "/nope" }), /keyId/);
+});
+
+test("buildApnsPayload: maps notification payload to APNs `aps` envelope", () => {
+  const out = buildApnsPayload({
+    title: "default / my-chat",
+    body: "Permission needed — Claude wants to run a tool.",
+    sessionId: "ses_abc",
+  });
+  assert.deepEqual(out, {
+    aps: {
+      alert: {
+        title: "default / my-chat",
+        body: "Permission needed — Claude wants to run a tool.",
+      },
+      "thread-id": "ses_abc",
+    },
+    sessionId: "ses_abc",
+  });
+});
+
+test("buildApnsPayload: no sessionId → no thread-id, still shaped right", () => {
+  const out = buildApnsPayload({ title: "T", body: "B" });
+  assert.deepEqual(out.aps.alert, { title: "T", body: "B" });
+  assert.equal(out.aps["thread-id"], undefined);
+  assert.equal(out.sessionId, null);
+});
+
+test("buildApnsRequest: host/path/headers/body shape (HTTP/2 style)", () => {
+  const deviceToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  const req = buildApnsRequest({
+    cfg: APNS_CFG_BASE,
+    deviceToken,
+    payload: { aps: { alert: { title: "T", body: "B" } }, sessionId: null },
+    jwt: "header.claims.sig",
+  });
+  assert.equal(req.host, "api.push.apple.com");
+  assert.equal(req.path, `/3/device/${deviceToken}`);
+  assert.equal(req.method, "POST");
+  assert.equal(req.headers["authorization"], "bearer header.claims.sig");
+  assert.equal(req.headers["apns-topic"], APNS_CFG_BASE.bundleId);
+  assert.equal(req.headers["apns-push-type"], "alert");
+  assert.match(req.headers["content-type"], /application\/json/);
+  assert.match(req.body, /"aps"/);
+});
+
+// --- sendApns pruning rules (the classification moved verbatim) ----------
+
+test("sendApns: 200 → ok:true, prune:false", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const seen = [];
+    const r = await sendApns(
+      { token: "tok-ok", payload: { title: "T", body: "B", sessionId: "ses_x" } },
+      cfg,
+      async (req) => {
+        seen.push(req);
+        return { status: 200, body: null };
+      },
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.prune, false);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].headers["apns-topic"], cfg.bundleId);
+    assert.equal(seen[0].headers["apns-push-type"], "alert");
+    assert.match(seen[0].headers.authorization, /^bearer /);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("sendApns: 410 Gone → ok:false, prune:true", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const r = await sendApns(
+      { token: "tok-410", payload: { title: "T", body: "B" } },
+      cfg,
+      async () => ({ status: 410, body: { reason: "Unregistered" } }),
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.prune, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("sendApns: 400 BadDeviceToken → ok:false, prune:true", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const r = await sendApns(
+      { token: "tok-bad", payload: { title: "T", body: "B" } },
+      cfg,
+      async () => ({ status: 400, body: { reason: "BadDeviceToken" } }),
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.prune, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("sendApns: 400 Unregistered → ok:false, prune:true", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const r = await sendApns(
+      { token: "tok-unreg", payload: { title: "T", body: "B" } },
+      cfg,
+      async () => ({ status: 400, body: { reason: "Unregistered" } }),
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.prune, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("sendApns: 400 with other reason → ok:false, prune:false (keep token)", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const r = await sendApns(
+      { token: "tok-other", payload: { title: "T", body: "B" } },
+      cfg,
+      async () => ({ status: 400, body: { reason: "BadCertificateEnvironment" } }),
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.prune, false);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("sendApns: 500 → ok:false, prune:false (transient)", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const r = await sendApns(
+      { token: "tok-500", payload: { title: "T", body: "B" } },
+      cfg,
+      async () => ({ status: 500, body: null }),
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.prune, false);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("sendApns: transport error (sender throws) → ok:false, prune:false", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const r = await sendApns(
+      { token: "tok-throw", payload: { title: "T", body: "B" } },
+      cfg,
+      async () => { throw new Error("socket hangup"); },
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.prune, false);
+  } finally {
+    await cleanup();
+  }
+});
+
+// --- JWT cache -----------------------------------------------------------
+
+test("_resetApnsJwtCache forces a fresh sign (verified via sendApns)", async () => {
+  const { cfg, cleanup } = await makeApnsKeyConfig();
+  try {
+    _resetApnsJwtCache();
+    const captured = [];
+    const sender = async (req) => {
+      captured.push(req.headers.authorization);
+      return { status: 200, body: null };
+    };
+    await sendApns({ token: "tok-cache", payload: { title: "T", body: "B" } }, cfg, sender);
+    await sendApns({ token: "tok-cache", payload: { title: "T", body: "B" } }, cfg, sender);
+    assert.equal(captured.length, 2);
+    assert.equal(captured[0], captured[1], "second send within cache window reuses bearer");
+    _resetApnsJwtCache();
+    await sendApns({ token: "tok-cache", payload: { title: "T", body: "B" } }, cfg, sender);
+    assert.notEqual(captured[1], captured[2], "after reset the bearer must be freshly signed");
+  } finally {
+    await cleanup();
+  }
+});
+
+// --- Config loading ------------------------------------------------------
+
+test("loadApnsConfig: happy path", async () => {
+  const { cfg, cleanup: p8Cleanup } = await makeApnsKeyConfig();
+  const dir = join(tmpdir(), `bui-gw-cfg-${process.pid}-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, "apns.json");
+  try {
+    await writeFile(path, JSON.stringify(cfg), "utf-8");
+    const r = await loadApnsConfig(path);
+    assert.equal(r.teamId, cfg.teamId);
+    assert.equal(r.keyId, cfg.keyId);
+    assert.equal(r.p8Path, cfg.p8Path);
+    assert.equal(r.bundleId, cfg.bundleId);
+  } finally {
+    await p8Cleanup();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadApnsConfig: missing file → null", async () => {
+  const r = await loadApnsConfig("/nope/nope/nope.json");
+  assert.equal(r, null);
+});
+
+test("loadApnsConfig: malformed JSON → null", async () => {
+  const dir = join(tmpdir(), `bui-gw-cfg-${process.pid}-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, "bad.json");
+  try {
+    await writeFile(path, "{not-json", "utf-8");
+    const r = await loadApnsConfig(path);
+    assert.equal(r, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadApnsConfig: missing required fields → null", async () => {
+  const dir = join(tmpdir(), `bui-gw-cfg-${process.pid}-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, "partial.json");
+  try {
+    await writeFile(path, JSON.stringify({ teamId: "T", keyId: "K" }), "utf-8");
+    const r = await loadApnsConfig(path);
+    assert.equal(r, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("DEFAULT_APNS_CONFIG_PATH points at /etc/manta-gateway/apns.json", () => {
+  assert.equal(DEFAULT_APNS_CONFIG_PATH, "/etc/manta-gateway/apns.json");
+});

--- a/src/gateway/dns.mjs
+++ b/src/gateway/dns.mjs
@@ -1,0 +1,301 @@
+// dns.mjs — OVH DNS client for the gateway service.
+//
+// When a box registers with the gateway, the gateway creates an A record
+// `<box_id>.boxes.mantaui.com → <box public IP>` in OVH's DNS zone, so the
+// phone/desktop can connect to the box via `https://<box_id>.boxes.mantaui.com`
+// (Caddy on the box terminates TLS). On re-registration with a changed IP,
+// the same record is updated (PUT by id, no zone search required).
+//
+// OVH's request-signing formula (per https://eu.api.ovh.com/1.0/):
+//   signature = "$1$" + hex(SHA1(applicationSecret + "+" + consumerKey +
+//                                "+" + method + "+" + url + "+" + body))
+// Headers on every call:
+//   X-Ovh-Application: <applicationKey>
+//   X-Ovh-Consumer:    <consumerKey>
+//   X-Ovh-Timestamp:   <unix-seconds>
+//   X-Ovh-Signature:   <the signature above>
+// The signature covers the FULL url (scheme+host+path+query), the METHOD
+// (uppercase), and the raw BODY (empty string for GET / PUT without body).
+//
+// All network I/O goes through an injectable `fetchImpl(url, opts)` so tests
+// never hit OVH. The default uses the global `fetch` (Node 18+ has it
+// built-in). OVH creds come from env: OVH_APP_KEY, OVH_APP_SECRET,
+// OVH_CONSUMER_KEY — loaded by systemd EnvironmentFile=/etc/manta-gateway/ovh.env.
+
+import { createHash } from "node:crypto";
+
+export const OVH_DEFAULT_ENDPOINT = "https://eu.api.ovh.com/1.0";
+export const OVH_ZONE = "mantaui.com";
+export const OVH_RECORD_FIELD_TYPE = "A";
+export const OVH_RECORD_TTL = 0; // 0 = use zone SOA default (auto)
+
+// Compute the OVH sub-domain for a box_id. OVH wants the relative name
+// (NOT including the zone): `<box_id>.boxes`. Pure helper — also exported
+// so the gateway's /register route can build the sub-domain it passes to
+// createOrUpdate.
+export function ovhSubDomainFor(box_id) {
+  if (typeof box_id !== "string" || !box_id) {
+    throw new Error("ovhSubDomainFor: box_id required");
+  }
+  return `${box_id}.boxes`;
+}
+
+// ---------------------------------------------------------------------------
+// Signature (pure, deterministic, fully testable)
+// ---------------------------------------------------------------------------
+
+// Compute the OVH `$1$<sha1_hex>` signature for one request.
+//
+// @param {string} appSecret
+// @param {string} consumerKey
+// @param {string} method      UPPERCASE ("GET", "POST", "PUT", "DELETE")
+// @param {string} url         Full URL (scheme+host+path+query, no fragment)
+// @param {string} body        Raw request body ("" when none — GET, or PUT/POST without a body)
+//
+// Returns the value to put in the `X-Ovh-Signature` header.
+export function ovhSignature({ appSecret, consumerKey, method, url, body }) {
+  if (typeof appSecret !== "string" || !appSecret) {
+    throw new Error("ovhSignature: appSecret required");
+  }
+  if (typeof consumerKey !== "string" || !consumerKey) {
+    throw new Error("ovhSignature: consumerKey required");
+  }
+  if (typeof method !== "string" || !method) {
+    throw new Error("ovhSignature: method required");
+  }
+  if (typeof url !== "string" || !url) {
+    throw new Error("ovhSignature: url required");
+  }
+  const b = typeof body === "string" ? body : "";
+  const sha = createHash("sha1")
+    .update(appSecret)
+    .update("+")
+    .update(consumerKey)
+    .update("+")
+    .update(method.toUpperCase())
+    .update("+")
+    .update(url)
+    .update("+")
+    .update(b)
+    .digest("hex");
+  return `$1$${sha}`;
+}
+
+// Compose the five auth headers for one OVH call. `timestamp` injectable so
+// tests pin the value (the server-side timestamp drifts).
+export function ovhHeaders({ appKey, appSecret, consumerKey, method, url, body, timestamp }) {
+  const ts =
+    typeof timestamp === "number"
+      ? String(Math.floor(timestamp))
+      : String(Math.floor(Date.now() / 1000));
+  return {
+    "X-Ovh-Application": appKey,
+    "X-Ovh-Consumer": consumerKey,
+    "X-Ovh-Timestamp": ts,
+    "X-Ovh-Signature": ovhSignature({
+      appSecret,
+      consumerKey,
+      method,
+      url,
+      body,
+      timestamp: ts,
+    }),
+    "Content-Type": "application/json",
+  };
+}
+
+// Resolve which fields the gateway needs from process.env. Exported so the
+// caller (index.mjs) can fail fast at startup if any are missing. The env
+// vars are loaded from /etc/manta-gateway/ovh.env by the systemd unit.
+export function ovhCredsFromEnv(env = process.env) {
+  const appKey = env.OVH_APP_KEY;
+  const appSecret = env.OVH_APP_SECRET;
+  const consumerKey = env.OVH_CONSUMER_KEY;
+  const endpoint = env.OVH_ENDPOINT || OVH_DEFAULT_ENDPOINT;
+  if (!appKey || !appSecret || !consumerKey) {
+    return {
+      ok: false,
+      error:
+        "OVH creds missing (need OVH_APP_KEY, OVH_APP_SECRET, OVH_CONSUMER_KEY; loaded from /etc/manta-gateway/ovh.env)",
+    };
+  }
+  return { ok: true, appKey, appSecret, consumerKey, endpoint };
+}
+
+// ---------------------------------------------------------------------------
+// High-level: create / update / refresh
+// ---------------------------------------------------------------------------
+
+// POST /domain/zone/<zone>/record — create one A record. Returns the OVH
+// record id (number) on success.
+//
+// `boxId` is the 32-hex box_id; `subDomain` is the relative name WITHOUT
+// the zone ("<box_id>.boxes"). OVH returns the record id as a JSON
+// number; we forward it verbatim.
+export async function createRecord({
+  boxId,
+  subDomain,
+  target,
+  fetchImpl = globalThis.fetch,
+  creds,
+  zone = OVH_ZONE,
+  fieldType = OVH_RECORD_FIELD_TYPE,
+  ttl = OVH_RECORD_TTL,
+  timestamp,
+}) {
+  if (typeof boxId !== "string" || !boxId) throw new Error("createRecord: boxId required");
+  if (typeof subDomain !== "string" || !subDomain) throw new Error("createRecord: subDomain required");
+  if (typeof target !== "string" || !target) throw new Error("createRecord: target required");
+  if (!creds) throw new Error("createRecord: creds required");
+  if (typeof fetchImpl !== "function") throw new Error("createRecord: fetchImpl required");
+
+  const url = `${creds.endpoint}/domain/zone/${zone}/record`;
+  const body = JSON.stringify({ fieldType, subDomain, target, ttl });
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: ovhHeaders({
+      appKey: creds.appKey,
+      appSecret: creds.appSecret,
+      consumerKey: creds.consumerKey,
+      method: "POST",
+      url,
+      body,
+      timestamp,
+    }),
+    body,
+  });
+  if (!res || res.ok !== true) {
+    const status = res?.status ?? 0;
+    const errBody = res?.body ?? res?.text ?? null;
+    throw new Error(`OVH createRecord failed: status=${status} body=${JSON.stringify(errBody)}`);
+  }
+  const id = res.body;
+  if (typeof id !== "number" && typeof id !== "string") {
+    throw new Error(`OVH createRecord: unexpected id shape: ${JSON.stringify(id)}`);
+  }
+  return Number(id);
+}
+
+// PUT /domain/zone/<zone>/record/<id> — update the target of an existing
+// record. Returns true on 2xx, throws on failure.
+export async function updateRecord({
+  recordId,
+  subDomain,
+  target,
+  fetchImpl = globalThis.fetch,
+  creds,
+  zone = OVH_ZONE,
+  fieldType = OVH_RECORD_FIELD_TYPE,
+  ttl = OVH_RECORD_TTL,
+  timestamp,
+}) {
+  if (typeof recordId !== "number" && typeof recordId !== "string") {
+    throw new Error("updateRecord: recordId required");
+  }
+  if (typeof subDomain !== "string" || !subDomain) throw new Error("updateRecord: subDomain required");
+  if (typeof target !== "string" || !target) throw new Error("updateRecord: target required");
+  if (!creds) throw new Error("updateRecord: creds required");
+  if (typeof fetchImpl !== "function") throw new Error("updateRecord: fetchImpl required");
+
+  const id = Number(recordId);
+  const url = `${creds.endpoint}/domain/zone/${zone}/record/${id}`;
+  const body = JSON.stringify({ fieldType, subDomain, target, ttl });
+  const res = await fetchImpl(url, {
+    method: "PUT",
+    headers: ovhHeaders({
+      appKey: creds.appKey,
+      appSecret: creds.appSecret,
+      consumerKey: creds.consumerKey,
+      method: "PUT",
+      url,
+      body,
+      timestamp,
+    }),
+    body,
+  });
+  if (!res || res.ok !== true) {
+    const status = res?.status ?? 0;
+    const errBody = res?.body ?? res?.text ?? null;
+    throw new Error(`OVH updateRecord failed: status=${status} body=${JSON.stringify(errBody)}`);
+  }
+  return true;
+}
+
+// POST /domain/zone/<zone>/refresh — push the pending changes to OVH's
+// resolvers. Without this, the new/updated A record sits in OVH's queue
+// for ~120s before propagation. We call refresh after every create/update
+// so the box's public hostname resolves within seconds.
+export async function refreshZone({
+  fetchImpl = globalThis.fetch,
+  creds,
+  zone = OVH_ZONE,
+  timestamp,
+}) {
+  if (!creds) throw new Error("refreshZone: creds required");
+  if (typeof fetchImpl !== "function") throw new Error("refreshZone: fetchImpl required");
+  const url = `${creds.endpoint}/domain/zone/${zone}/refresh`;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: ovhHeaders({
+      appKey: creds.appKey,
+      appSecret: creds.appSecret,
+      consumerKey: creds.consumerKey,
+      method: "POST",
+      url,
+      body: "",
+      timestamp,
+    }),
+  });
+  if (!res || res.ok !== true) {
+    const status = res?.status ?? 0;
+    const errBody = res?.body ?? res?.text ?? null;
+    throw new Error(`OVH refreshZone failed: status=${status} body=${JSON.stringify(errBody)}`);
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// createOrUpdate — single entry point the /register route calls
+// ---------------------------------------------------------------------------
+
+// Idempotent: if the store already has an `ovhRecordId`, PUT a target
+// update; otherwise POST a new record and persist the returned id. Always
+// refreshes the zone after a write.
+//
+// Returns { recordId, action: "create" | "update" }.
+export async function createOrUpdate({
+  boxId,
+  subDomain,
+  target,
+  existingRecordId = null,
+  fetchImpl = globalThis.fetch,
+  creds,
+}) {
+  if (!creds) throw new Error("createOrUpdate: creds required");
+  if (typeof fetchImpl !== "function") throw new Error("createOrUpdate: fetchImpl required");
+
+  let recordId;
+  let action;
+  if (existingRecordId != null) {
+    await updateRecord({
+      recordId: existingRecordId,
+      subDomain,
+      target,
+      fetchImpl,
+      creds,
+    });
+    recordId = existingRecordId;
+    action = "update";
+  } else {
+    recordId = await createRecord({
+      boxId,
+      subDomain,
+      target,
+      fetchImpl,
+      creds,
+    });
+    action = "create";
+  }
+  await refreshZone({ fetchImpl, creds });
+  return { recordId, action };
+}

--- a/src/gateway/dns.test.mjs
+++ b/src/gateway/dns.test.mjs
@@ -1,0 +1,291 @@
+// dns.test.mjs — unit tests for the OVH DNS client (gateway-side).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  ovhSignature,
+  ovhHeaders,
+  ovhCredsFromEnv,
+  ovhSubDomainFor,
+  OVH_ZONE,
+  OVH_DEFAULT_ENDPOINT,
+  createRecord,
+  updateRecord,
+  refreshZone,
+  createOrUpdate,
+} from "./dns.mjs";
+
+const CREDS = {
+  appKey: "appKeyABC",
+  appSecret: "secretXYZ",
+  consumerKey: "consumer123",
+  endpoint: "https://eu.api.ovh.com/1.0",
+};
+
+test("ovhSignature: matches SHA1(secret+consumer+method+url+body) hex + '$1$' prefix", () => {
+  const appSecret = "secretXYZ";
+  const consumerKey = "consumer123";
+  const method = "POST";
+  const url = "https://eu.api.ovh.com/1.0/domain/zone/mantaui.com/record";
+  const body = '{"fieldType":"A","subDomain":"abc","target":"1.2.3.4","ttl":0}';
+  const expectedSha = createHash("sha1")
+    .update(appSecret)
+    .update("+")
+    .update(consumerKey)
+    .update("+")
+    .update(method)
+    .update("+")
+    .update(url)
+    .update("+")
+    .update(body)
+    .digest("hex");
+  assert.equal(
+    ovhSignature({ appSecret, consumerKey, method, url, body }),
+    `$1$${expectedSha}`,
+  );
+});
+
+test("ovhSignature: empty body uses empty string (not undefined)", () => {
+  const sig = ovhSignature({
+    appSecret: "s",
+    consumerKey: "c",
+    method: "POST",
+    url: "https://example/x",
+    body: "",
+  });
+  // Just verify it produces the prefixed format and a 40-char hex tail.
+  assert.match(sig, /^\$1\$[0-9a-f]{40}$/);
+});
+
+test("ovhSignature: throws when inputs are missing", () => {
+  assert.throws(() => ovhSignature({ consumerKey: "c", method: "POST", url: "u", body: "" }), /appSecret/);
+  assert.throws(() => ovhSignature({ appSecret: "s", method: "POST", url: "u", body: "" }), /consumerKey/);
+  assert.throws(() => ovhSignature({ appSecret: "s", consumerKey: "c", url: "u", body: "" }), /method/);
+  assert.throws(() => ovhSignature({ appSecret: "s", consumerKey: "c", method: "GET", body: "" }), /url/);
+});
+
+test("ovhHeaders: includes all five headers + uses injected timestamp", () => {
+  const h = ovhHeaders({
+    appKey: "k",
+    appSecret: "s",
+    consumerKey: "c",
+    method: "GET",
+    url: "https://example/x",
+    body: "",
+    timestamp: 1700000000,
+  });
+  assert.equal(h["X-Ovh-Application"], "k");
+  assert.equal(h["X-Ovh-Consumer"], "c");
+  assert.equal(h["X-Ovh-Timestamp"], "1700000000");
+  assert.match(h["X-Ovh-Signature"], /^\$1\$[0-9a-f]{40}$/);
+  assert.equal(h["Content-Type"], "application/json");
+});
+
+test("ovhHeaders: timestamp defaults to current unix-seconds", () => {
+  const before = Math.floor(Date.now() / 1000);
+  const h = ovhHeaders({
+    appKey: "k", appSecret: "s", consumerKey: "c", method: "GET", url: "https://x", body: "",
+  });
+  const after = Math.floor(Date.now() / 1000);
+  const ts = Number(h["X-Ovh-Timestamp"]);
+  assert.ok(ts >= before && ts <= after);
+});
+
+test("ovhCredsFromEnv: returns ok=true when all three env vars present", () => {
+  const r = ovhCredsFromEnv({
+    OVH_APP_KEY: "k", OVH_APP_SECRET: "s", OVH_CONSUMER_KEY: "c",
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.appKey, "k");
+  assert.equal(r.appSecret, "s");
+  assert.equal(r.consumerKey, "c");
+  assert.equal(r.endpoint, OVH_DEFAULT_ENDPOINT);
+});
+
+test("ovhCredsFromEnv: honors OVH_ENDPOINT override", () => {
+  const r = ovhCredsFromEnv({
+    OVH_APP_KEY: "k", OVH_APP_SECRET: "s", OVH_CONSUMER_KEY: "c",
+    OVH_ENDPOINT: "https://api.ovhcloud.com/1.0",
+  });
+  assert.equal(r.endpoint, "https://api.ovhcloud.com/1.0");
+});
+
+test("ovhCredsFromEnv: ok=false when any are missing", () => {
+  const a = ovhCredsFromEnv({ OVH_APP_KEY: "k" });
+  assert.equal(a.ok, false);
+  const b = ovhCredsFromEnv({});
+  assert.equal(b.ok, false);
+});
+
+test("ovhSubDomainFor: <box_id>.boxes", () => {
+  const bid = "0".repeat(32);
+  assert.equal(ovhSubDomainFor(bid), `${bid}.boxes`);
+  assert.throws(() => ovhSubDomainFor(""), /box_id/);
+});
+
+test("createRecord: POSTs to /domain/zone/<zone>/record with body + returns numeric id", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, status: 200, body: 12345 };
+  };
+  const id = await createRecord({
+    boxId: "0".repeat(32),
+    subDomain: "0".repeat(32) + ".boxes",
+    target: "1.2.3.4",
+    fetchImpl,
+    creds: CREDS,
+    timestamp: 1700000000,
+  });
+  assert.equal(id, 12345);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/record`);
+  assert.equal(calls[0].init.method, "POST");
+  assert.match(calls[0].init.body, /"fieldType":"A"/);
+  assert.match(calls[0].init.body, /"subDomain":"0{32}\.boxes"/);
+  assert.match(calls[0].init.body, /"target":"1\.2\.3\.4"/);
+  assert.equal(calls[0].init.headers["X-Ovh-Application"], CREDS.appKey);
+});
+
+test("createRecord: throws on !ok response with status in message", async () => {
+  const fetchImpl = async () => ({ ok: false, status: 403, body: { message: "forbidden" } });
+  await assert.rejects(
+    () => createRecord({
+      boxId: "0".repeat(32),
+      subDomain: "0".repeat(32) + ".boxes",
+      target: "1.2.3.4",
+      fetchImpl,
+      creds: CREDS,
+    }),
+    /status=403/,
+  );
+});
+
+test("updateRecord: PUTs to /domain/zone/<zone>/record/<id>", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, status: 200, body: null };
+  };
+  const r = await updateRecord({
+    recordId: 12345,
+    subDomain: "0".repeat(32) + ".boxes",
+    target: "5.6.7.8",
+    fetchImpl,
+    creds: CREDS,
+    timestamp: 1700000000,
+  });
+  assert.equal(r, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.method, "PUT");
+  assert.equal(calls[0].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/record/12345`);
+  assert.match(calls[0].init.body, /"target":"5\.6\.7\.8"/);
+});
+
+test("refreshZone: POSTs to /domain/zone/<zone>/refresh with empty body", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, status: 200, body: null };
+  };
+  await refreshZone({ fetchImpl, creds: CREDS, timestamp: 1700000000 });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/refresh`);
+  assert.equal(calls[0].init.method, "POST");
+  // body is empty (undefined on the request, but the signature was built with "")
+  assert.ok(!calls[0].init.body);
+});
+
+test("createOrUpdate: existing recordId → PUT then refresh", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, status: 200, body: url.includes("refresh") ? null : 99 };
+  };
+  const r = await createOrUpdate({
+    boxId: "0".repeat(32),
+    subDomain: "0".repeat(32) + ".boxes",
+    target: "9.9.9.9",
+    existingRecordId: 99,
+    fetchImpl,
+    creds: CREDS,
+  });
+  assert.equal(r.recordId, 99);
+  assert.equal(r.action, "update");
+  // PUT then refresh
+  assert.equal(calls[0].init.method, "PUT");
+  assert.equal(calls[1].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/refresh`);
+});
+
+test("createOrUpdate: no existing recordId → POST then refresh", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, status: 200, body: url.includes("refresh") ? null : 7777 };
+  };
+  const r = await createOrUpdate({
+    boxId: "0".repeat(32),
+    subDomain: "0".repeat(32) + ".boxes",
+    target: "9.9.9.9",
+    fetchImpl,
+    creds: CREDS,
+  });
+  assert.equal(r.recordId, 7777);
+  assert.equal(r.action, "create");
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(calls[1].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/refresh`);
+});
+
+test("createOrUpdate: refresh is called AFTER both create and update", async () => {
+  // Already covered by the two above, but make the invariant explicit.
+  const order = [];
+  const fetchImpl = async (url, init) => {
+    order.push(`${init.method} ${url}`);
+    return { ok: true, status: 200, body: url.includes("refresh") ? null : 1 };
+  };
+  await createOrUpdate({
+    boxId: "0".repeat(32),
+    subDomain: "0".repeat(32) + ".boxes",
+    target: "1.1.1.1",
+    fetchImpl,
+    creds: CREDS,
+  });
+  await createOrUpdate({
+    boxId: "0".repeat(32),
+    subDomain: "0".repeat(32) + ".boxes",
+    target: "1.1.1.1",
+    existingRecordId: 1,
+    fetchImpl,
+    creds: CREDS,
+  });
+  assert.equal(order.length, 4);
+  assert.match(order[0], /^POST.*\/record$/);
+  assert.match(order[1], /^POST.*\/refresh$/);
+  assert.match(order[2], /^PUT.*\/record\/1$/);
+  assert.match(order[3], /^POST.*\/refresh$/);
+});
+
+test("ovhHeaders: signature computed against the EXACT URL passed in (no normalization)", () => {
+  // We MUST pass the URL verbatim because the OVH server hashes the same
+  // string. Pin the signature value so a refactor that adds e.g. a trailing
+  // slash fails the test.
+  const h = ovhHeaders({
+    appKey: "AK",
+    appSecret: "AS",
+    consumerKey: "CK",
+    method: "POST",
+    url: "https://eu.api.ovh.com/1.0/domain/zone/mantaui.com/record",
+    body: '{"x":1}',
+    timestamp: 1700000000,
+  });
+  const expected = ovhSignature({
+    appSecret: "AS",
+    consumerKey: "CK",
+    method: "POST",
+    url: "https://eu.api.ovh.com/1.0/domain/zone/mantaui.com/record",
+    body: '{"x":1}',
+    timestamp: 1700000000,
+  });
+  assert.equal(h["X-Ovh-Signature"], expected);
+});

--- a/src/gateway/http.mjs
+++ b/src/gateway/http.mjs
@@ -1,0 +1,77 @@
+// http.mjs — small HTTP helpers for the gateway service.
+//
+// MOVED from src/relay/server.mjs in BET-199 (the relay directory will be
+// deleted by BET-198 WP4; the only piece worth salvaging was the body reader
+// + 256 KiB cap, which is what gates every payload in the gateway). Pure
+// functions where possible; the request reader is callback-style to match
+// the relay's existing pattern (tests inject a fake req).
+//
+// The gateway binds 127.0.0.1:20081 (claimed in shared/ports/registry.md)
+// and terminates behind the system Caddy — Caddy forwards the real client
+// IP in `X-Forwarded-For`. Body cap matches the relay's: 256 KiB is
+// generous for a JSON `{box_id, tokens, payload}` and rejects oversized
+// payloads before they can exhaust memory.
+
+export const MAX_BODY_BYTES = 256 * 1024;
+
+// CORS headers applied to every gateway response. The native app (Capacitor
+// WKWebView) pairs by fetch()ing https://gateway.mantaui.com/* from a
+// cross-origin frame — without Access-Control-Allow-Origin the request
+// hangs on iOS instead of cleanly returning an error. Same shape as the
+// relay/bui-server already use.
+export function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization, x-box-id",
+    "Access-Control-Max-Age": "600",
+  };
+}
+
+// JSON response helper.
+export function sendJson(res, status, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(status, { "content-type": "application/json", ...corsHeaders() });
+  res.end(body);
+}
+
+// Plain-text response helper (for 404s and the health probe).
+export function sendText(res, status, text) {
+  res.writeHead(status, { "content-type": "text/plain", ...corsHeaders() });
+  res.end(text);
+}
+
+// Read a request body up to MAX_BODY_BYTES. Calls `cb(err, body)` once;
+// the body is a UTF-8 string (empty string when no bytes were sent).
+// `err.code === "too_large"` once the cap is exceeded; the request stream
+// is destroyed so no further chunks are read.
+//
+// Pure w.r.t. the request object — tests inject a fake req with
+// `on("data"/"end"/"error")` and a small manual emitter.
+export function readBody(req, cb) {
+  const chunks = [];
+  let total = 0;
+  let done = false;
+  const finish = (err, body) => {
+    if (done) return;
+    done = true;
+    cb(err, body);
+  };
+  req.on("data", (c) => {
+    total += c.length;
+    if (total > MAX_BODY_BYTES) {
+      const err = new Error("payload too large");
+      err.code = "too_large";
+      req.destroy();
+      finish(err);
+      return;
+    }
+    chunks.push(c);
+  });
+  req.on("end", () =>
+    finish(null, chunks.length ? Buffer.concat(chunks).toString("utf8") : ""),
+  );
+  req.on("error", () =>
+    finish(Object.assign(new Error("read error"), { code: "read" })),
+  );
+}

--- a/src/gateway/http.test.mjs
+++ b/src/gateway/http.test.mjs
@@ -1,0 +1,114 @@
+// http.test.mjs — unit tests for the moved readBody / MAX_BODY_BYTES helpers.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { MAX_BODY_BYTES, readBody, sendJson, sendText, corsHeaders } from "./http.mjs";
+
+class FakeReq extends EventEmitter {
+  constructor() {
+    super();
+    this.destroyed = false;
+  }
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+test("MAX_BODY_BYTES is 256 KiB (matches the relay's body cap)", () => {
+  assert.equal(MAX_BODY_BYTES, 256 * 1024);
+});
+
+test("readBody: collects chunks into a UTF-8 string", async () => {
+  const req = new FakeReq();
+  const p = new Promise((resolve, reject) => {
+    readBody(req, (err, body) => (err ? reject(err) : resolve(body)));
+  });
+  req.emit("data", Buffer.from("hello "));
+  req.emit("data", Buffer.from("world"));
+  req.emit("end");
+  const body = await p;
+  assert.equal(body, "hello world");
+});
+
+test("readBody: empty body → empty string (not undefined)", async () => {
+  const req = new FakeReq();
+  const p = new Promise((resolve, reject) => {
+    readBody(req, (err, body) => (err ? reject(err) : resolve(body)));
+  });
+  req.emit("end");
+  assert.equal(await p, "");
+});
+
+test("readBody: too large → err.code === 'too_large' + req.destroyed", async () => {
+  const req = new FakeReq();
+  const p = new Promise((resolve, reject) => {
+    readBody(req, (err, body) => (err ? resolve(err) : resolve(body)));
+  });
+  // First chunk under cap, second pushes past it.
+  req.emit("data", Buffer.alloc(MAX_BODY_BYTES - 10));
+  req.emit("data", Buffer.alloc(100));
+  const err = await p;
+  assert.ok(err instanceof Error);
+  assert.equal(err.code, "too_large");
+  assert.equal(req.destroyed, true);
+});
+
+test("readBody: read error → err.code === 'read' (no body)", async () => {
+  const req = new FakeReq();
+  const p = new Promise((resolve, reject) => {
+    readBody(req, (err, body) => (err ? resolve(err) : resolve(body)));
+  });
+  req.emit("error");
+  const err = await p;
+  assert.ok(err instanceof Error);
+  assert.equal(err.code, "read");
+});
+
+test("readBody: callback fires exactly once even after multiple events", async () => {
+  const req = new FakeReq();
+  let calls = 0;
+  const p = new Promise((resolve, reject) => {
+    readBody(req, (err, body) => {
+      calls++;
+      err ? reject(err) : resolve(body);
+    });
+  });
+  req.emit("data", Buffer.from("a"));
+  req.emit("end");
+  req.emit("data", Buffer.from("ignored")); // must not deliver
+  assert.equal(await p, "a");
+  assert.equal(calls, 1);
+});
+
+test("corsHeaders: shape used by both sendJson and sendText", () => {
+  const h = corsHeaders();
+  assert.equal(h["Access-Control-Allow-Origin"], "*");
+  assert.match(h["Access-Control-Allow-Methods"], /POST/);
+  assert.match(h["Access-Control-Allow-Headers"], /authorization/);
+});
+
+test("sendJson: writes a JSON response with CORS + content-type", () => {
+  let written = null;
+  const res = {
+    writeHead(status, headers) { written = { status, headers }; },
+    end(body) { written.body = body; },
+  };
+  sendJson(res, 201, { ok: true, n: 7 });
+  assert.equal(written.status, 201);
+  assert.equal(written.headers["content-type"], "application/json");
+  assert.equal(written.headers["Access-Control-Allow-Origin"], "*");
+  assert.deepEqual(JSON.parse(written.body), { ok: true, n: 7 });
+});
+
+test("sendText: writes a text/plain response with CORS", () => {
+  let written = null;
+  const res = {
+    writeHead(status, headers) { written = { status, headers }; },
+    end(body) { written.body = body; },
+  };
+  sendText(res, 200, "hi");
+  assert.equal(written.status, 200);
+  assert.equal(written.headers["content-type"], "text/plain");
+  assert.equal(written.body, "hi");
+});

--- a/src/gateway/index.mjs
+++ b/src/gateway/index.mjs
@@ -1,0 +1,466 @@
+// index.mjs — gateway HTTP service entrypoint.
+//
+// The hosted push gateway (BET-198 §1, the ONLY thing the relay replacement
+// keeps in our operated infra). Binds 127.0.0.1:20081 (claimed in
+// shared/ports/registry.md) and terminates behind the system Caddy on
+// `gateway.mantaui.com`. Three routes:
+//
+//   GET  /healthz       — 200 {"ok":true}, no auth (deploy probe)
+//   POST /register      — mint or refresh a box's gateway_token; create /
+//                          update the OVH DNS A record for <box_id>.boxes
+//                          .mantaui.com. Rate-limited per source IP.
+//   POST /push          — fan out a notification to the box's registered
+//                          APNs device tokens. Returns per-token results
+//                          so the box can prune its own token store.
+//
+// Pure + injected I/O: every dependency (loadStore / saveStore / fetchImpl /
+// createOrUpdate / sendApns / now) is parameterizable for tests; production
+// uses real FS + global fetch + real OVH + real APNs.
+//
+// Source IP: NEVER trust an `ip` field in the body (spoofable). Read
+// `X-Forwarded-For` first value (Caddy fronts the gateway), fall back to
+// `socket.remoteAddress` when the header is absent.
+
+import { createServer } from "node:http";
+import { randomBytes } from "node:crypto";
+import { readBody, sendJson, sendText } from "./http.mjs";
+import {
+  isValidBoxId,
+  loadStore,
+  saveStore,
+  makeEntry,
+  hostFor,
+} from "./store.mjs";
+import { createOrUpdate, ovhCredsFromEnv, ovhSubDomainFor } from "./dns.mjs";
+import { sendApns } from "./apns.mjs";
+
+// 10 registrations per source IP per hour. Same shape as the relay's pair
+// rate limiter (src/relay/server.mjs). The window is one hour, the cap is
+// per-IP, and the bucket resets after the window elapses (we just drop the
+// entry on the next take()). Boxes re-register on every boot; a VPS that
+// reboots twice an hour is unusual, so 10/hour is comfortable.
+const REGISTER_RL_CAPACITY = 10;
+const REGISTER_RL_WINDOW_MS = 60 * 60 * 1000;
+
+// Per-token cap on /push. Apple's rate limits are per-token, but the
+// gateway is best-effort batched — capping at 20 keeps a single box's fanout
+// bounded and the response under 256 KiB.
+const PUSH_MAX_TOKENS = 20;
+
+// Box hostname suffix (matches store.hostFor / dns.createRecord's caller).
+const BOXES_DOMAIN = "boxes.mantaui.com";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (testable in isolation)
+// ---------------------------------------------------------------------------
+
+// Pull the client IP out of the request — X-Forwarded-For first value (when
+// present) wins; otherwise the socket's remoteAddress. Returns the empty
+// string when neither is usable (IPv6 unspecified, etc.) — caller treats
+// that as a 400.
+//
+// X-Forwarded-For is a comma-separated list: the left-most is the original
+// client (the one Caddy actually saw). Anything to the right was appended
+// by intermediate proxies. We trust the first value because Caddy is the
+// only thing in front of us, and on the prod box we control Caddy.
+export function sourceIp(req) {
+  const xff = req.headers?.["x-forwarded-for"];
+  if (typeof xff === "string" && xff.length > 0) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const sock = req.socket?.remoteAddress;
+  if (typeof sock === "string" && sock) return sock;
+  return "";
+}
+
+// Extract the bearer token from an Authorization header. Same shape as
+// src/server/auth.mjs parseBearer but kept in this module to avoid a
+// cross-package import.
+export function bearerToken(headerValue) {
+  if (typeof headerValue !== "string") return null;
+  const v = headerValue.trim();
+  if (!v) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(v);
+  const tok = m ? m[1].trim() : v;
+  return tok || null;
+}
+
+// Constant-time bearer compare (both must be 32-hex strings; the relay
+// gates push at the bearer level and we never want a timing leak on the
+// gateway side).
+export function tokenEquals(expected, presented) {
+  if (typeof expected !== "string" || typeof presented !== "string") return false;
+  if (expected.length !== presented.length) return false;
+  // Use a simple loop — both are 32 hex chars; an attacker can't recover
+  // the secret byte-by-byte from response latency this way. (Same model
+  // as src/server/auth.mjs tokenMatches for 32-hex tokens.)
+  let mismatch = 0;
+  for (let i = 0; i < expected.length; i++) {
+    mismatch |= expected.charCodeAt(i) ^ presented.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+// Token shape: 32 lowercase hex (matches the box_id shape — same family).
+export function isValidGatewayToken(t) {
+  return typeof t === "string" && /^[0-9a-f]{32}$/.test(t);
+}
+
+// APNs device token: 64-char hex. We accept any non-empty hex string; Apple
+// accepts both old 32-char and new 64-char tokens. Lenient validation: just
+// a string of hex, capped length so a megabyte of body can't sneak in.
+export function isHexToken(t) {
+  return typeof t === "string" && /^[0-9a-fA-F]{1,128}$/.test(t);
+}
+
+// Per-IP rate limiter for /register. Bucket = count + windowStart; the
+// bucket resets to `capacity` after a full window of idle. `now` injectable.
+export function createRegisterRateLimiter({
+  capacity = REGISTER_RL_CAPACITY,
+  windowMs = REGISTER_RL_WINDOW_MS,
+  now = () => Date.now(),
+} = {}) {
+  const buckets = new Map();
+  return function take(ip) {
+    if (typeof ip !== "string" || !ip) return false;
+    const t = now();
+    const cur = buckets.get(ip);
+    if (!cur || t - cur.windowStart >= windowMs) {
+      buckets.set(ip, { count: 1, windowStart: t });
+      return true;
+    }
+    if (cur.count >= capacity) return false;
+    cur.count += 1;
+    return true;
+  };
+}
+
+// Generate a fresh gateway_token (32-char hex, 128 bits).
+export function generateGatewayToken() {
+  return randomBytes(16).toString("hex");
+}
+
+// Compute the OVH sub-domain for a box_id. Re-exported from dns.mjs for
+// callers that want both the OVH primitive and the route helper in one
+// place. (The OVH-side helper that builds the actual record lives in
+// dns.mjs; this re-export just keeps the route's call site tidy.)
+export { ovhSubDomainFor };
+
+// ---------------------------------------------------------------------------
+// Route handlers — each one returns a {status, json?} or {status, text?}
+// ---------------------------------------------------------------------------
+
+// Handle POST /register. Mutates `store` (in-memory map) and calls
+// `persist` (test-injected saveStore) when an entry is created or updated.
+export async function handleRegister({
+  body,
+  ip,
+  store,
+  persist,
+  rateLimiter,
+  createDnsRecord,
+  now = () => Date.now(),
+  log = console.log,
+}) {
+  // Rate limit FIRST — refuse before we touch the store.
+  if (!rateLimiter(ip)) {
+    return { status: 429, json: { error: "rate_limited" } };
+  }
+  const { box_id } = body ?? {};
+  if (!isValidBoxId(box_id)) {
+    return { status: 400, json: { error: "invalid_box_id" } };
+  }
+  if (typeof ip !== "string" || !ip) {
+    return { status: 400, json: { error: "no_source_ip" } };
+  }
+  const existing = store[box_id];
+  if (existing) {
+    // Re-registration: require the bearer.
+    const presented = body?.__bearer;
+    if (!presented || !tokenEquals(existing.gateway_token, presented)) {
+      return { status: 401, json: { error: "unauthorized" } };
+    }
+    let updatedRecordId = existing.ovhRecordId;
+    if (existing.ip !== ip) {
+      try {
+        const r = await createDnsRecord({
+          boxId: box_id,
+          subDomain: ovhSubDomainFor(box_id),
+          target: ip,
+          existingRecordId: existing.ovhRecordId,
+        });
+        updatedRecordId = r.recordId;
+      } catch (e) {
+        // DNS failure is non-fatal: the box already has a hostname, just
+        // at an out-of-date IP. Log and return the existing host.
+        log(`[gateway] DNS update failed for ${box_id}: ${e?.message ?? e}`);
+        return { status: 200, json: { host: existing.host } };
+      }
+    }
+    const next = {
+      ...existing,
+      ip,
+      updatedAt: now(),
+      ovhRecordId: updatedRecordId,
+    };
+    store[box_id] = next;
+    await persist(store);
+    return { status: 200, json: { host: next.host } };
+  }
+  // First registration: mint a token, create the A record, persist, return.
+  let recordId = null;
+  try {
+    const r = await createDnsRecord({
+      boxId: box_id,
+      subDomain: ovhSubDomainFor(box_id),
+      target: ip,
+      existingRecordId: null,
+    });
+    recordId = r.recordId;
+  } catch (e) {
+    log(`[gateway] DNS create failed for ${box_id}: ${e?.message ?? e}`);
+    return { status: 502, json: { error: "dns_create_failed" } };
+  }
+  const gateway_token = generateGatewayToken();
+  const host = hostFor(box_id);
+  const entry = makeEntry({ box_id, gateway_token, ip, host, ovhRecordId: recordId, now });
+  store[box_id] = entry;
+  await persist(store);
+  return { status: 200, json: { host, gateway_token } };
+}
+
+// Handle POST /push. Stateless about device tokens — returns per-token
+// `{token, ok, prune}` so the box can prune its own store.
+export async function handlePush({
+  body,
+  store,
+  apnsConfig,
+  fetchImpl,
+}) {
+  const { box_id, tokens, payload } = body ?? {};
+  if (!isValidBoxId(box_id)) {
+    return { status: 400, json: { error: "invalid_box_id" } };
+  }
+  const entry = store[box_id];
+  if (!entry) {
+    return { status: 401, json: { error: "unauthorized" } };
+  }
+  const presented = body?.__bearer;
+  if (!presented || !tokenEquals(entry.gateway_token, presented)) {
+    return { status: 401, json: { error: "unauthorized" } };
+  }
+  if (!Array.isArray(tokens)) {
+    return { status: 400, json: { error: "tokens_must_be_array" } };
+  }
+  if (tokens.length > PUSH_MAX_TOKENS) {
+    return { status: 400, json: { error: `too_many_tokens (max ${PUSH_MAX_TOKENS})` } };
+  }
+  for (const t of tokens) {
+    if (!isHexToken(t)) {
+      return { status: 400, json: { error: "invalid_token" } };
+    }
+  }
+  if (!payload || typeof payload !== "object") {
+    return { status: 400, json: { error: "payload_required" } };
+  }
+  if (!apnsConfig) {
+    return { status: 503, json: { error: "apns_disabled" } };
+  }
+  // Fan out — best-effort, every token gets its own result. Order
+  // preserved so the box can correlate results[tokens[i]] by index.
+  const results = [];
+  for (const token of tokens) {
+    try {
+      const r = await sendApns({ token, payload }, apnsConfig, fetchImpl);
+      results.push({ token, ok: r.ok, prune: r.prune });
+    } catch (e) {
+      results.push({ token, ok: false, prune: false });
+      console.warn(`[gateway-push] token error: ${e?.message ?? e}`);
+    }
+  }
+  return { status: 200, json: { results } };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the HTTP server. Production usage:
+ *
+ *   import { createGatewayServer } from "./index.mjs";
+ *   const { start, stop } = createGatewayServer({ apnsConfig, dnsCreds });
+ *   await start();
+ *
+ * Tests construct it with fakes:
+ *
+ *   createGatewayServer({
+ *     port: 0, // ephemeral
+ *     loadStore: () => ({}),
+ *     saveStore: async () => {},
+ *     fetchImpl: fakeFetch,
+ *     dnsCreds: { appKey, appSecret, consumerKey, endpoint },
+ *     apnsConfig: null,
+ *   });
+ *
+ * `port` = 0 yields an ephemeral port (for tests); prod binds 20081.
+ */
+export function createGatewayServer({
+  port = Number(process.env.GATEWAY_PORT) || 20081,
+  host = process.env.GATEWAY_HOST || "127.0.0.1",
+  storePath = process.env.GATEWAY_STORE_PATH || "/var/lib/manta-gateway/boxes.json",
+  load = () => loadStore(storePath),
+  save = (map) => saveStore(map, storePath),
+  fetchImpl = globalThis.fetch,
+  dnsCreds,
+  // Override the DNS-createOrUpdate wrapper. Production wires the real
+  // helper from dns.mjs; tests inject a fake that pushes to an in-memory
+  // calls array (no OVH, no record-id allocation).
+  createDnsRecord,
+  apnsConfig = null,
+  rateLimiter = createRegisterRateLimiter(),
+  log = console.log,
+  warn = console.warn,
+} = {}) {
+  const dnsCreateOrUpdate = createDnsRecord ?? ((args) => createOrUpdate({ ...args, fetchImpl, creds: dnsCreds }));
+  // Mutable in-memory copy of the store. Loaded once at start() and re-
+  // loaded on each mutation (cheap — single small JSON file). Tests inject
+  // a stable map; production wires the FS-backed load/save.
+  let store = {};
+
+  async function persist(next) {
+    store = next;
+    await save(next);
+  }
+
+  async function handle(req, res) {
+    const url = (req.url || "/").split("?")[0];
+    const ip = sourceIp(req);
+
+    // CORS preflight — short-circuit before any other handling.
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "content-type, authorization, x-box-id",
+        "Access-Control-Max-Age": "600",
+      });
+      return res.end();
+    }
+
+    if (req.method === "GET" && url === "/healthz") {
+      return sendText(res, 200, JSON.stringify({ ok: true }));
+    }
+    if (req.method !== "POST") {
+      return sendJson(res, 404, { error: "not_found" });
+    }
+
+    if (url !== "/register" && url !== "/push") {
+      return sendJson(res, 404, { error: "not_found" });
+    }
+
+    readBody(req, async (err, raw) => {
+      if (err) {
+        return sendJson(
+          res,
+          err.code === "too_large" ? 413 : 400,
+          { error: err.code === "too_large" ? "payload_too_large" : "bad_request" },
+        );
+      }
+      let body;
+      try {
+        body = raw ? JSON.parse(raw) : {};
+      } catch {
+        return sendJson(res, 400, { error: "invalid_json" });
+      }
+      // Stash the bearer on the body so route handlers don't have to
+      // re-parse the Authorization header. Tests inject __bearer directly.
+      body.__bearer = bearerToken(req.headers?.authorization);
+
+      try {
+        if (url === "/register") {
+          const r = await handleRegister({
+            body,
+            ip,
+            store,
+            persist,
+            rateLimiter,
+            createDnsRecord: dnsCreateOrUpdate,
+            log,
+          });
+          return sendJson(res, r.status, r.json);
+        }
+        // /push
+        const r = await handlePush({
+          body,
+          store,
+          apnsConfig,
+          fetchImpl,
+        });
+        return sendJson(res, r.status, r.json);
+      } catch (e) {
+        warn(`[gateway] handler error: ${e?.message ?? e}`);
+        return sendJson(res, 500, { error: "internal_error" });
+      }
+    });
+  }
+
+  const server = createServer((req, res) => {
+    handle(req, res).catch((e) => {
+      warn(`[gateway] unhandled: ${e?.message ?? e}`);
+      if (!res.headersSent) sendJson(res, 500, { error: "internal_error" });
+    });
+  });
+
+  async function start() {
+    store = await load();
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, host, () => resolve());
+    });
+    return { host, port: server.address()?.port };
+  }
+
+  function stop() {
+    return new Promise((resolve) => server.close(() => resolve()));
+  }
+
+  return { server, start, stop, get store() { return store; } };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry — start the gateway when run directly
+// ---------------------------------------------------------------------------
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("src/gateway/index.mjs");
+
+if (isMain) {
+  const creds = ovhCredsFromEnv();
+  if (!creds.ok) {
+    console.error(`[gateway] ${creds.error}`);
+    process.exit(1);
+  }
+  const apns = await loadApnsConfig(process.env.APNS_CONFIG_PATH || "/etc/manta-gateway/apns.json").catch(() => null);
+  if (!apns) {
+    console.warn("[gateway] apns config missing — /push will return 503");
+  }
+  const svc = createGatewayServer({
+    dnsCreds: { appKey: creds.appKey, appSecret: creds.appSecret, consumerKey: creds.consumerKey, endpoint: creds.endpoint },
+    apnsConfig: apns,
+  });
+  svc
+    .start()
+    .then(({ host, port }) => {
+      console.log(`[gateway] up on http://${host}:${port}`);
+    })
+    .catch((err) => {
+      console.error("[gateway] failed to start:", err);
+      process.exit(1);
+    });
+  const shutdown = () => svc.stop().finally(() => process.exit(0));
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}

--- a/src/gateway/push.test.mjs
+++ b/src/gateway/push.test.mjs
@@ -1,0 +1,313 @@
+// push.test.mjs — POST /push behavior.
+//
+// Gateway is STATELESS about device tokens: it does NOT maintain an
+// apns-tokens.json (that's box-side state). The gateway returns per-token
+// `{token, ok, prune}` results so the box can prune its own store. These
+// tests cover auth, the 20-token cap, the hex validation, the order-
+// preserved results, and the apnsConfig-disabled → 503 short-circuit.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFile, rm } from "node:fs/promises";
+import { handlePush } from "./index.mjs";
+import { isHexToken } from "./index.mjs";
+
+const VALID_BOX_ID = "abcdef0123456789abcdef0123456789";
+const makeToken = (seed) => seed.padStart(32, "0").slice(-32);
+const makeHexToken = (seed) => seed.padStart(64, "0").slice(-64);
+
+const ENTRY = {
+  gateway_token: makeToken("good"),
+  ip: "1.2.3.4",
+  host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+  registeredAt: 1,
+  updatedAt: 1,
+  ovhRecordId: 12345,
+};
+
+// Each test that exercises the APNs sender path needs a real .p8 file
+// (the JWT signing reads + verifies the PEM before any send). Generate one
+// per test that needs it; clean up in finally.
+async function makeApnsCfg() {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  const p8Path = join(
+    tmpdir(),
+    `bui-gw-pushtest-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.p8`,
+  );
+  await writeFile(p8Path, pem, "utf-8");
+  return {
+    cfg: {
+      teamId: "FSQ3HS4Z24",
+      keyId: "82P7483297",
+      bundleId: "com.antoinedc.mantaui",
+      p8Path,
+    },
+    cleanup: () => rm(p8Path, { force: true }),
+  };
+}
+
+function makeStore(entry = ENTRY) {
+  return { [VALID_BOX_ID]: entry };
+}
+
+test("isHexToken: accepts hex strings (1–128 chars)", () => {
+  assert.equal(isHexToken(makeHexToken("a")), true);
+  assert.equal(isHexToken("ABCDEF"), true);
+  assert.equal(isHexToken("xyz"), false); // non-hex
+  assert.equal(isHexToken(""), false);
+  assert.equal(isHexToken(null), false);
+});
+
+test("handlePush: 401 without Authorization header", async () => {
+  const r = await handlePush({
+    body: { box_id: VALID_BOX_ID, tokens: [], payload: { title: "T", body: "B" } },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 401);
+});
+
+test("handlePush: 401 when token does not match stored value", async () => {
+  const r = await handlePush({
+    body: {
+      box_id: VALID_BOX_ID,
+      tokens: [makeHexToken("a")],
+      payload: { title: "T", body: "B" },
+      __bearer: makeToken("wrong"),
+    },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 401);
+});
+
+test("handlePush: 401 when box_id is not in store", async () => {
+  const r = await handlePush({
+    body: {
+      box_id: "0".repeat(32),
+      tokens: [makeHexToken("a")],
+      payload: { title: "T", body: "B" },
+      __bearer: makeToken("good"),
+    },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 401);
+});
+
+test("handlePush: 400 when box_id is malformed", async () => {
+  const r = await handlePush({
+    body: { box_id: "XYZ", tokens: [], payload: {}, __bearer: makeToken("good") },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 400);
+});
+
+test("handlePush: 400 when tokens is not an array", async () => {
+  const r = await handlePush({
+    body: { box_id: VALID_BOX_ID, tokens: "not-an-array", payload: {}, __bearer: makeToken("good") },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 400);
+});
+
+test("handlePush: 400 when tokens exceeds 20", async () => {
+  const tokens = Array.from({ length: 21 }, (_, i) => makeHexToken(i.toString()));
+  const r = await handlePush({
+    body: { box_id: VALID_BOX_ID, tokens, payload: {}, __bearer: makeToken("good") },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 400);
+  assert.match(r.json.error, /too_many_tokens/);
+});
+
+test("handlePush: 400 when any token is not hex", async () => {
+  const tokens = [makeHexToken("a"), "NOT-HEX!"];
+  const r = await handlePush({
+    body: { box_id: VALID_BOX_ID, tokens, payload: {}, __bearer: makeToken("good") },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.json.error, "invalid_token");
+});
+
+test("handlePush: 400 when payload is missing", async () => {
+  const r = await handlePush({
+    body: { box_id: VALID_BOX_ID, tokens: [makeHexToken("a")], __bearer: makeToken("good") },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 400);
+});
+
+test("handlePush: 503 when apnsConfig is null (gateway not yet configured)", async () => {
+  const r = await handlePush({
+    body: {
+      box_id: VALID_BOX_ID,
+      tokens: [makeHexToken("a")],
+      payload: { title: "T", body: "B" },
+      __bearer: makeToken("good"),
+    },
+    store: makeStore(),
+    apnsConfig: null,
+    fetchImpl: async () => ({ status: 200, body: null }),
+  });
+  assert.equal(r.status, 503);
+  assert.equal(r.json.error, "apns_disabled");
+});
+
+test("handlePush: returns per-token results in input order with ok+prune shape", async () => {
+  const { cfg, cleanup } = await makeApnsCfg();
+  try {
+    const calls = [];
+    const tokA = makeHexToken("01");
+    const tokB = makeHexToken("02");
+    const tokC = makeHexToken("03");
+    const tokD = makeHexToken("04");
+    const sender = async (req) => {
+      calls.push(req.path);
+      if (req.path.includes(tokA)) return { status: 200, body: null };
+      if (req.path.includes(tokB)) return { status: 410, body: { reason: "Unregistered" } };
+      if (req.path.includes(tokC)) return { status: 400, body: { reason: "BadDeviceToken" } };
+      return { status: 500, body: null };
+    };
+    const tokens = [tokA, tokB, tokC, tokD];
+    const r = await handlePush({
+      body: {
+        box_id: VALID_BOX_ID,
+        tokens,
+        payload: { title: "T", body: "B" },
+        __bearer: makeToken("good"),
+      },
+      store: makeStore(),
+      apnsConfig: cfg,
+      fetchImpl: sender,
+    });
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.json.results, [
+      { token: tokA, ok: true,  prune: false },
+      { token: tokB, ok: false, prune: true  },
+      { token: tokC, ok: false, prune: true  },
+      { token: tokD, ok: false, prune: false }, // 500 = transient, keep
+    ]);
+    assert.equal(calls.length, 4, "every token must have been sent exactly once");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("handlePush: prune=true is returned for 410 Gone", async () => {
+  const { cfg, cleanup } = await makeApnsCfg();
+  try {
+    const r = await handlePush({
+      body: {
+        box_id: VALID_BOX_ID,
+        tokens: [makeHexToken("a")],
+        payload: { title: "T", body: "B" },
+        __bearer: makeToken("good"),
+      },
+      store: makeStore(),
+      apnsConfig: cfg,
+      fetchImpl: async () => ({ status: 410, body: { reason: "Unregistered" } }),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.results[0].prune, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("handlePush: prune=true is returned for 400 BadDeviceToken", async () => {
+  const { cfg, cleanup } = await makeApnsCfg();
+  try {
+    const r = await handlePush({
+      body: {
+        box_id: VALID_BOX_ID,
+        tokens: [makeHexToken("a")],
+        payload: { title: "T", body: "B" },
+        __bearer: makeToken("good"),
+      },
+      store: makeStore(),
+      apnsConfig: cfg,
+      fetchImpl: async () => ({ status: 400, body: { reason: "BadDeviceToken" } }),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.results[0].prune, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("handlePush: prune=true is returned for 400 Unregistered", async () => {
+  const { cfg, cleanup } = await makeApnsCfg();
+  try {
+    const r = await handlePush({
+      body: {
+        box_id: VALID_BOX_ID,
+        tokens: [makeHexToken("a")],
+        payload: { title: "T", body: "B" },
+        __bearer: makeToken("good"),
+      },
+      store: makeStore(),
+      apnsConfig: cfg,
+      fetchImpl: async () => ({ status: 400, body: { reason: "Unregistered" } }),
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.json.results[0].prune, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("handlePush: a throwing sender → ok:false, prune:false (call continues for siblings)", async () => {
+  const { cfg, cleanup } = await makeApnsCfg();
+  try {
+    const calls = [];
+    // Use distinct hex tokens for each; the sender inspects the path and
+    // throws on the middle one.
+    const tokGood = makeHexToken("01");
+    const tokBad = makeHexToken("02");
+    const tokGood2 = makeHexToken("03");
+    const sender = async (req) => {
+      calls.push(req.path);
+      if (req.path.includes(tokBad)) throw new Error("socket reset");
+      return { status: 200, body: null };
+    };
+    const r = await handlePush({
+      body: {
+        box_id: VALID_BOX_ID,
+        tokens: [tokGood, tokBad, tokGood2],
+        payload: { title: "T", body: "B" },
+        __bearer: makeToken("good"),
+      },
+      store: makeStore(),
+      apnsConfig: cfg,
+      fetchImpl: sender,
+    });
+    assert.equal(r.status, 200);
+    assert.equal(calls.length, 3, "all three tokens attempted even when one throws");
+    assert.deepEqual(r.json.results, [
+      { token: tokGood,  ok: true,  prune: false },
+      { token: tokBad,   ok: false, prune: false },
+      { token: tokGood2, ok: true,  prune: false },
+    ]);
+  } finally {
+    await cleanup();
+  }
+});

--- a/src/gateway/register.test.mjs
+++ b/src/gateway/register.test.mjs
@@ -1,0 +1,315 @@
+// register.test.mjs — POST /register behavior.
+//
+// The route is the gate to the entire gateway: it mints gateway_tokens for
+// fresh boxes, refreshes them on each box boot, and creates/updates the OVH
+// DNS A record that maps <box_id>.boxes.mantaui.com to the box's public IP.
+//
+// All dependencies are injected so these tests run hermetically:
+//   load / save   — in-memory store maps (no FS)
+//   fetchImpl     — fake that captures DNS calls (no OVH)
+//   createDnsRecord — same fake, but we route through the production
+//                     createOrUpdate wrapper so the dns.mjs signature is
+//                     exercised end-to-end
+//   rateLimiter   — injected for the 11th-call test
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFile } from "node:fs/promises";
+import {
+  handleRegister,
+  sourceIp,
+  bearerToken,
+  tokenEquals,
+  isValidGatewayToken,
+  isHexToken,
+  createRegisterRateLimiter,
+  ovhSubDomainFor,
+} from "./index.mjs";
+
+const VALID_BOX_ID = "abcdef0123456789abcdef0123456789";
+const OTHER_BOX_ID = "1234567890abcdef1234567890abcdef";
+
+// A token shape: 32 lowercase hex (same family as box_id).
+const makeToken = (seed) => seed.padStart(32, "0").slice(-32);
+
+function makeFakeDns() {
+  const calls = [];
+  const fetchImpl = async () => ({ ok: true, status: 200, body: null });
+  const createOrUpdate = async (args) => {
+    calls.push({ args, op: args.existingRecordId ? "update" : "create" });
+    return { recordId: calls.length * 100, action: calls[calls.length - 1].op };
+  };
+  return { calls, fetchImpl, createOrUpdate };
+}
+
+function makeStore(initial = {}) {
+  let store = { ...initial };
+  return {
+    get store() { return store; },
+    set store(next) { store = next; },
+    persist: async (next) => { store = next; },
+  };
+}
+
+test("isValidGatewayToken: 32 lowercase hex only", () => {
+  assert.equal(isValidGatewayToken(makeToken("a")), true);
+  assert.equal(isValidGatewayToken("UPPER".padEnd(32, "X")), false);
+  assert.equal(isValidGatewayToken("abc"), false);
+  assert.equal(isValidGatewayToken(null), false);
+});
+
+test("tokenEquals: same string → true", () => {
+  const t = makeToken("a");
+  assert.equal(tokenEquals(t, t), true);
+});
+
+test("tokenEquals: mismatch → false", () => {
+  const a = makeToken("a");
+  const b = makeToken("b");
+  assert.equal(tokenEquals(a, b), false);
+  assert.equal(tokenEquals(a, "not-the-same-length"), false);
+});
+
+test("tokenEquals: short-circuit when either is non-string", () => {
+  assert.equal(tokenEquals(undefined, makeToken("a")), false);
+  assert.equal(tokenEquals(makeToken("a"), null), false);
+});
+
+test("bearerToken: extracts token from Bearer header (case-insensitive)", () => {
+  assert.equal(bearerToken("Bearer abcdef0123456789abcdef0123456789"), makeToken("abcdef0123456789abcdef0123456789"));
+  assert.equal(bearerToken("bearer abcdef0123456789abcdef0123456789"), makeToken("abcdef0123456789abcdef0123456789"));
+  assert.equal(bearerToken("  Bearer abcdef0123456789abcdef0123456789  "), makeToken("abcdef0123456789abcdef0123456789"));
+});
+
+test("bearerToken: accepts bare token (legacy), rejects empty/missing", () => {
+  assert.equal(bearerToken("abcdef0123456789abcdef0123456789"), makeToken("abcdef0123456789abcdef0123456789"));
+  assert.equal(bearerToken(""), null);
+  assert.equal(bearerToken(null), null);
+});
+
+test("sourceIp: prefers X-Forwarded-For first value", () => {
+  assert.equal(
+    sourceIp({ headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.1" }, socket: { remoteAddress: "127.0.0.1" } }),
+    "1.2.3.4",
+  );
+});
+
+test("sourceIp: falls back to socket.remoteAddress when no XFF", () => {
+  assert.equal(sourceIp({ headers: {}, socket: { remoteAddress: "127.0.0.1" } }), "127.0.0.1");
+  assert.equal(sourceIp({ headers: {}, socket: {} }), "");
+});
+
+test("createRegisterRateLimiter: 10 calls from same IP within an hour pass", () => {
+  const take = createRegisterRateLimiter();
+  for (let i = 0; i < 10; i++) {
+    assert.equal(take("1.2.3.4"), true, `call ${i + 1} must succeed`);
+  }
+});
+
+test("createRegisterRateLimiter: 11th call from same IP within an hour → false", () => {
+  const take = createRegisterRateLimiter();
+  for (let i = 0; i < 10; i++) take("1.2.3.4");
+  assert.equal(take("1.2.3.4"), false);
+});
+
+test("createRegisterRateLimiter: different IPs each get the full bucket", () => {
+  const take = createRegisterRateLimiter();
+  for (let i = 0; i < 10; i++) assert.equal(take("1.2.3.4"), true);
+  // a different IP is unaffected
+  assert.equal(take("5.6.7.8"), true);
+});
+
+test("createRegisterRateLimiter: window resets after windowMs elapsed", () => {
+  let t = 0;
+  const take = createRegisterRateLimiter({ now: () => t });
+  for (let i = 0; i < 10; i++) assert.equal(take("1.2.3.4"), true);
+  assert.equal(take("1.2.3.4"), false);
+  t += 60 * 60 * 1000 + 1;
+  assert.equal(take("1.2.3.4"), true, "window elapsed → fresh bucket");
+});
+
+// --- handleRegister -------------------------------------------------------
+
+test("handleRegister: rejects invalid box_id (XYZ, 0xabc, wrong length, uppercase)", async () => {
+  const store = makeStore();
+  const dns = makeFakeDns();
+  for (const bad of ["XYZ", "0xabcdef", VALID_BOX_ID.slice(0, 31), VALID_BOX_ID.toUpperCase()]) {
+    const r = await handleRegister({
+      body: { box_id: bad },
+      ip: "1.2.3.4",
+      store: store.store,
+      persist: store.persist,
+      rateLimiter: () => true,
+      createDnsRecord: dns.createOrUpdate,
+    });
+    assert.equal(r.status, 400, `bad box_id "${bad}" must be rejected`);
+  }
+});
+
+test("handleRegister: first call mints a 32-hex token, creates DNS, persists", async () => {
+  const store = makeStore();
+  const dns = makeFakeDns();
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID },
+    ip: "1.2.3.4",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: dns.createOrUpdate,
+  });
+  assert.equal(r.status, 200);
+  assert.match(r.json.host, /^abcdef.*\.boxes\.mantaui\.com$/);
+  assert.match(r.json.gateway_token, /^[0-9a-f]{32}$/);
+  assert.equal(dns.calls.length, 1, "DNS create must have been called exactly once");
+  assert.equal(dns.calls[0].op, "create");
+  assert.equal(dns.calls[0].args.boxId, VALID_BOX_ID);
+  assert.equal(dns.calls[0].args.target, "1.2.3.4");
+  assert.equal(dns.calls[0].args.existingRecordId, null);
+  const persisted = store.store[VALID_BOX_ID];
+  assert.ok(persisted);
+  assert.equal(persisted.gateway_token, r.json.gateway_token);
+  assert.equal(persisted.ip, "1.2.3.4");
+  assert.equal(persisted.ovhRecordId, 100); // calls.length * 100
+});
+
+test("handleRegister: re-register with wrong token → 401 (no DNS update)", async () => {
+  const dns = makeFakeDns();
+  // Pre-seed the store.
+  const store = makeStore({
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("good"),
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 12345,
+    },
+  });
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID, __bearer: makeToken("bad") },
+    ip: "1.2.3.4",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: dns.createOrUpdate,
+  });
+  assert.equal(r.status, 401);
+  assert.equal(dns.calls.length, 0, "DNS must not have been touched");
+});
+
+test("handleRegister: re-register with correct token + same IP → 200 host only (no DNS)", async () => {
+  const dns = makeFakeDns();
+  const store = makeStore({
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("good"),
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 12345,
+    },
+  });
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID, __bearer: makeToken("good") },
+    ip: "1.2.3.4",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: dns.createOrUpdate,
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.json.host, `${VALID_BOX_ID}.boxes.mantaui.com`);
+  assert.equal(r.json.gateway_token, undefined, "no token re-issue");
+  assert.equal(dns.calls.length, 0, "no DNS update when IP unchanged");
+});
+
+test("handleRegister: re-register with correct token + changed IP → updates DNS", async () => {
+  const dns = makeFakeDns();
+  const store = makeStore({
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("good"),
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 12345,
+    },
+  });
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID, __bearer: makeToken("good") },
+    ip: "5.6.7.8",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: dns.createOrUpdate,
+  });
+  assert.equal(r.status, 200);
+  assert.equal(dns.calls.length, 1);
+  assert.equal(dns.calls[0].op, "update");
+  assert.equal(dns.calls[0].args.existingRecordId, 12345);
+  assert.equal(dns.calls[0].args.target, "5.6.7.8");
+  assert.equal(store.store[VALID_BOX_ID].ip, "5.6.7.8");
+});
+
+test("handleRegister: rate limit 429 takes precedence over validation", async () => {
+  const dns = makeFakeDns();
+  const store = makeStore();
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID },
+    ip: "1.2.3.4",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => false, // always reject
+    createDnsRecord: dns.createOrUpdate,
+  });
+  assert.equal(r.status, 429);
+  assert.equal(dns.calls.length, 0);
+  assert.equal(store.store[VALID_BOX_ID], undefined);
+});
+
+test("handleRegister: DNS create failure on first registration → 502", async () => {
+  const dns = makeFakeDns();
+  const failDns = async () => { throw new Error("OVH boom"); };
+  const store = makeStore();
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID },
+    ip: "1.2.3.4",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: failDns,
+  });
+  assert.equal(r.status, 502);
+  assert.equal(store.store[VALID_BOX_ID], undefined, "must NOT persist on DNS failure");
+});
+
+test("handleRegister: DNS update failure on re-register → 200 with existing host (non-fatal)", async () => {
+  const failDns = async () => { throw new Error("OVH timeout"); };
+  const store = makeStore({
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("good"),
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 12345,
+    },
+  });
+  const r = await handleRegister({
+    body: { box_id: VALID_BOX_ID, __bearer: makeToken("good") },
+    ip: "5.6.7.8",
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: failDns,
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.json.host, `${VALID_BOX_ID}.boxes.mantaui.com`);
+});
+
+test("ovhSubDomainFor: <box_id>.boxes", () => {
+  assert.equal(ovhSubDomainFor(VALID_BOX_ID), `${VALID_BOX_ID}.boxes`);
+});

--- a/src/gateway/server.test.mjs
+++ b/src/gateway/server.test.mjs
@@ -1,0 +1,379 @@
+// server.test.mjs — full HTTP server integration tests.
+//
+// Spins up createGatewayServer() on an ephemeral port, drives every
+// endpoint with real HTTP requests, and asserts the wire-level shape
+// (status, body, headers, CORS). All I/O is injected — the store is an
+// in-memory map, the DNS + APNs surfaces are fake senders.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { request as httpRequest } from "node:http";
+import { createGatewayServer, createRegisterRateLimiter } from "./index.mjs";
+
+const VALID_BOX_ID = "abcdef0123456789abcdef0123456789";
+const makeToken = (seed) => seed.padStart(32, "0").slice(-32);
+const makeHexToken = (seed) => seed.padStart(64, "0").slice(-64);
+
+// Helpers ------------------------------------------------------------------
+
+function makeFetchImpl() {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    if (url.includes("/refresh")) return { ok: true, status: 200, body: null };
+    // record POST → return a synthetic id
+    return { ok: true, status: 200, body: calls.length * 100 };
+  };
+  return { calls, fetchImpl };
+}
+
+async function buildServer({ store = {}, dns = makeFetchImpl(), apnsConfig = null, rateLimiter } = {}) {
+  let liveStore = { ...store };
+  const load = async () => ({ ...liveStore });
+  const save = async (m) => { liveStore = { ...m }; };
+  const { calls: dnsCalls, fetchImpl } = dns;
+  const apnsCalls = [];
+  const createDnsRecord = async (args) => {
+    dnsCalls.push({ url: "createOrUpdate", init: { method: args.existingRecordId ? "PUT" : "POST" }, args });
+    return { recordId: dnsCalls.length * 100, action: args.existingRecordId ? "update" : "create" };
+  };
+  const svc = createGatewayServer({
+    port: 0,
+    load,
+    save,
+    fetchImpl,
+    createDnsRecord,
+    apnsConfig,
+    rateLimiter: rateLimiter ?? createRegisterRateLimiter(),
+    log: () => {},
+    warn: () => {},
+  });
+  const { host, port } = await svc.start();
+  return {
+    svc,
+    host,
+    port,
+    dnsCalls,
+    // A LIVE reference to the test's in-memory store — callers must read
+    // `ctx.liveStore` at the moment they need the current value (don't
+    // destructure — the snapshot would go stale once `save` updates it).
+    get liveStore() { return liveStore; },
+    apnsCalls,
+  };
+}
+
+function postJson(port, path, body, headers = {}) {
+  const data = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: "127.0.0.1", port, method: "POST", path, headers: { "content-type": "application/json", "content-length": Buffer.byteLength(data), ...headers } },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString("utf-8") }));
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+function getRequest(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({ host: "127.0.0.1", port, method: "GET", path }, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString("utf-8") }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function withServer(opts, fn) {
+  const ctx = await buildServer(opts);
+  try {
+    await fn(ctx);
+  } finally {
+    await ctx.svc.stop();
+  }
+}
+
+// Tests --------------------------------------------------------------------
+
+test("GET /healthz → 200 {ok:true}, no auth", async () => {
+  await withServer({}, async ({ port }) => {
+    const r = await getRequest(port, "/healthz");
+    assert.equal(r.status, 200);
+    assert.deepEqual(JSON.parse(r.body), { ok: true });
+    assert.match(r.headers["content-type"], /text\/plain/);
+  });
+});
+
+test("unknown path → 404", async () => {
+  await withServer({}, async ({ port }) => {
+    const r = await getRequest(port, "/nope");
+    assert.equal(r.status, 404);
+  });
+});
+
+test("wrong method → 404", async () => {
+  await withServer({}, async ({ port }) => {
+    const r = await getRequest(port, "/register"); // GET on a POST route
+    assert.equal(r.status, 404);
+  });
+});
+
+test("POST /register (first time) → 200 {host, gateway_token} + DNS create", async () => {
+  await withServer({}, async (ctx) => {
+    const { port, dnsCalls } = ctx;
+    const r = await postJson(
+      port,
+      "/register",
+      { box_id: VALID_BOX_ID },
+      { "x-forwarded-for": "9.9.9.9" },
+    );
+    assert.equal(r.status, 200);
+    const j = JSON.parse(r.body);
+    assert.equal(j.host, `${VALID_BOX_ID}.boxes.mantaui.com`);
+    assert.match(j.gateway_token, /^[0-9a-f]{32}$/);
+    assert.equal(dnsCalls.length, 1);
+    assert.equal(dnsCalls[0].args.boxId, VALID_BOX_ID);
+    assert.equal(dnsCalls[0].args.target, "9.9.9.9");
+    assert.ok(ctx.liveStore[VALID_BOX_ID]);
+    assert.equal(ctx.liveStore[VALID_BOX_ID].ip, "9.9.9.9");
+  });
+});
+
+test("POST /register with invalid body → 400", async () => {
+  await withServer({}, async ({ port }) => {
+    const r = await postJson(port, "/register", { box_id: "XYZ" }, { "x-forwarded-for": "1.1.1.1" });
+    assert.equal(r.status, 400);
+    assert.equal(JSON.parse(r.body).error, "invalid_box_id");
+  });
+});
+
+test("POST /register (re-register) with valid bearer + same IP → 200 host, no DNS", async () => {
+  const token = makeToken("seed");
+  const store = {
+    [VALID_BOX_ID]: {
+      gateway_token: token,
+      ip: "9.9.9.9",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 1234,
+    },
+  };
+  await withServer({ store }, async ({ port, dnsCalls }) => {
+    const r = await postJson(
+      port,
+      "/register",
+      { box_id: VALID_BOX_ID, __bearer: token }, // __bearer is unused over the wire; the Authorization header is what counts
+      { authorization: `Bearer ${token}`, "x-forwarded-for": "9.9.9.9" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(JSON.parse(r.body).host, `${VALID_BOX_ID}.boxes.mantaui.com`);
+    assert.equal(dnsCalls.length, 0);
+  });
+});
+
+test("POST /register (re-register) with valid bearer + changed IP → DNS update", async () => {
+  const token = makeToken("seed");
+  const store = {
+    [VALID_BOX_ID]: {
+      gateway_token: token,
+      ip: "1.1.1.1",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 1234,
+    },
+  };
+  await withServer({ store }, async (ctx) => {
+    const { port, dnsCalls } = ctx;
+    const r = await postJson(
+      port,
+      "/register",
+      { box_id: VALID_BOX_ID },
+      { authorization: `Bearer ${token}`, "x-forwarded-for": "9.9.9.9" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(dnsCalls.length, 1);
+    assert.equal(dnsCalls[0].args.existingRecordId, 1234);
+    assert.equal(dnsCalls[0].args.target, "9.9.9.9");
+    assert.equal(ctx.liveStore[VALID_BOX_ID].ip, "9.9.9.9");
+  });
+});
+
+test("POST /register with wrong bearer → 401", async () => {
+  const store = {
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("right"),
+      ip: "1.1.1.1",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 1,
+    },
+  };
+  await withServer({ store }, async ({ port, dnsCalls }) => {
+    const r = await postJson(
+      port,
+      "/register",
+      { box_id: VALID_BOX_ID },
+      { authorization: `Bearer ${makeToken("wrong")}`, "x-forwarded-for": "1.1.1.1" },
+    );
+    assert.equal(r.status, 401);
+    assert.equal(dnsCalls.length, 0);
+  });
+});
+
+test("POST /register rate limit → 429 on the 11th call from same IP", async () => {
+  let count = 0;
+  const rateLimiter = () => {
+    count += 1;
+    return count <= 10;
+  };
+  await withServer({ rateLimiter }, async (ctx) => {
+    const { port, dnsCalls } = ctx;
+    for (let i = 0; i < 10; i++) {
+      // Use a UNIQUE box_id per call so each is a first-registration (no
+      // bearer required). The limiter is the only gate we want to exercise.
+      const bid = i.toString(16).padStart(32, "0");
+      const r = await postJson(
+        port,
+        "/register",
+        { box_id: bid },
+        { "x-forwarded-for": "1.2.3.4" },
+      );
+      assert.equal(r.status, 200, `call ${i + 1} should succeed`);
+    }
+    const r = await postJson(
+      port,
+      "/register",
+      { box_id: "f".repeat(32) },
+      { "x-forwarded-for": "1.2.3.4" },
+    );
+    assert.equal(r.status, 429);
+    // DNS was called 10 times (one per successful registration), not 11.
+    assert.equal(dnsCalls.length, 10);
+  });
+});
+
+test("POST /push without auth → 401", async () => {
+  await withServer({ apnsConfig: { teamId: "t", keyId: "k", p8Path: "/d", bundleId: "b" } }, async ({ port }) => {
+    const r = await postJson(
+      port,
+      "/push",
+      { box_id: VALID_BOX_ID, tokens: [makeHexToken("a")], payload: { title: "T", body: "B" } },
+    );
+    assert.equal(r.status, 401);
+  });
+});
+
+test("POST /push auth + tokens → 200 {results:[{token, ok, prune}]}", async () => {
+  const token = makeToken("good");
+  const store = {
+    [VALID_BOX_ID]: {
+      gateway_token: token,
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 1,
+    },
+  };
+  await withServer(
+    { store, apnsConfig: { teamId: "t", keyId: "k", p8Path: "/d", bundleId: "b" } },
+    async ({ port }) => {
+      const r = await postJson(
+        port,
+        "/push",
+        {
+          box_id: VALID_BOX_ID,
+          tokens: [makeHexToken("a"), makeHexToken("b")],
+          payload: { title: "T", body: "B" },
+        },
+        { authorization: `Bearer ${token}` },
+      );
+      // Note: this test passes a bogus p8Path ("/d") to apnsConfig, so the
+      // APNs JWT signing fails on every send. Each token therefore resolves
+      // to { ok: false, prune: false } from sendApns (the catch path). What
+      // we care about here is that the AUTH + shape are correct: 200 with
+      // one result per token. The proper APNs round-trip (200 + 410 prune)
+      // is covered in src/gateway/apns.test.mjs.
+      assert.equal(r.status, 200);
+      const j = JSON.parse(r.body);
+      assert.equal(j.results.length, 2);
+      assert.equal(typeof j.results[0].ok, "boolean");
+      assert.equal(typeof j.results[0].prune, "boolean");
+      assert.equal(typeof j.results[1].ok, "boolean");
+      assert.equal(typeof j.results[1].prune, "boolean");
+    },
+  );
+});
+
+test("POST /push with >20 tokens → 400 too_many_tokens", async () => {
+  const token = makeToken("good");
+  const store = {
+    [VALID_BOX_ID]: {
+      gateway_token: token,
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      ovhRecordId: 1,
+    },
+  };
+  await withServer(
+    { store, apnsConfig: { teamId: "t", keyId: "k", p8Path: "/d", bundleId: "b" } },
+    async ({ port }) => {
+      const tokens = Array.from({ length: 21 }, (_, i) => makeHexToken(i.toString()));
+      const r = await postJson(
+        port,
+        "/push",
+        { box_id: VALID_BOX_ID, tokens, payload: { title: "T", body: "B" } },
+        { authorization: `Bearer ${token}` },
+      );
+      assert.equal(r.status, 400);
+      assert.match(JSON.parse(r.body).error, /too_many_tokens/);
+    },
+  );
+});
+
+test("OPTIONS /register → 204 + CORS headers (preflight)", async () => {
+  await withServer({}, async ({ port }) => {
+    const r = await new Promise((resolve, reject) => {
+      const req = httpRequest({ host: "127.0.0.1", port, method: "OPTIONS", path: "/register" }, (res) => {
+        resolve({ status: res.statusCode, headers: res.headers });
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    assert.equal(r.status, 204);
+    assert.equal(r.headers["access-control-allow-origin"], "*");
+    assert.match(r.headers["access-control-allow-methods"], /POST/);
+  });
+});
+
+test("POST /register with malformed JSON → 400 invalid_json", async () => {
+  await withServer({}, async ({ port }) => {
+    const r = await new Promise((resolve, reject) => {
+      const req = httpRequest(
+        { host: "127.0.0.1", port, method: "POST", path: "/register", headers: { "content-type": "application/json", "content-length": 5 } },
+        (res) => {
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString("utf-8") }));
+        },
+      );
+      req.on("error", reject);
+      req.write("not-j");
+      req.end();
+    });
+    assert.equal(r.status, 400);
+    assert.equal(JSON.parse(r.body).error, "invalid_json");
+  });
+});

--- a/src/gateway/store.mjs
+++ b/src/gateway/store.mjs
@@ -1,0 +1,154 @@
+// store.mjs — registration store for the gateway service.
+//
+// A single JSON file at /var/lib/manta-gateway/boxes.json maps
+// box_id → { gateway_token, ip, host, registeredAt, updatedAt, ovhRecordId }.
+// Box-side callers (manta-server) register their box_id once at startup,
+// receive a gateway_token, then re-register on each boot to refresh the
+// DNS A record when the box's public IP changes.
+//
+// Atomic-write pattern (temp + rename + chmod 0600) copied verbatim from
+// src/server/secrets.mjs: rename(2) on the same filesystem is atomic, so a
+// crash mid-write cannot leave the file truncated or empty; chmod is
+// belt-and-suspenders in case the temp file pre-existed with looser perms.
+//
+// Path injectable via `path` so tests run against /tmp without touching the
+// real store. The default `/var/lib/manta-gateway/boxes.json` is created by
+// the systemd `StateDirectory=manta-gateway` directive on prod (BET-198 WP6
+// runbook step 4).
+//
+// The store keeps `ovhRecordId` (the OVH record-id assigned when the A
+// record was first created) so subsequent /register calls from the SAME box
+// can PUT a target update without ever searching the zone — a single DNS
+// read per box lifetime.
+
+import { writeFile, rename, mkdir, chmod } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const DEFAULT_STORE_PATH = "/var/lib/manta-gateway/boxes.json";
+
+// Cap on the entry map: a 128 MiB JSON file is more than enough to hold
+// every box in existence for the next decade, and bounds the worst-case
+// load() parse. Reads bigger than this fail loudly (better than silently
+// holding the whole zone in memory).
+export const MAX_STORE_BYTES = 128 * 1024 * 1024;
+
+// Same 32-hex shape as src/server/auth.mjs isValidToken. Re-exported as
+// its own validator so the gateway never has to import server-side modules
+// (the gateway service runs on its own port with its own deps).
+export function isValidBoxId(boxId) {
+  return typeof boxId === "string" && /^[0-9a-f]{32}$/.test(boxId);
+}
+
+// Pure entry shape (no surprises from JSON.parse, no extra fields from a
+// caller that wrote the file out-of-band). `host` is the public FQDN the
+// gateway will publish — <box_id>.boxes.mantaui.com for prod.
+export function normalizeEntry(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const { gateway_token, ip, host, registeredAt, updatedAt, ovhRecordId } = raw;
+  if (typeof gateway_token !== "string" || !gateway_token) return null;
+  if (typeof ip !== "string" || !ip) return null;
+  if (typeof host !== "string" || !host) return null;
+  if (typeof registeredAt !== "number") return null;
+  if (typeof updatedAt !== "number") return null;
+  return {
+    gateway_token,
+    ip,
+    host,
+    registeredAt,
+    updatedAt,
+    ovhRecordId: typeof ovhRecordId === "number" ? ovhRecordId : null,
+  };
+}
+
+// Atomic temp-rename write. `mode` is the file mode applied to BOTH the
+// temp file and the final rename target (rename keeps the temp's mode in
+// the same-filesystem case). 0600 = owner-only; the store holds gateway
+// tokens which are bearer secrets.
+async function atomicWriteJson(path, obj, mode = 0o600) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const data = JSON.stringify(obj, null, 2);
+  await writeFile(tmp, data, { mode });
+  await chmod(tmp, mode).catch(() => {});
+  await rename(tmp, path);
+  await chmod(path, mode).catch(() => {});
+}
+
+// Load the store as `{ [box_id]: entry }`. Returns `{}` when the file is
+// missing or corrupt — a fresh gateway always starts empty. Reads via
+// sync FS so the in-process HTTP handler can stay non-blocking only at the
+// request boundary; load() is called at request time and is small.
+//
+// The cap (MAX_STORE_BYTES) is enforced BEFORE parse so a runaway write
+// can't exhaust heap. The test uses a tmp file the test always cleans up.
+export function loadStore(path = DEFAULT_STORE_PATH) {
+  try {
+    if (!existsSync(path)) return {};
+    const stat = readFileSync(path, { encoding: null });
+    if (stat.byteLength > MAX_STORE_BYTES) {
+      throw new Error(
+        `store too large: ${stat.byteLength} > ${MAX_STORE_BYTES}`,
+      );
+    }
+    const text = stat.toString("utf-8");
+    if (!text.trim()) return {};
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (!isValidBoxId(k)) continue;
+      const norm = normalizeEntry(v);
+      if (norm) out[k] = norm;
+    }
+    return out;
+  } catch {
+    // corrupt/unreadable → empty store. The caller treats this as a fresh
+    // boot. Never crash the request loop on a bad file.
+    return {};
+  }
+}
+
+// Save the full map. Overwrites whatever is on disk. The caller is expected
+// to load → mutate → save; we do NOT expose diff APIs because the map is
+// small and the file is rewritten under rename, so concurrent writers are
+// already at the kernel's mercy.
+export async function saveStore(map, path = DEFAULT_STORE_PATH) {
+  const obj = {};
+  for (const [k, v] of Object.entries(map ?? {})) {
+    if (!isValidBoxId(k)) continue;
+    const norm = normalizeEntry(v);
+    if (norm) obj[k] = norm;
+  }
+  await atomicWriteJson(path, obj);
+}
+
+// Compose a fresh entry. `now` injectable for tests. `gateway_token` MUST
+// be passed in (the caller generates it) so the registration route can
+// return the token to the box on first registration.
+export function makeEntry({ box_id, gateway_token, ip, host, ovhRecordId = null, now = () => Date.now() }) {
+  if (!isValidBoxId(box_id)) throw new Error("makeEntry: invalid box_id");
+  if (typeof gateway_token !== "string" || !gateway_token) {
+    throw new Error("makeEntry: gateway_token required");
+  }
+  if (typeof ip !== "string" || !ip) throw new Error("makeEntry: ip required");
+  if (typeof host !== "string" || !host) throw new Error("makeEntry: host required");
+  const t = now();
+  return {
+    gateway_token,
+    ip,
+    host,
+    registeredAt: t,
+    updatedAt: t,
+    ovhRecordId,
+  };
+}
+
+// Pure: build the host FQDN for a box_id. One domain, no friendly names
+// (BET-198 §4: "Box hostname = full 32-hex box_id").
+export function hostFor(box_id) {
+  if (!isValidBoxId(box_id)) throw new Error("hostFor: invalid box_id");
+  return `${box_id}.boxes.mantaui.com`;
+}

--- a/src/gateway/store.test.mjs
+++ b/src/gateway/store.test.mjs
@@ -1,0 +1,199 @@
+// store.test.mjs — unit tests for the gateway registration store.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { statSync } from "node:fs";
+import {
+  isValidBoxId,
+  loadStore,
+  saveStore,
+  makeEntry,
+  normalizeEntry,
+  hostFor,
+  MAX_STORE_BYTES,
+} from "./store.mjs";
+
+function freshTmpPath(label) {
+  const dir = mkdtempSync(join(tmpdir(), `bui-gw-store-${label}-`));
+  return { dir, path: join(dir, "boxes.json") };
+}
+
+const NOW = 1_700_000_000_000;
+
+test("isValidBoxId: accepts exactly 32 lowercase hex chars", () => {
+  assert.equal(isValidBoxId("0".repeat(32)), true);
+  assert.equal(isValidBoxId("abcdef0123456789abcdef0123456789"), true);
+  assert.equal(isValidBoxId("XYZ"), false);
+  assert.equal(isValidBoxId("0xabc"), false);
+  assert.equal(isValidBoxId("abcdef0123456789abcdef012345678"), false); // 31 chars
+  assert.equal(isValidBoxId("ABCDEF0123456789ABCDEF0123456789"), false); // uppercase
+  assert.equal(isValidBoxId("abcdef0123456789abcdef01234567890"), false); // 33 chars
+  assert.equal(isValidBoxId(""), false);
+  assert.equal(isValidBoxId(null), false);
+});
+
+test("hostFor: returns <box_id>.boxes.mantaui.com", () => {
+  const bid = "abcdef0123456789abcdef0123456789";
+  assert.equal(hostFor(bid), `${bid}.boxes.mantaui.com`);
+  assert.throws(() => hostFor("nope"), /invalid box_id/);
+});
+
+test("makeEntry: creates an entry with both timestamps equal on first call", () => {
+  const e = makeEntry({
+    box_id: "0".repeat(32),
+    gateway_token: "0".repeat(32),
+    ip: "1.2.3.4",
+    host: "0".repeat(32) + ".boxes.mantaui.com",
+    ovhRecordId: 42,
+    now: () => NOW,
+  });
+  assert.equal(e.gateway_token, "0".repeat(32));
+  assert.equal(e.ip, "1.2.3.4");
+  assert.equal(e.host, "0".repeat(32) + ".boxes.mantaui.com");
+  assert.equal(e.ovhRecordId, 42);
+  assert.equal(e.registeredAt, NOW);
+  assert.equal(e.updatedAt, NOW);
+});
+
+test("normalizeEntry: drops malformed entries silently", () => {
+  assert.equal(normalizeEntry(null), null);
+  assert.equal(normalizeEntry({}), null);
+  assert.equal(normalizeEntry({ gateway_token: "x", ip: "1.2.3.4", host: "h" }), null); // timestamps missing
+  assert.equal(
+    normalizeEntry({
+      gateway_token: "x",
+      ip: "1.2.3.4",
+      host: "h",
+      registeredAt: 1,
+      updatedAt: 1,
+    })?.gateway_token,
+    "x",
+  );
+});
+
+test("atomic write round-trip: save then load returns the same map", async () => {
+  const { dir, path } = freshTmpPath("roundtrip");
+  try {
+    const entry = makeEntry({
+      box_id: "0".repeat(32),
+      gateway_token: "a".repeat(32),
+      ip: "1.2.3.4",
+      host: "0".repeat(32) + ".boxes.mantaui.com",
+      ovhRecordId: 99,
+      now: () => NOW,
+    });
+    await saveStore({ [entry.gateway_token ? "0".repeat(32) : "bad"]: entry }, path);
+    // The key in the map MUST be the box_id (32-hex). Re-save with the right key.
+    await saveStore({ ["0".repeat(32)]: entry }, path);
+    const loaded = loadStore(path);
+    assert.equal(loaded["0".repeat(32)].ip, "1.2.3.4");
+    assert.equal(loaded["0".repeat(32)].ovhRecordId, 99);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("saveStore → file mode is 0600 (owner-only)", async () => {
+  const { dir, path } = freshTmpPath("mode");
+  try {
+    await saveStore(
+      {
+        ["0".repeat(32)]: makeEntry({
+          box_id: "0".repeat(32),
+          gateway_token: "a".repeat(32),
+          ip: "1.2.3.4",
+          host: "0".repeat(32) + ".boxes.mantaui.com",
+          now: () => NOW,
+        }),
+      },
+      path,
+    );
+    const s = statSync(path);
+    // mode is the lower 12 bits of st_mode (0o777 + file-type bits).
+    assert.equal(s.mode & 0o777, 0o600, `expected 0600, got 0${(s.mode & 0o777).toString(8)}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStore: missing file → empty map (no crash)", () => {
+  const { dir, path } = freshTmpPath("missing");
+  try {
+    const loaded = loadStore(path);
+    assert.deepEqual(loaded, {});
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStore: corrupt file → empty map (no crash)", async () => {
+  const { dir, path } = freshTmpPath("corrupt");
+  try {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(path, "{not-json");
+    const loaded = loadStore(path);
+    assert.deepEqual(loaded, {});
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStore: ignores entries with non-32-hex keys (defense)", async () => {
+  const { dir, path } = freshTmpPath("badkey");
+  try {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        ["0".repeat(32)]: makeEntry({
+          box_id: "0".repeat(32),
+          gateway_token: "a".repeat(32),
+          ip: "1.2.3.4",
+          host: "0".repeat(32) + ".boxes.mantaui.com",
+          now: () => NOW,
+        }),
+        "BADKEY": { gateway_token: "x", ip: "1", host: "h", registeredAt: 1, updatedAt: 1 },
+      }),
+    );
+    const loaded = loadStore(path);
+    assert.equal(Object.keys(loaded).length, 1);
+    assert.ok("0".repeat(32) in loaded);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("saveStore round-trip preserves multiple entries", async () => {
+  const { dir, path } = freshTmpPath("multi");
+  try {
+    const map = {};
+    const expectedIps = {};
+    for (let i = 0; i < 3; i++) {
+      const bid = i.toString(16).padStart(32, "0");
+      const ip = `10.0.0.${i + 1}`;
+      map[bid] = makeEntry({
+        box_id: bid,
+        gateway_token: i.toString(16).padStart(32, "0"),
+        ip,
+        host: `${bid}.boxes.mantaui.com`,
+        now: () => NOW + i,
+      });
+      expectedIps[bid] = ip;
+    }
+    await saveStore(map, path);
+    const loaded = loadStore(path);
+    assert.equal(Object.keys(loaded).length, 3);
+    for (const [k, v] of Object.entries(loaded)) {
+      assert.equal(v.ip, expectedIps[k]);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("MAX_STORE_BYTES is bounded (128 MiB)", () => {
+  assert.equal(MAX_STORE_BYTES, 128 * 1024 * 1024);
+});

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -40,14 +40,10 @@
 import webpush from "web-push";
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { readFileSync } from "node:fs";
-import { createSign } from "node:crypto";
-import http2 from "node:http2";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { STATE_DIRNAME } from "../shared/paths.mjs";
 import * as tmux from "./tmux.mjs";
-import * as local from "./local.mjs";
 
 const DIR = join(homedir(), STATE_DIRNAME);
 const VAPID_PATH = join(DIR, "vapid.json");
@@ -57,7 +53,8 @@ const APNS_TOKENS_PATH = join(DIR, "apns-tokens.json");
 // Apple's apns-topic header = the bundleId. The APNs spec requires the JWT
 // to be cached for 20–60 minutes; we rotate at 45 min (mid-range) to balance
 // JWT sign cost against a clock skew with Apple's clock on the other end.
-const APNS_JWT_TTL_SEC = 45 * 60;
+// (JWT TTL constant moved to src/gateway/apns.mjs in BET-199 — the gateway
+// is the sole APNs client now.)
 
 // VAPID `subject` must be a mailto: or https: URI identifying the sender.
 const VAPID_SUBJECT = "mailto:app@mantaui.com";
@@ -754,248 +751,37 @@ async function sendWebPush(payload) {
 // ---------------------------------------------------------------------------
 // APNs native-push delivery leg (BET-181)
 //
-// Activated when local.apnsConfig() returns a valid block. Pure building
-// blocks (buildApnsJwt, buildApnsRequest, buildApnsPayload) are exported for
-// unit tests; sendApns + sendApnsFanout are the stateful glue that reads the
-// device-token store + makes the HTTP/2 call. NO new npm dependency —
-// everything uses Node's built-in `crypto` (ES256 sign) and `http2`.
-//
-// Apple rotates the JWT at 20–60 min; we cache it for 45 min inside the
-// process. The token cache is per-cfg (teamId/keyId/p8Path), so rotating
-// any of those immediately invalidates the cache (see _apnsJwtCache).
-//
-// Errors that mean "this token is dead, stop sending to it":
-//   - 410 Gone (token expired; Apple requires it be unregistered)
-//   - 400 with reason BadDeviceToken
-//   - 400 with reason Unregistered
-// All other failures are logged but don't prune the token (transient —
-// network blip, Apple's 500s, rate-limit, etc).
+// APNs moved to src/gateway/apns.mjs in BET-199 (the gateway is the sole
+// APNs client now — boxes no longer hold the .p8). This file still owns
+// the box-side device-token store (APNS_TOKENS_PATH / addApnsToken /
+// removeApnsToken) and the fan-out entry point (sendApnsFanout). The fan-
+// out body is a no-op STUB for now; BET-200 replaces it with a POST to the
+// gateway (/push) that drives the moved sendApns. Keeping the stub
+// intentional: sendApnsFanout stays exported so existing tests / call
+// sites don't break, but it currently sends nothing.
 // ---------------------------------------------------------------------------
 
-let _apnsJwtCache = null; // { teamId, keyId, p8Path, jwt, exp }
-
 /**
- * Pure: build the ES256 JWT used for APNs auth. Reads the .p8 PEM off disk
- * and signs the JWT claims with Node's built-in crypto. Apple requires:
- *   header: { alg:"ES256", kid:<keyId> }
- *   claims: { iss:<teamId>, iat:<unix-seconds> }
- * ES256 = ECDSA over the P-256 curve with SHA-256. Apple's .p8 is the
- * PKCS#8 PEM of an EC private key, which Node's crypto accepts directly.
+/**
+ * Stateful fan-out entry point (BET-181). Exported so existing call sites
+ * + tests keep working while the box-side push.mjs is being split across
+ * BET-199 (this slice) and BET-200 (fan-out via the gateway).
  *
- * @param {{teamId:string, keyId:string, p8Path:string}} cfg
- * @param {{now?: number}} [opts] injectable clock for tests (iat claim)
- * @returns {string} compact-serialized JWT (header.claims.signature)
- */
-export async function buildApnsJwt(cfg, { now } = {}) {
-  if (!cfg?.teamId || !cfg?.keyId || !cfg?.p8Path) {
-    throw new Error("buildApnsJwt: missing teamId/keyId/p8Path");
-  }
-  const pem = readFileSync(cfg.p8Path, "utf-8");
-  const header = { alg: "ES256", kid: cfg.keyId };
-  const iat = now ?? Math.floor(Date.now() / 1000);
-  const claims = { iss: cfg.teamId, iat };
-  const enc = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
-  const signingInput = `${enc(header)}.${enc(claims)}`;
-  const signer = createSign("SHA256");
-  signer.update(signingInput);
-  signer.end();
-  const signature = signer
-    .sign({ key: pem, dsaEncoding: "ieee-p1363" })
-    .toString("base64url");
-  return `${signingInput}.${signature}`;
-}
-
-/**
- * Cache-and-reuse the APNs JWT for APNS_JWT_TTL_SEC. Pure with respect to
- * time (caller-injected `now`); mutates module-level `_apnsJwtCache`.
- */
-async function getApnsJwt(cfg) {
-  const now = Math.floor(Date.now() / 1000);
-  const c = _apnsJwtCache;
-  if (
-    c &&
-    c.teamId === cfg.teamId &&
-    c.keyId === cfg.keyId &&
-    c.p8Path === cfg.p8Path &&
-    c.exp > now
-  ) {
-    return c.jwt;
-  }
-  const jwt = await buildApnsJwt(cfg, { now });
-  _apnsJwtCache = {
-    teamId: cfg.teamId,
-    keyId: cfg.keyId,
-    p8Path: cfg.p8Path,
-    jwt,
-    exp: now + APNS_JWT_TTL_SEC,
-  };
-  return jwt;
-}
-
-/** Test hook: drop the JWT cache so the next send rebuilds. */
-export function _resetApnsJwtCache() {
-  _apnsJwtCache = null;
-}
-
-/**
- * Pure: build the HTTP/2 request shape for one APNs send. Used by sendApns
- * (with Node's http2 client) AND by tests that want to assert the request
- * without actually opening a connection.
+ * CURRENT BODY (BET-199): no-op. APNs signing + HTTP/2 lives in
+ * src/gateway/apns.mjs; this module will be rewired in BET-200 to POST
+ * the gateway. Until then, APNs deliveries are NOT made from the box.
  *
- * @param {{cfg: {bundleId:string}, deviceToken:string, payload: any, jwt:string}} args
- * @returns {{ host:string, path:string, method:string, headers:object, body:string }}
- */
-export function buildApnsRequest({ cfg, deviceToken, payload, jwt }) {
-  if (!cfg?.bundleId) throw new Error("buildApnsRequest: missing bundleId");
-  if (typeof deviceToken !== "string" || !deviceToken) {
-    throw new Error("buildApnsRequest: missing deviceToken");
-  }
-  return {
-    host: "api.push.apple.com",
-    path: `/3/device/${encodeURIComponent(deviceToken)}`,
-    method: "POST",
-    headers: {
-      authorization: `bearer ${jwt}`,
-      "apns-topic": cfg.bundleId,
-      "apns-push-type": "alert",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  };
-}
-
-/**
- * Pure: map an internal notification payload to the APNs `aps` envelope.
- * Apple requires the title/body under `aps.alert`. `thread-id` groups
- * notifications from the same session into one stack on the lock screen;
- * we hoist the sessionId up so iOS does the grouping for us.
+ * Web Push (sendWebPush) is still active and unaffected.
  *
- * @param {{title:string, body:string, sessionId?:string|null}} payload
- * @returns {{aps:{alert:{title:string, body:string}, "thread-id"?:string}, sessionId:string|null}}
- */
-export function buildApnsPayload(payload) {
-  const title = typeof payload?.title === "string" ? payload.title : "";
-  const body = typeof payload?.body === "string" ? payload.body : "";
-  const sessionId =
-    typeof payload?.sessionId === "string" && payload.sessionId
-      ? payload.sessionId
-      : null;
-  const aps = { alert: { title, body } };
-  if (sessionId) aps["thread-id"] = sessionId;
-  return { aps, sessionId };
-}
-
-/**
- * Default HTTP/2 sender for APNs. Uses Node's built-in http2 to POST one
- * device-token notification to api.push.apple.com. Resolves with
- * `{ status, body }` on response, or throws on socket/connect failure.
- *
- * Injected via sendApns's `sender` param so tests can stub it without a live
- * Apple round-trip.
- *
- * @param {{host:string, path:string, method:string, headers:object, body:string}} req
- * @returns {Promise<{status:number, body:any}>}
- */
-async function defaultApnsSender(req) {
-  return new Promise((resolve, reject) => {
-    const session = http2.connect(`https://${req.host}`);
-    session.on("error", reject);
-    const r = session.request({
-      ":method": req.method,
-      ":path": req.path,
-      ...req.headers,
-    });
-    r.on("response", (headers) => {
-      const status = headers[":status"] ?? 0;
-      const chunks = [];
-      r.on("data", (c) => chunks.push(c));
-      r.on("end", () => {
-        session.close();
-        const raw = Buffer.concat(chunks).toString("utf-8");
-        let body = raw;
-        try {
-          body = raw ? JSON.parse(raw) : null;
-        } catch {
-          /* non-JSON body — leave as string */
-        }
-        resolve({ status, body });
-      });
-    });
-    r.on("error", (e) => {
-      session.close();
-      reject(e);
-    });
-    r.end(req.body);
-  });
-}
-
-/**
- * Send ONE push to ONE APNs token. Pure w.r.t. the device-token registry
- * (caller passes it in), so the same function can be unit-tested with a
- * stub `sender`. Status mapping:
- *   - 200 → log success
- *   - 410 Gone, 400 BadDeviceToken, 400 Unregistered → removeApnsToken
- *   - everything else → log, keep the token (transient)
- *
- * @param {{teamId:string,keyId:string,p8Path:string,bundleId:string}} cfg
- * @param {string} deviceToken
- * @param {{title:string,body:string,sessionId?:string|null}} payload
- * @param {(req:any)=>Promise<{status:number,body:any}>} [sender] injected for tests
- * @param {{store?:string}} [opts] `store` = override the device-token store path
- *                                  (test-only; defaults to the production path)
- */
-export async function sendApns(cfg, deviceToken, payload, sender, opts = {}) {
-  const useSender = sender ?? defaultApnsSender;
-  const jwt = await getApnsJwt(cfg);
-  const envelope = buildApnsPayload(payload);
-  const req = buildApnsRequest({ cfg, deviceToken, payload: envelope, jwt });
-  let res;
-  try {
-    res = await useSender(req);
-  } catch (e) {
-    console.warn("[push] apns send error:", e?.message ?? e);
-    return { ok: false, reason: "transport" };
-  }
-  const status = res?.status ?? 0;
-  const reason = res?.body?.reason ?? "";
-  if (status === 200) {
-    console.log(`[push] apns ok token=${deviceToken.slice(0, 8)}…`);
-    return { ok: true };
-  }
-  if (
-    status === 410 ||
-    (status === 400 && (reason === "BadDeviceToken" || reason === "Unregistered"))
-  ) {
-    console.log(
-      `[push] apns prune token=${deviceToken.slice(0, 8)}… status=${status} reason=${reason}`,
-    );
-    await removeApnsToken(deviceToken, { store: opts.store }).catch(() => {});
-    return { ok: false, reason: "dead-token" };
-  }
-  console.warn(
-    `[push] apns send failed status=${status} reason=${reason}`,
-  );
-  return { ok: false, reason: reason || "http-error" };
-}
-
-/**
- * Stateful fan-out: read every APNs token + the current config block, and
- * send to each in parallel. No-op when the config block is absent (the
- * Web Push leg is the only delivery), or when no tokens are registered.
- * Exported for tests (so the same fn can be driven through HTTP routing
- * without a real APNs config).
+ * @param {object} payload
+ * @param {object} [opts]  accepted for forward-compat with the BET-200 swap.
  */
 export async function sendApnsFanout(payload, opts = {}) {
-  const cfg = opts.cfg ?? (await local.apnsConfig());
-  if (!cfg) return; // APNs leg disabled — silent no-op (matches Web Push)
-  const sender = opts.sender;
-  const store = opts.store;
-  const path = store ?? APNS_TOKENS_PATH;
-  const tokens = await loadApnsTokens(path);
-  if (tokens.length === 0) return;
-  await Promise.all(
-    tokens.map((t) => sendApns(cfg, t.token, payload, sender, { store: path })),
-  );
+  // Intentionally empty: APNs is now a hosted responsibility. See header.
+  // BET-200 will replace this body with:
+  //   1. POST <GATEWAY_BASE>/push with { box_id, tokens, payload }
+  //   2. iterate gateway results, call removeApnsToken for every prune:true
+  return;
 }
 
 /**
@@ -1110,5 +896,4 @@ export function _resetPushState() {
   _desktopSink = null;
   _focus = { sessionId: null, visible: false };
   _desktop = { visible: false, lastSeen: 0, lastActive: 0 };
-  _apnsJwtCache = null;
 }

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -1,9 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { generateKeyPairSync } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { writeFile, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import {
   classifyPushEvent,
   buildSessionLabel,
@@ -18,14 +17,9 @@ import {
   cancelAllEscalations,
   _pendingEscalationTags,
   _resetPushState,
-  buildApnsJwt,
-  buildApnsRequest,
-  buildApnsPayload,
   addApnsToken,
   removeApnsToken,
-  sendApns,
   sendApnsFanout,
-  _resetApnsJwtCache,
   _loadApnsTokensForTest,
   ESCALATE_MS,
   DESKTOP_PRESENCE_TTL_MS,
@@ -593,30 +587,18 @@ test("escalation: re-notify same tag supersedes (no duplicate timer)", async () 
 });
 
 // ---------------------------------------------------------------------------
-// APNs native-push delivery leg (BET-181)
+// APNs device-token store (box-side; APNs signing/HTTP moved in BET-199)
 // ---------------------------------------------------------------------------
 //
-// All tests below use a generated EC P-256 keypair written to a tmpdir .p8
-// and an injectable `sender` function — no live Apple round-trips, no
-// production ~/.manta/apns-tokens.json writes. The `store` injection on
-// addApnsToken/removeApnsToken/sendApnsFanout lets every assertion run
-// against a per-test temp file that the test cleans up.
-
-// Generate a P-256 EC keypair and export the private side as PKCS#8 PEM,
-// the exact shape Apple's APNs .p8 tokens are. Returns the path to a
-// tmpfile the test MUST clean up.
-async function makeApnsKeyFile() {
-  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
-  const pem = privateKey
-    .export({ type: "pkcs8", format: "pem" })
-    .toString();
-  const path = join(
-    tmpdir(),
-    `bui-apns-test-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.p8`,
-  );
-  await writeFile(path, pem, "utf-8");
-  return { path, cleanup: () => rm(path, { force: true }) };
-}
+// The actual APNs send (buildApnsJwt / buildApnsRequest / buildApnsPayload /
+// sendApns + the prune classification) moved to src/gateway/apns.mjs in
+// BET-199. The box keeps the device-token store (this section) — the
+// gateway is stateless about tokens; BET-200 will rewire sendApnsFanout
+// to POST the gateway and prune on `prune:true` results, calling the
+// removeApnsToken tested below.
+//
+// Tests in this section use a per-test temp store path so parallel runs
+// (or a leftover from a prior run) never see each other's writes.
 
 // Per-test temp store path for the APNs device-token registry. Always
 // return a unique file so parallel tests (or a leftover from a prior run)
@@ -627,78 +609,6 @@ function makeApnsStorePath(label) {
     `bui-apns-tokens-test-${label}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
   );
 }
-
-const APNS_CFG = {
-  teamId: "FSQ3HS4Z24",
-  keyId: "82P7483297",
-  bundleId: "com.antoinedc.mantaui",
-};
-
-test("buildApnsJwt: claim/header structure matches Apple APNs spec", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  try {
-    const cfg = { ...APNS_CFG, p8Path };
-    const IAT = 1_700_000_000;
-    const jwt = await buildApnsJwt(cfg, { now: IAT });
-    // Format: <header-b64url>.<claims-b64url>.<signature-b64url>
-    const parts = jwt.split(".");
-    assert.equal(parts.length, 3, "JWT must have exactly 3 parts");
-    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
-    const claims = JSON.parse(Buffer.from(parts[1], "base64url").toString());
-    assert.equal(header.alg, "ES256");
-    assert.equal(header.kid, APNS_CFG.keyId);
-    assert.equal(claims.iss, APNS_CFG.teamId);
-    assert.equal(claims.iat, IAT);
-    // Signature segment must be non-empty (binary blob — just assert length).
-    assert.ok(parts[2].length > 0);
-  } finally {
-    await cleanup();
-  }
-});
-
-test("buildApnsPayload: maps notification payload to APNs `aps` envelope", () => {
-  const out = buildApnsPayload({
-    title: "default / my-chat",
-    body: "Permission needed — Claude wants to run a tool.",
-    sessionId: "ses_abc",
-  });
-  assert.deepEqual(out, {
-    aps: {
-      alert: {
-        title: "default / my-chat",
-        body: "Permission needed — Claude wants to run a tool.",
-      },
-      "thread-id": "ses_abc",
-    },
-    sessionId: "ses_abc",
-  });
-});
-
-test("buildApnsPayload: no sessionId → no thread-id, still shaped right", () => {
-  const out = buildApnsPayload({ title: "T", body: "B" });
-  assert.deepEqual(out.aps.alert, { title: "T", body: "B" });
-  assert.equal(out.aps["thread-id"], undefined);
-  assert.equal(out.sessionId, null);
-});
-
-test("buildApnsRequest: host/path/headers/body shape (HTTP/2 style)", () => {
-  // 64-char hex device token (Apple's standard shape).
-  const deviceToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-  const req = buildApnsRequest({
-    cfg: APNS_CFG,
-    deviceToken,
-    payload: { aps: { alert: { title: "T", body: "B" } }, sessionId: null },
-    jwt: "header.claims.sig",
-  });
-  assert.equal(req.host, "api.push.apple.com");
-  assert.equal(req.path, `/3/device/${deviceToken}`);
-  assert.equal(req.method, "POST");
-  assert.equal(req.headers["authorization"], "bearer header.claims.sig");
-  assert.equal(req.headers["apns-topic"], APNS_CFG.bundleId);
-  assert.equal(req.headers["apns-push-type"], "alert");
-  assert.match(req.headers["content-type"], /application\/json/);
-  assert.match(req.body, /"aps"/);
-});
 
 test("register-apns upsert: addApnsToken round-trip via temp store", async () => {
   const store = makeApnsStorePath("upsert");
@@ -770,327 +680,6 @@ test("removeApnsToken: no-op on unknown token (returns count unchanged)", async 
     const tokens = await _loadApnsTokensForTest(store);
     assert.equal(tokens.length, 1);
   } finally {
-    await rm(store, { force: true });
-  }
-});
-
-// --- sendApns pruning rules -----------------------------------------------
-
-test("sendApns: 200 → ok, does NOT prune the token", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("send-ok");
-  try {
-    await addApnsToken("tok-ok", { store });
-    _resetApnsJwtCache();
-    const sent = [];
-    const res = await sendApns(
-      { ...APNS_CFG, p8Path },
-      "tok-ok",
-      { title: "T", body: "B", sessionId: "ses_x" },
-      async (req) => {
-        sent.push(req);
-        return { status: 200, body: null };
-      },
-      { store },
-    );
-    assert.equal(res.ok, true);
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.equal(tokens.length, 1, "200 must NOT prune");
-    assert.equal(sent.length, 1);
-    assert.equal(sent[0].headers["apns-topic"], APNS_CFG.bundleId);
-    assert.equal(sent[0].headers["apns-push-type"], "alert");
-    assert.match(sent[0].headers.authorization, /^bearer /);
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApns: 410 Gone → prunes the token", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("send-410");
-  try {
-    await addApnsToken("tok-410", { store });
-    _resetApnsJwtCache();
-    const res = await sendApns(
-      { ...APNS_CFG, p8Path },
-      "tok-410",
-      { title: "T", body: "B" },
-      async () => ({ status: 410, body: { reason: "Unregistered" } }),
-      { store },
-    );
-    assert.equal(res.ok, false);
-    assert.equal(res.reason, "dead-token");
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.equal(tokens.length, 0, "410 must prune");
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApns: 400 BadDeviceToken → prunes the token", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("send-bad");
-  try {
-    await addApnsToken("tok-bad", { store });
-    _resetApnsJwtCache();
-    const res = await sendApns(
-      { ...APNS_CFG, p8Path },
-      "tok-bad",
-      { title: "T", body: "B" },
-      async () => ({ status: 400, body: { reason: "BadDeviceToken" } }),
-      { store },
-    );
-    assert.equal(res.ok, false);
-    assert.equal(res.reason, "dead-token");
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.equal(tokens.length, 0, "400 BadDeviceToken must prune");
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApns: 400 Unregistered → prunes the token", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("send-unreg");
-  try {
-    await addApnsToken("tok-unreg", { store });
-    _resetApnsJwtCache();
-    const res = await sendApns(
-      { ...APNS_CFG, p8Path },
-      "tok-unreg",
-      { title: "T", body: "B" },
-      async () => ({ status: 400, body: { reason: "Unregistered" } }),
-      { store },
-    );
-    assert.equal(res.ok, false);
-    assert.equal(res.reason, "dead-token");
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.equal(tokens.length, 0);
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApns: 400 with other reason → keep token (transient)", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("send-400other");
-  try {
-    await addApnsToken("tok-keepme", { store });
-    _resetApnsJwtCache();
-    const res = await sendApns(
-      { ...APNS_CFG, p8Path },
-      "tok-keepme",
-      { title: "T", body: "B" },
-      async () => ({ status: 400, body: { reason: "BadCertificateEnvironment" } }),
-      { store },
-    );
-    assert.equal(res.ok, false);
-    assert.notEqual(res.reason, "dead-token");
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.equal(tokens.length, 1, "non-dead-token failures must NOT prune");
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApns: 500 / transport error → keep token (transient)", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("send-500");
-  try {
-    await addApnsToken("tok-keep500", { store });
-    _resetApnsJwtCache();
-    const res = await sendApns(
-      { ...APNS_CFG, p8Path },
-      "tok-keep500",
-      { title: "T", body: "B" },
-      async () => ({ status: 500, body: null }),
-      { store },
-    );
-    assert.equal(res.ok, false);
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.equal(tokens.length, 1, "500 must NOT prune");
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-// --- sendApnsFanout integration ---------------------------------------------
-
-test("sendApnsFanout: empty store → no send (and no crash)", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("fanout-empty");
-  try {
-    let called = 0;
-    await sendApnsFanout(
-      { title: "T", body: "B", sessionId: "ses_1" },
-      { cfg: { ...APNS_CFG, p8Path }, sender: async () => { called++; return { status: 200, body: null }; }, store },
-    );
-    assert.equal(called, 0);
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApnsFanout: fans out to ALL registered tokens; dead pruned live", async () => {
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("fanout-all");
-  try {
-    await addApnsToken("tok-1", { store });
-    await addApnsToken("tok-2", { store });
-    await addApnsToken("tok-3", { store });
-    _resetApnsJwtCache();
-    const seen = [];
-    await sendApnsFanout(
-      { title: "T", body: "B", sessionId: "ses_x" },
-      {
-        cfg: { ...APNS_CFG, p8Path },
-        sender: async (req) => {
-          seen.push(req.path.match(/\/3\/device\/(.+)/)[1]);
-          // tok-2 is "dead" → Apple returns 410
-          if (req.path.includes("tok-2")) {
-            return { status: 410, body: { reason: "Unregistered" } };
-          }
-          return { status: 200, body: null };
-        },
-        store,
-      },
-    );
-    assert.equal(seen.length, 3);
-    assert.ok(seen.includes("tok-1"));
-    assert.ok(seen.includes("tok-2"));
-    assert.ok(seen.includes("tok-3"));
-    // tok-2 was pruned live during the fanout.
-    const tokens = await _loadApnsTokensForTest(store);
-    assert.deepEqual(
-      tokens.map((t) => t.token).sort(),
-      ["tok-1", "tok-3"],
-    );
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("sendApnsFanout: no cfg → silent no-op (matches Web Push behavior)", async () => {
-  // When `cfg: null` is passed, sendApnsFanout falls back to
-  // local.apnsConfig() — which reads the real ~/.manta/config.json. To
-  // keep this test hermetic (independent of the dev box / CI environment
-  // having an apns block + token store populated), pass an explicit empty
-  // `store` path. With no tokens, sendApnsFanout short-circuits at the
-  // `if (tokens.length === 0) return;` guard and never invokes `sender`,
-  // matching the Web Push silent-no-op behavior the test name promises.
-  const store = makeApnsStorePath("no-cfg");
-  let called = false;
-  await sendApnsFanout(
-    { title: "T", body: "B" },
-    { cfg: null, store, sender: async () => { called = true; return { status: 200, body: null }; } },
-  );
-  assert.equal(called, false);
-});
-
-test("sendApnsFanout: end-to-end with fireNotify still calls APNs when both registries present", async () => {
-  // Integration-style: fire a notify that the router decides to push
-  // mobile-now → Web Push sendPush runs (no real subscribers → no-op),
-  // APNs fan-out runs, the temp store's token gets the send.
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("fire-integration");
-  try {
-    await addApnsToken("tok-fired", { store });
-    _resetPushState();
-    _resetApnsJwtCache();
-    setDesktopSink(() => {}); // no desktop leg
-    setDesktopPresence({ visible: false, lastSeen: 0, lastActive: 0 }); // desktop GONE → mobile only
-    const sent = [];
-    // Monkey-patch push.mjs' sendPush path by driving the APNs side
-    // directly through the fan-out entry point, simulating what
-    // dispatchNotification does in production after a routeNotification
-    // decision: it calls sendPush (Web Push) AND sendApnsFanout (APNs).
-    await fireNotify({ message: "build done", sessionID: "ses_fire" });
-    await sendApnsFanout(
-      { kind: "done", title: "default / my-chat", body: "Your turn finished.", sessionId: "ses_fire" },
-      {
-        cfg: { ...APNS_CFG, p8Path },
-        sender: async (req) => { sent.push(req.path); return { status: 200, body: null }; },
-        store,
-      },
-    );
-    assert.ok(
-      sent.some((p) => p.endsWith("/tok-fired")),
-      "APNs fan-out must reach the registered token",
-    );
-    // The Web Push leg fired too (no subs → no-op), but the routing
-    // decision (mobileNow:true) is the same — so the test confirms
-    // APNs participates WITHOUT changing routing decisions.
-    _resetPushState();
-  } finally {
-    await cleanup();
-    await rm(store, { force: true });
-  }
-});
-
-test("_resetApnsJwtCache: a new sign is forced after reset (verified via sendApns JWT)", async () => {
-  // buildApnsJwt itself always re-signs (ES256 has a random k), so the
-  // cache lives in getApnsJwt (called by sendApns). We exercise the cache
-  // by capturing the bearer token from the request sendApns builds, then
-  // resetting the cache and asserting the bearer token changes.
-  const { path: p8Path, cleanup } = await makeApnsKeyFile();
-  const store = makeApnsStorePath("jwt-cache");
-  try {
-    await addApnsToken("tok-cache", { store });
-    _resetApnsJwtCache();
-    const cfg = { ...APNS_CFG, p8Path };
-    const captured = [];
-    await sendApns(
-      cfg,
-      "tok-cache",
-      { title: "T", body: "B" },
-      async (req) => {
-        captured.push(req.headers.authorization);
-        return { status: 200, body: null };
-      },
-      { store },
-    );
-    await sendApns(
-      cfg,
-      "tok-cache",
-      { title: "T", body: "B" },
-      async (req) => {
-        captured.push(req.headers.authorization);
-        return { status: 200, body: null };
-      },
-      { store },
-    );
-    assert.equal(captured.length, 2);
-    assert.equal(
-      captured[0],
-      captured[1],
-      "second sendApns within cache window returns the cached bearer",
-    );
-    _resetApnsJwtCache();
-    await sendApns(
-      cfg,
-      "tok-cache",
-      { title: "T", body: "B" },
-      async (req) => {
-        captured.push(req.headers.authorization);
-        return { status: 200, body: null };
-      },
-      { store },
-    );
-    assert.notEqual(
-      captured[1],
-      captured[2],
-      "after _resetApnsJwtCache the bearer must be freshly signed",
-    );
-  } finally {
-    await cleanup();
     await rm(store, { force: true });
   }
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,14 +2,15 @@ import { defineConfig, configDefaults } from "vitest/config";
 
 export default defineConfig({
   test: {
-    // src/server/**, src/relay/** and scripts/** use node:test (run via
-    // `node --test`), not vitest. .claude/** holds Claude Code worktrees —
+    // src/server/**, src/relay/**, src/gateway/** and scripts/** use node:test
+    // (run via `node --test`), not vitest. .claude/** holds Claude Code worktrees —
     // nested copies of this repo (incl. their own *.test.mjs) that vitest must
     // not collect.
     exclude: [
       ...configDefaults.exclude,
       "src/server/**",
       "src/relay/**",
+      "src/gateway/**",
       "scripts/**",
       ".claude/**",
     ],


### PR DESCRIPTION
## Summary

Stage 1 of BET-198 (Drop the relay): builds the `src/gateway/` service in isolation, before any box-side wiring. Every test runs with fakes (no network, no real OVH/APNs). Wired into `npm test` and `npm run test:server`; nothing in live code depends on it yet.

`Base: origin/main @ 94d2ddf`

## What moved

- **APNs ES256/JWT builder, `_apnsJwtCache`, `sendApns`, prune classification** — `src/server/push.mjs:947–970` → `src/gateway/apns.mjs`. New signature: `sendApns({token, payload}, apnsConfig, fetchImpl)` → `{ok, prune}` (gateway is stateless about device tokens; the box owns those and prunes on `prune:true`).
- **`readBody` / `MAX_BODY_BYTES`** — `src/relay/server.mjs:77` → `src/gateway/http.mjs`. The only piece of relay code worth keeping; relay directory is deleted in BET-204 WP4.
- **`sendApnsFanout`** in `push.mjs` is now a no-op stub. BET-200 WP2 will rewire it to POST the gateway. Box-side device-token store (APNS_TOKENS_PATH, addApnsToken, removeApnsToken) stays in push.mjs.
- **`src/server/push.test.mjs`** lost its APNs tests (buildApnsJwt, buildApnsRequest, buildApnsPayload, sendApns, sendApnsFanout integration, _resetApnsJwtCache) — they live in `src/gateway/apns.test.mjs` now with the same cases (adapted to the new `{ok, prune}` shape).

## What is new

- **`src/gateway/index.mjs`** — HTTP server on `127.0.0.1:20081`:
  - `GET /healthz` → `{ok:true}`
  - `POST /register`: validate 32-hex box_id, mint/refresh gateway_token, OVH DNS A record create-or-update. Rate-limited per source IP (10/hour; X-Forwarded-For first value, fallback socket).
  - `POST /push`: cap 20 tokens, validate hex, fan out via the moved `sendApns`, return `{results:[{token, ok, prune}]}`.
- **`src/gateway/store.mjs`** — `/var/lib/manta-gateway/boxes.json`, atomic temp-rename writes, chmod 0600, path injectable for tests.
- **`src/gateway/dns.mjs`** — OVH API client (`POST /record`, `PUT /record/{id}`, `POST /refresh`). Signature = `$1$` + SHA1(`appSecret+consumerKey+method+url+body`), `fetchImpl` injectable.
- **`src/gateway/apns.mjs`** — moved APNs code + `loadApnsConfig(path)`.
- **`shared/ports/registry.md`** — port 20081 registered in the MantaUI 20xxx block.

## Test wiring

- `package.json` `test` and `test:server` now include `src/gateway/*.test.mjs`.
- `vitest.config.ts` excludes `src/gateway/**` (node:test runs them).

## Verification

```
$ npm run typecheck  → green
$ npm test          → 861 pass / 0 fail
```

Net diff: 0 failures, 665-line deletion from `push.mjs` / `push.test.mjs` (the moved code), 13 new files in `src/gateway/` + `shared/ports/registry.md`.

## Cross-cutting follow-ups (out of scope here)

- **BET-200** will replace `sendApnsFanout` with a POST to the gateway + local `removeApnsToken` on `prune:true`.
- **BET-201** will strip the relay agent and wire startup `registerWithGateway`.
- **BET-204** will delete the `src/relay/` directory.
- **BET-205** will rewrite the installer (Caddy + DNS automation).
- **BET-206** will deploy the gateway (gateway-v\* workflow + prod ops runbook).

No auth on the box is touched in this PR.