### PR TITLE
fix(prod): healthcheck probes both per-arch tarballs + sha256-verifies against manta-latest.txt (BET-271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,15 @@ steps in each file's header are human-only (agent Hard Rule #4 forbids
 
 - **Monitoring** (`scripts/prod/healthcheck.mjs`, scheduled every 10 min
   on the dev box via `schedule_create`): off-site probes of `mantaui.com`,
-  `gateway.mantaui.com/healthz` (200 = healthy), `app.mantaui.com`,
-  `/install.sh`, `/releases/manta-latest.tar.gz` (and the live
-  `manta-latest.txt` manifest's `sha256_linux_x64` must match the served
-  tarball). On failure the opencode turn calls `notify` urgent:true naming
-  the failing URL.
+  `gateway.mantaui.com/healthz` (200 = healthy), `app.mantaui.com`, and
+  `/install.sh`, plus the per-arch tarball drift check: HEAD the tarballs
+  the live `manta-latest.txt` manifest declares (`file_linux_x64=`,
+  `file_linux_arm64=`) AND sha256-verify each against the manifest's
+  `sha256_linux_x64` / `sha256_linux_arm64`. Same loop publish.sh runs at
+  verify-time, pushed out off-site so it catches tarballs that drift from
+  the manifest AFTER publish (BET-171 F4 class, BET-264 two-arch). On
+  failure the opencode turn calls `notify` urgent:true naming the failing
+  URL.
 - **Log caps** (`scripts/prod/systemd-journald.conf`,
   `scripts/prod/caddy-logrotate`): journald capped at 500M; Caddy access
   logs (only if they exist on the box — check first) rotated daily with

--- a/scripts/prod/healthcheck.mjs
+++ b/scripts/prod/healthcheck.mjs
@@ -16,11 +16,26 @@
 //   failing URL.
 //
 // Override (env): HEALTHCHECK_TARGETS (JSON array — see DEFAULT_TARGETS).
+// The override filters the FLAT probes only; the manifest↔tarball drift
+// check (the most important leg) runs unconditionally — there's no clean
+// way to express "fetch manifest, then iterate arches" in a JSON array of
+// { url, kind, expect } entries, and an off-site drift check is the whole
+// point of this script.
 
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Single source of truth — mirror scripts/release/publish.sh.
+// Adding an arch = one entry in ARCH_KEYS + one entry in publish.sh's
+// ARCHES. No copy-pasted per-arch blocks downstream of this list.
+// ---------------------------------------------------------------------------
+
+export const SITE_URL = "https://mantaui.com";
+export const ARCH_KEYS = ["linux_x64", "linux_arm64"];
 
 // ---------------------------------------------------------------------------
 // Default probe set (single source of truth — also used by the test suite).
@@ -31,6 +46,11 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 //      (defends against Caddy returning a 200 default page for a missing
 //      asset — "200 OK" + wrong content is still a healthy 200, but a
 //      missing /install.sh would silently serve the homepage).
+//
+// Note: the per-arch tarball URLs are NOT listed here — they live behind
+// the manifest (manta-latest.txt) and shift on every publish. We HEAD +
+// sha256-verify them in verifyManifestDrift below, which is the same shape
+// as publish.sh's post-upload verify loop (publish.sh:245-257).
 // ---------------------------------------------------------------------------
 
 export const DEFAULT_TARGETS = [
@@ -38,8 +58,167 @@ export const DEFAULT_TARGETS = [
   { url: "https://gateway.mantaui.com",              kind: "body", expect: { status: 200 } },
   { url: "https://app.mantaui.com",                  kind: "body", expect: { status: 200 } },
   { url: "https://mantaui.com/install.sh",           kind: "body", expect: { status: 200, bodyStartsWith: "#!/" } },
-  { url: "https://mantaui.com/releases/manta-latest.tar.gz", kind: "head", expect: { status: 200 } },
 ];
+
+// ---------------------------------------------------------------------------
+// Manifest parser — pure, mirrors the install.sh `manifest_get` shape
+// (scripts/install.sh reads `key=value` lines, first-occurrence wins).
+// Keys we care about per arch: file_<archkey>= and sha256_<archkey>=
+// (e.g. file_linux_x64=manta-1.2.3-linux-x64.tar.gz). Future keys are
+// ignored — we never want a new arch to break a stale parser.
+// ---------------------------------------------------------------------------
+
+export function parseManifest(text) {
+  const out = {};
+  if (typeof text !== "string") return out;
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^([a-zA-Z0-9_]+)=(.+)$/);
+    if (!m) continue;
+    if (!(m[1] in out)) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest ↔ tarball drift check (BET-171 F4 class, generalized to BOTH
+// arches per BET-264). Same loop publish.sh runs at verify-time, but
+// pushed out to every 10 min from an off-site box: catches the case
+// where the served tarball silently drifted from what manta-latest.txt
+// promises (file replaced, partial upload, etc.) AFTER publish.sh's
+// one-shot verification has already passed.
+//
+// Flow per arch:
+//   1. parse file_<archkey>= + sha256_<archkey>= from the served manifest
+//   2. HEAD <site>/releases/<file_<archkey>=>  → expect 200
+//   3. GET <site>/releases/<file_<archkey>=>, sha256 it, compare to
+//      sha256_<archkey>=. Mismatch → failure (client would sha256-fail
+//      on install and die).
+//
+// Every I/O surface is injected so the test suite can run without the
+// network. `fetchFn(url, init?)` must return a Response-like with
+// { status, text(), arrayBuffer() } — same contract as globalThis.fetch.
+// ---------------------------------------------------------------------------
+
+export async function verifyManifestDrift({
+  siteUrl = SITE_URL,
+  archKeys = ARCH_KEYS,
+  fetchFn = globalThis.fetch,
+  log = () => {},
+} = {}) {
+  const failures = [];
+  const base = String(siteUrl ?? "").replace(/\/+$/, "");
+  if (base === "") {
+    return { ok: false, failures: [{ url: "<manifest>", reason: "siteUrl is empty" }] };
+  }
+  const manifestUrl = `${base}/releases/manta-latest.txt`;
+
+  // 1. Fetch + parse the manifest. If this fails we can't do anything else
+  // (the whole point of the drift check is the manifest). Bail early with a
+  // single failure entry rather than speculating about per-arch URLs.
+  let manifestText = "";
+  try {
+    const res = await fetchFn(manifestUrl);
+    const status = res?.status;
+    if (typeof status !== "number") {
+      log(`${manifestUrl}: no status (fetch returned no Response)`);
+      failures.push({ url: manifestUrl, reason: `expected status 200, got no-status` });
+      return { ok: false, failures };
+    }
+    if (status !== 200) {
+      log(`${manifestUrl}: status=${status} expected=200`);
+      failures.push({ url: manifestUrl, reason: `expected status 200, got ${status}` });
+      return { ok: false, failures };
+    }
+    manifestText = await res.text();
+  } catch (e) {
+    const reason = `fetch error: ${e?.message ?? e}`;
+    log(`${manifestUrl}: ${reason}`);
+    failures.push({ url: manifestUrl, reason });
+    return { ok: false, failures };
+  }
+
+  const kv = parseManifest(manifestText);
+
+  // 2. For each arch: HEAD the file_<arch>= URL, then GET+sha256 it.
+  for (const key of archKeys) {
+    const fileKey = `file_${key}`;
+    const shaKey  = `sha256_${key}`;
+    const fileVal = kv[fileKey];
+    const shaVal  = kv[shaKey];
+
+    if (typeof fileVal !== "string" || fileVal === "") {
+      const reason = `manifest missing ${fileKey}= (arch=${key})`;
+      log(`${manifestUrl}: ${reason}`);
+      failures.push({ url: manifestUrl, reason });
+      continue;
+    }
+    if (typeof shaVal !== "string" || shaVal === "") {
+      const reason = `manifest missing ${shaKey}= (arch=${key})`;
+      log(`${manifestUrl}: ${reason}`);
+      failures.push({ url: manifestUrl, reason });
+      continue;
+    }
+    // Guard against manifest entries that try to escape the releases dir
+    // (a `file_linux_x64=../../etc/passwd` would curl-fetch outside our
+    // intent). Tarball names in publish.sh are produced by pack.mjs and
+    // match `manta-<version>-linux-<arch>.tar.gz` — anything else is
+    // almost certainly a corrupted manifest.
+    if (fileVal.includes("/") || fileVal.includes("..") || fileVal.includes("\0")) {
+      const reason = `manifest ${fileKey}= contains unsafe characters (${JSON.stringify(fileVal)})`;
+      log(`${manifestUrl}: ${reason}`);
+      failures.push({ url: manifestUrl, reason });
+      continue;
+    }
+    const tarballUrl = `${base}/releases/${fileVal}`;
+
+    // HEAD — the cheap liveness probe. A 200 here + a sha256 mismatch below
+    // is the classic "served file replaced post-publish" scenario.
+    try {
+      const headRes = await fetchFn(tarballUrl, { method: "HEAD" });
+      const status = headRes?.status;
+      if (typeof status !== "number" || status !== 200) {
+        const got = typeof status === "number" ? status : "no-status";
+        log(`${tarballUrl}: HEAD status=${got} expected=200`);
+        failures.push({ url: tarballUrl, reason: `expected status 200, got ${got}` });
+        continue;
+      }
+    } catch (e) {
+      const reason = `HEAD fetch error: ${e?.message ?? e}`;
+      log(`${tarballUrl}: ${reason}`);
+      failures.push({ url: tarballUrl, reason });
+      continue;
+    }
+
+    // GET + sha256. Bytes flow through Node Buffer for the hash so we
+    // don't pull in a streaming pipeline for a one-shot ~100MB tarball.
+    try {
+      const getRes = await fetchFn(tarballUrl, { method: "GET" });
+      const status = getRes?.status;
+      if (typeof status !== "number" || status !== 200) {
+        const got = typeof status === "number" ? status : "no-status";
+        log(`${tarballUrl}: GET status=${got} expected=200`);
+        failures.push({ url: tarballUrl, reason: `expected status 200, got ${got}` });
+        continue;
+      }
+      const ab = await getRes.arrayBuffer();
+      const buf = Buffer.from(ab);
+      const actualSha = createHash("sha256").update(buf).digest("hex");
+      if (actualSha !== shaVal) {
+        const reason = `sha256 mismatch: manifest=${shaVal} actual=${actualSha} (arch=${key})`;
+        log(`${tarballUrl}: ${reason}`);
+        failures.push({ url: tarballUrl, reason });
+        continue;
+      }
+      log(`${tarballUrl}: OK (sha256 matches ${shaKey}, ${buf.length} bytes)`);
+    } catch (e) {
+      const reason = `sha256 verify error: ${e?.message ?? e}`;
+      log(`${tarballUrl}: ${reason}`);
+      failures.push({ url: tarballUrl, reason });
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}
 
 // ---------------------------------------------------------------------------
 // Probe runner — pure: every I/O surface is injected so the test suite can
@@ -47,20 +226,23 @@ export const DEFAULT_TARGETS = [
 // ---------------------------------------------------------------------------
 
 /**
- * Run every target; return `{ ok, failures }` where `failures` is the list
- * of { url, reason } entries (empty when ok).
+ * Run every target + the manifest drift check; return `{ ok, failures }`
+ * where `failures` is the list of { url, reason } entries (empty when ok).
  *
  * @param {object} opts
- * @param {Array}  opts.targets        probe list (default DEFAULT_TARGETS).
+ * @param {Array}  opts.targets        flat probe list (default DEFAULT_TARGETS).
  * @param {object} opts.env            env-like object (default process.env).
  * @param {Function} opts.fetchFn      fetch implementation.
  * @param {Function} opts.log          (line) => void — per-target progress.
+ * @param {boolean} [opts.skipDriftCheck=false]  escape hatch for tests
+ *                  that only want to exercise the flat probe set.
  */
 export async function runHealthcheck({
   targets = parseTargetsEnv(process.env),
   env = process.env,
   fetchFn = globalThis.fetch,
   log = () => {},
+  skipDriftCheck = false,
 } = {}) {
   const list = targets ?? DEFAULT_TARGETS;
   const failures = [];
@@ -68,11 +250,22 @@ export async function runHealthcheck({
     const fail = await checkOne(t, { fetchFn, log });
     if (fail) failures.push(fail);
   }
+  if (!skipDriftCheck) {
+    const drift = await verifyManifestDrift({
+      siteUrl: SITE_URL,
+      archKeys: ARCH_KEYS,
+      fetchFn,
+      log,
+    });
+    for (const f of drift.failures) failures.push(f);
+  }
   return { ok: failures.length === 0, failures };
 }
 
-// HEALTHCHECK_TARGETS overrides the default probe set. JSON-encoded array
-// of the same shape as DEFAULT_TARGETS. Empty/missing → default.
+// HEALTHCHECK_TARGETS overrides the default FLAT probe set. JSON-encoded
+// array of the same shape as DEFAULT_TARGETS. Empty/missing → default.
+// Note: this filters the flat probes only; the manifest drift check
+// always runs (see file header).
 export function parseTargetsEnv(env) {
   const raw = env?.HEALTHCHECK_TARGETS;
   if (typeof raw !== "string" || raw === "") return null;
@@ -131,7 +324,7 @@ async function cliMain() {
     }
     process.exit(1);
   }
-  process.stderr.write(`[healthcheck] OK: all ${DEFAULT_TARGETS.length} targets healthy\n`);
+  process.stderr.write(`[healthcheck] OK: all ${DEFAULT_TARGETS.length} flat targets + ${ARCH_KEYS.length} arch drift checks healthy\n`);
   process.exit(0);
 }
 

--- a/scripts/prod/healthcheck.test.mjs
+++ b/scripts/prod/healthcheck.test.mjs
@@ -4,8 +4,21 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 
-import { DEFAULT_TARGETS, runHealthcheck, parseTargetsEnv } from "./healthcheck.mjs";
+import {
+  DEFAULT_TARGETS,
+  SITE_URL,
+  ARCH_KEYS,
+  parseManifest,
+  verifyManifestDrift,
+  runHealthcheck,
+  parseTargetsEnv,
+} from "./healthcheck.mjs";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
 
 function fakeFetch(perUrl) {
   return async (url, init = {}) => {
@@ -15,50 +28,109 @@ function fakeFetch(perUrl) {
   };
 }
 
-function makeRes({ status = 200, body = "" } = {}) {
+function makeRes({ status = 200, body = "", bodyBytes = null } = {}) {
+  // bodyBytes lets the drift-check test inject pre-hashed tarball bytes so
+  // the fake fetch returns a real sha256 the verifier can compare.
+  let bytes = bodyBytes;
+  if (bytes == null) bytes = new TextEncoder().encode(body).buffer;
   return {
     status,
-    text: async () => body,
+    text: async () => (typeof body === "string" ? body : new TextDecoder().decode(bytes)),
+    arrayBuffer: async () => bytes,
   };
 }
 
-test("DEFAULT_TARGETS covers every surface in the issue body", () => {
+// Build a tarball-shaped body whose sha256 matches what we put in the
+// manifest. We use a small fixed string ("tarball-bytes:<arch>") so the
+// sha256 is deterministic + cheap to compute in the test.
+function tarballBytes(archKey) {
+  const s = `tarball-bytes:${archKey}`;
+  return {
+    bytes: new TextEncoder().encode(s).buffer,
+    sha256: createHash("sha256").update(s).digest("hex"),
+  };
+}
+
+// Manifest content (combined, post-Stage-2 / BET-264). Two arches.
+const GOOD_MANIFEST = [
+  "version=1.2.3",
+  `file_linux_x64=manta-1.2.3-linux-x64.tar.gz`,
+  `sha256_linux_x64=${tarballBytes("linux_x64").sha256}`,
+  `file_linux_arm64=manta-1.2.3-linux-arm64.tar.gz`,
+  `sha256_linux_arm64=${tarballBytes("linux_arm64").sha256}`,
+  "release_channel=stable",
+].join("\n");
+
+// Handlers that make every default-target URL return healthy 200s.
+function defaultHealthyHandlers(manifestText = GOOD_MANIFEST) {
+  const tb = {
+    "linux_x64": tarballBytes("linux_x64"),
+    "linux_arm64": tarballBytes("linux_arm64"),
+  };
+  const manifestUrl = `${SITE_URL}/releases/manta-latest.txt`;
+  return {
+    "https://mantaui.com": () => makeRes({ status: 200 }),
+    "https://gateway.mantaui.com": () => makeRes({ status: 200 }),
+    "https://app.mantaui.com": () => makeRes({ status: 200 }),
+    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
+    [manifestUrl]: ({ method }) => makeRes({ status: 200, body: manifestText }),
+    [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: ({ method }) =>
+      method === "HEAD"
+        ? makeRes({ status: 200 })
+        : makeRes({ status: 200, bodyBytes: tb.linux_x64.bytes }),
+    [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: ({ method }) =>
+      method === "HEAD"
+        ? makeRes({ status: 200 })
+        : makeRes({ status: 200, bodyBytes: tb.linux_arm64.bytes }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants — single source of truth mirrors publish.sh.
+// ---------------------------------------------------------------------------
+
+test("SITE_URL + ARCH_KEYS match scripts/release/publish.sh (single source of truth)", () => {
+  assert.equal(SITE_URL, "https://mantaui.com");
+  assert.deepEqual(ARCH_KEYS, ["linux_x64", "linux_arm64"]);
+});
+
+test("DEFAULT_TARGETS covers the live surfaces but NOT the per-arch tarballs (those live behind the manifest)", () => {
   const urls = DEFAULT_TARGETS.map((t) => t.url);
   for (const required of [
     "https://mantaui.com",
     "https://gateway.mantaui.com",
     "https://app.mantaui.com",
     "https://mantaui.com/install.sh",
-    "https://mantaui.com/releases/manta-latest.tar.gz",
   ]) {
     assert.ok(urls.includes(required), `default targets missing ${required}`);
   }
+  // The combined legacy `manta-latest.tar.gz` is NOT served (BET-264
+  // dropped it; only per-arch tarballs behind the manifest remain). A
+  // stale probe here would 404 forever and flood notify().
+  assert.ok(
+    !urls.some((u) => u.endsWith("/manta-latest.tar.gz")),
+    `DEFAULT_TARGETS must not probe the dead manta-latest.tar.gz URL`,
+  );
   // gateway.mantaui.com must expect 200 — that IS the healthz route being healthy.
   const gateway = DEFAULT_TARGETS.find((t) => t.url === "https://gateway.mantaui.com");
   assert.equal(gateway.expect.status, 200, "gateway.mantaui.com must expect 200");
 });
 
-test("runHealthcheck returns ok:true when every target matches", async () => {
-  const fetchFn = fakeFetch({
-    "https://mantaui.com": () => makeRes({ status: 200 }),
-    "https://gateway.mantaui.com": () => makeRes({ status: 200 }),
-    "https://app.mantaui.com": () => makeRes({ status: 200 }),
-    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
-    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
-  });
+// ---------------------------------------------------------------------------
+// runHealthcheck — flat probes (regression coverage)
+// ---------------------------------------------------------------------------
+
+test("runHealthcheck returns ok:true when every flat target matches AND the manifest drift check passes", async () => {
+  const fetchFn = fakeFetch(defaultHealthyHandlers());
   const result = await runHealthcheck({ fetchFn, log: () => {} });
   assert.equal(result.ok, true);
   assert.deepEqual(result.failures, []);
 });
 
-test("runHealthcheck flags a status mismatch", async () => {
-  const fetchFn = fakeFetch({
-    "https://mantaui.com": () => makeRes({ status: 500 }),
-    "https://gateway.mantaui.com": () => makeRes({ status: 200 }),
-    "https://app.mantaui.com": () => makeRes({ status: 200 }),
-    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
-    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
-  });
+test("runHealthcheck flags a flat status mismatch (manifest drift still passes)", async () => {
+  const handlers = defaultHealthyHandlers();
+  handlers["https://mantaui.com"] = () => makeRes({ status: 500 });
+  const fetchFn = fakeFetch(handlers);
   const result = await runHealthcheck({ fetchFn, log: () => {} });
   assert.equal(result.ok, false);
   assert.equal(result.failures.length, 1);
@@ -67,27 +139,20 @@ test("runHealthcheck flags a status mismatch", async () => {
 });
 
 test("runHealthcheck flags a body-prefix mismatch (e.g. Caddy serves the homepage for a missing asset)", async () => {
-  const fetchFn = fakeFetch({
-    "https://mantaui.com": () => makeRes({ status: 200 }),
-    "https://gateway.mantaui.com": () => makeRes({ status: 200 }),
-    "https://app.mantaui.com": () => makeRes({ status: 200 }),
-    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "<!doctype html>\n<html>..." }),
-    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
-  });
+  const handlers = defaultHealthyHandlers();
+  handlers["https://mantaui.com/install.sh"] = () =>
+    makeRes({ status: 200, body: "<!doctype html>\n<html>..." });
+  const fetchFn = fakeFetch(handlers);
   const result = await runHealthcheck({ fetchFn, log: () => {} });
   assert.equal(result.ok, false);
   assert.equal(result.failures[0].url, "https://mantaui.com/install.sh");
   assert.match(result.failures[0].reason, /body did not start with/);
 });
 
-test("runHealthcheck flags a fetch error (DNS / network)", async () => {
-  const fetchFn = fakeFetch({
-    "https://mantaui.com": () => makeRes({ status: 200 }),
-    "https://gateway.mantaui.com": async () => { throw new Error("ENOTFOUND"); },
-    "https://app.mantaui.com": () => makeRes({ status: 200 }),
-    "https://mantaui.com/install.sh": () => makeRes({ status: 200, body: "#!/usr/bin/env bash\n" }),
-    "https://mantaui.com/releases/manta-latest.tar.gz": () => makeRes({ status: 200 }),
-  });
+test("runHealthcheck flags a flat fetch error (DNS / network)", async () => {
+  const handlers = defaultHealthyHandlers();
+  handlers["https://gateway.mantaui.com"] = async () => { throw new Error("ENOTFOUND"); };
+  const fetchFn = fakeFetch(handlers);
   const result = await runHealthcheck({ fetchFn, log: () => {} });
   assert.equal(result.ok, false);
   assert.equal(result.failures[0].url, "https://gateway.mantaui.com");
@@ -103,11 +168,166 @@ test("runHealthcheck uses HEAD method for HEAD-kind targets", async () => {
   await runHealthcheck({
     fetchFn,
     log: () => {},
-    targets: [{ url: "https://mantaui.com/releases/manta-latest.tar.gz", kind: "head", expect: { status: 200 } }],
+    targets: [{ url: "https://mantaui.com/install.sh", kind: "head", expect: { status: 200 } }],
+    skipDriftCheck: true,
   });
   assert.equal(seen.length, 1);
   assert.equal(seen[0].method, "HEAD");
 });
+
+// ---------------------------------------------------------------------------
+// parseManifest — pure parser for the BET-264 combined manifest shape.
+// ---------------------------------------------------------------------------
+
+test("parseManifest extracts every key=value line (first occurrence wins)", () => {
+  const text = [
+    "version=1.2.3",
+    "file_linux_x64=manta-1.2.3-linux-x64.tar.gz",
+    "sha256_linux_x64=aaaa",
+    "file_linux_arm64=manta-1.2.3-linux-arm64.tar.gz",
+    "sha256_linux_arm64=bbbb",
+    "release_channel=stable",
+    "# a comment-looking line",
+    "malformed line no equals",
+    "version=9.9.9", // first-occurrence wins → ignored
+  ].join("\n");
+  assert.deepEqual(parseManifest(text), {
+    version: "1.2.3",
+    file_linux_x64: "manta-1.2.3-linux-x64.tar.gz",
+    sha256_linux_x64: "aaaa",
+    file_linux_arm64: "manta-1.2.3-linux-arm64.tar.gz",
+    sha256_linux_arm64: "bbbb",
+    release_channel: "stable",
+  });
+});
+
+test("parseManifest returns {} on empty / non-string input", () => {
+  assert.deepEqual(parseManifest(""), {});
+  assert.deepEqual(parseManifest(null), {});
+  assert.deepEqual(parseManifest(undefined), {});
+  assert.deepEqual(parseManifest(42), {});
+});
+
+// ---------------------------------------------------------------------------
+// verifyManifestDrift — the headline check (BET-171 F4 class, BET-264 two-arch).
+// ---------------------------------------------------------------------------
+
+test("verifyManifestDrift returns ok:true when every arch HEAD+sha256 matches", async () => {
+  const handlers = defaultHealthyHandlers();
+  // Drop the flat-probe URLs so a stray reference doesn't accidentally
+  // pass — this test only exercises the drift check.
+  const fetchFn = fakeFetch({
+    [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+  });
+  const result = await verifyManifestDrift({ fetchFn, log: () => {} });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("verifyManifestDrift flags a missing manifest (404 → single failure)", async () => {
+  const fetchFn = fakeFetch({
+    [`${SITE_URL}/releases/manta-latest.txt`]: () => makeRes({ status: 404 }),
+  });
+  const result = await verifyManifestDrift({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].url, `${SITE_URL}/releases/manta-latest.txt`);
+  assert.match(result.failures[0].reason, /expected status 200, got 404/);
+});
+
+test("verifyManifestDrift flags a manifest that lacks one arch's keys", async () => {
+  // Manifest is missing file_linux_arm64 + sha256_linux_arm64 entirely.
+  const malformed = [
+    "version=1.2.3",
+    "file_linux_x64=manta-1.2.3-linux-x64.tar.gz",
+    `sha256_linux_x64=${tarballBytes("linux_x64").sha256}`,
+  ].join("\n");
+  const handlers = defaultHealthyHandlers(malformed);
+  const fetchFn = fakeFetch({
+    [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
+  });
+  const result = await verifyManifestDrift({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => /missing file_linux_arm64=/.test(f.reason)),
+    `expected a 'missing file_linux_arm64=' failure, got ${JSON.stringify(result.failures)}`,
+  );
+});
+
+test("verifyManifestDrift flags a tarball HEAD 404 on one arch", async () => {
+  const handlers = defaultHealthyHandlers();
+  handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`] = ({ method }) =>
+    method === "HEAD"
+      ? makeRes({ status: 404 })
+      : makeRes({ status: 200, bodyBytes: tarballBytes("linux_arm64").bytes });
+  const fetchFn = fakeFetch({
+    [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+  });
+  const result = await verifyManifestDrift({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  const arm = result.failures.find((f) => f.url.endsWith("linux-arm64.tar.gz"));
+  assert.ok(arm, "expected a failure for the arm64 tarball URL");
+  assert.match(arm.reason, /expected status 200, got 404/);
+});
+
+test("verifyManifestDrift flags a sha256 mismatch on one arch (the headline BET-171 F4 case)", async () => {
+  const handlers = defaultHealthyHandlers();
+  // Swap the arm64 tarball bytes for unrelated content — sha256 won't match.
+  handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`] = ({ method }) =>
+    method === "HEAD"
+      ? makeRes({ status: 200 })
+      : makeRes({ status: 200, bodyBytes: new TextEncoder().encode("REPLACED-CONTENT").buffer });
+  const fetchFn = fakeFetch({
+    [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+  });
+  const result = await verifyManifestDrift({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  const arm = result.failures.find((f) => f.url.endsWith("linux-arm64.tar.gz"));
+  assert.ok(arm, "expected a failure for the arm64 tarball URL");
+  assert.match(arm.reason, /sha256 mismatch/);
+  assert.match(arm.reason, /arch=linux_arm64/);
+});
+
+test("verifyManifestDrift refuses manifest entries with path-traversal / slashes", async () => {
+  // A corrupted manifest pointing file_linux_x64 outside the releases dir
+  // must NOT result in a curl-fetch outside our intent.
+  const evil = [
+    "version=1.2.3",
+    "file_linux_x64=../../etc/passwd",
+    "sha256_linux_x64=aaaa",
+    "file_linux_arm64=manta-1.2.3-linux-arm64.tar.gz",
+    `sha256_linux_arm64=${tarballBytes("linux_arm64").sha256}`,
+  ].join("\n");
+  const handlers = defaultHealthyHandlers(evil);
+  const fetchFn = fakeFetch({
+    [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
+    [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+  });
+  const result = await verifyManifestDrift({ fetchFn, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => /unsafe characters/.test(f.reason)),
+    `expected an unsafe-characters failure, got ${JSON.stringify(result.failures)}`,
+  );
+});
+
+test("verifyManifestDrift returns a single failure for an empty siteUrl", async () => {
+  const result = await verifyManifestDrift({ siteUrl: "", fetchFn: globalThis.fetch, log: () => {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0].reason, /siteUrl is empty/);
+});
+
+// ---------------------------------------------------------------------------
+// parseTargetsEnv — env-override behavior is unchanged by the refactor.
+// ---------------------------------------------------------------------------
 
 test("parseTargetsEnv parses a JSON override", () => {
   const parsed = parseTargetsEnv({


### PR DESCRIPTION
## What

Replaces the dead `manta-latest.tar.gz` probe in `scripts/prod/healthcheck.mjs` with a manifest-driven drift check that mirrors publish.sh's post-upload verify loop. The flat-probe set (mantaui.com / gateway / app / install.sh) is unchanged. README's Monitoring bullet updated to match.

## Why

BET-263 / BET-264 (the two-arch transition) stopped uploading the combined `manta-latest.tar.gz` — publish.sh now only ships per-arch tarballs (`manta-<version>-linux-x64.tar.gz` + `manta-<version>-linux-arm64.tar.gz`) and uses `manta-latest.txt` as the atomic latest-pointer. healthcheck.mjs wasn't updated, so every scheduled off-site run 404'd on the dead URL and the cron turn fired `notify urgent:true` naming it. The x64-only sha256 implied by the README bullet also had a silent coverage gap on arm64.

## How

New `verifyManifestDrift()` in healthcheck.mjs:

1. GET `manta-latest.txt`, parse `file_<arch>=` + `sha256_<arch>=` for every arch in `ARCH_KEYS`
2. For each arch: HEAD `<site>/releases/<file_<arch>=>` → expect 200
3. GET the same URL, sha256 it, compare to `sha256_<arch>=` → mismatch = failure

`SITE_URL` and `ARCH_KEYS = ["linux_x64", "linux_arm64"]` are exported as the single source of truth (mirror of `publish.sh`). `HEALTHCHECK_TARGETS` env override still filters ONLY the flat probes — the drift check runs unconditionally, since an off-site drift check is the whole point of the script. `runHealthcheck` calls it after the flat probes and merges the failures list.

Manifest entries with `/` or `..` or NULs are refused (path-traversal guard) — a corrupted manifest pointing outside `/releases/` is rejected as a manifest failure, never fetched.

## Tests

8 → 18 tests in `scripts/prod/healthcheck.test.mjs`:
- The previous "covers every surface" test is replaced with one that asserts the dead URL IS NOT probed and the live ones are.
- 10 new tests: `parseManifest` (happy path, empty input), `verifyManifestDrift` (happy path, manifest 404, missing arch keys, tarball HEAD 404, sha256 mismatch, path-traversal, empty siteUrl).
- Existing flat-probe tests updated to provide manifest + per-arch tarball handlers.

## Verification results

**Files changed:** `3` files. `README.md`, `scripts/prod/healthcheck.mjs`, `scripts/prod/healthcheck.test.mjs` (+466 / −49 lines).

- PR branch (`multica/BET-271-healthcheck-two-arch` @ `bc23b2d`):
  - typecheck: exit 0. Errors: none. log sha256: `f9ce168cdd0844f85954a91d4c9ba781ab6ac4bb98081d184e73113654e3bdd2`
  - test: exit 0, **742** pass / 0 fail / 0 skip. log sha256: `c6a7b5a2c575d91c3f1f96acd9a0db9b5e1c701ae0b992efe1ca5c5386e651a2`
- Base (`main` @ `9e0fdc9`):
  - typecheck: exit 0. Errors: none. log sha256: `f9ce168cdd0844f85954a91d4c9ba781ab6ac4bb98081d184e73113654e3bdd2`
  - test: exit 0, **742** pass / 0 fail / 0 skip. log sha256: `7aa658a458643514dc64c812ec86267e0fbe2f73b4c2cfb78e5894f357f5c86f`
- **Conclusion:** 0 test failures pre-existing, 0 new, 0 resolved. Healthcheck test file grew from 8 → 18 cases; rest of the suite unchanged.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

## Out of scope (flagged for follow-up, not in this PR)

- **README.md:232-240** ("Rollback" block) still says `cp -f manta-<prev-version>.tar.gz manta-latest.tar.gz` — that file no longer exists post-Stage-2 either, so the documented rollback is dead. Same drift class as the healthcheck bug but a separate fix.

Base: `origin/main` @ `9e0fdc9`