### PR TITLE
fix(gateway): unblock prod deploy — startup crash + OVH→Cloudflare DNS (BET-222, BET-223)

### DIFF
--- a/src/gateway/dns.mjs
+++ b/src/gateway/dns.mjs
@@ -1,195 +1,171 @@
-// dns.mjs — OVH DNS client for the gateway service.
+// dns.mjs — Cloudflare DNS client for the gateway service.
 //
 // When a box registers with the gateway, the gateway creates an A record
-// `<box_id>.boxes.mantaui.com → <box public IP>` in OVH's DNS zone, so the
-// phone/desktop can connect to the box via `https://<box_id>.boxes.mantaui.com`
-// (Caddy on the box terminates TLS). On re-registration with a changed IP,
-// the same record is updated (PUT by id, no zone search required).
+// `<box_id>.boxes.mantaui.com → <box public IP>` in the `mantaui.com`
+// Cloudflare zone, so the phone/desktop can connect to the box via
+// `https://<box_id>.boxes.mantaui.com` (Caddy on the box terminates TLS via
+// Let's Encrypt HTTP-01). On re-registration with a changed IP the same
+// record is updated (PUT by id — the store keeps the record id, so no zone
+// search is needed).
 //
-// OVH's request-signing formula (per https://eu.api.ovh.com/1.0/):
-//   signature = "$1$" + hex(SHA1(applicationSecret + "+" + consumerKey +
-//                                "+" + method + "+" + url + "+" + body))
-// Headers on every call:
-//   X-Ovh-Application: <applicationKey>
-//   X-Ovh-Consumer:    <consumerKey>
-//   X-Ovh-Timestamp:   <unix-seconds>
-//   X-Ovh-Signature:   <the signature above>
-// The signature covers the FULL url (scheme+host+path+query), the METHOD
-// (uppercase), and the raw BODY (empty string for GET / PUT without body).
+// Cloudflare's API is a plain REST surface authenticated with a single
+// bearer token (no request-signing formula like OVH). The token must have
+// Zone:DNS:Edit on the mantaui.com zone.
+//   POST   /zones/<zone>/dns_records            create
+//   PUT    /zones/<zone>/dns_records/<id>       update target
+//   (no separate "refresh" step — Cloudflare propagates immediately.)
+//
+// Records are created UNPROXIED (`proxied: false`): the phone connects
+// straight to the box's IP and the box's own Caddy terminates TLS, so the
+// record must be a grey-cloud A record, not an orange-cloud proxy.
 //
 // All network I/O goes through an injectable `fetchImpl(url, opts)` so tests
-// never hit OVH. The default uses the global `fetch` (Node 18+ has it
-// built-in). OVH creds come from env: OVH_APP_KEY, OVH_APP_SECRET,
-// OVH_CONSUMER_KEY — loaded by systemd EnvironmentFile=/etc/manta-gateway/ovh.env.
+// never hit Cloudflare. The default uses the global `fetch`. Creds come from
+// env: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID — loaded by systemd
+// EnvironmentFile=/etc/manta-gateway/cloudflare.env.
 
-import { createHash } from "node:crypto";
+export const CF_DEFAULT_ENDPOINT = "https://api.cloudflare.com/client/v4";
+export const DNS_ZONE = "mantaui.com";
+export const DNS_RECORD_TYPE = "A";
+// TTL 60s — records change only when a box's IP changes (rare); a short TTL
+// keeps a moved box reachable quickly. 1 = "automatic" in Cloudflare, but we
+// want a concrete short value for box-IP churn.
+export const DNS_RECORD_TTL = 60;
 
-export const OVH_DEFAULT_ENDPOINT = "https://eu.api.ovh.com/1.0";
-export const OVH_ZONE = "mantaui.com";
-export const OVH_RECORD_FIELD_TYPE = "A";
-export const OVH_RECORD_TTL = 0; // 0 = use zone SOA default (auto)
+// Back-compat alias: index.mjs and store.mjs historically referenced OVH_ZONE.
+// Kept so no other module needs to change its import.
+export const OVH_ZONE = DNS_ZONE;
 
-// Compute the OVH sub-domain for a box_id. OVH wants the relative name
-// (NOT including the zone): `<box_id>.boxes`. Pure helper — also exported
-// so the gateway's /register route can build the sub-domain it passes to
-// createOrUpdate.
-export function ovhSubDomainFor(box_id) {
+// Compute the box's DNS sub-domain for a box_id. Cloudflare wants the FULL
+// record name (including the zone): `<box_id>.boxes.mantaui.com`. Pure helper
+// — also exported so the gateway's /register route can build the name it
+// passes to createOrUpdate. Kept the historical `ovhSubDomainFor` name (as an
+// alias) so index.mjs's re-export keeps working.
+export function dnsRecordName(box_id, zone = DNS_ZONE) {
   if (typeof box_id !== "string" || !box_id) {
-    throw new Error("ovhSubDomainFor: box_id required");
+    throw new Error("dnsRecordName: box_id required");
   }
-  return `${box_id}.boxes`;
+  return `${box_id}.boxes.${zone}`;
+}
+
+// Historical alias — index.mjs imports { ovhSubDomainFor } and re-exports it,
+// and handleRegister calls ovhSubDomainFor(box_id) to build the `subDomain`
+// it hands to createOrUpdate. For Cloudflare the "subDomain" argument IS the
+// full record name, so this returns the full name.
+export function ovhSubDomainFor(box_id) {
+  return dnsRecordName(box_id);
 }
 
 // ---------------------------------------------------------------------------
-// Signature (pure, deterministic, fully testable)
+// Creds
 // ---------------------------------------------------------------------------
 
-// Compute the OVH `$1$<sha1_hex>` signature for one request.
+// Resolve the fields the gateway needs from process.env. Exported so the
+// caller (index.mjs) can fail fast at startup if any are missing. Loaded from
+// /etc/manta-gateway/cloudflare.env by the systemd unit.
 //
-// @param {string} appSecret
-// @param {string} consumerKey
-// @param {string} method      UPPERCASE ("GET", "POST", "PUT", "DELETE")
-// @param {string} url         Full URL (scheme+host+path+query, no fragment)
-// @param {string} body        Raw request body ("" when none — GET, or PUT/POST without a body)
-//
-// Returns the value to put in the `X-Ovh-Signature` header.
-export function ovhSignature({ appSecret, consumerKey, method, url, body }) {
-  if (typeof appSecret !== "string" || !appSecret) {
-    throw new Error("ovhSignature: appSecret required");
+// Returns the same `{ok, ...}` shape the old ovhCredsFromEnv did so index.mjs
+// needs no change. `endpoint` is included for parity + test override.
+export function cloudflareCredsFromEnv(env = process.env) {
+  const apiToken = env.CLOUDFLARE_API_TOKEN;
+  const zoneId = env.CLOUDFLARE_ZONE_ID;
+  const endpoint = env.CLOUDFLARE_ENDPOINT || CF_DEFAULT_ENDPOINT;
+  if (!apiToken || !zoneId) {
+    return {
+      ok: false,
+      error:
+        "Cloudflare creds missing (need CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID; loaded from /etc/manta-gateway/cloudflare.env)",
+    };
   }
-  if (typeof consumerKey !== "string" || !consumerKey) {
-    throw new Error("ovhSignature: consumerKey required");
-  }
-  if (typeof method !== "string" || !method) {
-    throw new Error("ovhSignature: method required");
-  }
-  if (typeof url !== "string" || !url) {
-    throw new Error("ovhSignature: url required");
-  }
-  const b = typeof body === "string" ? body : "";
-  const sha = createHash("sha1")
-    .update(appSecret)
-    .update("+")
-    .update(consumerKey)
-    .update("+")
-    .update(method.toUpperCase())
-    .update("+")
-    .update(url)
-    .update("+")
-    .update(b)
-    .digest("hex");
-  return `$1$${sha}`;
+  return { ok: true, apiToken, zoneId, endpoint };
 }
 
-// Compose the five auth headers for one OVH call. `timestamp` injectable so
-// tests pin the value (the server-side timestamp drifts).
-export function ovhHeaders({ appKey, appSecret, consumerKey, method, url, body, timestamp }) {
-  const ts =
-    typeof timestamp === "number"
-      ? String(Math.floor(timestamp))
-      : String(Math.floor(Date.now() / 1000));
+// Back-compat alias for index.mjs, which imports { ovhCredsFromEnv }.
+export const ovhCredsFromEnv = cloudflareCredsFromEnv;
+
+// Auth headers for one Cloudflare call.
+function cfHeaders(creds) {
   return {
-    "X-Ovh-Application": appKey,
-    "X-Ovh-Consumer": consumerKey,
-    "X-Ovh-Timestamp": ts,
-    "X-Ovh-Signature": ovhSignature({
-      appSecret,
-      consumerKey,
-      method,
-      url,
-      body,
-      timestamp: ts,
-    }),
+    Authorization: `Bearer ${creds.apiToken}`,
     "Content-Type": "application/json",
   };
 }
 
-// Resolve which fields the gateway needs from process.env. Exported so the
-// caller (index.mjs) can fail fast at startup if any are missing. The env
-// vars are loaded from /etc/manta-gateway/ovh.env by the systemd unit.
-export function ovhCredsFromEnv(env = process.env) {
-  const appKey = env.OVH_APP_KEY;
-  const appSecret = env.OVH_APP_SECRET;
-  const consumerKey = env.OVH_CONSUMER_KEY;
-  const endpoint = env.OVH_ENDPOINT || OVH_DEFAULT_ENDPOINT;
-  if (!appKey || !appSecret || !consumerKey) {
-    return {
-      ok: false,
-      error:
-        "OVH creds missing (need OVH_APP_KEY, OVH_APP_SECRET, OVH_CONSUMER_KEY; loaded from /etc/manta-gateway/ovh.env)",
-    };
+// Parse a Cloudflare JSON response body regardless of whether fetchImpl
+// returned a real Response (with .json()) or a test fake (with a `body`
+// field). Real global fetch → await res.json(); test fakes → res.body.
+async function readCfBody(res) {
+  if (res && typeof res.json === "function") {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
   }
-  return { ok: true, appKey, appSecret, consumerKey, endpoint };
+  return res?.body ?? null;
 }
 
 // ---------------------------------------------------------------------------
-// High-level: create / update / refresh
+// Low-level create / update
 // ---------------------------------------------------------------------------
 
-// POST /domain/zone/<zone>/record — create one A record. Returns the OVH
-// record id (number) on success.
+// POST /zones/<zoneId>/dns_records — create one A record. Returns the
+// Cloudflare record id (string) on success.
 //
-// `boxId` is the 32-hex box_id; `subDomain` is the relative name WITHOUT
-// the zone ("<box_id>.boxes"). OVH returns the record id as a JSON
-// number; we forward it verbatim.
+// `subDomain` is the FULL record name (`<box_id>.boxes.mantaui.com`), built
+// by dnsRecordName / ovhSubDomainFor.
 export async function createRecord({
-  boxId,
   subDomain,
   target,
   fetchImpl = globalThis.fetch,
   creds,
-  zone = OVH_ZONE,
-  fieldType = OVH_RECORD_FIELD_TYPE,
-  ttl = OVH_RECORD_TTL,
-  timestamp,
+  recordType = DNS_RECORD_TYPE,
+  ttl = DNS_RECORD_TTL,
 }) {
-  if (typeof boxId !== "string" || !boxId) throw new Error("createRecord: boxId required");
   if (typeof subDomain !== "string" || !subDomain) throw new Error("createRecord: subDomain required");
   if (typeof target !== "string" || !target) throw new Error("createRecord: target required");
   if (!creds) throw new Error("createRecord: creds required");
   if (typeof fetchImpl !== "function") throw new Error("createRecord: fetchImpl required");
 
-  const url = `${creds.endpoint}/domain/zone/${zone}/record`;
-  const body = JSON.stringify({ fieldType, subDomain, target, ttl });
+  const url = `${creds.endpoint}/zones/${creds.zoneId}/dns_records`;
+  const body = JSON.stringify({
+    type: recordType,
+    name: subDomain,
+    content: target,
+    ttl,
+    proxied: false,
+  });
   const res = await fetchImpl(url, {
     method: "POST",
-    headers: ovhHeaders({
-      appKey: creds.appKey,
-      appSecret: creds.appSecret,
-      consumerKey: creds.consumerKey,
-      method: "POST",
-      url,
-      body,
-      timestamp,
-    }),
+    headers: cfHeaders(creds),
     body,
   });
-  if (!res || res.ok !== true) {
+  const parsed = await readCfBody(res);
+  if (!res || res.ok !== true || parsed?.success !== true) {
     const status = res?.status ?? 0;
-    const errBody = res?.body ?? res?.text ?? null;
-    throw new Error(`OVH createRecord failed: status=${status} body=${JSON.stringify(errBody)}`);
+    throw new Error(
+      `Cloudflare createRecord failed: status=${status} errors=${JSON.stringify(parsed?.errors ?? null)}`,
+    );
   }
-  const id = res.body;
-  if (typeof id !== "number" && typeof id !== "string") {
-    throw new Error(`OVH createRecord: unexpected id shape: ${JSON.stringify(id)}`);
+  const id = parsed?.result?.id;
+  if (typeof id !== "string" || !id) {
+    throw new Error(`Cloudflare createRecord: unexpected id shape: ${JSON.stringify(id)}`);
   }
-  return Number(id);
+  return id;
 }
 
-// PUT /domain/zone/<zone>/record/<id> — update the target of an existing
-// record. Returns true on 2xx, throws on failure.
+// PUT /zones/<zoneId>/dns_records/<id> — update an existing record's target.
+// Returns true on success, throws on failure.
 export async function updateRecord({
   recordId,
   subDomain,
   target,
   fetchImpl = globalThis.fetch,
   creds,
-  zone = OVH_ZONE,
-  fieldType = OVH_RECORD_FIELD_TYPE,
-  ttl = OVH_RECORD_TTL,
-  timestamp,
+  recordType = DNS_RECORD_TYPE,
+  ttl = DNS_RECORD_TTL,
 }) {
-  if (typeof recordId !== "number" && typeof recordId !== "string") {
+  if (typeof recordId !== "string" || !recordId) {
     throw new Error("updateRecord: recordId required");
   }
   if (typeof subDomain !== "string" || !subDomain) throw new Error("updateRecord: subDomain required");
@@ -197,59 +173,25 @@ export async function updateRecord({
   if (!creds) throw new Error("updateRecord: creds required");
   if (typeof fetchImpl !== "function") throw new Error("updateRecord: fetchImpl required");
 
-  const id = Number(recordId);
-  const url = `${creds.endpoint}/domain/zone/${zone}/record/${id}`;
-  const body = JSON.stringify({ fieldType, subDomain, target, ttl });
+  const url = `${creds.endpoint}/zones/${creds.zoneId}/dns_records/${recordId}`;
+  const body = JSON.stringify({
+    type: recordType,
+    name: subDomain,
+    content: target,
+    ttl,
+    proxied: false,
+  });
   const res = await fetchImpl(url, {
     method: "PUT",
-    headers: ovhHeaders({
-      appKey: creds.appKey,
-      appSecret: creds.appSecret,
-      consumerKey: creds.consumerKey,
-      method: "PUT",
-      url,
-      body,
-      timestamp,
-    }),
+    headers: cfHeaders(creds),
     body,
   });
-  if (!res || res.ok !== true) {
+  const parsed = await readCfBody(res);
+  if (!res || res.ok !== true || parsed?.success !== true) {
     const status = res?.status ?? 0;
-    const errBody = res?.body ?? res?.text ?? null;
-    throw new Error(`OVH updateRecord failed: status=${status} body=${JSON.stringify(errBody)}`);
-  }
-  return true;
-}
-
-// POST /domain/zone/<zone>/refresh — push the pending changes to OVH's
-// resolvers. Without this, the new/updated A record sits in OVH's queue
-// for ~120s before propagation. We call refresh after every create/update
-// so the box's public hostname resolves within seconds.
-export async function refreshZone({
-  fetchImpl = globalThis.fetch,
-  creds,
-  zone = OVH_ZONE,
-  timestamp,
-}) {
-  if (!creds) throw new Error("refreshZone: creds required");
-  if (typeof fetchImpl !== "function") throw new Error("refreshZone: fetchImpl required");
-  const url = `${creds.endpoint}/domain/zone/${zone}/refresh`;
-  const res = await fetchImpl(url, {
-    method: "POST",
-    headers: ovhHeaders({
-      appKey: creds.appKey,
-      appSecret: creds.appSecret,
-      consumerKey: creds.consumerKey,
-      method: "POST",
-      url,
-      body: "",
-      timestamp,
-    }),
-  });
-  if (!res || res.ok !== true) {
-    const status = res?.status ?? 0;
-    const errBody = res?.body ?? res?.text ?? null;
-    throw new Error(`OVH refreshZone failed: status=${status} body=${JSON.stringify(errBody)}`);
+    throw new Error(
+      `Cloudflare updateRecord failed: status=${status} errors=${JSON.stringify(parsed?.errors ?? null)}`,
+    );
   }
   return true;
 }
@@ -258,13 +200,15 @@ export async function refreshZone({
 // createOrUpdate — single entry point the /register route calls
 // ---------------------------------------------------------------------------
 
-// Idempotent: if the store already has an `ovhRecordId`, PUT a target
-// update; otherwise POST a new record and persist the returned id. Always
-// refreshes the zone after a write.
+// Idempotent: if the store already has a `recordId`, PUT a target update;
+// otherwise POST a new record and return the id to persist. Cloudflare needs
+// no separate zone-refresh step (changes propagate immediately), unlike OVH.
 //
-// Returns { recordId, action: "create" | "update" }.
+// Returns { recordId, action: "create" | "update" }. Signature preserved from
+// the OVH version so index.mjs's call site is unchanged (it passes `boxId`,
+// which is now unused here but accepted).
 export async function createOrUpdate({
-  boxId,
+  boxId, // accepted for call-site compatibility; unused (name is full-qualified)
   subDomain,
   target,
   existingRecordId = null,
@@ -274,28 +218,10 @@ export async function createOrUpdate({
   if (!creds) throw new Error("createOrUpdate: creds required");
   if (typeof fetchImpl !== "function") throw new Error("createOrUpdate: fetchImpl required");
 
-  let recordId;
-  let action;
   if (existingRecordId != null) {
-    await updateRecord({
-      recordId: existingRecordId,
-      subDomain,
-      target,
-      fetchImpl,
-      creds,
-    });
-    recordId = existingRecordId;
-    action = "update";
-  } else {
-    recordId = await createRecord({
-      boxId,
-      subDomain,
-      target,
-      fetchImpl,
-      creds,
-    });
-    action = "create";
+    await updateRecord({ recordId: existingRecordId, subDomain, target, fetchImpl, creds });
+    return { recordId: existingRecordId, action: "update" };
   }
-  await refreshZone({ fetchImpl, creds });
-  return { recordId, action };
+  const recordId = await createRecord({ subDomain, target, fetchImpl, creds });
+  return { recordId, action: "create" };
 }

--- a/src/gateway/dns.test.mjs
+++ b/src/gateway/dns.test.mjs
@@ -1,159 +1,107 @@
-// dns.test.mjs — unit tests for the OVH DNS client (gateway-side).
+// dns.test.mjs — unit tests for the Cloudflare DNS client (gateway-side).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import {
-  ovhSignature,
-  ovhHeaders,
+  cloudflareCredsFromEnv,
   ovhCredsFromEnv,
+  dnsRecordName,
   ovhSubDomainFor,
+  DNS_ZONE,
   OVH_ZONE,
-  OVH_DEFAULT_ENDPOINT,
+  CF_DEFAULT_ENDPOINT,
   createRecord,
   updateRecord,
-  refreshZone,
   createOrUpdate,
 } from "./dns.mjs";
 
 const CREDS = {
-  appKey: "appKeyABC",
-  appSecret: "secretXYZ",
-  consumerKey: "consumer123",
-  endpoint: "https://eu.api.ovh.com/1.0",
+  apiToken: "cf-token-abc",
+  zoneId: "zone123",
+  endpoint: CF_DEFAULT_ENDPOINT,
 };
 
-test("ovhSignature: matches SHA1(secret+consumer+method+url+body) hex + '$1$' prefix", () => {
-  const appSecret = "secretXYZ";
-  const consumerKey = "consumer123";
-  const method = "POST";
-  const url = "https://eu.api.ovh.com/1.0/domain/zone/mantaui.com/record";
-  const body = '{"fieldType":"A","subDomain":"abc","target":"1.2.3.4","ttl":0}';
-  const expectedSha = createHash("sha1")
-    .update(appSecret)
-    .update("+")
-    .update(consumerKey)
-    .update("+")
-    .update(method)
-    .update("+")
-    .update(url)
-    .update("+")
-    .update(body)
-    .digest("hex");
-  assert.equal(
-    ovhSignature({ appSecret, consumerKey, method, url, body }),
-    `$1$${expectedSha}`,
-  );
-});
+// A Cloudflare-shaped fetch fake. `result` is the object the API would put in
+// `.result`; success defaults to true. Records every call.
+function cfFetch({ result = { id: "rec_xyz" }, success = true, status = 200, calls } = {}) {
+  return async (url, init) => {
+    calls?.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => ({ success, result, errors: success ? [] : [{ message: "nope" }] }),
+    };
+  };
+}
 
-test("ovhSignature: empty body uses empty string (not undefined)", () => {
-  const sig = ovhSignature({
-    appSecret: "s",
-    consumerKey: "c",
-    method: "POST",
-    url: "https://example/x",
-    body: "",
-  });
-  // Just verify it produces the prefixed format and a 40-char hex tail.
-  assert.match(sig, /^\$1\$[0-9a-f]{40}$/);
-});
-
-test("ovhSignature: throws when inputs are missing", () => {
-  assert.throws(() => ovhSignature({ consumerKey: "c", method: "POST", url: "u", body: "" }), /appSecret/);
-  assert.throws(() => ovhSignature({ appSecret: "s", method: "POST", url: "u", body: "" }), /consumerKey/);
-  assert.throws(() => ovhSignature({ appSecret: "s", consumerKey: "c", url: "u", body: "" }), /method/);
-  assert.throws(() => ovhSignature({ appSecret: "s", consumerKey: "c", method: "GET", body: "" }), /url/);
-});
-
-test("ovhHeaders: includes all five headers + uses injected timestamp", () => {
-  const h = ovhHeaders({
-    appKey: "k",
-    appSecret: "s",
-    consumerKey: "c",
-    method: "GET",
-    url: "https://example/x",
-    body: "",
-    timestamp: 1700000000,
-  });
-  assert.equal(h["X-Ovh-Application"], "k");
-  assert.equal(h["X-Ovh-Consumer"], "c");
-  assert.equal(h["X-Ovh-Timestamp"], "1700000000");
-  assert.match(h["X-Ovh-Signature"], /^\$1\$[0-9a-f]{40}$/);
-  assert.equal(h["Content-Type"], "application/json");
-});
-
-test("ovhHeaders: timestamp defaults to current unix-seconds", () => {
-  const before = Math.floor(Date.now() / 1000);
-  const h = ovhHeaders({
-    appKey: "k", appSecret: "s", consumerKey: "c", method: "GET", url: "https://x", body: "",
-  });
-  const after = Math.floor(Date.now() / 1000);
-  const ts = Number(h["X-Ovh-Timestamp"]);
-  assert.ok(ts >= before && ts <= after);
-});
-
-test("ovhCredsFromEnv: returns ok=true when all three env vars present", () => {
-  const r = ovhCredsFromEnv({
-    OVH_APP_KEY: "k", OVH_APP_SECRET: "s", OVH_CONSUMER_KEY: "c",
+test("cloudflareCredsFromEnv: ok=true when token + zoneId present", () => {
+  const r = cloudflareCredsFromEnv({
+    CLOUDFLARE_API_TOKEN: "t",
+    CLOUDFLARE_ZONE_ID: "z",
   });
   assert.equal(r.ok, true);
-  assert.equal(r.appKey, "k");
-  assert.equal(r.appSecret, "s");
-  assert.equal(r.consumerKey, "c");
-  assert.equal(r.endpoint, OVH_DEFAULT_ENDPOINT);
+  assert.equal(r.apiToken, "t");
+  assert.equal(r.zoneId, "z");
+  assert.equal(r.endpoint, CF_DEFAULT_ENDPOINT);
 });
 
-test("ovhCredsFromEnv: honors OVH_ENDPOINT override", () => {
-  const r = ovhCredsFromEnv({
-    OVH_APP_KEY: "k", OVH_APP_SECRET: "s", OVH_CONSUMER_KEY: "c",
-    OVH_ENDPOINT: "https://api.ovhcloud.com/1.0",
+test("cloudflareCredsFromEnv: honors CLOUDFLARE_ENDPOINT override", () => {
+  const r = cloudflareCredsFromEnv({
+    CLOUDFLARE_API_TOKEN: "t",
+    CLOUDFLARE_ZONE_ID: "z",
+    CLOUDFLARE_ENDPOINT: "https://api.cf.test/v4",
   });
-  assert.equal(r.endpoint, "https://api.ovhcloud.com/1.0");
+  assert.equal(r.endpoint, "https://api.cf.test/v4");
 });
 
-test("ovhCredsFromEnv: ok=false when any are missing", () => {
-  const a = ovhCredsFromEnv({ OVH_APP_KEY: "k" });
-  assert.equal(a.ok, false);
-  const b = ovhCredsFromEnv({});
-  assert.equal(b.ok, false);
+test("cloudflareCredsFromEnv: ok=false when any are missing", () => {
+  assert.equal(cloudflareCredsFromEnv({ CLOUDFLARE_API_TOKEN: "t" }).ok, false);
+  assert.equal(cloudflareCredsFromEnv({ CLOUDFLARE_ZONE_ID: "z" }).ok, false);
+  assert.equal(cloudflareCredsFromEnv({}).ok, false);
 });
 
-test("ovhSubDomainFor: <box_id>.boxes", () => {
+test("ovhCredsFromEnv is an alias of cloudflareCredsFromEnv (back-compat)", () => {
+  assert.equal(ovhCredsFromEnv, cloudflareCredsFromEnv);
+});
+
+test("OVH_ZONE alias equals DNS_ZONE (mantaui.com)", () => {
+  assert.equal(DNS_ZONE, "mantaui.com");
+  assert.equal(OVH_ZONE, DNS_ZONE);
+});
+
+test("dnsRecordName / ovhSubDomainFor: <box_id>.boxes.mantaui.com (full name)", () => {
   const bid = "0".repeat(32);
-  assert.equal(ovhSubDomainFor(bid), `${bid}.boxes`);
-  assert.throws(() => ovhSubDomainFor(""), /box_id/);
+  assert.equal(dnsRecordName(bid), `${bid}.boxes.mantaui.com`);
+  assert.equal(ovhSubDomainFor(bid), `${bid}.boxes.mantaui.com`);
+  assert.throws(() => dnsRecordName(""), /box_id/);
 });
 
-test("createRecord: POSTs to /domain/zone/<zone>/record with body + returns numeric id", async () => {
+test("createRecord: POSTs to /zones/<id>/dns_records unproxied + returns string id", async () => {
   const calls = [];
-  const fetchImpl = async (url, init) => {
-    calls.push({ url, init });
-    return { ok: true, status: 200, body: 12345 };
-  };
+  const fetchImpl = cfFetch({ result: { id: "rec_777" }, calls });
   const id = await createRecord({
-    boxId: "0".repeat(32),
-    subDomain: "0".repeat(32) + ".boxes",
+    subDomain: "0".repeat(32) + ".boxes.mantaui.com",
     target: "1.2.3.4",
     fetchImpl,
     creds: CREDS,
-    timestamp: 1700000000,
   });
-  assert.equal(id, 12345);
+  assert.equal(id, "rec_777");
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/record`);
+  assert.equal(calls[0].url, `${CREDS.endpoint}/zones/${CREDS.zoneId}/dns_records`);
   assert.equal(calls[0].init.method, "POST");
-  assert.match(calls[0].init.body, /"fieldType":"A"/);
-  assert.match(calls[0].init.body, /"subDomain":"0{32}\.boxes"/);
-  assert.match(calls[0].init.body, /"target":"1\.2\.3\.4"/);
-  assert.equal(calls[0].init.headers["X-Ovh-Application"], CREDS.appKey);
+  assert.equal(calls[0].init.headers.Authorization, `Bearer ${CREDS.apiToken}`);
+  const body = JSON.parse(calls[0].init.body);
+  assert.equal(body.type, "A");
+  assert.equal(body.name, "0".repeat(32) + ".boxes.mantaui.com");
+  assert.equal(body.content, "1.2.3.4");
+  assert.equal(body.proxied, false);
 });
 
-test("createRecord: throws on !ok response with status in message", async () => {
-  const fetchImpl = async () => ({ ok: false, status: 403, body: { message: "forbidden" } });
+test("createRecord: throws on success=false with status in message", async () => {
+  const fetchImpl = cfFetch({ success: false, status: 403 });
   await assert.rejects(
     () => createRecord({
-      boxId: "0".repeat(32),
-      subDomain: "0".repeat(32) + ".boxes",
+      subDomain: "0".repeat(32) + ".boxes.mantaui.com",
       target: "1.2.3.4",
       fetchImpl,
       creds: CREDS,
@@ -162,130 +110,94 @@ test("createRecord: throws on !ok response with status in message", async () => 
   );
 });
 
-test("updateRecord: PUTs to /domain/zone/<zone>/record/<id>", async () => {
+test("createRecord: throws when result.id is not a string", async () => {
+  const fetchImpl = cfFetch({ result: { id: 12345 } });
+  await assert.rejects(
+    () => createRecord({
+      subDomain: "x.boxes.mantaui.com",
+      target: "1.2.3.4",
+      fetchImpl,
+      creds: CREDS,
+    }),
+    /unexpected id shape/,
+  );
+});
+
+test("updateRecord: PUTs to /zones/<id>/dns_records/<recordId>", async () => {
   const calls = [];
-  const fetchImpl = async (url, init) => {
-    calls.push({ url, init });
-    return { ok: true, status: 200, body: null };
-  };
+  const fetchImpl = cfFetch({ result: { id: "rec_777" }, calls });
   const r = await updateRecord({
-    recordId: 12345,
-    subDomain: "0".repeat(32) + ".boxes",
+    recordId: "rec_777",
+    subDomain: "0".repeat(32) + ".boxes.mantaui.com",
     target: "5.6.7.8",
     fetchImpl,
     creds: CREDS,
-    timestamp: 1700000000,
   });
   assert.equal(r, true);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].init.method, "PUT");
-  assert.equal(calls[0].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/record/12345`);
-  assert.match(calls[0].init.body, /"target":"5\.6\.7\.8"/);
+  assert.equal(calls[0].url, `${CREDS.endpoint}/zones/${CREDS.zoneId}/dns_records/rec_777`);
+  assert.equal(JSON.parse(calls[0].init.body).content, "5.6.7.8");
 });
 
-test("refreshZone: POSTs to /domain/zone/<zone>/refresh with empty body", async () => {
-  const calls = [];
-  const fetchImpl = async (url, init) => {
-    calls.push({ url, init });
-    return { ok: true, status: 200, body: null };
-  };
-  await refreshZone({ fetchImpl, creds: CREDS, timestamp: 1700000000 });
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/refresh`);
-  assert.equal(calls[0].init.method, "POST");
-  // body is empty (undefined on the request, but the signature was built with "")
-  assert.ok(!calls[0].init.body);
+test("updateRecord: requires a string recordId", async () => {
+  await assert.rejects(
+    () => updateRecord({
+      recordId: 123,
+      subDomain: "x.boxes.mantaui.com",
+      target: "5.6.7.8",
+      fetchImpl: cfFetch(),
+      creds: CREDS,
+    }),
+    /recordId required/,
+  );
 });
 
-test("createOrUpdate: existing recordId → PUT then refresh", async () => {
+test("createOrUpdate: no existing recordId → POST, action=create", async () => {
   const calls = [];
-  const fetchImpl = async (url, init) => {
-    calls.push({ url, init });
-    return { ok: true, status: 200, body: url.includes("refresh") ? null : 99 };
-  };
+  const fetchImpl = cfFetch({ result: { id: "rec_new" }, calls });
   const r = await createOrUpdate({
     boxId: "0".repeat(32),
-    subDomain: "0".repeat(32) + ".boxes",
-    target: "9.9.9.9",
-    existingRecordId: 99,
-    fetchImpl,
-    creds: CREDS,
-  });
-  assert.equal(r.recordId, 99);
-  assert.equal(r.action, "update");
-  // PUT then refresh
-  assert.equal(calls[0].init.method, "PUT");
-  assert.equal(calls[1].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/refresh`);
-});
-
-test("createOrUpdate: no existing recordId → POST then refresh", async () => {
-  const calls = [];
-  const fetchImpl = async (url, init) => {
-    calls.push({ url, init });
-    return { ok: true, status: 200, body: url.includes("refresh") ? null : 7777 };
-  };
-  const r = await createOrUpdate({
-    boxId: "0".repeat(32),
-    subDomain: "0".repeat(32) + ".boxes",
+    subDomain: "0".repeat(32) + ".boxes.mantaui.com",
     target: "9.9.9.9",
     fetchImpl,
     creds: CREDS,
   });
-  assert.equal(r.recordId, 7777);
+  assert.equal(r.recordId, "rec_new");
   assert.equal(r.action, "create");
+  assert.equal(calls.length, 1);
   assert.equal(calls[0].init.method, "POST");
-  assert.equal(calls[1].url, `${CREDS.endpoint}/domain/zone/${OVH_ZONE}/refresh`);
 });
 
-test("createOrUpdate: refresh is called AFTER both create and update", async () => {
-  // Already covered by the two above, but make the invariant explicit.
-  const order = [];
-  const fetchImpl = async (url, init) => {
-    order.push(`${init.method} ${url}`);
-    return { ok: true, status: 200, body: url.includes("refresh") ? null : 1 };
-  };
+test("createOrUpdate: existing recordId → PUT, action=update, no create call", async () => {
+  const calls = [];
+  const fetchImpl = cfFetch({ result: { id: "rec_existing" }, calls });
+  const r = await createOrUpdate({
+    boxId: "0".repeat(32),
+    subDomain: "0".repeat(32) + ".boxes.mantaui.com",
+    target: "9.9.9.9",
+    existingRecordId: "rec_existing",
+    fetchImpl,
+    creds: CREDS,
+  });
+  assert.equal(r.recordId, "rec_existing");
+  assert.equal(r.action, "update");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.method, "PUT");
+  assert.equal(calls[0].url, `${CREDS.endpoint}/zones/${CREDS.zoneId}/dns_records/rec_existing`);
+});
+
+test("createOrUpdate: no Cloudflare refresh step (single call per op)", async () => {
+  // OVH needed a POST /refresh after every write; Cloudflare does not. Assert
+  // exactly ONE network call happens per createOrUpdate (regression guard).
+  const calls = [];
+  const fetchImpl = cfFetch({ result: { id: "rec_1" }, calls });
   await createOrUpdate({
     boxId: "0".repeat(32),
-    subDomain: "0".repeat(32) + ".boxes",
+    subDomain: "x.boxes.mantaui.com",
     target: "1.1.1.1",
     fetchImpl,
     creds: CREDS,
   });
-  await createOrUpdate({
-    boxId: "0".repeat(32),
-    subDomain: "0".repeat(32) + ".boxes",
-    target: "1.1.1.1",
-    existingRecordId: 1,
-    fetchImpl,
-    creds: CREDS,
-  });
-  assert.equal(order.length, 4);
-  assert.match(order[0], /^POST.*\/record$/);
-  assert.match(order[1], /^POST.*\/refresh$/);
-  assert.match(order[2], /^PUT.*\/record\/1$/);
-  assert.match(order[3], /^POST.*\/refresh$/);
-});
-
-test("ovhHeaders: signature computed against the EXACT URL passed in (no normalization)", () => {
-  // We MUST pass the URL verbatim because the OVH server hashes the same
-  // string. Pin the signature value so a refactor that adds e.g. a trailing
-  // slash fails the test.
-  const h = ovhHeaders({
-    appKey: "AK",
-    appSecret: "AS",
-    consumerKey: "CK",
-    method: "POST",
-    url: "https://eu.api.ovh.com/1.0/domain/zone/mantaui.com/record",
-    body: '{"x":1}',
-    timestamp: 1700000000,
-  });
-  const expected = ovhSignature({
-    appSecret: "AS",
-    consumerKey: "CK",
-    method: "POST",
-    url: "https://eu.api.ovh.com/1.0/domain/zone/mantaui.com/record",
-    body: '{"x":1}',
-    timestamp: 1700000000,
-  });
-  assert.equal(h["X-Ovh-Signature"], expected);
+  assert.equal(calls.length, 1);
 });

--- a/src/gateway/index.mjs
+++ b/src/gateway/index.mjs
@@ -7,15 +7,16 @@
 //
 //   GET  /healthz       — 200 {"ok":true}, no auth (deploy probe)
 //   POST /register      — mint or refresh a box's gateway_token; create /
-//                          update the OVH DNS A record for <box_id>.boxes
-//                          .mantaui.com. Rate-limited per source IP.
+//                          update the Cloudflare DNS A record for
+//                          <box_id>.boxes.mantaui.com. Rate-limited per
+//                          source IP.
 //   POST /push          — fan out a notification to the box's registered
 //                          APNs device tokens. Returns per-token results
 //                          so the box can prune its own token store.
 //
 // Pure + injected I/O: every dependency (loadStore / saveStore / fetchImpl /
 // createOrUpdate / sendApns / now) is parameterizable for tests; production
-// uses real FS + global fetch + real OVH + real APNs.
+// uses real FS + global fetch + real Cloudflare DNS + real APNs.
 //
 // Source IP: NEVER trust an `ip` field in the body (spoofable). Read
 // `X-Forwarded-For` first value (Caddy fronts the gateway), fall back to
@@ -31,7 +32,7 @@ import {
   makeEntry,
   hostFor,
 } from "./store.mjs";
-import { createOrUpdate, ovhCredsFromEnv, ovhSubDomainFor } from "./dns.mjs";
+import { createOrUpdate, cloudflareCredsFromEnv, ovhSubDomainFor } from "./dns.mjs";
 import { sendApns, loadApnsConfig } from "./apns.mjs";
 
 // 10 registrations per source IP per hour. Same shape as the relay's pair
@@ -141,10 +142,10 @@ export function generateGatewayToken() {
   return randomBytes(16).toString("hex");
 }
 
-// Compute the OVH sub-domain for a box_id. Re-exported from dns.mjs for
-// callers that want both the OVH primitive and the route helper in one
-// place. (The OVH-side helper that builds the actual record lives in
-// dns.mjs; this re-export just keeps the route's call site tidy.)
+// Compute the DNS record name for a box_id. Re-exported from dns.mjs so the
+// /register route can build the record name it hands to createOrUpdate.
+// (Historical name `ovhSubDomainFor` — kept as an alias through the OVH→
+// Cloudflare migration; it now returns the FULL record name.)
 export { ovhSubDomainFor };
 
 // ---------------------------------------------------------------------------
@@ -181,14 +182,14 @@ export async function handleRegister({
     if (!presented || !tokenEquals(existing.gateway_token, presented)) {
       return { status: 401, json: { error: "unauthorized" } };
     }
-    let updatedRecordId = existing.ovhRecordId;
+    let updatedRecordId = existing.recordId;
     if (existing.ip !== ip) {
       try {
         const r = await createDnsRecord({
           boxId: box_id,
           subDomain: ovhSubDomainFor(box_id),
           target: ip,
-          existingRecordId: existing.ovhRecordId,
+          existingRecordId: existing.recordId,
         });
         updatedRecordId = r.recordId;
       } catch (e) {
@@ -202,7 +203,7 @@ export async function handleRegister({
       ...existing,
       ip,
       updatedAt: now(),
-      ovhRecordId: updatedRecordId,
+      recordId: updatedRecordId,
     };
     store[box_id] = next;
     await persist(store);
@@ -224,7 +225,7 @@ export async function handleRegister({
   }
   const gateway_token = generateGatewayToken();
   const host = hostFor(box_id);
-  const entry = makeEntry({ box_id, gateway_token, ip, host, ovhRecordId: recordId, now });
+  const entry = makeEntry({ box_id, gateway_token, ip, host, recordId, now });
   store[box_id] = entry;
   await persist(store);
   return { status: 200, json: { host, gateway_token } };
@@ -438,7 +439,7 @@ const isMain =
   process.argv[1]?.endsWith("src/gateway/index.mjs");
 
 if (isMain) {
-  const creds = ovhCredsFromEnv();
+  const creds = cloudflareCredsFromEnv();
   if (!creds.ok) {
     console.error(`[gateway] ${creds.error}`);
     process.exit(1);
@@ -448,7 +449,7 @@ if (isMain) {
     console.warn("[gateway] apns config missing — /push will return 503");
   }
   const svc = createGatewayServer({
-    dnsCreds: { appKey: creds.appKey, appSecret: creds.appSecret, consumerKey: creds.consumerKey, endpoint: creds.endpoint },
+    dnsCreds: { apiToken: creds.apiToken, zoneId: creds.zoneId, endpoint: creds.endpoint },
     apnsConfig: apns,
   });
   svc

--- a/src/gateway/index.mjs
+++ b/src/gateway/index.mjs
@@ -32,7 +32,7 @@ import {
   hostFor,
 } from "./store.mjs";
 import { createOrUpdate, ovhCredsFromEnv, ovhSubDomainFor } from "./dns.mjs";
-import { sendApns } from "./apns.mjs";
+import { sendApns, loadApnsConfig } from "./apns.mjs";
 
 // 10 registrations per source IP per hour. Same shape as the relay's pair
 // rate limiter (src/relay/server.mjs). The window is one hour, the cap is

--- a/src/gateway/push.test.mjs
+++ b/src/gateway/push.test.mjs
@@ -25,7 +25,7 @@ const ENTRY = {
   host: `${VALID_BOX_ID}.boxes.mantaui.com`,
   registeredAt: 1,
   updatedAt: 1,
-  ovhRecordId: 12345,
+  recordId: 12345,
 };
 
 // Each test that exercises the APNs sender path needs a real .p8 file

--- a/src/gateway/push.test.mjs
+++ b/src/gateway/push.test.mjs
@@ -54,6 +54,24 @@ function makeStore(entry = ENTRY) {
   return { [VALID_BOX_ID]: entry };
 }
 
+// Invoke handlePush with the common defaults (seeded store, a no-op fetch,
+// and the good bearer). `body` fields merge onto a valid baseline; `store`,
+// `apnsConfig`, and `fetchImpl` are overridable per test.
+function callPush({ body = {}, store = makeStore(), apnsConfig = null, fetchImpl } = {}) {
+  return handlePush({
+    body: {
+      box_id: VALID_BOX_ID,
+      tokens: [makeHexToken("a")],
+      payload: { title: "T", body: "B" },
+      __bearer: makeToken("good"),
+      ...body,
+    },
+    store,
+    apnsConfig,
+    fetchImpl: fetchImpl ?? (async () => ({ status: 200, body: null })),
+  });
+}
+
 test("isHexToken: accepts hex strings (1–128 chars)", () => {
   assert.equal(isHexToken(makeHexToken("a")), true);
   assert.equal(isHexToken("ABCDEF"), true);
@@ -88,86 +106,40 @@ test("handlePush: 401 when token does not match stored value", async () => {
 });
 
 test("handlePush: 401 when box_id is not in store", async () => {
-  const r = await handlePush({
-    body: {
-      box_id: "0".repeat(32),
-      tokens: [makeHexToken("a")],
-      payload: { title: "T", body: "B" },
-      __bearer: makeToken("good"),
-    },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ body: { box_id: "0".repeat(32) } });
   assert.equal(r.status, 401);
 });
 
 test("handlePush: 400 when box_id is malformed", async () => {
-  const r = await handlePush({
-    body: { box_id: "XYZ", tokens: [], payload: {}, __bearer: makeToken("good") },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ body: { box_id: "XYZ", tokens: [], payload: {} } });
   assert.equal(r.status, 400);
 });
 
 test("handlePush: 400 when tokens is not an array", async () => {
-  const r = await handlePush({
-    body: { box_id: VALID_BOX_ID, tokens: "not-an-array", payload: {}, __bearer: makeToken("good") },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ body: { tokens: "not-an-array", payload: {} } });
   assert.equal(r.status, 400);
 });
 
 test("handlePush: 400 when tokens exceeds 20", async () => {
   const tokens = Array.from({ length: 21 }, (_, i) => makeHexToken(i.toString()));
-  const r = await handlePush({
-    body: { box_id: VALID_BOX_ID, tokens, payload: {}, __bearer: makeToken("good") },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ body: { tokens, payload: {} } });
   assert.equal(r.status, 400);
   assert.match(r.json.error, /too_many_tokens/);
 });
 
 test("handlePush: 400 when any token is not hex", async () => {
-  const tokens = [makeHexToken("a"), "NOT-HEX!"];
-  const r = await handlePush({
-    body: { box_id: VALID_BOX_ID, tokens, payload: {}, __bearer: makeToken("good") },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ body: { tokens: [makeHexToken("a"), "NOT-HEX!"], payload: {} } });
   assert.equal(r.status, 400);
   assert.equal(r.json.error, "invalid_token");
 });
 
 test("handlePush: 400 when payload is missing", async () => {
-  const r = await handlePush({
-    body: { box_id: VALID_BOX_ID, tokens: [makeHexToken("a")], __bearer: makeToken("good") },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ body: { tokens: [makeHexToken("a")], payload: undefined } });
   assert.equal(r.status, 400);
 });
 
 test("handlePush: 503 when apnsConfig is null (gateway not yet configured)", async () => {
-  const r = await handlePush({
-    body: {
-      box_id: VALID_BOX_ID,
-      tokens: [makeHexToken("a")],
-      payload: { title: "T", body: "B" },
-      __bearer: makeToken("good"),
-    },
-    store: makeStore(),
-    apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
-  });
+  const r = await callPush({ apnsConfig: null });
   assert.equal(r.status, 503);
   assert.equal(r.json.error, "apns_disabled");
 });
@@ -212,68 +184,28 @@ test("handlePush: returns per-token results in input order with ok+prune shape",
   }
 });
 
-test("handlePush: prune=true is returned for 410 Gone", async () => {
-  const { cfg, cleanup } = await makeApnsCfg();
-  try {
-    const r = await handlePush({
-      body: {
-        box_id: VALID_BOX_ID,
-        tokens: [makeHexToken("a")],
-        payload: { title: "T", body: "B" },
-        __bearer: makeToken("good"),
-      },
-      store: makeStore(),
-      apnsConfig: cfg,
-      fetchImpl: async () => ({ status: 410, body: { reason: "Unregistered" } }),
-    });
-    assert.equal(r.status, 200);
-    assert.equal(r.json.results[0].prune, true);
-  } finally {
-    await cleanup();
-  }
-});
-
-test("handlePush: prune=true is returned for 400 BadDeviceToken", async () => {
-  const { cfg, cleanup } = await makeApnsCfg();
-  try {
-    const r = await handlePush({
-      body: {
-        box_id: VALID_BOX_ID,
-        tokens: [makeHexToken("a")],
-        payload: { title: "T", body: "B" },
-        __bearer: makeToken("good"),
-      },
-      store: makeStore(),
-      apnsConfig: cfg,
-      fetchImpl: async () => ({ status: 400, body: { reason: "BadDeviceToken" } }),
-    });
-    assert.equal(r.status, 200);
-    assert.equal(r.json.results[0].prune, true);
-  } finally {
-    await cleanup();
-  }
-});
-
-test("handlePush: prune=true is returned for 400 Unregistered", async () => {
-  const { cfg, cleanup } = await makeApnsCfg();
-  try {
-    const r = await handlePush({
-      body: {
-        box_id: VALID_BOX_ID,
-        tokens: [makeHexToken("a")],
-        payload: { title: "T", body: "B" },
-        __bearer: makeToken("good"),
-      },
-      store: makeStore(),
-      apnsConfig: cfg,
-      fetchImpl: async () => ({ status: 400, body: { reason: "Unregistered" } }),
-    });
-    assert.equal(r.status, 200);
-    assert.equal(r.json.results[0].prune, true);
-  } finally {
-    await cleanup();
-  }
-});
+// Every APNs rejection that means "this device token is dead" must surface
+// prune=true so the box drops it. Table-driven over the (status, reason)
+// pairs the classification treats as prunable.
+for (const { label, status, reason } of [
+  { label: "410 Gone", status: 410, reason: "Unregistered" },
+  { label: "400 BadDeviceToken", status: 400, reason: "BadDeviceToken" },
+  { label: "400 Unregistered", status: 400, reason: "Unregistered" },
+]) {
+  test(`handlePush: prune=true is returned for ${label}`, async () => {
+    const { cfg, cleanup } = await makeApnsCfg();
+    try {
+      const r = await callPush({
+        apnsConfig: cfg,
+        fetchImpl: async () => ({ status, body: { reason } }),
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.json.results[0].prune, true);
+    } finally {
+      await cleanup();
+    }
+  });
+}
 
 test("handlePush: a throwing sender → ok:false, prune:false (call continues for siblings)", async () => {
   const { cfg, cleanup } = await makeApnsCfg();

--- a/src/gateway/register.test.mjs
+++ b/src/gateway/register.test.mjs
@@ -172,7 +172,7 @@ test("handleRegister: first call mints a 32-hex token, creates DNS, persists", a
   assert.ok(persisted);
   assert.equal(persisted.gateway_token, r.json.gateway_token);
   assert.equal(persisted.ip, "1.2.3.4");
-  assert.equal(persisted.ovhRecordId, 100); // calls.length * 100
+  assert.equal(persisted.recordId, 100); // calls.length * 100
 });
 
 test("handleRegister: re-register with wrong token → 401 (no DNS update)", async () => {
@@ -185,7 +185,7 @@ test("handleRegister: re-register with wrong token → 401 (no DNS update)", asy
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 12345,
+      recordId: 12345,
     },
   });
   const r = await handleRegister({
@@ -209,7 +209,7 @@ test("handleRegister: re-register with correct token + same IP → 200 host only
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 12345,
+      recordId: 12345,
     },
   });
   const r = await handleRegister({
@@ -235,7 +235,7 @@ test("handleRegister: re-register with correct token + changed IP → updates DN
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 12345,
+      recordId: 12345,
     },
   });
   const r = await handleRegister({
@@ -295,7 +295,7 @@ test("handleRegister: DNS update failure on re-register → 200 with existing ho
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 12345,
+      recordId: 12345,
     },
   });
   const r = await handleRegister({
@@ -310,6 +310,7 @@ test("handleRegister: DNS update failure on re-register → 200 with existing ho
   assert.equal(r.json.host, `${VALID_BOX_ID}.boxes.mantaui.com`);
 });
 
-test("ovhSubDomainFor: <box_id>.boxes", () => {
-  assert.equal(ovhSubDomainFor(VALID_BOX_ID), `${VALID_BOX_ID}.boxes`);
+test("ovhSubDomainFor: full record name <box_id>.boxes.mantaui.com", () => {
+  // Cloudflare wants the FULL record name (not the OVH-style relative name).
+  assert.equal(ovhSubDomainFor(VALID_BOX_ID), `${VALID_BOX_ID}.boxes.mantaui.com`);
 });

--- a/src/gateway/register.test.mjs
+++ b/src/gateway/register.test.mjs
@@ -54,6 +54,38 @@ function makeStore(initial = {}) {
   };
 }
 
+// A store pre-seeded with the standard VALID_BOX_ID entry (token seed "good",
+// IP 1.2.3.4, recordId 12345). Overrides merge onto the seeded entry.
+function seededStore(entryOverrides = {}) {
+  return makeStore({
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("good"),
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      recordId: 12345,
+      ...entryOverrides,
+    },
+  });
+}
+
+// Invoke handleRegister with the common wiring (store, its persist, an
+// always-allow rate limiter, and the fake DNS createOrUpdate). `body`, `ip`,
+// and any explicit `overrides` (e.g. a rejecting rateLimiter or a failing
+// createDnsRecord) are caller-supplied.
+function callRegister({ store, dns, body, ip, ...overrides }) {
+  return handleRegister({
+    body,
+    ip,
+    store: store.store,
+    persist: store.persist,
+    rateLimiter: () => true,
+    createDnsRecord: dns.createOrUpdate,
+    ...overrides,
+  });
+}
+
 test("isValidGatewayToken: 32 lowercase hex only", () => {
   assert.equal(isValidGatewayToken(makeToken("a")), true);
   assert.equal(isValidGatewayToken("UPPER".padEnd(32, "X")), false);
@@ -137,14 +169,7 @@ test("handleRegister: rejects invalid box_id (XYZ, 0xabc, wrong length, uppercas
   const store = makeStore();
   const dns = makeFakeDns();
   for (const bad of ["XYZ", "0xabcdef", VALID_BOX_ID.slice(0, 31), VALID_BOX_ID.toUpperCase()]) {
-    const r = await handleRegister({
-      body: { box_id: bad },
-      ip: "1.2.3.4",
-      store: store.store,
-      persist: store.persist,
-      rateLimiter: () => true,
-      createDnsRecord: dns.createOrUpdate,
-    });
+    const r = await callRegister({ store, dns, body: { box_id: bad }, ip: "1.2.3.4" });
     assert.equal(r.status, 400, `bad box_id "${bad}" must be rejected`);
   }
 });
@@ -152,13 +177,10 @@ test("handleRegister: rejects invalid box_id (XYZ, 0xabc, wrong length, uppercas
 test("handleRegister: first call mints a 32-hex token, creates DNS, persists", async () => {
   const store = makeStore();
   const dns = makeFakeDns();
-  const r = await handleRegister({
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID },
     ip: "1.2.3.4",
-    store: store.store,
-    persist: store.persist,
-    rateLimiter: () => true,
-    createDnsRecord: dns.createOrUpdate,
   });
   assert.equal(r.status, 200);
   assert.match(r.json.host, /^abcdef.*\.boxes\.mantaui\.com$/);
@@ -177,24 +199,11 @@ test("handleRegister: first call mints a 32-hex token, creates DNS, persists", a
 
 test("handleRegister: re-register with wrong token → 401 (no DNS update)", async () => {
   const dns = makeFakeDns();
-  // Pre-seed the store.
-  const store = makeStore({
-    [VALID_BOX_ID]: {
-      gateway_token: makeToken("good"),
-      ip: "1.2.3.4",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 12345,
-    },
-  });
-  const r = await handleRegister({
+  const store = seededStore();
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID, __bearer: makeToken("bad") },
     ip: "1.2.3.4",
-    store: store.store,
-    persist: store.persist,
-    rateLimiter: () => true,
-    createDnsRecord: dns.createOrUpdate,
   });
   assert.equal(r.status, 401);
   assert.equal(dns.calls.length, 0, "DNS must not have been touched");
@@ -202,23 +211,11 @@ test("handleRegister: re-register with wrong token → 401 (no DNS update)", asy
 
 test("handleRegister: re-register with correct token + same IP → 200 host only (no DNS)", async () => {
   const dns = makeFakeDns();
-  const store = makeStore({
-    [VALID_BOX_ID]: {
-      gateway_token: makeToken("good"),
-      ip: "1.2.3.4",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 12345,
-    },
-  });
-  const r = await handleRegister({
+  const store = seededStore();
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID, __bearer: makeToken("good") },
     ip: "1.2.3.4",
-    store: store.store,
-    persist: store.persist,
-    rateLimiter: () => true,
-    createDnsRecord: dns.createOrUpdate,
   });
   assert.equal(r.status, 200);
   assert.equal(r.json.host, `${VALID_BOX_ID}.boxes.mantaui.com`);
@@ -228,23 +225,11 @@ test("handleRegister: re-register with correct token + same IP → 200 host only
 
 test("handleRegister: re-register with correct token + changed IP → updates DNS", async () => {
   const dns = makeFakeDns();
-  const store = makeStore({
-    [VALID_BOX_ID]: {
-      gateway_token: makeToken("good"),
-      ip: "1.2.3.4",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 12345,
-    },
-  });
-  const r = await handleRegister({
+  const store = seededStore();
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID, __bearer: makeToken("good") },
     ip: "5.6.7.8",
-    store: store.store,
-    persist: store.persist,
-    rateLimiter: () => true,
-    createDnsRecord: dns.createOrUpdate,
   });
   assert.equal(r.status, 200);
   assert.equal(dns.calls.length, 1);
@@ -257,13 +242,11 @@ test("handleRegister: re-register with correct token + changed IP → updates DN
 test("handleRegister: rate limit 429 takes precedence over validation", async () => {
   const dns = makeFakeDns();
   const store = makeStore();
-  const r = await handleRegister({
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID },
     ip: "1.2.3.4",
-    store: store.store,
-    persist: store.persist,
     rateLimiter: () => false, // always reject
-    createDnsRecord: dns.createOrUpdate,
   });
   assert.equal(r.status, 429);
   assert.equal(dns.calls.length, 0);
@@ -272,14 +255,12 @@ test("handleRegister: rate limit 429 takes precedence over validation", async ()
 
 test("handleRegister: DNS create failure on first registration → 502", async () => {
   const dns = makeFakeDns();
-  const failDns = async () => { throw new Error("OVH boom"); };
+  const failDns = async () => { throw new Error("dns boom"); };
   const store = makeStore();
-  const r = await handleRegister({
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID },
     ip: "1.2.3.4",
-    store: store.store,
-    persist: store.persist,
-    rateLimiter: () => true,
     createDnsRecord: failDns,
   });
   assert.equal(r.status, 502);
@@ -287,23 +268,13 @@ test("handleRegister: DNS create failure on first registration → 502", async (
 });
 
 test("handleRegister: DNS update failure on re-register → 200 with existing host (non-fatal)", async () => {
-  const failDns = async () => { throw new Error("OVH timeout"); };
-  const store = makeStore({
-    [VALID_BOX_ID]: {
-      gateway_token: makeToken("good"),
-      ip: "1.2.3.4",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 12345,
-    },
-  });
-  const r = await handleRegister({
+  const dns = makeFakeDns();
+  const failDns = async () => { throw new Error("dns timeout"); };
+  const store = seededStore();
+  const r = await callRegister({
+    store, dns,
     body: { box_id: VALID_BOX_ID, __bearer: makeToken("good") },
     ip: "5.6.7.8",
-    store: store.store,
-    persist: store.persist,
-    rateLimiter: () => true,
     createDnsRecord: failDns,
   });
   assert.equal(r.status, 200);

--- a/src/gateway/server.test.mjs
+++ b/src/gateway/server.test.mjs
@@ -163,7 +163,7 @@ test("POST /register (re-register) with valid bearer + same IP → 200 host, no 
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 1234,
+      recordId: 1234,
     },
   };
   await withServer({ store }, async ({ port, dnsCalls }) => {
@@ -188,7 +188,7 @@ test("POST /register (re-register) with valid bearer + changed IP → DNS update
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 1234,
+      recordId: 1234,
     },
   };
   await withServer({ store }, async (ctx) => {
@@ -215,7 +215,7 @@ test("POST /register with wrong bearer → 401", async () => {
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 1,
+      recordId: 1,
     },
   };
   await withServer({ store }, async ({ port, dnsCalls }) => {
@@ -282,7 +282,7 @@ test("POST /push auth + tokens → 200 {results:[{token, ok, prune}]}", async ()
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 1,
+      recordId: 1,
     },
   };
   await withServer(
@@ -324,7 +324,7 @@ test("POST /push with >20 tokens → 400 too_many_tokens", async () => {
       host: `${VALID_BOX_ID}.boxes.mantaui.com`,
       registeredAt: 1,
       updatedAt: 1,
-      ovhRecordId: 1,
+      recordId: 1,
     },
   };
   await withServer(

--- a/src/gateway/server.test.mjs
+++ b/src/gateway/server.test.mjs
@@ -62,16 +62,22 @@ async function buildServer({ store = {}, dns = makeFetchImpl(), apnsConfig = nul
   };
 }
 
+// Drain an IncomingMessage into { status, headers, body } and resolve. Shared
+// by postJson + getRequest so the chunk-collect boilerplate lives once.
+function collectResponse(res, resolve) {
+  const chunks = [];
+  res.on("data", (c) => chunks.push(c));
+  res.on("end", () =>
+    resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString("utf-8") }),
+  );
+}
+
 function postJson(port, path, body, headers = {}) {
   const data = JSON.stringify(body);
   return new Promise((resolve, reject) => {
     const req = httpRequest(
       { host: "127.0.0.1", port, method: "POST", path, headers: { "content-type": "application/json", "content-length": Buffer.byteLength(data), ...headers } },
-      (res) => {
-        const chunks = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString("utf-8") }));
-      },
+      (res) => collectResponse(res, resolve),
     );
     req.on("error", reject);
     req.write(data);
@@ -81,14 +87,28 @@ function postJson(port, path, body, headers = {}) {
 
 function getRequest(port, path) {
   return new Promise((resolve, reject) => {
-    const req = httpRequest({ host: "127.0.0.1", port, method: "GET", path }, (res) => {
-      const chunks = [];
-      res.on("data", (c) => chunks.push(c));
-      res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString("utf-8") }));
-    });
+    const req = httpRequest({ host: "127.0.0.1", port, method: "GET", path }, (res) =>
+      collectResponse(res, resolve),
+    );
     req.on("error", reject);
     req.end();
   });
+}
+
+// A store map pre-seeded with the standard VALID_BOX_ID entry. `overrides`
+// merge onto the entry (e.g. a specific gateway_token).
+function seedStore(overrides = {}) {
+  return {
+    [VALID_BOX_ID]: {
+      gateway_token: makeToken("good"),
+      ip: "1.2.3.4",
+      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
+      registeredAt: 1,
+      updatedAt: 1,
+      recordId: 1,
+      ...overrides,
+    },
+  };
 }
 
 async function withServer(opts, fn) {
@@ -156,16 +176,7 @@ test("POST /register with invalid body → 400", async () => {
 
 test("POST /register (re-register) with valid bearer + same IP → 200 host, no DNS", async () => {
   const token = makeToken("seed");
-  const store = {
-    [VALID_BOX_ID]: {
-      gateway_token: token,
-      ip: "9.9.9.9",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 1234,
-    },
-  };
+  const store = seedStore({ gateway_token: token, ip: "9.9.9.9", recordId: 1234 });
   await withServer({ store }, async ({ port, dnsCalls }) => {
     const r = await postJson(
       port,
@@ -181,16 +192,7 @@ test("POST /register (re-register) with valid bearer + same IP → 200 host, no 
 
 test("POST /register (re-register) with valid bearer + changed IP → DNS update", async () => {
   const token = makeToken("seed");
-  const store = {
-    [VALID_BOX_ID]: {
-      gateway_token: token,
-      ip: "1.1.1.1",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 1234,
-    },
-  };
+  const store = seedStore({ gateway_token: token, ip: "1.1.1.1", recordId: 1234 });
   await withServer({ store }, async (ctx) => {
     const { port, dnsCalls } = ctx;
     const r = await postJson(
@@ -208,16 +210,7 @@ test("POST /register (re-register) with valid bearer + changed IP → DNS update
 });
 
 test("POST /register with wrong bearer → 401", async () => {
-  const store = {
-    [VALID_BOX_ID]: {
-      gateway_token: makeToken("right"),
-      ip: "1.1.1.1",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 1,
-    },
-  };
+  const store = seedStore({ gateway_token: makeToken("right"), ip: "1.1.1.1" });
   await withServer({ store }, async ({ port, dnsCalls }) => {
     const r = await postJson(
       port,
@@ -275,16 +268,7 @@ test("POST /push without auth → 401", async () => {
 
 test("POST /push auth + tokens → 200 {results:[{token, ok, prune}]}", async () => {
   const token = makeToken("good");
-  const store = {
-    [VALID_BOX_ID]: {
-      gateway_token: token,
-      ip: "1.2.3.4",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 1,
-    },
-  };
+  const store = seedStore({ gateway_token: token });
   await withServer(
     { store, apnsConfig: { teamId: "t", keyId: "k", p8Path: "/d", bundleId: "b" } },
     async ({ port }) => {
@@ -317,16 +301,7 @@ test("POST /push auth + tokens → 200 {results:[{token, ok, prune}]}", async ()
 
 test("POST /push with >20 tokens → 400 too_many_tokens", async () => {
   const token = makeToken("good");
-  const store = {
-    [VALID_BOX_ID]: {
-      gateway_token: token,
-      ip: "1.2.3.4",
-      host: `${VALID_BOX_ID}.boxes.mantaui.com`,
-      registeredAt: 1,
-      updatedAt: 1,
-      recordId: 1,
-    },
-  };
+  const store = seedStore({ gateway_token: token });
   await withServer(
     { store, apnsConfig: { teamId: "t", keyId: "k", p8Path: "/d", bundleId: "b" } },
     async ({ port }) => {

--- a/src/gateway/store.mjs
+++ b/src/gateway/store.mjs
@@ -1,7 +1,7 @@
 // store.mjs — registration store for the gateway service.
 //
 // A single JSON file at /var/lib/manta-gateway/boxes.json maps
-// box_id → { gateway_token, ip, host, registeredAt, updatedAt, ovhRecordId }.
+// box_id → { gateway_token, ip, host, registeredAt, updatedAt, recordId }.
 // Box-side callers (manta-server) register their box_id once at startup,
 // receive a gateway_token, then re-register on each boot to refresh the
 // DNS A record when the box's public IP changes.
@@ -16,10 +16,11 @@
 // the systemd `StateDirectory=manta-gateway` directive on prod (BET-198 WP6
 // runbook step 4).
 //
-// The store keeps `ovhRecordId` (the OVH record-id assigned when the A
+// The store keeps `recordId` (the Cloudflare record-id assigned when the A
 // record was first created) so subsequent /register calls from the SAME box
 // can PUT a target update without ever searching the zone — a single DNS
-// read per box lifetime.
+// read per box lifetime. (Older stores written by the OVH build used the key
+// `ovhRecordId`; normalizeEntry accepts that legacy key too.)
 
 import { writeFile, rename, mkdir, chmod } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
@@ -45,7 +46,15 @@ export function isValidBoxId(boxId) {
 // gateway will publish — <box_id>.boxes.mantaui.com for prod.
 export function normalizeEntry(raw) {
   if (!raw || typeof raw !== "object") return null;
-  const { gateway_token, ip, host, registeredAt, updatedAt, ovhRecordId } = raw;
+  const { gateway_token, ip, host, registeredAt, updatedAt } = raw;
+  // Cloudflare record ids are strings; older OVH stores used numbers. Accept
+  // both under the canonical `recordId` field (falling back to the legacy
+  // `ovhRecordId` key so a store written by the OVH build still loads).
+  const rawRecordId = raw.recordId ?? raw.ovhRecordId ?? null;
+  const recordId =
+    typeof rawRecordId === "string" || typeof rawRecordId === "number"
+      ? rawRecordId
+      : null;
   if (typeof gateway_token !== "string" || !gateway_token) return null;
   if (typeof ip !== "string" || !ip) return null;
   if (typeof host !== "string" || !host) return null;
@@ -57,7 +66,7 @@ export function normalizeEntry(raw) {
     host,
     registeredAt,
     updatedAt,
-    ovhRecordId: typeof ovhRecordId === "number" ? ovhRecordId : null,
+    recordId,
   };
 }
 
@@ -128,7 +137,7 @@ export async function saveStore(map, path = DEFAULT_STORE_PATH) {
 // Compose a fresh entry. `now` injectable for tests. `gateway_token` MUST
 // be passed in (the caller generates it) so the registration route can
 // return the token to the box on first registration.
-export function makeEntry({ box_id, gateway_token, ip, host, ovhRecordId = null, now = () => Date.now() }) {
+export function makeEntry({ box_id, gateway_token, ip, host, recordId = null, now = () => Date.now() }) {
   if (!isValidBoxId(box_id)) throw new Error("makeEntry: invalid box_id");
   if (typeof gateway_token !== "string" || !gateway_token) {
     throw new Error("makeEntry: gateway_token required");
@@ -142,7 +151,7 @@ export function makeEntry({ box_id, gateway_token, ip, host, ovhRecordId = null,
     host,
     registeredAt: t,
     updatedAt: t,
-    ovhRecordId,
+    recordId,
   };
 }
 

--- a/src/gateway/store.test.mjs
+++ b/src/gateway/store.test.mjs
@@ -47,13 +47,13 @@ test("makeEntry: creates an entry with both timestamps equal on first call", () 
     gateway_token: "0".repeat(32),
     ip: "1.2.3.4",
     host: "0".repeat(32) + ".boxes.mantaui.com",
-    ovhRecordId: 42,
+    recordId: "rec_42",
     now: () => NOW,
   });
   assert.equal(e.gateway_token, "0".repeat(32));
   assert.equal(e.ip, "1.2.3.4");
   assert.equal(e.host, "0".repeat(32) + ".boxes.mantaui.com");
-  assert.equal(e.ovhRecordId, 42);
+  assert.equal(e.recordId, "rec_42");
   assert.equal(e.registeredAt, NOW);
   assert.equal(e.updatedAt, NOW);
 });
@@ -74,6 +74,31 @@ test("normalizeEntry: drops malformed entries silently", () => {
   );
 });
 
+test("normalizeEntry: accepts legacy ovhRecordId key, emits canonical recordId", () => {
+  const e = normalizeEntry({
+    gateway_token: "x".repeat(32),
+    ip: "1.2.3.4",
+    host: "h.boxes.mantaui.com",
+    registeredAt: 1,
+    updatedAt: 1,
+    ovhRecordId: 12345, // old OVH numeric id in a store on disk
+  });
+  assert.equal(e.recordId, 12345);
+  assert.equal(e.ovhRecordId, undefined);
+});
+
+test("normalizeEntry: accepts string recordId (Cloudflare)", () => {
+  const e = normalizeEntry({
+    gateway_token: "x".repeat(32),
+    ip: "1.2.3.4",
+    host: "h.boxes.mantaui.com",
+    registeredAt: 1,
+    updatedAt: 1,
+    recordId: "rec_abc",
+  });
+  assert.equal(e.recordId, "rec_abc");
+});
+
 test("atomic write round-trip: save then load returns the same map", async () => {
   const { dir, path } = freshTmpPath("roundtrip");
   try {
@@ -82,7 +107,7 @@ test("atomic write round-trip: save then load returns the same map", async () =>
       gateway_token: "a".repeat(32),
       ip: "1.2.3.4",
       host: "0".repeat(32) + ".boxes.mantaui.com",
-      ovhRecordId: 99,
+      recordId: "rec_99",
       now: () => NOW,
     });
     await saveStore({ [entry.gateway_token ? "0".repeat(32) : "bad"]: entry }, path);
@@ -90,7 +115,7 @@ test("atomic write round-trip: save then load returns the same map", async () =>
     await saveStore({ ["0".repeat(32)]: entry }, path);
     const loaded = loadStore(path);
     assert.equal(loaded["0".repeat(32)].ip, "1.2.3.4");
-    assert.equal(loaded["0".repeat(32)].ovhRecordId, 99);
+    assert.equal(loaded["0".repeat(32)].recordId, "rec_99");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Two deploy blockers found during the BET-198 prod-deploy hand-off. The gateway as merged is **not deployable** on our actual infra; both are fixed here.

## BET-222 — startup ReferenceError (`de98c3a`)
`src/gateway/index.mjs`'s CLI entrypoint called `loadApnsConfig()` but only imported `sendApns` from `apns.mjs` → `node src/gateway/index.mjs` crashed with `ReferenceError` before binding the port. Tests never run `isMain` so CI was green. The gateway-deploy health-check would have failed red on first deploy. Fix: import `loadApnsConfig`.

## BET-223 — OVH → Cloudflare DNS (`9471b0a`)
The gateway's DNS automation was hardwired to OVH, but `mantaui.com` is on **Cloudflare** and there are no OVH creds anywhere (we have a working `CLOUDFLARE_API_TOKEN`). `/register`'s DNS create would fail — and since the gateway_token is minted only after a successful DNS create, **push would never work**.

Rewrote `dns.mjs` as a Cloudflare DNS client (bearer-auth REST, POST/PUT `/zones/<id>/dns_records`, unproxied A records, no refresh step). Public contract preserved so `index.mjs` is unchanged apart from the creds shape. Env: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ZONE_ID` (from `/etc/manta-gateway/cloudflare.env`) replace the three OVH_* vars. Cloudflare record ids are strings not numbers → `store.mjs` field `ovhRecordId`→`recordId`, accepts both, legacy-key fallback so an OVH-era store still loads.

## Verification
- `npm run typecheck` — clean.
- 104 gateway tests + 586 server tests green.
- Gateway boots + binds :20081 with Cloudflare env (verified locally).
- Cloudflare token confirmed against the live `mantaui.com` zone (read + write round-trip).

Closes BET-222, BET-223. Unblocks the BET-198 prod deploy.