### PR TITLE
fix(electron): set dev-mode macOS dock icon to Manta UI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,11 @@
-import { app, BrowserWindow, clipboard, ipcMain, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  ipcMain,
+  nativeImage,
+  shell,
+} from "electron";
 import { join, basename } from "node:path";
 import { watch as fsWatch } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -178,6 +185,17 @@ app.setAppUserModelId("com.antoinedc.mantaui");
 app.whenReady().then(() => {
   config = loadConfig();
   registerHandlers();
+  // Dev-only: packaged builds get their dock icon from electron-builder
+  // (assets/icon.icns). In dev the Electron binary has no icon, so the dock
+  // shows the generic Electron icon + "Electron" tooltip. Set it at runtime
+  // from the PNG so the dev dock matches the packaged app. app.isPackaged is
+  // false in dev; app.dock only exists on macOS.
+  if (!app.isPackaged && process.platform === "darwin" && app.dock) {
+    const icon = nativeImage.createFromPath(
+      join(__dirname, "../../assets/icons/512x512.png"),
+    );
+    if (!icon.isEmpty()) app.dock.setIcon(icon);
+  }
   createWindow();
   // Defer poller start until renderer is ready to receive events.
   mainWindow?.webContents.once("did-finish-load", () => {


### PR DESCRIPTION
## Problem

In dev mode (`npm run dev`), the macOS dock shows the default Electron icon and the tooltip reads 'Electron' instead of 'Manta UI'. Packaged builds are fine — electron-builder bakes in `assets/icon.icns` — but the unpackaged Electron binary has no icon at runtime, so `app.dock` falls back to the Electron binary's own icon.

## Fix

Dev-only `app.dock.setIcon(icon)` call inside `app.whenReady()`, guarded by `!app.isPackaged && process.platform === 'darwin' && app.dock`. Reuses the existing `assets/icons/512x512.png` (no new assets, no regenerated icons). The packaged-build path (`electron-builder.yml` `mac.icon: assets/icon.icns`) is untouched.

The `__dirname`-relative depth (`../../assets/...`) is verified against `electron.vite.config.*` — the main build lands in `out/main/` (electron-vite default; no explicit `outDir` override), so two `../` segments resolve to `<repo-root>/assets/...`, which matches the file confirmed to exist.

`nativeImage` added to the existing `electron` import.

## Scope hygiene

- Dev-only: `!app.isPackaged` guard. No change to electron-builder config or packaging.
- Reuses existing asset. No new icon files generated.
- No `icon:` option added to `BrowserWindow`. Keeps the change limited to the macOS dock via `app.dock.setIcon()`.

## Out-of-scope

If the dock tooltip still literally reads 'Electron' after this change, that is a known limitation of running the unpackaged Electron binary (the bundle is `Electron.app`). Per the issue, no bundle renaming or Info.plist surgery is attempted.

## Verification

**Base:** origin/main @ `0333734`

**PR branch** (`multica/BET-213-dev-dock-icon` @ `82061d2`):
- typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
- vitest: `60 passed (60)`. log sha256: `49441162d2a11df10aa7c19696dcd06bbfaecbcfa807d4cbec55da27dd2561f0`
- node:test (`src/server` + `src/relay` + `src/gateway` + `scripts`): exit `1`, `883 pass / 1 fail / 0 skip`. Failure: `not ok 29 - formatPairingOutput produces a stable human block` at `scripts/install.test.mjs:489`. log sha256: `50b4a3b92e1f55f141813aec47d3ba0d25581db95c984ebbe181c3779b24d219`

**Base** (`main` @ `0333734`):
- typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
- vitest: `60 passed (60)` on clean run; one stale-failure `tests/unit/e2e-smoke.test.ts` (Playwright not installed on this Linux box) on flaky re-runs. Same on master.
- node:test: exit `1`, `883 pass / 1 fail`. Same failure as PR (`not ok 29 - formatPairingOutput produces a stable human block`).

**Conclusion:** `0` new failures. The single node:test failure (`formatPairingOutput`) is pre-existing on `main` and identical between branches — not caused by this PR. Vitest failure (Playwright e2e-smoke) is environment-dependent (Playwright not installed) and also pre-existing on `main`. Typecheck clean on both.

**Visual verification (macOS dock):** not possible on this Linux box (`app.dock` is `undefined` and the block is a no-op — that no-op is correct and expected per the issue). The dev-mode macOS dock visual confirmation is a manual step the reviewer should run on a Mac: `npm run dev` → dock icon should be the Manta UI icon, not the generic Electron icon. If the tooltip still says 'Electron', that is the documented dev-binary limitation and out of scope.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/vitest-pr.log`, `/tmp/test-pr-node.log` for spot-check.