### PR TITLE
fix(desktop): BET-211 expand ~ in revealInFolder + request notification permission at startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, clipboard, ipcMain, shell } from "electron";
 import { join, basename } from "node:path";
-import { watch as fsWatch } from "node:fs";
+import { existsSync, watch as fsWatch } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -264,9 +264,19 @@ function registerHandlers(): void {
     return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
   });
 
-  // Reveal a local file in Finder / the OS file manager.
+  // Reveal a local file in Finder / the OS file manager. Expands a leading
+  // `~/` against the user's home dir so callers can pass "shell-style" paths
+  // (e.g. the Settings "Open plugins folder" button passes `~/.manta/plugins`)
+  // — Electron's `shell.showItemInFolder` does NOT expand `~` itself, so
+  // passing the literal string is a silent no-op. The folder's existence is
+  // guarded so a stale/missing path no-ops instead of erroring to the renderer.
   ipcMain.handle(IPC.revealInFolder, (_e, localPath: string) => {
-    if (localPath) shell.showItemInFolder(localPath);
+    if (!localPath) return;
+    const abs = localPath.startsWith("~/")
+      ? join(homedir(), localPath.slice(2))
+      : localPath;
+    if (!existsSync(abs)) return;
+    shell.showItemInFolder(abs);
   });
 
   ipcMain.handle(IPC.openExternal, (_e, url: string) => shell.openExternal(url));

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -316,9 +316,20 @@ export function App() {
   useEffect(() => {
     if (!window.api.onDesktopNotify) return;
     const off = window.api.onDesktopNotify((payload) => {
+      // Diagnostic log (BET-211): record every directive we receive along
+      // with the live Notification.permission value, so the next "no
+      // notification" report is a one-Axiom-query lookup by `source=desktop`
+      // tag rather than guess-and-check. Mirrors BET-207/210 observability.
+      console.log(
+        "[desktop-notify] received",
+        payload.tag,
+        "perm=",
+        Notification.permission,
+      );
       const sid = payload.sessionId;
       if (document.hasFocus() && sid && activeChatRef.current === sid) return;
       if (typeof Notification === "undefined") return;
+      if (Notification.permission !== "granted") return;
       const show = () => {
         try {
           const n = new Notification(payload.title || "Manta UI", {
@@ -344,14 +355,21 @@ export function App() {
           /* Notification construction can throw if permission was revoked */
         }
       };
-      if (Notification.permission === "granted") show();
-      else if (Notification.permission !== "denied")
-        void Notification.requestPermission().then((perm) => {
-          if (perm === "granted") show();
-        });
+      show();
     });
     return off;
   }, [setActive]);
+
+  // BET-211: request Notification permission ONCE at startup, not lazily on
+  // first event. The lazy request raced with the first directive arriving —
+  // macOS would pop the OS prompt AFTER the renderer had already dropped the
+  // notify, so the user never saw it. Settling permission at mount means the
+  // first event always has a known `granted` / `denied` / `default` answer.
+  useEffect(() => {
+    if (typeof Notification === "undefined") return;
+    if (Notification.permission !== "default") return;
+    void Notification.requestPermission();
+  }, []);
 
   // Without this, dropping a file anywhere outside the terminal area causes
   // Chromium to navigate the renderer to the file:// URL.

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -859,10 +859,10 @@ export function Settings({ onClose }: { onClose: () => void }) {
                   onClick={() => {
                     const preload = getBuiPreload();
                     if (preload?.revealInFolder) {
-                      // Reuse the existing OS-bridge: resolves to the user's
-                      // home dir on the Mac; pass a `~`-prefixed path the
-                      // shell resolves. Preload's revealInFolder shells out
-                      // to the OS file manager.
+                      // Pass the `~`-prefixed plugins path; main's
+                      // revealInFolder handler expands it against homedir()
+                      // before shell.showItemInFolder (BET-211 — Electron
+                      // does not expand `~` itself).
                       void preload.revealInFolder("~/.manta/plugins");
                     }
                   }}


### PR DESCRIPTION
## Defects fixed

**Defect A** — Settings → Plugins → "Open plugins folder" silently no-op'd.

Root cause: the Settings button calls `preload.revealInFolder('~/.manta/plugins')`, and main's handler passed the literal string straight to `shell.showItemInFolder`. Electron does **not** expand `~` (only a shell does), so the OS file manager received a non-existent path.

Fix: expand a leading `~/` to `join(homedir(), rest)` inside the `revealInFolder` IPC handler — one place, fixes every caller that passes a shell-style path. Guard with `existsSync` so a stale/missing path is a silent no-op (per the issue spec).

**Defect B** — desktop notifications never appeared.

Root cause: `App.tsx` requested `Notification.requestPermission()` **lazily inside the first-event handler**. macOS showed the OS prompt *after* the renderer had already constructed-then-dropped the notify, so the first one (and often every one until the user clicked through the prompt) was lost.

Fix: request permission **once at App mount** when `Notification.permission === 'default'`. Settling the grant before any event arrives means every directive has a known `granted` / `denied` / `default` answer. Added a `[desktop-notify] received <tag> perm=<p>` `console.log` so the next "no notification" report is one Axiom query away (`source=desktop`) — mirrors the BET-207/210 observability pattern. The focus-suppression gate is unchanged.

## httpApi.onDesktopNotify is on the shared /events WS

Confirmed in `src/renderer/api/httpApi.ts:686` — registered via `on<DesktopNotifyPayload>('desktopNotify', cb)`, which routes through the same dispatch (`dispatchFrame` at line 459) used by every other kind (opencode, pty, status, screenshot, agentFile). No special filtering. The WS reconnect state machine + liveness watchdog (BET-115) apply identically.

## Constraints honored

- Reuse `homedir()`/`join()` in **one place** — main, not scattered across callers
- **No new IPC channels** — the dir-open branch is left to `showItemInFolder`. Per the issue: *"do NOT add a second bridge speculatively."* If Mac testing shows the dir isn't visibly opened, add an `openPath` bridge in a follow-up.
- Focus-suppression + deep-link-on-click logic intact
- Desktop-only surface (`src/main` + `src/renderer`); no server, mobile, or manifest changes
- `mobile/www/` unchanged

## Mac-build caveat (document, not a code bug)

If macOS still suppresses notifications after the fix lands, the remaining blocker is OS-level: enable **Manta UI** in **System Settings → Notifications** (unsigned dev build initially attributes notifies to "Electron"). This is an env note, not a code defect — the renderer request goes through, the user just needs to grant the OS-level toggle.

**Base: origin/main @ `0333734`**

## Verification results

- PR branch (`multica/BET-211-plugins-folder-notify` @ `481d94c`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 1, 1127 pass / 1 fail / 0 skip. Failures: `tests/unit/e2e-smoke.test.ts > BET-8 E2E Smoke Gate > should confirm Playwright is installed` (env: Playwright not installed in this Linux box). log sha256: `78891aa0e8bd46f2ce684e675532cc5abe212d31c79feae04dbc289cd2f19602`
- Base (`main` @ `0333734`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 1, 1127 pass / 1 fail / 0 skip. Failures: same Playwright install check. log sha256: `32540e3ad812d4ccce8267e962ad6ccab52ba11f1c07bf4efff2de829e6be2fa`
- **Conclusion:** 1 pre-existing failure identical between branches (Playwright install check, env-only — not exercised by this PR). 0 new failures. 0 resolved.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Files changed

```
src/main/index.ts         | 16 +++++++++++++---
src/renderer/App.tsx      | 28 +++++++++++++++++++++++-----
src/renderer/Settings.tsx |  8 ++++----
3 files changed, 40 insertions(+), 12 deletions(-)
```