### PR TITLE
Add CODEOWNERS for native gate protection (public repo, BET-247)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS — native replacement for the two-tier merge-on-command approval
+# policy, now that MantaUI is a PUBLIC repo (GitHub Free enforces branch
+# protection + required Code Owner review on public repos).
+#
+# Rationale
+# ---------
+# The old `.github/workflows/merge-on-command.yml` gate existed ONLY because
+# GitHub Free does not enforce branch protection on PRIVATE repos — so a custom
+# `/merge` workflow simulated it. On a public repo, GitHub enforces protection
+# natively, so the gate collapses to two native mechanisms:
+#
+#   1. A branch ruleset on `main` requiring status checks
+#      (typecheck-test, secret-scan, dep-audit) + a pull request + Code Owner
+#      review. (Configured in Settings → Rules → Rulesets — not in-repo.)
+#   2. THIS file, which reproduces the old policy's ONLY human-class rows:
+#      changes under `.github/**` and to `.gitleaks.toml` require @antoinedc's
+#      review (a PR touching the gate/CI/secret-scan config cannot self-approve).
+#
+# Everything NOT listed here has no required Code Owner — matching the old
+# policy's `** -> auto` default, where any non-gate file could merge on green
+# checks alone. So an agent-authored app-code PR merges once required checks
+# pass; a gate-file PR additionally needs @antoinedc.
+#
+# Ordering: last matching pattern wins (GitHub CODEOWNERS semantics), so the
+# two gate patterns below are the only ones that assign an owner.
+
+# ── Gate integrity: only @antoinedc reviews changes to the merge/CI machinery ──
+/.github/**        @antoinedc
+/.gitleaks.toml    @antoinedc


### PR DESCRIPTION
Now that **MantaUI is a public repo**, GitHub Free enforces branch protection + required Code Owner review natively — which is the exact thing `merge-on-command.yml` was hand-rolling because private repos on Free don't get it.

## What this adds
`.github/CODEOWNERS` making **@antoinedc** the required reviewer for the two human-class paths from `approval-policy.json`:
- `/.github/**` (merge/CI workflows + policy files)
- `/.gitleaks.toml` (secret-scan config)

Everything else is intentionally owner-less → mergeable on green checks alone, matching the old `** -> auto` default.

## The payoff (answers "can the PM merge directly?")
Once you add the branch ruleset below, the PM merges with a normal `gh pr merge` as `antoinedc` and **GitHub enforces the gates natively** — no `/merge` comment, no `manta-agent[bot]` auth needed. A gate-file PR still needs your review (native, can't self-approve).

## Ruleset to configure (one-time, browser — needs repo admin)
**Settings → Rules → Rulesets → New branch ruleset**, target `main`:
- ☑ Require a pull request before merging
- ☑ Require status checks to pass → add \`typecheck-test\`, \`secret-scan\`, \`dep-audit\`
- ☑ Require review from Code Owners
- (optional) ☑ Require branches up to date before merging

## Follow-up (separate PR, after the ruleset is verified live)
`merge-on-command.yml` becomes redundant and can be deleted — leaving it for now so nothing breaks mid-transition. The Manta Agent App + runner rename from PR #197 stay as-is.

## Note
⚠️ This PR touches \`.github/**\` = the gate path — under the CURRENT policy it needs @antoinedc's \`/merge\`. (After the ruleset lands, it'd need your Code Owner review — same human gate, native.)