### PR TITLE
chore(website): BET-233 remove 'Download for Linux' buttons from homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -278,7 +278,6 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
     </div>
     <div class="cta">
       <a class="btn btn-primary" href="https://mantaui.com/downloads/Manta-latest.dmg">Download for macOS</a>
-      <a class="btn btn-ghost" href="https://mantaui.com/downloads/Manta-latest.AppImage">Download for Linux</a>
     </div>
     <div class="meta">macOS build is signed — first launch: right-click the app → Open. Free &amp; <a href="https://github.com/antoinedc/MantaUI">open source</a>.</div>
 
@@ -436,7 +435,6 @@ footer{padding:40px 0;border-top:1px solid var(--border-subtle);font-size:13px;c
     </div>
     <div class="cta" style="margin-top:20px">
       <a class="btn btn-primary" href="https://mantaui.com/downloads/Manta-latest.dmg">Download for macOS</a>
-      <a class="btn btn-ghost" href="https://mantaui.com/downloads/Manta-latest.AppImage">Download for Linux</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
**Files changed:** 1 file. `website/index.html` (−2 lines)

**Base:** `origin/main` @ `b4e4b72`

**Verification results:**
- PR branch (`multica/BET-233-remove-linux-download` @ `debdf56`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `709` pass / `0` fail / `0` skip. Failures: none. log sha256: `87572ba895ce26674b90d8b162457e32d0909d6ec4ac0d9f8b72e55a92d0949c`
- Base (`master` @ `b4e4b72`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `709` pass / `0` fail / `0` skip. Failures: none. log sha256: `909a8d85faab1e0688c878ffdd22bda9deb6c8c255cf9a93ea0e1a0b8422d174`
- **Conclusion:** 0 test failures on either branch; 0 typecheck errors on either branch. Pure HTML removal, no logic touched.

**Grep gates (per issue spec):**
- `grep -c "Download for Linux" website/index.html` → `0` ✓
- `grep -c "Manta-latest.AppImage" website/index.html` → `0` ✓
- `grep -c "Download for macOS" website/index.html` → `2` ✓

**HTML validity:** Both `<div class="cta">` blocks now contain a single `<a class="btn btn-primary">Download for macOS</a>` child. `.btn-ghost` is still used by the GitHub link in the hero (line 248), so the CSS class is not stranded.

**Out of scope (not touched):**
- `electron-builder.yml` AppImage config — separate concern, per the issue.
- Install-command tabs / `install.sh` copy button — kept.
- Deploy / `web-v*` tag — per the issue, merge to `main` + tag is not part of this PR.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.
