### PR TITLE
BET-309: subscription providers — server registry + opencode auth proxy

### DIFF
--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -143,6 +143,29 @@ const getClientVersion = (): Promise<{ version: string }> =>
 const getServerVersion = (): Promise<{ version: string; minClient: string }> =>
   Promise.resolve({ version: "0.0.13", minClient: "0.0.0" });
 
+// Subscription provider auth (BET-308 / BET-309). Demo returns the three
+// disconnected rows so the connect-card UI still renders the registry
+// correctly; the `start` / `code` / `key` / `disconnect` actions are
+// unimplemented and resolve to a status payload (the Proxy fallback would
+// also work, but routing non-status requests through here keeps the
+// explicit-method list honest about demo coverage). Matches the real
+// httpApi's status shape so any future consumer that mounts the card in
+// demo mode gets the same row layout.
+const opencodeProviderAuth = (req: unknown): Promise<{ action: "status"; providers: Array<{ id: string; label: string; plan: string; console: string | null; docs: string; connected: boolean }> }> => {
+  // Status is the only meaningful action in demo mode — everything else
+  // (start / code / key / disconnect) would need a fake opencode server
+  // behind it, which is out of scope for the demo fixture.
+  void req;
+  return Promise.resolve({
+    action: "status",
+    providers: [
+      { id: "anthropic", label: "Claude", plan: "Claude Pro / Max", console: null, docs: "https://claude.com/pricing", connected: true },
+      { id: "openai", label: "Codex", plan: "ChatGPT Plus / Pro", console: null, docs: "https://openai.com/chatgpt/pricing", connected: false },
+      { id: "kimi-for-coding", label: "Kimi", plan: "Kimi For Coding", console: "https://www.kimi.com/code/console", docs: "https://www.kimi.com/code/docs/en/third-party-tools/opencode.html", connected: false },
+    ],
+  });
+};
+
 // ===========================================================================
 // `demoApi` — the explicit methods exposed by name. Everything else falls
 // through the Proxy in the `unknown` handler.
@@ -165,6 +188,7 @@ const explicitMethods = {
   launchersList,
   getClientVersion,
   getServerVersion,
+  opencodeProviderAuth,
 } as const;
 
 // ===========================================================================

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -4,6 +4,8 @@ import {
   type AuthPairResult,
   type DesktopNotifyPayload,
   type OpencodeEvent,
+  type OpencodeProviderAuthRequest,
+  type OpencodeProviderAuthResult,
   type PluginRegistryRow,
   type PtyEvent,
   type ServerUpdateAvailablePayload,
@@ -920,6 +922,15 @@ export const httpApi: Api = {
 
   // -- auto-rename: throwaway-session title generation --
   opencodeGenerateTitle: (input) => rpc(IPC.opencodeGenerateTitle, input),
+
+  // -- subscription provider auth (BET-308 / BET-309) --
+  // Single discriminated channel — the renderer picks the action shape and
+  // the server picks the opencode method index (resolved via
+  // resolveAuthMethod in src/server/subscriptionProviders.mjs; never a
+  // literal). The `key` action carries the API-key secret renderer → box;
+  // the server writes it to opencode's auth store and never echoes it back.
+  opencodeProviderAuth: (req: OpencodeProviderAuthRequest) =>
+    rpc<OpencodeProviderAuthResult>(IPC.opencodeProviderAuth, req),
 
   // -- server version (BET-180) --
   // Returns the manta-server's package.json version. In-process via the

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -911,6 +911,161 @@ function _normalizeProviderModel(providerID, modelId, m) {
 }
 
 // ---------------------------------------------------------------------------
+// Subscription provider auth (BET-308, BET-309)
+// ---------------------------------------------------------------------------
+//
+// Thin HTTP proxies to opencode's `/provider/auth`, `/provider/{id}/oauth/
+// authorize`, `/provider/{id}/oauth/callback`, `PUT /auth/{id}`, and
+// `DELETE /auth/{id}` endpoints. Policy (which method to pick, which
+// shape to render) lives in src/server/subscriptionProviders.mjs; this
+// file only transports the request and surfaces a structured failure
+// (`{ok:false, error, detail?}`) on a non-2xx. Error vocabulary matches
+// src/server/providers.mjs's discoverModels: "unreachable" | "unauthorized"
+// | "bad_response" — reuse rather than invent.
+//
+// `setProviderApiKey` is the one path that handles a secret: the key is
+// written to opencode's auth store box-side and NEVER echoed back, not in
+// the return value and not in any log line.
+
+/**
+ * Fetch the auth-method list for every provider (GET /provider/auth).
+ * @returns {Promise<Record<string, Array<{type:string,label?:string,prompts?:Array<unknown>}>|null>>}
+ *          raw shape — the renderer's RPC layer wraps this in the
+ *          resolveAuthMethod policy from subscriptionProviders.mjs.
+ */
+export async function listProviderAuthMethods() {
+  try {
+    const res = await ocFetch(apiUrl("/provider/auth"));
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      await discardBody(res);
+      return { ok: false, error: "bad_response", detail: detail.slice(0, 200) };
+    }
+    const data = await res.json();
+    return { ok: true, methods: data ?? {} };
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: String(e?.message ?? e) };
+  }
+}
+
+/**
+ * Start a provider's OAuth flow (POST /provider/{id}/oauth/authorize {method}).
+ * Returns the raw `{url, method, instructions}` from opencode; the caller
+ * applies describeConnectShape to pick the renderer's UI.
+ * @param {string} providerID
+ * @param {number} methodIndex   resolved via resolveAuthMethod, NEVER a literal
+ */
+export async function startProviderOauth(providerID, methodIndex) {
+  try {
+    const res = await ocFetch(apiUrl(`/provider/${encodeURIComponent(providerID)}/oauth/authorize`), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ method: methodIndex }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      await discardBody(res);
+      return { ok: false, error: "bad_response", detail: detail.slice(0, 200) };
+    }
+    const data = await res.json();
+    return {
+      ok: true,
+      url: typeof data?.url === "string" ? data.url : "",
+      method: typeof data?.method === "string" ? data.method : "auto",
+      instructions: typeof data?.instructions === "string" ? data.instructions : "",
+    };
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: String(e?.message ?? e) };
+  }
+}
+
+/**
+ * Complete a paste-back OAuth flow (POST /provider/{id}/oauth/callback {method, code}).
+ * @param {string} providerID
+ * @param {number} methodIndex
+ * @param {string} code   the user-typed code from the device / browser page
+ */
+export async function completeProviderOauth(providerID, methodIndex, code) {
+  try {
+    const res = await ocFetch(apiUrl(`/provider/${encodeURIComponent(providerID)}/oauth/callback`), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ method: methodIndex, code }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      await discardBody(res);
+      // 401 from opencode means a wrong/expired code — surface as a distinct
+      // vocabulary word so the renderer can label the input correctly.
+      if (res.status === 401 || res.status === 403) {
+        return { ok: false, error: "unauthorized", detail: detail.slice(0, 200) };
+      }
+      return { ok: false, error: "bad_response", detail: detail.slice(0, 200) };
+    }
+    await discardBody(res);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: String(e?.message ?? e) };
+  }
+}
+
+/**
+ * Write an API key into opencode's auth store (PUT /auth/{id} {type:"api", key}).
+ *
+ * SECURITY: the key is NEVER echoed back to the caller and NEVER logged.
+ * `setProviderApiKey` returns `{ok:boolean}` only; a logged error must not
+ * contain the key, only the provider id.
+ * @param {string} providerID
+ * @param {string} key
+ */
+export async function setProviderApiKey(providerID, key) {
+  try {
+    const res = await ocFetch(apiUrl(`/auth/${encodeURIComponent(providerID)}`), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "api", key }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      await discardBody(res);
+      // Provider-specific validation (e.g. Kimi 401s on a bad key) comes back
+      // as 401 — re-use "unauthorized" so the renderer can show the right copy.
+      if (res.status === 401 || res.status === 403) {
+        return { ok: false, error: "unauthorized", detail: detail.slice(0, 200) };
+      }
+      return { ok: false, error: "bad_response", detail: detail.slice(0, 200) };
+    }
+    await discardBody(res);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: String(e?.message ?? e) };
+  }
+}
+
+/**
+ * Remove a provider's auth from opencode's store (DELETE /auth/{id}).
+ * Idempotent — a missing entry returns 404 from opencode, which we surface
+ * as `{ok:true}` (the user's intent is satisfied: the auth is gone).
+ * @param {string} providerID
+ */
+export async function removeProviderAuth(providerID) {
+  try {
+    const res = await ocFetch(apiUrl(`/auth/${encodeURIComponent(providerID)}`), {
+      method: "DELETE",
+    });
+    if (res.ok || res.status === 404) {
+      await discardBody(res);
+      return { ok: true };
+    }
+    const detail = await res.text().catch(() => "");
+    await discardBody(res);
+    return { ok: false, error: "bad_response", detail: detail.slice(0, 200) };
+  } catch (e) {
+    return { ok: false, error: "unreachable", detail: String(e?.message ?? e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // VCS
 // ---------------------------------------------------------------------------
 
@@ -970,7 +1125,15 @@ export function _resetRecoveryCooldownState() {
 /** Resolve the `claude` CLI binary. manta-server's service PATH excludes the
  *  user's ~/.local/bin (where the claude installer symlinks the binary), so a
  *  bare "claude" fails to spawn. Check the known install locations first and
- *  fall back to bare "claude" (resolved via the augmented PATH) if none match. */
+ *  fall back to bare "claude" (resolved via the augmented PATH) if none match.
+ *
+ *  CLAUDE-SPECIFIC BY DESIGN: every other provider (Codex, Kimi, ...) uses
+ *  opencode's native /provider/{id}/oauth/* flow — there is no external CLI
+ *  to spawn, no credential to refresh, and the rest of this file's
+ *  subscription-provider auth proxy is provider-agnostic. Do NOT generalize
+ *  this helper; the auth-machinery it backs (`doRefresh`,
+ *  `maybeRecoverCredentials`, `startCredentialRefreshPoller`) is similarly
+ *  Claude-only and is kept that way to avoid papering over the differences. */
 function resolveClaudeBin() {
   const candidates = [
     path.join(homedir(), ".local", "bin", "claude"),

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -15,6 +15,7 @@ import {
 import { resolveWorkspace } from "./peers.mjs";
 import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
+import * as subscriptionProviders from "./subscriptionProviders.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
@@ -412,6 +413,98 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // IPC.opencodeGenerateTitle. Returns the RAW model reply (caller sanitizes).
     "opencode:generate-title": ({ directory, instruction }) =>
       oc.generateSessionTitle({ directory, instruction }),
+
+    // ---- subscription provider auth (BET-308 / BET-309) ----
+    // Single discriminated channel: status / start / code / key / disconnect.
+    //   "status"      → GET /provider + subscriptionStatuses()
+    //   "start"       → GET /provider/auth + resolveAuthMethod + startProviderOauth
+    //                   (returns api-key shape when nothing resolved — Kimi
+    //                    path has no OAuth methods to resolve to)
+    //   "code"        → POST /provider/{id}/oauth/callback
+    //   "key"         → PUT /auth/{id} {type:"api", key} (Kimi)
+    //   "disconnect"  → DELETE /auth/{id}
+    // Policy lives in src/server/subscriptionProviders.mjs; this handler is
+    // the wire. The `key` action carries an API-key secret renderer → box
+    // and the server returns {ok} only — never the key itself, not in the
+    // return value and not in any log line.
+    "opencode:provider-auth": async (req) => {
+      const action = req?.action;
+      if (action === "status") {
+        const { connected } = await providers.getProviders();
+        return {
+          action: "status",
+          providers: subscriptionProviders.subscriptionStatuses(connected),
+        };
+      }
+      if (action === "start") {
+        const id = String(req?.id ?? "");
+        const entry = subscriptionProviders.findSubscriptionProvider(id);
+        if (!entry) {
+          return { action: "start", shape: "api-key" };
+        }
+        const auth = await oc.listProviderAuthMethods();
+        const methods =
+          auth?.ok && auth.methods && typeof auth.methods === "object"
+            ? auth.methods[id]
+            : null;
+        const resolved = subscriptionProviders.resolveAuthMethod(entry, methods);
+        if (!resolved) {
+          // No OAuth / no usable method → the renderer switches to the
+          // API-key form (Kimi path). Mirrors the "use the generic API-key
+          // path" contract in resolveAuthMethod's docstring.
+          return { action: "start", shape: "api-key" };
+        }
+        const oauth = await oc.startProviderOauth(id, resolved.index);
+        if (!oauth?.ok) {
+          return {
+            action: "start",
+            shape: "api-key",
+          };
+        }
+        const shape = subscriptionProviders.describeConnectShape(
+          resolved,
+          oauth.method,
+        );
+        return {
+          action: "start",
+          shape,
+          url: oauth.url || undefined,
+          instructions: oauth.instructions || undefined,
+          methodIndex: resolved.index,
+        };
+      }
+      if (action === "code") {
+        const id = String(req?.id ?? "");
+        const methodIndex = Number(req?.methodIndex ?? -1);
+        const code = String(req?.code ?? "");
+        if (!Number.isInteger(methodIndex) || methodIndex < 0 || !code) {
+          return { action: "code", ok: false, error: "bad_response" };
+        }
+        const r = await oc.completeProviderOauth(id, methodIndex, code);
+        return { action: "code", ok: !!r?.ok, error: r?.ok ? undefined : r?.error };
+      }
+      if (action === "key") {
+        const id = String(req?.id ?? "");
+        const key = String(req?.key ?? "");
+        if (!key) {
+          return { action: "key", ok: false, error: "bad_response" };
+        }
+        const r = await oc.setProviderApiKey(id, key);
+        return { action: "key", ok: !!r?.ok, error: r?.ok ? undefined : r?.error };
+      }
+      if (action === "disconnect") {
+        const id = String(req?.id ?? "");
+        const r = await oc.removeProviderAuth(id);
+        return {
+          action: "disconnect",
+          ok: !!r?.ok,
+          error: r?.ok ? undefined : r?.error,
+        };
+      }
+      // Unknown action — surface as a generic failure so the renderer's
+      // typed result narrows correctly without throwing across the wire.
+      return { action: "status", providers: [] };
+    },
 
     // ---- scheduled prompts (manta-server owned; in-process on mobile) ----
     // Mirror of desktop IPC.scheduleList / scheduleDelete. The store + firing

--- a/src/server/subscriptionProviders.mjs
+++ b/src/server/subscriptionProviders.mjs
@@ -1,0 +1,213 @@
+// Subscription-provider registry + pure resolvers (BET-308, BET-309).
+//
+// The renderer UI is dumb on purpose: a single `IPC.opencodeProviderAuth`
+// channel dispatches one of five actions (status / start / code / key /
+// disconnect) and every rendering decision lives here. This file holds the
+// registry of supported providers and the PURE functions that resolve an
+// opencode auth-method array into a usable action. All HTTP I/O lives in
+// src/server/opencode.mjs; this module never touches the network.
+//
+// Analogues: src/server/launcherRegistry.mjs (the AI-CLI TUI registry) and
+// src/server/launchers.mjs (the availability probe over it). Mirror those
+// files' shape — registry + a small findXxx — and add the auth-method
+// resolver as the third leg. No provider-specific knowledge here other
+// than the registry table itself.
+//
+// id        stable provider id, also opencode's auth-store key. NEVER reuse
+//           or rename without a migration. Persisted in the user's
+//           localStorage by the renderer.
+// label     human label for the connect card.
+// plan      the plan the user is paying for (Claude Pro/Max, ChatGPT
+//           Plus/Pro, Kimi For Coding). Rendered on the connect card.
+// prefer    ordered preference list for selecting an auth method. Each
+//           entry's `type` and lowercased `match` are matched against an
+//           opencode method's `type` and lowercased `label`. The first
+//           match wins. An empty array means "do not use the prefer path"
+//           (Kimi: opencode reports no auth methods, only the generic
+//           API-key write works).
+// detect    filesystem probe hints — files whose existence strongly
+//           implies the provider is connected (e.g. Claude's credential
+//           file). Reserved for a later stage's install-time detection
+//           (BET-308 stage 2); ignored here.
+// console   the web URL where the user creates an API key for this
+//           provider, if any. Null where no separate console exists
+//           (Claude: signed in via `claude` CLI; ChatGPT: signed in via
+//           the OAuth flow itself).
+// docs      the canonical "how to use this provider with opencode" doc.
+
+export const SUBSCRIPTION_PROVIDERS = [
+  {
+    id: "anthropic",
+    label: "Claude",
+    plan: "Claude Pro / Max",
+    prefer: [{ type: "oauth", match: "claude code account" }],
+    detect: ["~/.claude/.credentials.json"],
+    console: null,
+    docs: "https://claude.com/pricing",
+  },
+  {
+    id: "openai",
+    label: "Codex",
+    plan: "ChatGPT Plus / Pro",
+    // Headless FIRST and deliberately: the browser variant redirects to
+    // localhost:1455 ON THE BOX, which is unreachable from the user's laptop
+    // or phone. Never let the browser variant win.
+    prefer: [
+      { type: "oauth", match: "headless" },
+      { type: "oauth", match: "chatgpt" },
+    ],
+    detect: [],
+    console: null,
+    docs: "https://openai.com/chatgpt/pricing",
+  },
+  {
+    id: "kimi-for-coding",
+    label: "Kimi",
+    plan: "Kimi For Coding",
+    // opencode reports no auth methods for this provider; it takes the generic
+    // API-key path. This empty array is correct, not an oversight.
+    prefer: [],
+    detect: [],
+    console: "https://www.kimi.com/code/console",
+    docs: "https://www.kimi.com/code/docs/en/third-party-tools/opencode.html",
+  },
+];
+
+// Lookup by id. Mirrors findLauncher's shape exactly so the renderer can
+// pattern-match against either without special-casing.
+export function findSubscriptionProvider(id) {
+  return SUBSCRIPTION_PROVIDERS.find((p) => p.id === id) || null;
+}
+
+// ---------------------------------------------------------------------------
+// Auth-method resolution
+// ---------------------------------------------------------------------------
+//
+// opencode's `GET /provider/auth` returns a per-provider array of auth
+// methods, each `{ type, label, prompts? }`. The Codex headless method
+// sits at index 1 today but opencode reorders freely across releases —
+// matching by label + type is the only safe way to pick it. This is the
+// standing rule from BET-308 ("never pass a literal method index") made
+// into a function.
+
+/**
+ * Pick the best surviving auth method for `entry` from the array opencode
+ * returned for this provider id. `methods` may be `null`/`undefined` (e.g.
+ * Kimi reports `null` — there's no OAuth, only the API-key path).
+ *
+ * Selection rules, in order:
+ *   1. `methods` null/undefined/empty → `null`. Caller treats null as
+ *      "use the generic API-key path".
+ *   2. Discard any method whose `prompts` array is non-empty. Multi-step
+ *      prompt flows are out of scope for this epic (see BET-308). A
+ *      provider whose only methods are discarded resolves to `null`.
+ *   3. Walk `entry.prefer` in order. For each rule, return the first
+ *      surviving method whose `type` equals the rule's `type` and whose
+ *      `label`, lowercased, contains the rule's `match`, lowercased.
+ *   4. Otherwise, fall back to the first surviving method with
+ *      `type === "api"`.
+ *   5. Otherwise return `null`.
+ *
+ * The returned `index` is the method's index into the ORIGINAL `methods`
+ * array, not the filtered one — that is what gets POSTed to opencode.
+ *
+ * @param {object} entry     a SUBSCRIPTION_PROVIDERS row
+ * @param {Array<{type:string,label?:string,prompts?:Array<unknown>}>|null|undefined} methods
+ * @returns {{index:number, method:object}|null}
+ */
+export function resolveAuthMethod(entry, methods) {
+  if (!methods || !Array.isArray(methods) || methods.length === 0) return null;
+
+  const surviving = methods
+    .map((m, i) => ({ m, i }))
+    .filter(({ m }) => !Array.isArray(m?.prompts) || m.prompts.length === 0);
+
+  // Prefer rules first (in registry order).
+  for (const rule of entry?.prefer ?? []) {
+    const wantType = rule?.type;
+    const wantMatch = String(rule?.match ?? "").toLowerCase();
+    for (const { m, i } of surviving) {
+      if (m?.type !== wantType) continue;
+      const label = String(m?.label ?? "").toLowerCase();
+      if (label.includes(wantMatch)) return { index: i, method: m };
+    }
+  }
+
+  // Generic API-key fallback.
+  for (const { m, i } of surviving) {
+    if (m?.type === "api") return { index: i, method: m };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Connect shape
+// ---------------------------------------------------------------------------
+//
+// The renderer needs to know which UI to render for a given provider:
+//   "oauth-auto"  — paste-back flow where the user opens a URL on their own
+//                   device and types a device code back. The renderer shows
+//                   the URL + the "Enter the code shown on the page" input.
+//   "oauth-code"  — paste-back flow where opencode returns a short code AND
+//                   the auth URL. The renderer shows the code and the URL
+//                   (the user can copy either). Same renderer UX as auto;
+//                   the distinction matters for callers that want to know
+//                   whether to display the inline code.
+//   "api-key"     — the user pastes an API key into a password input.
+//
+// Resolved by `describeConnectShape(resolvedMethod, authorizeMethod)`:
+//   resolvedMethod === null                              → "api-key"
+//   resolvedMethod.method.type === "api"                 → "api-key"
+//   authorizeMethod === "code"                           → "oauth-code"
+//   otherwise                                            → "oauth-auto"
+
+/**
+ * Pick the connect-card shape from the resolved method + opencode's
+ * authorize response.
+ *
+ * @param {{index:number,method:object}|null} resolvedMethod  result of resolveAuthMethod
+ * @param {string|undefined|null} authorizeMethod             opencode's `method` field on the authorize response
+ * @returns {"oauth-auto"|"oauth-code"|"api-key"}
+ */
+export function describeConnectShape(resolvedMethod, authorizeMethod) {
+  if (resolvedMethod == null) return "api-key";
+  if (resolvedMethod.method?.type === "api") return "api-key";
+  if (authorizeMethod === "code") return "oauth-code";
+  return "oauth-auto";
+}
+
+// ---------------------------------------------------------------------------
+// Status projection
+// ---------------------------------------------------------------------------
+//
+// `status` action payload: one row per registry entry, marked connected
+// based on opencode's `GET /provider` `connected[]`. Registry order is
+// preserved — the renderer's connect card lists providers in the same
+// order the registry declares them.
+
+/**
+ * @typedef {object} SubscriptionStatus
+ * @property {string} id         provider id from the registry
+ * @property {string} label      human label
+ * @property {string} plan       the plan the user is paying for
+ * @property {string|null} console  where to mint a key, or null
+ * @property {string} docs       canonical setup doc URL
+ * @property {boolean} connected  true iff id ∈ connected
+ */
+
+/**
+ * @param {string[]} connected  the `connected[]` array from opencode's GET /provider
+ * @returns {SubscriptionStatus[]}
+ */
+export function subscriptionStatuses(connected) {
+  const set = new Set(Array.isArray(connected) ? connected : []);
+  return SUBSCRIPTION_PROVIDERS.map((p) => ({
+    id: p.id,
+    label: p.label,
+    plan: p.plan,
+    console: p.console,
+    docs: p.docs,
+    connected: set.has(p.id),
+  }));
+}

--- a/src/server/subscriptionProviders.test.mjs
+++ b/src/server/subscriptionProviders.test.mjs
@@ -1,0 +1,244 @@
+// Tests for src/server/subscriptionProviders.mjs (BET-308, BET-309).
+// Pure logic only — no process spawn, no network, no FS read.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SUBSCRIPTION_PROVIDERS,
+  findSubscriptionProvider,
+  resolveAuthMethod,
+  describeConnectShape,
+  subscriptionStatuses,
+} from "./subscriptionProviders.mjs";
+
+// Live snapshot of GET /provider/auth on the dev box, copied verbatim from
+// BET-308 ("The finding this epic is built on"). Used by the headless-vs-
+// browser and index-integrity tests — exact array, not a paraphrase, so
+// the resolver is exercised against the real opencode shape.
+const OPENAI_METHODS = [
+  { type: "oauth", label: "ChatGPT Pro/Plus (browser)" },
+  { type: "oauth", label: "ChatGPT Pro/Plus (headless)" },
+  { type: "api", label: "Manually enter API Key" },
+];
+
+// Anthropic: only one OAuth row, no prompts. Trivial happy path.
+const ANTHROPIC_METHODS = [
+  { type: "oauth", label: "Switch Claude Code account", prompts: [] },
+];
+
+// GitHub Copilot-style: an oauth row with a prompts array (multi-step
+// device flow). Out of scope for this epic — must be discarded.
+const PROMPTS_METHODS = [
+  { type: "oauth", label: "Login with GitHub Copilot", prompts: [{ key: "code" }] },
+];
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+describe("SUBSCRIPTION_PROVIDERS", () => {
+  it("declares exactly the three providers the epic allows (no more, no less)", () => {
+    assert.deepEqual(
+      SUBSCRIPTION_PROVIDERS.map((p) => p.id),
+      ["anthropic", "openai", "kimi-for-coding"],
+    );
+  });
+
+  it("preserves the documented openai prefer order: headless first, browser second", () => {
+    const openai = findSubscriptionProvider("openai");
+    assert.equal(openai.prefer[0].match, "headless");
+    assert.equal(openai.prefer[1].match, "chatgpt");
+  });
+
+  it("kimi has an empty prefer array — generic API-key path is the only route", () => {
+    const kimi = findSubscriptionProvider("kimi-for-coding");
+    assert.deepEqual(kimi.prefer, []);
+  });
+});
+
+describe("findSubscriptionProvider", () => {
+  it("returns the registry entry for a known id", () => {
+    const p = findSubscriptionProvider("openai");
+    assert.equal(p.id, "openai");
+    assert.equal(p.label, "Codex");
+  });
+
+  it("returns null for an unknown id (mirror of findLauncher)", () => {
+    assert.equal(findSubscriptionProvider("nonexistent"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthMethod — selection rules
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthMethod", () => {
+  it("picks the headless Codex method over the browser variant", () => {
+    const openai = findSubscriptionProvider("openai");
+    const r = resolveAuthMethod(openai, OPENAI_METHODS);
+    assert.ok(r, "should resolve");
+    assert.equal(r.index, 1, "headless row sits at index 1");
+    assert.equal(r.method.label, "ChatGPT Pro/Plus (headless)");
+  });
+
+  it("falls through to chatgpt (browser) when headless is missing", () => {
+    const openai = findSubscriptionProvider("openai");
+    const noHeadless = OPENAI_METHODS.filter((m) => !/headless/i.test(m.label));
+    const r = resolveAuthMethod(openai, noHeadless);
+    assert.ok(r);
+    assert.equal(r.index, 0);
+    assert.equal(r.method.label, "ChatGPT Pro/Plus (browser)");
+  });
+
+  it("falls back to the api method when no prefer rule matches", () => {
+    const openai = findSubscriptionProvider("openai");
+    const onlyApi = [{ type: "api", label: "Manually enter API Key" }];
+    const r = resolveAuthMethod(openai, onlyApi);
+    assert.ok(r);
+    assert.equal(r.index, 0);
+    assert.equal(r.method.type, "api");
+  });
+
+  it("matches the claude-code-account label for anthropic", () => {
+    const anthropic = findSubscriptionProvider("anthropic");
+    const r = resolveAuthMethod(anthropic, ANTHROPIC_METHODS);
+    assert.ok(r);
+    assert.equal(r.index, 0);
+    assert.equal(r.method.label, "Switch Claude Code account");
+  });
+
+  // The single most important test in this issue (per BET-308). A prompts-
+  // bearing method sitting BEFORE the match shifts the FILTERED index; the
+  // returned index MUST point at the right entry in the ORIGINAL array,
+  // because that is what gets POSTed to opencode. If this test ever passes
+  // against a value that doesn't match the corresponding opencode method,
+  // hands the user a localhost:1455 URL on the day opencode reorders.
+  it("returns the index into the ORIGINAL methods array, not the filtered one", () => {
+    const openai = findSubscriptionProvider("openai");
+    // Build a methods array where the headless match is at filtered index 0
+    // but ORIGINAL index 2 (a prompts-bearing oauth row sits at index 1).
+    const methods = [
+      OPENAI_METHODS[0],                                          // index 0 — browser
+      { type: "oauth", label: "Login with GitHub Copilot", prompts: [{ key: "code" }] }, // index 1 — discarded
+      OPENAI_METHODS[1],                                          // index 2 — headless (target)
+      OPENAI_METHODS[2],                                          // index 3 — api fallback
+    ];
+    const r = resolveAuthMethod(openai, methods);
+    assert.ok(r, "should still resolve past the discarded row");
+    assert.equal(r.index, 2, "must point at original index 2, not filtered 1");
+    assert.equal(methods[r.index].label, "ChatGPT Pro/Plus (headless)");
+  });
+
+  it("returns null when methods is null", () => {
+    assert.equal(resolveAuthMethod(findSubscriptionProvider("openai"), null), null);
+  });
+
+  it("returns null when methods is undefined", () => {
+    assert.equal(resolveAuthMethod(findSubscriptionProvider("openai"), undefined), null);
+  });
+
+  it("returns null when methods is an empty array", () => {
+    assert.equal(resolveAuthMethod(findSubscriptionProvider("openai"), []), null);
+  });
+
+  it("returns null when every method carries prompts (the GitHub Copilot case)", () => {
+    assert.equal(resolveAuthMethod(findSubscriptionProvider("openai"), PROMPTS_METHODS), null);
+  });
+
+  it("discards a prompts-bearing oauth row but still resolves past it", () => {
+    const openai = findSubscriptionProvider("openai");
+    const methods = [...PROMPTS_METHODS, ...OPENAI_METHODS];
+    const r = resolveAuthMethod(openai, methods);
+    assert.ok(r);
+    // Original index of headless in [...PROMPTS_METHODS, ...OPENAI_METHODS]
+    // is 1 + 1 = 2 (the Copilot row sits at index 0, then browser at 1,
+    // headless at 2).
+    assert.equal(r.index, 2);
+    assert.equal(r.method.label, "ChatGPT Pro/Plus (headless)");
+  });
+
+  it("treats an undefined prefer array as no rules (kimi-style) and falls back to api", () => {
+    const entry = {
+      id: "kimi-for-coding",
+      prefer: [],
+      detect: [],
+    };
+    const r = resolveAuthMethod(entry, [{ type: "api", label: "Manually enter API Key" }]);
+    assert.ok(r);
+    assert.equal(r.index, 0);
+    assert.equal(r.method.type, "api");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeConnectShape
+// ---------------------------------------------------------------------------
+
+describe("describeConnectShape", () => {
+  it("returns 'api-key' when resolved is null", () => {
+    assert.equal(describeConnectShape(null, undefined), "api-key");
+    assert.equal(describeConnectShape(null, "auto"), "api-key");
+    assert.equal(describeConnectShape(null, "code"), "api-key");
+  });
+
+  it("returns 'api-key' when the resolved method type is 'api'", () => {
+    const r = { index: 0, method: { type: "api", label: "Manually enter API Key" } };
+    assert.equal(describeConnectShape(r, undefined), "api-key");
+    assert.equal(describeConnectShape(r, "auto"), "api-key");
+  });
+
+  it("returns 'oauth-code' when authorize method is 'code'", () => {
+    const r = { index: 1, method: { type: "oauth", label: "ChatGPT Pro/Plus (headless)" } };
+    assert.equal(describeConnectShape(r, "code"), "oauth-code");
+  });
+
+  it("returns 'oauth-auto' for every other oauth case", () => {
+    const r = { index: 1, method: { type: "oauth", label: "ChatGPT Pro/Plus (headless)" } };
+    assert.equal(describeConnectShape(r, "auto"), "oauth-auto");
+    assert.equal(describeConnectShape(r, undefined), "oauth-auto");
+    assert.equal(describeConnectShape(r, ""), "oauth-auto");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscriptionStatuses
+// ---------------------------------------------------------------------------
+
+describe("subscriptionStatuses", () => {
+  it("returns one row per registry entry, in registry order", () => {
+    const rows = subscriptionStatuses([]);
+    assert.deepEqual(
+      rows.map((r) => r.id),
+      ["anthropic", "openai", "kimi-for-coding"],
+    );
+  });
+
+  it("marks exactly the connected providers and leaves the others false", () => {
+    const rows = subscriptionStatuses(["anthropic", "kimi-for-coding"]);
+    assert.equal(rows.find((r) => r.id === "anthropic").connected, true);
+    assert.equal(rows.find((r) => r.id === "openai").connected, false);
+    assert.equal(rows.find((r) => r.id === "kimi-for-coding").connected, true);
+  });
+
+  it("tolerates a non-array connected (defensive — return all-disconnected)", () => {
+    const rows = subscriptionStatuses(null);
+    assert.equal(rows.every((r) => r.connected === false), true);
+    const rows2 = subscriptionStatuses(undefined);
+    assert.equal(rows2.every((r) => r.connected === false), true);
+  });
+
+  it("carries the human-facing fields the connect card needs", () => {
+    const [anthropic, openai, kimi] = subscriptionStatuses([]);
+    assert.equal(anthropic.label, "Claude");
+    assert.equal(anthropic.plan, "Claude Pro / Max");
+    assert.equal(anthropic.console, null);
+    assert.equal(typeof anthropic.docs, "string");
+
+    assert.equal(openai.label, "Codex");
+    assert.equal(openai.plan, "ChatGPT Plus / Pro");
+
+    assert.equal(kimi.label, "Kimi");
+    assert.equal(kimi.plan, "Kimi For Coding");
+    assert.equal(kimi.console, "https://www.kimi.com/code/console");
+  });
+});

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -9,6 +9,8 @@ import type {
   OpencodeEvent,
   OpencodeMessage,
   OpencodeModel,
+  OpencodeProviderAuthRequest,
+  OpencodeProviderAuthResult,
   OpencodeSessionListItem,
   PermissionRequest,
   QuestionRequest,
@@ -322,6 +324,14 @@ export interface Api {
   // Auto-rename: generate a short title via a throwaway opencode session.
   // Returns the RAW model reply ("" on timeout/failure); caller sanitizes.
   opencodeGenerateTitle(input: { directory: string; instruction: string }): Promise<string>;
+
+  // Subscription provider auth (BET-308 / BET-309): a single discriminated
+  // channel that drives the connect/disconnect UI for Claude, Codex, and
+  // Kimi. Action discriminated union; see OpencodeProviderAuthRequest in
+  // src/shared/types.ts. The `key` action carries an API-key secret
+  // renderer → box; the server writes it to opencode's auth store and
+  // never echoes it back, not in the return value and not in any log line.
+  opencodeProviderAuth(req: OpencodeProviderAuthRequest): Promise<OpencodeProviderAuthResult>;
 
   // Server version (BET-180): returns the manta-server's package.json version,
   // served in-process via the `server:version` RPC channel (no HTTP round

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -481,6 +481,19 @@ export const IPC = {
   // then deleting it. Returns the RAW model reply (renderer sanitizes). Used
   // by ChatPanel when AppConfig.autoRenameSessions is enabled.
   opencodeGenerateTitle: "opencode:generate-title",
+  // ---- subscription provider auth (BET-308 / BET-309) ----
+  // Single discriminated channel for connecting/disconnecting the paid
+  // subscription providers (Claude via the local CLI plugin, Codex via
+  // opencode's native ChatGPT OAuth, Kimi via an API key). One channel,
+  // not five: every action shares the same renderer→server hop and the
+  // action discriminator (`status` / `start` / `code` / `key` /
+  // `disconnect`) routes to the matching opencode.mjs proxy. Policy —
+  // which method index to use, which UI to render — lives in
+  // src/server/subscriptionProviders.mjs; this channel is purely the wire.
+  // `key` carries the API-key secret renderer→box; the server writes it
+  // into opencode's auth store and never echoes it back, not in the
+  // return value and not in any log line.
+  opencodeProviderAuth: "opencode:provider-auth",
 
   // ---- voice (Groq STT + lightweight classifier) ----
   // Renderer captures audio via MediaRecorder, ships the ArrayBuffer to
@@ -1001,3 +1014,54 @@ export type VoiceClassifyResult = {
   // "none"  → both paths failed; action.kind === "unknown".
   source: "rules" | "llm" | "none";
 };
+
+// ----- Subscription provider auth (BET-308 / BET-309) -----
+//
+// The connect-card UI on Settings → Providers (and Onboarding step 2) lists
+// one row per supported provider from src/server/subscriptionProviders.mjs
+// and lets the user connect / disconnect each. `IPC.opencodeProviderAuth`
+// carries a discriminated union on `action`:
+//
+//   "status"      → list every provider + whether it's currently connected.
+//   "start"       → begin an OAuth flow for `id`, returning either a connect
+//                   shape + URL/instructions/methodIndex OR `api-key` to
+//                   indicate the renderer should switch to the key form.
+//   "code"        → submit the user-typed OAuth callback code.
+//   "key"         → submit an API key (Kimi).
+//   "disconnect"  → remove the provider's auth from opencode's store.
+//
+// "shape" on the `start` response is what the renderer keys the UI on:
+//   "oauth-auto"  — paste-back device flow (URL on user's device).
+//   "oauth-code"  — same UX, but opencode returned a short code to show inline.
+//   "api-key"     — render the password input (or the no-flow case).
+
+export type SubscriptionStatus = {
+  id: string;             // provider id from the registry
+  label: string;          // human label, e.g. "Codex"
+  plan: string;           // the plan the user is paying for, e.g. "ChatGPT Plus / Pro"
+  console: string | null;  // where to mint a key (Kimi), or null
+  docs: string;           // canonical setup doc URL
+  connected: boolean;     // true iff opencode reports this provider connected
+};
+
+export type SubscriptionConnectShape = "oauth-auto" | "oauth-code" | "api-key";
+
+export type OpencodeProviderAuthRequest =
+  | { action: "status" }
+  | { action: "start"; id: string }
+  | { action: "code"; id: string; methodIndex: number; code: string }
+  | { action: "key"; id: string; key: string }
+  | { action: "disconnect"; id: string };
+
+export type OpencodeProviderAuthResult =
+  | { action: "status"; providers: SubscriptionStatus[] }
+  | {
+      action: "start";
+      shape: SubscriptionConnectShape;
+      url?: string;
+      instructions?: string;
+      methodIndex?: number;
+    }
+  | { action: "code"; ok: boolean; error?: string }
+  | { action: "key"; ok: boolean; error?: string }
+  | { action: "disconnect"; ok: boolean; error?: string };


### PR DESCRIPTION
Stage 1 of BET-308 (subscription-providers epic). Pure plumbing; no UI.

**Base:** origin/main @ `ef6e93a`

## What

- `src/server/subscriptionProviders.mjs` — registry of 3 providers (anthropic, openai, kimi-for-coding) + 4 pure resolvers: `findSubscriptionProvider`, `resolveAuthMethod`, `describeConnectShape`, `subscriptionStatuses`. No I/O.
- `src/server/opencode.mjs` — 5 thin HTTP proxies (`listProviderAuthMethods`, `startProviderOauth`, `completeProviderOauth`, `setProviderApiKey`, `removeProviderAuth`) returning structured `{ok,error,detail}` failures with discoverModels's vocabulary (`unreachable` / `unauthorized` / `bad_response`). API-key write returns `{ok}` only — never echoes the key, never logs it.
- `src/shared/types.ts`, `src/shared/api.ts`, `src/renderer/api/httpApi.ts`, `src/renderer/api/demoApi.ts`, `src/server/rpc.mjs` — 5-site wiring for a single `IPC.opencodeProviderAuth` channel with a 5-arm discriminated union (`status` / `start` / `code` / `key` / `disconnect`). No preload, no ipcMain.

## Why this shape

Per BET-308's standing rule ("never pass a literal auth-method index"), `resolveAuthMethod` picks by `type` + lowercased label-substring match. The Codex headless method sits at index 1 today but opencode reorders freely — hardcoding `1` would silently break on the next release.

## Tests

`src/server/subscriptionProviders.test.mjs` — 24 node:test cases, pure-only. Includes the BET-308 "single most important test": with a prompts-bearing method sitting BEFORE the match, the resolved index must still point at the right entry in the ORIGINAL `methods` array, not the filtered one.

## Verification

- `npm run typecheck` ✓
- `npm test` ✓ (914 pass / 0 fail)
- `grep -rn "method: *[0-9]" src/` ✓ no literal method indices outside tests