### PR TITLE
macOS box: end-to-end install smoke on Apple Silicon + the three defects it found

### DIFF
--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -308,10 +308,22 @@ jobs:
           cat "$RUNNER_TEMP/new-session.json"; echo
           projects="$(curl -fsS http://127.0.0.1:8787/api/projects -H "authorization: Bearer $MANTA_TOKEN")"
           printf '%s\n' "$projects"
-          # tmux uniquifies the session name (`smoke` → `smoke_0`), so match the
-          # prefix rather than the exact string.
-          printf '%s' "$projects" | grep -q '"tmuxSession":"smoke' \
-            || { echo "FAIL: the server cannot see the tmux session it just created (tmux missing from the launchd PATH?)"; exit 1; }
+          # The name must come back EXACTLY as created and the session must have
+          # its window. Both were wrong before the locale fix: a service gets no
+          # locale from launchd, tmux then replaced the TAB field separator in
+          # its -F output with `_`, so the session was reported as `smoke_0`
+          # (name + attached flag glued together) and every window line was
+          # orphaned and dropped. Anything less than an exact match here would
+          # let that regression back in.
+          printf '%s' "$projects" | python3 -c '
+          import json, sys
+          projects = json.load(sys.stdin)
+          names = [p["tmuxSession"] for p in projects]
+          assert names == ["smoke"], f"expected exactly the session we created, got {names}"
+          wins = projects[0]["windows"]
+          assert len(wins) >= 1, "session reported with no windows"
+          print("session", names[0], "with", len(wins), "window(s):", [w["name"] for w in wins])
+          ' || { echo "FAIL: the server sees a corrupted view of tmux"; exit 1; }
           # Independent confirmation from outside the server: the tmux server
           # the RPC spawned is real and reachable on the user's default socket.
           tmux list-sessions || { echo "FAIL: no tmux server running after the RPC"; exit 1; }

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -154,7 +154,11 @@ jobs:
           # is still exercised for real.
           ver="$(gh api repos/anomalyco/opencode/releases/latest --jq .tag_name | sed 's/^v//')"
           echo "pinning opencode $ver"
-          curl -fsSL https://opencode.ai/install | bash -s -- --version "$ver" </dev/null
+          # Script from a FILE, stdin from /dev/null — `curl … | bash -s -- …
+          # </dev/null` starves bash of its own script (the same trap install.sh
+          # itself hit).
+          curl -fsSL https://opencode.ai/install -o "$RUNNER_TEMP/oc-install.sh"
+          bash "$RUNNER_TEMP/oc-install.sh" --version "$ver" </dev/null
           echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
           "$HOME/.opencode/bin/opencode" --version
 

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -325,23 +325,30 @@ jobs:
           # `smoke` — i.e. the TAB that src/server/tmux.mjs uses to separate
           # format fields is not surviving this tmux. Dump the raw bytes for a
           # few candidate separators so the fix is chosen on evidence.
-          # Replay the EXACT two queries src/server/tmux.mjs runs (same formats,
-          # including the @manta-* user options) and dump the raw bytes.
+          # The server reports this session as `smoke_0` with NO windows, while
+          # the same query from this shell returns a clean tab-separated line —
+          # i.e. the TAB that src/server/tmux.mjs uses as its field separator
+          # comes back as `_` for the server but not for us. Everything else
+          # (binary, socket, cwd) is identical, so the difference has to be the
+          # environment launchd gives the agent. Bisect it.
           node -e '
             const { execFileSync } = require("child_process");
             const FS = "\t";
-            const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
-            const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}`;
-            for (const [label, args] of [
-              ["list-sessions", ["list-sessions", "-F", sessFmt]],
-              ["list-windows ", ["list-windows", "-a", "-F", winFmt]],
-            ]) {
+            const fmt = `#{session_name}${FS}#{?session_attached,1,0}`;
+            const run = (label, env) => {
               try {
-                console.log(label, JSON.stringify(execFileSync("tmux", args, { encoding: "utf8" })));
+                console.log(label, JSON.stringify(execFileSync("tmux", ["list-sessions", "-F", fmt], { encoding: "utf8", env })));
               } catch (e) {
                 console.log(label, "FAILED", String(e.stderr ?? e.message).trim());
               }
-            }
+            };
+            const PATH = process.env.PATH;
+            run("inherited     ", process.env);
+            run("bare PATH     ", { PATH });
+            run("PATH+TERM     ", { PATH, TERM: "xterm-256color" });
+            run("PATH+LANG     ", { PATH, LANG: "en_US.UTF-8" });
+            run("PATH+TERM+LANG", { PATH, TERM: "xterm-256color", LANG: "en_US.UTF-8" });
+            console.log("our TERM:", JSON.stringify(process.env.TERM), "LANG:", JSON.stringify(process.env.LANG), "LC_ALL:", JSON.stringify(process.env.LC_ALL));
           ' || true
           echo "ok — server-side tmux works."
 

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -218,12 +218,17 @@ jobs:
       - name: Assert — servers answer on loopback
         run: |
           set -euo pipefail
-          curl -fsS http://127.0.0.1:8787/auth/status >/dev/null \
-            || { echo "FAIL: manta-server /auth/status unreachable"; exit 1; }
-          code="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4096/ || true)"
-          [ -n "$code" ] && [ "$code" != "000" ] \
+          # ANY HTTP status means the listener is up — /auth/status answers 401
+          # to an unauthenticated caller, which is correct behaviour for a box
+          # that has not been paired yet. Only "000" (no response) is a failure.
+          # This mirrors waitForHealth's acceptAnyStatus contract.
+          mcode="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/auth/status || true)"
+          [ -n "$mcode" ] && [ "$mcode" != "000" ] \
+            || { echo "FAIL: manta-server not listening on 8787"; exit 1; }
+          ocode="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4096/ || true)"
+          [ -n "$ocode" ] && [ "$ocode" != "000" ] \
             || { echo "FAIL: opencode-serve not listening on 4096"; exit 1; }
-          echo "manta-server ok; opencode http=$code"
+          echo "manta-server http=$mcode; opencode http=$ocode"
 
       - name: Assert — restarting the agent brings the server back
         run: |
@@ -232,7 +237,8 @@ jobs:
           # KeepAlive + RunAtLoad put it back on the port.
           launchctl kickstart -k "gui/$(id -u)/com.mantaui.server"
           for i in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:8787/auth/status >/dev/null 2>&1; then
+            # Any status (incl. the unpaired 401) = the listener is back.
+            if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/auth/status || true)" != "000" ]; then
               echo "server back after ${i}s"; exit 0
             fi
             sleep 1
@@ -296,8 +302,8 @@ jobs:
           [ "$before" = "$after" ] || { echo "FAIL: box_id changed on re-install ($before -> $after)"; exit 1; }
           grep -q "preserving it" "$GITHUB_WORKSPACE/install2.log" \
             || { echo "FAIL: re-install did not report a preserved identity"; exit 1; }
-          curl -fsS http://127.0.0.1:8787/auth/status >/dev/null \
-            || { echo "FAIL: server unhealthy after re-install"; exit 1; }
+          [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/auth/status || true)" != "000" ] \
+            || { echo "FAIL: server not listening after re-install"; exit 1; }
           echo "identity preserved: $after"
 
       - name: Collect diagnostics

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -133,25 +133,30 @@ jobs:
           done
           echo "clean."
 
-      - name: Diagnose the third-party opencode installer (non-fatal)
-        continue-on-error: true
+      - name: Pre-install opencode (works around GitHub's anonymous API rate limit)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          set +e
-          # install.sh shells out to `curl -fsSL https://opencode.ai/install | bash`
-          # and can only report "opencode install failed". Split the pipeline so a
-          # failure names itself: fetch, then run, then probe the binary.
-          curl -fsSL https://opencode.ai/install -o "$RUNNER_TEMP/oc-install.sh" \
-            -w 'fetch: http=%{http_code} time=%{time_total}s size=%{size_download}\n'
-          echo "curl exit=$?"
-          ls -l "$RUNNER_TEMP/oc-install.sh"; head -3 "$RUNNER_TEMP/oc-install.sh"
-          echo "--- bash version ---"; bash --version | head -1
-          echo "--- running installer ---"
-          bash "$RUNNER_TEMP/oc-install.sh" </dev/null 2>&1 | tail -40
-          echo "installer exit=${PIPESTATUS[0]}"
-          echo "--- probe ---"
-          ls -l "$HOME/.opencode/bin" 2>&1
-          command -v opencode || echo "(not on PATH)"
-          true
+          set -euo pipefail
+          # WHY: opencode's own installer resolves "latest" through the
+          # UNAUTHENTICATED GitHub API (api.github.com/repos/anomalyco/opencode/
+          # releases/latest). GitHub-hosted runners share egress IPs and are
+          # routinely rate-limited there, so the call returns nothing and the
+          # installer dies with "Failed to fetch version information" — which
+          # install.sh can only report as "opencode install failed". Verified on
+          # this runner: the fetch of the install script itself is a clean 200 in
+          # 40ms; only the API call fails.
+          #
+          # Resolving the tag with the job's GITHUB_TOKEN and passing --version
+          # skips that API call entirely. install.sh then takes its
+          # "opencode already installed" branch, which is a legitimate real-world
+          # state (a box that already had opencode) — everything downstream of it
+          # is still exercised for real.
+          ver="$(gh api repos/anomalyco/opencode/releases/latest --jq .tag_name | sed 's/^v//')"
+          echo "pinning opencode $ver"
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$ver" </dev/null
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+          "$HOME/.opencode/bin/opencode" --version
 
       - name: Run the installer
         run: |

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -133,6 +133,26 @@ jobs:
           done
           echo "clean."
 
+      - name: Diagnose the third-party opencode installer (non-fatal)
+        continue-on-error: true
+        run: |
+          set +e
+          # install.sh shells out to `curl -fsSL https://opencode.ai/install | bash`
+          # and can only report "opencode install failed". Split the pipeline so a
+          # failure names itself: fetch, then run, then probe the binary.
+          curl -fsSL https://opencode.ai/install -o "$RUNNER_TEMP/oc-install.sh" \
+            -w 'fetch: http=%{http_code} time=%{time_total}s size=%{size_download}\n'
+          echo "curl exit=$?"
+          ls -l "$RUNNER_TEMP/oc-install.sh"; head -3 "$RUNNER_TEMP/oc-install.sh"
+          echo "--- bash version ---"; bash --version | head -1
+          echo "--- running installer ---"
+          bash "$RUNNER_TEMP/oc-install.sh" </dev/null 2>&1 | tail -40
+          echo "installer exit=${PIPESTATUS[0]}"
+          echo "--- probe ---"
+          ls -l "$HOME/.opencode/bin" 2>&1
+          command -v opencode || echo "(not on PATH)"
+          true
+
       - name: Run the installer
         run: |
           set -euo pipefail

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -21,13 +21,14 @@
 # does real network I/O (mantaui.com, github.com, opencode.ai) and takes ~10
 # min, so it is deliberately not wired into the PR gate.
 #
-# GATEWAY REGISTRATION IS SKIPPED BY DEFAULT. Sub-step 7.5-B of the installer
-# POSTs a fresh box_id to gateway.mantaui.com/register, which publishes a real
-# per-box DNS A record on the prod zone. A CI box is thrown away minutes later,
-# so the default points MANTA_GATEWAY_BASE at a dead loopback port: curl fails
-# fast, the installer warns and continues (the documented degraded path), and
-# prod DNS stays clean. Pass gateway=real to exercise the registration for
-# real — expect a junk A record afterwards.
+# GATEWAY REGISTRATION. `gateway=skip` (the default) points the INSTALLER's
+# MANTA_GATEWAY_BASE at a dead loopback port so its own registration POST fails
+# fast and takes the documented degraded path. Be aware this does NOT stop the
+# registration entirely: manta-server ALSO registers itself on boot against the
+# built-in gateway URL, and the LaunchAgent plist passes it no override — so a
+# run does leave one throwaway `<box_id>.boxes.mantaui.com` A record behind on
+# the prod zone. Harmless (it points at a dead runner IP) but worth knowing
+# before scheduling this hourly.
 #
 # WHAT A GREEN RUN PROVES
 #   1. Prereq detection works with BSD tooling (shasum, no coreutils).
@@ -113,7 +114,30 @@ jobs:
           echo "shasum: $(command -v shasum)"
           echo "sha256sum: $(command -v sha256sum || echo '(absent — expected on a stock Mac)')"
 
+      # Full history: the branch-mode step below publishes HEAD into a local
+      # bare repo, and git refuses to push out of a shallow clone.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Point the deploy at this PR's code (branch mode only)
+        if: env.INSTALLER == 'branch'
+        run: |
+          set -euo pipefail
+          # install.sh re-creates $MANTA_HOME as a git checkout and does
+          # `fetch origin main && reset --hard origin/main` (step 4b) so
+          # self-update.sh has something to pull. Left alone, that would deploy
+          # `main`'s server code even though we are testing a PR — the branch's
+          # install.sh would run, but every file it deploys (src/server/**, the
+          # launchd templates) would come from main. Publishing HEAD as `main`
+          # in a local bare repo makes the deploy the PR's code, so a change to
+          # a plist or to the server is actually exercised on the Mac.
+          # (node_modules + runtime/ still come from the released tarball —
+          # untracked paths survive `reset --hard`.)
+          git init --bare -q "$RUNNER_TEMP/manta.git"
+          git push -q "$RUNNER_TEMP/manta.git" "HEAD:refs/heads/main"
+          echo "MANTA_REPO_URL=file://$RUNNER_TEMP/manta.git" >> "$GITHUB_ENV"
+          echo "deploy source: this PR ($(git rev-parse --short HEAD))"
 
       - name: Install box prerequisites (tmux)
         run: |

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -331,37 +331,10 @@ jobs:
           # windows array (so `defaultCwd` falls back to "~"). Print the raw
           # window list so a future run can say whether tmux really created no
           # window or whether `list-windows -a` is what's misbehaving here.
+          # Context for whoever debugs the next failure here: tmux's own view,
+          # to compare against what the server reported above.
           echo "--- tmux list-windows -a ---"; tmux list-windows -a || true
           tmux -V
-          # The API reports the session as `smoke_0` while tmux itself calls it
-          # `smoke` — i.e. the TAB that src/server/tmux.mjs uses to separate
-          # format fields is not surviving this tmux. Dump the raw bytes for a
-          # few candidate separators so the fix is chosen on evidence.
-          # The server reports this session as `smoke_0` with NO windows, while
-          # the same query from this shell returns a clean tab-separated line —
-          # i.e. the TAB that src/server/tmux.mjs uses as its field separator
-          # comes back as `_` for the server but not for us. Everything else
-          # (binary, socket, cwd) is identical, so the difference has to be the
-          # environment launchd gives the agent. Bisect it.
-          node -e '
-            const { execFileSync } = require("child_process");
-            const FS = "\t";
-            const fmt = `#{session_name}${FS}#{?session_attached,1,0}`;
-            const run = (label, env) => {
-              try {
-                console.log(label, JSON.stringify(execFileSync("tmux", ["list-sessions", "-F", fmt], { encoding: "utf8", env })));
-              } catch (e) {
-                console.log(label, "FAILED", String(e.stderr ?? e.message).trim());
-              }
-            };
-            const PATH = process.env.PATH;
-            run("inherited     ", process.env);
-            run("bare PATH     ", { PATH });
-            run("PATH+TERM     ", { PATH, TERM: "xterm-256color" });
-            run("PATH+LANG     ", { PATH, LANG: "en_US.UTF-8" });
-            run("PATH+TERM+LANG", { PATH, TERM: "xterm-256color", LANG: "en_US.UTF-8" });
-            console.log("our TERM:", JSON.stringify(process.env.TERM), "LANG:", JSON.stringify(process.env.LANG), "LC_ALL:", JSON.stringify(process.env.LC_ALL));
-          ' || true
           echo "ok — server-side tmux works."
 
       - name: Assert — re-running the installer preserves box identity

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -315,6 +315,12 @@ jobs:
           # Independent confirmation from outside the server: the tmux server
           # the RPC spawned is real and reachable on the user's default socket.
           tmux list-sessions || { echo "FAIL: no tmux server running after the RPC"; exit 1; }
+          # FYI, not an assertion: the API reports the new session with an EMPTY
+          # windows array (so `defaultCwd` falls back to "~"). Print the raw
+          # window list so a future run can say whether tmux really created no
+          # window or whether `list-windows -a` is what's misbehaving here.
+          echo "--- tmux list-windows -a ---"; tmux list-windows -a || true
+          tmux -V
           echo "ok — server-side tmux works."
 
       - name: Assert — re-running the installer preserves box identity

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -308,8 +308,13 @@ jobs:
           cat "$RUNNER_TEMP/new-session.json"; echo
           projects="$(curl -fsS http://127.0.0.1:8787/api/projects -H "authorization: Bearer $MANTA_TOKEN")"
           printf '%s\n' "$projects"
-          printf '%s' "$projects" | grep -q '"smoke"' \
+          # tmux uniquifies the session name (`smoke` → `smoke_0`), so match the
+          # prefix rather than the exact string.
+          printf '%s' "$projects" | grep -q '"tmuxSession":"smoke' \
             || { echo "FAIL: the server cannot see the tmux session it just created (tmux missing from the launchd PATH?)"; exit 1; }
+          # Independent confirmation from outside the server: the tmux server
+          # the RPC spawned is real and reachable on the user's default socket.
+          tmux list-sessions || { echo "FAIL: no tmux server running after the RPC"; exit 1; }
           echo "ok — server-side tmux works."
 
       - name: Assert — re-running the installer preserves box identity

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -325,16 +325,23 @@ jobs:
           # `smoke` — i.e. the TAB that src/server/tmux.mjs uses to separate
           # format fields is not surviving this tmux. Dump the raw bytes for a
           # few candidate separators so the fix is chosen on evidence.
+          # Replay the EXACT two queries src/server/tmux.mjs runs (same formats,
+          # including the @manta-* user options) and dump the raw bytes.
           node -e '
             const { execFileSync } = require("child_process");
-            const probe = (label, sep) => {
-              const out = execFileSync("tmux", ["list-sessions", "-F", `#{session_name}${sep}#{?session_attached,1,0}`], { encoding: "utf8" });
-              console.log(label, JSON.stringify(out));
-            };
-            probe("tab   ", "\t");
-            probe("unit  ", "\u001f");
-            probe("pipe  ", "|");
-            probe("dcolon", "::");
+            const FS = "\t";
+            const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
+            const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}`;
+            for (const [label, args] of [
+              ["list-sessions", ["list-sessions", "-F", sessFmt]],
+              ["list-windows ", ["list-windows", "-a", "-F", winFmt]],
+            ]) {
+              try {
+                console.log(label, JSON.stringify(execFileSync("tmux", args, { encoding: "utf8" })));
+              } catch (e) {
+                console.log(label, "FAILED", String(e.stderr ?? e.message).trim());
+              }
+            }
           ' || true
           echo "ok — server-side tmux works."
 

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -321,6 +321,21 @@ jobs:
           # window or whether `list-windows -a` is what's misbehaving here.
           echo "--- tmux list-windows -a ---"; tmux list-windows -a || true
           tmux -V
+          # The API reports the session as `smoke_0` while tmux itself calls it
+          # `smoke` — i.e. the TAB that src/server/tmux.mjs uses to separate
+          # format fields is not surviving this tmux. Dump the raw bytes for a
+          # few candidate separators so the fix is chosen on evidence.
+          node -e '
+            const { execFileSync } = require("child_process");
+            const probe = (label, sep) => {
+              const out = execFileSync("tmux", ["list-sessions", "-F", `#{session_name}${sep}#{?session_attached,1,0}`], { encoding: "utf8" });
+              console.log(label, JSON.stringify(out));
+            };
+            probe("tab   ", "\t");
+            probe("unit  ", "\u001f");
+            probe("pipe  ", "|");
+            probe("dcolon", "::");
+          ' || true
           echo "ok — server-side tmux works."
 
       - name: Assert — re-running the installer preserves box identity

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -1,0 +1,301 @@
+# macOS install smoke — prove `install.sh` really works on an Apple Silicon box.
+#
+# WHY THIS EXISTS
+# ---------------
+# BET-274/276/277 added macOS as a supported BOX OS (loopback-only, LaunchAgents
+# instead of systemd, no Caddy/apt/DNS). Every part of that path is untestable
+# from the Linux dev box: `launchctl bootstrap gui/$(id -u)`, the plist render,
+# the darwin-arm64 tarball's native node-pty binding, `shasum` instead of
+# `sha256sum`, and the "installer never prints a systemctl command on macOS"
+# rule. This workflow runs the REAL installer end-to-end on a GitHub-hosted
+# macos-14 (Apple Silicon) runner and asserts it reaches the pairing code —
+# then proves the code is live by claiming it and driving one authenticated RPC.
+#
+# RUNNER CHOICE: GitHub-hosted `macos-14` (arm64), NOT the self-hosted runner
+# and NOT Codemagic. It costs zero wall-clock on `manta-dev-runner` (the single
+# self-hosted box every PR queues behind — see AGENTS.md "CI runs on ONE
+# runner"), and the repo already builds the darwin-arm64 tarball on macos-14 in
+# server-tarball-deploy.yml, so the image is known-good for this stack.
+#
+# NOT A REQUIRED CHECK. It is manual (workflow_dispatch) + a weekly cron. It
+# does real network I/O (mantaui.com, github.com, opencode.ai) and takes ~10
+# min, so it is deliberately not wired into the PR gate.
+#
+# GATEWAY REGISTRATION IS SKIPPED BY DEFAULT. Sub-step 7.5-B of the installer
+# POSTs a fresh box_id to gateway.mantaui.com/register, which publishes a real
+# per-box DNS A record on the prod zone. A CI box is thrown away minutes later,
+# so the default points MANTA_GATEWAY_BASE at a dead loopback port: curl fails
+# fast, the installer warns and continues (the documented degraded path), and
+# prod DNS stays clean. Pass gateway=real to exercise the registration for
+# real — expect a junk A record afterwards.
+#
+# WHAT A GREEN RUN PROVES
+#   1. Prereq detection works with BSD tooling (shasum, no coreutils).
+#   2. The darwin-arm64 tarball downloads, sha256-verifies and extracts.
+#   3. opencode installs and comes up on 127.0.0.1:4096.
+#   4. Both LaunchAgents load into the GUI domain and keep their process alive.
+#   5. manta-server answers /auth/status on 127.0.0.1:8787.
+#   6. The install tail prints a 6-digit pairing code (the last screen a user
+#      sees) and NEVER prints a systemctl command.
+#   7. `manta pair` (the ~/.local/bin shim) mints a FRESH code…
+#   8. …which /auth/claim exchanges for a real box_token…
+#   9. …that authenticates a tmux RPC — i.e. the server can actually reach the
+#      `tmux` binary from its launchd environment (launchd does NOT inherit a
+#      login shell PATH, so a Homebrew-only tmux is a genuine failure mode).
+#  10. Re-running the installer preserves the box identity (box_id unchanged).
+
+name: macOS install smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      installer:
+        description: "Which install.sh to run"
+        type: choice
+        default: published
+        options:
+          - published # curl https://mantaui.com/install.sh | bash  (the real user path)
+          - branch # bash scripts/install.sh from this checkout
+      version:
+        description: "MANTA_VERSION to install (manifest key)"
+        type: string
+        default: latest
+      gateway:
+        description: "Gateway registration (real = publishes a prod DNS record)"
+        type: choice
+        default: skip
+        options:
+          - skip
+          - real
+  schedule:
+    # Mondays 06:00 UTC — catches drift in install.sh, the darwin tarball, or
+    # the macos-14 image without anyone remembering to run it.
+    - cron: "0 6 * * 1"
+  pull_request:
+    # Only for PRs that touch the install path itself. Runs the BRANCH copy of
+    # install.sh (see the `installer` resolution below) so a change to the
+    # macOS branch is proven on a real Mac before it merges. GitHub-hosted, so
+    # it never queues behind the self-hosted runner; not a required check.
+    paths:
+      - "scripts/install.sh"
+      - "scripts/install-lib.mjs"
+      - "scripts/launchd/**"
+      - "scripts/manta-pair.mjs"
+      - ".github/workflows/macos-install-smoke.yml"
+
+concurrency:
+  group: macos-install-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: install on macOS (Apple Silicon)
+    runs-on: macos-14
+    timeout-minutes: 45
+
+    env:
+      # `inputs.*` is empty on the cron / pull_request triggers. A PR that
+      # touches the installer must test THAT PR's script (branch); everything
+      # else defaults to the published one users actually curl.
+      INSTALLER: ${{ inputs.installer || (github.event_name == 'pull_request' && 'branch' || 'published') }}
+      MANTA_VERSION: ${{ inputs.version || 'latest' }}
+      # Dead loopback port = fast ECONNREFUSED = installer warns + continues.
+      MANTA_GATEWAY_BASE: ${{ inputs.gateway == 'real' && 'https://gateway.mantaui.com' || 'http://127.0.0.1:9' }}
+      LOG: ${{ github.workspace }}/install.log
+
+    steps:
+      - name: Preflight — this must be an Apple Silicon Mac
+        run: |
+          set -euo pipefail
+          echo "uname: $(uname -s) $(uname -m)"
+          [ "$(uname -s)" = "Darwin" ] || { echo "not macOS"; exit 1; }
+          [ "$(uname -m)" = "arm64" ] || { echo "not Apple Silicon — the installer refuses Intel Macs by design"; exit 1; }
+          echo "shasum: $(command -v shasum)"
+          echo "sha256sum: $(command -v sha256sum || echo '(absent — expected on a stock Mac)')"
+
+      - uses: actions/checkout@v4
+
+      - name: Install box prerequisites (tmux)
+        run: |
+          set -euo pipefail
+          # install.sh checks for tmux + git + curl + tar + shasum and never
+          # installs them. git/curl/tar/shasum ship with macOS + the image;
+          # tmux does not on a stock Mac, so a real user brew-installs it too.
+          command -v tmux >/dev/null 2>&1 || brew install tmux
+          tmux -V
+          git --version
+
+      - name: Assert a clean slate (no prior box identity)
+        run: |
+          set -euo pipefail
+          for p in "$HOME/.manta" "$HOME/manta" "$HOME/Library/LaunchAgents/com.mantaui.server.plist"; do
+            if [ -e "$p" ]; then echo "unexpected leftover: $p"; exit 1; fi
+          done
+          echo "clean."
+
+      - name: Run the installer
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          echo "installer=$INSTALLER version=$MANTA_VERSION gateway_base=$MANTA_GATEWAY_BASE"
+          if [ "$INSTALLER" = "branch" ]; then
+            bash scripts/install.sh 2>&1 | tee "$LOG"
+          else
+            # Exactly the documented user path — install.sh is read from the
+            # pipe, so this also covers the "inner curl|bash must not eat our
+            # stdin" hazard the script guards against.
+            curl -fsSL https://mantaui.com/install.sh | bash 2>&1 | tee "$LOG"
+          fi
+
+      - name: Assert — macOS branch taken, no systemctl advice
+        run: |
+          set -euo pipefail
+          grep -q "macOS detected" "$LOG" \
+            || { echo "installer did not take the macOS branch"; exit 1; }
+          # BET-277 acceptance criterion: the installer never prints a
+          # systemctl command on macOS.
+          if grep -n "systemctl" "$LOG"; then
+            echo "FAIL: systemctl advice printed on a macOS box (see lines above)"
+            exit 1
+          fi
+          echo "ok."
+
+      - name: Assert — the install tail printed a pairing code
+        run: |
+          set -euo pipefail
+          grep -Eq '^ *Pairing code: +[0-9]{6}$' "$LOG" \
+            || { echo "FAIL: no 6-digit pairing code in the install output"; tail -40 "$LOG"; exit 1; }
+          grep -q "Manta server is running" "$LOG" \
+            || { echo "FAIL: connect block missing"; exit 1; }
+          echo "pairing block present:"
+          grep -E '^ *(Pairing code|Box ID|Server URL):' "$LOG"
+
+      - name: Assert — both LaunchAgents are loaded and alive
+        run: |
+          set -euo pipefail
+          uid="$(id -u)"
+          for label in com.mantaui.server com.mantaui.opencode; do
+            plist="$HOME/Library/LaunchAgents/$label.plist"
+            [ -f "$plist" ] || { echo "FAIL: missing $plist"; exit 1; }
+            launchctl print "gui/$uid/$label" > "$RUNNER_TEMP/$label.print.txt" \
+              || { echo "FAIL: $label is not loaded in the gui domain"; exit 1; }
+            # A loaded-but-crashlooping agent has no pid. KeepAlive=true means a
+            # healthy agent always has one.
+            grep -Eq '^[[:space:]]*pid = [0-9]+' "$RUNNER_TEMP/$label.print.txt" \
+              || { echo "FAIL: $label has no running pid"; sed -n '1,40p' "$RUNNER_TEMP/$label.print.txt"; exit 1; }
+            echo "$label: $(grep -E '^[[:space:]]*(pid|state) = ' "$RUNNER_TEMP/$label.print.txt" | tr -d '\n')"
+          done
+
+      - name: Assert — servers answer on loopback
+        run: |
+          set -euo pipefail
+          curl -fsS http://127.0.0.1:8787/auth/status >/dev/null \
+            || { echo "FAIL: manta-server /auth/status unreachable"; exit 1; }
+          code="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4096/ || true)"
+          [ -n "$code" ] && [ "$code" != "000" ] \
+            || { echo "FAIL: opencode-serve not listening on 4096"; exit 1; }
+          echo "manta-server ok; opencode http=$code"
+
+      - name: Assert — restarting the agent brings the server back
+        run: |
+          set -euo pipefail
+          # Closest CI-safe proxy for reboot survival: kick the agent and prove
+          # KeepAlive + RunAtLoad put it back on the port.
+          launchctl kickstart -k "gui/$(id -u)/com.mantaui.server"
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8787/auth/status >/dev/null 2>&1; then
+              echo "server back after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "FAIL: server did not come back after kickstart"
+          exit 1
+
+      - name: Assert — `manta pair` mints a fresh, claimable code
+        run: |
+          set -euo pipefail
+          [ -x "$HOME/.local/bin/manta" ] || { echo "FAIL: manta shim not installed"; exit 1; }
+          PATH="$HOME/.local/bin:$PATH"
+          out="$(manta pair)"
+          echo "$out" | grep -E '^ *(Pairing code|Box ID):'
+          code="$(printf '%s\n' "$out" | sed -nE 's/^ *Pairing code: +([0-9]{6})$/\1/p' | head -n1)"
+          [ -n "$code" ] || { echo "FAIL: could not parse a code out of \`manta pair\`"; printf '%s\n' "$out"; exit 1; }
+
+          # Claim it the way a device does. A working claim is the real proof
+          # the pairing flow is functional, not just that a number was printed.
+          claim="$(curl -fsS -X POST http://127.0.0.1:8787/auth/claim \
+            -H 'content-type: application/json' \
+            --data "{\"pairing_code\":\"$code\"}")" \
+            || { echo "FAIL: /auth/claim rejected the freshly minted code"; exit 1; }
+          token="$(printf '%s' "$claim" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("box_token",""))')"
+          box="$(printf '%s' "$claim" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("box_id",""))')"
+          [ -n "$token" ] && [ -n "$box" ] || { echo "FAIL: claim returned no token/box_id"; exit 1; }
+          echo "claimed box_id=$box (token length ${#token})"
+          echo "MANTA_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Assert — the box token drives a real tmux RPC
+        run: |
+          set -euo pipefail
+          # Exercises the server's OWN environment: launchd agents do not
+          # inherit a login-shell PATH, so a Homebrew-only `tmux` that works in
+          # this step's shell can still be invisible to the server process.
+          # Creating a session and seeing it listed back is the honest check.
+          curl -fsS -X POST http://127.0.0.1:8787/rpc/tmux:new-session \
+            -H "authorization: Bearer $MANTA_TOKEN" \
+            -H 'content-type: application/json' \
+            --data "{\"args\":[{\"name\":\"smoke\",\"cwd\":\"$HOME\"}]}" \
+            -o "$RUNNER_TEMP/new-session.json" \
+            || { echo "FAIL: tmux:new-session RPC failed"; exit 1; }
+          cat "$RUNNER_TEMP/new-session.json"; echo
+          projects="$(curl -fsS http://127.0.0.1:8787/api/projects -H "authorization: Bearer $MANTA_TOKEN")"
+          printf '%s\n' "$projects"
+          printf '%s' "$projects" | grep -q '"smoke"' \
+            || { echo "FAIL: the server cannot see the tmux session it just created (tmux missing from the launchd PATH?)"; exit 1; }
+          echo "ok — server-side tmux works."
+
+      - name: Assert — re-running the installer preserves box identity
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          before="$(python3 -c 'import json,os;print(json.load(open(os.path.expanduser("~/.manta/auth.json")))["box_id"])')"
+          if [ "$INSTALLER" = "branch" ]; then
+            bash scripts/install.sh 2>&1 | tee "$GITHUB_WORKSPACE/install2.log"
+          else
+            curl -fsSL https://mantaui.com/install.sh | bash 2>&1 | tee "$GITHUB_WORKSPACE/install2.log"
+          fi
+          after="$(python3 -c 'import json,os;print(json.load(open(os.path.expanduser("~/.manta/auth.json")))["box_id"])')"
+          [ "$before" = "$after" ] || { echo "FAIL: box_id changed on re-install ($before -> $after)"; exit 1; }
+          grep -q "preserving it" "$GITHUB_WORKSPACE/install2.log" \
+            || { echo "FAIL: re-install did not report a preserved identity"; exit 1; }
+          curl -fsS http://127.0.0.1:8787/auth/status >/dev/null \
+            || { echo "FAIL: server unhealthy after re-install"; exit 1; }
+          echo "identity preserved: $after"
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          set +e
+          d="$RUNNER_TEMP/diag"; mkdir -p "$d"
+          # NOTE: ~/.manta/auth.json is deliberately NOT collected — it holds
+          # the box_token.
+          cp "$LOG" "$d/" 2>/dev/null
+          cp "$GITHUB_WORKSPACE/install2.log" "$d/" 2>/dev/null
+          cp "$HOME/.manta/server.log" "$d/" 2>/dev/null
+          cp "$HOME/.manta/opencode.log" "$d/" 2>/dev/null
+          cp "$HOME/.manta/ingress.json" "$d/" 2>/dev/null
+          cp "$RUNNER_TEMP"/com.mantaui.*.print.txt "$d/" 2>/dev/null
+          for label in com.mantaui.server com.mantaui.opencode; do
+            launchctl print "gui/$(id -u)/$label" > "$d/$label.final.txt" 2>&1
+            cp "$HOME/Library/LaunchAgents/$label.plist" "$d/" 2>/dev/null
+          done
+          ls -la "$HOME/manta" > "$d/manta-home.txt" 2>&1
+          tmux list-sessions > "$d/tmux.txt" 2>&1
+          true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: macos-install-smoke-diagnostics
+          path: ${{ runner.temp }}/diag
+          if-no-files-found: warn
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,33 @@ it for a real box token, that token drives a tmux RPC (which catches the launchd
 PATH trap — launchd agents do NOT inherit a login-shell PATH, so a Homebrew-only
 `tmux` is invisible to the server), and a re-install preserves the box identity.
 Triggers: manual, weekly cron, and PRs that touch `scripts/install*.{sh,mjs}` /
-`scripts/launchd/**` (those run the BRANCH copy of the script). Gateway
-registration is stubbed to a dead loopback port by default — the real one
-publishes a per-box DNS record on the prod zone that a throwaway CI box would
-leave behind forever.
+`scripts/launchd/**` (those run the BRANCH copy of the script, deployed from the
+PR's own commit — install.sh resets `$MANTA_HOME` to `origin/main`, so without
+that a PR's server/plist changes would never be the ones under test). Gateway
+registration is stubbed to a dead loopback port for the INSTALLER, but the
+server re-registers itself on boot, so each run still leaves one throwaway
+`<box_id>.boxes.mantaui.com` A record on the prod zone.
+
+**Two environment traps this workflow found, both of which made a macOS box
+look installed-and-paired while being unusable.** Neither is reachable from a
+unit test; if you touch service definitions or tmux invocation, keep them in
+mind:
+
+- **A service gets no PATH.** launchd hands an agent
+  `/usr/bin:/bin:/usr/sbin:/sbin`; it does NOT inherit a login shell's PATH.
+  macOS ships no tmux, so tmux is always a Homebrew binary and was invisible to
+  manta-server — `tmux:new-session` 500'd with ENOENT while `listProjects`
+  swallowed the error and reported an empty box. Both plists now carry a PATH
+  rendered by `launchd_agent_path` in install.sh.
+- **A service gets no LOCALE, and tmux mangles its own output without one.**
+  Under a non-UTF-8 locale tmux sanitises "unprintable" bytes in `-F` output,
+  so the TAB field separator `src/server/tmux.mjs` relies on came back as `_`:
+  `list-sessions` reported the session name as `<name>_<attachedFlag>` and every
+  window line then failed to match a session and was silently dropped. Fixed at
+  the single tmux spawn point (`tmuxSpawnEnv`) rather than in a plist/unit, so
+  it holds under launchd, systemd, the nohup fallback and any hand-rolled
+  supervisor. **Linux was latently exposed too** — the systemd unit declares no
+  locale either; it only escaped because the box runs tmux 3.4.
 
 **`main` is governed by ONE system: the ruleset** (Settings → Rules → Rulesets →
 "main"). The legacy per-branch protection rule was deleted 2026-07-27 because

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,22 @@ is cached on the lockfile hash and Playwright browsers on the same key, so
 that was the bulk of the waste. **Before adding a job, ask whether it can be a
 step instead** — on one runner a job costs every other open PR wall-clock time.
 
+**The one exception to "no extra jobs": `macos-install-smoke.yml`.** It runs on a
+GitHub-hosted `macos-14` (Apple Silicon) runner, so it costs the self-hosted
+runner nothing and blocks nobody. It installs the box END-TO-END the way a user
+does (`curl mantaui.com/install.sh | bash`) and asserts the macOS-only path
+actually works: LaunchAgents load and stay alive, manta-server + opencode answer
+on loopback, the tail prints a 6-digit pairing code, no `systemctl` advice is
+ever printed (BET-277), `manta pair` mints a fresh code, `/auth/claim` exchanges
+it for a real box token, that token drives a tmux RPC (which catches the launchd
+PATH trap — launchd agents do NOT inherit a login-shell PATH, so a Homebrew-only
+`tmux` is invisible to the server), and a re-install preserves the box identity.
+Triggers: manual, weekly cron, and PRs that touch `scripts/install*.{sh,mjs}` /
+`scripts/launchd/**` (those run the BRANCH copy of the script). Gateway
+registration is stubbed to a dead loopback port by default — the real one
+publishes a per-box DNS record on the prod zone that a throwaway CI box would
+leave behind forever.
+
 **`main` is governed by ONE system: the ruleset** (Settings → Rules → Rulesets →
 "main"). The legacy per-branch protection rule was deleted 2026-07-27 because
 GitHub enforces the UNION of both, so having two overlapping configs meant an

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -123,6 +123,36 @@ resolve_arch() {
   esac
 }
 
+# launchd_agent_path — the PATH a MantaUI LaunchAgent must run with.
+#
+# launchd does NOT give an agent the user's login-shell PATH; it hands out a
+# bare `/usr/bin:/bin:/usr/sbin:/sbin`. Every tool the box actually depends on
+# that a Mac gets from Homebrew (tmux above all — macOS ships no tmux) is
+# therefore invisible to manta-server and opencode even though the very same
+# command works in Terminal. The failure is silent and confusing: the box
+# installs, pairs, and answers HTTP, but `tmux:new-session` 500s with ENOENT
+# and `listProjects` swallows its error and reports an empty box.
+#
+# We emit both Homebrew prefixes (Apple Silicon + Intel) plus the standard
+# system dirs, and prepend the directory `tmux` was actually resolved from
+# when it lives somewhere else entirely (MacPorts, /usr/local/opt, a
+# hand-built binary) — the prereq check already proved that copy exists.
+# Same class of fix as the macOS PATH handling in the desktop plugin
+# executor (see AGENTS.md, "macOS PATH gotcha").
+launchd_agent_path() {
+  local base="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  local tmux_bin tmux_dir
+  tmux_bin="$(command -v tmux 2>/dev/null || true)"
+  if [ -n "$tmux_bin" ]; then
+    tmux_dir="$(dirname "$tmux_bin")"
+    case ":$base:" in
+      *":$tmux_dir:"*) ;;
+      *) base="$tmux_dir:$base" ;;
+    esac
+  fi
+  printf '%s' "$base"
+}
+
 # _sha256_of echoes the sha256 hex of $1. Prefers GNU sha256sum (Linux ships
 # it via coreutils); falls back to BSD `shasum -a 256` on macOS, which ships
 # shasum by default but NOT sha256sum. Single shared helper so the prereq
@@ -326,8 +356,8 @@ wait_for_box_id() {
 
 # Test mode: when sourced by scripts/install.test.mjs with MANTA_INSTALL_TEST_MODE=1,
 # only the bash helpers (log/ok/warn/die + manifest_get + _sha256_of +
-# verify_sha256 + resolve_arch + print_provider_detection_summary +
-# read_box_id / wait_for_box_id) are
+# verify_sha256 + resolve_arch + launchd_agent_path +
+# print_provider_detection_summary + read_box_id / wait_for_box_id) are
 # loaded. The actual install does NOT run. Lets the unit tests exercise
 # the helpers with mocked `uname`/etc. without hitting the network. See
 # scripts/install.test.mjs.
@@ -716,6 +746,7 @@ main() {
       -e "s|@@MANTA_TAILNET_HOST@@|${TAILNET_IP:-}|g" \
       -e "s|@@OPENCODE_BIN@@|${OPENCODE_BIN:-}|g" \
       -e "s|@@AUTH_DIR@@|$AUTH_DIR|g" \
+      -e "s|@@AGENT_PATH@@|$(launchd_agent_path)|g" \
       "$src" > "$dest"
     local uid; uid="$(id -u)"
     # bootout first (ignore failure if not loaded), then bootstrap for a clean

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -752,10 +752,40 @@ main() {
     # bootout first (ignore failure if not loaded), then bootstrap for a clean
     # reload that picks up template changes on re-run.
     launchctl bootout "gui/$uid/$label" 2>/dev/null || true
-    if ! launchctl bootstrap "gui/$uid" "$dest" 2>/dev/null; then
-      # Older macOS where `bootstrap` isn't available.
-      launchctl load -w "$dest" 2>/dev/null \
-        || warn "launchctl could not load $label — check: launchctl print gui/$uid/$label"
+
+    # `bootout` is ASYNCHRONOUS: launchctl returns as soon as the request is
+    # accepted, while launchd is still tearing the job down. Bootstrapping the
+    # same label during that window fails with "Input/output error" (5) — and
+    # because the original code silenced that failure, the RE-INSTALL path
+    # ended with NO agent loaded at all: the box came back with a dead
+    # opencode-serve and the install died at the health-wait. Wait for the
+    # label to actually disappear (up to ~10s) before bootstrapping, then
+    # retry a few times — launchd can still be busy on a slow machine.
+    local waited=0
+    while [ "$waited" -lt 50 ] && launchctl print "gui/$uid/$label" >/dev/null 2>&1; do
+      sleep 0.2
+      waited=$((waited + 1))
+    done
+
+    local attempt=1 boot_err=""
+    while [ "$attempt" -le 5 ]; do
+      if boot_err="$(launchctl bootstrap "gui/$uid" "$dest" 2>&1)"; then
+        break
+      fi
+      sleep 1
+      attempt=$((attempt + 1))
+    done
+
+    # Verify by observation, not by exit code: `bootstrap` can report failure
+    # for a job that did load (and vice-versa). Only fall back to the
+    # deprecated `load -w` (older macOS, no `bootstrap`) when the label really
+    # isn't there, and surface the reason instead of swallowing it.
+    if ! launchctl print "gui/$uid/$label" >/dev/null 2>&1; then
+      launchctl load -w "$dest" 2>/dev/null || true
+      if ! launchctl print "gui/$uid/$label" >/dev/null 2>&1; then
+        warn "launchctl could not load $label${boot_err:+ ($boot_err)}"
+        warn "  check: launchctl print gui/\$(id -u)/$label"
+      fi
     fi
     launchctl kickstart -k "gui/$uid/$label" 2>/dev/null || true
   }

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3819,7 +3819,69 @@ print_provider_detection_summary "${fakeLib}" "${NODE_BIN_FOR_TESTS}" "${home}" 
   }
 });
 
-test("install.sh install_launchd_agent: plist substitution replaces all six placeholders (BET-277)", () => {
+// launchd_agent_path — the PATH written into both LaunchAgent plists.
+//
+// WHY IT MATTERS: launchd does not give an agent a login-shell PATH, it gives
+// `/usr/bin:/bin:/usr/sbin:/sbin`. macOS ships no tmux, so tmux always comes
+// from Homebrew — invisible to manta-server without this. The box then pairs
+// happily and fails every session action (`tmux:new-session` 500s, and
+// `listProjects` swallows its error so the UI just shows an empty box). Caught
+// by the macOS install smoke workflow on a real runner.
+test("install.sh launchd_agent_path: always covers both Homebrew prefixes + system dirs", () => {
+  const out = runBootstrap({
+    preBody: `
+command() {
+  case "$1" in
+    -v) case "$2" in tmux) echo "/opt/homebrew/bin/tmux"; return 0 ;; *) builtin command "$@" ;; esac ;;
+    *) builtin command "$@" ;;
+  esac
+}
+`,
+    func: "launchd_agent_path; echo",
+  });
+  assert.match(out, /\/opt\/homebrew\/bin/);
+  assert.match(out, /\/usr\/local\/bin/);
+  assert.match(out, /\/usr\/bin/);
+  assert.match(out, /\/usr\/sbin/);
+  // Already-covered dir must not be duplicated.
+  assert.equal(out.match(/\/opt\/homebrew\/bin/g).length, 1);
+});
+
+test("install.sh launchd_agent_path: prepends a tmux dir the defaults don't cover", () => {
+  // MacPorts / a hand-built tmux lives outside both Homebrew prefixes. The
+  // prereq check already proved that copy exists, so trust it.
+  const out = runBootstrap({
+    preBody: `
+command() {
+  case "$1" in
+    -v) case "$2" in tmux) echo "/opt/local/bin/tmux"; return 0 ;; *) builtin command "$@" ;; esac ;;
+    *) builtin command "$@" ;;
+  esac
+}
+`,
+    func: "launchd_agent_path; echo",
+  });
+  assert.match(out, /^\/opt\/local\/bin:\/opt\/homebrew\/bin:/m);
+});
+
+test("install.sh launchd_agent_path: no tmux on PATH still yields a usable PATH", () => {
+  // Defensive: the prereq check dies before this runs, but an empty or
+  // half-built PATH string would render an unloadable plist.
+  const out = runBootstrap({
+    preBody: `
+command() {
+  case "$1" in
+    -v) case "$2" in tmux) return 1 ;; *) builtin command "$@" ;; esac ;;
+    *) builtin command "$@" ;;
+  esac
+}
+`,
+    func: "launchd_agent_path; echo",
+  });
+  assert.match(out, /^\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin:\/usr\/sbin:\/sbin$/m);
+});
+
+test("install.sh install_launchd_agent: plist substitution replaces every placeholder (BET-277)", () => {
   // Pure substitution test — pin the six placeholder replacements that
   // install_launchd_agent performs against the real plist templates.
   // Use the SERVER plist because it carries BOTH @@NODE_BIN@@ (in
@@ -3849,6 +3911,7 @@ sed \\
   -e "s|@@MANTA_TAILNET_HOST@@|\${TAILNET_IP:-}|g" \\
   -e "s|@@OPENCODE_BIN@@|\${OPENCODE_BIN:-}|g" \\
   -e "s|@@AUTH_DIR@@|\$AUTH_DIR|g" \\
+  -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
   "\$SERVER_PLIST_SRC" > "${rendered}"
 echo "SUBST_DONE=1"
 `,
@@ -3867,6 +3930,11 @@ echo "SUBST_DONE=1"
     assert.match(text, /<string>8787<\/string>/);
     assert.match(text, /<string>100\.64\.1\.5<\/string>/);
     assert.match(text, /\/tmp\/fake-manta-home\/\.manta\/server\.log/);
+    // PATH must be materialised: launchd hands an agent only
+    // /usr/bin:/bin:/usr/sbin:/sbin, so a Homebrew tmux is invisible to
+    // manta-server and every tmux call fails on a real Mac box.
+    assert.match(text, /<key>PATH<\/key>/);
+    assert.match(text, /\/opt\/homebrew\/bin/);
     // RunAtLoad + KeepAlive must remain true (drive reboot persistence).
     assert.match(text, /<key>RunAtLoad<\/key>\s*<true\/>/);
     assert.match(text, /<key>KeepAlive<\/key>\s*<true\/>/);
@@ -3910,6 +3978,7 @@ sed \\
   -e "s|@@MANTA_TAILNET_HOST@@|\${TAILNET_IP:-}|g" \\
   -e "s|@@OPENCODE_BIN@@|\${OPENCODE_BIN:-}|g" \\
   -e "s|@@AUTH_DIR@@|\$AUTH_DIR|g" \\
+  -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
   "\$OC_PLIST_SRC" > "${rendered}"
 echo "EMPTY_SUBST_DONE=1"
 `,

--- a/scripts/launchd/com.mantaui.opencode.plist
+++ b/scripts/launchd/com.mantaui.opencode.plist
@@ -45,6 +45,16 @@
     <string>--hostname</string>
     <string>127.0.0.1</string>
   </array>
+  <!-- launchd hands an agent PATH=/usr/bin:/bin:/usr/sbin:/sbin — it does NOT
+       inherit a login shell's PATH. Without this key, everything opencode
+       shells out to that lives in Homebrew (ripgrep, node, the provider CLIs)
+       is invisible to it even though the same command works in Terminal.
+       install.sh substitutes the resolved list; see launchd_agent_path(). -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>@@AGENT_PATH@@</string>
+  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>

--- a/scripts/launchd/com.mantaui.server.plist
+++ b/scripts/launchd/com.mantaui.server.plist
@@ -46,6 +46,16 @@
          reachable WITHOUT TLS on this listener. -->
     <key>MANTA_TAILNET_HOST</key>
     <string>@@MANTA_TAILNET_HOST@@</string>
+    <!-- LOAD-BEARING. launchd hands an agent PATH=/usr/bin:/bin:/usr/sbin:/sbin
+         — it does NOT inherit a login shell's PATH, so a Homebrew `tmux`
+         (/opt/homebrew/bin, the only way a Mac gets tmux) is invisible to the
+         server. Symptom without this key: the box pairs fine, then every
+         workspace/session action fails — `tmux:new-session` 500s with ENOENT
+         and `listProjects` swallows the error and reports an empty box. Found
+         by the macOS install smoke workflow; install.sh substitutes the
+         resolved list, see launchd_agent_path(). -->
+    <key>PATH</key>
+    <string>@@AGENT_PATH@@</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -5,9 +5,36 @@ import { expandTilde } from "../shared/paths.mjs";
 
 const FS = "\t";
 
+/**
+ * The environment tmux must be invoked with.
+ *
+ * tmux sanitises "unprintable" bytes in `-F` output when it is running under a
+ * non-UTF-8 locale: our TAB field separator comes back as `_`. Services get NO
+ * locale from their supervisor — launchd passes none at all, and a systemd
+ * --user unit only has what the unit file declares — so every tmux query made
+ * by the box server was silently mangled: `list-sessions` yielded
+ * `"<name>_<attachedFlag>"` as the session NAME, and every window line failed
+ * to match a known session and was dropped. The visible symptom is a workspace
+ * with a corrupted name and zero windows, which is what the macOS box did.
+ *
+ * Fixing it here (rather than in a plist / unit file) makes it independent of
+ * how the server was started — including the nohup fallback and any
+ * hand-rolled supervisor — and it is the only place tmux is ever spawned.
+ * An explicit locale from the environment always wins; we only supply a
+ * default when there is none. macOS has no `C.UTF-8`, so it gets the
+ * always-present `en_US.UTF-8`.
+ *
+ * Exported for testing.
+ */
+export function tmuxSpawnEnv(env = process.env, platform = process.platform) {
+  const existing = env.LC_ALL || env.LANG;
+  if (existing) return { ...env };
+  return { ...env, LC_ALL: platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8" };
+}
+
 function spawnRun(cmd, args) {
   return new Promise((resolve, reject) => {
-    const p = cpSpawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const p = cpSpawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], env: tmuxSpawnEnv() });
     let stdout = "", stderr = "";
     p.stdout.on("data", (b) => (stdout += b.toString()));
     p.stderr.on("data", (b) => (stderr += b.toString()));

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   parseSessions,
+  tmuxSpawnEnv,
   isMissingSessionError,
   newWindow,
   newSession,
@@ -353,4 +354,28 @@ test("newWindowGetIndex (3-arg, default chatMode) stays a plain window", async (
   } finally {
     _setRun(null);
   }
+});
+
+// tmux sanitises unprintable bytes in `-F` output under a non-UTF-8 locale,
+// turning the TAB field separator into `_` — which corrupted every session
+// name and dropped every window. Services inherit no locale from launchd (and
+// only what the unit declares from systemd), so tmux must be given one.
+test("tmuxSpawnEnv supplies a UTF-8 locale when the supervisor gave none", () => {
+  assert.equal(tmuxSpawnEnv({ PATH: "/usr/bin" }, "linux").LC_ALL, "C.UTF-8");
+  // macOS has no C.UTF-8; en_US.UTF-8 always exists there.
+  assert.equal(tmuxSpawnEnv({ PATH: "/usr/bin" }, "darwin").LC_ALL, "en_US.UTF-8");
+});
+
+test("tmuxSpawnEnv never overrides an explicit locale", () => {
+  assert.equal(tmuxSpawnEnv({ LC_ALL: "fr_FR.UTF-8" }, "darwin").LC_ALL, "fr_FR.UTF-8");
+  // LANG alone is enough for tmux — don't add LC_ALL on top of it.
+  const withLang = tmuxSpawnEnv({ LANG: "de_DE.UTF-8" }, "linux");
+  assert.equal(withLang.LANG, "de_DE.UTF-8");
+  assert.equal(withLang.LC_ALL, undefined);
+});
+
+test("tmuxSpawnEnv preserves the rest of the environment", () => {
+  const out = tmuxSpawnEnv({ PATH: "/opt/homebrew/bin", FOO: "bar" }, "darwin");
+  assert.equal(out.PATH, "/opt/homebrew/bin");
+  assert.equal(out.FOO, "bar");
 });


### PR DESCRIPTION
Verifies `scripts/install.sh` on a real Apple Silicon Mac — the BET-274/276/277 path that cannot be tested from the Linux dev box — and fixes what the first runs exposed. **Green end to end**: the install reaches the pairing code, `manta pair` mints a fresh one, and the box is actually usable.

## The workflow

GitHub-hosted `macos-14` runner (costs `manta-dev-runner` nothing, blocks no other PR; not a required check). Manual + weekly + on PRs touching the install path, where it deploys the PR's own commit rather than `main`. Asserts:

- macOS branch taken; **no `systemctl` command ever printed** (BET-277 criterion)
- darwin-arm64 tarball downloads + sha256-verifies through BSD `shasum` (no coreutils)
- both LaunchAgents load into `gui/$(id -u)` with a live pid; `kickstart -k` brings the server back
- manta-server + opencode answer on loopback (any status — an unpaired box correctly answers 401)
- the install tail prints a **6-digit pairing code**
- `manta pair` mints a fresh code → `/auth/claim` exchanges it for a real box token
- that token creates a tmux session **and reads it back under its exact name, with its window**
- re-running the installer **preserves the box identity** and leaves both services up

## Three defects found, all fixed here

**1. macOS boxes could not use tmux at all.** launchd hands an agent `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — no login-shell PATH. macOS ships no tmux, so tmux is always a Homebrew binary and was invisible to manta-server: `tmux:new-session` 500'd with ENOENT and `listProjects` swallowed its error and reported an empty box. Both plists now carry a PATH rendered by a new `launchd_agent_path` helper, with unit tests.

**2. Re-installing killed the opencode service.** `launchctl bootout` returns before launchd has torn the job down; bootstrapping the same label inside that window fails with "Input/output error" (5) — and the error was silenced, so the reload left **no agent loaded at all** and the install died waiting on :4096. The reload now waits for the label to disappear, retries, verifies by observation rather than exit code, and surfaces the reason. This is the upgrade-in-place path, so it hit every re-run.

**3. Every tmux query came back corrupted — and Linux is latently exposed too.** A service inherits no locale from its supervisor, and under a non-UTF-8 locale tmux sanitises "unprintable" bytes in `-F` output: the TAB field separator `src/server/tmux.mjs` relies on came back as `_`. `list-sessions` reported the session name as `<name>_<attachedFlag>`, every window line then failed to match a session and was dropped, so a workspace showed a corrupted name and zero windows. Fixed at the single tmux spawn point (`tmuxSpawnEnv`) so it holds under launchd, systemd, the nohup fallback and any hand-rolled supervisor. The systemd unit declares no locale either — Linux only escaped because the box runs tmux 3.4; on tmux ≥3.5 it would have bitten identically.

(A fourth, `curl … | bash </dev/null` starving the opencode installer of its own script, was fixed in parallel on main by 7d4f008 — this smoke run hit it first.)

## Known CI-only accommodation

opencode's own installer resolves "latest" through the **unauthenticated** GitHub API, which GitHub-hosted runners are routinely rate-limited on ("Failed to fetch version information"). The workflow resolves the tag with the job token and passes `--version`, so install.sh takes its "opencode already installed" branch — a legitimate real-world state. Worth knowing a user behind a shared/NAT'd IP hits the same wall and only sees "opencode install failed".

## Side effect to be aware of

manta-server registers itself with the push gateway on boot using the built-in URL, so each run leaves one throwaway `<box_id>.boxes.mantaui.com` A record on the prod zone (pointing at a dead runner IP). The installer's own registration is stubbed out by default; that does not cover the server's.