### PR TITLE
refactor(renderer): extract <Switch> helper in ModelsCard.tsx (BET-219)

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -36,6 +36,47 @@ const TIER_CLASS: Record<string, string> = {
   deep: "bg-purple-900/20 text-purple-400",
 };
 
+// iOS-style toggle switch used by the Main + Sub columns. Consolidates the
+// two near-identical checkbox blocks (BET-215 reviewer nit, BET-219 follow-up).
+// The bound state, disabled flag, and an optional aria-label are the only
+// per-call-site differences; rendering is shared.
+interface SwitchProps {
+  checked: boolean;
+  disabled: boolean;
+  onChange: () => void;
+  "aria-label"?: string;
+}
+
+function Switch({ checked, disabled, onChange, "aria-label": ariaLabel }: SwitchProps) {
+  return (
+    <label className="inline-flex items-center cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+        aria-label={ariaLabel}
+        className="peer sr-only"
+      />
+      <span
+        className={`w-[30px] h-[18px] rounded-full border transition-colors relative ${
+          checked
+            ? "bg-accent-soft/40 border-accent"
+            : "bg-bg border-border-strong"
+        }`}
+      >
+        <span
+          className={`absolute top-[2px] w-[12px] h-[12px] rounded-full transition-transform ${
+            checked
+              ? "translate-x-[12px] bg-accent"
+              : "translate-x-[2px] bg-text-faint"
+          }`}
+        />
+      </span>
+    </label>
+  );
+}
+
 export function ModelsCard() {
   const setStoreDefaultModel = useStore((s) => s.setDefaultModel);
   // Saved default echoed in the banner above the search. Mirror the SAVED
@@ -358,56 +399,18 @@ export function ModelsCard() {
                     />
                   </td>
                   <td className="px-3 py-2 align-middle text-center">
-                    <label className="inline-flex items-center cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={isMain}
-                        disabled={isBusy}
-                        onChange={() => void toggleMain(key, isMain)}
-                        className="peer sr-only"
-                      />
-                      <span
-                        className={`w-[30px] h-[18px] rounded-full border transition-colors relative ${
-                          isMain
-                            ? "bg-accent-soft/40 border-accent"
-                            : "bg-bg border-border-strong"
-                        }`}
-                      >
-                        <span
-                          className={`absolute top-[2px] w-[12px] h-[12px] rounded-full transition-transform ${
-                            isMain
-                              ? "translate-x-[12px] bg-accent"
-                              : "translate-x-[2px] bg-text-faint"
-                          }`}
-                        />
-                      </span>
-                    </label>
+                    <Switch
+                      checked={isMain}
+                      disabled={isBusy}
+                      onChange={() => void toggleMain(key, isMain)}
+                    />
                   </td>
                   <td className="px-3 py-2 align-middle text-center">
-                    <label className="inline-flex items-center cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={isSub}
-                        disabled={isBusy}
-                        onChange={() => void toggleSub(key, isSub)}
-                        className="peer sr-only"
-                      />
-                      <span
-                        className={`w-[30px] h-[18px] rounded-full border transition-colors relative ${
-                          isSub
-                            ? "bg-accent-soft/40 border-accent"
-                            : "bg-bg border-border-strong"
-                        }`}
-                      >
-                        <span
-                          className={`absolute top-[2px] w-[12px] h-[12px] rounded-full transition-transform ${
-                            isSub
-                              ? "translate-x-[12px] bg-accent"
-                              : "translate-x-[2px] bg-text-faint"
-                          }`}
-                        />
-                      </span>
-                    </label>
+                    <Switch
+                      checked={isSub}
+                      disabled={isBusy}
+                      onChange={() => void toggleSub(key, isSub)}
+                    />
                   </td>
                 </tr>
               );


### PR DESCRIPTION
Consolidates the two near-identical `<input type="checkbox">` switch blocks in the Main + Sub columns into a small `<Switch>` helper inside `src/renderer/ModelsCard.tsx`. Removes the copy-paste flagged by the BET-215 reviewer (non-blocking nit).

### Scope (per BET-219)
- Pure refactor; no behavior change.
- Helper defined inside `ModelsCard.tsx` (NOT extracted to its own file).
- NOT generalized to a shared component (`SubagentsCard` is already deleted in BET-215; `ProvidersCard` uses different markup and is out of scope).
- The helper exposes `checked`, `disabled`, `onChange`, and an optional `aria-label` as props (the three the call sites need today plus the one the reviewer noted for completeness).

### Diff
- 1 file, 51 insertions / 48 deletions (`src/renderer/ModelsCard.tsx`).
- Net JSX reduction at the call sites: ~25 lines (matching the issue's estimate).
- Two call sites now pass only `checked`/`disabled`/`onChange`; the helper accepts an optional `aria-label` for future a11y work.

### Verification
- `npm run typecheck`: exit 0, no errors.
- `npm test`: 698 / 698 pass, 0 fail (server suite `src/server/*.test.mjs` is byte-identical — ModelsCard isn't covered by tests; refactor only touches renderer JSX).

### Out of scope (NOT done, per the issue)
- Adding `aria-label` strings at the call sites — that's a behavior change (accessibility improvement) and the issue explicitly says "no behavior change". The prop is plumbed through so a follow-up can add labels without re-touching the markup.
- Generalizing across `ProvidersCard` / a future `SubagentsCard`.

Base: origin/main @ `37658f6`