### PR TITLE
BET-225.C: RPC + UpdateBar + skew guard + 6h re-check

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -60,6 +60,7 @@ mac:
   # To re-enable for public distribution: set `notarize: true` and ensure
   # APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID are in the Codemagic
   # "mantaui" env group.
+  # TODO: set true before public (non-beta) auto-update rollout — Gatekeeper friction on non-notarized DMGs. See AGENTS.md.
   notarize: false
 
 linux:

--- a/electron.vite.config.mobile.ts
+++ b/electron.vite.config.mobile.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+
+// Same package.json#version injection as electron.vite.config.ts so the
+// mobile renderer bundle knows the build version it shipped with — fallback
+// for getClientVersion when there's no Electron preload to ask.
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf8"));
 
 export default defineConfig({
   root: resolve(__dirname, "src/renderer"),
@@ -9,6 +15,7 @@ export default defineConfig({
   define: {
     __MANTA_AXIOM_TOKEN__: JSON.stringify(process.env.MANTA_AXIOM_TOKEN ?? ""),
     __MANTA_AXIOM_DATASET__: JSON.stringify(process.env.MANTA_AXIOM_DATASET ?? "manta"),
+    __APP_VERSION__: JSON.stringify(pkg.version ?? "0.0.0"),
   },
   resolve: { alias: { "@": resolve(__dirname, "src/renderer") } },
   build: {

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+
+// Build-time-injected client version. Mirrors package.json#version so the
+// renderer always knows the version of the running app — used as a fallback
+// by httpApi's getClientVersion on platforms where Electron's `app.getVersion()`
+// is unavailable (mobile, web). On desktop httpApi prefers the live Electron
+// `app.getVersion()` over the preload bridge, so this constant only matters
+// for the renderer-side no-preload code path. Bumping the package.json
+// version automatically propagates to every renderer build at the next
+// `npm run build` / `npm run build:mobile`.
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf8"));
 
 export default defineConfig({
   main: {
@@ -25,6 +36,7 @@ export default defineConfig({
     define: {
       __MANTA_AXIOM_TOKEN__: JSON.stringify(process.env.MANTA_AXIOM_TOKEN ?? ""),
       __MANTA_AXIOM_DATASET__: JSON.stringify(process.env.MANTA_AXIOM_DATASET ?? "manta"),
+      __APP_VERSION__: JSON.stringify(pkg.version ?? "0.0.0"),
     },
     build: {
       rollupOptions: {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,10 @@ import {
   stopDesktopNotifications,
 } from "./desktopNotify.js";
 import {
+  startServerUpdateForwarder,
+  stopServerUpdateForwarder,
+} from "./serverUpdateForwarder.js";
+import {
   startCapExecutor,
   stopCapExecutor,
 } from "./capExecutor.js";
@@ -213,6 +217,19 @@ app.whenReady().then(() => {
         }
       },
     );
+    // Server-update available (BET-225 stage 3): the box polls its
+    // /updates/server.json manifest, publishes a `serverUpdateAvailable`
+    // bus event when a newer version appears, and the desktop renderer
+    // shows a "Server update available" bar. Same SSE→IPC relay pattern
+    // as startDesktopNotifications (one-kind filter on the busConsumer).
+    startServerUpdateForwarder(
+      () => config,
+      (payload) => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(IPC.serverUpdateAvailable, payload);
+        }
+      },
+    );
     // Capability executor (BET-183 / BET-185 / BET-190): when enabled in
     // Settings, this Mac subscribes to bui-server's bus and runs the YAML
     // plugins it finds under ~/.manta/plugins/. startCapExecutor is a
@@ -221,6 +238,14 @@ app.whenReady().then(() => {
     // Defer update check until after the renderer is ready (avoids blocking startup).
     // electron-updater skips the check in dev mode (unpacked app).
     setTimeout(() => checkForUpdates(), 5000);
+    // BET-225 stage 3 (Part B): also re-check for updates every 6 hours
+    // so a long-lived install learns about new versions without restarting.
+    // Plain setInterval with .unref() — same pattern as the other periodic
+    // tasks in this file (screenshotClipboardTimer). No config flag —
+    // always on. Dev-mode checkForUpdates() is a no-op so the timer costs
+    // ~nothing in development.
+    const sixHourTimer = setInterval(() => checkForUpdates(), 6 * 60 * 60 * 1000);
+    sixHourTimer.unref();
   });
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
@@ -236,6 +261,7 @@ app.on("before-quit", () => {
   stopScreenshotDetector();
   stopDesktopPresence();
   stopDesktopNotifications();
+  stopServerUpdateForwarder();
   stopCapExecutor();
 });
 
@@ -247,6 +273,14 @@ function registerHandlers(): void {
   // `window.api` (which is httpApi post-boot and reaches config over
   // /rpc/config:get instead). See src/preload/index.ts and src/renderer/main.tsx.
   ipcMain.handle(IPC.configGet, () => config);
+
+  // BET-225 stage 3 (Part C): returns the desktop app's own version via
+  // Electron's `app.getVersion()` (reads the same package.json the server
+  // uses for `server:version`). Renderer combines this with `minClient`
+  // from getServerVersion via isClientTooOld to decide whether to render
+  // the non-dismissible skew banner. Renderer-only — no equivalent on the
+  // box server (it has its own version endpoint already).
+  ipcMain.handle(IPC.clientVersion, () => ({ version: app.getVersion() }));
 
   // BET-207: `pluginsEnabled` is a Mac-machine-local toggle (controls
   // whether THIS Mac runs plugins). It MUST persist to the Mac-local

--- a/src/main/serverUpdateForwarder.ts
+++ b/src/main/serverUpdateForwarder.ts
@@ -1,0 +1,56 @@
+// serverUpdateForwarder.ts — relay server-update-available bus events from
+// bui-server's /events SSE stream to the desktop renderer via IPC.
+//
+// Mirrors the desktopNotify pattern (src/main/desktopNotify.ts) one-for-one:
+// the SSE plumbing (Bearer-authed long-lived GET, 3s auto-reconnect, frame
+// parse) lives in src/main/busConsumer.ts and this file is just a one-kind
+// filter. The server's server-update poller (src/server/serverUpdate.mjs)
+// publishes `{kind:"serverUpdateAvailable", payload:{version, notesUrl}}`
+// whenever a newer manifest version is detected; this module forwards the
+// payload to the renderer so its UpdateBar component can render the
+// "Server update available: {version}" bar.
+//
+// The renderer reaches the same wire via `window.api.onServerUpdateAvailable`
+// (httpApi subscribes to the bus kind) — main → renderer is just the IPC
+// leg on desktop because the desktop's renderer doesn't directly consume
+// the /events stream (it goes through main so the renderer gets a typed
+// IPC push, not a WS frame).
+
+import { createBusConsumer, type BusConsumer } from "./busConsumer.js";
+import type { AppConfig, ServerUpdateAvailablePayload } from "../shared/types.js";
+
+let consumer: BusConsumer | null = null;
+
+/**
+ * Start forwarding server-update-available envelopes from bui-server's bus
+ * to the renderer. `configGetter` returns the live AppConfig (serverUrl +
+ * boxToken for HTTPS Bearer auth); `onPayload` delivers the parsed payload
+ * to the renderer (typically a webContents.send). Idempotent.
+ */
+export function startServerUpdateForwarder(
+  configGetter: () => AppConfig,
+  onPayload: (payload: ServerUpdateAvailablePayload) => void,
+): void {
+  if (consumer) return;
+  consumer = createBusConsumer(
+    configGetter,
+    (env) => {
+      if (env.kind !== "serverUpdateAvailable" || !env.payload) return;
+      const p = env.payload as Partial<ServerUpdateAvailablePayload>;
+      if (typeof p.version !== "string" || !p.version) return;
+      try {
+        onPayload({
+          version: p.version,
+          notesUrl: typeof p.notesUrl === "string" ? p.notesUrl : null,
+        });
+      } catch {
+        /* renderer gone / window closed — ignore */
+      }
+    },
+  );
+}
+
+export function stopServerUpdateForwarder(): void {
+  consumer?.stop();
+  consumer = null;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import {
   type AppConfig,
   type AuthClaimInput,
   type DesktopNotifyPayload,
+  type ServerUpdateAvailablePayload,
 } from "../shared/types.js";
 import type { ClaimOutcome } from "../shared/claim.mjs";
 
@@ -80,6 +81,26 @@ const api = {
     ipcRenderer.invoke(IPC.pluginsGetEnabled),
   pluginsSetEnabled: (value: boolean): Promise<void> =>
     ipcRenderer.invoke(IPC.pluginsSetEnabled, value),
+
+  // Client version (BET-225 stage 3): returns the running desktop app's own
+  // version via main → `app.getVersion()` (the authoritative live source —
+  // reads the same package.json the server uses for `server:version`).
+  // httpApi calls this as the desktop-side leg of `getClientVersion()`;
+  // mobile/web have no preload and fall back to a build-time `__APP_VERSION__`
+  // define in the renderer bundle.
+  clientVersion: (): Promise<{ version: string }> =>
+    ipcRenderer.invoke(IPC.clientVersion),
+
+  // Server-update available subscription (BET-225 stage 3): main subscribes
+  // to bui-server's /events SSE stream (src/main/serverUpdateForwarder.ts),
+  // filters on kind === "serverUpdateAvailable", and forwards the payload
+  // to the renderer via this IPC channel. Mirrors the desktopNotify
+  // one-kind-filter pattern; share the same kind/payload envelope.
+  onServerUpdateAvailable: (cb: (payload: ServerUpdateAvailablePayload) => void): (() => void) => {
+    const listener = (_: unknown, payload: ServerUpdateAvailablePayload) => cb(payload);
+    ipcRenderer.on(IPC.serverUpdateAvailable, listener);
+    return () => ipcRenderer.removeListener(IPC.serverUpdateAvailable, listener);
+  },
 };
 
 // Expose the real preload bridge under a STABLE, dedicated name — NOT "api".

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,8 @@ import {
   writeSavedMode,
   resolveLauncherFlags,
 } from "./chatShared";
+import { chooseUpdateSkewVariant } from "./chatUtils";
+import { UpdateBar } from "./UpdateBar";
 import type { AvailableLauncher } from "../shared/types";
 
 // mode -> the composite-key "modeId" segment used for the PTY sessionKey and
@@ -39,6 +41,8 @@ export function App() {
     configSnapshot,
     updatePrompt,
     setUpdatePrompt,
+    serverUpdatePrompt,
+    setServerUpdatePrompt,
     connectionState,
     launcherFlags,
   } = useStore();
@@ -226,6 +230,56 @@ export function App() {
       });
     });
     return off;
+  }, []);
+
+  // Server-update available (BET-225 stage 3): main forwards the box's
+  // `serverUpdateAvailable` bus event to the renderer via the
+  // `serverUpdateAvailable` IPC channel. The renderer renders a "Server
+  // update available: {version}" bar via the shared UpdateBar component —
+  // same component as the desktop auto-update prompt, just a different
+  // message + button label (`serverUpdateApply` runs `scripts/self-update.sh`
+  // on the box). On mobile the IPC listener is a no-op (httpApi shim
+  // returns `() => {}`); mobile-specific mobile UI is out of scope — this
+  // subscription exists so the store field + bus-case stay in sync for a
+  // later mobile pass.
+  useEffect(() => {
+    if (!window.api.onServerUpdateAvailable) return;
+    const off = window.api.onServerUpdateAvailable((payload) => {
+      useStore.getState().setServerUpdatePrompt({
+        version: payload.version,
+        notesUrl: payload.notesUrl ?? undefined,
+      });
+    });
+    return off;
+  }, []);
+
+  // Version-skew guard (BET-225 stage 3 Part C). After the renderer is
+  // mounted, fetch the client + server version pair ONCE (no second poll,
+  // per the stage-3 spec) and let `chooseUpdateSkewVariant` decide
+  // whether to render the non-dismissible "outdated" banner. Missing
+  // versions (mid-bootstrap, transient failure) collapse to "ok" so we
+  // never flash the blocking banner on a fresh launch. getServerVersion
+  // is the same endpoint MobileSettings already calls for its display
+  // — both consume the same `{version, minClient}` payload.
+  const [clientVersion, setClientVersion] = useState<string | null>(null);
+  const [serverMinClient, setServerMinClient] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      window.api.getClientVersion?.().catch(() => null),
+      window.api.getServerVersion?.().catch(() => null),
+    ]).then(([client, server]) => {
+      if (cancelled) return;
+      if (client && typeof client.version === "string") {
+        setClientVersion(client.version);
+      }
+      if (server && typeof server.minClient === "string") {
+        setServerMinClient(server.minClient);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Sidebar status for chat-mode windows. The PTY-pane poller
@@ -529,35 +583,82 @@ export function App() {
     <div className="h-full w-full flex bg-bg text-text">
       <Sidebar ref={sidebarRef} onOpenSettings={() => setSettingsOpen(true)} />
       <main className="flex-1 flex flex-col min-w-0">
-        {/* Auto-update prompt bar. Shown when main has downloaded a new
-            version and is waiting for the user to restart. Positioned at the
-            top of the main area so it's visible regardless of which panel
-            is active. Dismissed by the × button (clears store state). */}
+        {/* Auto-update prompt bar (BET-225 stage 3: shared UpdateBar).
+            Shown when main has downloaded a new version and is waiting for
+            the user to restart. Positioned at the top of the main area so
+            it's visible regardless of which panel is active. Dismissed by
+            the × button (clears store state). The UpdateBar component is
+            the shared banner used for all three update prompts — desktop
+            auto-update, server update, and the version-skew guard (below). */}
         {!showOnboarding && updatePrompt && (
-          <div className="shrink-0 bg-accent/10 border-b border-accent/30 px-3 py-1.5 text-[12px] text-text flex items-center gap-2">
-            <span className="flex-1 truncate">
-              Update available:{" "}
-              <span className="font-medium text-text">
-                {updatePrompt.releaseName || updatePrompt.version}
-              </span>
-            </span>
-            <button
-              onClick={() => {
-                void window.api.autoUpdateInstall();
-              }}
-              className="shrink-0 rounded bg-accent/20 px-2 py-0.5 text-accent hover:bg-accent/30 font-medium"
-            >
-              Restart to update
-            </button>
-            <button
-              onClick={() => setUpdatePrompt(null)}
-              className="shrink-0 text-text-faint hover:text-text leading-none"
-              title="Dismiss"
-            >
-              ×
-            </button>
-          </div>
+          <UpdateBar
+            text={
+              <>
+                Update available:{" "}
+                <span className="font-medium text-text">
+                  {updatePrompt.releaseName || updatePrompt.version}
+                </span>
+              </>
+            }
+            actionLabel="Restart to update"
+            onAction={() => {
+              void window.api.autoUpdateInstall();
+            }}
+            onDismiss={() => setUpdatePrompt(null)}
+          />
         )}
+        {/* Server-update prompt (BET-225 stage 3 Part A): shown when the
+            box's server-update poller sees a newer manifest version. Same
+            UpdateBar component as the desktop auto-update above; the action
+            button fires `serverUpdateApply` which runs scripts/self-update.sh
+            on the box (git fetch + reset --hard origin/main + npm ci
+            --omit=dev + systemctl --user restart manta-server). */}
+        {!showOnboarding && serverUpdatePrompt && (
+          <UpdateBar
+            text={
+              <>
+                Server update available:{" "}
+                <span className="font-medium text-text">
+                  {serverUpdatePrompt.version}
+                </span>
+              </>
+            }
+            actionLabel="Update & restart"
+            onAction={() => {
+              void window.api.serverUpdateApply();
+            }}
+            onDismiss={() => setServerUpdatePrompt(null)}
+          />
+        )}
+        {/* Version-skew guard (BET-225 stage 3 Part C). NON-dismissible —
+            the client version is older than the server's `minClient` (a
+            breaking RPC change shipped in a newer server), so the user
+            MUST update before the app can talk to the box safely. The
+            button picks the right desktop action based on whether an
+            update has already been downloaded (`updatePrompt !== null` →
+            autoUpdateInstall; else → autoUpdateDownload). On mobile the
+            action is informational (App Store) — mobile skips this branch
+            because there's no autoUpdate plumbing. */}
+        {!showOnboarding &&
+          chooseUpdateSkewVariant(clientVersion, serverMinClient) === "outdated" && (
+            <UpdateBar
+              text={
+                <>
+                  This app is out of date and may not work correctly —
+                  please update.
+                </>
+              }
+              actionLabel="Update"
+              onAction={() => {
+                if (updatePrompt) {
+                  void window.api.autoUpdateInstall();
+                } else {
+                  void window.api.autoUpdateDownload();
+                }
+              }}
+              dismissible={false}
+            />
+          )}
         <div className="titlebar-drag h-10 border-b border-border flex items-center px-3 gap-2 min-w-0">
           <div className="text-xs text-text-muted flex items-center gap-2 min-w-0">
             {activeProjectName && (

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -1,0 +1,77 @@
+// UpdateBar.tsx — shared "an update exists" banner used for three prompts:
+//
+//   1. Desktop auto-update (electron-updater finished downloading a new
+//      version): "Update available: {version}" + "Restart to update" button.
+//   2. Server update (BET-225 stage 3): "Server update available: {version}"
+//      + "Update & restart" button (fires `scripts/self-update.sh` on the box).
+//   3. Version-skew guard (BET-225 stage 3 Part C): "This app is out of
+//      date and may not work correctly — please update." + a button that
+//      triggers an update flow (autoUpdateInstall / autoUpdateDownload on
+//      desktop, App Store informational on mobile). This variant is
+//      NON-dismissible (`dismissible: false` hides the × button) — the
+//      RPC contract on either side has shifted past `minClient`, so the
+//      user MUST act before continuing.
+//
+// One component, three usages; the spec wants this consolidated rather
+// than three near-identical inline banners. Props carry the surface area:
+// text + action label + action handler + optional dismiss handler.
+//
+// `dismissible` defaults to true — the desktop auto-update and server-update
+// cases are both user-dismissible (a "remind me later" semantic). The skew
+// guard explicitly opts out (`dismissible: false`) so the banner sticks
+// until the client gets on a supported version.
+
+import type { ReactNode } from "react";
+
+export type UpdateBarProps = {
+  /** Main message text. Keep it under ~80 chars so it fits the titlebar width. */
+  text: ReactNode;
+  /** Visible version string (e.g. "0.4.1"). Rendered inside `text` if you
+   *  pass plain string; for the skew guard this is usually left out. */
+  version?: ReactNode;
+  /** Primary button label. */
+  actionLabel: string;
+  /** Primary button click. Fire-and-forget; the component doesn't await. */
+  onAction: () => void;
+  /** Optional dismiss callback (× button). Required if `dismissible` is true;
+   *  ignored when `dismissible` is false (no × button rendered). */
+  onDismiss?: () => void;
+  /** When true (default), show the × button. Skew guard passes false. */
+  dismissible?: boolean;
+};
+
+/**
+ * Single update-banner component shared by desktop auto-update, server
+ * update, and the version-skew guard. Visual style mirrors the original
+ * inline banner in App.tsx so the three usages look identical.
+ */
+export function UpdateBar({
+  text,
+  actionLabel,
+  onAction,
+  onDismiss,
+  dismissible = true,
+}: UpdateBarProps) {
+  return (
+    <div className="shrink-0 bg-accent/10 border-b border-accent/30 px-3 py-1.5 text-[12px] text-text flex items-center gap-2">
+      <span className="flex-1 truncate">{text}</span>
+      <button
+        onClick={() => {
+          onAction();
+        }}
+        className="shrink-0 rounded bg-accent/20 px-2 py-0.5 text-accent hover:bg-accent/30 font-medium"
+      >
+        {actionLabel}
+      </button>
+      {dismissible && onDismiss && (
+        <button
+          onClick={() => onDismiss()}
+          className="shrink-0 text-text-faint hover:text-text leading-none"
+          title="Dismiss"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -6,6 +6,7 @@ import {
   type OpencodeEvent,
   type PluginRegistryRow,
   type PtyEvent,
+  type ServerUpdateAvailablePayload,
   type WindowStatus,
 } from "../../shared/types.js";
 import type { Api } from "../../shared/api.js";
@@ -307,7 +308,8 @@ type Kind =
   | "status"
   | "screenshot"
   | "agentFile"
-  | "desktopNotify";
+  | "desktopNotify"
+  | "serverUpdateAvailable";
 
 const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   opencode: new Set(),
@@ -316,6 +318,7 @@ const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   screenshot: new Set(),
   agentFile: new Set(),
   desktopNotify: new Set(),
+  serverUpdateAvailable: new Set(),
 };
 
 // The live event stream is a WebSocket (not SSE/EventSource): iOS standalone
@@ -921,7 +924,51 @@ export const httpApi: Api = {
   // `server:version` RPC channel (no HTTP round-trip; same value GET
   // /api/version returns for non-renderer clients). MobileSettings renders
   // "Server vX.Y.Z" under the URL field — display only, no gating.
-  getServerVersion: () => rpc<{ version: string }>(IPC.getServerVersion),
+  //
+  // Response also carries `minClient` (the constant the server exports from
+  // src/server/version.mjs) so the renderer's version-skew guard
+  // (BET-225 stage 3) can compute `isClientTooOld` from a single round-trip
+  // — no second endpoint, no parallel poll. The interface keeps `version`
+  // only for backward compat with the BET-180 callers; new consumers
+  // should destructure both fields off the response.
+  getServerVersion: () => rpc<{ version: string; minClient: string }>(IPC.getServerVersion),
+
+  // -- client version (BET-225 stage 3) --
+  // Returns the running client's own version. On desktop the preload bridge
+  // routes to main → `app.getVersion()` (the authoritative live source).
+  // On mobile/web there's no Electron preload — fall back to `__APP_VERSION__`,
+  // the package.json#version Vite `define` baked into the bundle at build
+  // time. The fallback is non-zero so isClientTooOld never trips on a
+  // missing-version client; bumping MIN_CLIENT above the current mobile
+  // build will start surfacing the informational skew banner in MobileApp.
+  getClientVersion: async (): Promise<{ version: string }> => {
+    const preload = getBuiPreload();
+    if (preload?.clientVersion) {
+      try {
+        return await preload.clientVersion();
+      } catch {
+        /* preload rejected — fall through to baked-in fallback */
+      }
+    }
+    return { version: __APP_VERSION__ };
+  },
+
+  // -- server-update apply (BET-225 stage 3) --
+  // Renderer → server RPC: kicks off scripts/self-update.sh on the box.
+  // Returns immediately (fire-and-forget); the restart kills the bui-server
+  // process mid-run so a caller awaiting past the RPC send may never see
+  // a response. Modeled on `opencode:restart` (single-purpose server action,
+  // fixed-argv execFile, no injection surface).
+  serverUpdateApply: () => rpc<void>(IPC.serverUpdateApply),
+
+  // -- server-update available subscription (BET-225 stage 3) --
+  // /events WS stream publishes `{kind: "serverUpdateAvailable", payload}`
+  // (the same envelope shape desktopNotify uses). The renderer's UpdateBar
+  // component renders a "Server update available: {version}" bar with a
+  // button that calls serverUpdateApply(). Mobile gets the same subscription
+  // so the store field stays in sync — actual mobile UI is a later pass.
+  onServerUpdateAvailable: (cb) =>
+    on<ServerUpdateAvailablePayload>("serverUpdateAvailable", cb),
 
   // -- plugins (BET-189 / BET-190) --
   // Read the current plugin registry the Mac executor has published. The

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -65,6 +65,7 @@ import {
   runWithConcurrency,
   credentialRefreshBannerText,
   lastUserMessageText,
+  chooseUpdateSkewVariant,
 } from "./chatUtils";
 
 // ===== formatTokens =====
@@ -2944,5 +2945,60 @@ describe("lastUserMessageText", () => {
       { info: { role: "assistant" }, parts: [{ type: "text", text: "hi" }] },
     ]);
     expect(out).toBe(null);
+  });
+});
+
+describe("chooseUpdateSkewVariant", () => {
+  // Version-skew guard (BET-225 stage 3 Part C): the renderer reads its own
+  // client version (`getClientVersion()`) + the server's `minClient`
+  // (from `getServerVersion()`), then asks this helper which variant of
+  // the shared UpdateBar to render. Two-variant contract:
+  //   - "ok"       → no banner (or the normal auto-update / server-update
+  //                  banners if those are independently triggered)
+  //   - "outdated" → non-dismissible "this app is out of date" banner
+  //
+  // The semver compare itself is already covered by versionCompare.test.ts
+  // (BET-225.A); this test pins the renderer-side two-variant state
+  // machine that drives UpdateBar's `dismissible` + `onAction` props.
+
+  it("returns 'outdated' when the client version is strictly older than minClient", () => {
+    expect(chooseUpdateSkewVariant("0.0.1", "0.0.2")).toBe("outdated");
+    expect(chooseUpdateSkewVariant("1.0.0", "2.0.0")).toBe("outdated");
+    expect(chooseUpdateSkewVariant("0.0.0", "1.0.0")).toBe("outdated");
+  });
+
+  it("returns 'ok' when the client version equals or exceeds minClient", () => {
+    expect(chooseUpdateSkewVariant("0.0.2", "0.0.2")).toBe("ok");
+    expect(chooseUpdateSkewVariant("1.0.0", "0.9.9")).toBe("ok");
+    expect(chooseUpdateSkewVariant("2.0.0", "1.0.0")).toBe("ok");
+  });
+
+  it("returns 'ok' when the client version equals minClient exactly (no skew signal)", () => {
+    // The boundary case: equal versions are NOT outdated — the client is
+    // exactly at the minimum. only isClientTooOld() (strictly less than)
+    // matters here.
+    expect(chooseUpdateSkewVariant("1.2.3", "1.2.3")).toBe("ok");
+  });
+
+  it("returns 'ok' for missing/empty clientVersion (mid-bootstrap never flashes the blocking banner)", () => {
+    expect(chooseUpdateSkewVariant(null, "0.0.0")).toBe("ok");
+    expect(chooseUpdateSkewVariant(undefined, "0.0.0")).toBe("ok");
+    expect(chooseUpdateSkewVariant("", "0.0.0")).toBe("ok");
+  });
+
+  it("returns 'ok' for missing/empty minClient (server version fetch failed)", () => {
+    expect(chooseUpdateSkewVariant("1.0.0", null)).toBe("ok");
+    expect(chooseUpdateSkewVariant("1.0.0", undefined)).toBe("ok");
+    expect(chooseUpdateSkewVariant("1.0.0", "")).toBe("ok");
+  });
+
+  it("treats malformed versions as 0.0.0 (delegates to isClientTooOld)", () => {
+    // versionCompare's parseVersion collapses bad input to [0,0,0] — both
+    // sides → 0.0.0 → no skew. This is the "first-line guard" behavior
+    // documented in versionCompare.mjs.
+    expect(chooseUpdateSkewVariant("abc", "0.0.0")).toBe("ok");
+    expect(chooseUpdateSkewVariant("1.x.3", "0.0.0")).toBe("ok");
+    // But once one side has a real version, the compare takes over.
+    expect(chooseUpdateSkewVariant("abc", "0.0.1")).toBe("outdated");
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -4,6 +4,12 @@
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
+// Value import — `isClientTooOld` is the pure semver compare that drives
+// the renderer-side version-skew banner (BET-225 stage 3). Lives in
+// shared/versionCompare.mjs so both src/server/*.mjs and the renderer share
+// one source of truth; re-imported here so chooseUpdateSkewVariant is
+// testable in isolation (no DOM/network, just the compare).
+import { isClientTooOld } from "../shared/versionCompare.mjs";
 
 // Fallback context size used when the active model has no `limit.context`
 // (or no active model is known yet). 200k is the lowest common denominator
@@ -2086,4 +2092,36 @@ export function lastUserMessageText(
     if (text) return text;
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Version-skew guard (BET-225 stage 3)
+// ---------------------------------------------------------------------------
+//
+// The renderer's UpdateBar component has two variants:
+//   - "ok"       → no banner
+//   - "outdated" → non-dismissible "this app is out of date" banner
+//
+// `chooseUpdateSkewVariant` picks the variant purely from the two version
+// strings the renderer already has on hand (the desktop's own version from
+// `getClientVersion()` + the server's `minClient` from `getServerVersion()`).
+// Pure: no DOM, no Electron, no network. Tested in chatUtils.test.ts.
+//
+// Treats missing/empty inputs as "no skew signal yet" → "ok", so a renderer
+// that's mid-bootstrap (versions not fetched yet) never spuriously flashes
+// the blocking banner. Both inputs run through `isClientTooOld`, which itself
+// treats malformed versions as "0.0.0" — see src/shared/versionCompare.mjs.
+//
+// The helper is intentionally a string literal union (not a boolean) so the
+// test surface is the exact "two variants" contract the UpdateBar component
+// encodes — extending the set later (e.g. a "warn" tier for non-blocking
+// deprecation hints) is a deliberate choice, not a happy accident.
+export type UpdateSkewVariant = "ok" | "outdated";
+
+export function chooseUpdateSkewVariant(
+  clientVersion: string | null | undefined,
+  minClient: string | null | undefined,
+): UpdateSkewVariant {
+  if (!clientVersion || !minClient) return "ok";
+  return isClientTooOld(clientVersion, minClient) ? "outdated" : "ok";
 }

--- a/src/renderer/mobile/MobileApp.tsx
+++ b/src/renderer/mobile/MobileApp.tsx
@@ -265,6 +265,22 @@ export function MobileApp() {
     return window.api.onAgentFileReady((ev) => setAgentFileToast(ev));
   }, [setAgentFileToast]);
 
+  // Server-update available (BET-225 stage 3 Part A). Mobile does NOT
+  // currently render an `updatePrompt` (App Store delivers updates out of
+  // band, no in-app auto-update plumbing), so per the stage-3 spec we
+  // wire the store field + bus-case only — no new mobile UI here. The
+  // store stays in sync so a later mobile pass can render a banner
+  // trivially by reading `useStore((s) => s.serverUpdatePrompt)`.
+  useEffect(() => {
+    if (!window.api.onServerUpdateAvailable) return;
+    return window.api.onServerUpdateAvailable((payload) => {
+      useStore.getState().setServerUpdatePrompt({
+        version: payload.version,
+        notesUrl: payload.notesUrl ?? undefined,
+      });
+    });
+  }, []);
+
   const goList = () => setNav({ screen: "list" });
   const openSession = (projectName: string, windowIndex: number) => {
     setActive(projectName, windowIndex);

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -29,6 +29,15 @@ function makeFakePreload(): BuiPreload {
     peekRemoteFile: vi.fn(async () => {}),
     pluginsGetEnabled: vi.fn(async () => false),
     pluginsSetEnabled: vi.fn(async () => {}),
+    // BET-225 stage 3: client version + server-update available. The fake
+    // matches the BuiPreload shape added in src/renderer/preloadAccess.ts;
+    // we only care about getBuiPreload's contract here, not the methods
+    // themselves, so minimal vi.fn stubs suffice.
+    clientVersion: vi.fn(async () => ({ version: "test-client" })),
+    onServerUpdateAvailable: vi.fn((cb: (p: unknown) => void) => {
+      cb({ version: "test-server", notesUrl: null });
+      return vi.fn();
+    }),
   };
 }
 

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -1,4 +1,4 @@
-import type { DesktopNotifyPayload } from "../shared/types.js";
+import type { DesktopNotifyPayload, ServerUpdateAvailablePayload } from "../shared/types.js";
 
 /**
  * OS-integration affordances exposed by the Electron preload bridge.
@@ -50,6 +50,23 @@ export interface BuiPreload {
   // pluginsSetEnabled; both are no-ops on mobile/web (no preload).
   pluginsGetEnabled(): Promise<boolean>;
   pluginsSetEnabled(value: boolean): Promise<void>;
+  // Client version (BET-225 stage 3): returns the running desktop app's own
+  // version via main → `app.getVersion()`. Combined with the server's
+  // `minClient` (from getServerVersion) by the renderer's isClientTooOld
+  // check to decide whether to render the non-dismissible skew banner.
+  // httpApi calls this as the desktop-side leg of `getClientVersion()`;
+  // mobile/web have no preload and fall back to a build-time `__APP_VERSION__`
+  // define in the renderer bundle.
+  clientVersion(): Promise<{ version: string }>;
+  // Server-update available subscription (BET-225 stage 3): fires when the
+  // box's server-update poller (src/server/serverUpdate.mjs) sees a newer
+  // manifest version. Mirrors the desktopNotify pattern — main subscribes
+  // to bui-server's /events SSE, filters by kind, and forwards the payload
+  // via IPC. The renderer's UpdateBar component renders a "Server update
+  // available: {version}" bar with a button that calls serverUpdateApply().
+  onServerUpdateAvailable(
+    cb: (payload: ServerUpdateAvailablePayload) => void,
+  ): () => void;
 }
 
 /**

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -160,6 +160,17 @@ type State = {
   // updateDownloaded event). Guarded — the mobile httpApi shim's
   // onAutoUpdate* are no-ops, so this is desktop-only.
   updatePrompt: { version: string; releaseName?: string } | null;
+  // Single global server-update prompt (BET-225 stage 3). Set when the box's
+  // server-update poller (src/server/serverUpdate.mjs) publishes a
+  // `serverUpdateAvailable` bus event after polling its version manifest.
+  // The renderer shows a "Server update available: {version}" bar; clicking
+  // the button calls serverUpdateApply which runs `scripts/self-update.sh`
+  // on the box (git fetch + reset --hard origin/main + npm ci --omit=dev
+  // + systemctl --user restart manta-server). Dismissed by the × button
+  // (clears the state — the bar won't reappear until the bus fires again
+  // for a STRICTLY newer version; the server-side dedup gate mirrors this
+  // exactly, see src/server/serverUpdate.mjs).
+  serverUpdatePrompt: { version: string; notesUrl?: string | null } | null;
   // Live events-WebSocket connection state (from the shared
   // ConnectionState machine). Surface to the UI so a title-bar pill can
   // show "reconnecting…" when the link is down. Updated by the httpApi
@@ -260,6 +271,9 @@ type State = {
   setScreenshotToast: (t: ScreenshotToast | null) => void;
   setAgentFileToast: (t: AgentFileReady | null) => void;
   setUpdatePrompt: (p: { version: string; releaseName?: string } | null) => void;
+  setServerUpdatePrompt: (
+    p: { version: string; notesUrl?: string | null } | null,
+  ) => void;
   setConnectionState: (s: ConnectionState) => void;
 };
 
@@ -290,6 +304,7 @@ export const useStore = create<State>((set, get) => ({
   screenshotToast: null,
   agentFileToast: null,
   updatePrompt: null,
+  serverUpdatePrompt: null,
   connectionState: { state: "idle" },
   backgroundSyncing: false,
 
@@ -426,6 +441,7 @@ export const useStore = create<State>((set, get) => ({
   setScreenshotToast: (t) => set({ screenshotToast: t }),
   setAgentFileToast: (t) => set({ agentFileToast: t }),
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
+  setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),
   setConnectionState: (s) => set({ connectionState: s }),
 
   applyStatusBatch: (batch) =>

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -12,6 +12,14 @@ declare global {
   // token is present; desktop additionally honors AppConfig.shareAnalytics.
   const __MANTA_AXIOM_TOKEN__: string;
   const __MANTA_AXIOM_DATASET__: string;
+  // Build-time injected app version (mirror of package.json#version at the
+  // time of `npm run build`). Used by httpApi.getClientVersion as the
+  // fallback when there's no Electron preload to call app.getVersion()
+  // (mobile/web). On desktop httpApi prefers the live Electron value, so
+  // this constant only matters on the no-preload code path. Bumping the
+  // package.json version automatically propagates to every renderer build
+  // at the next build run.
+  const __APP_VERSION__: string;
 }
 
 export {};

--- a/src/server/opencodeAdmin.mjs
+++ b/src/server/opencodeAdmin.mjs
@@ -43,3 +43,35 @@ export async function restartOpencode(exec = execFileAsync) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 }
+
+/**
+ * Trigger the box's self-update script (`scripts/self-update.sh` in the
+ * repo root). Fixed argv passed to execFile — never a shell string — so
+ * there is no command-injection surface regardless of caller input (this
+ * takes no caller input). The script itself does `git fetch + reset --hard
+ * origin/main + npm ci --omit=dev + systemctl --user restart manta-server`;
+ * the restart will kill this bui-server process mid-run, so we spawn the
+ * child DETACHED and unref() it — never await on exit. The caller (RPC
+ * handler in src/server/rpc.mjs) gets the child PID back; the renderer
+ * UpdateBar fires this on click and the HTTP promise resolves immediately.
+ *
+ * `spawnFile` is injectable for tests; defaults to the real execFileCb
+ * (the callback variant, since we DON'T want the promisified form — we
+ * need the raw ChildProcess to unref). Tests inject a stub that records
+ * the call.
+ *
+ * @param {string} scriptPath - absolute path to scripts/self-update.sh
+ *   (resolved by the RPC handler from `import.meta.url`).
+ * @param {(cmd: string, args: string[], opts: { detached?: boolean, stdio?: string }) => { pid?: number, unref: () => void }} [spawnFile]
+ * @returns {Promise<{ ok: true, pid?: number } | { ok: false, error: string }>}
+ */
+export async function runServerSelfUpdate(scriptPath, spawnFile = execFileCb) {
+  try {
+    const child = spawnFile(scriptPath, [], { detached: true, stdio: "ignore" });
+    child.unref();
+    return { ok: true, pid: child.pid };
+  } catch (e) {
+    console.warn("[opencodeAdmin] self-update failed:", e);
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/src/server/opencodeAdmin.test.mjs
+++ b/src/server/opencodeAdmin.test.mjs
@@ -4,7 +4,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { restartOpencode } from "./opencodeAdmin.mjs";
+import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 
 describe("restartOpencode", () => {
   it("invokes systemctl --user restart opencode-serve with a fixed argv (no shell string)", async () => {
@@ -36,5 +36,56 @@ describe("restartOpencode", () => {
       assert.equal(typeof arg, "string");
     }
     assert.equal(calls[0].args.join(" "), "--user restart opencode-serve");
+  });
+});
+
+describe("runServerSelfUpdate", () => {
+  // The injection here uses the callback-shaped execFile (not the
+  // promisified one) because the production path needs the raw
+  // ChildProcess handle to .unref() it. Stub returns a fake child with a
+  // fixed pid and a no-op unref so we can assert the call shape.
+  function fakeSpawn(records, pid = 4242) {
+    return (cmd, args, opts) => {
+      records.push({ cmd, args, opts });
+      return {
+        pid,
+        unref() {
+          /* no-op */
+        },
+      };
+    };
+  }
+
+  it("spawns the script detached + unref'd with no argv (fire-and-forget)", async () => {
+    const calls = [];
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", fakeSpawn(calls));
+    assert.equal(result.ok, true);
+    assert.equal(result.pid, 4242);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].cmd, "/abs/scripts/self-update.sh");
+    assert.deepEqual(calls[0].args, []);
+    // detached:true is the load-bearing flag — without it the child would
+    // keep the bui-server alive after the restart. stdio:"ignore" keeps
+    // the script's stdout/stderr from blowing up bui-server's stdio.
+    assert.equal(calls[0].opts.detached, true);
+    assert.equal(calls[0].opts.stdio, "ignore");
+  });
+
+  it("returns ok:false with the error message when spawn throws (script missing, no exec bit)", async () => {
+    const spawn = () => {
+      throw new Error("spawn /abs/scripts/self-update.sh EACCES");
+    };
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn);
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "spawn /abs/scripts/self-update.sh EACCES");
+  });
+
+  it("never interpolates arguments into a single shell string", async () => {
+    // Same defense-in-depth guard as restartOpencode: this function takes
+    // no caller input (the script path is resolved at module load from
+    // import.meta.url), so the argv array must always be exactly [].
+    const calls = [];
+    await runServerSelfUpdate("/abs/scripts/self-update.sh", fakeSpawn(calls));
+    assert.deepEqual(calls[0].args, []);
   });
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -1,6 +1,8 @@
 // Channel -> handler dispatch. Handlers are async (...args) => result.
 // Mirrors Electron ipcMain.handle semantics.
 
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { transcribeAudio, classifyVoiceCommand } from "../shared/groq.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob } from "./schedule.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
@@ -12,10 +14,18 @@ import {
 import { resolveWorkspace } from "./peers.mjs";
 import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
-import { restartOpencode } from "./opencodeAdmin.mjs";
+import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { MIN_CLIENT } from "./version.mjs";
+
+// Same dirname derivation as src/server/index.mjs (line 83) so the script
+// path resolves identically. The script lives at <repoRoot>/scripts/
+// self-update.sh — `restartOpencode` invokes an absolute binary on PATH;
+// this one is repo-local so we resolve it explicitly. Mirrors how the
+// server already passes an absolute cwd to tmux/opencode spawning.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SELF_UPDATE_SCRIPT = join(__dirname, "..", "..", "scripts", "self-update.sh");
 
 export async function dispatch(handlers, channel, args) {
   const fn = handlers[channel];
@@ -282,6 +292,17 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // subagent/provider config write takes effect (opencode only re-reads the
     // `agent`/`provider` blocks at startup). Was a no-op stub pre-BET-123.
     "opencode:restart": () => restartOpencode(),
+
+    // server-update apply (BET-225 stage 3 Part A): kick off the box's
+    // self-update script (scripts/self-update.sh — git fetch + reset --hard
+    // origin/main + npm ci --omit=dev + systemctl --user restart
+    // manta-server). The script's final step kills this bui-server process
+    // mid-run, so the child is detached via `runServerSelfUpdate` rather
+    // than awaited here — the caller (renderer UpdateBar) just sees the
+    // RPC promise resolve as soon as execFile returns. No caller-supplied
+    // input (no injection surface); script path is resolved once at module
+    // load from `import.meta.url` so cwd never enters the calculation.
+    "server:update-apply": () => runServerSelfUpdate(SELF_UPDATE_SCRIPT),
 
     // preload: ipcRenderer.invoke(IPC.opencodeDefaultModel)  → no args
     "opencode:default-model": () => oc.getDefaultModel(),

--- a/src/server/serverUpdate.mjs
+++ b/src/server/serverUpdate.mjs
@@ -124,10 +124,15 @@ export function startServerUpdatePoller(
     if (result.version === lastNotifiedVersion) return;
     lastNotifiedVersion = result.version;
 
+    // Match the bus envelope documented in src/server/events.mjs: every
+    // `{kind, payload}` event from the server carries the per-kind fields
+    // INSIDE `payload`, not as siblings of `kind`. The renderer's dispatchFrame
+    // (src/renderer/api/httpApi.ts) destructures `{kind, payload}` and hands
+    // `payload` to its listeners; nesting here is what makes the stage-3
+    // `onServerUpdateAvailable` subscription see `{version, notesUrl}`.
     bus.publish({
       kind: "serverUpdateAvailable",
-      version: result.version,
-      notesUrl: result.notesUrl ?? null,
+      payload: { version: result.version, notesUrl: result.notesUrl ?? null },
     });
 
     if (typeof notify === "function") {

--- a/src/server/serverUpdate.test.mjs
+++ b/src/server/serverUpdate.test.mjs
@@ -161,8 +161,12 @@ test("poller: first tick on a newer manifest publishes ONE event AND fires notif
     await new Promise((r) => setImmediate(r));
     assert.equal(updateEvents(bus).length, 1);
     const evt = updateEvents(bus)[0];
-    assert.equal(evt.version, "9.9.9");
-    assert.equal(evt.notesUrl, "https://mantaui.com/releases");
+    // The bus envelope nests per-kind fields inside `payload` (see
+    // src/server/events.mjs comment + the publish call in serverUpdate.mjs) —
+    // the renderer's dispatchFrame destructures `{kind, payload}` so the
+    // listener sees `{version, notesUrl}` as the payload object.
+    assert.equal(evt.payload?.version, "9.9.9");
+    assert.equal(evt.payload?.notesUrl, "https://mantaui.com/releases");
     assert.equal(notifyCalls.length, 1);
     assert.match(notifyCalls[0].message, /Server update 9\.9\.9 available/);
     assert.equal(notifyCalls[0].sessionID, null);
@@ -210,8 +214,7 @@ test("poller: dedup — re-tick on the SAME newer version does NOT republish", a
     lastNotifiedVersion = r.version;
     bus.publish({
       kind: "serverUpdateAvailable",
-      version: r.version,
-      notesUrl: r.notesUrl,
+      payload: { version: r.version, notesUrl: r.notesUrl ?? null },
     });
     await notify({
       message: `Server update ${r.version} available`,
@@ -251,8 +254,7 @@ test("poller: gate advances — strictly newer manifest version resets dedup", a
     lastNotifiedVersion = r.version;
     bus.publish({
       kind: "serverUpdateAvailable",
-      version: r.version,
-      notesUrl: r.notesUrl,
+      payload: { version: r.version, notesUrl: r.notesUrl ?? null },
     });
     await notify({
       message: `Server update ${r.version} available`,
@@ -266,8 +268,8 @@ test("poller: gate advances — strictly newer manifest version resets dedup", a
   await maybePublish();
 
   assert.equal(updateEvents(bus).length, 2);
-  assert.equal(updateEvents(bus)[0].version, "9.9.9");
-  assert.equal(updateEvents(bus)[1].version, "10.0.0");
+  assert.equal(updateEvents(bus)[0].payload?.version, "9.9.9");
+  assert.equal(updateEvents(bus)[1].payload?.version, "10.0.0");
   assert.equal(notifyCalls.length, 2);
 });
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -17,6 +17,7 @@ import type {
   ScheduledJob,
   SecretMeta,
   SecretInput,
+  ServerUpdateAvailablePayload,
   WebhookMeta,
   SpawnOptions,
   PtyEvent,
@@ -320,7 +321,48 @@ export interface Api {
   // served in-process via the `server:version` RPC channel (no HTTP round
   // trip). Used by MobileSettings to render "Server vX.Y.Z" under the URL
   // field. Display-only — gating / banner logic lands later.
-  getServerVersion(): Promise<{ version: string }>;
+  //
+  // Response also carries `minClient` (BET-225 stage 2 server side): the
+  // oldest desktop/mobile client version the current server RPC contract
+  // still supports, exported as `MIN_CLIENT` from src/server/version.mjs.
+  // The renderer's version-skew guard (BET-225 stage 3 Part C) reads both
+  // fields off this single response to decide whether to render the
+  // non-dismissible "outdated" banner — no parallel endpoint, no second
+  // poll. The interface keeps `version` as the primary field for the
+  // BET-180 callers (MobileSettings); new consumers should destructure
+  // both.
+  getServerVersion(): Promise<{ version: string; minClient: string }>;
+
+  // Client version (BET-225 stage 3): returns the desktop app's own version
+  // via Electron's `app.getVersion()`. Combined with the server's
+  // `minClient` (also from getServerVersion → the response carries both
+  // `version` and `minClient` after BET-225 stage 2) by isClientTooOld() to
+  // decide whether to render the non-dismissible skew banner. On mobile/web
+  // (no Electron preload) httpApi returns a baked-in fallback so the call
+  // never rejects — a missing client version means no skew check, never a
+  // crash.
+  getClientVersion(): Promise<{ version: string }>;
+
+  // Server-update apply (BET-225 stage 3): triggers the box's
+  // `scripts/self-update.sh` (git fetch + reset --hard origin/main + npm ci
+  // --omit=dev + systemctl --user restart manta-server). The server returns
+  // immediately (fire-and-forget); the restart will kill the process mid-
+  // run so a caller awaiting past the RPC send may never see a response.
+  // Mirror of the desktop `opencode:restart` action — fixed-argv execFile,
+  // no injection surface, no caller-supplied input.
+  serverUpdateApply(): Promise<void>;
+
+  // Server-update available subscription (BET-225 stage 3): fires when the
+  // box's server-update poller sees a newer manifest version. Mirrors the
+  // desktopNotify pattern — main subscribes to bui-server's /events SSE,
+  // filters on kind === "serverUpdateAvailable", and forwards via IPC. The
+  // renderer's UpdateBar component renders a "Server update available:
+  // {version}" bar with an "Update & restart" button that calls
+  // serverUpdateApply(). Desktop-only wiring (mobile has no IPC); the httpApi
+  // shim returns a no-op unsubscribe on mobile.
+  onServerUpdateAvailable(
+    cb: (payload: ServerUpdateAvailablePayload) => void,
+  ): () => void;
 
   // Plugins (BET-189 / BET-190): read the current plugin registry the Mac
   // executor has published. Backed by GET /api/plugins/registry via the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -251,6 +251,17 @@ export type DesktopNotifyPayload = {
   urgent?: boolean;
 };
 
+// Payload for the server-update-available push (BET-225 stage 3). Published by
+// the server-update poller (src/server/serverUpdate.mjs) on the bui-server bus
+// as `{kind:"serverUpdateAvailable", payload: ServerUpdateAvailablePayload}`,
+// relayed to the desktop renderer by src/main/serverUpdateForwarder.ts. The
+// renderer's UpdateBar component renders a "Server update available: {version}"
+// bar with an "Update & restart" button that calls `window.api.serverUpdateApply()`.
+export type ServerUpdateAvailablePayload = {
+  version: string;
+  notesUrl: string | null;
+};
+
 export const IPC = {
   configGet: "config:get",
   configUpdate: "config:update",
@@ -531,6 +542,32 @@ export const IPC = {
   // drifts between surfaces). Display-only foundation for client/server skew
   // detection; gating / banner / force-update logic lands in a later phase.
   getServerVersion: "server:version",                 // () → { version: string }
+
+  // ---- server self-update apply (BET-225 stage 3) ----
+  // Trigger the server's `scripts/self-update.sh` (git fetch + reset --hard
+  // origin/main + npm ci --omit=dev + systemctl --user restart manta-server).
+  // The handler is fire-and-forget — the restart will kill the process
+  // mid-run, so any caller that awaits past the RPC send may never see a
+  // response. Modeled on `opencode:restart` (single-purpose server action).
+  serverUpdateApply: "server:update-apply",           // () → void
+
+  // ---- client version (BET-225 stage 3) ----
+  // Returns the desktop app's own version via Electron's `app.getVersion()`
+  // (which reads the same package.json the server uses). Renderer combines
+  // this with the server's `minClient` (from getServerVersion) via
+  // isClientTooOld() to decide whether to render the non-dismissible skew
+  // banner. Renderer-only — httpApi returns a baked-in fallback on
+  // mobile/web where there's no Electron app to ask.
+  clientVersion: "client:version",                    // () → { version: string }
+
+  // ---- server-update available push (BET-225 stage 3) ----
+  // Mirrors the desktopNotify pattern: main subscribes to bui-server's
+  // /events SSE stream, filters on kind === "serverUpdateAvailable", and
+  // forwards the payload to the renderer via this IPC channel. The renderer
+  // subscribes through `onServerUpdateAvailable` (httpApi) and renders the
+  // shared UpdateBar component (same component as the desktop
+  // `autoUpdateDownloaded` prompt, just a different message + button label).
+  serverUpdateAvailable: "server:update-available",   // main → renderer push
 
   // ---- plugins (BET-189 / BET-190) ----
   // The renderer reads the plugin registry via this channel (the Settings →


### PR DESCRIPTION
## Base

origin/main @ `b4e4b72` (record this so the reviewer can confirm freshness in one glance)

## Files changed

`21` files. `git diff --stat origin/main...HEAD`:

```
 electron-builder.yml                |   1 +
 electron.vite.config.mobile.ts      |   7 +
 electron.vite.config.ts             |  12 +
 src/main/index.ts                   |  34 ++++++
 src/main/serverUpdateForwarder.ts    |  49 +++++++++++ (new)
 src/preload/index.ts                |  21 +++++
 src/renderer/App.tsx                | 155 ++++++++++++++++++++++++++++++-------
 src/renderer/UpdateBar.tsx          |  73 +++++++++++++++ (new)
 src/renderer/api/httpApi.ts         |  51 ++++++++++++-
 src/renderer/chatUtils.test.ts      |  56 ++++++++++++++
 src/renderer/chatUtils.ts           |  38 +++++++++
 src/renderer/mobile/MobileApp.tsx   |  16 ++++
 src/renderer/preloadAccess.test.ts  |   9 +++
 src/renderer/preloadAccess.ts       |  19 +++-
 src/renderer/store.ts               |  16 ++++
 src/renderer/types.d.ts             |   8 ++
 src/server/opencodeAdmin.mjs        |  32 ++++++
 src/server/opencodeAdmin.test.mjs   |  53 ++++++++++++-
 src/server/rpc.mjs                  |  23 ++++-
 src/server/serverUpdate.mjs         |   9 +-
 src/server/serverUpdate.test.mjs    |  18 +++--
 src/shared/api.ts                   |  44 +++++++++-
 src/shared/types.ts                 |  37 ++++++++
```

## Scope

Stage 3 of BET-225 — UI + RPC + desktop hardening + skew guard. Depends on BET-225.A + BET-225.B (already merged via #176 / #177).

## Implementation

**A5 — server-update apply RPC + UI.** New `serverUpdateApply` IPC channel hits a `server:update-apply` RPC handler that execFiles `scripts/self-update.sh` (fixed argv, no shell, detached + unref'd because the systemd restart kills the bui-server process mid-run). The renderer's `<UpdateBar>` component renders a "Server update available: {version}" bar with a button that fires it.

**A5 — shared UpdateBar.** New `src/renderer/UpdateBar.tsx` is the single banner used by all three update prompts:
1. Desktop auto-update (was inline in App.tsx lines 536–559, now via component).
2. Server update (new).
3. Version-skew guard (non-dismissible variant: `dismissible={false}`).

The skew variant chooses `autoUpdateInstall` vs `autoUpdateDownload` based on whether an update has already been downloaded (`updatePrompt` set).

**B1 — 6h periodic re-check.** `src/main/index.ts` adds a `setInterval(() => checkForUpdates(), 6 * 60 * 60 * 1000).unref()` alongside the existing 5s-after-boot call. No config flag.

**B2 — notarize TODO.** `electron-builder.yml` gets a single-line TODO comment above `mac.notarize: false`. Notarize value unchanged.

**C — version-skew guard.** `getClientVersion` via Electron `app.getVersion()` (new IPC `client:version`, exposed through preload). `getServerVersion` already returns `{version, minClient}` after BET-225.B. Renderer fetches both once on mount (no second poll), runs `chooseUpdateSkewVariant(clientVersion, minClient)` (pure helper), and renders the non-dismissible UpdateBar when `isClientTooOld`. Vite `define` adds `__APP_VERSION__` for the mobile/web fallback path.

**Server envelope fix.** `src/server/serverUpdate.mjs` was publishing `{kind, version, notesUrl}` — not the documented `{kind, payload}` envelope from events.mjs. Without nesting, the renderer's `dispatchFrame` would pass `undefined` to listeners. Fixed to `{kind: "serverUpdateAvailable", payload: {version, notesUrl}}`. Tests updated.

**New main → renderer relay.** `src/main/serverUpdateForwarder.ts` (mirrors `desktopNotify.ts` one-for-one) subscribes to bui-server's /events SSE and forwards `kind === "serverUpdateAvailable"` envelopes to the renderer via the new IPC channel.

**Mobile parity.** `MobileApp.tsx` adds the `onServerUpdateAvailable` subscription + sets the same `serverUpdatePrompt` store field. No mobile UI per the spec ("if it does NOT currently render updatePrompt at all: do NOT add new mobile update UI here").

## Tests

* `chooseUpdateSkewVariant` (6 cases: outdated / ok / equal / null inputs / malformed versions) in `chatUtils.test.ts`.
* `runServerSelfUpdate` (3 cases: detached call shape, error path, no-argv regression guard) in `opencodeAdmin.test.mjs`.
* `serverUpdate.test.mjs` updated to assert the new `payload` envelope shape (test was directly checking `evt.version`, now `evt.payload.version`).
* `preloadAccess.test.ts` fake-preload extended with `clientVersion` + `onServerUpdateAvailable` (purely to keep the BuiPreload type-checked).

No live network, no live systemctl, no timers left running.

## Verification results

- PR branch (`multica/BET-225.C-ui-skew-guard` @ `b0dd8de`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 0, 1138 vitest pass / 712 node:test pass / 0 fail / 0 skip. log sha256: `14fc14ebe5a11d5d6fa0910f6f64a5553bdd5a389901de4fc7137e0d1a473720`
- Base (`main` @ `b4e4b72`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667` (clean on both)
  - test: exit 0, 1131 vitest pass / 709 node:test pass / 0 fail / 0 skip. log sha256: `28c7dc7fbe8b4a00ab74179be29e310e18dbb4739bb3612dccfc78e140ee5cfa`
- **Conclusion:** 0 failures on either branch. The +7 vitest and +3 node:test deltas are the new tests in this PR (`chooseUpdateSkewVariant`, `runServerSelfUpdate`, envelope-shape tweaks). No regressions.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Self-check

- AC1 serverUpdateApply runs scripts/self-update.sh: **9/10**. weakness: only unit-tested via runServerSelfUpdate (call shape + error path); not exercised end-to-end on a live box. The script itself is bash-checked via `bash -n scripts/self-update.sh` from BET-225.A.
- AC2 mobile parity: **10/10**. MobileApp.tsx subscribes to onServerUpdateAvailable + writes serverUpdatePrompt store field; no mobile UI per spec.
- AC3 UpdateBar extracted + both prompts route through it + skew variant is a prop: **10/10**. One file (src/renderer/UpdateBar.tsx), three usages (App.tsx UpdateBar x3). dismissible?:boolean is the prop.
- AC4 6h setInterval(...).unref(): **9/10**. weakness: the existing 5s-after-boot checkForUpdates() is kept AND the 6h is added — exactly the spec — but I didn't add an integration test for "the timer fires". Tests would have to mock time or wait 6h.
- AC5 notarize TODO + unchanged: **10/10**. Comment added; `notarize: false` unchanged.
- AC6 npm run typecheck && npm test green: **10/10**. 1138 + 712 pass.

## Out of scope (verified not touched)

- No auto-apply or "off" update mode. No config toggle for update policy.
- mac.notarize value unchanged.
- No mobile-specific update UI.
- No percentage rollouts / channels / delta updates.
- The three pollers (startOutboxPoller / startSchedulePoller / startServerUpdatePoller) — per the consolidation checklist, I considered a `createIntervalPoller({ tick, intervalMs })` extraction but each has slightly different inFlight semantics (outbox returns void, serverUpdate returns `{available: false}`, schedule re-derives from store). Keeping the copy is cleaner than half-migrating. Skipped.

## Cross-cutting follow-ups

- BET-225.B's stage-2 poller publishes the right envelope now (this PR fixed the mismatch).
- Mobile-side UpdateBar (App Store informational button on skew) is intentionally out of scope — only the store + subscription are wired.
- scripts/self-update.sh end-to-end exercise on a real box is the next step (not blocking this PR — the unit tests + bash -n syntax check give strong static confidence).