### PR TITLE
release: bump desktop 0.0.12 + iOS 1.0.13, fix server-tarball VERSION

### DIFF
--- a/.github/workflows/server-tarball-deploy.yml
+++ b/.github/workflows/server-tarball-deploy.yml
@@ -126,7 +126,18 @@ jobs:
       # duplicating `node -p` in each one.
       - id: vars
         name: Resolve version
-        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+        # NOTE: do NOT backslash-escape the inner quotes of the node script.
+        # `node -p 'require(\"./package.json\").version'` makes node evaluate a
+        # literal backslash-quote, which is a syntax error → stdout is empty →
+        # VERSION="" → every downstream path becomes `manta--linux-*` and the
+        # merge/upload/verify steps fail (server-v1's first-run failure). Read
+        # package.json without any inner double quotes instead.
+        run: |
+          set -euo pipefail
+          version=$(node -e 'process.stdout.write(require("./package.json").version)')
+          test -n "$version" || { echo "::error::empty version from package.json"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "resolved version=$version"
 
       # Pull both per-arch artifacts into one dist/ — merge-manifest reads
       # from the same dir it expects (matches publish.sh's layout).

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.12;
+				MARKETING_VERSION = 1.0.13;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -375,7 +375,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.12;
+				MARKETING_VERSION = 1.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",


### PR DESCRIPTION
Ships pending release work + fixes a first-run CI defect found while shipping.

## Version bumps (mac + iOS)
- `package.json` 0.0.11 → 0.0.12 → after merge, push `mac-v0.0.12`
- `MARKETING_VERSION` 1.0.12 → 1.0.13 → `ios-release-tag.yml` auto-tags `ios-v1.0.13`

Carries the tailnet server-URL pairing changes (BET-266/267/268) to desktop + TestFlight.

## Fix: server-tarball-deploy empty VERSION
`server-v1` (first-ever run) failed at the manifest-merge step: `node -p 'require(\"./package.json\").version'` backslash-escaped its inner quotes, so node threw a syntax error, stdout was empty, and `VERSION=""` made every path `manta--linux-*`. Fixed to read package.json with real quotes in a block scalar + assert non-empty. Re-tag `server-v2` after merge.

typecheck + all 765 tests green locally.