### PR TITLE
fix(install): brace-guard $VAR before ellipsis so macOS bash 3.2 doesn't trip set -u

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -442,7 +442,7 @@ main() {
   OPENCODE_AGENTS="$OPENCODE_CONFIG_DIR/AGENTS.md"
   if [ -d "$OPENCODE_TOOLS_SRC" ]; then
     mkdir -p "$OPENCODE_TOOLS_DIR"
-    log "Copying manta-native opencode tools into $OPENCODE_TOOLS_DIR…"
+    log "Copying manta-native opencode tools into ${OPENCODE_TOOLS_DIR}…"
     # cp -f overwrites — tools are versioned with the tarball, so a re-run
     # naturally picks up upgrades. EXCLUDE *.test.ts: opencode loads EVERY file
     # in tools/ as a tool, and a test file imports vitest (absent under
@@ -471,7 +471,7 @@ main() {
     if [ -f "$OPENCODE_AGENTS" ] && grep -q '^## manta scheduled tasks' "$OPENCODE_AGENTS"; then
       ok "opencode AGENTS.md already contains manta guidance — skipping append."
     else
-      log "Appending manta opencode agent guidance to $OPENCODE_AGENTS…"
+      log "Appending manta opencode agent guidance to ${OPENCODE_AGENTS}…"
       {
         [ -f "$OPENCODE_AGENTS" ] && cat "$OPENCODE_AGENTS" && printf '\n'
         cat "$OPENCODE_TOOLS_SRC/AGENTS.md"
@@ -1134,7 +1134,7 @@ main() {
   #    wait for. The install just confirms the loopback server is healthy
   #    and prints the pair link.
   # ---------------------------------------------------------------------------
-  log "Waiting for the server to become healthy at $MANTA_HEALTH_URL…"
+  log "Waiting for the server to become healthy at ${MANTA_HEALTH_URL}…"
   "$NODE" -e '
     import("'"$LIB"'").then(async (m) => {
       const r = await m.waitForHealth(process.env.MANTA_HEALTH_URL, { maxAttempts: 60, intervalMs: 1000 });


### PR DESCRIPTION
## Problem

macOS install via `curl -fsSL https://mantaui.com/install.sh | bash` fails right after "opencode.jsonc seeded" with:

```
bash: line 445: OPENCODE_TOOLS_DIR<garbage>: unbound variable
```

## Root cause

`curl | bash` on macOS runs Apple's **bash 3.2.57** (Apple hasn't shipped a newer bash since 2007, GPLv3). Three `log` lines had a shell variable directly abutting a UTF-8 ellipsis (`…`) with no braces:

- `"$OPENCODE_TOOLS_DIR…"` (line 445)
- `"$OPENCODE_AGENTS…"` (line 474)
- `"$MANTA_HEALTH_URL…"` (line 1137)

bash 3.2's parameter-name scanner swallows the multibyte ellipsis bytes (E2 80 A6) into the identifier, yielding an unknown variable name. With `set -u` (nounset) in effect, the expansion aborts the whole script. Linux (bash 5.x) parses `$VAR…` correctly, so this was macOS-only.

## Fix

Brace-guard the three sites (`${VAR}…`). Swept the whole file — no other `$VAR` abuts a non-ASCII byte.

## Verify

- `bash -n scripts/install.sh` clean
- `grep -nP '\$[A-Za-z_][A-Za-z0-9_]*[\x80-\xff]' scripts/install.sh` → none
- `node --test scripts/install.test.mjs` → 145 pass

Ship with a `web-v11` tag (served install.sh is the web-deploy target).