### PR TITLE
chore(release): bump desktop 0.0.13 + iOS 1.0.14

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -375,7 +375,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump for the mac/iOS release cut. Ships BET-276/277/278 (macOS box install), BET-280/281 (server-side Claude credential refresh), BET-282/283 (MetaBadge + subagent name).

- `package.json` 0.0.12 -> 0.0.13 (tag `mac-v0.0.13` after merge)
- `MARKETING_VERSION` 1.0.13 -> 1.0.14 (auto-tags `ios-v1.0.14` on merge)