### PR TITLE
fix(renderer): require explicit Connect click for deep-link pairing (BET-335)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,7 +17,6 @@ import {
 import { chooseUpdateSkewVariant } from "./chatUtils";
 import { UpdateBar } from "./UpdateBar";
 import { parsePairPayload } from "./mobile/pairPayload";
-import { claimBox } from "./pairClaim";
 import type { AvailableLauncher } from "../shared/types";
 
 // mode -> the composite-key "modeId" segment used for the PTY sessionKey and
@@ -203,16 +202,23 @@ export function App() {
     return off;
   }, []);
 
-  // Deep-link pairing (BET-240, BET-255): the OS protocol handler
+  // Deep-link pairing (BET-240, BET-335, #277): the OS protocol handler
   // (electron-builder `protocols:` + Electron `setAsDefaultProtocolClient`)
   // delivers a manta://pair?... URL via the preload's `pair:link-received`
-  // IPC. We validate with the SAME `parsePairPayload` PairStep / mobile
-  // share, then auto-claim via the SHARED `claimBox` helper (the same code
-  // path PairStep's Connect button runs). On success `finishOnboarding()`
-  // drops the shell to the normal app — the user is paired, no manual
-  // "Connect" click required. On failure we fall back to the OLD behaviour
-  // of opening onboarding at step 1 (Onboarding reads `pendingPairLink` to
-  // force step 1) so the user can retry by hand.
+  // IPC. Two outcomes:
+  //
+  //  • Malformed / legacy-shape link (#277): silently dropping leaves the
+  //    user staring at a launched-but-empty window — the OS opened us for
+  //    the manta:// scheme, so it looked like the link did nothing. Surface
+  //    the reason on the pair step via setPairLinkError and open onboarding
+  //    if it isn't already up. PairStep renders pairLinkError in the same
+  //    inline slot a manual Connect failure uses.
+  //
+  //  • Valid link (BET-335): stash the URL via setPendingPairLink so
+  //    Onboarding jumps to step 1 and PairStep prefills Box ID + code from
+  //    prefillFromPairLink. The click on Connect is the confirmation — no
+  //    silent auto-claim, the pair page's "click Connect" copy becomes
+  //    true.
   useEffect(() => {
     const pre = getMantaPreload();
     if (!pre?.onPairLink) return;
@@ -234,44 +240,14 @@ export function App() {
         if (!onboardingOpen) void st.relaunchOnboarding();
         return;
       }
-      // Auto-claim immediately. claimBox() handles the IPC, persists the
-      // credentials to config.json, mirrors them into the store, and swaps
-      // window.api to httpApi — all the same side effects PairStep does on
-      // a manual Connect. We don't await it on purpose: the listener is
-      // sync from the preload's perspective and the claim is best-effort
-      // (failures fall through to the onboarding-open fallback below).
-      void (async () => {
-        const result = await claimBox({ boxId: payload.boxId, code: payload.code });
-        if (result.ok) {
-          // Re-read config so the store carries the new boxToken, then bump
-          // the claim counter so a MOUNTED Onboarding re-derives its step.
-          //
-          // Both halves are required. `finishOnboarding()` alone only clears
-          // `onboardingForced`; it does NOT unmount the flow, because App
-          // holds it open behind `onboardingLatched` (deliberately — step 1
-          // writes a boxToken, which would otherwise tear the shell down
-          // before steps 2-4 ran). With nothing advancing the step, a
-          // SUCCESSFUL auto-claim left the user staring at the pair form
-          // with the code field focused — the "deep link opens the app but
-          // does nothing" report. The counter is what moves them forward.
-          await useStore.getState().finishOnboarding();
-          useStore.getState().notePairLinkClaimed();
-          return;
-        }
-        // Failure: open onboarding at step 1 with the URL stashed so the
-        // shell jumps to step 1, and carry the REASON so PairStep can show
-        // it inline. Without the reason the user gets an empty form and no
-        // explanation for why the link appeared to do nothing — the common
-        // case being a one-time code that already expired (~5 min TTL) or
-        // was already consumed.
-        const st = useStore.getState();
-        st.setPendingPairLink(url);
-        st.setPairLinkError(result.message);
-        const alreadyOnboarding =
-          st.onboardingForced ||
-          resolveTransportMode(st.configSnapshot()) === "onboarding";
-        if (!alreadyOnboarding) void st.relaunchOnboarding();
-      })();
+      // Valid link (BET-335): stash the URL and open onboarding at step 1.
+      // PairStep prefills Box ID + code; the user clicks Connect to claim.
+      const st = useStore.getState();
+      st.setPendingPairLink(url);
+      const alreadyOnboarding =
+        st.onboardingForced ||
+        resolveTransportMode(st.configSnapshot()) === "onboarding";
+      if (!alreadyOnboarding) void st.relaunchOnboarding();
     });
   }, []);
 

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useRef, useState } from "react";
 import { normalizeCode } from "../shared/claim.mjs";
-import { canConnectSetup, normalizeServerUrl } from "./mobile/setupLogic";
+import {
+  canConnectSetup,
+  normalizeServerUrl,
+  prefillFromPairLink,
+} from "./mobile/setupLogic";
 import { isValidBoxToken } from "../shared/transport.mjs";
 import { claimBox } from "./pairClaim";
 import { useStore } from "./store";
 
 // PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2,
-// BET-255, BET-268).
+// BET-255, BET-268, BET-335).
 //
 // Mounts into Onboarding.tsx's step-1 slot. Owns the pairing form:
 //   • a Box ID input (32-hex box id)
@@ -30,11 +34,14 @@ import { useStore } from "./store";
 // session (BET-254). Finally we call onPaired() to let the shell advance to
 // Step 2.
 //
-// The deep-link `manta://pair?box=…&code=…` flow no longer lands here —
-// App.tsx's onPairLink handler auto-claims via the SAME `claimBox` helper and
-// advances via `finishOnboarding()`. If the auto-claim fails, the handler
-// falls back to opening onboarding at step 1 (Onboarding.tsx still reads
-// `pendingPairLink` to force step 1) so the user can retry by hand.
+// The deep-link `manta://pair?box=…&code=…` flow DOES land here (BET-335):
+// App.tsx's onPairLink handler stashes the URL via `setPendingPairLink` and
+// opens onboarding at step 1 (Onboarding reads `pendingPairLink` to force
+// step 1). We lazily prefill Box ID + code from that URL via
+// `prefillFromPairLink` — the user lands on the Connect screen with both
+// fields filled, and the click on Connect IS the confirmation the pair page
+// promises. We clear `pendingPairLink` on a successful claim so a later
+// re-pair doesn't re-prefill a stale link.
 //
 // All non-React logic (Box ID validation, the submit gate, the 6-digit
 // contract, server-URL normalization, HTTP-outcome classification, the claim
@@ -58,8 +65,17 @@ export function PairStep({
   onPaired: () => void;
   onSkip: () => void;
 }) {
-  const [boxId, setBoxId] = useState("");
-  const [code, setCode] = useState("");
+  // Deep-link prefill (BET-335): if App.tsx stashed a valid `manta://pair?…`
+  // URL into `pendingPairLink` before this step mounted, seed both fields
+  // from it. Lazy init via `useState(() => …)` so we read the store ONCE at
+  // mount — the user can then edit the fields freely without our re-reading
+  // the stashed URL on every keystroke. `prefillFromPairLink` returns null
+  // for any nullish/empty/invalid input (foreign URL, bad box, bad code),
+  // which falls through to empty fields — the same default the form already
+  // used for a non-deep-link open.
+  const prefill = prefillFromPairLink(useStore.getState().pendingPairLink);
+  const [boxId, setBoxId] = useState(() => prefill?.boxId ?? "");
+  const [code, setCode] = useState(() => prefill?.code ?? "");
   const [serverUrl, setServerUrl] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -107,6 +123,10 @@ export function PairStep({
       serverUrl: serverUrlTrimmed,
     });
     if (result.ok) {
+      // Consume the stashed deep-link (BET-335): otherwise a later re-pair
+      // (different box, or fresh claim failure on this same box) would
+      // re-prefill the fields from a stale URL.
+      useStore.getState().setPendingPairLink(null);
       setSubmitting(false);
       onPaired();
       return;

--- a/src/renderer/mobile/setupLogic.test.ts
+++ b/src/renderer/mobile/setupLogic.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSetupServerUrl,
   resolveConnectRoute,
   normalizeServerUrl,
+  prefillFromPairLink,
 } from "./setupLogic";
 import { boxDirectUrl } from "../../shared/transport.mjs";
 
@@ -195,5 +196,55 @@ describe("resolveConnectRoute", () => {
 
   it("returns 'direct' for empty/unset base (fresh install)", () => {
     expect(resolveConnectRoute("")).toBe("direct");
+  });
+});
+
+describe("prefillFromPairLink (BET-335 deep-link prefill)", () => {
+  const validLink = `manta://pair?box=${VALID_BOX}&code=123456`;
+  const validHttps = `https://box.example.com/m/?box=${VALID_BOX}&code=123456`;
+
+  it("returns {boxId, code} for a valid box-form manta:// pair link", () => {
+    expect(prefillFromPairLink(validLink)).toEqual({
+      boxId: VALID_BOX,
+      code: "123456",
+    });
+  });
+
+  it("returns {boxId, code} for a valid https deferred-deeplink form", () => {
+    expect(prefillFromPairLink(validHttps)).toEqual({
+      boxId: VALID_BOX,
+      code: "123456",
+    });
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(prefillFromPairLink(`  ${validLink}  `)).toEqual({
+      boxId: VALID_BOX,
+      code: "123456",
+    });
+  });
+
+  it("returns null for null / undefined / empty / whitespace-only input", () => {
+    expect(prefillFromPairLink(null)).toBeNull();
+    expect(prefillFromPairLink(undefined)).toBeNull();
+    expect(prefillFromPairLink("")).toBeNull();
+    expect(prefillFromPairLink("   ")).toBeNull();
+  });
+
+  it("returns null for a foreign URL (not a pairing payload)", () => {
+    expect(prefillFromPairLink("https://example.com/foo")).toBeNull();
+    expect(prefillFromPairLink("manta://other?box=x&code=y")).toBeNull();
+  });
+
+  it("returns null for a malformed pair link (bad box / bad code)", () => {
+    expect(
+      prefillFromPairLink(`manta://pair?box=not-a-box&code=123456`),
+    ).toBeNull();
+    expect(
+      prefillFromPairLink(`manta://pair?box=${VALID_BOX}&code=abc`),
+    ).toBeNull();
+    expect(
+      prefillFromPairLink(`manta://pair?box=${VALID_BOX}&code=12345`),
+    ).toBeNull();
   });
 });

--- a/src/renderer/mobile/setupLogic.ts
+++ b/src/renderer/mobile/setupLogic.ts
@@ -1,5 +1,6 @@
 import { isSubmittableCode } from "../../shared/claim.mjs";
 import { boxDirectUrl, isValidBoxToken } from "../../shared/transport.mjs";
+import { parsePairPayload } from "./pairPayload";
 
 export type SetupFields = {
   boxId: string;
@@ -114,4 +115,29 @@ export function resolveSetupServerUrl(input: {
  */
 export function resolveConnectRoute(_serverBase: string): "direct" {
   return "direct";
+}
+
+/**
+ * Prefill helper for the deep-link pairing flow (BET-335).
+ *
+ * PairStep lazily initializes its Box ID + code fields from this function so
+ * clicking a `manta://pair?box=…&code=…` link opens the Connect screen with
+ * both fields already filled — the user clicks Connect to confirm. Routing
+ * through the existing screen (rather than auto-claiming) means the pair
+ * page's "click Connect" copy is true.
+ *
+ * Pure — delegates to the canonical `parsePairPayload` parser (the same one
+ * App.tsx uses to validate the deep-link URL) and returns `null` for any
+ * nullish/empty/invalid input. Lives here (not in the component) because
+ * setupLogic is the project's home for pure pairing helpers and is already
+ * covered by setupLogic.test.ts — that's what makes the behaviour testable
+ * without mounting React.
+ */
+export function prefillFromPairLink(
+  raw: string | null | undefined,
+): { boxId: string; code: string } | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return parsePairPayload(trimmed);
 }

--- a/src/server/pair.html
+++ b/src/server/pair.html
@@ -137,7 +137,7 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
       <h1>Connect it to your box</h1>
       <p class="lead">One click — Manta opens and asks you to confirm the pairing.</p>
       <div class="action"><a class="btn btn-primary" id="openlink" href="#" onclick="go(3)">Open in Manta</a></div>
-      <p class="hint">Manta shows <b>"Connect to box <span id="confirm-short">…</span>?"</b> — click Connect.</p>
+      <p class="hint">Manta opens with box <b><span id="confirm-short">…</span></b> filled in — click Connect.</p>
       <details>
         <summary>Nothing happened?</summary>
         <div class="dbody">


### PR DESCRIPTION
## Summary

The deep-link `manta://pair?box=…&code=…` flow used to call `claimBox` silently
and persist credentials without any user confirmation — while `pair.html`
instructed users to look for a "Connect to box …?" prompt that did not exist.
The page was lying; the safety net that a follow-up issue needs was also
missing. Route the deep-link through the existing PairStep screen instead of
auto-claiming.

## Changes (rebased onto `origin/main @ ab9b5ea`)

Reviewer caught that the PR was originally branched off `0dd0223` and missed
#277's `setPairLinkError(...)` feedback on the malformed-link branch —
silently regressing "deep link opened but did nothing" UX that #277
explicitly closed. Rebased onto the current `origin/main` and preserved
the malformed-link error-feedback path:

- **Valid link** (BET-335): stash the URL via `setPendingPairLink` so
  Onboarding jumps to step 1 and PairStep prefills Box ID + code from
  `prefillFromPairLink`. The click on Connect is the confirmation.
- **Malformed link** (#277, preserved): call `setPairLinkError(...)` with
  the "generate a fresh one on your box" message and open onboarding so
  PairStep renders the inline error. Without this, a hand-edited /
  legacy-shape `manta://pair?…` link would re-create the silent-failure
  UX #277 was added to close.

The auto-claim IIFE (the BET-255 silent-success path) is deleted entirely
per the BET-335 spec. Its failure branch — which carried the classified
claim reason into `pairLinkError` — disappears with it; that error path is
now handled inside PairStep's own `connect()` and surfaced through the
local `error` state.

### File changes vs current `origin/main @ ab9b5ea`

```
 src/renderer/App.tsx                   | 70 +++++++++++-----------------------
 src/renderer/PairStep.tsx              | 38 +++++++++++++-----
 src/renderer/mobile/setupLogic.test.ts | 51 +++++++++++++++++++++++++
 src/renderer/mobile/setupLogic.ts      | 26 +++++++++++++
 src/server/pair.html                   |  2 +-
 5 files changed, 130 insertions(+), 57 deletions(-)
```

## Follow-ups

- **BET-338 (parked, low priority)** — `pairLinkClaims` /
  `notePairLinkClaimed` / the `Onboarding` `useEffect` watching
  `pairLinkClaims` become dead code now that BET-335 deletes the
  auto-claim path. `pairLinkError` + `setPairLinkError` and the
  PairStep `useEffect` watching them STAY live (still called by the
  malformed-link branch). Filed as a child of BET-335.

## Verification results

- PR branch (`multica/BET-335-deep-link-pairing-confirmation` @ `3af5c33`):
  - typecheck: exit 0. No errors.
  - test: exit 0, **950 pass / 0 fail / 0 skip** (`npm test`).
- Base (`origin/main` @ `ab9b5ea`):
  - typecheck + test baseline matches (no pre-existing failures introduced or
    resolved by this PR).
- **Conclusion:** 0 new failures, 0 pre-existing failures. 950 tests pass.

### E2E renderer smoke (xvfb + Playwright Electron launcher)

Targeted assertions for the onboarding render path (the surface the deep-link
route now lands on):

- `A.window_alive` — PASS (`title: "Manta UI"`)
- `B.onboarding_pairstep` — PASS (PairStep fully rendered: heading "Connect
  to your server", Box ID input, Pairing code input, Connect button,
  Advanced button, Skip setup button)
- `C.no_shell_in_onboarding` — PASS (no sidebar/main/titlebar on fresh
  install — onboarding replaces them, as designed)
- `D.no_real_errors` — PASS (0 real console errors)

The malformed-link error-feedback path is now reachable: if a `manta://pair`
link with an invalid payload arrives, `setPairLinkError(...)` writes the
message and `relaunchOnboarding()` opens step 1. PairStep's existing
`useEffect` watching `pairLinkError` then surfaces the message inline.

## Behavioural check

Clicking a valid `manta://pair?box=…&code=…` link opens the app on the
Connect screen with Box ID and code already filled, and pairing completes
only after the user clicks Connect.

Clicking a malformed `manta://pair?…` link opens the Connect screen with
an inline error: "That pairing link isn't valid. Generate a fresh one on
your box (`manta pair`) and open the new link." — same UX as #277 closed.

## Definition of done

- No code path pairs the desktop without an explicit user click. ✅ (auto-claim
  branch removed; success now requires the PairStep Connect click)
- `App.tsx`'s deep-link effect is strictly smaller than before. ✅ (net
  ~30-line deletion of the auto-claim IIFE; `claimBox` import dropped)
- The pair page's step-2 copy matches observable behaviour. ✅ (copy
  rewritten to describe prefill + click-to-confirm)
- `npm run typecheck && npm test` green. ✅ (950/950 pass, exit 0)
- (From review feedback) Malformed-link error feedback from #277 is
  preserved. ✅ (setPairLinkError + relaunchOnboarding kept on the
  `if (!payload)` branch)

**Base: `origin/main` @ `ab9b5ea`**
