### PR TITLE
refactor(server): drop launcher provider gate; add Codex + Kimi (BET-310)

### DIFF
--- a/src/server/launcherRegistry.mjs
+++ b/src/server/launcherRegistry.mjs
@@ -6,8 +6,6 @@
 //          migration.
 // label    dropdown label.
 // bin      binary probed with `command -v` for availability.
-// provider opencode provider id that must be `connected` for availability, or
-//          null for a pure-CLI launcher with no opencode auth gate.
 // flags    flag schema: [{ key, label, type:"boolean", default, arg }]. `arg`
 //          is the CLI flag emitted when a boolean flag is truthy.
 // buildArgs(values) -> string[] argv (excluding the bin itself).
@@ -17,7 +15,6 @@ export const LAUNCHERS = [
     id: "claude",
     label: "Claude Code",
     bin: "claude",
-    provider: "anthropic",
     flags: [
       {
         key: "skipPermissions",
@@ -35,8 +32,20 @@ export const LAUNCHERS = [
       return args;
     },
   },
-  // Future example (do NOT add in v1 — illustration only):
-  // { id: "codex", label: "Codex", bin: "codex", provider: "openai", flags: [], buildArgs: () => [] },
+  {
+    id: "codex",
+    label: "Codex",
+    bin: "codex",
+    flags: [],
+    buildArgs: () => [],
+  },
+  {
+    id: "kimi",
+    label: "Kimi Code",
+    bin: "kimi",
+    flags: [],
+    buildArgs: () => [],
+  },
 ];
 
 export function findLauncher(id) {

--- a/src/server/launchers.mjs
+++ b/src/server/launchers.mjs
@@ -1,7 +1,6 @@
 // Reports which AI CLI TUI launchers (src/server/launcherRegistry.mjs) are
 // currently available on this box, for the session-mode dropdown (BET-138
-// refinement). "Available" = the binary resolves on PATH AND (if the
-// launcher declares a `provider`) opencode reports that provider connected.
+// refinement, BET-310). "Available" = the binary resolves on PATH.
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -24,19 +23,11 @@ export async function binExists(bin) {
   }
 }
 
-// getProviders() -> { all, connected, default }. `connected` is the list of
-// provider ids opencode has working auth for.
 export async function listAvailableLaunchers({
   binExists: probe = binExists,
-  getProviders,
 }) {
-  const providers = await getProviders().catch(() => ({ connected: [] }));
-  const connected = new Set(providers.connected || []);
   const out = [];
   for (const l of LAUNCHERS) {
-    // provider === null/undefined means "no provider gate" (pure-CLI launcher).
-    const providerOk = l.provider == null || connected.has(l.provider);
-    if (!providerOk) continue;
     if (!(await probe(l.bin))) continue;
     out.push({
       id: l.id,

--- a/src/server/launchers.test.mjs
+++ b/src/server/launchers.test.mjs
@@ -1,6 +1,6 @@
 // Tests for src/server/launchers.mjs + launcherRegistry.mjs (BET-138
-// refinement). Pure logic only — binExists/getProviders are injected so no
-// real process spawn or opencode HTTP call happens.
+// refinement, BET-310). Pure logic only — binExists is injected so no real
+// process spawn happens.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -28,53 +28,41 @@ describe("binExists", () => {
 });
 
 // ---------------------------------------------------------------------------
-// listAvailableLaunchers — filters on BOTH provider-connected AND bin-present
+// listAvailableLaunchers — filters on bin-present only (BET-310)
 // ---------------------------------------------------------------------------
 
 describe("listAvailableLaunchers", () => {
-  it("includes a launcher only when its bin exists AND its provider is connected", async () => {
+  it("includes a launcher when its bin exists", async () => {
     const out = await listAvailableLaunchers({
       binExists: async (bin) => bin === "claude",
-      getProviders: async () => ({ connected: ["anthropic"] }),
     });
     assert.deepEqual(out.map((l) => l.id), ["claude"]);
     assert.equal(out[0].label, "Claude Code");
   });
 
-  it("excludes a launcher when the bin is missing even if the provider is connected", async () => {
+  it("excludes a launcher when its bin is missing", async () => {
     const out = await listAvailableLaunchers({
       binExists: async () => false,
-      getProviders: async () => ({ connected: ["anthropic"] }),
     });
     assert.deepEqual(out, []);
   });
 
-  it("excludes a launcher when the provider isn't connected even if the bin exists", async () => {
+  it("returns exactly the present-launchers in registry order when only some bins resolve (BET-310: claude+codex present, kimi absent)", async () => {
     const out = await listAvailableLaunchers({
-      binExists: async () => true,
-      getProviders: async () => ({ connected: [] }),
+      binExists: async (bin) => bin === "claude" || bin === "codex",
     });
-    assert.deepEqual(out, []);
-  });
-
-  it("tolerates getProviders() rejecting — treats it as no connected providers", async () => {
-    const out = await listAvailableLaunchers({
-      binExists: async () => true,
-      getProviders: async () => { throw new Error("opencode unreachable"); },
-    });
-    assert.deepEqual(out, []);
+    assert.deepEqual(out.map((l) => l.id), ["claude", "codex"]);
   });
 
   it("returns each launcher's flag schema without the server-only `arg` field", async () => {
     const out = await listAvailableLaunchers({
       binExists: async () => true,
-      getProviders: async () => ({ connected: ["anthropic"] }),
     });
-    assert.equal(out.length, 1);
-    assert.deepEqual(out[0].flags, [
+    const claude = out.find((l) => l.id === "claude");
+    assert.deepEqual(claude.flags, [
       { key: "skipPermissions", label: "Skip all permission prompts", type: "boolean", default: true },
     ]);
-    assert.equal(out[0].flags[0].arg, undefined);
+    assert.equal(claude.flags[0].arg, undefined);
   });
 });
 

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -3,7 +3,6 @@
 // Ports the pure helpers from src/main/providers.ts (parseModelsResponse,
 // upsertProviderBlock, removeProviderBlock, readProviderEndpoints,
 // findStoredApiKey, stripUrlUserinfo) and adds server-side I/O functions:
-//   getProviders      — fetch opencode's /provider endpoint (via ocFetch)
 //   discoverModels    — fetch <baseURL>/models directly (server IS the box)
 //   setProviders      — read/merge/write opencode.jsonc locally
 //
@@ -283,26 +282,6 @@ export async function getProviderEndpoints(readConfig = readRemoteConfig) {
   } catch (e) {
     console.warn("[providers] could not read provider endpoints:", e);
     return [];
-  }
-}
-
-/**
- * Fetch the provider list from opencode's /provider endpoint.
- * Returns the raw shape: { all: [...], connected: [...], default: {...} }.
- *
- * Uses native fetch directly (opencode.mjs's ocFetch is not exported).
- * The server IS on the box, so 127.0.0.1:4096 is reachable without SSH.
- */
-export async function getProviders() {
-  try {
-    const res = await fetch("http://127.0.0.1:4096/provider");
-    if (!res.ok) {
-      await res.text().catch(() => {});
-      return { all: [], connected: [], default: {} };
-    }
-    return await res.json();
-  } catch {
-    return { all: [], connected: [], default: {} };
   }
 }
 

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -14,7 +14,6 @@ import {
   discoverModels,
   discoverModelsForEndpoint,
   setProviders,
-  getProviders,
   getProviderEndpoints,
   upsertAgentBlock,
   removeAgentBlock,
@@ -523,26 +522,6 @@ describe("getProviderEndpoints", () => {
   it("returns [] for a config with no providers", async () => {
     const result = await getProviderEndpoints(async () => ({}));
     assert.deepEqual(result, []);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// getProviders — handler test (mocks ocFetch)
-// ---------------------------------------------------------------------------
-
-describe("getProviders", () => {
-  // getProviders uses ocFetch from opencode.mjs, which uses a pooled http
-  // agent. We test it by mocking ocFetch via the transport mechanism.
-  // For simplicity, we just verify the function doesn't throw and returns
-  // a shape — the real integration is tested by the RPC handler test.
-
-  it("returns a shape even when opencode is unreachable", async () => {
-    // This test verifies graceful degradation. In a real test environment
-    // opencode won't be running, so getProviders should return empty shape.
-    const result = await getProviders();
-    assert.ok(result);
-    assert.ok(Array.isArray(result.all ?? []));
-    assert.ok(Array.isArray(result.connected ?? []));
   });
 });
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -526,14 +526,12 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     //   → args[0] = sessionKey
     "pty:kill": (sessionKey) => pty.kill(sessionKey),
 
-    // ---- launcher availability (BET-138 refinement) ----
+    // ---- launcher availability (BET-138 refinement, BET-310) ----
     // IPC.launchersList = "launchers:list" — which AI CLI TUIs (see
     // src/server/launcherRegistry.mjs) are available on this box right now:
-    // binary on PATH AND (if the launcher declares one) opencode reports its
-    // provider connected. Cheap; the renderer fetches on active-session
-    // change, no polling.
-    "launchers:list": () =>
-      launchers.listAvailableLaunchers({ getProviders: providers.getProviders }),
+    // binary on PATH. Cheap; the renderer fetches on active-session change,
+    // no polling.
+    "launchers:list": () => launchers.listAvailableLaunchers(),
   };
 }
 


### PR DESCRIPTION
## Summary

The session-mode dropdown now shows any AI CLI TUI launcher whose binary resolves on PATH, regardless of whether opencode reports its provider connected. Two new registry entries (Codex and Kimi Code) added.

## Why

The CLI holds its own credentials — gating the dropdown on opencode's connection silently hid working CLIs (Claude Code would vanish from the dropdown while working perfectly in a terminal if opencode's Anthropic side lapsed), and would have hidden Codex entirely since Codex has no opencode auth.

## Changes

- src/server/launchers.mjs — listAvailableLaunchers no longer takes getProviders. One availability condition: the binary resolves.
- src/server/launcherRegistry.mjs — removed provider field from claude entry; added codex + kimi entries (flag-free).
- src/server/rpc.mjs — launchers:list dispatch no longer threads providers.getProviders.
- src/server/providers.mjs — getProviders had no remaining callers; deleted.
- src/server/providers.test.mjs — getProviders test deleted.
- src/server/launchers.test.mjs — provider-gate tests deleted; new test asserts registry order when only some bins resolve (claude + codex present, kimi absent → exactly two).

## Out of scope (per issue)

- Did not touch src/server/pty.mjs (findLauncher keeps working unchanged).
- Did not touch any renderer component.
- Did not add codex/kimi CLI installation anywhere.

## Acceptance criteria

- npm run typecheck green.
- npm test green (888 tests pass).
- grep -rn provider src/server/launcherRegistry.mjs src/server/launchers.mjs returns nothing.
- Net line count across launchers.mjs + launcherRegistry.mjs + launchers.test.mjs excluding the two new entries is -24 lines (209 → 185).

## Verification

npm run typecheck: exit 0
npm test: exit 0, 888 pass / 0 fail

Base: origin/main @ ef6e93a