### PR TITLE
fix(renderer): reserve right padding in code/tool blocks so long lines clear the copy button (BET-245)

### DIFF
--- a/src/renderer/MarkdownBody.tsx
+++ b/src/renderer/MarkdownBody.tsx
@@ -279,7 +279,7 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
       />
       {tooLarge ? (
         <pre
-          className="px-2 py-1.5 text-[12px] overflow-x-auto max-w-full whitespace-pre"
+          className="px-2 py-1.5 pr-7 text-[12px] overflow-x-auto max-w-full whitespace-pre"
           style={{ background: "transparent" }}
         >
           <code>{cleaned}</code>
@@ -292,7 +292,7 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
         >
           {({ tokens, getLineProps, getTokenProps }) => (
             <pre
-              className="px-2 py-1.5 text-[12px] overflow-x-auto max-w-full whitespace-pre"
+              className="px-2 py-1.5 pr-7 text-[12px] overflow-x-auto max-w-full whitespace-pre"
               // vsDark's default bg would override our bg-bg-soft — disable it.
               style={{ background: "transparent" }}
             >

--- a/src/renderer/ToolBodies.tsx
+++ b/src/renderer/ToolBodies.tsx
@@ -49,7 +49,7 @@ export const ToolOutput = memo(function ToolOutput({ output }: { output: string 
           pinnedRef.current =
             el.scrollHeight - el.scrollTop - el.clientHeight < 8;
         }}
-        className="text-[12px] bg-bg-soft border border-border rounded px-2 py-1 max-h-64 overflow-auto whitespace-pre"
+        className="text-[12px] bg-bg-soft border border-border rounded px-2 py-1 pr-7 max-h-64 overflow-auto whitespace-pre"
       >
         <code>{output}</code>
       </pre>


### PR DESCRIPTION
Fixes [BET-245](mention://issue/2e06d990-839c-4c9c-a7d2-00a92e636cbc).

**Root cause:** the absolutely-positioned copy button sits on top of the scrollable `<pre>` in code blocks and tool-output blocks. The `<pre>` had no right padding, so `whitespace-pre` content extended straight under the button.

**Fix:** add `pr-7` (1.75rem) to the three scrollable `<pre>` classNames so text stops before the button, while horizontal scroll still reveals the rest. `pr-7` is the same value the `lang` header (directly above the code, same button overlay) already uses — no design decision required.

**Files (3 edits):**
- `src/renderer/MarkdownBody.tsx` — both `<pre>` in `CodeBlock` (tooLarge + Highlight branches)
- `src/renderer/ToolBodies.tsx` — the `<pre>` in `ToolOutput`

**Untouched (per spec):** `CopyButton.tsx`, `whitespace-pre` semantics, no new wrapper/props/components, no extracted className constant.

**Anti-spaghetti check:** grep across `src/renderer/` confirmed exactly the 3 `<pre>` elements enumerated in the issue use the shared `CopyButton` overlay — no other site has the defect.

**Base:** origin/main @ 913d3a0

**Files changed:** 2 files, 3 insertions, 3 deletions.

**Verification results:**
- PR branch (`multica/BET-245-code-block-right-padding` @ 0494d7d):
  - typecheck: exit 0. Errors: none. log sha256: `<see comment>`
  - test: exit 0, 730 pass / 0 fail / 0 skip. log sha256: `<see comment>`
- Base (`main` @ 913d3a0):
  - typecheck: exit 0. Errors: none. log sha256: `<see comment>`
  - test: exit 0, 730 pass / 0 fail / 0 skip. log sha256: `<see comment>`
- **Conclusion:** 0 new failures, 0 resolved failures, 0 pre-existing failures. Pure CSS-class edit, no test impact. Logs cached at `/tmp/tc-pr.log`, `/tmp/tc-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log`.

Manual verification deferred to reviewer (this CI has no running renderer). The fix mirrors the proven `pr-7` clearance already used by the `lang` header in the same component.