### PR TITLE
BET-232: add copy button to code blocks and tool output blocks

### DIFF
--- a/src/renderer/CopyButton.tsx
+++ b/src/renderer/CopyButton.tsx
@@ -1,0 +1,82 @@
+// ===== Copy button (chat code/tool blocks) =====
+//
+// Tiny reusable "copy" affordance for the top-right corner of code/output
+// blocks in the chat transcript. Reused by CodeBlock (MarkdownBody.tsx) and
+// the plain-output branch of ToolOutput (ToolBodies.tsx) — one component, two
+// callers, no duplicated clipboard logic.
+//
+// Pattern matches PanelCards.tsx `copyUrl` (lines 140–148): `navigator.clipboard`
+// with optional-chaining + no-op on failure (clipboard blocked). A click IS a
+// user gesture, so the Electron desktop's silent block on `navigator.clipboard`
+// (see Terminal.tsx note) does not apply — we follow the established convention.
+//
+// Positioning is the consumer's responsibility: this component is
+// position-agnostic, accepts an arbitrary `className`, and the callers pass
+// `absolute top-1 right-1 z-10` (etc.) against a `relative` parent.
+
+import { memo, useEffect, useState } from "react";
+
+export const CopyButton = memo(function CopyButton({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(t);
+  }, [copied]);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard?.writeText(text).then(
+          () => setCopied(true),
+          () => {
+            /* clipboard blocked — no-op */
+          },
+        );
+      }}
+      title="Copy"
+      aria-label="Copy"
+      className={
+        className ??
+        "text-[10px] text-text-faint hover:text-text px-1 rounded"
+      }
+    >
+      {copied ? (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          width="12"
+          height="12"
+          aria-hidden="true"
+        >
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          width="12"
+          height="12"
+          aria-hidden="true"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" />
+          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+});

--- a/src/renderer/MarkdownBody.tsx
+++ b/src/renderer/MarkdownBody.tsx
@@ -15,6 +15,7 @@ import remarkGfm from "remark-gfm";
 import type { Components as MarkdownComponents } from "react-markdown";
 import { CLAUDE_ORANGE } from "./chatShared";
 import { getBuiPreload } from "./preloadAccess";
+import { CopyButton } from "./CopyButton";
 
 // Streamed-fence resilience: while a code block is still streaming, the
 // closing ``` hasn't arrived yet. Without a recovery step, remark sees the
@@ -266,12 +267,16 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
     countLines(cleaned) > CODEBLOCK_MAX_LINES;
 
   return (
-    <div className="my-2 rounded border border-border bg-bg-soft overflow-hidden">
+    <div className="my-2 rounded border border-border bg-bg-soft overflow-hidden relative">
       {lang && (
-        <div className="px-2 py-0.5 text-[10px] text-text-faint border-b border-border bg-bg-elev">
+        <div className="px-2 py-0.5 text-[10px] text-text-faint border-b border-border bg-bg-elev pr-7">
           {lang}
         </div>
       )}
+      <CopyButton
+        text={cleaned}
+        className="absolute top-1 right-1 z-10 text-[10px] text-text-faint hover:text-text px-1 rounded"
+      />
       {tooLarge ? (
         <pre
           className="px-2 py-1.5 text-[12px] overflow-x-auto max-w-full whitespace-pre"

--- a/src/renderer/ToolBodies.tsx
+++ b/src/renderer/ToolBodies.tsx
@@ -9,6 +9,7 @@
 import { memo, useLayoutEffect, useRef, useState } from "react";
 import { resolveToolOutput } from "./chatUtils";
 import { CLAUDE_ORANGE, type ToolState } from "./chatShared";
+import { CopyButton } from "./CopyButton";
 
 // Renders a tool's `output` string. If it looks like a unified diff (starts
 // with `--- ` or `@@`, or has multiple `@@` headers), each line is colored
@@ -36,17 +37,23 @@ export const ToolOutput = memo(function ToolOutput({ output }: { output: string 
   }
   // Plain code/text output — small monospace block, scroll on overflow.
   return (
-    <pre
-      ref={preRef}
-      onScroll={(e) => {
-        const el = e.currentTarget;
-        pinnedRef.current =
-          el.scrollHeight - el.scrollTop - el.clientHeight < 8;
-      }}
-      className="text-[12px] bg-bg-soft border border-border rounded px-2 py-1 max-h-64 overflow-auto whitespace-pre"
-    >
-      <code>{output}</code>
-    </pre>
+    <div className="relative">
+      <CopyButton
+        text={output}
+        className="absolute top-1 right-1 z-10 text-[10px] text-text-faint hover:text-text px-1 rounded"
+      />
+      <pre
+        ref={preRef}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          pinnedRef.current =
+            el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+        }}
+        className="text-[12px] bg-bg-soft border border-border rounded px-2 py-1 max-h-64 overflow-auto whitespace-pre"
+      >
+        <code>{output}</code>
+      </pre>
+    </div>
   );
 });
 


### PR DESCRIPTION
Adds a single shared CopyButton component, wired into CodeBlock (MarkdownBody) and the plain-output branch of ToolOutput (ToolBodies). Click copies the block's raw text to the clipboard, with a brief 'copied' confirmation.

**Files changed:** 3 files, +107 / -13 LoC.
- `src/renderer/CopyButton.tsx` (new, ~80 LoC): `memo`-wrapped, `useState` copied flag, 1500ms timeout, inline clipboard/check SVGs.
- `src/renderer/MarkdownBody.tsx`: import + `relative` on outer wrapper + `<CopyButton text={cleaned} className="absolute top-1 right-1 z-10 …" />`. Language label gets `pr-7` so the button never overlaps the text.
- `src/renderer/ToolBodies.tsx`: import + wrap plain-output `<pre>` in a `<div className="relative">` with the CopyButton inside. Diff branch (`UnifiedDiff`) and pin-to-bottom `preRef/onScroll` logic untouched.

**Verification results:**
- PR branch (`multica/BET-232-copy-button-code-tool-blocks` @ `ab86a22`):
  - typecheck: exit 0. No errors. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 0, 709 pass / 0 fail / 0 skip. log sha256: `e9c07fec0049392f1001b0b7b31252f9e507b468a2a3ccaac22b0c350e874813`
- Base (`master` @ `08ea822`):
  - typecheck: exit 0. No errors. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667` (byte-identical to PR)
  - test: exit 0, 709 pass / 0 fail / 0 skip. log sha256: `75330557a20b44c5d77c5a5509436c904914cf7a4208cbed95f0a7ef9866fa73`
- **Conclusion:** typecheck is byte-identical between branches; test counts are identical (709/709/0). 0 new failures, 0 pre-existing failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for spot-check.

**Design notes:**
- Clipboard access mirrors `PanelCards.tsx` `copyUrl` exactly (`navigator.clipboard?.writeText(text).then(ok, noop)`) — a click IS a user gesture, so the Electron desktop's silent block on `navigator.clipboard` (per Terminal.tsx note) does not apply.
- One `CopyButton`, two consumers. No duplicated clipboard logic. Component is position-agnostic (consumers pass the positioning className).
- No new deps. No new Tailwind colors. Uses existing `text-text-faint`/`text-text`/`bg-bg-soft`/`border-border` tokens + `text-[10px]` sizing already in the area.
- `memo` wrapper — same prop stability reasoning as the rest of the renderer memo chain.

**Base:** origin/main @ 08ea822