### PR TITLE
feat(server): proactive pre-expiry Claude credential refresh poller (BET-281)

### DIFF
--- a/src/server/claudeAuth.mjs
+++ b/src/server/claudeAuth.mjs
@@ -135,3 +135,30 @@ export function shouldAttemptRecovery(lastAttemptAt, now, cooldownMs = 60_000) {
   if (lastAttemptAt == null) return true;
   return now - lastAttemptAt >= cooldownMs;
 }
+
+/**
+ * Pre-expiry gate for the proactive refresh poller (BET-281). Returns true
+ * when the OAuth access token is "about to expire" (within `leadMs`) AND a
+ * refresh is still possible (the refresh token itself is not expired).
+ *
+ * True when ALL of:
+ *   - `creds` is non-null
+ *   - `typeof creds.expiresAt === "number"`
+ *   - `creds.expiresAt - now <= leadMs`
+ *   - `isRefreshTokenExpired(creds, now)` is false
+ *
+ * Returns false otherwise. Pure — no IO, no imports beyond what this file
+ * already has. Reuses `isRefreshTokenExpired` rather than re-implementing the
+ * refresh-token check (single source of truth).
+ *
+ * @param {{ expiresAt?: number, refreshTokenExpiresAt?: number } | null | undefined} creds
+ * @param {number} now        epoch ms
+ * @param {number} [leadMs=30 * 60_000]  refresh this far before expiry
+ * @returns {boolean}
+ */
+export function shouldRefreshAhead(creds, now, leadMs = 30 * 60_000) {
+  if (!creds) return false;
+  if (typeof creds.expiresAt !== "number") return false;
+  if (creds.expiresAt - now > leadMs) return false;
+  return !isRefreshTokenExpired(creds, now);
+}

--- a/src/server/claudeAuth.test.mjs
+++ b/src/server/claudeAuth.test.mjs
@@ -6,6 +6,7 @@ import {
   classifyRefreshOutcome,
   isClaudeCredentialError,
   shouldAttemptRecovery,
+  shouldRefreshAhead,
 } from "./claudeAuth.mjs";
 
 // ===== parseCredentials =====
@@ -161,4 +162,71 @@ test("shouldAttemptRecovery: respects a custom cooldown", () => {
   assert.equal(shouldAttemptRecovery(1_000_000 - 30_000, 1_000_000, 20_000), true);
   // 30s ago, 60s cooldown → within cooldown → false.
   assert.equal(shouldAttemptRecovery(1_000_000 - 30_000, 1_000_000, 60_000), false);
+});
+
+// ===== shouldRefreshAhead (BET-281) =====
+
+test("shouldRefreshAhead: true when expiresAt is within the default 30 min lead", () => {
+  // now=1_000_000, expiresAt=now+10min (600_000ms) — within 30min lead → true.
+  const now = 1_000_000;
+  assert.equal(
+    shouldRefreshAhead({ expiresAt: now + 10 * 60_000, refreshTokenExpiresAt: now + 10_000_000 }, now),
+    true,
+  );
+});
+
+test("shouldRefreshAhead: true when expiresAt is already in the past", () => {
+  // Already expired — clearly within the lead window — but the refresh token
+  // is still valid so the CLI refresh can succeed.
+  const now = 1_000_000;
+  assert.equal(
+    shouldRefreshAhead({ expiresAt: now - 60_000, refreshTokenExpiresAt: now + 10_000_000 }, now),
+    true,
+  );
+});
+
+test("shouldRefreshAhead: false when expiresAt is comfortably in the future (5h away)", () => {
+  // 5h > 30min default lead → too early.
+  const now = 1_000_000;
+  assert.equal(
+    shouldRefreshAhead({ expiresAt: now + 5 * 60 * 60_000, refreshTokenExpiresAt: now + 10_000_000 }, now),
+    false,
+  );
+});
+
+test("shouldRefreshAhead: false when refreshTokenExpiresAt is in the past", () => {
+  // Within the lead window BUT the refresh token is dead → CLI refresh can't
+  // succeed, the reactive path / `claude auth login` is the only fix.
+  const now = 1_000_000;
+  assert.equal(
+    shouldRefreshAhead({ expiresAt: now + 5 * 60_000, refreshTokenExpiresAt: now - 1000 }, now),
+    false,
+  );
+});
+
+test("shouldRefreshAhead: false for null / undefined creds", () => {
+  assert.equal(shouldRefreshAhead(null, 1_000_000), false);
+  assert.equal(shouldRefreshAhead(undefined, 1_000_000), false);
+});
+
+test("shouldRefreshAhead: false when creds has no expiresAt (we have no clock to read)", () => {
+  // Defensive: without expiresAt we can't decide ahead-of-time. The reactive
+  // path (isClaudeCredentialError) still applies.
+  assert.equal(shouldRefreshAhead({}, 1_000_000), false);
+  // expiresAt non-number (string from a corrupt file) → also no.
+  assert.equal(shouldRefreshAhead({ expiresAt: "soon" }, 1_000_000), false);
+});
+
+test("shouldRefreshAhead: respects a custom leadMs", () => {
+  const now = 1_000_000;
+  // expiresAt 2h out, lead 1h → 2h > 1h, too early.
+  assert.equal(
+    shouldRefreshAhead({ expiresAt: now + 2 * 60 * 60_000, refreshTokenExpiresAt: now + 10_000_000 }, now, 60 * 60_000),
+    false,
+  );
+  // Same creds, lead 3h → within window.
+  assert.equal(
+    shouldRefreshAhead({ expiresAt: now + 2 * 60 * 60_000, refreshTokenExpiresAt: now + 10_000_000 }, now, 3 * 60 * 60_000),
+    true,
+  );
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -272,6 +272,14 @@ const { stop: stopFileServer } = startFileServer();
 // eslint-disable-next-line no-unused-vars
 const { stop: stopServePageCleanup } = startCleanupPoller();
 
+// Proactive pre-expiry Claude credential refresh (BET-281): clocks
+// ~/.claude/.credentials.json every 10 min and refreshes ~30 min ahead of
+// expiry. Reactive recovery (BET-280) becomes a backup. See
+// src/server/opencode.mjs (startCredentialRefreshPoller) — same shape as
+// the other timer pollers above.
+// eslint-disable-next-line no-unused-vars
+const { stop: stopCredentialRefreshPoller } = oc.startCredentialRefreshPoller();
+
 // Forward every opencode SSE event into the bus so mobile clients
 // subscribed to /events receive live chat updates.
 // subscribeEvents reconnects silently on failure (opencode may not be up

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -19,6 +19,7 @@ import {
   classifyRefreshOutcome,
   isClaudeCredentialError,
   shouldAttemptRecovery,
+  shouldRefreshAhead,
 } from "./claudeAuth.mjs";
 
 const REMOTE_PORT = 4096;
@@ -1117,6 +1118,67 @@ function logAndReturn(result) {
     result.expiresAt ?? "-",
   );
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Proactive pre-expiry refresh poller (BET-281)
+// ---------------------------------------------------------------------------
+//
+// Today the access token is only refreshed reactively — `maybeRecoverCredentials`
+// fires when an `session.error` matches the credential-expired predicate. The
+// user eats one broken turn on every ~8h expiry window. This poller clocks
+// `~/.claude/.credentials.json` and runs the existing `refreshClaudeCredentials`
+// ahead of time, so the reactive path becomes a backup rather than the only
+// line of defense.
+//
+// Shape mirrors `startCleanupPoller` / `createCleanupSweep` in servePage.mjs:
+// factory body guarded by an `inFlight` boolean so a slow tick can't overlap
+// the next, immediate `sweep()` at startup, `setInterval` with `unref()` so
+// the timer never holds the event loop open.
+//
+// Default interval: 10 min. Default lead time (inside `shouldRefreshAhead`):
+// 30 min. With Claude tokens living ~8h, those defaults give us >= 1
+// refresh-ahead per token window while limiting the cost of an unexpected
+// loopback FS read to ~144/day. Not configurable per the issue spec.
+
+const CREDENTIAL_REFRESH_MS = 10 * 60 * 1000;
+
+export function createCredentialRefreshSweep({
+  readCreds = readCredsSnapshot,
+  refresh = refreshClaudeCredentials,
+  shouldRefresh = shouldRefreshAhead,
+  now = Date.now,
+} = {}) {
+  let inFlight = false;
+
+  async function sweep() {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const creds = readCreds();
+      if (shouldRefresh(creds, now())) {
+        try {
+          await refresh();
+        } catch {
+          // never throw — a refresh failure must not kill the timer
+        }
+      }
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return { sweep };
+}
+
+export function startCredentialRefreshPoller({ intervalMs = CREDENTIAL_REFRESH_MS } = {}) {
+  const { sweep } = createCredentialRefreshSweep();
+  // Run once immediately so a fresh server boot doesn't have to wait
+  // intervalMs to discover an already-near-expiry credential.
+  sweep();
+  const timer = setInterval(sweep, intervalMs);
+  timer.unref();
+  return { stop: () => clearInterval(timer) };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Base:** `origin/main` @ `c08e015`

**Files changed:** 4 files, +165 lines.
- `src/server/claudeAuth.mjs` — new pure export `shouldRefreshAhead(creds, now, leadMs = 30*60_000)`.
- `src/server/claudeAuth.test.mjs` — 7 new test cases (covers null creds, no `expiresAt`, refresh-token-expired, future expiry, past expiry, custom leadMs).
- `src/server/opencode.mjs` — new `createCredentialRefreshSweep` / `startCredentialRefreshPoller`. Shape mirrors `createCleanupSweep` / `startCleanupPoller` from `servePage.mjs` (inFlight guard, immediate sweep, `setInterval`, `unref`, returned `stop()`). Never throws.
- `src/server/index.mjs` — wired next to the other timer pollers.

**Verification results:**
- PR branch (`multica/BET-281-proactive-cred-refresh` @ `db4c74f`):
  - typecheck: exit `0`. Errors: none.
  - test: 792 pass / 0 fail / 0 skip (7 new `shouldRefreshAhead` cases included).
- Base (`origin/main` @ `c08e015`):
  - typecheck: exit `0`. Errors: none.
  - test: 785 pass / 0 fail / 0 skip.
- **Conclusion:** 0 new failures, 7 new tests added, all pre-existing tests still pass.

The poller reuses the existing `refreshClaudeCredentials()` and `readCredsSnapshot()` — no duplicate credential-reading logic (verified via `grep readCredsSnapshot|parseCredentials src/server/`, single call site in `opencode.mjs`).

**Out of scope (per spec):** no config field / AppConfig key / Settings toggle / env var; no UI; no RPC channel; no change to `refreshClaudeCredentials` itself.

**Refs:** unblocks the proactive side of BET-280's reactive recovery.