### PR TITLE
feat(scripts): single connect block — DMG + iOS links, kill bash duplicates (BET-241)

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -50,6 +50,11 @@ export const DEFAULT_RELEASE_HOST = "https://mantaui.com";
 // touches box identity. `MANTA_HOME` overrides the code location only.
 export const DEFAULT_HOME_DIRNAME = "manta";
 
+// Download links printed in the pairing block. IOS_APP_URL is a placeholder
+// until the App Store listing is live — update it there, nowhere else.
+export const DESKTOP_DMG_URL = "https://mantaui.com/downloads/Manta-latest.dmg";
+export const IOS_APP_URL = "https://mantaui.com";
+
 // Persisted box identity — the file ensureAuth() writes on first server run.
 // Its presence is the idempotency signal: "identity already exists, preserve it."
 export const AUTH_DIRNAME = STATE_DIRNAME;
@@ -649,13 +654,23 @@ export const readBoxIdentity = loadAuth;
  * ingress the user set up — tailscale/reverse-proxy/cloudflared). We can't know
  * it, so it's passed in (or omitted, in which case we print a hint line).
  *
+ * The output is the single connect block both install.sh and `manta pair`
+ * print — install.sh captures it once and emits it LAST so the user sees it
+ * at rest; `manta pair` prints the same block on every re-mint (intentional:
+ * it always surfaces the download links + the iOS hint).
+ *
+ * The 6-digit code validation throw, the injected `qrRender` (with its
+ * try/catch degradation), and the per-row QR indenting loop are all kept
+ * intact — only the assembled line list changes.
+ *
  * BET-177 §2.4: the pair link `manta://pair?box=<id>&code=<code>` is
  * always included in the output (when a box_id + a valid 6-digit code are
  * present) as BOTH a copy-paste line AND a terminal-rendered QR. The QR is
  * for the user who wants to scan with the iOS Camera instead of pasting the
  * link. The link string is the canonical box-form produced by
- * `buildPairLink` (local helper) — single source of truth, shared with
- * install.sh's heredoc via the test that asserts the round-trip.
+ * `buildPairLink` (local helper) — single source of truth, consumed
+ * exclusively by this function now (install.sh's heredoc duplicate was
+ * retired in BET-241).
  *
  * The QR generator is injected (`qrRender`) so tests can capture the output
  * without pulling in `qrcode-terminal` at module-load. The default
@@ -671,35 +686,22 @@ export function formatPairingOutput(
     throw new Error("formatPairingOutput: pairing_code must be 6 digits");
   }
   const lines = [];
-  lines.push("");
-  lines.push("  ✓ manta server is running.");
-  lines.push("");
-  lines.push(`  Pairing code:  ${pairing_code}`);
-  if (expiresAt != null) {
-    lines.push(`  Expires:       ${formatExpiry(expiresAt)}`);
-  }
   if (box_id) {
-    lines.push(`  Box ID:        ${box_id}`);
-  }
-  lines.push("");
-  if (serverUrl) {
-    lines.push(`  Server URL:    ${serverUrl}`);
+    // Branch A — full gateway install (box_id + valid 6-digit code).
     lines.push("");
-  } else {
-    lines.push("  Expose this box to your phone/desktop (pick one):");
-    lines.push("    • Tailscale / VPN  → use the box's tailnet address");
-    lines.push("    • Reverse proxy    → point it at 127.0.0.1:8787");
+    lines.push("  ✓ Manta server is running — connect your devices:");
     lines.push("");
-  }
-  // Render the canonical pair link + QR when we have both halves. The link is
-  // the direct-mode shape (manta://pair?box=<id>&code=<code>) — the desktop /
-  // phone resolve it to https://<box_id>.boxes.mantaui.com and claim against
-  // the box's own /auth/claim.
-  if (box_id && /^[0-9]{6}$/.test(pairing_code)) {
+    lines.push("  1. Get the desktop app (macOS, Apple silicon)");
+    lines.push(`       ${DESKTOP_DMG_URL}`);
+    lines.push("");
+    lines.push("  2. Pair it — click this link, or paste it into the app's Connect screen");
     const pairLink = buildPairLink(box_id, pairing_code);
-    lines.push("  Pair page:     " + buildPairPageUrl(box_id, pairing_code));
-    lines.push("  Pair link:     " + pairLink);
-    lines.push("                 (paste into the desktop app, or scan as a QR)");
+    lines.push(`       Pair page:     ${buildPairPageUrl(box_id, pairing_code)}`);
+    lines.push(`       ${pairLink}`);
+    lines.push("");
+    lines.push("  3. iPhone (optional) — scan the QR below with your camera");
+    lines.push(`       App download: ${IOS_APP_URL}  (App Store link coming soon)`);
+    lines.push("");
     let qr;
     try {
       qr = qrRender(pairLink);
@@ -713,14 +715,42 @@ export function formatPairingOutput(
       // Indent every QR row to match the surrounding two-space indent. The QR
       // itself is rendered with no leading indent; we wrap each line
       // individually so terminal width differences don't break alignment.
-      lines.push("");
       for (const row of String(qr).split("\n")) lines.push("  " + row);
       lines.push("");
     }
-    lines.push("");
+    lines.push(`  Pairing code:  ${pairing_code}`);
+    lines.push(`  Box ID:        ${box_id}`);
+    if (serverUrl) {
+      lines.push(`  Server URL:    ${serverUrl}`);
+    }
+    if (expiresAt != null) {
+      lines.push(`  Expires:       ${formatExpiry(expiresAt)}`);
+    }
+    lines.push("                 (one-time — mint a fresh one any time with `manta pair`)");
   } else {
-    lines.push("  → Enter the pairing code in the Manta desktop app to connect.");
+    // Branch B — degraded / no-gateway install (no box_id). Pair-link + QR
+    // can't be rendered (there's no box half of the link), so we surface the
+    // code + the ingress hint + a tail-line that names the desktop app URL
+    // the user is meant to type the code into.
     lines.push("");
+    lines.push("  ✓ Manta server is running.");
+    lines.push("");
+    lines.push(`  Pairing code:  ${pairing_code}`);
+    if (expiresAt != null) {
+      lines.push(`  Expires:       ${formatExpiry(expiresAt)}`);
+    }
+    lines.push("");
+    if (serverUrl) {
+      lines.push(`  Server URL:    ${serverUrl}`);
+      lines.push("");
+    } else {
+      lines.push("  Expose this box to your phone/desktop (pick one):");
+      lines.push("    • Tailscale / VPN  → use the box's tailnet address");
+      lines.push("    • Reverse proxy    → point it at 127.0.0.1:8787");
+      lines.push("");
+    }
+    lines.push("  → Enter the pairing code in the Manta desktop app to connect.");
+    lines.push(`     Desktop app: ${DESKTOP_DMG_URL}`);
   }
   return lines.join("\n");
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -895,25 +895,8 @@ main() {
   ok "Server is healthy."
 
   log "Minting pairing code…"
-  # Delegate to the same `manta pair` CLI the user runs later (loopback GET /auth/pair).
-  # We CAPTURE stdout this time so the install-sh heredoc below can quote the
-  # ready-to-paste `manta://pair?box=…&code=…` link — BET-156 §1. manta-pair.mjs
-  # prints a stable "  Pairing code:  NNNNNN" line via formatPairingOutput, which
-  # we sed-extract (no second JSON round-trip; the format is the contract).
+  # Capture the formatted pairing block; printed at the very end of main().
   PAIR_BLOCK="$("$NODE" "$MANTA_HOME/scripts/manta-pair.mjs" 2>/dev/null || true)"
-  # Echo the formatted block so the user still sees it on stdout (the heredoc
-  # below ONLY surfaces the box id + ready-to-paste link, not the full block).
-  printf '%s\n' "$PAIR_BLOCK"
-  PAIR_CODE="$(printf '%s\n' "$PAIR_BLOCK" | sed -n 's/^  Pairing code:[[:space:]]\+\([0-9]\{6\}\).*/\1/p' | head -n1)"
-  export PAIR_CODE
-  if [ -z "$PAIR_CODE" ]; then
-    warn "could not extract a 6-digit code from manta-pair.mjs output — pair link will be omitted."
-  fi
-
-  # Read the box_id from ~/.manta/auth.json via the tested install-lib loader
-  # (NEVER re-parse the JSON in bash — auth.json's shape belongs to the server).
-  BOX_ID_DISPLAY="$(read_box_id_for_gateway)"
-  export BOX_ID_DISPLAY
 
   cat <<EOF
 
@@ -938,20 +921,7 @@ desktop / mobile app discovers it directly via the box_id below; no relay,
 no tunnel, no dial-out.
 EOF
 
-  if [ -n "$BOX_ID_DISPLAY" ]; then
-    printf '\n  Box ID:        %s\n' "$BOX_ID_DISPLAY"
-  fi
-
-  # Ready-to-paste pair link (BET-156 §1) — the desktop app parses this directly
-  # via parsePairPayload and pairs against https://<box_id>.boxes.mantaui.com.
-  if [ -n "${BOX_ID_DISPLAY:-}" ] && [ -n "${PAIR_CODE:-}" ]; then
-    printf '\n  Pair link:     manta://pair?box=%s&code=%s\n' "$BOX_ID_DISPLAY" "$PAIR_CODE"
-    printf '                 (paste into the desktop app, or scan as a QR)\n'
-  fi
-
   cat <<EOF
-
-  (Pairing code printed above by manta pair — re-run any time to mint a fresh one.)
 
 Re-run this installer any time to upgrade in place (your box identity is preserved).
 Run 'manta pair' (or 'node "$NODE" "$MANTA_HOME/scripts/manta-pair.mjs"') to mint a fresh pairing code.
@@ -970,6 +940,9 @@ EOF
     warn "Run \`claude\` once on this box to sign in, then:"
     warn "  systemctl --user restart opencode-serve"
   fi
+
+  # The connect block prints LAST so it's what the user sees at rest.
+  printf '%s\n' "$PAIR_BLOCK"
 
   # Cleanup: the previous install lives at $MANTA_HOME.prev until this point.
   # If we got here, everything is healthy and the new install is serving — drop

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -28,6 +28,8 @@ import {
   OPENCODE_CLAUDE_AUTH_PLUGIN,
   DEFAULT_PORT,
   DEFAULT_RELEASE_HOST,
+  DESKTOP_DMG_URL,
+  IOS_APP_URL,
 } from "./install-lib.mjs";
 
 const HOME = "/home/tester";
@@ -428,9 +430,11 @@ test("readBoxIdentity returns null on a corrupt auth.json (server will mint a fr
 // ----------------------------------------------------------------------------
 
 test("formatPairingOutput produces a stable human block", () => {
-  // BET-177 §2.4: when both box_id AND a 6-digit code are present the output
-  // includes the canonical pair link + a terminal-rendered QR (via the real
-  // qrcode-terminal in default mode). We assert on the TEXT half only so the
+  // BET-177 §2.4 + BET-241 Branch A: when both box_id AND a 6-digit code are
+  // present the output includes the single connect block — desktop app link,
+  // the Pair page URL, the canonical pair link, the iOS app hint + QR (via
+  // the real qrcode-terminal in default mode), then the greppable Pairing
+  // code / Box ID / Expires footer. We assert on the TEXT half only so the
   // test doesn't depend on qrcode-terminal being installed or on specific QR
   // rendering — QR-specific assertions (block chars, indentation) live in the
   // stub-based tests below which inject a controlled renderer.
@@ -439,22 +443,40 @@ test("formatPairingOutput produces a stable human block", () => {
     box_id: "0123456789abcdef0123456789abcdef",
     expiresAt: Date.UTC(2026, 6, 3, 12, 34, 56),
   });
+  assert.match(out, /✓ Manta server is running — connect your devices:/);
+  assert.match(out, /1\. Get the desktop app \(macOS, Apple silicon\)/);
+  assert.match(out, new RegExp(DESKTOP_DMG_URL.replace(/\//g, "\\/")));
+  assert.match(out, /2\. Pair it/);
+  // Canonical pair-link regex (the wire shape is unchanged; just the
+  // surrounding prefix moved into step 2 of the numbered block).
+  assert.match(out, /manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291/);
+  assert.match(out, /3\. iPhone \(optional\)/);
+  assert.match(out, new RegExp(`App download: ${IOS_APP_URL.replace(/\//g, "\\/")}  \\(App Store link coming soon\\)`));
   assert.match(out, /Pairing code:  847291/);
   assert.match(out, /Box ID:        0123456789abcdef0123456789abcdef/);
   assert.match(out, /Expires:       2026-07-03 12:34:56 UTC/);
-  assert.match(out, /Pair link:     manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291/);
+  // BET-239: Pair page URL surfaces under step 2 (above the manta:// link),
+  // indented the same 7 spaces as the link itself.
   assert.match(out, /Pair page:     https:\/\/0123456789abcdef0123456789abcdef\.boxes\.mantaui\.com\/pair#code=847291/);
-  assert.match(out, /paste into the desktop app, or scan as a QR/);
+  // BET-241 Branch A footer: greppable one-time note at the very end of the block.
+  assert.match(out, /\(one-time — mint a fresh one any time with `manta pair`\)/);
 });
 
 test("formatPairingOutput prints ingress hint when no serverUrl given", () => {
+  // BET-241 Branch B — no box_id (degraded / no-gateway install).
   const out = formatPairingOutput({ pairing_code: "000123" });
   assert.match(out, /Pairing code:  000123/);
   assert.match(out, /Tailscale/);
   assert.match(out, /Reverse proxy/);
+  // Branch B surfaces the desktop app URL so the user knows where to paste
+  // the code (no QR + no pair link when box_id is absent).
+  assert.match(out, new RegExp(`Desktop app: ${DESKTOP_DMG_URL.replace(/\//g, "\\/")}`));
 });
 
 test("formatPairingOutput includes serverUrl when provided", () => {
+  // Branch B with serverUrl: the Server URL line replaces the ingress-hint
+  // block (serverUrl goes right after Pairing code in Branch B since Box ID
+  // doesn't exist). Branch A would put Server URL under Box ID instead.
   const out = formatPairingOutput({
     pairing_code: "111111",
     serverUrl: "https://box.tailnet.ts.net",
@@ -467,6 +489,20 @@ test("formatPairingOutput rejects a non-6-digit code", () => {
   assert.throws(() => formatPairingOutput({ pairing_code: "12345" }), /6 digits/);
   assert.throws(() => formatPairingOutput({ pairing_code: "abcdef" }), /6 digits/);
   assert.throws(() => formatPairingOutput({}), /6 digits/);
+});
+
+test("formatPairingOutput pins the greppable 'Pairing code' line shape", () => {
+  // llms-install.md tells AI-installing agents to grep the install output
+  // for `^  Pairing code:  NNNNNN$` to capture the code. formatPairingOutput
+  // is the single source for that line — pin the EXACT shape (two-space
+  // indent, "Pairing code:", two spaces, six digits, end-of-line) so a
+  // future refactor of the block can't silently shift it.
+  const out = formatPairingOutput({
+    pairing_code: "847291",
+    box_id: HEX32,
+    expiresAt: Date.UTC(2026, 6, 3, 12, 34, 56),
+  });
+  assert.match(out, /^  Pairing code:  847291$/m);
 });
 
 // ----------------------------------------------------------------------------
@@ -506,13 +542,14 @@ test("buildPairLink rejects a non-6-digit code", () => {
   assert.throws(() => buildPairLink(HEX32, ""), /6 digits/);
 });
 
-test("buildPairLink shape matches install.sh's heredoc literal (BET-177 §2.4)", () => {
+test("buildPairLink produces the canonical box-form pair link (BET-177 §2.4)", () => {
   // The renderer's `parsePairPayload` is the gate the mobile app uses to
-  // decide whether a QR is valid; install.sh's heredoc prints the canonical
-  // box-form link in lockstep. The install.test suite is plain Node — we
-  // don't load the .ts parser here — but we CAN enforce the wire shape on
-  // both the install-lib helper AND the literal install.sh heredoc printf,
-  // so a future drift in either side is caught here.
+  // decide whether a QR is valid; install.sh prints the canonical box-form
+  // link (now via formatPairingOutput — BET-241 deleted the install.sh
+  // heredoc duplicate) in lockstep with this helper. The install.test
+  // suite is plain Node — we don't load the .ts parser here — but we CAN
+  // enforce the wire shape on the install-lib helper so a future drift is
+  // caught here.
   //
   // 1. install-lib's buildPairLink produces the canonical shape:
   const fromLib = buildPairLink(HEX32, "847291");
@@ -521,22 +558,6 @@ test("buildPairLink shape matches install.sh's heredoc literal (BET-177 §2.4)",
     "manta://pair?box=0123456789abcdef0123456789abcdef&code=847291",
     "install-lib buildPairLink produces the canonical box-form URL",
   );
-  // 2. install.sh's heredoc uses the SAME shape — read the literal printf
-  //    template and assert it matches the install-lib output structure:
-  const installShSrc = readFileSync(INSTALL_SH, "utf-8");
-  const printfMatch = installShSrc.match(
-    /manta:\/\/pair\?box=%s&code=%s/,
-  );
-  assert.ok(
-    printfMatch,
-    "install.sh heredoc uses the canonical box-form printf template",
-  );
-  // 3. The printf template `manta://pair?box=%s&code=%s` MUST round-trip —
-  //    when sprintf'd with a 32-hex boxId + 6-digit code, it produces the
-  //    same string buildPairLink produces for the same inputs. We pin
-  //    BOTH the printf template AND the install-lib output so a future
-  //    drift in either side surfaces here.
-  assert.match(printfMatch[0], /^manta:\/\/pair\?box=%s&code=%s$/);
 });
 
 // ----------------------------------------------------------------------------
@@ -592,33 +613,42 @@ test("formatPairingOutput includes the pair link + QR", () => {
       qrRender: () => qrText,
     },
   );
-  assert.match(out, /Pair link:     manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291/);
+  // Pair link is now rendered inside step 2 of the numbered block (the
+  // "Pair link:" prefix was retired in BET-241; the canonical URL string is
+  // unchanged — the wire shape still round-trips through buildPairLink).
+  assert.match(out, /manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291/);
+  assert.match(out, /2\. Pair it — click this link, or paste it into the app's Connect screen/);
+  // BET-239: Pair page URL surfaces under step 2 (above the manta:// link),
+  // indented the same 7 spaces as the link itself.
   assert.match(out, /Pair page:     https:\/\/0123456789abcdef0123456789abcdef\.boxes\.mantaui\.com\/pair#code=847291/);
-  assert.match(out, /paste into the desktop app, or scan as a QR/);
   // Stubbed QR rows are indented to match the surrounding 2-space indent.
   // We use a literal newline+two-spaces prefix in the regex (no \s — `s`
   // is .includes-sensitive and we want the exact byte sequence the formatter
   // emits).
   assert.match(out, /\n  \[stubbed QR rows\]/);
   assert.match(out, /\n  row 2/);
-  // The trailing "Enter the pairing code" line is REPLACED by the link+QR
-  // block — only one of them should appear.
+  // Branch B's trailing "Enter the pairing code" line is REPLACED by the
+  // Branch A link+QR block — only Branch B's phrasing should ever appear
+  // when no box_id is provided.
   assert.doesNotMatch(out, /Enter the pairing code in the Manta desktop app/);
 });
 
 test("formatPairingOutput falls back to the text-only block when qrRender throws", () => {
   // A broken qrcode-terminal (e.g. a stripped dev node_modules) must NOT
   // crash the install — the link text is the source of truth, the QR is
-  // best-effort. The text link + the "scan as a QR" hint still appear so the
+  // best-effort. The text link + the iOS-hint line still appear so the
   // operator can paste; only the QR ROWS are absent (the text talks about
   // scanning, but no QR is rendered).
   const out = formatPairingOutput(
     { pairing_code: "847291", box_id: HEX32 },
     { qrRender: () => { throw new Error("qrcode-terminal exploded"); } },
   );
-  assert.match(out, /Pair link:     manta:\/\/pair\?box=/);
+  // Pair link + Pair page are still emitted (the QR row bytes are the only
+  // thing missing — BET-239 added the Pair page URL alongside the manta://
+  // link; BET-241 moved the manta:// URL into step 2 of the numbered block).
+  assert.match(out, /manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291/);
   assert.match(out, /Pair page:     https:\/\/0123456789abcdef0123456789abcdef\.boxes\.mantaui\.com\/pair#code=847291/);
-  assert.match(out, /scan as a QR/);
+  assert.match(out, /3\. iPhone \(optional\) — scan the QR below with your camera/);
   // QR block chars (qrcode-terminal draws U+2588 FULL BLOCK + U+2584 LOWER
   // HALF BLOCK) are absent. We assert on the QR's STUB marker rather than
   // guessing which ANSI bytes the real renderer uses.


### PR DESCRIPTION
## Summary

Installer now ends with ONE formatted connect block (`formatPairingOutput`), emitted last so it's what the user sees at rest. Replaces the install.sh heredoc + sed-extract printf duplicates that printed the box id and pair link a second time.

- `install-lib.mjs`: add `DESKTOP_DMG_URL` + `IOS_APP_URL` constants; reshape `formatPairingOutput` into Branch A (full gateway — numbered 1/2/3 steps + greppable Pairing code / Box ID / Server URL / Expires footer) and Branch B (no `box_id` — degraded path).
- `install.sh`: delete the `PAIR_CODE` sed extract, the `BOX_ID_DISPLAY` export, the Box ID printf, the Pair link printf, and the stale `'(Pairing code printed above by manta pair)'` heredoc line. Keep the `PAIR_BLOCK` capture and emit it last, after the claude-credentials check.
- `install.test.mjs`: pin the new layout with assertions on the numbered steps + the desktop/iOS URLs (importing the constants directly), pin the `  Pairing code:  847291` greppable shape `llms-install.md` relies on, drop the now-defunct install.sh printf/sed heredoc assertions.

**Base:** `origin/main` @ `2ff67bd` (BET-241 branch from this base).
**Files changed:** 3 files, +117 / -93.

## Verification results

- PR branch (`multica/BET-241-installer-single-connect-block` @ `98862b3`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `713` pass / `0` fail / `0` skip (master baseline was `712`; +1 is the new greppable Pairing code test). log sha256: `dc84b292cfe0d51ad590836655d81ba19065363aa2a20b941f9f5592249573cc`
- Base (`main` @ `2ff67bd`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `712` pass / `0` fail / `0` skip. log sha256: `4f723ca5d701bbeaefc6b189480e85ffbe81596ea077f0d0a638a5e0e8a78eac`
- **Conclusion:** 0 test failures pre-existing, 0 new failures, 1 added (greppable Pairing code line test).

Greps hold: `PAIR_CODE=0`, `BOX_ID_DISPLAY=0`, `Pair link:=0`, `PAIR_BLOCK=2`. `bash -n scripts/install.sh` exits 0.

`manta pair` inherits the new block automatically (it calls `formatPairingOutput`; no changes to `manta-pair.mjs`). Re-minting therefore surfaces the download links too — intentional per spec.

## Out-of-scope (per spec)

- `scripts/manta-pair.mjs`, `llms-install.md`, the website, the pair page (BET-239), the desktop protocol handler ticket — untouched.
- The QR renderer / `qrcode-terminal` handling — unchanged.
- `read_box_id_for_gateway` and the gateway/Caddy section of install.sh — kept.
- The `IOS_APP_URL` value (`https://mantaui.com`) — placeholder until App Store listing is live; one-constant edit later.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.