### PR TITLE
fix(install): bound each opencode health probe so the wait can't hang

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -169,6 +169,16 @@ export function checkIdentity(cfg, { exists = existsSync } = {}) {
  * Deterministic + testable: inject `fetchFn`, `sleep`, and `now`. No real
  * timers when those are provided.
  *
+ * Each attempt is bounded by `requestTimeoutMs` (via AbortController). This is
+ * load-bearing: opencode binds :4096 EARLY on first boot but then stalls before
+ * it can answer (loading the claude-auth plugin / doing first-run OAuth). A
+ * fetch to that half-open socket connects and then waits for a response body
+ * that never comes — Node's global fetch (undici) has a very long default, so
+ * without an abort the very first probe hangs FOREVER and the maxAttempts
+ * ceiling is never reached ("installer hangs on 'waiting for opencode',
+ * restart fixes it"). The timeout turns a stalled request into a failed
+ * attempt so the loop retries and the budget is actually enforced.
+ *
  * @returns { ok:true, attempts } on success, or { ok:false, attempts, error }
  *          after `maxAttempts` exhausted.
  */
@@ -177,6 +187,7 @@ export async function waitForHealth(
   {
     maxAttempts = 60,
     intervalMs = 1000,
+    requestTimeoutMs = 5000,
     acceptAnyStatus = true,
     fetchFn = globalThis.fetch,
     sleep = defaultSleep,
@@ -191,7 +202,7 @@ export async function waitForHealth(
   let lastError = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const res = await fetchFn(url);
+      const res = await fetchWithTimeout(fetchFn, url, requestTimeoutMs);
       // Any HTTP answer means the socket is bound and serving.
       if (res && typeof res.status === "number") {
         if (acceptAnyStatus) {
@@ -220,6 +231,26 @@ export async function waitForHealth(
 
 function defaultSleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Call `fetchFn(url)` but abort it after `timeoutMs` so a half-open / stalled
+ * connection rejects (and is retried) instead of hanging the whole poll. A
+ * non-positive `timeoutMs`, or a `fetchFn` that ignores the abort signal (e.g.
+ * an injected test stub), falls back to the bare call — the timeout is a
+ * safety net, not a contract.
+ */
+async function fetchWithTimeout(fetchFn, url, timeoutMs) {
+  if (!(timeoutMs > 0) || typeof AbortController !== "function") {
+    return fetchFn(url);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchFn(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -483,13 +483,16 @@ main() {
   fi
   # Health-wait: opencode is loopback-only on :4096. acceptAnyStatus:true is
   # the default in waitForHealth; we pass it explicitly so a future reader
-  # sees the intent ("any response = listening").
+  # sees the intent ("any response = listening"). requestTimeoutMs bounds each
+  # probe so a half-open socket (opencode binds :4096 before it can answer on
+  # first boot) can't hang the whole wait — see waitForHealth's doc comment.
   log "Waiting for opencode-serve at http://127.0.0.1:4096/…"
   "$NODE" -e '
     import("'"$LIB"'").then(async (m) => {
       const r = await m.waitForHealth("http://127.0.0.1:4096/", {
         maxAttempts: 30,
         intervalMs: 1000,
+        requestTimeoutMs: 5000,
         acceptAnyStatus: true,
       });
       if (!r.ok) { console.error(r.error); process.exit(1); }

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -906,6 +906,48 @@ test("waitForHealth acceptAnyStatus=true (default) accepts 404 as healthy", asyn
 });
 
 // ----------------------------------------------------------------------------
+// waitForHealth — per-request timeout (the "installer hangs on 'waiting for
+// opencode', restart fixes it" bug). opencode binds :4096 before it can answer
+// on first boot; a fetch to that half-open socket must abort + retry, not hang.
+// ----------------------------------------------------------------------------
+
+test("waitForHealth aborts a hung request and keeps polling (does not hang)", async () => {
+  let calls = 0;
+  const res = await waitForHealth("http://127.0.0.1:4096/", {
+    maxAttempts: 3,
+    requestTimeoutMs: 20,
+    sleep: async () => {},
+    // Attempt 1 + 2 simulate a stalled socket: resolve ONLY when aborted.
+    // Attempt 3 answers immediately.
+    fetchFn: (url, opts) => {
+      calls += 1;
+      if (calls >= 3) return Promise.resolve({ status: 200 });
+      return new Promise((_resolve, reject) => {
+        opts.signal.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      });
+    },
+  });
+  assert.equal(res.ok, true, "must recover once the socket answers");
+  assert.equal(res.attempts, 3);
+  assert.equal(calls, 3);
+});
+
+test("waitForHealth passes an abort signal to fetchFn when requestTimeoutMs > 0", async () => {
+  let sawSignal = false;
+  await waitForHealth("http://127.0.0.1:4096/", {
+    requestTimeoutMs: 100,
+    sleep: async () => {},
+    fetchFn: (_url, opts) => {
+      sawSignal = Boolean(opts && opts.signal);
+      return Promise.resolve({ status: 200 });
+    },
+  });
+  assert.equal(sawSignal, true);
+});
+
+// ----------------------------------------------------------------------------
 // install.sh — bash syntax + manifest_get / verify_sha256 / resolve_arch
 // ----------------------------------------------------------------------------
 //


### PR DESCRIPTION
## Problem

The installer hangs on **"Waiting for opencode-serve…"** on first install; restarting opencode (or the installer) fixes it.

## Root cause

`waitForHealth` (`scripts/install-lib.mjs`) polls `http://127.0.0.1:4096/` up to 30×/1s, intending a ~30s budget. But each `fetch` had **no per-request timeout**.

On a cold first boot, opencode binds :4096 *early* but stalls before it can answer — it's still loading the `opencode-claude-auth` plugin / doing first-run Anthropic OAuth. A fetch to that half-open socket connects and then waits forever for a response body (Node/undici default is effectively unbounded). So attempt #1 never returns, the `maxAttempts` ceiling is never reached, and the installer hangs indefinitely.

Restarting "fixes" it only because the plugin is cached and creds are resolved by then, so the first request answers immediately.

## Fix

- `install-lib.mjs`: add `requestTimeoutMs` (default 5000ms) to `waitForHealth`, wrapping each `fetchFn` call in an `AbortController` via a new `fetchWithTimeout` helper. A stalled request now aborts and counts as a failed attempt → the loop retries and the budget is actually enforced. Falls back to the bare call when `timeoutMs<=0` or `fetchFn` ignores the signal (test stubs).
- `install.sh`: pass `requestTimeoutMs: 5000` explicitly at the call site (worst case now bounded ~30×6s).
- `install.test.mjs`: hung request aborts + recovers on a later attempt; abort signal is passed through.

## Verification

- `node --test scripts/install.test.mjs` — 117/117 pass (2 new).
- `bash -n scripts/install.sh` — clean.

## Note (out of scope)

`self-update.sh` restarts only `manta-server`, never opencode — so an already-wedged opencode isn't healed by a self-update. Not touched here.