### PR TITLE
fix(plugins): thread buildEnv() result into step exec (BET-210)

### DIFF
--- a/src/main/capExecutor.test.ts
+++ b/src/main/capExecutor.test.ts
@@ -1,0 +1,105 @@
+// Tests for src/main/capExecutor.ts — the Mac-side plugin executor.
+//
+// BET-210 regression: ctx.exec was dropping opts.env at the spawn boundary,
+// so manifest `env:` and `MANTA_INPUT_*` never reached the `run:` shell.
+// These tests spawn a real /bin/sh through the public `makeExec` helper
+// (re-exported for testing) and assert the env actually crosses the spawn
+// boundary. No mocks — the whole point of the bug is that env must reach
+// the child process, and the only honest assertion is to look at the
+// child's own stdout.
+
+import { describe, it, expect } from "vitest";
+import { makeExec, type CapCtx } from "./capExecutor.js";
+
+// Shared abort signal that never fires — tests rely on the spawn exiting
+// quickly under their own /bin/sh -c command. If it doesn't, vitest's
+// default timeout will fail the test with a clearer message than a hung
+// AbortController would.
+const signal = new AbortController().signal;
+const noop = () => {};
+
+describe("capExecutor — makeExec env passthrough (BET-210)", () => {
+  it("passes opts.env entries into the spawned shell", async () => {
+    const exec = makeExec(signal, noop);
+    const r = await exec(
+      "/bin/sh",
+      ["-c", "printf '%s' \"$MANTA_INPUT_FOO\""],
+      { env: { MANTA_INPUT_FOO: "bar-from-opts" } },
+    );
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("bar-from-opts");
+  });
+
+  it("preserves multiple env vars, including manifest-style keys", async () => {
+    const exec = makeExec(signal, noop);
+    // Mirror a realistic buildEnv() output: MANTA_INPUT_* + a manifest env
+    // key + MANTA_PLUGIN/MANTA_JOB_ID. The /bin/sh -c script prints them
+    // in order, separated by a delimiter that can't appear in the values.
+    const env = {
+      MANTA_INPUT_SIMULATOR: "iPhone 16 Pro",
+      MANTA_INPUT_SCHEME: "MantaUI",
+      WORKSPACE: "/tmp/does-not-need-to-exist",
+      MANTA_PLUGIN: "ios-mantaui",
+      MANTA_JOB_ID: "deadbeef",
+    };
+    const r = await exec(
+      "/bin/sh",
+      [
+        "-c",
+        "printf '%s|%s|%s|%s|%s' \"$MANTA_INPUT_SIMULATOR\" \"$MANTA_INPUT_SCHEME\" \"$WORKSPACE\" \"$MANTA_PLUGIN\" \"$MANTA_JOB_ID\"",
+      ],
+      { env },
+    );
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("iPhone 16 Pro|MantaUI|/tmp/does-not-need-to-exist|ios-mantaui|deadbeef");
+  });
+
+  it("falls back to process.env when opts.env is omitted (legacy behavior)", async () => {
+    const exec = makeExec(signal, noop);
+    // HOME is set on every sane process; if opts.env is omitted, HOME must
+    // still reach the child (proves the PATH-patch path didn't regress the
+    // no-opts branch).
+    const r = await exec(
+      "/bin/sh",
+      ["-c", "printf '%s' \"$HOME\""],
+      {},
+    );
+    expect(r.code).toBe(0);
+    // Don't assert the exact value — $HOME is environment-dependent.
+    // Assert that it is non-empty (env reached the child at all).
+    expect(r.stdout.length).toBeGreaterThan(0);
+    expect(r.stdout).toBe(process.env.HOME ?? "");
+  });
+
+  it("re-applies the PATH prefix onto opts.env so Homebrew stays visible", async () => {
+    const exec = makeExec(signal, noop);
+    // Even when the caller supplies its own PATH (e.g. buildEnv() inherits
+    // process.env.PATH), the Homebrew PATH_PREFIX must still be prepended.
+    // We assert by checking that PATH starts with PATH_PREFIX; exact tail
+    // is environment-dependent.
+    const r = await exec(
+      "/bin/sh",
+      ["-c", "printf '%s' \"$PATH\""],
+      { env: { PATH: "/usr/bin:/bin" } },
+    );
+    expect(r.code).toBe(0);
+    expect(r.stdout.startsWith("/opt/homebrew/bin:/usr/local/bin:")).toBe(true);
+    expect(r.stdout.endsWith("/usr/bin:/bin")).toBe(true);
+  });
+
+  it("exposes env on the CapCtx exec opts type (compile-time + runtime)", async () => {
+    // Compile-time: this assignment only type-checks if `env` is part of
+    // the opts shape. Runtime: re-assert that the env reaches the child so
+    // a future refactor that adds `env` to the type but forgets the spawn
+    // plumbing is still caught.
+    const ctx: Pick<CapCtx, "exec"> = {
+      exec: makeExec(signal, noop),
+    };
+    const r = await ctx.exec(
+      "/bin/sh",
+      ["-c", "printf '%s' \"$MANTA_INPUT_PROOF\""],
+      { env: { MANTA_INPUT_PROOF: "yes" } },
+    );
+    expect(r.stdout).toBe("yes");
+  });
+});

--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -97,10 +97,15 @@ export type CapCtx = {
   log(line: string): void;
   // Spawn helper — argv array, never a shell string. PATH is pre-patched by
   // capExecutor so Homebrew/nvm binaries are visible to this GUI app.
+  // Optional `env` is layered ON TOP of the executor's PATH patch — callers
+  // (the manifest runner) pass `buildEnv()`'s result so manifest `env:` and
+  // `MANTA_INPUT_*` variables reach the spawned shell. The PATH patch is
+  // reapplied to the supplied env (its PATH is prepended with PATH_PREFIX)
+  // so Homebrew visibility survives.
   exec(
     cmd: string,
     args: string[],
-    opts?: { cwd?: string; quiet?: boolean },
+    opts?: { cwd?: string; quiet?: boolean; env?: NodeJS.ProcessEnv },
   ): Promise<ExecResult>;
   signal: AbortSignal;
 };
@@ -619,6 +624,7 @@ function makeManifestHandler(manifest: PluginManifest) {
         const res = await ctx.exec("/bin/sh", ["-c", step.run], {
           cwd: cwdResolved,
           quiet: false,
+          env,
         });
         if (res.code !== 0 && !step.continue_on_error) {
           throw new Error(`step ${i + 1} (${label}) exited with code ${res.code}`);
@@ -759,7 +765,10 @@ async function postDone(
 // ctx.exec — argv spawn with PATH patch + capture + abort handling.
 // ---------------------------------------------------------------------------
 
-function makeExec(
+// Exported for tests — `src/main/capExecutor.test.ts` spawns a real /bin/sh
+// through makeExec to assert that opts.env reaches the child (BET-210).
+// Not part of the renderer/IPC surface; main-process-only.
+export function makeExec(
   signal: AbortSignal,
   logLine: (line: string) => void,
 ): CapCtx["exec"] {
@@ -772,11 +781,18 @@ function makeExec(
 
       let child: ReturnType<typeof spawn>;
       try {
+        // Use the caller-supplied env (manifest + inputs) when provided; fall
+        // back to process.env. Either way, the PATH patch is re-applied so
+        // Homebrew/nvm binaries stay visible to this GUI-launched process.
+        // `buildEnv` already includes process.env + manifest env + inputs
+        // + MANTA_PLUGIN/MANTA_JOB_ID, so passing it here is what makes the
+        // shell see $MANTA_INPUT_* / $WORKSPACE / etc. in `run:` scripts.
+        const baseEnv = opts?.env ?? process.env;
         child = spawn(cmd, args, {
           cwd,
           env: {
-            ...process.env,
-            PATH: PATH_PREFIX + (process.env.PATH ?? ""),
+            ...baseEnv,
+            PATH: PATH_PREFIX + (baseEnv.PATH ?? process.env.PATH ?? ""),
           },
           signal,
         });


### PR DESCRIPTION
## Summary

The plugin executor was dropping the manifest env at the spawn boundary: every `run:` script saw an empty env, so `$MANTA_INPUT_*` and every manifest `env:$KEY` interpolated to empty inside the shell.

Root cause: `makeExec` was hard-wired to `spawn({env: ...process.env + PATH patch})` — the per-step `buildEnv()` result that the manifest handler already computed (line ~604) was only used for `resolveCwd`, never threaded through to the step's shell.

## Fix

- Extended `CapCtx.exec` opts to accept an optional `env`.
- `makeExec` now honors `opts.env` when present, with the PATH patch re-applied on top so Homebrew/nvm visibility (load-bearing for GUI-launched apps) is unchanged.
- Manifest handler passes the already-computed `env` (`buildEnv(...)` result) at the single step exec call site.

No changes to `buildEnv`, `resolveCwd`, or the manifest schema. No new per-step `env:` overlay support (out of scope; intentionally unimplemented).

## Verification

```
Files changed: 2 (capExecutor.ts +24/-4, capExecutor.test.ts new)
Base: origin/main @ 8273593
PR branch (multica/BET-210-exec-env-passthrough @ 7c2dbaf):
  typecheck: PASS (tsc --noEmit -p tsconfig.node.json && -p tsconfig.web.json)
  test:      PASS (vitest: 60 files / 1128 tests; node:test: 869 tests)
```

New test file `src/main/capExecutor.test.ts` spawns a real `/bin/sh -c` through `makeExec` and asserts:
1. `opts.env` entries (`MANTA_INPUT_FOO`, etc.) reach the spawned shell.
2. Realistic buildEnv() output (`MANTA_INPUT_SIMULATOR`, `MANTA_INPUT_SCHEME`, `WORKSPACE`, `MANTA_PLUGIN`, `MANTA_JOB_ID`) all cross the spawn boundary.
3. The no-opts-env branch still inherits `process.env` (legacy regression guard — `$HOME` reaches the child).
4. PATH_PREFIX is re-prepended onto a caller-supplied PATH so Homebrew stays visible.
5. The `env` field exists on `CapCtx.exec` opts at the type level.

The first test would have failed before the fix — that is the regression pin.

## Out-of-band verification (human, on Mac)

Re-run `plugin_run("ios-mantaui", {action: "compile-only"})` after rebuild — step 5's xcodebuild must now receive a non-empty `-destination "platform=iOS Simulator,name=iPhone 16 Pro"` and proceed past the previous `missing value for key 'name'` error.

## Cross-cutting follow-ups

None.