### PR TITLE
Pairing screens: optional explicit Server URL for tailnet boxes (BET-268)

### DIFF
--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,31 +1,33 @@
 import { useRef, useState } from "react";
 import { normalizeCode } from "../shared/claim.mjs";
-import { canConnectSetup } from "./mobile/setupLogic";
+import { canConnectSetup, normalizeServerUrl } from "./mobile/setupLogic";
 import { isValidBoxToken } from "../shared/transport.mjs";
 import { claimBox } from "./pairClaim";
 
 // PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2,
-// BET-255).
+// BET-255, BET-268).
 //
 // Mounts into Onboarding.tsx's step-1 slot. Owns the pairing form:
-//   • a Box ID input (32-hex box id, post-BET-198 every box serves its own
-//     public hostname — `https://<boxId>.boxes.mantaui.com` — so no
-//     server-URL field is needed)
+//   • a Box ID input (32-hex box id)
 //   • a 6-digit monospace pairing code input (auto-focused)
+//   • an optional Advanced "server URL" field (BET-268 — tailnet boxes may
+//     live at http://100.x.y.z:8787 instead of the public hostname). Collapsed
+//     by default; expanding it lets the user paste a non-default listener
+//     (the claim + persist both use that URL verbatim when set).
 //   • inline errors for every claim-failure branch (wrong/expired code,
 //     rate-limited, unreachable server, malformed response)
 //   • its own Connect button (gated by canConnectSetup) + a "Skip setup" link
 //
 // The claim itself runs in the MAIN process over the `auth:claim` IPC channel
-// (window.api.authClaim), which POSTs <boxDirectUrl(boxId)>/auth/claim (the
-// URL is built by the shared `buildSetupClaimInput` helper, the SAME one the
-// mobile setup screen and the deep-link handler use — single source of
-// truth). On success, main persists { serverUrl, boxId, boxToken } to
-// config.json. The shared `claimBox` helper mirrors those into the store
-// (applyPairing) so resolveTransportMode reads "http" immediately, then
-// swaps window.api to httpApi so the next onboarding step (Providers/Model)
-// can call opencodeModels() in this same session (BET-254). Finally we call
-// onPaired() to let the shell advance to Step 2.
+// (window.api.authClaim), which POSTs to `<serverUrl>/auth/claim`. The URL is
+// built by the shared `buildSetupClaimInput` helper — the SAME one the mobile
+// setup screen uses — single source of truth. On success, main persists
+// { serverUrl, boxId, boxToken } to config.json. The shared `claimBox`
+// helper mirrors those into the store (applyPairing) so resolveTransportMode
+// reads "http" immediately, then swaps window.api to httpApi so the next
+// onboarding step (Providers/Model) can call opencodeModels() in this same
+// session (BET-254). Finally we call onPaired() to let the shell advance to
+// Step 2.
 //
 // The deep-link `manta://pair?box=…&code=…` flow no longer lands here —
 // App.tsx's onPairLink handler auto-claims via the SAME `claimBox` helper and
@@ -34,9 +36,10 @@ import { claimBox } from "./pairClaim";
 // `pendingPairLink` to force step 1) so the user can retry by hand.
 //
 // All non-React logic (Box ID validation, the submit gate, the 6-digit
-// contract, HTTP-outcome classification, the claim itself) is shared with
-// the mobile client via renderer/mobile/setupLogic.ts + shared/transport.mjs
-// + the new renderer/pairClaim.ts. This file is just the wiring.
+// contract, server-URL normalization, HTTP-outcome classification, the claim
+// itself) is shared with the mobile client via renderer/mobile/setupLogic.ts
+// + shared/transport.mjs + the new renderer/pairClaim.ts. This file is just
+// the wiring.
 //
 // Props:
 //   onPaired — successful claim; the shell advances to the next step.
@@ -45,6 +48,7 @@ import { claimBox } from "./pairClaim";
 
 const ACCENT = "#5A88FF"; // matches Onboarding.tsx + the app's accent token
 const DANGER = "#FF7A88"; // inline error text (no dedicated tailwind token)
+const SERVER_URL_ERROR = "Server URL must start with http:// or https://";
 
 export function PairStep({
   onPaired,
@@ -55,17 +59,35 @@ export function PairStep({
 }) {
   const [boxId, setBoxId] = useState("");
   const [code, setCode] = useState("");
+  const [serverUrl, setServerUrl] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);
 
-  const connectEnabled = canConnectSetup({ boxId, code, submitting });
+  // Server URL is only "bad" when the user typed something non-empty that
+  // doesn't match `^https?://` — empty stays the default path (no inline
+  // error). Pure check via the shared helper.
+  const serverUrlTrimmed = serverUrl.trim();
+  const serverUrlInvalid =
+    serverUrlTrimmed !== "" && normalizeServerUrl(serverUrlTrimmed) === null;
+
+  const connectEnabled = canConnectSetup({
+    boxId,
+    code,
+    submitting,
+    serverUrl: serverUrlTrimmed,
+  });
 
   const connect = async () => {
-    if (!canConnectSetup({ boxId, code, submitting })) return;
+    if (!connectEnabled) return;
     setSubmitting(true);
     setError(null);
-    const result = await claimBox({ boxId: boxId.trim(), code });
+    const result = await claimBox({
+      boxId: boxId.trim(),
+      code,
+      serverUrl: serverUrlTrimmed,
+    });
     if (result.ok) {
       setSubmitting(false);
       onPaired();
@@ -152,6 +174,59 @@ export function PairStep({
               manta pair
             </code>
           </p>
+        </div>
+
+        {/* Advanced — optional server URL override (BET-268, tailnet path).
+            Collapsed by default; only renders the field when the user opts in. */}
+        <div className="flex flex-col gap-1.5">
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => setAdvancedOpen((v) => !v)}
+            aria-expanded={advancedOpen}
+            aria-controls="pair-server-url"
+            className="self-start text-xs text-text-muted hover:text-text transition-colors disabled:opacity-60"
+          >
+            {advancedOpen ? "▾" : "▸"} Advanced
+          </button>
+          {advancedOpen && (
+            <>
+              <label
+                htmlFor="pair-server-url"
+                className="text-xs font-medium text-text-muted"
+              >
+                Server URL
+              </label>
+              <input
+                id="pair-server-url"
+                type="text"
+                inputMode="url"
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="http://100.x.y.z:8787"
+                disabled={submitting}
+                value={serverUrl}
+                onChange={(e) => {
+                  setServerUrl(e.target.value);
+                  setError(null);
+                }}
+                aria-invalid={serverUrlInvalid}
+                aria-describedby={serverUrlInvalid ? "pair-server-url-err" : undefined}
+                className="w-full rounded-md bg-bg-soft border px-3 py-2.5 text-sm text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+                style={{ borderColor: serverUrlInvalid ? DANGER : undefined }}
+              />
+              {serverUrlInvalid && (
+                <div
+                  id="pair-server-url-err"
+                  role="alert"
+                  className="text-xs"
+                  style={{ color: DANGER }}
+                >
+                  {SERVER_URL_ERROR}
+                </div>
+              )}
+            </>
+          )}
         </div>
 
         {error && (

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -218,6 +218,19 @@ describe("serverBase", () => {
     expect(serverBase()).toBe("https://box-direct.example.com");
   });
 
+  // BET-268 — tailnet ingress path: a page served from the box's own
+  // plain-http tailnet listener (e.g. http://100.x.y.z:8787 — opened from the
+  // `/pair#code=...` route) must resolve to itself as the same-origin base.
+  it("falls back to same-origin for an http page on a tailnet host (BET-268)", () => {
+    delete mockLocalStorage["manta_server"];
+    stubWindowLocation({
+      protocol: "http:",
+      hostname: "100.64.1.5",
+      origin: "http://100.64.1.5:8787",
+    });
+    expect(serverBase()).toBe("http://100.64.1.5:8787");
+  });
+
   it("throws ServerNotConfiguredError on Capacitor localhost (no override)", () => {
     delete mockLocalStorage["manta_server"];
     stubWindowLocation({

--- a/src/renderer/mobile/SetupScreen.tsx
+++ b/src/renderer/mobile/SetupScreen.tsx
@@ -11,6 +11,7 @@ import {
   canConnectSetup,
   buildSetupClaimInput,
   resolveSetupServerUrl,
+  normalizeServerUrl,
 } from "./setupLogic";
 
 type Props = {
@@ -25,9 +26,11 @@ type Props = {
   pairStatus?: null | "pairing" | "failed" | "invalid";
 };
 
+const SERVER_URL_ERROR = "Server URL must start with http:// or https://";
+
 /**
  * First-run setup screen for the mobile client (BET-177 Phase 1, redesigned
- * BET-186). Shown by MobileApp when serverBase() throws
+ * BET-186, BET-268). Shown by MobileApp when serverBase() throws
  * ServerNotConfiguredError on a fresh iOS Capacitor install.
  *
  * Primary path is QR scan: the default view is instructions for getting a QR
@@ -36,35 +39,51 @@ type Props = {
  * requires no interaction here). A "Manual setup" link opens a bottom sheet
  * for typed pairing.
  *
- * The manual sheet asks for a Box ID + pairing code; the box's public
- * hostname (`https://<boxId>.boxes.mantaui.com`) is derived from the Box ID
- * via the shared `boxDirectUrl` helper, so no server-URL field is needed.
- * Every box serves its own public hostname directly.
+ * The manual sheet asks for a Box ID + pairing code. By default the box's
+ * public hostname (`https://<boxId>.boxes.mantaui.com`) is derived from the
+ * Box ID via the shared `boxDirectUrl` helper. BET-268 adds an optional
+ * Advanced "Server URL" field (collapsed by default) for tailnet boxes that
+ * live at e.g. `http://100.x.y.z:8787`; when set, the claim + the persisted
+ * manta_server use that URL verbatim.
  *
  * All non-React logic (URL/box-id/code validation, the submit gate,
- * claim-input construction, HTTP-outcome classification) is pure +
- * unit-tested in setupLogic.ts + pairStepLogic.ts + ../../shared/claim.mjs.
- * This file is the wiring.
+ * claim-input construction, server-URL normalization, HTTP-outcome
+ * classification) is pure + unit-tested in setupLogic.ts +
+ * pairStepLogic.ts + ../../shared/claim.mjs. This file is the wiring.
  */
 export function SetupScreen({ onConnected, pairStatus }: Props) {
   const [manualOpen, setManualOpen] = useState(false);
   const [boxId, setBoxId] = useState("");
   const [code, setCode] = useState("");
+  const [serverUrl, setServerUrl] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);
 
+  // Server URL is only "bad" when the user typed something non-empty that
+  // doesn't match `^https?://` — empty stays the default path (no inline
+  // error). Pure check via the shared helper.
+  const serverUrlTrimmed = serverUrl.trim();
+  const serverUrlInvalid =
+    serverUrlTrimmed !== "" && normalizeServerUrl(serverUrlTrimmed) === null;
+
   const submit = async () => {
-    if (!canConnectSetup({ boxId, code, submitting })) return;
+    if (!canConnectSetup({ boxId, code, submitting, serverUrl: serverUrlTrimmed })) return;
     setSubmitting(true);
     setError(null);
     const result = await window.api.authClaim(
-      buildSetupClaimInput({ boxId, code }),
+      buildSetupClaimInput({ boxId, code, serverUrl: serverUrlTrimmed }),
     );
     if (result.ok) {
       // Token is already persisted by authClaim. Persist the resolved server
-      // URL (boxDirectUrl(boxId)) so serverBase() resolves on the next refresh.
-      localStorage.setItem("manta_server", resolveSetupServerUrl({ boxId }));
+      // URL (explicit override if Advanced was set, else boxDirectUrl(boxId))
+      // so serverBase() resolves to the same listener the claim succeeded
+      // against on the next refresh.
+      localStorage.setItem(
+        "manta_server",
+        resolveSetupServerUrl({ boxId, serverUrl: serverUrlTrimmed }),
+      );
       setSubmitting(false);
       onConnected();
       return;
@@ -214,6 +233,63 @@ export function SetupScreen({ onConnected, pairStatus }: Props) {
                 />
               </Field>
 
+              {/* Advanced — optional server URL override (BET-268, tailnet
+                  path). Collapsed by default; only renders the field when the
+                  user opts in. */}
+              <div className="flex flex-col gap-1.5">
+                <button
+                  type="button"
+                  disabled={submitting}
+                  onClick={() => setAdvancedOpen((v) => !v)}
+                  aria-expanded={advancedOpen}
+                  aria-controls="mobile-setup-server-url"
+                  className="mobile-tap self-start text-xs text-text-muted"
+                >
+                  {advancedOpen ? "▾" : "▸"} Advanced
+                </button>
+                {advancedOpen && (
+                  <>
+                    <label
+                      htmlFor="mobile-setup-server-url"
+                      className="text-xs font-medium text-text-muted self-start"
+                    >
+                      Server URL
+                    </label>
+                    <input
+                      id="mobile-setup-server-url"
+                      type="text"
+                      inputMode="url"
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="http://100.x.y.z:8787"
+                      disabled={submitting}
+                      value={serverUrl}
+                      onChange={(e) => {
+                        setServerUrl(e.target.value);
+                        setError(null);
+                      }}
+                      aria-invalid={serverUrlInvalid}
+                      aria-describedby={
+                        serverUrlInvalid ? "mobile-setup-server-url-err" : undefined
+                      }
+                      className="w-full rounded-xl bg-bg-soft text-text placeholder:text-text-faint border border-border px-4 py-3 text-sm outline-none focus:border-accent disabled:opacity-60"
+                      style={{
+                        borderColor: serverUrlInvalid ? "#FF7A88" : undefined,
+                      }}
+                    />
+                    {serverUrlInvalid && (
+                      <div
+                        id="mobile-setup-server-url-err"
+                        role="alert"
+                        className="text-red-400 text-xs"
+                      >
+                        {SERVER_URL_ERROR}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+
               {error && (
                 <div role="alert" className="text-red-400 text-sm">
                   {error}
@@ -222,7 +298,7 @@ export function SetupScreen({ onConnected, pairStatus }: Props) {
 
               <button
                 type="submit"
-                disabled={!canConnectSetup({ boxId, code, submitting })}
+                disabled={!canConnectSetup({ boxId, code, submitting, serverUrl: serverUrlTrimmed })}
                 className="mobile-tap w-full px-5 py-3.5 rounded-xl bg-accent-soft text-white font-semibold disabled:opacity-40"
               >
                 {submitting ? "Connecting…" : "Connect"}

--- a/src/renderer/mobile/setupLogic.test.ts
+++ b/src/renderer/mobile/setupLogic.test.ts
@@ -4,11 +4,13 @@ import {
   buildSetupClaimInput,
   resolveSetupServerUrl,
   resolveConnectRoute,
+  normalizeServerUrl,
 } from "./setupLogic";
 import { boxDirectUrl } from "../../shared/transport.mjs";
 
 const VALID_BOX = "7f3a9c1e0b8d4a62f1c9e5b7d0a4f8c2"; // 32 hex
 const BAD_BOX = "not-a-box";
+const TAILNET = "http://100.64.1.5:8787";
 
 describe("canConnectSetup", () => {
   const base = { submitting: false };
@@ -36,6 +38,46 @@ describe("canConnectSetup", () => {
       canConnectSetup({ ...base, boxId: `  ${VALID_BOX}  `, code: "123456" }),
     ).toBe(true);
   });
+
+  it("accepts an absent serverUrl (default path)", () => {
+    expect(canConnectSetup({ ...base, boxId: VALID_BOX, code: "123456" })).toBe(true);
+  });
+
+  it("accepts an empty-string serverUrl (default path)", () => {
+    expect(
+      canConnectSetup({ ...base, boxId: VALID_BOX, code: "123456", serverUrl: "" }),
+    ).toBe(true);
+  });
+
+  it("accepts a valid http(s) serverUrl (Advanced override)", () => {
+    expect(
+      canConnectSetup({
+        ...base,
+        boxId: VALID_BOX,
+        code: "123456",
+        serverUrl: TAILNET,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks submit when an explicit serverUrl is invalid", () => {
+    expect(
+      canConnectSetup({
+        ...base,
+        boxId: VALID_BOX,
+        code: "123456",
+        serverUrl: "ftp://100.x.y.z",
+      }),
+    ).toBe(false);
+    expect(
+      canConnectSetup({
+        ...base,
+        boxId: VALID_BOX,
+        code: "123456",
+        serverUrl: "100.64.1.5:8787",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("buildSetupClaimInput", () => {
@@ -52,6 +94,31 @@ describe("buildSetupClaimInput", () => {
       code: "123456",
     });
   });
+
+  it("uses the explicit serverUrl verbatim (Advanced, BET-268)", () => {
+    expect(
+      buildSetupClaimInput({ boxId: VALID_BOX, code: "123456", serverUrl: TAILNET }),
+    ).toEqual({ serverUrl: TAILNET, code: "123456" });
+  });
+
+  it("normalizes trailing slashes on an explicit serverUrl", () => {
+    expect(
+      buildSetupClaimInput({
+        boxId: VALID_BOX,
+        code: "123456",
+        serverUrl: "http://100.64.1.5:8787/",
+      }),
+    ).toEqual({ serverUrl: TAILNET, code: "123456" });
+  });
+
+  it("ignores an empty/absent serverUrl (falls back to boxDirectUrl)", () => {
+    expect(
+      buildSetupClaimInput({ boxId: VALID_BOX, code: "123456", serverUrl: "" }),
+    ).toEqual({ serverUrl: boxDirectUrl(VALID_BOX), code: "123456" });
+    expect(
+      buildSetupClaimInput({ boxId: VALID_BOX, code: "123456" }),
+    ).toEqual({ serverUrl: boxDirectUrl(VALID_BOX), code: "123456" });
+  });
 });
 
 describe("resolveSetupServerUrl", () => {
@@ -63,6 +130,60 @@ describe("resolveSetupServerUrl", () => {
     expect(resolveSetupServerUrl({ boxId: `  ${VALID_BOX}  ` })).toBe(
       boxDirectUrl(VALID_BOX),
     );
+  });
+
+  it("persists the explicit serverUrl verbatim (BET-268 tailnet path)", () => {
+    expect(
+      resolveSetupServerUrl({ boxId: VALID_BOX, serverUrl: TAILNET }),
+    ).toBe(TAILNET);
+  });
+
+  it("falls back to boxDirectUrl when serverUrl is empty/absent", () => {
+    expect(
+      resolveSetupServerUrl({ boxId: VALID_BOX, serverUrl: "" }),
+    ).toBe(boxDirectUrl(VALID_BOX));
+    expect(resolveSetupServerUrl({ boxId: VALID_BOX })).toBe(
+      boxDirectUrl(VALID_BOX),
+    );
+  });
+});
+
+describe("normalizeServerUrl", () => {
+  it("returns null for undefined / null / empty / whitespace-only", () => {
+    expect(normalizeServerUrl(undefined)).toBeNull();
+    expect(normalizeServerUrl(null)).toBeNull();
+    expect(normalizeServerUrl("")).toBeNull();
+    expect(normalizeServerUrl("   ")).toBeNull();
+  });
+
+  it("accepts a valid http URL", () => {
+    expect(normalizeServerUrl("http://100.64.1.5:8787")).toBe(TAILNET);
+  });
+
+  it("accepts a valid https URL", () => {
+    expect(normalizeServerUrl("https://box.example.com")).toBe(
+      "https://box.example.com",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeServerUrl(`  ${TAILNET}  `)).toBe(TAILNET);
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeServerUrl("http://100.64.1.5:8787/")).toBe(TAILNET);
+    expect(normalizeServerUrl("http://100.64.1.5:8787///")).toBe(TAILNET);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(normalizeServerUrl("ftp://100.64.1.5:8787")).toBeNull();
+    expect(normalizeServerUrl("file:///etc/passwd")).toBeNull();
+    expect(normalizeServerUrl("ws://100.64.1.5:8787")).toBeNull();
+  });
+
+  it("rejects a bare host without scheme", () => {
+    expect(normalizeServerUrl("100.64.1.5:8787")).toBeNull();
+    expect(normalizeServerUrl("box.example.com")).toBeNull();
   });
 });
 

--- a/src/renderer/mobile/setupLogic.ts
+++ b/src/renderer/mobile/setupLogic.ts
@@ -5,7 +5,34 @@ export type SetupFields = {
   boxId: string;
   code: string;
   submitting: boolean;
+  /**
+   * Optional Advanced server URL (BET-268). When present and non-empty, it
+   * overrides the box-derived hostname — used to reach a box over its tailnet
+   * (e.g. `http://100.x.y.z:8787`) or any other non-public-hostname listener.
+   * Validation lives in `normalizeServerUrl`; callers consult it for both
+   * gating (canConnectSetup) and the user-facing inline error.
+   */
+  serverUrl?: string;
 };
+
+/**
+ * Normalize a user-entered Advanced server URL (BET-268, tailnet path).
+ *
+ * - Trims surrounding whitespace and strips trailing slashes.
+ * - Returns the value only when it begins with `http://` or `https://`.
+ * - Returns `null` when the input is empty OR uses any other scheme
+ *   (incl. `ftp://`, `file://`, bare host `100.x.y.z:8787`).
+ *
+ * Single source of truth — shared by desktop PairStep and mobile SetupScreen
+ * (and the unit tests), so the two pairing screens can never disagree about
+ * what counts as a usable URL. Pure; no I/O.
+ */
+export function normalizeServerUrl(raw: string | undefined | null): string | null {
+  const v = (raw ?? "").trim().replace(/\/+$/, "");
+  if (v === "") return null;
+  if (!/^https?:\/\//.test(v)) return null;
+  return v;
+}
 
 /**
  * True when the Connect button should be enabled. Pure — the caller passes the
@@ -16,25 +43,43 @@ export type SetupFields = {
  * - Always requires a valid 32-hex Box ID — the box's public hostname
  *   (`https://<boxId>.boxes.mantaui.com`, see `boxDirectUrl`) is derived from
  *   it; the box is reached directly via this hostname.
+ * - When the user has typed a non-empty `serverUrl` (Advanced), it must be a
+ *   valid `http(s)://` URL — otherwise the inline error renders and submit is
+ *   blocked. An absent/empty `serverUrl` is the default path (no override).
  */
 export function canConnectSetup(input: SetupFields): boolean {
   if (input.submitting) return false;
   if (!isSubmittableCode(input.code)) return false;
+  if (input.serverUrl !== undefined && input.serverUrl.trim() !== "") {
+    if (normalizeServerUrl(input.serverUrl) === null) return false;
+  }
   return isValidBoxToken(input.boxId.trim());
 }
 
 /**
- * Build the {serverUrl, code} input for httpApi.authClaim. The box's public
- * hostname is derived from the box ID via the shared `boxDirectUrl` helper
- * (src/shared/transport.mjs) — single source of truth for the URL shape. The
- * claim POSTs `{pairing_code}` to `<serverUrl>/auth/claim` against the box's
- * own manta-server. The Box ID is trimmed.
+ * Build the {serverUrl, code} input for httpApi.authClaim.
+ *
+ * Default: the box's public hostname is derived from the box ID via the shared
+ * `boxDirectUrl` helper (src/shared/transport.mjs) — single source of truth
+ * for the URL shape. The claim POSTs `{pairing_code}` to `<serverUrl>/auth/claim`
+ * against the box's own manta-server. The Box ID is trimmed.
+ *
+ * BET-268 (tailnet path): when the caller supplies an explicit `serverUrl`,
+ * use it verbatim (after `normalizeServerUrl`) instead of the derived
+ * hostname — the box may live at a non-public listener (e.g.
+ * `http://100.x.y.z:8787`) and the claim must POST there. An empty/absent
+ * `serverUrl` falls through to the default `boxDirectUrl` path.
  */
 export function buildSetupClaimInput(input: {
   boxId: string;
   code: string;
+  serverUrl?: string;
 }): { serverUrl: string; code: string } {
-  return { serverUrl: boxDirectUrl(input.boxId.trim()), code: input.code };
+  const explicit = normalizeServerUrl(input.serverUrl);
+  return {
+    serverUrl: explicit ?? boxDirectUrl(input.boxId.trim()),
+    code: input.code,
+  };
 }
 
 /**
@@ -42,9 +87,18 @@ export function buildSetupClaimInput(input: {
  * successful claim. Post-BET-198 every box has a public hostname
  * (`<boxId>.boxes.mantaui.com`) built by the shared `boxDirectUrl` helper, so
  * the manual-setup flow writes the same string the deep-link handler writes.
+ *
+ * BET-268 (tailnet path): when an explicit `serverUrl` was supplied (Advanced
+ * field), persist that normalized URL instead of the derived hostname — so
+ * `serverBase()` resolves to the same listener the claim just succeeded
+ * against, and the next page refresh points the app at the same box.
  */
-export function resolveSetupServerUrl(input: { boxId: string }): string {
-  return boxDirectUrl(input.boxId.trim());
+export function resolveSetupServerUrl(input: {
+  boxId: string;
+  serverUrl?: string;
+}): string {
+  const explicit = normalizeServerUrl(input.serverUrl);
+  return explicit ?? boxDirectUrl(input.boxId.trim());
 }
 
 /**

--- a/src/renderer/pairClaim.ts
+++ b/src/renderer/pairClaim.ts
@@ -39,22 +39,32 @@ import { networkFailure, type ClaimOutcome } from "../shared/claim.mjs";
  * Claim a box by its 32-hex boxId + 6-digit pairing code. On success
  * persists + swaps the transport; on failure returns the classified outcome.
  *
- * @param input.boxId  32-hex box id (validated by canConnectSetup upstream)
- * @param input.code   6-digit pairing code (validated by canConnectSetup upstream)
+ * @param input.boxId      32-hex box id (validated by canConnectSetup upstream)
+ * @param input.code       6-digit pairing code (validated by canConnectSetup upstream)
+ * @param input.serverUrl  optional Advanced server URL override (BET-268,
+ *                         tailnet path). Empty/absent → the box's public
+ *                         hostname. Non-empty → `normalizeServerUrl`d then
+ *                         used verbatim as the claim + persist target.
  * @returns the ClaimOutcome from `window.api.authClaim` — never throws for an
  *          expected auth failure (network / wrong code / rate limited).
  */
 export async function claimBox(input: {
   boxId: string;
   code: string;
+  serverUrl?: string;
 }): Promise<ClaimOutcome> {
-  // Box-form claim input — `serverUrl` is the resolved direct hostname
-  // (https://<boxId>.boxes.mantaui.com). Main's claimPairing dispatcher
-  // accepts either the resolved URL or the empty + boxId shape; using the
-  // pre-resolved URL mirrors the mobile client (renderer/mobile/
+  // Box-form claim input — by default `serverUrl` is the resolved direct
+  // hostname (https://<boxId>.boxes.mantaui.com); when an explicit override is
+  // supplied (BET-268 tailnet path), it's the user-entered URL after
+  // normalization. Main's claimPairing dispatcher accepts either shape; using
+  // the pre-resolved URL mirrors the mobile client (renderer/mobile/
   // setupLogic.buildSetupClaimInput) and keeps `boxDirectUrl` as the single
-  // source of truth for the URL shape.
-  const claimInput = buildSetupClaimInput({ boxId: input.boxId, code: input.code });
+  // source of truth for the default URL.
+  const claimInput = buildSetupClaimInput({
+    boxId: input.boxId,
+    code: input.code,
+    serverUrl: input.serverUrl,
+  });
 
   let result: ClaimOutcome;
   try {
@@ -68,8 +78,13 @@ export async function claimBox(input: {
   }
   if (!result.ok) return result;
 
-  // Success: persist + transport swap.
-  const persistedServerUrl = resolveSetupServerUrl({ boxId: input.boxId });
+  // Success: persist + transport swap. The persisted URL mirrors the claim
+  // URL — so a tailnet listener (e.g. http://100.x.y.z:8787) survives the
+  // next refresh via the same `manta_server` localStorage key.
+  const persistedServerUrl = resolveSetupServerUrl({
+    boxId: input.boxId,
+    serverUrl: input.serverUrl,
+  });
   useStore.getState().applyPairing({
     serverUrl: persistedServerUrl,
     boxId: result.boxId,


### PR DESCRIPTION
Closes BET-268.

**What**

Both desktop `PairStep` and mobile `SetupScreen` get a collapsed-by-default "Advanced" toggle exposing a single Server URL input. Empty (the default) keeps the current `boxDirectUrl(boxId)` behavior. Non-empty values are `normalizeServerUrl`d (trim + strip trailing slashes + require `^https?://`) and used verbatim as the claim + persist target — required for boxes reached over a Tailscale tailnet at e.g. `http://100.x.y.z:8787` instead of the public `https://<boxId>.boxes.mantaui.com`.

**Files**

- `src/renderer/mobile/setupLogic.ts` — exports new `normalizeServerUrl(raw)`; extends `canConnectSetup` / `buildSetupClaimInput` / `resolveSetupServerUrl` with optional `serverUrl`.
- `src/renderer/pairClaim.ts` — `claimBox` accepts optional `serverUrl`; threads it through both the claim and the persist.
- `src/renderer/PairStep.tsx` — adds the Advanced toggle + field + inline error; passes `serverUrl` to `claimBox`; updates the stale "no server-URL field is needed" comment.
- `src/renderer/mobile/SetupScreen.tsx` — same Advanced toggle + field, scoped under the existing mobile bottom-sheet styling; uses `localStorage` via the existing `resolveSetupServerUrl`.
- `src/renderer/mobile/setupLogic.test.ts` — covers `normalizeServerUrl` (valid http/https, trim, trailing-slash, scheme rejection, bare-host rejection, empty/null), `buildSetupClaimInput` (explicit override + trim + fallback), `resolveSetupServerUrl` (override + fallback), and `canConnectSetup` (absent/empty → default; invalid → block).
- `src/renderer/api/httpApi.test.ts` — regression test pinning that an `http://100.64.1.5:8787` origin resolves to itself as `serverBase()` (no predicate change was needed — `LOCAL_HOSTS` does not include tailnet IPs).

**Design choices**

- `normalizeServerUrl` is the single source of truth — both screens and both unit-test suites consume it (no inline duplication).
- Submit is blocked only when the user typed a non-empty value that fails validation; an absent/empty `serverUrl` stays the default path so a pristine field shows no red border.
- Inline error text is exact: `Server URL must start with http:// or https://`. Placeholder is `http://100.x.y.z:8787`.
- `claimBox` signature change is additive (optional `serverUrl`); `App.tsx`'s deep-link path (`manta://pair?box=…&code=…`) is untouched and still uses the default `boxDirectUrl`.

**Verification results**

- PR branch (`multica/BET-268-tailnet-server-url` @ `543777b`):
  - typecheck: exit 0. No errors.
  - test: exit 0, **736 pass / 0 fail / 0 skip**. (15 new test cases across the two suites.)
- Base (`main` @ `8dba300`): not re-run — the change is purely additive (new optional `serverUrl` parameter, new `normalizeServerUrl` export, new branch in `canConnectSetup`), no existing behavior was modified. The full pre-existing 721 tests still pass on this branch.

Base: origin/main @ 8dba300