### PR TITLE
BET-214: ci: close BET issue on Multica inside merge-on-command (bot-merge path)

### DIFF
--- a/.github/workflows/merge-on-command.yml
+++ b/.github/workflows/merge-on-command.yml
@@ -111,13 +111,25 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           ACTOR: ${{ github.event.comment.user.login }}
+          # BET-214: close the BET-N issue on the Multica side after the merge.
+          # Needed because `pull_request_target: closed` events are NOT delivered
+          # when the PR was closed via the GitHub API using GITHUB_TOKEN
+          # (documented at docs.github.com/actions/concepts/security/github_token
+          # — "Other pull_request activity types (such as ... closed) do not
+          # create workflow runs"). So merge-on-command has to do the close
+          # itself; the standalone multica-close-on-merge workflow still handles
+          # the human-via-GitHub-UI merge case.
+          MULTICA_TOKEN: ${{ secrets.MULTICA_TOKEN }}
+          MULTICA_WORKSPACE_ID: 264c89bb-4659-4570-af7b-5f8daaf87985
         run: |
           set -euo pipefail
           python3 <<'PY'
           import json
           import os
+          import re
           import subprocess
           import sys
+          import urllib.request
 
           pr = os.environ["PR_NUMBER"]
           repo = os.environ["REPO"]
@@ -302,4 +314,37 @@ jobs:
 
           post("🟢 Merging — all gates passed.")
           print("Merged.")
+
+          # ── Close the BET issue on Multica (BET-214) ────────────────────
+          # Pulled into this workflow because `pull_request_target: closed`
+          # is suppressed when the closer is the GITHUB_TOKEN identity —
+          # see env:MULTICA_TOKEN comment above for the GitHub docs citation.
+          multica_token = os.environ.get("MULTICA_TOKEN", "")
+          ws_id = os.environ.get("MULTICA_WORKSPACE_ID", "")
+          title = pr_json.get("title") or ""
+          head_ref = ((pr_json.get("head") or {}).get("ref")) or ""
+          m = re.search(r"BET-(\d+)", title) or re.search(r"BET-(\d+)", head_ref)
+          if not multica_token or not ws_id:
+              print("::notice::Multica close skipped (MULTICA_TOKEN or workspace id missing).")
+          elif not m:
+              print(f"::notice::Multica close skipped (no BET-N in title='{title}' or branch='{head_ref}').")
+          else:
+              issue_key = f"BET-{m.group(1)}"
+              try:
+                  api_resp = urllib.request.urlopen(urllib.request.Request(
+                      f"https://api.multica.ai/api/issues/{issue_key}?workspace_id={ws_id}",
+                      method="PUT",
+                      headers={
+                          "Authorization": f"Bearer {multica_token}",
+                          "Content-Type": "application/json",
+                      },
+                      data=json.dumps({"status": "done"}).encode("utf-8"),
+                  ), timeout=15)
+                  print(f"Set {issue_key} to done (HTTP {api_resp.status}).")
+              except Exception as exc:
+                  # Never fail the workflow on a Multica-API hiccup — the merge
+                  # already succeeded; the worst case is the issue stays open
+                  # in Multica until the next manual close or the
+                  # reconcile-done-with-open-prs / human followup catches it.
+                  print(f"::warning::Multica close failed for {issue_key}: {exc}")
           PY


### PR DESCRIPTION
## Root cause

`multica-close-on-merge.yml` (trigger: `pull_request_target: types: [closed]`) was silently skipping every PR merged via `/merge`, including PR #160 (BET-202). The PR title's "Issue marked done" never propagated to Multica.

GitHub Actions documented behavior: when a PR is closed via the GitHub API using `GITHUB_TOKEN`, `pull_request` events with activity types other than `opened`/`synchronize`/`reopened` (notably `closed`) do **not** create a new workflow run. See https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs.

PRs closed by `github-actions[bot]` (i.e. every PR that went through the `merge-on-command` workflow) all hit this on 2026-07-20:

| PR | Branch | Merged by | close-on-merge fired? |
|---|---|---|---|
| #154 | BET-201 strip relay agent | github-actions[bot] @ 17:09:37Z | NO |
| #155 | BET-210 exec env | github-actions[bot] @ 17:12:23Z | NO |
| #157 | BET-212 remove titlebar hostname | github-actions[bot] @ 18:12:05Z | NO |
| #158 | BET-211 plugins folder notify | **antoinedc** @ 18:24:49Z | YES ✓ |
| #159 | BET-213 dev dock icon | github-actions[bot] @ 18:48:24Z | NO |
| #160 | BET-202 shared transport | github-actions[bot] @ 19:13:19Z | NO |

PR #158 (merged by the human via the GitHub UI button) and PR #156 (closed by the human without merging) both still fire close-on-merge correctly — only the API-closed-by-bot path is broken.

Note: the issue body says "The same workflow fired successfully for PR #154 (BET-201) earlier the same day" — that premise is incorrect; PR #154 was also merged by `github-actions[bot]` and did **not** fire. (Verified via the workflow runs API; see `gh run list --workflow multica-close-on-merge.yml`.)

## Fix

Pull the close logic into `merge-on-command.yml` itself, right after the successful `gh pr merge` call:

1. Extract BET-N from the PR title or head branch (same regex as the standalone workflow).
2. PUT `status=done` to `https://api.multica.ai/api/issues/<key>?workspace_id=...`.
3. Wrap in `try/except` and use `::warning::` — never fail the merge on a Multica-API hiccup; the merge already succeeded at that point, and the worst case is the issue stays open in Multica until the next `reconcile-done-with-open-prs` tick or human followup.

The standalone `multica-close-on-merge.yml` stays in place to cover the human-via-UI merge path.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/merge-on-command.yml'))"`).
- Local smoke of the close block: extracts `BET-202` from PR #160's title and would PUT to `https://api.multica.ai/api/issues/BET-202?workspace_id=...` with `{"status": "done"}`.
- `npm run typecheck` GREEN.
- `npm test` GREEN except for `tests/unit/e2e-smoke.test.ts` which is a pre-existing Playwright-missing-on-this-box failure (verified by stashing the change and re-running) — unrelated to this YAML-only change.

## Regression check

Next time any agent merges a PR via `/merge`, the new step runs in the same workflow as the merge. The Multica issue should flip to `done` within seconds. To verify: trigger a follow-up `/merge` on any open PR and watch the merge-on-command run logs for `Set BET-NNN to done (HTTP 2xx)`.

If the API call fails the step logs `::warning::Multica close failed for BET-NNN: <reason>` and exits 0 — the workflow stays green.