### PR TITLE
fix(ci): rebuild mobile bundle via auto-merged PR (ruleset blocks direct push to main)

### DIFF
--- a/.github/workflows/build-mobile-bundle.yml
+++ b/.github/workflows/build-mobile-bundle.yml
@@ -53,17 +53,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need a real ref (not detached HEAD) to commit + push back to main,
-          # and the token must be able to push.
+          # Need a real ref (not detached HEAD) to commit + push back the
+          # rebuilt bundle, and the token must be able to (a) push a new branch
+          # and (b) call `gh pr create` / `gh pr merge`.
           #
-          # BUNDLE_PUSH_TOKEN is an admin-owned PAT (antoinedc). main's branch
-          # protection requires 3 status checks (typecheck-test, secret-scan,
-          # dep-audit) enforced at level `non_admins`. The default GITHUB_TOKEN
-          # (github-actions[bot]) is a non-admin, so its direct push to main is
-          # rejected ("required status checks are expected"). An admin PAT
-          # bypasses the required-checks gate, so the bundle commit lands.
+          # main's repository ruleset (id 19571599) has no bypass actors and
+          # requires a PR + 3 status checks, so direct pushes to main are now
+          # rejected for every token — including this admin PAT. The bundle
+          # lands via an auto-merged PR (a mobile/www-only PR touches no
+          # CODEOWNERS path and needs 0 approvals). BUNDLE_PUSH_TOKEN is still
+          # required because the default GITHUB_TOKEN cannot open a PR that the
+          # ruleset then has to evaluate. fetch-depth: 0 so the branch carries
+          # full history for the PR.
           ref: main
           token: ${{ secrets.BUNDLE_PUSH_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -86,22 +90,47 @@ jobs:
           GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          # Reuse BUNDLE_PUSH_TOKEN for the gh CLI so the workflow can open +
+          # auto-merge its own PR. The default GITHUB_TOKEN would be rejected
+          # by the ruleset's code-owner / required-check evaluation.
+          GH_TOKEN: ${{ secrets.BUNDLE_PUSH_TOKEN }}
         run: |
           set -euo pipefail
-          # Force-add: mobile/www/ is gitignored, so a plain `git add` is a
-          # no-op. -f stages the freshly built (ignored) bundle.
+
+          # mobile/www/ is gitignored, so -f is required to stage the freshly built bundle.
           git add -f mobile/www
 
-          # Nothing staged → source produced an identical bundle (this is the
-          # steady state, including the loop-guard follow-up run). Exit clean.
+          # No diff → source produced an identical bundle (steady state / loop-guard
+          # follow-up run). Nothing to do.
           if git diff --cached --quiet; then
             echo "mobile/www/ already up to date with source — nothing to commit."
             exit 0
           fi
 
-          # [skip ci] keeps the push-triggered CI/other workflows from running
-          # on a pure bundle commit. This workflow still re-runs (see loop-guard
-          # note in the header) but no-ops on the next pass.
+          BRANCH="chore/mobile-bundle-${GITHUB_SHA::12}"
+          git checkout -b "$BRANCH"
           git commit -m "chore(mobile): rebuild mobile/www bundle [skip ci]"
-          git push origin HEAD:main
-          echo "Committed + pushed rebuilt mobile/www bundle."
+          git push origin "$BRANCH"
+
+          # Open the PR and merge it. A mobile/www-only PR touches no CODEOWNERS path,
+          # so it needs 0 approvals — it merges as soon as required checks are green.
+          PR_URL=$(gh pr create \
+            --base main --head "$BRANCH" \
+            --title "chore(mobile): rebuild mobile/www bundle" \
+            --body "Automated PWA bundle rebuild. mobile/www/ is a build artifact of src/renderer/; this keeps main's served bundle in sync. Auto-merged on green checks.")
+
+          # --auto queues the merge to fire the moment required checks pass; if repo
+          # auto-merge is unavailable the fallback poll-and-merge below still merges it.
+          gh pr merge "$PR_URL" --merge --delete-branch --auto || {
+            echo "auto-merge unavailable; polling for green checks then merging"
+            for i in $(seq 1 40); do
+              if gh pr checks "$PR_URL" | grep -qE '\bfail'; then
+                echo "a required check failed"; exit 1
+              fi
+              if ! gh pr checks "$PR_URL" | grep -q pending; then
+                gh pr merge "$PR_URL" --merge --delete-branch && exit 0
+              fi
+              sleep 20
+            done
+            echo "timed out waiting for checks"; exit 1
+          }


### PR DESCRIPTION
## Summary

Fixes BET-249.

The `.github/workflows/build-mobile-bundle.yml` workflow rebuilds `mobile/www/` on every push to `main` and committed + pushed directly to `main`. BET-247 replaced classic branch protection with a GitHub **repository ruleset** on `main` (id `19571599`) with a `pull_request` rule and **zero bypass actors** — direct pushes are now rejected for every token, including the admin `BUNDLE_PUSH_TOKEN`. Result: every merge to `main` left the served PWA bundle stale and the workflow red.

This PR changes the workflow so the rebuilt bundle lands via an auto-merged PR instead:

1. Build `mobile/www/` (unchanged).
2. Force-add + commit on a short-lived `chore/mobile-bundle-<sha12>` branch.
3. Push the branch (rulesets only block pushes to `main`, not new branches).
4. Open a PR to `main` — a `mobile/www/`-only PR touches no CODEOWNERS path, so it needs 0 approvals and merges as soon as the 3 required checks are green.
5. `gh pr merge --auto --delete-branch`, with a poll-and-merge fallback if the repo's auto-merge setting is off.

## Changes

- `.github/workflows/build-mobile-bundle.yml` — single-file edit:
  - Updated the stale comment that claimed `BUNDLE_PUSH_TOKEN` bypasses the required-checks gate (no longer true; replaced with accurate note about the ruleset and PR-based path).
  - Added `fetch-depth: 0` to `actions/checkout` so the branch carries full history for the PR.
  - Replaced the `git push origin HEAD:main` step with: branch → push → `gh pr create` → `gh pr merge --auto`.
  - Set `GH_TOKEN: ${{ secrets.BUNDLE_PUSH_TOKEN }}` on the step env so the `gh` CLI is authenticated.

Everything else (header `WHY THIS EXISTS`/`THE FIX`/`LOOP GUARD` prose, `concurrency` group, `setup-node`, `npm ci`, `npm run build:mobile`, the `git add -f` + `git diff --cached --quiet` no-op guard, the `[skip ci]` commit message, the 6-step-permission block) is untouched.

Out of scope (per issue): no other workflows touched, no new secrets, no deploy/build-on-the-box changes, no `.gitignore`/untrack changes, no repo auto-merge toggle, no ruleset bypass actors.

## Verification

- `git grep -n "bypasses the required-checks gate" .github/` → no matches (stale claim removed).
- YAML is valid (Python `yaml.safe_load`).
- Workflow's intent preserved: bundle still lands on `main` automatically after each push, deploy model unchanged (`git pull + restart` on the box).

**Base: origin/main @ `d3645ec`**

**Verification results:**
- PR branch (`multica/BET-249-fix-build-mobile-bundle-push` @ `84d50a2`):
  - typecheck: exit 0. Errors: none. log sha256: `36e631757a954dc940c0025ae7098353a30cc53c7739dbb0f346dae34b7e5b0b`
  - test: exit 0, 731 pass / 0 fail / 0 skip. log sha256: `ad8f80428ce8523a2d1bf7c9bbee54d46e5fa6dc8bdf90132a141b6e38219365`
- Base (`main` @ `d3645ec`):
  - typecheck: exit 0. Errors: none. log sha256: `36e631757a954dc940c0025ae7098353a30cc53c7739dbb0f346dae34b7e5b0b`
  - test: exit 0, 731 pass / 0 fail / 0 skip. log sha256: `399da5624dcd47a2bb9419a564f17d21d786f538e6bb0b7fb15abbed1e219d0d`
- **Conclusion:** 0 new failures, 0 pre-existing failures. Identical pass/fail counts (731/0/0) on both branches; test-log hash diff is purely timing/non-determinism in the test runner. typecheck logs are byte-identical.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Notes for reviewer

- This is a workflow change → `.github/**` is a CODEOWNERS path → human review required (per PM dispatch note). Reviewer should approve; merge will be requested in a follow-up comment, not done by this PR's author agent.
- The PR is opened **draft** so the reviewer can inspect before any auto-merge attempt. The workflow's auto-merge only runs when the workflow itself is triggered (i.e., on push to `main`), not by this PR.
- I did not push a test commit to `main` to actually exercise the workflow end-to-end (that would require a bypass token we don't have); verification above is offline + typecheck + test. The actual workflow run is gated behind a successful merge.