### PR TITLE
BET-261: fix Mobile Attach photo sheet button dead control in fresh-window branch

### DIFF
--- a/src/renderer/mobile/SessionScreen.tsx
+++ b/src/renderer/mobile/SessionScreen.tsx
@@ -384,19 +384,19 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
             ) : (
               <>
                 <button onClick={startRename}>Rename</button>
-                <button
-                  onClick={() => {
-                    // iOS only opens the picker from a user gesture — the click
-                    // on the hidden input must happen synchronously in this
-                    // tap handler (BET-260).
-                    fileInputRef.current?.click();
-                    closeSheet();
-                  }}
-                >
-                  Attach photo or file…
-                </button>
                 {sid && (
                   <>
+                    <button
+                      onClick={() => {
+                        // iOS only opens the picker from a user gesture — the click
+                        // on the hidden input must happen synchronously in this
+                        // tap handler (BET-260).
+                        fileInputRef.current?.click();
+                        closeSheet();
+                      }}
+                    >
+                      Attach photo or file…
+                    </button>
                     <button onClick={forkSession}>Fork session</button>
                     <button onClick={compactSession}>Compact context</button>
                     <button


### PR DESCRIPTION
**Base:** origin/main @ `9c71896` (Merge pull request #217 from antoinedc/multica/BET-260-mobile-attach-photo-sheet)

## What
Move the `Attach photo or file…` button JSX inside the `{sid && (…)}` block in `src/renderer/mobile/SessionScreen.tsx`. Per the BET-260 spec it was supposed to be the FIRST entry of that block, but landed OUTSIDE it.

## Why
In the `!sid` branch (fresh window, no session selected) the button is a dead control:
1. User taps → native picker opens (fine — happens in the click handler)
2. User picks a file → the hidden `<input type="file">`'s `onChange` gates on `if (sid && …)` and silently drops the file
3. User gets zero feedback

## How
One-button JSX move. The click handler (`fileInputRef.current?.click(); closeSheet();`) is unchanged. The hidden `<input type="file">` element, its `onChange`, and the `manta-attach-files` dispatch are not touched. No styling changed.

Per the spec out-of-scope section: no disabled-state fallback added; the whole-sheet-disappears rule is honored by virtue of the button living in the gated block.

## Verification
**Files changed:** 1 file.
```
src/renderer/mobile/SessionScreen.tsx | 22 ++++++++++++-----------
1 file changed, 11 insertions(+), 11 deletions(-)
```

- PR branch (`multica/BET-261-fix-mobile-attach-sheet-dead-control` @ `4ef2de2`):
  - typecheck: exit 0. Errors: none.
  - test: 734 pass / 0 fail / 0 skip.
- **Conclusion:** all green; no pre-existing failures to attribute.

Diff:
```diff
-                <button
-                  onClick={() => {
-                    // iOS only opens the picker from a user gesture — the click
-                    // on the hidden input must happen synchronously in this
-                    // tap handler (BET-260).
-                    fileInputRef.current?.click();
-                    closeSheet();
-                  }}
-                >
-                  Attach photo or file…
-                </button>
                 {sid && (
                   <>
+                    <button
+                      onClick={() => {
+                        // iOS only opens the picker from a user gesture — the click
+                        // on the hidden input must happen synchronously in this
+                        // tap handler (BET-260).
+                        fileInputRef.current?.click();
+                        closeSheet();
+                      }}
+                    >
+                      Attach photo or file…
+                    </button>
                     <button onClick={forkSession}>Fork session</button>
```