### PR TITLE
BET-264 stage 2: two-arch CI + two-arch publish.sh verify

### DIFF
--- a/.github/workflows/server-tarball-deploy.yml
+++ b/.github/workflows/server-tarball-deploy.yml
@@ -1,0 +1,226 @@
+# Server tarball deploy — build BOTH arch tarballs (x64 + arm64) and publish
+# them + a combined two-arch manifest on a `server-v*` git tag.
+#
+# WHY THIS EXISTS
+# ---------------
+# The Linux box server tarball is the artifact install.sh downloads. Until
+# BET-263 it was x64-only (the tarball filename encoded the arch; the manifest
+# only carried the x64 sha). Stage 1 (BET-263) made the build/install scripts
+# arch-parameterized. This workflow is the matching CI side: builds the arm64
+# tarball natively (no QEMU, no cross-compile — node-pty's native binding
+# cannot be cross-compiled), then publishes BOTH tarballs + the combined
+# manifest in a single deploy.
+#
+# WHAT IT DEPLOYS
+#   dist/manta-<v>-linux-x64.tar.gz    → <PROD_HOST>:/var/www/mantaui/releases/
+#   dist/manta-<v>-linux-arm64.tar.gz  → <PROD_HOST>:/var/www/mantaui/releases/
+#   dist/manta-<v>.txt                 → <PROD_HOST>:/var/www/mantaui/releases/
+#   (then cp manta-<v>.txt → manta-latest.txt, last — atomicity guarantee)
+#
+# BUILD HOST CHOICE
+#   GitHub-hosted ubuntu-latest (x64) + ubuntu-24.04-arm (arm64) runners, one
+#   pack.mjs invocation per arch. node-pty's prebuilt .node binding compiles
+#   natively for its runner's ABI — no QEMU, no cross-compile (BET-262 design
+#   constraint). Both runners are GitHub-hosted, so no self-hosted runner
+#   capacity is burned on the slow arm64 build.
+#
+# PUBLISH HOST + AUTH
+#   Self-hosted runner (same as website-deploy.yml + gateway-deploy.yml) —
+#   reaches prod over SSH with the deploy key at ~/.manta-deploy/prod_key. No
+#   GitHub secret needed. Reuses website-deploy.yml's scp/ssh invocation
+#   verbatim.
+#
+# ATOMICITY
+#   tarballs + versioned manifest are uploaded FIRST; manta-latest.txt is the
+#   pointer that install.sh fetches by default, and it is copied LAST. A client
+#   therefore either sees the OLD latest.txt (and the OLD tarballs are still
+#   served) OR the NEW latest.txt (and the NEW tarballs are already uploaded).
+#   Drift between manifest and tarballs is impossible. (Same rule publish.sh
+#   documents — generalized to both arches via a loop.)
+#
+# VERIFY
+#   After publish, fail red on:
+#     - any tarball URL returning non-200
+#     - served manta-latest.txt's version != the version we just published
+#     - any arch's served tarball sha256 != the manifest's sha256_<archkey>
+#   This is the two-arch generalization of publish.sh's existing drift check.
+#
+# TRIGGER: push a tag matching server-v* (e.g. server-v1). Also runnable
+#   manually via workflow_dispatch (deploys current main).
+
+name: Server tarball deploy
+
+on:
+  push:
+    tags:
+      - "server-v*"
+  workflow_dispatch:
+
+# Serialize: two quick tags must not race two deploys that overwrite each
+# other's manifests / tarballs. Same group shape as build-mobile-bundle.yml +
+# gateway-deploy.yml.
+concurrency:
+  group: server-tarball-deploy
+  cancel-in-progress: false
+
+env:
+  PROD_HOST: root@91.107.196.2
+  SSH_KEY: /home/dev/.manta-deploy/prod_key
+  RELEASES_DIR: /var/www/mantaui/releases
+  SITE: https://mantaui.com
+
+jobs:
+  build:
+    name: pack (${{ matrix.arch }})
+    # One job per arch — node-pty's native binding cannot be cross-compiled,
+    # so each arch needs its own runner's ABI.
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # System node only RUNS pack.mjs; pack downloads its own vendored node
+      # internally. We just need a recent enough node for the script.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # devDeps are needed by pack.mjs's `npm run build:mobile` step (vite
+      # builds the mobile/www bundle that gets embedded in the tarball).
+      - run: npm ci
+
+      - name: pack ${{ matrix.arch }}
+        run: node scripts/release/pack.mjs --arch ${{ matrix.arch }}
+
+      - name: Upload tarball + manifest artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-tarball-${{ matrix.arch }}
+          path: |
+            dist/manta-*-linux-${{ matrix.arch }}.tar.gz
+            dist/manta-*-linux-${{ matrix.arch }}.txt
+          if-no-files-found: error
+
+  publish:
+    name: publish + verify
+    needs: build
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Resolve VERSION once (from package.json) so the steps below can
+      # reference it via ${{ steps.vars.outputs.version }} instead of
+      # duplicating `node -p` in each one.
+      - id: vars
+        name: Resolve version
+        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      # Pull both per-arch artifacts into one dist/ — merge-manifest reads
+      # from the same dir it expects (matches publish.sh's layout).
+      - name: Download per-arch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: server-tarball-*
+          path: dist
+          merge-multiple: true
+
+      - name: Merge per-arch manifests into the combined manifest
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/release/merge-manifest.mjs \
+            "dist/manta-${VERSION}-linux-x64.txt" \
+            "dist/manta-${VERSION}-linux-arm64.txt" \
+            --out "dist/manta-${VERSION}.txt"
+          echo "✓ combined manifest: dist/manta-${VERSION}.txt"
+
+      # Same scp/ssh plumbing as website-deploy.yml — no new secrets, no new
+      # key path. tarballs + versioned manifest first; manta-latest.txt pointer
+      # LAST so a client either sees old (and old tarballs) or new (and new
+      # tarballs are already uploaded) — drift is impossible.
+      - name: Upload tarballs + combined manifest to prod
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          SSH="ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+          SCP="scp -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+
+          for arch in linux-x64 linux-arm64; do
+            tarball="dist/manta-${VERSION}-${arch}.tar.gz"
+            echo "▸ Uploading ${tarball}"
+            $SCP "$tarball" "$PROD_HOST:$RELEASES_DIR/"
+          done
+          manifest="dist/manta-${VERSION}.txt"
+          echo "▸ Uploading ${manifest}"
+          $SCP "$manifest" "$PROD_HOST:$RELEASES_DIR/"
+
+          echo "▸ Publishing manta-latest.txt pointer (LAST — atomicity)"
+          $SSH "$PROD_HOST" "cd $RELEASES_DIR && cp -f manta-${VERSION}.txt manta-latest.txt"
+
+      - name: Verify deploy (both arches)
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          echo "▸ HEAD each tarball URL → 200"
+          for arch in linux-x64 linux-arm64; do
+            url="$SITE/releases/manta-${VERSION}-${arch}.tar.gz"
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo 000)
+            if [ "$code" != "200" ]; then
+              echo "::error::${url} → ${code} (expected 200)"
+              fail=1
+            else
+              echo "✓ ${url} → 200"
+            fi
+          done
+
+          echo "▸ Fetch served manta-latest.txt and assert version"
+          served=$(curl -fsSL "$SITE/releases/manta-latest.txt")
+          served_version=$(printf '%s\n' "$served" | grep '^version=' | head -n1 | cut -d= -f2-)
+          if [ "$served_version" != "$VERSION" ]; then
+            echo "::error::served version='${served_version}' expected='${VERSION}'"
+            exit 1
+          fi
+          echo "✓ served version=${served_version}"
+
+          echo "▸ For each arch: download served tarball, assert sha256 against the manifest"
+          for arch in linux-x64 linux-arm64; do
+            arch_key=$(printf '%s' "$arch" | tr '-' '_')
+            served_file=$(printf '%s\n' "$served" | grep "^file_${arch_key}=" | head -n1 | cut -d= -f2-)
+            served_sha=$(printf '%s\n' "$served"  | grep "^sha256_${arch_key}=" | head -n1 | cut -d= -f2-)
+            if [ -z "$served_file" ] || [ -z "$served_sha" ]; then
+              echo "::error::served manifest is missing file_${arch_key} or sha256_${arch_key}"
+              fail=1
+              continue
+            fi
+            actual_sha=$(curl -fsSL "$SITE/releases/${served_file}" | sha256sum | cut -d' ' -f1)
+            if [ "$actual_sha" != "$served_sha" ]; then
+              echo "::error::${arch}: tarball/manifest drift — served sha=${served_sha} actual=${actual_sha}"
+              fail=1
+            else
+              echo "✓ ${arch} (${served_file}) sha256 matches manifest"
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more verifications failed."
+            exit 1
+          fi
+          echo "All verifications passed (x64 + arm64, both sha256s match the served manifest)."

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pair": "node scripts/manta-pair.mjs",
     "pack": "node scripts/release/pack.mjs",
     "pack:desktop": "electron-vite build && electron-builder --config electron-builder.yml",
-    "test": "vitest run && node --test src/server/*.test.mjs src/gateway/*.test.mjs scripts/*.test.mjs",
+    "test": "vitest run && node --test src/server/*.test.mjs src/gateway/*.test.mjs scripts/*.test.mjs scripts/release/*.test.mjs",
     "test:server": "node --test src/server/*.test.mjs src/gateway/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts"

--- a/scripts/release/merge-manifest.mjs
+++ b/scripts/release/merge-manifest.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// merge-manifest.mjs — merge N per-arch release manifest sidecars (one per
+// pack.mjs --arch invocation) into a single combined manifest the installer
+// fetches.
+//
+//   node scripts/release/merge-manifest.mjs <sidecar1.txt> [<sidecar2.txt> ...] --out <combined.txt>
+//
+// Each sidecar carries `version=`, `file_<archkey>=`, `sha256_<archkey>=` where
+// `<archkey>` is the underscore form (`linux_x64`, `linux_arm64`). The combined
+// manifest echoes `version=` first, then each sidecar's arch pair in the order
+// the sidecars were passed in. Unknown keys are dropped silently (forward
+// compatibility). Mismatched `version=` between sidecars is a hard error —
+// that means the two arch builds are from different commits.
+//
+// Pure node, no deps. Kept tiny (this file is intentionally short — it is
+// only used by publish.sh + server-tarball-deploy.yml, never on the box).
+
+import { readFile, writeFile } from "node:fs/promises";
+
+function die(msg) {
+  process.stderr.write(`✗ ${msg}\n`);
+  process.exit(1);
+}
+
+function log(msg) {
+  process.stdout.write(`▸ ${msg}\n`);
+}
+
+// Parse a sidecar body into { version, arches: { archKey: { file, sha } } }.
+// `archKey` is the underscore form (linux_x64 / linux_arm64). Values may
+// contain `=` — split on the first one only.
+function parseSidecar(body) {
+  const out = { version: null, arches: {} };
+  for (const line of body.split(/\r?\n/)) {
+    if (!line.includes("=")) continue;
+    const eq = line.indexOf("=");
+    const key = line.slice(0, eq);
+    const value = line.slice(eq + 1);
+    if (key === "version") {
+      if (out.version === null) out.version = value;
+      continue;
+    }
+    // Recognize file_<archkey> + sha256_<archkey>. Drop unknown keys.
+    const m = key.match(/^(file|sha256)_(linux_(?:x64|arm64))$/);
+    if (!m) continue;
+    const [, kind, archKey] = m;
+    const arch = (out.arches[archKey] ||= {});
+    // First occurrence wins (matches install.sh's manifest_get shape).
+    if (kind === "file") arch.file ??= value;
+    else arch.sha ??= value;
+  }
+  return out;
+}
+
+// Validate a parsed sidecar — every arch must have both `file` and `sha`.
+function validateSidecar(parsed, source) {
+  if (!parsed.version) die(`${source}: missing version=`);
+  for (const [archKey, { file, sha }] of Object.entries(parsed.arches)) {
+    if (!file) die(`${source}: missing file_${archKey}`);
+    if (!sha) die(`${source}: missing sha256_${archKey}`);
+  }
+}
+
+function parseArgs(argv) {
+  const positional = [];
+  let outPath = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") outPath = argv[++i];
+    else positional.push(argv[i]);
+  }
+  if (positional.length === 0) die("no sidecar inputs — pass at least one .txt");
+  if (!outPath) die("missing --out <path>");
+  return { inputs: positional, outPath };
+}
+
+async function main() {
+  const { inputs, outPath } = parseArgs(process.argv.slice(2));
+  let version = null;
+  // Order of insertion = order of sidecar args = order in the combined file.
+  const arches = {};
+  for (const input of inputs) {
+    const body = await readFile(input, "utf-8");
+    const parsed = parseSidecar(body);
+    validateSidecar(parsed, input);
+    if (version === null) version = parsed.version;
+    else if (parsed.version !== version) {
+      die(`version mismatch: ${input} has version=${parsed.version}, expected ${version} (sidecar args must come from the same release commit)`);
+    }
+    for (const [archKey, entry] of Object.entries(parsed.arches)) {
+      arches[archKey] = entry;
+    }
+  }
+  const lines = [`version=${version}`];
+  for (const [archKey, { file, sha }] of Object.entries(arches)) {
+    lines.push(`file_${archKey}=${file}`);
+    lines.push(`sha256_${archKey}=${sha}`);
+  }
+  await writeFile(outPath, lines.join("\n") + "\n");
+  log(`merged ${inputs.length} sidecar(s) → ${outPath} (${Object.keys(arches).join(", ")})`);
+}
+
+main().catch((e) => die(String(e?.stack ?? e)));

--- a/scripts/release/merge-manifest.test.mjs
+++ b/scripts/release/merge-manifest.test.mjs
@@ -1,0 +1,103 @@
+// merge-manifest.test.mjs — node:test cases for scripts/release/merge-manifest.mjs
+//
+// Covers the four scenarios the issue requires:
+//   1. Two-arch merge produces a single combined file with version= first,
+//      then each arch's file+sha pair.
+//   2. Version mismatch between sidecars dies loudly.
+//   3. One-arch input still produces a valid single-arch combined manifest.
+//   4. Unknown extra keys are dropped gracefully (forward compatibility).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const SCRIPT = join(import.meta.dirname, "merge-manifest.mjs");
+
+function fresh() {
+  return mkdtempSync(join(tmpdir(), "merge-manifest-test-"));
+}
+
+// Tiny helper: invoke the merger against sidecar files, return the combined
+// body. Throws (with stderr surfaced) on non-zero exit — tests assert on
+// either the body or the rejection.
+function runMerge(args, opts = {}) {
+  return execFileSync("node", [SCRIPT, ...args], { encoding: "utf-8", ...opts });
+}
+
+function writeSidecar(dir, name, body) {
+  const p = join(dir, name);
+  writeFileSync(p, body);
+  return p;
+}
+
+test("merges two sidecars into a single combined manifest", () => {
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "a.txt", "version=1.2.3\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n");
+    const b = writeSidecar(dir, "b.txt", "version=1.2.3\nfile_linux_arm64=manta-1.2.3-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n");
+    const out = join(dir, "combined.txt");
+    runMerge([a, b, "--out", out]);
+    const got = readFileSync(out, "utf-8");
+    assert.equal(
+      got,
+      "version=1.2.3\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\nfile_linux_arm64=manta-1.2.3-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("dies on version mismatch between sidecars", () => {
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "a.txt", "version=1.2.3\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n");
+    const b = writeSidecar(dir, "b.txt", "version=9.9.9\nfile_linux_arm64=manta-9.9.9-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n");
+    assert.throws(
+      () => runMerge([a, b, "--out", join(dir, "combined.txt")]),
+      /version mismatch/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("one-arch input produces a valid single-arch combined manifest", () => {
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "x64.txt", "version=0.0.1\nfile_linux_x64=manta-0.0.1-linux-x64.tar.gz\nsha256_linux_x64=cafe\n");
+    const out = join(dir, "combined.txt");
+    runMerge([a, "--out", out]);
+    const got = readFileSync(out, "utf-8");
+    assert.equal(got, "version=0.0.1\nfile_linux_x64=manta-0.0.1-linux-x64.tar.gz\nsha256_linux_x64=cafe\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ignores unknown extra keys gracefully", () => {
+  const dir = fresh();
+  try {
+    const a = writeSidecar(
+      dir,
+      "x64.txt",
+      "version=1.0.0\nfile_linux_x64=manta-1.0.0-linux-x64.tar.gz\nsha256_linux_x64=dead\nsome_future_key=ignored\nrelease_channel=stable\n",
+    );
+    const b = writeSidecar(
+      dir,
+      "arm64.txt",
+      "version=1.0.0\nfile_linux_arm64=manta-1.0.0-linux-arm64.tar.gz\nsha256_linux_arm64=beef\nanother_future_thing=skip\n",
+    );
+    const out = join(dir, "combined.txt");
+    runMerge([a, b, "--out", out]);
+    const got = readFileSync(out, "utf-8");
+    assert.equal(
+      got,
+      "version=1.0.0\nfile_linux_x64=manta-1.0.0-linux-x64.tar.gz\nsha256_linux_x64=dead\nfile_linux_arm64=manta-1.0.0-linux-arm64.tar.gz\nsha256_linux_arm64=beef\n",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -6,16 +6,22 @@
 # What it does (in order; each step idempotent and runs unconditionally unless
 # its artifact is missing — desktop is a separately-shippable leg, not a failure):
 #   1. preflight   refuse if git tree is dirty, if v<version> tag already
-#                  exists, or if dist/manta-<version>-linux-x64.tar.gz OR
-#                  dist/manta-<version>.txt (the manifest) is absent.
-#                  (Run `npm run pack` first.)
-#   2. tarball     scp dist/manta-<version>-linux-x64.tar.gz + the manifest
-#                  to <host>:/var/www/mantaui/releases/. THEN (strictly last)
+#                  exists, or if EITHER per-arch tarball (linux-x64 +
+#                  linux-arm64) OR its per-arch manifest sidecar is absent.
+#                  publish.sh is the manual FULL release path — it requires
+#                  BOTH arches. To build + publish only one arch locally, run
+#                  the server-tarball-deploy.yml workflow (which builds + ships
+#                  both via matrix on a tag). Or to ship both from this box,
+#                  run pack.mjs --arch x64 AND --arch arm64 first.
+#   2. tarballs    merge the two per-arch sidecars into the combined manifest
+#                  (scripts/release/merge-manifest.mjs), then scp BOTH
+#                  tarballs + the combined manifest to
+#                  <host>:/var/www/mantaui/releases/. THEN (strictly last)
 #                  ssh to copy manta-<version>.txt → manta-latest.txt — this
 #                  ordering is the atomicity guarantee: a client either sees
-#                  the OLD manifest (and old tarball) or the NEW manifest
-#                  (with new tarball already uploaded). Drift between the two
-#                  is impossible.
+#                  the OLD manifest (and old tarballs) or the NEW manifest
+#                  (with new tarballs already uploaded). Drift between the
+#                  manifest and either tarball is impossible.
 #   3. desktop     if dist/desktop/ has binaries: scp them + the latest-*.yml
 #                  feeds to <host>:/var/www/mantaui/updates/ and the binaries
 #                  to /var/www/mantaui/downloads/, then refresh
@@ -30,12 +36,14 @@
 #                  the repo checkout, but Caddy serves install.sh statically
 #                  from the web root, so without this copy the advertised
 #                  one-liner keeps serving the stale installer (BET-171).
-#   5. verify      HEAD each published URL — tarball 200, manifest live with
-#                  matching version + tarball sha, install.sh 200, install.sh
-#                  body byte-matches the repo. Fail loudly on any non-200,
-#                  manifest drift, or install.sh drift. This makes the
-#                  script/tarball/manifest drift (the F4 class from BET-171)
-#                  fail the publish loudly.
+#   5. verify      HEAD each published tarball URL (both arches) → 200, fetch
+#                  served manta-latest.txt and assert version match, then for
+#                  each arch download the referenced tarball and assert its
+#                  sha256 equals the manifest's sha256_<archkey>. Plus the
+#                  install.sh / llms-install.md byte-match loop (arch-
+#                  independent). Fail loudly on any non-200, manifest drift,
+#                  or install.sh drift. This makes the script/tarball/manifest
+#                  drift (the F4 class from BET-171) fail the publish loudly.
 #   6. tag         git tag v<version> && git push origin v<version> (a tag
 #                  means "published and verified").
 #
@@ -59,13 +67,22 @@ PROD_HOST="${MANTA_PROD_HOST:-root@91.107.196.2}"
 SITE="${MANTA_SITE:-https://mantaui.com}"
 
 VERSION="$(node -p 'require("./package.json").version')"
-TARBALL="dist/manta-${VERSION}-linux-x64.tar.gz"
-MANIFEST="dist/manta-${VERSION}.txt"
+# Filename form (matches tarball basename + nodejs.org convention):
+#   linux-x64 → ARCH_KEY linux_x64, linux-arm64 → linux_arm64.
+# Single source of truth — adding an arch is one line here + one entry in
+# pack.mjs's resolveArch / install.sh's resolve_arch. No copy-pasted per-arch
+# blocks downstream.
+ARCHES=(linux-x64 linux-arm64)
+COMBINED_MANIFEST="dist/manta-${VERSION}.txt"
 DESKTOP_DIR="dist/desktop"
 WEBROOT_DIR="/var/www/mantaui"
 RELEASES_DIR="${WEBROOT_DIR}/releases"
 UPDATES_DIR="${WEBROOT_DIR}/updates"
 DOWNLOADS_DIR="${WEBROOT_DIR}/downloads"
+
+# Derive the underscore manifest-key form from the hyphen filename form
+# (`linux-x64` → `linux_x64`). Used for file_<key>= / sha256_<key>= lookups.
+arch_key() { printf '%s' "$1" | tr '-' '_'; }
 
 log()  { printf '\033[36m▸\033[0m %s\n' "$*"; }
 ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
@@ -83,28 +100,50 @@ if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
   die "tag v${VERSION} already exists — a tag means 'published and verified'. To re-publish the same version (idempotent), delete the tag first: git tag -d v${VERSION} && git push origin :v${VERSION}"
 fi
 
-if [ ! -f "${TARBALL}" ]; then
-  die "${TARBALL} missing — run \`npm run pack\` first"
+if [ ! -f "${COMBINED_MANIFEST}" ] && [ ! -f "dist/manta-${VERSION}-linux-x64.txt" ]; then
+  die "no manifest artifacts in dist/ — run pack.mjs for both arches first (x64 + arm64)"
 fi
 
-if [ ! -f "${MANIFEST}" ]; then
-  die "${MANIFEST} missing — run \`npm run pack\` first (the tarball's manifest sidecar)"
+# Publish.sh is the full manual release path — require both arches so the
+# published manifest always lists every arch we ship. A laptop with only x64
+# built should push a `server-v*` tag instead (server-tarball-deploy.yml builds
+# both via matrix on a tag).
+missing_arch=""
+for arch in "${ARCHES[@]}"; do
+  if [ ! -f "dist/manta-${VERSION}-${arch}.tar.gz" ] || [ ! -f "dist/manta-${VERSION}-${arch}.txt" ]; then
+    missing_arch="${arch}"
+    break
+  fi
+done
+if [ -n "${missing_arch}" ]; then
+  die "${missing_arch} tarball or per-arch manifest missing from dist/ — publish.sh requires BOTH arches
+    Run \`node scripts/release/pack.mjs --arch ${missing_arch%%-*}\` to build the missing arch locally,
+    OR push a server-v* tag so server-tarball-deploy.yml builds both via matrix."
 fi
 
 ok "preflight ok"
 
-# --- 2. tarball + manifest (atomicity: tarball first, manifest pointer last) -
-log "Uploading ${TARBALL} → ${PROD_HOST}:${RELEASES_DIR}/…"
-scp "${TARBALL}" "${PROD_HOST}:${RELEASES_DIR}/"
-log "Uploading ${MANIFEST} → ${PROD_HOST}:${RELEASES_DIR}/…"
-scp "${MANIFEST}" "${PROD_HOST}:${RELEASES_DIR}/"
+# --- 2. tarballs + combined manifest (atomicity: tarballs first, pointer last) -
+log "Merging per-arch manifests → ${COMBINED_MANIFEST}…"
+node scripts/release/merge-manifest.mjs \
+  "dist/manta-${VERSION}-linux-x64.txt" \
+  "dist/manta-${VERSION}-linux-arm64.txt" \
+  --out "${COMBINED_MANIFEST}"
+ok "combined manifest written"
+
+for arch in "${ARCHES[@]}"; do
+  log "Uploading dist/manta-${VERSION}-${arch}.tar.gz → ${PROD_HOST}:${RELEASES_DIR}/…"
+  scp "dist/manta-${VERSION}-${arch}.tar.gz" "${PROD_HOST}:${RELEASES_DIR}/"
+done
+log "Uploading ${COMBINED_MANIFEST} → ${PROD_HOST}:${RELEASES_DIR}/…"
+scp "${COMBINED_MANIFEST}" "${PROD_HOST}:${RELEASES_DIR}/"
 
 # The latest-pointer copy goes LAST. Clients either see the old manifest (the
-# old tarball is still served too) OR the new manifest (and the new tarball is
-# already up). Drift between manifest and tarball is impossible.
+# old tarballs are still served too) OR the new manifest (and the new tarballs
+# are already up). Drift between manifest and any arch's tarball is impossible.
 log "Publishing manifest pointer ${PROD_HOST}:${RELEASES_DIR}/manta-latest.txt…"
 ssh "${PROD_HOST}" "cd ${RELEASES_DIR} && cp -f manta-${VERSION}.txt manta-latest.txt"
-ok "tarball + manifest published"
+ok "tarballs + manifest published"
 
 # --- 3. desktop (optional leg) ----------------------------------------------
 shopt -s nullglob
@@ -183,32 +222,40 @@ check_200() {
   ok "${url} → 200"
 }
 
-check_200 "${SITE}/releases/manta-${VERSION}-linux-x64.tar.gz"
+for arch in "${ARCHES[@]}"; do
+  check_200 "${SITE}/releases/manta-${VERSION}-${arch}.tar.gz"
+done
 for pair in "${WEBROOT_DOCS[@]}"; do
   check_200 "${SITE}/${pair##*:}"
 done
 
-# Manifest + tarball drift check (BET-171 F4 class). The publish script just
-# pushed both files; we re-fetch the manifest over HTTPS and assert that the
-# served tarball's sha256 matches the manifest's sha256_linux_x64 line. A
-# failure here means we shipped a tarball + manifest that disagree — clients
-# would download the tarball, sha256-fail it, and die. Catch that HERE.
-log "Verifying manifest ↔ tarball drift…"
+# Manifest + tarball drift check (BET-171 F4 class), generalized to BOTH
+# arches via the same loop. The publish script just pushed both tarballs and
+# the combined manifest; we re-fetch the served manifest over HTTPS and for
+# each arch download the referenced tarball + assert its sha256 matches the
+# manifest's sha256_<archkey> line. A failure here means we shipped a
+# tarball + manifest that disagree — clients would download the tarball,
+# sha256-fail it, and die. Catch that HERE.
+log "Verifying manifest ↔ tarball drift (both arches)…"
 SERVED_MANIFEST="$(curl -fsSL "${SITE}/releases/manta-latest.txt")"
 SERVED_VERSION="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^version=' | head -n1 | cut -d= -f2-)"
 if [ "$SERVED_VERSION" != "$VERSION" ]; then
   die "manifest not live: served version='${SERVED_VERSION}' expected='${VERSION}'"
 fi
-SERVED_FILE="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^file_linux_x64=' | head -n1 | cut -d= -f2-)"
-SERVED_SHA="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^sha256_linux_x64=' | head -n1 | cut -d= -f2-)"
-if [ -z "$SERVED_FILE" ] || [ -z "$SERVED_SHA" ]; then
-  die "served manifest is malformed (missing file_linux_x64 or sha256_linux_x64)"
-fi
-ACTUAL_SHA="$(curl -fsSL "${SITE}/releases/${SERVED_FILE}" | sha256sum | awk '{print $1}')"
-if [ "$ACTUAL_SHA" != "$SERVED_SHA" ]; then
-  die "tarball/manifest drift: served sha=${SERVED_SHA} actual=${ACTUAL_SHA} for ${SERVED_FILE}"
-fi
-ok "served manifest live (version=${VERSION}, sha=${ACTUAL_SHA})"
+for arch in "${ARCHES[@]}"; do
+  key="$(arch_key "${arch}")"
+  SERVED_FILE="$(printf '%s\n' "$SERVED_MANIFEST" | grep "^file_${key}=" | head -n1 | cut -d= -f2-)"
+  SERVED_SHA="$(printf '%s\n' "$SERVED_MANIFEST" | grep "^sha256_${key}=" | head -n1 | cut -d= -f2-)"
+  if [ -z "$SERVED_FILE" ] || [ -z "$SERVED_SHA" ]; then
+    die "served manifest is malformed (missing file_${key} or sha256_${key})"
+  fi
+  ACTUAL_SHA="$(curl -fsSL "${SITE}/releases/${SERVED_FILE}" | sha256sum | awk '{print $1}')"
+  if [ "$ACTUAL_SHA" != "$SERVED_SHA" ]; then
+    die "tarball/manifest drift (${arch}): served sha=${SERVED_SHA} actual=${ACTUAL_SHA} for ${SERVED_FILE}"
+  fi
+  ok "${arch} (${SERVED_FILE}) sha256 matches manifest"
+done
+ok "served manifest live (version=${VERSION}, both arches verified)"
 
 # A 200 is not enough — a stale file also 200s (BET-171). Verify each
 # web-root doc byte-matches the repo so we know the deploy actually took.


### PR DESCRIPTION
Stage 2 of BET-262 (arm64 box support). Builds on BET-263 (Stage 1 — per-arch
pack.mjs + per-arch manifest sidecars).

**Base: origin/main @ `8dba300`** · **Head: `f217902`**

### What this PR does

1. **`scripts/release/merge-manifest.mjs` (new, ~60 LOC, pure node, no deps)** —
   reads N per-arch sidecars (`manta-<v>-linux-x64.txt`, `manta-<v>-linux-arm64.txt`),
   asserts they all agree on `version=`, emits one combined
   `manta-<v>.txt` carrying both arches' `file_<archkey>=` + `sha256_<archkey>=`
   pairs. Unknown extra keys are dropped (forward compatibility). One-arch input
   is graceful — produces a valid single-arch combined manifest.

2. **`.github/workflows/server-tarball-deploy.yml` (new)** — triggers on
   `server-v*` tag (new tag prefix, mirrors `web-v*` / `gateway-v*`). One
   matrixed build job (`x64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm`
   — native compile, no QEMU, since node-pty cannot be cross-compiled) plus
   one self-hosted publish job. Publish downloads both per-arch artifacts,
   runs `merge-manifest.mjs`, scp's BOTH tarballs + the combined manifest,
   copies `manta-latest.txt` LAST (atomicity), then verifies: HEAD each
   tarball URL → 200, served version matches, each arch's sha256 matches
   the served manifest. Reuses `website-deploy.yml`'s scp/ssh plumbing
   verbatim (same `~/.manta-deploy/prod_key`, same `BatchMode` flags, same
   env shape).

3. **`scripts/release/publish.sh` (refactored)** — single `ARCHES=(linux-x64
   linux-arm64)` list drives ONE loop body for preflight, scp, `check_200`,
   and sha-drift verify. The preflight now requires BOTH per-arch tarballs +
   sidecars (a laptop with only one arch gets a clear error pointing them at
   the `server-v*` tag path). The `merge-manifest.mjs` step produces
   `dist/manta-<version>.txt` from the per-arch sidecars before upload. The
   F4-class drift detection (BET-171) generalizes to both arches through
   the same loop. Desktop / server-deploy / webroot-docs legs UNCHANGED
   (arch-independent).

4. **`package.json`** — `npm test` now globs `scripts/release/*.test.mjs` so
   `merge-manifest.test.mjs` is discovered.

### Files changed (5 files, +524 / −46)

```
.github/workflows/server-tarball-deploy.yml | 226 +++++++++++++++++++++++++
package.json                                |   2 +-
scripts/release/merge-manifest.mjs          | 102 +++++++++++
scripts/release/merge-manifest.test.mjs     | 103 +++++++++++
scripts/release/publish.sh                  | 137 ++++++++++--------
```

### Acceptance / self-check

| Criterion | Score | Notes |
|---|---|---|
| `npm test` passes including `merge-manifest.test.mjs` | 10/10 | 4 new tests, all pass; 740 total |
| Workflow exists, single matrixed build + one publish job, reuses website-deploy.yml plumbing, triggers on `server-v*` | 10/10 | yes, all four |
| `publish.sh` handles both arches through ONE loop, requires both tarballs, produces + verifies combined manifest | 10/10 | one `ARCHES=(…)` loop, both `check_200` and sha-drift use it |
| No duplicated per-arch blocks in publish.sh or the workflow | 10/10 | matrix on the workflow side; single loop on the script side |
| YAML lints / actionlint clean | N/A | actionlint not installed locally; verified by hand-parse |

### Verification results

**PR branch** (`multica/BET-264-server-tarball-deploy` @ `f217902`):
- `npm run typecheck`: exit `0`. Errors: none.
  log sha256: `0bd277cde622078c4255f6a03358097c809146275560fc1632dfcf9d83e7182b` (at `/tmp/typecheck-pr.log`)
- `npm test`: exit `0`, **740 pass / 0 fail / 0 skip** (4 new merge-manifest tests; 736 pre-existing).
  log sha256: `2024943c4674f191e883d07e45a68117a4f30c510478db29e901e3eb54bd2117` (at `/tmp/test-pr.log`)

**Base** (`main` @ `8dba300`):
- `npm run typecheck`: exit `0`. Errors: none.
  log sha256: see `/tmp/typecheck-base.log`
- `node --test src/server/*.test.mjs src/gateway/*.test.mjs scripts/*.test.mjs`: **736 pass / 0 fail / 0 skip**.
  log sha256: see `/tmp/test-base.log`

**Conclusion:** 0 new failures (only ADDED 4 tests, all pass). The 4 new
`merge-manifest.test.mjs` tests are the only delta; the base's 736 tests
all still pass on the PR branch.

### Anti-spaghetti / reuse notes

- `resolveArch` (pack.mjs) + `resolve_arch` (install.sh) remain the ONLY
  places arch strings are enumerated — this PR only adds the consumer side
  (`merge-manifest.mjs` reads the keys; `publish.sh` iterates a single
  filename-form list and derives the underscore key inline).
- No new secrets; same `~/.manta-deploy/prod_key` as the other deploy
  workflows.
- No new HTTP endpoints; the served URL shape (`manta-<v>-linux-<arch>.tar.gz`
  + `manta-<v>.txt` + `manta-latest.txt`) is unchanged.

### Follow-ups filed

None — every actionable change in this PR is in scope of BET-264.

Stage 3 (BET-265, docs sync for arm64) is tracked as a sibling child of
BET-262 and is intentionally separate from this PR per the parent's
staged structure.