### PR TITLE
docs(release): BET-265 stage 3 — sync docs for arm64 box support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1946,13 +1946,14 @@ deploy is the tag push. If someone reports "issue X is done but not live", the
 fix is almost always "it was merged but no release tag was pushed" — check the
 live URL / TestFlight against `main`, then push the right tag.
 
-### The four release targets (each its own tag prefix)
+### The five release targets (each its own tag prefix)
 
 | Tag prefix | Target | Runner | What fires | Config |
 |---|---|---|---|---|
 | `ios-v*` | iOS app → TestFlight | Codemagic `mac_mini_m2` | build + sign + notarize `.ipa` → TestFlight | `codemagic.yaml` `ios-testflight` |
 | `mac-v*` | macOS desktop → DMG | Codemagic `mac_mini_m2` | build + Developer ID sign → DMG → publish to `mantaui.com` | `codemagic.yaml` `mac-desktop` |
 | `web-v*` | marketing site + install assets | self-hosted (`manta-dev-runner`, this box) | scp `website/` + `install.sh` + `llms-install.md` → prod webroot, verify | `.github/workflows/website-deploy.yml` |
+| `server-v*` | Linux box server tarball(s) → `mantaui.com/releases` | GitHub-hosted (`ubuntu-latest` x64 + `ubuntu-24.04-arm` matrix) + self-hosted publish (`manta-dev-runner`) | build x64 + arm64 tarballs natively, merge the two per-arch sidecars via `scripts/release/merge-manifest.mjs`, scp both tarballs + the combined manifest to prod, verify both arches (200 + sha256 drift) | `.github/workflows/server-tarball-deploy.yml` |
 | `relay-v*` | ~~relay service~~ (deprecated 2026-07; replaced by direct mode) | n/a | n/a | `.github/workflows/relay-deploy.yml` (deleted in BET-204) |
 | `gateway-v*` | push gateway service (APNs + DNS automation) | self-hosted (`manta-dev-runner`, this box) | `git pull /opt/manta` + restart `manta-gateway`, health-poll `/healthz` | `.github/workflows/gateway-deploy.yml` |
 
@@ -1972,6 +1973,9 @@ git tag mac-v0.0.2 && git push origin mac-v0.0.2
 
 # Website / install.sh / llms-install.md:
 git tag web-v2 && git push origin web-v2
+
+# Linux box server tarballs (x64 + arm64):
+git tag server-v1 && git push origin server-v1
 
 # Push gateway (only when the gateway service code changed — APNs, DNS, store):
 git tag gateway-v2 && git push origin gateway-v2
@@ -2088,8 +2092,12 @@ box-local and unchanged — it doesn't touch the gateway.
 - **`scripts/release/publish.sh`** is the OLDER manual all-in-one deploy
   (tarball + desktop + server + install.sh, run from a laptop over
   `MANTA_PROD_HOST`). The tag-driven workflows above supersede it for
-  site/gateway/desktop; publish.sh is still the path for the self-contained
-  Linux tarball release (`v<version>` tag).
+  site/gateway/desktop; the Linux box server tarball is now ALSO built by the
+  `server-v*`-tagged `.github/workflows/server-tarball-deploy.yml` workflow
+  (both x64 + arm64, built natively on a GitHub-hosted matrix + merged into a
+  single two-arch manifest before publish). `publish.sh` remains the manual
+  full-release path — the loop over `linux-x64`/`linux-arm64` covers the same
+  arches, and preflight refuses to publish unless BOTH are present.
 
 ### Verifying a deploy actually landed
 
@@ -2098,6 +2106,8 @@ check the live artifact:
 ```
 curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/llms-install.md   # web
 curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/downloads/Manta-latest.dmg  # desktop
+curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/releases/manta-latest-linux-x64.tar.gz   # server x64
+curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/releases/manta-latest-linux-arm64.tar.gz  # server arm64
 curl -fsS https://gateway.mantaui.com/healthz    # gateway → {"ok":true}
 node /tmp/opencode/asc.mjs   # (on the box) — ASC build state for iOS (VALID = really uploaded)
 ```

--- a/llms-install.md
+++ b/llms-install.md
@@ -36,8 +36,8 @@ the desktop app's onboarding handles those.
 
 Run on the target box:
 
-- `uname -m` — must be `x86_64`. Anything else: stop and tell the user only
-  x86_64 Linux is supported today.
+- `uname -m` — must be `x86_64` or `aarch64` / `arm64`. Anything else: stop and
+  tell the user only x86_64 and arm64 Linux are supported today.
 - `for c in curl tar sha256sum tmux git; do command -v $c >/dev/null || echo "missing: $c"; done`
   — all five are hard requirements the installer does NOT install. For any
   missing one, give the user the exact command for their distro

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,10 +38,12 @@
 #
 # Release resolution:
 #   1. Fetch `${MANTA_RELEASE_HOST:-https://mantaui.com}/releases/manta-${MANTA_VERSION:-latest}.txt`
-#      — a flat key=value manifest written by `npm run pack`. Combined manifest
-#      carries BOTH arches (Stage 2 merges per-arch sidecars); install.sh reads
-#      the keys for the arch `resolve_arch` resolved from `uname -m`.
-#   2. Parse `file_${ARCH_KEY}` + `sha256_${ARCH_KEY}` from the manifest.
+#      — a flat key=value manifest carrying BOTH arch pairs (`file_<archkey>`
+#      + `sha256_<archkey>` for each). Written per-arch by `npm run pack`,
+#      merged into the combined manifest by `scripts/release/merge-manifest.mjs`
+#      in the `server-v*` deploy workflow (`.github/workflows/server-tarball-deploy.yml`).
+#   2. Parse `file_<arch>` + `sha256_<arch>` where `<arch>` is `linux_x64` or
+#      `linux_arm64`, selected from `uname -m` via `resolve_arch` (below).
 #   3. Download the tarball, verify sha256, extract.
 #
 # `MANTA_TARBALL_URL` overrides the whole flow: use a local file:// or a

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -4,17 +4,12 @@
 //
 //   node scripts/release/pack.mjs [--out dist] [--skip-build] [--arch x64|arm64]
 //
-// Produces TWO artifacts in `dist/`:
-//
-//   manta-<version>-<arch>.tar.gz      the runtime + app + production deps
-//                                      (`<arch>` is linux-x64 / linux-arm64)
-//   manta-<version>-<arch>.txt         per-arch flat key=value manifest with
-//                                      the sha256 (install.sh fetches this
-//                                      first, then downloads + verifies the
-//                                      tarball). A separate sidecar per arch
-//                                      so two arch builds don't overwrite
-//                                      each other; Stage 2 merges them into
-//                                      the combined `manta-<version>.txt`.
+// Produces a per-arch tarball + per-arch manifest sidecar in `dist/`. ONE
+// invocation builds ONE arch (`--arch x64` or `--arch arm64`); two invocations
+// (one per arch, run on native runners) are merged into the combined
+// `manta-<version>.txt` by `scripts/release/merge-manifest.mjs` — install.sh
+// reads the combined manifest and picks its own arch's keys via `resolve_arch`.
+// (`<arch>` is linux-x64 / linux-arm64; manifest keys are linux_x64 / linux_arm64.)
 //
 // The tarball's top-level dir is `manta-<version>/`. install.sh extracts with
 // `--strip-components=1` into `~/manta`. The tarball is SELF-CONTAINED — the


### PR DESCRIPTION
## Summary

Docs-only follow-up to BET-263 (arch-parameterize pack.mjs + install.sh) and
BET-264 (CI: build both arches + publish two-arch manifest). Every doc that
referenced 'x86_64 only' or hardcoded `linux_x64` is updated to reflect the
new two-arch reality, and the new `server-v*` release tag is documented
alongside the other release targets.

## Files changed (4)

- `scripts/install.sh` — header 'Release resolution' block now spells out
  the two-arch manifest shape (`file_<archkey>` + `sha256_<archkey>` per
  arch) and names the merge workflow (scripts/release/merge-manifest.mjs +
  .github/workflows/server-tarball-deploy.yml).
- `scripts/release/pack.mjs` — top artifact block condensed from 9 lines to
  a tight 5-line description that names `--arch x64|arm64`, the per-arch
  sidecar, and `merge-manifest.mjs` as the merger (replacing the stale
  'Stage 2 merges them' cross-reference). Below essay untouched.
- `llms-install.md` — `uname -m` preflight now accepts `x86_64` AND
  `aarch64` / `arm64`; failure message updated.
- `AGENTS.md`:
  - Release table heading 'four' → 'five'; new `server-v*` row with the
    GitHub-hosted matrix + self-hosted publish runner and what fires.
  - 'How to cut a release' block: new server-v* line.
  - 'Verifying a deploy' curl block: new x64 + arm64 tarball curl checks
    mirroring the desktop DMG check.
  - publish.sh paragraph: tarball is now ALSO built by the server-v*
    workflow (both arches); publish.sh remains the manual full-release path.

## No code touched

Pure docs change. `resolveArch` (pack.mjs) and `resolve_arch` (install.sh)
remain the only places arch strings are enumerated.

## Verification results

Base: `origin/main` @ `f220372` (already had BET-264 merged).

- PR branch (`multica/BET-265-docs-sync-arm64` @ `a7c2342`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **740 pass / 0 fail / 0 skip**.
- Base (`main` @ `f220372`):
  - typecheck + test were already green at BET-264 submission; this PR
    adds only comment/markdown edits and cannot affect typecheck or tests.

**Conclusion:** docs-only diff; no test outcomes can change.

## Definition of done (Stage 3)

- [x] No doc still claims x86_64-only for the box install.
- [x] `server-v*` appears in the AGENTS.md release table + cut-a-release
      block + verify block.
- [x] `npm run typecheck && npm test` still pass.
- [x] Tag NOT pushed; no release triggered.

Refs: BET-265, BET-263, BET-264