### PR TITLE
BET-206: gateway deploy workflow + prod ops runbook

### DIFF
--- a/.github/workflows/gateway-deploy.yml
+++ b/.github/workflows/gateway-deploy.yml
@@ -1,0 +1,87 @@
+# Push gateway deploy — update + restart the APNs/DNS push gateway on the prod box
+# on a `gateway-v*` git tag.
+#
+# WHY THIS EXISTS
+# ---------------
+# The push gateway (node /opt/manta/src/gateway/index.mjs, systemd
+# `manta-gateway` on the prod box) is the ONLY operated backend left after
+# BET-198/"drop the relay": phones now connect directly to their box's
+# `<box_id>.boxes.mantaui.com`, and every APNs notification is signed by the
+# gateway. Before this workflow a merged gateway fix (APNs bug, DNS-OVH
+# refresh tweak, store schema change) had to be shipped by hand over SSH.
+# This makes it a one-step action: push a `gateway-v*` tag.
+#
+# REPLACES THE OLD RELAY-DEPLOY WORKFLOW (deleted in BET-204). Same shape,
+# same runner, same SSH key — only the tag prefix and the systemd unit name
+# changed. Kept SEPARATE from `web-v*` on purpose: restarting the gateway
+# briefly drops in-flight APNs deliveries (Apple's retry window covers it),
+# so a static-website copy must never bounce it — only tag `gateway-v*` when
+# `src/gateway/**` (or anything the gateway service imports) actually changed.
+#
+# HEALTH-GATED: after the restart it polls `GET /healthz`; any 200 means "up",
+# a connection failure after ~30s of retries FAILS the workflow red so a bad
+# deploy is caught immediately instead of leaving the gateway silently down
+# (which would break ALL push notifications across every box — silent
+# outage).
+#
+# RUNNER + AUTH: self-hosted bui-dev-runner (this dev box), SSH to prod via
+#   ~/.manta-deploy/prod_key. No GitHub secret needed (public half is already
+#   in the prod box's authorized_keys).
+#
+# TRIGGER: push a tag matching gateway-v* (e.g. gateway-v1). Also
+#   workflow_dispatch (deploys current main).
+
+name: Gateway deploy
+
+on:
+  push:
+    tags:
+      - "gateway-v*"
+  workflow_dispatch:
+
+concurrency:
+  group: gateway-deploy
+  cancel-in-progress: false
+
+env:
+  PROD_HOST: root@91.107.196.2
+  SSH_KEY: /home/dev/.manta-deploy/prod_key
+  GATEWAY_URL: https://gateway.mantaui.com
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    timeout-minutes: 10
+    steps:
+      - name: Pull + restart the gateway
+        run: |
+          set -euo pipefail
+          SSH="ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+          echo "▸ Pulling /opt/manta to origin/main"
+          $SSH "$PROD_HOST" "git -C /opt/manta fetch origin main -q && git -C /opt/manta reset --hard origin/main -q && git -C /opt/manta log --oneline -1"
+          echo "▸ Restarting manta-gateway"
+          $SSH "$PROD_HOST" "systemctl restart manta-gateway && sleep 2 && systemctl is-active manta-gateway"
+
+      - name: Health-check the gateway
+        run: |
+          set -euo pipefail
+          # /healthz is the no-auth liveness endpoint: 200 {"ok":true} means up.
+          # Connection failure / timeout (000) means the gateway didn't come
+          # back. Poll up to ~30s before failing red.
+          ok=0
+          for i in $(seq 1 15); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+              "$GATEWAY_URL/healthz" || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "✓ gateway responding (HTTP $code) after ${i} attempt(s)"
+              ok=1
+              break
+            fi
+            echo "… gateway not up yet (HTTP $code, attempt $i), retrying"
+            sleep 2
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::Gateway did not respond 200 on /healthz after restart — it may be down."
+            exit 1
+          fi
+          echo "Gateway deployed + healthy."


### PR DESCRIPTION
# BET-206: gateway deploy workflow + prod ops runbook

Closes BET-206 (stage 8 of BET-198/"drop the relay"). The ONLY operated
backend left post-BET-198 is the APNs push gateway at
`gateway.mantaui.com`; this PR adds the one-step deploy workflow that
the old `relay-deploy.yml` provided for the relay.

**Base:** `origin/main` @ `43af1da`

## What's in the PR

- **NEW** `.github/workflows/gateway-deploy.yml` — mirrors the old
  `relay-deploy.yml` shape exactly:
  - Self-hosted `bui-dev-runner` (this dev box), SSH to prod with
    `~/.manta-deploy/prod_key` (no GitHub secret).
  - Trigger: `gateway-v*` tag push + `workflow_dispatch` (manual).
  - On prod: `git -C /opt/manta reset --hard origin/main`, then
    `systemctl restart manta-gateway`.
  - Health-poll: `curl https://gateway.mantaui.com/healthz` 200 = "up";
    connection failure after ~30s of retries fails red.
  - `concurrency: gateway-deploy, cancel-in-progress: false` (same as
    website/relay-deploy).

- **NOT TOUCHED:** `.github/workflows/relay-deploy.yml` is already
  deleted (BET-204). `scripts/install.sh`, `src/**`, and other
  workflows are explicitly out of scope (BET-205 / BET-206 split).

## Why SEPARATE from `web-v*`

Same rationale the old `relay-deploy.yml` had. Restarting the gateway
briefly drops in-flight APNs deliveries (Apple's retry window covers
it), so a static-website copy must never bounce it. Tag `gateway-v*`
only when `src/gateway/**` (or anything the gateway service imports)
actually changed.

## Verification results

**Files changed:** `1` file (`.github/workflows/gateway-deploy.yml`,
+87 / -0). Workflow YAML validated with `python3 -c yaml.safe_load(...)`
(no `actionlint` on the runner; the duplication-gate ignores `.yml`,
and `npm test` does not exercise workflow files).

- PR branch (`multica/BET-206-gateway-deploy` @ `6f58433`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `695` pass / `1` fail / `0` skip. Failures: `[scripts/install.test.mjs:429 formatPairingOutput produces a stable human block]` (expects qrcode-terminal block characters; renderer produces none in this env). log sha256: `ff42dc64e3658dc04512ea594887cdcd2b77f6f20e06deb860a6767190898254`
- Base (`main` @ `43af1da`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `695` pass / `1` fail / `0` skip. Failures: `[scripts/install.test.mjs:429 formatPairingOutput produces a stable human block]`. log sha256: `405a928544f42222d2711fe0b43bb92b0e4ff177fdb654efd68db13e4efc87e8`
- **Conclusion:** the 1 test failure is pre-existing on `main` (identical
  on base and PR, byte-equal except for vitest's relative timing log);
  this PR introduces **0 new failures** and resolves **0 failures**.
  Workflow YAML files are not exercised by `npm test`, so the +87/.yml
  diff cannot regress a test.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`,
`/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Self-check (vs. BET-206 acceptance criteria)

| Criterion | Score | Note |
|---|---|---|
| `.github/workflows/gateway-deploy.yml` exists, mirrors `relay-deploy.yml` shape | 10/10 | Same runner, SSH key, deploy mechanism, health-poll pattern. |
| `.github/workflows/relay-deploy.yml` gone | 10/10 | Deleted in BET-204; verified via `git ls-files .github/workflows/` (no `relay-deploy.yml`). |
| PR body contains prod ops runbook (steps 1–7) verbatim | 10/10 | Below. |
| `npm run typecheck && npm test` GREEN | 9/10 | typecheck exit 0; tests 695/696, the 1 fail is pre-existing on `main` (qrcode-terminal block-char assertion). |
| Push `multica/BET-206-*` branch + open PR | 10/10 | This PR. |
| Reassign to `bui-reviewer` | pending | Done after PR opens. |

All 8+. Submitting to reviewer.

## Cross-cutting follow-ups (none required)

This PR is a single workflow file. It does not change IPC, renderer,
main process, preload, server routes, or any other cross-cutting seam.

---

## Prod ops runbook (executed by `@antoinedc`, NOT by this agent)

The human runs these steps over SSH after this PR merges. **Order
matters.** Steps copied verbatim from BET-206 §"Prod ops runbook".

### 1. Prepare gateway config on prod BEFORE deploying

```
mkdir -p /etc/manta-gateway /var/lib/manta-gateway
```

Copy APNs `.p8` + `{teamId, keyId, bundleId}` from the dev box's
`~/.manta/config.json` `apns` block (scp the p8 from `p8Path`) into
`/etc/manta-gateway/apns.json` + `/etc/manta-gateway/apns.p8`. Copy
OVH creds `/etc/caddy/ovh.env` → `/etc/manta-gateway/ovh.env` (both
root-only 0600).

### 2. DNS

Create A record `gateway.mantaui.com → 91.107.196.2` in the OVH zone
(one-time, OVH API or console — same method used for `*.pages`).

### 3. Caddy on prod

Add vhost `gateway.mantaui.com { reverse_proxy 127.0.0.1:20081 }`.
REMOVE the `relay.mantaui.com` vhost block. `systemctl reload caddy`.

### 4. Systemd on prod

Create `/etc/systemd/system/manta-gateway.service`
(`ExecStart=node /opt/manta/src/gateway/index.mjs`,
`EnvironmentFile=/etc/manta-gateway/ovh.env`, `Restart=always`,
`StateDirectory=manta-gateway`). `systemctl enable --now
manta-gateway`. Then `systemctl disable --now manta-relay` and remove
its unit file.

### 5. Dev box

Remove the `apns` block from `~/.manta/config.json`; restart
`manta-server`; verify the startup log shows successful gateway
registration AND `dig +short <box_id>.boxes.mantaui.com` →
`157.90.224.92`; add the Caddy vhost on the dev box for its own
`<box_id>.boxes.mantaui.com` (same block as BET-206 step 4).

### 6. Re-pair devices (human step)

Phone + desktop re-pair via fresh code
(`curl -s http://127.0.0.1:8787/auth/pair` on the box).

### 7. Optionally delete the `relay.mantaui.com` DNS record after a week.

---

After step 4 lands, push `git tag gateway-v1 && git push origin
gateway-v1` to prove the workflow.
