### PR TITLE
fix(main): thread buildEnv into per-step shell exec (BET-210)

### DIFF
--- a/src/main/capExecutor.test.ts
+++ b/src/main/capExecutor.test.ts
@@ -1,0 +1,60 @@
+// Tests for src/main/capExecutor.ts — focused on the per-step env plumbing
+// (BET-210). Keeps the surface small: real /bin/sh spawn, no spawn mocking.
+// `makeExec` is exported for these tests so the env path is reachable
+// without going through the manifest handler.
+
+import { describe, it, expect } from "vitest";
+import { makeExec } from "./capExecutor.js";
+
+const NOOP_LOG = () => {};
+
+describe("makeExec — per-step env plumbing (BET-210)", () => {
+  it("delivers opts.env vars to the spawned shell", async () => {
+    const exec = makeExec(new AbortController().signal, NOOP_LOG);
+    const res = await exec("/bin/sh", ["-c", 'echo "$MANTA_INPUT_FOO"'], {
+      env: { MANTA_INPUT_FOO: "bar" },
+    });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe("bar\n");
+  });
+
+  it("merges opts.env with the PATH patch (Homebrew prefix preserved on macOS)", async () => {
+    const exec = makeExec(new AbortController().signal, NOOP_LOG);
+    const res = await exec("/bin/sh", ["-c", 'echo "$MANTA_INPUT_BREW:$PATH"'], {
+      env: { MANTA_INPUT_BREW: "ok" },
+    });
+    expect(res.code).toBe(0);
+    const stdout = res.stdout.replace(/\n$/, "");
+    // The executor unconditionally prepends "/opt/homebrew/bin:/usr/local/bin:"
+    // to the spawn PATH so GUI-launched macOS shells see Homebrew binaries
+    // (see AGENTS.md "macOS PATH gotcha"). The test asserts the prefix lands
+    // regardless of the host's actual PATH (this test box may be Linux).
+    expect(stdout.startsWith("ok:/opt/homebrew/bin:/usr/local/bin:")).toBe(true);
+  });
+
+  it("falls back to process.env when opts.env is omitted (regression)", async () => {
+    const exec = makeExec(new AbortController().signal, NOOP_LOG);
+    // HOME is in process.env on every supported platform — use it as a probe.
+    const expected = process.env.HOME ?? "";
+    const res = await exec("/bin/sh", ["-c", 'echo "$HOME"']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe(`${expected}\n`);
+  });
+
+  it("propagates manifest env: values alongside the PATH patch", async () => {
+    const exec = makeExec(new AbortController().signal, NOOP_LOG);
+    // Simulate what buildEnv returns: process.env + manifest env + MANTA_INPUT_*.
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      REPO: "/tmp/repo",
+      MANTA_INPUT_SIMULATOR: "iPhone 16 Pro",
+    };
+    const res = await exec(
+      "/bin/sh",
+      ["-c", 'echo "$REPO/$MANTA_INPUT_SIMULATOR"'],
+      { env },
+    );
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe("/tmp/repo/iPhone 16 Pro\n");
+  });
+});

--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -100,7 +100,7 @@ export type CapCtx = {
   exec(
     cmd: string,
     args: string[],
-    opts?: { cwd?: string; quiet?: boolean },
+    opts?: { cwd?: string; quiet?: boolean; env?: NodeJS.ProcessEnv },
   ): Promise<ExecResult>;
   signal: AbortSignal;
 };
@@ -619,6 +619,7 @@ function makeManifestHandler(manifest: PluginManifest) {
         const res = await ctx.exec("/bin/sh", ["-c", step.run], {
           cwd: cwdResolved,
           quiet: false,
+          env,
         });
         if (res.code !== 0 && !step.continue_on_error) {
           throw new Error(`step ${i + 1} (${label}) exited with code ${res.code}`);
@@ -759,7 +760,9 @@ async function postDone(
 // ctx.exec — argv spawn with PATH patch + capture + abort handling.
 // ---------------------------------------------------------------------------
 
-function makeExec(
+// Exported for tests (capExecutor.test.ts) — keeps the env plumbing
+// coverable without mocking spawn. Not part of the public API.
+export function makeExec(
   signal: AbortSignal,
   logLine: (line: string) => void,
 ): CapCtx["exec"] {
@@ -767,6 +770,7 @@ function makeExec(
     new Promise((resolve, reject) => {
       const cwd = opts?.cwd;
       const quiet = opts?.quiet === true;
+      const baseEnv = opts?.env ?? process.env;
       let stdout = "";
       let stdoutTruncated = false;
 
@@ -775,8 +779,8 @@ function makeExec(
         child = spawn(cmd, args, {
           cwd,
           env: {
-            ...process.env,
-            PATH: PATH_PREFIX + (process.env.PATH ?? ""),
+            ...baseEnv,
+            PATH: PATH_PREFIX + (baseEnv.PATH ?? process.env.PATH ?? ""),
           },
           signal,
         });


### PR DESCRIPTION
**Fix:** the executor computed `buildEnv(...)` per step but never passed it to `ctx.exec`. Every step's `/bin/sh` received only `process.env` + the PATH patch, so manifest `env:` and `MANTA_INPUT_*` were silently dropped from `run:` bodies. Surfaced live by the BET-192 Mac leg as `xcodebuild: error: missing value for key 'name' of option 'Destination'` (`$MANTA_INPUT_SIMULATOR` expanded empty).

**Change:** 3-line thread-through — extend `CapCtx.exec` opts to accept `env?`, `makeExec` honors it via `baseEnv = opts?.env ?? process.env` (preserving the PATH-prefix behavior), the per-step call site forwards the already-computed `env`. No recompute; `buildEnv`/`resolveCwd`/schema untouched.

**Tests:** new `src/main/capExecutor.test.ts` (4 cases) — opts.env delivered to spawn, PATH patch preserved across the merge, process.env fallback regression-free, full `buildEnv`-style env (manifest env + MANTA_INPUT_*) propagated. Exports `makeExec` for the test (only test-surface change).

**Files changed:** 2 files. `src/main/capExecutor.ts` (+8/-4), `src/main/capExecutor.test.ts` (new, +60).

**Verification:**
- typecheck: exit 0 (no errors). log: see `npm run typecheck`.
- test (vitest): 1127/1127 pass. capExecutor.test.ts new file: 4/4 pass.
- test (node): 787/787 pass.

**Base:** `origin/main @ 8273593`
**Branch:** `multica/BET-210-executor-thread-env @ 3588816`

**Out of scope** (per BET-210 spec): per-step `env:` overlay, manifest/schema changes, `plugin.write` built-in path (it doesn't use step exec), box-server changes, AI tools.

**Live re-test required** after Mac rebuild: `plugin_run("ios-mantaui", {action: "compile-only"})` — step 5 xcodebuild must receive `-destination "platform=iOS Simulator,name=iPhone 16 Pro"` (non-empty) and proceed past the destination-error stop. Tasks D/E/F of the BET-192 runbook can then complete.

Resolves BET-210.
