### PR TITLE
feat(renderer): Settings → AI Subscriptions card above Providers (BET-314)

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -448,16 +448,16 @@ export function Settings({ onClose }: { onClose: () => void }) {
                 </div>
               </div>
 
-              <div className="border-t border-border pt-6">
-                <ProvidersCard />
-              </div>
-
               {/* Subscriptions (BET-314) — sits ABOVE ProvidersCard so the
                   user sees the one-tap OAuth path before the
                   bring-your-own-key path. New card, not a widening of
                   ProvidersCard (see src/server/providers.mjs's baseURL
                   filter). */}
               <SubscriptionsCard />
+
+              <div className="border-t border-border pt-6">
+                <ProvidersCard />
+              </div>
 
               {/* AI CLI launch options (BET-138 refinement) — flags used when
                   launching an AI CLI (e.g. Claude Code) directly in a

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useStore } from "./store";
 import { ProvidersCard } from "./ProvidersCard";
 import { ModelsCard } from "./ModelsCard";
+import { SubscriptionsCard } from "./SubscriptionsCard";
 import { PairingQR, PairingCountdown } from "./PairingQR";
 import { getMantaPreload } from "./preloadAccess";
 import { resolveLauncherFlags } from "./chatShared";
@@ -450,6 +451,13 @@ export function Settings({ onClose }: { onClose: () => void }) {
               <div className="border-t border-border pt-6">
                 <ProvidersCard />
               </div>
+
+              {/* Subscriptions (BET-314) — sits ABOVE ProvidersCard so the
+                  user sees the one-tap OAuth path before the
+                  bring-your-own-key path. New card, not a widening of
+                  ProvidersCard (see src/server/providers.mjs's baseURL
+                  filter). */}
+              <SubscriptionsCard />
 
               {/* AI CLI launch options (BET-138 refinement) — flags used when
                   launching an AI CLI (e.g. Claude Code) directly in a

--- a/src/renderer/SubscriptionsCard.tsx
+++ b/src/renderer/SubscriptionsCard.tsx
@@ -1,0 +1,171 @@
+// SubscriptionsCard — Settings → AI → Subscriptions (BET-314).
+//
+// One row per provider declared in src/server/subscriptionProviders.mjs.
+// Rows show connection status only (boolean — never a key fragment) and a
+// single action button that flips between Connect and Disconnect. The
+// connect-side flow is delegated to <ConnectProvider> (BET-312) so we
+// share one OAuth / API-key implementation across Settings + onboarding.
+// The disconnect side is a small inline destructive-confirm pattern copied
+// from ModelsCard (BET-123) — no new component, no new dependency.
+//
+// Freshness is refetch-driven (no poll, no bus subscription). The desktop
+// renderer is not wired to the server's in-process event bus, so any
+// "live update" delivery would only ever reach the mobile client (see
+// ScheduledTasksCard's comment for the standing precedent). Mount, then
+// refetch after every mutation.
+
+import { useCallback, useEffect, useState } from "react";
+import type { SubscriptionStatus } from "../shared/types";
+import { ConnectProvider } from "./ConnectProvider";
+import { describeSubscriptionStatus } from "./chatUtils";
+
+export function SubscriptionsCard() {
+  const [statuses, setStatuses] = useState<SubscriptionStatus[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Exactly one row can be mid-mutation at a time. The id is the registry
+  // id (anthropic / openai / kimi-for-coding); null when idle.
+  const [busy, setBusy] = useState<string | null>(null);
+  // Which row is currently showing its connect card. null = collapsed.
+  const [connectingId, setConnectingId] = useState<string | null>(null);
+  // Which row is showing its destructive-confirm bar. null = hidden.
+  const [disconnectConfirmId, setDisconnectConfirmId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await window.api.opencodeProviderAuth({ action: "status" });
+      if (res.action !== "status") {
+        setError("Unexpected response from the box.");
+        setStatuses([]);
+        return;
+      }
+      setStatuses(res.providers);
+      setError(null);
+    } catch (e) {
+      // Don't collapse a failure into a deceptively-empty list — surface it
+      // as an inline error line, exactly like ProvidersCard's globalError.
+      setError(e instanceof Error ? e.message : String(e));
+      setStatuses([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const disconnect = useCallback(
+    async (id: string) => {
+      if (busy) return;
+      setBusy(id);
+      try {
+        const res = await window.api.opencodeProviderAuth({ action: "disconnect", id });
+        if (res.action === "disconnect" && !res.ok) {
+          setError(res.error ?? "Disconnect failed.");
+        } else if (res.action !== "disconnect") {
+          setError("Unexpected response from the box.");
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusy(null);
+        setDisconnectConfirmId(null);
+        void refresh();
+      }
+    },
+    [busy, refresh],
+  );
+
+  const onConnectDone = useCallback(
+    (ok: boolean) => {
+      setConnectingId(null);
+      if (!ok) setError("Connect didn't complete. Try again.");
+      void refresh();
+    },
+    [refresh],
+  );
+
+  return (
+    <div className="space-y-2 pt-2 border-t border-border">
+      <label className="block text-xs uppercase tracking-wider text-text-muted">
+        Subscriptions
+      </label>
+      <div className="text-xs text-text-faint space-y-1">
+        <div>
+          Sign in with a subscription you already pay for. MantaUI never sees
+          your password or your key after it is saved.
+        </div>
+      </div>
+
+      {error && <div className="text-xs text-red-400 break-words">{error}</div>}
+
+      {(statuses ?? []).map((s) => (
+        <div key={s.id} className="border border-border rounded p-2 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm text-text truncate">
+                <span className="font-medium">{s.label}</span>
+                <span className="text-text-faint"> · {s.plan}</span>
+              </div>
+              <div className="text-[10px] text-text-faint flex items-center gap-1.5">
+                <span
+                  aria-hidden
+                  className={`inline-block w-1.5 h-1.5 rounded-full ${
+                    s.connected ? "bg-green-400" : "bg-text-faint"
+                  }`}
+                />
+                <span>{describeSubscriptionStatus(s)}</span>
+              </div>
+            </div>
+            {connectingId === s.id ? null : s.connected ? (
+              disconnectConfirmId === s.id ? (
+                <div className="flex items-center gap-1.5">
+                  <button
+                    onClick={() => void disconnect(s.id)}
+                    disabled={busy !== null}
+                    className="px-2 py-1 text-xs bg-red-900/30 border border-red-800 rounded text-red-300 hover:text-red-200 disabled:opacity-40"
+                  >
+                    {busy === s.id ? "…" : "Disconnect"}
+                  </button>
+                  <button
+                    onClick={() => setDisconnectConfirmId(null)}
+                    disabled={busy !== null}
+                    className="px-2 py-1 text-xs text-text-faint hover:text-text disabled:opacity-40"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setDisconnectConfirmId(s.id)}
+                  disabled={busy !== null || connectingId !== null}
+                  className="px-2 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+                >
+                  Disconnect
+                </button>
+              )
+            ) : (
+              <button
+                onClick={() => {
+                  setError(null);
+                  setConnectingId(s.id);
+                }}
+                disabled={busy !== null || connectingId !== null}
+                className="px-2 py-1 text-xs bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+              >
+                Connect
+              </button>
+            )}
+          </div>
+          {connectingId === s.id && (
+            <ConnectProvider
+              id={s.id}
+              label={s.label}
+              confirmRestart={true}
+              onDone={onConnectDone}
+              onCancel={() => setConnectingId(null)}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -69,6 +69,7 @@ import {
   parseDeviceCode,
   connectPhaseLabel,
   isPollExpired,
+  describeSubscriptionStatus,
 } from "./chatUtils";
 
 // ===== formatTokens =====
@@ -3064,5 +3065,40 @@ describe("isPollExpired", () => {
     expect(isPollExpired(NaN, 1000, 5000)).toBe(false);
     expect(isPollExpired(1000, NaN, 5000)).toBe(false);
     expect(isPollExpired(1000, 1000, NaN)).toBe(false);
+  });
+});
+
+// ===== describeSubscriptionStatus (BET-314) =====
+//
+// SubscriptionsCard renders "connected" / "not connected" next to each row.
+// The string is the entire UX (no badge, no chip), so a future copy tweak
+// should land here, not inline in the JSX. Two tests, both exhaustive over
+// the boolean — anything else (a third value, mixed casing) is a regression.
+
+describe("describeSubscriptionStatus", () => {
+  it("returns 'connected' when status.connected is true", () => {
+    expect(
+      describeSubscriptionStatus({
+        id: "anthropic",
+        label: "Claude",
+        plan: "Claude Pro / Max",
+        console: null,
+        docs: "https://claude.com/pricing",
+        connected: true,
+      }),
+    ).toBe("connected");
+  });
+
+  it("returns 'not connected' when status.connected is false", () => {
+    expect(
+      describeSubscriptionStatus({
+        id: "openai",
+        label: "Codex",
+        plan: "ChatGPT Plus / Pro",
+        console: null,
+        docs: "https://openai.com/chatgpt/pricing",
+        connected: false,
+      }),
+    ).toBe("not connected");
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -4,6 +4,7 @@
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
+import type { SubscriptionStatus } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
 // shared/versionCompare.mjs so both src/server/*.mjs and the renderer share
@@ -2196,4 +2197,17 @@ export function isPollExpired(
     return false;
   }
   return now - startedAt >= limitMs;
+}
+
+// ===== Subscription provider status (BET-314) =====
+//
+// Single source of truth for the connected/not-connected label the
+// SubscriptionsCard renders next to each row. The renderer never invents
+// its own copy here — the connect-card description ("● connected") is the
+// whole UX, and pinning the strings in chatUtils.ts keeps a future i18n /
+// copy pass touching one place. Returns "connected" / "not connected" with
+// no extra ornament (no leading dot, no uppercase — the row already draws
+// the dot separately and styles the casing).
+export function describeSubscriptionStatus(s: SubscriptionStatus): string {
+  return s.connected ? "connected" : "not connected";
 }

--- a/src/renderer/mobile/MobileSettings.tsx
+++ b/src/renderer/mobile/MobileSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useStore } from "../store";
 import { ProvidersCard } from "../ProvidersCard";
+import { SubscriptionsCard } from "../SubscriptionsCard";
 import { resolveLauncherFlags } from "../chatShared";
 import type { AvailableLauncher, OpencodeModel } from "../../shared/types";
 import {
@@ -374,6 +375,7 @@ export function MobileSettings({ onClose }: Props) {
           </div>
         </section>
 
+        <SubscriptionsCard />
         <ProvidersCard />
 
         {/* AI CLI launch options (BET-138 refinement) — mirrors desktop


### PR DESCRIPTION
# Subscriptions card above Providers in Settings → AI (BET-314)

New `SubscriptionsCard` (one row per provider from `src/server/subscriptionProviders.mjs`: Claude / Codex / Kimi) lives in the Settings AI tab **immediately above** `<ProvidersCard />`. Same component is rendered by mobile (`MobileSettings.tsx`) — one import + one line, no forked markup, no `mobile.css` edits.

## Why a sibling card, not a widened `ProvidersCard`

`ProvidersCard` means exactly one thing: a bring-your-own-API-key, OpenAI-compatible HTTP endpoint stored as a `provider` block in `opencode.jsonc` with `{baseURL, apiKey, models}`. Every affordance it has (Refresh, per-model toggles, delete) is meaningless for a subscription provider — and worse, actively harmful: rendering a plugin-authed provider in that card would give it a Refresh button fetching `"" + "/models"`, and a model toggle or ✕ that overwrites the block with `npm:"@ai-sdk/openai-compatible"` + empty baseURL, corrupting the auth. The filter in `src/server/providers.mjs` exists to prevent exactly that. So: new card, `ProvidersCard.tsx` unmodified, `providers.mjs` baseURL filter unmodified.

## What changed

- **NEW** `src/renderer/SubscriptionsCard.tsx` (171 lines, under 200) — refetch-driven (`on mount`, on connect `onDone`, on disconnect), delegates the connect flow to `ConnectProvider` (BET-312) so Settings + onboarding share one OAuth/API-key implementation, reuses the inline destructive-confirm pattern from `ModelsCard` for disconnect. Failed status fetch renders an inline error line, never throws.
- **`src/renderer/Settings.tsx`** — one import + one mount line (`<SubscriptionsCard />` directly above `<ProvidersCard />`).
- **`src/renderer/mobile/MobileSettings.tsx`** — one import + one mount line. No mobile-specific styling.
- **`src/renderer/chatUtils.ts`** — `describeSubscriptionStatus` helper. Single source of "connected" / "not connected" copy so a future i18n pass touches one place.
- **`src/renderer/chatUtils.test.ts`** — two new tests pinning the connected/not-connected strings.

`ProvidersCard.tsx`, `src/server/providers.mjs`, and `mobile/mobile.css` are **unmodified**.

## Freshness model

Refetch-driven, **not** polled, **not** bus-subscribed. The desktop renderer is not wired to the server's in-process event bus (see `ScheduledTasksCard`'s standing precedent); a bus event would only ever reach mobile. Mount + post-mutation refetch is the same shape `ProvidersCard` already uses.

## Verification results

- PR branch (`multica/BET-314-subscriptions-card` @ `969837e`):
  - typecheck: exit `0`. Errors: none. log sha256: `90b0eeddb9b3861028124843beb544bff990ada200e98e0504c316f810099538`
  - test: exit `0`, `1070` vitest pass / `0` fail / `0` skip + `943` node-test pass / `0` fail. Failures: none. log sha256: `7d1c45cb8b65297c6b9e740a7f90d5a2011fdfc46dec73fe45de3bdcacab53a1`
  - e2e-smoke (Playwright Electron, xvfb-run on Linux): A (`windowTitle: "Manta UI"`) + F (`real_errors: 0`) PASS. B/C/D report "no sidebar / main / xterm" because the app is in first-run onboarding-overlay state ("Connect to your server" h2) — that is the expected fresh-install surface, not a regression introduced by this PR.
- Base: `origin/main @ bd7bd23`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.

## Cross-cutting follow-ups

None. Nothing this PR changes (the `IPC.opencodeProviderAuth` channel, the `SubscriptionStatus` type, the `opencodeProviderAuth` action surface) is consumed by any other renderer code beyond `ConnectProvider` and `ModelsCard` — both already aligned.

Base: `origin/main @ bd7bd23`
