### PR TITLE
fix(server): add getProviders() export — opencode:provider-auth status no longer throws (BET-318)

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -860,6 +860,37 @@ export async function getDefaultModel() {
 }
 
 /**
+ * Read the live provider state from opencode's `GET /provider`.
+ * Single source of truth for callers that need the authoritative
+ * `connected[]` list (and the full `all`/`default` shape when available).
+ *
+ * Used by the `opencode:provider-auth` `status` action to feed
+ * `subscriptionProviders.subscriptionStatuses(connected)`.
+ *
+ * @returns {Promise<{ connected: string[], all?: Array<{id:string}>, default?: Record<string,string> }>}
+ *   Never throws — a transport failure or non-2xx response yields
+ *   `{ connected: [] }` so the caller's `connected[]` reads are safe.
+ */
+export async function getProviders() {
+  try {
+    const res = await ocFetch(apiUrl("/provider"));
+    if (!res.ok) {
+      await discardBody(res);
+      return { connected: [] };
+    }
+    const data = await res.json();
+    return {
+      connected: Array.isArray(data?.connected) ? data.connected : [],
+      all: Array.isArray(data?.all) ? data.all : undefined,
+      default:
+        data?.default && typeof data.default === "object" ? data.default : undefined,
+    };
+  } catch {
+    return { connected: [] };
+  }
+}
+
+/**
  * List all models from CONNECTED providers only.
  * Strips raw API keys by reconstructing the model shape (normalizeProviderModel).
  * @returns {Promise<Array<{ id: string, providerID: string, name: string, ... }>>}

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -28,6 +28,7 @@ import {
   _getOcAgent,
   _pooledOcRequest,
   discardBody,
+  getProviders,
 } from "./opencode.mjs";
 
 test("apiUrl targets local opencode port 4096", () => {
@@ -686,6 +687,70 @@ test("discardBody swallows errors on an already-consumed body", async () => {
   await res.text(); // consume it
   await discardBody(res); // cancelling a used body would throw — must be swallowed
   assert.ok(true);
+});
+
+// ---------------------------------------------------------------------------
+// getProviders — live provider state from opencode's GET /provider
+// (BET-309 follow-up: BET-318). Feeds the `opencode:provider-auth` `status`
+// action. Must never throw — transport failures degrade to
+// `{ connected: [] }` so the caller's `connected[]` reads stay safe.
+// ---------------------------------------------------------------------------
+
+test("getProviders returns {connected:[...]} for a 200 with a populated connected[]", async () => {
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic", "openai"],
+          all: [{ id: "anthropic" }, { id: "openai" }, { id: "deepseek" }],
+          default: { anthropic: "claude-sonnet-4-6", openai: "gpt-5" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      const out = await getProviders();
+      assert.deepEqual(out.connected, ["anthropic", "openai"]);
+      assert.equal(out.all.length, 3);
+      assert.equal(out.default.anthropic, "claude-sonnet-4-6");
+    },
+  );
+});
+
+test("getProviders returns {connected:[]} on a non-2xx response", async () => {
+  await withMockFetch(
+    async () => new Response("server gone", { status: 503 }),
+    async () => {
+      const out = await getProviders();
+      assert.deepEqual(out.connected, []);
+    },
+  );
+});
+
+test("getProviders returns {connected:[]} on a transport throw", async () => {
+  await withMockFetch(
+    async () => { throw new Error("ECONNREFUSED"); },
+    async () => {
+      const out = await getProviders();
+      assert.deepEqual(out.connected, []);
+    },
+  );
+});
+
+test("getProviders coerces a non-array connected[] to []", async () => {
+  // Defensive: opencode has been observed to return shapes that drift over
+  // versions; the renderer's `connected.includes(id)` check must not break
+  // when the server returns e.g. `{connected: "anthropic"}`.
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({ connected: "anthropic", all: null, default: null }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      const out = await getProviders();
+      assert.deepEqual(out.connected, []);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -430,7 +430,7 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     "opencode:provider-auth": async (req) => {
       const action = req?.action;
       if (action === "status") {
-        const { connected } = await providers.getProviders();
+        const { connected } = await oc.getProviders();
         return {
           action: "status",
           providers: subscriptionProviders.subscriptionStatuses(connected),

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -338,3 +338,45 @@ test("tmux:new-session swallows projectMetaUpsert failures (best-effort)", async
   });
   assert.deepEqual(result, [], "tmux.newSession result returned (no throw)");
 });
+
+// ---- BET-309 follow-up (BET-318): opencode:provider-auth `status` -------
+//
+// Regression: BET-309 wired the `status` action to call
+// `providers.getProviders()`, but no such export existed → every status call
+// 500'd. Fix lifts the `GET /provider` fetch into a named export in
+// opencode.mjs (oc.getProviders) and switches the rpc handler to that.
+//
+// These tests assert the end-to-end shape the renderer sees from the rpc
+// channel, with the underlying opencode call stubbed via the `oc` dep.
+
+test("opencode:provider-auth status returns subscriptionStatuses for the connected set", async () => {
+  const { deps } = makeDeps([]);
+  deps.oc.getProviders = async () => ({
+    connected: ["anthropic", "openai"],
+  });
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({ action: "status" });
+  assert.equal(result.action, "status");
+  assert.ok(Array.isArray(result.providers));
+  // anthropic + openai show as connected; kimi-for-coding is the third
+  // SUBSCRIPTION_PROVIDERS entry — must NOT be connected.
+  const byId = Object.fromEntries(result.providers.map((p) => [p.id, p.connected]));
+  assert.equal(byId.anthropic, true);
+  assert.equal(byId.openai, true);
+  assert.equal(byId["kimi-for-coding"], false);
+});
+
+test("opencode:provider-auth status rejects with the upstream error (no try/catch in handler)", async () => {
+  const { deps } = makeDeps([]);
+  deps.oc.getProviders = async () => { throw new Error("upstream gone"); };
+  const handlers = buildHandlers(deps);
+  // The status branch awaits `oc.getProviders()` directly (no try/catch in
+  // the handler) — a thrown upstream surfaces as a rejected promise that
+  // the renderer's typed result would treat as an error. Pin the
+  // current behavior so a future "wrap with try/catch" change is a
+  // conscious one.
+  await assert.rejects(
+    () => handlers["opencode:provider-auth"]({ action: "status" }),
+    /upstream gone/,
+  );
+});


### PR DESCRIPTION
fix(server): add getProviders() export — opencode:provider-auth status no longer throws

BET-309's server side shipped an `opencode:provider-auth` channel that called `providers.getProviders()` at `rpc.mjs:433`, but the helper was never written. Every `status` call returned HTTP 500 with `providers.getProviders is not a function`, blocking every consumer of the subscription-provider epic (ConnectProvider, install-time detection, SubscriptionsCard, onboarding rewrite).

Fix is surgical:
- Lift the `GET /provider` fetch into a named export in `opencode.mjs` (`getProviders`), single source of truth for live provider state. Mirrors `getDefaultModel` / `listModels` above it.
- Switch `rpc.mjs` to call `oc.getProviders()` so the function is injectable via `buildHandlers` (the test seam every other channel uses).
- 4 unit tests for `getProviders` (happy / non-2xx / transport throw / non-array defensive) using `_setOcTransport`.
- 2 rpc integration tests for the `status` action — the previously uncovered channel (BET-309 had no `rpc.test.mjs` case for it).

Out of scope: `getDefaultModel`'s inlined `/provider` fetch. Same shape, different return — kept surgical per issue's "Do not" guidance. Can be a follow-up.

**Files changed:** 4 files.
```
 src/server/opencode.mjs      | 30 ++++++++++++++++++++++++++++++
 src/server/opencode.test.mjs | 71 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 src/server/rpc.mjs           |  2 +-
 src/server/rpc.test.mjs      | 36 ++++++++++++++++++++++++++++++++++++
```

**Verification results:**
- PR branch (`multica/BET-318-provider-auth-status-fix` @ `41a5f34`):
  - typecheck: exit `0`. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538`
  - test: exit `0`, `918` pass / `0` fail / `0` skip. Failures: none. log sha256: `2e197e201e741139961a6c8374f1ac4516e59dcfd0b3066757f09137c0075ddc`
- Base (`main` @ `db5b330`):
  - typecheck: exit `0`. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538`
  - test: exit `0`, `912` pass / `0` fail / `0` skip. Failures: none. log sha256: `9ebba3c34209763667d9ed4e1cbf6fa27221318d7e2767e3b3ec7b5f82f0c72e`
- **Conclusion:** 0 pre-existing failures, 0 new failures. PR adds 6 new tests (all passing): 4 for `getProviders` (happy / non-2xx / transport throw / non-array), 2 for the `opencode:provider-auth` `status` action (happy / upstream-throws).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

`Base: origin/main @ db5b330`
