### PR TITLE
BET-317: wire homepage comparison-table tfoot to /vs-* pages

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -520,12 +520,9 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
         <tfoot><tr>
           <td></td>
           <td class="us"></td>
-          <!-- TODO: /vs-orca -->
-          <td><a href="#">Full comparison →</a></td>
-          <!-- TODO: /vs-conductor -->
-          <td><a href="#">Full comparison →</a></td>
-          <!-- TODO: /vs-ssh-tmux -->
-          <td><a href="#">Full comparison →</a></td>
+          <td><a href="/vs-orca">Full comparison →</a></td>
+          <td><a href="/vs-conductor">Full comparison →</a></td>
+          <td><a href="/vs-ssh-tmux">Full comparison →</a></td>
         </tr></tfoot>
       </table>
     </div>


### PR DESCRIPTION
## Scope
Wire the homepage comparison-table `<tfoot>`'s three "Full comparison →" links to the three pages added in BET-298 (PR #254). Those pages already exist at `/vs-orca`, `/vs-conductor`, `/vs-ssh-tmux` and are linked from the `<footer>`; the comparison table `<tfoot>` was missed during the BET-298 merge.

**Diff:** +3 / -6 in `website/index.html` (lines 523–528). Three `<!-- TODO: /vs-* -->` placeholders removed, three `<a href="#">` rewritten to the correct `/vs-*` paths.

**Base:** `origin/main` @ `db5b330`
**PR branch:** `multica/BET-317-vs-tfoot-links` @ `79fc411`

## Verification results

**Files changed:** 1 file. `website/index.html`.

- PR branch (`multica/BET-317-vs-tfoot-links` @ `79fc411`):
  - typecheck: exit 0. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538`
  - test: exit 1, 909 pass / 1 fail / 0 skip. Failures: `src/server/pty.test.mjs` (native node-pty module fails to load — see below). log sha256: `faa61804ee0be29dac681c33d4fa2fa431899710a1799f9eeaf096f9c16e9789`
- Base (`main` @ `db5b330`):
  - typecheck: exit 0. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538` (identical to PR branch)
  - test: exit 1, 909 pass / 1 fail / 0 skip. Failures: `src/server/pty.test.mjs`. log sha256: `642065c4caf817434ca5d718bc6fe4e016a184201a435f8a99f18559ba95826e`
- **Conclusion:** 1 test failure is pre-existing on `main` (identical failure mode — `node-pty` native module fails to load in the agent sandbox because `electron-rebuild` was skipped during `npm install --ignore-scripts`). 0 new failures, 0 resolved failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

## Acceptance criteria self-check
- Three tfoot `href="#"` rewritten to `/vs-orca`, `/vs-conductor`, `/vs-ssh-tmux`. → **9/10** (verified by grep — only intentional dead `href="#"` on line 603 "Read the docs" remains, explicitly out of scope)
- `grep -c 'TODO: /vs' website/index.html` → 0. → **10/10**
- `grep -nE 'href="#"' website/index.html | grep -i 'Full comparison'` → empty. → **10/10**
- `npm run typecheck` green. → **10/10** (identical to `main`)
- `npm test` no new failures. → **9/10** (1 pre-existing environment failure on `src/server/pty.test.mjs`, identical to `main`)
- `<footer>` chrome (lines 621–623) untouched. → **10/10** (verified by grep)
- `<tfoot>` styling (CSS class `.cmp tfoot a`) untouched. → **10/10** (HTML-only diff)
- Out-of-scope: "Read the docs" `href="#"` at line 603 not touched. → **10/10** (out of scope per issue)
- No edits to `website/vs-*.html` or `website/site.css`. → **10/10** (diff stat shows only `website/index.html`)
- No `web-v*` tag pushed. → **10/10**

All criteria 9+.

Closes BET-317.