### PR TITLE
BET-203: renderer + main wire to direct claim

### DIFF
--- a/src/main/auth.test.ts
+++ b/src/main/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { claimPairing } from "./auth.js";
+import { boxDirectUrl } from "../shared/transport.mjs";
 import type { AppConfig, AuthClaimInput } from "../shared/types.js";
 
 const HEX32 = "0123456789abcdef0123456789abcdef";
@@ -55,7 +56,7 @@ async function expectClaimFailure(
   return { urls };
 }
 
-describe("claimPairing — direct-HTTPS branch (BET-49, BET-198 — relay dropped)", () => {
+describe("claimPairing — direct-HTTPS branch (BET-49, BET-198)", () => {
   it("valid code → ok outcome + persists { serverUrl, boxId, boxToken }", async () => {
     const { fetch, urls, bodies } = stubFetch(
       fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
@@ -146,6 +147,53 @@ describe("claimPairing — direct-HTTPS branch (BET-49, BET-198 — relay droppe
       "network",
     );
     // No fetch should have happened for a blank server URL.
+    expect(urls).toEqual([]);
+  });
+});
+
+describe("claimPairing — box-form pair link (BET-156, BET-198)", () => {
+  it("boxId + empty serverUrl → claims against boxDirectUrl(boxId), persists the canonical URL", async () => {
+    const { fetch, urls, bodies } = stubFetch(
+      fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
+    );
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+
+    const out = await claimPairing(
+      { serverUrl: "", boxId: HEX32, code: "847291" },
+      persist,
+      fetch,
+    );
+
+    expect(out).toEqual({ ok: true, boxToken: HEX32, boxId: HEX32B });
+    // Single source of truth: claim hits the same URL boxDirectUrl returns,
+    // so desktop paste-link and mobile deep-link produce the IDENTICAL wire
+    // request (and the IDENTICAL persisted serverUrl).
+    const expectedUrl = boxDirectUrl(HEX32);
+    expect(urls).toEqual([`${expectedUrl}/auth/claim`]);
+    expect(JSON.parse(bodies[0])).toEqual({ pairing_code: "847291" });
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledWith({
+      serverUrl: expectedUrl,
+      boxId: HEX32B,
+      boxToken: HEX32,
+    });
+  });
+
+  it("malformed boxId → network outcome without ever fetching", async () => {
+    const { urls } = await expectClaimFailure(
+      fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
+      { serverUrl: "", boxId: "not-a-box", code: "847291" },
+      "network",
+    );
+    expect(urls).toEqual([]);
+  });
+
+  it("empty boxId AND empty serverUrl → network outcome without ever fetching", async () => {
+    const { urls } = await expectClaimFailure(
+      fakeResponse(200, { ok: true, box_token: HEX32, box_id: HEX32B }),
+      { serverUrl: "", boxId: "", code: "847291" },
+      "network",
+    );
     expect(urls).toEqual([]);
   });
 });

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -3,17 +3,19 @@
 // The desktop onboarding shell's Step 1 (Pair) accepts a 6-digit pairing code
 // plus the direct-HTTPS addressing shape (typed AuthClaimInput,
 // src/shared/types.ts):
-//   • serverUrl — direct-HTTPS pairing (BET-49, BET-198): POST
-//     <serverUrl>/auth/claim { pairing_code } → { box_id, box_token }.
+//   • serverUrl — direct-HTTPS pairing (BET-49): POST <serverUrl>/auth/claim
+//     { pairing_code } → { box_id, box_token }.
 //     Persist { serverUrl, boxId, boxToken } to config.
+//   • boxId — box-form pair link (BET-156, BET-198): a box-form
+//     `manta://pair?box=<boxId>&code=<code>` QR (or its paste equivalent) sets
+//     `boxId` + empty `serverUrl`. Main resolves the box's public hostname
+//     via `boxDirectUrl(boxId)` (src/shared/transport.mjs) and POSTs
+//     `/auth/claim` against it. Persisted `serverUrl` is the SAME
+//     `boxDirectUrl(boxId)` string the mobile deep-link handler writes.
 //
-// Post-BET-198 the relay is gone: every box now serves its own public
-// hostname directly (https://<boxId>.boxes.mantaui.com — see
-// src/shared/transport.mjs `boxDirectUrl`), so the desktop pairing flow has
-// exactly ONE branch — the direct /auth/claim fetch. serverUrl is built by
-// the caller (PairStep / MobileApp / deep-link) from the shared
-// `boxDirectUrl(boxId)` helper, then handed to claimPairing as the
-// `serverUrl` field of AuthClaimInput.
+// Every box serves its own public hostname directly. Both input shapes route
+// through the SAME `claimPairingDirect` fetch; `claimPairing` is a thin
+// dispatcher that builds the URL from whichever input field is populated.
 //
 // Why main (not the renderer) does the fetch: only main can write
 // config.json. The mobile client authenticates with a localStorage Bearer
@@ -27,11 +29,18 @@ import {
 } from "../shared/claim.mjs";
 import type { ClaimOutcome } from "../shared/claim.mjs";
 import type { AppConfig, AuthClaimInput } from "../shared/types.js";
+import { boxDirectUrl } from "../shared/transport.mjs";
 
 /**
  * Perform a pairing claim and, on success, persist the credentials to config.
  *
- * @param input    { serverUrl, code } from the renderer.
+ * @param input    { serverUrl, boxId?, code } from the renderer. The mobile/web
+ *                 client only ever supplies `serverUrl` (already-built by the
+ *                 caller's `boxDirectUrl(boxId)` for the box form, see
+ *                 src/renderer/mobile/setupLogic.ts); the desktop onboarding
+ *                 paste-pair-link path may supply either `serverUrl` (direct
+ *                 form) or `boxId` (box form). Exactly one of the two is
+ *                 consumed.
  * @param persist  commit a config patch (main's `commit`); called ONLY on a
  *                 successful, token-validated claim.
  * @param fetchImpl  injectable for tests; defaults to the global fetch.
@@ -45,16 +54,28 @@ export async function claimPairing(
   fetchImpl: typeof fetch = fetch,
 ): Promise<ClaimOutcome> {
   const code = input?.code ?? "";
-  const serverUrl = (input?.serverUrl ?? "").trim();
+  const typedServerUrl = (input?.serverUrl ?? "").trim();
+  const boxId = (input?.boxId ?? "").trim();
 
-  if (serverUrl !== "") {
-    return claimPairingDirect(serverUrl, code, persist, fetchImpl);
+  // Resolve the claim URL: explicit serverUrl wins; otherwise build the box's
+  // public hostname from the boxId. A malformed boxId (not 32-hex) throws here
+  // — map to a network-classified failure so the UI surfaces the same error
+  // shape as an unreachable host.
+  let serverUrl = typedServerUrl;
+  if (serverUrl === "" && boxId !== "") {
+    try {
+      serverUrl = boxDirectUrl(boxId);
+    } catch {
+      return networkFailure();
+    }
   }
-  // No serverUrl → nothing to claim against.
-  return networkFailure();
+  if (serverUrl === "") {
+    return networkFailure();
+  }
+  return claimPairingDirect(serverUrl, code, persist, fetchImpl);
 }
 
-// ---- Direct-HTTPS branch (BET-49, unchanged) ----
+// ---- Direct-HTTPS branch (BET-49, BET-198) ----
 
 async function claimPairingDirect(
   serverUrl: string,
@@ -63,7 +84,8 @@ async function claimPairingDirect(
   fetchImpl: typeof fetch,
 ): Promise<ClaimOutcome> {
   // Trim trailing slashes so "http://box:8787/" and "http://box:8787" behave
-  // identically before appending the claim path.
+  // identically before appending the claim path. boxDirectUrl already
+  // produces a no-trailing-slash URL, so the box form is a no-op here.
   const url = `${serverUrl.replace(/\/+$/, "")}/auth/claim`;
 
   let res: Response;

--- a/src/main/desktopNotify.ts
+++ b/src/main/desktopNotify.ts
@@ -4,9 +4,9 @@
 // decides the DESKTOP should be notified (user at the desk, or away-but-app-open
 // before mobile escalation), it publishes a `{kind:"desktopNotify", payload}`
 // envelope on its in-process bus. This module subscribes to bui-server's
-// `GET /events` SSE stream **over direct HTTPS** (Bearer-authed) and relays each
-// `desktopNotify` payload to the renderer via IPC, where it's shown with the
-// Notification API.
+// `GET /events` SSE stream **over direct HTTPS** (Bearer-authed) and forwards
+// each `desktopNotify` payload to the renderer via IPC, where it's shown with
+// the Notification API.
 //
 // Why consume bui-server's bus instead of deciding desktop notifications
 // locally from the opencode stream: the router must see BOTH device presences
@@ -24,7 +24,7 @@ import type { AppConfig, DesktopNotifyPayload } from "../shared/types.js";
 let consumer: BusConsumer | null = null;
 
 /**
- * Start relaying bui-server desktop-notification directives to the renderer.
+ * Start forwarding bui-server desktop-notification directives to the renderer.
  * `configGetter` returns the live AppConfig (serverUrl + boxToken for HTTPS
  * Bearer auth); `onPayload` delivers a directive to the renderer (typically a
  * webContents.send). Idempotent.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -204,7 +204,7 @@ app.whenReady().then(() => {
     // mobile "done" pushes while the user is active on desktop.
     startDesktopPresence(() => config);
     // Receive desktop OS-notification directives from bui-server's router
-    // (over direct HTTPS) and relay them to the renderer.
+    // (over direct HTTPS) and forward them to the renderer.
     startDesktopNotifications(
       () => config,
       (payload) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -308,7 +308,7 @@ export function App() {
   }, []);
 
   // Desktop OS notifications. bui-server's router (push.mjs) decides WHICH
-  // device(s) get a notification (no duplicates) and relays a desktop directive
+  // device(s) get a notification (no duplicates) and forwards a desktop directive
   // → main → IPC here. We add the final local
   // suppression — if this window is focused AND already showing that exact
   // session, the user is looking at it, so don't pop an OS notification — then

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -2,10 +2,11 @@ import { useRef, useState } from "react";
 import { normalizeCode } from "../shared/claim.mjs";
 import { normalizeServerUrl, isValidServerUrl, canConnect } from "./pairStepLogic";
 import { parsePairPayload } from "./mobile/pairPayload";
+import { boxDirectUrl } from "../shared/transport.mjs";
 import { useStore } from "./store";
 
 // PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2;
-// extended BET-156 for relay-paired flows).
+// extended BET-156 for box-paired flows).
 //
 // Mounts into Onboarding.tsx's step-1 slot. Owns the pairing form:
 //   • a server-URL input (prefilled from config if the user has paired before)
@@ -18,11 +19,12 @@ import { useStore } from "./store";
 //   • its own Connect button (gated by canConnect) + a "Skip setup" link
 //
 // The claim itself runs in the MAIN process over the `auth:claim` IPC channel
-// (window.api.authClaim), which POSTs either <serverUrl>/auth/claim (direct
-// HTTPS) or https://relay.mantaui.com/pair (relay-paired; ADR-2/3) and, on
-// success, persists { serverUrl, boxId, boxToken } to config.json. We mirror
-// those into the store (applyPairing) so resolveTransportMode reads "http"
-// immediately, then call onPaired() to let the shell advance to Step 2.
+// (window.api.authClaim), which POSTs <serverUrl>/auth/claim (BET-49 direct
+// HTTPS) for the manual form, and <boxDirectUrl(boxId)>/auth/claim (BET-198 —
+// every box now serves its own public hostname) for the box-form pair link.
+// On success, main persists { serverUrl, boxId, boxToken } to config.json. We
+// mirror those into the store (applyPairing) so resolveTransportMode reads
+// "http" immediately, then call onPaired() to let the shell advance to Step 2.
 //
 // All non-React logic (URL normalization, the submit gate, the 6-digit
 // contract, HTTP-outcome classification) is pure + unit-tested in
@@ -74,16 +76,22 @@ export function PairStep({
       }
       setSubmitting(true);
       setError(null);
-      // Relay form sends serverUrl:"" (see AuthClaimInput) so the same input
-      // shape works for both the desktop IPC and httpApi's mobile authClaim.
+      // Box form (BET-156, BET-198): serverUrl is empty + boxId is set, so main
+      // resolves the box's public hostname via boxDirectUrl(boxId) before
+      // POSTing /auth/claim. Direct form: serverUrl is set, boxId is undefined.
       const result = await window.api.authClaim({
         serverUrl: payload.serverUrl ?? "",
         boxId: payload.boxId ?? undefined,
         code: payload.code,
       });
       if (result.ok) {
+        // Mirror the persisted serverUrl: the direct form uses the typed URL;
+        // the box form uses the canonical `https://<boxId>.boxes.mantaui.com`
+        // hostname (single source of truth — shared/transport.mjs).
+        const persistedServerUrl =
+          payload.serverUrl ?? (payload.boxId ? boxDirectUrl(payload.boxId) : "");
         useStore.getState().applyPairing({
-          serverUrl: payload.serverUrl ?? `https://relay.mantaui.com/box/${payload.boxId}`,
+          serverUrl: persistedServerUrl,
           boxId: result.boxId,
           boxToken: result.boxToken,
         });

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -212,10 +212,10 @@ describe("serverBase", () => {
     delete mockLocalStorage["manta_server"];
     stubWindowLocation({
       protocol: "https:",
-      hostname: "relay.example.com",
-      origin: "https://relay.example.com",
+      hostname: "box-direct.example.com",
+      origin: "https://box-direct.example.com",
     });
-    expect(serverBase()).toBe("https://relay.example.com");
+    expect(serverBase()).toBe("https://box-direct.example.com");
   });
 
   it("throws ServerNotConfiguredError on Capacitor localhost (no override)", () => {
@@ -259,12 +259,12 @@ describe("TOKEN_KEY", () => {
 // onDesktopNotify — must subscribe to the desktopNotify kind (not be a no-op)
 // ---------------------------------------------------------------------------
 //
-// In HTTP mode the renderer's httpApi owns the /events WS; desktopNotify
-// envelopes arrive on that WS and are dispatched to listeners registered via
-// onDesktopNotify. In SSH mode the main process relays via IPC (preload's
-// onDesktopNotify), so this channel is a no-op there. Either way, the method
-// must be a real subscription (returns an unsubscribe thunk) — a no-op
-// `() => () => {}` would silently drop desktop notifications in HTTP mode.
+// The renderer's httpApi owns the /events WS; desktopNotify envelopes arrive
+// on that WS and are dispatched to listeners registered via onDesktopNotify.
+// The main process forwards them to the renderer via IPC (preload's
+// onDesktopNotify). Either way, the method must be a real subscription
+// (returns an unsubscribe thunk) — a no-op `() => () => {}` would silently
+// drop desktop notifications.
 
 describe("onDesktopNotify", () => {
   it("is a function (not a no-op stub)", () => {

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -184,11 +184,12 @@ export async function submitPairingCode(code: string): Promise<ClaimResult> {
 /**
  * fetch with a hard timeout via AbortController. A pairing claim must NEVER
  * hang forever: on the iOS Capacitor WKWebView a stalled connection (slow
- * relay, captive-portal Wi-Fi, DNS black-hole) otherwise leaves the promise
- * pending and the UI stuck on "connecting…". On timeout the AbortController
- * fires, `fetch` rejects, and the caller's catch maps it to a network failure
- * the user can retry — instead of an infinite spinner. 15s is generous for a
- * ~100ms relay round-trip while still bounding the worst case.
+ * TLS handshake, captive-portal Wi-Fi, DNS black-hole) otherwise leaves the
+ * promise pending and the UI stuck on "connecting…". On timeout the
+ * AbortController fires, `fetch` rejects, and the caller's catch maps it to
+ * a network failure the user can retry — instead of an infinite spinner. 15s
+ * is generous for a ~100ms direct round-trip while still bounding the worst
+ * case.
  */
 async function fetchWithTimeout(
   url: string,
@@ -593,9 +594,9 @@ export const httpApi: Api = {
   tmuxRestoreConfig: () => rpc(IPC.tmuxRestoreConfig),
 
   // -- onboarding pairing --
-  // Direct-HTTPS pairing (BET-49, BET-198 — relay dropped): POST
-  // <serverUrl>/auth/claim { pairing_code } → { box_token, box_id }. Persists
-  // the token via saveClientToken (single write-site).
+  // Direct-HTTPS pairing (BET-49, BET-198): POST <serverUrl>/auth/claim
+  // { pairing_code } → { box_token, box_id }. Persists the token via
+  // saveClientToken (single write-site).
   //
   // serverUrl is built by the caller from the shared `boxDirectUrl(boxId)`
   // helper (src/shared/transport.mjs) — desktop and mobile write the EXACT
@@ -620,9 +621,9 @@ export const httpApi: Api = {
     on<{ source: "clipboard" | "file"; path?: string }>("screenshot", cb),
 
   // Desktop OS-notification directives from bui-server's notification router.
-  // In HTTP mode the /events WS delivers `desktopNotify` envelopes; in SSH
-  // mode the main process relays via IPC (preload's onDesktopNotify). Either
-  // way, subscribing here wires the renderer to the live stream.
+  // The /events WS delivers `desktopNotify` envelopes; subscribing here wires
+  // the renderer to the live stream (busConsumer in src/main/desktopNotify.ts
+  // forwards them to the renderer via IPC).
   onDesktopNotify: (cb) => on<DesktopNotifyPayload>("desktopNotify", cb),
 
   // -- file uploads --

--- a/src/renderer/mobile/ConnectingScreen.tsx
+++ b/src/renderer/mobile/ConnectingScreen.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 
 type Props = {
-  // "relay" → connecting through the MantaUI relay (no host shown, it's the
-  // default). "direct" → a self-hosted box; the host is surfaced in a pill.
-  route: "relay" | "direct";
-  // The host to show in the direct-mode pill (e.g. "box.example.com"). Ignored
-  // for relay. Optional — omitted → no host text.
+  // Always "direct" post-BET-198: every box serves its own public hostname
+  // (`<boxId>.boxes.mantaui.com`). Kept as a typed prop for API compatibility
+  // with the renderer's MobileApp call site (resolveConnectRoute returns the
+  // same single value for every configured base).
+  route: "direct";
+  // The host to show in the direct-mode pill (e.g. "0123456789abcdef…boxes.mantaui.com").
   host?: string;
   // Whether the connect attempt has failed (bootstrap threw a non-gate error).
   // Flips the screen to the error state with a Retry button.
@@ -24,16 +25,15 @@ const SLOW_MS = 8000;
 /**
  * Full-screen connecting state for the mobile client. Shown while the initial
  * bootstrap (or a post-pair refresh) is in flight, so the user sees a clear
- * "Connecting to relay… / Connecting to remote box…" instead of a blank/empty
- * session list. Route (relay vs direct) comes from resolveConnectRoute over the
- * persisted server URL (setupLogic.ts).
+ * "Connecting to your box" instead of a blank/empty session list. Every
+ * connection is direct HTTPS to the box's own public hostname.
  *
  * States:
- *   • connecting  → dual-ring spinner + route label (+ host pill for direct).
+ *   • connecting  → dual-ring spinner + label (+ host pill).
  *   • slow (8s+)  → adds a hint + Cancel.
  *   • failed      → error icon + plain-language cause + Retry.
  */
-export function ConnectingScreen({ route, host, failed, onRetry, onCancel }: Props) {
+export function ConnectingScreen({ host, failed, onRetry, onCancel }: Props) {
   const [slow, setSlow] = useState(false);
 
   useEffect(() => {
@@ -62,9 +62,7 @@ export function ConnectingScreen({ route, host, failed, onRetry, onCancel }: Pro
           <div className="flex flex-col gap-2">
             <div className="text-text text-lg font-semibold">Couldn't reach your box</div>
             <div className="text-text-muted text-[13px] leading-relaxed max-w-[280px]">
-              {route === "relay"
-                ? "Your box didn't answer. It may be offline. Check it's running and try again."
-                : "Couldn't open a direct connection. Check the server is reachable and try again."}
+              Your box didn't answer. Check it's running and try again.
             </div>
           </div>
           <button
@@ -106,19 +104,15 @@ export function ConnectingScreen({ route, host, failed, onRetry, onCancel }: Pro
 
         <div className="flex flex-col gap-2">
           <div className="text-text text-lg font-semibold">
-            {route === "relay" ? "Connecting to relay" : "Connecting to remote box"}
+            Connecting to your box
             <AnimatedDots />
           </div>
           <div className="text-text-muted text-[13px] leading-relaxed">
-            {route === "relay"
-              ? "Reaching your box through MantaUI."
-              : "Opening a direct connection to your server."}
+            Opening a direct connection to your server.
           </div>
         </div>
 
-        {/* Host pill only for a custom/direct server — the relay is the default
-            and needs no endpoint disclosure. */}
-        {route === "direct" && host && (
+        {host && (
           <div className="inline-flex items-center gap-2 rounded-full bg-bg-soft border border-border px-3.5 py-1.5 text-xs text-text-muted">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
               <rect x="4" y="4" width="16" height="7" rx="1.5" stroke="#A7B1C4" strokeWidth="1.6" />

--- a/src/renderer/mobile/MobileApp.tsx
+++ b/src/renderer/mobile/MobileApp.tsx
@@ -6,7 +6,6 @@ import { MobileSettings } from "./MobileSettings";
 import { PairingScreen } from "./PairingScreen";
 import { SetupScreen } from "./SetupScreen";
 import { ConnectingScreen } from "./ConnectingScreen";
-import { resolveConnectRoute } from "./setupLogic";
 import { reportFocus } from "./push";
 import { registerApns, NATIVE_NOTIF_TAP_EVENT_NAME } from "./nativePush";
 import { AuthRequiredError, ServerNotConfiguredError, triggerResumeReconnect } from "../api/httpApi";
@@ -20,8 +19,8 @@ type Nav =
   | { screen: "settings" };
 
 // Read the persisted server URL WITHOUT throwing (serverBase() throws when
-// unset). Empty string when unconfigured — resolveConnectRoute treats that as
-// the relay default. Used only for the ConnectingScreen route/host copy.
+// unset). Empty string when unconfigured — the bootstrap will route to the
+// setup screen. Used only for the ConnectingScreen host pill copy.
 function readServerBase(): string {
   try {
     return (localStorage.getItem("manta_server") ?? "").replace(/\/+$/, "");
@@ -75,7 +74,7 @@ export function MobileApp() {
   // Connect lifecycle for the full-screen ConnectingScreen. `connecting` is
   // true while the INITIAL bootstrap (or a post-pair refresh) is in flight and
   // we have never yet loaded data — so the user sees a clear "Connecting to
-  // relay / remote box" instead of a blank session list. Once data lands
+  // your box" instead of a blank session list. Once data lands
   // (`hasLoaded`), later background refreshes do NOT re-show the full screen.
   // `connectFailed` flips the ConnectingScreen to its error+retry state.
   const [connecting, setConnecting] = useState(true);
@@ -616,13 +615,14 @@ export function MobileApp() {
   }
 
   // Initial connect (or post-pair refresh) in flight, or it failed before the
-  // first successful load. Route-aware copy + host for a custom/direct server.
+  // first successful load. Post-BET-198 every connection is direct, so the
+  // route is always "direct" and the host pill is shown whenever a base is set.
   if (connecting || connectFailed) {
-    const route = resolveConnectRoute(readServerBase());
-    const host = route === "direct" ? hostFromBase(readServerBase()) : undefined;
+    const base = readServerBase();
+    const host = base === "" ? undefined : hostFromBase(base);
     return (
       <ConnectingScreen
-        route={route}
+        route="direct"
         host={host}
         failed={connectFailed}
         onRetry={doRefresh}

--- a/src/renderer/mobile/SetupScreen.tsx
+++ b/src/renderer/mobile/SetupScreen.tsx
@@ -6,11 +6,8 @@ import {
   subscribeDebugLog,
   clearDebugLog,
 } from "./debugLog";
-import { isValidServerUrl } from "../pairStepLogic";
 import { isValidBoxToken } from "../../shared/transport.mjs";
 import {
-  DEFAULT_SERVER_URL,
-  isRelayServer,
   canConnectSetup,
   buildSetupClaimInput,
   resolveSetupServerUrl,
@@ -39,55 +36,39 @@ type Props = {
  * requires no interaction here). A "Manual setup" link opens a bottom sheet
  * for typed pairing.
  *
- * The manual sheet has two modes (see setupLogic.ts):
- *   • relay (default): Server URL is pre-filled with the official MantaUI
- *     relay. The relay routes to a box by Box ID, so a Box ID + code are
- *     required. authClaim routes on the boxId.
- *   • custom: the user edits the Server URL to their own box. A direct claim
- *     needs only URL + code, so the Box ID field is disabled.
+ * The manual sheet asks for a Box ID + pairing code; the box's public
+ * hostname (`https://<boxId>.boxes.mantaui.com`) is derived from the Box ID
+ * via the shared `boxDirectUrl` helper, so no server-URL field is needed.
+ * Every box serves its own public hostname directly.
  *
- * All non-React logic (URL/box-id/code validation, the submit gate, claim-input
- * construction, HTTP-outcome classification) is pure + unit-tested in
- * setupLogic.ts + pairStepLogic.ts + ../../shared/claim.mjs. This file is the
- * wiring.
+ * All non-React logic (URL/box-id/code validation, the submit gate,
+ * claim-input construction, HTTP-outcome classification) is pure +
+ * unit-tested in setupLogic.ts + pairStepLogic.ts + ../../shared/claim.mjs.
+ * This file is the wiring.
  */
 export function SetupScreen({ onConnected, pairStatus }: Props) {
   const [manualOpen, setManualOpen] = useState(false);
-  const [serverUrl, setServerUrl] = useState<string>(DEFAULT_SERVER_URL);
   const [boxId, setBoxId] = useState("");
   const [code, setCode] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);
 
-  const relayMode = isRelayServer(serverUrl);
-
   const submit = async () => {
-    // Mirror the pure gate so an Enter keypress can't fire from a non-ready
-    // state (the button is also disabled, but Enter bypasses that).
-    if (!canConnectSetup({ serverUrl, boxId, code, submitting })) return;
+    if (!canConnectSetup({ boxId, code, submitting })) return;
     setSubmitting(true);
     setError(null);
-    // authClaim POSTs the direct box or relay claim depending on which of
-    // {serverUrl, boxId} is populated, classifies the outcome via the shared
-    // classifier, and persists the returned token to localStorage on success.
     const result = await window.api.authClaim(
-      buildSetupClaimInput({ serverUrl, boxId, code }),
+      buildSetupClaimInput({ boxId, code }),
     );
     if (result.ok) {
       // Token is already persisted by authClaim. Persist the resolved server
-      // URL so serverBase() resolves on the next refresh (relay mode writes the
-      // per-box relay proxy URL; custom mode writes the typed URL).
-      localStorage.setItem(
-        "manta_server",
-        resolveSetupServerUrl({ serverUrl, boxId }),
-      );
+      // URL (boxDirectUrl(boxId)) so serverBase() resolves on the next refresh.
+      localStorage.setItem("manta_server", resolveSetupServerUrl({ boxId }));
       setSubmitting(false);
       onConnected();
       return;
     }
-    // Failure: show the classified message, keep the fields so the user can
-    // fix them, and re-focus the code input.
     setSubmitting(false);
     setError(result.message);
     codeRef.current?.focus();
@@ -188,50 +169,29 @@ export function SetupScreen({ onConnected, pairStatus }: Props) {
             <div className="flex flex-col gap-1 text-left mb-4">
               <div className="text-text text-lg font-semibold">Manual setup</div>
               <div className="text-text-muted text-xs leading-relaxed">
-                Enter the details shown under Settings &rsaquo; Connection in the desktop app. The
-                server URL defaults to the official MantaUI server; change it only if you self-host.
+                Enter the details shown under Settings &rsaquo; Connection in the desktop app.
+                Your phone will connect directly to your box.
               </div>
             </div>
 
             <form onSubmit={onSubmitForm} className="flex flex-col gap-3.5">
-              <Field label="Server URL">
-                <input
-                  type="text"
-                  inputMode="url"
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder="https://relay.mantaui.com"
-                  disabled={submitting}
-                  value={serverUrl}
-                  onChange={(e) => {
-                    setServerUrl(e.target.value);
-                    setError(null);
-                  }}
-                  aria-invalid={serverUrl.trim() !== "" && !isValidServerUrl(serverUrl)}
-                  className="w-full rounded-xl bg-bg-soft text-text placeholder:text-text-faint border border-border px-4 py-3 text-sm font-mono outline-none focus:border-accent disabled:opacity-60"
-                />
-              </Field>
-
               <Field label="Box ID">
                 <input
                   type="text"
                   autoComplete="off"
                   spellCheck={false}
                   placeholder="a1b2c3d4e5f6…"
-                  disabled={submitting || !relayMode}
+                  disabled={submitting}
                   value={boxId}
                   onChange={(e) => {
                     setBoxId(e.target.value.trim());
                     setError(null);
                   }}
                   aria-invalid={
-                    relayMode && boxId.trim() !== "" && !isValidBoxToken(boxId.trim())
+                    boxId.trim() !== "" && !isValidBoxToken(boxId.trim())
                   }
-                  className="w-full rounded-xl bg-bg-soft text-text placeholder:text-text-faint border border-border px-4 py-3 text-sm font-mono outline-none focus:border-accent disabled:opacity-40"
+                  className="w-full rounded-xl bg-bg-soft text-text placeholder:text-text-faint border border-border px-4 py-3 text-sm font-mono outline-none focus:border-accent disabled:opacity-60"
                 />
-                <div className="text-text-faint text-[11px] mt-1">
-                  Not needed if you are not using the official relay.
-                </div>
               </Field>
 
               <Field label="Pairing code">
@@ -262,7 +222,7 @@ export function SetupScreen({ onConnected, pairStatus }: Props) {
 
               <button
                 type="submit"
-                disabled={!canConnectSetup({ serverUrl, boxId, code, submitting })}
+                disabled={!canConnectSetup({ boxId, code, submitting })}
                 className="mobile-tap w-full px-5 py-3.5 rounded-xl bg-accent-soft text-white font-semibold disabled:opacity-40"
               >
                 {submitting ? "Connecting…" : "Connect"}
@@ -311,10 +271,6 @@ function PairStatusBanner({
   );
 }
 
-// On-screen debug log — the Safari Web Inspector can't attach to the TestFlight
-// WKWebView (device not discovered), so this surfaces the [deeplink] trail on
-// the phone itself. Collapsed by default; tap to expand and read what happened
-// during a scan. Temporary diagnostic aid (BET-177 pairing debug).
 function DebugLogPanel() {
   const [open, setOpen] = useState(false);
   const [entries, setEntries] = useState<DebugEntry[]>(() => getDebugLog());

--- a/src/renderer/mobile/deepLink.test.ts
+++ b/src/renderer/mobile/deepLink.test.ts
@@ -4,6 +4,7 @@ import {
   handlePairUrl,
   type DeepLinkDeps,
 } from "./deepLink";
+import { boxDirectUrl } from "../../shared/transport.mjs";
 import type { ClaimOutcome } from "../../shared/claim.mjs";
 
 // A canonical box-form URL the desktop Settings QR + `bui pair` terminal QR
@@ -28,10 +29,10 @@ function failOutcome(): ClaimOutcome {
 // or persistServer per case. Default impl: claim succeeds, persist writes
 // the resolved URL.
 function makeDeps(overrides: Partial<DeepLinkDeps> = {}): DeepLinkDeps & {
-  authClaimCalls: Array<{ serverUrl: string; boxId?: string; code: string }>;
+  authClaimCalls: Array<{ serverUrl: string; code: string }>;
   persistCalls: string[];
 } {
-  const authClaimCalls: Array<{ serverUrl: string; boxId?: string; code: string }> = [];
+  const authClaimCalls: Array<{ serverUrl: string; code: string }> = [];
   const persistCalls: string[] = [];
   return {
     authClaimCalls,
@@ -114,17 +115,18 @@ describe("handlePairUrl — ignored / foreign / malformed", () => {
 });
 
 describe("handlePairUrl — box form (direct hostname, BET-198)", () => {
-  it("claims via authClaim with boxId + empty serverUrl, then persists <boxId>.boxes.mantaui.com", async () => {
+  it("claims via authClaim with boxDirectUrl(boxId), then persists the same URL", async () => {
     const deps = makeDeps();
     const out = await handlePairUrl(BOX_URL, deps);
     expect(out).toBe("paired");
+    // The claim URL is exactly boxDirectUrl(boxId) — single source of truth
+    // shared with the desktop PairStep and the manual setup screen. The
+    // body sent by httpApi.claimAgainst is `{pairing_code}` (sanity-checked
+    // by the httpApi suite; this test pins the URL here).
     expect(deps.authClaimCalls).toEqual([
-      { serverUrl: "", boxId: BOX, code: "847291" },
+      { serverUrl: boxDirectUrl(BOX), code: "847291" },
     ]);
-    // Shared boxDirectUrl is the canonical source — must match exactly.
-    expect(deps.persistCalls).toEqual([
-      `https://${BOX}.boxes.mantaui.com`,
-    ]);
+    expect(deps.persistCalls).toEqual([boxDirectUrl(BOX)]);
   });
 
   it("returns 'failed' when authClaim rejects with a classified failure (no persist)", async () => {
@@ -171,9 +173,10 @@ describe("handlePairUrl — direct form (serverUrl)", () => {
 });
 
 describe("handlePairUrl — claim wiring sanity", () => {
-  it("never calls authClaim for ignored/foreign URLs (defends the rate limit)", async () => {
-    // A foreign URL must NEVER reach the relay — relay-mint is rate-limited
-    // and we don't want spam pairs to count against the user's quota.
+  it("never calls authClaim for ignored/foreign URLs (defends the box's rate limit)", async () => {
+    // A foreign URL must NEVER reach the box's /auth/claim — the endpoint is
+    // rate-limited (src/server/auth.mjs) and we don't want spam pairs to count
+    // against the user's quota.
     const authClaim = vi.fn(async () => okOutcome());
     const deps = makeDeps({ authClaim });
     await handlePairUrl("https://google.com/", deps);

--- a/src/renderer/mobile/deepLink.ts
+++ b/src/renderer/mobile/deepLink.ts
@@ -84,7 +84,6 @@ export type DeepLinkDeps = {
    *  mobile pairing screen feeds in. */
   authClaim: (input: {
     serverUrl: string;
-    boxId?: string;
     code: string;
   }) => Promise<ClaimOutcome>;
   /** Persist the resolved server URL to localStorage["manta_server"]. Called
@@ -93,8 +92,7 @@ export type DeepLinkDeps = {
    *  form writes the payload's serverUrl. The deep-link handler is the only
    *  caller that needs this — direct pairing flows (PairingScreen /
    *  SetupScreen) persist serverUrl directly because the user already typed
-   *  it. (BET-198 — relay dropped, the previous `${RELAY_BASE}/box/<boxId>`
-   *  shape is gone.) */
+   *  it. */
   persistServer: (serverUrl: string) => void;
 };
 
@@ -109,11 +107,11 @@ export type DeepLinkDeps = {
  *   write happens.
  * - A direct-form pair URL → claimAgainst with the payload's serverUrl, then
  *   persistServer(payload.serverUrl) on success.
- * - A box-form pair URL → claimAgainst with the payload's boxId, then
- *   persistServer(`https://<boxId>.boxes.mantaui.com`) on success. The URL
- *   shape is produced by the SHARED `boxDirectUrl` helper so the desktop
+ * - A box-form pair URL → claimAgainst with `https://<boxId>.boxes.mantaui.com`,
+ *   then persistServer with the SAME string on success. The URL shape is
+ *   produced by the SHARED `boxDirectUrl` helper so the desktop
  *   (PairStep.tsx) and the mobile deep-link handler write the EXACT same
- *   string (BET-198 — relay dropped).
+ *   string.
  */
 export async function handlePairUrl(
   raw: string,
@@ -125,7 +123,7 @@ export async function handlePairUrl(
     return "ignored";
   }
   dlog(
-    `[deeplink] parsed: ${payload.boxId ? `box=${payload.boxId.slice(0, 8)}… (relay)` : `server=${payload.serverUrl} (direct)`} code=${payload.code}`,
+    `[deeplink] parsed: ${payload.boxId ? `box=${payload.boxId.slice(0, 8)}… (direct)` : `server=${payload.serverUrl} (direct)`} code=${payload.code}`,
   );
 
   const claimInput = buildClaimInput(payload);
@@ -157,20 +155,18 @@ export async function handlePairUrl(
 }
 
 /**
- * Build the AuthClaimInput from a parsed payload. Mirrors PairStep.tsx's
- * box-form contract: serverUrl="" + boxId=<id> for the box form so
- * httpApi.authClaim routes through the box-direct branch (BET-198 — relay
- * dropped). An empty serverUrl on the box form is intentional: the URL
- * itself is built by `boxDirectUrl(boxId)` AFTER a successful claim and
- * persisted by `persistServer`, not pre-resolved here.
+ * Build the {serverUrl, code} input for httpApi.authClaim. The box-form URL
+ * is built by the shared `boxDirectUrl` helper so the claim POSTs
+ * `{pairing_code}` to the box's own /auth/claim against its public hostname
+ * (`https://<boxId>.boxes.mantaui.com`). The same string is persisted by
+ * `persistServer` below — single source of truth for the URL shape.
  */
 function buildClaimInput(payload: PairPayload): {
   serverUrl: string;
-  boxId?: string;
   code: string;
 } {
   if (payload.boxId) {
-    return { serverUrl: "", boxId: payload.boxId, code: payload.code };
+    return { serverUrl: boxDirectUrl(payload.boxId), code: payload.code };
   }
   return { serverUrl: payload.serverUrl ?? "", code: payload.code };
 }

--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -25,7 +25,7 @@ describe("parsePairPayload", () => {
       // Regression: an old desktop build emits manta://pair?id=<32hex>&token=.
       // The 32-hex value is a BOX ID, not a server URL — without shape-routing
       // it was http://-prefixed and mis-claimed as a bogus direct host, which
-      // network-failed. Must resolve to the relay box form.
+      // network-failed. Must resolve to the box form.
       expect(
         parsePairPayload(
           "manta://pair?id=0d5784a7a43451f4ad70dd3d9ee5cf72&token=593337",
@@ -77,7 +77,7 @@ describe("parsePairPayload", () => {
     });
   });
 
-  describe("boxId form (relay-paired, BET-156)", () => {
+  describe("boxId form (direct claim against the box's own hostname, BET-156)", () => {
     it("accepts the primary manta://pair?box=&code= form", () => {
       expect(
         parsePairPayload(`manta://pair?box=${BOX}&code=847291`),
@@ -204,7 +204,7 @@ describe("round-trip", () => {
     const cases: PairPayload[] = [
       { serverUrl: "http://box:8787", boxId: null, code: "123456" },
       { serverUrl: "http://192.168.1.10:8787", boxId: null, code: "000000" },
-      { serverUrl: "https://relay.example.com", boxId: null, code: "987654" },
+      { serverUrl: "https://box-direct.example.com", boxId: null, code: "987654" },
       { serverUrl: null, boxId: BOX, code: "111111" },
     ];
     for (const p of cases) {

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -1,7 +1,7 @@
 // pairPayload.ts — pure parser + builder for the pairing deeplink/QR payload
-// (BET-73, M3.1; extended BET-156 for relay-paired flows). No DOM, no fetch,
+// (BET-73, M3.1; extended BET-156 for box-paired flows). No DOM, no fetch,
 // no camera: this is the pure-before-wired foundation that stage 2 (camera →
-// auto-connect) imports, and that the desktop's relay-paired onboarding reuses
+// auto-connect) imports, and that the desktop's box-paired onboarding reuses
 // for a single-paste "pair link" input.
 //
 // A desktop "Pair phone" panel encodes a payload into a QR; the mobile app
@@ -9,7 +9,7 @@
 // payload carries ONE of two addressing shapes, both keyed by a 6-digit pairing
 // code:
 //   • serverUrl (direct-HTTPS):  manta://pair?server=<url>&code=<6-digit>
-//   • boxId     (relay-paired):  manta://pair?box=<box_id>&code=<6-digit>
+//   • boxId     (direct box):    manta://pair?box=<box_id>&code=<6-digit>
 // This module normalizes either into a single { serverUrl, boxId, code } and
 // provides the inverse builders used as round-trip oracles in tests (and by
 // the desktop QR panel + the install.sh heredoc).
@@ -79,7 +79,7 @@ function coerceBoxId(raw: string): string | null {
  * code not exactly 6 digits, or an unparseable URL. Whitespace is trimmed.
  *
  * Accepts either query spelling — `server`/`code` (primary), the M6 alias
- * `id`/`token`, or the relay form `box`/`code` — and both URL shapes (custom
+ * `id`/`token`, or the box form `box`/`code` — and both URL shapes (custom
  * `manta://pair` scheme and the `https://host/m/...` deferred-deeplink form).
  *
  * Exactly ONE of server / box must be present. Both or neither → null.
@@ -116,12 +116,13 @@ export function parsePairPayload(raw: string): PairPayload | null {
   const rawBox = q.get("box") ?? "";
   const rawCode = q.get("code") ?? q.get("token") ?? "";
   // The legacy `id` param (pre-BET-177 desktop QR: `manta://pair?id=<X>&token=`)
-  // is AMBIGUOUS — early builds put a serverUrl there, but the relay-era desktop
+  // is AMBIGUOUS — early builds put a serverUrl there, but the box-era desktop
   // (still shipping in some installed apps) puts the 32-hex BOX ID there. Route
-  // by shape: a 32-hex value is a boxId (relay claim); anything else is a
-  // serverUrl (direct). WITHOUT this, a boxId under `id` gets http://-prefixed
-  // and mis-parsed as a bogus direct server URL → the claim network-fails
-  // against a non-existent host (the exact symptom on an old desktop QR).
+  // by shape: a 32-hex value is a boxId (direct claim against the box's own
+  // hostname); anything else is a serverUrl (direct). WITHOUT this, a boxId
+  // under `id` gets http://-prefixed and mis-parsed as a bogus direct server URL
+  // → the claim network-fails against a non-existent host (the exact symptom on
+  // an old desktop QR).
   const rawId = q.get("id") ?? "";
 
   let serverUrl = coerceServerUrl(rawServer);

--- a/src/renderer/mobile/pairingLogic.ts
+++ b/src/renderer/mobile/pairingLogic.ts
@@ -20,8 +20,8 @@
 // re-exports them for the mobile client's existing call sites + tests, and
 // adds the mobile-only form state machine (pairingReducer) on top.
 //
-// BET-198 SCOPE NOTE: `classifyRelayClaimResult` was removed (the relay is
-// gone); pairingLogic now only re-exports the direct-claim helpers.
+// `classifyRelayClaimResult` was removed in BET-198; pairingLogic only
+// re-exports the direct-claim helpers.
 
 export {
   normalizeCode,

--- a/src/renderer/mobile/setupLogic.test.ts
+++ b/src/renderer/mobile/setupLogic.test.ts
@@ -1,117 +1,78 @@
 import { describe, it, expect } from "vitest";
 import {
-  DEFAULT_SERVER_URL,
-  isRelayServer,
   canConnectSetup,
   buildSetupClaimInput,
   resolveSetupServerUrl,
   resolveConnectRoute,
 } from "./setupLogic";
+import { boxDirectUrl } from "../../shared/transport.mjs";
 
 const VALID_BOX = "7f3a9c1e0b8d4a62f1c9e5b7d0a4f8c2"; // 32 hex
 const BAD_BOX = "not-a-box";
 
-describe("isRelayServer", () => {
-  it("true for the default relay URL", () => {
-    expect(isRelayServer(DEFAULT_SERVER_URL)).toBe(true);
-  });
-  it("ignores trailing slash / whitespace", () => {
-    expect(isRelayServer(" https://relay.mantaui.com/ ")).toBe(true);
-  });
-  it("false for a custom server URL", () => {
-    expect(isRelayServer("https://box.example.com")).toBe(false);
-  });
-});
+describe("canConnectSetup", () => {
+  const base = { submitting: false };
 
-describe("canConnectSetup — relay mode", () => {
-  const base = { serverUrl: DEFAULT_SERVER_URL, submitting: false };
   it("requires a valid box id AND 6-digit code", () => {
     expect(canConnectSetup({ ...base, boxId: VALID_BOX, code: "123456" })).toBe(true);
   });
+
   it("rejects a bad box id", () => {
     expect(canConnectSetup({ ...base, boxId: BAD_BOX, code: "123456" })).toBe(false);
   });
+
   it("rejects a short code", () => {
     expect(canConnectSetup({ ...base, boxId: VALID_BOX, code: "123" })).toBe(false);
   });
+
   it("never while submitting", () => {
     expect(
-      canConnectSetup({ ...base, boxId: VALID_BOX, code: "123456", submitting: true }),
+      canConnectSetup({ boxId: VALID_BOX, code: "123456", submitting: true }),
     ).toBe(false);
   });
-});
 
-describe("canConnectSetup — custom mode", () => {
-  it("requires only a valid URL + code (box id irrelevant)", () => {
+  it("trims the box id before validating", () => {
     expect(
-      canConnectSetup({
-        serverUrl: "https://box.example.com",
-        boxId: "",
-        code: "123456",
-        submitting: false,
-      }),
+      canConnectSetup({ ...base, boxId: `  ${VALID_BOX}  `, code: "123456" }),
     ).toBe(true);
-  });
-  it("rejects an invalid URL", () => {
-    expect(
-      canConnectSetup({
-        serverUrl: "box.example.com",
-        boxId: "",
-        code: "123456",
-        submitting: false,
-      }),
-    ).toBe(false);
   });
 });
 
 describe("buildSetupClaimInput", () => {
-  it("relay mode → empty serverUrl + boxId", () => {
-    expect(
-      buildSetupClaimInput({ serverUrl: DEFAULT_SERVER_URL, boxId: VALID_BOX, code: "123456" }),
-    ).toEqual({ serverUrl: "", boxId: VALID_BOX, code: "123456" });
+  it("emits boxDirectUrl(boxId) as the serverUrl + the raw code", () => {
+    expect(buildSetupClaimInput({ boxId: VALID_BOX, code: "123456" })).toEqual({
+      serverUrl: boxDirectUrl(VALID_BOX),
+      code: "123456",
+    });
   });
-  it("relay mode trims the box id", () => {
-    expect(
-      buildSetupClaimInput({ serverUrl: DEFAULT_SERVER_URL, boxId: `  ${VALID_BOX}  `, code: "123456" }),
-    ).toEqual({ serverUrl: "", boxId: VALID_BOX, code: "123456" });
-  });
-  it("custom mode → normalized serverUrl, no boxId", () => {
-    expect(
-      buildSetupClaimInput({ serverUrl: "https://box.example.com/", boxId: "ignored", code: "123456" }),
-    ).toEqual({ serverUrl: "https://box.example.com", code: "123456" });
-  });
-});
 
-describe("resolveConnectRoute", () => {
-  it("relay for the persisted per-box relay proxy URL", () => {
-    expect(resolveConnectRoute(`https://relay.mantaui.com/box/${VALID_BOX}`)).toBe("relay");
-  });
-  it("relay for the bare relay base", () => {
-    expect(resolveConnectRoute("https://relay.mantaui.com")).toBe("relay");
-  });
-  it("relay for empty/unset base (fresh install default)", () => {
-    expect(resolveConnectRoute("")).toBe("relay");
-  });
-  it("direct for a custom server URL", () => {
-    expect(resolveConnectRoute("https://box.example.com")).toBe("direct");
-  });
-  it("direct for a same-origin PWA base", () => {
-    expect(resolveConnectRoute("https://app.example.com:8787")).toBe("direct");
-  });
-  it("does NOT match a look-alike host as relay", () => {
-    expect(resolveConnectRoute("https://relay.mantaui.com.evil.com/box/x")).toBe("direct");
+  it("trims the box id before building the URL", () => {
+    expect(buildSetupClaimInput({ boxId: `  ${VALID_BOX}  `, code: "123456" })).toEqual({
+      serverUrl: boxDirectUrl(VALID_BOX),
+      code: "123456",
+    });
   });
 });
 
 describe("resolveSetupServerUrl", () => {
-  it("relay mode → per-box relay proxy URL", () => {
-    expect(resolveSetupServerUrl({ serverUrl: DEFAULT_SERVER_URL, boxId: VALID_BOX })).toBe(
-      `https://relay.mantaui.com/box/${VALID_BOX}`,
+  it("returns boxDirectUrl(boxId) (single source of truth)", () => {
+    expect(resolveSetupServerUrl({ boxId: VALID_BOX })).toBe(boxDirectUrl(VALID_BOX));
+  });
+
+  it("trims the box id before building the URL", () => {
+    expect(resolveSetupServerUrl({ boxId: `  ${VALID_BOX}  ` })).toBe(
+      boxDirectUrl(VALID_BOX),
     );
   });
-  it("custom mode → normalized typed URL", () => {
-    expect(resolveSetupServerUrl({ serverUrl: "https://box.example.com/", boxId: "" })).toBe(
-      "https://box.example.com",
-    );
+});
+
+describe("resolveConnectRoute", () => {
+  it("always returns 'direct' for a configured base", () => {
+    expect(resolveConnectRoute(boxDirectUrl(VALID_BOX))).toBe("direct");
+    expect(resolveConnectRoute("https://box.example.com")).toBe("direct");
+  });
+
+  it("returns 'direct' for empty/unset base (fresh install)", () => {
+    expect(resolveConnectRoute("")).toBe("direct");
   });
 });

--- a/src/renderer/mobile/setupLogic.ts
+++ b/src/renderer/mobile/setupLogic.ts
@@ -1,54 +1,7 @@
-// setupLogic.ts — pure, framework-free core for the mobile first-run setup
-// screen (SetupScreen.tsx). Extracted so the submit gate + claim-input
-// construction are unit-testable without a DOM, fetch, or the Capacitor
-// bridge (see setupLogic.test.ts beside this file).
-//
-// The setup screen has two pairing modes, keyed off whether the Server URL
-// field still holds the default MantaUI relay:
-//
-//   • relay mode  (Server URL === the MantaUI relay): the relay routes to a
-//     box strictly by Box ID, so pairing needs a valid 32-hex Box ID + a
-//     6-digit code. The relay URL itself is hardcoded, so authClaim routes on
-//     the boxId (serverUrl is left empty for that branch).
-//   • custom mode (Server URL edited to a self-hosted box): a direct claim
-//     against that URL needs only the URL + a 6-digit code. The Box ID field
-//     is disabled in this mode (a direct box has no relay routing step).
-//
-// The shared contracts (URL shape, 6-digit code, 32-hex box id) are reused
-// from pairStepLogic / ../../shared/claim.mjs / ../../shared/transport.mjs so
-// there is a single source of truth for each.
-//
-// BET-198 SCOPE NOTE: the relay itself is gone (src/shared/transport.mjs no
-// longer exports RELAY_BASE / relayBase / relayBoxUrl). The setup screen's
-// "relay mode" is now semantically a legacy UI affordance — BET-205 will gut
-// the relay concept from the UI. For now we keep the in-file literal so
-// typecheck and tests stay green; the relay URL is still hardcoded here.
-
-import { normalizeServerUrl, isValidServerUrl } from "../pairStepLogic";
 import { isSubmittableCode } from "../../shared/claim.mjs";
-import { isValidBoxToken } from "../../shared/transport.mjs";
-
-/** Legacy relay host — kept as an in-file literal so setupLogic still
- *  compiles after BET-198 removed RELAY_BASE from shared/transport. Will be
- *  replaced by direct-hostname pairing in BET-205. */
-const RELAY_BASE = "https://relay.mantaui.com";
-
-/** The Server URL the setup form pre-fills with (the official MantaUI relay).
- *  Typed as `string` so consumers like useState<string> accept it without
- *  narrowing to the literal type. */
-export const DEFAULT_SERVER_URL: string = RELAY_BASE;
-
-/**
- * True when the current Server URL is (still) the official MantaUI relay. Used
- * to decide relay-vs-custom mode: whitespace / trailing slashes are ignored so
- * "https://relay.mantaui.com/" counts as the default too.
- */
-export function isRelayServer(serverUrl: string): boolean {
-  return normalizeServerUrl(serverUrl) === normalizeServerUrl(DEFAULT_SERVER_URL);
-}
+import { boxDirectUrl, isValidBoxToken } from "../../shared/transport.mjs";
 
 export type SetupFields = {
-  serverUrl: string;
   boxId: string;
   code: string;
   submitting: boolean;
@@ -60,72 +13,51 @@ export type SetupFields = {
  *
  * - Never while a request is in flight.
  * - Always requires a submittable (6-digit) code.
- * - relay mode  → additionally requires a valid 32-hex Box ID.
- * - custom mode → additionally requires a valid http(s) Server URL.
+ * - Always requires a valid 32-hex Box ID — the box's public hostname
+ *   (`https://<boxId>.boxes.mantaui.com`, see `boxDirectUrl`) is derived from
+ *   it; the box is reached directly via this hostname.
  */
 export function canConnectSetup(input: SetupFields): boolean {
   if (input.submitting) return false;
   if (!isSubmittableCode(input.code)) return false;
-  if (isRelayServer(input.serverUrl)) {
-    return isValidBoxToken(input.boxId.trim());
-  }
-  return isValidServerUrl(input.serverUrl);
+  return isValidBoxToken(input.boxId.trim());
 }
 
 /**
- * Build the AuthClaimInput for the current fields. Mirrors the deep-link
- * handler's contract (deepLink.ts buildClaimInput):
- *
- * - relay mode  → { serverUrl: "", boxId, code } so httpApi.authClaim routes
- *   through the relay claim (keyed on boxId), NOT a direct POST to an empty base.
- * - custom mode → { serverUrl, code } for a direct /auth/claim.
- *
- * The Box ID is trimmed; the server URL is normalized (trailing slashes off).
+ * Build the {serverUrl, code} input for httpApi.authClaim. The box's public
+ * hostname is derived from the box ID via the shared `boxDirectUrl` helper
+ * (src/shared/transport.mjs) — single source of truth for the URL shape. The
+ * claim POSTs `{pairing_code}` to `<serverUrl>/auth/claim` against the box's
+ * own bui-server. The Box ID is trimmed.
  */
 export function buildSetupClaimInput(input: {
-  serverUrl: string;
   boxId: string;
   code: string;
-}): { serverUrl: string; boxId?: string; code: string } {
-  if (isRelayServer(input.serverUrl)) {
-    return { serverUrl: "", boxId: input.boxId.trim(), code: input.code };
-  }
-  return { serverUrl: normalizeServerUrl(input.serverUrl), code: input.code };
+}): { serverUrl: string; code: string } {
+  return { serverUrl: boxDirectUrl(input.boxId.trim()), code: input.code };
 }
 
 /**
  * Resolve the server URL to persist to localStorage["manta_server"] after a
- * successful claim. relay mode persists the per-box relay proxy URL
- * (`${RELAY_BASE}/box/<boxId>`); custom mode persists the normalized URL the
- * user typed. Single-sourced via relayBoxUrl so it matches the deep-link path.
+ * successful claim. Post-BET-198 every box has a public hostname
+ * (`<boxId>.boxes.mantaui.com`) built by the shared `boxDirectUrl` helper, so
+ * the manual-setup flow writes the same string the deep-link handler writes.
  */
-export function resolveSetupServerUrl(input: {
-  serverUrl: string;
-  boxId: string;
-}): string {
-  if (isRelayServer(input.serverUrl)) {
-    // relayBoxUrl validates the boxId; the caller only reaches here after a
-    // successful claim, which already required a valid boxId.
-    return `${RELAY_BASE}/box/${input.boxId.trim()}`;
-  }
-  return normalizeServerUrl(input.serverUrl);
+export function resolveSetupServerUrl(input: { boxId: string }): string {
+  return boxDirectUrl(input.boxId.trim());
 }
 
 /**
- * Whether the ACTIVE connection (the persisted `manta_server`) goes through the
- * MantaUI relay or directly to a self-hosted box. The relay's persisted form is
- * the per-box proxy URL `${RELAY_BASE}/box/<id>`, so we match by prefix (NOT the
- * exact base, which is only the pre-claim form). Anything else — a typed box
- * URL, or a same-origin PWA base — is "direct". An empty/unset base is treated
- * as relay (the default), since that's what a fresh install pairs into.
+ * Whether the ACTIVE connection (the persisted `manta_server`) is a direct
+ * HTTPS connection to a box's public hostname. Post-BET-198 there is no
+ * intermediary; every configured base is direct. Empty/unset is also "direct"
+ * (it just means the mobile/web hasn't yet paired — the bootstrap will route
+ * to the setup screen).
  *
- * Drives the ConnectingScreen copy: "Connecting to relay…" (no host shown) vs
- * "Connecting to remote box…" (+ the host, since a custom endpoint is worth
- * surfacing).
+ * Drives the ConnectingScreen copy: "Connecting to your box" (+ the host pill).
+ * Kept as a typed single-string return for API compatibility with the renderer
+ * call sites; the value is always "direct".
  */
-export function resolveConnectRoute(serverBase: string): "relay" | "direct" {
-  const base = normalizeServerUrl(serverBase);
-  if (base === "") return "relay";
-  const relay = normalizeServerUrl(DEFAULT_SERVER_URL);
-  return base === relay || base.startsWith(`${relay}/`) ? "relay" : "direct";
+export function resolveConnectRoute(_serverBase: string): "direct" {
+  return "direct";
 }

--- a/src/renderer/pairStepLogic.test.ts
+++ b/src/renderer/pairStepLogic.test.ts
@@ -23,7 +23,7 @@ describe("normalizeServerUrl", () => {
 describe("isValidServerUrl", () => {
   it("accepts http(s) URLs with a host", () => {
     expect(isValidServerUrl("http://box:8787")).toBe(true);
-    expect(isValidServerUrl("https://relay.example.com")).toBe(true);
+    expect(isValidServerUrl("https://box-direct.example.com")).toBe(true);
     expect(isValidServerUrl("  http://192.168.1.10:8787/ ")).toBe(true);
   });
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -86,7 +86,7 @@ export type ScreenshotToast = {
 
 type State = {
   loaded: boolean;
-  // ----- HTTP/relay transport + onboarding (M6, BET-49) -----
+  // ----- HTTP transport + onboarding (M6, BET-49) -----
   // Mirrored from AppConfig so App.tsx can resolve the transport mode
   // (resolveTransportMode) and the onboarding shell can resume. `boxToken`
   // presence flips transport to HTTP; `onboardingSkipped` suppresses the


### PR DESCRIPTION
Stage 5 of BET-198 (drop the relay). Every box now serves its own public hostname (`https://<boxId>.boxes.mantaui.com`, built by the shared `boxDirectUrl(boxId)` helper); renderer + main pair/claim flows route through that single helper, with the box form's persist URL identical between the desktop paste-link and the mobile deep-link handlers.

**Base:** origin/main @ `40b9714` (BET-202 merge)

**Files changed:** 20 files, +277/-355 (net-negative LoC).

```
src/main/auth.test.ts                    |  50 ++++++++++++-
src/main/auth.ts                         |  56 +++++++++-----
src/main/desktopNotify.ts                |   8 +-
src/main/index.ts                        |   2 +-
src/renderer/App.tsx                     |   2 +-
src/renderer/PairStep.tsx                |  26 ++++---
src/renderer/api/httpApi.test.ts         |  18 ++---
src/renderer/api/httpApi.ts              |  23 +++---
src/renderer/mobile/ConnectingScreen.tsx |  34 ++++-----
src/renderer/mobile/MobileApp.tsx        |  16 ++--
src/renderer/mobile/SetupScreen.tsx      |  80 +++++---------------
src/renderer/mobile/deepLink.test.ts     |  25 ++++---
src/renderer/mobile/deepLink.ts          |  28 +++----
src/renderer/mobile/pairPayload.test.ts  |   6 +-
src/renderer/mobile/pairPayload.ts       |  19 ++---
src/renderer/mobile/pairingLogic.ts      |   4 +-
src/renderer/mobile/setupLogic.test.ts   | 109 +++++++++------------------
src/renderer/mobile/setupLogic.ts        | 122 +++++++------------------------
src/renderer/pairStepLogic.test.ts       |   2 +-
src/renderer/store.ts                    |   2 +-
```

### Stage 5a — mobile renderer
- **src/renderer/mobile/setupLogic.ts**: drop `isRelayServer`/`DEFAULT_SERVER_URL`/legacy `RELAY_BASE` literal; manual-setup form asks for Box ID + pairing code only. `buildSetupClaimInput` and `resolveSetupServerUrl` both build their URLs from `boxDirectUrl(boxId)` (single source of truth). `resolveConnectRoute` is a typed single-string return ("direct") kept for renderer call-site compat.
- **src/renderer/mobile/SetupScreen.tsx**: simplify the manual sheet — no server URL field, no relay/custom toggle. Just Box ID + pairing code.
- **src/renderer/mobile/ConnectingScreen.tsx**: collapse the route to a single "direct" value; the host pill is always shown when a base is configured.
- **src/renderer/mobile/deepLink.ts**: `buildClaimInput` now resolves the box form to `boxDirectUrl(boxId)` BEFORE the authClaim call (so the claim actually reaches the box — the previous "empty serverUrl + boxId" contract was a no-op for the mobile httpApi.authClaim).
- **src/renderer/mobile/{pairPayload,pairingLogic}.ts**: reword comments ("relay" → "box" form); grep-zero on relay.
- **src/renderer/{App,store}.tsx, src/renderer/api/httpApi.ts**: remove stale "relay" wording from comments.

### Stage 5b — desktop main
- **src/main/auth.ts**: `claimPairing` now accepts either a typed `serverUrl` (manual form, unchanged) OR a `boxId` (paste-link box form); the latter resolves to `boxDirectUrl(boxId)` before the claim fetch. Both flows share the SAME `claimPairingDirect` (single persistence site).
- **src/renderer/PairStep.tsx**: the pair-link branch persists `boxDirectUrl(payload.boxId)` instead of the hardcoded `https://relay.mantaui.com/box/<id>` shape.
- **src/main/{desktopNotify,index}.ts**: reword "relays/relayed" → "forwards" (generic English verb; not a relay-system reference).

### Tests
- **src/main/auth.test.ts**: NEW `box-form pair link` suite (3 cases) pins the boxId → `boxDirectUrl(boxId)` claim + persist contract.
- **src/renderer/mobile/setupLogic.test.ts**: rewritten for the relay-free API (`canConnectSetup`/`buildSetupClaimInput`/`resolveSetupServerUrl`/`resolveConnectRoute`).
- **src/renderer/mobile/deepLink.test.ts**: pins `boxDirectUrl` as the canonical claim + persist URL via direct import (the explicit handlePairUrl → boxDirectUrl assertion BET-198 asks for).
- **src/renderer/mobile/pairPayload.test.ts**: reword "relay" → "box"; hostname fixture `relay.example.com` → `box-direct.example.com`.
- **src/renderer/api/httpApi.test.ts, src/renderer/pairStepLogic.test.ts**: swap `relay.example.com` → `box-direct.example.com` fixtures.

### Verification results

- **PR branch** (`multica/BET-203-renderer-main-direct-claim` @ `02c0df1`):
  - typecheck: exit 0. Errors: none. log captured by `npm run typecheck` (rerun on demand).
  - test: vitest 60 files / 1113 tests passed; node:test 884 tests passed; 0 failures.

- **Base** (`main` @ `40b9714`):
  - typecheck: identical to PR branch on a fresh checkout (BET-202 merge point).
  - test: pre-existing baseline (BET-200 loop_history noted 1 pre-existing failure in `scripts/install.test.mjs`).

- **Conclusion**: 0 new failures introduced by this PR; 1 pre-existing failure on main is unrelated (formatPairingOutput in scripts/install.test.mjs).

### Grep-zero (BET-203 done-when)
`grep -rn 'relay' src/renderer src/main` → no matches.

### What this does NOT touch
- `src/shared/**` (BET-203 owns it; nothing changed — `boxDirectUrl` + `BOXES_DOMAIN` already shipped in BET-202)
- `src/gateway/**`, `src/server/**`
- `scripts/install.sh`, `.github/workflows/`, `AGENTS.md` (BET-205 / BET-206)