### PR TITLE
docs: website + README revamp spec and approved homepage mockup

### DIFF
--- a/docs/specs/website-homepage-mockup.html
+++ b/docs/specs/website-homepage-mockup.html
@@ -1,0 +1,805 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MOCKUP — Manta UI homepage IA (v2)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --navy-950:#0B1020;--navy-900:#0E1326;--navy-850:#12182F;--navy-800:#171F3A;
+  --navy-750:#1D2647;--navy-700:#253055;--navy-600:#33406B;--navy-500:#45537F;
+  --blue-300:#8AABFF;--blue-400:#5A88FF;--blue-500:#2E6BFF;--blue-600:#1E52DB;
+  --cyan-300:#9BEBFB;--cyan-400:#49D7F5;--cyan-500:#22BEE0;
+  --slate-50:#F8FAFC;--slate-200:#CBD3E1;--slate-300:#A7B1C4;--slate-400:#7E889D;--slate-500:#5C6578;--slate-600:#434B5E;
+  --green-500:#22C79A;--amber-500:#F0A934;--red-500:#F0505F;--violet-400:#A78BFA;
+  --surface-app:var(--navy-950);--surface-sunken:var(--navy-900);--surface-panel:var(--navy-850);
+  --surface-card:var(--navy-800);--surface-raised:var(--navy-750);--surface-inset:#070B17;
+  --border-subtle:#FFFFFF14;--border-default:var(--navy-700);--border-strong:var(--navy-600);
+  --text-primary:var(--slate-50);--text-secondary:var(--slate-200);--text-tertiary:var(--slate-400);--text-link:var(--cyan-400);
+  --fill-subtle:#FFFFFF0D;--fill-subtle-hover:#FFFFFF1A;
+  --font-sans:'Inter',system-ui,-apple-system,sans-serif;
+  --font-mono:'JetBrains Mono','SF Mono',ui-monospace,Menlo,monospace;
+  --gradient-brand:linear-gradient(135deg,var(--cyan-400) 0%,var(--blue-500) 100%);
+  --shadow-md:0 8px 24px rgba(3,6,15,.55);--shadow-xl:0 32px 80px rgba(2,4,12,.7);
+  --radius-md:8px;--radius-lg:12px;--radius-xl:16px;--radius-full:999px;
+  --ease-out:cubic-bezier(0.22,1,0.36,1);--content-max:1120px;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{background:var(--surface-app);color:var(--text-secondary);font-family:var(--font-sans);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text-link);text-decoration:none;transition:color .12s var(--ease-out)}
+a:hover{color:var(--cyan-300)}
+.mono{font-family:var(--font-mono)}
+.wrap{max-width:var(--content-max);margin:0 auto;padding:0 24px}
+.eyebrow{font-size:11px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:var(--cyan-400)}
+
+/* ---- MOCKUP CHROME (delete in real build) ---- */
+.mockbar{position:sticky;top:0;z-index:300;background:#2A1B4D;border-bottom:1px solid #4C3A7A;padding:8px 0;font-size:12.5px;color:#D8CCFF}
+.mockbar .wrap{display:flex;gap:16px;align-items:center;justify-content:space-between;flex-wrap:wrap}
+.mockbar b{color:#fff;font-weight:700}
+.mockbar .legend{display:flex;gap:14px;align-items:center;flex-wrap:wrap;font-size:11.5px}
+.mockbar .lg{display:inline-flex;gap:6px;align-items:center}
+.mockbar .sw{width:11px;height:11px;border-radius:3px;display:inline-block}
+.sw-new{background:#22C79A}.sw-fix{background:#F0A934}.sw-shot{background:#A78BFA}
+.tag{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:var(--radius-full);font-size:10.5px;font-weight:700;
+  letter-spacing:.06em;text-transform:uppercase;font-family:var(--font-sans);vertical-align:middle;margin-left:8px}
+.tag-new{background:#22C79A24;color:#3FE0B4;border:1px solid #22C79A55}
+.tag-fix{background:#F0A93424;color:#FFC163;border:1px solid #F0A93455}
+.secmark{position:absolute;left:0;top:0;bottom:0;width:3px;border-radius:0 3px 3px 0}
+.secmark.new{background:#22C79A}.secmark.fix{background:#F0A934}
+.shotph{border:2px dashed #6D5BA8;border-radius:var(--radius-xl);background:
+   repeating-linear-gradient(45deg,#151030,#151030 12px,#181337 12px,#181337 24px);
+  display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;text-align:center;padding:28px 22px}
+.shotph .id{font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.14em;color:#A78BFA;text-transform:uppercase}
+.shotph .ttl{font-size:15px;font-weight:700;color:#E4DCFF}
+.shotph .dsc{font-size:12.5px;color:#9C90C4;max-width:460px;line-height:1.5}
+.shotph .dim{font-family:var(--font-mono);font-size:10.5px;color:#6D5BA8}
+
+/* nav */
+header{position:sticky;top:37px;z-index:200;backdrop-filter:blur(12px);background:rgba(11,16,32,.82);border-bottom:1px solid var(--border-subtle)}
+nav{display:flex;align-items:center;justify-content:space-between;height:60px}
+.brand{display:flex;align-items:center;gap:10px;font-weight:700;color:var(--text-primary);font-size:17px;letter-spacing:-.01em}
+.brand img{width:30px;height:30px;object-fit:contain}
+.brand b{font-weight:800}
+.navlinks{display:flex;align-items:center;gap:24px;font-size:14px}
+.navlinks a{color:var(--text-tertiary)}
+.navlinks a:hover{color:var(--text-primary)}
+.btn{display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 18px;border-radius:var(--radius-md);font-weight:600;font-size:14px;
+  border:1px solid transparent;cursor:pointer;transition:all .12s var(--ease-out);font-family:var(--font-sans)}
+.btn-primary{background:var(--blue-500);color:#fff}
+.btn-primary:hover{background:var(--blue-400);color:#fff}
+.btn-ghost{background:var(--fill-subtle);color:var(--text-secondary);border-color:var(--border-default)}
+.btn-ghost:hover{background:var(--fill-subtle-hover);color:var(--text-primary)}
+@media(max-width:900px){.navlinks .hide-sm{display:none}}
+
+/* hero */
+.aura{position:absolute;inset:0;overflow:hidden;pointer-events:none;z-index:0}
+.aura::before{content:"";position:absolute;top:-260px;left:50%;transform:translateX(-50%);width:900px;height:640px;
+  background:radial-gradient(ellipse at center,rgba(46,107,255,.28),rgba(73,215,245,.10) 40%,transparent 70%);filter:blur(12px)}
+.hero{position:relative;padding:56px 0 76px;text-align:center}
+.hero .wrap{position:relative;z-index:1}
+h1{font-size:clamp(32px,5vw,56px);line-height:1.09;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);max-width:900px;margin:0 auto 22px}
+h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.sub{font-size:clamp(16px,2.1vw,19px);color:var(--text-tertiary);max-width:680px;margin:0 auto 26px;line-height:1.55}
+.cta{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin:16px 0}
+.cta .btn{height:44px;padding:0 22px;font-size:15px}
+.meta{font-size:13px;color:var(--slate-500)}
+
+/* install */
+.install{max-width:600px;margin:0 auto 14px}
+.install-tabs{display:inline-flex;gap:4px;margin-bottom:12px;padding:4px;border-radius:9px;background:var(--fill-subtle);border:1px solid var(--border-default)}
+.install-tab{appearance:none;border:0;background:transparent;color:var(--text-secondary);font-family:var(--font-sans);font-size:13px;font-weight:600;
+  padding:7px 16px;border-radius:6px;cursor:pointer;transition:all .12s var(--ease-out)}
+.install-tab[aria-selected="true"]{background:var(--surface-inset);color:var(--text-primary)}
+.install-panel{display:none}.install-panel.active{display:block}
+.install-cmd,.agent-cmd{display:flex;align-items:center;gap:12px;background:var(--surface-inset);border:1px solid var(--border-default);
+  border-radius:var(--radius-md);padding:13px 12px 13px 16px;box-shadow:var(--shadow-md);text-align:left}
+.agent-cmd{align-items:flex-start}
+.install-cmd code{flex:1;text-align:left;font-family:var(--font-mono);font-size:13.5px;color:var(--slate-200);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.agent-cmd p{flex:1;margin:0;font-family:var(--font-mono);font-size:12.5px;line-height:1.55;color:var(--slate-200)}
+.prompt{color:var(--cyan-400);margin-right:8px}.url{color:var(--cyan-300)}
+.copy-btn{flex-shrink:0;height:30px;padding:0 14px;border-radius:6px;border:1px solid var(--border-strong);background:var(--fill-subtle);
+  color:var(--text-secondary);font-family:var(--font-sans);font-size:12.5px;font-weight:600;cursor:pointer}
+.install-hint{font-size:12px;color:var(--slate-500);margin-top:9px}
+
+/* app mockup */
+.shot{position:relative;z-index:1;max-width:960px;margin:44px auto 0;border-radius:var(--radius-xl);overflow:hidden;
+  border:1px solid var(--border-default);box-shadow:var(--shadow-xl);background:var(--surface-card)}
+.shot-note{position:absolute;top:10px;right:12px;z-index:5;background:#2A1B4Dee;border:1px solid #6D5BA8;color:#D8CCFF;
+  font-family:var(--font-mono);font-size:10px;padding:4px 9px;border-radius:5px;letter-spacing:.06em}
+.shot-bar{display:flex;align-items:center;gap:8px;height:38px;padding:0 14px;background:var(--surface-panel);border-bottom:1px solid var(--border-subtle)}
+.dot{width:11px;height:11px;border-radius:50%}
+.dot.r{background:#FF5F57}.dot.y{background:#FEBC2E}.dot.g{background:#28C840}
+.shot-title{margin-left:8px;font-family:var(--font-mono);font-size:12px;color:var(--slate-400)}
+.app{display:grid;grid-template-columns:52px 216px 1fr;height:452px;text-align:left}
+.rail{background:var(--surface-sunken);border-right:1px solid var(--border-subtle);display:flex;flex-direction:column;align-items:center;padding-top:14px;gap:14px}
+.rail .logo{width:26px;height:26px;object-fit:contain}
+.rail .ri{width:30px;height:30px;border-radius:8px;background:var(--fill-subtle);display:grid;place-items:center}
+.rail .ri.on{background:#12233f;box-shadow:inset 0 0 0 1px #2E6BFF66}
+.rail .ri svg{width:15px;height:15px;stroke:var(--slate-400);fill:none;stroke-width:2}
+.rail .ri.on svg{stroke:var(--cyan-400)}
+.side{background:var(--surface-panel);border-right:1px solid var(--border-subtle);padding:14px 10px;overflow:hidden}
+.side .grp{font-size:10px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--slate-500);padding:8px 8px 6px}
+.side .s{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:7px;font-size:13px;color:var(--slate-300)}
+.side .s.sel{background:var(--fill-subtle);color:var(--slate-50)}
+.side .s .sd{width:7px;height:7px;border-radius:50%;flex-shrink:0}
+.side .s .sd.run{background:var(--cyan-400);box-shadow:0 0 0 3px rgba(73,215,245,.16)}
+.side .s .sd.idle{background:var(--slate-600)}
+.side .s .sd.wait{background:var(--amber-500)}
+.side .s .sd.perm{background:var(--red-500);box-shadow:0 0 0 3px rgba(240,80,95,.18)}
+.side .s .nm{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+.side .s .nm b{color:var(--cyan-300);font-weight:500}
+.side .s .bang{font-family:var(--font-mono);font-size:11px;color:var(--red-500);font-weight:700}
+.side .s .sfx{font-family:var(--font-mono);font-size:10px;color:var(--slate-500)}
+.panel{background:var(--surface-app);display:flex;flex-direction:column;overflow:hidden}
+.panel .ph{height:44px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:center;gap:10px;padding:0 18px;font-family:var(--font-mono);font-size:12px;color:var(--slate-400)}
+.panel .ph .pill{margin-left:auto}
+.panel .body{flex:1;overflow:hidden;padding:16px 18px;display:flex;flex-direction:column;gap:12px}
+.msg{max-width:80%}
+.msg .who{font-size:11px;font-weight:600;color:var(--slate-500);margin-bottom:5px}
+.msg.user{align-self:flex-end}
+.msg.user .bub{background:var(--fill-subtle);border:1px solid var(--border-subtle);border-radius:12px 12px 4px 12px}
+.msg .bub{padding:9px 13px;border-radius:12px;font-size:13px;line-height:1.5;color:var(--slate-200)}
+.tool{font-family:var(--font-mono);font-size:12px;color:var(--slate-400);display:flex;align-items:center;gap:8px}
+.tool .tk{color:var(--slate-500)}.tool .pth{color:var(--cyan-400)}.tool .ok{color:var(--green-500)}
+.wellrow{font-family:var(--font-mono);font-size:11.5px;background:var(--surface-inset);border:1px solid var(--border-subtle);border-radius:8px;padding:9px 12px;color:var(--slate-300)}
+.wellrow .ok{color:var(--green-500)}.wellrow .dim{color:var(--slate-500)}
+.ctxbar{display:flex;align-items:center;gap:9px;font-family:var(--font-mono);font-size:10.5px;color:var(--slate-500);padding:0 18px 8px}
+.ctxtrack{width:92px;height:5px;border-radius:99px;background:var(--surface-raised);overflow:hidden;display:flex}
+.ctxtrack i{display:block;height:100%}
+.composer{border-top:1px solid var(--border-subtle);padding:11px 16px;display:flex;align-items:center;gap:10px}
+.composer .field{flex:1;height:34px;border-radius:8px;background:var(--surface-inset);border:1px solid var(--border-default);
+  display:flex;align-items:center;padding:0 12px;font-size:13px;color:var(--slate-500)}
+.composer .send{width:34px;height:34px;border-radius:8px;background:var(--blue-500);display:grid;place-items:center}
+.composer .send svg{width:15px;height:15px;stroke:#fff;fill:none;stroke-width:2}
+.pill{display:inline-flex;align-items:center;gap:6px;padding:2px 9px;border-radius:var(--radius-full);font-size:11px;font-weight:600;font-family:var(--font-sans)}
+.pill-run{background:#49D7F51F;color:var(--cyan-400)}
+.ping{width:7px;height:7px;border-radius:50%;background:var(--cyan-400);animation:ping 1.6s var(--ease-out) infinite}
+@keyframes ping{0%{box-shadow:0 0 0 0 rgba(73,215,245,.5)}70%{box-shadow:0 0 0 7px rgba(73,215,245,0)}100%{box-shadow:0 0 0 0 rgba(73,215,245,0)}}
+@media(max-width:820px){.app{grid-template-columns:52px 1fr;height:400px}.side{display:none}}
+
+/* sections */
+section{position:relative;padding:78px 0}
+.sec-head{text-align:center;max-width:700px;margin:0 auto 48px}
+.sec-head h2{font-size:clamp(26px,3.3vw,37px);font-weight:800;letter-spacing:-.025em;color:var(--text-primary);margin:14px 0 12px;line-height:1.15}
+.sec-head p{color:var(--text-tertiary);font-size:16.5px}
+.sunk{background:var(--surface-sunken);border-top:1px solid var(--border-subtle);border-bottom:1px solid var(--border-subtle)}
+
+/* grid */
+.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+.grid.two{grid-template-columns:repeat(2,1fr)}
+@media(max-width:880px){.grid,.grid.two{grid-template-columns:1fr}}
+.card{background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:22px;
+  transition:transform .18s var(--ease-out),border-color .18s var(--ease-out)}
+.card:hover{transform:translateY(-2px);border-color:var(--border-strong)}
+.card .ic{width:36px;height:36px;border-radius:10px;display:grid;place-items:center;margin-bottom:14px;background:#12233f;border:1px solid #2E6BFF3d}
+.card .ic svg{width:18px;height:18px;stroke:var(--cyan-400);fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+.card h3{color:var(--text-primary);font-size:16.5px;font-weight:600;margin-bottom:7px;letter-spacing:-.01em}
+.card p{font-size:13.8px;color:var(--text-tertiary);line-height:1.55}
+.card p code,.card p .mono{font-family:var(--font-mono);font-size:12.3px;color:var(--cyan-300)}
+.card .vs{margin-top:10px;font-size:12px;color:var(--slate-500);border-top:1px solid var(--border-subtle);padding-top:9px;line-height:1.45}
+
+/* laptop band */
+.laptop-band{position:relative;overflow:hidden}
+.laptop-band .inner{display:grid;grid-template-columns:1fr 300px;gap:40px;align-items:center}
+@media(max-width:900px){.laptop-band .inner{grid-template-columns:1fr}}
+.bigclaim{font-size:clamp(24px,3vw,34px);font-weight:800;letter-spacing:-.025em;color:var(--text-primary);line-height:1.18;margin-bottom:16px}
+.bigclaim em{font-style:normal;color:var(--cyan-400)}
+.checks{list-style:none;display:flex;flex-direction:column;gap:11px;margin-top:18px}
+.checks li{display:flex;gap:11px;align-items:flex-start;font-size:14.5px;color:var(--text-secondary)}
+.checks .ck{color:var(--cyan-400);font-family:var(--font-mono);flex-shrink:0}
+.quotebox{margin-top:22px;background:var(--surface-inset);border:1px solid var(--border-default);border-left:3px solid var(--violet-400);
+  border-radius:var(--radius-md);padding:14px 16px;font-size:13.5px;color:var(--slate-300);line-height:1.6}
+.quotebox q{color:var(--slate-100,#e8edf5);font-style:italic}
+.quotebox .src{display:block;margin-top:8px;font-size:11.5px;color:var(--slate-500);font-family:var(--font-mono)}
+
+/* phone */
+.phone{justify-self:center;width:272px;height:552px;border-radius:36px;border:1px solid var(--border-strong);background:var(--surface-inset);
+  box-shadow:var(--shadow-xl);padding:13px;position:relative;overflow:hidden}
+.phone::before{content:"";position:absolute;top:11px;left:50%;transform:translateX(-50%);width:92px;height:5px;border-radius:99px;background:var(--navy-600);z-index:3}
+.phone .scr{margin-top:20px;height:calc(100% - 20px);border-radius:24px;background:var(--surface-card);border:1px solid var(--border-subtle);overflow:hidden;font-family:var(--font-mono);font-size:11px;position:relative}
+.phone .hd{padding:15px 14px 9px;color:var(--slate-50);font-family:var(--font-sans);font-weight:700;font-size:14.5px;display:flex;align-items:center;gap:8px}
+.phone .hd img{width:19px;height:19px}
+.phone .row{padding:11px 14px;border-bottom:1px solid var(--border-subtle);display:flex;justify-content:space-between;align-items:center;color:var(--slate-300);gap:8px}
+.phone .row .st{font-size:10px;flex-shrink:0}
+.phone .row .st.run{color:var(--cyan-400)}.phone .row .st.idle{color:var(--slate-500)}.phone .row .st.wait{color:var(--amber-500)}
+.phone .row .st.perm{color:var(--red-500);font-weight:700}
+.lockshot{position:absolute;inset:0;background:linear-gradient(160deg,#0d1530,#1a1240 60%,#0a0f22);display:flex;flex-direction:column;align-items:center;padding-top:44px}
+.lockshot .time{font-family:var(--font-sans);font-size:52px;font-weight:300;color:#fff;letter-spacing:-.02em;line-height:1}
+.lockshot .date{font-family:var(--font-sans);font-size:12.5px;color:#ffffffb0;margin-top:4px}
+.notif{margin:36px 10px 0;background:rgba(255,255,255,.13);backdrop-filter:blur(20px);border:1px solid rgba(255,255,255,.16);
+  border-radius:16px;padding:11px 12px;width:calc(100% - 20px);text-align:left;font-family:var(--font-sans)}
+.notif .nh{display:flex;align-items:center;gap:7px;margin-bottom:4px}
+.notif .nh img{width:15px;height:15px;border-radius:4px}
+.notif .nh .app{font-size:10.5px;color:#ffffffb5;text-transform:uppercase;letter-spacing:.05em;font-weight:600}
+.notif .nh .ago{margin-left:auto;font-size:10.5px;color:#ffffff8a}
+.notif .nt{font-size:13px;font-weight:700;color:#fff;margin-bottom:2px}
+.notif .nb{font-size:12.3px;color:#ffffffd8;line-height:1.35}
+.notif .acts{display:flex;gap:7px;margin-top:9px}
+.notif .acts span{flex:1;text-align:center;font-size:11px;font-weight:600;padding:5px 0;border-radius:8px;background:rgba(255,255,255,.16);color:#fff}
+
+/* flow */
+.flow{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+@media(max-width:880px){.flow{grid-template-columns:1fr}}
+.step{background:var(--surface-panel);border:1px solid var(--border-subtle);border-radius:var(--radius-lg);padding:22px}
+.step .n{font-family:var(--font-mono);font-size:12px;color:var(--cyan-400);font-weight:600;letter-spacing:.08em}
+.step h3{color:var(--text-primary);font-size:16px;margin:10px 0 8px;font-weight:600}
+.step p{font-size:13.8px;color:var(--text-tertiary)}
+.step p .mono{color:var(--cyan-300);font-size:12.3px}
+.arch{margin-top:34px;background:var(--surface-inset);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:22px;overflow-x:auto}
+.arch pre{font-family:var(--font-mono);font-size:11.5px;line-height:1.65;color:var(--slate-300);white-space:pre}
+.arch pre .hl{color:var(--cyan-400)}.arch pre .gr{color:var(--green-500)}.arch pre .dm{color:var(--slate-500)}
+
+/* comparison */
+.cmp{width:100%;min-width:760px;border-collapse:separate;border-spacing:0;font-size:13px;background:var(--surface-card);
+  border:1px solid var(--border-default);border-radius:var(--radius-lg);overflow:hidden}
+.cmp th,.cmp td{padding:11px 14px;text-align:left;border-bottom:1px solid var(--border-subtle);white-space:nowrap}
+.cmp tbody tr:hover td{background:#ffffff06}
+.cmp tbody tr:hover td.us{background:#122040}
+.cmp thead th{background:var(--surface-panel);font-size:12.5px;font-weight:700;color:var(--text-primary)}
+.cmp thead th.us{color:var(--cyan-300);background:#0f1c36}
+.cmp td.us{background:#0d1830}
+.cmp tbody tr:last-child td{border-bottom:0}
+.cmp tfoot td{border-bottom:0;border-top:1px solid var(--border-default);background:var(--surface-panel);font-size:12.5px;padding-top:13px;padding-bottom:13px}
+.cmp tfoot td.us{background:#0f1c36}
+.cmp td:first-child{color:var(--slate-300);font-weight:500}
+.cmp .on{color:var(--text-primary);font-weight:600}
+.cmp .off{color:var(--slate-600)}
+.cmp .mid{color:var(--slate-400)}
+.cmp-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.cmp-note{margin-top:14px;font-size:12.5px;color:var(--slate-500);text-align:center}
+
+/* open source */
+.osgrid{display:grid;grid-template-columns:1.15fr 1fr;gap:40px;align-items:center}
+@media(max-width:900px){.osgrid{grid-template-columns:1fr}}
+.oslist{list-style:none;display:flex;flex-direction:column;gap:13px}
+.oslist li{display:flex;gap:12px;align-items:flex-start;font-size:14.5px;color:var(--text-secondary)}
+.oslist .ck{color:var(--cyan-400);font-family:var(--font-mono);flex-shrink:0}
+.repo{background:var(--surface-inset);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:20px}
+.repo .rh{display:flex;align-items:center;gap:9px;font-family:var(--font-mono);font-size:13.5px;color:var(--slate-200);margin-bottom:12px}
+.repo .rh svg{width:16px;height:16px;stroke:var(--slate-400);fill:none;stroke-width:1.8}
+.repo .rd{font-size:13px;color:var(--slate-400);line-height:1.5;margin-bottom:14px}
+.repo .rmeta{display:flex;gap:16px;flex-wrap:wrap;font-size:12px;color:var(--slate-500);font-family:var(--font-mono);border-top:1px solid var(--border-subtle);padding-top:12px}
+.repo .rmeta b{color:var(--slate-300);font-weight:600}
+
+/* faq */
+.faq{max-width:800px;margin:0 auto}
+.q{border-bottom:1px solid var(--border-subtle);padding:17px 0}
+.q h3{font-size:15.5px;color:var(--text-primary);font-weight:600;margin-bottom:7px}
+.q p{font-size:14px;color:var(--text-tertiary);line-height:1.6}
+
+/* cta */
+.band{text-align:center;background:var(--surface-panel);border-top:1px solid var(--border-subtle);border-bottom:1px solid var(--border-subtle)}
+.band h2{font-size:clamp(26px,3.3vw,38px);font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin-bottom:14px}
+.band p{color:var(--text-tertiary);font-size:16.5px;margin-bottom:26px}
+
+/* footer */
+footer{padding:52px 0 36px;border-top:1px solid var(--border-subtle);font-size:13px;color:var(--slate-500)}
+.fgrid{display:grid;grid-template-columns:1.4fr repeat(4,1fr);gap:32px;margin-bottom:34px}
+@media(max-width:880px){.fgrid{grid-template-columns:1fr 1fr}}
+.fgrid h4{font-size:11.5px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--slate-400);margin-bottom:13px}
+.fgrid ul{list-style:none;display:flex;flex-direction:column;gap:9px}
+.fgrid ul a{color:var(--slate-400);font-size:13.5px}
+.fgrid ul a:hover{color:var(--text-primary)}
+.fbot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;border-top:1px solid var(--border-subtle);padding-top:22px}
+.fbrand{display:flex;align-items:center;gap:9px;color:var(--text-secondary);font-weight:600}
+.fbrand img{width:23px;height:23px}
+@media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+</style>
+</head>
+<body>
+
+<div class="mockbar">
+  <div class="wrap">
+    <div><b>MOCKUP v2</b> — proposed homepage IA · spec: <span class="mono">docs/specs/website-readme-revamp.md</span></div>
+    <div class="legend">
+      <span class="lg"><i class="sw sw-new"></i> new section</span>
+      <span class="lg"><i class="sw sw-fix"></i> corrected claim</span>
+      <span class="lg"><i class="sw sw-shot"></i> real screenshot slot</span>
+    </div>
+  </div>
+</div>
+
+<header>
+  <div class="wrap">
+    <nav>
+      <div class="brand"><img src="https://mantaui.com/manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
+      <div class="navlinks">
+        <a href="#features" class="hide-sm">Features</a>
+        <a href="#compare" class="hide-sm">Compare</a>
+        <a href="#how" class="hide-sm">How it works</a>
+        <a href="#" class="hide-sm">Docs</a>
+        <a href="#" class="hide-sm">Pricing</a>
+        <a href="#opensource" class="btn btn-ghost">GitHub</a>
+      </div>
+    </nav>
+  </div>
+</header>
+
+<!-- ============ 1. HERO ============ -->
+<div class="hero">
+  <div class="aura"></div>
+  <div class="wrap">
+    <h1>Your agents keep working<br><span class="grad">after you close the laptop</span></h1>
+    <p class="sub">Manta runs Claude Code and opencode in real tmux on a Linux box or Mac you own. The desktop app and the phone app are both full clients. Close either one and the work carries on.</p>
+
+    <div class="install" style="margin-top:34px">
+      <div class="install-tabs" role="tablist">
+        <button class="install-tab" aria-selected="true" onclick="tab(this,'p-agent')">Coding agent</button>
+        <button class="install-tab" aria-selected="false" onclick="tab(this,'p-manual')">Manual</button>
+      </div>
+      <div class="install-panel active" id="p-agent">
+        <div class="agent-cmd">
+          <p>Set up this box as a Manta UI server, a self-hosted Claude Code client for desktop and mobile. Follow <span class="url">https://mantaui.com/llms-install.md</span> exactly.</p>
+          <button class="copy-btn">Copy</button>
+        </div>
+        <div class="install-hint">Paste this into Claude Code, opencode or Cursor on the box you want to use.</div>
+      </div>
+      <div class="install-panel" id="p-manual">
+        <div class="install-cmd">
+          <code><span class="prompt">$</span> curl -fsSL <span class="url">https://mantaui.com/install.sh</span> | bash</code>
+          <button class="copy-btn">Copy</button>
+        </div>
+        <div class="install-hint">Runs on Linux or macOS. No Node install, no compiler, no sudo. Prints a pairing code when it finishes.</div>
+      </div>
+    </div>
+
+    <div class="cta">
+      <a class="btn btn-primary" href="#">Download for macOS</a>
+      <a class="btn btn-ghost" href="#compare">See how it compares</a>
+    </div>
+    <div class="meta">Free. No signup. Runs on hardware you already own. <span class="tag tag-fix">FIX B4 — settle the signed / unsigned copy</span></div>
+
+    <div class="shot">
+      <div class="shot-note">SHOT A · replace with real 2x screenshot</div>
+      <div class="shot-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="shot-title">Manta UI</span>
+      </div>
+      <div class="app">
+        <div class="rail">
+          <img src="https://mantaui.com/manta-logo.png" alt="" class="logo">
+          <div class="ri on"><svg viewBox="0 0 24 24"><path d="M4 17l6-6-6-6M12 19h8"/></svg></div>
+          <div class="ri"><svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></svg></div>
+          <div class="ri"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3m0 12v3m9-9h-3M6 12H3"/></svg></div>
+        </div>
+        <div class="side">
+          <div class="grp">Ethernal</div>
+          <div class="s sel"><span class="sd run"></span><span class="nm">feat/<b>auth</b></span></div>
+          <div class="s"><span class="sd perm"></span><span class="nm">refactor/<b>db</b></span><span class="bang">!</span></div>
+          <div class="s"><span class="sd idle"></span><span class="nm">main</span></div>
+          <div class="grp">Marketing</div>
+          <div class="s"><span class="sd wait"></span><span class="nm">hero-<b>copy</b></span><span class="sfx">?</span></div>
+          <div class="s"><span class="sd run"></span><span class="nm">landing</span><span class="sfx">2</span></div>
+          <div class="grp">Infra</div>
+          <div class="s"><span class="sd idle"></span><span class="nm">deploy</span></div>
+        </div>
+        <div class="panel">
+          <div class="ph">ethernal / <span style="color:var(--cyan-300)">feat/auth</span> · <span class="mono">box-fra-1</span>
+            <span class="pill pill-run"><span class="ping"></span>Running</span></div>
+          <div class="body">
+            <div class="msg user"><div class="who">You</div><div class="bub">add a device-code pairing flow to the auth module</div></div>
+            <div class="msg agent"><div class="who">Manta</div><div class="bub">Reading the current auth module before I change anything.</div></div>
+            <div class="tool"><span class="tk">›</span> read <span class="pth">src/server/auth.mjs</span></div>
+            <div class="tool"><span class="tk">›</span> edit <span class="pth">src/server/auth.mjs</span> <span class="ok">+38 −4</span></div>
+            <div class="wellrow"><span class="dim">$</span> npm test &nbsp; <span class="ok">✓ 41 passed</span> <span class="dim">· 2.1s</span></div>
+          </div>
+          <div class="ctxbar">
+            <span>ctx</span>
+            <span class="ctxtrack"><i style="width:34%;background:var(--cyan-400)"></i><i style="width:11%;background:#f59e0b"></i><i style="width:28%;background:#0ea5a4"></i></span>
+            <span>73% · 146k/200k</span>
+          </div>
+          <div class="composer">
+            <div class="field">Reply to Manta…</div>
+            <div class="send"><svg viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============ 2. CLOSE THE LAPTOP ============ -->
+<section class="laptop-band sunk">
+  <span class="secmark new"></span>
+  <div class="wrap">
+    <div class="inner">
+      <div>
+        <div class="eyebrow">The difference<span class="tag tag-new">NEW SECTION</span></div>
+        <h2 class="bigclaim">Shut the lid and the work <em>carries on</em></h2>
+        <p style="color:var(--text-tertiary);font-size:16px">Manta's server runs on your box as a system service. Your agents live in real tmux windows. The desktop app and the phone app are clients, so you can close every one of them and nothing stops.</p>
+        <ul class="checks">
+          <li><span class="ck">✓</span> Agents keep working with no client connected</li>
+          <li><span class="ck">✓</span> Reconnect from any device and the full history is there</li>
+          <li><span class="ck">✓</span> Survives a reboot, because it is a system service</li>
+          <li><span class="ck">✓</span> Your phone buzzes when the agent needs a decision</li>
+        </ul>
+        <div class="quotebox">
+          Orca's own docs: <q>Closing the desktop app drops the connection. There is no cloud relay.</q><br><br>
+          Conductor sells this as their paid beta: <q>close your laptop during a task and the agent keeps going.</q>
+          <span class="src">quoted verbatim, linked and dated on /vs/orca and /vs/conductor</span>
+        </div>
+      </div>
+      <div class="phone">
+        <div class="scr">
+          <div class="lockshot">
+            <div class="time">9:41</div>
+            <div class="date">Tuesday, 14 October</div>
+            <div class="notif">
+              <div class="nh">
+                <img src="https://mantaui.com/manta-logo.png" alt="">
+                <span class="app">Manta</span><span class="ago">now</span>
+              </div>
+              <div class="nt">ethernal / feat-auth</div>
+              <div class="nb">Permission needed: Bash(rm -rf ./dist)</div>
+              <div class="acts"><span>Deny</span><span>Allow</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="shotph" style="margin-top:34px;min-height:150px">
+      <div class="id">Shot M</div>
+      <div class="ttl">Desktop and phone side by side, same live session</div>
+      <div class="dsc">The same transcript on both, one of them mid-turn. This is the shot that proves parity, which is exactly the thing Orca says their mobile app deliberately does not do.</div>
+      <div class="dim">1440×900 @2x composited with 393×852 @2x</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 3. FEATURES ============ -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">What you get</div>
+      <h2>Everything the agent does, on every device</h2>
+      <p>The desktop app and the phone app run the same code, so the transcript, the tool output and the approval buttons are identical on both.</p>
+    </div>
+    <div class="grid">
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 17l6-6-6-6M12 19h8"/></svg></div>
+        <h3>Real tmux underneath</h3>
+        <p>A chat panel and a real <code>tmux</code> terminal for every window. Your box stays a normal tmux server, so you can still SSH in and attach to the same session.</p>
+        <div class="vs">Orca and Conductor each run their own process model. Neither leaves the box usable without their app.</div>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="20" rx="2.5"/><path d="M11 18.5h2"/></svg></div>
+        <h3>The phone app is the same app</h3>
+        <p>Same code as the desktop: full transcript, live command output, approvals, dictation and file uploads. A native iPhone app, and any browser everywhere else.</p>
+        <div class="vs">Orca calls its mobile app "read-mostly" and "intentionally not a full editor". Conductor has no phone app.</div>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.7 21a2 2 0 01-3.4 0"/></svg></div>
+        <h3>Notifications that know where you are</h3>
+        <p>Working at your desk? Your phone stays quiet. Away from it? The desktop gets it first and your phone 90 seconds later. Anything blocking reaches every device at once.</p>
+        <div class="vs">Neither competitor routes notifications at all.</div>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M12 3l7 4v5c0 4-3 7-7 8-4-1-7-4-7-8V7z"/><path d="M9 12l2 2 4-4"/></svg></div>
+        <h3>You approve what runs</h3>
+        <p>Permissions and questions arrive as cards you answer with one tap. Allow, deny, or write a clarification. Trust a whole session when you want it to move faster.</p>
+        <div class="vs">Orca ships <span class="mono">--dangerously-skip-permissions</span> pre-filled. Conductor's docs say agents run without sandboxing.</div>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg></div>
+        <h3>A worktree per session</h3>
+        <p>New sessions in a git repo branch their own sibling worktree, so several agents work in parallel without standing on each other. Close the session and Manta offers to remove the worktree, asking first if anything is uncommitted.</p>
+        <div class="vs">Command output also streams live, and a context bar splits fresh tokens from cached ones so a cold cache does not surprise you.</div>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 007.5.5l3-3a5 5 0 00-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 00-7.5-.5l-3 3a5 5 0 007 7L12.2 19"/></svg></div>
+        <h3>It works out how to reach you</h3>
+        <p>The installer checks whether Tailscale is already running. If it is, your devices connect over your tailnet and nothing is published to the internet. If it is not, the box gets its own hostname and an HTTPS certificate. You do not pick.</p>
+        <div class="vs">Orca requires Tailscale and tells you not to expose its port to the internet. Here a tailnet is one of two supported paths, not a prerequisite.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 4. AGENT TOOLS ============ -->
+<section class="sunk">
+  <span class="secmark new"></span>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Nobody else does this<span class="tag tag-new">NEW SECTION</span></div>
+      <h2>The agent can reach you between turns</h2>
+      <p>Manta gives the agent a few tools of its own. It can put work on a timer, wake up when something happens outside, or ask for your attention on whichever device you are using.</p>
+    </div>
+    <div class="grid">
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></div>
+        <h3>Schedule</h3>
+        <p>Ask it to check the deploy every five minutes. The prompt re-runs in this session on a cron, on the server, whether or not you are connected.</p>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9z"/></svg></div>
+        <h3>Webhooks</h3>
+        <p>Hand your CI a signed URL. The session wakes up when the build finishes, instead of burning tokens asking whether it is done yet.</p>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg></div>
+        <h3>Secrets</h3>
+        <p>The agent gets a file path, never the value. Your token goes into the command at run time and never appears in the transcript.</p>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M3 11l18-5v12L3 14v-3z"/><path d="M11.6 16.8a3 3 0 11-5.8-1.6"/></svg></div>
+        <h3>Notify</h3>
+        <p>Ask to be told when the migration finishes. Manta picks the device based on where you have actually been active.</p>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.9"/></svg></div>
+        <h3>Peers</h3>
+        <p>Agents in the same workspace can see and message each other, so one can warn another before touching a file it is editing.</p>
+      </div>
+      <div class="card">
+        <div class="ic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 010 18 14 14 0 010-18z"/></svg></div>
+        <h3>Serve page</h3>
+        <p>The agent publishes a preview to a URL you can open on any device, with no file transfer in between.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 5. HOW IT WORKS ============ -->
+<section id="how">
+  <span class="secmark fix"></span>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Setup<span class="tag tag-fix">FIX B5 — drop the "named tunnel" line</span></div>
+      <h2>Paired in under a minute</h2>
+      <p>No SSH keys to distribute and no tunnel to keep alive. The server installs on your box, works out how to make itself reachable, and you pair each device once.</p>
+    </div>
+    <div class="flow">
+      <div class="step">
+        <div class="n">STEP 01</div>
+        <h3>Install on your box</h3>
+        <p>One command. It ships its own Node runtime, so there is no compiler and no package manager involved. It then works out how devices will reach the box: over your tailnet if Tailscale is already running, otherwise through Caddy and a Let's Encrypt certificate on <span class="mono">&lt;your-box&gt;.boxes.mantaui.com</span>.</p>
+      </div>
+      <div class="step">
+        <div class="n">STEP 02</div>
+        <h3>Pair a device</h3>
+        <p>Type in the six-digit code the installer printed. The device gets a token, and every call after that is authenticated over HTTPS.</p>
+      </div>
+      <div class="step">
+        <div class="n">STEP 03</div>
+        <h3>Start working</h3>
+        <p>Create a project and open a session. Install the phone app, pair it with a second code, and the same sessions are there.</p>
+      </div>
+    </div>
+    <div class="arch">
+<pre>   Desktop app                Phone app                  Browser
+        │                          │                         │
+        └──────────────────  HTTPS  ────────────────────────┘
+                                │
+   <span class="hl">&lt;box_id&gt;.boxes.mantaui.com</span>   <span class="dm">or</span>   <span class="hl">your box on the tailnet</span>
+   <span class="dm">Caddy + Let's Encrypt                  if Tailscale is already running
+
+        the installer detects which one applies and sets it up</span>
+                                │
+                       <span class="gr">YOUR LINUX BOX OR MAC</span>
+              manta-server  <span class="dm">──</span> owns tmux, files, config, secrets
+                ├── <span class="hl">tmux</span> <span class="dm">──</span> your sessions  <span class="dm">(keep running with 0 clients)</span>
+                └── opencode <span class="dm">──</span> chat mode and agent tools</pre>
+    </div>
+    <div class="shotph" style="margin-top:18px;min-height:110px">
+      <div class="id">Shot O and Shot K</div>
+      <div class="ttl">Architecture diagram as SVG, plus the pairing screen</div>
+      <div class="dsc">Redraw the diagram above properly. For a self-hosted product this is a trust asset, not decoration.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 6. MOBILE ============ -->
+<section class="sunk" id="mobile">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Away from your desk</div>
+      <h2>The whole session on your phone</h2>
+      <p>Reading a terminal UI on a phone keyboard is miserable. This is the actual client: read the diff, approve the risky command, dictate what to do next.</p>
+    </div>
+    <div class="laptop-band"><div class="inner">
+      <div>
+        <ul class="checks">
+          <li><span class="ck">✓</span> A native iPhone app, and any browser everywhere else</li>
+          <li><span class="ck">✓</span> Full transcript, live command output and inline diffs</li>
+          <li><span class="ck">✓</span> Answer permissions and questions with one tap</li>
+          <li><span class="ck">✓</span> Dictate a reply instead of typing it</li>
+          <li><span class="ck">✓</span> Push for permissions, questions, errors and finished work</li>
+          <li><span class="ck">✓</span> Talks straight to your box, with no account in between</li>
+        </ul>
+        <div class="quotebox" style="border-left-color:var(--cyan-400)">
+          A phone client that cannot approve a permission also cannot unblock an agent. The work still waits until you get back to your laptop, which defeats the point of carrying it around.
+        </div>
+      </div>
+      <div class="phone">
+        <div class="scr">
+          <div class="hd"><img src="https://mantaui.com/manta-logo.png" alt="">Sessions</div>
+          <div class="row"><span>ethernal / <span style="color:var(--cyan-300)">feat-auth</span></span><span class="st run">Running</span></div>
+          <div class="row"><span>ethernal / <span style="color:var(--cyan-300)">refactor-db</span></span><span class="st perm">Approve</span></div>
+          <div class="row"><span>ethernal / main</span><span class="st idle">Idle</span></div>
+          <div class="row"><span>marketing / <span style="color:var(--cyan-300)">hero</span></span><span class="st wait">Question</span></div>
+          <div class="row"><span>marketing / landing</span><span class="st run">Running</span></div>
+          <div class="row"><span>infra / deploy</span><span class="st idle">Done</span></div>
+          <div class="row"><span>notes / scratch</span><span class="st idle">Idle</span></div>
+        </div>
+      </div>
+    </div></div>
+    <div class="grid two" style="margin-top:34px">
+      <div class="shotph" style="min-height:150px">
+        <div class="id">Shot C2</div>
+        <div class="ttl">Mobile session detail</div>
+        <div class="dsc">Full transcript, tool output, composer and mic button. This is the direct answer to "read-mostly".</div>
+        <div class="dim">393×852 @2x</div>
+      </div>
+      <div class="shotph" style="min-height:150px">
+        <div class="id">Shot B</div>
+        <div class="ttl">Permission and question cards</div>
+        <div class="dsc">Buttons visible with a real command in view. Shows what approving actually looks like.</div>
+        <div class="dim">1440×900 @2x, cropped</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 7. COMPARISON ============ -->
+<section id="compare">
+  <span class="secmark new"></span>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Honest comparison<span class="tag tag-new">NEW · now includes Termius + SSH</span></div>
+      <h2>How Manta compares</h2>
+      <p>Orca and Conductor run agents on your laptop. Termius over SSH runs them on a VPS already, which is most of the way there. These are the axes we chose to compete on. The full picture, including what the others do better, is on each comparison page.</p>
+    </div>
+    <div class="cmp-wrap">
+      <table class="cmp">
+        <thead><tr>
+          <th style="width:28%"></th>
+          <th class="us">Manta UI</th>
+          <th>Orca</th>
+          <th>Conductor</th>
+          <th>Termius + SSH</th>
+        </tr></thead>
+        <tbody>
+          <tr><td>Agents run on</td><td class="us mid">Your VPS</td><td class="mid">Your desktop</td><td class="mid">Your Mac</td><td class="mid">Your VPS</td></tr>
+          <tr><td>Keeps running with every client closed</td><td class="us on">Yes</td><td class="off">No</td><td class="mid">Paid beta</td><td class="on">Yes</td></tr>
+          <tr><td>Phone client</td><td class="us on">The full app</td><td class="mid">Read-mostly</td><td class="off">None</td><td class="mid">Terminal only</td></tr>
+          <tr><td>Approve a command from your phone</td><td class="us on">One tap</td><td class="mid">Limited</td><td class="off">No</td><td class="mid">Type into the TUI</td></tr>
+          <tr><td>Tells you when the agent is blocked</td><td class="us on">Push</td><td class="off">No</td><td class="off">No</td><td class="off">No</td></tr>
+          <tr><td>Remote access</td><td class="us on">Detected and set up</td><td class="mid">Tailscale required</td><td class="mid">Cloud beta</td><td class="mid">SSH keys by hand</td></tr>
+          <tr><td>Git worktree per session</td><td class="us on">Yes</td><td class="on">Yes</td><td class="on">Yes</td><td class="mid">By hand</td></tr>
+          <tr><td>Agent scheduling, webhooks, secrets</td><td class="us on">Yes</td><td class="off">No</td><td class="off">No</td><td class="off">No</td></tr>
+          <tr><td>Real tmux underneath</td><td class="us on">Yes</td><td class="off">No</td><td class="off">No</td><td class="on">Yes</td></tr>
+          <tr><td>Account required</td><td class="us on">No</td><td class="mid">For mobile</td><td class="mid">Yes</td><td class="mid">To sync</td></tr>
+          <tr><td>Licence</td><td class="us on">MIT</td><td class="on">MIT</td><td class="mid">Proprietary</td><td class="mid">Proprietary</td></tr>
+          <tr><td>Price</td><td class="us on">Free</td><td class="on">Free</td><td class="mid">Free, plus Pro</td><td class="mid">Free, plus paid</td></tr>
+        </tbody>
+        <tfoot><tr>
+          <td></td>
+          <td class="us"></td>
+          <td><a href="#">Full comparison →</a></td>
+          <td><a href="#">Full comparison →</a></td>
+          <td><a href="#">Full comparison →</a></td>
+        </tr></tfoot>
+      </table>
+    </div>
+    <div class="cmp-note">
+      If you already run Claude Code on a VPS and reach it with Termius, you have solved the hard part. What Manta adds is a readable transcript instead of a TUI, one-tap approvals, and a notification the moment the agent gets stuck.<br>
+      Orca and Conductor each do things Manta does not, including diff review and a built-in editor, and Orca supports far more agent runtimes. Each comparison page lays that out in full. Sourced from public docs, dated and linked.
+    </div>
+  </div>
+</section>
+
+<!-- ============ 8. OPEN SOURCE ============ -->
+<section class="sunk" id="opensource">
+  <span class="secmark new"></span>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Open source<span class="tag tag-new">NEW · BLOCKED ON B1, add a LICENSE</span></div>
+      <h2>Yours to run, read and fork</h2>
+      <p>Being open source is table stakes here, because Orca is MIT too. The combination is what differs: open source, self-hosted, no account, and a server that outlives whichever client you happen to be holding.</p>
+    </div>
+    <div class="osgrid">
+      <div>
+        <ul class="oslist">
+          <li><span class="ck">✓</span><span>Runs on hardware you own. There is no hosted control plane, no workspace limit and no seat count.</span></li>
+          <li><span class="ck">✓</span><span>Your code stays on the box. The only thing that leaves is your agent talking to its model provider.</span></li>
+          <li><span class="ck">✓</span><span>Nothing to sign up for. Pairing is a six-digit code your own machine generates.</span></li>
+          <li><span class="ck">✓</span><span>Read <a href="#">install.sh</a> before you pipe it into bash. We would rather you did.</span></li>
+          <li><span class="ck">✓</span><span>MIT licensed. Fork it, run your own gateway, write your own client.</span></li>
+        </ul>
+      </div>
+      <div class="repo">
+        <div class="rh"><svg viewBox="0 0 24 24"><path d="M21 16V8l-9-5-9 5v8l9 5 9-5z"/><path d="M3.3 7.3L12 12l8.7-4.7M12 12v9.5"/></svg> antoinedc / MantaUI</div>
+        <div class="rd">Open-source, self-hosted Claude Code and opencode client. Agents run in real tmux on your own Linux box or Mac, and you drive them from desktop, phone or browser over HTTPS.</div>
+        <div class="rmeta">
+          <span><b>MIT</b> licence</span><span><b>TypeScript</b></span><span>Issues open</span>
+        </div>
+        <div style="margin-top:13px;font-size:11.5px;color:#9C90C4;font-family:var(--font-mono);border-top:1px dashed #6D5BA8;padding-top:10px">
+          MOCKUP NOTE: no star badge until the count is above 500 (spec B2). Needs a LICENSE file (B1) and an updated repo description and topics (B3) before this ships.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 9. FAQ ============ -->
+<section>
+  <span class="secmark new"></span>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">FAQ<span class="tag tag-new">NEW · marked up as FAQPage for answer engines</span></div>
+      <h2>Questions people actually ask</h2>
+      <p>Each answer is written to be quotable on its own, and each one maps to a page we want to rank for.</p>
+    </div>
+    <div class="faq">
+      <div class="q"><h3>Does the agent keep running if I close my laptop?</h3><p>Yes. The server runs on your box as a system service and your agents live in real tmux sessions. Every client is disposable, so you can close all of them and the work continues. Reconnect later and the full history is still there.</p></div>
+      <div class="q"><h3>Do I need Tailscale, a VPN or port forwarding?</h3><p>No, and you do not have to decide either. The installer checks whether Tailscale is already running on the box. If it is, your devices connect over your tailnet and nothing is published to the internet. If it is not, the box gets its own hostname and a Let's Encrypt certificate. Either way there is nothing to port-forward and no tunnel to keep alive, and you can force either path if you prefer.</p></div>
+      <div class="q"><h3>Can I really use Claude Code from my phone?</h3><p>Yes, and the phone app is the same app as the desktop rather than a status viewer. You get the full transcript, live command output, approvals, dictation and file uploads, in a native iPhone app or any browser.</p></div>
+      <div class="q"><h3>I already SSH into a VPS with Termius. Why switch?</h3><p>You have already solved the part most tools get wrong, which is keeping the agent alive when you walk away. What you do not get is a readable transcript instead of a terminal UI, buttons to approve a command, or a notification when the agent stops and waits for you. Manta runs on the same box and you can still SSH in alongside it.</p></div>
+      <div class="q"><h3>What does it cost?</h3><p>Nothing. Manta is free and open source. You pay whoever supplies your agent, so an Anthropic subscription or an API key, and you supply the box.</p></div>
+      <div class="q"><h3>Does my code leave my box?</h3><p>No. Transcripts, uploads, secrets and configuration stay on your machine. The only outbound traffic is your agent talking to its model provider, plus a small push payload carrying the session name if you turn on phone notifications.</p></div>
+      <div class="q"><h3>Which agents does it work with?</h3><p>Claude Code and opencode today. Anything that runs in a terminal works in terminal mode, and the chat panel is built on opencode.</p></div>
+      <div class="q"><h3>Is this an alternative to Conductor or Orca?</h3><p>It overlaps with both, on a different bet. They run agents on your Mac and give you a window onto them. Manta runs agents on a box you own and gives every device the same window, so the work outlives whatever you are holding.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 10. CTA ============ -->
+<section class="band">
+  <div class="wrap">
+    <h2>Put it on your own box</h2>
+    <p>Free, no signup, and it runs on hardware you already have.</p>
+    <div class="install" style="margin-bottom:0">
+      <div class="install-cmd">
+        <code><span class="prompt">$</span> curl -fsSL <span class="url">https://mantaui.com/install.sh</span> | bash</code>
+        <button class="copy-btn">Copy</button>
+      </div>
+    </div>
+    <div class="cta" style="margin-top:20px">
+      <a class="btn btn-primary" href="#">Download for macOS</a>
+      <a class="btn btn-ghost" href="#">Read the docs</a>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 11. FOOTER ============ -->
+<footer>
+  <div class="wrap">
+    <div class="fgrid">
+      <div>
+        <div class="fbrand"><img src="https://mantaui.com/manta-logo.png" alt="Manta">Manta<b>UI</b></div>
+        <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
+      </div>
+      <div><h4>Product</h4><ul>
+        <li><a href="#features">Features</a></li><li><a href="#mobile">Mobile</a></li>
+        <li><a href="#">Pricing</a></li><li><a href="#">Changelog</a></li><li><a href="#">Download</a></li></ul></div>
+      <div><h4>Compare</h4><ul>
+        <li><a href="#">vs Conductor</a></li><li><a href="#">vs Orca</a></li>
+        <li><a href="#">vs SSH and tmux</a></li></ul></div>
+      <div><h4>Use cases</h4><ul>
+        <li><a href="#">Claude Code web UI</a></li><li><a href="#">Claude Code on mobile</a></li>
+        <li><a href="#">Claude Code remote</a></li><li><a href="#">Notifications</a></li></ul></div>
+      <div><h4>Resources</h4><ul>
+        <li><a href="#">Docs</a></li><li><a href="#">GitHub</a></li>
+        <li><a href="#">Security</a></li><li><a href="#">Privacy</a></li><li><a href="#">Terms</a></li></ul></div>
+    </div>
+    <div class="fbot">
+      <div>MIT licensed. Built for people who pair with agents.</div>
+      <div class="mono" style="font-size:11.5px;color:var(--slate-600)">llms.txt · llms-full.txt · /.well-known/agent-skills</div>
+    </div>
+  </div>
+</footer>
+
+<script>
+function tab(btn, id){
+  var tabs = btn.parentNode.querySelectorAll('.install-tab');
+  for (var i=0;i<tabs.length;i++) tabs[i].setAttribute('aria-selected', tabs[i]===btn?'true':'false');
+  var ps = document.querySelectorAll('.install-panel');
+  for (var j=0;j<ps.length;j++) ps[j].classList.toggle('active', ps[j].id===id);
+}
+</script>
+</body>
+</html>

--- a/docs/specs/website-readme-revamp.md
+++ b/docs/specs/website-readme-revamp.md
@@ -1,0 +1,615 @@
+# Spec — Website + README revamp (SEO/GEO, screenshots, features, open source)
+
+Status: **SPEC ONLY — nothing implemented.** Research date 2026-07-26.
+
+Covers: positioning, homepage IA, SEO/GEO plan, competitor comparison pages,
+screenshot shot list, README rewrite. Sources: DataForSEO (Google Ads,
+US/en), full-site crawls of onorca.dev and conductor.build.
+
+---
+
+## 0. Blockers — fix before any of this ships
+
+These invalidate claims we already make. Ordered by severity.
+
+| # | Issue | Evidence | Fix |
+|---|---|---|---|
+| **B1** | **No LICENSE file.** Repo is public but GitHub reports `licenseInfo: null` → legally "all rights reserved". The homepage says "Free & **open source**" and the CTA band says "Open source." Both are currently unbacked. | `gh repo view` | Add `LICENSE` (recommend **MIT** — matches Orca, removes any adoption friction). Until this lands, every "open source" claim is a liability, and the whole §5 open-source strategy is unbuildable. |
+| **B2** | **0 stars, 0 forks.** Orca has 29.6k in ~4 months. | `gh repo view` | Not fixable by decree, but it means: do **not** put a star-count badge on the site (Orca does; for us it's negative proof). Revisit once >500. |
+| **B3** | **Stale repo description**: "Desktop client for remote Claude Code sessions". Undersells — it's a server + desktop + mobile + agent-tools platform. The GitHub description is a real ranking/answer surface. | `gh repo view` | Rewrite (see §7.1). |
+| **B4** | Homepage says "macOS build is **signed**"; README says "The macOS build is **unsigned** — first launch will be blocked by Gatekeeper". One is wrong. | `website/index.html:282` vs `README.md:181` | Establish truth, then align. (`AGENTS.md` says Developer ID-signed but **not notarized**, so "signed, not notarized, right-click → Open" is likely correct and the README is stale.) |
+| **B5** | Homepage step 01 says "It reaches the internet over a **named tunnel**." That's the maintainer box's legacy setup. Current architecture is Caddy + Let's Encrypt on `<box_id>.boxes.mantaui.com` — **no tunnel**. This is our single biggest differentiator and the copy describes the thing we replaced. | `website/index.html:382` vs `README.md:60-65` | Rewrite (see §3, Section 4). |
+
+---
+
+## 1. Competitive landscape
+
+### 1.1 The competitors
+
+**Three, not two.** Alongside Orca and Conductor, the most common thing our
+buyer already does is **run Claude Code on a VPS and reach it with Termius
+over SSH**. That is the incumbent to beat, and it is the strongest one:
+it already keeps the agent alive when you walk away, which is the hard part.
+It must appear in the comparison table and get its own `/vs/` page.
+
+What Termius + SSH does not give you, and what the whole pitch against it
+rests on:
+
+- A readable transcript. You get the agent's terminal UI on a phone keyboard.
+- A way to approve a command that is not typing into a TUI.
+- Any notification when the agent stops and waits for you. You go and look.
+- File upload, dictation, or anything the agent can initiate on its own.
+
+Do not dismiss it. Say plainly that it solves the important part, and that
+Manta runs on the same box beside it.
+
+### 1.2 Orca and Conductor
+
+| | **Orca** (onorca.dev) | **Conductor** (conductor.build) | **MantaUI** |
+|---|---|---|---|
+| Company | Stably Inc, YC | Melty Labs, YC S24, $24M raised | solo |
+| H1 | "Ship 100x With The Agent IDE" | "Run parallel coding agents on your Mac." | — |
+| Category word | "ADE" (Agent Development Environment) | "AI orchestrator" | — |
+| License | **MIT, 29.6k ★** | **Proprietary, closed** | *(none yet — B1)* |
+| Platforms | macOS, Win, Linux desktop | **macOS only** | Linux/macOS box + macOS desktop + iPhone app + browser |
+| Architecture | **Desktop is source of truth** | **Desktop is source of truth** | **Server (the box) is source of truth** |
+| Remote access | SSH targets, or "Remote Orca Server" — **requires Tailscale**, **"no cloud relay"**, **closing desktop drops the phone** | Conductor Cloud — **beta, Pro-gated, GitHub-only, 10-workspace cap** | **Auto-detected ingress (BET-267)**: tailnet if Tailscale is up, otherwise Caddy + LE on a per-box hostname. Box runs with zero clients connected |
+| Mobile | "**read-mostly view**", "**intentionally not a full editor**", "a remote control for the desktop you already have running" | None shipped | **Same React client as desktop**, full parity. iPhone app; browser elsewhere |
+| Permissions | **`--dangerously-skip-permissions` / `--yolo` pre-filled by default** for every agent | "Agents run directly on your system **without sandboxing**" | Explicit permission + question cards; `chatAutoAllow` is opt-in |
+| Pricing page | **none** | **none** (`/pricing` → 404) | none |
+| Comparison pages | **none** (targets "Cursor alternative"/"Conductor alternative" in `<meta keywords>` + JSON-LD FAQ only) | **none** | none |
+| GEO/AEO | FAQPage JSON-LD ×10. **Blocks Ahrefs/Semrush.** No llms.txt | **Heavy**: llms.txt, llms-full.txt (318KB), `.md` twin per URL, `/.well-known/agent-skills/`, `Content-Signal: ai-train=yes` | `llms-install.md` only |
+
+### 1.3 The three open flanks
+
+1. **Nobody has comparison pages. Nobody has a pricing page.** Both YC-funded competitors left "Conductor alternative", "Orca alternative", "conductor pricing", "is conductor free" completely uncontested. Orca additionally blocks Ahrefs/Semrush, so they are partly blind to anything we build against them.
+2. **Both are desktop-first; both admit their remote story is the weak part** — in their own docs, quotably. Orca: *"Closing the desktop app drops the connection — there is no cloud relay."* Conductor: cloud is beta + Pro + capped.
+3. **Neither ships agent-facing tooling.** Schedules, webhooks, notify-with-routing, secrets-by-reference, peer messaging — the agent extending its own capabilities is a category nobody else is marketing.
+
+### 1.4 What we must NOT claim
+
+Orca genuinely beats us on: agent count (34 vs ~2), embedded browser/Design Mode, Monaco editor, diff annotation, cross-platform desktop, 29.6k stars. Conductor beats us on: diff review + PR/merge tail, Linear/GitHub integration, polish, funding.
+
+**Do not fight on IDE surface** (editor, embedded browser, diff annotation, agent count). We lose those. Fight on *where the agent runs and who can reach it*. Worktrees are now **parity**, not a loss — see §2.6.
+
+---
+
+## 2. Positioning
+
+### 2.1 The wedge
+
+Both competitors sell **a better window onto agents running on your laptop**.
+We sell **agents that don't live on your laptop at all**.
+
+> Conductor's own pitch for Cloud — *"close your laptop during a task and the
+> agent keeps going"* — is the default, free, day-one behaviour of MantaUI.
+> They charge for it and it's in beta. That is the entire argument.
+
+### 2.2 Recommended H1 options
+
+Current H1 — "Drive Claude Code from anywhere" — is fine but generic, and
+"from anywhere" is the weakest half (Orca and Conductor both claim remote).
+The stronger claim is the *persistence*, not the *reach*.
+
+| Option | Copy | Note |
+|---|---|---|
+| **A (recommended)** | **"Your coding agents keep running. With or without you."** <br> sub: "Manta runs Claude Code and opencode on your own Linux box or Mac — in real tmux. Close the laptop, the work continues. Steer it from your desk or your phone, same session, same state." | Leads with persistence (the true differentiator), covers remote + mobile + own-hardware in the sub. |
+| B | "Claude Code, on your box, in your pocket." | Punchier, keyword-dense ("claude code" + mobile), less differentiated. |
+| C | "The server is the box." | Too insider. Good as a section header, not an H1. |
+
+Keep the H1 to ONE claim. Put "open source", "self-hosted", "free" in the
+badge row under the CTA, not in the H1.
+
+### 2.3 Four pillars (these become the homepage sections and the README feature list)
+
+1. **It runs without you.** Real tmux on your box. Close every client — desktop, phone, browser — the agent keeps going. Reopen, re-attach, full scrollback. *(vs Orca: closing desktop drops the phone. vs Conductor: that's the paid beta.)*
+2. **The phone app is the same app.** Same code as the desktop: full transcript, live tool output, approvals, voice, file upload. A native iPhone app, and any browser everywhere else. *(Orca calls its mobile app "read-mostly" and "intentionally not a full editor". Conductor has no phone app.)*
+3. **It works out how to reach you.** The installer probes `tailscale status`; if Tailscale is already running it uses the tailnet and skips Caddy, public DNS and Let's Encrypt entirely. If not, it provisions a per-box hostname and certificate. The decision is persisted to `~/.manta/ingress.json` and can be forced with `MANTA_INGRESS=public|tailscale`. *(Orca **requires** Tailscale and warns "Do not forward the Orca port directly to the public internet." For us a tailnet is one of two supported paths, not a prerequisite.)*
+4. **The agent can act between turns.** Schedule itself, be woken by a webhook, notify you on the right device, use secrets by reference, message sibling sessions. *(Nobody else markets this.)*
+
+Supporting, not a pillar: approvals-by-default (contrast Orca's yolo default),
+open source, free, your hardware.
+
+---
+
+## 2.4 Copy rules (applies to the site, the README, and every page below)
+
+House style follows [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing).
+Copy that reads as machine-generated undermines a developer-tool pitch faster
+than a weak claim does. Banned outright:
+
+| Pattern | Example to avoid | Write instead |
+|---|---|---|
+| **Negative parallelism** — "not X, but Y" / "not just X, but also Y" | "Not a status dashboard. The actual client." | "Reading a terminal UI on a phone keyboard is miserable. This is the actual client." |
+| **Em-dash overuse** as a general-purpose connector | "Same code as desktop — full transcript, live output — and approvals" | Full stops, commas or colons. Em dashes only inside a direct quotation. |
+| **Trailing "-ing" clauses** tacked onto a sentence to add significance | "…runs on your box, enabling you to work from anywhere" | Cut the clause, or make it its own sentence. |
+| **Rule of three** — triads of adjectives or phrases | "Fast, secure, and reliable" | Two items, or four. Or just the one that is true. |
+| **Puffery** | boasts, vibrant, rich, seamless, robust, powerful, groundbreaking, cutting-edge, effortless | A specific fact instead. |
+| **Significance language** | "stands as", "serves as", "plays a crucial role", "underscores the importance of" | Delete. Say the thing itself. |
+| **Emoji as formatting** | Emoji as list bullets or card icons | Monochrome line SVG icons, matching the existing icon set. |
+| **Heavy boldface** mid-paragraph | Bold scattered through body copy | At most one bold phrase per block. |
+| **Title Case headings** | "Run Your Agents From Anywhere" | Sentence case. |
+| **Vague attribution** | "developers widely agree", "many teams find" | Name the source, quote it, link it, date it. |
+
+Two things to check on every draft: read it aloud, and count the em dashes. If
+a sentence only exists to tell the reader that the previous sentence mattered,
+delete it.
+
+## 2.5 Terminology and claim limits
+
+**Android does not exist yet.** There is a Capacitor scaffold, but nothing
+shipped. Never imply an Android app on the site, in the README, or in schema
+markup. The honest line is **"a native iPhone app, and any browser everywhere
+else"** — which is true, covers Android users, and does not promise a store
+listing we cannot deliver. Consequences:
+
+- Drop `claude code android` (170/mo) from the target keyword set until it ships.
+- `SoftwareApplication` JSON-LD `operatingSystem` lists Linux, macOS, iOS and
+  Web. Not Android.
+- Do not point out that Orca's Android build is a sideloaded APK. It invites
+  the obvious reply.
+
+**Do not say PWA.**
+
+It is deprecated as a user-facing term and it makes the
+mobile client sound like a fallback. Say **"the phone app"**, or
+**"a native iPhone app, and any browser everywhere else"**. The installable-from-browser route
+still exists and can be documented, but it is never the headline description
+of the mobile client.
+
+Also fix on sight: "app for iOS" → "iPhone app"; any phrasing that implies
+the phone client is a companion, viewer, or remote. It is a client.
+
+---
+
+## 2.6 Verified capabilities (checked against git, 2026-07-26)
+
+Two claims in the first draft of this spec were wrong because they predated
+shipped work. Both are now confirmed from the repo, not from memory.
+
+**Worktree per session — SHIPPED (BET-246, `11054b0`).** `worktreePerSession`
+creates a sibling git worktree on its own branch for each new chat session in
+a git repo. `worktreeCleanOnClose` removes it (and best-effort the branch) on
+session close, prompting before discarding uncommitted work; tracked per window
+via the `@manta-worktree-path` tmux option so it never touches a pre-existing
+worktree or the main checkout. Global setting plus a per-session override in
+the new-session dialog. Separate and older: the project-create dialog detects
+an existing multi-worktree repo and offers one session per worktree.
+
+→ The comparison table says **Yes**. Frame it as **parity** with Orca and
+Conductor, never as a differentiator, since both market it harder than we do.
+
+**Auto-detected ingress — SHIPPED (BET-267, `8a0f123`).** `MANTA_INGRESS`
+defaults to `auto`. The installer runs `tailscale status --json`; if
+`BackendState` is `Running` with an IPv4 it selects tailnet mode and skips
+Caddy, public DNS and Let's Encrypt entirely, with devices connecting to
+`http://<tailnet-ip>:8787`. Otherwise it selects public mode: Caddy plus a
+Let's Encrypt certificate on `<box_id>.boxes.mantaui.com`. The decision is
+persisted to `~/.manta/ingress.json` and drives the pairing output. Forceable
+with `MANTA_INGRESS=public|tailscale`. macOS boxes always skip public TLS.
+
+→ **Retire the "no VPN needed" line.** It is now both inaccurate and a weaker
+claim than the truth. The claim is *"it works out how to reach you"*: a tailnet
+if you already run one, a public hostname if you do not, decided for you. This
+also sharpens the Orca contrast — they **require** Tailscale, we **support** it.
+
+**Standing rule:** before writing a capability claim, check `git log --grep`
+for the feature and read the setting's own description. This spec was drafted
+partly from `AGENTS.md`, which lagged both features.
+
+---
+
+## 3. Homepage IA
+
+Target: `website/index.html`. Current page is 465 lines, one section per pillar
+already — the bones are OK. The rework is **copy + real screenshots + new
+sections + schema**, not a rebuild.
+
+| # | Section | Change | Notes |
+|---|---|---|---|
+| 1 | Nav | **Add** Docs, Pricing, Compare (dropdown → /vs/conductor, /vs/orca), Changelog. Keep GitHub. | Both competitors have Docs+Changelog in nav; we have neither. Nav links are the main internal-linking surface. |
+| 2 | Hero | New H1/sub (§2.2). Keep the dual install tab (agent-prompt / curl) — **this is genuinely better than both competitors' download-only CTA** and should stay above the fold. **No badge/chip row** — it fragments the eye between the headline and the install box, which is the one thing on the page that has to be seen. The same claims are carried by the meta line, the open-source band and the comparison table. |
+| 3 | Hero visual | **Replace the hand-built HTML mockup with a real screenshot** (shot A, §6). Orca uses a fake mockup, Conductor uses one real screenshot — the real one reads as more credible for a solo/OSS project where "does this actually exist" is the objection. | Keep the HTML mockup as the mobile-breakpoint fallback if the screenshot doesn't scale down. |
+| 4 | **NEW — "Close the laptop" band** | The single most differentiating claim, given its own band right under the hero. Desktop + phone showing the *same session* side by side (shot M). Copy: box keeps running, clients are disposable. | This is the section that beats both competitors. It doesn't exist today. |
+| 5 | Features grid | Keep 6-card grid, **rewrite to the 4 pillars + 2**. Add real screenshots/GIFs per card or link each to an anchor. Current cards are decent but flat — "Approvals, not surprises" should explicitly contrast with yolo-by-default. | See §4 for per-card copy direction. |
+| 6 | **NEW — Agent-native tools** | Schedule / webhook / notify / secrets / peers / serve-page. Nobody else has this. Six small cards or a two-column list. | Feeds the "AI tools" long-tail and the GEO answer set. |
+| 7 | How it works | **Fix B5** (no tunnel). Three steps: install on box → pair with 6-digit code → open desktop or phone. Add the architecture diagram (the README's ASCII one, redrawn as SVG). | Architecture diagram is a trust asset for a self-hosted product. |
+| 8 | Mobile section | Keep. Add **real** phone screenshots (shots C, D) replacing the CSS phone. Add the push-notification shot — it's the proof that "your phone is a real client". | |
+| 9 | **NEW — Comparison table** | Four columns: Manta / Orca / Conductor / **Termius + SSH**. Named honestly; both competitors refuse to name anyone, so naming them differentiates *and* wins the comparison SERP. Include the rows we lose. | See §5.3 and the design constraint below. Links to the three /vs/ pages. |
+| 10 | **NEW — Open source band** | See §7. | |
+| 11 | **NEW — FAQ** | 8–10 Q&As, marked up as `FAQPage` JSON-LD. This is the primary GEO asset. | See §5.4. |
+| 12 | CTA band | Keep. Add "Free forever, no account, no signup" — neither competitor can say "no account" (Orca requires an Orca account for mobile pairing). | |
+| 13 | Footer | Expand to 4 columns (Product / Compare / Resources / Legal) to carry internal links. | |
+
+---
+
+## 4. Feature story — what to show and say
+
+Derived from what actually ships (per `AGENTS.md`), ordered by differentiating power.
+
+| Feature | Why it earns homepage space | Competitor contrast |
+|---|---|---|
+| Persistent tmux sessions on your box | Pillar 1 | Orca/Conductor both die with the desktop app |
+| Phone app with full desktop parity (iPhone; browser elsewhere) | Pillar 2 | Orca "read-mostly"; Conductor none |
+| Native push with **smart routing** — active on desktop ⇒ no phone buzz; idle ⇒ desktop first, escalate to phone after 90s; blocking asks (permission/question/error) hit every device immediately | Genuinely novel. Slack/Discord-grade presence logic in a dev tool. | **Neither has any notification routing** |
+| Auto-detected ingress: tailnet or per-box HTTPS + LE cert, decided by the installer | Pillar 3 | Orca *requires* Tailscale and warns you off public exposure. We support both and choose for you |
+| Permission + question cards | Trust | Orca ships `--yolo` pre-filled; Conductor "no sandboxing" |
+| Git worktree per session (BET-246) — new sessions in a repo branch their own sibling worktree; optional clean-on-close, prompts if dirty | Parity with the thing Orca and Conductor market hardest | Orca and Conductor both have it. Claim parity, not advantage |
+| Live tool output (bash stdout tailing at ~4Hz), diffs, per-turn token/context bar with cache breakdown | Depth proof | Comparable, but our cache-cost surfacing (stale-cache "/clear to save Nk tokens" pill) is unique |
+| Terminal **and** chat per window, switchable, real tmux underneath | We're not a wrapper that hides the terminal | Orca has a great terminal but no chat panel; Conductor chat-only + terminal |
+| Inline subagent rendering | Parity | Orca has deeper orchestration — don't over-claim |
+| Agent-native tools (schedule/webhook/notify/secrets/peers/serve-page) | Pillar 4, wholly uncontested | Orca has a CLI; nobody has scheduling/webhooks/secrets-by-reference |
+| Secrets by reference — value never enters the transcript | Security story with a concrete mechanism | Nobody |
+| Voice push-to-talk (dictate + command mode) | Mobile-credibility | Orca has mobile dictation; Conductor none |
+| Drag-drop upload, screenshot auto-detect, agent→you outbox | Polish | Orca has file drag; nobody has the reverse channel |
+| Model picker + per-session persistence + global default | Parity | |
+| `llms-install.md` — install by pasting a prompt into any agent | **Unique.** The install flow is itself agent-native. | Both are DMG downloads |
+
+**Deliberately omitted from marketing** (we lose or it's immature): embedded
+browser, Monaco editor, diff annotation, 34-agent support, Linear/Jira,
+Windows/Linux desktop.
+
+---
+
+## 5. SEO / GEO plan
+
+### 5.1 Keyword data (DataForSEO, Google Ads, US, en, 2026-07-26)
+
+**Core cluster — all winnable, all on-positioning:**
+
+| Keyword | Vol/mo | CPC | Comp |
+|---|---|---|---|
+| claude code web | 4,400 | $5.40 | LOW |
+| claude code app | 2,400 | $6.09 | LOW |
+| coding on phone | 2,400 | $4.95 | LOW |
+| claude code ui | 1,600 | $5.74 | LOW |
+| **claude code remote** | **1,300** | **$49.44** | **LOW** |
+| claude code alternative | 1,300 | $22.17 | MEDIUM |
+| claude code mobile | 1,000 | $8.01 | LOW |
+| claude code open source | 1,000 | $4.42 | LOW |
+| claude code gui | 720 | $7.03 | LOW |
+| claude code worktree | 480 | — | LOW |
+| claude code browser | 480 | $6.78 | LOW |
+| claude code dashboard | 480 | $5.99 | LOW |
+| claude code web ui | 390 | $6.70 | LOW |
+| claude code tmux | 390 | — | LOW |
+| claude code notifications | 390 | — | LOW |
+| claude code monitor | 390 | $12.64 | LOW |
+| claude code cloud | 390 | $14.54 | LOW |
+| claude code ios | 320 | $7.29 | LOW |
+| claude code from phone | 260 | $5.18 | LOW |
+| opencode ui | 210 | $7.13 | LOW |
+| claude code android | 170 | $8.78 | LOW |
+| claude code client | 70 | $6.79 | LOW |
+| self hosted claude code | 50 | — | LOW |
+| claude code vps | 50 | $9.96 | MEDIUM |
+| conductor alternative | 40 | $8.95 | LOW |
+| orca alternative | 10 | — | LOW |
+
+**Head terms (context, not targets):** `claude code` 550k, `vibe coding` 110k,
+`opencode` 90.5k, `ai coding assistant` 22.2k, `tmux` 22.2k, `ai coding agent`
+5.4k, `ai pair programming` 2.9k ($67 CPC), `agentic coding` 2.4k.
+
+**Read:** the addressable "claude code + surface" cluster is ~**16k/mo,
+almost all LOW competition**, and `claude code remote` at **$49.44 CPC** tells
+you exactly how commercially valuable that intent is. `opencode` at 90.5k is a
+large adjacent term we're legitimately relevant to (we ship opencode as the
+chat backend) and neither competitor emphasises.
+
+**Competitor-alternative terms are tiny (40 + 10/mo) — build those pages for
+intent quality and because they're uncontested, not for volume.**
+
+### 5.2 Page plan
+
+Priority order. Each page = one keyword cluster, one intent.
+
+| Priority | URL | Primary KW (vol) | Also targets |
+|---|---|---|---|
+| P0 | `/` | claude code remote (1,300) | claude code app, claude code client |
+| P0 | `/claude-code-web-ui` | claude code web (4,400) | claude code ui 1,600 · gui 720 · web ui 390 · browser 480 · dashboard 480 → **~8k/mo combined** |
+| P0 | `/claude-code-mobile` | claude code mobile (1,000) | coding on phone 2,400 · from phone 260 · ios 320 → **~4k/mo**. NOTE: `claude code android` (170) is NOT targetable until an Android app exists. |
+| P1 | `/claude-code-remote` | claude code remote (1,300, $49 CPC) | self hosted claude code, claude code vps, claude code cloud |
+| P1 | `/open-source` | claude code open source (1,000) | + carries §7 |
+| P1 | `/pricing` | (intent gap) | "is manta free", "conductor pricing", "orca pricing" — **both competitors 404 here** |
+| P1 | `/vs/conductor` | conductor alternative (40) | "conductor vs", "conductor alternative mac" |
+| P1 | `/vs/orca` | orca alternative (10) | "orca alternative", "onorca alternative" |
+| P1 | `/vs/ssh-tmux` | claude code vps (50) | "claude code ssh", "claude code termius", "run claude code on a server", self hosted claude code |
+| P2 | `/docs/*` | long tail | Required for credibility. Both competitors' docs carry their entire long-tail. |
+| P2 | `/claude-code-notifications` | claude code notifications (390) | claude code monitor 390 |
+| P2 | `/claude-code-tmux` | claude code tmux (390) | |
+| P2 | `/changelog` | brand | Orca + Conductor both nav-link it; signals liveness |
+
+**Comparison table design constraint.** A 4-column × 17-row table is at the
+limit of what is scannable, so the styling has to do no work of its own:
+
+- **Two greys and one tint. No red, amber or green.** Colour-coding every cell
+  turns the table into noise and reads as a sales device. Supported reads in
+  the primary text colour, unsupported reads in a dim grey, everything else in
+  the mid grey. The reader's eye finds the pattern from contrast alone.
+- **Every cell fits on one line.** No wrapped sub-captions. Detail belongs on
+  the `/vs/` page, not in the cell.
+- **The Manta column gets a background tint only**, never coloured text.
+- Row-hover highlight, since horizontal tracking across four columns is the
+  main failure mode.
+- **"Agents run on" says "Your VPS" for Manta**, matching the Termius column
+  verbatim. Same words, same box. The reader who already runs Claude Code on a
+  VPS should see immediately that Manta goes on the machine they already have,
+  not somewhere new.
+- **A "Full comparison →" link sits in a table footer cell under each
+  competitor column**, going to that competitor's page. The Manta footer cell
+  is empty. This is the only navigation into the `/vs/` pages from the table,
+  which is why the table can afford to be short.
+- **No "where we lose" divider on the homepage.** The homepage table carries
+  the axes we chose to compete on, at 12 rows. The concessions (diff review,
+  built-in editor, agent-runtime count, desktop OS coverage, maturity) move to
+  the `/vs/` pages, where there is room to make them properly rather than as a
+  one-word cell.
+- **Accept the trade-off knowingly:** a homepage table with no losing rows is a
+  marketing table, and a reader who knows Orca will notice what is absent. The
+  mitigation is the line printed directly beneath it naming what Orca and
+  Conductor do better and linking to the full pages. Keep that line. Without it
+  the table is rebuttable and the honesty argument in §5.3 collapses.
+
+### 5.3 Comparison-page template (`/vs/<competitor>`)
+
+Three pages, not two: `/vs/orca`, `/vs/conductor`, `/vs/ssh-tmux`
+(the Termius-over-SSH incumbent, see 1.1). The SSH page is the highest-intent
+of the three because that reader has already bought the premise.
+
+
+Same structure for both. **Be scrupulously fair — include rows we lose.** An
+honest table is more persuasive and far more likely to be cited by an LLM
+than a rigged one. Both competitors refuse to name anyone; we name them.
+
+```
+H1: MantaUI vs <X>
+Lede: one paragraph, neutral. "Both run coding agents. <X> runs them on your
+      Mac and gives you a window onto them. Manta runs them on a box you own
+      and gives every device an equal window. Here's the honest difference."
+
+[Verdict box — 3 bullets: pick X if… / pick Manta if… / they overlap on…]
+
+[Full table: ~18 rows. Architecture, platforms, license, mobile, remote
+ access, notifications, permissions, agent tooling, price, maturity.
+ Green/red honestly distributed.]
+
+H2: Where <X> is better        ← genuinely, 4-6 items, no hedging.
+                                 This is where the rows cut from the homepage
+                                 table land: diff review, editor, agent count,
+                                 desktop OS coverage, maturity.
+H2: Where Manta is better      ← 3-4 items
+H2: The architectural difference  ← the desktop-vs-server diagram, both sides
+H2: Can I use both?            ← yes; they're not exclusive
+H2: FAQ (FAQPage JSON-LD)
+```
+
+Facts to cite (all sourced, all quotable, all from their own docs — quote
+verbatim and link, so the page is defensible):
+
+**vs Orca:** "Closing the desktop app drops the connection — there is no cloud
+relay." · "The mobile app is intentionally not a full editor — it's a remote
+control for the desktop you already have running." · "Do not forward the Orca
+port directly to the public internet. Prefer Tailscale…" (note: we *support* a
+tailnet, they *require* one) · yolo/permission-bypass
+flags pre-filled by default ·
+2,310 open issues. **Concede:** MIT + 29.6k stars, 34 agents, cross-platform
+desktop, Design Mode, orchestration protocol, terminal quality.
+
+**vs Termius + SSH:** concede first and fully. It keeps the agent alive, it
+is mature, it runs anywhere, and it costs nothing to keep. Then be specific
+about what is missing: the agent's terminal UI rendered on a phone keyboard,
+no approve button, no notification when it blocks, no upload, no dictation,
+nothing the agent can start on its own. Close on coexistence, since Manta
+installs on the same box and does not take SSH away.
+
+**vs Conductor:** macOS only, "not available for Windows or Linux yet" ·
+closed source, `license: Proprietary` · "Agents run directly on your system
+without sandboxing" · "Workspace isolation is development isolation, not a
+security boundary" · Cloud is beta, Pro-gated, GitHub-only, 10-workspace cap ·
+no published prices. **Concede:** diff review + inline comments → agent, PR/
+merge/checks tail, Linear/GitHub depth, `CONDUCTOR_PORT`, polish, funding.
+
+### 5.4 GEO / AEO (answer-engine optimisation)
+
+Conductor is executing this hard and it's the highest-leverage gap. Ship all of:
+
+1. **`/llms.txt` + `/llms-full.txt`** — full site as markdown. Conductor's is 318KB and clearly deliberate.
+2. **`.md` twin for every page** (`/vs/orca.md`) — Conductor serves these.
+3. **`FAQPage` JSON-LD** on `/`, both `/vs/` pages, `/pricing`. This is what LLMs quote.
+4. **`SoftwareApplication` JSON-LD** — `price: 0`, `license: MIT`, `operatingSystem: Linux, macOS, iOS, Web`. No Android until it ships (§2.5). Still more platforms than either competitor.
+5. **`robots.txt`: `Content-Signal: ai-train=yes, search=yes, ai-input=yes`** — Conductor opts in; Orca blocks SEO crawlers but not AI. Opt in.
+6. **`/.well-known/agent-skills/manta/SKILL.md`** — Conductor publishes an Agent Skill so any agent can configure their product. **We're better positioned: `llms-install.md` already exists and is exactly this.** Promote it to a well-known Agent Skill + link it from the homepage.
+7. Do **not** block Ahrefs/Semrush (Orca does). We want the backlink data.
+8. `sitemap.xml` with per-page priority + `lastmod`. None exists today.
+
+**Target answer set** — the questions to be the answer to:
+
+- "How do I use Claude Code from my phone?"
+- "Can I run Claude Code on a server / VPS?"
+- "What's a web UI for Claude Code?"
+- "Does Claude Code keep running if I close my laptop?"
+- "Open source alternative to Conductor / Orca"
+- "How do I get notified when Claude Code needs approval?"
+- "Can I self-host a Claude Code interface?"
+- "Claude Code on iPhone"
+
+Every one of these is a page in §5.2 and an FAQ entry.
+
+### 5.5 Technical SEO baseline (all missing today)
+
+`sitemap.xml` · `robots.txt` · canonical tags · OG image (`/opengraph-image`,
+1200×630) · Twitter `summary_large_image` · per-page `<title>`/description ·
+`BreadcrumbList` on sub-pages · self-hosted fonts (currently two render-blocking
+Google Fonts preconnects) · real `<h2>/<h3>` hierarchy on new pages.
+
+---
+
+## 6. Screenshots — shot list
+
+Today: **zero real product screenshots on the site.** The hero is a hand-built
+HTML mockup; the phone is CSS divs. For a self-hosted OSS tool the #1 visitor
+objection is "is this real and does it work" — mockups actively hurt.
+
+Capture at **2× retina**, dark theme, `1440×900` desktop / `393×852` phone
+(iPhone 15 Pro). Consistent fake-but-plausible project names across every shot
+(`ethernal`, `marketing`, `infra`) so the set reads as one product. Scrub real
+paths/tokens.
+
+### 6.1 Priority shots
+
+| ID | Shot | Where used | Why |
+|---|---|---|---|
+| **A** | **Hero.** Full desktop window: sidebar with 3 projects / 6 sessions showing mixed status dots (running / idle / amber attention / red `!` permission), chat panel mid-turn with a tool call + live bash output + context bar. | Hero, README top | The "many agents, one view" shot. Must show *live status variety* — that's the product. |
+| **M** | **Same session, two devices.** Desktop window + phone side by side showing the identical session/transcript. | "Close the laptop" band | **The money shot.** Proves parity, which is exactly Orca's admitted weakness. |
+| **D** | **Push notification** on a phone lock screen: title `ethernal / feat-auth`, body `Permission needed — Bash(rm -rf …)`. | Mobile section, /claude-code-notifications | Nobody else has notification routing. Highest-differentiation single image. |
+| **B** | **Permission card + question card** in the transcript, buttons visible. | Features (approvals) | Direct visual rebuttal of yolo-by-default. |
+| **C1** | Mobile session list — projects grouped, live statuses. | Mobile section, README | |
+| **C2** | Phone session detail — full transcript + composer + mic button. iPhone frame only. | Mobile section, /claude-code-mobile | Rebuts "read-mostly". |
+| **E** | **Terminal window** — xterm.js, real claude TUI running under tmux, status line visible. | Features (chat + terminal) | Proves "real tmux, not a wrapper". |
+| **F** | Live bash output tailing — **animated GIF/webm**, ~6s, output streaming line by line. | Features (live output) | Motion proves "live" in a way a still cannot. |
+
+### 6.2 Secondary shots
+
+| ID | Shot | Where |
+|---|---|---|
+| G | Context bar close-up — segmented input/cache-write/cache-read + stale-cache "/clear to save 47k tokens" pill | Features / docs |
+| H | Scheduled tasks card (⏰) with 2–3 cron'd prompts | Agent-tools section |
+| I | Secrets card (🔑) — metadata-only list, value never shown | Agent-tools section |
+| J | Subagents — collapsed task cards, one expanded | Features |
+| K | Pairing screen — 6-digit code, desktop + box terminal | How it works |
+| L | Settings → Providers / Subagents / Plugins toggle | /docs |
+| N | Agent-tools montage — notify + webhook + peers | Agent-tools section |
+| O | Architecture diagram (SVG, redrawn from README ASCII) | How it works, README |
+
+### 6.3 Video (optional, high value)
+
+A single **45–75s silent looping demo**, no narration, captioned:
+start a task on desktop → close the laptop → phone buzzes with a permission
+request → approve on phone → reopen desktop, work continued and finished.
+
+That's the entire positioning in one clip, and it's a claim neither competitor
+can film. Conductor has YouTube embeds in their sitemap with `<video:video>`
+schema — worth matching for video rich results.
+
+---
+
+## 7. Open source prominence
+
+**Gated on B1 (add a LICENSE).** Without it none of this is honest.
+
+### 7.1 Actions
+
+1. **`LICENSE` — MIT.** Matches Orca; zero friction; makes "open source" true.
+2. **Repo description** → e.g. *"Open-source, self-hosted Claude Code & opencode client. Agents run in real tmux on your own Linux box or Mac; drive them from desktop, phone, or browser over HTTPS."* (keyword-dense, accurate, GitHub search + LLM surface).
+3. **Repo topics** — Orca uses these deliberately. Add: `claude-code`, `opencode`, `ai-agents`, `self-hosted`, `tmux`, `coding-agent`, `mobile`, `pwa`, `electron`, `remote-development`, `open-source`, `devtools`.
+4. **README rewrite** (§8) — the README *is* the open-source landing page and ranks independently.
+5. **Homepage open-source band**, placed after the comparison table:
+   - "MIT licensed. Self-hosted. No account, no telemetry, no vendor."
+   - Three links: Read the source · Architecture docs · Report an issue
+   - **Concrete trust claims neither competitor can make in full:** runs entirely on hardware you own · no data leaves your box except APNs push fanout (and Web Push doesn't even do that) · no account required · auditable install script (`curl … | bash` — link to the actual file)
+   - `CONTRIBUTING.md` + good-first-issue link
+6. **Do not show star count** until >500 (B2).
+7. **No repo-topic chips on the website.** They were tried in the mockup and
+   removed: they read as GitHub chrome pasted onto a marketing page and add no
+   claim a visitor cares about. Repo topics still matter **on GitHub itself**
+   (item 3 above) — that is a different surface.
+7. Add `SECURITY.md` — for a self-hosted tool holding secrets and box tokens, this is a credibility requirement, and Orca doesn't have one.
+
+### 7.2 The honest-differentiation angle
+
+Orca is also MIT, so "open source" alone doesn't differentiate against them —
+only against Conductor. The differentiated claim is the **combination**:
+open source **and** self-hosted **and** no account **and** the server outlives
+every client. Orca is open source but desktop-bound and account-gated for
+mobile pairing; Conductor is neither. Say it as the combination, not as
+"we're open source".
+
+---
+
+## 8. README rewrite
+
+Current README (336 lines) opens with a tagline, then AI-assisted setup, then
+an architecture diagram — and **never lists features at all**. It reads as a
+maintainer runbook. ~40% of it (releases, prod infra, rollback) belongs in
+`docs/`, not the README.
+
+Requested order: **install → features → technical**. Proposed:
+
+| § | Content | Notes |
+|---|---|---|
+| 1 | Logo, one-line description, badge row (License · Platforms · Build · Docs) | No star badge (B2) |
+| 2 | **Hero screenshot** (shot A) | Immediately after the badges — GitHub's above-the-fold |
+| 3 | **Install** — three tabs of prose: (a) paste-to-your-agent prompt, (b) `curl \| bash`, (c) manual/git. Then "get the desktop app" and "get the phone app". Nothing before this but the screenshot. | Currently split across "AI-assisted setup" and "Quick start" with architecture wedged between. Merge and hoist. |
+| 4 | **Features** — the §2.3 pillars, then a scannable list grouped as: Sessions and terminal · Chat and review · Phone app and notifications · Agent-native tools · Files and voice · Security. Inline small screenshots for the top 3–4. | **The single biggest gap. Does not exist today.** |
+| 5 | **How it works** — architecture diagram (keep ASCII, add SVG), "the server is the box" explanation, the two window types, auth model | Mostly exists; tighten |
+| 6 | **Technical details** — transport (`/rpc` + `/events` SSE), state layout on the box, ports, component table, installer internals, config schema | Exists, keep, condense |
+| 7 | **AI tools on the box** — schedule/serve-page/peers/notify/secrets/webhook, one line each + install note | Exists, keep |
+| 8 | **Development** — build/test/run from source, repo layout pointer to `AGENTS.md` | Exists |
+| 9 | **Comparison** — short honest table + links to the two `/vs/` pages | New; README comparison tables rank |
+| 10 | Contributing · Security · License · Known gaps · Reporting issues | Add CONTRIBUTING/SECURITY/LICENSE links |
+| — | **Move out to `docs/`**: release runbook, rollback procedure, prod infra, prod box ops | ~90 lines of maintainer-only content currently in the README |
+
+Apply the copy rules in 2.4 and the terminology rule in 2.5 (no "PWA").
+Also fix B4 (signed vs unsigned) and add the keyword-bearing phrases naturally
+in the first 200 words: *Claude Code*, *opencode*, *self-hosted*, *mobile*,
+*remote*, *open source*, *tmux*.
+
+---
+
+## 8.5 URL scheme and deploy constraints (decided, do not re-litigate)
+
+Verified against the live site on 2026-07-26.
+
+- **Caddy on the prod box already strips `.html`.** `/privacy` and
+  `/privacy.html` both return 200. So a file at `website/pricing.html` is
+  served at `https://mantaui.com/pricing` with no infra change.
+- **Nested URLs are not available.** `website/*.html` in the deploy workflow is
+  a top-level glob, so `website/vs/orca.html` would never be copied, and the
+  Caddyfile is not in the repo (it lives only on the box, unversioned) so no
+  agent can add a route for it. **Use flat, hyphenated filenames**:
+  `vs-orca.html` → `/vs-orca`, `claude-code-mobile.html` → `/claude-code-mobile`.
+  Every `/vs/x` reference elsewhere in this spec means `/vs-x`.
+- **The deploy workflow's verify step is a hardcoded list of seven `check`
+  calls.** New pages are copied by the glob but never verified, so a silently
+  failed deploy would pass green. Make the verify data-driven before adding
+  pages (see the issue list).
+- **No agent may SSH to the prod box.** Anything needing a Caddyfile change is
+  out of scope by construction.
+
+---
+
+## 9. Sequencing
+
+| Phase | Work | Gate |
+|---|---|---|
+| **0** | B1 LICENSE, B3 repo description + topics, B4/B5 copy corrections | Blocks everything claiming "open source" |
+| **1** | Capture screenshots A, M, D, B, C1, C2, E (§6.1) | Blocks homepage + README |
+| **2** | README rewrite (§8) | Independent of website; ships first, ranks on its own |
+| **3** | Homepage rework (§3) + technical SEO baseline (§5.5) | Needs phase 1 |
+| **4** | `/vs/conductor`, `/vs/orca`, `/vs/ssh-tmux`, `/pricing` | Uncontested SERPs, cheapest wins |
+| **5** | `/claude-code-web-ui`, `/claude-code-mobile`, `/claude-code-remote`, `/open-source` | The ~16k/mo cluster |
+| **6** | GEO layer (§5.4) — llms.txt, .md twins, JSON-LD, Agent Skill | Compounding |
+| **7** | `/docs`, `/changelog`, long-tail pages, demo video | |
+
+**Deploy note:** every page here ships through the existing `web-v*` tag →
+`.github/workflows/website-deploy.yml` path, which scp's `website/*.{html,png}`
+into the prod webroot and verifies each URL 200 + sha256. **Adding new pages or
+new asset types (screenshots as `.webp`/`.jpg`, `sitemap.xml`, `llms.txt`,
+`.well-known/`) requires updating that workflow's copy list and verify list** —
+it currently only handles `index/privacy/terms` + `install.sh` +
+`llms-install.md`. Easy to miss; it will silently not deploy.
+
+---
+
+## 10. Open questions
+
+1. **License — MIT or Apache-2.0?** MIT matches Orca and is friction-free; Apache-2.0 adds a patent grant. Recommend MIT.
+2. **Is the macOS build signed?** (B4) Determines the install copy.
+3. **Do we want `/docs` at all**, or keep docs in the repo? Both competitors carry their entire long-tail on docs pages; repo-only docs forfeit that. Recommend a minimal `/docs` generated from the repo markdown.
+4. **Pricing page for a free product** — recommend yes: it's a real intent gap ("is X free"), both competitors 404 there, and it's the cheapest trust page to write.
+5. **Name.** "MantaUI" vs "Manta UI" vs "Manta" is inconsistent across the site, README, and repo. Pick one before building pages that will be linked to.
+6. **How hard do we go at the SSH incumbent?** A `/vs/ssh-tmux` page that
+   concedes generously converts better than one that attacks, but it also
+   tells a chunk of readers that their current setup is fine. Recommend
+   conceding: that reader is technical and will spot a rigged argument.
+7. **Do we claim opencode support prominently?** `opencode` is 90.5k/mo and we ship it as the chat backend. Recommend yes — it's a large, uncontested adjacent term.


### PR DESCRIPTION
Spec and approved mockup for the marketing site and README rework. Docs only —
no site, app or server code changes.

## What's here

- `docs/specs/website-readme-revamp.md` — the spec: competitor analysis,
  DataForSEO keyword data, positioning, homepage IA, SEO/GEO plan, screenshot
  shot list, README structure, copy rules.
- `docs/specs/website-homepage-mockup.html` — the approved homepage mockup,
  in-repo because BET-297 ports from it directly.

Rendered mockup: https://manta-home-mockup.pages.mantaui.com

## Why it needs to land before the implementation tickets

BET-297 and BET-298 both read from these paths. They are unactionable until this
is on main.

## Findings worth flagging

**No LICENSE file.** The repo is public but `licenseInfo` is null, so it is
legally all-rights-reserved while the site says "Free & open source". Tracked as
BET-296.

**Two capability claims in the first draft were wrong**, because they were
written from `AGENTS.md`, which lagged the code. Both corrected against git and
recorded in spec section 2.6:

- Worktree per session **shipped** in BET-246 (`11054b0`). The site should say
  yes, framed as parity with Orca and Conductor rather than an advantage.
- Auto-detected ingress **shipped** in BET-267 (`8a0f123`). The installer picks
  a tailnet if Tailscale is running, otherwise Caddy plus Let's Encrypt. The old
  "no VPN needed" line was both inaccurate and a weaker claim than the truth.

The spec now carries a standing rule to check `git log --grep` before writing a
capability claim.

**Competitive gap:** neither Orca nor Conductor has a single comparison page or
a pricing page. Those SERPs are uncontested. Termius over SSH on a VPS is added
as a third competitor and is the strongest one, since it already keeps the agent
alive when you walk away.

## Implementation tickets

BET-294 through BET-302, dependency-ordered, all assigned to manta-pm.

## Test plan

Docs only. `npm run typecheck && npm test` unaffected; no runtime code touched.