### PR TITLE
feat(renderer+server): auto-create git worktree for new sessions (+ clean-on-close) [BET-246]

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -41,6 +41,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
     voiceCommandModel,
     launcherFlags,
     shareAnalytics,
+    worktreePerSession,
+    worktreeCleanOnClose,
     refresh,
   } = useStore();
 
@@ -59,6 +61,10 @@ export function Settings({ onClose }: { onClose: () => void }) {
   // Files fields (Files tab)
   const [agentPush, setAgentPush] = useState(allowAgentPush);
   const [dlDir, setDlDir] = useState(downloadsDir);
+  // BET-246: worktree-per-session + clean-on-close toggles. Global-only;
+  // the per-session override lives in the new-session dialog in Sidebar.
+  const [worktreeOn, setWorktreeOn] = useState(worktreePerSession);
+  const [worktreeClean, setWorktreeClean] = useState(worktreeCleanOnClose);
 
   // General fields (General tab)
   const [autoRename, setAutoRename] = useState(autoRenameSessions);
@@ -110,7 +116,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
     setVoiceCmdModel(voiceCommandModel);
     setLauncherFlagValues(launcherFlags ?? {});
     setAnalytics(shareAnalytics);
-  }, [skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, launcherFlags, shareAnalytics]);
+    setWorktreeOn(worktreePerSession);
+    setWorktreeClean(worktreeCleanOnClose);
+  }, [skillRegistryUrls, cacheTtl, allowAgentPush, autoRenameSessions, downloadsDir, groqApiKey, voiceTranscriptionModel, voiceCommandModel, launcherFlags, shareAnalytics, worktreePerSession, worktreeCleanOnClose]);
 
   // Seed the Mac-local `pluginsEnabled` toggle from the desktop's config
   // (BET-207). The store mirrors the BOX config (via httpApi.configGet),
@@ -190,6 +198,10 @@ export function Settings({ onClose }: { onClose: () => void }) {
         voiceCommandModel: voiceCmdModel.trim(),
         shareAnalytics: analytics,
         launcherFlags: launcherFlagValues,
+        // BET-246: per-session worktree defaults — global settings only;
+        // the per-window override lives in Sidebar's new-session dialog.
+        worktreePerSession: worktreeOn,
+        worktreeCleanOnClose: worktreeClean,
       });
       // BET-207: persist `pluginsEnabled` to the Mac-local config via the
       // preload bridge — NOT via window.api.configUpdate (which writes the
@@ -620,6 +632,45 @@ export function Settings({ onClose }: { onClose: () => void }) {
                       Destination for AI-sent files. Absolute path; leave empty for your OS Downloads folder.
                     </div>
                   </div>
+                </div>
+              </div>
+              {/* BET-246: per-session git-worktree creation + clean-on-close.
+                  Two independent toggles, same markup as allowAgentPush.
+                  Global-only — the per-window override lives in Sidebar. */}
+              <div className="border-t border-border pt-6">
+                <h3 className="text-base font-semibold mb-4">Session worktrees</h3>
+                <div className="space-y-3">
+                  <label className="flex items-start gap-3 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={worktreeOn}
+                      onChange={(e) => setWorktreeOn(e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      Create git worktree for new sessions
+                      <span className="block text-xs text-text-faint mt-1">
+                        When creating a new chat session in a project that's a git
+                        repo, automatically branch a sibling worktree and start the
+                        session on its own branch. Has no effect on non-git projects.
+                      </span>
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-3 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={worktreeClean}
+                      onChange={(e) => setWorktreeClean(e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      Remove worktree when a session is closed
+                      <span className="block text-xs text-text-faint mt-1">
+                        Deletes the session's git worktree on close. Prompts
+                        before discarding uncommitted changes.
+                      </span>
+                    </span>
+                  </label>
                 </div>
               </div>
             </div>

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -41,6 +41,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     setActive,
     refresh,
     backgroundSyncing,
+    // BET-246: worktree defaults from Settings (Global default for the
+    // new-session checkbox + the clean-on-close gate).
+    worktreePerSession,
+    worktreeCleanOnClose,
   } = useStore();
 
   const showError = (e: unknown) => {
@@ -63,10 +67,21 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
 
   const [newSessionFor, setNewSessionFor] = useState<string | null>(null);
   const [newSessionName, setNewSessionName] = useState("");
+  // BET-246: per-session worktree override. Seeded from the global
+  // worktreePerSession setting; the dialog disables the checkbox when the
+  // project's cwd isn't a git repo. Defaults to false (non-git projects
+  // always force it false here too).
+  const [newSessionWorktree, setNewSessionWorktree] = useState(false);
+  const [newSessionIsGitRepo, setNewSessionIsGitRepo] = useState(false);
 
   const [confirmDeleteFor, setConfirmDeleteFor] = useState<
     | { kind: "session"; project: string; index: number; name: string }
     | { kind: "project"; project: string }
+    // BET-246: killWindow ran the safe git worktree remove and got the
+    // dirty-checkout refusal — ask the user whether to --force (Remove)
+    // or keep the worktree (Keep). Either choice continues to teardown;
+    // Cancel bails entirely.
+    | { kind: "worktree-dirty"; project: string; index: number; name: string; worktreePath: string }
     | null
   >(null);
 
@@ -86,6 +101,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
       if (activeProjectName) {
         setNewSessionFor(activeProjectName);
         setNewSessionName("");
+        // BET-246: seed checkbox + probe git. Non-git projects force the
+        // checkbox off; the dialog disables + mutes it visually.
+        setNewSessionWorktree(worktreePerSession);
+        void probeGitForProject(activeProjectName);
         setCollapsed((prev) => {
           const next = new Set(prev);
           next.delete(activeProjectName);
@@ -94,6 +113,44 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
       }
     },
   }));
+
+  // Project cwd resolution (mirror of server-side resolveProjectCwd, but
+  // enough for the renderer's is-git-repo probe + worktree-create cwd).
+  // Prefer the project's stored defaultCwd; fall back to the active
+  // window's paneCurrentPath; "~" / empty → not a usable git probe.
+  const resolveProjectCwd = (projectName: string): string => {
+    const proj = projects.find((p) => p.tmuxSession === projectName);
+    const stored = (proj?.defaultCwd ?? "").trim();
+    if (stored && stored !== "~") return stored;
+    const activeIdx = activeWindowByProject[projectName];
+    const w = proj?.windows.find((x) => x.index === activeIdx)
+      ?? proj?.windows.find((x) => x.active)
+      ?? proj?.windows[0];
+    return (w?.paneCurrentPath ?? "").trim();
+  };
+
+  // Probe whether the project's cwd is inside a git repo. Reuses the
+  // existing gitListWorktrees channel — a non-empty list means at least
+  // the main worktree is registered, which only happens for git repos.
+  const probeGitForProject = async (projectName: string) => {
+    const cwd = resolveProjectCwd(projectName);
+    if (!cwd || cwd === "~") {
+      setNewSessionIsGitRepo(false);
+      setNewSessionWorktree(false);
+      return;
+    }
+    try {
+      const wts = await window.api.gitListWorktrees(cwd);
+      const isRepo = Array.isArray(wts) && wts.length > 0;
+      setNewSessionIsGitRepo(isRepo);
+      if (!isRepo) setNewSessionWorktree(false);
+    } catch {
+      // Probe failure (transient) → leave state alone; the existing checkbox
+      // value stays, and the user sees a non-checked state until they retry
+      // by reopening the form.
+      setNewSessionIsGitRepo(false);
+    }
+  };
 
   const toggleCollapse = (id: string) =>
     setCollapsed((prev) => {
@@ -257,6 +314,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   const startNewSession = (projectName: string) => {
     setNewSessionFor(projectName);
     setNewSessionName("");
+    // BET-246: seed checkbox + probe git for the clicked project. Same
+    // dance as openNewSessionInActive above.
+    setNewSessionWorktree(worktreePerSession);
+    void probeGitForProject(projectName);
     setCollapsed((prev) => {
       const next = new Set(prev);
       next.delete(projectName);
@@ -266,27 +327,46 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
 
   const createSession = async () => {
     if (!newSessionFor) return;
+    const sessionFor = newSessionFor;
     const windowName = newSessionName.trim() || "session";
+    // BET-246: when the user opted in AND the project is a git repo,
+    // branch a sibling worktree first, then create the window with that
+    // path as its cwd. Fail-closed: any worktree error surfaces and the
+    // window is NOT created (no silent fall-through to the shared dir).
+    // The unchecked/non-git path is byte-for-byte the legacy flow.
+    const wantWorktree = newSessionWorktree && newSessionIsGitRepo;
+    let worktreePath: string | undefined;
+    if (wantWorktree) {
+      const projectCwd = resolveProjectCwd(sessionFor);
+      if (!projectCwd || projectCwd === "~") {
+        showError(new Error("project has no cwd; cannot create worktree"));
+        return;
+      }
+      try {
+        const wt = await window.api.gitAddWorktree({ cwd: projectCwd, name: windowName });
+        worktreePath = wt.path;
+      } catch (e) {
+        showError(e);
+        return;
+      }
+    }
     try {
-      // No cwd override — new windows inherit their cwd from the project's
-      // stored defaultCwd. The user already chose a path when they created
-      // the project; needing to retype it for every window was confusing
-      // and led to silent fall-through to ~ when left blank.
       const projects = await window.api.tmuxNewWindow({
-        sessionName: newSessionFor,
+        sessionName: sessionFor,
         windowName,
+        ...(worktreePath ? { cwd: worktreePath, worktreePath } : {}),
         chatMode: true,
       });
       setNewSessionFor(null);
       await refresh();
       // Activate the new window (it'll be at the highest index in this session)
-      const proj = projects.find((p) => p.tmuxSession === newSessionFor);
+      const proj = projects.find((p) => p.tmuxSession === sessionFor);
       const w = proj?.windows.find((x) => x.name === windowName);
       if (w) {
-        setActive(newSessionFor, w.index);
+        setActive(sessionFor, w.index);
         try {
           await window.api.tmuxSelectWindow({
-            sessionName: newSessionFor,
+            sessionName: sessionFor,
             windowIndex: w.index,
           });
         } catch (e) {
@@ -315,7 +395,64 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   };
 
   const killWindow = async (project: string, index: number) => {
+    // BET-246: BEFORE teardown, run the safe worktree remove (if gated).
+    // Only act on windows whose `@manta-worktree-path` is set — that's the
+    // one signal that MantaUI itself created the worktree (a pre-existing
+    // worktree or the main checkout is never stamped, so it's never
+    // cleaned here).
+    const proj = projects.find((p) => p.tmuxSession === project);
+    const w = proj?.windows.find((x) => x.index === index);
+    const wtPath = w?.worktreePath ?? null;
+    if (worktreeCleanOnClose && wtPath) {
+      try {
+        const res = await window.api.gitRemoveWorktree({ path: wtPath, force: false });
+        if (res && res.removed === false && res.reason === "dirty") {
+          // Pause teardown; surface the confirm dialog. The user picks
+          // Remove (force) or Keep (skip).
+          setConfirmDeleteFor({
+            kind: "worktree-dirty",
+            project,
+            index,
+            name: w?.name ?? "",
+            worktreePath: wtPath,
+          });
+          return;
+        }
+      } catch (e) {
+        // Anything other than a classified dirty refusal → show the error
+        // but still continue to teardown. Closing the session must not be
+        // blocked by a cleanup failure.
+        showError(e);
+      }
+    }
     setConfirmDeleteFor(null);
+    try {
+      await window.api.tmuxKillWindow({ sessionName: project, windowIndex: index });
+      await refresh();
+    } catch (e) {
+      showError(e);
+    }
+  };
+
+  // Second-stage kill after the worktree-dirty confirm. force=true retries
+  // git worktree remove with --force; force=false skips removal entirely
+  // (the worktree + branch remain on disk). Either way the tmux window
+  // itself is then torn down — both branches lead to teardown per spec.
+  const killWorktreeDirtyAndClose = async (
+    project: string,
+    index: number,
+    wtPath: string,
+    force: boolean,
+  ) => {
+    setConfirmDeleteFor(null);
+    if (force) {
+      try {
+        await window.api.gitRemoveWorktree({ path: wtPath, force: true });
+      } catch (e) {
+        // Force-remove failed — surface but still close the session.
+        showError(e);
+      }
+    }
     try {
       await window.api.tmuxKillWindow({ sessionName: project, windowIndex: index });
       await refresh();
@@ -675,6 +812,15 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                               onCancel={() => setConfirmDeleteFor(null)}
                             />
                           )}
+                        {confirmDeleteFor?.kind === "worktree-dirty" &&
+                          confirmDeleteFor.project === p.tmuxSession &&
+                          confirmDeleteFor.index === w.index && (
+                            <ConfirmWorktreeDirty
+                              worktreePath={confirmDeleteFor.worktreePath}
+                              onRemove={() => killWorktreeDirtyAndClose(p.tmuxSession, w.index, confirmDeleteFor.worktreePath, true)}
+                              onKeep={() => killWorktreeDirtyAndClose(p.tmuxSession, w.index, confirmDeleteFor.worktreePath, false)}
+                            />
+                          )}
                       </div>
                     );
                   })}
@@ -692,6 +838,26 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                         }}
                         className="w-full bg-bg-soft border border-border px-2 py-0.5 text-xs rounded focus:outline-none focus:border-accent"
                       />
+                      {/* BET-246: per-session worktree override. Disabled
+                          (visibly muted) when the project cwd isn't inside
+                          a git repo; the spec's "disabled, not hidden"
+                          choice. Reuses the same checkbox markup as the
+                          Settings toggles. */}
+                      <label
+                        className={`flex items-center gap-2 text-xs ${
+                          newSessionIsGitRepo ? "cursor-pointer" : "cursor-not-allowed opacity-50"
+                        }`}
+                        title={newSessionIsGitRepo ? undefined : "not a git repository"}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={newSessionWorktree}
+                          disabled={!newSessionIsGitRepo}
+                          onChange={(e) => setNewSessionWorktree(e.target.checked)}
+                          className="accent-accent"
+                        />
+                        <span>Create git worktree</span>
+                      </label>
                       <div className="flex gap-2">
                         <button
                           onClick={createSession}
@@ -928,6 +1094,54 @@ function ConfirmDelete({
           className="text-xs px-2 py-0.5 text-text-faint hover:text-text"
         >
           Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// BET-246: second-stage confirm after the safe git worktree remove hit a
+// dirty checkout. Both buttons lead to teardown — Remove retries with
+// --force (and discards uncommitted work), Keep skips the worktree remove
+// entirely and just closes the tmux window. Same visual shape as
+// ConfirmDelete; reusing the existing confirmDeleteFor state avoids
+// introducing a parallel modal system.
+function ConfirmWorktreeDirty({
+  worktreePath,
+  onRemove,
+  onKeep,
+}: {
+  worktreePath: string;
+  onRemove: () => void;
+  onKeep: () => void;
+}) {
+  return (
+    <div className="ml-2 mt-1 mb-1 px-2 py-1.5 rounded bg-bg-soft border border-border space-y-1.5">
+      <div className="text-xs text-text-muted">
+        <code className="break-all">{worktreePath}</code> has uncommitted
+        changes. Removing the worktree will permanently delete that work.
+        Remove anyway?
+      </div>
+      <div className="flex flex-wrap gap-1">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-300 hover:bg-red-500/30"
+          title="git worktree remove --force (discards uncommitted changes)"
+        >
+          Remove
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onKeep();
+          }}
+          className="text-xs px-2 py-0.5 text-text-faint hover:text-text"
+          title="leave the worktree + branch on disk; just close the session"
+        >
+          Keep worktree
         </button>
       </div>
     </div>

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -587,6 +587,10 @@ export const httpApi: Api = {
 
   // -- git --
   gitListWorktrees: (cwd) => rpc(IPC.gitListWorktrees, cwd),
+  // BET-246: auto-create a sibling git worktree for a new chat session.
+  gitAddWorktree: (input) => rpc(IPC.gitAddWorktree, input),
+  // BET-246: remove a worktree MantaUI created (safe by default; force on retry).
+  gitRemoveWorktree: (input) => rpc(IPC.gitRemoveWorktree, input),
 
   // -- filesystem --
   fsListDirs: (partial) => rpc(IPC.fsListDirs, partial),

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -112,6 +112,15 @@ type State = {
   // Agent → laptop push trust flag. When true, files the AI drops in its
   // remote outbox are pulled to the downloads dir without confirmation.
   allowAgentPush: boolean;
+  // BET-246: per-session git-worktree creation default (Settings → Files
+  // tab). Mirrors AppConfig.worktreePerSession. The new-session dialog
+  // seeds its checkbox from this value and lets the user override for
+  // one window. Settings-only — rides the generic configUpdate channel.
+  worktreePerSession: boolean;
+  // BET-246: when true, closing a session whose @manta-worktree-path
+  // user-option is set removes the worktree (and best-effort deletes its
+  // branch) first. Global only — no per-session override.
+  worktreeCleanOnClose: boolean;
   // Override destination for agent-pushed files. "" = main's default (~/Downloads).
   downloadsDir: string;
   // Global default model for new/cleared sessions. Set in Settings, persisted
@@ -297,6 +306,8 @@ export const useStore = create<State>((set, get) => ({
   chatAutoAllow: false,
   autoRenameSessions: false,
   allowAgentPush: false,
+  worktreePerSession: false,
+  worktreeCleanOnClose: false,
   downloadsDir: "",
   defaultModel: null,
   deactivatedMainModels: [],
@@ -415,6 +426,8 @@ export const useStore = create<State>((set, get) => ({
       chatAutoAllow: c.chatAutoAllow ?? false,
       autoRenameSessions: c.autoRenameSessions ?? false,
       allowAgentPush: c.allowAgentPush ?? false,
+      worktreePerSession: c.worktreePerSession ?? false,
+      worktreeCleanOnClose: c.worktreeCleanOnClose ?? false,
       downloadsDir: c.downloadsDir ?? "",
       defaultModel: c.defaultModel ?? null,
       deactivatedMainModels: c.deactivatedMainModels ?? [],

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { STATE_DIRNAME } from "../shared/paths.mjs";
+import { deriveWorktree, isWorktreeDirtyError } from "../shared/worktree.mjs";
 
 // ============================================================
 // Config persistence (real implementation — renderer depends on it)
@@ -42,6 +43,10 @@ async function atomicWrite(path, data) {
 const DEFAULT_CONFIG = {
   projects: [],
   chatAutoAllow: false,
+  // BET-246: per-session worktree defaults (settings-only — read via the
+  // generic configGet/configUpdate channel like every other AppConfig field).
+  worktreePerSession: false,
+  worktreeCleanOnClose: false,
 };
 
 let _config = null;
@@ -150,6 +155,105 @@ export async function gitListWorktrees(cwd) {
   const { stdout } = await run("git", ["-C", cwd, "worktree", "list", "--porcelain"])
     .catch(() => ({ stdout: "" }));
   return parseWorktrees(stdout);
+}
+
+// gitAddWorktree({ cwd, name }) → { path, branch }
+// preload: ipcRenderer.invoke(IPC.gitAddWorktree, { cwd, name }) → args[0] = { cwd, name }
+// Resolve repoRoot via `git -C <cwd> rev-parse --show-toplevel`; pick a
+// non-colliding sibling path + branch via the pure deriveWorktree helper;
+// then run `git worktree add -b <branch> <path>` from the repo root. Errors
+// propagate (fail-closed) so the renderer's createSession can surface them
+// without falling back to the shared dir. Pure naming + collision logic
+// lives in src/shared/worktree.mjs — keep all string-shape work there.
+export async function gitAddWorktree({ cwd, name }) {
+  if (!cwd || !cwd.trim()) throw new Error("cwd is required");
+  if (!name || !name.trim()) throw new Error("name is required");
+  const { stdout: repoRootRaw } = await run("git", [
+    "-C", cwd, "rev-parse", "--show-toplevel",
+  ]);
+  const repoRoot = (repoRootRaw ?? "").trim();
+  if (!repoRoot) throw new Error("not a git repository");
+  // Pre-resolve the full branch set so deriveWorktree's collision check
+  // matches reality in a single pass (avoids a per-candidate git fork).
+  const { stdout: branchesRaw } = await run("git", [
+    "-C", repoRoot, "for-each-ref", "--format=%(refname:short)", "refs/heads",
+  ]);
+  const branchSet = new Set(
+    (branchesRaw ?? "").split("\n").map((b) => b.trim()).filter(Boolean),
+  );
+  const { path, branch } = deriveWorktree({
+    repoRoot,
+    name,
+    dirExists: (p) => existsSync(p),
+    branchExists: (b) => branchSet.has(b),
+  });
+  try {
+    await run("git", ["-C", repoRoot, "worktree", "add", "-b", branch, path]);
+  } catch (err) {
+    // Re-throw with the git stderr in the message so the renderer can show
+    // it without having to inspect the raw error object.
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(msg);
+  }
+  return { path, branch };
+}
+
+// gitRemoveWorktree({ path, force }) → { removed, reason? }
+// preload: ipcRenderer.invoke(IPC.gitRemoveWorktree, { path, force }) → args[0] = { path, force }
+// Safe-first remove; on git's "dirty checkout" refusal, return
+// { removed:false, reason:"dirty" } so the renderer can confirm before
+// retrying with --force. Any OTHER error rethrows so the renderer can show
+// it verbatim. The renderer MUST NOT string-match git output — all of it
+// lives in isWorktreeDirtyError (src/shared/worktree.mjs).
+export async function gitRemoveWorktree({ path: wtPath, force }) {
+  if (!wtPath || !wtPath.trim()) throw new Error("path is required");
+  // Resolve branch BEFORE removal: after `worktree remove` the worktree
+  // directory is gone and `git -C <wt>` would fail. Best-effort branch
+  // delete — a non-clean branch with `-d` will refuse, and that's fine
+  // (the renderer chose not to force the worktree, so we don't force
+  // the branch either).
+  let branch = "";
+  let parentRepo = "";
+  try {
+    const { stdout } = await run("git", [
+      "-C", wtPath, "rev-parse", "--abbrev-ref", "HEAD",
+    ]);
+    branch = (stdout ?? "").trim();
+    const { stdout: commonDir } = await run("git", [
+      "-C", wtPath, "rev-parse", "--path-format=absolute", "--git-common-dir",
+    ]);
+    // git-common-dir is the shared .git dir; the repo root for branch
+    // commands is its grandparent (or the same dir for non-linked worktrees).
+    parentRepo = dirname((commonDir ?? "").trim() || wtPath);
+  } catch {
+    // branch resolution failed → skip the branch delete (best-effort).
+  }
+  let removeErr = null;
+  try {
+    const args = ["worktree", "remove", ...(force ? ["--force"] : []), wtPath];
+    await run("git", ["-C", wtPath, ...args]);
+  } catch (err) {
+    removeErr = err;
+  }
+  if (removeErr) {
+    // run()'s rejection message already embeds the stderr ("<cmd> exited N: <stderr>"),
+    // so feed err.message straight into the classifier — no separate stderr field.
+    const msg = removeErr instanceof Error ? removeErr.message : String(removeErr);
+    if (!force && isWorktreeDirtyError(msg)) {
+      return { removed: false, reason: "dirty" };
+    }
+    throw new Error(msg);
+  }
+  if (branch && parentRepo) {
+    try {
+      await run("git", [
+        "-C", parentRepo, "branch", force ? "-D" : "-d", branch,
+      ]);
+    } catch {
+      // Best-effort: an unmerged branch will refuse -d; that's fine.
+    }
+  }
+  return { removed: true };
 }
 
 // ============================================================

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -112,6 +112,19 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // preload: ipcRenderer.invoke(IPC.gitListWorktrees, cwd)  → args[0] = cwd (string)
     "git:list-worktrees": (cwd) => local.gitListWorktrees(cwd),
 
+    // BET-246: auto-create a sibling git worktree for a new chat session.
+    // preload: ipcRenderer.invoke(IPC.gitAddWorktree, { cwd, name })
+    //   → args[0] = { cwd: string, name: string }
+    "git:add-worktree": (i) => local.gitAddWorktree(i),
+
+    // BET-246: safe/force remove of a worktree MantaUI created. Returns
+    // { removed:false, reason:"dirty" } for the uncommitted-changes case
+    // so the renderer can confirm before retrying with --force; throws on
+    // any other failure.
+    // preload: ipcRenderer.invoke(IPC.gitRemoveWorktree, { path, force })
+    //   → args[0] = { path: string, force: boolean }
+    "git:remove-worktree": (i) => local.gitRemoveWorktree(i),
+
     // preload: ipcRenderer.invoke(IPC.fsListDirs, partial)  → args[0] = partial (string)
     "fs:list-dirs": (partial) => local.fsListDirs(partial),
 

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -56,12 +56,16 @@ export function parseSessions(sessStdout, winStdout) {
   // Phase 2: join windows into their session. Skip orphan window lines.
   for (const line of winStdout.split("\n").filter(Boolean)) {
     const parts = line.split(FS);
-    const [session, index, wname, active, pane, sidRaw] = parts;
+    const [session, index, wname, active, pane, sidRaw, wtRaw] = parts;
     if (!sessions.has(session)) continue; // defensive: orphan
     sessions.get(session).windows.push({
       index: Number(index), name: wname,
       active: active === "1", paneCurrentPath: pane,
       opencodeSessionId: sidRaw ? sidRaw : null,
+      // BET-246: when MantaUI auto-created a worktree for this window, the
+      // absolute path is stamped on `@manta-worktree-path`. Empty/null = not
+      // a worktree window — clean-on-close must skip it.
+      worktreePath: wtRaw ? wtRaw : null,
     });
   }
   return Array.from(sessions.values()).map((s) => ({
@@ -72,7 +76,7 @@ export function parseSessions(sessStdout, winStdout) {
 
 export async function listProjects() {
   const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
-  const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}`;
+  const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}`;
   const sess = await run("tmux", ["list-sessions", "-F", sessFmt]).catch(() => ({ stdout: "" }));
   const wins = await run("tmux", ["list-windows", "-a", "-F", winFmt]).catch(() => ({ stdout: "" }));
   return parseSessions(sess.stdout, wins.stdout);
@@ -179,7 +183,7 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, o
   if (sid) await restampSessionId(name, idx, sid);
   return listProjects();
 }
-export async function newWindow({ sessionName, windowName, cwd, chatMode, oc }) {
+export async function newWindow({ sessionName, windowName, cwd, chatMode, worktreePath, oc }) {
   const sid = await maybeCreateChatSession(
     oc, chatMode, cwd ?? ".", `${sessionName} / ${windowName}`,
   );
@@ -196,6 +200,11 @@ export async function newWindow({ sessionName, windowName, cwd, chatMode, oc }) 
     await applySessionSurvivability(sessionName);
   }
   if (sid) await restampSessionId(sessionName, idx, sid);
+  // BET-246: stamp the worktree path (if any) so clean-on-close knows this
+  // window owns the worktree and may safely remove it. Mirrors the
+  // restampSessionId pattern — separate option name so the two stamps
+  // never collide.
+  if (worktreePath) await stampWorktreePath(sessionName, idx, worktreePath);
   return listProjects();
 }
 
@@ -259,5 +268,24 @@ export async function restampSessionId(sessionName, windowIndex, sessionId) {
     "set-window-option",
     "-t", `${sessionName}:${windowIndex}`,
     "@manta-session-id", sessionId,
+  ]);
+}
+
+/**
+ * Stamp (or update) the @manta-worktree-path user-option on a tmux window.
+ * Used by BET-246's clean-on-close to know which windows own a worktree
+ * that manta created (vs. pre-existing worktrees, which must NEVER be
+ * removed). Mirrors restampSessionId verbatim — separate option name so
+ * the two stamps never collide.
+ *
+ * @param {string} sessionName
+ * @param {number} windowIndex
+ * @param {string} path   absolute worktree path
+ */
+export async function stampWorktreePath(sessionName, windowIndex, path) {
+  await run("tmux", [
+    "set-window-option",
+    "-t", `${sessionName}:${windowIndex}`,
+    "@manta-worktree-path", path,
   ]);
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -82,6 +82,10 @@ export interface Api {
     windowName: string;
     cwd?: string;
     chatMode?: boolean;
+    // BET-246: when set, the new tmux window also stamps the worktree path
+    // on `@manta-worktree-path` so clean-on-close knows it owns this
+    // worktree. Optional — omitted for non-worktree windows.
+    worktreePath?: string;
   }): Promise<Project[]>;
   tmuxRenameSession(input: { oldName: string; newName: string }): Promise<Project[]>;
   tmuxRenameWindow(input: {
@@ -94,6 +98,15 @@ export interface Api {
   tmuxSelectWindow(input: { sessionName: string; windowIndex: number }): Promise<void>;
 
   gitListWorktrees(cwd: string): Promise<WorktreeInfo[]>;
+  // BET-246: create a sibling git worktree next to `cwd`'s repo root, named
+  // after `name` (slugified). Returns the new { path, branch }. Errors
+  // propagate so the renderer can fail-closed (no silent fallback to the
+  // shared dir).
+  gitAddWorktree(input: { cwd: string; name: string }): Promise<{ path: string; branch: string }>;
+  // BET-246: remove a worktree MantaUI created. `force:false` returns
+  // { removed:false, reason:"dirty" } on a dirty checkout so the renderer
+  // can confirm before the retry. Any other failure throws.
+  gitRemoveWorktree(input: { path: string; force: boolean }): Promise<{ removed: boolean; reason?: "dirty" | "other" }>;
 
   fsListDirs(partial: string): Promise<string[]>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -60,6 +60,23 @@ export type AppConfig = {
   // so tool calls run without prompting. Closest analog to Claude Code's
   // --dangerously-skip-permissions. Off by default.
   chatAutoAllow?: boolean;
+  // BET-246: when true, every new chat session (window) auto-creates a
+  // sibling git worktree next to the project's repo root, named after the
+  // session. The window's `cwd` is set to the new worktree so the AI
+  // starts on its own branch. Per-session override available in the
+  // new-session dialog (defaults to this value). Only honored when the
+  // project's cwd is inside a git repo — otherwise the override is
+  // disabled and ignored. Settings-only — no IPC channel of its own,
+  // rides the generic configUpdate path.
+  worktreePerSession?: boolean;
+  // BET-246: when true, closing a chat session that has a MantaUI-created
+  // worktree removes the worktree (and best-effort deletes its branch)
+  // first. Safe-by-default: a dirty checkout prompts the user before
+  // `--force`. Global only (no per-session override). Tracked per-window
+  // via the `@manta-worktree-path` tmux user-option — never cleans
+  // pre-existing worktrees or the main checkout. Settings-only — rides
+  // the generic configUpdate path.
+  worktreeCleanOnClose?: boolean;
   // Auto-rename chat-mode tmux windows from the conversation. When true,
   // ChatPanel periodically (every Nth user turn) asks opencode to summarize
   // the recent transcript into a 1-2 word title and renames the window via
@@ -158,6 +175,13 @@ export type TmuxWindow = {
   // Presence of this id is THE signal that the renderer should show ChatPanel
   // instead of Terminal for this window.
   opencodeSessionId: string | null;
+  // BET-246: absolute path of the worktree MantaUI auto-created for this
+  // window (stamped as `@manta-worktree-path`). Null when the window has no
+  // manta-owned worktree (e.g. a legacy window, or one created without the
+  // checkbox). Clean-on-close gates on this field being set + non-null —
+  // a pre-existing worktree is never identified by this stamp, so the
+  // renderer can safely remove ONLY what manta created.
+  worktreePath?: string | null;
 };
 
 export type TmuxSession = {
@@ -282,6 +306,11 @@ export const IPC = {
 
   // Git: detect worktrees under a cwd (for auto-populating sessions on project create)
   gitListWorktrees: "git:list-worktrees",
+  // BET-246: create / remove a git worktree for a new chat session. The
+  // renderer stamps the new path on the tmux window so clean-on-close
+  // knows it can remove the worktree later.
+  gitAddWorktree: "git:add-worktree",
+  gitRemoveWorktree: "git:remove-worktree",
 
   // Directory autocomplete: given a partial path, list matching subdirectories
   fsListDirs: "fs:list-dirs",

--- a/src/shared/worktree.d.mts
+++ b/src/shared/worktree.d.mts
@@ -1,0 +1,10 @@
+export function slugify(name: string | null | undefined): string;
+
+export function deriveWorktree(input: {
+  repoRoot: string;
+  name: string;
+  dirExists: (p: string) => boolean;
+  branchExists: (b: string) => boolean;
+}): { path: string; branch: string };
+
+export function isWorktreeDirtyError(stderr: string | null | undefined): boolean;

--- a/src/shared/worktree.mjs
+++ b/src/shared/worktree.mjs
@@ -1,0 +1,87 @@
+// worktree.mjs — pure logic backing the "auto-create a git worktree when
+// creating a new chat session (window)" feature (BET-246). Three functions:
+//
+//   slugify              — turn a free-form session/window name into a
+//                          filesystem- and git-branch-safe slug.
+//   deriveWorktree       — pick a non-colliding { path, branch } pair for
+//                          a sibling worktree next to the repo root.
+//   isWorktreeDirtyError — classify git's "worktree remove" stderr so the
+//                          renderer can decide whether to confirm a force.
+//
+// Pure + framework-free (no fs, no fetch). Imports `node:path` only for the
+// pure `dirname` / `basename` helpers — the I/O lives in
+// src/server/local.mjs (gitAddWorktree / gitRemoveWorktree).
+
+import { dirname, basename } from "node:path";
+
+// Lowercase, non-[a-z0-9] runs → "-", trim leading/trailing "-". Empty
+// (or all-symbol / all-unicode) result → "session". Kept in sync with the
+// collision-safe naming style of deriveSubagentName in subagentSync.mjs.
+export function slugify(name) {
+  const slug = String(name ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "session";
+}
+
+/**
+ * Compute the { path, branch } for a sibling worktree next to `repoRoot`.
+ *
+ *   parent = dirname(repoRoot); base = basename(repoRoot).
+ *   baseSlug = slugify(name).
+ *   branch candidates: baseSlug, baseSlug-2, baseSlug-3, ...
+ *   path  candidates: `${parent}/${base}-${candidate}`, same suffix in lockstep.
+ *   Return the first candidate where neither `dirExists(path)` nor
+ *   `branchExists(branch)` is true.
+ *
+ * Pure: the caller injects the `dirExists` / `branchExists` predicates so
+ * this function can be unit-tested without spawning git or touching the
+ * filesystem. Mirrors deriveSubagentName's collision loop.
+ *
+ * @param {object} input
+ * @param {string} input.repoRoot     absolute path to the git repo top-level
+ * @param {string} input.name         session/window name to derive from
+ * @param {(p: string) => boolean} input.dirExists
+ * @param {(b: string) => boolean} input.branchExists
+ * @returns {{ path: string, branch: string }}
+ */
+export function deriveWorktree({ repoRoot, name, dirExists, branchExists }) {
+  const base = basename(repoRoot);
+  const parent = dirname(repoRoot);
+  const baseSlug = slugify(name);
+  let candidate = baseSlug;
+  let n = 2;
+  while (
+    dirExists(`${parent}/${base}-${candidate}`) ||
+    branchExists(candidate)
+  ) {
+    candidate = `${baseSlug}-${n}`;
+    n += 1;
+  }
+  return { path: `${parent}/${base}-${candidate}`, branch: candidate };
+}
+
+/**
+ * Classify git's "worktree remove" stderr to detect the dirty-checkout case
+ * (uncommitted / untracked content blocks the safe remove and requires the
+ * user to confirm `--force`). Lives here so the renderer never has to
+ * string-match git output — gitRemoveWorktree in src/server/local.mjs returns
+ * the discriminated `{ removed:false, reason:"dirty" }` for this case.
+ *
+ * Match shape (paraphrased): git's stderr ends with the line
+ *   "fatal: '<path>' contains modified or untracked files, use --force to delete it"
+ * when refusing a safe remove. We test for both signals (the "use --force"
+ * call-to-action AND a modified/untracked mention) to keep false positives
+ * away from other errors that happen to mention "force".
+ *
+ * @param {string} stderr
+ * @returns {boolean}
+ */
+export function isWorktreeDirtyError(stderr) {
+  if (typeof stderr !== "string" || !stderr) return false;
+  const hasForceHint = stderr.includes("use --force");
+  const hasDirtyHint =
+    stderr.includes("modified") || stderr.includes("untracked");
+  return hasForceHint && hasDirtyHint;
+}

--- a/src/shared/worktree.test.ts
+++ b/src/shared/worktree.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  slugify,
+  deriveWorktree,
+  isWorktreeDirtyError,
+} from "./worktree.mjs";
+
+describe("slugify", () => {
+  it("lowercases, collapses spaces and strips symbols", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("collapses runs of non-alphanumeric chars into a single '-'", () => {
+    expect(slugify("foo!!  bar??baz")).toBe("foo-bar-baz");
+  });
+
+  it("trims leading and trailing '-'", () => {
+    expect(slugify("  --hello--  ")).toBe("hello");
+  });
+
+  it("returns 'session' for an all-symbol / empty name", () => {
+    expect(slugify("")).toBe("session");
+    expect(slugify("___")).toBe("session");
+    expect(slugify("   ")).toBe("session");
+    expect(slugify("!!!")).toBe("session");
+  });
+
+  it("strips unicode to a '-', then collapses/trims to 'session'", () => {
+    expect(slugify("café — résumé")).toBe("caf-r-sum");
+  });
+
+  it("treats null/undefined as empty → 'session'", () => {
+    expect(slugify(null as unknown as string)).toBe("session");
+    expect(slugify(undefined as unknown as string)).toBe("session");
+  });
+});
+
+describe("deriveWorktree", () => {
+  const REPO = "/home/me/projects/myapp";
+  const PARENT = "/home/me/projects";
+  const BASE = "myapp";
+  const noDir = () => false;
+  const noBranch = () => false;
+
+  it("returns the base sibling + slugged branch when nothing collides", () => {
+    const r = deriveWorktree({
+      repoRoot: REPO,
+      name: "Feature A",
+      dirExists: noDir,
+      branchExists: noBranch,
+    });
+    expect(r).toEqual({ path: `${PARENT}/${BASE}-feature-a`, branch: "feature-a" });
+  });
+
+  it("falls back to 'session' branch when the name slugifies to empty", () => {
+    const r = deriveWorktree({
+      repoRoot: REPO,
+      name: "!!!",
+      dirExists: noDir,
+      branchExists: noBranch,
+    });
+    expect(r).toEqual({ path: `${PARENT}/${BASE}-session`, branch: "session" });
+  });
+
+  it("appends -2, -3, … when the directory collides", () => {
+    const takenDirs = new Set([`${PARENT}/${BASE}-feature-a`]);
+    const r = deriveWorktree({
+      repoRoot: REPO,
+      name: "feature-a",
+      dirExists: (p) => takenDirs.has(p),
+      branchExists: noBranch,
+    });
+    expect(r).toEqual({ path: `${PARENT}/${BASE}-feature-a-2`, branch: "feature-a-2" });
+  });
+
+  it("appends -2, -3, … when the branch collides", () => {
+    const takenBranches = new Set(["feature-a"]);
+    const r = deriveWorktree({
+      repoRoot: REPO,
+      name: "feature-a",
+      dirExists: noDir,
+      branchExists: (b) => takenBranches.has(b),
+    });
+    expect(r).toEqual({ path: `${PARENT}/${BASE}-feature-a-2`, branch: "feature-a-2" });
+  });
+
+  it("keeps the numeric suffix in lockstep across two collisions", () => {
+    // dir AND branch both collide at base + -2 → bump to -3.
+    const takenDirs = new Set([
+      `${PARENT}/${BASE}-feature-a`,
+      `${PARENT}/${BASE}-feature-a-2`,
+    ]);
+    const takenBranches = new Set(["feature-a", "feature-a-2"]);
+    const r = deriveWorktree({
+      repoRoot: REPO,
+      name: "feature-a",
+      dirExists: (p) => takenDirs.has(p),
+      branchExists: (b) => takenBranches.has(b),
+    });
+    expect(r).toEqual({ path: `${PARENT}/${BASE}-feature-a-3`, branch: "feature-a-3" });
+  });
+});
+
+describe("isWorktreeDirtyError", () => {
+  it("matches git's real dirty-worktree stderr", () => {
+    const stderr =
+      "fatal: '/repo/feature-a' contains modified or untracked files, use --force to delete it";
+    expect(isWorktreeDirtyError(stderr)).toBe(true);
+  });
+
+  it("matches an untracked-only variant", () => {
+    const stderr =
+      "fatal: '/repo/feature-a' contains untracked files, use --force to delete it";
+    expect(isWorktreeDirtyError(stderr)).toBe(true);
+  });
+
+  it("rejects non-dirty errors (path missing, no 'use --force')", () => {
+    expect(isWorktreeDirtyError("fatal: cannot find worktree '/x'")).toBe(false);
+    expect(isWorktreeDirtyError("permission denied")).toBe(false);
+  });
+
+  it("rejects messages that mention 'force' but no modified/untracked", () => {
+    // would-be false positive — must not classify as dirty.
+    expect(isWorktreeDirtyError("fatal: unable to force-replace branch")).toBe(false);
+  });
+
+  it("handles empty / non-string input safely", () => {
+    expect(isWorktreeDirtyError("")).toBe(false);
+    expect(isWorktreeDirtyError(undefined as unknown as string)).toBe(false);
+    expect(isWorktreeDirtyError(null as unknown as string)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Auto-create a sibling git worktree when a user creates a new chat session (window), controlled by a global setting + per-window override checkbox. Optional global "clean on close" removes the worktree (with a dirty-checkout confirm before `--force`).

**Base:** `origin/main @ 7c0b9d9`

## Files changed
12 files, +710 / −12:
- new: `src/shared/worktree.mjs`, `src/shared/worktree.d.mts`, `src/shared/worktree.test.ts`
- modified: `src/server/local.mjs`, `src/server/rpc.mjs`, `src/server/tmux.mjs`, `src/shared/api.ts`, `src/shared/types.ts`, `src/renderer/store.ts`, `src/renderer/Settings.tsx`, `src/renderer/Sidebar.tsx`, `src/renderer/api/httpApi.ts`

## Architecture
- `src/shared/worktree.mjs` owns all pure logic + git stderr classification (`isWorktreeDirtyError`). The renderer never string-matches git output.
- `gitAddWorktree` (server): resolves repo root via `git rev-parse --show-toplevel`, pre-resolves the branch set in one `git for-each-ref` pass, picks a non-colliding sibling + branch via `deriveWorktree` (-2/-3 suffix loop mirroring `deriveSubagentName`), runs `git worktree add -b <branch> <path>`. Fail-closed on any error.
- `gitRemoveWorktree` (server): safe-by-default. Discriminated `{removed:false, reason:"dirty"}` result so the renderer can confirm before retrying with `--force`. Branch delete is best-effort.
- `tmux`: window now reads + writes `@manta-worktree-path` (mirrors `@manta-session-id` plumbing). `newWindow` accepts optional `worktreePath`; `newSession` is intentionally untouched (decision 7).
- `AppConfig`: `worktreePerSession` + `worktreeCleanOnClose` (default false). Ride the generic `configUpdate` channel — no new RPC / preload / IPC for config plumbing.
- `Settings → Files` tab: two toggles next to `allowAgentPush`. Desktop-only (no `MobileSettings` change — mirrors the `allowAgentPush` scope).
- `Sidebar`: new-session dialog has a "Create git worktree" checkbox (disabled with "not a git repository" tooltip on non-git projects). `createSession` branches once on the checkbox (single shared post-create activation path). `killWindow` runs the safe remove BEFORE teardown; on a dirty refusal, surfaces a Remove/Keep dialog by extending the existing `confirmDeleteFor` union. `killProject` unchanged (decision 9).

## Verification

`npm run typecheck`: exit 0. Errors: none.

`npm test`:
- 988 vitest tests pass (incl. 16 new pure-logic tests for `worktree.mjs`)
- 730 node:test pass, 0 fail

Tests cover: slugify (spaces / symbols / empty / unicode→stripped / null-undefined), deriveWorktree (no-collision / dir-only / branch-only / both-collide-twice → -3, all-suffix-name→"session"), isWorktreeDirtyError (real git message + non-dirty false-positives + empty/non-string input).

## Out of scope (deliberately NOT implemented)
- Per-session override for clean-on-close (global only)
- Worktree creation in the new-project dialog
- Cleanup on app quit / session switch / project delete
- Branch-selection UI (branch is always derived from the session name)