### PR TITLE
feat(desktop): register manta:// deep-link pairing (BET-240)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,15 @@ files:
 extraMetadata:
   main: out/main/index.js
 
+# Custom URL scheme for OS-level deep-link pairing (BET-240). electron-builder
+# generates `CFBundleURLTypes` on macOS and the `MimeType=x-scheme-handler/manta`
+# entry on Linux `.desktop` files from this block — do NOT hand-edit any plist.
+# iOS already handles `manta://` via mobile/ios/.../Info.plist (BET-156).
+protocols:
+  - name: MantaUI Pairing
+    schemes:
+      - manta
+
 mac:
   icon: "assets/icon.icns"
   category: "public.app-category.developer-tools"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@ import {
   nativeImage,
   shell,
 } from "electron";
-import { join, basename } from "node:path";
+import { basename, join, resolve as resolvePath } from "node:path";
 import { existsSync, watch as fsWatch } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -178,6 +178,61 @@ function createWindow(): void {
 // config.json (host, projects) and leaving the app with no configured host.
 app.setPath("userData", join(app.getPath("appData"), "better-ui"));
 
+// ---------------------------------------------------------------------------
+// manta:// deep-link pairing (protocol handler).
+// Registration + capture live in main; parsing/validation happens renderer-
+// side with the same parsePairPayload the PairStep paste field uses, so
+// there is exactly ONE parser for the wire format.
+// ---------------------------------------------------------------------------
+if (process.defaultApp) {
+  // dev mode (`electron .`): register with explicit exec path + args
+  if (process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient("manta", process.execPath, [
+      resolvePath(process.argv[1]),
+    ]);
+  }
+} else {
+  app.setAsDefaultProtocolClient("manta");
+}
+
+let pendingPairUrl: string | null = null;
+
+function deliverPairLink(url: string): void {
+  if (typeof url !== "string" || !url.startsWith("manta://")) return;
+  if (mainWindow && !mainWindow.webContents.isLoading()) {
+    mainWindow.webContents.send(IPC.pairLinkReceived, url);
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
+  } else {
+    // window not up yet (cold start) — flushed from the did-finish-load hook
+    pendingPairUrl = url;
+  }
+}
+
+// macOS delivers protocol URLs via open-url (warm AND cold start — cold-start
+// delivery arrives before ready, which is why pendingPairUrl exists).
+app.on("open-url", (event, url) => {
+  event.preventDefault();
+  deliverPairLink(url);
+});
+
+// Windows/Linux deliver protocol URLs as argv of a SECOND instance; the lock
+// forwards them to the running one.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", (_event, argv) => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+    const url = argv.find((a) => a.startsWith("manta://"));
+    if (url) deliverPairLink(url);
+  });
+}
+
 // Set the app name as early as possible (before `ready`). This drives the
 // product name shown in the macOS menu bar, the dock, AND — for packaged
 // builds — the source name on OS notifications (otherwise the renderer's
@@ -203,6 +258,14 @@ app.whenReady().then(() => {
   createWindow();
   // Defer poller start until renderer is ready to receive events.
   mainWindow?.webContents.once("did-finish-load", () => {
+    // Deep-link cold start: macOS parked the URL in pendingPairUrl (open-url
+    // fires pre-ready); Windows/Linux pass it in this process's argv.
+    const argvPairUrl = process.argv.find((a) => a.startsWith("manta://")) ?? null;
+    const coldPairUrl = pendingPairUrl ?? argvPairUrl;
+    pendingPairUrl = null;
+    if (coldPairUrl) {
+      mainWindow?.webContents.send(IPC.pairLinkReceived, coldPairUrl);
+    }
     startScreenshotDetector();
     // Report desktop focus to the mobile server so it suppresses redundant
     // mobile "done" pushes while the user is active on desktop.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,17 @@ import type { ClaimOutcome } from "../shared/claim.mjs";
 // object). See `src/renderer/preloadAccess.ts` for the typed accessor most
 // callers should use (`getMantaPreload()`), and BET-127 for the extraction
 // history.
+
+// pair-link buffering: main may push the URL (cold start) before React has
+// mounted and subscribed. Register the ipc listener immediately at preload
+// load; hold the last URL until the renderer attaches its callback.
+let bufferedPairUrl: string | null = null;
+let pairLinkCb: ((url: string) => void) | null = null;
+ipcRenderer.on(IPC.pairLinkReceived, (_event, url: string) => {
+  if (pairLinkCb) pairLinkCb(url);
+  else bufferedPairUrl = url;
+});
+
 const api = {
   // Read ONLY by main.tsx's boot sequence (`chooseDesktopTransport`), before
   // httpApi is installed as `window.api` — used to seed httpApi's
@@ -45,6 +56,18 @@ const api = {
     const listener = (_: unknown, ev: { source: "clipboard" | "file"; path?: string }) => cb(ev);
     ipcRenderer.on(IPC.screenshotDetected, listener);
     return () => ipcRenderer.removeListener(IPC.screenshotDetected, listener);
+  },
+
+  onPairLink: (cb: (url: string) => void): (() => void) => {
+    pairLinkCb = cb;
+    if (bufferedPairUrl) {
+      const url = bufferedPairUrl;
+      bufferedPairUrl = null;
+      cb(url);
+    }
+    return () => {
+      if (pairLinkCb === cb) pairLinkCb = null;
+    };
   },
 
   // manta-server's notification router decided the desktop should show an OS

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import {
 } from "./chatShared";
 import { chooseUpdateSkewVariant } from "./chatUtils";
 import { UpdateBar } from "./UpdateBar";
+import { parsePairPayload } from "./mobile/pairPayload";
 import type { AvailableLauncher } from "../shared/types";
 
 // mode -> the composite-key "modeId" segment used for the PTY sessionKey and
@@ -199,6 +200,23 @@ export function App() {
       useStore.getState().setScreenshotToast(ev);
     });
     return off;
+  }, []);
+
+  // Deep-link pairing (BET-240): the OS protocol handler (electron-builder
+  // `protocols:` + Electron `setAsDefaultProtocolClient`) delivers a
+  // manta://pair?... URL via the preload's `pair:link-received` IPC. We
+  // validate with the SAME parsePairPayload PairStep's paste field uses,
+  // stash the URL in the store for PairStep to prefill, and reuse the
+  // existing relaunchOnboarding so a re-pair to a new box lands on step 1
+  // even when resolveInitialStep would skip past it (already paired).
+  useEffect(() => {
+    const pre = getMantaPreload();
+    if (!pre?.onPairLink) return;
+    return pre.onPairLink((url) => {
+      if (!parsePairPayload(url)) return; // not a valid pair link — ignore
+      useStore.getState().setPendingPairLink(url);
+      void useStore.getState().relaunchOnboarding();
+    });
   }, []);
 
   // Agent → laptop file push. Same single-listener pattern as screenshots: a

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ONBOARDING_STEPS,
   STEP_LABELS,
@@ -109,9 +109,23 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   // Derive the resume point once from the current config so a quit-mid-flow
   // reopens at the first incomplete step. Read straight from the store's
   // config snapshot (App gates on `loaded`, so config is present by mount).
+  //
+  // Deep-link pairing (BET-240): if a manta://pair?... URL is pending in the
+  // store, force step 1 regardless of the resume point — re-pairing to a new
+  // box is a legitimate flow that resolveInitialStep would otherwise skip.
   const [pos, setPos] = useState<OnboardingPosition>(() =>
-    resolveInitialStep(useStore.getState().configSnapshot()),
+    useStore.getState().pendingPairLink
+      ? 1
+      : resolveInitialStep(useStore.getState().configSnapshot()),
   );
+
+  // Deep-link pairing (BET-240): a link that arrives WHILE onboarding is
+  // already open (e.g. user clicked the link from Terminal after the app
+  // was running) must also jump to step 1.
+  const pendingPairLink = useStore((s) => s.pendingPairLink);
+  useEffect(() => {
+    if (pendingPairLink) setPos(1);
+  }, [pendingPairLink]);
 
   const goNext = () => setPos((p) => nextPosition(p));
   const goBack = () => setPos((p) => prevPosition(p));

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { normalizeCode } from "../shared/claim.mjs";
 import { normalizeServerUrl, isValidServerUrl, canConnect } from "./pairStepLogic";
 import { parsePairPayload } from "./mobile/pairPayload";
@@ -55,6 +55,18 @@ export function PairStep({
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);
   const pairLinkRef = useRef<HTMLInputElement>(null);
+
+  // Deep-link pairing (BET-240): prefill the paste field from a pending
+  // manta:// pair URL that App.tsx stashed in the store when the OS protocol
+  // handler fired. The existing `linkHasContent` gate below makes the link
+  // win over any typed server/code values; the existing connect() claim path
+  // does the rest when the user clicks Connect.
+  const pendingPairLink = useStore((s) => s.pendingPairLink);
+  useEffect(() => {
+    if (!pendingPairLink) return;
+    setPairLink(pendingPairLink);
+    useStore.getState().setPendingPairLink(null); // consume once
+  }, [pendingPairLink]);
 
   // When the user pastes a pair link, the link's payload takes precedence
   // over any typed server/code fields. The submit gate follows.

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -16,6 +16,10 @@ function makeFakePreload(): MantaPreload {
       cb({ source: "clipboard" });
       return vi.fn();
     }),
+    // BET-240: deep-link pairing bridge. Matches the MantaPreload shape in
+    // src/renderer/preloadAccess.ts; we don't exercise its buffering here —
+    // that's tested implicitly by App.tsx's wiring + PairStep's prefill.
+    onPairLink: vi.fn((_cb: (url: string) => void) => vi.fn()),
     clipboardWriteText: vi.fn(async () => {}),
     clipboardReadImage: vi.fn(async () => null),
     readLocalFile: vi.fn(async () => new ArrayBuffer(0)),

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -16,6 +16,12 @@ export interface MantaPreload {
   onScreenshotDetected(
     cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
   ): () => void;
+  // Subscribe to manta:// pair links delivered by the OS protocol handler.
+  // The renderer validates the URL with parsePairPayload and routes it into
+  // the onboarding PairStep. Buffering lives in the preload so a URL that
+  // arrives before React mounts is replayed on subscribe. Absent on
+  // mobile/web (no window.__mantaPreload).
+  onPairLink(cb: (url: string) => void): () => void;
   clipboardWriteText(text: string): Promise<void>;
   // Read the current clipboard image as PNG bytes (null if no image). Only
   // main can touch the OS clipboard — this must go through the preload, NOT

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -691,3 +691,23 @@ describe("setDefaultModel (onboarding Step 3 + Settings)", () => {
     expect(useStore.getState().defaultModel).toBeNull();
   });
 });
+
+describe("setPendingPairLink (BET-240 deep-link pairing)", () => {
+  beforeEach(() => {
+    useStore.setState({ pendingPairLink: null });
+  });
+
+  it("writes the raw URL into pendingPairLink", () => {
+    const url = "manta://pair?box=0123456789abcdef0123456789abcdef&code=123456";
+    useStore.getState().setPendingPairLink(url);
+    expect(useStore.getState().pendingPairLink).toBe(url);
+  });
+
+  it("clears the field when null is passed (consume-on-use)", () => {
+    useStore.setState({
+      pendingPairLink: "manta://pair?box=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&code=111111",
+    });
+    useStore.getState().setPendingPairLink(null);
+    expect(useStore.getState().pendingPairLink).toBeNull();
+  });
+});

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -100,6 +100,11 @@ type State = {
   // that would otherwise resolve to "http" mode (e.g. an already-paired
   // box). Cleared when the flow completes or is skipped. Not persisted.
   onboardingForced: boolean;
+  // Deep-link pairing (BET-240): the raw manta://pair?… URL delivered by the
+  // OS protocol handler. Set in App.tsx when the preload pushes a URL, read
+  // by Onboarding (to force step 1) and PairStep (to prefill the paste field).
+  // Cleared once consumed. Not persisted — purely transient routing state.
+  pendingPairLink: string | null;
   chatAutoAllow: boolean;
   // Auto-rename chat-mode windows from the conversation (opt-in). See
   // AppConfig.autoRenameSessions.
@@ -274,6 +279,10 @@ type State = {
   setServerUpdatePrompt: (
     p: { version: string; notesUrl?: string | null } | null,
   ) => void;
+  // Deep-link pairing (BET-240): write/clear the pending pair link. Pass
+  // null to consume (PairStep clears on use); App.tsx writes the URL when
+  // the preload's pair:link-received IPC fires.
+  setPendingPairLink: (url: string | null) => void;
   setConnectionState: (s: ConnectionState) => void;
 };
 
@@ -284,6 +293,7 @@ export const useStore = create<State>((set, get) => ({
   boxToken: "",
   onboardingSkipped: false,
   onboardingForced: false,
+  pendingPairLink: null,
   chatAutoAllow: false,
   autoRenameSessions: false,
   allowAgentPush: false,
@@ -384,6 +394,8 @@ export const useStore = create<State>((set, get) => ({
     const next = await window.api.configUpdate({ onboardingSkipped: false });
     set({ onboardingSkipped: next.onboardingSkipped ?? false });
   },
+
+  setPendingPairLink: (url) => set({ pendingPairLink: url }),
 
   finishOnboarding: async () => {
     // Drop the force flag and re-read config so the app transitions to the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -346,6 +346,12 @@ export const IPC = {
   // path is only set for file-based detections (Desktop watcher).
   screenshotDetected: "screenshot:detected",
 
+  // Deep-link pairing: main → renderer push when the OS delivers a
+  // manta://pair?... URL (protocol handler). Payload: the raw URL string;
+  // the renderer validates it with parsePairPayload and routes it into
+  // the onboarding PairStep. Invalid URLs are dropped renderer-side.
+  pairLinkReceived: "pair:link-received",
+
   // main → renderer push: the manta-server notification router decided the
   // desktop should show an OS notification. Relayed from the server's
   // `desktopNotify` bus event. Payload:


### PR DESCRIPTION
# feat(desktop): register manta:// deep-link pairing (BET-240)

Clicking a `manta://pair?box=…&code=…` link anywhere — browser, terminal,
AI-agent output — now opens Manta prefilled to the PairStep. The user
confirms by clicking Connect (no auto-claim, no dialog, no toast).

`Base: origin/main @ 2ff67bd`

## What changed

**OS protocol handler** (3 layers, exactly the same parser):

- `electron-builder.yml` — declare the `manta` scheme (`electron-builder`
  generates `CFBundleURLTypes` on macOS and the `MimeType=x-scheme-handler/manta`
  entry on Linux `.desktop` files from it; do NOT hand-edit any plist).
- `src/main/index.ts` — `setAsDefaultProtocolClient` + single-instance lock +
  `open-url` (macOS, fires both warm AND cold) + `second-instance` (Windows/
  Linux, the second process's argv carries the URL) + cold-start flush in
  `did-finish-load`.
- `src/preload/index.ts` — buffer a URL that arrives before React subscribes
  (cold start) so the renderer never loses a deep link; expose `onPairLink`.
- `src/renderer/preloadAccess.ts` — `onPairLink` on the `MantaPreload` bridge.

**Wire contract** (one parser, two layers):

- `src/shared/types.ts` — `IPC.pairLinkReceived` channel.
- `src/renderer/store.ts` — `pendingPairLink` + `setPendingPairLink`
  (transient, not persisted).
- `src/renderer/App.tsx` — subscribe once on mount; validate with
  `parsePairPayload` (the SAME parser PairStep's paste field uses);
  stash the URL and call `relaunchOnboarding` so a re-pair to a new box
  lands on step 1 even when `resolveInitialStep` would skip past it.
- `src/renderer/Onboarding.tsx` — force step 1 when `pendingPairLink` is set
  (both the initial-step ternary AND an effect for a link that arrives
  while onboarding is already open).
- `src/renderer/PairStep.tsx` — prefill the paste field, consume the store
  value; the existing `linkHasContent` gate + `connect()` claim path do
  the rest when the user clicks Connect.

**Tests:**

- `src/renderer/store.test.ts` — `setPendingPairLink` write + clear.
- `src/renderer/preloadAccess.test.ts` — fake preload now includes
  `onPairLink` so the existing `MantaPreload` shape stays in sync.

## Decided behavior (matches the spec — do not deviate)

- A received pair link NEVER auto-claims. PairStep IS the confirmation UI.
- Invalid/unparseable URLs are silently ignored (`parsePairPayload` returns
  null → `App.tsx` early-returns).
- Works warm (app running) AND cold (app launched by the link).
- Single-instance lock so a second launch forwards the URL to the running
  instance on Windows/Linux.
- `relaunchOnboarding` is the singular forcing mechanism — no parallel
  toggling of `onboardingForced`.

## Verification

- typecheck: clean (both `tsconfig.node.json` and `tsconfig.web.json`).
- test: 712 pass / 0 fail (both PR branch and `main` baseline).
- Logs: `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`,
  `/tmp/typecheck-master.log`, `/tmp/test-master.log`.

### Release-verification checklist (CI cannot exercise the OS handler)

1. Build a packaged DMG (`electron-builder --mac` or the next `mac-v*`
   release pipeline).
2. `open "manta://pair?box=0123456789abcdef0123456789abcdef&code=123456"`
   in Terminal — app cold-launches (or focuses if running); onboarding
   opens at the Connect step with the link field pre-filled.
3. Repeat while the app is already running and paired — same result
   (onboarding re-opens at step 1, prefilled).
4. `open "manta://garbage"` — app focuses, nothing else happens
   (silently ignored).
5. Confirm the packaged `Info.plist`:
   `plutil -p "/Applications/Manta UI.app/Contents/Info.plist" | grep -A3 URL`
   shows `CFBundleURLSchemes` → `manta`.

## Out of scope

- Auto-claiming without a user click, confirmation dialogs, toasts.
- The box-served `/pair` page (BET-239 — independent).
- Clipboard-based deferred pairing, custom DMGs.
- Mobile (`manta://` already handled on iOS via
  `mobile/ios/.../Info.plist`), `mobile-rn/`, `src/server/`.
- NSIS-specific tweaks beyond the standard `second-instance` code.
- New npm dependencies.

## Follow-ups

None surfaced that meet the "above the bar" file threshold. The
`pendingPairLink` field is purely transient routing state — no drift
risk. The wire-format parser (`parsePairPayload`) is the same one
PairStep's paste field already uses, so there is exactly ONE validator
on the wire.
