### PR TITLE
fix(renderer): deep-link pairing succeeded but left the shell stuck on step 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -218,7 +218,22 @@ export function App() {
     if (!pre?.onPairLink) return;
     return pre.onPairLink((url) => {
       const payload = parsePairPayload(url);
-      if (!payload) return; // not a valid pair link — ignore
+      if (!payload) {
+        // Malformed / legacy-shape link (e.g. an old box still minting the
+        // `id=`/`token=` form). The OS still LAUNCHED us for the manta://
+        // scheme, so silently returning looks exactly like a broken app —
+        // the window comes to front and nothing else happens. Surface the
+        // reason on the pair step, opening the flow if it isn't already up.
+        const st = useStore.getState();
+        st.setPairLinkError(
+          "That pairing link isn't valid. Generate a fresh one on your box (run `manta pair`) and open the new link.",
+        );
+        const onboardingOpen =
+          st.onboardingForced ||
+          resolveTransportMode(st.configSnapshot()) === "onboarding";
+        if (!onboardingOpen) void st.relaunchOnboarding();
+        return;
+      }
       // Auto-claim immediately. claimBox() handles the IPC, persists the
       // credentials to config.json, mirrors them into the store, and swaps
       // window.api to httpApi — all the same side effects PairStep does on
@@ -228,20 +243,30 @@ export function App() {
       void (async () => {
         const result = await claimBox({ boxId: payload.boxId, code: payload.code });
         if (result.ok) {
-          // Drop out of onboarding: clears `onboardingForced` + re-reads
-          // config so the app renders the normal shell with the new
-          // boxToken. Works whether we were already in the normal shell
-          // (just a config refresh) or in onboarding (the new boxToken
-          // flips resolveTransportMode to "http" on the re-read).
+          // Re-read config so the store carries the new boxToken, then bump
+          // the claim counter so a MOUNTED Onboarding re-derives its step.
+          //
+          // Both halves are required. `finishOnboarding()` alone only clears
+          // `onboardingForced`; it does NOT unmount the flow, because App
+          // holds it open behind `onboardingLatched` (deliberately — step 1
+          // writes a boxToken, which would otherwise tear the shell down
+          // before steps 2-4 ran). With nothing advancing the step, a
+          // SUCCESSFUL auto-claim left the user staring at the pair form
+          // with the code field focused — the "deep link opens the app but
+          // does nothing" report. The counter is what moves them forward.
           await useStore.getState().finishOnboarding();
+          useStore.getState().notePairLinkClaimed();
           return;
         }
         // Failure: open onboarding at step 1 with the URL stashed so the
-        // shell jumps to step 1 (PairStep shows empty fields for the user
-        // to retry by hand — the URL gives the shell enough signal to land
-        // on the pair step even from a paired/normal config).
+        // shell jumps to step 1, and carry the REASON so PairStep can show
+        // it inline. Without the reason the user gets an empty form and no
+        // explanation for why the link appeared to do nothing — the common
+        // case being a one-time code that already expired (~5 min TTL) or
+        // was already consumed.
         const st = useStore.getState();
         st.setPendingPairLink(url);
+        st.setPairLinkError(result.message);
         const alreadyOnboarding =
           st.onboardingForced ||
           resolveTransportMode(st.configSnapshot()) === "onboarding";

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ONBOARDING_STEPS,
   STEP_LABELS,
@@ -126,6 +126,26 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   useEffect(() => {
     if (pendingPairLink) setPos(1);
   }, [pendingPairLink]);
+
+  // Deep-link pairing: a manta:// link that SUCCEEDS must move the flow off
+  // step 1. App keeps this shell mounted through a latch after pairing (so
+  // steps 2-4 stay reachable), so without this the user sat on the pair form
+  // with the code field focused even though they were already paired — the
+  // "the link opens the app but does nothing" bug.
+  //
+  // Re-derive from the freshly re-read config rather than calling goNext():
+  // a re-pair from an already-configured box should land on the first step
+  // that's still incomplete, not blindly on step 2.
+  //
+  // The ref pins the mount-time value so this only fires on a claim that
+  // happens WHILE mounted. Firing on mount would clobber the step-1 forcing
+  // that `pendingPairLink` does for a FAILED link on an already-paired box.
+  const pairLinkClaims = useStore((s) => s.pairLinkClaims);
+  const claimsAtMount = useRef(pairLinkClaims);
+  useEffect(() => {
+    if (pairLinkClaims === claimsAtMount.current) return;
+    setPos(resolveInitialStep(useStore.getState().configSnapshot()));
+  }, [pairLinkClaims]);
 
   const goNext = () => setPos((p) => nextPosition(p));
   const goBack = () => setPos((p) => prevPosition(p));

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { normalizeCode } from "../shared/claim.mjs";
 import { canConnectSetup, normalizeServerUrl } from "./mobile/setupLogic";
 import { isValidBoxToken } from "../shared/transport.mjs";
 import { claimBox } from "./pairClaim";
+import { useStore } from "./store";
 
 // PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2,
 // BET-255, BET-268).
@@ -64,6 +65,23 @@ export function PairStep({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);
+
+  // Deep-link failure reason. The manta:// auto-claim in App.tsx runs with no
+  // UI of its own, so when it fails it parks the classified message here and
+  // routes the user to this step. Rendering it in the SAME inline slot a
+  // manual Connect failure uses means the user sees "code expired" /
+  // "couldn't reach your box" instead of a blank form that looks like the
+  // link did nothing at all.
+  //
+  // Consume-on-read (clear the store field) so an identical second failure
+  // still changes the value and re-fires this effect.
+  const pairLinkError = useStore((s) => s.pairLinkError);
+  useEffect(() => {
+    if (!pairLinkError) return;
+    setError(pairLinkError);
+    useStore.getState().setPairLinkError(null);
+    codeRef.current?.focus();
+  }, [pairLinkError]);
 
   // Server URL is only "bad" when the user typed something non-empty that
   // doesn't match `^https?://` — empty stays the default path (no inline

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -711,3 +711,40 @@ describe("setPendingPairLink (BET-240 deep-link pairing)", () => {
     expect(useStore.getState().pendingPairLink).toBeNull();
   });
 });
+
+describe("deep-link claim outcome (stuck-on-pair-step regression)", () => {
+  beforeEach(() => {
+    useStore.setState({ pairLinkClaims: 0, pairLinkError: null, pendingPairLink: null });
+  });
+
+  it("notePairLinkClaimed bumps the counter so a mounted Onboarding re-derives", () => {
+    useStore.getState().notePairLinkClaimed();
+    expect(useStore.getState().pairLinkClaims).toBe(1);
+  });
+
+  it("REGRESSION: the counter changes identity on EVERY claim — a second link is not a no-op", () => {
+    // A boolean would latch true here and the second deep link would never
+    // move the flow off step 1 (the exact shape of the original bug).
+    useStore.getState().notePairLinkClaimed();
+    const first = useStore.getState().pairLinkClaims;
+    useStore.getState().notePairLinkClaimed();
+    expect(useStore.getState().pairLinkClaims).toBe(first + 1);
+  });
+
+  it("a successful claim clears the stale pending link + error from an earlier failure", () => {
+    useStore.setState({
+      pendingPairLink: "manta://pair?box=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&code=111111",
+      pairLinkError: "That code has expired.",
+    });
+    useStore.getState().notePairLinkClaimed();
+    expect(useStore.getState().pendingPairLink).toBeNull();
+    expect(useStore.getState().pairLinkError).toBeNull();
+  });
+
+  it("setPairLinkError carries the failure reason, and null consumes it", () => {
+    useStore.getState().setPairLinkError("Couldn't reach your box.");
+    expect(useStore.getState().pairLinkError).toBe("Couldn't reach your box.");
+    useStore.getState().setPairLinkError(null);
+    expect(useStore.getState().pairLinkError).toBeNull();
+  });
+});

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -105,6 +105,27 @@ type State = {
   // by Onboarding (to force step 1) and PairStep (to prefill the paste field).
   // Cleared once consumed. Not persisted — purely transient routing state.
   pendingPairLink: string | null;
+  // Deep-link pairing: monotonic counter bumped by App.tsx after a manta://
+  // link auto-claim SUCCEEDS and the config re-read has landed.
+  //
+  // Why a counter and not a boolean: Onboarding must re-derive its step from
+  // the FRESH config every time a link lands, including a second link in the
+  // same session. A counter changes identity on every claim; a boolean would
+  // latch true and the second link would be a no-op.
+  //
+  // This exists because a successful auto-claim used to leave the shell
+  // pinned on the onboarding flow at step 1. `finishOnboarding()` clears
+  // `onboardingForced` and re-reads config, but App keeps the flow MOUNTED
+  // behind a local latch (so steps 2-4 stay reachable after step 1 writes a
+  // boxToken). Nothing advanced the step, so a successful pairing rendered
+  // as an untouched pair form with the code field focused — indistinguishable
+  // from "the deep link did nothing".
+  pairLinkClaims: number;
+  // Deep-link pairing: why the last auto-claim failed, surfaced inline by
+  // PairStep. The auto-claim runs with no visible UI, so without this the
+  // failure reason (wrong/expired code, unreachable box, malformed link) was
+  // computed and then discarded — the user saw a blank form and no cause.
+  pairLinkError: string | null;
   chatAutoAllow: boolean;
   // Auto-rename chat-mode windows from the conversation (opt-in). See
   // AppConfig.autoRenameSessions.
@@ -292,6 +313,12 @@ type State = {
   // null to consume (PairStep clears on use); App.tsx writes the URL when
   // the preload's pair:link-received IPC fires.
   setPendingPairLink: (url: string | null) => void;
+  // Record a SUCCESSFUL deep-link auto-claim. Call AFTER the config re-read
+  // (finishOnboarding) so any listener that re-derives from config sees the
+  // post-pairing state. Also clears any stale pendingPairLink/pairLinkError
+  // left by an earlier failed attempt.
+  notePairLinkClaimed: () => void;
+  setPairLinkError: (message: string | null) => void;
   setConnectionState: (s: ConnectionState) => void;
 };
 
@@ -303,6 +330,8 @@ export const useStore = create<State>((set, get) => ({
   onboardingSkipped: false,
   onboardingForced: false,
   pendingPairLink: null,
+  pairLinkClaims: 0,
+  pairLinkError: null,
   chatAutoAllow: false,
   autoRenameSessions: false,
   allowAgentPush: false,
@@ -419,6 +448,15 @@ export const useStore = create<State>((set, get) => ({
   },
 
   setPendingPairLink: (url) => set({ pendingPairLink: url }),
+
+  notePairLinkClaimed: () =>
+    set((s) => ({
+      pairLinkClaims: s.pairLinkClaims + 1,
+      pendingPairLink: null,
+      pairLinkError: null,
+    })),
+
+  setPairLinkError: (message) => set({ pairLinkError: message }),
 
   finishOnboarding: async () => {
     // Drop the force flag and re-read config so the app transitions to the


### PR DESCRIPTION
## What was broken

A `manta://pair?...` link **paired successfully** and then left the user staring at the pairing form with the code field focused — indistinguishable from "the deep link opened the app and did nothing". Retyping the code then failed for real, because the one-time code had already been consumed by the successful auto-claim.

Shipped in `mac-v0.0.13`. Reported twice.

## Root cause

BET-255 removed the form prefill and made the link auto-claim. On success it calls `finishOnboarding()` directly, which clears `onboardingForced` and re-reads config — but does **not** unmount the onboarding shell. `App` holds it open behind `onboardingLatched`, deliberately: step 1 writing a `boxToken` would otherwise tear the flow down before steps 2-4 run.

That latch is released by exactly one thing — `Onboarding`'s `onDone`. The manual **Connect** button routes through it. The deep-link path never does, so nothing ever advanced the step.

## Fix

- On a successful auto-claim, re-read config and bump a `pairLinkClaims` counter. A mounted `Onboarding` re-derives its position from the fresh config via `resolveInitialStep` — Providers on a first run, further along for a re-pair.
- **Counter, not a boolean.** A boolean latches true and the second link in a session becomes a no-op — the naive fix, which silently breaks every link after the first. Locked in by a regression test.

## Also: two silent-failure paths closed

Both made this undiagnosable from the UI.

- A **failed** auto-claim classified the reason and then discarded it. Now carried in `pairLinkError` and rendered in the same inline slot a manual Connect failure uses, so "code expired" / "couldn't reach your box" is visible instead of a blank form. The most common real failure is the one-time code's ~5 min TTL.
- A **malformed / legacy-shape** link (an old box still minting `id=`/`token=`, which the current parser rejects) was dropped with zero feedback — the OS launched the app, the window came to front, nothing else happened. Now opens the pair step with an explanation.

## Version bump

`package.json` → `0.0.14`. The `mac-v*` tag selects what Codemagic builds, but electron-updater decides whether to **offer** it by comparing this version against what's installed. Shipping under `0.0.13` would publish a second `0.0.13` that no existing install would pick up — i.e. the fix would appear not to ship, again.

## Verification

- `npm run typecheck` clean
- 1076 renderer + 949 server tests pass
- 5 new store tests, incl. the second-link regression

Follow-up after merge: tag `mac-v0.0.14` to trigger the build.