### PR TITLE
fix(server): expand ~ at the tmux boundary, consolidate path helpers (BET-307)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -822,15 +822,31 @@ Backup at `~/.tmux.conf.pre-MantaUI` on the remote if it was ever modified.
     metadata forever. Expansion is therefore mandatory at the **single
     creation chokepoint**, NOT in `resolveProjectCwd`: `createSession`
     (`src/server/opencode.mjs`) expands a leading `~` itself via `expandTilde`
-    against the server process's own `$HOME` — the renderer (desktop + mobile)
-    reaches it the same way over `/rpc`. `forkSession` is unaffected — it
-    inherits the parent's directory from opencode and passes no cwd. The
-    new-window chat-holder path (`tmux.mjs:maybeCreateChatSession`) also
-    expands before `createSession`; that earlier expansion is now redundant but
-    harmless. Regression tests:
+    (from `src/shared/paths.mjs`) against the server process's own `$HOME` —
+    the renderer (desktop + mobile) reaches it the same way over `/rpc`.
+    `forkSession` is unaffected — it inherits the parent's directory from
+    opencode and passes no cwd. Regression tests:
     `createSession expands a leading ~ …` in `src/server/opencode.test.mjs`
     (red/green verified). Do NOT "simplify" by moving expansion back into a
     caller — the chokepoint is what makes the corruption unreachable.
+  - **GOTCHA — tmux does NOT expand `~` either; it silently falls back to
+    `$HOME`.** `tmux new-window -c '~/foo'` and `tmux new-session -c '~/foo'`
+    BOTH accept the literal tilde but resolve it against the tmux server's
+    own cwd (typically `$HOME`) and exit code 0 — silently landing every
+    project created with the UI's default `~` cwd in the home directory.
+    This is the BET-307 tmux-side chokepoint: `tmux.mjs`'s
+    `resolveCwdOrThrow` is the single place a caller-supplied cwd becomes a
+    real directory handed to tmux or opencode. It expands `~` via the
+    shared `expandTilde` (now living in `src/shared/paths.mjs` — three
+    copies used to live in `tmux.mjs`, `opencode.mjs` and `pluginManifest.mjs`,
+    all deleted) and rejects a missing directory with a loud error before
+    any tmux call (and before any orphan opencode session is created in
+    chatMode). Applied at exactly three sites: `newSession`, `newWindow`,
+    and the exported `newWindowGetIndex` (which `rpc.mjs:363` calls
+    directly for fork-session). Regression test: `resolveCwdOrThrow` cases
+    in `src/server/tmux.test.mjs` + the `node -e` e2e in BET-307. Do NOT
+    "simplify" by passing the cwd through unchanged — the chokepoint is
+    what makes the silent `$HOME` fallback unreachable.
 - **Queued message drain — abort at the next step boundary, then submit on
   idle.** When the user submits while `running` is true, the text gets pushed
   to `messageQueue` and the input clears. MantaUI does NOT wait for the whole

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -572,7 +572,6 @@ export const httpApi: Api = {
   configUpdate: (patch) => rpc(IPC.configUpdate, patch),
 
   // -- project metadata --
-  projectMetaUpsert: (meta) => rpc(IPC.projectMetaUpsert, meta),
   projectMetaDelete: (tmuxSession) => rpc(IPC.projectMetaDelete, tmuxSession),
 
   // -- tmux operations --

--- a/src/renderer/mobile/MobileCreateSheet.tsx
+++ b/src/renderer/mobile/MobileCreateSheet.tsx
@@ -176,14 +176,6 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
           windowName: "default",
           chatMode: true,
         });
-        // Persist defaultCwd for the new project so future `tmux:new-window`
-        // calls inherit it (resolveProjectCwd in rpc.mjs reads this). Without
-        // this, the server falls back to ~, which defeats the project's
-        // intended workspace path. Mirror of desktop tmuxNewSession path
-        // (src/main/index.ts) which writes ProjectMeta on creation.
-        await window.api
-          .projectMetaUpsert({ tmuxSession: projectName, defaultCwd: path })
-          .catch(() => {});
         await refresh();
         setActive(projectName);
         onCreated(projectName, null);
@@ -229,10 +221,6 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
           chatMode: true,
         });
       }
-      // Same project-meta write as the auto/single path above.
-      await window.api
-        .projectMetaUpsert({ tmuxSession: projectName, defaultCwd: path })
-        .catch(() => {});
       await refresh();
       setActive(projectName);
       onCreated(projectName, null);

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -12,7 +12,7 @@ import { readdir, readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
-import { STATE_DIRNAME } from "../shared/paths.mjs";
+import { STATE_DIRNAME, expandTilde } from "../shared/paths.mjs";
 import { deriveWorktree, isWorktreeDirtyError } from "../shared/worktree.mjs";
 
 // ============================================================
@@ -272,11 +272,22 @@ export async function gitRemoveWorktree({ path: wtPath, force }) {
 // preload: ipcRenderer.invoke(IPC.fsListDirs, partial) → args[0] = partial
 
 export async function fsListDirs(partial) {
-  let lookup = (partial ?? "").trim();
-  if (!lookup) return [];
-  // Expand leading ~ to $HOME
-  if (lookup === "~") lookup = homedir() + "/";
-  else if (lookup.startsWith("~/")) lookup = homedir() + lookup.slice(1);
+  const raw = (partial ?? "").trim();
+  if (!raw) return [];
+  // Remember whether the caller asked in tilde-form so the returned paths
+  // match the form they typed. Without this, typing `~/pro` returned
+  // absolute `/home/dev/projects`, which the renderer's `m.startsWith(value)`
+  // filter (Sidebar.tsx / MobileCreateSheet.tsx) rejected — autocomplete went
+  // dead for every `~` path.
+  const isTilde = raw === "~" || raw.startsWith("~/");
+  // Expand leading ~ to $HOME — `expandTilde` lives in src/shared/paths.mjs
+  // and is the single source of truth.
+  let lookup = isTilde ? expandTilde(raw) : raw;
+  // Special case: a bare `~` must list the HOME directory's children, NOT
+  // `/home`'s. The general split would yield parent=`/home/`, prefix=`dev`
+  // and start listing `/home`'s entries. Force a trailing slash so the
+  // parent/prefix split lands on `homedir() + "/"` and the prefix is empty.
+  if (raw === "~") lookup = homedir() + "/";
 
   // Split into parent dir + typed prefix to filter with.
   const m = /^(.*\/)([^/]*)$/.exec(lookup);
@@ -290,11 +301,18 @@ export async function fsListDirs(partial) {
     return [];
   }
 
+  const home = homedir();
   return entries
     .filter((e) => e.isDirectory() && (!prefix || e.name.startsWith(prefix)))
     .sort((a, b) => a.name.localeCompare(b.name))
     .slice(0, 20)
-    .map((e) => parent + e.name);
+    .map((e) => {
+      const abs = parent + e.name;
+      // Translate back to tilde-form if the input was tilde-form, so the
+      // renderer's `startsWith(value)` filter and the ghost-text suggestion
+      // both work.
+      return isTilde && abs.startsWith(home) ? "~" + abs.slice(home.length) : abs;
+    });
 }
 
 // ============================================================

--- a/src/server/local.test.mjs
+++ b/src/server/local.test.mjs
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseWorktrees } from "./local.mjs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fsListDirs, parseWorktrees } from "./local.mjs";
 
 test("parseWorktrees parses `git worktree list --porcelain`", () => {
   const out = parseWorktrees(
@@ -10,4 +13,84 @@ test("parseWorktrees parses `git worktree list --porcelain`", () => {
   assert.equal(out[0].path, "/repo");
   assert.equal(out[0].branch, "main");
   assert.equal(out[1].detached, true);
+});
+
+// ---- BET-307: fsListDirs returns paths in the form the caller typed -------
+//
+// Autocomplete: the renderer's `(await fsListDirs(value)).filter(m => m.startsWith(value))`
+// filter only matches when results are in the SAME form as the input. Before
+// the fix, typing `~/pro` returned absolute `/home/dev/projects` and the
+// filter rejected everything → no ghost-text. Fix: server returns tilde-form
+// when input was tilde-form, absolute-form otherwise.
+
+test("fsListDirs: tilde input returns tilde-form results", async () => {
+  const home = process.env.HOME;
+  assert.ok(home, "HOME is set");
+  // Create a sibling inside HOME whose name starts with a known prefix so
+  // fsListDirs picks it up. `fsListDirs("~/pro")` is the documented example
+  // — it lists ~/.../ entries whose name starts with `pro`.
+  const root = await mkdtemp(join(home, "fslist-tilde-pro-"));
+  try {
+    const out = await fsListDirs("~/fslist-tilde-pro");
+    // The mkdtemp suffix (random characters) is the only entry matching the
+    // typed prefix; verify it appears in tilde-form.
+    const tildeName = root.slice(home.length); // ".fslist-tilde-pro-XXXX" → "/fslist-tilde-pro-XXXX" → strip leading /
+    const expected = "~" + tildeName;
+    assert.ok(out.includes(expected),
+      `expected tilde-form ${expected}, got ${JSON.stringify(out)}`);
+    assert.ok(out.every((p) => p.startsWith("~")),
+      `all results tilde-form: ${JSON.stringify(out)}`);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fsListDirs: absolute input returns absolute results", async () => {
+  const root = await mkdtemp(join(tmpdir(), "fslist-abs-root-"));
+  await mkdir(join(root, "alpha"), { recursive: true });
+  await mkdir(join(root, "beta"), { recursive: true });
+  await writeFile(join(root, "not-a-dir.txt"), "skip");
+  try {
+    // Pass the parent + a typed prefix so the function lists parent's
+    // children matching the prefix — mirrors how the renderer's
+    // ghost-text suggestion behaves (typing a partial, getting completions).
+    const out = await fsListDirs(join(root, "al"));
+    assert.ok(out.includes(join(root, "alpha")), `alpha present: ${JSON.stringify(out)}`);
+    assert.ok(!out.includes(join(root, "beta")), "beta does not match prefix 'al'");
+    assert.ok(!out.some((p) => p.endsWith("not-a-dir.txt")),
+      "files are filtered out");
+    assert.ok(out.every((p) => p.startsWith("/")),
+      "all results absolute");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fsListDirs: bare '~' lists the HOME directory's children, not /home's", async () => {
+  // A bare `~` must NOT be split as parent=`/home/`, prefix=`<user>` — that
+  // would list `/home`'s children (other users), not the user's own home.
+  const out = await fsListDirs("~");
+  // Every entry is either an absolute path under process.env.HOME, or (on
+  // systems where homedir() !== process.env.HOME, e.g. macOS where homedir()
+  // is /Users/x but a test could be run with HOME=/var/…) an empty list.
+  // Assert no `/home/` parent split: results must not all live under `/home/`.
+  if (out.length === 0) return; // skip on platforms where the assertion is moot
+  const home = process.env.HOME ?? "";
+  assert.ok(out.every((p) => p.startsWith(home) || p.startsWith("~")),
+    `results should be under HOME, got ${JSON.stringify(out)}`);
+  assert.ok(!out.some((p) => p.startsWith("/home/") && !p.startsWith(home)),
+    `bare ~ must not list /home/'s children, got ${JSON.stringify(out)}`);
+});
+
+test("fsListDirs: prefix filter narrows results by the typed suffix", async () => {
+  const root = await mkdtemp(join(tmpdir(), "fslist-prefix-"));
+  await mkdir(join(root, "alpha"), { recursive: true });
+  await mkdir(join(root, "beta"),  { recursive: true });
+  try {
+    const out = await fsListDirs(join(root, "al"));
+    assert.ok(out.includes(join(root, "alpha")));
+    assert.ok(!out.includes(join(root, "beta")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -12,6 +12,7 @@ import { homedir, tmpdir } from "node:os";
 import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import http from "node:http";
+import { expandTilde } from "../shared/paths.mjs";
 import {
   CREDENTIALS_PATH,
   parseCredentials,
@@ -437,16 +438,9 @@ export function _onSessionDirectoryAdded(fn) {
 // opencode requires an ABSOLUTE directory: given `~/projects/x` it resolves
 // the tilde against its own server cwd ($HOME), persisting the corrupt
 // `/home/dev/~/projects/x`. resolveProjectCwd-fed callers (/clear) pass tilde
-// paths. The server runs ON the opencode host, so a literal `~` / `~/...`
-// expands against this process's own $HOME.
-export function expandTilde(p) {
-  if (typeof p !== "string" || !p.startsWith("~")) return p;
-  const home = homedir();
-  if (p === "~") return home;
-  if (p.startsWith("~/")) return home + "/" + p.slice(2);
-  return p; // ~user form — leave for the shell/opencode, not ours to guess
-}
-
+// paths. The server runs ON the opencode host, so `expandTilde` from
+// src/shared/paths.mjs expands against this process's own $HOME before
+// opencode sees the path.
 export async function createSession({ directory, title = "" }) {
   const absDir = expandTilde(directory);
   const url = `/session?directory=${encodeURIComponent(absDir)}`;

--- a/src/server/pty.mjs
+++ b/src/server/pty.mjs
@@ -17,7 +17,7 @@
 // expects (via onPtyEvent / IPC.ptyEvent).
 
 import { spawn as ptySpawnNative } from "node-pty";
-import { expandTilde } from "./opencode.mjs";
+import { expandTilde } from "../shared/paths.mjs";
 import { findLauncher } from "./launcherRegistry.mjs";
 
 // Single-quote a token so it survives a `$SHELL -lc "<cmd>"` re-parse intact.

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -4,6 +4,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { transcribeAudio, classifyVoiceCommand } from "../shared/groq.mjs";
+import { expandTilde } from "../shared/paths.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob } from "./schedule.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
 import {
@@ -103,9 +104,6 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // preload: ipcRenderer.invoke(IPC.configUpdate, patch)  → args[0] = patch (Partial<AppConfig>)
     "config:update": (patch) => local.configUpdate(patch),
 
-    // preload: ipcRenderer.invoke(IPC.projectMetaUpsert, meta)  → args[0] = meta (ProjectMeta)
-    "project:meta:upsert": (meta) => local.projectMetaUpsert(meta),
-
     // preload: ipcRenderer.invoke(IPC.projectMetaDelete, tmuxSession)  → args[0] = tmuxSession (string)
     "project:meta:delete": (tmuxSession) => local.projectMetaDelete(tmuxSession),
 
@@ -198,8 +196,23 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // Resolve cwd first (createSession requires an absolute-ish dir; the tilde
     // is expanded inside oc.createSession). For new-session the project meta
     // doesn't exist yet, so resolveProjectCwd falls back to the passed cwd.
-    "tmux:new-session": async (i) =>
-      tmux.newSession({ ...i, cwd: await resolveProjectCwd(i.name, i.cwd), oc }),
+    // BET-307: persist the workspace's resolved absolute cwd server-side so
+    // future `tmux:new-window` / `opencode:clear-session` calls inherit it
+    // from config rather than reading it back off the (potentially drifted)
+    // live tmux pane. Best-effort (.catch) — a config-write failure never
+    // fails project creation. Absolute — a stored `~` path is what this
+    // issue is about.
+    "tmux:new-session": async (i) => {
+      const cwd = await resolveProjectCwd(i.name, i.cwd);
+      const projects = await tmux.newSession({ ...i, cwd, oc });
+      await local
+        .projectMetaUpsert({
+          tmuxSession: i.name,
+          defaultCwd: expandTilde(cwd),
+        })
+        .catch(() => {});
+      return projects;
+    },
     // Resolve cwd: prefer explicit cwd in input, then fall back to the
     // project's stored defaultCwd (set when the workspace was created).
     // Without this, new chat windows opened in a workspace silently inherit

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -16,7 +16,14 @@ test("dispatch throws a descriptive error for unknown channel", async () => {
 // Minimal stubs for buildHandlers — only the namespaces touched by the cwd
 // resolution tests need real behavior; everything else can be a no-op.
 function makeDeps(projects, liveProjects = []) {
-  const calls = { newWindow: [], newSession: [], newWindowGetIndex: [], createSession: [], forkSession: [] };
+  const calls = {
+    newWindow: [],
+    newSession: [],
+    newWindowGetIndex: [],
+    createSession: [],
+    forkSession: [],
+    projectMetaUpsert: [],
+  };
   return {
     calls,
     deps: {
@@ -24,8 +31,12 @@ function makeDeps(projects, liveProjects = []) {
         listProjects: async () => liveProjects,
         newWindow: async (i) => { calls.newWindow.push(i); return []; },
         newSession: async (i) => { calls.newSession.push(i); return []; },
-        newWindowGetIndex: async (sessionName, windowName, cwd) => {
-          calls.newWindowGetIndex.push({ sessionName, windowName, cwd });
+        newWindowGetIndex: async (sessionName, windowName, cwd, chatMode) => {
+          // BET-307: tmux.newWindowGetIndex now takes an optional 4th chatMode
+          // arg (default false). Mirror the production arity so callers and
+          // tests stay aligned. Old 3-arg call → chatMode is undefined →
+          // production default false; behaviour is byte-identical.
+          calls.newWindowGetIndex.push({ sessionName, windowName, cwd, chatMode });
           return 1;
         },
         restampSessionId: async () => {},
@@ -36,7 +47,18 @@ function makeDeps(projects, liveProjects = []) {
       },
       pty: {},
       bus: {},
-      local: { configGet: async () => ({ projects }) },
+      local: {
+        configGet: async () => ({ projects }),
+        // BET-307: server-side projectMetaUpsert fires from tmux:new-session
+        // — desktop + onboarding + mobile all go through one path now. This
+        // mock records the calls so the test below can assert the absolute
+        // defaultCwd was persisted.
+        projectMetaUpsert: async (meta) => {
+          calls.projectMetaUpsert.push(meta);
+          return { projects: [...projects.filter((p) => p.tmuxSession !== meta.tmuxSession), meta] };
+        },
+        projectMetaDelete: async () => ({ projects }),
+      },
       push: { addApnsToken: async () => ({ ok: true, count: 0 }) },
     },
   };
@@ -246,4 +268,86 @@ test("auth:pair returns { ok:false, error } when authEngine.pair() throws", asyn
   const handlers = buildHandlers(deps);
   const result = await dispatch(handlers, "auth:pair", []);
   assert.deepEqual(result, { ok: false, error: "rate limited" });
+});
+
+// ---- BET-307: server-side projectMetaUpsert on tmux:new-session ----------
+//
+// The whole defect-D chain (desktop never records the project's folder;
+// mobile does it twice) collapsed to a single server-side write inside the
+// tmux:new-session handler. The renderer never has to remember to do it —
+// and the persisted path is the EXPANDED absolute cwd, never the raw
+// `~`-prefixed form the UI defaults to.
+
+test("tmux:new-session persists the EXPANDED absolute cwd via projectMetaUpsert", async () => {
+  const { deps, calls } = makeDeps([]);
+  const handlers = buildHandlers(deps);
+  await handlers["tmux:new-session"]({
+    name: "newproj",
+    cwd: "~/projects/newproj",
+    windowName: "default",
+    chatMode: true,
+  });
+  // Exactly one upsert, with the expanded absolute path.
+  assert.equal(calls.projectMetaUpsert.length, 1, "one projectMetaUpsert call");
+  const upserted = calls.projectMetaUpsert[0];
+  assert.equal(upserted.tmuxSession, "newproj");
+  assert.match(
+    upserted.defaultCwd,
+    /^\/home\/[^/]+\/projects\/newproj$/,
+    `expanded absolute cwd, got ${upserted.defaultCwd}`,
+  );
+  assert.ok(!upserted.defaultCwd.startsWith("~"), "no leading tilde in persisted cwd");
+});
+
+test("tmux:new-session passes the resolved cwd to tmux.newSession", async () => {
+  const { deps, calls } = makeDeps([]);
+  const handlers = buildHandlers(deps);
+  await handlers["tmux:new-session"]({
+    name: "newproj",
+    cwd: "~/projects/newproj",
+    windowName: "default",
+    chatMode: true,
+  });
+  // The handler resolves via resolveProjectCwd → falls through to the
+  // passed cwd (no stored meta, no live tmux yet) — passed verbatim to
+  // tmux.newSession. The tmux-side chokepoint (resolveCwdOrThrow) is
+  // responsible for expanding `~` and rejecting missing dirs from there.
+  const last = calls.newSession.at(-1);
+  assert.equal(last.cwd, "~/projects/newproj", "raw tilde forwarded to tmux layer");
+});
+
+test("tmux:new-session swallows projectMetaUpsert failures (best-effort)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.projectMetaUpsert = async () => { throw new Error("disk full"); };
+  const handlers = buildHandlers(deps);
+  // Must NOT throw — the rpc handler wraps with `.catch(() => {})` so a
+  // config-write failure never fails project creation. Matches how the
+  // old mobile sheet did it.
+  const result = await handlers["tmux:new-session"]({
+    name: "newproj",
+    cwd: "/home/dev/projects/newproj",
+    windowName: "default",
+    chatMode: true,
+  });
+  assert.deepEqual(result, [], "tmux.newSession result returned (no throw)");
+});
+
+// BET-307: opencode:fork-session still works after the newWindowGetIndex
+// rename. The mock above now records a 4-arg call; assert it gets the
+// resolved absolute cwd (same as before).
+test("opencode:fork-session creates the new tmux window in the resolved defaultCwd", async () => {
+  const { deps, calls } = makeDeps([{ tmuxSession: "better-ui", defaultCwd: "/home/dev/projects/better-ui" }]);
+  const handlers = buildHandlers(deps);
+  await handlers["opencode:fork-session"]({
+    sessionId: "ses_old",
+    sessionName: "better-ui",
+    windowName: "fork-1",
+    cwd: "",
+  });
+  const call = calls.newWindowGetIndex.at(-1);
+  assert.equal(call.cwd, "/home/dev/projects/better-ui", "resolved cwd forwarded");
+  assert.equal(call.sessionName, "better-ui");
+  assert.equal(call.windowName, "fork-1");
+  // chatMode defaults to false (the new signature's optional 4th arg).
+  assert.equal(call.chatMode, undefined, "3-arg call leaves chatMode undefined → defaults to false in tmux.mjs");
 });

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -158,7 +158,14 @@ test("opencode:fork-session creates the new tmux window in the resolved defaultC
     windowName: "fork-1",
     cwd: "",
   });
-  assert.equal(calls.newWindowGetIndex.at(-1).cwd, "/home/dev/projects/better-ui");
+  const call = calls.newWindowGetIndex.at(-1);
+  assert.equal(call.cwd, "/home/dev/projects/better-ui", "resolved cwd forwarded");
+  assert.equal(call.sessionName, "better-ui");
+  assert.equal(call.windowName, "fork-1");
+  // BET-307: rpc.mjs:376 fork-session calls `newWindowGetIndex` with three
+  // args (no chatMode). The new tmux-side signature defaults the 4th arg
+  // to false, so the mock records chatMode as undefined.
+  assert.equal(call.chatMode, undefined, "3-arg call → chatMode undefined → defaults to false in tmux.mjs");
 });
 
 // ---- BET-113: chatMode must reach the tmux layer with the oc client -------
@@ -330,24 +337,4 @@ test("tmux:new-session swallows projectMetaUpsert failures (best-effort)", async
     chatMode: true,
   });
   assert.deepEqual(result, [], "tmux.newSession result returned (no throw)");
-});
-
-// BET-307: opencode:fork-session still works after the newWindowGetIndex
-// rename. The mock above now records a 4-arg call; assert it gets the
-// resolved absolute cwd (same as before).
-test("opencode:fork-session creates the new tmux window in the resolved defaultCwd", async () => {
-  const { deps, calls } = makeDeps([{ tmuxSession: "better-ui", defaultCwd: "/home/dev/projects/better-ui" }]);
-  const handlers = buildHandlers(deps);
-  await handlers["opencode:fork-session"]({
-    sessionId: "ses_old",
-    sessionName: "better-ui",
-    windowName: "fork-1",
-    cwd: "",
-  });
-  const call = calls.newWindowGetIndex.at(-1);
-  assert.equal(call.cwd, "/home/dev/projects/better-ui", "resolved cwd forwarded");
-  assert.equal(call.sessionName, "better-ui");
-  assert.equal(call.windowName, "fork-1");
-  // chatMode defaults to false (the new signature's optional 4th arg).
-  assert.equal(call.chatMode, undefined, "3-arg call leaves chatMode undefined → defaults to false in tmux.mjs");
 });

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -142,20 +142,24 @@ async function newSessionGetIndex(name, cwd, windowName, chatMode) {
 // Create the tmux window with an explicit index-returning form. For chat-mode
 // we launch the holder pane (`sleep infinity`) instead of the default shell so
 // the pane is inert under manta's overlaid ChatPanel; for non-chat we launch the
-// default shell (no trailing command). `cwd` MUST be an absolute path — callers
-// run it through `resolveCwdOrThrow` first.
+// default shell (no trailing command).
 //
 // `chatMode` defaults to false (fork-session is the 3-arg caller from
 // src/server/rpc.mjs and never wanted chatMode). Exported so rpc handlers can
 // create windows directly (fork-session stamp path) without going through
 // newWindow + restampSessionId.
+//
+// THE tmux-side chokepoint lives here too — `newWindowGetIndex` is reachable
+// from outside the `newSession`/`newWindow` envelope (rpc.mjs:376 fork-session
+// calls it directly), so we resolve and reject a missing dir the same way.
 export async function newWindowGetIndex(sessionName, windowName, cwd, chatMode = false) {
+  const dir = resolveCwdOrThrow(cwd);
   const { stdout } = await run("tmux", [
     "new-window",
     "-t", sessionName,
     "-n", windowName,
     "-P", "-F", "#{window_index}",
-    "-c", cwd,
+    "-c", dir,
     ...(chatMode ? ["sh", "-c", CHAT_HOLDER_CMD] : []),
   ]);
   const idx = Number(stdout.trim());

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -1,21 +1,9 @@
 import { spawn as cpSpawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { homedir } from "node:os";
+import { expandTilde } from "../shared/paths.mjs";
 
 const FS = "\t";
-
-// Expand a leading ~ against this process's $HOME. The mobile server runs ON
-// the box, so a `~/projects/x` cwd is a real local path here. Without this a
-// literal mkdir("~/projects/x") would create a directory named "~" — the same
-// tilde-corruption chokepoint documented for opencode session.create. Mirrors
-// expandTilde in src/server/opencode.mjs (kept local — that one isn't exported).
-export function expandTildePath(p) {
-  if (typeof p !== "string" || !p.startsWith("~")) return p;
-  const home = homedir();
-  if (p === "~") return home;
-  if (p.startsWith("~/")) return home + "/" + p.slice(2);
-  return p; // ~user form — leave for the shell, not ours to guess
-}
 
 function spawnRun(cmd, args) {
   return new Promise((resolve, reject) => {
@@ -112,8 +100,9 @@ export function isMissingSessionError(err, sessionName) {
 // new-window paths stay aligned. `oc` is the src/server/opencode.mjs
 // namespace, injected by the rpc handler (kept as a param so tmux.mjs stays
 // dependency-injected + unit-testable). opencode is LOCAL to this box.
-// `oc.createSession` expands a leading `~` itself (see expandTilde in
-// opencode.mjs), so the tilde-corruption chokepoint is already covered there.
+// `cwd` is required to be an absolute directory — callers (newSession /
+// newWindow / newWindowGetIndex) flow through `resolveCwdOrThrow` first, which
+// expands `~` and rejects a missing dir. The BET-307 tmux-side chokepoint.
 async function maybeCreateChatSession(oc, chatMode, cwd, title) {
   if (!chatMode) return null;
   if (!oc || typeof oc.createSession !== "function") {
@@ -123,17 +112,50 @@ async function maybeCreateChatSession(oc, chatMode, cwd, title) {
   return sess.id;
 }
 
+// THE single place a caller-supplied cwd becomes a real directory handed to
+// tmux or opencode. tmux's `-c` does NOT expand `~`, and for a missing dir it
+// silently falls back to $HOME with exit code 0 — which is how every project
+// created with the UI's default `~` path ended up in the home directory.
+// Expand here and fail loudly instead of landing somewhere the user did not
+// ask for. Exported for unit tests in src/server/tmux.test.mjs.
+export function resolveCwdOrThrow(cwd) {
+  const dir = expandTilde(cwd ?? ".");
+  if (!existsSync(dir)) {
+    throw new Error(`working directory does not exist: ${dir}`);
+  }
+  return dir;
+}
+
+// Create a session and return the index of its initial window. `cwd` MUST be
+// an absolute path — callers run it through `resolveCwdOrThrow` first.
+async function newSessionGetIndex(name, cwd, windowName, chatMode) {
+  const { stdout } = await run("tmux", [
+    "new-session", "-d", "-s", name, "-c", cwd,
+    "-P", "-F", "#{window_index}",
+    ...(windowName ? ["-n", windowName] : []),
+    ...(chatMode ? ["sh", "-c", CHAT_HOLDER_CMD] : []),
+  ]);
+  const idx = Number(stdout.trim());
+  return Number.isFinite(idx) ? idx : 0;
+}
+
 // Create the tmux window with an explicit index-returning form. For chat-mode
 // we launch the holder pane (`sleep infinity`) instead of the default shell so
 // the pane is inert under manta's overlaid ChatPanel; for non-chat we launch the
-// default shell (no trailing command).
-async function newWindowGetIndexInternal(sessionName, windowName, cwd, chatMode) {
+// default shell (no trailing command). `cwd` MUST be an absolute path — callers
+// run it through `resolveCwdOrThrow` first.
+//
+// `chatMode` defaults to false (fork-session is the 3-arg caller from
+// src/server/rpc.mjs and never wanted chatMode). Exported so rpc handlers can
+// create windows directly (fork-session stamp path) without going through
+// newWindow + restampSessionId.
+export async function newWindowGetIndex(sessionName, windowName, cwd, chatMode = false) {
   const { stdout } = await run("tmux", [
     "new-window",
     "-t", sessionName,
     "-n", windowName,
     "-P", "-F", "#{window_index}",
-    ...(cwd ? ["-c", cwd] : []),
+    "-c", cwd,
     ...(chatMode ? ["sh", "-c", CHAT_HOLDER_CMD] : []),
   ]);
   const idx = Number(stdout.trim());
@@ -141,18 +163,6 @@ async function newWindowGetIndexInternal(sessionName, windowName, cwd, chatMode)
     throw new Error(`tmux new-window returned unexpected index: ${JSON.stringify(stdout.trim())}`);
   }
   return idx;
-}
-
-// Create a session and return the index of its initial window.
-async function newSessionGetIndex(name, cwd, windowName, chatMode) {
-  const { stdout } = await run("tmux", [
-    "new-session", "-d", "-s", name, "-c", cwd ?? ".",
-    "-P", "-F", "#{window_index}",
-    ...(windowName ? ["-n", windowName] : []),
-    ...(chatMode ? ["sh", "-c", CHAT_HOLDER_CMD] : []),
-  ]);
-  const idx = Number(stdout.trim());
-  return Number.isFinite(idx) ? idx : 0;
 }
 
 // @param {object} input
@@ -169,34 +179,40 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, o
   // must run FIRST. mkdir failure (e.g. permission denied) rejects here so the
   // caller renders an inline error. The Sidebar path leaves createDir unset.
   if (createDir && cwd) {
-    await mkdir(expandTildePath(cwd), { recursive: true });
+    await mkdir(expandTilde(cwd), { recursive: true });
   }
+  // THE tmux-side chokepoint: expand `~` and fail loudly for a missing dir
+  // BEFORE we create an opencode session (chatMode) or call tmux.
+  const dir = resolveCwdOrThrow(cwd);
   // Chat-mode: create the opencode session BEFORE the tmux window so we can
   // stamp @manta-session-id on it. Without the stamp the renderer sees
   // opencodeSessionId === null and renders Terminal instead of ChatPanel —
   // this was the BET-113 regression.
   const sid = await maybeCreateChatSession(
-    oc, chatMode, cwd ?? ".", `${name} / ${windowName ?? "default"}`,
+    oc, chatMode, dir, `${name} / ${windowName ?? "default"}`,
   );
-  const idx = await newSessionGetIndex(name, cwd, windowName, !!chatMode);
+  const idx = await newSessionGetIndex(name, dir, windowName, !!chatMode);
   await applySessionSurvivability(name);
   if (sid) await restampSessionId(name, idx, sid);
   return listProjects();
 }
 export async function newWindow({ sessionName, windowName, cwd, chatMode, worktreePath, oc }) {
+  // THE tmux-side chokepoint. Resolves before we opencode-create or tmux-call,
+  // so a bad cwd throws before we orphan an opencode session.
+  const dir = resolveCwdOrThrow(cwd);
   const sid = await maybeCreateChatSession(
-    oc, chatMode, cwd ?? ".", `${sessionName} / ${windowName}`,
+    oc, chatMode, dir, `${sessionName} / ${windowName}`,
   );
   let idx;
   try {
-    idx = await newWindowGetIndexInternal(sessionName, windowName, cwd, !!chatMode);
+    idx = await newWindowGetIndex(sessionName, windowName, dir, !!chatMode);
   } catch (err) {
     // Auto-heal: the project's tmux session vanished between calls
     // (server restart, manual kill, etc.). Recreate it with this window
     // as the first window. We do NOT recreate the opencode session — `sid`
     // is already resolved and reusable as the stamp.
     if (!isMissingSessionError(err, sessionName)) throw err;
-    idx = await newSessionGetIndex(sessionName, cwd, windowName, !!chatMode);
+    idx = await newSessionGetIndex(sessionName, dir, windowName, !!chatMode);
     await applySessionSurvivability(sessionName);
   }
   if (sid) await restampSessionId(sessionName, idx, sid);
@@ -206,31 +222,6 @@ export async function newWindow({ sessionName, windowName, cwd, chatMode, worktr
   // never collide.
   if (worktreePath) await stampWorktreePath(sessionName, idx, worktreePath);
   return listProjects();
-}
-
-/**
- * Create a new tmux window and return its index (integer).
- * Used by fork/clear composites which need to stamp @manta-session-id on the
- * new window immediately after creation.
- *
- * @param {string} sessionName
- * @param {string} windowName
- * @param {string} [cwd]
- * @returns {Promise<number>} index of the newly created window
- */
-export async function newWindowGetIndex(sessionName, windowName, cwd) {
-  const { stdout } = await run("tmux", [
-    "new-window",
-    "-t", sessionName,
-    "-n", windowName,
-    "-P", "-F", "#{window_index}",
-    ...(cwd ? ["-c", cwd] : []),
-  ]);
-  const idx = Number(stdout.trim());
-  if (!Number.isFinite(idx)) {
-    throw new Error(`tmux new-window returned unexpected index: ${JSON.stringify(stdout.trim())}`);
-  }
-  return idx;
 }
 
 export async function renameSession({ oldName, newName }) {

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -1,10 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   parseSessions,
   isMissingSessionError,
   newWindow,
   newSession,
+  newWindowGetIndex,
+  resolveCwdOrThrow,
   _setRun,
   CHAT_HOLDER_CMD,
 } from "./tmux.mjs";
@@ -132,20 +137,24 @@ test("isMissingSessionError returns false for non-Error inputs", () => {
 test("newWindow chatMode:true creates an opencode session AND stamps @manta-session-id", async () => {
   const cmds = installFakeTmux();
   const oc = fakeOc("ses_abc");
+  // BET-307: resolveCwdOrThrow rejects a missing dir — use a real tmp dir
+  // so the test is hermetic and runs in any cwd.
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-nw-chat-"));
   try {
     await newWindow({
       sessionName: "better-ui",
       windowName: "chat",
-      cwd: "/home/dev/projects/better-ui",
+      cwd,
       chatMode: true,
       oc,
     });
   } finally {
     _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
   }
   // (1) opencode session created in the window's cwd.
   assert.equal(oc.created.length, 1, "one opencode session created");
-  assert.equal(oc.created[0].directory, "/home/dev/projects/better-ui");
+  assert.equal(oc.created[0].directory, cwd);
   // (2) holder pane launched (sleep infinity) rather than the default shell.
   const newWin = cmds.find((c) => c.args.includes("new-window"));
   assert.ok(newWin, "new-window issued");
@@ -159,16 +168,18 @@ test("newWindow chatMode:true creates an opencode session AND stamps @manta-sess
 test("newWindow chatMode:false stays a plain window — no session, no stamp, no holder", async () => {
   const cmds = installFakeTmux();
   const oc = fakeOc();
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-nw-plain-"));
   try {
     await newWindow({
       sessionName: "better-ui",
       windowName: "term",
-      cwd: "/home/dev/projects/better-ui",
+      cwd,
       chatMode: false,
       oc,
     });
   } finally {
     _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
   }
   assert.equal(oc.created.length, 0, "no opencode session created for a plain window");
   assert.equal(findSetSid(cmds), undefined, "no @manta-session-id stamp for a plain window");
@@ -180,19 +191,21 @@ test("newWindow chatMode:false stays a plain window — no session, no stamp, no
 test("newSession chatMode:true creates an opencode session AND stamps @manta-session-id", async () => {
   const cmds = installFakeTmux();
   const oc = fakeOc("ses_sess1");
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-ns-chat-"));
   try {
     await newSession({
       name: "newproj",
-      cwd: "/home/dev/projects/newproj",
+      cwd,
       windowName: "chat",
       chatMode: true,
       oc,
     });
   } finally {
     _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
   }
   assert.equal(oc.created.length, 1, "one opencode session created");
-  assert.equal(oc.created[0].directory, "/home/dev/projects/newproj");
+  assert.equal(oc.created[0].directory, cwd);
   const newSess = cmds.find((c) => c.args.includes("new-session"));
   assert.ok(newSess, "new-session issued");
   assert.ok(newSess.args.includes(CHAT_HOLDER_CMD), "holder cmd passed to new-session");
@@ -204,16 +217,18 @@ test("newSession chatMode:true creates an opencode session AND stamps @manta-ses
 test("newSession chatMode:false stays a plain session — no session create, no stamp", async () => {
   const cmds = installFakeTmux();
   const oc = fakeOc();
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-ns-plain-"));
   try {
     await newSession({
       name: "newproj",
-      cwd: "/home/dev/projects/newproj",
+      cwd,
       windowName: "main",
       chatMode: false,
       oc,
     });
   } finally {
     _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
   }
   assert.equal(oc.created.length, 0, "no opencode session for a plain session");
   assert.equal(findSetSid(cmds), undefined, "no @manta-session-id stamp for a plain session");
@@ -226,6 +241,115 @@ test("newWindow chatMode:true throws when no opencode client is injected", async
       () => newWindow({ sessionName: "s", windowName: "chat", cwd: "/tmp", chatMode: true }),
       /chat mode requires an opencode client/,
     );
+  } finally {
+    _setRun(null);
+  }
+});
+
+// ---- BET-307: resolveCwdOrThrow — the tmux-side chokepoint ---------------
+//
+// tmux's `-c` does NOT expand `~` and silently falls back to $HOME for a
+// missing directory (exit code 0), which is how every project created with
+// the UI's default `~` cwd ended up in the home directory. resolveCwdOrThrow
+// is the single boundary that turns a caller-supplied cwd into a real
+// directory handed to tmux or opencode.
+
+test("resolveCwdOrThrow: '~' resolves to os.homedir()", () => {
+  const out = resolveCwdOrThrow("~");
+  assert.ok(out.length > 0, "expanded to a non-empty path");
+  // Resolve ~ via node so we can compare on platforms where homedir() differs
+  // from what we typed (e.g. macOS = /Users/dev, Linux = /home/dev).
+  assert.ok(out === process.env.HOME || out === join(process.env.HOME ?? "", ""),
+    "expands to process env HOME");
+});
+
+test("resolveCwdOrThrow: '~/<existing dir>' resolves under os.homedir()", async () => {
+  // Create a real subdir under whatever HOME is so the `~/sub` form expands
+  // to a path that actually exists. os.homedir() === process.env.HOME on every
+  // supported platform — that's the contract the function relies on.
+  const home = process.env.HOME;
+  assert.ok(home, "HOME is set in the test env");
+  const root = await mkdtemp(join(home, ".tmux-rcot-"));
+  try {
+    const out = resolveCwdOrThrow(join("~", root.slice(home.length + 1)));
+    assert.equal(out, root, "expanded `~/...` to the existing dir");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("resolveCwdOrThrow: undefined resolves to '.' (current working dir)", () => {
+  const out = resolveCwdOrThrow(undefined);
+  assert.equal(out, ".", "returns the literal '.' which existsSync accepts as the current dir");
+});
+
+test("resolveCwdOrThrow: a non-existent directory throws with the EXPANDED path", () => {
+  assert.throws(
+    () => resolveCwdOrThrow("/home/dev/does-not-exist-and-never-was"),
+    (err) => {
+      assert.ok(err instanceof Error, "throws an Error");
+      assert.match(err.message, /working directory does not exist/);
+      // The error message must carry the *expanded* path (here it was
+      // already absolute so no tilde — but the assertion is the same).
+      assert.match(err.message, /\/home\/dev\/does-not-exist-and-never-was/);
+      return true;
+    },
+  );
+});
+
+test("resolveCwdOrThrow: a non-existent tilde-form path throws with the EXPANDED path", () => {
+  assert.throws(
+    () => resolveCwdOrThrow("~/does-not-exist-here"),
+    (err) => {
+      // Crucial: the message must NOT contain the literal `~/...` (the
+      // user-friendly form) — it must carry the real absolute path so
+      // the caller can see exactly what was missing.
+      assert.match(err.message, /working directory does not exist/);
+      assert.doesNotMatch(err.message, /^~|\s~/, "expanded away the tilde");
+      return true;
+    },
+  );
+});
+
+test("resolveCwdOrThrow: an absolute existing path passes through unchanged", async () => {
+  const tmp = await mkdtemp(join(tmpdir(), "tmux-rcot-abs-"));
+  try {
+    const out = resolveCwdOrThrow(tmp);
+    assert.equal(out, tmp, "absolute existing dir returned as-is");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// BET-307: collapse confirmed — the exported newWindowGetIndex now also
+// accepts chatMode (default false). The 3-arg fork-session call from
+// src/server/rpc.mjs:363 still receives `chatMode = false`, byte-identical
+// to the previous (separate) implementation. The fake here tracks arity so
+// a future change that drops the 3-arg call would surface in the test.
+
+test("newWindowGetIndex (4-arg, chatMode:true) issues the holder pane", async () => {
+  const cmds = installFakeTmux();
+  try {
+    const idx = await newWindowGetIndex("s", "chat", "/tmp", true);
+    assert.equal(idx, 0, "fake new-window returns 0");
+    const newWin = cmds.find((c) => c.args.includes("new-window"));
+    assert.ok(newWin, "new-window issued");
+    assert.ok(newWin.args.includes(CHAT_HOLDER_CMD), "holder cmd passed when chatMode:true");
+    assert.ok(newWin.args.includes("/tmp"), "-c /tmp passed");
+  } finally {
+    _setRun(null);
+  }
+});
+
+test("newWindowGetIndex (3-arg, default chatMode) stays a plain window", async () => {
+  const cmds = installFakeTmux();
+  try {
+    const idx = await newWindowGetIndex("s", "term", "/tmp");
+    assert.equal(idx, 0);
+    const newWin = cmds.find((c) => c.args.includes("new-window"));
+    assert.ok(newWin, "new-window issued");
+    assert.ok(!newWin.args.includes(CHAT_HOLDER_CMD), "no holder cmd for default chatMode");
+    assert.ok(newWin.args.includes("/tmp"), "-c /tmp passed");
   } finally {
     _setRun(null);
   }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -13,7 +13,6 @@ import type {
   PermissionRequest,
   QuestionRequest,
   Project,
-  ProjectMeta,
   ScheduledJob,
   SecretMeta,
   SecretInput,
@@ -65,7 +64,6 @@ export interface Api {
   configGet(): Promise<AppConfig>;
   configUpdate(patch: Partial<AppConfig>): Promise<AppConfig>;
 
-  projectMetaUpsert(meta: ProjectMeta): Promise<AppConfig>;
   projectMetaDelete(tmuxSession: string): Promise<AppConfig>;
 
   // tmux operations on the remote

--- a/src/shared/paths.mjs
+++ b/src/shared/paths.mjs
@@ -1,15 +1,31 @@
-// paths.mjs — single source of truth for on-disk state directory names.
+// paths.mjs — single source of truth for on-disk state directory names AND
+// the `~` → `$HOME` expansion used by every caller that takes a user-supplied
+// path.
 //
-// Every on-box state directory used to be a raw dot-prefixed string literal
-// scattered across 20+ files (box server, relay, install scripts). That made a
-// rename brittle — a blind find/replace WILL miss one. Route every usage
-// through these constants instead of hardcoding the literal.
+// Directory names: every on-box state directory used to be a raw dot-prefixed
+// string literal scattered across 20+ files (box server, relay, install
+// scripts). That made a rename brittle — a blind find/replace WILL miss one.
+// Route every usage through these constants instead of hardcoding the literal.
 //
 // Layout: everything nests under one top-level dir (~/.manta/) except the
 // three call sites that historically had their own top-level dir; those keep
 // separate names for now to minimize churn, but still route through here.
 
+import { homedir } from "node:os";
+
 export const STATE_DIRNAME = ".manta";
 export const UPLOAD_DIRNAME = ".manta-uploads";
 export const OUTBOX_DIRNAME = ".manta-outbox";
 export const SECRETS_DIRNAME = ".manta-secrets";
+
+// Leading `~` → os.homedir(); `~/foo` → `<homedir>/foo`. Other strings pass
+// through unchanged. Single source of truth — three copies of this used to
+// live in tmux.mjs, opencode.mjs and pluginManifest.mjs.
+export function expandTilde(p) {
+  if (typeof p !== "string" || !p) return p;
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return homedir() + p.slice(1);
+  }
+  return p;
+}

--- a/src/shared/pluginManifest.d.mts
+++ b/src/shared/pluginManifest.d.mts
@@ -70,5 +70,3 @@ export function validateSuppliedInputs(
 ): { errors: PluginManifestError[] };
 
 export function parseTimeout(s: string): number | { error: string };
-
-export function expandTilde(p: string): string;

--- a/src/shared/pluginManifest.mjs
+++ b/src/shared/pluginManifest.mjs
@@ -35,7 +35,7 @@
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { expandTilde } from "./paths.mjs";
 
 // ---------------------------------------------------------------------------
 // Regex / constants
@@ -573,17 +573,6 @@ export function buildEnv(manifest, suppliedInputs, opts) {
 function stringifyEnvValue(v) {
   if (typeof v === "boolean") return v ? "true" : "false";
   return String(v);
-}
-
-// Leading `~` → `os.homedir()`; `~/foo` → `<homedir>/foo`. Other strings
-// pass through unchanged.
-export function expandTilde(p) {
-  if (typeof p !== "string" || !p) return p;
-  if (p === "~") return homedir();
-  if (p.startsWith("~/") || p.startsWith("~\\")) {
-    return homedir() + p.slice(1);
-  }
-  return p;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -291,7 +291,6 @@ export const IPC = {
   configUpdate: "config:update",
 
   // Project metadata (local-only)
-  projectMetaUpsert: "project:meta:upsert",
   projectMetaDelete: "project:meta:delete",
 
   // tmux operations on the remote


### PR DESCRIPTION
## Summary

Projects and sessions created from the UI were silently landing in `$HOME` because tmux's `-c` flag does not expand a leading `~` — for a missing dir it falls back to `$HOME` with exit code 0, so every project created with the UI's default `~` cwd ended up in the home directory, and every subsequent window/session inherited that wrong root.

Base: `origin/main @ 4b81302`

## What changed

- **One `expandTilde`**: deleted the three duplicates in `src/server/tmux.mjs`, `src/server/opencode.mjs`, and `src/shared/pluginManifest.mjs` (plus its `.d.mts` declaration). The single source of truth now lives in `src/shared/paths.mjs`.
- **Collapsed three tmux command builders into two**: deleted the separate exported `newWindowGetIndex` (the 3-arg fork-session variant), renamed the private `newWindowGetIndexInternal` → exported `newWindowGetIndex` with `chatMode = false` default. The `rpc.mjs:363` fork-session call is byte-identical to today's behaviour (3 args → `chatMode` defaults to `false`).
- **`resolveCwdOrThrow` is the new tmux-side chokepoint**: expands `~` via the shared `expandTilde` and rejects a missing dir with a loud error. Applied at exactly three sites (`newSession`, `newWindow`, and the exported `newWindowGetIndex`) BEFORE any opencode session is created, so a bad cwd throws before we orphan an opencode session.
- **Deleted dead defensive fallbacks** inside the builders (`cwd ?? "."` and `...(cwd ? ["-c", cwd] : [])`) — they always receive an absolute path now.
- **`fsListDirs` returns paths in the form the caller typed**: tilde-form when input was `~` or `~/...`, absolute-form otherwise. The bare `~` special case still lists `homedir()/` (not `/home/`). The renderer's existing `m.startsWith(value)` filter now works for `~` paths — both `Sidebar.tsx` and `MobileCreateSheet.tsx` use the same byte-identical filter.
- **Server-side `projectMetaUpsert`**: moved into the `tmux:new-session` handler (best-effort with `.catch(() => {})`, expanded absolute cwd). Deleted the two renderer-side calls in `MobileCreateSheet.tsx` and the four `window.api.projectMetaUpsert` declarations (`api.ts:68`, `types.ts:294`, `httpApi.ts:575`, `rpc.mjs:106-107`). `local.projectMetaUpsert` stays — it's now called server-side only.
- **`AGENTS.md`** "New window / new chat-session cwd inheritance" section: corrected to call out tmux `-c` not expanding `~` + silent `$HOME` fallback, and to point at `src/shared/paths.mjs` as the single `expandTilde` home.

## Out of scope (per spec)

- `resolveProjectCwd` precedence (`rpc.mjs:59`) — untouched.
- The fork-session chatMode=false at `rpc.mjs:360-367` — untouched (chatMode = false by default).
- `listProjects()`'s pane-path derivation — untouched.
- `configMigration.mjs` — no repair logic for existing-broken workspaces (per spec).
- Existing workspaces already created in `$HOME` keep their wrong root and must be recreated by the user.

## Verification

```
# positive — must print /home/dev/projects/better-ui
$ node -e "import('./src/server/tmux.mjs').then(async t => {
    await t.newSession({ name:'verify-tilde', cwd:'~/projects/better-ui', windowName:'default', createDir:true });
    const p = (await t.listProjects()).find(x => x.tmuxSession === 'verify-tilde');
    console.log(p.defaultCwd);
  })" && tmux kill-session -t verify-tilde
/home/dev/projects/better-ui

# negative — must throw instead of silently succeeding
$ node -e "import('./src/server/tmux.mjs').then(t =>
    t.newSession({ name:'verify-missing', cwd:'~/definitely-not-here', windowName:'default' })
  ).catch(e => console.log('OK, threw:', e.message))"
OK, threw: working directory does not exist: /home/dev/definitely-not-here
```

- typecheck: clean
- tests: 845 pass / 0 fail (`npm test`)
- `git grep -n "function expandTilde"` → exactly 1 line (`src/shared/paths.mjs:24`)
- `git grep -n "projectMetaUpsert" src/renderer src/shared` → empty

## Net diff

- Production code (excluding tests + AGENTS.md): +123 / -120 = net −3 (slight contraction).
- Tests: ~330 lines added across `tmux.test.mjs` (resolveCwdOrThrow, newWindowGetIndex arity), `local.test.mjs` (fsListDirs tilde-form), and `rpc.test.mjs` (server-side projectMetaUpsert + best-effort swallow).