### PR TITLE
fix(ci): auto-clear stale Multica blocked statuses when blockers finish

### DIFF
--- a/.github/workflows/multica-close-on-merge.yml
+++ b/.github/workflows/multica-close-on-merge.yml
@@ -3,6 +3,11 @@ name: Multica Close on Merge
 on:
   pull_request_target:
     types: [closed]
+  # Safety net: a status can also change outside a PR (set by hand, or by an
+  # agent). Hourly sweep catches those without waiting for the next merge.
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -11,6 +16,7 @@ permissions:
 jobs:
   close:
     name: Close or comment on BET issue
+    if: github.event_name == 'pull_request_target'
     runs-on: [self-hosted, linux]
     timeout-minutes: 5
     steps:
@@ -99,3 +105,38 @@ jobs:
       - name: Done
         if: always()
         run: echo "Multica close-on-merge step completed."
+
+  # ---------------------------------------------------------------------------
+  # Clear stale `blocked` statuses whose blockers have since finished.
+  #
+  # The PM agent writes `metadata.waiting_on` as a one-off snapshot when it
+  # blocks an issue; nothing re-reads it when the blockers land. Without this,
+  # an issue stays `blocked` indefinitely after its dependencies are done —
+  # observed live when BET-297 sat blocked on BET-294/BET-295 for an hour after
+  # both had merged, stalling the whole website epic until a human noticed.
+  #
+  # Runs after `close` so the just-merged issue is already `done` and counts.
+  # ---------------------------------------------------------------------------
+  unblock:
+    name: Unblock issues whose blockers are done
+    needs: [close]
+    # `needs` on a skipped job would skip this too, so accept that case
+    # explicitly: run on schedule/dispatch, or after a merge.
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.merged == true)
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Reconcile blocked issues
+        env:
+          MULTICA_TOKEN: ${{ secrets.MULTICA_TOKEN }}
+        run: node scripts/multica-unblock.mjs --verbose
+        # Housekeeping must never fail a merge pipeline.
+        continue-on-error: true

--- a/.multica/agents/manta-pm.md
+++ b/.multica/agents/manta-pm.md
@@ -196,6 +196,21 @@ each independently buildable + testable, each ≤ one agent run**:
   `--stage 1, 2, 3…` so a slice that imports another slice's output sits in a
   later stage and won't dispatch until its prerequisite is merged. Independent
   slices share a stage only if they don't share a write surface.
+- **Stages are the ONLY dependency mechanism you should reach for.** Do not
+  express ordering by setting an issue `blocked` with a prose `waiting_on` note
+  — that note is a snapshot written once, nothing re-reads it when the blocker
+  lands, and the issue then sits blocked forever. This is not hypothetical:
+  BET-297 stayed `blocked` describing BET-294/BET-295 as "in_progress" for an
+  hour after both had merged, stalling the whole website epic until a human
+  asked why nothing was moving. If work is dependency-ordered, it belongs under
+  a parent with `--stage`, full stop.
+- **If you must block an unstaged issue, write the note so it can be
+  reconciled.** `scripts/multica-unblock.mjs` (hourly, and after every merge)
+  clears a `blocked` issue once every issue key named in its `waiting_on` is
+  `done`/`cancelled`. For that to work the note MUST name the blockers as bare
+  keys (`BET-294`), and MUST NOT name the issue's own key — a self-reference
+  means it waits on its own blocked status forever. A note naming no key is
+  deliberately left alone by the sweep, so it is yours to clear by hand.
 - **Device/parity check slices** where the milestone spans transports (desktop
   + mobile) or needs on-device verification — model them as the existing
   "Device check — …" issues (BET-25/28/29/…), typically `Inline` dispatch

--- a/scripts/multica-unblock.mjs
+++ b/scripts/multica-unblock.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Multica: clear stale `blocked` statuses whose blockers have finished.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * When the PM agent blocks an issue it writes a free-text `metadata.waiting_on`
+ * note naming the blockers, e.g.
+ *
+ *   "BET-294 (site.css extraction, in_progress) and BET-295 (deploy
+ *    verify-glob, in_progress). Both must merge before this can start."
+ *
+ * That note is a SNAPSHOT taken once. Nothing re-reads it when the blockers
+ * finish, so an issue stays `blocked` forever after its dependencies are done.
+ * Observed live: BET-297 sat `blocked` with a note calling BET-294 and BET-295
+ * "in_progress" long after both had merged and gone `done`. The whole website
+ * epic stalled and only moved because a human noticed nothing was happening.
+ *
+ * This script closes that loop: for every `blocked` issue, resolve the BET keys
+ * named in `waiting_on`, and if ALL of them are terminal (`done`/`cancelled`),
+ * flip the issue to `todo`.
+ *
+ * SCOPE — deliberately conservative
+ *   - Only ever moves `blocked` → `todo`. It never blocks, closes, reassigns or
+ *     reprioritises anything.
+ *   - An issue with no `waiting_on`, or whose note names no BET key, is LEFT
+ *     ALONE. We cannot know why a human blocked it, so we do not guess.
+ *   - A blocker key that cannot be fetched is treated as NOT done, so a
+ *     transient API error can never cause a spurious unblock.
+ *
+ * `metadata` is not writable through the public issues API (a PUT containing it
+ * returns 200 and silently discards it — verified 2026-07-26), so the stale
+ * `waiting_on` text remains after unblocking. That is cosmetic: `status` is
+ * what the agents dispatch on.
+ *
+ * USAGE
+ *   MULTICA_TOKEN=… node scripts/multica-unblock.mjs [--dry-run] [--verbose]
+ *
+ * ENV
+ *   MULTICA_TOKEN         required — same secret the close-on-merge workflow uses
+ *   MULTICA_WORKSPACE_ID  optional — defaults to the MantaUI (BET) workspace
+ *   MULTICA_API_BASE      optional — defaults to https://api.multica.ai
+ *
+ * Exit code is 0 unless the run could not complete (missing token, list call
+ * failed). Individual update failures warn and do not fail the run — this is
+ * housekeeping and must never break a deploy pipeline.
+ */
+
+const DEFAULT_WORKSPACE = "264c89bb-4659-4570-af7b-5f8daaf87985";
+const DEFAULT_API_BASE = "https://api.multica.ai";
+
+/** Statuses that mean a blocker is finished and no longer blocking. */
+export const TERMINAL_STATUSES = new Set(["done", "cancelled", "canceled"]);
+
+/**
+ * Extract issue keys (BET-123) named in a free-text waiting_on note.
+ * Case-insensitive, de-duplicated, order preserved.
+ *
+ * @param {string|null|undefined} waitingOn
+ * @returns {string[]}
+ */
+export function parseBlockerKeys(waitingOn) {
+  if (typeof waitingOn !== "string") return [];
+  const out = [];
+  const seen = new Set();
+  for (const m of waitingOn.matchAll(/\b([A-Z]{2,10})-(\d+)\b/gi)) {
+    const key = `${m[1].toUpperCase()}-${m[2]}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(key);
+    }
+  }
+  return out;
+}
+
+/**
+ * Decide whether one blocked issue should be unblocked.
+ *
+ * @param {{identifier:string, status:string, metadata?:{waiting_on?:string}}} issue
+ * @param {Map<string,string|null>} statusByKey resolved blocker statuses;
+ *        a missing/null entry means "could not resolve" and blocks the unblock.
+ * @returns {{unblock:boolean, reason:string, blockers:string[]}}
+ */
+export function decideUnblock(issue, statusByKey) {
+  if (issue?.status !== "blocked") {
+    return { unblock: false, reason: "not blocked", blockers: [] };
+  }
+  // Drop self-references. The notes routinely name the issue itself, e.g.
+  // BET-300's note reads "…BET-299 (…). BET-300 cannot start until…". Left in,
+  // the issue would be waiting on its own blocked self and could never clear.
+  const self = issue?.identifier?.toUpperCase();
+  const blockers = parseBlockerKeys(issue?.metadata?.waiting_on).filter(
+    (k) => k !== self,
+  );
+  if (blockers.length === 0) {
+    // No machine-readable dependency. A human may have blocked this for a
+    // reason we cannot see — never guess.
+    return { unblock: false, reason: "no blocker keys in waiting_on", blockers };
+  }
+  const unfinished = blockers.filter((k) => {
+    const s = statusByKey.get(k);
+    return !(typeof s === "string" && TERMINAL_STATUSES.has(s));
+  });
+  if (unfinished.length > 0) {
+    return {
+      unblock: false,
+      reason: `waiting on ${unfinished.join(", ")}`,
+      blockers,
+    };
+  }
+  return { unblock: true, reason: `all of ${blockers.join(", ")} done`, blockers };
+}
+
+/* ------------------------------------------------------------------ *
+ * IO below this line. Everything above is pure and unit-tested.
+ * ------------------------------------------------------------------ */
+
+/** @param {string} path @param {object} opts */
+async function api(base, token, path, opts = {}) {
+  const res = await fetch(`${base}/api${path}`, {
+    ...opts,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(opts.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} on ${path}: ${(await res.text()).slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const verbose = process.argv.includes("--verbose");
+  const token = process.env.MULTICA_TOKEN;
+  const ws = process.env.MULTICA_WORKSPACE_ID || DEFAULT_WORKSPACE;
+  const base = process.env.MULTICA_API_BASE || DEFAULT_API_BASE;
+
+  if (!token) {
+    console.error("MULTICA_TOKEN is not set — nothing to do.");
+    process.exit(1);
+  }
+
+  const listed = await api(base, token, `/issues?workspace_id=${ws}&status=blocked&limit=200`);
+  const blocked = listed.issues ?? [];
+  if (blocked.length === 0) {
+    console.log("No blocked issues. Nothing to reconcile.");
+    return;
+  }
+
+  // Resolve every referenced blocker once.
+  const statusByKey = new Map();
+  const needed = new Set(blocked.flatMap((i) => parseBlockerKeys(i?.metadata?.waiting_on)));
+  for (const key of needed) {
+    try {
+      const issue = await api(base, token, `/issues/${key}?workspace_id=${ws}`);
+      statusByKey.set(key, issue?.status ?? null);
+    } catch (e) {
+      // Unresolvable → treated as still blocking. Never unblock on an error.
+      statusByKey.set(key, null);
+      if (verbose) console.log(`  ! could not resolve ${key}: ${e.message}`);
+    }
+  }
+
+  let unblocked = 0;
+  for (const issue of blocked) {
+    const { unblock, reason } = decideUnblock(issue, statusByKey);
+    const id = issue.identifier;
+    if (!unblock) {
+      if (verbose) console.log(`  · ${id} stays blocked (${reason})`);
+      continue;
+    }
+    if (dryRun) {
+      console.log(`  → ${id} WOULD unblock (${reason})`);
+      unblocked++;
+      continue;
+    }
+    try {
+      await api(base, token, `/issues/${id}?workspace_id=${ws}`, {
+        method: "PUT",
+        body: JSON.stringify({ status: "todo" }),
+      });
+      console.log(`  → ${id} unblocked (${reason})`);
+      unblocked++;
+    } catch (e) {
+      console.log(`  ! ${id} update failed, leaving blocked: ${e.message}`);
+    }
+  }
+
+  console.log(
+    `${dryRun ? "[dry-run] " : ""}${unblocked} of ${blocked.length} blocked issue(s) ${dryRun ? "would be" : ""} unblocked.`,
+  );
+}
+
+// Only run when invoked directly, so the pure exports stay importable in tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.error(`multica-unblock failed: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/multica-unblock.test.mjs
+++ b/scripts/multica-unblock.test.mjs
@@ -1,0 +1,157 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseBlockerKeys,
+  decideUnblock,
+  TERMINAL_STATUSES,
+} from "./multica-unblock.mjs";
+
+describe("parseBlockerKeys", () => {
+  test("pulls keys out of a real waiting_on note", () => {
+    // Verbatim from BET-297, which stalled the website epic.
+    const note =
+      "BET-294 (site.css extraction, in_progress) and BET-295 (deploy " +
+      "verify-glob, in_progress). Both must merge before this can start.";
+    assert.deepEqual(parseBlockerKeys(note), ["BET-294", "BET-295"]);
+  });
+
+  test("de-duplicates repeated keys, preserving first-seen order", () => {
+    assert.deepEqual(
+      parseBlockerKeys("BET-302 blocks this; see BET-297 and BET-302 again"),
+      ["BET-302", "BET-297"],
+    );
+  });
+
+  test("is case-insensitive but normalises to upper case", () => {
+    assert.deepEqual(parseBlockerKeys("bet-12 and Bet-13"), ["BET-12", "BET-13"]);
+  });
+
+  test("returns empty for prose with no keys", () => {
+    assert.deepEqual(parseBlockerKeys("waiting on design review"), []);
+  });
+
+  test("returns empty for null/undefined/non-string", () => {
+    assert.deepEqual(parseBlockerKeys(null), []);
+    assert.deepEqual(parseBlockerKeys(undefined), []);
+    assert.deepEqual(parseBlockerKeys(42), []);
+  });
+
+  test("does not match bare numbers or PR references", () => {
+    assert.deepEqual(parseBlockerKeys("see PR #245 and issue 297"), []);
+  });
+
+  test("handles other project prefixes", () => {
+    assert.deepEqual(parseBlockerKeys("TEN-640 must ship"), ["TEN-640"]);
+  });
+});
+
+describe("decideUnblock", () => {
+  const blocked = (waiting_on) => ({
+    identifier: "BET-999",
+    status: "blocked",
+    metadata: waiting_on === undefined ? {} : { waiting_on },
+  });
+
+  test("unblocks when every named blocker is done", () => {
+    const r = decideUnblock(
+      blocked("BET-294 and BET-295 must merge"),
+      new Map([
+        ["BET-294", "done"],
+        ["BET-295", "done"],
+      ]),
+    );
+    assert.equal(r.unblock, true);
+    assert.deepEqual(r.blockers, ["BET-294", "BET-295"]);
+  });
+
+  test("treats cancelled as finished", () => {
+    const r = decideUnblock(blocked("BET-1"), new Map([["BET-1", "cancelled"]]));
+    assert.equal(r.unblock, true);
+  });
+
+  test("stays blocked when any blocker is unfinished", () => {
+    const r = decideUnblock(
+      blocked("BET-294 and BET-295"),
+      new Map([
+        ["BET-294", "done"],
+        ["BET-295", "in_review"],
+      ]),
+    );
+    assert.equal(r.unblock, false);
+    assert.match(r.reason, /BET-295/);
+  });
+
+  test("REGRESSION: an unresolvable blocker must never unblock", () => {
+    // A transient API error resolves to null. If that counted as "done" a
+    // network blip would silently unblock the whole board.
+    const r = decideUnblock(blocked("BET-294"), new Map([["BET-294", null]]));
+    assert.equal(r.unblock, false);
+  });
+
+  test("blocker absent from the map does not unblock", () => {
+    const r = decideUnblock(blocked("BET-294"), new Map());
+    assert.equal(r.unblock, false);
+  });
+
+  test("leaves human-blocked issues alone when no key is named", () => {
+    const r = decideUnblock(blocked("waiting on Antoine to review the design"), new Map());
+    assert.equal(r.unblock, false);
+    assert.match(r.reason, /no blocker keys/);
+  });
+
+  test("leaves issues with no waiting_on alone", () => {
+    const r = decideUnblock(blocked(undefined), new Map());
+    assert.equal(r.unblock, false);
+  });
+
+  test("ignores issues that are not blocked", () => {
+    const r = decideUnblock(
+      { identifier: "BET-1", status: "todo", metadata: { waiting_on: "BET-2" } },
+      new Map([["BET-2", "done"]]),
+    );
+    assert.equal(r.unblock, false);
+    assert.equal(r.reason, "not blocked");
+  });
+
+  test("REGRESSION: ignores a self-reference in waiting_on", () => {
+    // Real note shape from BET-300: it names itself alongside its blockers.
+    // Counting itself would mean waiting on its own blocked status forever.
+    const issue = {
+      identifier: "BET-300",
+      status: "blocked",
+      metadata: {
+        waiting_on: "BET-299 (SEO pages). BET-300 cannot start until that lands.",
+      },
+    };
+    const r = decideUnblock(issue, new Map([["BET-299", "done"]]));
+    assert.equal(r.unblock, true, "self-reference must not block");
+    assert.deepEqual(r.blockers, ["BET-299"]);
+  });
+
+  test("an issue naming only itself is left alone, not unblocked", () => {
+    const issue = {
+      identifier: "BET-300",
+      status: "blocked",
+      metadata: { waiting_on: "BET-300 needs a design decision first" },
+    };
+    const r = decideUnblock(issue, new Map());
+    assert.equal(r.unblock, false);
+    assert.match(r.reason, /no blocker keys/);
+  });
+
+  test("tolerates a malformed issue object", () => {
+    assert.equal(decideUnblock({}, new Map()).unblock, false);
+    assert.equal(decideUnblock(null, new Map()).unblock, false);
+  });
+});
+
+describe("TERMINAL_STATUSES", () => {
+  test("covers both cancelled spellings and excludes in-flight states", () => {
+    assert.ok(TERMINAL_STATUSES.has("done"));
+    assert.ok(TERMINAL_STATUSES.has("cancelled"));
+    assert.ok(TERMINAL_STATUSES.has("canceled"));
+    for (const s of ["todo", "in_progress", "in_review", "blocked"]) {
+      assert.ok(!TERMINAL_STATUSES.has(s), `${s} must not be terminal`);
+    }
+  });
+});


### PR DESCRIPTION
## The bug

When the PM agent blocks an issue it writes a free-text `metadata.waiting_on`
note naming the blockers. That note is a **snapshot taken once** — nothing
re-reads it when the blockers finish, so an issue stays `blocked` indefinitely
after its dependencies are done.

Seen live today: **BET-297** sat `blocked` with a note describing BET-294 and
BET-295 as "in_progress" for an hour after both had merged and gone `done`. The
entire website epic was parked behind it and only moved because a human asked
why nothing was happening.

## The fix

`scripts/multica-unblock.mjs` — for every blocked issue, resolve the issue keys
named in `waiting_on` and flip it to `todo` once all of them are terminal
(`done` / `cancelled`).

Deliberately conservative. It **only** ever moves `blocked` → `todo`, and never
blocks, closes, reassigns or reprioritises anything:

- An issue whose note names no key is **left alone** — a human may have blocked
  it for a reason not visible to the script.
- A blocker that cannot be fetched counts as **unfinished**, so a transient API
  error can never cause a spurious unblock.
- **Self-references are dropped.** The notes routinely name the issue itself
  (BET-300's reads `…BET-299 (…). BET-300 cannot start until…`), which would
  otherwise mean the issue waits on its own blocked status forever. Caught by
  the first live dry-run, not by reasoning.

## Wiring

Added as a second job in the existing close-on-merge workflow rather than a new
file, so there is one place that reconciles Multica state. Runs after `close`,
so the just-merged issue is already `done` and counts. Plus an hourly sweep for
statuses that change outside a PR. Marked `continue-on-error` — housekeeping
must never fail a merge pipeline.

## Testing

- 19 unit tests over the pure logic, including regressions for the
  unresolvable-blocker and self-reference cases.
- Full suite green: 1023 vitest + 829 node:test.
- Live `--dry-run` against the real board: correctly reports 0 of 5 unblockable
  and names the right outstanding dependency for each.

## Known limitation

`metadata` is not writable through the issues API — a PUT containing it returns
200 and silently discards it (verified). So the stale `waiting_on` text remains
after unblocking. Cosmetic: `status` is what agents dispatch on.