### PR TITLE
fix(renderer): remove server hostname from desktop title bar (BET-212)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -542,16 +542,9 @@ export function App() {
         )}
         <div className="titlebar-drag h-10 border-b border-border flex items-center px-3 gap-2 min-w-0">
           <div className="text-xs text-text-muted flex items-center gap-2 min-w-0">
-            <span className="shrink-0">
-              {serverUrl
-                ? (() => { try { return new URL(serverUrl).hostname; } catch { return serverUrl; } })()
-                : boxId
-                  ? boxId.slice(0, 8) + "…"
-                  : "Not configured"}
-            </span>
             {activeProjectName && (
               <span className="text-text-faint shrink-0">
-                · {activeProjectName}
+                {activeProjectName}
                 {activeWinName && ` / ${activeWinName}`}
               </span>
             )}


### PR DESCRIPTION
Removes the relay/server hostname (e.g. `app.mantaui.com`) that was rendered as the first item in the desktop title bar.

**Files changed:** `src/renderer/App.tsx` (-8 / +1)

**Change:**
- Delete the `<span className="shrink-0">` that displayed `new URL(serverUrl).hostname`, `boxId.slice(0,8)+'…'`, or `"Not configured"` — all variants are server-identity leakage that doesn't belong in the chrome.
- Drop the leading `· ` from the next sibling (`activeProjectName` span) since it was a separator from the deleted element and would now orphan as the first item.

**serverUrl destructure:** left in place — still consumed at the empty-projects CTA (`{serverUrl || boxId ? "Create a project …" : "Open Settings to connect …"}`). Only the title-bar use was the dead ref.

**Base:** `origin/main @ 0333734`
**Branch head:** `a1acbe8`

**Verification results:**
- PR branch (`multica/BET-212-remove-titlebar-hostname` @ `a1acbe8`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 0, 884 pass / 0 fail / 0 skip. log sha256: `9bea98f1278c55e0c50959694d094822d8b4e0a7a88d9cccdb76670e2ad1a35c`
- Base (`main` @ `0333734`):
  - typecheck: ran clean on a fresh main in install — not re-run, identical tsc config.
  - test: same.

Logs cached at `/tmp/typecheck-pr.log` and `/tmp/test-pr.log` for reviewer spot-check.