### PR TITLE
fix(transcript): wrap all chat content, no horizontal scroll (desktop + mobile)

### DIFF
--- a/src/renderer/MarkdownBody.tsx
+++ b/src/renderer/MarkdownBody.tsx
@@ -115,7 +115,7 @@ const MD_COMPONENTS: MarkdownComponents = {
     </blockquote>
   ),
   table: ({ children }) => (
-    <div className="my-2 overflow-x-auto">
+    <div className="my-2 overflow-x-auto max-w-full">
       <table className="text-[12px] border-collapse">{children}</table>
     </div>
   ),
@@ -274,7 +274,7 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
       )}
       {tooLarge ? (
         <pre
-          className="px-2 py-1.5 text-[12px] overflow-x-auto whitespace-pre"
+          className="px-2 py-1.5 text-[12px] overflow-x-auto max-w-full whitespace-pre"
           style={{ background: "transparent" }}
         >
           <code>{cleaned}</code>
@@ -287,7 +287,7 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
         >
           {({ tokens, getLineProps, getTokenProps }) => (
             <pre
-              className="px-2 py-1.5 text-[12px] overflow-x-auto whitespace-pre"
+              className="px-2 py-1.5 text-[12px] overflow-x-auto max-w-full whitespace-pre"
               // vsDark's default bg would override our bg-bg-soft — disable it.
               style={{ background: "transparent" }}
             >

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -131,7 +131,7 @@ export const ActiveTodos = memo(function ActiveTodos({ todos }: { todos: Array<R
             >
               {icon}
             </span>
-            <span className={`flex-1 whitespace-pre-wrap break-words ${textCls}`}>
+            <span className={`flex-1 min-w-0 whitespace-pre-wrap break-words ${textCls}`}>
               {content}
             </span>
           </div>
@@ -143,7 +143,7 @@ export const ActiveTodos = memo(function ActiveTodos({ todos }: { todos: Array<R
             {lastVisibleIdx < 0 ? "⎿" : " "}
           </span>
           <span className="select-none w-4 shrink-0" />
-          <span className="flex-1 text-text-faint">{summary}</span>
+            <span className="flex-1 min-w-0 text-text-faint">{summary}</span>
         </div>
       )}
     </div>
@@ -295,7 +295,7 @@ export const MessageRow = memo(function MessageRow({
           ) : (
             <div className="-mx-4 px-4 py-0.5 bg-bg-soft flex">
               <span className="text-text-faint select-none mr-2 shrink-0">›</span>
-              <span className="flex-1 whitespace-pre-wrap break-words text-text">
+              <span className="flex-1 min-w-0 whitespace-pre-wrap break-words text-text">
                 {text}
               </span>
             </div>

--- a/src/renderer/ToolBodies.tsx
+++ b/src/renderer/ToolBodies.tsx
@@ -224,7 +224,7 @@ function CollapsibleCode({ body, maxLines }: { body: string; maxLines: number })
   const hiddenCount = lines.length - maxLines;
   return (
     <div className="text-[12px] bg-bg-soft border border-border rounded">
-      <pre className="px-2 py-1 overflow-x-auto whitespace-pre">
+      <pre className="px-2 py-1 overflow-x-auto max-w-full whitespace-pre">
         <code>{shown}</code>
       </pre>
       {overflow && (
@@ -248,7 +248,7 @@ function CollapsiblePathList({ paths, maxLines }: { paths: string[]; maxLines: n
   const hiddenCount = paths.length - maxLines;
   return (
     <div className="text-[12px] bg-bg-soft border border-border rounded">
-      <div className="px-2 py-1 overflow-x-auto">
+      <div className="px-2 py-1 overflow-x-auto max-w-full">
         {shown.map((p, i) => (
           <div key={i} className="text-text-muted whitespace-pre">
             {p}
@@ -279,7 +279,7 @@ export function UnifiedDiff({ text }: { text: string }) {
   let oldLine = 0;
   let newLine = 0;
   return (
-    <div className="font-mono leading-snug my-1 overflow-x-auto">
+    <div className="font-mono leading-snug my-1 overflow-x-auto max-w-full">
       {lines.map((line, i) => {
         // Hunk header: parse counters silently. Skip the visible row — the
         // header carries file/range metadata that's noise next to the actual

--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -106,7 +106,7 @@ export const AssistantPart = memo(function AssistantPart({
           <span className="select-none w-4 shrink-0">
             {first ? <Prefix char="●" color={color} pulse={pulse} /> : <span className="invisible">●</span>}
           </span>
-          <div className="flex-1">{renderMarkdown(text)}</div>
+          <div className="flex-1 min-w-0">{renderMarkdown(text)}</div>
         </div>
       </div>
     );
@@ -125,7 +125,7 @@ export const AssistantPart = memo(function AssistantPart({
           <span className="select-none w-4 shrink-0">
             <span style={{ color: CLAUDE_ORANGE, opacity: 0.6 }}>✻ </span>
           </span>
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <div className="text-text-faint not-italic mb-1">Thinking…</div>
             <div>{text}</div>
           </div>
@@ -146,7 +146,7 @@ export const AssistantPart = memo(function AssistantPart({
         <span className="select-none w-4 shrink-0">
           <span style={{ color: CLAUDE_ORANGE, opacity: 0.6 }}>⎿ </span>
         </span>
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           {files.length === 0
             ? "patched"
             : `patched ${files.length} file${files.length === 1 ? "" : "s"}: ${files.join(", ")}`}
@@ -164,7 +164,7 @@ export const AssistantPart = memo(function AssistantPart({
         <span className="select-none w-4 shrink-0">
           <span style={{ color: CLAUDE_ORANGE, opacity: 0.6 }}>⎿ </span>
         </span>
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           <span className="text-text-muted">{filename || "(file)"}</span>
           {mime && <span className="text-text-faint"> · {mime}</span>}
         </div>
@@ -177,7 +177,7 @@ export const AssistantPart = memo(function AssistantPart({
       <span className="select-none w-4 shrink-0">
         <span style={{ color: CLAUDE_ORANGE, opacity: 0.5 }}>○ </span>
       </span>
-      <div className="flex-1 text-xs">[{part.type}]</div>
+      <div className="flex-1 min-w-0 text-xs">[{part.type}]</div>
     </div>
   );
 });
@@ -223,7 +223,7 @@ export const ToolCall = memo(function ToolCall({ part, verbose }: { part: Openco
             ●{" "}
           </span>
         </span>
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           <span className="text-text">{toolName}</span>
           {state.title && (
             <span className="text-text-muted">({state.title})</span>

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -60,7 +60,7 @@ export function Transcript({
   onRejectQuestion,
 }: TranscriptProps) {
   return (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3">
       <TaskContext.Provider value={taskContextValue}>
         <div className="flex flex-col justify-end min-h-full">
           {messages.length === 0 ? (

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -4,6 +4,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Wrap unbreakable tokens (URLs, long file paths) instead of overflowing.
+   Tailwind's `break-words` is `overflow-wrap: break-word`, which is
+   insufficient on WebKit for path-like strings; `anywhere` forces a break.
+   Applied globally so desktop AND mobile behave identically (BET-230 — the
+   transcript-scrolling fix moved this from a mobile-only band-aid to one
+   shared rule). */
+.break-words {
+  overflow-wrap: anywhere;
+}
+
 html, body, #root {
   height: 100%;
   margin: 0;

--- a/src/renderer/mobile/mobile.css
+++ b/src/renderer/mobile/mobile.css
@@ -276,68 +276,34 @@ body,
    footer button means schedules are reachable + their live count visible
    right next to the composer on phone too.) */
 
-/* The ChatPanel transcript is `flex-1 overflow-y-auto px-4 py-3` — a
-   y-only scroller, but it has NO x-axis clamp, so an oversized child
-   (a tool output, a wide table, a wrapped row that didn't actually wrap,
-   the user-message `-mx-4` bar with a long URL, etc.) scrolls
-   horizontally INSIDE the transcript. That's what the user sees as
-   "the message area scrolls sideways" even after .mobile-body has
-   overflow: hidden — the page doesn't scroll, but the transcript box
-   does, which is the same visible bug.
+/* ---- Transcript horizontal-scroll fix moved into shared components (BET-230) ----
 
-   Force overflow-x: hidden on the transcript scroller. The horizontal
-   scroll has nowhere useful to go — the `<pre>` blocks inside still get
-   their own overflow-x: auto and scrollbar (from the rule below), so
-   long code lines remain reachable, they just don't drag the entire
-   transcript with them. Targeted at the FIRST overflow-y-auto inside
-   .mobile-body (ChatPanel's scrollRef container) — not @-typeahead
-   popups or model-picker dropdowns, which use absolute positioning and
-   shouldn't be affected by an x clamp anyway. */
-.mobile-body [class*="overflow-y-auto"] {
-  overflow-x: hidden;
-}
+   The transcript, message rows, and tool rendering components are shared by
+   desktop and mobile, so the root-cause fixes for the chat transcript
+   horizontal-scroll bug now live in the SHARED components rather than as
+   `.mobile-body`-scoped overrides here:
 
-/* ---- Inner-overflow clamps: stop the chat panel pushing past viewport ----
+   - The transcript scroll container's x-axis clamp is set in Transcript.tsx
+     itself (`overflow-x-hidden` next to its existing `overflow-y-auto`).
+   - Every `flex-1` content column inside the shared message-row / tool-call
+     renderers carries `min-w-0` so flex items can shrink below their
+     min-content width and let the inner content wrap.
+   - Wide leaf elements (`<pre>`, `<table>`, `.overflow-x-auto`) carry
+     `max-w-full` so they scroll on their OWN scrollbar instead of dragging
+     the transcript.
+   - `.break-words { overflow-wrap: anywhere }` is now global in index.css so
+     unbreakable tokens (URLs, long file paths) wrap on both transports.
 
-   ChatPanel paints `<pre>`, `<table>` and `overflow-x-auto` containers as
-   children of flex columns that don't carry `min-width: 0`. A flex item's
-   default `min-width` is `auto`, which is the intrinsic min-content width of
-   its content — a `<pre>` with `white-space: pre` reports its widest line as
-   that intrinsic size, so the flex refuses to shrink, the row grows, and
-   `overflow-x-auto` becomes a no-op (the element is already as wide as it
-   wants to be). The desktop avoids this because its <main> wrapper has
-   `min-w-0` baked in, but the mobile wrapper is `absolute inset-0` and the
-   `flex-1` siblings inside ChatPanel weren't authored for a viewport-sized
-   panel.
-
-   Per the AGENTS rule we don't edit ChatPanel; reshape its descendants via
-   `.mobile-body` here instead. These three rules together remove the leaks:
-
-   1. Clamp pre/table/overflow-x-auto containers to the panel width and let
-      the inner content scroll horizontally on its own scrollbar.
-   2. Force `min-width: 0` on ANY .flex-1 inside .mobile-body — the most
-      common flex-item-grows-with-content pattern in ChatPanel (assistant
-      bullet → text column, tool body wrappers, etc.).
-   3. Same for the ModelPicker dropdown's hardcoded `min-w-[240px]`, which
-      can push the panel right when the picker is wrapped to the right of
-      the composer row at phone width. */
-.mobile-body pre,
-.mobile-body table,
-.mobile-body .overflow-x-auto {
-  max-width: 100%;
-}
-.mobile-body .flex-1 {
-  min-width: 0;
-}
+   This keeps desktop and mobile on one code path. The `.mobile-body div[class*="min-w-[240px]"]`
+   rule below stays because it is ModelPicker-dropdown-specific (not the
+   transcript overflow bug). */
+/* ModelPicker dropdown clamp — dropdown-specific, NOT part of the
+   transcript-overflow fix; it forces the dropdown's hardcoded
+   `min-w-[240px]` to shrink to fit phone width when the picker is wrapped
+   into the composer row. */
 .mobile-body div[class*="min-w-[240px]"] {
   min-width: 0;
   max-width: calc(100vw - 32px);
-}
-/* Long unbreakable tokens (URLs, file paths) in user-message bars should
-   wrap rather than push the row. `break-words` alone isn't enough on
-   WebKit for path-like strings — `overflow-wrap: anywhere` is. */
-.mobile-body .break-words {
-  overflow-wrap: anywhere;
 }
 
 /* iOS Safari auto-zooms <input>/<textarea> with font-size < 16px on focus,


### PR DESCRIPTION
Fixes BET-230.

## Root cause

Classic flexbox `min-width: auto` overflow. Flex items in the transcript rows default to `min-width: auto` (their content's intrinsic min-content width). When a child is an unbreakable wide element (`<pre>`, long inline code, URL, file path, wide table), the flex item refuses to shrink, the row grows past the panel, and the transcript scroll container — with no x-axis clamp — scrolls sideways.

## Fix

Root-cause fixes in the **shared** transcript components so desktop and mobile behave identically. No new CSS file, no duplicated band-aids.

| File | Change |
|---|---|
| `src/renderer/ToolCall.tsx` | `min-w-0` on 6 `flex-1` content columns (text, reasoning, patch, file, fallback, header) |
| `src/renderer/MessageRow.tsx` | `min-w-0` on 3 `flex-1` content columns (ActiveTodos content, ActiveTodos summary, user-message text) |
| `src/renderer/MarkdownBody.tsx` | `max-w-full` on table wrapper + 2 code-block `<pre>`s |
| `src/renderer/ToolBodies.tsx` | `max-w-full` on CollapsibleCode `<pre>`, CollapsiblePathList wrapper, UnifiedDiff wrapper |
| `src/renderer/Transcript.tsx` | Add `overflow-x-hidden` next to existing `overflow-y-auto` on the scroll container (safety net) |
| `src/renderer/index.css` | Add global `.break-words { overflow-wrap: anywhere }` so unbreakable tokens wrap on both transports (Tailwind's default `break-word` is insufficient on WebKit for path-like strings) |
| `src/renderer/mobile/mobile.css` | **DELETE** 4 redundant `.mobile-body`-scoped band-aids (overflow-y-auto clamp, pre/table clamp, .flex-1 clamp, .break-words override). **KEEP** the ModelPicker `min-w-[240px]` dropdown clamp and the iOS `textarea` font-size fix (unrelated to this bug). |

Net diff: **+48 / −72 lines** — code removal over addition, one code path for both transports.

## Verification results

**Files changed:** 7 files. `MarkdownBody.tsx, MessageRow.tsx, ToolBodies.tsx, ToolCall.tsx, Transcript.tsx, index.css, mobile/mobile.css`

- PR branch (`multica/BET-230-transcript-wrap-no-horizontal-scroll` @ `c71ca4c`):
  - typecheck: exit 0 (both `tsconfig.node.json` + `tsconfig.web.json` clean). log: `/tmp/typecheck-pr.log`
  - test: vitest 1132/1132 pass; node:test 1 fail (`formatPairingOutput produces a stable human block` in `scripts/install.test.mjs:429`, **pre-existing**). log: `/tmp/test-pr.log`
- Base (`main` @ `53549a7`):
  - typecheck: exit 0. log: `/tmp/typecheck-master.log`
  - test: vitest 1132/1132 pass; node:test **same 1 fail** (`formatPairingOutput produces a stable human block`). log: `/tmp/test-master.log`
- **Conclusion:** 0 new failures, 1 pre-existing failure (`formatPairingOutput`) reproduced identically on both branches — unrelated to this PR.

## Cross-cutting follow-ups

- No IPC / main / server / preload changes. Renderer-only.
- The shared `ChatPanel.tsx` is untouched (per its long-standing rule). The fix is in the EXTRACTED components (`Transcript.tsx`, `MessageRow.tsx`, `ToolCall.tsx`, `MarkdownBody.tsx`, `ToolBodies.tsx`) which the issue explicitly permits editing.
- The mobile `min-w-[240px]` dropdown clamp and the iOS 16px textarea fix remain in `mobile.css` — they are ModelPicker- and iOS-specific concerns unrelated to the transcript-overflow bug.

**Base: origin/main @ 53549a7**