### PR TITLE
Mobile: attach photo/file via the header ⋯ sheet (BET-260)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -227,6 +227,80 @@ describe("ChatPanel session resources", () => {
     // would silently wipe the wrong session.
     expect(api.calls.opencodeClearSession ?? []).toEqual([]);
   });
+
+  // Mobile ⋯ sheet → attach-files bridge (BET-260). The hidden <input
+  // type="file"> inside SessionScreen's ⋯ sheet dispatches
+  // `manta-attach-files` with the user's selected File[]; ChatPanel hands
+  // them to addDroppedFiles, which renders the uploading→ready chip and
+  // ships bytes via uploadBuffer (the byte path on mobile — getPathForFile
+  // returns ""). No new upload code lives in ChatPanel; this test pins the
+  // wiring so the bridge can't silently regress to a no-op.
+  it("uploads attached files when the manta-attach-files bridge fires for this session", async () => {
+    ({ api } = installMockApi({
+      uploadBuffer: () => Promise.resolve("/remote/img.png"),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const fakeFile = new File(["x"], "img.png", { type: "image/png" });
+    // jsdom's File doesn't implement arrayBuffer() — addDroppedFiles reads
+    // bytes via file.arrayBuffer() on the byte path (getPathForFile → ""),
+    // so polyfill it for the test. Real browsers (incl. mobile webviews)
+    // ship arrayBuffer; this is purely a jsdom gap.
+    (fakeFile as File & { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer =
+      () => Promise.resolve(new ArrayBuffer(1));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("manta-attach-files", {
+          detail: { sessionId: "ses_test", files: [fakeFile] },
+        }),
+      );
+    });
+    await h.flush();
+
+    // The bridge routes through addDroppedFiles → uploadBuffer with the
+    // correct filename and project. Bytes ride the byte path because
+    // jsdom's getPathForFile mock returns "".
+    const calls = api.calls.uploadBuffer ?? [];
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0][0]).toMatchObject({
+      projectName: "proj",
+      filename: "img.png",
+    });
+    // Chip landed in "ready" state — title attr carries the remotePath.
+    const chip = h.container.querySelector('[title="/remote/img.png"]');
+    expect(chip).toBeTruthy();
+  });
+
+  it("ignores a manta-attach-files bridge for another session id", async () => {
+    ({ api } = installMockApi({
+      uploadBuffer: () => Promise.resolve("/remote/img.png"),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const fakeFile = new File(["x"], "img.png", { type: "image/png" });
+    (fakeFile as File & { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer =
+      () => Promise.resolve(new ArrayBuffer(1));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("manta-attach-files", {
+          detail: { sessionId: "ses_OTHER", files: [fakeFile] },
+        }),
+      );
+    });
+    await h.flush();
+
+    // A bridge for a different session must NOT upload to THIS panel's
+    // session. Without the gate, an accidental global dispatch would
+    // attach a file to the wrong tmux window's session.
+    expect(api.calls.uploadBuffer ?? []).toEqual([]);
+    expect(h.container.querySelector('[title="/remote/img.png"]')).toBeNull();
+  });
 });
 
 // ===== Transcript rendering (via the mounted ChatPanel) =====

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1229,6 +1229,29 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     [tmuxSession],
   );
 
+  // Mobile ⋯ sheet → attach-files bridge (BET-260). The hidden <input
+  // type="file"> inside SessionScreen's ⋯ sheet dispatches this with the
+  // user's selected File[]; we hand them to addDroppedFiles, which already
+  // runs the byte path on mobile (getPathForFile → ""), renders the
+  // uploading→ready chip, and converts ready media chips into FileParts at
+  // submit. No new upload code lives here. The listener sits next to
+  // addDroppedFiles so the function is in scope (the existing mobile
+  // bridges — manta-scroll-to-question, manta-run-clear — sit higher up
+  // because they only need state primitives declared earlier).
+  useEffect(() => {
+    const onAttachFiles = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { sessionId?: string; files?: File[] }
+        | undefined;
+      if (detail?.sessionId !== sessionId) return;
+      const files = detail?.files ?? [];
+      if (files.length === 0) return;
+      void addDroppedFiles(files);
+    };
+    window.addEventListener("manta-attach-files", onAttachFiles);
+    return () => window.removeEventListener("manta-attach-files", onAttachFiles);
+  }, [sessionId, addDroppedFiles]);
+
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);

--- a/src/renderer/mobile/SessionScreen.tsx
+++ b/src/renderer/mobile/SessionScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useStore, resolveSessionOwner } from "../store";
 import { ChatPanel } from "../ChatPanel";
 import { Terminal } from "../Terminal";
@@ -32,6 +32,14 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
   // used to surface it) is hidden on mobile (BET-258), so the sheet carries
   // it instead. Count is omitted entirely on 0 or fetch failure.
   const [scheduleCount, setScheduleCount] = useState(0);
+
+  // Hidden <input type="file"> that the "Attach photo or file…" sheet button
+  // clicks via .click() — iOS only opens the native picker from a user
+  // gesture, so the click on the input must happen synchronously in the
+  // tap handler (BET-260). Rendered at the component root (NOT inside the
+  // conditional sheet subtree) so it survives the sheet closing while the
+  // native picker is up.
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const project = projects.find((p) => p.tmuxSession === projectName);
   const win = project?.windows.find((w) => w.index === windowIndex);
@@ -220,6 +228,25 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
 
   return (
     <div className="mobile-screen">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*,application/pdf"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          const files = e.target.files;
+          if (sid && files && files.length > 0) {
+            window.dispatchEvent(
+              new CustomEvent("manta-attach-files", {
+                detail: { sessionId: sid, files: Array.from(files) },
+              }),
+            );
+          }
+          // Reset so picking the same file twice re-fires change.
+          e.target.value = "";
+        }}
+      />
       <div className="mobile-header">
         <button
           className="mobile-tap text-accent text-2xl leading-none"
@@ -357,6 +384,17 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
             ) : (
               <>
                 <button onClick={startRename}>Rename</button>
+                <button
+                  onClick={() => {
+                    // iOS only opens the picker from a user gesture — the click
+                    // on the hidden input must happen synchronously in this
+                    // tap handler (BET-260).
+                    fileInputRef.current?.click();
+                    closeSheet();
+                  }}
+                >
+                  Attach photo or file…
+                </button>
                 {sid && (
                   <>
                     <button onClick={forkSession}>Fork session</button>


### PR DESCRIPTION
## Summary

Mobile had no way to attach an image — desktop's drag-drop, ⌘V paste, and screenshot watcher don't exist on a phone. The full upload pipeline already works on mobile (`addDroppedFiles` → `uploadBuffer` byte path); only the entry point was missing.

This wires a native picker into the existing header `⋯` bottom-sheet and feeds the selected `File[]` straight into `addDroppedFiles`. No new upload code, no composer button, no paste handling, no share-sheet target (all explicitly out of scope per the spec).

## Changes

- **`src/renderer/mobile/SessionScreen.tsx`**: hidden `<input type="file">` at the component root, clicked via ref from a new "Attach photo or file…" sheet button as the first entry after Rename. The input lives at the root (not inside the sheet subtree) so it survives the sheet closing while the native picker is up. The `.click()` fires synchronously in the tap handler so iOS treats it as a user gesture (iOS only opens the picker from a user gesture). Input resets on change so picking the same file twice re-fires.
- **`src/renderer/ChatPanel.tsx`**: window-event bridge `manta-attach-files` that hands the selected `File[]` straight to `addDroppedFiles`. Gates on `detail.sessionId === sessionId`. The listener sits next to `addDroppedFiles` (instead of next to the other mobile bridges) because it needs `addDroppedFiles` in scope; the existing bridges sit higher up because they only need state primitives declared earlier.
- **`src/renderer/ChatPanel.harness.test.tsx`**: two harness tests pin the bridge wiring (matching session → `uploadBuffer` called with `filename: "img.png"` + chip reaches "ready"; foreign session → `uploadBuffer` not called). jsdom's `File` doesn't ship `arrayBuffer()` — polyfilled in the test with a one-liner; real browsers (incl. mobile webviews) ship it.

## Files changed

```
 src/renderer/ChatPanel.harness.test.tsx | 74 +++++++++++++++++++++++++++++++++
 src/renderer/ChatPanel.tsx              | 23 ++++++++++
 src/renderer/mobile/SessionScreen.tsx   | 40 +++++++++++++++++-
 3 files changed, 136 insertions(+), 1 deletion(-)
```

## Verification results

- PR branch (`multica/BET-260-mobile-attach-photo-sheet` @ `2d5c77c`):
  - typecheck: exit 0. Errors: none. log sha256: `0bd277cde622078c4255f6a03358097c809146275560fc1632dfcf9d83e7182b`
  - test (vitest): 1008 pass / 0 fail / 0 skip. log sha256: `baf7a528670da7c7f986c61f54afc91efd3562f05f4a10b33b0024ae858828ce`
  - test (node): 734 pass / 0 fail / 0 skip.
- Base (`main` @ `e2d0af7`):
  - typecheck: exit 0. Errors: none. log sha256: `0bd277cde622078c4255f6a03358097c809146275560fc1632dfcf9d83e7182b`
  - test (vitest): 1006 pass / 0 fail / 0 skip. log sha256: `0a4e9815429066f835fc18f63832d2b31c084f8853a506e4a352c6db8c542a67`
  - test (node): 734 pass / 0 fail / 0 skip.
- **Conclusion:** 0 new failures, 0 pre-existing failures. The 2-test delta (1006 → 1008) is this PR's new harness coverage.

**Base: `main` @ `e2d0af7`**

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Manual verification (post-merge)

Per the issue's "Verification (manual)" section — needs a real device:
- iOS: `⋯` → "Attach photo or file…" → native picker (Photo Library / Take Photo / Choose File) opens. Picking from Photo Library is the key user path for screenshots.
- Android: same flow, system chooser.
- Selected image shows the chip ("uploading" → "ready"), lands in `~/.manta-uploads/<session>/<batch>/` on the box, submitting a prompt sends it as a FilePart the model can see.

## Out of scope (per spec)

No composer button, no paste handling, no share-sheet target — explicitly deferred as future follow-ups.

## Commits

- `2d5c77c` feat(mobile): attach photo/file via the header ⋯ sheet (BET-260)