### PR TITLE
feat(renderer): ?demo URL swap to fictional fixture + transport (BET-302)

### DIFF
--- a/src/renderer/api/demoApi.test.ts
+++ b/src/renderer/api/demoApi.test.ts
@@ -1,0 +1,193 @@
+// demoApi.test.ts — smoke tests for the demo transport (BET-302).
+//
+// The demo build replaces httpApi with a Proxy that reads from
+// demoFixture.ts. These tests pin:
+//   1. The agreed project names (ethernal / marketing / infra) are present
+//      and there are no real-looking names that would leak into the
+//      marketing surface.
+//   2. The fixture has the required session-state variety (running, idle,
+//      pending question, pending permission, subagent count > 0).
+//   3. The transcript contains the required part types (user turn,
+//      assistant turn, read, edit with +38 −4 diff, bash with multi-line
+//      output, todo checklist with one item in_progress).
+//   4. A pending question + a pending permission both live on the active
+//      session so both cards render without interaction.
+//   5. The Proxy fallback returns benign no-ops (Promise<null> for methods,
+//      `() => {}` for subscriptions).
+//
+// `grep` for the project names is also part of the acceptance criteria —
+// the test mirrors that check so future edits can't silently drop a name.
+
+import { describe, it, expect } from "vitest";
+import { demoState } from "./demoFixture.js";
+import { demoApi } from "./demoApi.js";
+
+// The three fictional project names. Mirrors the shot list in
+// `docs/specs/website-readme-revamp.md` section 6 — every screenshot /
+// video frame renders the same brand.
+const PROJECT_NAMES = ["ethernal", "marketing", "infra"] as const;
+
+describe("demo fixture — project + session structure", () => {
+  it("contains exactly the three agreed fictional project names", () => {
+    const names = demoState.projects.map((p) => p.tmuxSession);
+    expect(names).toEqual([...PROJECT_NAMES]);
+  });
+
+  it("has six or seven sessions total across the three projects", () => {
+    const total = demoState.projects.reduce(
+      (n, p) => n + p.windows.length,
+      0,
+    );
+    expect(total).toBeGreaterThanOrEqual(6);
+    expect(total).toBeLessThanOrEqual(7);
+  });
+
+  it("exhibits at least one running session, one idle, one pending question, one pending permission", () => {
+    const allStatuses = Object.values(demoState.status).flatMap(
+      (byWindow) => Object.values(byWindow),
+    );
+    const runningCount = allStatuses.filter((s) => s.running).length;
+    const idleAttentionCount = allStatuses.filter(
+      (s) => !s.running && s.attention && (s.attentionKind ?? "idle") === "idle",
+    ).length;
+    const questionAttentionCount = allStatuses.filter(
+      (s) => s.attentionKind === "question",
+    ).length;
+    const permissionAttentionCount = allStatuses.filter(
+      (s) => s.attentionKind === "permission",
+    ).length;
+    expect(runningCount).toBeGreaterThanOrEqual(1);
+    expect(idleAttentionCount).toBeGreaterThanOrEqual(1);
+    expect(questionAttentionCount).toBeGreaterThanOrEqual(1);
+    expect(permissionAttentionCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("has at least one session showing a non-zero subagent count", () => {
+    const hasSubagents = Object.values(demoState.status).some((byWindow) =>
+      Object.values(byWindow).some((s) => s.subagents > 0),
+    );
+    expect(hasSubagents).toBe(true);
+  });
+});
+
+describe("demo fixture — transcript", () => {
+  // Narrow the parts list to tool parts only — typed as the wider OpencodePart
+  // shape, then cast through `unknown` so the per-tool fields (state, tool,
+  // metadata) are reachable in the assertions below.
+  const toolParts = demoState.messages
+    .flatMap((m) => m.parts)
+    .filter((p) => p.type === "tool") as unknown as Array<{
+    tool: string;
+    state: {
+      input?: Record<string, unknown>;
+      metadata?: Record<string, unknown>;
+    };
+  }>;
+
+  it("includes a user turn and an assistant turn", () => {
+    const roles = demoState.messages.map((m) => m.info.role);
+    expect(roles).toContain("user");
+    expect(roles).toContain("assistant");
+  });
+
+  it("includes a read tool call", () => {
+    expect(toolParts.some((p) => p.tool === "read")).toBe(true);
+  });
+
+  it("includes an edit tool call with a +38 / −4 diff", () => {
+    const edits = toolParts.filter((p) => p.tool === "edit");
+    expect(edits.length).toBeGreaterThanOrEqual(1);
+    const diff = edits[0].state.metadata?.filediff as
+      | { additions?: number; deletions?: number }
+      | undefined;
+    expect(diff?.additions).toBe(38);
+    expect(diff?.deletions).toBe(4);
+  });
+
+  it("includes a bash tool call with multi-line output", () => {
+    const bashes = toolParts.filter((p) => p.tool === "bash");
+    expect(bashes.length).toBeGreaterThanOrEqual(1);
+    const liveOutput = bashes[0].state.metadata?.output;
+    expect(typeof liveOutput).toBe("string");
+    expect((liveOutput as string).split("\n").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("includes a todowrite with at least one item in_progress", () => {
+    const todos = toolParts.find((p) => p.tool === "todowrite")?.state
+      .input as { todos?: Array<{ status?: string }> };
+    expect(todos?.todos).toBeDefined();
+    const inProgress = (todos?.todos ?? []).filter(
+      (t) => t.status === "in_progress",
+    );
+    expect(inProgress.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("demo fixture — visible cards", () => {
+  it("has a pending permission on the active session", () => {
+    expect(demoState.permission.sessionID).toBe(demoState.activeSessionId);
+    expect(demoState.permission.id).toBeTruthy();
+    expect(demoState.permission.permission).toBeTruthy();
+  });
+
+  it("has a pending question on the active session with a usable requestId", () => {
+    expect(demoState.question.sessionID).toBe(demoState.activeSessionId);
+    // Without requestId the QuestionCard's reply path is unanswerable.
+    expect(typeof demoState.question.requestId).toBe("string");
+    expect(demoState.question.requestId).toBeTruthy();
+  });
+});
+
+describe("demo fixture — config (transport-mode resolver lands on 'http')", () => {
+  it("carries a valid 32-hex boxToken so resolveTransportMode returns 'http'", () => {
+    expect(demoState.config.boxToken).toMatch(/^[0-9a-f]{32}$/);
+    expect(demoState.config.boxId).toMatch(/^[0-9a-f]{32}$/);
+    expect(demoState.config.serverUrl).toMatch(/^https:\/\/.+\.boxes\.mantaui\.com$/);
+  });
+
+  it("leaves chatAutoAllow off so the permission card stays visible (no bypass banner)", () => {
+    // The App.tsx shell renders the bypass-permissions banner only when
+    // chatAutoAllow is true. The demo must keep it false.
+    expect(demoState.config.chatAutoAllow).toBe(false);
+  });
+});
+
+describe("demoApi — Proxy fallback", () => {
+  it("explicit methods return the fixture values", async () => {
+    expect(await demoApi.configGet()).toBe(demoState.config);
+    expect(await demoApi.tmuxList()).toEqual(demoState.projects);
+    const messages = await demoApi.opencodeMessages(demoState.activeSessionId);
+    expect(messages).toBe(demoState.messages);
+    expect(await demoApi.opencodeQuestions(demoState.activeSessionId)).toEqual([
+      demoState.question,
+    ]);
+    expect(await demoApi.opencodePermissions(demoState.activeSessionId)).toEqual([
+      demoState.permission,
+    ]);
+    expect(await demoApi.opencodeVcsBranch("/tmp")).toBe(demoState.branch);
+  });
+
+  it("subscriptions return a no-op unsubscribe", () => {
+    expect(demoApi.onStatusEvent(() => {})()).toBeUndefined();
+    expect(demoApi.onOpencodeEvent(() => {})()).toBeUndefined();
+    expect(demoApi.onAgentFileReady(() => {})()).toBeUndefined();
+    expect(demoApi.onDesktopNotify(() => {})()).toBeUndefined();
+    expect(demoApi.onScreenshotDetected(() => {})()).toBeUndefined();
+    expect(demoApi.onServerUpdateAvailable(() => {})()).toBeUndefined();
+  });
+
+  it("unknown methods resolve to null without throwing", async () => {
+    // Methods not in the explicit set fall through the Proxy. They must
+    // return a benign Promise<null> so destructuring / .catch(() => {})
+    // guards stay quiet across every renderer call site.
+    expect(await (demoApi as unknown as { tmuxKillSession(s: string): Promise<unknown> }).tmuxKillSession("foo")).toBeNull();
+    expect(
+      await (demoApi as unknown as { opencodePrompt(s: string, t: string): Promise<unknown> }).opencodePrompt("s", "t"),
+    ).toBeNull();
+    // onStatusEvent fires the callback once with the fixture batch — verify
+    // it doesn't throw on the unknown-method code path.
+    expect(() =>
+      (demoApi as unknown as { onWhatever(cb: () => void): () => void }).onWhatever(() => {}),
+    ).not.toThrow();
+  });
+});

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -1,0 +1,202 @@
+// demoApi.ts — fake transport for the renderer demo build (BET-302).
+//
+// Backed by `demoFixture.ts` (the fictional project / session / transcript
+// state). The renderer treats it as `window.api`; the real React app then
+// renders from this snapshot, with zero network calls.
+//
+// Shape contract: matches `Api` in src/shared/api.ts — the same contract
+// httpApi satisfies. Demo callers SHOULD hit one of the explicit methods
+// below; everything else falls through the Proxy to a benign no-op:
+//
+//   - Promises resolve to `null` (so destructuring / array checks get a
+//     clean "nothing here" signal and the renderer's optional-chaining
+//     guards stay quiet).
+//   - Subscription methods (`on…`) return `() => {}` so listener cleanup
+//     runs harmlessly.
+//
+// The set of explicit methods is the minimum the UI touches during
+// load and first render. They were discovered by running the demo build
+// with the Proxy in place and watching the warnings fall out — these are
+// the ones that actually fired during mount:
+//
+//   configGet, tmuxList, onStatusEvent,
+//   opencodeMessages, opencodeMessagesCached,
+//   opencodePermissions, opencodeQuestions, opencodeVcsBranch,
+//   opencodeListSessions, opencodeModels, opencodeDefaultModel,
+//   opencodeOpenStream, opencodeCloseStream, onOpencodeEvent,
+//   launchersList,
+//   getClientVersion, getServerVersion
+//
+// Anything beyond that is a click-through or interaction that the demo
+// doesn't have to support visually — the Proxy handles it. If a future
+// consumer needs richer demo behavior, add the method here; do NOT add a
+// parallel setWindowApi seam (the existing transportInstall.ts setWindowApi
+// is the single install point).
+
+import type { Api } from "../../shared/api.js";
+import { demoState } from "./demoFixture.js";
+
+// ===========================================================================
+// Explicit methods — the ones the renderer actually calls during load +
+// first render. Listed in the order they appear in demoFixture.ts.
+// ===========================================================================
+
+const configGet = (): Promise<typeof demoState.config> =>
+  Promise.resolve(demoState.config);
+
+const tmuxList = (): Promise<typeof demoState.projects> =>
+  Promise.resolve(demoState.projects);
+
+// SSE-style push subscription. The renderer (App.tsx) registers one
+// onStatusEvent listener; we call it back once with the full fixture status
+// batch so the sidebar dots render with the right colors from frame 1. The
+// returned unsubscribe is a no-op — there's nothing to tear down.
+const onStatusEvent = (
+  cb: (batch: unknown[]) => void,
+): (() => void) => {
+  const batch = Object.entries(demoState.status).flatMap(([session, byWindow]) =>
+    Object.entries(byWindow).map(([windowIndex, s]) => ({
+      session,
+      windowIndex: Number(windowIndex),
+      running: s.running,
+      subagents: s.subagents,
+    })),
+  );
+  // Microtask defer — matches the real SSE "fire on the next tick" cadence
+  // so the renderer's first render isn't blocked by us.
+  queueMicrotask(() => cb(batch));
+  return () => {};
+};
+
+// `opencodeMessages` is the chat-panel mount-time transcript fetch. We
+// return the demo transcript for the active session; empty arrays for
+// anything else (a future consumer would only ever ask for the active
+// session at first render).
+const opencodeMessages = (sessionId: string): Promise<unknown[]> => {
+  if (sessionId === demoState.activeSessionId) {
+    return Promise.resolve(demoState.messages);
+  }
+  return Promise.resolve([]);
+};
+
+// The renderer uses `opencodeMessagesCached` as a fast first paint; a null
+// cache miss means "fall through to opencodeMessages". Match that exact
+// contract — a real cache hit would be the full transcript.
+const opencodeMessagesCached = (_sessionId: string): Promise<unknown[] | null> =>
+  Promise.resolve(null);
+
+// Pending question + permission lists are session-scoped (see
+// opencodePermissions/opencodeQuestions in shared/api.ts). The active
+// session has both pending in the fixture; other sessions have none.
+const opencodePermissions = (sessionId?: string): Promise<unknown[]> => {
+  if (!sessionId || sessionId === demoState.activeSessionId) {
+    return Promise.resolve([demoState.permission]);
+  }
+  return Promise.resolve([]);
+};
+
+const opencodeQuestions = (sessionId?: string): Promise<unknown[]> => {
+  if (!sessionId || sessionId === demoState.activeSessionId) {
+    return Promise.resolve([demoState.question]);
+  }
+  return Promise.resolve([]);
+};
+
+// Footer branch chip — single string for the active window's cwd.
+const opencodeVcsBranch = (_directory?: string): Promise<string | null> =>
+  Promise.resolve(demoState.branch);
+
+// Session list drives `backfillLastMessageTimes` (BET-119). The fixture
+// carries `time.updated` for each session; the renderer stamps that onto
+// the sidebar's age label so even idle windows show a sensible elapsed.
+const opencodeListSessions = (_directory?: string): Promise<typeof demoState.sessions> =>
+  Promise.resolve(demoState.sessions);
+
+const opencodeModels = (): Promise<typeof demoState.models> =>
+  Promise.resolve(demoState.models);
+
+const opencodeDefaultModel = (): Promise<{ providerID: string; modelID: string } | null> =>
+  Promise.resolve(demoState.config.defaultModel ?? null);
+
+// Stream open/close are no-ops in demo mode — there's no real SSE bus. The
+// real httpApi also no-ops these for the same reason (no per-directory
+// stream in the server). Return undefined so the renderer's
+// optional-chaining guards stay quiet.
+const opencodeOpenStream = (_sessionId: string): Promise<void> =>
+  Promise.resolve();
+
+const opencodeCloseStream = (_sessionId: string): Promise<void> =>
+  Promise.resolve();
+
+const onOpencodeEvent = (_cb: (ev: unknown) => void): (() => void) => () => {};
+
+// Available AI CLI TUI launchers. Demo returns an empty list — the chat
+// session's mode dropdown will show just Chat + Terminal.
+const launchersList = (): Promise<unknown[]> => Promise.resolve([]);
+
+// Version skew guard (BET-225 stage 3 Part C). Pretend the client and
+// server are perfectly aligned — the renderer reads these in an effect and
+// decides whether to render the non-dismissible "outdated" banner.
+const getClientVersion = (): Promise<{ version: string }> =>
+  Promise.resolve({ version: "0.0.13" });
+
+const getServerVersion = (): Promise<{ version: string; minClient: string }> =>
+  Promise.resolve({ version: "0.0.13", minClient: "0.0.0" });
+
+// ===========================================================================
+// `demoApi` — the explicit methods exposed by name. Everything else falls
+// through the Proxy in the `unknown` handler.
+// ===========================================================================
+const explicitMethods = {
+  configGet,
+  tmuxList,
+  onStatusEvent,
+  opencodeMessages,
+  opencodeMessagesCached,
+  opencodePermissions,
+  opencodeQuestions,
+  opencodeVcsBranch,
+  opencodeListSessions,
+  opencodeModels,
+  opencodeDefaultModel,
+  opencodeOpenStream,
+  opencodeCloseStream,
+  onOpencodeEvent,
+  launchersList,
+  getClientVersion,
+  getServerVersion,
+} as const;
+
+// ===========================================================================
+// Proxy fallback — every property access not in `explicitMethods` lands
+// here. Two patterns:
+//   - `on*` returns a no-op subscribe that, when called with a callback,
+//     returns a no-op unsubscribe function. The renderer's App-level
+//     effects (onStatusEvent, onAgentFileReady, ...) register a callback
+//     and keep the returned unsubscribe around for cleanup; both halves
+//     must be callable without side effects.
+//   - Everything else returns a Promise that resolves to `null` so
+//     destructuring / `.catch(() => {})` stays quiet.
+// ===========================================================================
+type AnyMethod = (...args: unknown[]) => unknown;
+const subscriptionMethod = /^on[A-Z]/;
+const proxyTarget = explicitMethods as unknown as Record<string, AnyMethod>;
+const demoApiProxy = new Proxy(proxyTarget, {
+  get(target, prop: string | symbol): AnyMethod | undefined {
+    if (typeof prop === "symbol") return undefined;
+    const explicit = target[prop];
+    if (explicit) return explicit;
+    // Subscription methods: calling the returned function with a callback
+    // hands back a no-op unsubscribe so the renderer's cleanup logic stays
+    // happy. Non-subscription methods: call returns a Promise<null>.
+    if (subscriptionMethod.test(prop)) {
+      return () => () => {};
+    }
+    return () => Promise.resolve(null);
+  },
+});
+
+// `demoApi` is typed as `Api` so the renderer sees the same contract
+// httpApi satisfies; at runtime it's a Proxy whose fallback covers every
+// missing method with the benign no-op above.
+export const demoApi = demoApiProxy as unknown as Api;

--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -1,0 +1,674 @@
+// demoFixture.ts — fictional state for the renderer demo build (BET-302).
+//
+// `npm run dev` (or the mobile build) with `?demo` in the URL swaps the real
+// httpApi for `demoApi` (see ./demoApi.ts) which reads its answers from the
+// object exported here. The renderer renders the full desktop UI from this
+// state — three projects, six-or-seven sessions, a realistic chat transcript,
+// a pending question and a pending permission — without ever talking to a
+// box, tmux, or opencode.
+//
+// ALL content in this file is fictional. Project names are exactly
+// `ethernal`, `marketing`, `infra` so every screenshot / video frame renders
+// the same brand ("the website spec section 6 shot list", `docs/specs/
+// website-readme-revamp.md`). Real client project names, real hostnames, and
+// real box tokens MUST NEVER appear here — the demo is what we ship on the
+// homepage, so any non-fictional detail leaks into the marketing surface.
+//
+// The `tokens` block in the latest assistant step drives a realistic context
+// bar; the transcript intentionally includes read/edit/bash/todowrite parts
+// because that's the minimum to make a chat panel look lived-in. The
+// transcript task is "add a CSV export endpoint to the billing service" —
+// recognisable developer work, fictional, and not about building this website.
+
+import type {
+  AppConfig,
+  OpencodeMessage,
+  OpencodeModel,
+  PermissionRequest,
+  Project,
+  QuestionRequest,
+  OpencodeSessionListItem,
+} from "../../shared/types.js";
+
+// 32-lowercase-hex — the boxId shape httpApi + transport.mjs validate against.
+// Same shape as src/server/auth.mjs isValidToken. Fictional, but well-formed so
+// resolveTransportMode() resolves to "http" and the demo drops into the normal
+// shell instead of the onboarding flow.
+const BOX_ID = "9f3b1d4c8e7a2b5d0c6e4f7a3b9d2c1e";
+const BOX_TOKEN = "a2c4e6f8b1d3c5a7e9f2b4d6c8e1a3f5";
+const SERVER_URL = `https://${BOX_ID}.boxes.mantaui.com`;
+
+// Git branch shown in the footer chip (App.tsx renders it from
+// `branch` returned by opencodeVcsBranch). Pick something the reader can
+// picture but obviously fictional.
+const BRANCH = "feat/orders-csv-export";
+
+// One fictional opencode chat session id. Any `ses_…`-shaped id works; the
+// renderer only treats the string as opaque.
+const SES_INFRA = "ses_3a7f2b1c9d8e4f6a";
+const SES_ETHERNAL_RUN = "ses_2c8d4f6a1e9b3c5d";
+const SES_ETHERNAL_IDLE = "ses_5e9c1b3a7d2f4e6c";
+const SES_ETHERNAL_QUESTION = "ses_8b4d6c2e1a9f3d5b";
+const SES_MARKETING_PERM = "ses_6f1a3c5e9b2d4f8c";
+
+// =============================================================================
+// AppConfig — what configGet returns. Includes a valid boxToken so the
+// transport-mode resolver lands on "http" (App.tsx renders the normal shell,
+// not the onboarding flow). chatAutoAllow is FALSE — that's what enables the
+// permission card to stay visible (the bus-side bypass warning is gated on
+// chatAutoAllow === true).
+// =============================================================================
+export const demoAppConfig: AppConfig = {
+  // Project metadata is empty here because the renderer resolves per-window
+  // cwd from `tmuxList().defaultCwd` (and the per-window paneCurrentPath);
+  // the config carries only the on-disk persistable bits.
+  projects: [
+    { tmuxSession: "ethernal", defaultCwd: "/home/dev/projects/ethernal" },
+    { tmuxSession: "marketing", defaultCwd: "/home/dev/projects/marketing-site" },
+    { tmuxSession: "infra", defaultCwd: "/home/dev/projects/infra" },
+  ],
+  serverUrl: SERVER_URL,
+  boxId: BOX_ID,
+  boxToken: BOX_TOKEN,
+  // Critical: leave false so the demo renders the actual permission card.
+  // The spec explicitly forbids the "bypass permissions" banner, which the
+  // App.tsx shell surfaces when this is true.
+  chatAutoAllow: false,
+  autoRenameSessions: true,
+  allowAgentPush: true,
+  worktreePerSession: true,
+  worktreeCleanOnClose: false,
+  downloadsDir: "",
+  defaultModel: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+  deactivatedMainModels: [],
+  skillRegistryUrls: ["https://example.com/manta-skills-extra.json"],
+  cacheTtl: "1h",
+  launcherFlags: {},
+  groqApiKey: "",
+  voiceTranscriptionModel: "",
+  voiceCommandModel: "",
+  shareAnalytics: false,
+  pluginsEnabled: false,
+};
+
+// =============================================================================
+// Projects + windows — what tmuxList returns. Seven sessions across three
+// projects; each session has an explicit `status` value the sidebar
+// StatusIndicator consumes to render distinct affordances (pulsing blue /
+// amber steady / pulsing red ? / pulsing red ! / subagent count).
+// =============================================================================
+export const demoProjects: Project[] = [
+  {
+    tmuxSession: "ethernal",
+    defaultCwd: "/home/dev/projects/ethernal",
+    attached: true,
+    windows: [
+      // Running with two subagents — sidebar shows pulsing blue dot + `·2`.
+      {
+        index: 0,
+        name: "Add CSV export",
+        active: false,
+        paneCurrentPath: "/home/dev/projects/ethernal/services/billing",
+        opencodeSessionId: SES_ETHERNAL_RUN,
+        worktreePath:
+          "/home/dev/projects/ethernal/services/billing.worktrees/csv-export",
+      },
+      // Idle, recently completed — sidebar shows amber steady dot + "now" age.
+      {
+        index: 1,
+        name: "Refactor auth middleware",
+        active: false,
+        paneCurrentPath: "/home/dev/projects/ethernal/services/auth",
+        opencodeSessionId: SES_ETHERNAL_IDLE,
+      },
+      // Pending question — sidebar shows pulsing red dot + `?` glyph.
+      {
+        index: 2,
+        name: "Investigate 500s in /api/v1/orders",
+        active: false,
+        paneCurrentPath: "/home/dev/projects/ethernal/services/orders",
+        opencodeSessionId: SES_ETHERNAL_QUESTION,
+      },
+    ],
+  },
+  {
+    tmuxSession: "marketing",
+    defaultCwd: "/home/dev/projects/marketing-site",
+    attached: true,
+    windows: [
+      // Pending permission — sidebar shows pulsing red dot + `!` glyph.
+      {
+        index: 0,
+        name: "Landing page copy",
+        active: false,
+        paneCurrentPath: "/home/dev/projects/marketing-site/app",
+        opencodeSessionId: SES_MARKETING_PERM,
+      },
+      // Bare terminal — no opencodeSessionId → App.tsx renders Terminal, not
+      // ChatPanel. Lets the screenshot showcase the terminal-mode branch
+      // without writing extra code.
+      {
+        index: 1,
+        name: "Build pipeline",
+        active: false,
+        paneCurrentPath: "/home/dev/projects/marketing-site",
+        opencodeSessionId: null,
+      },
+    ],
+  },
+  {
+    tmuxSession: "infra",
+    defaultCwd: "/home/dev/projects/infra",
+    attached: true,
+    windows: [
+      // Active session — chat-mode. Holds the rendered transcript + the
+      // visible permission card + visible question card. Both blocks at once
+      // satisfies "permission card and question card are both visible without
+      // interaction" without forcing a navigation.
+      {
+        index: 0,
+        name: "Deploy new billing service",
+        active: true,
+        paneCurrentPath: "/home/dev/projects/infra/terraform/billing",
+        opencodeSessionId: SES_INFRA,
+      },
+    ],
+  },
+];
+
+// =============================================================================
+// Per-window status (sidebar dots + subagent counts). Mirrors the WindowStatusUI
+// shape store.ts uses; demoApi.applyStatusBatch reads from here on first
+// onStatusEvent subscribe (see demoApi.ts).
+// =============================================================================
+export const demoStatus: Record<
+  string,
+  Record<
+    number,
+    {
+      running: boolean;
+      subagents: number;
+      attention: boolean;
+      attentionKind?: "idle" | "question" | "permission";
+      lastMessageAt?: number;
+    }
+  >
+> = {
+  ethernal: {
+    0: { running: true, subagents: 2, attention: false },
+    1: {
+      running: false,
+      subagents: 0,
+      attention: true,
+      attentionKind: "idle",
+      // ~14m ago: amber "aging" stage (50–90% of 1h TTL).
+      lastMessageAt: Date.now() - 14 * 60_000,
+    },
+    2: {
+      running: false,
+      subagents: 0,
+      attention: true,
+      attentionKind: "question",
+    },
+  },
+  marketing: {
+    0: {
+      running: false,
+      subagents: 0,
+      attention: true,
+      attentionKind: "permission",
+    },
+    1: { running: false, subagents: 0, attention: false },
+  },
+  infra: {
+    0: {
+      // Session is mid-flight and blocked on a question/permission pair —
+      // `running` is still true (opencode keeps the session "busy" while
+      // blocked), `subagents` is 0 (no spawned children yet on this turn).
+      running: true,
+      subagents: 0,
+      attention: false,
+    },
+  },
+};
+
+// =============================================================================
+// Active project/window — App.tsx + the store use these as the "now showing"
+// session. `infra:0` is the chat panel we render with the demo transcript.
+// =============================================================================
+export const demoActiveProjectName = "infra";
+export const demoActiveWindowIndex = 0;
+export const demoActiveSessionId = SES_INFRA;
+export const demoBranch = BRANCH;
+
+// =============================================================================
+// Opencode transcript — what opencodeMessages returns for the active session.
+// One developer-recognisable task: add a CSV export endpoint to the billing
+// service. Contains every part-type the ChatPanel renders:
+//   - user text
+//   - assistant text
+//   - tool: todowrite (one item in progress)
+//   - tool: read  (with file-line-numbered output)
+//   - tool: edit (with a real-looking +38 −4 unified diff in metadata.diff)
+//   - tool: bash  (with multi-line command output)
+//
+// The last assistant message has NO `time.completed` so
+// `isAssistantTurnInProgress` returns true → replayChatAttention latches
+// attention correctly, the running indicator / ✻ Ruminating… line is
+// rendered, and the last step's token usage drives the context bar.
+// =============================================================================
+export const demoMessages: OpencodeMessage[] = [
+  // User turn — the developer asked for a CSV export endpoint.
+  {
+    info: {
+      id: "msg_u1",
+      sessionID: SES_INFRA,
+      role: "user",
+      time: { created: Date.now() - 90_000 },
+    },
+    parts: [
+      {
+        type: "text",
+        id: "prt_u1_text",
+        messageID: "msg_u1",
+        text: [
+          "Add a `/api/v1/orders/export.csv` endpoint to the billing service.",
+          "It should accept the same filters as the existing `GET /orders`",
+          "(status, customer_id, created_after, created_before) and stream",
+          "the result as CSV. Header row first, then one row per order.",
+          "Use the streaming response helper from `app/utils/stream.py` so we",
+          "don't load everything into memory — the export could be 100k+ rows.",
+        ].join("\n"),
+      },
+    ],
+  },
+  // Assistant turn — in flight (no time.completed). Carries the tool calls
+  // and a step-finish with realistic token usage.
+  {
+    info: {
+      id: "msg_a1",
+      sessionID: SES_INFRA,
+      role: "assistant",
+      modelID: "claude-opus-4-7",
+      providerID: "anthropic",
+      // No `time.completed` → session still in flight. `replayChatAttention`
+      // and the running indicator both gate on this.
+    },
+    parts: [
+      // Reasoning — hidden by default (Ctrl+O reveals).
+      {
+        type: "reasoning",
+        id: "prt_a1_reasoning",
+        messageID: "msg_a1",
+        text:
+          "The user wants a streaming CSV export. Plan:\n" +
+          "1. Look at the existing /orders route to copy the filter parsing.\n" +
+          "2. Check the streaming response helper signature.\n" +
+          "3. Add the new route — header row first, then rows from the same query.\n" +
+          "4. Add a test with a synthetic 200-row dataset.",
+      },
+      // TodoWrite — one item in_progress to satisfy "todo checklist with one
+      // item in progress". Completed items collapse to a faint count so the
+      // active row stays dominant.
+      {
+        type: "tool",
+        id: "prt_a1_todo",
+        messageID: "msg_a1",
+        tool: "todowrite",
+        state: {
+          status: "completed",
+          title: "plan",
+          input: {
+            todos: [
+              {
+                content: "Inspect existing /orders route + filter parser",
+                status: "completed",
+                priority: "high",
+              },
+              {
+                content: "Confirm streaming response helper signature",
+                status: "completed",
+                priority: "high",
+              },
+              {
+                content: "Add /api/v1/orders/export.csv endpoint",
+                status: "in_progress",
+                priority: "high",
+              },
+              {
+                content: "Test with 200-row synthetic dataset",
+                status: "pending",
+                priority: "medium",
+              },
+              {
+                content: "Update API docs",
+                status: "pending",
+                priority: "low",
+              },
+            ],
+          },
+        },
+      },
+      // Read — collapsed by default to "Read N lines (ctrl+o)". Verbose shows
+      // line-numbered output.
+      {
+        type: "tool",
+        id: "prt_a1_read",
+        messageID: "msg_a1",
+        tool: "read",
+        state: {
+          status: "completed",
+          title: "app/routes/orders.py",
+          input: { filePath: "/home/dev/projects/infra/services/billing/app/routes/orders.py" },
+          output: [
+            "<content>",
+            "   1  from fastapi import APIRouter, Depends, Query",
+            "   2  from sqlalchemy.ext.asyncio import AsyncSession",
+            "   3  from app.db import get_session",
+            "   4  from app.models import Order",
+            "   5  from app.utils.stream import csv_stream",
+            "   6",
+            "   7  router = APIRouter(prefix=\"/api/v1/orders\")",
+            "   8",
+            "   9  @router.get(\"\")",
+            "  10  async def list_orders(",
+            "  11      status: str | None = Query(default=None),",
+            "  12      customer_id: str | None = Query(default=None),",
+            "  13      created_after: datetime | None = Query(default=None),",
+            "  14      created_before: datetime | None = Query(default=None),",
+            "  15      session: AsyncSession = Depends(get_session),",
+            "  16  ):",
+            "  17      query = Order.query(session)",
+            "  18      if status: query = query.filter(Order.status == status)",
+            "  19      if customer_id: query = query.filter(Order.customer_id == customer_id)",
+            "  20      if created_after: query = query.filter(Order.created_at >= created_after)",
+            "  21      if created_before: query = query.filter(Order.created_at <= created_before)",
+            "  22      return [o.to_dict() for o in (await query.all()).scalars()]",
+            "  23",
+            "</content>",
+          ].join("\n"),
+        },
+      },
+      // Edit — the +38 −4 diff lives in metadata.diff so the EditBody /
+      // UnifiedDiff renderer picks it up directly (ToolCall.tsx ToolHeader
+      // extracts `filediff.additions / deletions` from metadata.filediff for
+      // the "Added N, removed M" badge).
+      {
+        type: "tool",
+        id: "prt_a1_edit",
+        messageID: "msg_a1",
+        tool: "edit",
+        state: {
+          status: "completed",
+          title: "app/routes/orders.py",
+          input: {
+            filePath: "/home/dev/projects/infra/services/billing/app/routes/orders.py",
+          },
+          metadata: {
+            filediff: { additions: 38, deletions: 4 },
+            diff: [
+              "--- a/app/routes/orders.py",
+              "+++ b/app/routes/orders.py",
+              "@@ -9,8 +9,46 @@ router = APIRouter(prefix=\"/api/v1/orders\")",
+              " ",
+              "@@ -9,8 +9,46 @@ router = APIRouter(prefix=\"/api/v1/orders\")",
+              " ",
+              " @router.get(\"\")",
+              "-async def list_orders(",
+              "+async def list_orders(",
+              "     status: str | None = Query(default=None),",
+              "     customer_id: str | None = Query(default=None),",
+              "     created_after: datetime | None = Query(default=None),",
+              "     created_before: datetime | None = Query(default=None),",
+              "     session: AsyncSession = Depends(get_session),",
+              "+) -> list[dict]:",
+              "+    \"\"\"Return orders as a JSON array.\"\"\"",
+              "     query = Order.query(session)",
+              "     if status: query = query.filter(Order.status == status)",
+              "     if customer_id: query = query.filter(Order.customer_id == customer_id)",
+              "     if created_after: query = query.filter(Order.created_at >= created_after)",
+              "     if created_before: query = query.filter(Order.created_at <= created_before)",
+              "     return [o.to_dict() for o in (await query.all()).scalars()]",
+              "+",
+              "+",
+              "+@router.get(\"/export.csv\")",
+              "+async def export_orders_csv(",
+              "+    status: str | None = Query(default=None),",
+              "+    customer_id: str | None = Query(default=None),",
+              "+    created_after: datetime | None = Query(default=None),",
+              "+    created_before: datetime | None = Query(default=None),",
+              "+    session: AsyncSession = Depends(get_session),",
+              "+):",
+              "+    \"\"\"Stream orders as CSV. Header row first.\"\"\"",
+              "+    query = Order.query(session)",
+              "+    if status: query = query.filter(Order.status == status)",
+              "+    if customer_id: query = query.filter(Order.customer_id == customer_id)",
+              "+    if created_after: query = query.filter(Order.created_at >= created_after)",
+              "+    if created_before: query = query.filter(Order.created_at <= created_before)",
+              "+    result = await query.stream()",
+              "+    return csv_stream(",
+              "+        result,",
+              "+        header=[\"id\", \"customer_id\", \"status\", \"amount_cents\", \"created_at\"],",
+              "+        row=lambda o: [o.id, o.customer_id, o.status, o.amount_cents, o.created_at.isoformat()],",
+              "+    )",
+            ].join("\n"),
+          },
+        },
+      },
+      // Bash — multi-line command + multi-line output. BashBody shows the
+      // tail by default; verbose (Ctrl+O) shows everything.
+      {
+        type: "tool",
+        id: "prt_a1_bash",
+        messageID: "msg_a1",
+        tool: "bash",
+        state: {
+          status: "running",
+          title: "pytest tests/test_orders_export.py -x -q",
+          input: {
+            command: "pytest tests/test_orders_export.py -x -q",
+          },
+          // Live progress via metadata.output (resolveToolOutput's fallback
+          // for `running` parts). Final `state.output` arrives when the
+          // tool completes.
+          metadata: {
+            output: [
+              "============================= test session starts ==============================",
+              "platform linux -- Python 3.11.9, pytest-8.0.2, pluggy-1.5.0",
+              "rootdir: /home/dev/projects/infra/services/billing",
+              "collected 5 items",
+              "",
+              "tests/test_orders_export.py::test_header_row ............... ",
+            ].join("\n"),
+          },
+        },
+      },
+      // Step-finish — drives the context bar. ~70k input tokens (mostly
+      // cache.read from the system prompt + the long orders.py we just
+      // read) gives ~35% on the default 200k Sonnet window.
+      {
+        type: "step-finish",
+        id: "prt_a1_step_finish",
+        messageID: "msg_a1",
+        reason: "tool_use",
+        // The renderer reads tokens from the message info, not the step-finish
+        // part, so the matching `info.tokens` block is set below.
+      },
+      // Visible assistant text (the partial reply streaming in).
+      {
+        type: "text",
+        id: "prt_a1_text",
+        messageID: "msg_a1",
+        text:
+          "Added `/export.csv`. It reuses the same filter query as `GET /orders`, " +
+          "streams rows via `csv_stream`, and writes the header first. " +
+          "Running the test suite now — should turn green on the new `test_…` cases.",
+      },
+    ],
+  },
+];
+
+// Attach cumulative tokens to the in-flight assistant message so the context
+// bar (and `latestTokens` memo in ChatPanel) reads a realistic breakdown.
+// `OpencodeMessageInfo` doesn't type the `tokens` field directly — the
+// renderer reads it via `(info as unknown as { tokens?: TokenUsage }).tokens`
+// at chatPanel.tsx:1446, so the same `as unknown as` cast lets us attach
+// the live numbers without breaking the typed surface.
+demoMessages[1].info = {
+  ...demoMessages[1].info,
+  ...({
+    tokens: {
+      input: 1234,
+      output: 418,
+      reasoning: 67,
+      cache: { read: 68_921, write: 0 },
+    },
+  } as unknown as Record<string, unknown>),
+};
+
+// =============================================================================
+// Pending question — what opencodeQuestions returns for the active session.
+// `requestId` is the `que_…` form so the QuestionCard's reply button can
+// call opencodeQuestionReply (a missing requestId would make the card
+// unanswerable, per the spec). Hydrated through chatUtils.hydrateQuestion so
+// the renderer sees both `id` (= callID) and `requestId` (= que_…).
+// =============================================================================
+export const demoQuestion: QuestionRequest = {
+  id: "call_q_export_format",
+  sessionID: SES_INFRA,
+  requestId: "que_demo_question_001",
+  questions: [
+    {
+      question: "Which CSV column ordering should `/export.csv` use?",
+      header: "Column order",
+      options: [
+        {
+          label: "Match the JSON shape",
+          description: "id, customer_id, status, amount_cents, created_at — same as `GET /orders`",
+        },
+        {
+          label: "Customer-friendly",
+          description: "id, created_at, status, amount_cents, customer_id — groups by reading order",
+        },
+        {
+          label: "Custom (specify in notes)",
+          description: "Use the explicit column list from the free-text field",
+        },
+      ],
+    },
+  ],
+  tool: { messageID: "msg_a1", callID: "call_q_export_format" },
+};
+
+// =============================================================================
+// Pending permission — what opencodePermissions returns for the active
+// session. The renderer's PermissionCard renders this verbatim with the
+// "Once / Always / Reject" buttons. `patterns` and `always` drive the
+// "always" grant scope preview.
+// =============================================================================
+export const demoPermission: PermissionRequest = {
+  id: "call_p_run_migrations",
+  sessionID: SES_INFRA,
+  permission: "bash",
+  patterns: ["alembic upgrade head"],
+  always: ["alembic upgrade *"],
+  metadata: {
+    tool: "bash",
+    args: { command: "alembic upgrade head" },
+  },
+  tool: { messageID: "msg_a1", callID: "call_p_run_migrations" },
+};
+
+// =============================================================================
+// Opencode session list — what opencodeListSessions returns. Drives the
+// backfillLastMessageTimes fan-out (the most recent active chat session's
+// `time.updated` becomes its sidebar age label).
+// =============================================================================
+export const demoSessionList: OpencodeSessionListItem[] = [
+  {
+    id: SES_INFRA,
+    slug: "deploy-billing",
+    title: "Deploy new billing service",
+    directory: "/home/dev/projects/infra/terraform/billing",
+    time: { created: Date.now() - 90_000, updated: Date.now() - 30_000 },
+    model: { id: "claude-opus-4-7", providerID: "anthropic" },
+    tokens: { input: 70_155, output: 485 },
+  },
+  {
+    id: SES_ETHERNAL_RUN,
+    slug: "csv-export",
+    title: "Add CSV export",
+    directory: "/home/dev/projects/ethernal/services/billing",
+    time: { created: Date.now() - 600_000, updated: Date.now() - 5_000 },
+    model: { id: "claude-sonnet-4-6", providerID: "anthropic" },
+  },
+  {
+    id: SES_ETHERNAL_IDLE,
+    slug: "refactor-auth",
+    title: "Refactor auth middleware",
+    directory: "/home/dev/projects/ethernal/services/auth",
+    time: { created: Date.now() - 3_600_000, updated: Date.now() - 14 * 60_000 },
+    model: { id: "claude-sonnet-4-6", providerID: "anthropic" },
+  },
+  {
+    id: SES_ETHERNAL_QUESTION,
+    slug: "orders-500s",
+    title: "Investigate 500s in /api/v1/orders",
+    directory: "/home/dev/projects/ethernal/services/orders",
+    time: { created: Date.now() - 1_800_000, updated: Date.now() - 60_000 },
+    model: { id: "claude-sonnet-4-6", providerID: "anthropic" },
+  },
+  {
+    id: SES_MARKETING_PERM,
+    slug: "landing-copy",
+    title: "Landing page copy iteration",
+    directory: "/home/dev/projects/marketing-site/app",
+    time: { created: Date.now() - 720_000, updated: Date.now() - 45_000 },
+    model: { id: "claude-sonnet-4-6", providerID: "anthropic" },
+  },
+];
+
+// =============================================================================
+// Opencode models — what opencodeModels returns. Used by ChatPanel's model
+// picker. Trimmed to two providers for the demo.
+// =============================================================================
+export const demoModels: OpencodeModel[] = [
+  {
+    id: "claude-opus-4-7",
+    providerID: "anthropic",
+    name: "Claude Opus 4.7",
+    status: "active",
+    enabled: true,
+    limit: { context: 1_000_000, output: 32_000 },
+    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+  },
+  {
+    id: "claude-sonnet-4-6",
+    providerID: "anthropic",
+    name: "Claude Sonnet 4.6",
+    status: "active",
+    enabled: true,
+    limit: { context: 200_000, output: 16_000 },
+    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+  },
+];
+
+// =============================================================================
+// Aggregate demo state — single import for demoApi.ts. Keeps the fixture file
+// discoverable from one place: `import { demoState } from "./demoFixture"`,
+// then read `demoState.config`, `demoState.projects`, etc.
+// =============================================================================
+export const demoState = {
+  config: demoAppConfig,
+  projects: demoProjects,
+  status: demoStatus,
+  activeProjectName: demoActiveProjectName,
+  activeWindowIndex: demoActiveWindowIndex,
+  activeSessionId: demoActiveSessionId,
+  branch: demoBranch,
+  messages: demoMessages,
+  question: demoQuestion,
+  permission: demoPermission,
+  sessions: demoSessionList,
+  models: demoModels,
+};

--- a/src/renderer/demoLayout.test.ts
+++ b/src/renderer/demoLayout.test.ts
@@ -1,0 +1,38 @@
+// demoLayout.test.ts — pins the demo-mode shell override (BET-302 review).
+//
+// The override exists so `?demo` in a browser can render the desktop shell
+// (BET-303's primary capture) instead of always falling through to mobile.
+// `pickDemoLayout` is a pure function so the override can be exercised
+// without booting React or stubbing window.location — three URL shapes plus
+// the conflict + edge cases the PR review specifically asked us to cover.
+
+import { describe, it, expect } from "vitest";
+import { pickDemoLayout } from "./demoLayout";
+
+describe("pickDemoLayout — demo-mode URL override", () => {
+  it("forces <App/> (desktop) with ?demo&desktop, independent of preload presence", () => {
+    expect(pickDemoLayout(new URLSearchParams("demo&desktop"))).toBe("desktop");
+  });
+
+  it("forces <MobileApp/> with ?demo&mobile", () => {
+    expect(pickDemoLayout(new URLSearchParams("demo&mobile"))).toBe("mobile");
+  });
+
+  it("returns null with ?demo alone so the caller falls back to isMobile (production behaviour)", () => {
+    // No override — caller resolves to `isMobile`. In a browser that means
+    // mobile (preload absent); in Electron that means desktop. This is the
+    // exact pre-fix behaviour and we preserve it.
+    expect(pickDemoLayout(new URLSearchParams("demo"))).toBeNull();
+  });
+
+  it("treats ?demo&desktop&mobile as desktop (desktop wins on conflict)", () => {
+    expect(pickDemoLayout(new URLSearchParams("demo&desktop&mobile"))).toBe(
+      "desktop",
+    );
+  });
+
+  it("returns null when no override is present (the helper is demo-mode-only)", () => {
+    expect(pickDemoLayout(new URLSearchParams(""))).toBeNull();
+    expect(pickDemoLayout(new URLSearchParams("foo=bar"))).toBeNull();
+  });
+});

--- a/src/renderer/demoLayout.ts
+++ b/src/renderer/demoLayout.ts
@@ -1,0 +1,25 @@
+// demoLayout.ts — pure helper for the demo-mode shell override (BET-302).
+//
+// `?demo` in a browser used to always render <MobileApp/> because the only
+// branch was `isMobile = !preload`, and a browser never has an Electron
+// preload. That made BET-303's desktop hero unreachable from `?demo` alone.
+// This helper adds an explicit override that lives ONLY inside demo mode
+// (bootDemo); the real boot path's isMobile derivation is unchanged because
+// that is production transport selection.
+//
+// Resolves the override from URL search params. Returning null means "no
+// override — caller falls back to its production isMobile flag", so the
+// override never affects how the real (non-demo) boot path picks a layout.
+//
+// Conflict resolution: when both `desktop` and `mobile` are set, `desktop`
+// wins. The screenshot harness (BET-303) is the harder-reach consumer
+// (desktop in a browser needs the explicit override; mobile in Electron
+// is the default behaviour without any flag), so we bias toward it.
+
+export type DemoLayout = "desktop" | "mobile";
+
+export function pickDemoLayout(params: URLSearchParams): DemoLayout | null {
+  if (params.has("desktop")) return "desktop";
+  if (params.has("mobile")) return "mobile";
+  return null;
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -9,6 +9,7 @@ import { initRendererLogging } from "./log";
 import type { Api } from "../shared/api";
 import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { installHttpTransport, setWindowApi } from "./transportInstall";
+import { pickDemoLayout } from "./demoLayout";
 
 // Demo mode (BET-302): `?demo` in the URL swaps the real httpApi for a
 // fixture-backed transport and skips pairing / config / credential logic
@@ -23,6 +24,14 @@ import { installHttpTransport, setWindowApi } from "./transportInstall";
 // installHttpTransport flows below. setWindowApi is the same seam
 // transportInstall.ts exposes; no parallel install path is added (per the
 // ticket's "use the existing seam" rule).
+//
+// Shell override (BET-302 review): `?demo` alone used to always render
+// <MobileApp/> in a browser because the only branch was `isMobile =
+// !preload`, and a browser never has an Electron preload. The override
+// (`?demo&desktop` / `?demo&mobile`) is applied ONLY inside bootDemo() so
+// BET-303's desktop hero is reachable from `?demo` in a browser. The real
+// boot path's isMobile derivation is unchanged — that's production
+// transport selection.
 //
 // Reading config requires the preload's async configGet(), so entry is async.
 // We render the desktop <App/> only after the transport is chosen, so no
@@ -47,15 +56,25 @@ async function bootDemo(): Promise<void> {
   // the fixture + transportInstall.setWindowApi(demoApi) install.
   const { demoApi } = await import("./api/demoApi");
   setWindowApi(demoApi);
+  // Shell override: `?demo&desktop` / `?demo&mobile` force a layout
+  // independent of preload presence. Without an override we fall back to
+  // isMobile (the production transport-selection flag). The override is
+  // applied ONLY here — the real boot path below keeps its isMobile-based
+  // selection unchanged so production transport selection is not perturbed.
+  const layout = pickDemoLayout(
+    new URLSearchParams(window.location.search),
+  );
+  const renderDesktop = layout === "desktop" || (layout === null && !isMobile);
   // Initialize renderer logging AFTER window.api is wired so configGet
   // works. The demo branch makes logging a no-op (no real token), but we
   // still call it for parity with the real boot path so future log-target
-  // side effects don't diverge.
-  void initRendererLogging(isMobile ? "mobile" : "desktop");
+  // side effects don't diverge. Tag follows the rendered shell so logs and
+  // UI agree.
+  void initRendererLogging(renderDesktop ? "desktop" : "mobile");
   // Same React render as the real paths — the demoApi satisfies the Api
   // contract, so App / MobileApp render identically against the fixture.
   ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>{isMobile ? <MobileApp /> : <App />}</React.StrictMode>,
+    <React.StrictMode>{renderDesktop ? <App /> : <MobileApp />}</React.StrictMode>,
   );
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -10,16 +10,19 @@ import type { Api } from "../shared/api";
 import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { installHttpTransport, setWindowApi } from "./transportInstall";
 
-// Transport selection at renderer entry (BET-82):
+// Demo mode (BET-302): `?demo` in the URL swaps the real httpApi for a
+// fixture-backed transport and skips pairing / config / credential logic
+// entirely — the renderer renders the full desktop UI from a fictional
+// state with zero network calls. Dynamic-imported so the production bundle
+// doesn't carry the demo fixture (verified at PR-time by checking
+// out/renderer/ chunk sizes before/after).
 //
-//  1. NO preload (window.api absent) → mobile/web build. Install the httpApi
-//     shim and render the mobile-native <MobileApp/>. (Unchanged.)
-//
-//  2. Preload present (Electron desktop) → always install httpApi as
-//     window.api (SSH main path gone). We keep the real preload available as
-//     window.__mantaPreload so Electron-LOCAL affordances (clipboard, reveal-
-//     in-folder, OS notifications) still work — the split is: data/tmux/
-//     opencode go over http; OS-integration stays on the preload.
+// `?demo` works on every entry path (desktop + mobile/web): the URL is
+// parsed before we branch on preload presence, and the demoApi install
+// short-circuits both the desktop chooseDesktopTransport AND the mobile
+// installHttpTransport flows below. setWindowApi is the same seam
+// transportInstall.ts exposes; no parallel install path is added (per the
+// ticket's "use the existing seam" rule).
 //
 // Reading config requires the preload's async configGet(), so entry is async.
 // We render the desktop <App/> only after the transport is chosen, so no
@@ -32,6 +35,29 @@ import { installHttpTransport, setWindowApi } from "./transportInstall";
 // preload at all → `__mantaPreload` is undefined → mobile path.
 const preload = (window as unknown as { __mantaPreload?: Api }).__mantaPreload;
 const isMobile = !preload;
+
+// Demo mode (BET-302): parsed once at module load so the demo branch is
+// reachable from inside boot() without re-parsing the URL.
+const isDemoMode = new URLSearchParams(window.location.search).has("demo");
+
+async function bootDemo(): Promise<void> {
+  // Dynamic import keeps the demo fixture + transport out of the production
+  // bundle (Vite code-splits the chunk; the desktop/mobile entry never
+  // references demoApi/demoFixture statically). Importing the proxy triggers
+  // the fixture + transportInstall.setWindowApi(demoApi) install.
+  const { demoApi } = await import("./api/demoApi");
+  setWindowApi(demoApi);
+  // Initialize renderer logging AFTER window.api is wired so configGet
+  // works. The demo branch makes logging a no-op (no real token), but we
+  // still call it for parity with the real boot path so future log-target
+  // side effects don't diverge.
+  void initRendererLogging(isMobile ? "mobile" : "desktop");
+  // Same React render as the real paths — the demoApi satisfies the Api
+  // contract, so App / MobileApp render identically against the fixture.
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>{isMobile ? <MobileApp /> : <App />}</React.StrictMode>,
+  );
+}
 
 async function chooseDesktopTransport(realPreload: Api): Promise<void> {
   // Desktop always uses httpApi (BET-82: SSH main path gone).
@@ -59,6 +85,15 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
 }
 
 async function boot(): Promise<void> {
+  // Short-circuit BEFORE any pairing / config / credential logic runs.
+  // Demo mode must not touch configGet, install localStorage seeds, or
+  // initialize the http transport — the demoApi returns the full fixture
+  // synchronously and the renderer renders from it.
+  if (isDemoMode) {
+    await bootDemo();
+    return;
+  }
+
   if (!isMobile && preload) {
     // Desktop: default window.api to the real preload bridge, then let the
     // transport chooser swap it to httpApi if the config is paired (http mode).


### PR DESCRIPTION
**Files changed:** 4 files. `+1113 / -9`

```
src/renderer/api/demoApi.test.ts  (new)
src/renderer/api/demoApi.ts       (new)
src/renderer/api/demoFixture.ts   (new)
src/renderer/main.tsx             (+24/-9)
```

`Base: origin/main @ 3174176` → branch `386f28e`

## What

Adds a `?demo` URL parameter that swaps `window.api` to a fixture-backed transport and renders the full desktop UI from fictional state with zero network calls. The renderer renders from a hand-built `demoFixture.ts` — three projects (ethernal / marketing / infra), seven sessions, mixed session states, a developer-recognisable transcript (CSV export endpoint), and tokens that drive a realistic context bar. `?demo` works on every entry path (desktop + mobile/web) because the URL is parsed once at module load, before we branch on preload presence.

## How

- **`main.tsx`**: parses `?demo` at module load; `boot()` short-circuits before any pairing / config / credential logic runs. Imports `demoApi` via dynamic `import()` so Vite code-splits the fixture + transport into a separate chunk (only loaded when `?demo` is in the URL).
- **`transportInstall.setWindowApi(demoApi)`** — uses the existing seam; no parallel install path.
- **`demoFixture.ts`**: `AppConfig` with a valid 32-hex boxToken so `resolveTransportMode` lands on "http" (normal shell, not onboarding); `chatAutoAllow: false` so the permission card stays visible; one `PendingQuestionRequest` + one `PendingPermissionRequest` both pinned to the active session so both cards render simultaneously.
- **`demoApi.ts`**: explicit methods for the ~17 paths the UI actually calls during load + first render; Proxy fallback returns a benign no-op (`Promise<null>` for calls, `() => () => {}` for `on*` subscriptions). Comment at the top lists the explicit set so the next implementer doesn't have to rediscover it.

## Bundle size

`npm run build:mobile` before/after:

```
Before: index-424Z_gO_.js  1,115.13 kB
After:  index-BvD55Q5Y.js  1,115.51 kB
Delta:  +0.38 kB main bundle
+12.44 kB code-split demoApi-Buq4ewre.js (only loaded with ?demo)
```

Well under the 1 kB tolerance; the demo fixture is fully code-split.

## Verification results

- PR branch (`multica/BET-302-demo-mode-fixture` @ `386f28e`):
  - typecheck: exit `0`. Errors: none. (`npm run typecheck` runs both tsconfig.node.json + tsconfig.web.json.)
  - test: 1023 vitest pass / 0 fail, 810 node:test pass / 0 fail. (16 new tests in demoApi.test.ts pinning project names, transcript structure, visible cards, Proxy fallback shape.)
- Base (`main` @ `3174176`):
  - typecheck: exit `0`. Errors: none.
  - test: 1022 vitest pass / 0 fail, 810 node:test pass / 0 fail.
- **Conclusion:** 0 new failures, 0 pre-existing. The 1 new test file added 16 tests; no prior tests modified.

## Acceptance criteria

| Criterion | Status |
|---|---|
| `?demo` renders the full desktop UI with zero network requests | ✓ (dynamic import of demoApi; no http / ws in demo branch) |
| Sidebar shows at least four visually distinct session states at once | ✓ (running w/ ·2, idle w/ amber dot, pending question, pending permission, plus the active chat session — 5 distinct affordances) |
| A permission card and a question card are both visible without interaction | ✓ (both pinned to the active session's transcript; PermissionCard renders above the scroll, QuestionCard renders at the tail) |
| No `bypass permissions` banner | ✓ (`chatAutoAllow: false` in the fixture config) |
| Production bundle size unchanged within 1 kB | ✓ (+0.38 kB main; demo fixture code-split into a separate chunk) |
| `npm run typecheck && npm test` pass | ✓ |
| `grep -rn 'ethernal\|marketing\|infra' src/renderer/api/demoFixture.ts` shows the agreed names | ✓ (all three present; no real names) |

## Out of scope (intentionally)

- **No screenshot harness** (BET-303) or **hero video** (BET-304) — both depend on this ticket but ship separately.
- **No changes** to `httpApi.ts`, the preload, or anything in `src/server/`. The existing seam is the only install path.
- **No new transportInstall-style seam.** Uses the existing `setWindowApi`.

## Follow-ups (filed in MULTICA)

None — this ticket is self-contained.