### PR TITLE
docs(release): BET-270 — sync README Releases + Rollback to post-Stage-2 two-arch flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,27 +216,61 @@ session by POST). Install/update = copy to `~/.config/opencode/tools/`
 In order. No decisions, no extra steps:
 
 1. Bump `package.json` version.
-2. `npm run pack` — produces `dist/manta-<version>-linux-x64.tar.gz` (the
-   self-contained tarball) AND `dist/manta-<version>.txt` (the key=value
-   manifest install.sh fetches first).
+2. Build the box-server tarballs (one invocation per arch; requires BOTH
+   arches before `publish.sh` will proceed):
+   - `node scripts/release/pack.mjs --arch x64` — produces
+     `dist/manta-<version>-linux-x64.tar.gz` (the self-contained
+     tarball) AND `dist/manta-<version>-linux-x64.txt` (the per-arch
+     key=value manifest sidecar).
+   - `node scripts/release/pack.mjs --arch arm64` — same two outputs
+     with `linux-arm64` in the filename. Run on a native arm64 host
+     (the arm64 `node-pty` binding cannot be cross-compiled; the
+     `server-tarball-deploy.yml` workflow builds both arches in a
+     matrix on a `server-v<version>` tag — see `AGENTS.md` "Release &
+     CD pipeline").
+   - `node scripts/release/merge-manifest.mjs \
+       dist/manta-<version>-linux-x64.txt \
+       dist/manta-<version>-linux-arm64.txt \
+       --out dist/manta-<version>.txt` — assembles the combined
+     key=value manifest `install.sh` fetches at runtime.
 3. (Mac only, on a Mac) `bash scripts/release/desktop.sh` — produces
    `dist/desktop/*.dmg` and the `latest-*.yml` updater feeds. Linux
    builds run on any host.
-4. `bash scripts/release/publish.sh` — uploads the tarball + desktop
-   artifacts, restarts `manta-server` on prod, HEAD-checks every URL,
-   tags `v<version>`. Idempotent: re-publishing the same version is a safe
-   no-op. Override the target with `MANTA_PROD_HOST=...` for staging.
+4. `bash scripts/release/publish.sh` — uploads both per-arch tarballs
+   + the combined manifest, restarts `manta-server` on prod,
+   HEAD-checks every URL, tags `v<version>`. Idempotent: re-publishing
+   the same version is a safe no-op. Override the target with
+   `MANTA_PROD_HOST=...` for staging.
 
 Done.
 
-**Rollback:** point `manta-latest.tar.gz` at the previous tarball on the
-prod box and restart the server:
+**Rollback:** the atomic pointer is `manta-latest.txt` (the combined
+manifest), not a tarball — `publish.sh` uploads every release's
+per-arch tarballs (`manta-<version>-linux-x64.tar.gz` +
+`manta-<version>-linux-arm64.tar.gz`) into `/var/www/mantaui/releases/`
+and never deletes the previous release's files, so reversing the
+manifest pointer is all that's needed to restore an older release on
+the box:
 
 ```
 ssh $MANTA_PROD_HOST 'cd /var/www/mantaui/releases \\
-    && cp -f manta-<prev-version>.tar.gz manta-latest.tar.gz \\
+    && cp -f manta-<prev-version>.txt manta-latest.txt \\
     && git -C /opt/manta checkout v<prev-version> \\
     && systemctl restart manta-server'
+```
+
+If `manta-<prev-version>.txt` is missing on the prod box, recover it
+by re-merging the previous release's per-arch sidecars (still served
+under their versioned filenames) on any host that has
+`scripts/release/merge-manifest.mjs`:
+
+```
+scp $MANTA_PROD_HOST:/var/www/mantaui/releases/manta-<prev-version>-{linux-x64,linux-arm64}.txt .
+node scripts/release/merge-manifest.mjs \
+    manta-<prev-version>-linux-x64.txt \
+    manta-<prev-version>-linux-arm64.txt \
+    --out manta-<prev-version>.txt
+scp manta-<prev-version>.txt $MANTA_PROD_HOST:/var/www/mantaui/releases/
 ```
 
 ## Production infra (ours)


### PR DESCRIPTION
## Summary

BET-265 (docs sync for arm64 box support, PR #225) deliberately scoped its
doc edits to four files (scripts/install.sh, scripts/release/pack.mjs,
llms-install.md, AGENTS.md) and excluded README.md. That left the maintainer
runbook on post-Stage-2 main describing the pre-Stage-2 single-arch release
flow:

* **Releases step 2** claimed `npm run pack` produced both the
  `manta-<version>-linux-x64.tar.gz` tarball AND the combined
  `manta-<version>.txt` manifest. Post-Stage-2, pack.mjs takes
  `--arch x64|arm64` and emits one tarball + one per-arch sidecar per
  invocation; the combined manifest is assembled by
  `scripts/release/merge-manifest.mjs`.
* **Rollback** pointed `manta-latest.tar.gz` at a single combined tarball.
  No such file is published anymore — the atomic rollback pointer is
  `manta-latest.txt` (the combined manifest); per-arch tarballs for every
  prior release remain on the prod box because `publish.sh` never deletes
  them.

Both blocks now describe the actual post-Stage-2 layout, including the
`server-v*` tag → matrix-build escape hatch (already documented in
AGENTS.md) and the re-merge recovery path if a previous release's combined
manifest is missing on the prod box.

## Out of scope (per BET-270 description)

* AGENTS.md / llms-install.md / scripts/install.sh header — BET-265 covered those.
* Marketing site — README lives on GitHub, not mantaui.com.

## Files changed

```
README.md | 54 ++++++++++++++++++++++++++++++++++++++++++++----------
1 file changed, 44 insertions(+), 10 deletions(-)
```

## Base

`Base: origin/main @ 9e0fdc9` (merged PR #225, the BET-265 docs-sync PR).
PR branch: `multica/BET-270-readme-pack-rollback-doc-sync` @ `97e5de2`.

## Verification results

- PR branch (`multica/BET-270-readme-pack-rollback-doc-sync` @ `97e5de2`):
  - typecheck: exit `0`. Errors: none. log sha256: `c82e32823b0efb2e3cc5e80fe1f6610d1e5672da7f3a1b7b17927b4ed91831c3`
  - test: exit `0`, `742` pass / `0` fail / `0` skip. Failures: none. log sha256: `090d31aee198c01c2f555c184df03c5b6de26170aa8e2f95cf0439aa9ea50afc`
- Base (`main` @ `9e0fdc9`):
  - typecheck: exit `0`. Errors: none. log sha256: `c82e32823b0efb2e3cc5e80fe1f6610d1e5672da7f3a1b7b17927b4ed91831c3`
  - test: exit `0`, `742` pass / `0` fail / `0` skip. Failures: none. log sha256: `437f58b55487b81677cc7343726e7e0b40c6d6f7d1e01c8f3f9151a60289258d`
- **Conclusion:** Both runs pass identically (typecheck logs are
  byte-identical; test logs differ only in `duration_ms`). 0 new failures,
  0 pre-existing failures, 0 failures resolved by this PR. Docs-only — no
  source/test files touched.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`,
`/tmp/test-pr.log`, `/tmp/test-master.log` for spot-check.
