### PR TITLE
fix(plugins): raise registry publish body cap, stop swallowing failures

### DIFF
--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -398,6 +398,11 @@ async function publishRegistry(
   // oversized body is the nastiest case — the server destroys the socket,
   // so this surfaces as a thrown network error with no status at all.
   const body = JSON.stringify(rows);
+  // Byte length, NOT body.length — manifests are full of non-ASCII (arrows,
+  // em-dashes), so the UTF-16 string length understates the bytes actually
+  // sent. This number exists to be compared against a byte limit; reporting
+  // the wrong unit here would mislead exactly when it matters most.
+  const bytes = Buffer.byteLength(body);
   try {
     const res = await fetch(
       `${c.serverUrl.replace(/\/+$/, "")}/api/plugins/registry`,
@@ -413,13 +418,13 @@ async function publishRegistry(
     if (!res.ok) {
       console.warn(
         `[plugins] registry publish REJECTED: HTTP ${res.status} ` +
-          `(${rows.length} rows, ${body.length}B) — server list is now STALE`,
+          `(${rows.length} rows, ${bytes}B) — server list is now STALE`,
       );
     }
   } catch (err) {
     console.warn(
       `[plugins] registry publish FAILED: ${err instanceof Error ? err.message : String(err)} ` +
-        `(${rows.length} rows, ${body.length}B) — server list is now STALE; ` +
+        `(${rows.length} rows, ${bytes}B) — server list is now STALE; ` +
         `a body this size may exceed the server's limit`,
     );
   }

--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -389,8 +389,17 @@ async function publishRegistry(
       timeoutMs: null,
     };
   });
+  // Publishing is best-effort, but it must NEVER be SILENT. A swallowed
+  // failure here is indistinguishable from "nothing changed": the server
+  // keeps serving its last good snapshot, so Settings and plugin_list show
+  // a plausible-but-frozen list while the executor happily runs plugins the
+  // server has never heard of. That exact divergence (executor: 10 plugins,
+  // server: 8) went unnoticed because both ends logged nothing. An
+  // oversized body is the nastiest case — the server destroys the socket,
+  // so this surfaces as a thrown network error with no status at all.
+  const body = JSON.stringify(rows);
   try {
-    await fetch(
+    const res = await fetch(
       `${c.serverUrl.replace(/\/+$/, "")}/api/plugins/registry`,
       {
         method: "PUT",
@@ -398,11 +407,21 @@ async function publishRegistry(
           ...(c.boxToken ? { authorization: `Bearer ${c.boxToken}` } : {}),
           "content-type": "application/json",
         },
-        body: JSON.stringify(rows),
+        body,
       },
     );
-  } catch {
-    /* swallow — best-effort */
+    if (!res.ok) {
+      console.warn(
+        `[plugins] registry publish REJECTED: HTTP ${res.status} ` +
+          `(${rows.length} rows, ${body.length}B) — server list is now STALE`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[plugins] registry publish FAILED: ${err instanceof Error ? err.message : String(err)} ` +
+        `(${rows.length} rows, ${body.length}B) — server list is now STALE; ` +
+        `a body this size may exceed the server's limit`,
+    );
   }
 }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1048,7 +1048,17 @@ const handleRequest = async (req, res) => {
   if (path === "/api/plugins/registry") {
     try {
       if (req.method === "PUT") {
-        const body = await readJsonBody(req);
+        // NOT the default 64KB cap. This body carries the FULL YAML of
+        // EVERY installed manifest, so it scales with plugin count (~7.5KB
+        // per row in practice) — 64KB silently capped the registry at ~8
+        // plugins. Worse, exceeding a readBody limit destroys the socket,
+        // so the executor's PUT failed as a network error it could not see
+        // and the registry FROZE at the last payload that happened to fit
+        // (real incident: adding a 9th plugin stopped every subsequent
+        // publish, and both sides logged nothing). 2MB ≈ 260 plugins; the
+        // route is Bearer-authenticated, so this is a sizing bound, not a
+        // trust boundary.
+        const body = await readJsonBody(req, 2 * 1024 * 1024);
         const size = pluginsPutRegistry(body);
         respondJson(res, 200, { count: size });
         return;


### PR DESCRIPTION
## What was wrong

The Mac executor publishes the **entire** plugin registry in a single PUT, and each row carries that manifest's full YAML source (~7.5KB per plugin). The route used the default **64KB** body cap, so the payload outgrew it at roughly **8 plugins**.

Exceeding a `readBody` limit destroys the socket. So the PUT surfaced on the executor as a bare network error — which `publishRegistry` was explicitly discarding as "best effort" — and the server never got far enough to log anything.

**Both ends were silent.** The registry simply froze at the last payload that happened to fit, while the executor carried on running plugins the server had never heard of.

Observed live before the fix:

| | plugins |
|---|---|
| executor (in-memory, correct) | 10 |
| server registry (served to UI + `plugin_list`) | 8 |

The two missing ones were the most recently authored. Every publish since crossing the cap had been rejected.

Restarting the desktop app did **not** help and could not: a restart rescans and republishes the *same* oversized payload, which is rejected identically. This made it look like a stale server-side cache, which is why it was misdiagnosed.

## Changes

- **server** — read this route's body with a 2MB cap (~260 plugins). The route is Bearer-authenticated, so this is a sizing bound, not a trust boundary.
- **executor** — check `res.ok` and log both the rejected and the thrown case. A silent publish failure is indistinguishable from "nothing changed"; that silence is what turned a routine size limit into a full investigation.

## Verification

Reproduced and fixed against the live box:

- Before: real 10-row payload = 73.2KB → connection destroyed, `HTTP 000`, registry unchanged at 8 rows.
- After: registry accepts all 10 rows; payload now 80.5KB.
- `plugin_list` returns all 10, including the two that had been invisible.
- `npm run typecheck` clean; `npm test` 890/890 pass.

Note the payload grows ~7.5KB per plugin — under the old cap this was ~3 plugins away from recurring regardless.

## Known gap

No regression test. The route reads its body inline in the server entry's `handleRequest`, which isn't exported and initialises the whole server on import. Locking this with a route-level test needs that seam extracted first — deliberately out of scope for a hotfix, worth doing separately.