### PR TITLE
fix(renderer,server): update stale axiomToken comments to reference shareAnalytics (BET-218)

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -103,9 +103,9 @@ async function boot(): Promise<void> {
   } else {
     // Mobile/web: install the shim (no preload to preserve).
     setWindowApi(httpApi);
-    // Mobile reads config (and thus axiomToken) via the same httpApi
-    // configGet; no MobileSettings UI per the spec — token is entered once
-    // on desktop.
+    // Mobile reads config (and thus shareAnalytics) via the same httpApi
+    // configGet; no MobileSettings UI per the spec — preference is set
+    // once on desktop. Mobile always ships regardless.
     void initRendererLogging("mobile");
   }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -22,12 +22,14 @@ import * as local from "./local.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
-// Axiom when MANTA_AXIOM_TOKEN is set in env OR `axiomToken` lives in
-// AppConfig. Without a token, resolveAxiomConfig returns null and this
-// block is a silent no-op — the server behaves EXACTLY as before, no
-// fetches to axiom.co, no console noise. Must run BEFORE createBus() /
-// any subsequent `console.log` so the existing `[push]` / `[opencode-pump]`
-// / `[push]` / `[opencode-pump]` / `[auth]` call sites ship transparently.
+// Axiom when MANTA_AXIOM_TOKEN is set in env AND AppConfig.shareAnalytics
+// is not explicitly false (BET-217 dropped the user-typed axiomToken field;
+// the gating boolean is the sole opt-out). Without a token or when opted
+// out, resolveAxiomConfig returns null and this block is a silent no-op —
+// the server behaves EXACTLY as before, no fetches to axiom.co, no console
+// noise. Must run BEFORE createBus() / any subsequent `console.log` so the
+// existing `[push]` / `[opencode-pump]` / `[push]` / `[opencode-pump]` /
+// `[auth]` call sites ship transparently.
 {
   const axiomCfg = resolveAxiomConfig({ env: process.env, config: await local.configGet() });
   if (axiomCfg) {


### PR DESCRIPTION
BET-217 replaced the user-typed `axiomToken` AppConfig field with a single boolean `shareAnalytics` toggle. Two doc-rot comments were left referencing the removed field, both explicitly out of scope for BET-217 (per its "nothing outside this list" spec).

**Changes:**
- `src/renderer/main.tsx:106` — mobile configGet comment now references `shareAnalytics` (mobile always ships regardless).
- `src/server/index.mjs:25` — BET-187 axiomCfg comment now references `shareAnalytics` as the gating opt-out.

The shared `resolveAxiomConfig` still defensively accepts `config.axiomToken` for relay/test callers (not AppConfig-driven), so `logShip.mjs` + `logShip.d.mts` + `logShip.test.ts` are intentionally unchanged.

Triggered by: BET-217 reviewer nits on PR #165.

**Files changed:** 2 files (comment-only). Diff: `+11/-9`.

**Verification results:**
- PR branch (`multica/BET-218-stale-axiomToken-comments` @ `b44e1df`, base `origin/main` @ `bdc4519`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 0, 712 pass / 0 fail / 0 skip. log sha256: `2ea9f222543ae03ba79b022bd3e8342d1274bcc89ec8de49e4524d52cdee8cd8`
- Base (`origin/main` @ `bdc4519`):
  - typecheck: exit 0. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit 0, 712 pass / 0 fail / 0 skip. log sha256: `8b32022783d0369ca97dc0e0492f2a5c6936fca5fc6f17889b9e18db29aaf603`
- **Conclusion:** Typecheck log identical between branches (byte-equal). Test logs differ only by per-test `duration_ms` timestamps (same 712 pass / 0 fail). 0 new failures, 0 pre-existing failures, no behavior change (comment-only).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.