### PR TITLE
feat(mobile): keyboard accessory bar (esc/arrows/@/slash/clear) for chat mode (BET-259)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -176,6 +176,57 @@ describe("ChatPanel session resources", () => {
     expect((api?.calls?.secretsList?.length ?? 0) >= 0).toBe(true);
     expect(h.container.querySelector("input[type=password]")).not.toBeNull();
   });
+
+  // Mobile keyboard bar → /clear (BET-259). The KeyboardBar's `clear` key
+  // already showed the user a confirm; this bridge hands control to the
+  // existing /clear builtin so optimistic-message cleanup and model-override
+  // carry-over to the new session behave exactly like a typed `/clear`.
+  it("runs /clear when the manta-run-clear bridge fires for this session", async () => {
+    ({ api } = installMockApi());
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("manta-run-clear", { detail: { sessionId: "ses_test" } }),
+      );
+    });
+    await h.flush();
+
+    // The bridge set input to "/clear" and submitted via submitRef; the
+    // submit hits the /clear builtin path which calls opencodeClearSession
+    // with the owning tmux window. The mock auto-records every call.
+    expect(api.calls.opencodeClearSession ?? []).toEqual([
+      [
+        {
+          sessionName: "proj",
+          windowIndex: 1,
+          cwd: "/home/dev/projects/x",
+          title: "proj / cleared",
+        },
+      ],
+    ]);
+  });
+
+  it("ignores a manta-run-clear bridge for another session id", async () => {
+    ({ api } = installMockApi());
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("manta-run-clear", { detail: { sessionId: "ses_OTHER" } }),
+      );
+    });
+    await h.flush();
+
+    // A bridge for a different session must NOT trigger a clear in THIS
+    // panel. Without the gate, the spec's "must reuse /clear builtin" rule
+    // would silently wipe the wrong session.
+    expect(api.calls.opencodeClearSession ?? []).toEqual([]);
+  });
 });
 
 // ===== Transcript rendering (via the mounted ChatPanel) =====

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -478,6 +478,28 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
 
+  // Mobile keyboard-bar → /clear bridge (BET-259). The KeyboardBar's
+  // `clear` key already showed the user a confirm; this listener hands the
+  // clear to ChatPanel's existing /clear builtin path so optimistic-message
+  // cleanup and model-override carry-over to the new session behave exactly
+  // like a typed `/clear`. The submit is deferred via setTimeout(…, 0) so the
+  // setInput("/clear") re-render commits first — calling submit() in the
+  // same tick would read the stale input closure. Don't call
+  // opencodeClearSession directly; the builtin path in submit() owns the
+  // model-carry-over.
+  useEffect(() => {
+    const onRunClear = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
+      if (detail?.sessionId !== sessionId) return;
+      setInput("/clear");
+      setTimeout(() => {
+        submitRef.current?.();
+      }, 0);
+    };
+    window.addEventListener("manta-run-clear", onRunClear);
+    return () => window.removeEventListener("manta-run-clear", onRunClear);
+  }, [sessionId, setInput]);
+
   // (manta-open-schedules / -secrets / -webhooks mobile bridges moved to
   // useSessionResources.)
 

--- a/src/renderer/mobile/KeyboardBar.tsx
+++ b/src/renderer/mobile/KeyboardBar.tsx
@@ -1,0 +1,217 @@
+// Mobile keyboard accessory bar (BET-259).
+//
+// Slim key bar that docks on top of the on-screen keyboard on mobile chat
+// windows. Soft keyboards don't ship arrow keys, Esc, @ or / — chat mode on
+// a phone loses prompt-history nav, interrupt, and the typeahead prefixes
+// without this affordance.
+//
+// The bar REUSES the existing input-handling logic instead of duplicating it:
+//
+//   esc / ↑ / ↓  →  dispatch a synthetic keydown to .mobile-body textarea;
+//                   React's root delegation re-runs InputArea.tsx's existing
+//                   onKeyDown (typeahead nav, history nav, queued-pop,
+//                   esc-abort-while-running).
+//   @ / /        →  insert the character through the normal execCommand
+//                   "insertText" path so React's onChange/input event picks
+//                   it up — opening the file/command typeahead naturally.
+//   clear        →  confirm with the user, then dispatch the `manta-run-clear`
+//                   CustomEvent. ChatPanel owns the /clear builtin path
+//                   (optimistic-message cleanup + model-override carry-over)
+//                   and the bridge hands control to it.
+//
+// Visibility: shown when the composer textarea is focused OR the session is
+// running. When running + keyboard closed, the bar sits above the composer as
+// the intended interrupt affordance replacing the header Esc.
+
+import { useEffect, useState } from "react";
+import { useStore } from "../store";
+import { computeKeyboardInset } from "./keyboardInset";
+
+type Props = {
+  sessionId: string;
+  projectName: string;
+  windowIndex: number;
+};
+
+const composerTextarea = (): HTMLTextAreaElement | null =>
+  document.querySelector<HTMLTextAreaElement>(".mobile-body textarea");
+
+function dispatchKey(ta: HTMLTextAreaElement, key: string) {
+  ta.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+  );
+}
+
+function insertChar(ta: HTMLTextAreaElement, ch: string) {
+  ta.focus();
+  // execCommand is deprecated but universally supported in WebKit/Chromium
+  // and fires the input event React's onChange listens to. The native setter
+  // fallback covers engines that return false (or for the few that have
+  // removed execCommand entirely).
+  const ok = document.execCommand("insertText", false, ch);
+  if (ok) return;
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(ta, ta.value + ch);
+  ta.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+export function KeyboardBar({ sessionId, projectName, windowIndex }: Props) {
+  const running = useStore(
+    (s) => s.status[projectName]?.[windowIndex]?.running === true,
+  );
+  const [focused, setFocused] = useState(false);
+
+  // Composer-focus tracking via window-level focusin/focusout. The pointerdown
+  // preventDefault on every key below means tapping a bar key never fires
+  // focusout on the textarea — the only way to lose focus is the OS-level
+  // blur (tap outside, dismiss keyboard, etc.).
+  useEffect(() => {
+    const onFocusIn = (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.matches?.(".mobile-body textarea")) setFocused(true);
+    };
+    const onFocusOut = (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.matches?.(".mobile-body textarea")) setFocused(false);
+    };
+    window.addEventListener("focusin", onFocusIn);
+    window.addEventListener("focusout", onFocusOut);
+    return () => {
+      window.removeEventListener("focusin", onFocusIn);
+      window.removeEventListener("focusout", onFocusOut);
+    };
+  }, []);
+
+  // Visual-viewport keyboard inset. iOS Safari overlay: inset > 0, translate
+  // the bar up. Capacitor resize: inset ≈ 0, normal flow. The hook is a
+  // no-op when visualViewport is undefined (older browsers).
+  const [inset, setInset] = useState(0);
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const recompute = () => {
+      setInset(computeKeyboardInset(window.innerHeight, vv.height, vv.offsetTop));
+    };
+    recompute();
+    vv.addEventListener("resize", recompute);
+    vv.addEventListener("scroll", recompute);
+    return () => {
+      vv.removeEventListener("resize", recompute);
+      vv.removeEventListener("scroll", recompute);
+    };
+  }, []);
+
+  if (!focused && !running) return null;
+
+  const onKeyPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    // Classic accessory-bar gotcha: tapping a key blurs the textarea and
+    // dismisses the keyboard. preventDefault on pointerdown keeps the
+    // textarea focused for the entire gesture.
+    e.preventDefault();
+  };
+
+  const onEsc = () => {
+    const ta = composerTextarea();
+    if (!ta) return;
+    dispatchKey(ta, "Escape");
+  };
+  const onArrowUp = () => {
+    const ta = composerTextarea();
+    if (!ta) return;
+    dispatchKey(ta, "ArrowUp");
+  };
+  const onArrowDown = () => {
+    const ta = composerTextarea();
+    if (!ta) return;
+    dispatchKey(ta, "ArrowDown");
+  };
+  const onAt = () => {
+    const ta = composerTextarea();
+    if (!ta) return;
+    insertChar(ta, "@");
+  };
+  const onSlash = () => {
+    const ta = composerTextarea();
+    if (!ta) return;
+    insertChar(ta, "/");
+  };
+  const onClear = () => {
+    // The confirm lives here and only here — no confirm is added to any other
+    // clear path (typing /clear, voice, etc.).
+    const ok = window.confirm(
+      "Clear session? The transcript is discarded and context resets.",
+    );
+    if (!ok) return;
+    window.dispatchEvent(
+      new CustomEvent("manta-run-clear", { detail: { sessionId } }),
+    );
+  };
+
+  return (
+    <div
+      className="mobile-kbar"
+      style={inset > 0 ? { transform: `translateY(-${inset}px)` } : undefined}
+    >
+      <button
+        type="button"
+        className={`mobile-kbar-key${
+          running ? " mobile-kbar-key--danger" : ""
+        } mobile-kbar-key--wide`}
+        onPointerDown={onKeyPointerDown}
+        onClick={onEsc}
+        aria-label="Esc"
+      >
+        esc
+      </button>
+      <button
+        type="button"
+        className="mobile-kbar-key"
+        onPointerDown={onKeyPointerDown}
+        onClick={onArrowUp}
+        aria-label="Previous prompt"
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        className="mobile-kbar-key"
+        onPointerDown={onKeyPointerDown}
+        onClick={onArrowDown}
+        aria-label="Next prompt"
+      >
+        ↓
+      </button>
+      <span className="mobile-kbar-spacer" />
+      <button
+        type="button"
+        className="mobile-kbar-key"
+        onPointerDown={onKeyPointerDown}
+        onClick={onAt}
+        aria-label="Mention file or agent"
+      >
+        @
+      </button>
+      <button
+        type="button"
+        className="mobile-kbar-key"
+        onPointerDown={onKeyPointerDown}
+        onClick={onSlash}
+        aria-label="Slash command"
+      >
+        /
+      </button>
+      <button
+        type="button"
+        className="mobile-kbar-key mobile-kbar-key--wide"
+        onPointerDown={onKeyPointerDown}
+        onClick={onClear}
+        aria-label="Clear session"
+      >
+        clear
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/mobile/SessionScreen.tsx
+++ b/src/renderer/mobile/SessionScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useStore, resolveSessionOwner } from "../store";
 import { ChatPanel } from "../ChatPanel";
 import { Terminal } from "../Terminal";
+import { KeyboardBar } from "./KeyboardBar";
 import {
   type SessionMode,
   readSavedMode,
@@ -153,24 +154,18 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
   };
 
   // Esc / stop — interrupt the running agent. Mobile soft keyboards rarely
-  // expose an Esc key, so it gets an explicit header button that works for
-  // BOTH session kinds. It's always available (not gated on a "running"
-  // flag): a stuck agent is exactly the case where the running indicator may
-  // be stale, so the stop must work regardless. Aborting an already-idle
-  // session is a harmless no-op.
-  //   - chat mode → opencodeAbort(sid), same as the desktop "Esc to stop"
-  //     keybind in ChatPanel.
-  //   - terminal / AI CLI TUI mode (or a legacy foreign window with no sid,
-  //     which manta never creates anymore) → write \x1b to that mode's shell
-  //     PTY. Select the tmux window first: mobile navigation doesn't
-  //     select-window on open, and the legacy fallback path's PTY follows
-  //     the active tmux window, so without this ESC could land on a
-  //     different window than the one shown.
+  // expose an Esc key, so terminal / AI CLI TUI windows keep an explicit
+  // header button that writes \x1b to the mode's shell PTY. Chat mode's
+  // interrupt lives in the KeyboardBar (which dispatches a synthetic Escape
+  // keydown to the textarea → ChatPanel's existing onKeyDown → abort()).
+  // Always available (not gated on a "running" flag): a stuck agent is
+  // exactly the case where the running indicator may be stale, so the stop
+  // must work regardless. Writing \x1b to an idle PTY is a harmless no-op.
+  // Select the tmux window first: mobile navigation doesn't select-window
+  // on open, and the legacy fallback path's PTY follows the active tmux
+  // window, so without this ESC could land on a different window than the
+  // one shown.
   const sendEsc = () => {
-    if (sid) {
-      window.api.opencodeAbort(sid).catch(() => {});
-      return;
-    }
     window.api
       .tmuxSelectWindow({ sessionName: projectName, windowIndex: win.index })
       .catch(() => {})
@@ -231,17 +226,22 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
           )}
         </div>
         {/* Esc / stop — interrupts the running agent the way pressing Esc
-            would on desktop. Shown for both chat and terminal windows; see
-            sendEsc for why it's always available rather than gated on a
-            running flag. */}
-        <button
-          className="mobile-tap text-text-muted text-xs font-semibold px-2 border border-border rounded"
-          onClick={sendEsc}
-          aria-label="Send Esc to stop the agent"
-          title="Esc"
-        >
-          Esc
-        </button>
+            would on desktop. Shown ONLY in terminal / AI CLI TUI mode; chat
+            mode's interrupt lives in the KeyboardBar (esc key → synthetic
+            keydown → textarea handler → abort). Always available rather than
+            gated on a running flag: a stuck agent is exactly the case where
+            the running indicator may be stale, so the stop must work
+            regardless. */}
+        {!(sid && mode === "chat") && (
+          <button
+            className="mobile-tap text-text-muted text-xs font-semibold px-2 border border-border rounded"
+            onClick={sendEsc}
+            aria-label="Send Esc to stop the agent"
+            title="Esc"
+          >
+            Esc
+          </button>
+        )}
         {/* Action sheet is available for both chat and terminal windows now —
             terminal windows get rename + kill; chat windows additionally get
             fork / compact / delete. */}
@@ -272,6 +272,20 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
           />
         )}
       </div>
+
+      {/* Keyboard accessory bar — chat mode only (BET-259). Rendered as the
+          last child of the .mobile-screen flex column so normal flow docks
+          it directly above the composer / on-screen keyboard on hosts that
+          resize the viewport (Capacitor). iOS Safari's overlay-keyboard
+          host uses an explicit translateY(-inset) computed from
+          window.visualViewport (see KeyboardBar.tsx). */}
+      {sid && mode === "chat" && (
+        <KeyboardBar
+          sessionId={sid}
+          projectName={projectName}
+          windowIndex={win.index}
+        />
+      )}
 
       {sheetOpen && (
         <div className="mobile-sheet-backdrop" onClick={closeSheet}>

--- a/src/renderer/mobile/keyboardInset.test.ts
+++ b/src/renderer/mobile/keyboardInset.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { computeKeyboardInset } from "./keyboardInset";
+
+describe("computeKeyboardInset", () => {
+  it("returns 0 when the keyboard is closed (innerHeight === vvHeight)", () => {
+    expect(computeKeyboardInset(800, 800, 0)).toBe(0);
+  });
+
+  it("returns the keyboard height when the visual viewport has shrunk", () => {
+    // iOS Safari overlay: layout 800, visual 400, no offset → 400px keyboard.
+    expect(computeKeyboardInset(800, 400, 0)).toBe(400);
+  });
+
+  it("subtracts the visual-viewport offset (scrolled visual viewport)", () => {
+    // After Safari's form-zoom scroll, the visual viewport is offset 60px
+    // from the layout origin; the keyboard is only 300px tall (800 - 500).
+    expect(computeKeyboardInset(800, 500, 60)).toBe(300 - 60);
+  });
+
+  it("clamps negative values to 0 (Capacitor resizes the layout viewport instead)", () => {
+    // Capacitor resizes the WebView to innerHeight 400, vvHeight 400 (already
+    // 0 inset), but a stale offsetTop of 50 would otherwise yield a negative
+    // result. Clamp to 0 — the bar uses no transform, normal flow applies.
+    expect(computeKeyboardInset(400, 400, 50)).toBe(0);
+  });
+});

--- a/src/renderer/mobile/keyboardInset.ts
+++ b/src/renderer/mobile/keyboardInset.ts
@@ -1,0 +1,29 @@
+// Visual-viewport keyboard-inset computation (BET-259).
+//
+// On iOS Safari (PWA mode) the layout viewport does NOT resize when the
+// soft keyboard opens — the keyboard overlays the page. To dock a bar above
+// the keyboard we translate it up by the gap between the layout viewport
+// (window.innerHeight) and the visual viewport (window.visualViewport.height)
+// plus the offset the visual viewport has scrolled from the layout origin.
+//
+// On Capacitor (Android & iOS native shell) the WebView resizes the layout
+// viewport as the keyboard slides in, so innerHeight === visualViewport.height
+// and the helper returns 0 → the bar sits in normal flow at the bottom of
+// the flex column, exactly where its sibling .mobile-body already accounts
+// for the resize. One code path serves both hosts.
+//
+// Pure function — no DOM access — so it's trivially testable.
+
+export function computeKeyboardInset(
+  innerHeight: number,
+  vvHeight: number,
+  vvOffsetTop: number,
+): number {
+  // `innerHeight - vvHeight` is the gap covered by the keyboard.
+  // `vvOffsetTop` is the visual viewport's offset from the layout origin
+  // (positive when Safari's "shrink viewport" / form-zoom has pushed the
+  // visual viewport down inside the layout). Subtracting it makes the
+  // computed inset track the keyboard edge rather than the layout edge.
+  const inset = innerHeight - vvHeight - vvOffsetTop;
+  return Math.max(0, inset);
+}

--- a/src/renderer/mobile/mobile.css
+++ b/src/renderer/mobile/mobile.css
@@ -367,6 +367,44 @@ body,
   color: #FF7A88;
 }
 
+/* Key bar docked above the on-screen keyboard (chat mode, BET-259). On
+   hosts that resize the WebView on keyboard open (Capacitor), normal flow
+   at the bottom of the .mobile-screen flex column lands the bar flush on
+   top of the keyboard with no positioning work. On iOS Safari (PWA), the
+   keyboard overlays the layout viewport, so the bar applies a translateY
+   equal to the visual-viewport keyboard inset (see KeyboardBar.tsx). The
+   safe-area padding only matters in the keyboard-closed running state —
+   when the keyboard is open the OS gesture bar is behind it. */
+.mobile-kbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px calc(6px + env(safe-area-inset-bottom, 0px));
+  background: #10162B;
+  border-top: 1px solid #253055;
+  position: relative;
+  z-index: 40;
+  flex: none;
+}
+.mobile-kbar-key {
+  min-width: 44px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #171F3A;
+  border: 1px solid #33406B;
+  border-radius: 7px;
+  color: #F8FAFC;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: ui-monospace, Menlo, monospace;
+}
+.mobile-kbar-key:active { background: #1E2747; }
+.mobile-kbar-key--wide { min-width: 52px; }
+.mobile-kbar-key--danger { color: #F0505F; }
+.mobile-kbar-spacer { flex: 1; }
+
 /* Spinner rotation for ConnectingScreen. A @keyframes is global (not a
    selector) so it's exempt from the "no unscoped selector" rule above — the
    ring elements it animates are inside the .mobile tree. */


### PR DESCRIPTION
Implements BET-259. Mobile soft keyboards don't expose arrow keys, Esc, or @ /, so prompt-history navigation, interrupt, and the typeahead prefixes are unreachable in chat mode on phones. Adds a slim key bar docked above the soft keyboard in mobile chat mode.

**Reuse, not duplication:**
- esc/↑/↓: synthetic KeyboardEvent on the composer textarea; React root delegation re-runs InputArea.tsx's onKeyDown (typeahead nav, history nav with first/last-row guard, Up-pop-queued-while-running, Esc-abort-while-running).
- @//: execCommand('insertText') so React's onChange picks it up and the typeahead opens naturally; native-setter fallback.
- clear: window.confirm, then dispatch manta-run-clear CustomEvent; ChatPanel reuses the /clear builtin (optimistic-message cleanup + model-override carry-over) via setInput+deferred submitRef.

**Layout:**
- Last child of .mobile-screen flex column → normal flow docks above keyboard on hosts that resize (Capacitor).
- iOS Safari overlay-keyboard host: explicit translateY(-inset) computed from window.visualViewport via a pure helper (computeKeyboardInset).
- Visible when composer is focused OR the session is running (interrupt affordance replaces the header Esc in chat mode).

**Files**
- src/renderer/mobile/KeyboardBar.tsx (new)
- src/renderer/mobile/keyboardInset.ts (new)
- src/renderer/mobile/keyboardInset.test.ts (new — 4 cases)
- src/renderer/mobile/SessionScreen.tsx (mount KeyboardBar in chat mode; gate header Esc; simplify sendEsc to PTY-only)
- src/renderer/mobile/mobile.css (.mobile-kbar styles)
- src/renderer/ChatPanel.tsx (manta-run-clear bridge)
- src/renderer/ChatPanel.harness.test.tsx (2 new bridge tests)

**Verification**
- npm run typecheck ✓
- npx vitest run → 49 files / 1006 tests pass (includes the new 6)
- npm test → 733/734 node tests pass; the 1 failure (subscribeEvents eager-open de-dupes) is a pre-existing flaky race on main, unrelated to BET-259.

The pre-existing simulator mockup at https://mobile-composer-spec.pages.mantaui.com (section 3, K1 FINAL + clear-confirm dialog) matches the implemented bar — same key order, same confirm copy.