### PR TITLE
feat(server): optional tailnet second listener via MANTA_TAILNET_HOST (BET-266)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -368,6 +368,7 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
 
 const PORT = Number(process.env.MANTA_MOBILE_PORT ?? 8787);
 const HOST = process.env.MANTA_MOBILE_HOST ?? "0.0.0.0";
+const TAILNET_HOST = process.env.MANTA_TAILNET_HOST ?? "";
 
 // ---------- static file serving ----------
 
@@ -585,7 +586,7 @@ async function handleDownload(req, res, url) {
 
 // ---------- HTTP ----------
 
-const server = createServer(async (req, res) => {
+const handleRequest = async (req, res) => {
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
   const path = url.pathname;
 
@@ -1500,7 +1501,9 @@ const server = createServer(async (req, res) => {
 
   res.writeHead(404, { "content-type": "text/plain" });
   res.end("not found");
-});
+};
+
+const server = createServer(handleRequest);
 
 // ---------- WebSocket: /events live stream + /pty terminal bridge ----------
 //
@@ -1516,7 +1519,7 @@ const server = createServer(async (req, res) => {
 
 const wss = new WebSocketServer({ noServer: true });
 
-server.on("upgrade", (req, socket, head) => {
+const handleUpgrade = (req, socket, head) => {
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
   // Auth gate for WS upgrades. Browsers can't set an Authorization header on a
@@ -1555,7 +1558,9 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
   socket.destroy();
-});
+};
+
+server.on("upgrade", handleUpgrade);
 
 server.listen(PORT, HOST, () => {
   console.log(`manta listening on http://${HOST}:${PORT}`);
@@ -1569,3 +1574,19 @@ server.listen(PORT, HOST, () => {
     console.warn(`[gateway-register] unexpected: ${String(err?.message ?? err)}`);
   });
 });
+
+if (TAILNET_HOST) {
+  const tailnetServer = createServer(handleRequest);
+  tailnetServer.on("upgrade", handleUpgrade);
+  const listenTailnet = () => {
+    tailnetServer.listen(PORT, TAILNET_HOST, () => {
+      console.log(`manta listening on http://${TAILNET_HOST}:${PORT} (tailnet)`);
+    });
+  };
+  tailnetServer.on("error", (err) => {
+    console.warn(`[tailnet] listener error (${err.code ?? err.message}); retrying in 30s`);
+    const t = setTimeout(listenTailnet, 30_000);
+    t.unref();
+  });
+  listenTailnet();
+}


### PR DESCRIPTION
## Summary

Add an optional second HTTP+WS listener on the box's Tailscale IP, controlled by the new `MANTA_TAILNET_HOST` env var. When unset, behavior is byte-identical to `main`. When set (e.g. to a 100.x.y.z Tailscale address), the server opens a second `createServer` on that IP, reusing the **same** `handleRequest` and **same** `handleUpgrade` as the primary listener. The tailnet listener is non-fatal: on listen failure (typically `EADDRNOTAVAIL` because `tailscaled` isn't up yet at boot), it logs a warning and retries every 30s, leaving the primary listener untouched.

No auth changes — `/auth/pair` stays guarded by the loopback REMOTE-address check, so tailnet clients still cannot mint pairing codes. No TLS — WireGuard already encrypts tailnet traffic end-to-end.

**Base:** `origin/main @ 8dba300`

## Files changed

`src/server/index.mjs` (+25 / −4)

`git diff --stat origin/main...HEAD`:
```
 src/server/index.mjs | 29 +++++++++++++++++++++++++----
 1 file changed, 25 insertions(+), 4 deletions(-)
```

## Design notes

1. Renamed the inline closure passed to `createServer` to `handleRequest` (and the `upgrade` listener to `handleUpgrade`) so the tailnet listener can share them. Handler bodies are byte-identical.
2. The tailnet listener is created **only when** `TAILNET_HOST` is non-empty, so the no-env-var path has zero new code paths executing.
3. Primary listener still calls `registerWithGateway()` exactly once. Tailnet listener does not call it.
4. Retry uses `setTimeout(..., 30_000).unref()` so the timer never holds the process open after shutdown.

## Verification

**Verification results:**
- PR branch (`multica/BET-266-tailnet-second-listener` @ `9ffbc0c`):
  - typecheck: exit 0. Errors: none. log sha256: `0bd277cd…7182b`
  - test: exit 0, 736 pass / 0 fail / 0 skip. Failures: none. log sha256: `d2552624…818da8`
- Base (`main` @ `8dba300`):
  - typecheck: exit 0. Errors: none. log sha256: `0bd277cd…7182b` (byte-identical to PR)
  - test: exit 0, 736 pass / 0 fail / 0 skip. Failures: none. log sha256: `16215c7c…6d859`
- **Conclusion:** 0 new failures, 0 pre-existing failures, no regressions.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Manual listener verification (per spec)

````
# Both interfaces served:
MANTA_MOBILE_HOST=127.0.0.1 MANTA_TAILNET_HOST=127.0.0.2 MANTA_MOBILE_PORT=8790 node src/server/index.mjs &
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.2:8790/events   # 401  (auth-gated, served by tailnet listener)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8790/events   # 401  (served by primary listener)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.3:8790/events   # 000  (neither — connection refused)

# Server log:
manta listening on http://127.0.0.1:8790
manta listening on http://127.0.0.2:8790 (tailnet)

# TAILNET_HOST unset → single log line, no '(tailnet)':
MANTA_MOBILE_PORT=8791 node src/server/index.mjs &
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8791/events   # 401
# Server log:
manta listening on http://0.0.0.0:8791
```

## Out of scope (separate issues)

- Installer / systemd template changes (BET-XYZ: "Installer: Tailscale ingress path")
- Pairing UI for tailnet-direct installs
- TLS / `tailscale serve` / cert work — deliberately not used.