### PR TITLE
feat(install): Tailscale ingress path — skip Caddy/DNS, pair over tailnet (BET-267)

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -435,6 +435,80 @@ export function mergeGatewayAuth(
 }
 
 // ---------------------------------------------------------------------------
+// Tailscale status parser — pure (BET-267).
+//
+// `tailscale status --json` returns a large JSON blob; the only fields we need
+// are `BackendState` (must be exactly "Running") and `Self.TailscaleIPs` (a
+// string array; we want the FIRST IPv4 — Tailscale's order is stable and IPv4
+// comes first on a typical box, but we don't rely on it: we filter).
+//
+// Returns `{ ip: string }` on success, `null` for any failure: invalid JSON,
+// BackendState != "Running", missing TailscaleIPs, or no IPv4 in the list. Raw
+// IP only — we deliberately do NOT return the MagicDNS name. Plain HTTP over
+// the WireGuard tunnel needs the raw IP (MagicDNS resolution requires the
+// `tailscale0` interface up on the requester).
+//
+// IPv4 regex is intentionally permissive (`\d{1,3}` per octet, not `0-255`) —
+// the caller doesn't need to validate octet ranges, just that the shape is
+// dotted-quad. A Tailscale-allocated IP is always a valid 100.64.0.0/10
+// address, so an over-permissive regex is harmless here.
+// ---------------------------------------------------------------------------
+const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+export function parseTailscaleStatus(jsonText) {
+  if (typeof jsonText !== "string" || jsonText.trim() === "") return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  if (parsed.BackendState !== "Running") return null;
+  const ips = parsed?.Self?.TailscaleIPs;
+  if (!Array.isArray(ips)) return null;
+  for (const candidate of ips) {
+    if (typeof candidate === "string" && IPV4_RE.test(candidate)) {
+      return { ip: candidate };
+    }
+  }
+  return null;
+}
+
+// Build the ingress.json payload — pure helper. Validates that tailscale mode
+// carries both an IP and a port (the CLI subcommand below also enforces this,
+// but the pure form lets the test assert without spawning a subprocess).
+//
+// Returns { ok: true, text, changed } | { ok: false, error }.
+//   text is the rendered JSON (pretty-printed + trailing newline, matching the
+//   mergeGatewayAuth output shape so the on-disk style stays consistent).
+//   changed reflects whether the new JSON differs from the existing text (used
+//   to avoid needless atomic writes on a re-run with identical state).
+const INGRESS_MODES = new Set(["public", "tailscale"]);
+export function buildIngressJson(
+  existingText,
+  { mode, tailnetIp, port } = {},
+) {
+  if (!INGRESS_MODES.has(mode)) {
+    return { ok: false, error: `buildIngressJson: mode must be "public" or "tailscale" (got ${JSON.stringify(mode)})` };
+  }
+  let next;
+  if (mode === "tailscale") {
+    if (typeof tailnetIp !== "string" || !IPV4_RE.test(tailnetIp)) {
+      return { ok: false, error: "buildIngressJson: tailscale mode requires tailnetIp (IPv4)" };
+    }
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      return { ok: false, error: "buildIngressJson: tailscale mode requires port (1-65535)" };
+    }
+    next = { mode: "tailscale", tailnetIp, serverUrl: `http://${tailnetIp}:${port}` };
+  } else {
+    next = { mode: "public" };
+  }
+  const text = JSON.stringify(next, null, 2) + "\n";
+  const changed = text !== (typeof existingText === "string" ? existingText : "");
+  return { ok: true, text, changed };
+}
+
+// ---------------------------------------------------------------------------
 // DNS-resolution poller — pure, used by install.sh after gateway registration
 // (BET-205 WP5). Once the box has registered with the gateway, OVH needs a
 // few seconds to publish the new A record (<box_id>.boxes.mantaui.com). We
@@ -726,16 +800,33 @@ export function formatPairingOutput(
     lines.push(`       ${DESKTOP_DMG_URL}`);
     lines.push("");
     lines.push("  2. Pair it — click this link, or paste it into the app's Connect screen");
-    const pairLink = buildPairLink(box_id, pairing_code);
-    lines.push(`       Pair page:     ${buildPairPageUrl(box_id, pairing_code)}`);
-    lines.push(`       ${pairLink}`);
+    // BET-267: when a non-public serverUrl is provided (tailscale path), the
+    // pair-page URL and the QR must point at THAT base. We also drop the
+    // `manta://pair?…` deep-link line: the resolver on the mobile/desktop side
+    // routes that link through `boxDirectUrl` → `https://<boxId>.boxes.mantaui.com`,
+    // which is unreachable on the tailscale path. The pair-page URL is the
+    // single source of truth for the connect block in tailscale mode.
+    const useServerUrl = typeof serverUrl === "string" && serverUrl !== "";
+    const pairPageUrl = buildPairPageUrl(box_id, pairing_code, {
+      baseUrl: useServerUrl ? serverUrl : undefined,
+    });
+    lines.push(`       Pair page:     ${pairPageUrl}`);
+    if (!useServerUrl) {
+      // Public path keeps the manta:// deep link for one-tap mobile pairing.
+      const pairLink = buildPairLink(box_id, pairing_code);
+      lines.push(`       ${pairLink}`);
+    }
     lines.push("");
     lines.push("  3. iPhone (optional) — scan the QR below with your camera");
     lines.push(`       App download: ${IOS_APP_URL}  (App Store link coming soon)`);
     lines.push("");
+    // QR encodes the pair-page URL when a serverUrl is in play (the QR has to
+    // open a URL the scanning device can actually reach), the manta:// link
+    // otherwise (preserves the old wire shape for the public install).
+    const qrPayload = useServerUrl ? pairPageUrl : buildPairLink(box_id, pairing_code);
     let qr;
     try {
-      qr = qrRender(pairLink);
+      qr = qrRender(qrPayload);
     } catch {
       // qrcode-terminal missing / broken (e.g. a dev's stripped node_modules) —
       // degrade to text-only rather than crash the install. The QR is a
@@ -815,13 +906,24 @@ export function buildPairLink(boxId, code) {
  * Pair-page URL — the ONE link a fresh install reports. Fragment carries the
  * code so it never reaches server logs; the page derives the box id from its
  * own hostname. Shares buildPairLink's validation rules.
+ *
+ * `options.baseUrl` (BET-267): when the box is reached over a non-public
+ * ingress (currently Tailscale), the pair-page URL must use THAT base, not the
+ * canonical `<boxId>.boxes.mantaui.com`. The fragment (#code=) is preserved
+ * so the page still gets the code from the URL fragment and the box id from
+ * the host header. The boxId regex check is skipped in that mode — the page
+ * derives the box id from the request's host header, not from the URL path.
  */
-export function buildPairPageUrl(boxId, code) {
+export function buildPairPageUrl(boxId, code, { baseUrl } = {}) {
   if (!/^[0-9a-f]{32}$/.test(boxId ?? "")) {
     throw new Error("buildPairPageUrl: boxId must be a 32-hex token");
   }
   if (!/^[0-9]{6}$/.test(code ?? "")) {
     throw new Error("buildPairPageUrl: code must be 6 digits");
+  }
+  if (typeof baseUrl === "string" && baseUrl !== "") {
+    const trimmed = baseUrl.replace(/\/+$/, "");
+    return `${trimmed}/pair#code=${code}`;
   }
   return `https://${boxId}.boxes.mantaui.com/pair#code=${code}`;
 }
@@ -1092,9 +1194,97 @@ async function cliMain(argv) {
     process.stdout.write(JSON.stringify(status) + "\n");
     return 0;
   }
+  if (cmd === "parse-tailscale-status") {
+    // node install-lib.mjs parse-tailscale-status
+    // Reads ALL of stdin (the JSON output of `tailscale status --json`), and
+    // on success prints the chosen Tailscale IPv4 to stdout (no trailing
+    // newline — install.sh's `$()` capture strips them anyway, and a stray
+    // newline would leak into the systemd unit). On any failure exits 1
+    // silently so install.sh's `||` short-circuits the tailscale path.
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    const raw = Buffer.concat(chunks).toString("utf-8");
+    const res = parseTailscaleStatus(raw);
+    if (res === null) {
+      return 1;
+    }
+    process.stdout.write(res.ip);
+    return 0;
+  }
+  if (cmd === "write-ingress") {
+    // node install-lib.mjs write-ingress --file <path> --mode <public|tailscale>
+    //                                 [--tailnet-ip <ip>] [--port <N>]
+    // Persists the install's ingress decision to <file> (default:
+    // ~/.manta/ingress.json) atomically (write <path>.tmp then rename + 0600).
+    // `tailscale` mode REQUIRES --tailnet-ip AND --port — they're used to
+    // derive the serverUrl the device side connects to. On a no-op rewrite
+    // (existing file already matches) we still go through the atomic write
+    // path so permissions are normalised, but `changed=0` is reported so
+    // callers can log if they care.
+    const filePath = flags.file;
+    const mode = flags.mode;
+    if (!filePath) {
+      process.stderr.write("write-ingress: --file <path> required\n");
+      return 2;
+    }
+    if (mode !== "public" && mode !== "tailscale") {
+      process.stderr.write(`write-ingress: --mode must be "public" or "tailscale" (got ${JSON.stringify(mode ?? "")})\n`);
+      return 2;
+    }
+    let tailnetIp;
+    let port;
+    if (mode === "tailscale") {
+      tailnetIp = flags["tailnet-ip"];
+      if (!tailnetIp) {
+        process.stderr.write("write-ingress: tailscale mode requires --tailnet-ip <ip>\n");
+        return 2;
+      }
+      const portStr = flags.port;
+      const portNum = portStr ? Number(portStr) : NaN;
+      if (!Number.isInteger(portNum) || portNum <= 0 || portNum > 65535) {
+        process.stderr.write("write-ingress: tailscale mode requires --port <N> (1-65535)\n");
+        return 2;
+      }
+      port = portNum;
+    }
+    const { existsSync: existsSyncLocal, readFileSync: readFileSyncLocal, mkdirSync, writeFileSync, renameSync, chmodSync } = await import("node:fs");
+    const { dirname: dirnameLocal } = await import("node:path");
+    let existing = "";
+    if (existsSyncLocal(filePath)) {
+      try {
+        existing = readFileSyncLocal(filePath, "utf-8");
+      } catch (e) {
+        process.stderr.write(`write-ingress: read failed: ${e?.message ?? e}\n`);
+        return 1;
+      }
+    }
+    const res = buildIngressJson(existing, { mode, tailnetIp, port });
+    if (!res.ok) {
+      process.stderr.write(`write-ingress: ${res.error}\n`);
+      return 1;
+    }
+    try {
+      mkdirSync(dirnameLocal(filePath), { recursive: true });
+      writeFileSync(`${filePath}.tmp`, res.text);
+      renameSync(`${filePath}.tmp`, filePath);
+      // 0600 — same shape as auth.json; the file's only "secret" is the IP
+      // (not strictly sensitive), but matching the auth.json convention keeps
+      // a single chmod policy for everything in ~/.manta/.
+      try {
+        chmodSync(filePath, 0o600);
+      } catch {
+        // chmod can fail on weird fs (e.g. FAT mounts); ignore.
+      }
+    } catch (e) {
+      process.stderr.write(`write-ingress: write failed: ${e?.message ?? e}\n`);
+      return 1;
+    }
+    process.stderr.write(`changed=${res.changed ? "1" : "0"}\n`);
+    return 0;
+  }
   process.stderr.write(
     `install-lib: unknown command ${JSON.stringify(cmd)}\n` +
-      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|merge-gateway|wait-for-dns|render-caddy-vhost|detect-distro|render-systemd-unit> [--version X] [--file P] [--template P] [--hostname H] [--expected-ip IP] [--max-attempts N] [--interval-ms MS] [--box-id ID] [--port N] [--mode M] [--os-release PATH] [--placeholder K=V]\n",
+      "  usage: node install-lib.mjs <print-config|check-identity|merge-opencode-config|merge-gateway|wait-for-dns|render-caddy-vhost|detect-distro|render-systemd-unit|parse-tailscale-status|write-ingress> [--version X] [--file P] [--template P] [--hostname H] [--expected-ip IP] [--max-attempts N] [--interval-ms MS] [--box-id ID] [--port N] [--mode M] [--os-release PATH] [--tailnet-ip IP] [--placeholder K=V]\n",
   );
   return 2;
 }
@@ -1118,6 +1308,7 @@ function parseFlags(args) {
     "port",
     "mode",
     "os-release",
+    "tailnet-ip",
   ]);
   for (let i = 0; i < args.length; i++) {
     const tok = args[i];

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -508,6 +508,46 @@ main() {
   # ---------------------------------------------------------------------------
   # 7. manta-server systemd --user unit: substitute placeholders and enable.
   # ---------------------------------------------------------------------------
+
+  # --- Ingress mode (BET-267) ----------------------------------------------
+  # Resolved BEFORE step 7 so the systemd unit template can be rendered
+  # with the correct MANTA_TAILNET_HOST value (empty on public path, the
+  # Tailscale IPv4 on the tailnet path). The decision is persisted to
+  # ~/.manta/ingress.json as the single source of truth for `manta pair`
+  # (which has no access to the install's env vars).
+  #
+  # MANTA_INGRESS: auto (default — tailnet iff Tailscale is up) | public |
+  # tailscale (force tailnet; die if detection fails).
+  MANTA_INGRESS="${MANTA_INGRESS:-auto}"
+  TAILNET_IP=""
+  case "$MANTA_INGRESS" in
+    public) ;;
+    tailscale)
+      TAILNET_IP="$(detect_tailscale_ip)" \
+        || die "MANTA_INGRESS=tailscale but Tailscale is not running (need 'tailscale status' BackendState=Running with an IPv4). Start tailscale, or use MANTA_INGRESS=public."
+      ;;
+    auto)
+      TAILNET_IP="$(detect_tailscale_ip 2>/dev/null || true)"
+      ;;
+    *) die "MANTA_INGRESS must be auto, public, or tailscale (got: $MANTA_INGRESS)" ;;
+  esac
+  INGRESS_MODE="public"
+  if [ -n "$TAILNET_IP" ]; then INGRESS_MODE="tailscale"; fi
+
+  # Persist the decision. write-ingress creates the parent dir if missing
+  # and writes 0600 atomically (write <file>.tmp then rename).
+  INGRESS_JSON="$AUTH_DIR/ingress.json"
+  if [ "$DRY_RUN" = "1" ]; then
+    dry_log "would persist ingress decision to $INGRESS_JSON (mode=$INGRESS_MODE${TAILNET_IP:+, tailnetIp=$TAILNET_IP})"
+  else
+    ING_ARGS=("$NODE" "$LIB" write-ingress --file "$INGRESS_JSON" --mode "$INGRESS_MODE")
+    if [ -n "$TAILNET_IP" ]; then
+      ING_ARGS+=(--tailnet-ip "$TAILNET_IP" --port "$MANTA_PORT")
+    fi
+    "${ING_ARGS[@]}" >/dev/null 2>/tmp/manta-ingress.err \
+      || warn "write-ingress failed (see /tmp/manta-ingress.err) — \`manta pair\` will fall back to public-default connect block."
+  fi
+
   UNIT_SRC="$MANTA_HOME/scripts/systemd/manta-server.service"
   [ -f "$UNIT_SRC" ] || die "missing systemd template: $UNIT_SRC"
 
@@ -518,6 +558,7 @@ main() {
       -e "s|@@MANTA_HOME@@|$MANTA_HOME|g" \
       -e "s|@@NODE_BIN@@|$NODE|g" \
       -e "s|@@MANTA_PORT@@|$MANTA_PORT|g" \
+      -e "s|@@MANTA_TAILNET_HOST@@|$TAILNET_IP|g" \
       "$UNIT_SRC" > "$UNIT_DIR/manta-server.service"
 
     # Survive logout/reboot without an active session.
@@ -531,7 +572,7 @@ main() {
   else
     warn "systemctl not found (not a systemd host?). Starting the server in the background instead."
     warn "It will NOT survive reboot — set up your own supervisor for that."
-    ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
+    ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" MANTA_TAILNET_HOST="$TAILNET_IP" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
     SERVER_MANAGED=nohup
   fi
 
@@ -556,6 +597,21 @@ main() {
         process.stdout.write(id?.box_id ?? "");
       }).catch(() => process.stdout.write(""));
     ' 2>/dev/null || true
+  }
+
+  # detect_tailscale_ip — wrapper around `tailscale status --json` piped
+  # through the lib's `parse-tailscale-status` subcommand. Returns the
+  # detected Tailscale IPv4 on stdout, exit 0 — OR exits 1 with no output
+  # when Tailscale is missing / not running / has no IPv4. install.sh uses
+  # the exit code to drive the INGRESS_MODE decision (BET-267).
+  #
+  # Silent on stderr by design: install.sh logs the result separately so
+  # we never want a `tailscale: command not found` warning to leak through
+  # the box's user-facing output (the absence of tailscale is normal on
+  # the public-path install).
+  detect_tailscale_ip() {
+    command -v tailscale >/dev/null 2>&1 || return 1
+    tailscale status --json 2>/dev/null | "$NODE" "$LIB" parse-tailscale-status
   }
 
   # ===========================================================================
@@ -613,8 +669,15 @@ main() {
   # (the dry_log lines are below). In real mode we bail with a clear
   # bring-your-own-proxy hint when distro isn't Debian/Ubuntu or sudo
   # isn't usable.
+  #
+  # Tailscale path (BET-267): distro / sudo checks are irrelevant — no sudo
+  # is needed at all on the tailnet path (the whole point is "skip Caddy +
+  # public DNS"). PRIVILEGED_SECTION_SKIP is left at 0 so sub-steps B + C
+  # (gateway register + merge-gateway) still run — they are user-space and
+  # the gateway_token is still needed for APNs push. A/D/E/port-check/reload
+  # are gated on `INGRESS_MODE != tailscale` further down.
   PRIVILEGED_SECTION_SKIP=0
-  if [ "$DRY_RUN" != "1" ]; then
+  if [ "$DRY_RUN" != "1" ] && [ "$INGRESS_MODE" != "tailscale" ]; then
     # Distro check (Debian/Ubuntu only for v1 — see reviewer guidance §4).
     DISTRO_STATUS="$("$NODE" "$LIB" detect-distro 2>/dev/null || echo "")"
     DISTRO_SUPPORTED="$(printf '%s' "$DISTRO_STATUS" | "$NODE" -e '
@@ -670,12 +733,73 @@ main() {
     fi
   fi
 
-  if [ "$PRIVILEGED_SECTION_SKIP" = "1" ]; then
+  if [ "$INGRESS_MODE" = "tailscale" ]; then
+    # Tailscale path (BET-267): skip Caddy install + DNS wait + vhost write +
+    # port-check + caddy reload. B/C (gateway register + merge-gateway) still
+    # run below — the gateway_token is still needed for APNs push.
+    log "Tailscale detected ($TAILNET_IP) — skipping Caddy + public DNS; devices connect over the tailnet."
+  elif [ "$PRIVILEGED_SECTION_SKIP" = "1" ]; then
     log "Skipping public-TLS step (bring-your-own-proxy keeps the rest of the install working)."
   else
     log "Configuring public TLS via Caddy + gateway registration (privileged)…"
+  fi
 
-    # --- A. Install Caddy if absent ------------------------------------------
+  # --- B/C. Register with the gateway + persist gateway_token -------------
+  # B (POST /register) and C (merge-gateway into auth.json) are user-space and
+  # run in BOTH ingress modes. On tailscale the gateway records an A record
+  # that is unused but harmless; the persisted gateway_token is still the
+  # APNs push credential (BET-198). Skipped entirely only on distro/sudo
+  # failure (PRIVILEGED_SECTION_SKIP=1) where the rest of the section is
+  # being skipped.
+  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ]; then
+    BOX_ID_FOR_GATEWAY="$(read_box_id_for_gateway)"
+
+    if [ -z "$BOX_ID_FOR_GATEWAY" ]; then
+      warn "no box_id in $MANTA_AUTH_FILE yet — skipping gateway registration."
+      warn "  start the manta-server at least once (systemctl --user restart manta-server) and re-run."
+    else
+      GATEWAY_BASE="${MANTA_GATEWAY_BASE:-https://gateway.mantaui.com}"
+      # Use the existing gateway_token if present so re-registration is an
+      # idempotent IP refresh; otherwise POST /register with no auth and the
+      # gateway returns a fresh token + host. The gateway response always
+      # carries {host}; the token is only present on first registration.
+      PRIOR_TOKEN="$("$NODE" -e '
+        const fs = require("node:fs");
+        try {
+          const a = JSON.parse(fs.readFileSync(process.env.MANTA_AUTH_FILE, "utf-8"));
+          process.stdout.write(typeof a?.gateway_token === "string" ? a.gateway_token : "");
+        } catch { process.stdout.write(""); }
+      ' 2>/dev/null || true)"
+
+      if [ "$DRY_RUN" = "1" ]; then
+        dry_log "would POST $GATEWAY_BASE/register with box_id=$BOX_ID_FOR_GATEWAY (prior_token=${PRIOR_TOKEN:+set})"
+        dry_log "would persist gateway response into $MANTA_AUTH_FILE via merge-gateway"
+      else
+        log "Registering with gateway $GATEWAY_BASE/register…"
+        REGISTER_ARGS=(-fsSL -X POST -H "content-type: application/json" --data "$(printf '{"box_id":"%s"}' "$BOX_ID_FOR_GATEWAY")")
+        if [ -n "$PRIOR_TOKEN" ]; then
+          REGISTER_ARGS+=(-H "authorization: Bearer $PRIOR_TOKEN")
+        fi
+        GW_RESP="$(curl "${REGISTER_ARGS[@]}" "$GATEWAY_BASE/register")" \
+          || { warn "gateway registration POST failed — the box will retry on every server restart.
+            Pair the device via SSH port-forward or use a non-gateway ingress until this works."; GW_RESP=""; }
+        if [ -n "$GW_RESP" ]; then
+          # Pipe the JSON to merge-gateway via stdin (lib subcommand) so the
+          # auth.json write is atomic temp-rename + 0600, preserving
+          # box_id / box_token / created_at.
+          printf '%s' "$GW_RESP" | "$NODE" "$LIB" merge-gateway --file "$MANTA_AUTH_FILE" 2>/tmp/manta-gateway-merge.err \
+            || warn "merge-gateway failed (see /tmp/manta-gateway-merge.err) — the server will re-register on next boot."
+          ok "gateway registration complete."
+        fi
+      fi
+    fi
+  fi
+
+  # --- A. Install Caddy if absent ------------------------------------------
+  # A, D, E/port-check/reload only run on the public path (BET-267). The
+  # tailscale path never binds :80/:443, never writes a Caddy vhost, never
+  # waits on DNS, never reloads Caddy.
+  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$INGRESS_MODE" != "tailscale" ]; then
     if command -v caddy >/dev/null 2>&1; then
       ok "caddy already installed ($(caddy version 2>/dev/null || echo unknown))."
     elif [ "$DRY_RUN" = "1" ]; then
@@ -743,53 +867,11 @@ main() {
         || die "apt-get install caddy failed"
       ok "caddy installed ($(caddy version 2>/dev/null || echo unknown))."
     fi
+  fi
 
-    # --- B/C. Register with the gateway + persist gateway_token -------------
-  # Read box_id from auth.json (the server's first start minted it). Skip
-  # the registration block entirely if we can't find one — a re-run before
-  # the server has booted at least once has no box_id to register.
-  BOX_ID_FOR_GATEWAY="$(read_box_id_for_gateway)"
-
-  if [ -z "$BOX_ID_FOR_GATEWAY" ]; then
-    warn "no box_id in $MANTA_AUTH_FILE yet — skipping gateway registration + Caddy setup."
-    warn "  start the manta-server at least once (systemctl --user restart manta-server) and re-run."
-  else
-    GATEWAY_BASE="${MANTA_GATEWAY_BASE:-https://gateway.mantaui.com}"
-    # Use the existing gateway_token if present so re-registration is an
-    # idempotent IP refresh; otherwise POST /register with no auth and the
-    # gateway returns a fresh token + host. The gateway response always
-    # carries {host}; the token is only present on first registration.
-    PRIOR_TOKEN="$("$NODE" -e '
-      const fs = require("node:fs");
-      try {
-        const a = JSON.parse(fs.readFileSync(process.env.MANTA_AUTH_FILE, "utf-8"));
-        process.stdout.write(typeof a?.gateway_token === "string" ? a.gateway_token : "");
-      } catch { process.stdout.write(""); }
-    ' 2>/dev/null || true)"
-
-    if [ "$DRY_RUN" = "1" ]; then
-      dry_log "would POST $GATEWAY_BASE/register with box_id=$BOX_ID_FOR_GATEWAY (prior_token=${PRIOR_TOKEN:+set})"
-      dry_log "would persist gateway response into $MANTA_AUTH_FILE via merge-gateway"
-    else
-      log "Registering with gateway $GATEWAY_BASE/register…"
-      REGISTER_ARGS=(-fsSL -X POST -H "content-type: application/json" --data "$(printf '{"box_id":"%s"}' "$BOX_ID_FOR_GATEWAY")")
-      if [ -n "$PRIOR_TOKEN" ]; then
-        REGISTER_ARGS+=(-H "authorization: Bearer $PRIOR_TOKEN")
-      fi
-      GW_RESP="$(curl "${REGISTER_ARGS[@]}" "$GATEWAY_BASE/register")" \
-        || { warn "gateway registration POST failed — the box will retry on every server restart.
-          Pair the device via SSH port-forward or use a non-gateway ingress until this works."; GW_RESP=""; }
-      if [ -n "$GW_RESP" ]; then
-        # Pipe the JSON to merge-gateway via stdin (lib subcommand) so the
-        # auth.json write is atomic temp-rename + 0600, preserving
-        # box_id / box_token / created_at.
-        printf '%s' "$GW_RESP" | "$NODE" "$LIB" merge-gateway --file "$MANTA_AUTH_FILE" 2>/tmp/manta-gateway-merge.err \
-          || warn "merge-gateway failed (see /tmp/manta-gateway-merge.err) — the server will re-register on next boot."
-        ok "gateway registration complete."
-      fi
-    fi
-
-    # --- D. Poll DNS until <box_id>.boxes.mantaui.com resolves to us -------
+  # --- D. Poll DNS until <box_id>.boxes.mantaui.com resolves to us -------
+  # Public path only (BET-267); the tailnet path has no DNS wait.
+  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$INGRESS_MODE" != "tailscale" ]; then
     # Re-read gateway_host (or default to the canonical pattern if the
     # gateway didn't return one yet) for the polling target.
     GATEWAY_HOST="$("$NODE" -e '
@@ -970,7 +1052,6 @@ main() {
       fi
     fi
   fi
-  fi # close: if [ "$PRIVILEGED_SECTION_SKIP" = "1" ] (step 7.5 wrapper)
 
   # ---------------------------------------------------------------------------
   # 8. Wait for health, then mint + print a pairing code. Devices connect
@@ -1033,14 +1114,29 @@ Chat backend (opencode-serve) on http://127.0.0.1:4096:
 EOF
 
   # Trailing-pairing block — direct mode only. The Box ID line and the footer
-  # are always printed.
-  cat <<EOF
+  # are always printed. The "how does this box reach the internet" line varies
+  # by ingress mode (BET-267): on the public path Caddy terminates TLS at
+  # https://<box_id>.boxes.mantaui.com; on the tailscale path the server binds
+  # a second listener on the Tailscale interface at http://<tailscale-ip>:<port>
+  # (plain HTTP — WireGuard encrypts the hop), and no public DNS / Caddy is
+  # involved.
+  if [ "$INGRESS_MODE" = "tailscale" ]; then
+    cat <<EOF
+
+Tailscale detected ($TAILNET_IP) — your box is reachable over the tailnet at
+http://$TAILNET_IP:$MANTA_PORT (plain HTTP; WireGuard encrypts the hop). No public
+DNS, no Caddy, no Let's Encrypt on this path. Devices on the same tailnet can
+connect directly; off-tailnet devices need Tailscale access first.
+EOF
+  else
+    cat <<EOF
 
 Your box serves its own public hostname — https://<box_id>.boxes.mantaui.com
 (Caddy on this box terminates TLS and reverse-proxies 127.0.0.1:8787). The
 desktop / mobile app discovers it directly via the box_id below; no relay,
 no tunnel, no dial-out.
 EOF
+  fi
 
   cat <<EOF
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -509,6 +509,30 @@ main() {
   # 7. manta-server systemd --user unit: substitute placeholders and enable.
   # ---------------------------------------------------------------------------
 
+  # detect_tailscale_ip — wrapper around `tailscale status --json` piped
+  # through the lib's `parse-tailscale-status` subcommand. Returns the
+  # detected Tailscale IPv4 on stdout, exit 0 — OR exits 1 with no output
+  # when Tailscale is missing / not running / has no IPv4. install.sh uses
+  # the exit code to drive the INGRESS_MODE decision (BET-267).
+  #
+  # HOISTED ABOVE the mode-resolution block (BET-267 review fix): bash does
+  # NOT forward-reference function definitions within the same function, so
+  # defining this AFTER its call sites (the original placement, near
+  # read_box_id_for_gateway) silently failed with
+  # `detect_tailscale_ip: command not found` and the auto branch fell through
+  # to public mode even when Tailscale was running. Moving the definition
+  # above the call sites is the minimal fix; `bash -n` parses but does not
+  # execute, so this only shows up under real (or DRY_RUN=1) tracing.
+  #
+  # Silent on stderr by design: install.sh logs the result separately so
+  # we never want a `tailscale: command not found` warning to leak through
+  # the box's user-facing output (the absence of tailscale is normal on
+  # the public-path install).
+  detect_tailscale_ip() {
+    command -v tailscale >/dev/null 2>&1 || return 1
+    tailscale status --json 2>/dev/null | "$NODE" "$LIB" parse-tailscale-status
+  }
+
   # --- Ingress mode (BET-267) ----------------------------------------------
   # Resolved BEFORE step 7 so the systemd unit template can be rendered
   # with the correct MANTA_TAILNET_HOST value (empty on public path, the
@@ -597,21 +621,6 @@ main() {
         process.stdout.write(id?.box_id ?? "");
       }).catch(() => process.stdout.write(""));
     ' 2>/dev/null || true
-  }
-
-  # detect_tailscale_ip — wrapper around `tailscale status --json` piped
-  # through the lib's `parse-tailscale-status` subcommand. Returns the
-  # detected Tailscale IPv4 on stdout, exit 0 — OR exits 1 with no output
-  # when Tailscale is missing / not running / has no IPv4. install.sh uses
-  # the exit code to drive the INGRESS_MODE decision (BET-267).
-  #
-  # Silent on stderr by design: install.sh logs the result separately so
-  # we never want a `tailscale: command not found` warning to leak through
-  # the box's user-facing output (the absence of tailscale is normal on
-  # the public-path install).
-  detect_tailscale_ip() {
-    command -v tailscale >/dev/null 2>&1 || return 1
-    tailscale status --json 2>/dev/null | "$NODE" "$LIB" parse-tailscale-status
   }
 
   # ===========================================================================

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -20,6 +20,8 @@ import {
   stripJsoncLineComments,
   mergeOpencodeConfig,
   mergeGatewayAuth,
+  parseTailscaleStatus,
+  buildIngressJson,
   waitForDns,
   renderCaddyVhost,
   readOsReleaseIds,
@@ -2266,4 +2268,305 @@ echo "RELOAD_RAN=$RELOAD_RAN"
   });
   assert.match(out, /PORT_CHECK_RAN=1/);
   assert.match(out, /RELOAD_RAN=1/);
+});
+
+// ----------------------------------------------------------------------------
+// Tailscale ingress path (BET-267)
+//
+// install.sh's tailscale detection drives an "INGRESS_MODE=tailscale" branch
+// that skips Caddy/DNS and pairs over http://<tailscale-ip>:<port>. The pure
+// helpers + CLI subcommands live in install-lib.mjs and are tested here
+// directly; the bash orchestration tests above pin the gate behavior.
+// ----------------------------------------------------------------------------
+
+test("parseTailscaleStatus returns the first IPv4 when BackendState is Running", () => {
+  // The headlining acceptance criterion for BET-267's Tailscale detection:
+  // given a real `tailscale status --json` blob (or a faithful fixture),
+  // parseTailscaleStatus returns the IPv4 the installer is going to bind
+  // its tailnet listener to.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5", "fd7a:115c:a1e0::1"] },
+  });
+  const res = parseTailscaleStatus(fixture);
+  assert.deepEqual(res, { ip: "100.64.1.5" });
+});
+
+test("parseTailscaleStatus picks IPv4 even when IPv6 comes first in the list", () => {
+  // Tailscale returns an array in a stable order, but we MUST NOT rely on
+  // it — IPv6 may be listed first on some boxes / daemons. The function
+  // filters for the first IPv4-shaped entry.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["fd7a:115c:a1e0::1", "fd00::1", "100.99.99.99"] },
+  });
+  const res = parseTailscaleStatus(fixture);
+  assert.deepEqual(res, { ip: "100.99.99.99" });
+});
+
+test("parseTailscaleStatus returns null when BackendState is not Running", () => {
+  const fixture = JSON.stringify({
+    BackendState: "Stopped",
+    Self: { TailscaleIPs: ["100.64.1.5"] },
+  });
+  assert.equal(parseTailscaleStatus(fixture), null);
+});
+
+test("parseTailscaleStatus returns null when Self.TailscaleIPs is missing", () => {
+  const fixture = JSON.stringify({ BackendState: "Running" });
+  assert.equal(parseTailscaleStatus(fixture), null);
+});
+
+test("parseTailscaleStatus returns null when only IPv6 addresses are present", () => {
+  // The function deliberately filters on `\d+\.\d+\.\d+\.\d+` so an
+  // IPv6-only tailnet (rare, but possible) does NOT bind a listener on
+  // an unreachable address — installer falls back to public mode.
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["fd7a:115c:a1e0::1", "fd7a:115c:a1e0::2"] },
+  });
+  assert.equal(parseTailscaleStatus(fixture), null);
+});
+
+test("parseTailscaleStatus returns null on invalid JSON", () => {
+  assert.equal(parseTailscaleStatus("{ not json"), null);
+  assert.equal(parseTailscaleStatus(""), null);
+  assert.equal(parseTailscaleStatus(null), null);
+});
+
+test("buildIngressJson tailscale mode emits {mode, tailnetIp, serverUrl}", () => {
+  // The install persists this exact shape to ~/.manta/ingress.json on
+  // the tailnet path; `manta pair` reads it back to compose the connect
+  // block. serverUrl is derived from tailnetIp + port so the two never
+  // drift.
+  const res = buildIngressJson("", {
+    mode: "tailscale",
+    tailnetIp: "100.64.1.5",
+    port: 8787,
+  });
+  assert.equal(res.ok, true);
+  const parsed = JSON.parse(res.text);
+  assert.deepEqual(parsed, {
+    mode: "tailscale",
+    tailnetIp: "100.64.1.5",
+    serverUrl: "http://100.64.1.5:8787",
+  });
+  assert.equal(res.changed, true);
+});
+
+test("buildIngressJson tailscale mode requires a valid IPv4 + port", () => {
+  const missingIp = buildIngressJson("", { mode: "tailscale", port: 8787 });
+  assert.equal(missingIp.ok, false);
+  assert.match(missingIp.error, /tailnetIp/);
+  const badIp = buildIngressJson("", { mode: "tailscale", tailnetIp: "fd00::1", port: 8787 });
+  assert.equal(badIp.ok, false);
+  const missingPort = buildIngressJson("", { mode: "tailscale", tailnetIp: "100.64.1.5" });
+  assert.equal(missingPort.ok, false);
+  assert.match(missingPort.error, /port/);
+  const badPort = buildIngressJson("", { mode: "tailscale", tailnetIp: "100.64.1.5", port: 99999 });
+  assert.equal(badPort.ok, false);
+});
+
+test("buildIngressJson public mode emits {mode:'public'} and reports no change on re-run", () => {
+  const res = buildIngressJson("", { mode: "public" });
+  assert.equal(res.ok, true);
+  const parsed = JSON.parse(res.text);
+  assert.deepEqual(parsed, { mode: "public" });
+  assert.equal(res.changed, true);
+  // Re-running with the same shape is a no-op (changed=false) so the
+  // atomic write is skipped — a no-op rewrite would still be safe, but
+  // skipping it keeps a re-install truly idempotent.
+  const again = buildIngressJson(res.text, { mode: "public" });
+  assert.equal(again.ok, true);
+  assert.equal(again.changed, false);
+  assert.equal(again.text, res.text);
+});
+
+test("buildIngressJson rejects unknown modes", () => {
+  const res = buildIngressJson("", { mode: "cloudflared" });
+  assert.equal(res.ok, false);
+  assert.match(res.error, /must be "public" or "tailscale"/);
+});
+
+test("parse-tailscale-status CLI subcommand prints the IP on a running fixture", () => {
+  const fixture = JSON.stringify({
+    BackendState: "Running",
+    Self: { TailscaleIPs: ["100.64.1.5"] },
+  });
+  const out = execSync(
+    `node ${join(__dirname, "install-lib.mjs")} parse-tailscale-status`,
+    { input: fixture, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+  );
+  // No trailing newline: install.sh captures via `$()` which strips it,
+  // and a stray newline would leak into the systemd unit's environment line.
+  assert.equal(out, "100.64.1.5");
+});
+
+test("parse-tailscale-status CLI subcommand exits 1 on a stopped fixture", () => {
+  const fixture = JSON.stringify({
+    BackendState: "Stopped",
+    Self: { TailscaleIPs: ["100.64.1.5"] },
+  });
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} parse-tailscale-status`,
+      { input: fixture, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.fail("parse-tailscale-status must exit non-zero on Stopped backend");
+  } catch (e) {
+    assert.equal(e.status, 1);
+    assert.equal(e.stdout ?? "", "", "no stdout on failure");
+  }
+});
+
+test("write-ingress CLI subcommand persists tailscale mode with derived serverUrl", () => {
+  // Mirror of the merge-gateway test style (BET-267 inherits the same
+  // atomic-write + 0600 contract). The file's contents must round-trip
+  // exactly through JSON.parse so manta-pair.mjs's `cfg.authDir + ingress.json`
+  // read finds a serverUrl it can hand to formatPairingOutput.
+  const dir = mkdtempSync(join(tmpdir(), "manta-write-ingress-"));
+  const ingressFile = join(dir, "ingress.json");
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file ${ingressFile} --mode tailscale --tailnet-ip 100.64.1.5 --port 8787`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const written = JSON.parse(readFileSync(ingressFile, "utf-8"));
+    assert.deepEqual(written, {
+      mode: "tailscale",
+      tailnetIp: "100.64.1.5",
+      serverUrl: "http://100.64.1.5:8787",
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("write-ingress CLI subcommand persists public mode", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-write-ingress-public-"));
+  const ingressFile = join(dir, "ingress.json");
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file ${ingressFile} --mode public`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const written = JSON.parse(readFileSync(ingressFile, "utf-8"));
+    assert.deepEqual(written, { mode: "public" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("write-ingress CLI subcommand rejects tailscale without --tailnet-ip", () => {
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file /tmp/__no_tailnet__ --mode tailscale --port 8787`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.fail("write-ingress tailscale without --tailnet-ip must exit non-zero");
+  } catch (e) {
+    assert.match(e.stderr ?? "", /--tailnet-ip/);
+  }
+});
+
+test("write-ingress CLI subcommand rejects an unknown --mode", () => {
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file /tmp/__bad_mode__ --mode cloudflared`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.fail("write-ingress with unknown --mode must exit non-zero");
+  } catch (e) {
+    assert.match(e.stderr ?? "", /--mode must be/);
+  }
+});
+
+test("write-ingress CLI subcommand creates the parent dir if it does not exist", () => {
+  // Same safety-net the install relies on: ~/.manta/ is created on the
+  // first install. The lib uses mkdirSync({ recursive: true }), so the
+  // nested parent dir + the file land in one atomic write.
+  const dir = mkdtempSync(join(tmpdir(), "manta-write-ingress-nested-"));
+  const ingressFile = join(dir, "nested", "deeper", "ingress.json");
+  try {
+    execSync(
+      `node ${join(__dirname, "install-lib.mjs")} write-ingress ` +
+        `--file ${ingressFile} --mode public`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const written = JSON.parse(readFileSync(ingressFile, "utf-8"));
+    assert.deepEqual(written, { mode: "public" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildPairPageUrl accepts an explicit baseUrl (BET-267 tailnet path)", () => {
+  // When the install sets INGRESS_MODE=tailscale it passes the tailnet
+  // serverUrl as `baseUrl` so the pair page points at the box's Tailscale
+  // listener instead of <boxId>.boxes.mantaui.com (which would be
+  // unreachable on the tailnet path). The fragment (#code=) is preserved
+  // so the pair page still derives box_id from the request's host header.
+  const url = buildPairPageUrl(HEX32, "847291", { baseUrl: "http://100.64.1.5:8787" });
+  assert.equal(url, "http://100.64.1.5:8787/pair#code=847291");
+});
+
+test("buildPairPageUrl strips a trailing slash from baseUrl", () => {
+  // Defensive: install.sh's tailnet serverUrl is rendered with no
+  // trailing slash today, but if a future caller passes one (e.g. via an
+  // env var override), the helper must not produce a doubled slash in
+  // the final URL.
+  const url = buildPairPageUrl(HEX32, "847291", { baseUrl: "http://100.64.1.5:8787/" });
+  assert.equal(url, "http://100.64.1.5:8787/pair#code=847291");
+});
+
+test("buildPairPageUrl falls back to the canonical host when baseUrl is empty", () => {
+  // Empty baseUrl is treated the same as no option — preserves the public
+  // path's wire shape (regression guard against a future caller passing
+  // an unset env var through to the option).
+  const url = buildPairPageUrl(HEX32, "847291", { baseUrl: "" });
+  assert.equal(url, `https://${HEX32}.boxes.mantaui.com/pair#code=847291`);
+});
+
+test("formatPairingOutput uses serverUrl as the pair-page base on the tailnet path (BET-267)", () => {
+  // Headline acceptance criterion for BET-267 Branch A: when a non-public
+  // serverUrl is provided, the connect block must point at THAT base.
+  // The manta:// deep-link is dropped because the mobile/desktop resolver
+  // routes that link through `boxDirectUrl` → https://<boxId>.boxes.mantaui.com,
+  // which is unreachable on the tailnet path. The canonical
+  // boxes.mantaui.com hostname MUST NOT appear in the tailnet output
+  // (a stray one would mislead the device).
+  const out = formatPairingOutput({
+    pairing_code: "847291",
+    box_id: HEX32,
+    expiresAt: Date.UTC(2026, 6, 3, 12, 34, 56),
+    serverUrl: "http://100.64.1.5:8787",
+  });
+  assert.match(out, /Pair page:     http:\/\/100\.64\.1\.5:8787\/pair#code=847291/);
+  assert.doesNotMatch(out, /manta:\/\/pair/);
+  assert.doesNotMatch(out, /boxes\.mantaui\.com/);
+  // The footer (Pairing code / Box ID / Server URL) stays identical to
+  // the public-path shape — only the pair-page URL + dropped deep link
+  // change.
+  assert.match(out, /Server URL:    http:\/\/100\.64\.1\.5:8787/);
+  assert.match(out, /Pairing code:  847291/);
+  assert.match(out, /Box ID:        0123456789abcdef0123456789abcdef/);
+});
+
+test("formatPairingOutput keeps the manta:// deep-link on the public path (BET-267 regression guard)", () => {
+  // Companion to the above: when no serverUrl is passed (or a public
+  // https URL is), the existing wire shape (manta:// deep link +
+  // canonical boxes.mantaui.com pair page) MUST stay unchanged so a
+  // reinstall of an existing public box produces an identical connect
+  // block. Pin the exact strings.
+  const out = formatPairingOutput({
+    pairing_code: "847291",
+    box_id: HEX32,
+    expiresAt: Date.UTC(2026, 6, 3, 12, 34, 56),
+  });
+  assert.match(out, /Pair page:     https:\/\/0123456789abcdef0123456789abcdef\.boxes\.mantaui\.com\/pair#code=847291/);
+  assert.match(out, /manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291/);
 });

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -980,6 +980,47 @@ test("install.sh is bash-syntax-clean (bash -n)", () => {
   }
 });
 
+test("install.sh defines detect_tailscale_ip BEFORE every call site (BET-267 review regression)", () => {
+  // Regression guard for the BET-267 review finding: bash does NOT forward-
+  // reference function definitions within the same function body, so a
+  // detect_tailscale_ip() definition placed AFTER its call sites silently
+  // fails with `command not found`. The auto branch then falls through to
+  // public mode even when Tailscale is running, and the tailscale branch
+  // dies with a misleading "Tailscale is not running" message.
+  //
+  // `bash -n` parses the script but does not execute it, so it cannot catch
+  // this; we do a static-layout check instead — every $(detect_tailscale_ip…)
+  // call site must come after the function definition. Comments that mention
+  // the helper name in prose are explicitly excluded.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  const defMatch = src.match(/^[ \t]*detect_tailscale_ip\(\)[ \t]*\{/m);
+  assert.ok(defMatch, "expected a detect_tailscale_ip() function definition in install.sh");
+  // Locate the definition's line number by finding the byte offset of the
+  // match and counting newlines before it.
+  const defOffset = src.indexOf(defMatch[0]);
+  const defLine = src.slice(0, defOffset).split("\n").length;
+  const lines = src.split("\n");
+  let firstCallLine = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip comment lines that mention the helper in prose.
+    if (/^\s*#/.test(line)) continue;
+    // Look for `$(detect_tailscale_ip` (with optional whitespace after `$(`).
+    if (/\$\(\s*detect_tailscale_ip/.test(line)) {
+      firstCallLine = i + 1;
+      break;
+    }
+  }
+  assert.ok(
+    firstCallLine !== null,
+    "expected at least one $(detect_tailscale_ip…) call site in install.sh",
+  );
+  assert.ok(
+    defLine < firstCallLine,
+    `detect_tailscale_ip() must be defined BEFORE its call site: def at line ${defLine}, first call at line ${firstCallLine}. Bash does not forward-reference function definitions within the same function — defining the helper after its call sites silently fails with "command not found".`,
+  );
+});
+
 // ----------------------------------------------------------------------------
 // manifest_get — the bash helper install.sh uses to read key=value from the
 // release manifest BEFORE any node exists on the box.

--- a/scripts/manta-pair.mjs
+++ b/scripts/manta-pair.mjs
@@ -18,7 +18,29 @@
 // the request wasn't local). Keep the logic thin — all formatting lives in the
 // tested install-lib.mjs.
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { resolveConfig, formatPairingOutput } from "./install-lib.mjs";
+
+// BET-267: the install writes `~/.manta/ingress.json` so `manta pair` (which
+// does NOT receive env vars from the install) can pick the right base URL for
+// the connect block. A missing file or unparseable JSON falls back to "public"
+// — the legacy default; the pair-page URL points at <boxId>.boxes.mantaui.com
+// and the manta:// deep-link is preserved. This is intentionally permissive
+// because the only thing the file controls is the printed URL; it never
+// affects what the server actually serves.
+function readIngressServerUrl(authDir) {
+  try {
+    const raw = readFileSync(join(authDir, "ingress.json"), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed?.mode === "tailscale" && typeof parsed.serverUrl === "string" && parsed.serverUrl !== "") {
+      return parsed.serverUrl;
+    }
+  } catch {
+    // missing file / unparseable JSON — fall through to the public default.
+  }
+  return undefined;
+}
 
 async function main() {
   const cfg = resolveConfig();
@@ -70,6 +92,7 @@ async function main() {
       pairing_code: data?.pairing_code,
       box_id: data?.box_id,
       expiresAt: data?.expiresAt,
+      serverUrl: readIngressServerUrl(cfg.authDir),
     });
     process.stdout.write(block + "\n");
   } catch (e) {

--- a/scripts/systemd/manta-server.service
+++ b/scripts/systemd/manta-server.service
@@ -27,6 +27,12 @@ WorkingDirectory=@@MANTA_HOME@@
 ExecStart=@@NODE_BIN@@ @@MANTA_HOME@@/src/server/index.mjs
 Environment=MANTA_MOBILE_HOST=127.0.0.1
 Environment=MANTA_MOBILE_PORT=@@MANTA_PORT@@
+# Optional second listener bound to the Tailscale interface (BET-266).
+# Set to a Tailscale IPv4 by install.sh on the tailnet ingress path;
+# left empty (single-quoted empty string) on the public path so the
+# server's tailnet listener is a no-op. WireGuard encrypts the tailnet
+# hop, so the box is reachable WITHOUT TLS on this listener.
+Environment=MANTA_TAILNET_HOST=@@MANTA_TAILNET_HOST@@
 Restart=on-failure
 RestartSec=2
 # Give the server a moment to flush on stop before SIGKILL.


### PR DESCRIPTION
## Summary

When the box runs Tailscale, devices connect over the tailnet at `http://<tailscale-ip>:<port>` (plain HTTP, WireGuard encrypts the hop) and the public Caddy + DNS + Let's Encrypt path is skipped entirely. No sudo needed on the tailnet path.

**Base: `origin/main @ 9e0fdc9`**

## Mode selection

`MANTA_INGRESS` env var (default `auto`):
- `auto` — tailnet iff Tailscale is up; otherwise public
- `public` — always public, even if Tailscale is running
- `tailscale` — force tailnet; `die` if detection fails

Detection = `tailscale status --json` parses with `BackendState === "Running"` AND `Self.TailscaleIPs` contains at least one IPv4 (raw IP, NOT MagicDNS).

## What changes

| Path | Public | Tailscale |
|---|---|---|
| `scripts/install.sh` step 7 systemd render | (unchanged) | adds `MANTA_TAILNET_HOST=<tailscale-ip>` |
| Step 7.5 distro / sudo gates | runs | **skipped (no sudo needed)** |
| Step 7.5 A — install Caddy | runs | **skipped** |
| Step 7.5 B — gateway register | runs | runs (APNs push needs `gateway_token`) |
| Step 7.5 C — merge-gateway persist | runs | runs |
| Step 7.5 D — DNS wait | runs | **skipped** |
| Step 7.5 E — Caddy vhost + reload | runs | **skipped** |
| Step 7.5 port-check (80/443) | runs | **skipped** |
| Pair-page URL (Branch A) | `https://<boxId>.boxes.mantaui.com/pair#code=…` | `http://<tailscale-ip>:<port>/pair#code=…` |
| `manta://pair?…` deep link | printed | **dropped** (its resolver routes through `boxDirectUrl` → `https://<boxId>.…`, unreachable on tailnet) |
| QR payload | `manta://pair?…` | the pair-page URL (so the device can actually open it) |
| Trailing heredoc | "Your box serves its own public hostname…" | "Tailscale detected — your box is reachable over the tailnet…" |

The decision is persisted to `~/.manta/ingress.json` (`{"mode":"public"}` or `{"mode":"tailscale","tailnetIp":"100.x.y.z","serverUrl":"http://100.x.y.z:<port>"}`, 0600, atomic temp-write + rename — same shape as `auth.json`). `scripts/manta-pair.mjs` reads it and passes `serverUrl` into `formatPairingOutput` so every subsequent `manta pair` produces the right connect block.

## Files changed

5 files, +678 / −59:

- `scripts/install-lib.mjs` — `parseTailscaleStatus`, `buildIngressJson`, `parse-tailscale-status` + `write-ingress` CLI subcommands, `buildPairPageUrl` accepts `{ baseUrl }`, `formatPairingOutput` Branch A uses it.
- `scripts/install.sh` — `detect_tailscale_ip` helper, `MANTA_INGRESS` resolution, `ingress.json` persist, systemd template gets `@@MANTA_TAILNET_HOST@@`, step 7.5 restructured so B/C always run while A/D/E/port-check/reload are gated on `INGRESS_MODE != tailscale`, trailing heredoc varies by mode.
- `scripts/manta-pair.mjs` — reads `~/.manta/ingress.json`, passes `serverUrl` to `formatPairingOutput`.
- `scripts/systemd/manta-server.service` — adds `Environment=MANTA_TAILNET_HOST=@@MANTA_TAILNET_HOST@@` (empty on public, Tailscale IPv4 on tailnet; server treats empty as "off" — see BET-266).
- `scripts/install.test.mjs` — 23 new tests covering parseTailscaleStatus (6), buildIngressJson (4), parse-tailscale-status / write-ingress CLI subcommands (7), buildPairPageUrl `baseUrl` option (3), formatPairingOutput tailscale vs public regression (2), plus the existing `bash -n` syntax check.

## Verification results

- PR branch (`multica/BET-267-tailscale-ingress @ 8a0f123`):
  - typecheck: exit 0. Errors: none. (no tsc errors)
  - test: exit 0, **764 pass / 0 fail / 0 skip** (23 new tests for this PR).
- Base (`main @ 9e0fdc9`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **741 pass / 0 fail / 0 skip**.
- **Conclusion:** 0 new failures, **23 new tests added** (regression coverage for the tailnet path and the existing public path).

## Manual QA

Pending — needs a real Tailscale box to exercise the full flow end-to-end. The expected pairing output on the tailnet path:

```
Pair page:     http://100.64.1.5:8787/pair#code=847291
Pairing code:  847291
Box ID:        0123456789abcdef0123456789abcdef
Server URL:    http://100.64.1.5:8787
```

(No `manta://pair?…` line, no `boxes.mantaui.com` reference.)

## Out of scope (per the issue)

- Client pairing screens ("Pairing screens: optional explicit Server URL" is a separate issue)
- Removing or altering the public Caddy path
- `tailscale serve`, MagicDNS names, TLS certs on the tailnet path (deliberately not used)
- `scripts/self-update.sh` (no ingress involvement)

## Dependency

Gated on [BET-266](https://github.com/antoinedc/MantaUI/pull/221) (server-side `MANTA_TAILNET_HOST` support) — already merged on `main`.