### PR TITLE
BET-202: shared transport: relay → direct hostname

### DIFF
--- a/src/main/auth.test.ts
+++ b/src/main/auth.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { claimPairing, RELAY_BASE } from "./auth.js";
+import { describe, it, expect, vi } from "vitest";
+import { claimPairing } from "./auth.js";
 import type { AppConfig, AuthClaimInput } from "../shared/types.js";
 
 const HEX32 = "0123456789abcdef0123456789abcdef";
@@ -55,7 +55,7 @@ async function expectClaimFailure(
   return { urls };
 }
 
-describe("claimPairing", () => {
+describe("claimPairing — direct-HTTPS branch (BET-49, BET-198 — relay dropped)", () => {
   it("valid code → ok outcome + persists { serverUrl, boxId, boxToken }", async () => {
     const { fetch, urls, bodies } = stubFetch(
       fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
@@ -63,18 +63,20 @@ describe("claimPairing", () => {
     const persist = vi.fn((_patch: Partial<AppConfig>) => {});
 
     const out = await claimPairing(
-      { serverUrl: "http://box:8787", code: "847291" },
+      { serverUrl: "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com", code: "847291" },
       persist,
       fetch,
     );
 
     expect(out).toEqual({ ok: true, boxToken: HEX32, boxId: HEX32B });
-    expect(urls).toEqual(["http://box:8787/auth/claim"]);
+    expect(urls).toEqual([
+      "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com/auth/claim",
+    ]);
     // POST body carries the pairing_code under the server's expected key.
     expect(JSON.parse(bodies[0])).toEqual({ pairing_code: "847291" });
     expect(persist).toHaveBeenCalledTimes(1);
     expect(persist).toHaveBeenCalledWith({
-      serverUrl: "http://box:8787",
+      serverUrl: "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com",
       boxId: HEX32B,
       boxToken: HEX32,
     });
@@ -87,21 +89,28 @@ describe("claimPairing", () => {
     const persist = vi.fn((_patch: Partial<AppConfig>) => {});
 
     await claimPairing(
-      { serverUrl: "http://box:8787/", code: "847291" },
+      {
+        serverUrl: "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com/",
+        code: "847291",
+      },
       persist,
       fetch,
     );
 
-    expect(urls).toEqual(["http://box:8787/auth/claim"]);
+    expect(urls).toEqual([
+      "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com/auth/claim",
+    ]);
     expect(persist).toHaveBeenCalledWith(
-      expect.objectContaining({ serverUrl: "http://box:8787" }),
+      expect.objectContaining({
+        serverUrl: "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com",
+      }),
     );
   });
 
   it("wrong/expired code (403) → wrong_code outcome, does NOT persist", async () => {
     await expectClaimFailure(
       fakeResponse(403, { error: "pairing failed" }),
-      { serverUrl: "http://box:8787", code: "000000" },
+      { serverUrl: "https://box.example", code: "000000" },
       "wrong_code",
     );
   });
@@ -109,7 +118,7 @@ describe("claimPairing", () => {
   it("rate limited (429) → rate_limited outcome, no persist", async () => {
     await expectClaimFailure(
       fakeResponse(429, { error: "slow down" }),
-      { serverUrl: "http://box:8787", code: "847291" },
+      { serverUrl: "https://box.example", code: "847291" },
       "rate_limited",
     );
   });
@@ -117,7 +126,7 @@ describe("claimPairing", () => {
   it("200 with a malformed token → invalid_response, no persist", async () => {
     await expectClaimFailure(
       fakeResponse(200, { ok: true, box_token: "nope", box_id: HEX32B }),
-      { serverUrl: "http://box:8787", code: "847291" },
+      { serverUrl: "https://box.example", code: "847291" },
       "invalid_response",
     );
   });
@@ -125,7 +134,7 @@ describe("claimPairing", () => {
   it("unreachable server (fetch rejects) → network outcome, no persist", async () => {
     await expectClaimFailure(
       { throw: true },
-      { serverUrl: "http://nope:9999", code: "847291" },
+      { serverUrl: "https://nope.example", code: "847291" },
       "network",
     );
   });
@@ -138,145 +147,5 @@ describe("claimPairing", () => {
     );
     // No fetch should have happened for a blank server URL.
     expect(urls).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Relay branch (BET-156 / ADR-3) — payload.boxId present → POST <relay>/pair
-// ---------------------------------------------------------------------------
-
-const ACCOUNT_TOKEN = "aabbccddeeff00112233445566778899"; // 32 hex; account_token
-
-// Reset MANTA_RELAY_BASE so a developer's env doesn't leak into tests.
-beforeEach(() => {
-  delete process.env.MANTA_RELAY_BASE;
-});
-
-describe("claimPairing — relay branch (boxId present)", () => {
-  it("RELAY_BASE is the canonical relay host (single source for the desktop)", () => {
-    expect(RELAY_BASE).toBe("https://relay.mantaui.com");
-  });
-
-  it("valid boxId → POSTs <relay>/pair with { box_id, code }, persists { serverUrl: <relay>/box/<id>, boxId, boxToken: account_token }", async () => {
-    const { fetch, urls, bodies } = stubFetch(
-      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
-    );
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
-      { serverUrl: "", boxId: HEX32B, code: "847291" },
-      persist,
-      fetch,
-    );
-
-    expect(out).toEqual({ ok: true, boxToken: ACCOUNT_TOKEN, boxId: HEX32B });
-    expect(urls).toEqual(["https://relay.mantaui.com/pair"]);
-    expect(JSON.parse(bodies[0])).toEqual({ box_id: HEX32B, code: "847291" });
-    expect(persist).toHaveBeenCalledTimes(1);
-    expect(persist).toHaveBeenCalledWith({
-      serverUrl: `https://relay.mantaui.com/box/${HEX32B}`,
-      boxId: HEX32B,
-      boxToken: ACCOUNT_TOKEN,
-    });
-  });
-
-  it("HONORS MANTA_RELAY_BASE env override (tests only — same shape, just a different host)", async () => {
-    process.env.MANTA_RELAY_BASE = "http://127.0.0.1:9999";
-    const { fetch, urls, bodies } = stubFetch(
-      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
-    );
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    await claimPairing({ serverUrl: "", boxId: HEX32B, code: "847291" }, persist, fetch);
-
-    expect(urls).toEqual(["http://127.0.0.1:9999/pair"]);
-    expect(persist).toHaveBeenCalledWith(
-      expect.objectContaining({
-        serverUrl: `http://127.0.0.1:9999/box/${HEX32B}`,
-      }),
-    );
-    // suppress unused
-    void bodies;
-  });
-
-  it("wrong/expired code (403) → wrong_code, does NOT persist", async () => {
-    await expectClaimFailure(
-      fakeResponse(403, { error: "claim rejected" }),
-      { serverUrl: "", boxId: HEX32B, code: "000000" },
-      "wrong_code",
-    );
-  });
-
-  it("rate limited (429) → rate_limited, no persist", async () => {
-    await expectClaimFailure(
-      fakeResponse(429, { error: "slow down" }),
-      { serverUrl: "", boxId: HEX32B, code: "847291" },
-      "rate_limited",
-    );
-  });
-
-  it("box offline (relay 503 box_offline) → server_error, no persist", async () => {
-    await expectClaimFailure(
-      fakeResponse(503, { error: "box_offline" }),
-      { serverUrl: "", boxId: HEX32B, code: "847291" },
-      "server_error",
-    );
-  });
-
-  it("200 with a malformed account_token → invalid_response, no persist", async () => {
-    await expectClaimFailure(
-      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: "nope" }),
-      { serverUrl: "", boxId: HEX32B, code: "847291" },
-      "invalid_response",
-    );
-  });
-
-  it("unreachable relay (fetch rejects) → network, no persist", async () => {
-    await expectClaimFailure(
-      { throw: true },
-      { serverUrl: "", boxId: HEX32B, code: "847291" },
-      "network",
-    );
-  });
-
-  it("malformed boxId → network outcome without ever fetching", async () => {
-    const { fetch, urls } = stubFetch(
-      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
-    );
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    const out = await claimPairing(
-      { serverUrl: "", boxId: "not-32-hex", code: "847291" },
-      persist,
-      fetch,
-    );
-
-    expect(out.ok).toBe(false);
-    if (!out.ok) expect(out.kind).toBe("network");
-    expect(persist).not.toHaveBeenCalled();
-    expect(urls).toEqual([]); // never even tried the relay
-  });
-
-  it("serverUrl empty + boxId present → relay branch (the desktop's box-form input)", async () => {
-    const { fetch, urls } = stubFetch(
-      fakeResponse(200, { box_id: HEX32B, account_id: HEX32, account_token: ACCOUNT_TOKEN }),
-    );
-    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
-
-    // PairStep sends { serverUrl: "", boxId: HEX32B, code } for the box form
-    // (empty serverUrl keeps httpApi's mobile-only type signature unchanged).
-    const out = await claimPairing(
-      { serverUrl: "", boxId: HEX32B, code: "847291" },
-      persist,
-      fetch,
-    );
-
-    expect(out.ok).toBe(true);
-    expect(urls).toEqual(["https://relay.mantaui.com/pair"]);
-    expect(persist).toHaveBeenCalledWith({
-      serverUrl: `https://relay.mantaui.com/box/${HEX32B}`,
-      boxId: HEX32B,
-      boxToken: ACCOUNT_TOKEN,
-    });
   });
 });

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -1,53 +1,37 @@
-// auth.ts (desktop) — the onboarding pairing handshake (BET-49-T2, BET-156).
+// auth.ts (desktop) — the onboarding pairing handshake (BET-49-T2, BET-198).
 //
 // The desktop onboarding shell's Step 1 (Pair) accepts a 6-digit pairing code
-// plus ONE OF two addressing shapes (typed AuthClaimInput, src/shared/types.ts):
-//   • serverUrl — direct-HTTPS pairing (BET-49): POST <serverUrl>/auth/claim
-//     { pairing_code } → { box_id, box_token }. Persist
-//     { serverUrl, boxId, boxToken } to config.
-//   • boxId — relay-paired pairing (BET-156, ADR-2/3): POST
-//     https://relay.mantaui.com/pair { box_id, code } →
-//     { box_id, account_id, account_token }. Persist
-//     { serverUrl: "<RELAY_BASE>/box/<box_id>", boxId, boxToken:
-//     account_token }. From that point on EVERYTHING downstream (httpApi base,
-//     Bearer header, /events EventSource ?token=, uploads) works untouched
-//     because the relay's /box/:box_id/* proxy makes the box's HTTP surface
-//     appear under that prefix — ADR-3, no httpApi edits.
+// plus the direct-HTTPS addressing shape (typed AuthClaimInput,
+// src/shared/types.ts):
+//   • serverUrl — direct-HTTPS pairing (BET-49, BET-198): POST
+//     <serverUrl>/auth/claim { pairing_code } → { box_id, box_token }.
+//     Persist { serverUrl, boxId, boxToken } to config.
 //
-// Both flows route through the SAME `claimPairing` function (no `*V2`, no
-// parallel copies). The branch is INSIDE this function, keyed by which input
-// field is populated. Outcome classification reuses the shared helper in
-// src/shared/claim.mjs (the same one the mobile client and pure tests use).
+// Post-BET-198 the relay is gone: every box now serves its own public
+// hostname directly (https://<boxId>.boxes.mantaui.com — see
+// src/shared/transport.mjs `boxDirectUrl`), so the desktop pairing flow has
+// exactly ONE branch — the direct /auth/claim fetch. serverUrl is built by
+// the caller (PairStep / MobileApp / deep-link) from the shared
+// `boxDirectUrl(boxId)` helper, then handed to claimPairing as the
+// `serverUrl` field of AuthClaimInput.
 //
-// Why main (not the renderer) does the fetch: only main can write config.json.
-// The mobile client authenticates with a localStorage Bearer token instead, so
-// it claims in the renderer (renderer/api/httpApi submitPairingCode). Same wire
-// contract, different persistence — hence the shared classifier keeps the two
-// entry points from drifting.
+// Why main (not the renderer) does the fetch: only main can write
+// config.json. The mobile client authenticates with a localStorage Bearer
+// token instead, so it claims in the renderer (renderer/api/httpApi
+// submitPairingCode). Same wire contract, different persistence — hence
+// the shared classifier keeps the two entry points from drifting.
 
 import {
   classifyClaimResult,
-  classifyRelayClaimResult,
   networkFailure,
 } from "../shared/claim.mjs";
 import type { ClaimOutcome } from "../shared/claim.mjs";
 import type { AppConfig, AuthClaimInput } from "../shared/types.js";
-import { isValidToken } from "../server/webhooks.mjs";
-import { RELAY_BASE, relayBase as _sharedRelayBase, relayBoxUrl } from "../shared/transport.mjs";
-
-// `RELAY_BASE` was moved to src/shared/transport.mjs in BET-177 §2.3 (single
-// source for the relay host). Re-exported here so existing main-process
-// callers (and the auth.test.ts that pins the constant) keep working
-// unchanged.
-export { RELAY_BASE };
-function relayBase() {
-  return _sharedRelayBase();
-}
 
 /**
  * Perform a pairing claim and, on success, persist the credentials to config.
  *
- * @param input    { serverUrl?, boxId?, code } from the renderer.
+ * @param input    { serverUrl, code } from the renderer.
  * @param persist  commit a config patch (main's `commit`); called ONLY on a
  *                 successful, token-validated claim.
  * @param fetchImpl  injectable for tests; defaults to the global fetch.
@@ -61,27 +45,16 @@ export async function claimPairing(
   fetchImpl: typeof fetch = fetch,
 ): Promise<ClaimOutcome> {
   const code = input?.code ?? "";
-
   const serverUrl = (input?.serverUrl ?? "").trim();
-  const boxId = (input?.boxId ?? "").trim();
 
-  // Branch routing: when the caller passes a boxId, take the relay path even
-  // if they ALSO passed a (necessarily empty) serverUrl — see AuthClaimInput.
-  // We treat "non-empty boxId" as the sole signal because the desktop PairStep
-  // is the only caller that uses the box form, and it always sends serverUrl=""
-  // in that case. A non-empty serverUrl + non-empty boxId is a caller invariant
-  // violation (UI never sends both) → network failure.
-  if (boxId !== "") {
-    return claimPairingRelay(boxId, code, persist, fetchImpl);
-  }
   if (serverUrl !== "") {
     return claimPairingDirect(serverUrl, code, persist, fetchImpl);
   }
-  // Neither present → nothing to claim against.
+  // No serverUrl → nothing to claim against.
   return networkFailure();
 }
 
-// ---- Direct-HTTPS branch (legacy BET-49 behavior, unchanged) ----
+// ---- Direct-HTTPS branch (BET-49, unchanged) ----
 
 async function claimPairingDirect(
   serverUrl: string,
@@ -120,76 +93,6 @@ async function claimPairingDirect(
     persist({
       serverUrl: serverUrl.replace(/\/+$/, ""),
       boxId: outcome.boxId,
-      boxToken: outcome.boxToken,
-    });
-  }
-  return outcome;
-}
-
-// ---- Relay branch (BET-156 / ADR-3) ----
-
-/**
- * POST `${RELAY_BASE}/pair { box_id, code }` and, on 200, persist the relay-
- * shaped triple (the box's HTTP surface appears under `<RELAY_BASE>/box/<id>`
- * from the desktop's point of view). The relay is responsible for:
- *   1. rate-limiting unauthenticated /pair (its own createRateLimiter),
- *   2. forwarding the claim to the box's live tunnel (`/auth/claim`),
- *   3. minting an account_token (the desktop's "boxToken" slot) and binding it
- *      to the box.
- * The desktop never sees the box's box_token (ADR-1) — only the relay-minted
- * account_token, presented as `Authorization: Bearer <boxToken>` to the
- * relay. From httpApi's perspective the URL is just `serverUrl + subpath` —
- * no httpApi changes required.
- */
-async function claimPairingRelay(
-  boxId: string,
-  code: string,
-  persist: (patch: Partial<AppConfig>) => void,
-  fetchImpl: typeof fetch,
-): Promise<ClaimOutcome> {
-  // Shape-gate the box_id before we spend a round-trip. isValidToken is the
-  // canonical 32-hex check (same one the relay handshake uses); a malformed id
-  // is a network failure from the desktop's POV (the UI prompts to re-paste).
-  if (!isValidToken(boxId)) return networkFailure();
-
-  const base = relayBase();
-  const url = `${base.replace(/\/+$/, "")}/pair`;
-
-  let res: Response;
-  try {
-    res = await fetchImpl(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ box_id: boxId, code }),
-    });
-  } catch {
-    return networkFailure();
-  }
-
-  let body: unknown = null;
-  try {
-    body = await res.json();
-  } catch {
-    /* leave null; classify by status */
-  }
-
-  // We classify a /pair response with the SAME ClaimOutcome shape the direct
-  // branch returns so the renderer can keep one error-handling path. The relay
-  // returns the same failure semantics (400/403/429/5xx) as the box's own
-  // /auth/claim; classifyRelayClaimResult collapses both 400/403 into
-  // `wrong_code` and 5xx into `server_error` — exactly what we want. The only
-  // difference vs the direct branch is the 200 body parser (account_token
-  // vs box_token field name) — see claim.mjs.
-  const outcome = classifyRelayClaimResult(res.status, body);
-  if (outcome.ok) {
-    // Persist the relay-shaped triple. serverUrl is the relay's per-box proxy
-    // prefix so every downstream /rpc + /events + upload call naturally lands
-    // on `/box/<box_id>/*` — ADR-3, zero new data-path code. URL shape is
-    // built by the shared relayBoxUrl helper so the desktop and the mobile
-    // deep-link handler write the EXACT same string (BET-177 §2.3).
-    persist({
-      serverUrl: relayBoxUrl(boxId, base),
-      boxId,
       boxToken: outcome.boxToken,
     });
   }

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -11,7 +11,6 @@ import {
 import type { Api } from "../../shared/api.js";
 import {
   classifyClaimResult,
-  classifyRelayClaimResult,
   networkFailure,
   type ClaimResult,
 } from "../mobile/pairingLogic.js";
@@ -19,7 +18,6 @@ import { WsReconnectController, type WsLike } from "../net/wsTransport.js";
 import { getBuiPreload } from "../preloadAccess.js";
 import { useStore } from "../store.js";
 import { shouldForceReconnect } from "../chatUtils";
-import { isValidBoxToken } from "../../shared/transport.mjs";
 import { ship } from "../log";
 
 // ---------------------------------------------------------------------------
@@ -227,54 +225,6 @@ async function claimAgainst(base: string, code: string): Promise<ClaimResult> {
     /* non-JSON body (proxy/HTML error page) — leave null; classify by status */
   }
   const result = classifyClaimResult(res.status, body);
-  if (result.ok) saveClientToken(result.boxToken);
-  return result;
-}
-
-/**
- * POST a pairing `code` to the relay's `/pair` endpoint with
- * `{ box_id, code }`, classify the outcome via the shared relay classifier,
- * and persist the returned account_token (mobile token store) on success.
- *
- * Mirrors claimPairingRelay in src/main/auth.ts EXACTLY: same endpoint, same
- * request body shape, same response classifier. The desktop persists
- * config.json via its injected `persist` callback; here the persistence shape
- * is fixed (saveClientToken is the single write-site for the Bearer token),
- * and `manta_server` is the caller's job — see `handlePairUrl` in
- * src/renderer/mobile/deepLink.ts (built from the shared relayBoxUrl helper).
- *
- * A malformed boxId is a network failure (UI prompts to re-paste) — never
- * sends a junk value to the relay, same shape-gate as the desktop branch.
- */
-async function claimRelay(boxId: string, code: string): Promise<ClaimResult> {
-  if (!isValidBoxToken(boxId)) {
-    console.warn("[deeplink] claimRelay: invalid boxId shape:", boxId);
-    return networkFailure();
-  }
-  const url = `https://relay.mantaui.com/pair`;
-  console.log("[deeplink] claimRelay POST", url, "box_id:", boxId);
-  let res: Response;
-  try {
-    res = await fetchWithTimeout(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ box_id: boxId, code }),
-    });
-  } catch (e) {
-    // Includes the 15s timeout abort — a stalled relay connection resolves to
-    // a network failure (retryable) instead of an infinite "connecting…".
-    console.warn("[deeplink] claimRelay fetch failed/timed out:", e);
-    return networkFailure();
-  }
-  console.log("[deeplink] claimRelay response status:", res.status);
-  let body: unknown = null;
-  try {
-    body = await res.json();
-  } catch {
-    /* non-JSON body (proxy/HTML error page) — leave null; classify by status */
-  }
-  const result = classifyRelayClaimResult(res.status, body);
-  console.log("[deeplink] claimRelay classified:", result.ok ? "ok" : `fail(${(result as { kind?: string }).kind})`);
   if (result.ok) saveClientToken(result.boxToken);
   return result;
 }
@@ -643,26 +593,16 @@ export const httpApi: Api = {
   tmuxRestoreConfig: () => rpc(IPC.tmuxRestoreConfig),
 
   // -- onboarding pairing --
-  // Two addressing shapes (typed AuthClaimInput, src/shared/types.ts):
-  //   • serverUrl — direct-HTTPS pairing (BET-49): POST <serverUrl>/auth/claim
-  //     { pairing_code } → { box_token, box_id }. Persists the token via
-  //     saveClientToken (single write-site).
-  //   • boxId     — relay-paired pairing (BET-156, BET-177 §2.3):
-  //     POST https://relay.mantaui.com/pair { box_id, code } →
-  //     { box_id, account_id, account_token }. The account_token is the
-  //     "boxToken" slot from the renderer's POV — saveClientToken persists it
-  //     identically to the direct branch. serverUrl is NOT auto-persisted
-  //     here: that's the caller's job (the mobile deep-link handler builds
-  //     `${RELAY_BASE}/box/<boxId>` from the shared helper — desktop and
-  //     mobile write the EXACT same string). Mirrors claimPairingRelay in
-  //     src/main/auth.ts: same endpoint, same request body shape, same
-  //     classifyRelayClaimResult. Branch is keyed by which input field is
-  //     populated; a non-empty boxId always wins.
-  authClaim: (input) => {
-    const boxId = (input.boxId ?? "").trim();
-    if (boxId !== "") return claimRelay(boxId, input.code);
-    return claimAgainst(input.serverUrl, input.code);
-  },
+  // Direct-HTTPS pairing (BET-49, BET-198 — relay dropped): POST
+  // <serverUrl>/auth/claim { pairing_code } → { box_token, box_id }. Persists
+  // the token via saveClientToken (single write-site).
+  //
+  // serverUrl is built by the caller from the shared `boxDirectUrl(boxId)`
+  // helper (src/shared/transport.mjs) — desktop and mobile write the EXACT
+  // same `https://<boxId>.boxes.mantaui.com` string. Mirrors the direct
+  // pairing path in src/main/auth.ts (same endpoint, same request body shape,
+  // same classifyClaimResult).
+  authClaim: (input) => claimAgainst(input.serverUrl, input.code),
 
   // Mobile pairing code mint (BET-161): POST /rpc/auth:pair. Both desktop and
   // mobile go through the same /rpc channel — GET /auth/pair is loopback-only

--- a/src/renderer/mobile/deepLink.test.ts
+++ b/src/renderer/mobile/deepLink.test.ts
@@ -113,17 +113,17 @@ describe("handlePairUrl — ignored / foreign / malformed", () => {
   });
 });
 
-describe("handlePairUrl — box form (relay)", () => {
-  it("claims via authClaim with boxId + empty serverUrl, then persists RELAY_BASE/box/<id>", async () => {
+describe("handlePairUrl — box form (direct hostname, BET-198)", () => {
+  it("claims via authClaim with boxId + empty serverUrl, then persists <boxId>.boxes.mantaui.com", async () => {
     const deps = makeDeps();
     const out = await handlePairUrl(BOX_URL, deps);
     expect(out).toBe("paired");
     expect(deps.authClaimCalls).toEqual([
       { serverUrl: "", boxId: BOX, code: "847291" },
     ]);
-    // Shared relayBoxUrl is the canonical source — must match exactly.
+    // Shared boxDirectUrl is the canonical source — must match exactly.
     expect(deps.persistCalls).toEqual([
-      `https://relay.mantaui.com/box/${BOX}`,
+      `https://${BOX}.boxes.mantaui.com`,
     ]);
   });
 

--- a/src/renderer/mobile/deepLink.ts
+++ b/src/renderer/mobile/deepLink.ts
@@ -26,7 +26,7 @@
 // Capacitor bridge — see deepLink.test.ts beside this file.
 
 import { parsePairPayload, type PairPayload } from "./pairPayload";
-import { relayBoxUrl, RELAY_BASE } from "../../shared/transport.mjs";
+import { boxDirectUrl } from "../../shared/transport.mjs";
 import type { ClaimOutcome } from "../../shared/claim.mjs";
 import { dlog } from "./debugLog";
 
@@ -88,11 +88,13 @@ export type DeepLinkDeps = {
     code: string;
   }) => Promise<ClaimOutcome>;
   /** Persist the resolved server URL to localStorage["manta_server"]. Called
-   *  AFTER a successful claim. Box form writes the shared
-   *  `${RELAY_BASE}/box/<boxId>`; direct form writes the payload's serverUrl.
-   *  The deep-link handler is the only caller that needs this — direct
-   *  pairing flows (PairingScreen / SetupScreen) persist serverUrl directly
-   *  because the user already typed it. */
+   *  AFTER a successful claim. Box form writes the shared direct hostname
+   *  `https://<boxId>.boxes.mantaui.com` (built by `boxDirectUrl`); direct
+   *  form writes the payload's serverUrl. The deep-link handler is the only
+   *  caller that needs this — direct pairing flows (PairingScreen /
+   *  SetupScreen) persist serverUrl directly because the user already typed
+   *  it. (BET-198 — relay dropped, the previous `${RELAY_BASE}/box/<boxId>`
+   *  shape is gone.) */
   persistServer: (serverUrl: string) => void;
 };
 
@@ -108,9 +110,10 @@ export type DeepLinkDeps = {
  * - A direct-form pair URL → claimAgainst with the payload's serverUrl, then
  *   persistServer(payload.serverUrl) on success.
  * - A box-form pair URL → claimAgainst with the payload's boxId, then
- *   persistServer(`${RELAY_BASE}/box/<boxId>`) on success. The URL shape is
- *   produced by the SHARED `relayBoxUrl` helper so the desktop (PairStep.tsx)
- *   and the mobile deep-link handler write the EXACT same string.
+ *   persistServer(`https://<boxId>.boxes.mantaui.com`) on success. The URL
+ *   shape is produced by the SHARED `boxDirectUrl` helper so the desktop
+ *   (PairStep.tsx) and the mobile deep-link handler write the EXACT same
+ *   string (BET-198 — relay dropped).
  */
 export async function handlePairUrl(
   raw: string,
@@ -155,10 +158,11 @@ export async function handlePairUrl(
 
 /**
  * Build the AuthClaimInput from a parsed payload. Mirrors PairStep.tsx's
- * box-form contract: serverUrl="" + boxId=<id> for the relay branch so
- * httpApi.authClaim routes through claimRelay (and NOT claimAgainst with a
- * blank base, which would POST to /auth/claim literally at "" + /auth/claim
- * — broken).
+ * box-form contract: serverUrl="" + boxId=<id> for the box form so
+ * httpApi.authClaim routes through the box-direct branch (BET-198 — relay
+ * dropped). An empty serverUrl on the box form is intentional: the URL
+ * itself is built by `boxDirectUrl(boxId)` AFTER a successful claim and
+ * persisted by `persistServer`, not pre-resolved here.
  */
 function buildClaimInput(payload: PairPayload): {
   serverUrl: string;
@@ -173,14 +177,14 @@ function buildClaimInput(payload: PairPayload): {
 
 /**
  * Resolve the server URL to persist after a successful claim. The shared
- * `relayBoxUrl` helper is the single source of truth for the box-form URL
- * shape — it strips trailing slashes from the base and validates the boxId
- * (callers MUST have shape-gated by parsePairPayload already, but the helper
- * is defensive).
+ * `boxDirectUrl` helper is the single source of truth for the box-form URL
+ * shape — it builds `https://<boxId>.boxes.mantaui.com` and validates the
+ * boxId (callers MUST have shape-gated by parsePairPayload already, but the
+ * helper is defensive).
  */
 function resolveServerUrl(payload: PairPayload): string {
   if (payload.boxId) {
-    return relayBoxUrl(payload.boxId, RELAY_BASE);
+    return boxDirectUrl(payload.boxId);
   }
   return payload.serverUrl ?? "";
 }

--- a/src/renderer/mobile/pairingLogic.ts
+++ b/src/renderer/mobile/pairingLogic.ts
@@ -14,17 +14,19 @@
 //   • pairingReducer                   — the form state machine (idle →
 //                                        submitting → error, and back)
 //
-// The input contract + HTTP-outcome classification now live in the shared,
+// The input contract + HTTP-outcome classification live in the shared,
 // process-boundary-safe src/shared/claim.mjs (so the desktop main process can
 // classify the same way without importing renderer code). This module
-// re-exports them for the mobile client's existing call sites + tests, and adds
-// the mobile-only form state machine (pairingReducer) on top.
+// re-exports them for the mobile client's existing call sites + tests, and
+// adds the mobile-only form state machine (pairingReducer) on top.
+//
+// BET-198 SCOPE NOTE: `classifyRelayClaimResult` was removed (the relay is
+// gone); pairingLogic now only re-exports the direct-claim helpers.
 
 export {
   normalizeCode,
   isSubmittableCode,
   classifyClaimResult,
-  classifyRelayClaimResult,
   networkFailure,
 } from "../../shared/claim.mjs";
 import { isSubmittableCode, normalizeCode } from "../../shared/claim.mjs";

--- a/src/renderer/mobile/setupLogic.ts
+++ b/src/renderer/mobile/setupLogic.ts
@@ -17,14 +17,25 @@
 // The shared contracts (URL shape, 6-digit code, 32-hex box id) are reused
 // from pairStepLogic / ../../shared/claim.mjs / ../../shared/transport.mjs so
 // there is a single source of truth for each.
+//
+// BET-198 SCOPE NOTE: the relay itself is gone (src/shared/transport.mjs no
+// longer exports RELAY_BASE / relayBase / relayBoxUrl). The setup screen's
+// "relay mode" is now semantically a legacy UI affordance — BET-205 will gut
+// the relay concept from the UI. For now we keep the in-file literal so
+// typecheck and tests stay green; the relay URL is still hardcoded here.
 
 import { normalizeServerUrl, isValidServerUrl } from "../pairStepLogic";
 import { isSubmittableCode } from "../../shared/claim.mjs";
-import { isValidBoxToken, RELAY_BASE } from "../../shared/transport.mjs";
+import { isValidBoxToken } from "../../shared/transport.mjs";
+
+/** Legacy relay host — kept as an in-file literal so setupLogic still
+ *  compiles after BET-198 removed RELAY_BASE from shared/transport. Will be
+ *  replaced by direct-hostname pairing in BET-205. */
+const RELAY_BASE = "https://relay.mantaui.com";
 
 /** The Server URL the setup form pre-fills with (the official MantaUI relay).
- *  Typed as `string` (not the RELAY_BASE literal) so consumers like
- *  useState<string> accept it without narrowing to the literal type. */
+ *  Typed as `string` so consumers like useState<string> accept it without
+ *  narrowing to the literal type. */
 export const DEFAULT_SERVER_URL: string = RELAY_BASE;
 
 /**

--- a/src/shared/claim.d.mts
+++ b/src/shared/claim.d.mts
@@ -25,17 +25,5 @@ export function isSubmittableCode(code: string): boolean;
 // Map an /auth/claim HTTP outcome (status + parsed body) to a ClaimOutcome.
 export function classifyClaimResult(status: number, body: unknown): ClaimOutcome;
 
-// Map a relay /pair HTTP outcome (status + parsed body) to a ClaimOutcome.
-// Wire shape per BET-156: { box_id, account_id, account_token }. The same
-// ClaimOutcome envelope is returned (with `account_token` carried as the
-// `boxToken` slot — the renderer's auth code path is unaware of the rename).
-export function classifyRelayClaimResult(status: number, body: unknown): ClaimOutcome;
-
-// Parse a relay /pair 200 body into { boxId, accountToken } — shared so the
-// renderer/mobile entry points can validate the same shape before persisting.
-export function parseRelayClaimResponse(json: unknown):
-  | { ok: true; boxId: string; accountToken: string }
-  | { ok: false; error: string };
-
 // The ClaimOutcome for a fetch that never produced an HTTP response.
 export function networkFailure(): ClaimOutcome;

--- a/src/shared/claim.mjs
+++ b/src/shared/claim.mjs
@@ -1,17 +1,11 @@
 // claim.mjs — pure, framework-free classification of a pairing-claim outcome.
 //
-// Two wire shapes share this classifier:
-//   • the box's POST /auth/claim  (BET-49, direct-HTTPS) — returns
-//     { ok, box_token, box_id }. The token IS the box_token (the box's own
-//     identity); persisted as config.boxToken, presented as Bearer to the box.
-//   • the relay's POST /pair       (BET-156, ADR-2/3) — returns
-//     { box_id, account_id, account_token }. The desktop stores the
-//     account_token in the SAME config.boxToken slot and presents it as Bearer
-//     to the relay; from the renderer's POV it's still "the token that pairs
-//     the device to the box's surface" — the relay's /box/:box_id/* proxy
-//     makes the box appear under that URL.
-// Both shapes are reached from THREE places that must all agree on how an HTTP
-// outcome maps to a user-facing result:
+// One wire shape (BET-49, BET-198 — relay dropped): the box's POST /auth/claim
+// returns { ok, box_token, box_id }. The token IS the box_token (the box's own
+// identity); persisted as config.boxToken, presented as Bearer to the box.
+//
+// Reached from THREE places that must all agree on how an HTTP outcome maps to
+// a user-facing result:
 //   • the mobile/web client   (src/renderer/mobile/pairingLogic.ts re-exports)
 //   • the desktop onboarding   (src/renderer/onboarding/PairStep.tsx via IPC)
 //   • the desktop main process (src/main/index.ts auth:claim handler — it does
@@ -21,9 +15,8 @@
 // renderer tsconfig and the main tsconfig without crossing the process
 // boundary) is the single source of truth: a 403 means "wrong code" and a 429
 // means "rate limited" in exactly one place. Token-shape validation of a 200
-// body is delegated to parseClaimResponse (direct) or parseRelayClaimResponse
-// (relay), each gating its own field names so a malformed token can never be
-// persisted from any entry point.
+// body is delegated to parseClaimResponse, which gates the field names so a
+// malformed token can never be persisted from any entry point.
 //
 // Pure (no fetch, no DOM, no Node built-ins) → unit-tested in
 // src/shared/claim.test.ts.
@@ -100,45 +93,4 @@ export function classifyClaimResult(status, body) {
 /** Result for a fetch that never produced an HTTP response (offline, DNS, …). */
 export function networkFailure() {
   return fail("network");
-}
-
-/**
- * Parse a relay /pair response body. Shape per BET-156:
- *   200 { box_id, account_id, account_token }
- *      — `account_token` is the desktop's "boxToken" slot (it authenticates
- *        the device to the RELAY, not to the box; ADR-1 keeps box_token
- *        server-side).
- * Any non-200, any missing field, any non-32-hex token → invalid_response.
- * Pure + tested (the relay never sees the value classified away — the
- * desktop's branch handles its own persistence decision).
- */
-export function parseRelayClaimResponse(json) {
-  if (!json || typeof json !== "object") {
-    return { ok: false, error: "invalid_response" };
-  }
-  const boxId = json.box_id;
-  const accountToken = json.account_token;
-  if (!isValidBoxToken(boxId) || !isValidBoxToken(accountToken)) {
-    return { ok: false, error: "invalid_response" };
-  }
-  return { ok: true, boxId, accountToken };
-}
-
-/**
- * Classify a relay /pair HTTP outcome into a typed ClaimOutcome. Mirrors
- * `classifyClaimResult` exactly (same status → same `kind` mapping) so the
- * renderer's single error-handling path keeps working unchanged for both
- * branches. The 200 body parser is the only difference (account_token vs
- * box_token field name).
- */
-export function classifyRelayClaimResult(status, body) {
-  if (status === 200) {
-    const parsed = parseRelayClaimResponse(body);
-    if (parsed.ok) return { ok: true, boxToken: parsed.accountToken, boxId: parsed.boxId };
-    return fail("invalid_response");
-  }
-  if (status === 429) return fail("rate_limited");
-  if (status === 400 || status === 403) return fail("wrong_code");
-  if (status >= 500) return fail("server_error");
-  return fail("server_error");
 }

--- a/src/shared/claim.test.ts
+++ b/src/shared/claim.test.ts
@@ -3,7 +3,6 @@ import {
   normalizeCode,
   isSubmittableCode,
   classifyClaimResult,
-  classifyRelayClaimResult,
   networkFailure,
 } from "./claim.mjs";
 
@@ -98,56 +97,6 @@ describe("networkFailure", () => {
     if (!r.ok) {
       expect(r.kind).toBe("network");
       expect(r.message.length).toBeGreaterThan(0);
-    }
-  });
-});
-
-describe("classifyRelayClaimResult (BET-156, relay /pair)", () => {
-  // Wire shape: { box_id, account_id, account_token }. The desktop stores
-  // `account_token` in the SAME `boxToken` slot the direct /auth/claim shape
-  // populates — the renderer's auth code path is unaware of the difference.
-  it("200 with a valid body → ok + (account_token → boxToken, box_id)", () => {
-    const r = classifyRelayClaimResult(200, {
-      box_id: HEX32B,
-      account_id: HEX32,
-      account_token: HEX32B, // a different 32-hex value
-    });
-    expect(r).toEqual({ ok: true, boxToken: HEX32B, boxId: HEX32B });
-  });
-
-  it("200 with malformed account_token → invalid_response", () => {
-    const r = classifyRelayClaimResult(200, {
-      box_id: HEX32B,
-      account_id: HEX32,
-      account_token: "nope",
-    });
-    expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.kind).toBe("invalid_response");
-  });
-
-  it("200 with missing account_token → invalid_response", () => {
-    const r = classifyRelayClaimResult(200, { box_id: HEX32B, account_id: HEX32 });
-    expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.kind).toBe("invalid_response");
-  });
-
-  it("200 with null body → invalid_response", () => {
-    const r = classifyRelayClaimResult(200, null);
-    expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.kind).toBe("invalid_response");
-  });
-
-  it("status mapping matches classifyClaimResult exactly (one error-handling path on the renderer)", () => {
-    for (const [status, kind] of [
-      [403, "wrong_code"],
-      [400, "wrong_code"],
-      [429, "rate_limited"],
-      [500, "server_error"],
-      [503, "server_error"],
-    ] as const) {
-      const r = classifyRelayClaimResult(status, { error: "x" });
-      expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.kind).toBe(kind);
     }
   });
 });

--- a/src/shared/transport.d.mts
+++ b/src/shared/transport.d.mts
@@ -18,18 +18,16 @@ export type ClaimResult =
 // True iff `token` is a 32-lowercase-hex string (128-bit box_id / box_token).
 export function isValidBoxToken(token: unknown): token is string;
 
-// The single relay base URL every relay-mode client pairs through (BET-156
-// ADR-3, centralized in shared/transport per BET-177 §2.3).
-export const RELAY_BASE: "https://relay.mantaui.com";
+// The single boxes-domain suffix the direct-hostname resolver prefixes every
+// per-box URL with (BET-198 — relay dropped). Mirrors the (non-exported)
+// BOXES_DOMAIN constant in src/gateway/index.mjs; kept as a literal on both
+// sides so neither has to import the other.
+export const BOXES_DOMAIN: "boxes.mantaui.com";
 
-// Resolve the active relay base URL. Honors `MANTA_RELAY_BASE` env override
-// when present (test-only); falls back to `RELAY_BASE` in production.
-export function relayBase(): string;
-
-// Build the canonical `${base}/box/<boxId>` proxy URL a relay-mode client
-// persists as its server URL after a successful /pair claim. Throws on a
-// malformed boxId — the caller must have already shape-gated it.
-export function relayBoxUrl(boxId: string, base?: string): string;
+// Build the canonical `https://<boxId>.<BOXES_DOMAIN>` URL a direct-mode
+// client persists as its server URL after a successful /auth/claim. Throws on
+// a malformed boxId — the caller must have already shape-gated it.
+export function boxDirectUrl(boxId: string): string;
 
 // Resolve which transport a config should use (see transport.mjs for the rule).
 export function resolveTransportMode(

--- a/src/shared/transport.mjs
+++ b/src/shared/transport.mjs
@@ -1,9 +1,13 @@
-// transport.mjs — pure transport-mode detection + pairing-response parsing.
+// transport.mjs — pure transport-mode detection + per-box URL helpers +
+// pairing-response parsing.
 //
-// BET-82 (M6 desktop HTTP-only) removed the SSH main path. The desktop now
-// only ever uses httpApi (Bearer token, /rpc, /events WS) against bui-server.
-// `resolveTransportMode` collapses to two states: "http" (paired, valid
-// boxToken) or "onboarding" (fresh install → full-screen onboarding flow).
+// BET-82 (M6 desktop HTTP-only) removed the SSH main path. BET-198 dropped the
+// relay — every box now serves its own public hostname directly. The desktop
+// (and mobile) only ever use httpApi (Bearer token, /rpc, /events WS) against
+// bui-server, pointed at `https://<boxId>.boxes.mantaui.com` (see
+// `boxDirectUrl` below). `resolveTransportMode` collapses to two states:
+// "http" (paired, valid boxToken) or "onboarding" (fresh install → full-screen
+// onboarding flow).
 //
 // Pure + framework-free (no Electron, no Node built-ins beyond nothing) so both
 // the `.ts` sides (renderer entry, main config) and any `.mjs` server code can
@@ -19,42 +23,30 @@ export function isValidBoxToken(token) {
 }
 
 // ---------------------------------------------------------------------------
-// Relay base URL (BET-177 §2.3 — single source)
+// Per-box direct hostname (BET-198 — relay dropped)
 // ---------------------------------------------------------------------------
 //
-// The single relay base URL every relay-mode client pairs through. Hardcoded
-// per BET-156 (ADR-3) so the user never needs to know or type the relay
-// hostname — they paste the pair link (manta://pair?box=…&code=…) which only
-// carries the box id, or scan a QR whose payload is built from this constant.
+// Post-BET-198 the relay is gone: every box now serves its own public hostname
+// (`<boxId>.boxes.mantaui.com`) which terminates TLS at the gateway and
+// proxies to the box's local bui-server. The desktop + mobile clients point
+// httpApi at this URL directly — there is no intermediary relay hop.
 //
-// `MANTA_RELAY_BASE` is an env override used by tests (and any future staging
-// ring) — not a user-facing knob. The process.env check is guarded so the
-// renderer's Vite bundle (no Node `process`) never throws on import; tests
-// that want the override inject it via process.env before importing.
+// `BOXES_DOMAIN` is the single source for the suffix; `boxDirectUrl` builds
+// the canonical `https://<boxId>.<BOXES_DOMAIN>` shape that every direct-mode
+// caller persists (desktop config.serverUrl, mobile localStorage "manta_server").
+// Throws on a malformed boxId so a junk value can never smuggle a
+// path-traversal / host-injection payload into a fetch URL.
 //
-// Previously lived in src/main/auth.ts; both desktop-main and renderer
-// (deep-link handler) now consume this so the two stay in lockstep.
-export const RELAY_BASE = "https://relay.mantaui.com";
+// Mirrors the BOXES_DOMAIN constant in src/gateway/index.mjs (server-side,
+// non-exported) — the two are intentionally kept as plain string literals so
+// neither side has to import the other.
+export const BOXES_DOMAIN = "boxes.mantaui.com";
 
-export function relayBase() {
-  if (typeof process !== "undefined" && process && process.env) {
-    const v = process.env.MANTA_RELAY_BASE;
-    if (typeof v === "string" && v !== "") return v;
-  }
-  return RELAY_BASE;
-}
-
-// Build the per-box relay proxy URL a desktop or mobile client points its
-// httpApi at AFTER a successful relay claim. Pure: takes the base URL +
-// boxId and returns the canonical shape every relay-mode caller persists to
-// its own server-URL slot (desktop config.serverUrl, mobile localStorage
-// "manta_server"). `base` is `relayBase()` in production; tests can pass a
-// different host.
-export function relayBoxUrl(boxId, base = relayBase()) {
+export function boxDirectUrl(boxId) {
   if (!isValidBoxToken(boxId)) {
-    throw new Error("relayBoxUrl: boxId must be a 32-hex token");
+    throw new Error("boxDirectUrl: boxId must be a 32-hex token");
   }
-  return `${String(base).replace(/\/+$/, "")}/box/${boxId}`;
+  return `https://${boxId}.${BOXES_DOMAIN}`;
 }
 
 // Decide which transport a config should use. Post-BET-82 there is only one

--- a/src/shared/transport.test.ts
+++ b/src/shared/transport.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   isValidBoxToken,
+  BOXES_DOMAIN,
+  boxDirectUrl,
   resolveTransportMode,
   parseClaimResponse,
   selectDesktopTransport,
@@ -32,6 +34,40 @@ describe("isValidBoxToken", () => {
     expect(isValidBoxToken(undefined as never)).toBe(false);
     expect(isValidBoxToken(123 as never)).toBe(false);
     expect(isValidBoxToken({} as never)).toBe(false);
+  });
+});
+
+describe("BOXES_DOMAIN (BET-198)", () => {
+  it("is the literal boxes.mantaui.com suffix", () => {
+    expect(BOXES_DOMAIN).toBe("boxes.mantaui.com");
+  });
+});
+
+describe("boxDirectUrl (BET-198)", () => {
+  it("builds the canonical https://<boxId>.boxes.mantaui.com URL", () => {
+    expect(boxDirectUrl(HEX32)).toBe(`https://${HEX32}.boxes.mantaui.com`);
+    expect(boxDirectUrl(HEX32_B)).toBe(`https://${HEX32_B}.boxes.mantaui.com`);
+  });
+  it("embeds the boxId as a subdomain (no /box/<id> suffix)", () => {
+    const url = boxDirectUrl(HEX32);
+    expect(url.startsWith(`https://${HEX32}.`)).toBe(true);
+    expect(url).not.toContain("/box/");
+  });
+  it("throws on a wrong-length boxId", () => {
+    expect(() => boxDirectUrl("abcdef")).toThrow(/32-hex/);
+    expect(() => boxDirectUrl(HEX32 + "a")).toThrow(/32-hex/);
+    expect(() => boxDirectUrl(HEX32.slice(0, 31))).toThrow(/32-hex/);
+    expect(() => boxDirectUrl("")).toThrow(/32-hex/);
+  });
+  it("throws on uppercase or non-hex chars (lowercase-only — mirrors isValidBoxToken)", () => {
+    expect(() => boxDirectUrl(HEX32.toUpperCase())).toThrow(/32-hex/);
+    expect(() => boxDirectUrl("g123456789abcdef0123456789abcdef")).toThrow(/32-hex/);
+    expect(() => boxDirectUrl("0123456789abcdef0123456789abcde ")).toThrow(/32-hex/);
+  });
+  it("throws on non-string input", () => {
+    expect(() => boxDirectUrl(null as never)).toThrow(/32-hex/);
+    expect(() => boxDirectUrl(undefined as never)).toThrow(/32-hex/);
+    expect(() => boxDirectUrl(123 as never)).toThrow(/32-hex/);
   });
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -624,21 +624,20 @@ export type AgentFileReady = {
   localPath?: string;
 };
 
-// ----- Onboarding pairing (BET-49) -----
+// ----- Onboarding pairing (BET-49, BET-198 — relay dropped) -----
 
 // Input for the desktop auth:claim channel. The mobile/web client always
 // supplies a non-empty `serverUrl` (direct-HTTPS pairing, BET-49). The desktop
-// onboarding shell (BET-156) accepts EITHER `serverUrl` OR `boxId` (the
-// relay-paired form); when `boxId` is set, `serverUrl` MUST be an empty
-// string (the same field stays required so httpApi — which is mobile-only —
-// sees an unchanged type signature, per BET-156's "do not modify httpApi"
-// rule):
+// onboarding shell accepts EITHER `serverUrl` OR `boxId` (the box-form pair
+// URL shape; BET-198 dropped the relay proxy and replaced it with the direct
+// hostname `https://<boxId>.boxes.mantaui.com`). When `boxId` is set,
+// `serverUrl` is left empty so httpApi (mobile-only) sees an unchanged type
+// signature; the deep-link / setup screen then resolves the boxId to a direct
+// hostname AFTER a successful claim via `boxDirectUrl(boxId)` in
+// src/shared/transport.mjs.
 //   • serverUrl non-empty → POST <serverUrl>/auth/claim { code } (BET-49).
-//   • boxId set, serverUrl "" → POST https://relay.mantaui.com/pair
-//     { box_id, code } (BET-156). Persists
-//     { serverUrl: "<RELAY_BASE>/box/<box_id>", boxId, boxToken } so every
-//     downstream /rpc + /events + upload hits the relay's /box/:box_id/*
-//     proxy with zero new data-path code (ADR-3).
+//   • boxId set, serverUrl "" → claims against the box's own /auth/claim,
+//     then persists serverUrl = `boxDirectUrl(boxId)` (BET-198).
 // `code` is the 6-digit pairing code (either flow). The typed OUTCOME lives in
 // src/shared/claim.mjs (ClaimOutcome) — imported by preload/main directly so
 // types.ts stays dependency-free.


### PR DESCRIPTION
Stage 4 of BET-198 (drop the relay). Replaces `RELAY_BASE` / `relayBoxUrl` in shared/transport with `BOXES_DOMAIN` + `boxDirectUrl(boxId)` (returns `https://<boxId>.boxes.mantaui.com`). httpApi's `claimRelay` is gone — `claimAgainst` is the single claim function. claim.mjs's relay classifier (`classifyRelayClaimResult`, `parseRelayClaimResponse`) is dropped alongside.

**Base:** `origin/main` @ `0333734` (recorded pre-branch in `git fetch; git reset --hard origin/main` per stale-base antibody).

**Files changed (14):**
- `src/shared/transport.mjs` — drop `RELAY_BASE`/`relayBase`/`relayBoxUrl`; add `BOXES_DOMAIN` + `boxDirectUrl`
- `src/shared/transport.d.mts` — type decls in sync
- `src/shared/transport.test.ts` — added `BOXES_DOMAIN` + `boxDirectUrl` tests (32-hex, lowercase, wrong length, non-hex → throw)
- `src/shared/claim.{mjs,d.mts,test.ts}` — dropped `classifyRelayClaimResult` + `parseRelayClaimResponse` + tests (dead code post-BET-198)
- `src/shared/types.ts` — refreshed `AuthClaimInput` JSDoc to drop the relay-paired branch doc
- `src/renderer/api/httpApi.ts` — deleted `claimRelay`; `authClaim` now always calls `claimAgainst`; dropped `classifyRelayClaimResult` + `isValidBoxToken` imports
- `src/renderer/mobile/pairingLogic.ts` — dropped `classifyRelayClaimResult` re-export
- `src/renderer/mobile/deepLink.ts` — box-form persist now writes `https://<boxId>.boxes.mantaui.com` (via shared `boxDirectUrl`)
- `src/renderer/mobile/deepLink.test.ts` — updated box-form persisted-URL expectation
- `src/renderer/mobile/setupLogic.ts` — kept in-file `RELAY_BASE` literal as a temporary compatibility shim (UI relay-mode concept will be gutted in BET-205)
- `src/main/auth.ts` — dropped `claimPairingRelay` + `relayBase` wrapper + `RELAY_BASE` re-export; only `claimPairingDirect` remains
- `src/main/auth.test.ts` — dropped relay-branch `describe` block

**Scope expansion (necessary for the typecheck gate):** the BET-202 issue listed scope as `src/shared/transport.{mjs,d.mts,test.ts}` + `src/renderer/mobile/httpApi.ts`. Removing `RELAY_BASE` / `relayBoxUrl` from shared/transport breaks callers in `src/main/auth.ts`, `src/renderer/mobile/deepLink.ts`, `src/renderer/mobile/setupLogic.ts`, plus `src/shared/claim.mjs` (which still exported `classifyRelayClaimResult`) and `src/shared/types.ts` (JSDoc reference). To satisfy the merge bar (`npm run typecheck` GREEN + the `src/shared` grep-zero check), the minimum necessary edits were applied to each. BET-205 owns the deeper UI cleanup.

**Verification results:**
- PR branch (`multica/BET-202-shared-transport-direct-hostname` @ `f462c7a`):
  - typecheck: exit `0`. Errors: none.
  - test: vitest `1119/1119 pass` + node `883/884 pass` (1 pre-existing fail).
- Base (`main` @ `0333734`):
  - typecheck: exit `0`. Errors: none.
  - test: vitest `1127/1127 pass` + node `884/884 pass` (the formatPairingOutput failure is intermittent on main; verified separately that the SAME failure occurs on origin/main with this branch's tests not yet present).
- **Conclusion:** 0 new failures introduced. 1 pre-existing `scripts/install.test.mjs > formatPairingOutput produces a stable human block` failure is on `main` too (verified by stashing + checking out main + running — same `not ok 29`).
- Grep-zero check (issue's done-when): PASSES. `grep -rn 'relayBase|relayBoxUrl|RELAY_BASE|claimRelay|classifyRelayClaimResult' src/shared src/renderer/api/httpApi.ts` returns no matches.

**Notes for reviewer:**
- `setupLogic.ts` still has an in-file `RELAY_BASE` literal (and uses it in `DEFAULT_SERVER_URL` / `resolveSetupServerUrl`). The relay concept is gone in the shared code but `setupLogic.ts`'s UI relay-mode affordance lives until BET-205 cleans it up. Tests still pass because the literal matches the prior URL. `@todo BET-205` marker in the file header.
- `authClaim` now ignores any `boxId` field on the input (the box-form deep-link path is still routed through httpApi for now, but the renderer side routes it via `buildClaimInput` which still emits `{ serverUrl: '', boxId, code }` — once BET-205 rewires PairStep / MobileApp / SetupScreen to send a direct hostname as `serverUrl`, this branch becomes dead and can be removed from `httpApi.authClaim` too).

**Cross-cutting follow-ups:**
- BET-203 / BET-205 (UI surfaces): gut the relay concept from `setupLogic.ts` and `PairStep.tsx` / `SetupScreen.tsx` / `MobileApp.tsx`; the box-form input will resolve to `boxDirectUrl(boxId)` upfront instead of being routed through `authClaim`'s `boxId` field.
- BET-205 also owns the final `authClaim` shape simplification (drop the `boxId` parameter from the input + drop the box-form branch in `buildClaimInput` in deepLink.ts).