### PR TITLE
fix(renderer): terminal shortcuts stop eating Ctrl+C on Windows/Linux (BET-333)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import {
   resolveLauncherFlags,
 } from "./chatShared";
 import { chooseUpdateSkewVariant } from "./chatUtils";
+import { MOD_KEY } from "./platform";
 import { UpdateBar } from "./UpdateBar";
 import { parsePairPayload } from "./mobile/pairPayload";
 import { claimBox } from "./pairClaim";
@@ -807,7 +808,7 @@ export function App() {
           {projects.length === 0 ? (
             <div className="h-full flex items-center justify-center text-text-faint text-sm">
               {serverUrl || boxId
-                ? "Create a project (⌘N) to start."
+                ? `Create a project (${MOD_KEY}N) to start.`
                 : "Open Settings to connect to your box."}
             </div>
           ) : (

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -8,6 +8,7 @@
 import { useRef } from "react";
 import type { VoiceMode, VoicePhase } from "./voice";
 import { CLAUDE_ORANGE, type Attachment, type TypeaheadRow } from "./chatShared";
+import { ALT_KEY } from "./platform";
 
 // SessionToolbar — footer affordances. fork / compact / delete moved out of the
 // footer (they live in the header ⋯ menu); only the ⏰ schedules toggle remains
@@ -274,7 +275,7 @@ export function MicButton({
           : "release · dictate"
       : floating
         ? "hold to talk"
-        : "hold to speak (⌥ = command)";
+        : `hold to speak (${ALT_KEY} = command)`;
 
   // Floating PTT FAB: round bubble, bottom-right (positioned by the
   // `.mobile-ptt-fab` rule in mobile.css — visual/layout lives there per the

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
 import { useStore, type WindowStatusUI } from "./store";
 import type { Project, WorktreeInfo } from "../shared/types";
 import { classifyCacheAge, formatAge, selectCacheTtlMs } from "./chatUtils";
+import { MOD_KEY } from "./platform";
 
 const COLLAPSE_KEY = "manta:collapsed-projects";
 
@@ -552,7 +553,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         <button
           onClick={() => setNewProjectOpen(true)}
           className="text-text-muted hover:text-text text-lg leading-none"
-          title="New project (⌘N)"
+          title={`New project (${MOD_KEY}N)`}
         >
           +
         </button>
@@ -687,7 +688,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
       <div className="flex-1 overflow-y-auto px-1 pb-2">
         {projects.length === 0 && !newProjectOpen && (
           <div className="px-2 py-3 text-xs text-text-faint">
-            No projects yet. Click + or press ⌘N.
+            No projects yet. Click + or press {MOD_KEY}N.
           </div>
         )}
 

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -6,6 +6,8 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { getMantaPreload } from "./preloadAccess";
+import { IS_MAC } from "./platform";
+import { terminalShortcut } from "./chatUtils";
 
 /**
  * Handle an OSC 52 escape sequence: decode the base64 payload and write the
@@ -252,34 +254,34 @@ export function Terminal({ sessionKey, cwd, active, launcher }: Props) {
         return false;
       }
 
-      const meta = ev.metaKey || ev.ctrlKey;
-      if (!meta) return true;
-
-      if (ev.key === "c") {
-        const sel = term.getSelection();
-        if (sel) {
-          navigator.clipboard.writeText(sel).catch(() => {});
+      // macOS: Cmd+C/V/F/K. Everywhere else: Ctrl+Shift+C/V/F/K. Plain Ctrl
+      // on Windows/Linux is the application modifier and must reach the
+      // process — see terminalShortcut's doc in chatUtils.ts.
+      switch (terminalShortcut(ev, IS_MAC)) {
+        case "copy": {
+          const sel = term.getSelection();
+          if (sel) {
+            navigator.clipboard.writeText(sel).catch(() => {});
+            return false;
+          }
+          return true;
+        }
+        case "paste":
+          navigator.clipboard.readText().then((t) => {
+            if (t) window.api.ptyWrite(sessionKey, t);
+          });
+          return false;
+        case "find": {
+          const q = window.prompt("Find:");
+          if (q) search.findNext(q);
           return false;
         }
-        return true;
+        case "clear":
+          term.clear();
+          return false;
+        default:
+          return true;
       }
-      if (ev.key === "v") {
-        navigator.clipboard.readText().then((t) => {
-          if (t) window.api.ptyWrite(sessionKey, t);
-        });
-        return false;
-      }
-      if (ev.key === "f") {
-        const q = window.prompt("Find:");
-        if (q) search.findNext(q);
-        return false;
-      }
-      // Cmd+K = clear xterm scrollback
-      if (ev.key === "k" && !ev.shiftKey) {
-        term.clear();
-        return false;
-      }
-      return true;
     });
 
     return () => {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -70,6 +70,7 @@ import {
   connectPhaseLabel,
   isPollExpired,
   describeSubscriptionStatus,
+  terminalShortcut,
 } from "./chatUtils";
 
 // ===== formatTokens =====
@@ -3100,5 +3101,169 @@ describe("describeSubscriptionStatus", () => {
         connected: false,
       }),
     ).toBe("not connected");
+  });
+});
+
+// ===== terminalShortcut (BET-333) =====
+//
+// Pure matcher behind Terminal.tsx's keydown handler. macOS triggers off Cmd
+// alone; every other platform triggers off Ctrl+Shift. The upper-case trap:
+// when Shift is held, browsers report `ev.key` as the shifted form ("C"), so
+// the switch must lowercase before comparing.
+
+const NO_MODS = { metaKey: false, ctrlKey: false, shiftKey: false, altKey: false };
+
+describe("terminalShortcut", () => {
+  describe("macOS (isMac: true)", () => {
+    it("maps Cmd+C → copy", () => {
+      expect(
+        terminalShortcut({ key: "c", ...NO_MODS, metaKey: true }, true),
+      ).toBe("copy");
+    });
+
+    it("maps Cmd+V → paste", () => {
+      expect(
+        terminalShortcut({ key: "v", ...NO_MODS, metaKey: true }, true),
+      ).toBe("paste");
+    });
+
+    it("maps Cmd+F → find", () => {
+      expect(
+        terminalShortcut({ key: "f", ...NO_MODS, metaKey: true }, true),
+      ).toBe("find");
+    });
+
+    it("maps Cmd+K → clear", () => {
+      expect(
+        terminalShortcut({ key: "k", ...NO_MODS, metaKey: true }, true),
+      ).toBe("clear");
+    });
+
+    it("plain Ctrl+C → null (Mac user's Ctrl+C must reach the process)", () => {
+      expect(
+        terminalShortcut({ key: "c", ...NO_MODS, ctrlKey: true }, true),
+      ).toBeNull();
+    });
+
+    it("Cmd+Shift+K → null (Cmd+Shift combos are not our shortcuts)", () => {
+      expect(
+        terminalShortcut(
+          { key: "K", metaKey: true, ctrlKey: false, shiftKey: true, altKey: false },
+          true,
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("non-macOS (isMac: false)", () => {
+    it("Ctrl+Shift+C with key:'C' → copy (regression test for the uppercase trap)", () => {
+      expect(
+        terminalShortcut(
+          { key: "C", metaKey: false, ctrlKey: true, shiftKey: true, altKey: false },
+          false,
+        ),
+      ).toBe("copy");
+    });
+
+    it("Ctrl+Shift+V → paste", () => {
+      expect(
+        terminalShortcut(
+          { key: "V", metaKey: false, ctrlKey: true, shiftKey: true, altKey: false },
+          false,
+        ),
+      ).toBe("paste");
+    });
+
+    it("Ctrl+Shift+F → find", () => {
+      expect(
+        terminalShortcut(
+          { key: "F", metaKey: false, ctrlKey: true, shiftKey: true, altKey: false },
+          false,
+        ),
+      ).toBe("find");
+    });
+
+    it("Ctrl+Shift+K → clear", () => {
+      expect(
+        terminalShortcut(
+          { key: "K", metaKey: false, ctrlKey: true, shiftKey: true, altKey: false },
+          false,
+        ),
+      ).toBe("clear");
+    });
+
+    it("plain Ctrl+C → null (the actual bug being fixed)", () => {
+      expect(
+        terminalShortcut(
+          { key: "c", metaKey: false, ctrlKey: true, shiftKey: false, altKey: false },
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it("plain Ctrl+K → null", () => {
+      expect(
+        terminalShortcut(
+          { key: "k", metaKey: false, ctrlKey: true, shiftKey: false, altKey: false },
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it("plain Ctrl+F → null", () => {
+      expect(
+        terminalShortcut(
+          { key: "f", metaKey: false, ctrlKey: true, shiftKey: false, altKey: false },
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it("plain Ctrl+V → null", () => {
+      expect(
+        terminalShortcut(
+          { key: "v", metaKey: false, ctrlKey: true, shiftKey: false, altKey: false },
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it("Cmd+C → null (some keyboards send Meta instead of Ctrl on Win/Linux)", () => {
+      expect(
+        terminalShortcut(
+          { key: "c", metaKey: true, ctrlKey: false, shiftKey: false, altKey: false },
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it("Ctrl+Shift+Alt+C → null (alt modifier disqualifies the trigger)", () => {
+      expect(
+        terminalShortcut(
+          { key: "c", metaKey: false, ctrlKey: true, shiftKey: true, altKey: true },
+          false,
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("trigger held with an unrelated key", () => {
+    it("macOS Cmd+X → null", () => {
+      expect(
+        terminalShortcut(
+          { key: "x", metaKey: true, ctrlKey: false, shiftKey: false, altKey: false },
+          true,
+        ),
+      ).toBeNull();
+    });
+
+    it("non-macOS Ctrl+Shift+X → null", () => {
+      expect(
+        terminalShortcut(
+          { key: "x", metaKey: false, ctrlKey: true, shiftKey: true, altKey: false },
+          false,
+        ),
+      ).toBeNull();
+    });
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2199,6 +2199,55 @@ export function isPollExpired(
   return now - startedAt >= limitMs;
 }
 
+// ===== Terminal keyboard shortcuts (BET-333) =====
+//
+// Inside a terminal, plain Ctrl on Windows / Linux is the application's own
+// modifier (it must reach the process — SIGINT, readline forward-char, etc.).
+// Treating Ctrl as equivalent to Cmd swallows Ctrl+C whenever text is
+// selected, so a running process can never be interrupted. The fix is the
+// every-other-terminal convention: on macOS the trigger is Cmd alone, on
+// every other platform the trigger is Ctrl+Shift. Plain Ctrl falls straight
+// through to the PTY.
+//
+// `terminalShortcut(ev, isMac)` is the pure matcher. Returns which terminal-
+// emulator action the keydown maps to (or null = "not ours, let it through").
+// The four actions map to the same four bodies xterm.js's custom key handler
+// already runs today (selection copy, clipboard paste, window.prompt find,
+// term.clear scrollback).
+//
+// `isMac` is passed in rather than read from `navigator` so the function is
+// testable in isolation and so all platform gating in the renderer reads
+// `src/renderer/platform.ts` (the only place `navigator.platform` is touched).
+export type TerminalShortcut = "copy" | "paste" | "find" | "clear" | null;
+
+export function terminalShortcut(
+  ev: {
+    key: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+  },
+  isMac: boolean,
+): TerminalShortcut {
+  const macTrigger = isMac
+    ? ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey
+    : ev.ctrlKey && ev.shiftKey && !ev.metaKey && !ev.altKey;
+  if (!macTrigger) return null;
+  switch (ev.key.toLowerCase()) {
+    case "c":
+      return "copy";
+    case "v":
+      return "paste";
+    case "f":
+      return "find";
+    case "k":
+      return "clear";
+    default:
+      return null;
+  }
+}
+
 // ===== Subscription provider status (BET-314) =====
 //
 // Single source of truth for the connected/not-connected label the

--- a/src/renderer/platform.ts
+++ b/src/renderer/platform.ts
@@ -1,0 +1,17 @@
+// The only place the renderer reads the host platform. Everything else takes
+// IS_MAC as an argument or imports these constants — see the epic's "one
+// platform switch per concept" rule.
+const platform =
+  (typeof navigator !== "undefined" &&
+    ((navigator as { userAgentData?: { platform?: string } }).userAgentData
+      ?.platform ??
+      navigator.platform)) ||
+  "";
+
+export const IS_MAC = /mac/i.test(platform);
+
+/** Prefix for the primary shortcut modifier: "⌘N" on macOS, "Ctrl+N" else. */
+export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl+";
+
+/** Prefix for the alt modifier: "⌥" on macOS, "Alt" else. */
+export const ALT_KEY = IS_MAC ? "⌥" : "Alt";


### PR DESCRIPTION
Treating Ctrl as equivalent to Cmd in Terminal.tsx's key handler meant plain Ctrl on Windows/Linux (the application's own modifier inside a terminal) was swallowed whenever text was selected — so a running process could not be interrupted, the user had to click to clear the selection first, and they had no idea why it sometimes worked.

The fix is the every-other-terminal convention: macOS keeps Cmd+C/V/F/K, everywhere else moves to Ctrl+Shift+C/V/F/K. Plain Ctrl now reaches the process, matching GNOME Terminal, Windows Terminal, and VS Code.

**Files changed:** 7 files. `src/renderer/platform.ts` (new, 17 lines), `src/renderer/chatUtils.ts` (+49), `src/renderer/chatUtils.test.ts` (+165, 18 new tests), `src/renderer/Terminal.tsx` (net -4 after the matcher swap), and 4 user-visible strings in `Sidebar.tsx` / `App.tsx` / `ComposerParts.tsx` use MOD_KEY/ALT_KEY instead of hardcoded ⌘/⌥.

```
src/renderer/App.tsx           |   3 +-
src/renderer/ComposerParts.tsx |   3 +-
src/renderer/Sidebar.tsx       |   5 +-
src/renderer/Terminal.tsx      |  52 ++++++-------
src/renderer/chatUtils.test.ts | 165 +++++++++++++++++++++++++++++++++++++++++
src/renderer/chatUtils.ts      |  49 ++++++++++++
src/renderer/platform.ts       |  17 +++++
```

**Base:** origin/main @ 2d64718

**Acceptance criteria** (every line of the issue's "Acceptance" section):
- `npm run typecheck && npm test` green — both runs captured below.
- `Terminal.tsx` no `metaKey`/`ctrlKey` except the Shift+Enter block — verified by grep, only line 250 (the unchanged newline handler) matches.
- `grep -rn '⌘\|⌥' src/renderer --include=*.tsx --include=*.ts` matches only comments and `platform.ts` — 9 matches, all comments or `platform.ts` lines.
- `navigator.platform` read in exactly one file in `src/renderer/` — only `platform.ts` reads it; `chatUtils.ts` mentions it in a JSDoc block.
- macOS behaviour: Cmd+C/V/F/K map to copy/paste/find/clear as before. (Cmd+Shift combos now return null too — that uniform !shiftKey requirement on macOS is the deliberate change called out in the issue body, making the four cases identical and matching GNOME/Windows Terminal/VS Code.)

**Verification results:**
- PR branch (`multica/BET-333-terminal-shortcuts` @ 243d49e):
  - typecheck: exit 0. Errors: none. log sha256: 42e43d8553ffd1afd4155ab126a5387b69a11b87fcef0f108c2776e13316b750
  - test: exit 0, 52 files / 1097 tests pass / 0 fail / 0 skip. log sha256: ed38a7bca476c93850c1cb6da37a13c354dd4837ae2e59800150d9274a7e20f6
- Base (`main` @ 2d64718):
  - typecheck: exit 0. Errors: none. log sha256: 42e43d8553ffd1afd4155ab126a5387b69a11b87fcef0f108c2776e13316b750
  - test: exit 0, 52 files / 1079 tests pass / 0 fail / 0 skip. log sha256: 9cb959ed3b3085ed3c7ccfd9da1cd2dafecbf7f49c695f87089ed0c4e178af03
- **Conclusion:** 0 pre-existing failures, 0 new failures, **18 new tests added** (all passing — the terminalShortcut matcher suite).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.