### PR TITLE
fix(renderer): bound row-list height with scroll on three PanelCards (BET-224)

### DIFF
--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -70,7 +70,7 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
       ) : jobs.length === 0 ? (
         <div className="text-text-muted">No scheduled tasks in this session.</div>
       ) : (
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5 max-h-[40vh] overflow-y-auto">
           {jobs.map((j) => {
             const next = describeNextRun(j.cron, j.recurring);
             return (
@@ -172,7 +172,7 @@ export const WebhooksCard = memo(function WebhooksCard({
           Multica ping this session when the task finishes”).
         </div>
       ) : (
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5 max-h-[40vh] overflow-y-auto">
           {hooks.map((h) => {
             const last =
               h.lastDeliveredAt != null
@@ -377,7 +377,7 @@ export const SecretsCard = memo(function SecretsCard({
           without ever seeing the value.
         </div>
       ) : (
-        <div className="flex flex-col gap-1.5 border-t border-border pt-1.5">
+        <div className="flex flex-col gap-1.5 border-t border-border pt-1.5 max-h-[40vh] overflow-y-auto">
           {secrets.map((s) => (
             <div key={s.id} className="flex items-center gap-2">
               <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

`ScheduledTasksCard`, `WebhooksCard`, and `SecretsCard` each rendered their row list inside an unbounded flex column. When a session accumulated many items, the list pushed past the viewport and bottom rows became unreachable.

Apply the same two Tailwind utility classes (`max-h-[40vh] overflow-y-auto`) to each list container so the row list scrolls inside the card while the header (× close) and the `SecretsCard` add form stay pinned.

## Scope

ONE file: `src/renderer/PanelCards.tsx`. No changes to `ChatPanel.tsx`, no new components, props, state, or CSS files. Per the file header, the cards are shared between desktop and mobile; no mobile-CSS edits needed.

## Edits

- L73 — `ScheduledTasksCard` jobs list: + `max-h-[40vh] overflow-y-auto`
- L175 — `WebhooksCard` hooks list: + `max-h-[40vh] overflow-y-auto`
- L380 — `SecretsCard` existing-secrets list (the `border-t border-border pt-1.5` row-list, NOT the add form above it): + `max-h-[40vh] overflow-y-auto`

The outer card wrapper, the header (× close), and the `SecretsCard` add/update form remain outside the scroll region so they stay fixed. `40vh` is intentional and matches the issue spec.

## Verification results

**Files changed:** `1` file (`src/renderer/PanelCards.tsx`, +3/-3 lines).

- PR branch (`multica/BET-224-cards-scroll-region` @ `4f623ed`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `698` pass / `0` fail / `0` skip. Failures: none. log sha256: `313f472c52bfb72dc6279b2e832f80e856ce03da92e193db9513f439dd338655`
- Base (`main` @ `52ac992`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `698` pass / `0` fail / `0` skip. Failures: none. log sha256: `82e1bff1759be7f1233c6fd5a33a14a499dabb302a5bb80078f5818e38b0698f`
- **Conclusion:** 0 new failures, 0 resolved failures, 0 pre-existing failures. Pure CSS-class addition with no logic or type changes.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

**Base:** origin/main @ `52ac992`