### PR TITLE
refactor(renderer): extract MetaBadge into chatShared (BET-282)

### DIFF
--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -13,7 +13,7 @@
 import { memo, useEffect, useRef, useState } from "react";
 import type { ScheduledJob, SecretMeta, SecretScope, WebhookMeta } from "../shared/types";
 import { describeCron, describeNextRun } from "./chatUtils";
-import { CLAUDE_ORANGE } from "./chatShared";
+import { CLAUDE_ORANGE, MetaBadge } from "./chatShared";
 
 // ScheduledTasksCard — pinned card above the composer showing this session's
 // scheduled prompts (created by the AI's `schedule` opencode tool) with a
@@ -186,12 +186,12 @@ export const WebhooksCard = memo(function WebhooksCard({
                       {h.label}
                     </span>
                     {h.unsigned && (
-                      <span
-                        className="shrink-0 px-1 rounded text-red-400 border border-red-500/30 text-[10px]"
+                      <MetaBadge
+                        tone="danger"
                         title="No signature required — anyone with the URL can trigger this hook"
                       >
                         unsigned
-                      </span>
+                      </MetaBadge>
                     )}
                   </div>
                   <div className="flex items-center gap-2 text-text-faint font-mono text-[11px]">
@@ -383,8 +383,7 @@ export const SecretsCard = memo(function SecretsCard({
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">
                   <span className="text-text font-mono truncate">{s.key}</span>
-                  <span
-                    className="shrink-0 rounded px-1 text-[10px] text-text-faint border border-border"
+                  <MetaBadge
                     title={
                       s.scope === "shared"
                         ? "Available to every session"
@@ -398,7 +397,7 @@ export const SecretsCard = memo(function SecretsCard({
                       : s.scope === "project"
                         ? `project:${s.project ?? "?"}`
                         : "session"}
-                  </span>
+                  </MetaBadge>
                 </div>
                 {s.hint && (
                   <div className="text-text-faint text-[11px] truncate" title={s.hint}>

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -10,7 +10,7 @@
 // No React rendering lives here; only createContext (a value factory) plus
 // pure helpers, so this stays cheap to import from anywhere.
 
-import { createContext } from "react";
+import { createContext, type ReactNode } from "react";
 import type { OpencodeMessage, OpencodeModel } from "../shared/types";
 
 // Claude's bullet/spinner accent. Inlined (not in tailwind config) so we only
@@ -384,4 +384,32 @@ export function mergePromptHistory(
     out.push(item);
   }
   return out;
+}
+
+// Small inline metadata badge: the faint bordered pill that sits next to a
+// primary label to name a secondary attribute (a secret's scope, a webhook's
+// unsigned state, a subagent's agent type). One definition so the call sites
+// cannot drift apart.
+//
+// Always render it as the `shrink-0` sibling of a `truncate` primary label
+// inside a `flex items-center gap-1.5` row — that is what keeps the badge
+// visible when the primary label is too long for the row.
+export function MetaBadge({
+  children,
+  tone = "neutral",
+  title,
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "danger";
+  title?: string;
+}) {
+  const toneClass =
+    tone === "danger"
+      ? "text-red-400 border-red-500/30"
+      : "text-text-faint border-border";
+  return (
+    <span className={"shrink-0 rounded border px-1 text-[10px] " + toneClass} title={title}>
+      {children}
+    </span>
+  );
 }


### PR DESCRIPTION
Refactor — zero visual change, zero behaviour change.

Two near-identical 'faint bordered pill' badges (WebhooksCard 'unsigned', SecretsCard scope) were hand-written with the same utility classes. Collapse them into a single `MetaBadge` component exported from `chatShared` before a third call site is added (subagent name badge — see follow-up issue).

**Files changed:** 2 files.
- `src/renderer/chatShared.ts` → `src/renderer/chatShared.tsx` (rename; no import statements edited — every importer already omits the extension)
- `src/renderer/PanelCards.tsx` (extend the existing `chatShared` import to add `MetaBadge`, replace both badge spans with `<MetaBadge>`)

**MetaBadge** accepts `tone: 'neutral' | 'danger'` (default `neutral`). Both call sites already sit inside `<div className="flex items-center gap-1.5">` next to a `truncate` label, so the surrounding markup is unchanged.

The SET of classes applied to the rendered `<span>` is identical to before (Tailwind is order-independent; class strings are reordered but the set is the same). `title` attribute and text content are byte-for-byte identical. The existing `chatShared.test.ts` is unchanged and still passes.

**Verification:**
- typecheck: exit 0 (tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json)
- test: 777 pass, 0 fail (vitest run + node:test on src/server, src/gateway, scripts, scripts/release)

**Base:** `origin/main` @ `f19b0ae`

**Note on Step 4 grep:** the literal grep `grep -rn 'border-red-500/30\|text-\[10px\] text-text-faint border border-border' src/renderer/` still shows `PanelCards.tsx` because the Cancel/Revoke/Delete *button* borders at lines 99/214/410 also use `border-red-500/30`. The two *badge* class strings themselves are fully removed from PanelCards.tsx (`shrink-0 px-1 rounded text-red-400 border border-red-500/30 text-[10px]` and `shrink-0 rounded px-1 text-[10px] text-text-faint border border-border` no longer appear anywhere in that file). The grep in the ticket is a substring grep that incidentally matches the button borders — happy to tighten the grep if the reviewer prefers.