### PR TITLE
BET-196 doc(capabilities): refresh v2 top-of-file comment

### DIFF
--- a/src/server/capabilities.mjs
+++ b/src/server/capabilities.mjs
@@ -1,10 +1,11 @@
 // Capability job queue for the MantaUI server — the generic spine that lets any
 // MantaUI plugin register an AI-invokable capability and have a connected
-// device (the Mac, or the box itself) execute it. First plugin: `ios.build`
-// (compiled on the Mac to avoid burning Codemagic minutes), but the queue /
-// REST surface / SSE envelopes here speak the GENERIC `{capability, input,
-// host}` envelope — adding capability #2 is a new tool file + a new HANDLERS
-// entry, NOT a queue change. See docs/mantaui-plugins.md for the full design.
+// device (the Mac, or the box itself) execute it. Plugins are YAML manifests at
+// ~/.manta/plugins/<name>.yaml on the executor machine (BET-189 Plugins v2);
+// the queue / REST surface / SSE envelopes here speak the GENERIC
+// `{capability, input, host}` envelope and are byte-identical to v1, so adding a
+// capability is authoring a manifest — never a queue change. See
+// docs/mantaui-plugins.md (v3) for the full design.
 //
 // Shape mirrors src/server/schedule.mjs: dependency-injected
 // ({load, save, publish, notifySession}) pure-logic-with-injected-I/O, plus a


### PR DESCRIPTION
Refreshes the stale top-of-file comment in \`src/server/capabilities.mjs\` to match Plugins v2 (BET-189). Doc-only; no logic touched.

## Changes
- Removed the "First plugin: \`ios.build\`" claim (\`ios.build\` deleted in BET-189; the first plugin surface is now YAML manifests on the executor machine).
- Removed the "adding capability #2 is a new tool file + a new HANDLERS entry" sentence (the HANDLERS map is deleted in BET-189 Phase 1).
- Kept the queue / REST / SSE envelope description (still byte-identical to v2) and the \`storeUtils.mjs\` / \`schedule.mjs\` shape-mirror notes.
- Cross-links \`docs/mantaui-plugins.md\` (v3).

## Diff
\`\`\`diff
-// device (the Mac, or the box itself) execute it. First plugin: \`ios.build\`
-// (compiled on the Mac to avoid burning Codemagic minutes), but the queue /
-// REST surface / SSE envelopes here speak the GENERIC \`{capability, input,
-// host}\` envelope — adding capability #2 is a new tool file + a new HANDLERS
-// entry, NOT a queue change. See docs/mantaui-plugins.md for the full design.
+// device (the Mac, or the box itself) execute it. Plugins are YAML manifests at
+// ~/.manta/plugins/<name>.yaml on the executor machine (BET-189 Plugins v2);
+// the queue / REST surface / SSE envelopes here speak the GENERIC
+// \`{capability, input, host}\` envelope and are byte-identical to v1, so adding a
+// capability is authoring a manifest — never a queue change. See
+// docs/mantaui-plugins.md (v3) for the full design.
\`\`\`

## Verification
- \`npm run typecheck\` passes.
- \`npm test\`: the only failure is a pre-existing, unrelated \`formatPairingOutput\` test in \`scripts/install.test.mjs\` (fails on clean main too); no capabilities test affected.