### PR TITLE
BET-188: fix stale 'bui' default in axiomDataset doc-comment

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -117,7 +117,7 @@ export type AppConfig = {
   // has no `~/.manta` directory on the prod box). Absent → entirely silent
   // no-op; no fetches to axiom.co are made.
   axiomToken?: string;
-  // Dataset name; defaults to "bui". Env var `MANTA_AXIOM_DATASET` wins when
+  // Dataset name; defaults to "manta". Env var `MANTA_AXIOM_DATASET` wins when
   // set.
   axiomDataset?: string;
   // Whisper-family transcription model. Default


### PR DESCRIPTION
## BET-188: stale "bui" default in src/shared/types.ts:120 doc-comment

Below-bar follow-up to BET-187. The runtime default for the Axiom dataset is `manta` (verified in `src/shared/logShip.mjs:43`, the test assertion at `src/shared/logShip.test.ts:77-79`, and the Settings placeholder at `src/renderer/Settings.tsx:659`), but the doc-comment on the `axiomDataset` field in `src/shared/types.ts` still read `defaults to "bui"`.

A future reader sees `"bui"` in the IDE hover and may try to "fix" the code to match the doc — the opposite of what's wanted. This PR replaces `"bui"` with `"manta"` in the doc-comment so the IDE hover matches reality.

**Scope:** 1-line edit in `src/shared/types.ts:120`. No production code change, no test change, no setting change.

**Files changed:** 1 file.
```
 src/shared/types.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

**Base:** `origin/main` @ `fb426ab`

**Verification results:**

- PR branch (`multica/BET-188-types-doc-default-manta` @ `0c681ee`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `884` pass / `0` fail / `0` skip. Failures: none. log sha256: `8c309bcfb08ebde89eec2f8500afa3f04b2f677e80cd1b5667c5595c2dad6197`
- Base (`main` @ `fb426ab`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `884` pass / `0` fail / `0` skip. Failures: none. log sha256: `5eb1a08ac2d8e0efd2cf2ed7958eb73619c1e6759f7579bd590c71edb239505d`
- **Conclusion:** `0` new failures, `0` pre-existing failures. The two test log sha256 differ only in non-deterministic timing / PID lines (start time, duration_ms, `(node:<pid>) ExperimentalWarning`). Same 884/884 result on both.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

**Out of scope (per issue body):** no other `"bui"` / `"MantaUI"` / brand-name references touched — the BET-147 rebrand is finished; this is the single-stale-doc-comment residue from BET-187's dataset-default change.
