### PR TITLE
BET-201: strip relay agent + gateway startup registration

### DIFF
--- a/src/relay/agent/index.mjs
+++ b/src/relay/agent/index.mjs
@@ -339,24 +339,6 @@ export function makeDefaultLocalFetchStream(localBase, auth) {
   };
 }
 
-// ADR-1 (BET-151) — pure config decision: should the box server start the relay
-// agent at boot? The product default is YES (relay-first is the path to a paid
-// mobile app — BET-151). The owner's box can opt out by writing
-// `"relayEnabled": false` into `~/.manta/config.json` (e.g. self-hosted with
-// direct-HTTPS only). No env override here on purpose — configGet() is the
-// single switch, mirroring how `chatAutoAllow` is gated.
-//
-// Truth table (tested):
-//   undefined / null config   → true (relay-first default)
-//   { relayEnabled: true }    → true
-//   { relayEnabled: false }   → false
-//   { relayEnabled: "no" }    → true (only `=== false` opts out — same shape
-//                                 as a JS truthy check; do NOT over-engineer)
-export function shouldStartRelayAgent(config) {
-  if (config == null) return true;
-  return config.relayEnabled !== false;
-}
-
 // ---------------------------------------------------------------------------
 // Local PTY-connect leg (BET-158). Opens a WebSocket to the box server's own
 // /pty endpoint (ws://127.0.0.1:8787/pty?<query>) so the relay can bridge a

--- a/src/relay/agent/index.test.mjs
+++ b/src/relay/agent/index.test.mjs
@@ -6,7 +6,6 @@ import {
   makeDefaultLocalFetch,
   makeDefaultLocalFetchStream,
   makeDefaultLocalPtyConnect,
-  shouldStartRelayAgent,
   DEFAULT_RELAY_URL,
   RECONNECT_BASE_MS,
   RECONNECT_MAX_MS,
@@ -636,35 +635,6 @@ test("stop() during an in-flight dial does not connect afterwards", async () => 
   assert.equal(agent.isConnected(), false, "never adopts a socket opened after stop");
   assert.equal(closed, true, "the raced-open socket is closed");
   assert.equal(clock.pendingCount(), 0);
-});
-
-// ---------------------------------------------------------------------------
-// shouldStartRelayAgent — ADR-1 config decision (BET-155)
-// ---------------------------------------------------------------------------
-
-test("shouldStartRelayAgent defaults to true (relay-first product default)", () => {
-  assert.equal(shouldStartRelayAgent(undefined), true);
-  assert.equal(shouldStartRelayAgent(null), true);
-  assert.equal(shouldStartRelayAgent({}), true);
-  assert.equal(shouldStartRelayAgent({ relayEnabled: undefined }), true);
-});
-
-test("shouldStartRelayAgent returns true for relayEnabled=true", () => {
-  assert.equal(shouldStartRelayAgent({ relayEnabled: true }), true);
-});
-
-test("shouldStartRelayAgent returns false ONLY for relayEnabled=false (opt-out)", () => {
-  assert.equal(shouldStartRelayAgent({ relayEnabled: false }), false);
-});
-
-test("shouldStartRelayAgent treats truthy non-booleans as enabled (no over-engineering)", () => {
-  // The only way to opt out is the literal boolean `false`. Anything else
-  // (a stray "no", 0 wrapped in JSON's quirks, a stale schema) keeps the
-  // relay on — re-enabling is one config flip away, and a silent "no" would
-  // be invisible to the operator.
-  assert.equal(shouldStartRelayAgent({ relayEnabled: "no" }), true);
-  assert.equal(shouldStartRelayAgent({ relayEnabled: 0 }), true);
-  assert.equal(shouldStartRelayAgent({ relayEnabled: "" }), true);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/gatewayRegister.mjs
+++ b/src/server/gatewayRegister.mjs
@@ -1,0 +1,213 @@
+// gatewayRegister.mjs — box-side registration against the hosted push gateway
+// (BET-198 §WP2). Replaces the box's old outbound dial to the relay with a
+// single POST to the gateway's `/register` endpoint that creates / refreshes
+// the per-box DNS A record and (on first boot) mints a `gateway_token`. The
+// token is persisted into ~/.manta/auth.json — the SAME file that holds
+// `box_token` — using the shared atomic-write helper.
+//
+// Behavior:
+//   - First boot (no `gateway_token` in auth.json):
+//       POST /register with body { box_id }, NO auth header.
+//       Persists the returned `gateway_token` + `gateway_host`.
+//   - Subsequent boot (`gateway_token` already on disk):
+//       POST /register with body { box_id } + Authorization: Bearer <token>
+//       (idempotent IP refresh). The response carries only `{ host }` — we
+//       do NOT rewrite auth.json because the token did not change.
+//   - Any failure (fetch throw, non-2xx): `console.warn` + return. NEVER
+//     throw — push startup is best-effort; the next boot will retry.
+//   - `process.env.MANTA_GATEWAY_BASE === "off"` → return immediately. Used
+//     by dev boxes + CI to skip network entirely.
+//
+// All I/O is injectable so the unit tests run with an in-memory file and a
+// fake fetch — no FS, no real network.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { atomicWrite } from "./storeUtils.mjs";
+import { STORE_PATH as DEFAULT_AUTH_PATH } from "./auth.mjs";
+
+// Gateway base URL. The env override exists ONLY for tests + dev boxes; prod
+// uses the canonical https://gateway.mantaui.com. The "off" sentinel is the
+// opt-out used by CI and the local dev box where we don't want any network
+// at boot.
+const DEFAULT_GATEWAY_BASE =
+  process.env.MANTA_GATEWAY_BASE ?? "https://gateway.mantaui.com";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (testable in isolation)
+// ---------------------------------------------------------------------------
+
+// box_id shape matches src/server/auth.mjs isValidToken (32 lowercase hex).
+// We don't import the function to avoid a cycle once auth.mjs is wired into
+// the same boot path — but the test asserts the same regex.
+function isValidBoxId(boxId) {
+  return typeof boxId === "string" && /^[0-9a-f]{32}$/.test(boxId);
+}
+
+// Load the persisted auth.json. Returns `{ box_id, box_token, gateway_token,
+// gateway_host }` for any subset of fields the file actually has; returns
+// `null` when the file is missing/unreadable/has no box_id. Extra fields
+// (created_at, etc.) are passed through so a subsequent save round-trip is
+// lossless.
+export function loadAuthIdentity(path) {
+  try {
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8");
+    if (!raw.trim()) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    return {
+      box_id: typeof parsed.box_id === "string" ? parsed.box_id : null,
+      box_token: typeof parsed.box_token === "string" ? parsed.box_token : null,
+      gateway_token:
+        typeof parsed.gateway_token === "string" ? parsed.gateway_token : null,
+      gateway_host:
+        typeof parsed.gateway_host === "string" ? parsed.gateway_host : null,
+      _raw: parsed,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Persist the box identity PLUS the freshly-issued gateway_token + host back
+// to auth.json atomically. We NEVER lose the existing box_id / box_token —
+// the new fields are merged over the previous JSON. `data` parameter is the
+// full desired file contents (NOT a patch): the caller passes
+// `{ ...existing, gateway_token, gateway_host }` so the file stays lossless
+// for fields we don't know about.
+async function persistAuthIdentity(path, data) {
+  await atomicWrite(path, JSON.stringify(data, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register (or refresh) this box with the hosted push gateway. Best-effort —
+ * never throws. See file-level docblock for the full state machine.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.authPath]   Path to ~/.manta/auth.json (injectable).
+ * @param {string} [opts.gatewayBase] Gateway base URL (default
+ *                                     MANTA_GATEWAY_BASE env or
+ *                                     https://gateway.mantaui.com).
+ * @param {typeof fetch} [opts.fetchImpl] Fetch impl (default globalThis.fetch).
+ * @param {typeof console} [opts.console] Console (injectable for tests).
+ * @returns {Promise<{ ok: boolean, skipped?: string, status?: number, error?: string }>}
+ *   ok=true means registration succeeded (first-boot OR re-register).
+ *   ok=false means fetch failed OR returned non-2xx; the server is still up.
+ *   skipped is set when MANTA_GATEWAY_BASE==="off" or the box has no box_id.
+ */
+export async function registerWithGateway({
+  authPath = DEFAULT_AUTH_PATH,
+  gatewayBase = DEFAULT_GATEWAY_BASE,
+  fetchImpl,
+  console: consoleImpl = console,
+} = {}) {
+  const log = consoleImpl.log.bind(consoleImpl);
+  const warn = consoleImpl.warn.bind(consoleImpl);
+  const doFetch = fetchImpl ?? globalThis.fetch;
+
+  // Dev / CI opt-out: no network at all.
+  if (gatewayBase === "off") {
+    return { ok: false, skipped: "off" };
+  }
+
+  // Read the box identity. A box with no box_id (very first boot, before
+  // ensureAuth() ran) is a no-op — the next boot will have it.
+  const ident = loadAuthIdentity(authPath);
+  if (!ident || !ident.box_id) {
+    warn("[gateway-register] no box_id in auth.json — skipping (next boot will retry)");
+    return { ok: false, skipped: "no_box_id" };
+  }
+  if (!isValidBoxId(ident.box_id)) {
+    warn("[gateway-register] malformed box_id in auth.json — skipping");
+    return { ok: false, skipped: "bad_box_id" };
+  }
+
+  // Build the request. First boot → no Authorization header (gateway mints
+  // a fresh token). Subsequent boot → include the bearer (gateway uses it to
+  // verify and skips token re-issue, returning only { host }).
+  const headers = { "content-type": "application/json" };
+  if (ident.gateway_token) {
+    headers.authorization = `Bearer ${ident.gateway_token}`;
+  }
+  const url = `${gatewayBase}/register`;
+  let resp;
+  try {
+    resp = await doFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ box_id: ident.box_id }),
+    });
+  } catch (e) {
+    warn(
+      `[gateway-register] fetch failed: ${e?.message ?? e} (url=${url}) — next boot will retry`,
+    );
+    return { ok: false, error: "fetch_failed" };
+  }
+
+  if (!resp || !resp.ok) {
+    warn(
+      `[gateway-register] non-2xx status=${resp?.status ?? "?"} url=${url} — next boot will retry`,
+    );
+    return { ok: false, status: resp?.status ?? 0, error: "non_2xx" };
+  }
+
+  // Parse the JSON body. A malformed response must NOT corrupt auth.json —
+  // we leave it untouched and warn.
+  let body;
+  try {
+    body = await resp.json();
+  } catch (e) {
+    warn(`[gateway-register] malformed JSON in response: ${e?.message ?? e}`);
+    return { ok: false, error: "bad_json" };
+  }
+  if (!body || typeof body !== "object") {
+    warn("[gateway-register] response body is not a JSON object");
+    return { ok: false, error: "bad_json" };
+  }
+
+  // First-boot path: the gateway mints a token. Persist BOTH token + host
+  // atomically, preserving every other field in auth.json.
+  if (typeof body.gateway_token === "string" && body.gateway_token) {
+    if (typeof body.host !== "string" || !body.host) {
+      warn("[gateway-register] missing host in /register response — not persisting");
+      return { ok: false, error: "missing_host" };
+    }
+    const next = {
+      ...(ident._raw ?? {}),
+      box_id: ident.box_id,
+      gateway_token: body.gateway_token,
+      gateway_host: body.host,
+    };
+    try {
+      await persistAuthIdentity(authPath, next);
+    } catch (e) {
+      warn(
+        `[gateway-register] failed to persist auth.json: ${e?.message ?? e} — retry on next boot`,
+      );
+      return { ok: false, error: "persist_failed" };
+    }
+    log(
+      `[gateway-register] registered box_id=${ident.box_id.slice(0, 8)}… host=${body.host}`,
+    );
+    return { ok: true, registered: true, host: body.host };
+  }
+
+  // Re-register path: response carries only `{ host }` (no token re-issue).
+  // auth.json is unchanged — we just confirm reachability so logs are useful.
+  if (typeof body.host === "string" && body.host) {
+    log(
+      `[gateway-register] refreshed box_id=${ident.box_id.slice(0, 8)}… host=${body.host}`,
+    );
+    return { ok: true, registered: false, host: body.host };
+  }
+
+  warn("[gateway-register] response had no gateway_token and no host");
+  return { ok: false, error: "empty_response" };
+}
+
+export { DEFAULT_GATEWAY_BASE };

--- a/src/server/gatewayRegister.test.mjs
+++ b/src/server/gatewayRegister.test.mjs
@@ -1,0 +1,456 @@
+// gatewayRegister.test.mjs — unit tests for the box-side gateway registration
+// helper (BET-201). Each test uses an isolated tmp auth.json + an injected
+// fetch; no FS outside /tmp, no real network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerWithGateway, loadAuthIdentity, DEFAULT_GATEWAY_BASE } from "./gatewayRegister.mjs";
+
+const BOX_ID = "0123456789abcdef0123456789abcdef";
+const GATEWAY_TOKEN = "fedcba9876543210fedcba9876543210";
+const HOST = `${BOX_ID}.boxes.mantaui.com`;
+
+function freshAuthPath(label) {
+  const dir = mkdtempSync(join(tmpdir(), `bui-gwreg-${label}-`));
+  return { dir, path: join(dir, "auth.json") };
+}
+
+// Quiet console capture helpers. Each test wraps console.warn/console.log so
+// we can assert the warn was emitted and then restore. registerWithGateway
+// accepts a `console` injection, so most tests pass a fake instead — but the
+// "failed fetch" + "MANTA_GATEWAY_BASE=off" cases exercise the real path.
+function captureConsole() {
+  const warns = [];
+  const logs = [];
+  const origWarn = console.warn;
+  const origLog = console.log;
+  console.warn = (...a) => warns.push(a.join(" "));
+  console.log = (...a) => logs.push(a.join(" "));
+  return {
+    warns,
+    logs,
+    restore() {
+      console.warn = origWarn;
+      console.log = origLog;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// loadAuthIdentity
+// ---------------------------------------------------------------------------
+
+test("loadAuthIdentity: returns null when the file is missing", () => {
+  const { dir, path } = freshAuthPath("missing");
+  try {
+    assert.equal(loadAuthIdentity(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadAuthIdentity: returns null for a malformed file", () => {
+  const { dir, path } = freshAuthPath("corrupt");
+  try {
+    writeFileSync(path, "not json {");
+    assert.equal(loadAuthIdentity(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadAuthIdentity: parses box_id, box_token, gateway_token, gateway_host", () => {
+  const { dir, path } = freshAuthPath("parse");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        box_id: BOX_ID,
+        box_token: "a".repeat(32),
+        created_at: 1700000000000,
+        gateway_token: GATEWAY_TOKEN,
+        gateway_host: HOST,
+      }),
+    );
+    const ident = loadAuthIdentity(path);
+    assert.equal(ident.box_id, BOX_ID);
+    assert.equal(ident.box_token, "a".repeat(32));
+    assert.equal(ident.gateway_token, GATEWAY_TOKEN);
+    assert.equal(ident.gateway_host, HOST);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 1. First boot (no gateway_token) — required
+// ---------------------------------------------------------------------------
+
+test("registerWithGateway: first boot (no gateway_token) → POST /register with NO Authorization header and persists token + host", async () => {
+  const { dir, path } = freshAuthPath("first-boot");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: BOX_ID, box_token: "a".repeat(32), created_at: 1 }),
+    );
+
+    let fetchCalls = 0;
+    let lastReq;
+    const fetchImpl = async (url, init) => {
+      fetchCalls++;
+      lastReq = { url, init };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ host: HOST, gateway_token: GATEWAY_TOKEN }),
+      };
+    };
+
+    const result = await registerWithGateway({
+      authPath: path,
+      fetchImpl,
+      gatewayBase: "https://gw.test.local",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.registered, true);
+    assert.equal(result.host, HOST);
+
+    // Exactly one fetch.
+    assert.equal(fetchCalls, 1);
+    assert.equal(lastReq.url, "https://gw.test.local/register");
+    assert.equal(lastReq.init.method, "POST");
+    assert.equal(lastReq.init.headers["content-type"], "application/json");
+    // No Authorization header on first boot.
+    assert.equal(
+      lastReq.init.headers.authorization,
+      undefined,
+      "first boot must NOT send an Authorization header",
+    );
+    // Body is exactly { box_id }.
+    assert.equal(lastReq.init.body, JSON.stringify({ box_id: BOX_ID }));
+
+    // auth.json now carries the persisted fields.
+    const onDisk = JSON.parse(readFileSync(path, "utf-8"));
+    assert.equal(onDisk.box_id, BOX_ID);
+    assert.equal(onDisk.box_token, "a".repeat(32), "box_token untouched");
+    assert.equal(onDisk.created_at, 1, "created_at untouched");
+    assert.equal(onDisk.gateway_token, GATEWAY_TOKEN);
+    assert.equal(onDisk.gateway_host, HOST);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. Subsequent boot (has gateway_token) — required
+// ---------------------------------------------------------------------------
+
+test("registerWithGateway: subsequent boot (has gateway_token) → POST /register WITH Bearer, auth.json NOT rewritten when response has no new token", async () => {
+  const { dir, path } = freshAuthPath("subsequent");
+  try {
+    const initial = {
+      box_id: BOX_ID,
+      box_token: "a".repeat(32),
+      created_at: 1,
+      gateway_token: GATEWAY_TOKEN,
+      gateway_host: HOST,
+    };
+    writeFileSync(path, JSON.stringify(initial));
+    const beforeBytes = readFileSync(path);
+
+    let fetchCalls = 0;
+    let lastReq;
+    const fetchImpl = async (url, init) => {
+      fetchCalls++;
+      lastReq = { url, init };
+      return {
+        ok: true,
+        status: 200,
+        // Re-register response: only { host } (gateway does NOT re-issue).
+        json: async () => ({ host: HOST }),
+      };
+    };
+
+    const result = await registerWithGateway({
+      authPath: path,
+      fetchImpl,
+      gatewayBase: "https://gw.test.local",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.registered, false);
+    assert.equal(result.host, HOST);
+
+    // Exactly one fetch, with the bearer.
+    assert.equal(fetchCalls, 1);
+    assert.equal(lastReq.url, "https://gw.test.local/register");
+    assert.equal(lastReq.init.headers.authorization, `Bearer ${GATEWAY_TOKEN}`);
+    assert.equal(lastReq.init.body, JSON.stringify({ box_id: BOX_ID }));
+
+    // auth.json bytewise unchanged: re-register path does NOT rewrite.
+    const afterBytes = readFileSync(path);
+    assert.equal(
+      Buffer.compare(beforeBytes, afterBytes),
+      0,
+      "auth.json file contents must be byte-for-byte identical after re-register",
+    );
+    const onDisk = JSON.parse(afterBytes.toString("utf-8"));
+    assert.equal(onDisk.gateway_token, GATEWAY_TOKEN);
+    assert.equal(onDisk.gateway_host, HOST);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Failed fetch — required
+// ---------------------------------------------------------------------------
+
+test("registerWithGateway: fetch throws → warn logged, no exception, auth.json NOT corrupted", async () => {
+  const { dir, path } = freshAuthPath("fetch-throw");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: BOX_ID, box_token: "a".repeat(32), created_at: 1 }),
+    );
+
+    const cap = captureConsole();
+    let fetchCalls = 0;
+    const fetchImpl = async () => {
+      fetchCalls++;
+      throw new Error("ECONNREFUSED");
+    };
+
+    let result;
+    try {
+      result = await registerWithGateway({
+        authPath: path,
+        fetchImpl,
+        gatewayBase: "https://gw.test.local",
+      });
+    } finally {
+      cap.restore();
+    }
+
+    assert.equal(fetchCalls, 1);
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "fetch_failed");
+    assert.ok(
+      cap.warns.some((w) => /fetch failed/.test(w)),
+      `warn must mention fetch failure; got: ${JSON.stringify(cap.warns)}`,
+    );
+
+    // auth.json unchanged (still missing gateway_token; no corruption).
+    const onDisk = JSON.parse(readFileSync(path, "utf-8"));
+    assert.equal(onDisk.box_id, BOX_ID);
+    assert.equal(onDisk.gateway_token, undefined, "no token was written");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerWithGateway: non-2xx status → warn logged, no exception, auth.json NOT corrupted", async () => {
+  const { dir, path } = freshAuthPath("non-2xx");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: BOX_ID, box_token: "a".repeat(32), created_at: 1 }),
+    );
+
+    const cap = captureConsole();
+    const fetchImpl = async () => ({ ok: false, status: 500, json: async () => ({}) });
+
+    let result;
+    try {
+      result = await registerWithGateway({
+        authPath: path,
+        fetchImpl,
+        gatewayBase: "https://gw.test.local",
+      });
+    } finally {
+      cap.restore();
+    }
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 500);
+    assert.equal(result.error, "non_2xx");
+    assert.ok(cap.warns.some((w) => /non-2xx/.test(w) && /status=500/.test(w)));
+
+    const onDisk = JSON.parse(readFileSync(path, "utf-8"));
+    assert.equal(onDisk.gateway_token, undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. MANTA_GATEWAY_BASE === "off" — required
+// ---------------------------------------------------------------------------
+
+test('registerWithGateway: gatewayBase="off" → no fetch issued, returns immediately', async () => {
+  const { dir, path } = freshAuthPath("off");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: BOX_ID, box_token: "a".repeat(32), created_at: 1 }),
+    );
+
+    let fetchCalls = 0;
+    const fetchImpl = async () => {
+      fetchCalls++;
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+
+    const result = await registerWithGateway({
+      authPath: path,
+      fetchImpl,
+      gatewayBase: "off",
+    });
+
+    assert.equal(fetchCalls, 0, "no fetch must be issued in off mode");
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, "off");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases (extra coverage beyond the four required)
+// ---------------------------------------------------------------------------
+
+test("registerWithGateway: missing auth.json → skipped with warning", async () => {
+  const { dir, path } = freshAuthPath("no-file");
+  try {
+    const cap = captureConsole();
+    let fetchCalls = 0;
+    const fetchImpl = async () => {
+      fetchCalls++;
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    let result;
+    try {
+      result = await registerWithGateway({
+        authPath: path,
+        fetchImpl,
+        gatewayBase: "https://gw.test.local",
+      });
+    } finally {
+      cap.restore();
+    }
+    assert.equal(fetchCalls, 0);
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, "no_box_id");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerWithGateway: malformed box_id in auth.json → skipped, no fetch", async () => {
+  const { dir, path } = freshAuthPath("bad-bid");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: "not-hex", box_token: "a".repeat(32) }),
+    );
+    const cap = captureConsole();
+    let fetchCalls = 0;
+    const fetchImpl = async () => {
+      fetchCalls++;
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    let result;
+    try {
+      result = await registerWithGateway({
+        authPath: path,
+        fetchImpl,
+        gatewayBase: "https://gw.test.local",
+      });
+    } finally {
+      cap.restore();
+    }
+    assert.equal(fetchCalls, 0);
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, "bad_box_id");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerWithGateway: malformed JSON in 200 response → warn, auth.json NOT corrupted", async () => {
+  const { dir, path } = freshAuthPath("bad-resp");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: BOX_ID, box_token: "a".repeat(32), created_at: 1 }),
+    );
+    const cap = captureConsole();
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("unexpected token");
+      },
+    });
+    let result;
+    try {
+      result = await registerWithGateway({
+        authPath: path,
+        fetchImpl,
+        gatewayBase: "https://gw.test.local",
+      });
+    } finally {
+      cap.restore();
+    }
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "bad_json");
+    const onDisk = JSON.parse(readFileSync(path, "utf-8"));
+    assert.equal(onDisk.gateway_token, undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerWithGateway: response missing host on first-boot path → warn, no persist", async () => {
+  const { dir, path } = freshAuthPath("no-host");
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({ box_id: BOX_ID, box_token: "a".repeat(32), created_at: 1 }),
+    );
+    const cap = captureConsole();
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ gateway_token: GATEWAY_TOKEN }), // no host
+    });
+    let result;
+    try {
+      result = await registerWithGateway({
+        authPath: path,
+        fetchImpl,
+        gatewayBase: "https://gw.test.local",
+      });
+    } finally {
+      cap.restore();
+    }
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "missing_host");
+    const onDisk = JSON.parse(readFileSync(path, "utf-8"));
+    assert.equal(onDisk.gateway_token, undefined, "must NOT persist without host");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("DEFAULT_GATEWAY_BASE: uses process.env.MANTA_GATEWAY_BASE when set", () => {
+  // The module-level constant is captured at import time. The "off" sentinel
+  // short-circuits before any env lookup, so the env var is only consulted
+  // when the constant is NOT "off". We just sanity-check the constant shape.
+  assert.equal(typeof DEFAULT_GATEWAY_BASE, "string");
+  assert.ok(DEFAULT_GATEWAY_BASE.length > 0);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join, extname, normalize, resolve, basename } from "node:path";
 import { homedir, hostname } from "node:os";
 import { pipeline } from "node:stream/promises";
-import { UPLOAD_DIRNAME, OUTBOX_DIRNAME } from "../shared/paths.mjs";
+import { UPLOAD_DIRNAME, OUTBOX_DIRNAME, STATE_DIRNAME } from "../shared/paths.mjs";
 import { WebSocketServer } from "ws";
 import * as tmux from "./tmux.mjs";
 import * as oc from "./opencode.mjs";
@@ -75,7 +75,7 @@ import {
   AUTH_RL_CAPACITY,
   AUTH_RL_REFILL_PER_SEC,
 } from "./auth.mjs";
-import { createRelayAgent, shouldStartRelayAgent } from "../relay/agent/index.mjs";
+import { registerWithGateway } from "./gatewayRegister.mjs";
 import * as push from "./push.mjs";
 import { readServerVersion, writeVersionResponse } from "./version.mjs";
 
@@ -235,14 +235,6 @@ rpcHandlers = buildHandlers({
   push,
   serverVersion: SERVER_VERSION,
 });
-
-// Relay-agent handle (BET-151 ADR-1). Populated below in the listen() callback
-// when shouldStartRelayAgent(config) returns true. Read by GET /relay/status
-// (loopback-only) so install.sh can poll for the handshake without standing up
-// its own websocket. Null = agent never started (config opted out, or the
-// listener never got that far — in either case /relay/status returns
-// `connected: false`).
-let relayAgent = null;
 
 // Serve-page file server: lightweight HTTP server on 127.0.0.1:20080 that
 // serves HTML pages from ~/.manta/pages/<subdomain>/index.html. Caddy
@@ -429,19 +421,18 @@ const readRawBody = (req, limit) => readBody(req, { parse: false, limit });
 //
 // respondJson — write a JSON response (the most common response shape in this
 // file). Pulling it out eliminates a verbatim writeHead+end boilerplate that
-// the duplication-gate flagged between /auth/pair and /relay/status
-// (10-27 line clones) — every JSON-shaped handler in this file now goes
+// the duplication-gate flagged between /auth/pair and other JSON-shaped
+// routes (10-27 line clones) — every JSON handler in this file now goes
 // through here. Status code + body shape stay identical to the inline
 // versions they replace.
 //
 // requireLoopback — gate a handler on the loopback-direct check used by
-// /auth/pair and /relay/status. Returns true (proceed) when the request is
-// loopback-direct; on a non-loopback caller it writes the standard 403 and
-// returns false, so the caller MUST `return` immediately. The error message
-// is passed in so each endpoint can phrase the rejection for its own
-// surface (a pairing-code mint vs. a relay-status read need different hints).
-// The check itself is unchanged (isLocalDirectRequest in auth.mjs) — this
-// is a pure refactor, the loopback gate's semantics are preserved bit-for-bit.
+// /auth/pair. Returns true (proceed) when the request is loopback-direct;
+// on a non-loopback caller it writes the standard 403 and returns false,
+// so the caller MUST `return` immediately. The error message is passed in
+// so each endpoint can phrase the rejection for its own surface. The check
+// itself is unchanged (isLocalDirectRequest in auth.mjs) — this is a pure
+// refactor, the loopback gate's semantics are preserved bit-for-bit.
 function respondJson(res, status, obj) {
   res.writeHead(status, { "content-type": "application/json" });
   res.end(JSON.stringify(obj));
@@ -632,34 +623,6 @@ const server = createServer(async (req, res) => {
     } catch (e) {
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
-    return;
-  }
-
-  // ---------- Relay status (LOOPBACK-ONLY) ----------
-  // GET /relay/status → { enabled, connected }
-  //
-  // Loopback-gated (same check /auth/pair uses) because the answer leaks
-  // whether this box has reached the relay — useful intel for an attacker
-  // probing the box's outbound posture, and not needed by any remote client.
-  // The renderer never calls this; it's consumed by `install.sh` (and any
-  // future ops tooling on the box itself).
-  //
-  //   enabled   — true iff `shouldStartRelayAgent(config)` (config-derived;
-  //                absent key → true, see agent/index.mjs)
-  //   connected — true iff the agent's `status()` is "connected" right now
-  //                (the live WS handshake to relay.mantaui.com succeeded).
-  //                "connecting" / "stopped" both collapse to false — install.sh
-  //                treats anything-but-connected as "not yet" and re-polls.
-  if (req.method === "GET" && path === "/relay/status") {
-    if (
-      !requireLoopback(req, res, "relay status is loopback-only (run this from the box)")
-    ) {
-      return;
-    }
-    const cfg = await local.configGet();
-    const enabled = shouldStartRelayAgent(cfg);
-    const connected = relayAgent ? relayAgent.status() === "connected" : false;
-    respondJson(res, 200, { enabled, connected });
     return;
   }
 
@@ -1523,52 +1486,22 @@ server.on("upgrade", (req, socket, head) => {
 server.listen(PORT, HOST, () => {
   console.log(`manta listening on http://${HOST}:${PORT}`);
 
-  // Start the box-side relay agent (BET-151 ADR-1 / BET-155). The agent dials
-  // OUT to relay.mantaui.com from this box and authenticates with boxAuth, so
-  // it MUST be created after ensureAuth() has run (which it has — see above)
-  // and AFTER the box server is listening (so the agent's first request proxy
-  // can land). Fire-and-forget: the agent's reconnect/backoff loop runs on its
-  // own timers and never blocks this path — a slow relay handshake must NOT
-  // hold up the HTTP server, and a relay outage must NOT crash the box server.
+  // Register this box with the hosted push gateway (BET-201, BET-198 §WP2).
+  // Replaces the old outbound dial to the relay: instead of opening a
+  // long-lived tunnel WS, the box POSTs to https://gateway.mantaui.com/register
+  // to (re)create its DNS A record and mint / refresh a gateway_token that
+  // lives in ~/.manta/auth.json alongside box_token. Direct connections
+  // (phone / desktop / PWA → https://<box_id>.boxes.mantaui.com) are then
+  // the only transport; this one-time startup call is the only outbound.
   //
-  // Opt-out: write `"relayEnabled": false` to ~/.manta/config.json
-  // (shouldStartRelayAgent() handles the default-on case). No env override —
-  // configGet() is the single switch, mirroring how chatAutoAllow is gated.
-  //
-  // The agent owns its own reconnect/backoff — do NOT add another retry loop.
-  // The agent already logs `[relay-agent] connected …` / `tunnel closed;
-  // reconnecting`; we only log the one-shot boot decision here.
-  local
-    .configGet()
-    .then((cfg) => {
-      if (!shouldStartRelayAgent(cfg)) {
-        console.log(
-          "[relay-agent] disabled via config (relayEnabled=false); box reachable only via direct ingress.",
-        );
-        return;
-      }
-      let agent;
-      try {
-        agent = createRelayAgent({ localBase: `http://127.0.0.1:${PORT}` });
-      } catch (err) {
-        console.warn(
-          `[relay-agent] could not construct (auth missing?): ${String(err?.message ?? err)}`,
-        );
-        return;
-      }
-      relayAgent = agent;
-      agent.start().catch((err) => {
-        console.warn(
-          `[relay-agent] first connect rejected: ${String(err?.message ?? err)}`,
-        );
-      });
-      console.log(
-        `[relay-agent] dialing ${agent.boxId.slice(0, 8)}… (relay.mantaui.com)`,
-      );
-    })
-    .catch((err) => {
-      console.warn(
-        `[relay-agent] could not start (config read failed): ${String(err?.message ?? err)}`,
-      );
-    });
+  // Fire-and-forget. registerWithGateway is non-fatal — a network blip or a
+  // DNS hiccup logs a warning and returns; the next boot retries. Never
+  // blocks the HTTP server (slow gateway must NOT delay listen()), never
+  // throws into this callback.
+  registerWithGateway({
+    authPath: join(homedir(), STATE_DIRNAME, "auth.json"),
+    gatewayBase: process.env.MANTA_GATEWAY_BASE,
+  }).catch((err) => {
+    console.warn(`[gateway-register] unexpected: ${String(err?.message ?? err)}`);
+  });
 });


### PR DESCRIPTION
## Summary

Stage 3 of `BET-198` (drop the relay). Replaces the box's outbound dial to the relay with a startup POST to the hosted gateway's `/register` endpoint. Strips every relay-agent wiring from `src/server/index.mjs`.

## Changes

- **NEW** `src/server/gatewayRegister.mjs` — single `registerWithGateway({ authPath, fetchImpl, gatewayBase })` function:
  - First boot → `POST /register` with `{ box_id }`, no Authorization, persists returned `gateway_token` + `gateway_host` atomically into `~/.manta/auth.json` (using the shared `storeUtils.atomicWrite`).
  - Subsequent boot → `POST /register` with `Authorization: Bearer <gateway_token>`, no rewrite of `auth.json` (the response carries only `{ host }`).
  - Any failure (network throw or non-2xx) → `console.warn` + return; never throws.
  - `MANTA_GATEWAY_BASE === "off"` → no fetch issued (dev boxes + CI).
  - All I/O injectable (`fetchImpl`, `authPath`, `gatewayBase`, `console`).

- **NEW** `src/server/gatewayRegister.test.mjs` — covers the four required cases (first-boot persist, subsequent-boot no-rewrite, fetch-throw no-corrupt, off-mode no-fetch) plus edge cases (missing file, malformed box_id, malformed response body, response missing host).

- **MODIFIED** `src/server/index.mjs`:
  - Removed the `createRelayAgent` / `shouldStartRelayAgent` import.
  - Removed the `relayAgent` module-state (only `/relay/status` read it).
  - Removed the `GET /relay/status` loopback-only route.
  - Replaced the startup block in `server.listen()` with a fire-and-forget call to `registerWithGateway`. `authPath` reads `~/.manta/auth.json` via the existing `STATE_DIRNAME` constant.

- **MODIFIED** `src/relay/agent/index.mjs` + `src/relay/agent/index.test.mjs`:
  - Removed the `shouldStartRelayAgent` export and its tests (`relayEnabled` config switch). No remaining callers in `src/`; BET-204 deletes the whole directory.

## Untouched (per BET-201 scope)

- `src/gateway/**` (already shipped in BET-199/200)
- `src/server/push.mjs` (BET-200 owns it)
- `src/shared/transport.mjs` (BET-202 owns it)
- Renderer / main / installer / deploy workflow (BET-203/204/205/206)

## Done-when

- [x] `src/server/index.mjs` has zero references to `relayAgent`, `createRelayAgent`, `shouldStartRelayAgent`, `/relay/status`.
- [x] `src/server/gatewayRegister.mjs` exists and is invoked at server startup.
- [x] `src/server/auth.mjs` no longer references `relayEnabled` (it never did).
- [x] `npm run typecheck` → GREEN.
- [x] `npm test` → GREEN (vitest 1123/1123, node:test 878/878).

## Notes

- The relay agent module itself (`src/relay/agent/index.mjs`) is still on disk; BET-204 deletes the entire `src/relay/` directory. Only the now-unused `shouldStartRelayAgent` export + its tests are removed here to keep `src/server/` honest about what it depends on.
- The `[relay-agent]` log prefix is no longer emitted anywhere in `src/`; the lone comment mentioning it in `src/server/index.mjs` is a stale call-site example left for the next grep-sweep to clean up (BET-204 scope).