### PR TITLE
fix(install): shasum fallback + macOS box docs (BET-278)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2108,11 +2108,72 @@ curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/llms-install.md   #
 curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/downloads/Manta-latest.dmg  # desktop
 curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/releases/manta-latest-linux-x64.tar.gz   # server x64
 curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/releases/manta-latest-linux-arm64.tar.gz  # server arm64
+curl -s -o /dev/null -w "%{http_code}\n" https://mantaui.com/releases/manta-latest-darwin-arm64.tar.gz  # server darwin-arm64 (Apple Silicon Mac box)
 curl -fsS https://gateway.mantaui.com/healthz    # gateway → {"ok":true}
 node /tmp/opencode/asc.mjs   # (on the box) — ASC build state for iOS (VALID = really uploaded)
 ```
 For byte-parity, `sha256sum` the live file vs the repo copy (the web workflow
 already does this and fails red on drift).
+
+## macOS box (BET-274) — design decisions, do not re-derive
+
+The installer supports macOS (Apple Silicon only) as a box OS alongside Linux.
+Don't re-litigate these — they're fixed by the BET-274 epic and a regression on
+any of them breaks the macOS path.
+
+- **Apple Silicon only.** `resolve_arch` in `scripts/install.sh` maps
+  `(uname -s=Darwin, uname -m=arm64)` → `darwin_arm64`; an Intel Mac
+  (`Darwin + x86_64`) dies immediately with a clear "Apple Silicon only"
+  message pointing at the desktop app. There is no `darwin-x64` build
+  target and there is no plan to add one.
+- **Service manager = `launchd` LaunchAgents, NOT systemd.** The two
+  services run as per-user LaunchAgents under
+  `~/Library/LaunchAgents/com.mantaui.{server,opencode}.plist`
+  (templates in `scripts/launchd/`). Loaded with `launchctl bootstrap
+  gui/$(id -u) <plist>`, restarted with
+  `launchctl kickstart -k gui/$(id -u)/<label>`. The Linux `systemd
+  --user` path is gated on `command -v systemctl`; macOS never has it,
+  so `install.sh` branches to `elif [ "$IS_MACOS" = "1" ]` for both
+  service installs. `self-update.sh` mirrors the same three-way branch
+  (`systemctl` → `launchctl` → manual warn). **LaunchAgents load at GUI
+  login and survive reboot as long as the user is logged in** — a
+  headless-never-logs-in Mac is unsupported (no `enable-linger` analog;
+  LaunchDaemon requires root and is out of scope).
+- **Loopback + Tailscale-only ingress.** The Caddy/apt/DNS/gateway-TLS
+  privileged section (install.sh 7.5 A/D/E) is gated on a single
+  `SKIP_PUBLIC_TLS` predicate, which merges the macOS case with the
+  existing tailscale case: both skip the public TLS sub-steps. **The
+  gateway-register sub-steps B/C STILL RUN on macOS** — they are
+  user-space and the gateway_token is still needed for APNs push.
+  `hostname -I` (BSD-incompatible), `ss -tlnH`, `loginctl
+  enable-linger`, and the Caddyfile `sed -i` (which is GNU-only) are
+  all inside OS-guarded blocks and macOS never reaches them. Confirmed
+  by the audit in BET-278 item #4. **Do not bypass the
+  `SKIP_PUBLIC_TLS` gate** — the macOS install dies on `:80`/`:443`
+  binding without sudo, and there's no path to making public TLS work
+  on macOS in v1.
+- **`darwin-arm64` tarball built on `macos-14` GitHub runner.** The
+  `server-tarball-deploy.yml` workflow matrix is
+  `[x64, arm64, darwin-arm64]`, with `runs-on` switching to
+  `macos-14` for the darwin leg. Cannot cross-compile: node-pty's
+  native ABI is host-tied, so the macOS build MUST run on a Mac.
+  Don't add a `darwin-x64` job — Apple Silicon Macs are the only ones
+  we ship a box for.
+- **Arch resolution single-source-of-truth.** Three files share the
+  same arch map and MUST stay in sync:
+  - `scripts/install.sh` `resolve_arch` → `linux_x64` | `linux_arm64` |
+    `darwin_arm64` (the underscore form is the manifest key).
+  - `scripts/release/pack.mjs` `resolveArch` → `{ key: "...", file: "..."
+    }`, where `file` is the hyphen form used in tarball filenames
+    AND nodejs.org's `node-v<v>-<file>.tar.gz` token
+    (`darwin-arm64`).
+  - The combined manifest (`file_darwin_arm64=` + `sha256_darwin_arm64=`
+    keys) emitted by `scripts/release/merge-manifest.mjs` and the
+    `server-v*` workflow.
+  If you rename or re-shape any of these three, do it in all three in
+  the same PR — `install.sh`'s `manifest_get "$manifest" "file_$ARCH_KEY"`
+  assumes the underscored key exists in the manifest, and the workflow's
+  matrix value is what the tarball filename uses.
 
 ## Plugins — YAML manifests (v2, BET-189)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ curl -fsSL https://mantaui.com/install.sh | bash
 
 Prints a pairing code. Re-running upgrades in place and preserves identity.
 
+**On your Mac (Apple Silicon)** — also supported as a box OS. The installer
+auto-detects macOS, runs without sudo (no Caddy / Let's Encrypt), installs
+two launchd LaunchAgents (`com.mantaui.{server,opencode}`) under
+`~/Library/LaunchAgents/`, and serves `127.0.0.1:8787` + (if Tailscale is
+running) the tailnet URL. There is no public `<box_id>.boxes.mantaui.com`
+on macOS — reach the box from off-network via Tailscale. The Mac must be
+logged in (LaunchAgents load at GUI login); Intel Macs are not supported
+as a box — install the desktop app on those instead. Same
+`curl … | bash` invocation, same idempotency, same pairing-code output.
+
 **On your Mac**: download the app from [mantaui.com](https://mantaui.com)
 (or run from source: `npm install && npm run dev`), enter the pairing code in
 onboarding, pick providers, create your first project (a tmux session).

--- a/llms-install.md
+++ b/llms-install.md
@@ -32,17 +32,44 @@ Ask the user exactly this question:
 Do NOT ask about chat mode (always installed), model providers, or projects —
 the desktop app's onboarding handles those.
 
+## macOS box (Apple Silicon) — read this if the answer was "this Mac"
+
+The installer supports macOS as a box OS **only on Apple Silicon (arm64)**
+machines running a recent macOS. **Intel Macs are not supported as a box** —
+the installer will refuse with a clear message rather than silently failing;
+if the user wants to USE Manta on an Intel Mac, point them at the desktop app
+instead (`https://mantaui.com/downloads/Manta-latest.dmg`).
+
+The macOS box path is **loopback + Tailscale-only**. There is NO public
+`<box_id>.boxes.mantaui.com` HTTPS endpoint on a macOS box — the installer
+deliberately skips the Caddy / Let's Encrypt / gateway DNS section that Linux
+boxes run (no `apt`, no Caddy, no public DNS, no root-level privileged
+section). To reach a macOS box from off-network, the user needs **Tailscale**
+(or another tailnet) installed and running; the installer auto-detects
+Tailscale and prints the tailnet URL on success.
+
+The macOS box runs as **launchd LaunchAgents** under the logged-in user
+(`~/Library/LaunchAgents/com.mantaui.{server,opencode}.plist`), which load at
+GUI login and survive reboot as long as the user is logged in. **A headless /
+never-logs-in Mac is NOT supported** — the LaunchAgents never load without a
+GUI session. If the user wants 24/7 box availability they need a Linux VPS
+(or a Mac that is logged in continuously).
+
 ## Step 2 — preflight
 
 Run on the target box:
 
-- `uname -m` — must be `x86_64` or `aarch64` / `arm64`. Anything else: stop and
-  tell the user only x86_64 and arm64 Linux are supported today.
-- `for c in curl tar sha256sum tmux git; do command -v $c >/dev/null || echo "missing: $c"; done`
-  — all five are hard requirements the installer does NOT install. For any
-  missing one, give the user the exact command for their distro
-  (`sudo apt-get install -y tmux git` / `sudo dnf install -y tmux git`;
-  `sha256sum` is in coreutils) and wait for them to run or approve it.
+- `uname -m` — must be `x86_64` or `aarch64` / `arm64` (Linux) OR `arm64`
+  (macOS / Apple Silicon). Intel Macs are not supported as a box — stop and
+  point the user at the desktop app.
+- `for c in curl tar tmux git; do command -v $c >/dev/null || echo "missing: $c"; done`
+  plus `command -v sha256sum || command -v shasum` — sha256sum (Linux /
+  coreutils) and `shasum` (macOS, ships by default) are both accepted; the
+  installer refuses if NEITHER is present. On macOS `shasum` ships out of the
+  box; do NOT require the user to `brew install coreutils`. All five are
+  hard requirements the installer does NOT install. For any missing one,
+  give the user the exact command for their distro
+  (`sudo apt-get install -y tmux git` / `sudo dnf install -y tmux git`).
 - The installer installs Caddy (apt repo) if absent, then registers the box
   with the hosted push gateway (`https://gateway.mantaui.com`) so the public
   hostname `<box_id>.boxes.mantaui.com` resolves and serves HTTPS. The box
@@ -70,7 +97,17 @@ systemd --user units, enables linger, and ends by printing a 6-digit pairing
 code, the box id, and a `manta://pair` link. Capture all of those for your
 final report.
 
+**macOS box:** the installer runs the same way — `curl … | bash` on the Mac
+terminal while logged in. It will (a) auto-detect the Mac, (b) skip the Caddy /
+Let's Encrypt / gateway DNS section, (c) install two LaunchAgents under
+`~/Library/LaunchAgents/` instead of systemd units, and (d) print the tailnet
+URL instead of `<box_id>.boxes.mantaui.com` if Tailscale is detected, or a
+loopback-only message otherwise. The pair code + box id + `manta://pair` link
+are still printed at the end.
+
 ## Step 4 — verify
+
+Linux box:
 
 - `systemctl --user is-active manta-server` → `active`
 - `systemctl --user is-active opencode-serve` → `active`
@@ -84,6 +121,20 @@ final report.
   `journalctl --user -u manta-server -n 50` for the `[push] gateway send failed`
   / `register` lines.
 
+macOS box (Apple Silicon):
+
+- `launchctl print gui/$(id -u)/com.mantaui.server` → reports `state = running`
+- `launchctl print gui/$(id -u)/com.mantaui.opencode` → reports `state = running`
+- `curl -s http://127.0.0.1:8787/auth/status` → responds (any JSON)
+- If Tailscale is detected: `curl -fsS http://<tailscale-ip>:8787/auth/status`
+  → responds from off-network devices on the same tailnet
+- `tail -F ~/.manta/server.log` and `tail -F ~/.manta/opencode.log` for
+  log tails (these are the `StandardOutPath`/`StandardErrorPath` paths the
+  LaunchAgent plists declare)
+- `<box_id>.boxes.mantaui.com` will NOT resolve from a macOS box — that
+  endpoint only exists for Linux boxes. The tailnet URL above is the
+  off-network access path on macOS.
+
 Pairing codes are one-time with a ~5 minute TTL. If the printed code expires
 before the user enters it, mint a fresh one:
 `curl -s http://127.0.0.1:8787/auth/pair` (loopback-only, run on the box).
@@ -93,36 +144,57 @@ before the user enters it, mint a fresh one:
 - **Installer died at a checksum mismatch** → corrupt download or a release
   being published right now; re-run once. If it persists, report it to the
   user verbatim.
+- **Installer died with "missing prerequisite: sha256sum or shasum"** →
+  neither sha256sum (Linux/coreutils) nor shasum (macOS) is on PATH. Linux:
+  install coreutils (`apt-get install -y coreutils` / `dnf install -y
+  coreutils`). macOS: `shasum` ships by default; if it's missing the user
+  has likely stripped `/usr/bin` from PATH — fix PATH first, then re-run.
 - **Installer died at "server did not become healthy"** →
-  `journalctl --user -u manta-server -n 50`; most common cause is a stale
-  partial install — re-run the installer (safe; the previous install is kept
-  at `~/manta.prev` until a run succeeds).
-- **`systemctl --user` errors with "Failed to connect to bus"** → the user
-  SSH'd in without a session bus; run
+  Linux: `journalctl --user -u manta-server -n 50`; macOS:
+  `tail -n 50 ~/.manta/server.log`. Most common cause is a stale partial
+  install — re-run the installer (safe; the previous install is kept at
+  `~/manta.prev` until a run succeeds).
+- **`systemctl --user` errors with "Failed to connect to bus"** → Linux only —
+  the user SSH'd in without a session bus; run
   `export XDG_RUNTIME_DIR=/run/user/$(id -u)` and retry, and make sure
   `loginctl enable-linger $USER` succeeded (may need sudo).
-- **`<box_id>.boxes.mantaui.com` never resolves** → box could not reach the
-  gateway at registration time (firewall, captive portal, DNS). Re-run the
-  installer once the user fixes outbound HTTPS to `gateway.mantaui.com:443`.
-- **Caddy reload fails on a non-standard port 80/443 binding** → another
-  service (Apache, nginx, Traefik) is already bound. Stop it, or edit the
-  Caddy vhost on the box to a non-standard port + your own reverse proxy.
+- **`<box_id>.boxes.mantaui.com` never resolves** → Linux only — box could
+  not reach the gateway at registration time (firewall, captive portal, DNS).
+  Re-run the installer once the user fixes outbound HTTPS to
+  `gateway.mantaui.com:443`. (macOS never gets this hostname — see "macOS
+  box" above.)
+- **Caddy reload fails on a non-standard port 80/443 binding** → Linux only —
+  another service (Apache, nginx, Traefik) is already bound. Stop it, or
+  edit the Caddy vhost on the box to a non-standard port + your own reverse
+  proxy.
 - **Installer warns "Caddy/gateway section skipped: passwordless sudo
-  is not configured"** → the installer continues normally (the loopback
-  server + pairing code still work), but `<box_id>.boxes.mantaui.com`
+  is not configured"** → Linux only — the installer continues normally (the
+  loopback server + pairing code still work), but `<box_id>.boxes.mantaui.com`
   won't be set up by the installer. The user can either configure
   passwordless sudo (`$USER ALL=(ALL) NOPASSWD:ALL` in
   `/etc/sudoers.d/`) and re-run, OR bring their own reverse proxy
   pointing at `127.0.0.1:8787`. The install prints the exact apt + gpg +
   tee commands to run by hand.
-- **Installer warns "distro X is not in the v1 supported list"** →
+- **Installer warns "distro X is not in the v1 supported list"** → Linux only —
   same as above (install continues, BYO proxy). v1 supports Debian,
   Ubuntu, and any distro with `ID_LIKE=debian` (Linux Mint, Raspbian,
   elementary OS). RHEL / Fedora / Arch / Alpine: out of scope for v1.
+- **Installer refuses with "unsupported Mac: x86_64"** → Intel Mac. Direct
+  the user to the desktop app download
+  (`https://mantaui.com/downloads/Manta-latest.dmg`).
+- **macOS LaunchAgents never load** → the Mac isn't logged in (no GUI
+  session). Headless-never-logs-in Macs are not supported; use a Linux VPS
+  for 24/7 box availability.
+- **macOS box is unreachable from off-network and Tailscale isn't
+  installed** → the only way to reach a macOS box from off-network is a
+  tailnet (Tailscale or equivalent). Install Tailscale on the Mac and
+  re-run the installer — it auto-detects the tailnet IP and prints it.
 - **Chat 401s** → `~/.claude/.credentials.json` missing (see preflight); after
-  the user logs in, `systemctl --user restart opencode-serve`.
+  the user logs in, Linux: `systemctl --user restart opencode-serve`;
+  macOS: `launchctl kickstart -k gui/$(id -u)/com.mantaui.opencode`.
 - Anything else: re-run the installer first (idempotent), then read the
-  journals of both units before attempting manual fixes.
+  journals (Linux: `journalctl --user -u manta-server -n 50`; macOS:
+  `tail -n 50 ~/.manta/server.log`) before attempting manual fixes.
 
 ## Step 6 — report back to the user
 
@@ -132,15 +204,21 @@ Tell the user, in this order:
    3-step wizard that walks them through downloading the desktop app,
    connecting it, and (optionally) installing the mobile app:
 
-   [Open this link to connect your devices](https://<box_id>.boxes.mantaui.com/pair#code=<code>)
+   - **Linux box:** [Open this link to connect your devices](https://<box_id>.boxes.mantaui.com/pair#code=<code>)
+   - **macOS box:** the installer prints the tailnet URL (or the loopback
+     URL if no Tailscale) in the same pair block — use that. There is no
+     public `<box_id>.boxes.mantaui.com` on macOS.
 
    The **pairing code** (and that it expires in ~5 minutes — you can mint a
    fresh one any time) and the **box id** below, as a fallback if they
    prefer to enter the values manually in the desktop app.
-2. Devices connect directly to `https://<box_id>.boxes.mantaui.com` —
+2. Linux: devices connect directly to `https://<box_id>.boxes.mantaui.com` —
    desktop: paste the `manta://pair` link or enter the code; phone: install
    the app / open the URL and pair the same way.
+   macOS: devices reach the box at the tailnet URL printed by the installer
+   (e.g. `http://<tailscale-ip>:8787`) — same pairing flow.
 3. Everything else (providers, first project) happens in the desktop app's
    onboarding.
 4. If claude login was missing: remind them to run `claude` on the box, then
-   `systemctl --user restart opencode-serve`.
+   `systemctl --user restart opencode-serve` (Linux) or
+   `launchctl kickstart -k gui/$(id -u)/com.mantaui.opencode` (macOS).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,10 @@
 #
 # Prerequisites on the box (we check, never install — same `require_cmd` tone
 # as Homebrew/rustup):
-#   * curl, tar, sha256sum  — download + verify the release tarball
+#   * curl, tar, sha256sum (or `shasum -a 256` on macOS)  — download + verify
+#     the release tarball. macOS ships shasum by default but NOT sha256sum
+#     (no coreutils out of the box); the installer accepts either, see
+#     `_sha256_of` + the prereq check in step 1.
 #   * tmux, git             — the manta server needs them at runtime
 #
 # Everything else (Node runtime, npm, node_modules with node-pty's native
@@ -120,9 +123,21 @@ resolve_arch() {
   esac
 }
 
+# _sha256_of echoes the sha256 hex of $1. Prefers GNU sha256sum (Linux ships
+# it via coreutils); falls back to BSD `shasum -a 256` on macOS, which ships
+# shasum by default but NOT sha256sum. Single shared helper so the prereq
+# check (step 1) and verify_sha256 can't drift — the BET-278 review concern.
+_sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
 # Verify $1's sha256 equals $2 (64-hex). Dies on mismatch.
 verify_sha256() {
-  local actual; actual="$(sha256sum "$1" | cut -d' ' -f1)"
+  local actual; actual="$(_sha256_of "$1")"
   [ "$actual" = "$2" ] || die "checksum mismatch for $1
       expected: $2
       actual:   $actual
@@ -130,10 +145,10 @@ verify_sha256() {
 }
 
 # Test mode: when sourced by scripts/install.test.mjs with MANTA_INSTALL_TEST_MODE=1,
-# only the bash helpers (log/ok/warn/die + manifest_get + verify_sha256 +
-# resolve_arch) are loaded. The actual install does NOT run. Lets the unit
-# tests exercise the helpers with mocked `uname`/etc. without hitting the
-# network. See scripts/install.test.mjs.
+# only the bash helpers (log/ok/warn/die + manifest_get + _sha256_of +
+# verify_sha256 + resolve_arch) are loaded. The actual install does NOT run.
+# Lets the unit tests exercise the helpers with mocked `uname`/etc. without
+# hitting the network. See scripts/install.test.mjs.
 if [ "${MANTA_INSTALL_TEST_MODE:-0}" = "1" ]; then
   return 0 2>/dev/null || exit 0
 fi
@@ -206,10 +221,19 @@ main() {
     fi
   }
 
-  log "Checking prerequisites (curl, tar, sha256sum, tmux, git)…"
+  log "Checking prerequisites (curl, tar, sha256sum|shasum, tmux, git)…"
   require_cmd curl      "apt-get install -y curl   # or your distro's package manager"
   require_cmd tar       "apt-get install -y tar"
-  require_cmd sha256sum "apt-get install -y coreutils"
+  # sha256sum (coreutils, Linux) or shasum (BSD/macOS) — accept either so
+  # the macOS box path doesn't need coreutils. _sha256_of picks whichever
+  # is available at runtime.
+  if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    die "missing prerequisite: sha256sum or shasum
+      Install one and re-run. Suggested:
+        apt-get install -y coreutils   # provides sha256sum
+        brew install coreutils         # provides sha256sum (macOS)
+        # macOS ships 'shasum' by default — no install needed on a stock Mac"
+  fi
   require_cmd git       "apt-get install -y git"
   require_cmd tmux      "apt-get install -y tmux"
   ok "Prerequisites present."

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1156,6 +1156,105 @@ verify_sha256 "${file}" "${wrongSha}"
 });
 
 // ----------------------------------------------------------------------------
+// _sha256_of — single shared helper used by verify_sha256 (install.sh) and
+// mirrored in self-update.sh. Prefers GNU `sha256sum` (Linux/coreutils);
+// falls back to BSD `shasum -a 256` (macOS, which ships shasum but NOT
+// sha256sum). Pinned by BET-278 so a macOS box doesn't blow up with a
+// cryptic "sha256sum: command not found" before the tarball even downloads.
+// ----------------------------------------------------------------------------
+
+test("_sha256_of uses sha256sum when present (Linux default)", () => {
+  // Linux CI has GNU sha256sum; this asserts the primary branch.
+  const dir = mkdtempSync(join(tmpdir(), "manta-sha256-of-"));
+  const file = join(dir, "blob");
+  writeFileSync(file, "hello world\n");
+  const expected = createHash("sha256").update(readFileSync(file)).digest("hex");
+  try {
+    const out = runBootstrap({
+      preBody: `
+echo "HASH=\$(_sha256_of "${file}")"
+`,
+    });
+    assert.match(out, new RegExp(`HASH=${expected}`));
+    assert.match(out, /BOOTSTRAP_EXIT=0/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("_sha256_of falls back to shasum -a 256 when sha256sum is absent (BET-278 macOS portability)", () => {
+  // Simulate a macOS box: shadow the `command` builtin so `command -v sha256sum`
+  // returns false, while `command -v shasum` still succeeds. Provide a shasum
+  // function that produces the BSD format `shasum` emits (`<hex>  <filename>`)
+  // — install.sh's helper pipes through `cut -d' ' -f1`, so any whitespace-
+  // separated first token works; we delegate to sha256sum behind the scenes
+  // since the test runs on Linux.
+  const dir = mkdtempSync(join(tmpdir(), "manta-sha256-of-"));
+  const file = join(dir, "blob");
+  writeFileSync(file, "hello world\n");
+  const expected = createHash("sha256").update(readFileSync(file)).digest("hex");
+  try {
+    const out = runBootstrap({
+      preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "sha256sum" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+shasum() {
+  if [ "$1" = "-a" ] && [ "$2" = "256" ]; then
+    sha256sum "$3" | cut -d' ' -f1
+    return 0
+  fi
+  return 1
+}
+echo "HASH=\$(_sha256_of "${file}")"
+`,
+    });
+    assert.match(out, new RegExp(`HASH=${expected}`));
+    assert.match(out, /BOOTSTRAP_EXIT=0/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("_sha256_of dies (via verify_sha256) with a clear mismatch message when shasum branch is taken", () => {
+  // End-to-end: with the shasum fallback forced, verify_sha256's die path
+  // still formats the message correctly (this is what the macOS install
+  // would print on a stale manifest).
+  const dir = mkdtempSync(join(tmpdir(), "manta-sha256-of-"));
+  const file = join(dir, "blob");
+  writeFileSync(file, "hello world\n");
+  const wrongSha = "f".repeat(64);
+  try {
+    const out = runBootstrap({
+      preBody: `
+command() {
+  if [ "$1" = "-v" ] && [ "$2" = "sha256sum" ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+shasum() {
+  if [ "$1" = "-a" ] && [ "$2" = "256" ]; then
+    sha256sum "$3" | cut -d' ' -f1
+    return 0
+  fi
+  return 1
+}
+verify_sha256 "${file}" "${wrongSha}"
+`,
+    });
+    assert.match(out, /checksum mismatch for/);
+    assert.match(out, new RegExp(`expected: ${wrongSha}`));
+    assert.match(out, /actual:/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ----------------------------------------------------------------------------
 // resolve_arch — map `(uname -s, uname -m)` to the manifest arch key
 // (`linux_x64` / `linux_arm64` / `darwin_arm64`). Sets the global
 // `ARCH_KEY` the manifest reader uses; dies on any (OS, arch) we don't

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -85,7 +85,14 @@ refresh_mobile_bundle() {
   fi
 
   local got_sha
-  got_sha="$(sha256sum "$tmp/bundle.tar.gz" | cut -d' ' -f1)"
+  # sha256sum (Linux/coreutils) or shasum (macOS) — pick whichever is present.
+  # Same logic as install.sh's _sha256_of; kept inline here so self-update.sh
+  # stays a self-contained script with no install.sh dependency.
+  if command -v sha256sum >/dev/null 2>&1; then
+    got_sha="$(sha256sum "$tmp/bundle.tar.gz" | cut -d' ' -f1)"
+  else
+    got_sha="$(shasum -a 256 "$tmp/bundle.tar.gz" | cut -d' ' -f1)"
+  fi
   if [ "$got_sha" != "$want_sha" ]; then
     echo "⚠ self-update: mobile bundle sha256 mismatch (got $got_sha want $want_sha) — keeping existing mobile/www/"
     return 0


### PR DESCRIPTION
Stage 3 of the macOS box epic (BET-274). Makes the macOS install path not die on a missing `sha256sum` and documents the macOS box support / constraints across the three user-facing doc surfaces.

**Base:** `origin/main` @ `d6b2ff6` (Merge pull request #233 from antoinedc/multica/BET-277-launchd-service-path).

**Files changed:** `6` files. `+314 / -35`

```
AGENTS.md                |  61 +++++++++++++++
README.md                |  10 ++++
llms-install.md          | 130 +++++++++++++++++++++++++++++++++++-------
scripts/install.sh       |  40 ++++++++----
scripts/install.test.mjs |  99 ++++++++++++++++++++++++++++
scripts/self-update.sh   |   9 ++-
```

**What changes**

1. **`scripts/install.sh`** — extract `_sha256_of` shared helper that prefers GNU `sha256sum` (Linux/coreutils) and falls back to BSD `shasum -a 256` (macOS, ships by default). Both `verify_sha256` and the prereq check use it — single source of truth. The prereq check now accepts EITHER `sha256sum` OR `shasum` (was: required `sha256sum`, hard fail on macOS).
2. **`scripts/self-update.sh`** — same `sha256sum`/`shasum` fallback inline (self-update.sh is intentionally self-contained, no install.sh dep).
3. **`scripts/install.test.mjs`** — 3 new tests pinning `_sha256_of`: `sha256sum` branch, `shasum` fallback (via mocked `command` builtin + `shasum` function), and end-to-end `verify_sha256` dies with a clear mismatch message on the `shasum` branch.
4. **`llms-install.md`** — new 'macOS box (Apple Silicon)' section stating Apple Silicon only + loopback/Tailscale-only + launchd + login-required. Step 2 preflight, Step 4 verify, Step 5 playbook, Step 6 report all branched on macOS vs Linux.
5. **`README.md`** — Quick-start gains a macOS (Apple Silicon) bullet alongside Linux; same `curl|bash` invocation, mentions launchd + tailnet caveats.
6. **`AGENTS.md`** — new 'macOS box (BET-274) — design decisions, do not re-derive' section pinning Apple-Silicon-only, launchd (NOT systemd), loopback+Tailscale-only via SKIP_PUBLIC_TLS, darwin-arm64 built on macos-14 runner, and the three-way arch map (install.sh resolve_arch ↔ pack.mjs resolveArch ↔ manifest keys).

**Audit (BET-278 item #4)**

- `loginctl enable-linger` — inside `command -v systemctl` block (install.sh:686) — macOS never reaches it.
- `hostname -I` — inside SKIP_PUBLIC_TLS gate (install.sh:1028) — macOS never reaches it.
- `ss -tlnH` — inside SKIP_PUBLIC_TLS gate — macOS never reaches it.
- `sed -i` — only in comment (install.sh:1142); actual code uses `awk + tmp + mv`, portable.
- `sha256sum` — was the only required change; now falls back to `shasum` on macOS.

**Verification results**

- PR branch (`multica/BET-278-shasum-portability` @ `94dff86`):
  - typecheck: exit `0`. Errors: none. log sha256: `2d3cc932c2f84b73ab9025fe53903ac19ef0b5dfc0a0df7b7e3aa06881deffe9`
  - test: exit `1`, `800` pass / `1` fail / `0` skip. Failures: `src/server/pty.test.mjs` (pre-existing on main; unhandled rejection at file level, none of the visible `parsePtyQuery` subtests fail). log sha256: `1b3b4120f9f9037d768f7d2e79bd4e9de190dd1089ba5472f5d9f8b3a7f0723b`
  - install.test.mjs subtest count: 160 → 163 (+3 new `_sha256_of` tests, all green).
- Base (`main` @ `d6b2ff6`):
  - typecheck: exit `0`. Errors: none. log sha256: `bb6d995e1b8df5d6009d0c7cbae3e574c0910b24dd0f3437730c1b84fbb1403b`
  - test: exit `1`, `797` pass / `1` fail / `0` skip. Failures: `src/server/pty.test.mjs` (same pre-existing failure as on the PR branch). log sha256: `4c251783cfdf159e89b1f7c7e9ab1a0de3394f9efe0c2616901cb794c651341b`
- **Conclusion:** `1` test failure is pre-existing (identical between branches); `0` new failures caused by this PR; `+3` new `_sha256_of` tests resolved (green). Linux behavior byte-identical — `_sha256_of` uses `sha256sum` when present (Linux always has it), the prereq check accepts either tool but Linux goes through the `sha256sum` arm.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-master.log`, `/tmp/test-pr.log`, `/tmp/test-master.log` for reviewer spot-check.

**Self-check (acceptance criteria)**

- AC1 (macOS support documented in 3 files): `9/10` weakness: cross-file consistency not asserted (the docs agree but no automated check).
- AC2 (`shasum` fallback via single helper): `10/10`
- AC3 (no Linux-only command on macOS path, audited): `10/10`
- AC4 (Linux byte-identical): `9/10`
- AC5 (typecheck + test pass): `10/10` (the single `test` exit-1 is a pre-existing master failure, identical between branches).