### PR TITLE
fix(gateway): /push was broken — DNS fetch passed to sendApns as APNs sender (BET-229)

### DIFF
--- a/src/gateway/index.mjs
+++ b/src/gateway/index.mjs
@@ -237,7 +237,12 @@ export async function handlePush({
   body,
   store,
   apnsConfig,
-  fetchImpl,
+  // The APNs sender: takes a built request object → { status, body }. In
+  // production this is UNDEFINED so sendApns falls back to its own HTTP/2
+  // `defaultApnsSender`. Tests inject an APNs-shaped fake here. It is NOT the
+  // DNS/global `fetch` — passing global fetch here breaks with "Failed to
+  // parse URL from [object Object]" because fetch expects a URL, not a req.
+  apnsSender,
 }) {
   const { box_id, tokens, payload } = body ?? {};
   if (!isValidBoxId(box_id)) {
@@ -273,7 +278,7 @@ export async function handlePush({
   const results = [];
   for (const token of tokens) {
     try {
-      const r = await sendApns({ token, payload }, apnsConfig, fetchImpl);
+      const r = await sendApns({ token, payload }, apnsConfig, apnsSender);
       results.push({ token, ok: r.ok, prune: r.prune });
     } catch (e) {
       results.push({ token, ok: false, prune: false });
@@ -320,6 +325,11 @@ export function createGatewayServer({
   // calls array (no OVH, no record-id allocation).
   createDnsRecord,
   apnsConfig = null,
+  // APNs sender injected into handlePush → sendApns. UNDEFINED in production so
+  // sendApns uses its own HTTP/2 defaultApnsSender. Kept SEPARATE from the DNS
+  // `fetchImpl` above — they have different call shapes (DNS wants a URL,
+  // APNs wants a built request object). Tests inject an APNs-shaped fake.
+  apnsSender,
   rateLimiter = createRegisterRateLimiter(),
   log = console.log,
   warn = console.warn,
@@ -397,7 +407,7 @@ export function createGatewayServer({
           body,
           store,
           apnsConfig,
-          fetchImpl,
+          apnsSender,
         });
         return sendJson(res, r.status, r.json);
       } catch (e) {

--- a/src/gateway/push.test.mjs
+++ b/src/gateway/push.test.mjs
@@ -56,8 +56,8 @@ function makeStore(entry = ENTRY) {
 
 // Invoke handlePush with the common defaults (seeded store, a no-op fetch,
 // and the good bearer). `body` fields merge onto a valid baseline; `store`,
-// `apnsConfig`, and `fetchImpl` are overridable per test.
-function callPush({ body = {}, store = makeStore(), apnsConfig = null, fetchImpl } = {}) {
+// `apnsConfig`, and `apnsSender` are overridable per test.
+function callPush({ body = {}, store = makeStore(), apnsConfig = null, apnsSender } = {}) {
   return handlePush({
     body: {
       box_id: VALID_BOX_ID,
@@ -68,7 +68,7 @@ function callPush({ body = {}, store = makeStore(), apnsConfig = null, fetchImpl
     },
     store,
     apnsConfig,
-    fetchImpl: fetchImpl ?? (async () => ({ status: 200, body: null })),
+    apnsSender: apnsSender ?? (async () => ({ status: 200, body: null })),
   });
 }
 
@@ -85,7 +85,7 @@ test("handlePush: 401 without Authorization header", async () => {
     body: { box_id: VALID_BOX_ID, tokens: [], payload: { title: "T", body: "B" } },
     store: makeStore(),
     apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
+    apnsSender: async () => ({ status: 200, body: null }),
   });
   assert.equal(r.status, 401);
 });
@@ -100,7 +100,7 @@ test("handlePush: 401 when token does not match stored value", async () => {
     },
     store: makeStore(),
     apnsConfig: null,
-    fetchImpl: async () => ({ status: 200, body: null }),
+    apnsSender: async () => ({ status: 200, body: null }),
   });
   assert.equal(r.status, 401);
 });
@@ -169,7 +169,7 @@ test("handlePush: returns per-token results in input order with ok+prune shape",
       },
       store: makeStore(),
       apnsConfig: cfg,
-      fetchImpl: sender,
+      apnsSender: sender,
     });
     assert.equal(r.status, 200);
     assert.deepEqual(r.json.results, [
@@ -197,7 +197,7 @@ for (const { label, status, reason } of [
     try {
       const r = await callPush({
         apnsConfig: cfg,
-        fetchImpl: async () => ({ status, body: { reason } }),
+        apnsSender: async () => ({ status, body: { reason } }),
       });
       assert.equal(r.status, 200);
       assert.equal(r.json.results[0].prune, true);
@@ -230,7 +230,7 @@ test("handlePush: a throwing sender → ok:false, prune:false (call continues fo
       },
       store: makeStore(),
       apnsConfig: cfg,
-      fetchImpl: sender,
+      apnsSender: sender,
     });
     assert.equal(r.status, 200);
     assert.equal(calls.length, 3, "all three tokens attempted even when one throws");


### PR DESCRIPTION
## Live prod bug (found during BET-198 deploy)

After the gateway went live, the **first real `/push` failed** with:
```
[gateway-apns] send error: Failed to parse URL from [object Object]
```

**Root cause:** `handlePush` threaded the server's DNS-oriented `fetchImpl` (`globalThis.fetch`) into `sendApns` as its APNs sender. But `sendApns`'s 3rd arg is an APNs sender that takes a **built request object** → `{status, body}`; global `fetch` expects a URL, so `new URL(reqObject)` throws and **every real push crashed at the gateway**. DNS (Cloudflare REST) legitimately uses global fetch; APNs uses an HTTP/2 sender — the two were conflated in the `createGatewayServer` wiring.

**Fix:** rename `handlePush`'s param to `apnsSender` + add a matching `createGatewayServer` option, **UNDEFINED in production** so `sendApns` falls back to its own `defaultApnsSender` (HTTP/2 → `api.push.apple.com`); tests inject an APNs-shaped fake. `push.test.mjs` `fetchImpl`→`apnsSender`.

**Why CI didn't catch it:** `sendApns` unit tests inject the sender directly and never exercise the server-factory wiring that passed the wrong function.

## Verification
- Manual `/push` against the live gateway with a real `gateway_token` + dummy device token now reaches Apple and returns a proper per-token result (was the URL-parse crash before this fix).
- 104 gateway tests green; typecheck clean; duplication-gate PASS.

Closes BET-229. Required for the BET-198 push E2E.