### PR TITLE
fix(mobile): pin the composer branch chip to its own footer line (BET-285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,8 +337,12 @@ match nothing).
 **Reshaping reused ChatPanel/Terminal internals on mobile:** the desktop
 composer footer is one non-wrapping flex row built for a wide panel; at
 phone width its children overlap. Fix is always `.mobile`-scoped CSS in
-`mobile/mobile.css` — never edit `ChatPanel.tsx`. ChatPanel has no semantic
-class hooks (Tailwind utilities only), so target structurally: ChatPanel is
+`mobile/mobile.css` — never edit `ChatPanel.tsx`. Prefer a stable `manta-*`
+hook class on the shared element (precedent: `manta-session-toolbar`,
+`manta-stale-full`/`manta-stale-min`, `manta-loading-divider`,
+`manta-composer-branch`) — adding a class name to a shared component is a
+desktop no-op. Only fall back to a positional selector when you truly
+cannot touch the component: ChatPanel is
 the lone `.mobile-body > div` (h-full flex-col); its composer is that div's
 `> div:last-child`; footer rows are matched via `div[class*="flex"]` /
 `[class*="justify-between"]` + child position. Established rules: composer
@@ -347,7 +351,8 @@ toolbar (`SessionToolbar` — actions live in the header `⋯` sheet on mobile);
 drop the context bar (`span[class*="w-24"]`, unique to ContextBar) but keep
 the stage-colored `%`; clamp the empty textarea placeholder to one line via
 `textarea:placeholder-shown` (reverts to `pre-wrap` once typed so
-`resizeInput` still owns height). Verify on-device: `cd mobile && npm run
+`resizeInput` still owns height); branch chip gets its own footer line via
+`.manta-composer-branch`. Verify on-device: `cd mobile && npm run
 apk`, `adb install -r`, screenshot the composer.
 
 ## Desktop transport (HTTP-only)

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -96,6 +96,20 @@ describe("ChatPanel render harness", () => {
     expect(h.text()).toContain("Welcome");
     expect(h.text()).toBe(before);
   });
+
+  it("stamps the manta-composer-branch hook on the footer branch chip", async () => {
+    // The default mock returns null for the branch, so the chip is not
+    // rendered; override it so the chip exists.
+    ({ bus } = installMockApi({
+      opencodeVcsBranch: () => Promise.resolve("feat/mobile-footer"),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    const chip = h.container.querySelector(".manta-composer-branch");
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("feat/mobile-footer");
+  });
 });
 
 // ===== useSessionResources integration (via the mounted ChatPanel) =====

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -398,8 +398,11 @@ export function InputArea({
       <div className="px-4 py-2 flex items-center justify-between gap-3">
         <span className="flex items-center gap-3 min-w-0">
           {branch && (
+            // `manta-composer-branch` is a styling hook only — it has no
+            // desktop rule. mobile.css uses it to give the branch chip its
+            // own line in the stacked mobile footer (see mobile.css).
             <span
-              className="text-text-faint shrink-0 truncate max-w-[160px]"
+              className="manta-composer-branch text-text-faint shrink-0 truncate max-w-[160px]"
               title={`Current branch: ${branch}`}
             >
               ⎇ {branch}

--- a/src/renderer/mobile/mobile.css
+++ b/src/renderer/mobile/mobile.css
@@ -251,6 +251,20 @@ body,
   min-width: 0;
   row-gap: 4px;
 }
+/* Meta-footer stacking (mobile only). Desired reading order, top→bottom:
+     1. ⎇ branch
+     2. model ▾ · ctx % · stale-cache pill
+     3. bypass-permissions toggle
+   The footer's left span already wraps (rule above), but with all four chips
+   sharing one wrapping line the break point moved with the branch/model name
+   length, so the order looked unstable. Giving the branch chip a whole flex
+   line pins it. `max-width` also releases the desktop 160px clamp so the
+   branch can use the full line width before it truncates.
+   Hook class is stamped in InputArea.tsx; there is no desktop rule for it. */
+.mobile-body .manta-composer-branch {
+  flex-basis: 100%;
+  max-width: 100%;
+}
 /* The static desktop keyboard-hint span (ctrl+o · shift+⏎ newline · ⏎ send)
    was removed from ChatPanel entirely, so there's no longer a hint span to
    hide here. The footer's right-hand group now holds the ⏰ schedules button


### PR DESCRIPTION
## Summary

On the **mobile** chat composer, the meta footer must always read top-to-bottom in this exact order:

```
line 1   ⎇ branch                      (only when a branch exists)
line 2   model ▾    38%    ⚠ 79k        (stale pill only when cache is stale)
line 3   ▷▷ bypass permissions off …
```

The DOM order was already correct (`InputArea.tsx` renders branch → ModelPicker → ContextBar in that sequence, and bypass-permissions is its own row below). The bug was purely layout: on mobile all four chips shared one wrapping flex line, so the wrap point moved depending on how long the branch name and model name happened to be.

**Desktop is untouched** — `max-w-[160px]` stays on the shared className, no `index.css` rule references the new hook.

## Changes

- **`src/renderer/InputArea.tsx`** — stamp `manta-composer-branch` on the branch chip (around line 400). Styling hook only; no desktop rule references it.
- **`src/renderer/mobile/mobile.css`** — one new rule (`.mobile-body .manta-composer-branch { flex-basis: 100%; max-width: 100%; }`) that pins the branch chip to its own flex line on phone width and releases the desktop 160px clamp.
- **`src/renderer/ChatPanel.harness.test.tsx`** — regression test asserting the hook class is actually stamped and contains the branch name (so a future rename of the class in the TSX can't silently break the mobile layout).
- **`AGENTS.md`** — fix the now-false "ChatPanel has no semantic class hooks" guidance in the "Reshaping reused ChatPanel/Terminal internals on mobile" section, list the established `manta-*` precedents, and append the new rule to the established-rules list.

Net new CSS selectors: **1**. Net new positional selectors: **0**.

## Why a hook class instead of a fifth positional rule

`mobile.css` currently reaches into the shared composer with long positional chains (`.mobile-body > div > div:last-child > div[class*="justify-between"] > span`). Adding a stable `manta-*` class hook follows the precedent already set by `manta-session-toolbar` (`ComposerParts.tsx:27`), `manta-stale-full` / `manta-stale-min` (`ContextBar.tsx:148,151`), and `manta-loading-divider` (`InputArea.tsx:273`). Adding a class name to a shared component is a desktop no-op and keeps the AGENTS.md guidance honest.

## Verification

**Base: `origin/main` @ `87f0ebc`**

- typecheck: exit `0`. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538`
- test (vitest): `Test Files 49 passed (49) / Tests 1021 passed (1021)`
- test (node): `# pass 810 / # fail 0`
- logs: `/tmp/typecheck-master.log`, `/tmp/test-master.log`

**PR branch (`multica/BET-285-mobile-composer-branch-line` @ `7511677`)**

- typecheck: exit `0`. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538`
- test (vitest): `Test Files 49 passed (49) / Tests 1022 passed (1022)` *(+1 new test)*
- test (node): `# pass 810 / # fail 0`
- logs: `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`

**Conclusion:** 0 new failures. 1 new passing test (the regression test for `manta-composer-branch`). 0 failures resolved, 0 introduced. typecheck and test logs are identical on typecheck (sha256 match); test log differs only in the +1 new test entry.

## Cross-cutting notes

None. The change is mobile-only; desktop CSS, IPC, server, and gateway code are untouched.

## Follow-ups

None surfaced.