### PR TITLE
install.sh: init git checkout at MANTA_HOME so self-update.sh works (BET-228.verify)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,6 +49,8 @@
 # Overrides (env):
 #   MANTA_TARBALL_URL   full URL of the release tarball (skips manifest fetch + sha256)
 #   MANTA_RELEASE_HOST  host for the manifest + tarball (default https://mantaui.com)
+#   MANTA_REPO_URL      git URL the deploy is initialised against for `scripts/self-update.sh`
+#                       (default https://github.com/antoinedc/MantaUI.git)
 #   MANTA_HOME          where code is unpacked (default ~/manta)
 #   MANTA_MOBILE_PORT   server port (default 8787)
 #   MANTA_VERSION       version to fetch when MANTA_TARBALL_URL is unset (default: latest)
@@ -250,6 +252,37 @@ main() {
        [ -d "$MANTA_HOME.prev" ] && mv "$MANTA_HOME.prev" "$MANTA_HOME"
        die "could not move extracted tarball into $MANTA_HOME — previous install restored"
     }
+
+  # ---------------------------------------------------------------------------
+  # 4b. Git-aware deploy init. `scripts/self-update.sh` (wired in BET-225.A5)
+  #     assumes $MANTA_HOME is a git checkout pointed at origin/main, so the
+  #     update path can do `git fetch + reset --hard origin/main`. The release
+  #     tarball ships WITHOUT a .git/ (pack.mjs strips it), so we re-create one
+  #     here. Idempotent: a re-run on an existing deploy updates the remote
+  #     URL in place (handles renames) and re-resets to origin/main so the
+  #     tarball + the working tree always agree. Untracked files
+  #     (runtime/, RELEASE.json) survive — `git reset --hard` only touches
+  #     tracked paths.
+  # ---------------------------------------------------------------------------
+  MANTA_REPO_URL="${MANTA_REPO_URL:-https://github.com/antoinedc/MantaUI.git}"
+  if [ "$DRY_RUN" = "1" ]; then
+    dry_log "would init git at $MANTA_HOME, fetch $MANTA_REPO_URL, reset --hard origin/main"
+  else
+    log "Initialising git checkout at $MANTA_HOME (origin=$MANTA_REPO_URL)"
+    if [ ! -d "$MANTA_HOME/.git" ]; then
+      git -C "$MANTA_HOME" init -q -b main \
+        || die "git init failed at $MANTA_HOME — install git and retry"
+    fi
+    # `git remote add` fails if the remote already exists (re-run case);
+    # `set-url` is the idempotent override.
+    git -C "$MANTA_HOME" remote set-url origin "$MANTA_REPO_URL" 2>/dev/null \
+      || git -C "$MANTA_HOME" remote add origin "$MANTA_REPO_URL"
+    git -C "$MANTA_HOME" fetch origin main -q \
+      || die "git fetch origin main failed — check network / MANTA_REPO_URL"
+    git -C "$MANTA_HOME" reset --hard origin/main -q \
+      || die "git reset --hard origin/main failed at $MANTA_HOME"
+    ok "Deploy is git-aware: $(git -C "$MANTA_HOME" rev-parse --short HEAD)"
+  fi
 
   # From here on, EVERY node invocation uses the vendored binary explicitly.
   # No path lookup, no reliance on a system node.


### PR DESCRIPTION
## Why

BET-228 wired `scripts/self-update.sh` to do `git fetch + reset --hard origin/main` on the box, but the release tarball ships without `.git/` (pack.mjs strips it) and `install.sh` had no step to recreate one. A fresh box therefore fails self-update.sh at the very first `git fetch origin main` because MANTA_HOME is not a git checkout.

BET-234 (the verification follow-up) ran self-update.sh end-to-end on alphaclaw and would have hit this gap on a fresh install. The verification passed only after I manually ran `git init + git remote add + git fetch + git reset --hard` at MANTA_HOME — that sequence is exactly what this PR moves into install.sh.

## What changes

A new step inserted after the atomic swap into MANTA_HOME (`scripts/install.sh`, between the existing steps 4 and 5):

1. `git init -q -b main` at MANTA_HOME (skip if .git/ already exists)
2. `git remote set-url origin $MANTA_REPO_URL || git remote add origin $MANTA_REPO_URL` — idempotent: re-runs update the URL in place (handles renames)
3. `git fetch origin main -q`
4. `git reset --hard origin/main -q`

`MANTA_REPO_URL` is a new env override, default `https://github.com/antoinedc/MantaUI.git`.

Untracked files at MANTA_HOME (`runtime/`, `RELEASE.json`) survive — `git reset --hard` only touches tracked paths.

`--dry-run` mode prints the same `[dry-run] would …` line as the rest of the script and skips the actual git ops (no network, no writes outside the user's --dry-run opt-in).

## Diff

```
scripts/install.sh | 33 +++++++++++++++++++++++++++++++++
1 file changed, 33 insertions(+)
```

## Verification

- `npm run typecheck`: 0 errors
- `npm test`: 1138 vitest + 712 node:test, 0 fail, 0 skip
- `node --test scripts/install.test.mjs`: 109/109 pass
- `bash -n scripts/install.sh`: syntax OK
- `scripts/install.sh --help`: unchanged output
- **Live end-to-end on alphaclaw (this box)**: reset the existing tarball-installed deploy to a pre-BET-228 commit, ran `scripts/self-update.sh` end-to-end — exit 0. HEAD advanced from `5bfc6a8` to `08d5493` (origin/main), manta-server.service PID changed, journalctl recorded a clean restart, GET /api/version still 200. Full before/after in BET-234 result comment.

## Out of scope

- Not bumping the release tarball — this PR is shell-only, no new tarball artifact needed.
- Not changing self-update.sh itself — the script's git-fetch-then-reset flow is correct; only install.sh was missing the git-init precondition.
- Not touching `bui-server.service` (the legacy pre-rename deploy still running on 0.0.0.0:8787) — that's a separate cleanup.

Refs: BET-228 (parent PR #182), BET-234 (verification).