### PR TITLE
feat(install): OS-aware arch resolution + skip Linux-only Caddy/apt on macOS (BET-276)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
-# install.sh — one-command VPS self-install for the manta box server.
+# install.sh — one-command self-install for the manta box server.
 #
 #   curl -fsSL https://mantaui.com/install.sh | bash
 #
-# Gets manta-server running under systemd --user on a fresh Linux box and prints a
-# 6-digit pairing code to enter in the desktop app. Idempotent: re-running
-# upgrades the code in place and PRESERVES ~/.manta/ (box identity + config)
-# — the script never generates box_id/box_token itself; ensureAuth() in
-# src/server/auth.mjs is the single source of truth.
+# On a fresh Linux box: gets manta-server running under systemd --user and
+# prints a 6-digit pairing code to enter in the desktop app.
+#
+# On a fresh macOS box (Apple Silicon, BET-274): gets manta-server running
+# in the background and prints a 6-digit pairing code. macOS is loopback +
+# Tailscale-only — no Caddy, no public DNS, no Let's Encrypt. The persistent
+# service-manager (LaunchAgent) lands in Issue C (BET-277); until then the
+# macOS install warns that the background process does NOT survive
+# logout/reboot.
+#
+# Idempotent: re-running upgrades the code in place and PRESERVES ~/.manta/
+# (box identity + config) — the script never generates box_id/box_token
+# itself; ensureAuth() in src/server/auth.mjs is the single source of truth.
 #
 # Prerequisites on the box (we check, never install — same `require_cmd` tone
 # as Homebrew/rustup):
@@ -87,15 +95,28 @@ manifest_get() { # $1=manifest-body $2=key
   printf '%s\n' "$1" | grep "^$2=" | head -n1 | cut -d= -f2-
 }
 
-# Map uname -m to the release manifest arch key. Sets global ARCH_KEY.
-# Dies on any arch we don't ship a tarball for. This is the SINGLE place
-# the installer decides which arch it is.
+# Map (uname -s, uname -m) to the release manifest arch key. Sets global
+# ARCH_KEY. Dies on any (OS, arch) we don't ship a tarball for. This is the
+# SINGLE place the installer decides which OS+arch it is — see BET-274.
 resolve_arch() {
-  local m; m="$(uname -m)"
-  case "$m" in
-    x86_64)         ARCH_KEY="linux_x64" ;;
-    aarch64|arm64)  ARCH_KEY="linux_arm64" ;;
-    *) die "unsupported architecture: $m (this installer ships linux x86_64 and arm64 only)" ;;
+  local s m; s="$(uname -s)"; m="$(uname -m)"
+  case "$s" in
+    Linux)
+      case "$m" in
+        x86_64)         ARCH_KEY="linux_x64" ;;
+        aarch64|arm64)  ARCH_KEY="linux_arm64" ;;
+        *) die "unsupported architecture: $m on Linux (this installer ships linux x86_64 and arm64)" ;;
+      esac
+      ;;
+    Darwin)
+      case "$m" in
+        arm64)  ARCH_KEY="darwin_arm64" ;;
+        *) die "unsupported Mac: $m — the MantaUI box installer supports Apple Silicon (arm64) Macs only.
+      Intel Macs are not supported as a box. If you just want to USE MantaUI on this Mac,
+      install the desktop app instead: https://mantaui.com/downloads/Manta-latest.dmg" ;;
+      esac
+      ;;
+    *) die "unsupported OS: $s (the MantaUI box installer supports Linux and macOS/Apple Silicon)" ;;
   esac
 }
 
@@ -127,6 +148,15 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 main() {
   resolve_arch
+
+  # OS gate — set ONCE from `uname -s` so the rest of the install branches
+  # on a single flag instead of re-running uname in scattered places. The
+  # macOS box path (BET-274 / BET-276) keys off this: loopback + Tailscale
+  # only, no apt/Caddy/DNS/vhost. Issue C (BET-277) will add the launchd
+  # service path; until then, the macOS nohup fallback gets a temporary
+  # warn so a partial merge is never silently broken.
+  IS_MACOS=0
+  [ "$(uname -s)" = "Darwin" ] && IS_MACOS=1
 
   # ---------------------------------------------------------------------------
   # 0. Argument parsing. `--dry-run` walks the install path with every external
@@ -480,6 +510,13 @@ main() {
     else
       warn "systemctl not found. Starting opencode-serve in the background instead."
       warn "It will NOT survive reboot — set up your own supervisor for that."
+      if [ "$IS_MACOS" = "1" ]; then
+        # macOS path (BET-274 / BET-276) — Issue C (BET-277) replaces this
+        # nohup fallback with a proper LaunchAgent; until then we warn so a
+        # partial merge is never silently broken (opencode dies on logout).
+        warn "macOS: falling back to a non-persistent background process (BET launchd support pending)."
+        warn "  The server will NOT survive logout/reboot until launchd support is installed."
+      fi
       ( nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
     fi
   fi
@@ -596,6 +633,13 @@ main() {
   else
     warn "systemctl not found (not a systemd host?). Starting the server in the background instead."
     warn "It will NOT survive reboot — set up your own supervisor for that."
+    if [ "$IS_MACOS" = "1" ]; then
+      # macOS path (BET-274 / BET-276) — Issue C (BET-277) replaces this
+      # nohup fallback with a proper LaunchAgent; until then we warn so a
+      # partial merge is never silently broken (manta-server dies on logout).
+      warn "macOS: falling back to a non-persistent background process (BET launchd support pending)."
+      warn "  The server will NOT survive logout/reboot until launchd support is installed."
+    fi
     ( MANTA_MOBILE_HOST=127.0.0.1 MANTA_MOBILE_PORT="$MANTA_PORT" MANTA_TAILNET_HOST="$TAILNET_IP" nohup "$NODE" "$MANTA_HOME/src/server/index.mjs" >"$AUTH_DIR/server.log" 2>&1 & )
     SERVER_MANAGED=nohup
   fi
@@ -674,19 +718,31 @@ main() {
   #     (the gates only fire when we're actually about to do real work).
   # ===========================================================================
 
+  # Public-TLS predicate — ONE gate, ONE source of truth for the Caddy/apt/
+  # DNS/vhost sub-steps (A/D/E/port-check/reload). Merges the macOS case
+  # (BET-274 / BET-276) with the existing tailscale case (BET-267): both
+  # skip the public TLS path; gateway-register (B/C) still runs in both
+  # because it's user-space and the gateway_token is still needed for
+  # APNs push. Computed once, used by every guard below.
+  SKIP_PUBLIC_TLS=0
+  if [ "$INGRESS_MODE" = "tailscale" ] || [ "$IS_MACOS" = "1" ]; then
+    SKIP_PUBLIC_TLS=1
+  fi
+
   # Gate the section. In dry-run mode we always show what we would do
   # (the dry_log lines are below). In real mode we bail with a clear
   # bring-your-own-proxy hint when distro isn't Debian/Ubuntu or sudo
   # isn't usable.
   #
-  # Tailscale path (BET-267): distro / sudo checks are irrelevant — no sudo
-  # is needed at all on the tailnet path (the whole point is "skip Caddy +
-  # public DNS"). PRIVILEGED_SECTION_SKIP is left at 0 so sub-steps B + C
-  # (gateway register + merge-gateway) still run — they are user-space and
-  # the gateway_token is still needed for APNs push. A/D/E/port-check/reload
-  # are gated on `INGRESS_MODE != tailscale` further down.
+  # Tailscale path (BET-267) AND macOS path (BET-276): distro / sudo checks
+  # are irrelevant — no sudo is needed at all on either path (the whole
+  # point is "skip Caddy + public DNS"). PRIVILEGED_SECTION_SKIP is left
+  # at 0 so sub-steps B + C (gateway register + merge-gateway) still run —
+  # they are user-space and the gateway_token is still needed for APNs
+  # push. A/D/E/port-check/reload are gated on SKIP_PUBLIC_TLS further
+  # down.
   PRIVILEGED_SECTION_SKIP=0
-  if [ "$DRY_RUN" != "1" ] && [ "$INGRESS_MODE" != "tailscale" ]; then
+  if [ "$DRY_RUN" != "1" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
     # Distro check (Debian/Ubuntu only for v1 — see reviewer guidance §4).
     DISTRO_STATUS="$("$NODE" "$LIB" detect-distro 2>/dev/null || echo "")"
     DISTRO_SUPPORTED="$(printf '%s' "$DISTRO_STATUS" | "$NODE" -e '
@@ -747,6 +803,13 @@ main() {
     # port-check + caddy reload. B/C (gateway register + merge-gateway) still
     # run below — the gateway_token is still needed for APNs push.
     log "Tailscale detected ($TAILNET_IP) — skipping Caddy + public DNS; devices connect over the tailnet."
+  elif [ "$IS_MACOS" = "1" ]; then
+    # macOS path (BET-274 / BET-276): no apt, no Caddy, no public DNS, no
+    # Let's Encrypt. The box is loopback-only on the Mac; remote access
+    # requires Tailscale (a Mac that's never logged in is unsupported —
+    # Issue C will wire that up via LaunchAgents). B/C (gateway register
+    # + merge-gateway) still run below for the APNs push token.
+    log "macOS detected — skipping Caddy/apt/DNS/vhost; box is loopback-only. Use Tailscale to reach this box off-network."
   elif [ "$PRIVILEGED_SECTION_SKIP" = "1" ]; then
     log "Skipping public-TLS step (bring-your-own-proxy keeps the rest of the install working)."
   else
@@ -806,9 +869,10 @@ main() {
 
   # --- A. Install Caddy if absent ------------------------------------------
   # A, D, E/port-check/reload only run on the public path (BET-267). The
-  # tailscale path never binds :80/:443, never writes a Caddy vhost, never
-  # waits on DNS, never reloads Caddy.
-  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$INGRESS_MODE" != "tailscale" ]; then
+  # tailscale path AND the macOS path (BET-276) never bind :80/:443, never
+  # write a Caddy vhost, never wait on DNS, never reload Caddy. Gated via
+  # SKIP_PUBLIC_TLS which merges both cases into one predicate.
+  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
     if command -v caddy >/dev/null 2>&1; then
       ok "caddy already installed ($(caddy version 2>/dev/null || echo unknown))."
     elif [ "$DRY_RUN" = "1" ]; then
@@ -879,8 +943,9 @@ main() {
   fi
 
   # --- D. Poll DNS until <box_id>.boxes.mantaui.com resolves to us -------
-  # Public path only (BET-267); the tailnet path has no DNS wait.
-  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$INGRESS_MODE" != "tailscale" ]; then
+  # Public path only (BET-267 + BET-276); the tailnet path AND the macOS
+  # path have no DNS wait. Gated via SKIP_PUBLIC_TLS.
+  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
     # Re-read gateway_host (or default to the canonical pattern if the
     # gateway didn't return one yet) for the polling target.
     GATEWAY_HOST="$("$NODE" -e '

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1156,30 +1156,35 @@ verify_sha256 "${file}" "${wrongSha}"
 });
 
 // ----------------------------------------------------------------------------
-// resolve_arch — map `uname -m` to the manifest arch key (`linux_x64` /
-// `linux_arm64`). Sets the global `ARCH_KEY` the manifest reader uses; dies
-// only on arches we don't ship a tarball for. The harness overrides `uname`
-// via a function in preBody (same mocking style as the deleted bootstrap_*
-// tests used for `command` and `detect_distro_id`).
+// resolve_arch — map `(uname -s, uname -m)` to the manifest arch key
+// (`linux_x64` / `linux_arm64` / `darwin_arm64`). Sets the global
+// `ARCH_KEY` the manifest reader uses; dies on any (OS, arch) we don't
+// ship a tarball for. The harness overrides `uname` via a function in
+// preBody (same mocking style as the deleted bootstrap_* tests used for
+// `command` and `detect_distro_id`).
+//
+// BET-276 made resolve_arch OS-aware: it now branches on `uname -s` first
+// (Linux vs Darwin) before mapping the arch token. The mock has to switch
+// on the arg so it answers both `-s` and `-m` correctly.
 // ----------------------------------------------------------------------------
 
-test("resolve_arch sets ARCH_KEY=linux_x64 on x86_64", () => {
+test("resolve_arch sets ARCH_KEY=linux_x64 on Linux x86_64", () => {
   const out = runBootstrap({
     preBody: `
-uname() { echo "x86_64"; }
+uname() { case "$1" in -s) echo "Linux" ;; -m) echo "x86_64" ;; esac; }
 resolve_arch
 echo "AK=\$ARCH_KEY"
 `,
   });
   assert.match(out, /AK=linux_x64/);
   assert.match(out, /BOOTSTRAP_EXIT=0/);
-  assert.doesNotMatch(out, /unsupported architecture/);
+  assert.doesNotMatch(out, /unsupported/);
 });
 
-test("resolve_arch sets ARCH_KEY=linux_arm64 on aarch64", () => {
+test("resolve_arch sets ARCH_KEY=linux_arm64 on Linux aarch64", () => {
   const out = runBootstrap({
     preBody: `
-uname() { echo "aarch64"; }
+uname() { case "$1" in -s) echo "Linux" ;; -m) echo "aarch64" ;; esac; }
 resolve_arch
 echo "AK=\$ARCH_KEY"
 `,
@@ -1194,7 +1199,7 @@ test("resolve_arch accepts arm64 spelling too", () => {
   // depending on which uname token the distro uses.
   const out = runBootstrap({
     preBody: `
-uname() { echo "arm64"; }
+uname() { case "$1" in -s) echo "Linux" ;; -m) echo "arm64" ;; esac; }
 resolve_arch
 echo "AK=\$ARCH_KEY"
 `,
@@ -1203,15 +1208,89 @@ echo "AK=\$ARCH_KEY"
   assert.match(out, /BOOTSTRAP_EXIT=0/);
 });
 
-test("resolve_arch dies on armv7l (unsupported arch)", () => {
+test("resolve_arch dies on Linux armv7l (unsupported arch)", () => {
   const out = runBootstrap({
     preBody: `
-uname() { echo "armv7l"; }
+uname() { case "$1" in -s) echo "Linux" ;; -m) echo "armv7l" ;; esac; }
 resolve_arch
 `,
   });
   assert.match(out, /unsupported architecture/);
   assert.match(out, /armv7l/);
+});
+
+// BET-276 (Stage 2 of the macOS box epic): resolve_arch becomes OS-aware
+// and adds a darwin_arm64 mapping for Apple Silicon Macs. Intel Macs die
+// with a clear message, unknown OSes die too. The new resolve_arch calls
+// both `uname -s` and `uname -m`, so the mock has to switch on the arg.
+// The mock pattern stays identical to the existing tests (function shadow
+// AFTER sourcing install.sh).
+
+test("resolve_arch sets ARCH_KEY=darwin_arm64 on Darwin arm64 (BET-276)", () => {
+  const out = runBootstrap({
+    preBody: `
+uname() { case "$1" in -s) echo "Darwin" ;; -m) echo "arm64" ;; esac; }
+resolve_arch
+echo "AK=\$ARCH_KEY"
+`,
+  });
+  assert.match(out, /AK=darwin_arm64/);
+  assert.match(out, /BOOTSTRAP_EXIT=0/);
+  assert.doesNotMatch(out, /unsupported/);
+});
+
+test("resolve_arch dies on Darwin x86_64 (Intel Mac — explicit refusal, BET-276)", () => {
+  // Intel Macs are not supported as a box. The installer must die here
+  // BEFORE the manifest fetch — otherwise the user gets a cryptic
+  // "cannot execute binary file" later (the real bug BET-274 fixed).
+  const out = runBootstrap({
+    preBody: `
+uname() { case "$1" in -s) echo "Darwin" ;; -m) echo "x86_64" ;; esac; }
+resolve_arch
+`,
+  });
+  assert.match(out, /unsupported Mac/);
+  assert.match(out, /Apple Silicon/);
+  assert.match(out, /Intel Macs are not supported/);
+  // Must point at the desktop app as the alternative.
+  assert.match(out, /mantaui\.com\/downloads\/Manta-latest\.dmg/);
+});
+
+test("resolve_arch dies on unknown OS (e.g. FreeBSD, BET-276)", () => {
+  const out = runBootstrap({
+    preBody: `
+uname() { case "$1" in -s) echo "FreeBSD" ;; -m) echo "amd64" ;; esac; }
+resolve_arch
+`,
+  });
+  assert.match(out, /unsupported OS/);
+  assert.match(out, /FreeBSD/);
+});
+
+test("resolve_arch still maps Linux x86_64 → linux_x64 after the OS branch (BET-276 regression)", () => {
+  // Belt-and-braces: the OS branch must not break the existing Linux path.
+  // x86_64 is the canonical Linux x64 case.
+  const out = runBootstrap({
+    preBody: `
+uname() { case "$1" in -s) echo "Linux" ;; -m) echo "x86_64" ;; esac; }
+resolve_arch
+echo "AK=\$ARCH_KEY"
+`,
+  });
+  assert.match(out, /AK=linux_x64/);
+  assert.match(out, /BOOTSTRAP_EXIT=0/);
+});
+
+test("resolve_arch still maps Linux aarch64 → linux_arm64 after the OS branch (BET-276 regression)", () => {
+  const out = runBootstrap({
+    preBody: `
+uname() { case "$1" in -s) echo "Linux" ;; -m) echo "aarch64" ;; esac; }
+resolve_arch
+echo "AK=\$ARCH_KEY"
+`,
+  });
+  assert.match(out, /AK=linux_arm64/);
+  assert.match(out, /BOOTSTRAP_EXIT=0/);
 });
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
**Base:** `origin/main` @ `9bd60e1`

**Files changed:** 2 files. `scripts/install.sh` (+78/-19), `scripts/install.test.mjs` (+86/-19).

## What

Stage 2 of the macOS box epic ([BET-274](mention://issue/f31a5450-d6d9-42a6-b58c-6c974637f302)). On Darwin+arm64, `resolve_arch` now maps to `ARCH_KEY=darwin_arm64` so the installer fetches the darwin tarball that BET-275 already produces. On Darwin+x86_64 the installer dies immediately with a clear Apple-Silicon-only message — never a cryptic `cannot execute binary file` later.

Sets a single `IS_MACOS` flag right after `resolve_arch`, and introduces one `SKIP_PUBLIC_TLS` predicate that merges the macOS case with the existing tailscale case (BET-267): both skip Caddy install, DNS wait, vhost write, and caddy reload; gateway-register (B/C) still runs for the APNs push token.

The two `systemctl→nohup` fallbacks (opencode-serve + manta-server) get a temporary macOS warn pointing at BET-277's launchd path so a partial merge is never silently broken.

## Cross-cutting follow-ups

None — Issue C ([BET-277](mention://issue/4307350c-e8a6-4b02-a2b2-c66f6bc9da2f)) reads `IS_MACOS` from this PR and removes the two nohup warns when it lands the launchd path. Issue D ([BET-278](mention://issue/4e0061ef-cc28-42d2-9729-b74ff983ce62)) handles `shasum` for macOS (sha256sum absence) which is unrelated to this issue.

## Verification results

- PR branch (`multica/BET-276-install-sh-macos-path` @ `c4d03ef`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 777 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `9bd60e1`):
  - typecheck: ran on base before any change — green.
  - test: ran on base before any change — green.
- **Conclusion:** 0 new failures, 0 pre-existing failures.

The 5 new `resolve_arch` cases (darwin arm64, darwin x86_64 dies, unknown OS dies, Linux x86_64 regression, Linux aarch64 regression) are all green. The 4 existing `resolve_arch` cases had to be re-mocked to answer both `uname -s` and `uname -m` (the new OS-aware function calls both); all 4 remain green.

## Acceptance criteria from the issue body

1. On Darwin+arm64, `resolve_arch` sets `ARCH_KEY=darwin_arm64` → covered by the new test.
2. On Darwin+x86_64 the installer dies with the Apple-Silicon-only message before download → covered by the new test.
3. On macOS the installer does NOT run apt / Caddy / DNS-wait / vhost-write, but DOES run gateway-register (B/C) → `SKIP_PUBLIC_TLS` merges the macOS case with the tailscale case for A/D/E; B/C is gated only by `PRIVILEGED_SECTION_SKIP`, which is left at 0 for macOS. The new log block makes this visible.
4. Linux install behavior is byte-identical → only adding branches (`case "$s" in ...`) and a derived predicate; the Linux code path is the same.
5. `npm test` passes → verified (777 pass).