### PR TITLE
BET-280: move Claude credential auto-refresh server-side

### DIFF
--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -58,35 +58,6 @@ export function RetryCard({
   );
 }
 
-// ===== Credential refresh card =====
-//
-// Rendered while the renderer auto-recovers from a ProviderAuthError (BET-139):
-// a background `claude` refresh runs server-side, and on success the failed
-// turn is auto-resent. Failure is surfaced via the sendError banner instead
-// (see credentialRefreshBannerText in chatUtils.ts) — this card renders
-// nothing for the "error" phase to avoid double-surfacing the message.
-
-export function CredRefreshCard({ state }: { state: "refreshing" | "ok" }) {
-  const isRefreshing = state === "refreshing";
-  return (
-    <div
-      className="rounded-md border bg-bg-elev px-3 py-2 text-[12px]"
-      style={{ borderColor: CLAUDE_ORANGE + "55" }}
-    >
-      <div className="flex items-center gap-2">
-        <span style={{ color: CLAUDE_ORANGE }}>
-          <span className={isRefreshing ? "inline-block animate-pulse" : "inline-block"}>
-            ↻
-          </span>
-        </span>
-        <span className="text-text">
-          {isRefreshing ? "Refreshing Claude credentials…" : "Credentials refreshed — resending."}
-        </span>
-      </div>
-    </div>
-  );
-}
-
 // ===== Compaction card =====
 //
 // Rendered while session.next.compaction.* events stream in. "running" shows

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -36,8 +36,6 @@ import {
   classifyScrollForPin,
   detectCommandFromText,
   formatBytes,
-  credentialRefreshBannerText,
-  lastUserMessageText,
   type StaleCacheResult,
 } from "./chatUtils";
 import {
@@ -56,7 +54,7 @@ import {
   type TokenUsage,
 } from "./chatShared";
 import { RunningIndicator } from "./MessageRow";
-import { CompactionCard, CredRefreshCard, PermissionCard, RetryCard } from "./Cards";
+import { CompactionCard, PermissionCard, RetryCard } from "./Cards";
 import { ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
@@ -180,19 +178,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   // can't watch localStorage on its own — we drive the re-read from here.
   const [historyEpoch, setHistoryEpoch] = useState(0);
 
-  // ===== Claude credential auto-refresh (BET-139) =====
-  //
-  // Driven by a ProviderAuthError session.error, routed here from useSseBus
-  // via the onProviderAuthError callback. `credRefresh` is a per-session
-  // live-event state, same convention as retryInfo/compactionState.
-  const [credRefresh, setCredRefresh] = useState<null | "refreshing" | "ok" | "error">(null);
-  // Indirection mirrors submitRef: the SSE effect inside useSseBus only
-  // depends on [sessionId], so a plain closure passed as a prop would be
-  // captured once (at mount / session change) and go stale against the
-  // freshest `messages`. Routing the call through a ref that's reassigned
-  // every render keeps it fresh without re-arming the SSE subscription.
-  const onProviderAuthErrorRef = useRef<() => void>(() => {});
-
   // ===== Transcript state (extracted to useTranscriptState) =====
   const {
     messages,
@@ -288,39 +273,7 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     submit: () => {}, // placeholder — ChatPanel's submit is used below
     submitRef,
     setInput,
-    // Indirection to dodge the circular dep: this callback needs setSendError
-    // (returned BY useSseBus) and the freshest `messages` (from
-    // useTranscriptState). onProviderAuthErrorRef.current is assigned below,
-    // after both are in scope — see the comment there.
-    onProviderAuthError: () => onProviderAuthErrorRef.current(),
   });
-
-  // Actual ProviderAuthError handler: refresh credentials server-side, then
-  // either auto-resend the failed turn (success) or surface an actionable
-  // banner (failure). Kept as a plain function (not useCallback) reassigned
-  // to the ref every render — see onProviderAuthErrorRef's declaration for
-  // why the indirection is needed.
-  onProviderAuthErrorRef.current = () => {
-    void (async () => {
-      setCredRefresh("refreshing");
-      const res = await window.api.opencodeRefreshCredentials();
-      if (res.ok) {
-        setCredRefresh("ok");
-        const lastText = lastUserMessageText(messages);
-        if (lastText) {
-          setInput(lastText);
-          setTimeout(() => {
-            submitRef.current?.();
-          }, 0);
-        }
-        setTimeout(() => setCredRefresh(null), 2500);
-      } else {
-        setCredRefresh("error");
-        setSendError(credentialRefreshBannerText(res.reason));
-        setCredRefresh(null);
-      }
-    })();
-  };
 
   // ===== ChatPanel-own state (not extracted to hooks) =====
   const [error, setError] = useState<string | null>(null);
@@ -378,8 +331,8 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   // resets messages/scroll/delta-buffer, useSseBus resets permissions/questions/
   // stepTokens/etc. via its SSE effect cleanup). We only need to reset the
   // ChatPanel-own state here: error, modelOverride, attachments, agentMentions,
-  // systemNotice, dragHover, credRefresh. The SSE stream open/close is also
-  // handled by useSseBus's effect now.
+  // systemNotice, dragHover. The SSE stream open/close is also handled by
+  // useSseBus's effect now.
   useEffect(() => {
     setError(null);
     setModelOverride(readSavedModel(sessionId) ?? configDefaultModel ?? null);
@@ -387,7 +340,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     setAgentMentions([]);
     setSystemNotice(null);
     setDragHover(false);
-    setCredRefresh(null);
     // Branch indicator: poll every 5s while this session is mounted.
     refreshBranch(cwd);
     const branchPoll = setInterval(() => refreshBranch(cwd), 5000);
@@ -1839,15 +1791,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       {compactionState && (
         <div className="shrink-0 px-4 pt-2">
           <CompactionCard state={compactionState} />
-        </div>
-      )}
-
-      {/* Claude credential auto-refresh (BET-139). Only "refreshing"/"ok" */}
-      {/* render here — "error" surfaces via the sendError banner instead */}
-      {/* (see onProviderAuthErrorRef above), so it's intentionally excluded. */}
-      {(credRefresh === "refreshing" || credRefresh === "ok") && (
-        <div className="shrink-0 px-4 pt-2">
-          <CredRefreshCard state={credRefresh} />
         </div>
       )}
 

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -872,7 +872,6 @@ export const httpApi: Api = {
   opencodeRestart: () => rpc(IPC.opencodeRestart),
   opencodeDefaultModel: () => rpc(IPC.opencodeDefaultModel),
   opencodeVcsBranch: (directory) => rpc(IPC.opencodeVcsBranch, directory),
-  opencodeRefreshCredentials: () => rpc(IPC.opencodeRefreshCredentials),
 
   // -- session management --
   opencodeListSessions: (directory) => rpc(IPC.opencodeListSessions, directory),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -63,8 +63,6 @@ import {
   shouldForceReconnect,
   shouldReconnectOnAppStateChange,
   runWithConcurrency,
-  credentialRefreshBannerText,
-  lastUserMessageText,
   chooseUpdateSkewVariant,
   arrowUpNavigatesHistory,
   arrowDownNavigatesHistory,
@@ -2385,7 +2383,7 @@ describe("isDrainAbortError", () => {
   });
 
   it("never swallows other error names even while draining", () => {
-    expect(isDrainAbortError("ProviderAuthError", true)).toBe(false);
+    expect(isDrainAbortError("ApiError", true)).toBe(false);
     expect(isDrainAbortError("ContextOverflowError", true)).toBe(false);
     expect(isDrainAbortError(undefined, true)).toBe(false);
   });
@@ -2888,65 +2886,6 @@ describe("runWithConcurrency", () => {
       seen.push(item);
     });
     expect(seen.sort((a, b) => a - b)).toEqual(items);
-  });
-});
-
-// ===== credentialRefreshBannerText =====
-
-describe("credentialRefreshBannerText", () => {
-  it("maps refresh-token-expired to a re-login instruction", () => {
-    expect(credentialRefreshBannerText("refresh-token-expired")).toBe(
-      "Claude login expired — run `opencode auth login anthropic` on the box, then retry.",
-    );
-  });
-
-  it("maps no-credentials to a login instruction", () => {
-    expect(credentialRefreshBannerText("no-credentials")).toBe(
-      "No Claude credentials found — run `opencode auth login anthropic` on the box.",
-    );
-  });
-
-  it("maps failed (and undefined) to a generic manual-fix instruction", () => {
-    const expected =
-      "Couldn't refresh Claude credentials automatically. Run `claude` on the box, then retry.";
-    expect(credentialRefreshBannerText("failed")).toBe(expected);
-    expect(credentialRefreshBannerText(undefined)).toBe(expected);
-  });
-});
-
-// ===== lastUserMessageText =====
-
-describe("lastUserMessageText", () => {
-  it("returns the most recent non-empty user message", () => {
-    const out = lastUserMessageText([
-      { info: { role: "user" }, parts: [{ type: "text", text: "first" }] },
-      { info: { role: "assistant" }, parts: [{ type: "text", text: "reply" }] },
-      { info: { role: "user" }, parts: [{ type: "text", text: "second" }] },
-    ]);
-    expect(out).toBe("second");
-  });
-
-  it("skips synthetic/ignored/empty user messages when searching backward", () => {
-    const out = lastUserMessageText([
-      { info: { role: "user" }, parts: [{ type: "text", text: "keep me" }] },
-      {
-        info: { role: "user" },
-        parts: [{ type: "text", text: "dropped", synthetic: true }],
-      },
-    ]);
-    expect(out).toBe("keep me");
-  });
-
-  it("returns null for null/empty transcripts", () => {
-    expect(lastUserMessageText(null)).toBe(null);
-    expect(lastUserMessageText([])).toBe(null);
-  });
-
-  it("returns null when there are no user messages", () => {
-    const out = lastUserMessageText([
-      { info: { role: "assistant" }, parts: [{ type: "text", text: "hi" }] },
-    ]);
-    expect(out).toBe(null);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2053,48 +2053,6 @@ export async function runWithConcurrency<T>(
 }
 
 // ---------------------------------------------------------------------------
-// Claude credential auto-refresh (BET-139)
-// ---------------------------------------------------------------------------
-
-/**
- * Map a failed `opencodeRefreshCredentials()` outcome to the actionable
- * banner text shown via `setSendError`. Pure so the copy is testable without
- * exercising the async refresh flow. Keep in sync with the reasons returned
- * by `refreshClaudeCredentials` in src/server/opencode.mjs.
- */
-export function credentialRefreshBannerText(
-  reason?: "no-credentials" | "refresh-token-expired" | "failed",
-): string {
-  switch (reason) {
-    case "refresh-token-expired":
-      return "Claude login expired — run `opencode auth login anthropic` on the box, then retry.";
-    case "no-credentials":
-      return "No Claude credentials found — run `opencode auth login anthropic` on the box.";
-    default:
-      return "Couldn't refresh Claude credentials automatically. Run `claude` on the box, then retry.";
-  }
-}
-
-/**
- * The text of the most recent user-role message with non-empty text —
- * i.e. the turn that just errored with ProviderAuthError and needs to be
- * auto-resent once credentials are refreshed. Returns null when there's no
- * such message (empty/synthetic transcript).
- */
-export function lastUserMessageText(
-  messages: { info: { role: string }; parts: OpencodePartLike[] }[] | null,
-): string | null {
-  if (!messages) return null;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (m.info.role !== "user") continue;
-    const text = extractTextFromParts(m.parts).trim();
-    if (text) return text;
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
 // Version-skew guard (BET-225 stage 3)
 // ---------------------------------------------------------------------------
 //

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -72,12 +72,13 @@ describe("useSseBus via ChatPanel", () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // ProviderAuthError
+    // Unknown generic error — the credential-error path is server-driven now
+    // (BET-280) and exercised in src/server/claudeAuth.test.mjs.
     await emitAndFlush(bus, h, {
       type: "session.error",
       properties: {
         sessionID: "ses_test",
-        error: { name: "ProviderAuthError", data: { message: "Invalid token" } },
+        error: { name: "ApiError", data: { message: "Invalid token" } },
       },
     });
 

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -136,10 +136,6 @@ export function useSseBus(params: {
   submit: () => void;
   submitRef: React.RefObject<() => void>;
   setInput: (v: string) => void;
-  // Called (fire-and-forget) on a ProviderAuthError session.error. The async
-  // refresh-then-resend logic lives in ChatPanel (with the rest of the panel
-  // logic) — this hook only routes the event to the callback.
-  onProviderAuthError: () => void;
 }): SseBus {
   const {
     sessionId,
@@ -159,7 +155,6 @@ export function useSseBus(params: {
     submit,
     submitRef,
     setInput,
-    onProviderAuthError,
   } = params;
 
   const [running, setRunning] = useState(false);
@@ -453,15 +448,12 @@ export function useSseBus(params: {
           setRunning(false);
           return;
         }
-        // ProviderAuthError is not surfaced as a plain banner — it triggers
-        // the credential auto-refresh flow (owned by ChatPanel) instead.
-        // Skip the generic switch entirely so its `setSendError` call below
-        // doesn't race the refresh's own (better, actionable) messaging.
-        if (err?.name === "ProviderAuthError") {
-          setRunning(false);
-          onProviderAuthError();
-          return;
-        }
+        // A Claude credential error (provider-name or message-shape) now
+        // falls through to `default:` and surfaces the raw message — which is
+        // already the correct, actionable text (e.g. "Run `claude` to refresh
+        // them."). Server-side recovery runs in parallel via the opencode
+        // event pump; if it succeeds the user can re-send ↑+Enter and the
+        // next turn will work.
         let msg: string;
         switch (err?.name) {
           case "ContextOverflowError":

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -67,7 +67,6 @@ function defaultApiImpl(): Record<string, unknown> {
     opencodeModels: () => Promise.resolve([]),
     opencodeDefaultModel: () => Promise.resolve(null),
     opencodeVcsBranch: () => Promise.resolve(null),
-    opencodeRefreshCredentials: () => Promise.resolve({ ok: false, reason: "failed" }),
     opencodeCommands: () => Promise.resolve([]),
     opencodeAgents: () => Promise.resolve([]),
     opencodeFindFiles: () => Promise.resolve([]),

--- a/src/server/claudeAuth.mjs
+++ b/src/server/claudeAuth.mjs
@@ -1,11 +1,15 @@
-// Pure helpers for the Claude credential auto-refresh flow (BET-139).
+// Pure helpers for the Claude credential auto-refresh flow (BET-139, BET-280).
 //
 // Chat mode authenticates to Anthropic via the opencode-claude-auth plugin,
 // which reads/writes ~/.claude/.credentials.json. When the plugin can't
-// refresh a stale access token, opencode emits a ProviderAuthError. The
-// user's manual fix today is to run `claude` once on the box, which re-mints
-// the token; this module supplies the PURE decision logic for automating
-// that fix. All IO (spawn, file read) lives in src/server/opencode.mjs
+// refresh a stale access token, opencode emits an error event whose
+// `error.data.message` reads "Claude Code credentials are unavailable or
+// expired. Run `claude` to refresh them." — opencode wraps the plugin's
+// plain `Error` throw as `UnknownError`, so the legacy ProviderAuthError
+// name match never fires in production (BET-280 follow-up). The user's
+// manual fix today is to run `claude` once on the box, which re-mints the
+// token; this module supplies the PURE decision logic for automating that
+// fix. All IO (spawn, file read) lives in src/server/opencode.mjs
 // (refreshClaudeCredentials) — this file has no top-level side effects and
 // no imports of node:fs / node:child_process, so it's directly node:test-able
 // with in-memory literals.
@@ -77,4 +81,57 @@ export function classifyRefreshOutcome({ credsBefore, credsAfter, now }) {
     return "ok";
   }
   return "failed";
+}
+
+/**
+ * True when an `error`-shaped payload (typically `evt.properties.error` from a
+ * `session.error` event) reports an expired/unavailable Claude credential.
+ *
+ * Returns true if EITHER:
+ *   1. `err.name === "ProviderAuthError"` — kept for forward compatibility if
+ *      opencode ever starts emitting that name again (it currently does NOT —
+ *      the plugin throws a plain `Error` that opencode wraps as
+ *      `UnknownError`); OR
+ *   2. the message — read from `err?.data?.message` and coerced via
+ *      `String(...)` — matches ALL THREE case-insensitive patterns:
+ *      `/claude/`, `/credential/`, `/(expired|unavailable)/`.
+ *
+ * Matching on the message shape (rather than the exact upstream string) is
+ * the entire point of BET-280: BET-139 keyed off `err.name` only and never
+ * fired in production because opencode wraps the plugin's throw. The
+ * three-substring AND keeps the gate tight enough not to catch unrelated
+ * errors, while tolerating minor wording changes upstream.
+ *
+ * Returns false for null, undefined, non-objects, and any payload that
+ * matches neither branch.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isClaudeCredentialError(err) {
+  if (err == null || typeof err !== "object") return false;
+  if (err.name === "ProviderAuthError") return true;
+  const raw = err?.data?.message;
+  if (raw == null) return false;
+  const msg = String(raw).toLowerCase();
+  return /claude/.test(msg) && /credential/.test(msg) && /(expired|unavailable)/.test(msg);
+}
+
+/**
+ * Cooldown gate for the auto-recovery trigger — returns true when enough time
+ * has passed since the last attempt. A single expired-credential burst on the
+ * live box produced ~12 error events in ~25 seconds; without this gate each
+ * one would spawn its own `claude` process.
+ *
+ * True when `lastAttemptAt == null` OR `now - lastAttemptAt >= cooldownMs`.
+ * Nothing else.
+ *
+ * @param {number | null | undefined} lastAttemptAt  epoch ms, or null/undefined for "never"
+ * @param {number} now                                epoch ms
+ * @param {number} [cooldownMs=60_000]                gate window
+ * @returns {boolean}
+ */
+export function shouldAttemptRecovery(lastAttemptAt, now, cooldownMs = 60_000) {
+  if (lastAttemptAt == null) return true;
+  return now - lastAttemptAt >= cooldownMs;
 }

--- a/src/server/claudeAuth.test.mjs
+++ b/src/server/claudeAuth.test.mjs
@@ -4,6 +4,8 @@ import {
   parseCredentials,
   isRefreshTokenExpired,
   classifyRefreshOutcome,
+  isClaudeCredentialError,
+  shouldAttemptRecovery,
 } from "./claudeAuth.mjs";
 
 // ===== parseCredentials =====
@@ -86,4 +88,77 @@ test("classifyRefreshOutcome: failed when credsAfter is null (file unreadable po
     classifyRefreshOutcome({ credsBefore, credsAfter: null, now }),
     "failed",
   );
+});
+
+// ===== isClaudeCredentialError (BET-280) =====
+
+test("isClaudeCredentialError: true for the live UnknownError payload from opencode-claude-auth", () => {
+  // Captured live from the box's opencode API (BET-280 context): the plugin
+  // throws a plain Error and opencode wraps it as UnknownError. The shape is
+  // exact; the message wording may drift upstream and this test should still
+  // match as long as all three substrings remain.
+  assert.equal(
+    isClaudeCredentialError({
+      name: "UnknownError",
+      data: {
+        message: "Claude Code credentials are unavailable or expired. Run `claude` to refresh them.",
+      },
+    }),
+    true,
+  );
+});
+
+test("isClaudeCredentialError: true when name is ProviderAuthError (forward compatibility)", () => {
+  assert.equal(isClaudeCredentialError({ name: "ProviderAuthError" }), true);
+  // Even with no data.message at all, the name alone is enough.
+  assert.equal(isClaudeCredentialError({ name: "ProviderAuthError" }), true);
+});
+
+test("isClaudeCredentialError: false for unrelated error names with similar messages", () => {
+  assert.equal(
+    isClaudeCredentialError({
+      name: "MessageAbortedError",
+      data: { message: "Aborted" },
+    }),
+    false,
+  );
+  assert.equal(
+    isClaudeCredentialError({
+      name: "UnknownError",
+      data: { message: "Something else failed" },
+    }),
+    false,
+  );
+});
+
+test("isClaudeCredentialError: false for null / undefined / empty object / non-objects", () => {
+  assert.equal(isClaudeCredentialError(null), false);
+  assert.equal(isClaudeCredentialError(undefined), false);
+  assert.equal(isClaudeCredentialError({}), false);
+  assert.equal(isClaudeCredentialError("ProviderAuthError"), false);
+  assert.equal(isClaudeCredentialError(42), false);
+});
+
+// ===== shouldAttemptRecovery (BET-280) =====
+
+test("shouldAttemptRecovery: true when lastAttemptAt is null/undefined (never tried)", () => {
+  assert.equal(shouldAttemptRecovery(null, 1_000_000), true);
+  assert.equal(shouldAttemptRecovery(undefined, 1_000_000), true);
+});
+
+test("shouldAttemptRecovery: false when last attempt is within the cooldown window", () => {
+  // 10s ago < 60_000 default cooldown.
+  assert.equal(shouldAttemptRecovery(1_000_000 - 10_000, 1_000_000), false);
+});
+
+test("shouldAttemptRecovery: true when last attempt is older than the cooldown window", () => {
+  // 90s ago > 60_000 default cooldown.
+  assert.equal(shouldAttemptRecovery(1_000_000 - 90_000, 1_000_000), true);
+});
+
+test("shouldAttemptRecovery: respects a custom cooldown", () => {
+  // 30s ago, 20s cooldown → past cooldown → true.
+  assert.equal(shouldAttemptRecovery(1_000_000 - 30_000, 1_000_000, 20_000), true);
+  // 30s ago, 60s cooldown → within cooldown → false.
+  assert.equal(shouldAttemptRecovery(1_000_000 - 30_000, 1_000_000, 60_000), false);
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -316,6 +316,8 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
   } catch (e) {
     console.warn("[webhook] observeEvent failed:", e?.message ?? e);
   }
+  // Auto-recover expired Claude credentials (server-side; works with no client attached).
+  oc.maybeRecoverCredentials(evt).catch(() => {});
   if (evt && evt.type === "permission.asked") {
     (async () => {
       try {

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -17,6 +17,8 @@ import {
   parseCredentials,
   isRefreshTokenExpired,
   classifyRefreshOutcome,
+  isClaudeCredentialError,
+  shouldAttemptRecovery,
 } from "./claudeAuth.mjs";
 
 const REMOTE_PORT = 4096;
@@ -948,12 +950,27 @@ export async function getVcsBranch(directory) {
 }
 
 // ---------------------------------------------------------------------------
-// Claude credential auto-refresh (BET-139)
+// Claude credential auto-refresh (BET-139, BET-280)
 // ---------------------------------------------------------------------------
 
-// Single-flight guard: concurrent ProviderAuthError events share one
-// in-flight refresh promise instead of racing multiple `claude` spawns.
+// Single-flight guard: concurrent auth-error events share one in-flight
+// refresh promise instead of racing multiple `claude` spawns. The cooldown
+// in `maybeRecoverCredentials` is the FIRST gate (saves most spawns);
+// this guard catches whatever still gets through inside the same burst.
 let _refreshInFlight = null;
+// Last-recovery timestamp (epoch ms) for the cooldown gate. A single
+// expired-credential burst on the live box produced ~12 error events in
+// ~25 seconds; without a cooldown each one would spawn its own `claude`
+// process.
+let _lastRecoveryAt = null;
+/** Test-only: peek the recovery cooldown state. */
+export function _getRecoveryCooldownState() {
+  return { lastRecoveryAt: _lastRecoveryAt };
+}
+/** Test-only: reset recovery cooldown state between scenarios. */
+export function _resetRecoveryCooldownState() {
+  _lastRecoveryAt = null;
+}
 
 /** Resolve the `claude` CLI binary. manta-server's service PATH excludes the
  *  user's ~/.local/bin (where the claude installer symlinks the binary), so a
@@ -990,9 +1007,10 @@ function readCredsSnapshot() {
  * CLI — the exact fix the user performs by hand today. Mirrors getVcsBranch's
  * cpSpawn-wrapped-in-a-Promise shape.
  *
- * Triggered from exactly ONE place: the renderer's ProviderAuthError handler
- * (via the opencode:refresh-credentials RPC channel). Single-flight guarded
- * so concurrent auth errors share one refresh instead of duplicate spawns.
+ * Triggered from exactly ONE place: `maybeRecoverCredentials` below, which is
+ * called from the opencode event pump (`src/server/index.mjs`). Single-flight
+ * guarded so concurrent auth errors share one refresh instead of duplicate
+ * spawns.
  *
  * @returns {Promise<{ ok: boolean, reason?: "no-credentials" | "refresh-token-expired" | "failed", expiresAt?: number }>}
  */
@@ -1002,6 +1020,42 @@ export async function refreshClaudeCredentials() {
     _refreshInFlight = null;
   });
   return _refreshInFlight;
+}
+
+/**
+ * Server-side trigger for the Claude credential auto-refresh (BET-280).
+ * Called from the opencode event pump on every `session.error`; only fires
+ * a refresh when the error matches our message-shape predicate (catches the
+ * UnknownError wrapper the plugin throws today AND the legacy error-name
+ * compatibility branch in `isClaudeCredentialError`) AND the cooldown gate
+ * is open (catches the burst).
+ *
+ * Runs without a client attached — that's the BET-280 whole point. The
+ * renderer used to drive this via an IPC channel + an SSE callback, which
+ * required a chat panel for the session to be mounted in a connected client.
+ * Errors on a session nobody was watching (the live failure) never recovered.
+ *
+ * Never throws — a rejection from `refreshClaudeCredentials` is swallowed
+ * (the function logs its own outcome line and the caller doesn't await the
+ * result anyway).
+ *
+ * @param {unknown} evt  opencode event from `subscribeEvents`
+ */
+export async function maybeRecoverCredentials(evt) {
+  try {
+    if (evt?.type !== "session.error") return;
+    if (!isClaudeCredentialError(evt.properties?.error)) return;
+    if (!shouldAttemptRecovery(_lastRecoveryAt, Date.now())) return;
+    _lastRecoveryAt = Date.now();
+    // The refresh function logs its own outcome; we don't await it because
+    // the pump must never block. A failure is benign (next event within the
+    // cooldown won't retry; one past the cooldown will).
+    void refreshClaudeCredentials();
+  } catch (e) {
+    // Defensive: a thrown predicate or unexpected shape must never escape
+    // into the pump. Log so the operator can see it happened.
+    console.warn("[claude-auth] maybeRecoverCredentials failed:", e?.message ?? e);
+  }
 }
 
 async function doRefresh() {

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -152,14 +152,14 @@ test("session.error MessageAbortedError → NO push (intentional abort/drain)", 
 
 test("session.error with non-abort error object → still notifies", () => {
   const p = classifyPushEvent(
-    {
-      type: "session.error",
-      properties: {
-        sessionID: "ses_err",
-        message: "real failure",
-        error: { name: "ProviderAuthError" },
-      },
+  {
+    type: "session.error",
+    properties: {
+      sessionID: "ses_err",
+      message: "real failure",
+      error: { name: "ApiError" },
     },
+  },
     NOFOCUS,
   );
   assert.equal(p?.kind, "error");

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -324,9 +324,6 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // → args[0] = directory (string | undefined)
     "opencode:vcs-branch": (directory) => oc.getVcsBranch(directory),
 
-    // preload: ipcRenderer.invoke(IPC.opencodeRefreshCredentials)  → no args
-    "opencode:refresh-credentials": () => oc.refreshClaudeCredentials(),
-
     // preload: ipcRenderer.invoke(IPC.opencodeListSessions, directory?)
     // → args[0] = directory (string | undefined)
     "opencode:list-sessions": (directory) => oc.listSessions(directory),

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -243,11 +243,6 @@ export interface Api {
   }): Promise<SubagentDef[]>;
   opencodeRestart(): Promise<void>;
   opencodeVcsBranch(directory?: string): Promise<string | null>;
-  opencodeRefreshCredentials(): Promise<{
-    ok: boolean;
-    reason?: "no-credentials" | "refresh-token-expired" | "failed";
-    expiresAt?: number;
-  }>;
 
   // Session management.
   opencodeListSessions(directory?: string): Promise<OpencodeSessionListItem[]>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -459,10 +459,6 @@ export const IPC = {
   // only fires on change, so the chat footer fetches the initial value on
   // mount via this channel.
   opencodeVcsBranch: "opencode:vcs-branch",
-  // Re-mint expired Claude OAuth credentials (spawns `claude` server-side)
-  // and report the outcome. Triggered by the renderer's ProviderAuthError
-  // handler — see the session.error switch in useSseBus.ts.
-  opencodeRefreshCredentials: "opencode:refresh-credentials",
   // Session management: list/fork/compact/delete.
   opencodeListSessions: "opencode:list-sessions",
   opencodeForkSession: "opencode:fork-session",     // returns new sessionId


### PR DESCRIPTION
Refactor (no behavior change for working flows).

**Base:** origin/main @ f19b0ae
**Branch:** multica/BET-280-server-credential-recovery @ c9a9af5

## Why

BET-139 shipped a renderer-driven refresh that never fired in production:
the trigger keyed off `err.name === 'ProviderAuthError'` but the
opencode-claude-auth plugin throws a plain Error, which opencode wraps
as `UnknownError`. The match never ran. A second problem: the trigger
lived in the renderer, so a session with no attached chat panel (the
live failure case) never recovered.

This moves the trigger into the opencode event pump on the box, with no
client required. The renderer loses all credential-specific code.

## What changed

**Server (new code):**
- `src/server/claudeAuth.mjs` — `isClaudeCredentialError(err)` matches
  EITHER the legacy ProviderAuthError name OR a message with /claude/ +
  /credential/ + /(expired|unavailable)/ (case-insensitive) — tolerates
  upstream wording drift. `shouldAttemptRecovery(lastAttemptAt, now,
  cooldownMs=60_000)` throttles the burst: one expired token produced
  ~12 error events in ~25s on the live box.
- `src/server/opencode.mjs` — `maybeRecoverCredentials(evt)` is the
  per-event gate (event-type + predicate + cooldown) that calls the
  existing single-flight `refreshClaudeCredentials()`. Never throws.
- `src/server/index.mjs` — one line in the existing pump callback,
  immediately after `webhookEngine.observeEvent`.

**Renderer (delete only):**
- `src/renderer/ChatPanel.tsx` — drop `credRefresh` state,
  `onProviderAuthErrorRef` ref + handler, `<CredRefreshCard>` JSX,
  `setCredRefresh(null)` reset, plus the `credentialRefreshBannerText`
  + `lastUserMessageText` imports.
- `src/renderer/hooks/useSseBus.ts` — drop `onProviderAuthError` prop
  + the session.error early-return branch. The credential error now
  falls through to `default:` in the switch and surfaces the raw
  message ('Run `claude` to refresh them.'), which is the actionable
  text the user needs while the server tries to recover.
- `src/renderer/Cards.tsx` — delete `CredRefreshCard`.
- `src/renderer/chatUtils.ts` + `chatUtils.test.ts` — delete
  `credentialRefreshBannerText` + `lastUserMessageText` + their
  tests.
- `src/renderer/testHarness.tsx` — drop the
  `opencodeRefreshCredentials` stub.
- `src/shared/api.ts` + `src/shared/types.ts` + `src/renderer/api/httpApi.ts` — drop the
  signature, IPC entry, and `rpc()` line.
- `src/server/rpc.mjs` — drop the `opencode:refresh-credentials` handler.

## Verification results

**Files changed:** 16 files, +219 / -241 (more deletions than insertions, as required).

- typecheck: exit 0, no errors
- tests: 785 pass / 0 fail (renderer Vitest + `node --test` server suite), including the new `isClaudeCredentialError` and `shouldAttemptRecovery` cases
- `grep -rn` sweep for `ProviderAuthError`, `credRefresh`, `CredRefreshCard`, `credentialRefreshBannerText`, `lastUserMessageText`, `opencodeRefreshCredentials`, `refresh-credentials`:
  - `ProviderAuthError`: hits only in `src/server/claudeAuth.mjs` + `src/server/claudeAuth.test.mjs` (the forward-compatibility branch in `isClaudeCredentialError` + its tests)
  - every other symbol: zero hits across `src/`
- no new npm dependency (`package.json` unchanged)