### PR TITLE
polish(renderer): keep-worktree feedback + resolveProjectCwd empty-cwd warn (BET-248)

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -52,6 +52,14 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     alert(msg);
   };
 
+  // BET-248: positive counterpart of showError — used when an action
+  // succeeded but left side-effects the user should know about (e.g.
+  // "Kept worktree at <path>"). Same alert() surface so the behavior is
+  // consistent across this file without introducing a new toast system.
+  const showNotice = (msg: string) => {
+    alert(msg);
+  };
+
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [newProjectName, setNewProjectName] = useState("");
@@ -126,7 +134,16 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     const w = proj?.windows.find((x) => x.index === activeIdx)
       ?? proj?.windows.find((x) => x.active)
       ?? proj?.windows[0];
-    return (w?.paneCurrentPath ?? "").trim();
+    const fallback = (w?.paneCurrentPath ?? "").trim();
+    // BET-248: silent empty return bit a future caller. When neither
+    // defaultCwd nor any paneCurrentPath resolved, surface a warn so the
+    // regression is visible during dev rather than in a downstream NPE.
+    if (!fallback) {
+      console.warn(
+        `[Sidebar] resolveProjectCwd: no usable cwd for project "${projectName}" (defaultCwd=${JSON.stringify(stored)}, paneCurrentPath missing)`,
+      );
+    }
+    return fallback;
   };
 
   // Probe whether the project's cwd is inside a git repo. Reuses the
@@ -452,6 +469,12 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         // Force-remove failed — surface but still close the session.
         showError(e);
       }
+    } else {
+      // BET-248: the worktree + branch remain on disk, but the session
+      // window still closes. Without this feedback the user gets no
+      // signal that the worktree was kept — the previous behavior left
+      // them wondering whether the click registered.
+      showNotice(`Kept worktree at ${wtPath}`);
     }
     try {
       await window.api.tmuxKillWindow({ sessionName: project, windowIndex: index });


### PR DESCRIPTION
**Files changed:** 1 file. `src/renderer/Sidebar.tsx` (+24 / −1).

Two reviewer Nits from BET-246 PR #195, both isolated to `src/renderer/Sidebar.tsx`, neither load-bearing:

1. **Keep worktree on dirty confirm** — the session window closes but the worktree + branch remain on disk with zero UI feedback, so users can't tell whether the click registered. Add a `showNotice` helper (alert-based, mirrors `showError`) and call it from the `!force` branch of `killWorktreeDirtyAndClose` with `'Kept worktree at <path>'`.

2. **`resolveProjectCwd` silent empty return** — when neither `defaultCwd` nor any `paneCurrentPath` is available, the function returns `''` silently. Downstream callers handle the empty case today, but the silent return will bite a future caller. Add a `console.warn` naming the project + the raw stored `defaultCwd` so the regression surfaces during dev.

**Base:** `origin/main` @ `0b04b9d`.

**Verification results:**
- PR branch (`multica/BET-248-kept-worktree-feedback` @ `e07d5cf`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `731` pass / `0` fail / `0` skip. Failures: none. log sha256: `08524806854a727f30971530792bd7918c688fa541ecc70aa60592d8fb8858c9`
- Base (`main` @ `0b04b9d`):
  - typecheck: exit `0`. Errors: none. log sha256: `139c60436aeae3ee087031cab3603b97f58acc2874526c66e944de4da209c667`
  - test: exit `0`, `731` pass / `0` fail / `0` skip. Failures: none. log sha256: `d4f450dc94db29913f7b962e473cf37ac5e7f273e7e0f773e3785b4951ed5d7c`
- **Conclusion:** 0 new failures, 0 pre-existing failures (test counts identical between branches; typecheck logs identical byte-for-byte). Both branches green from a clean checkout.

Logs cached at `/tmp/typecheck-bet248.log`, `/tmp/typecheck-master.log`, `/tmp/test-bet248.log`, `/tmp/test-master.log` for reviewer spot-check.