### PR TITLE
BET-225.A: version-compare helper + self-update script + manifest

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -13,6 +13,7 @@
 # WHAT IT DEPLOYS (all static web-root assets)
 #   website/*.html         → /var/www/mantaui/            (marketing site)
 #   website/*.png          → /var/www/mantaui/            (logo/assets)
+#   website/updates/*.json → /var/www/mantaui/updates/    (BET-225 version manifest)
 #   scripts/install.sh     → /var/www/mantaui/install.sh  (curl | bash installer)
 #   llms-install.md        → /var/www/mantaui/llms-install.md (AI install doc)
 #   docs/plugins-authoring.md
@@ -76,6 +77,12 @@ jobs:
           $SCP llms-install.md "$PROD_HOST:$WEBROOT/llms-install.md"
           $SCP docs/plugins-authoring.md "$PROD_HOST:$WEBROOT/llms-plugins.md"
 
+          echo "▸ Copying version manifest (BET-225)"
+          $SSH "$PROD_HOST" "mkdir -p $WEBROOT/updates"
+          if ls website/updates/*.json >/dev/null 2>&1; then
+            $SCP website/updates/*.json "$PROD_HOST:$WEBROOT/updates/"
+          fi
+
           echo "▸ Keeping /opt/manta clone current (source-of-truth parity)"
           $SSH "$PROD_HOST" "git -C /opt/manta fetch origin main -q && git -C /opt/manta reset --hard origin/main -q" || \
             echo "⚠ /opt/manta pull skipped (non-fatal — webroot already updated)"
@@ -103,6 +110,7 @@ jobs:
           check "install.sh" scripts/install.sh
           check "llms-install.md" llms-install.md
           check "llms-plugins.md" docs/plugins-authoring.md
+          check "updates/server.json" website/updates/server.json
           if [ "$fail" -ne 0 ]; then
             echo "::error::One or more web assets are not live or are stale."
             exit 1

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# self-update.sh — pull latest main on the box, reinstall deps, restart server.
+#
+# Wired up in BET-225 stage 2 (server-side update poller calls this on a
+# cadence). Manual invocation also works — idempotent.
+#
+# Resets the local checkout to origin/main, reinstalls prod-only deps, and
+# restarts the systemd --user service that runs manta-server. Safe to re-run.
+#
+# Run from anywhere; the script derives its checkout from $0 so the caller's
+# cwd doesn't matter.
+#
+# Requires: a clean working tree (git reset --hard will discard any local
+# edits), systemd --user with the manta-server.service unit enabled
+# (`loginctl enable-linger $USER`).
+#
+# No flags, no branch parameterization — always pins to origin/main.
+
+set -euo pipefail
+
+MANTA_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "▸ self-update: fetching origin/main into $MANTA_HOME"
+git -C "$MANTA_HOME" fetch origin main -q
+
+echo "▸ self-update: resetting to origin/main"
+git -C "$MANTA_HOME" reset --hard origin/main -q
+
+echo "▸ self-update: reinstalling prod-only deps"
+npm ci --omit=dev --prefix "$MANTA_HOME"
+
+echo "▸ self-update: restarting manta-server.service"
+systemctl --user restart manta-server.service
+
+echo "✓ self-update: complete"

--- a/src/shared/versionCompare.d.mts
+++ b/src/shared/versionCompare.d.mts
@@ -1,0 +1,29 @@
+// Hand-written type declarations for versionCompare.mjs. Implementation is plain
+// JS so both the renderer tsconfig and the server-side .mjs import it natively
+// (Node ESM resolves the .mjs directly, no declaration lookup needed). Keep in
+// sync with src/shared/versionCompare.mjs.
+
+/**
+ * Compare two dotted version strings numerically. Returns -1 if a < b, 1 if
+ * a > b, 0 if equal. Treats missing/malformed input as "0.0.0".
+ */
+export function compareVersions(a: string | null | undefined, b: string | null | undefined): -1 | 0 | 1;
+
+/**
+ * True when `latest` is strictly newer than `current` — i.e. an update is
+ * available for the running client.
+ */
+export function isUpdateAvailable(
+  current: string | null | undefined,
+  latest: string | null | undefined,
+): boolean;
+
+/**
+ * True when `clientVersion` is strictly older than `minClient` — the
+ * server-side version-skew guard rejects stale clients before they touch
+ * incompatible routes.
+ */
+export function isClientTooOld(
+  clientVersion: string | null | undefined,
+  minClient: string | null | undefined,
+): boolean;

--- a/src/shared/versionCompare.mjs
+++ b/src/shared/versionCompare.mjs
@@ -1,0 +1,88 @@
+// versionCompare.mjs — pure semver-lite compare used by the update system.
+//
+// Three exports, all pure + framework-free so both src/server/*.mjs and the
+// renderer can import the same source of truth (BET-225 stage 1 — stage 2
+// wires the helper into src/server/serverUpdate.mjs + src/server/version.mjs
+// `minClient`, stage 3 wires the banner/RPC/UI):
+//
+//   compareVersions(a, b)       → -1 | 0 | 1
+//   isUpdateAvailable(current, latest)
+//                              → true when latest > current
+//   isClientTooOld(client, min)
+//                              → true when client < min
+//
+// Semantics — deliberately narrow so the helper never disagrees with itself:
+//
+//   * Numeric-dotted compare: split on ".", parseInt each segment, compare
+//     numerically. Multi-digit segments compare correctly (1.10.0 > 1.9.0,
+//     which a string compare would mishandle).
+//   * Strip a leading `-suffix` pre-release tag and ignore it: "1.2.3-beta"
+//     compares equal to "1.2.3". The server only ships stable releases, so
+//     pre-release ranking (1.0.0-alpha < 1.0.0) is intentionally NOT
+//     implemented — it'd be untested dead code.
+//   * Treat missing/malformed input as "0.0.0": null, undefined, "", "abc",
+//     "1.x.3" — anything where a segment isn't all-digits. This is a
+//     first-line guard against the manifest poller tripping over a typo'd
+//     server.json or a client's empty version string during onboarding.
+//   * Always operate on a 3-tuple: fewer segments are zero-padded
+//     ("1.2" → 1.2.0), more are truncated ("1.2.3.4" → 1.2.3). Keeps the
+//     comparison uniform — anything outside 3 segments is invalid semver.
+//
+// Pure → unit-tested in src/shared/versionCompare.test.ts.
+
+const ZERO = [0, 0, 0];
+
+/**
+ * Parse a dotted version string into a 3-tuple of integers. Returns [0,0,0]
+ * for null/undefined/empty/non-numeric input.
+ */
+function parseVersion(v) {
+  if (v == null) return [...ZERO];
+  const s = String(v).trim();
+  if (s === "") return [...ZERO];
+  // Pre-release tag: everything after the first '-' is metadata, ignored.
+  const stable = s.split("-")[0];
+  const segments = stable.split(".");
+  const nums = [];
+  for (const seg of segments) {
+    if (!/^\d+$/.test(seg)) return [...ZERO];
+    nums.push(parseInt(seg, 10));
+  }
+  // Normalize to exactly 3 segments — pad with zeros, truncate extras.
+  while (nums.length < 3) nums.push(0);
+  return nums.slice(0, 3);
+}
+
+/**
+ * Compare two version strings numerically. Returns -1 if a < b, 1 if a > b,
+ * 0 if equal. Treats missing/malformed input as "0.0.0".
+ */
+export function compareVersions(a, b) {
+  const A = parseVersion(a);
+  const B = parseVersion(b);
+  for (let i = 0; i < 3; i++) {
+    if (A[i] < B[i]) return -1;
+    if (A[i] > B[i]) return 1;
+  }
+  return 0;
+}
+
+/**
+ * True when `latest` is strictly newer than `current` (i.e. a server-side
+ * update is available for the running client). Missing/malformed inputs
+ * collapse to "0.0.0", so a fresh install (empty current) sees any non-zero
+ * latest as an update.
+ */
+export function isUpdateAvailable(current, latest) {
+  return compareVersions(current, latest) < 0;
+}
+
+/**
+ * True when `clientVersion` is strictly older than `minClient` — the server
+ * uses this to gate endpoints with a "client too old" response so the
+ * version-skew guard (BET-225 stage 2) can reject stale desktop/mobile
+ * builds before they touch incompatible routes.
+ */
+export function isClientTooOld(clientVersion, minClient) {
+  return compareVersions(clientVersion, minClient) < 0;
+}

--- a/src/shared/versionCompare.test.ts
+++ b/src/shared/versionCompare.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareVersions,
+  isUpdateAvailable,
+  isClientTooOld,
+} from "./versionCompare.mjs";
+
+describe("compareVersions", () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    expect(compareVersions("0.0.0", "0.0.0")).toBe(0);
+  });
+
+  it("returns -1 when a < b (older)", () => {
+    expect(compareVersions("1.2.3", "1.2.4")).toBe(-1);
+    expect(compareVersions("1.2.3", "2.0.0")).toBe(-1);
+    expect(compareVersions("0.0.0", "0.0.1")).toBe(-1);
+  });
+
+  it("returns 1 when a > b (newer)", () => {
+    expect(compareVersions("1.2.4", "1.2.3")).toBe(1);
+    expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+    expect(compareVersions("0.0.1", "0.0.0")).toBe(1);
+  });
+
+  it("compares multi-digit segments numerically (1.10.0 > 1.9.0)", () => {
+    expect(compareVersions("1.9.0", "1.10.0")).toBe(-1);
+    expect(compareVersions("1.10.0", "1.9.0")).toBe(1);
+    expect(compareVersions("1.2.9", "1.2.10")).toBe(-1);
+  });
+
+  it("strips pre-release suffix and ignores it", () => {
+    expect(compareVersions("1.2.3-beta", "1.2.3")).toBe(0);
+    expect(compareVersions("1.2.3-beta.1", "1.2.3")).toBe(0);
+    expect(compareVersions("1.2.3-rc.1", "1.2.4")).toBe(-1);
+  });
+
+  it("treats missing/empty input as 0.0.0", () => {
+    expect(compareVersions("", "0.0.0")).toBe(0);
+    expect(compareVersions("0.0.0", "")).toBe(0);
+    expect(compareVersions(null, "0.0.0")).toBe(0);
+    expect(compareVersions(undefined, "0.0.0")).toBe(0);
+    expect(compareVersions(null, null)).toBe(0);
+  });
+
+  it("treats malformed (non-numeric segment) as 0.0.0", () => {
+    expect(compareVersions("abc", "0.0.0")).toBe(0);
+    expect(compareVersions("1.x.3", "1.0.0")).toBe(-1);
+    expect(compareVersions("not.a.version", "0.0.1")).toBe(-1);
+  });
+
+  it("pads shorter versions with zeros", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1", "1.0.0")).toBe(0);
+    expect(compareVersions("1.2", "1.2.1")).toBe(-1);
+  });
+
+  it("truncates longer versions to 3 segments", () => {
+    expect(compareVersions("1.2.3.4", "1.2.3")).toBe(0);
+    expect(compareVersions("1.2.3.4", "1.2.4")).toBe(-1);
+  });
+});
+
+describe("isUpdateAvailable", () => {
+  it("true when latest is strictly newer", () => {
+    expect(isUpdateAvailable("1.2.3", "1.2.4")).toBe(true);
+    expect(isUpdateAvailable("0.0.0", "0.0.1")).toBe(true);
+    expect(isUpdateAvailable("", "0.0.1")).toBe(true);
+  });
+
+  it("false when latest equals current", () => {
+    expect(isUpdateAvailable("1.2.3", "1.2.3")).toBe(false);
+  });
+
+  it("false when latest is older than current", () => {
+    expect(isUpdateAvailable("2.0.0", "1.2.3")).toBe(false);
+    expect(isUpdateAvailable("1.2.3", "1.2.3-beta")).toBe(false);
+  });
+});
+
+describe("isClientTooOld", () => {
+  it("true when client is strictly older than minClient", () => {
+    expect(isClientTooOld("0.9.0", "1.0.0")).toBe(true);
+    expect(isClientTooOld("", "0.0.1")).toBe(true);
+  });
+
+  it("false when client equals minClient", () => {
+    expect(isClientTooOld("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("false when client is newer than minClient", () => {
+    expect(isClientTooOld("1.2.3", "1.0.0")).toBe(false);
+  });
+});

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,0 +1,1 @@
+{ "version": "0.0.0", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }


### PR DESCRIPTION
Stage 1 of the BET-225 update system. Pure foundation — no live-code
dependencies; every artifact in this slice is new (helper + tests +
standalone script + manifest + workflow wiring) and will be wired into
the server by stage 2.

**Files changed:** 6 files, 255 insertions.

| File | What |
|---|---|
| `src/shared/versionCompare.mjs` | Pure semver-lite compare — 3 exports (compareVersions, isUpdateAvailable, isClientTooOld). Numeric-dotted, multi-digit safe (`1.10.0 > 1.9.0`), strips `-suffix` pre-release tags, treats missing/malformed as `0.0.0`, normalizes to a 3-tuple. |
| `src/shared/versionCompare.d.mts` | Hand-written type declarations so the renderer/main tsconfigs can import via declaration lookup (matches the pattern used by every other shared module — `claim.d.mts`, `transport.d.mts`, ...). |
| `src/shared/versionCompare.test.ts` | 15 vitest cases across all three helpers (equal / older / newer / multi-digit / pre-release / missing / malformed / pad / truncate). |
| `scripts/self-update.sh` | `git fetch` + `reset --hard origin/main` + `npm ci --omit=dev` + `systemctl --user restart manta-server.service`. Echoes a one-line status per step. Executable bit set. |
| `website/updates/server.json` | `{ "version": "0.0.0", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }` — pinned so the first `web-v*` deploy lights up the server-side poller's update check. |
| `.github/workflows/website-deploy.yml` | Adds the manifest deploy (under `/var/www/mantaui/updates/`) and a byte-check verify line. |

**tsconfig / importability check:** `tsconfig.web.json` already includes
`src/shared/**/*` (renderer path). `src/server/*.mjs` imports via relative
`../shared/X.mjs` (Node ESM, no tsconfig entry needed — same pattern as
`paths.mjs`, `groq.mjs`, etc.). No config changes required.

**Workflow change beyond strict scope:** the issue said "ADD `updates/server.json`
to [the verify] list" — I added a paired deploy line too, because the verify
alone would 404 (`/updates/server.json` is not on the prod box today) and
break the build red. The deploy mirrors the existing `llms-install.md` /
`llms-plugins.md` pattern (deploy + byte-check together). The pattern was
already established; this just extends it to one more file.

**Verification results:**
- PR branch (`multica/BET-225.A-foundation` @ `a3f43bd`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `1829` pass (`1132` vitest + `697` node:test) / `0` fail / `0` skip. log sha256: `78ae2cd6e4dc9dc9ba425396f14682250e6f325e340027abcb98113b8516d681`
- Base (`main` @ `49078cb`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `1814` pass / `0` fail. log sha256: `6fdd3ad79ad593df34f2e302064b358ebabce512ce6f57b2f75ef0c8e0322134`
- **Conclusion:** 0 new failures. The 15 new vitest cases I added are
  accounted for in the +15 vitest count (1132 - 1117) and the test SHA
  diff is pure timing noise (`# duration_ms 6205` vs `5872`).

`bash -n scripts/self-update.sh` exit 0 (logged separately, not in
typecheck/test cache).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`,
`/tmp/typecheck-master.log`, `/tmp/test-master.log` for spot-check.

**Out of scope (per issue, intentionally untouched):**
- `src/server/serverUpdate.mjs` (server poller) — stage 2.
- `src/server/version.mjs` `minClient` — stage 2.
- IPC / RPC / store / App.tsx changes — stage 3.
- Desktop `src/main/index.ts` 6h re-check — stage 3.
- `electron-builder.yml` notarize TODO — stage 3.

**Base:** `origin/main @ 49078cb`