### PR TITLE
fix(plugins): route pluginsEnabled to Mac-local + log catch-up branches (BET-207)

### DIFF
--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -197,8 +197,15 @@ export function startCapExecutor(
   async function catchUpJobs(): Promise<void> {
     const c = cfgOrNull(configGetter);
     if (!c) return;
+    // BET-207: every failure branch now logs — without these, a stranded
+    // queued job was indistinguishable from "nothing to claim" and was
+    // undiagnosable from logs. SSE has no replay, so this on-connect
+    // GET is the ONLY path that can recover jobs the AI queued while
+    // the Mac was offline/asleep. Reusing the dedup Set keeps double-
+    // delivery (SSE envelope + this list) safe.
+    let res: Response;
     try {
-      const res = await fetch(
+      res = await fetch(
         `${c.serverUrl.replace(/\/+$/, "")}/api/cap?host=mac&status=queued`,
         {
           headers: c.boxToken
@@ -206,15 +213,21 @@ export function startCapExecutor(
             : undefined,
         },
       );
-      if (!res.ok) return;
-      const body = (await res.json()) as { jobs?: Array<{ id: string; capability: string }> };
-      for (const j of body.jobs ?? []) {
-        enqueue(j.id, j.capability);
-      }
-    } catch {
-      // Catch-up is best-effort; the SSE path will deliver what catch-up
-      // misses (modulo the dedup Set) once the stream is live.
+    } catch (err) {
+      console.warn("[cap] catch-up threw", err);
+      return;
     }
+    if (!res.ok) {
+      console.warn("[cap] catch-up GET failed", res.status);
+      return;
+    }
+    const body = (await res.json()) as { jobs?: Array<{ id: string; capability: string }> };
+    const ids: string[] = [];
+    for (const j of body.jobs ?? []) {
+      ids.push(j.id);
+      enqueue(j.id, j.capability);
+    }
+    console.log(`[cap] catch-up: ${ids.length} queued jobs`, ids);
   }
 
   function onConnect(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -230,6 +230,18 @@ function registerHandlers(): void {
   // /rpc/config:get instead). See src/preload/index.ts and src/renderer/main.tsx.
   ipcMain.handle(IPC.configGet, () => config);
 
+  // BET-207: `pluginsEnabled` is a Mac-machine-local toggle (controls
+  // whether THIS Mac runs plugins). It MUST persist to the Mac-local
+  // config the executor reads — NOT the box config that httpApi's
+  // configUpdate writes. Handled here locally via commit() (same one-shot
+  // pattern as configGet) so it works regardless of whether window.api is
+  // the httpApi client. Renderer reaches these via the preload bridge,
+  // not window.api.
+  ipcMain.handle(IPC.pluginsGetEnabled, () => config.pluginsEnabled === true);
+  ipcMain.handle(IPC.pluginsSetEnabled, (_e, value: boolean) => {
+    commit({ pluginsEnabled: value === true });
+  });
+
   // Clipboard write via Electron main — bypasses renderer permission restrictions
   // that silently block navigator.clipboard.writeText for non-user-gesture writes.
   ipcMain.handle(IPC.clipboardWriteText, (_e, text: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,6 +69,17 @@ const api = {
 
   revealInFolder: (localPath: string): Promise<void> =>
     ipcRenderer.invoke(IPC.revealInFolder, localPath),
+
+  // BET-207: `pluginsEnabled` is a Mac-machine-local toggle — read/write
+  // goes through main's local handlers (commit() → Mac-local config) so
+  // it doesn't round-trip through httpApi/the box. Renderer reads the
+  // current value on Settings mount to seed the toggle, and writes the
+  // new value on Save. Same pattern as configGet (a local-only channel
+  // that's never part of window.api).
+  pluginsGetEnabled: (): Promise<boolean> =>
+    ipcRenderer.invoke(IPC.pluginsGetEnabled),
+  pluginsSetEnabled: (value: boolean): Promise<void> =>
+    ipcRenderer.invoke(IPC.pluginsSetEnabled, value),
 };
 
 // Expose the real preload bridge under a STABLE, dedicated name — NOT "api".

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -42,7 +42,6 @@ export function Settings({ onClose }: { onClose: () => void }) {
     groqApiKey,
     voiceTranscriptionModel,
     voiceCommandModel,
-    pluginsEnabled,
     launcherFlags,
     axiomToken,
     axiomDataset,
@@ -75,7 +74,14 @@ export function Settings({ onClose }: { onClose: () => void }) {
   // block on the Files tab). The toggle is OFF by default; toggling takes
   // effect on the next app launch (the executor gates itself at start
   // time — see src/main/capExecutor.ts).
-  const [pluginsOn, setPluginsOn] = useState(pluginsEnabled);
+  //
+  // BET-207: `pluginsEnabled` is a Mac-machine-local toggle. It is NOT
+  // mirrored through the store (the store mirrors the box config via
+  // configGet, and the toggle must persist to the Mac-local file the
+  // executor reads). Seed the toggle from the Mac-local value via the
+  // preload getter, and persist via the preload setter — never via
+  // configUpdate (which writes the box config).
+  const [pluginsOn, setPluginsOn] = useState(false);
   const [plugins, setPlugins] = useState<PluginRegistryRow[] | null>(null);
   const [pluginsError, setPluginsError] = useState<string | null>(null);
 
@@ -113,11 +119,21 @@ export function Settings({ onClose }: { onClose: () => void }) {
     setGroqKey(groqApiKey);
     setVoiceTrModel(voiceTranscriptionModel);
     setVoiceCmdModel(voiceCommandModel);
-    setPluginsOn(pluginsEnabled);
     setLauncherFlagValues(launcherFlags ?? {});
     setAxiomTok(axiomToken);
     setAxiomDs(axiomDataset);
-  }, [defaultModel, skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, pluginsEnabled, launcherFlags, axiomToken, axiomDataset]);
+  }, [defaultModel, skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, launcherFlags, axiomToken, axiomDataset]);
+
+  // Seed the Mac-local `pluginsEnabled` toggle from the desktop's config
+  // (BET-207). The store mirrors the BOX config (via httpApi.configGet),
+  // so seeding from the store would show the wrong value after a reload.
+  // Read once on mount — the toggle only changes via Save in this same
+  // panel, so a live listener isn't needed.
+  useEffect(() => {
+    const preload = getBuiPreload();
+    if (!preload?.pluginsGetEnabled) return; // mobile/web has no preload
+    preload.pluginsGetEnabled().then(setPluginsOn).catch(() => {});
+  }, []);
 
   // Fetch available models once (non-fatal — Settings works even if opencode is unreachable).
   useEffect(() => {
@@ -193,9 +209,16 @@ export function Settings({ onClose }: { onClose: () => void }) {
         voiceCommandModel: voiceCmdModel.trim(),
         axiomToken: axiomTok.trim(),
         axiomDataset: axiomDs.trim(),
-        pluginsEnabled: pluginsOn,
         launcherFlags: launcherFlagValues,
       });
+      // BET-207: persist `pluginsEnabled` to the Mac-local config via the
+      // preload bridge — NOT via window.api.configUpdate (which writes the
+      // box config the executor never reads). No-op on mobile/web where
+      // the plugins tab is not rendered.
+      const preload = getBuiPreload();
+      if (preload?.pluginsSetEnabled) {
+        await preload.pluginsSetEnabled(pluginsOn);
+      }
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : String(e));
       setSaving(false);

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -27,6 +27,8 @@ function makeFakePreload(): BuiPreload {
       return vi.fn();
     }),
     peekRemoteFile: vi.fn(async () => {}),
+    pluginsGetEnabled: vi.fn(async () => false),
+    pluginsSetEnabled: vi.fn(async () => {}),
   };
 }
 

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -43,6 +43,13 @@ export interface BuiPreload {
   // (httpApi.ts peekRemoteFile) actually finds the method instead of always
   // silently falling through to the (also-stubbed) server RPC no-op.
   peekRemoteFile(remotePath: string): Promise<void>;
+  // BET-207: `pluginsEnabled` is a Mac-machine-local toggle — the toggle
+  // MUST persist to the Mac-local config (the one capExecutor reads at
+  // start time), NOT the box config httpApi.configUpdate writes. Seed the
+  // toggle's initial state via pluginsGetEnabled and persist via
+  // pluginsSetEnabled; both are no-ops on mobile/web (no preload).
+  pluginsGetEnabled(): Promise<boolean>;
+  pluginsSetEnabled(value: boolean): Promise<void>;
 }
 
 /**

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -139,11 +139,6 @@ type State = {
   // changing the token requires an app relaunch.
   axiomToken: string;
   axiomDataset: string;
-  // Capability executor (BET-183 / BET-185 / BET-190). When true, this Mac
-  // runs YAML plugins from ~/.manta/plugins/ for jobs the AI queues. Mirrored
-  // from AppConfig.pluginsEnabled. Mirroring is read-only here — toggling
-  // takes effect on next app launch (the executor gates itself at start time).
-  pluginsEnabled: boolean;
   projects: Project[];
   activeProjectName: string | null;
   activeWindowByProject: Record<string, number>; // projectName -> windowIndex
@@ -288,7 +283,6 @@ export const useStore = create<State>((set, get) => ({
   voiceCommandModel: "",
   axiomToken: "",
   axiomDataset: "",
-  pluginsEnabled: false,
   projects: [],
   activeProjectName: null,
   activeWindowByProject: {},
@@ -404,7 +398,6 @@ export const useStore = create<State>((set, get) => ({
       voiceCommandModel: c.voiceCommandModel ?? "",
       axiomToken: c.axiomToken ?? "",
       axiomDataset: c.axiomDataset ?? "",
-      pluginsEnabled: c.pluginsEnabled ?? false,
     }),
 
   applyPairing: (p) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -534,6 +534,16 @@ export const IPC = {
   // (types → shared/api → httpApi → rpc.mjs → server/plugins.mjs).
   // → PluginRegistryRow[]
   pluginsRegistry: "plugins:registry",
+  // `pluginsEnabled` is a Mac-machine-local toggle (BET-207): it controls
+  // whether THIS Mac runs plugins, so it persists to the Mac-local config
+  // (read by capExecutor at start time) — NOT the box config that
+  // `configGet`/`configUpdate` round-trip through httpApi. Routed via the
+  // preload bridge (window.__buiPreload.pluginsSetEnabled / pluginsGetEnabled)
+  // exactly like configGet, which is also handled locally in main on
+  // HTTP mode so the renderer can read Mac-local state without an httpApi
+  // round-trip to the box.
+  pluginsSetEnabled: "plugins:set-enabled",  // (value: boolean) → void
+  pluginsGetEnabled: "plugins:get-enabled",  // () → boolean
 } as const;
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the


### PR DESCRIPTION
Two defects in BET-192 Phase 3 live verification, fixed in one PR.

## Defect 1 — `pluginsEnabled` toggle wrote the wrong config file

In HTTP mode, `Settings → Plugins` toggled `pluginsEnabled` via `window.api.configUpdate` → /rpc → `local.configUpdate` → **box** config (`~/.manta/config.json`). But `capExecutor` reads it from the **Mac-local** config (`<userData>/config.json`) via its `configGetter`. Two files, no shared write path — the toggle could never arm the executor.

### Fix

- New IPC channels `plugins:set-enabled` / `plugins:get-enabled`, handled **locally** in main next to `configGet` (reuses `commit()`, so the in-memory `config` the executor reads is updated atomically with the persisted Mac-local file).
- Exposed on `window.__buiPreload` (NOT `window.api` — httpApi only reaches the box). Added to `BuiPreload` in `src/renderer/preloadAccess.ts`.
- `Settings.tsx` seeds the toggle from `pluginsGetEnabled()` on mount and persists on Save via `pluginsSetEnabled()`. The Mac-local value is the source of truth for the toggle state, not the store.
- Removed the `pluginsEnabled` mirror from `store.ts` — no other consumer.
- Box side: `local.mjs` `configUpdate` is a free-form merge (no allowlist), so no code change needed there. The stray `pluginsEnabled: true` already written to the box during verification is dead but harmless — no migration code, per spec.

### Reuse / hygiene

- Reuses `commit()` — no new local-write path.
- Reuses the existing local-IPC pattern (`configGet`) — no httpApi round-trip.

## Defect 2 — `catchUpJobs` silently strands queued jobs

`catchUpJobs` had an empty `try/catch` + an `if (!res.ok) return;` with no log. Two `plugin.write` jobs (`67697b00`, `9750d6f9`) sat `status:"queued"` on the box across reconnects and the cause was undiagnosable.

### Fix

- Log on every failure branch:
  - `console.warn("[cap] catch-up threw", err)` — replaces the empty `catch {}`.
  - `console.warn("[cap] catch-up GET failed", res.status)` — replaces the silent non-ok early return.
  - `console.log("[cap] catch-up: N queued jobs", ids)` — new, makes a persistent "0" on a real backlog visible.
- Dropped the misleading `// SSE path will deliver what catch-up misses` comment. SSE has no replay — catch-up is the only path that can recover jobs the AI queued while the Mac was offline/asleep.

### Root-cause investigation

The three candidates the issue lists all check out structurally:
- (a) stale `boxToken` — `publishRegistry` uses the same token and works, so unlikely.
- (b) `POST /api/cap/{id}/start` rejects a `queued` claim — inspected `src/server/capabilities.mjs:startJob`: only `status === "queued"` transitions to `running`. Endpoint is correct.
- (c) response envelope mismatch — `GET /api/cap` returns `{jobs:[...]}` (line 976 of `src/server/index.mjs`), executor reads `body.jobs`. Matches.

The logs above are the diagnostic primitive for the next occurrence; the implementer-of-the-next-occurrence can read the box's logs (Axiom via BET-187 once `axiomToken` is set, or stderr in dev) and pinpoint the actual cause without code archaeology.

### Reuse / hygiene

- No new claim path. `runOne` → `POST /start` is still the only claim.
- No retry/polling fallback (explicitly forbidden in the issue).

## Files changed

```
 src/main/capExecutor.ts            | 35 +++++++++++++++++++++++++++--------
 src/main/index.ts                  | 12 ++++++++++++
 src/preload/index.ts               | 11 +++++++++++
 src/renderer/Settings.tsx          | 33 ++++++++++++++++++++++++++++-----
 src/renderer/preloadAccess.test.ts |  2 ++
 src/renderer/preloadAccess.ts      |  7 +++++++
 src/renderer/store.ts              |  7 -------
 src/shared/types.ts                | 10 ++++++++++
```

**Base:** `origin/main` @ `cceec0e`

## Verification results

- PR branch `multica/BET-207-plugins-toggle-and-catchup` @ `c96b9fd`:
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `771` pass / `0` fail / `0` skip.
- Base `main` @ `cceec0e`:
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `771` pass / `0` fail / `0` skip.
- **Conclusion:** 0 pre-existing failures (both branches are clean), 0 new failures introduced, 0 resolved by this PR (the codebase was already green at the base). Typecheck logs are byte-identical between the branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-base.log`, `/tmp/test-base.log` for reviewer spot-check.

## Manual Mac-leg steps (for the human)

Per the issue's verification block, this PR enables:

1. `Settings → Plugins` toggle ON → quit + relaunch → `~/.manta/plugins/` is created (proves the Mac-local flag is now set). Toggle OFF + relaunch → executor no-ops (folder may remain, but no scan/registry PUT — confirm via absence of the registry-PUT log line).
2. With the toggle ON and the app running, queue a `plugin.write` job via `plugin_save(...)` from a chat session while the Mac app is QUIT, then relaunch → within seconds of connect, catch-up claims + runs it; `plugin_status` → `done`; manifest lands in `~/.manta/plugins/`.
3. The two already-stranded jobs (`67697b00` map-form → fails validation as designed; `9750d6f9` array-form → writes `ios-mantaui.yaml`) get claimed on the next connect — Axiom logs (or stderr) will show the new `[cap] catch-up: 2 queued jobs [67697b00,9750d6f9]` line followed by `[cap] start 67697b00: ...`.

## Out of scope (per spec)

- Plugin manifest schema, `plugin.run` path, Settings UI beyond the toggle wiring.
- Migration to strip the dead box-side `pluginsEnabled` (harmless; leave it).
- A retry/polling fallback for catch-up (explicitly forbidden).