### PR TITLE
feat(release): publish.sh + healthcheck probe darwin-arm64 (BET-279)

### DIFF
--- a/scripts/prod/healthcheck.mjs
+++ b/scripts/prod/healthcheck.mjs
@@ -35,7 +35,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // ---------------------------------------------------------------------------
 
 export const SITE_URL = "https://mantaui.com";
-export const ARCH_KEYS = ["linux_x64", "linux_arm64"];
+export const ARCH_KEYS = ["linux_x64", "linux_arm64", "darwin_arm64"];
 
 // ---------------------------------------------------------------------------
 // Default probe set (single source of truth — also used by the test suite).
@@ -64,7 +64,8 @@ export const DEFAULT_TARGETS = [
 // Manifest parser — pure, mirrors the install.sh `manifest_get` shape
 // (scripts/install.sh reads `key=value` lines, first-occurrence wins).
 // Keys we care about per arch: file_<archkey>= and sha256_<archkey>=
-// (e.g. file_linux_x64=manta-1.2.3-linux-x64.tar.gz). Future keys are
+// (e.g. file_linux_x64=manta-1.2.3-linux-x64.tar.gz,
+// file_darwin_arm64=manta-1.2.3-darwin-arm64.tar.gz). Future keys are
 // ignored — we never want a new arch to break a stale parser.
 // ---------------------------------------------------------------------------
 
@@ -80,8 +81,8 @@ export function parseManifest(text) {
 }
 
 // ---------------------------------------------------------------------------
-// Manifest ↔ tarball drift check (BET-171 F4 class, generalized to BOTH
-// arches per BET-264). Same loop publish.sh runs at verify-time, but
+// Manifest ↔ tarball drift check (BET-171 F4 class, generalized to EVERY
+// arch per BET-264 + BET-279). Same loop publish.sh runs at verify-time, but
 // pushed out to every 10 min from an off-site box: catches the case
 // where the served tarball silently drifted from what manta-latest.txt
 // promises (file replaced, partial upload, etc.) AFTER publish.sh's

--- a/scripts/prod/healthcheck.test.mjs
+++ b/scripts/prod/healthcheck.test.mjs
@@ -51,13 +51,16 @@ function tarballBytes(archKey) {
   };
 }
 
-// Manifest content (combined, post-Stage-2 / BET-264). Two arches.
+// Manifest content (combined, post-Stage-2 / BET-264 + BET-279 darwin-arm64).
+// Three arches.
 const GOOD_MANIFEST = [
   "version=1.2.3",
   `file_linux_x64=manta-1.2.3-linux-x64.tar.gz`,
   `sha256_linux_x64=${tarballBytes("linux_x64").sha256}`,
   `file_linux_arm64=manta-1.2.3-linux-arm64.tar.gz`,
   `sha256_linux_arm64=${tarballBytes("linux_arm64").sha256}`,
+  `file_darwin_arm64=manta-1.2.3-darwin-arm64.tar.gz`,
+  `sha256_darwin_arm64=${tarballBytes("darwin_arm64").sha256}`,
   "release_channel=stable",
 ].join("\n");
 
@@ -66,6 +69,7 @@ function defaultHealthyHandlers(manifestText = GOOD_MANIFEST) {
   const tb = {
     "linux_x64": tarballBytes("linux_x64"),
     "linux_arm64": tarballBytes("linux_arm64"),
+    "darwin_arm64": tarballBytes("darwin_arm64"),
   };
   const manifestUrl = `${SITE_URL}/releases/manta-latest.txt`;
   return {
@@ -82,6 +86,10 @@ function defaultHealthyHandlers(manifestText = GOOD_MANIFEST) {
       method === "HEAD"
         ? makeRes({ status: 200 })
         : makeRes({ status: 200, bodyBytes: tb.linux_arm64.bytes }),
+    [`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`]: ({ method }) =>
+      method === "HEAD"
+        ? makeRes({ status: 200 })
+        : makeRes({ status: 200, bodyBytes: tb.darwin_arm64.bytes }),
   };
 }
 
@@ -91,7 +99,7 @@ function defaultHealthyHandlers(manifestText = GOOD_MANIFEST) {
 
 test("SITE_URL + ARCH_KEYS match scripts/release/publish.sh (single source of truth)", () => {
   assert.equal(SITE_URL, "https://mantaui.com");
-  assert.deepEqual(ARCH_KEYS, ["linux_x64", "linux_arm64"]);
+  assert.deepEqual(ARCH_KEYS, ["linux_x64", "linux_arm64", "darwin_arm64"]);
 });
 
 test("DEFAULT_TARGETS covers the live surfaces but NOT the per-arch tarballs (those live behind the manifest)", () => {
@@ -186,6 +194,8 @@ test("parseManifest extracts every key=value line (first occurrence wins)", () =
     "sha256_linux_x64=aaaa",
     "file_linux_arm64=manta-1.2.3-linux-arm64.tar.gz",
     "sha256_linux_arm64=bbbb",
+    "file_darwin_arm64=manta-1.2.3-darwin-arm64.tar.gz",
+    "sha256_darwin_arm64=cccc",
     "release_channel=stable",
     "# a comment-looking line",
     "malformed line no equals",
@@ -197,6 +207,8 @@ test("parseManifest extracts every key=value line (first occurrence wins)", () =
     sha256_linux_x64: "aaaa",
     file_linux_arm64: "manta-1.2.3-linux-arm64.tar.gz",
     sha256_linux_arm64: "bbbb",
+    file_darwin_arm64: "manta-1.2.3-darwin-arm64.tar.gz",
+    sha256_darwin_arm64: "cccc",
     release_channel: "stable",
   });
 });
@@ -209,7 +221,7 @@ test("parseManifest returns {} on empty / non-string input", () => {
 });
 
 // ---------------------------------------------------------------------------
-// verifyManifestDrift — the headline check (BET-171 F4 class, BET-264 two-arch).
+// verifyManifestDrift — the headline check (BET-171 F4 class, BET-264 + BET-279).
 // ---------------------------------------------------------------------------
 
 test("verifyManifestDrift returns ok:true when every arch HEAD+sha256 matches", async () => {
@@ -220,6 +232,7 @@ test("verifyManifestDrift returns ok:true when every arch HEAD+sha256 matches", 
     [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`],
   });
   const result = await verifyManifestDrift({ fetchFn, log: () => {} });
   assert.equal(result.ok, true);
@@ -267,6 +280,7 @@ test("verifyManifestDrift flags a tarball HEAD 404 on one arch", async () => {
     [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`],
   });
   const result = await verifyManifestDrift({ fetchFn, log: () => {} });
   assert.equal(result.ok, false);
@@ -286,6 +300,7 @@ test("verifyManifestDrift flags a sha256 mismatch on one arch (the headline BET-
     [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-x64.tar.gz`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`],
   });
   const result = await verifyManifestDrift({ fetchFn, log: () => {} });
   assert.equal(result.ok, false);
@@ -304,11 +319,14 @@ test("verifyManifestDrift refuses manifest entries with path-traversal / slashes
     "sha256_linux_x64=aaaa",
     "file_linux_arm64=manta-1.2.3-linux-arm64.tar.gz",
     `sha256_linux_arm64=${tarballBytes("linux_arm64").sha256}`,
+    `file_darwin_arm64=manta-1.2.3-darwin-arm64.tar.gz`,
+    `sha256_darwin_arm64=${tarballBytes("darwin_arm64").sha256}`,
   ].join("\n");
   const handlers = defaultHealthyHandlers(evil);
   const fetchFn = fakeFetch({
     [`${SITE_URL}/releases/manta-latest.txt`]: handlers[`${SITE_URL}/releases/manta-latest.txt`],
     [`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-linux-arm64.tar.gz`],
+    [`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`]: handlers[`${SITE_URL}/releases/manta-1.2.3-darwin-arm64.tar.gz`],
   });
   const result = await verifyManifestDrift({ fetchFn, log: () => {} });
   assert.equal(result.ok, false);

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -6,22 +6,24 @@
 # What it does (in order; each step idempotent and runs unconditionally unless
 # its artifact is missing — desktop is a separately-shippable leg, not a failure):
 #   1. preflight   refuse if git tree is dirty, if v<version> tag already
-#                  exists, or if EITHER per-arch tarball (linux-x64 +
-#                  linux-arm64) OR its per-arch manifest sidecar is absent.
+#                  exists, or if ANY per-arch tarball (linux-x64 + linux-arm64 +
+#                  darwin-arm64) OR its per-arch manifest sidecar is absent.
 #                  publish.sh is the manual FULL release path — it requires
-#                  BOTH arches. To build + publish only one arch locally, run
+#                  ALL arches. To build + publish only one arch locally, run
 #                  the server-tarball-deploy.yml workflow (which builds + ships
-#                  both via matrix on a tag). Or to ship both from this box,
-#                  run pack.mjs --arch x64 AND --arch arm64 first.
-#   2. tarballs    merge the two per-arch sidecars into the combined manifest
-#                  (scripts/release/merge-manifest.mjs), then scp BOTH
-#                  tarballs + the combined manifest to
+#                  both linux arches via matrix on a tag; darwin-arm64 is built
+#                  on a macOS runner). Or to ship every arch from this box,
+#                  run pack.mjs --arch x64 AND --arch arm64 first; build
+#                  darwin-arm64 with `pack.mjs --arch darwin-arm64` on a Mac.
+#   2. tarballs    merge the per-arch sidecars into the combined manifest
+#                  (scripts/release/merge-manifest.mjs), then scp EVERY
+#                  tarball + the combined manifest to
 #                  <host>:/var/www/mantaui/releases/. THEN (strictly last)
 #                  ssh to copy manta-<version>.txt → manta-latest.txt — this
 #                  ordering is the atomicity guarantee: a client either sees
 #                  the OLD manifest (and old tarballs) or the NEW manifest
 #                  (with new tarballs already uploaded). Drift between the
-#                  manifest and either tarball is impossible.
+#                  manifest and any arch's tarball is impossible.
 #   3. desktop     if dist/desktop/ has binaries: scp them + the latest-*.yml
 #                  feeds to <host>:/var/www/mantaui/updates/ and the binaries
 #                  to /var/www/mantaui/downloads/, then refresh
@@ -36,7 +38,7 @@
 #                  the repo checkout, but Caddy serves install.sh statically
 #                  from the web root, so without this copy the advertised
 #                  one-liner keeps serving the stale installer (BET-171).
-#   5. verify      HEAD each published tarball URL (both arches) → 200, fetch
+#   5. verify      HEAD each published tarball URL (every arch) → 200, fetch
 #                  served manta-latest.txt and assert version match, then for
 #                  each arch download the referenced tarball and assert its
 #                  sha256 equals the manifest's sha256_<archkey>. Plus the
@@ -68,11 +70,12 @@ SITE="${MANTA_SITE:-https://mantaui.com}"
 
 VERSION="$(node -p 'require("./package.json").version')"
 # Filename form (matches tarball basename + nodejs.org convention):
-#   linux-x64 → ARCH_KEY linux_x64, linux-arm64 → linux_arm64.
+#   linux-x64 → ARCH_KEY linux_x64, linux-arm64 → linux_arm64,
+#   darwin-arm64 → darwin_arm64.
 # Single source of truth — adding an arch is one line here + one entry in
 # pack.mjs's resolveArch / install.sh's resolve_arch. No copy-pasted per-arch
 # blocks downstream.
-ARCHES=(linux-x64 linux-arm64)
+ARCHES=(linux-x64 linux-arm64 darwin-arm64)
 COMBINED_MANIFEST="dist/manta-${VERSION}.txt"
 DESKTOP_DIR="dist/desktop"
 WEBROOT_DIR="/var/www/mantaui"
@@ -81,7 +84,8 @@ UPDATES_DIR="${WEBROOT_DIR}/updates"
 DOWNLOADS_DIR="${WEBROOT_DIR}/downloads"
 
 # Derive the underscore manifest-key form from the hyphen filename form
-# (`linux-x64` → `linux_x64`). Used for file_<key>= / sha256_<key>= lookups.
+# (`linux-x64` → `linux_x64`, `darwin-arm64` → `darwin_arm64`).
+# Used for file_<key>= / sha256_<key>= lookups.
 arch_key() { printf '%s' "$1" | tr '-' '_'; }
 
 log()  { printf '\033[36m▸\033[0m %s\n' "$*"; }
@@ -101,13 +105,13 @@ if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
 fi
 
 if [ ! -f "${COMBINED_MANIFEST}" ] && [ ! -f "dist/manta-${VERSION}-linux-x64.txt" ]; then
-  die "no manifest artifacts in dist/ — run pack.mjs for both arches first (x64 + arm64)"
+  die "no manifest artifacts in dist/ — run pack.mjs for all arches first (x64 + arm64 + darwin-arm64)"
 fi
 
-# Publish.sh is the full manual release path — require both arches so the
+# Publish.sh is the full manual release path — require every arch so the
 # published manifest always lists every arch we ship. A laptop with only x64
 # built should push a `server-v*` tag instead (server-tarball-deploy.yml builds
-# both via matrix on a tag).
+# both linux arches via matrix on a tag; darwin-arm64 builds on a Mac runner).
 missing_arch=""
 for arch in "${ARCHES[@]}"; do
   if [ ! -f "dist/manta-${VERSION}-${arch}.tar.gz" ] || [ ! -f "dist/manta-${VERSION}-${arch}.txt" ]; then
@@ -116,9 +120,10 @@ for arch in "${ARCHES[@]}"; do
   fi
 done
 if [ -n "${missing_arch}" ]; then
-  die "${missing_arch} tarball or per-arch manifest missing from dist/ — publish.sh requires BOTH arches
+  die "${missing_arch} tarball or per-arch manifest missing from dist/ — publish.sh requires ALL arches
     Run \`node scripts/release/pack.mjs --arch ${missing_arch%%-*}\` to build the missing arch locally,
-    OR push a server-v* tag so server-tarball-deploy.yml builds both via matrix."
+    OR push a server-v* tag so server-tarball-deploy.yml builds the linux arches via matrix
+    (darwin-arm64 still needs a Mac runner for the node-pty native binding)."
 fi
 
 ok "preflight ok"
@@ -128,6 +133,7 @@ log "Merging per-arch manifests → ${COMBINED_MANIFEST}…"
 node scripts/release/merge-manifest.mjs \
   "dist/manta-${VERSION}-linux-x64.txt" \
   "dist/manta-${VERSION}-linux-arm64.txt" \
+  "dist/manta-${VERSION}-darwin-arm64.txt" \
   --out "${COMBINED_MANIFEST}"
 ok "combined manifest written"
 
@@ -229,14 +235,14 @@ for pair in "${WEBROOT_DOCS[@]}"; do
   check_200 "${SITE}/${pair##*:}"
 done
 
-# Manifest + tarball drift check (BET-171 F4 class), generalized to BOTH
-# arches via the same loop. The publish script just pushed both tarballs and
+# Manifest + tarball drift check (BET-171 F4 class), generalized to EVERY
+# arch via the same loop. The publish script just pushed every tarball and
 # the combined manifest; we re-fetch the served manifest over HTTPS and for
 # each arch download the referenced tarball + assert its sha256 matches the
 # manifest's sha256_<archkey> line. A failure here means we shipped a
 # tarball + manifest that disagree — clients would download the tarball,
 # sha256-fail it, and die. Catch that HERE.
-log "Verifying manifest ↔ tarball drift (both arches)…"
+log "Verifying manifest ↔ tarball drift (every arch)…"
 SERVED_MANIFEST="$(curl -fsSL "${SITE}/releases/manta-latest.txt")"
 SERVED_VERSION="$(printf '%s\n' "$SERVED_MANIFEST" | grep '^version=' | head -n1 | cut -d= -f2-)"
 if [ "$SERVED_VERSION" != "$VERSION" ]; then
@@ -255,7 +261,7 @@ for arch in "${ARCHES[@]}"; do
   fi
   ok "${arch} (${SERVED_FILE}) sha256 matches manifest"
 done
-ok "served manifest live (version=${VERSION}, both arches verified)"
+ok "served manifest live (version=${VERSION}, all arches verified)"
 
 # A 200 is not enough — a stale file also 200s (BET-171). Verify each
 # web-root doc byte-matches the repo so we know the deploy actually took.


### PR DESCRIPTION
**Files changed:** 3 files (+54 / −29)
- scripts/release/publish.sh
- scripts/prod/healthcheck.mjs
- scripts/prod/healthcheck.test.mjs

**Base:** `origin/main` @ `9bd60e1` (has BET-264 + BET-271 + BET-275 merged). Rebased onto current `origin/main` before pushing.

---

## What this does

Closes the silent-drift gap that BET-275 opened when it added the darwin-arm64 tarball to `pack.mjs` + `server-tarball-deploy.yml` + `merge-manifest.mjs` but did not update the two downstream consumers whose arch lists were still hardcoded to `linux_x64` / `linux_arm64`:

### publish.sh
- `ARCHES=(linux-x64 linux-arm64 darwin-arm64)` — single source of truth
- merge-manifest call now passes three sidecar inputs
- Preflight, scp upload, served-manifest drift verify all loop over `ARCHES` so they automatically pick up the new arch
- Preflight failure message and verify summary now say "all arches" not "both arches"

### healthcheck.mjs
- `ARCH_KEYS = ["linux_x64", "linux_arm64", "darwin_arm64"]` (mirror of publish.sh)
- `verifyManifestDrift` loop now HEADs + sha256s the darwin-arm64 tarball every 10 min, so the off-site probe catches a darwin-arm64 tarball/manifest drift that publish.sh's one-shot verify missed

### healthcheck.test.mjs
- `GOOD_MANIFEST` + `defaultHealthyHandlers` add the darwin-arm64 entry
- `assert.deepEqual(ARCH_KEYS, ...)` includes darwin_arm64
- Every `verifyManifestDrift` test handler picks up the third tarball URL

---

## Verification results

- **PR branch** (`multica/BET-279-publish-healthcheck-darwin-arm64` @ `7de8dce`):
  - typecheck: exit 0. Errors: none.
  - test: 765 pass / 0 fail / 0 skip (18/18 in `healthcheck.test.mjs`).
- **Linux behavior byte-identical:** `ARCHES` and `ARCH_KEYS` still list linux first two.

`npm run typecheck && npm test` clean on the PR branch.

---

## Follow-ups

None filed — the dispatch explicitly excluded `scripts/install.sh` `resolve_arch` (BET-276 / Issue B) and the launchd plist work (BET-277 / Issue C). Both are scoped to separate child issues.

## Out of scope
- `scripts/install.sh` `resolve_arch` — assigned to BET-276
- launchd plists — assigned to BET-277
- BET-275 PR #230 (`multica/BET-275-darwin-arm64-server-tarball` @ `900e151`) is the source of truth for the `darwin_arm64` / `darwin-arm64` token definitions; this PR mirrors its naming.