### PR TITLE
fix(mobile): composer footer overlap (BET-258)

### DIFF
--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -24,7 +24,7 @@ export function SessionToolbar({
   onWebhooks: () => void;
 }) {
   return (
-    <span className="flex items-center gap-1 text-[10px]">
+    <span className="manta-session-toolbar flex items-center gap-1 text-[10px]">
       <button
         onClick={onSchedules}
         className="px-1.5 py-px rounded text-text-faint hover:text-text-muted"

--- a/src/renderer/ContextBar.tsx
+++ b/src/renderer/ContextBar.tsx
@@ -145,7 +145,12 @@ export function ContextBar({
             "(Cache TTL is set by opencode; manta predicts staleness from the Settings → Prompt cache TTL value. If this fires at the wrong time, that setting probably doesn't match opencode's cache_control.ttl.)",
           ].join("\n")}
         >
-          ⚠ /clear to save {formatTokensCompact(staleCache.staleTokens)} tokens
+          <span className="manta-stale-full">
+            ⚠ /clear to save {formatTokensCompact(staleCache.staleTokens)} tokens
+          </span>
+          <span className="manta-stale-min hidden">
+            ⚠ {formatTokensCompact(staleCache.staleTokens)}
+          </span>
         </span>
       )}
     </span>

--- a/src/renderer/mobile/SessionScreen.tsx
+++ b/src/renderer/mobile/SessionScreen.tsx
@@ -27,6 +27,10 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState<string | null>(null);
+  // Live schedules count for the ⋯ sheet label — the footer toolbar (which
+  // used to surface it) is hidden on mobile (BET-258), so the sheet carries
+  // it instead. Count is omitted entirely on 0 or fetch failure.
+  const [scheduleCount, setScheduleCount] = useState(0);
 
   const project = projects.find((p) => p.tmuxSession === projectName);
   const win = project?.windows.find((w) => w.index === windowIndex);
@@ -58,6 +62,28 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
       .then(setAvailableLaunchers)
       .catch(() => setAvailableLaunchers([]));
   }, [sid]);
+
+  // Fetch the schedules count when the ⋯ sheet opens so the live count
+  // shows on the sheet label (the footer toolbar that used to carry it
+  // is hidden on mobile). Guarded with a cancelled flag so a fast
+  // open/close can't land setState on an unmounted render.
+  useEffect(() => {
+    if (!sheetOpen || !sid) return;
+    let cancelled = false;
+    window.api
+      .scheduleList(sid)
+      .then((jobs) => {
+        if (cancelled) return;
+        setScheduleCount(Array.isArray(jobs) ? jobs.length : 0);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setScheduleCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sheetOpen, sid]);
 
   useEffect(() => {
     setModeState(sid ? readSavedMode(sid, availableLaunchers) : "chat");
@@ -333,7 +359,9 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
                         closeSheet();
                       }}
                     >
-                      Scheduled tasks
+                      {scheduleCount > 0
+                        ? `Scheduled tasks · ${scheduleCount}`
+                        : "Scheduled tasks"}
                     </button>
                     <button
                       onClick={() => {

--- a/src/renderer/mobile/mobile.css
+++ b/src/renderer/mobile/mobile.css
@@ -242,6 +242,15 @@ body,
   flex-wrap: wrap;
   row-gap: 4px;
 }
+/* The meta footer row's two inner spans (left: branch/model/ctx, right:
+   toolbar) are nested one level below the wrap rule above and were the
+   actual overlap: their shrink-0 children painted over the model label.
+   Let them wrap and shrink. */
+.mobile-body > div > div:last-child > div[class*="justify-between"] > span {
+  flex-wrap: wrap;
+  min-width: 0;
+  row-gap: 4px;
+}
 /* The static desktop keyboard-hint span (ctrl+o · shift+⏎ newline · ⏎ send)
    was removed from ChatPanel entirely, so there's no longer a hint span to
    hide here. The footer's right-hand group now holds the ⏰ schedules button
@@ -260,6 +269,14 @@ body,
   overflow: hidden;
 }
 
+/* Stale-cache pill: tokens number only on phone ("⚠ 79k"); the full
+   "/clear to save … tokens" copy is desktop-width text. */
+.mobile-body .manta-stale-full { display: none; }
+.mobile-body .manta-stale-min { display: inline; }
+
+/* 1px sweep is invisible at arm's length on phone DPI. */
+.mobile .manta-loading-divider { height: 2px; }
+
 /* Drop the dotted context-usage BAR on mobile but keep the % number.
    ChatPanel's ContextBar renders [ <span.w-24 track> , <span.tabular-nums %> ].
    The track is the only `w-24` element in the reused tree — hide just that;
@@ -268,13 +285,14 @@ body,
   display: none;
 }
 
-/* SessionToolbar now contains ONLY the ⏰ schedules toggle (fork/compact/
-   delete moved to the header ⋯ bottom-sheet). The schedules button IS wanted
-   on mobile — it's the only way to surface the schedules count + open the
-   ScheduledTasksCard from the composer — so it is NOT hidden here. (Mobile
-   previously had a redundant ⋯-sheet "Scheduled tasks" entry; keeping the
-   footer button means schedules are reachable + their live count visible
-   right next to the composer on phone too.) */
+/* SessionToolbar (⏰/🔑/🪝) is hidden on mobile — all three are reachable
+   from the header ⋯ bottom-sheet, and the live schedules count moved onto
+   the sheet label (see SessionScreen.tsx scheduleCount + SessionScreen
+   ⋯ sheet entry). Keeping the footer toolbar was crowding the meta row
+   alongside the model picker / ctx % / stale-cache pill. */
+/* ⏰🔑🪝 live in the header ⋯ sheet on mobile — the footer copies are
+   redundant and were crowding the meta row. */
+.mobile-body .manta-session-toolbar { display: none; }
 
 /* ---- Transcript horizontal-scroll fix moved into shared components (BET-230) ----
 
@@ -304,6 +322,11 @@ body,
 .mobile-body div[class*="min-w-[240px]"] {
   min-width: 0;
   max-width: calc(100vw - 32px);
+}
+/* ModelPicker trigger: truncate long provider/model ids instead of
+   crowding out the ctx % + stale pill. */
+.mobile-body > div > div:last-child div[class*="relative"][class*="min-w-0"] {
+  max-width: 40vw;
 }
 
 /* iOS Safari auto-zooms <input>/<textarea> with font-size < 16px on focus,


### PR DESCRIPTION
## Summary

Mobile composer's meta footer painted the ctx % and stale-cache pill *over* the model name. The existing flex-wrap rule in mobile.css only reached direct children of the composer wrapper; the two inner spans (left: branch / model / ctx, right: toolbar) were nested one level below it and held shrink-0 children that overlapped.

This commit also folds three small adjacent mobile-only cleanups (compact stale-cache pill on phone, drop the redundant footer toolbar, 2px loading divider) all per the BET-258 spec.

## Files changed

- `src/renderer/mobile/mobile.css` — wrap the two inner spans inside the `justify-between` row (A); cap ModelPicker trigger at 40vw on phones (B); hide the `manta-session-toolbar` on phones (D); swap stale-cache pill full → min on phones (C); bump the ambient loading divider to 2px (F); updated the now-stale comment block above the toolbar hide rule.
- `src/renderer/ContextBar.tsx` — split the stale-cache pill into two sibling spans (`manta-stale-full` default + `manta-stale-min hidden`) inside the same pill; the `title` tooltip attribute is byte-identical.
- `src/renderer/ComposerParts.tsx` — append `manta-session-toolbar` to SessionToolbar's root `<span>`. No desktop CSS for the new class.
- `src/renderer/mobile/SessionScreen.tsx` — `scheduleCount` state + a `sheetOpen && sid`-gated effect (cancelled-flag) that calls `window.api.scheduleList(sid)`; sheet label becomes `Scheduled tasks · N` when count > 0, otherwise the bare label. Count is omitted entirely on fetch failure.

No changes to `InputArea.tsx` / `ChatPanel.tsx` DOM structure. `SessionToolbar` is retained (desktop still uses it). `w-24` on the ContextBar track is untouched. `mobile/www/` is not built or committed.

## Desktop invariance

Every new mobile.css selector is scoped under `.mobile` or `.mobile-body`. The two new class hooks (`manta-session-toolbar`, `manta-stale-full`, `manta-stale-min`) carry no desktop CSS, and `.manta-stale-min` uses Tailwind's `hidden` utility (`display: none` by default) so desktop output is identical: one child visible with the full `/clear to save … tokens` copy.

## Verification

```
Base: origin/main @ 457a9e2
```

- PR branch (`multica/BET-258-mobile-composer-footer-overlap` @ `ccccf90`):
  - typecheck: exit 0, no errors. log: `/tmp/typecheck-pr.log`
  - test: exit 0, 734 pass / 0 fail / 0 skip. log: `/tmp/test-pr.log`
- Per the issue: no vitest case added — no new pure logic was extracted.