### PR TITLE
fix(main): busConsumer selects node:https for https:// serverUrl (BET-208)

### DIFF
--- a/src/main/busConsumer.ts
+++ b/src/main/busConsumer.ts
@@ -15,7 +15,8 @@
 // connect AND every reconnect — so the executor can run its SSE-replay
 // catch-up list. desktopNotify doesn't need it.
 
-import { request } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import type { IncomingMessage } from "node:http";
 import type { AppConfig } from "../shared/types.js";
 
@@ -79,7 +80,7 @@ export function createBusConsumer(
     if (cfg.boxToken) {
       headers["authorization"] = `Bearer ${cfg.boxToken}`;
     }
-    const req = request(
+    const req = (url.protocol === "https:" ? httpsRequest : httpRequest)(
       {
         hostname: url.hostname,
         port: url.port || (url.protocol === "https:" ? 443 : 80),


### PR DESCRIPTION
## What
`src/main/busConsumer.ts` imported `node:http` unconditionally and used it for the SSE bus connection. When the desktop's `serverUrl` is `https://` (e.g. `app.mantaui.com` over HTTPS), the request dialed port 443 with plaintext HTTP — the server refused, status 200 never reached, `onConnect` never fired.

This silently broke (a) `capExecutor`'s catch-up + `capJob` delivery over HTTPS and (b) `desktopNotify` over HTTPS. BET-207's new logging surfaced (a): the `[cap] catch-up: N queued jobs` line never appeared in the Mac main console.

## Fix (3 lines, one file)
Select the `request` function by `url.protocol` at the call site. `node:https`'s `request` has the identical signature to `node:http`'s and honors TLS on port 443 — no custom `agent`, `rejectUnauthorized`, or other TLS options added (the default trust store is correct for `app.mantaui.com`'s Cloudflare/OVH cert).

```diff
-import { request } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 ...
-    const req = request(
+    const req = (url.protocol === "https:" ? httpsRequest : httpRequest)(
```

The options object, callback, port default (`url.port || (https: ? 443 : 80)`), framing logic, and 3-second reconnect loop are all unchanged.

## Scope
- Touched: `src/main/busConsumer.ts` (the one file the issue pins).
- Not touched: `capExecutor.ts`, `desktopNotify.ts` — both consume `createBusConsumer` and are fixed for free.
- Not done: any fetch-based rewrite of the SSE consumer, any change to the plugin manifest schema or box server.

## Unit test
Not added — see commit message. Briefly: a clean test would need either a local HTTPS server with a self-signed cert (heavy) or `vi.mock` on `node:http`/`node:https` to spy on which `request` was called (brittle — tests implementation, not behavior). The manual Mac-side verification below is the meaningful check.

## Verification
- `npm run typecheck` → exit 0, no errors.
- `npm test` → 861 pass / 0 fail.
- Manual (human, Mac after rebuild): within ~3s of connect, `[cap] catch-up: N queued jobs` must appear in main stdout; the single queued `plugin.write` job `2b5d4f0b` (`ios-mantaui`, array-form, valid) must claim → `~/.manta/plugins/ios-mantaui.yaml` lands; any desktop notification push route must surface an OS banner.

## Base
`origin/main` @ `8d55d63`
