### PR TITLE
fix(desktop): repair auto-update end to end — feed checksum, dead UI, silent errors

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -326,6 +326,55 @@ workflows:
             xcrun stapler validate "$dmg" || { echo "  ⚠ stapler validate failed for $dmg"; FAIL=1; }
           done
           [ "$FAIL" = "0" ] || { echo "DMG verification failed."; exit 1; }
+      - name: Restamp the update feed to match the stapled DMG
+        script: |
+          # MUST run after stapling and before publish.
+          #
+          # electron-builder wrote latest-mac.yml (the electron-updater feed)
+          # back in the build step, recording the DMG's sha512 + size AT THAT
+          # MOMENT. The "Sign + notarize + staple" step above then rewrote the
+          # DMG in place — stapling embeds the notarization ticket, growing it
+          # ~11KB and changing its hash. The feed was never regenerated, so it
+          # described a pre-staple file that exists nowhere.
+          #
+          # electron-updater downloads the published DMG, verifies it against
+          # the feed's sha512, mismatches, and refuses to install. Auto-update
+          # was dead in EVERY notarized release (0.0.13 and 0.0.14 both shipped
+          # this way) — and silently, because src/main/autoUpdate.ts only
+          # console.warn()s on updater errors, so nobody saw a failure. Users
+          # simply never received an update.
+          set -e
+          node scripts/release/restamp-update-feed.mjs dist/desktop/latest-mac.yml
+      - name: Verify the feed validates against the artifacts
+        script: |
+          # Belt-and-braces: recompute each artifact's digest and diff it
+          # against the feed we are about to publish. This is the check that
+          # would have caught the broken feed at build time instead of leaving
+          # it to be discovered from a user's "it never updates" report.
+          set -e
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const crypto = require("node:crypto");
+            const YAML = require("yaml");
+            const feedPath = "dist/desktop/latest-mac.yml";
+            const feed = YAML.parse(fs.readFileSync(feedPath, "utf-8"));
+            let bad = 0;
+            for (const f of feed.files ?? []) {
+              const p = path.join(path.dirname(feedPath), f.url);
+              const buf = fs.readFileSync(p);
+              const sha = crypto.createHash("sha512").update(buf).digest("base64");
+              const ok = sha === f.sha512 && buf.length === f.size;
+              console.log((ok ? "  OK  " : "  BAD ") + f.url);
+              if (!ok) {
+                console.log("       feed:   sha512=" + f.sha512 + " size=" + f.size);
+                console.log("       actual: sha512=" + sha + " size=" + buf.length);
+                bad++;
+              }
+            }
+            if (bad) { console.error("Update feed does not match the artifacts — electron-updater would reject these."); process.exit(1); }
+            console.log("Update feed matches every artifact.");
+          '
       - name: Publish to mantaui.com (optional)
         script: |
           # Skips cleanly if no deploy key is configured, so the workflow still

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/scripts/release/restamp-update-feed.mjs
+++ b/scripts/release/restamp-update-feed.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// restamp-update-feed.mjs — rewrite electron-builder's `latest-mac.yml` so its
+// checksums describe the DMG we ACTUALLY publish.
+//
+//   node scripts/release/restamp-update-feed.mjs dist/desktop/latest-mac.yml
+//
+// WHY THIS EXISTS
+// ---------------
+// electron-builder writes `latest-mac.yml` (the electron-updater feed) at the
+// end of `electron-builder --mac`, recording each artifact's sha512 + size.
+// The codemagic `mac-desktop` workflow then runs a LATER step that
+// `codesign --force`s the DMG, submits it to the notary service, and staples
+// the ticket into it. Stapling REWRITES the file — ~11KB larger, completely
+// different hash.
+//
+// The feed is never regenerated, so it permanently describes a pre-staple file
+// that no longer exists anywhere. electron-updater downloads the published DMG,
+// verifies it against the feed's sha512, gets a mismatch, and REFUSES to
+// install. Auto-update is dead on arrival — and silently, because the desktop's
+// updater error handler only console.warn()s (src/main/autoUpdate.ts), so the
+// user sees no banner and no error, just an app that never updates.
+//
+// Shipped broken in every notarized release (0.0.13, 0.0.14 — both verified
+// against prod: feed size 98214660/97241753 vs actual 98226318/97253264).
+//
+// Run this AFTER the staple step and BEFORE publish, and the feed matches.
+//
+// The alternative — staple before electron-builder writes the feed — is not
+// available: electron-builder owns both the DMG creation and the feed write in
+// one invocation, and only notarizes the .app INSIDE the DMG, never the DMG.
+//
+// Pure node + the `yaml` dep (already a desktop runtime dependency).
+
+import { readFile, writeFile, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+import YAML from "yaml";
+
+function die(msg) {
+  process.stderr.write(`✗ ${msg}\n`);
+  process.exit(1);
+}
+
+function log(msg) {
+  process.stdout.write(`▸ ${msg}\n`);
+}
+
+/**
+ * electron-updater's checksum encoding: base64 of the raw sha512 digest (NOT
+ * hex). Getting this wrong produces a feed that parses fine and fails every
+ * update — the exact failure mode this script exists to fix — so it is pinned
+ * by a test against a known vector.
+ */
+export function sha512Base64(buffer) {
+  return createHash("sha512").update(buffer).digest("base64");
+}
+
+/**
+ * Rewrite a parsed latest-mac.yml so every `files[]` entry carries the real
+ * size + sha512 of the artifact on disk, and the legacy top-level `sha512` /
+ * `size` mirror whichever entry `path` names.
+ *
+ * Pure: takes the parsed feed + a { filename -> {sha512, size} } lookup and
+ * returns a NEW feed object. All IO stays in main().
+ *
+ * @param feed  parsed latest-mac.yml
+ * @param stats { [filename]: { sha512: string, size: number } }
+ * @returns { feed, changed: string[] } — `changed` lists files whose digest or
+ *          size actually moved (empty = the staple step was a no-op and the
+ *          feed was already correct).
+ */
+export function restampFeed(feed, stats) {
+  if (!feed || typeof feed !== "object") die("feed is not an object");
+  const files = Array.isArray(feed.files) ? feed.files : [];
+  if (files.length === 0) die("feed has no files[] entries — refusing to write an empty feed");
+
+  const changed = [];
+  const nextFiles = files.map((entry) => {
+    const name = entry?.url;
+    if (typeof name !== "string" || name === "") die("a files[] entry has no url");
+    const s = stats[name];
+    // A file named in the feed but missing on disk means the publish would ship
+    // a feed pointing at nothing. Fail loudly rather than silently keep the
+    // stale digest — a stale digest is precisely the bug.
+    if (!s) die(`feed references "${name}" but it was not found on disk`);
+    if (entry.sha512 !== s.sha512 || entry.size !== s.size) changed.push(name);
+    return { ...entry, sha512: s.sha512, size: s.size };
+  });
+
+  const next = { ...feed, files: nextFiles };
+
+  // The top-level `path` + `sha512` are the legacy single-artifact fields
+  // older electron-updater builds read. They must mirror the matching files[]
+  // entry or a client on the old path re-introduces the mismatch.
+  if (typeof next.path === "string") {
+    const primary = nextFiles.find((f) => f.url === next.path);
+    if (!primary) die(`feed.path "${next.path}" does not match any files[] entry`);
+    next.sha512 = primary.sha512;
+    // electron-builder omits a top-level `size`; only mirror it when present.
+    if ("size" in next) next.size = primary.size;
+  }
+
+  return { feed: next, changed };
+}
+
+async function main() {
+  const feedPath = process.argv[2];
+  if (!feedPath) die("usage: restamp-update-feed.mjs <path/to/latest-mac.yml>");
+
+  const raw = await readFile(feedPath, "utf-8");
+  const feed = YAML.parse(raw);
+  const dir = dirname(feedPath);
+
+  const names = (Array.isArray(feed?.files) ? feed.files : [])
+    .map((f) => f?.url)
+    .filter((u) => typeof u === "string" && u !== "");
+
+  const stats = {};
+  for (const name of names) {
+    const full = join(dir, name);
+    try {
+      const [buf, st] = await Promise.all([readFile(full), stat(full)]);
+      stats[name] = { sha512: sha512Base64(buf), size: st.size };
+    } catch {
+      die(`cannot read artifact "${full}" referenced by the feed`);
+    }
+  }
+
+  const { feed: next, changed } = restampFeed(feed, stats);
+
+  if (changed.length === 0) {
+    log(`update feed already matches the artifacts on disk (${names.join(", ")}) — nothing to restamp`);
+    return;
+  }
+
+  await writeFile(feedPath, YAML.stringify(next));
+  for (const name of changed) {
+    log(`restamped ${name} → sha512=${stats[name].sha512.slice(0, 16)}… size=${stats[name].size}`);
+  }
+  log(`wrote ${feedPath} — electron-updater will now validate the published DMG`);
+}
+
+// Only run main() when invoked as a CLI, so the pure helpers stay importable
+// from the test file without triggering argv parsing.
+if (process.argv[1] && process.argv[1].endsWith("restamp-update-feed.mjs")) {
+  main().catch((e) => die(String(e?.stack ?? e)));
+}

--- a/scripts/release/restamp-update-feed.test.mjs
+++ b/scripts/release/restamp-update-feed.test.mjs
@@ -1,0 +1,116 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import { restampFeed, sha512Base64 } from "./restamp-update-feed.mjs";
+
+// A feed shaped exactly like the one electron-builder emits for the mac
+// desktop build (captured from the real 0.0.14 release).
+function feedFixture() {
+  return {
+    version: "0.0.14",
+    files: [
+      {
+        url: "Manta UI-0.0.14-arm64.dmg",
+        sha512: "PRE_STAPLE_DIGEST==",
+        size: 97241753,
+      },
+    ],
+    path: "Manta UI-0.0.14-arm64.dmg",
+    sha512: "PRE_STAPLE_DIGEST==",
+    releaseDate: "2026-07-27T15:27:24.601Z",
+  };
+}
+
+describe("sha512Base64", () => {
+  test("is base64 of the raw digest, NOT hex", () => {
+    const expected = createHash("sha512").update("hello").digest("base64");
+    assert.equal(sha512Base64(Buffer.from("hello")), expected);
+    // Guard the encoding explicitly: electron-updater rejects a hex digest,
+    // and the failure mode (every update fails verification) is exactly the
+    // bug this script fixes, so a silent swap must not pass.
+    const hex = createHash("sha512").update("hello").digest("hex");
+    assert.notEqual(sha512Base64(Buffer.from("hello")), hex);
+  });
+});
+
+describe("restampFeed", () => {
+  test("REGRESSION: rewrites the digest + size the staple step invalidated", () => {
+    // The shipped bug: stapling grows the DMG ~11KB and changes its hash, but
+    // the feed keeps electron-builder's pre-staple values, so electron-updater
+    // downloads a valid DMG and rejects it on checksum.
+    const { feed, changed } = restampFeed(feedFixture(), {
+      "Manta UI-0.0.14-arm64.dmg": { sha512: "POST_STAPLE_DIGEST==", size: 97253264 },
+    });
+    assert.equal(feed.files[0].sha512, "POST_STAPLE_DIGEST==");
+    assert.equal(feed.files[0].size, 97253264);
+    assert.deepEqual(changed, ["Manta UI-0.0.14-arm64.dmg"]);
+  });
+
+  test("mirrors the restamped digest into the legacy top-level sha512", () => {
+    // Older electron-updater clients read the top-level `path`/`sha512` pair.
+    // Leaving it stale would keep auto-update broken for exactly those clients.
+    const { feed } = restampFeed(feedFixture(), {
+      "Manta UI-0.0.14-arm64.dmg": { sha512: "POST_STAPLE_DIGEST==", size: 97253264 },
+    });
+    assert.equal(feed.sha512, "POST_STAPLE_DIGEST==");
+  });
+
+  test("reports no change when the artifacts already match (idempotent)", () => {
+    const already = feedFixture();
+    const { feed, changed } = restampFeed(already, {
+      "Manta UI-0.0.14-arm64.dmg": { sha512: "PRE_STAPLE_DIGEST==", size: 97241753 },
+    });
+    assert.deepEqual(changed, []);
+    assert.equal(feed.files[0].sha512, "PRE_STAPLE_DIGEST==");
+  });
+
+  test("running it twice is a no-op the second time", () => {
+    const stats = {
+      "Manta UI-0.0.14-arm64.dmg": { sha512: "POST_STAPLE_DIGEST==", size: 97253264 },
+    };
+    const once = restampFeed(feedFixture(), stats);
+    const twice = restampFeed(once.feed, stats);
+    assert.deepEqual(twice.changed, []);
+    assert.deepEqual(twice.feed, once.feed);
+  });
+
+  test("preserves unrelated feed keys (version, releaseDate)", () => {
+    const { feed } = restampFeed(feedFixture(), {
+      "Manta UI-0.0.14-arm64.dmg": { sha512: "POST_STAPLE_DIGEST==", size: 97253264 },
+    });
+    assert.equal(feed.version, "0.0.14");
+    assert.equal(feed.releaseDate, "2026-07-27T15:27:24.601Z");
+  });
+
+  test("restamps every entry when the feed lists multiple artifacts", () => {
+    // Re-adding the x64 arch to electron-builder.yml must not silently leave
+    // the second artifact on a stale digest.
+    const multi = {
+      version: "0.0.15",
+      files: [
+        { url: "a-arm64.dmg", sha512: "OLD_A==", size: 1 },
+        { url: "b-x64.dmg", sha512: "OLD_B==", size: 2 },
+      ],
+      path: "a-arm64.dmg",
+      sha512: "OLD_A==",
+    };
+    const { feed, changed } = restampFeed(multi, {
+      "a-arm64.dmg": { sha512: "NEW_A==", size: 10 },
+      "b-x64.dmg": { sha512: "NEW_B==", size: 20 },
+    });
+    assert.equal(feed.files[0].sha512, "NEW_A==");
+    assert.equal(feed.files[1].sha512, "NEW_B==");
+    assert.equal(feed.sha512, "NEW_A==");
+    assert.deepEqual(changed, ["a-arm64.dmg", "b-x64.dmg"]);
+  });
+
+  test("does not mutate the input feed", () => {
+    const input = feedFixture();
+    restampFeed(input, {
+      "Manta UI-0.0.14-arm64.dmg": { sha512: "POST_STAPLE_DIGEST==", size: 97253264 },
+    });
+    assert.equal(input.files[0].sha512, "PRE_STAPLE_DIGEST==");
+    assert.equal(input.files[0].size, 97241753);
+  });
+});

--- a/src/main/autoUpdate.ts
+++ b/src/main/autoUpdate.ts
@@ -16,6 +16,7 @@
 import { autoUpdater } from "electron-updater";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { IPC } from "../shared/types.js";
+import { shouldSurfaceUpdateError, describeUpdateError } from "../shared/updateError.mjs";
 
 // Disable auto-download so we can prompt the user before installing.
 // This gives us a chance to show a "Restart to update" dialog.
@@ -46,7 +47,29 @@ autoUpdater.on("update-downloaded", (info) => {
 
 autoUpdater.on("error", (err) => {
   console.warn("[auto-update] Update error:", err.message);
+  // A transient error (offline, DNS, timeout) fixes itself and must not nag.
+  // A TERMINAL one (checksum/signature mismatch, can't replace the bundle)
+  // means this install will never update again on its own — the user has to
+  // act, so they have to be told. Swallowing these into the console above is
+  // how 0.0.13 and 0.0.14 both shipped with a broken update feed unnoticed:
+  // every launch failed verification in silence and the app just never
+  // updated. See src/shared/updateError.mjs.
+  if (!shouldSurfaceUpdateError(err.message)) return;
+  notifyUpdateError(describeUpdateError(err.message), err.message);
 });
+
+/**
+ * Push a terminal update failure to every open window. Separate from
+ * notifyRenderer() because it carries both the human-facing copy and the raw
+ * message (useful in logs / a support paste) rather than an UpdateInfo.
+ */
+function notifyUpdateError(message: string, raw: string): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(IPC.autoUpdateError, { message, raw });
+    }
+  }
+}
 
 /**
  * Send an update event to the renderer via IPC.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,8 @@ import {
   type AuthClaimInput,
   type DesktopNotifyPayload,
   type ServerUpdateAvailablePayload,
+  type AutoUpdateInfo,
+  type AutoUpdateErrorInfo,
 } from "../shared/types.js";
 import type { ClaimOutcome } from "../shared/claim.mjs";
 
@@ -124,6 +126,34 @@ const api = {
     const listener = (_: unknown, payload: ServerUpdateAvailablePayload) => cb(payload);
     ipcRenderer.on(IPC.serverUpdateAvailable, listener);
     return () => ipcRenderer.removeListener(IPC.serverUpdateAvailable, listener);
+  },
+
+  // ---- desktop auto-update (electron-updater) ----
+  // These MUST live on the preload bridge, not on window.api. On a paired
+  // desktop window.api is httpApi, whose auto-update entries are no-op stubs
+  // (correct for mobile/web, which has no updater). Desktop is ALWAYS in http
+  // mode since the SSH transport was removed, so before these existed main
+  // downloaded updates and pushed autoUpdate:* IPC into a renderer that was
+  // subscribed to a stub — the "Restart to update" banner could never appear
+  // and autoUpdateInstall() resolved without doing anything. httpApi now
+  // routes to these when window.__mantaPreload is present (same delegation
+  // pattern as peekRemoteFile).
+  autoUpdateDownload: (): Promise<void> => ipcRenderer.invoke(IPC.autoUpdateDownload),
+  autoUpdateInstall: (): Promise<void> => ipcRenderer.invoke(IPC.autoUpdateInstall),
+  onAutoUpdateAvailable: (cb: (info: AutoUpdateInfo) => void): (() => void) => {
+    const listener = (_: unknown, info: AutoUpdateInfo) => cb(info);
+    ipcRenderer.on(IPC.autoUpdateAvailable, listener);
+    return () => ipcRenderer.removeListener(IPC.autoUpdateAvailable, listener);
+  },
+  onAutoUpdateDownloaded: (cb: (info: AutoUpdateInfo) => void): (() => void) => {
+    const listener = (_: unknown, info: AutoUpdateInfo) => cb(info);
+    ipcRenderer.on(IPC.autoUpdateDownloaded, listener);
+    return () => ipcRenderer.removeListener(IPC.autoUpdateDownloaded, listener);
+  },
+  onAutoUpdateError: (cb: (info: AutoUpdateErrorInfo) => void): (() => void) => {
+    const listener = (_: unknown, info: AutoUpdateErrorInfo) => cb(info);
+    ipcRenderer.on(IPC.autoUpdateError, listener);
+    return () => ipcRenderer.removeListener(IPC.autoUpdateError, listener);
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -43,6 +43,8 @@ export function App() {
     configSnapshot,
     updatePrompt,
     setUpdatePrompt,
+    updateError,
+    setUpdateError,
     serverUpdatePrompt,
     setServerUpdatePrompt,
     connectionState,
@@ -302,6 +304,20 @@ export function App() {
         version: info.version,
         releaseName: info.releaseName,
       });
+    });
+    return off;
+  }, []);
+
+  // Terminal auto-update failure. Main only forwards failures the user has to
+  // ACT on (integrity / permission — see shared/updateError.mjs); transient
+  // network errors never arrive here, so this banner can't nag about a flaky
+  // connection. Before this existed every updater error went to console.warn
+  // and nowhere else, which is how a broken release feed silently stopped all
+  // desktop updates for two versions.
+  useEffect(() => {
+    if (!window.api.onAutoUpdateError) return;
+    const off = window.api.onAutoUpdateError((info) => {
+      useStore.getState().setUpdateError(info);
     });
     return off;
   }, []);
@@ -679,6 +695,23 @@ export function App() {
               void window.api.autoUpdateInstall();
             }}
             onDismiss={() => setUpdatePrompt(null)}
+          />
+        )}
+        {/* Terminal auto-update failure. An update exists but this install
+            cannot take it (checksum/signature mismatch, or the bundle can't
+            be replaced), so the only way forward is a manual download —
+            hence the action opens the downloads page rather than retrying an
+            install that is guaranteed to fail again. Dismissible: the user
+            may not want to deal with it right now, and it re-arms on the
+            next failed check. */}
+        {!showOnboarding && updateError && (
+          <UpdateBar
+            text={updateError.message}
+            actionLabel="Download"
+            onAction={() => {
+              void window.api.openExternal("https://mantaui.com/downloads/Manta-latest.dmg");
+            }}
+            onDismiss={() => setUpdateError(null)}
           />
         )}
         {/* Server-update prompt (BET-225 stage 3 Part A): shown when the

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -308,3 +308,63 @@ describe("onDesktopNotify", () => {
     unsub2();
   });
 });
+
+// ---------------------------------------------------------------------------
+// auto-update delegation — the stubs used to swallow the whole updater UX
+// ---------------------------------------------------------------------------
+
+describe("httpApi auto-update delegation", () => {
+  function withPreload(preload: unknown): void {
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      __mantaPreload: preload,
+    });
+  }
+
+  it("REGRESSION: forwards onAutoUpdateDownloaded to the preload instead of no-op'ing", () => {
+    // These entries were hardcoded `() => () => {}` and commented "desktop-
+    // only; no-op in http/mobile mode". Desktop has been permanently in http
+    // mode since the SSH transport was removed, so window.api IS httpApi on
+    // every paired desktop — main downloaded updates and fired autoUpdate:*
+    // IPC at a stub. The "Restart to update" banner could never appear.
+    const off = vi.fn();
+    const onAutoUpdateDownloaded = vi.fn(() => off);
+    withPreload({ onAutoUpdateDownloaded });
+
+    const cb = vi.fn();
+    const result = httpApi.onAutoUpdateDownloaded(cb);
+
+    expect(onAutoUpdateDownloaded).toHaveBeenCalledWith(cb);
+    expect(result).toBe(off);
+  });
+
+  it("forwards onAutoUpdateError to the preload", () => {
+    const off = vi.fn();
+    const onAutoUpdateError = vi.fn(() => off);
+    withPreload({ onAutoUpdateError });
+
+    const cb = vi.fn();
+    expect(httpApi.onAutoUpdateError(cb)).toBe(off);
+    expect(onAutoUpdateError).toHaveBeenCalledWith(cb);
+  });
+
+  it("REGRESSION: autoUpdateInstall actually reaches the preload (it used to resolve and do nothing)", async () => {
+    const autoUpdateInstall = vi.fn(async () => {});
+    withPreload({ autoUpdateInstall });
+
+    await httpApi.autoUpdateInstall();
+    expect(autoUpdateInstall).toHaveBeenCalled();
+  });
+
+  it("stays a safe no-op on mobile/web where there is no preload", async () => {
+    withPreload(undefined);
+
+    // Must not throw — mobile has no updater at all.
+    await httpApi.autoUpdateInstall();
+    await httpApi.autoUpdateDownload();
+    const off = httpApi.onAutoUpdateError(vi.fn());
+    expect(typeof off).toBe("function");
+    off();
+  });
+});

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -903,11 +903,31 @@ export const httpApi: Api = {
   // registry stays single-source-of-truth regardless of transport.
   pushRegisterApns: (token) => rpc(IPC.pushRegisterApns, token),
 
-  // -- auto-update (desktop-only; no-op in http/mobile mode) --
-  autoUpdateDownload: () => Promise.resolve(),
-  autoUpdateInstall: () => Promise.resolve(),
-  onAutoUpdateAvailable: () => () => {},
-  onAutoUpdateDownloaded: () => () => {},
+  // -- auto-update (electron-updater; delegated to the preload on desktop) --
+  //
+  // These used to be unconditional no-ops, commented "desktop-only; no-op in
+  // http/mobile mode". That reasoning was stale: desktop is ALWAYS in http
+  // mode since the SSH transport was removed (BET-82), so window.api is
+  // httpApi on every paired desktop and the stubs swallowed the entire
+  // updater UX — main downloaded the update, sent autoUpdate:* IPC, and the
+  // renderer was listening to `() => () => {}`. The "Restart to update"
+  // banner could never render and autoUpdateInstall() resolved without
+  // restarting. Combined with the release feed's checksum drift (fixed in
+  // scripts/release/restamp-update-feed.mjs) desktop auto-update was broken
+  // end to end, silently, for multiple releases.
+  //
+  // Route through window.__mantaPreload when it exists (desktop), fall back
+  // to a genuine no-op on mobile/web where there is no updater at all. Same
+  // delegation shape as peekRemoteFile above.
+  autoUpdateDownload: async () => {
+    await getMantaPreload()?.autoUpdateDownload();
+  },
+  autoUpdateInstall: async () => {
+    await getMantaPreload()?.autoUpdateInstall();
+  },
+  onAutoUpdateAvailable: (cb) => getMantaPreload()?.onAutoUpdateAvailable(cb) ?? (() => {}),
+  onAutoUpdateDownloaded: (cb) => getMantaPreload()?.onAutoUpdateDownloaded(cb) ?? (() => {}),
+  onAutoUpdateError: (cb) => getMantaPreload()?.onAutoUpdateError(cb) ?? (() => {}),
 
   // -- typeahead --
   opencodeCommands: () => rpc(IPC.opencodeCommands),

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -42,6 +42,14 @@ function makeFakePreload(): MantaPreload {
       cb({ version: "test-server", notesUrl: null });
       return vi.fn();
     }),
+    // Desktop auto-update bridge. These moved onto the preload because
+    // window.api is httpApi on every paired desktop and its auto-update
+    // entries were no-op stubs, so the updater's events reached nothing.
+    autoUpdateDownload: vi.fn(async () => {}),
+    autoUpdateInstall: vi.fn(async () => {}),
+    onAutoUpdateAvailable: vi.fn(() => vi.fn()),
+    onAutoUpdateDownloaded: vi.fn(() => vi.fn()),
+    onAutoUpdateError: vi.fn(() => vi.fn()),
   };
 }
 

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -1,4 +1,9 @@
-import type { DesktopNotifyPayload, ServerUpdateAvailablePayload } from "../shared/types.js";
+import type {
+  DesktopNotifyPayload,
+  ServerUpdateAvailablePayload,
+  AutoUpdateInfo,
+  AutoUpdateErrorInfo,
+} from "../shared/types.js";
 
 /**
  * OS-integration affordances exposed by the Electron preload bridge.
@@ -73,6 +78,18 @@ export interface MantaPreload {
   onServerUpdateAvailable(
     cb: (payload: ServerUpdateAvailablePayload) => void,
   ): () => void;
+  // Desktop auto-update. These live here rather than on window.api because a
+  // paired desktop's window.api is httpApi, whose auto-update entries are
+  // no-op stubs written for mobile/web. Desktop has been permanently in http
+  // mode since the SSH transport was removed, so routing auto-update through
+  // window.api meant every event was delivered to a stub — the updater
+  // downloaded fine and the UI never heard about it. httpApi delegates here
+  // when the preload is present (same pattern as peekRemoteFile).
+  autoUpdateDownload(): Promise<void>;
+  autoUpdateInstall(): Promise<void>;
+  onAutoUpdateAvailable(cb: (info: AutoUpdateInfo) => void): () => void;
+  onAutoUpdateDownloaded(cb: (info: AutoUpdateInfo) => void): () => void;
+  onAutoUpdateError(cb: (info: AutoUpdateErrorInfo) => void): () => void;
 }
 
 /**

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -195,6 +195,16 @@ type State = {
   // updateDownloaded event). Guarded — the mobile httpApi shim's
   // onAutoUpdate* are no-ops, so this is desktop-only.
   updatePrompt: { version: string; releaseName?: string } | null;
+  // A TERMINAL auto-update failure (integrity / permission). Set from main's
+  // autoUpdate:error IPC, which only fires for failures the user must act on
+  // — transient network errors are filtered server-side of the bridge.
+  //
+  // This exists because updater errors were previously swallowed into a
+  // console.warn. When the published update feed's checksum stopped matching
+  // the published binary, every launch failed verification in silence and the
+  // app simply never updated — across two releases, diagnosed only when a
+  // shipped fix was reported as missing.
+  updateError: { message: string; raw: string } | null;
   // Single global server-update prompt (BET-225 stage 3). Set when the box's
   // server-update poller (src/server/serverUpdate.mjs) publishes a
   // `serverUpdateAvailable` bus event after polling its version manifest.
@@ -306,6 +316,7 @@ type State = {
   setScreenshotToast: (t: ScreenshotToast | null) => void;
   setAgentFileToast: (t: AgentFileReady | null) => void;
   setUpdatePrompt: (p: { version: string; releaseName?: string } | null) => void;
+  setUpdateError: (p: { message: string; raw: string } | null) => void;
   setServerUpdatePrompt: (
     p: { version: string; notesUrl?: string | null } | null,
   ) => void;
@@ -354,6 +365,7 @@ export const useStore = create<State>((set, get) => ({
   screenshotToast: null,
   agentFileToast: null,
   updatePrompt: null,
+  updateError: null,
   serverUpdatePrompt: null,
   connectionState: { state: "idle" },
   backgroundSyncing: false,
@@ -516,6 +528,7 @@ export const useStore = create<State>((set, get) => ({
   setScreenshotToast: (t) => set({ screenshotToast: t }),
   setAgentFileToast: (t) => set({ agentFileToast: t }),
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
+  setUpdateError: (p) => set({ updateError: p }),
   setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),
   setConnectionState: (s) => set({ connectionState: s }),
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -298,6 +298,10 @@ export interface Api {
   onAutoUpdateDownloaded(
     cb: (info: { version: string; releaseName?: string; releaseNotes?: string }) => void,
   ): () => void;
+  // Fires only for TERMINAL update failures (integrity / permission). Transient
+  // network errors are filtered out in main — see src/shared/updateError.mjs.
+  // `message` is user-facing copy; `raw` is the underlying updater message.
+  onAutoUpdateError(cb: (info: { message: string; raw: string }) => void): () => void;
 
   // Typeahead sources.
   opencodeCommands(): Promise<OpencodeCommand[]>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -286,6 +286,23 @@ export type ServerUpdateAvailablePayload = {
   notesUrl: string | null;
 };
 
+// Desktop auto-update (electron-updater) payloads, shared by the preload
+// bridge, the httpApi delegation, and the renderer.
+export type AutoUpdateInfo = {
+  version: string;
+  releaseName?: string;
+  releaseNotes?: string;
+};
+
+// A TERMINAL update failure (integrity / permission). `message` is the
+// user-facing copy from shared/updateError.mjs; `raw` is electron-updater's
+// own message, kept for logs and support reports. Transient failures never
+// reach the renderer — main filters them out.
+export type AutoUpdateErrorInfo = {
+  message: string;
+  raw: string;
+};
+
 export const IPC = {
   configGet: "config:get",
   configUpdate: "config:update",
@@ -577,6 +594,12 @@ export const IPC = {
   autoUpdateInstall: "autoUpdate:install",            // renderer → main: trigger restart+install
   autoUpdateAvailable: "autoUpdate:available",        // main → renderer: an update is available
   autoUpdateDownloaded: "autoUpdate:downloaded",      // main → renderer: update is ready to install
+  // main → renderer: an update failed TERMINALLY (integrity/permission — see
+  // shared/updateError.mjs). Transient network errors are NOT forwarded. This
+  // channel exists because a silent `console.warn` on updater errors let two
+  // releases (0.0.13, 0.0.14) ship with an unusable update feed and nobody
+  // noticed — the app simply stopped updating without ever saying so.
+  autoUpdateError: "autoUpdate:error",
 
   // ---- server version (BET-180) ----
   // Returns the manta-server's package.json version (read once at server startup,

--- a/src/shared/updateError.d.mts
+++ b/src/shared/updateError.d.mts
@@ -1,0 +1,20 @@
+// Hand-written type declarations for updateError.mjs. Implementation is plain
+// JS so both the renderer tsconfig and the main-process TS import it natively.
+// Keep in sync with src/shared/updateError.mjs.
+
+/**
+ * - "integrity"  — an update exists but failed verification; the user will
+ *                  never receive it without intervention.
+ * - "permission" — the updater can't replace the app bundle.
+ * - "transient"  — offline / DNS / timeout / 5xx; resolves on its own.
+ */
+export type UpdateErrorKind = "integrity" | "permission" | "transient";
+
+/** Classify an electron-updater error message. Unknown → "transient". */
+export function classifyUpdateError(message: string | null | undefined): UpdateErrorKind;
+
+/** True when the failure is terminal enough to show the user. */
+export function shouldSurfaceUpdateError(message: string | null | undefined): boolean;
+
+/** User-facing copy telling the user what to DO about a surfaced failure. */
+export function describeUpdateError(message: string | null | undefined): string;

--- a/src/shared/updateError.mjs
+++ b/src/shared/updateError.mjs
@@ -1,0 +1,90 @@
+// updateError.mjs — classify electron-updater failures so the desktop can tell
+// the user when auto-update is BROKEN, without nagging about transient blips.
+//
+// WHY THIS EXISTS
+// ---------------
+// `src/main/autoUpdate.ts` used to swallow every updater error into a
+// `console.warn`. That is fine for a network hiccup and catastrophic for an
+// integrity failure: when the published update feed's sha512 doesn't match the
+// published binary, electron-updater downloads the update, rejects it, and
+// gives up — forever, on every launch, in total silence. The app just never
+// updates and never says why.
+//
+// That is not hypothetical. Desktop 0.0.13 and 0.0.14 both shipped with a feed
+// whose checksum described the pre-notarization DMG (the staple step rewrites
+// the file after the feed is written), so no installed copy could take an
+// update. It went unnoticed across two releases precisely because the failure
+// was invisible — a deep-link fix was reported as "never shipped" when in fact
+// it had shipped and could not be delivered.
+//
+// So: integrity/permission-class failures are SURFACED (they need a human —
+// re-download the app, or fix the release), transient ones stay quiet.
+
+/**
+ * Failure classes we distinguish.
+ *
+ * - "integrity"  — an update exists but cannot be verified/installed. The user
+ *                  will NEVER get it without intervention. Surface it.
+ * - "permission" — the updater can't write/replace the app bundle (read-only
+ *                  volume, quarantined app, missing privileges). Also terminal.
+ * - "transient"  — offline, DNS, timeout, 5xx. Resolves itself. Stay quiet.
+ *
+ * @typedef {"integrity" | "permission" | "transient"} UpdateErrorKind
+ */
+
+const INTEGRITY_PATTERNS = [
+  /sha512/i,
+  /checksum/i,
+  /integrity/i,
+  /signature/i,
+  /code signature/i,
+  /not signed/i,
+];
+
+const PERMISSION_PATTERNS = [/eacces/i, /eperm/i, /permission denied/i, /read-?only/i];
+
+/**
+ * Classify an electron-updater error message.
+ *
+ * Defaults to "transient" for anything unrecognized — a false quiet is much
+ * cheaper than a banner the user can't act on, and genuinely broken updates
+ * reliably say "sha512"/"checksum"/"signature".
+ *
+ * @param {string | null | undefined} message
+ * @returns {UpdateErrorKind}
+ */
+export function classifyUpdateError(message) {
+  const m = typeof message === "string" ? message : "";
+  if (m === "") return "transient";
+  if (INTEGRITY_PATTERNS.some((re) => re.test(m))) return "integrity";
+  if (PERMISSION_PATTERNS.some((re) => re.test(m))) return "permission";
+  return "transient";
+}
+
+/**
+ * Should this failure be shown to the user at all?
+ * @param {string | null | undefined} message
+ * @returns {boolean}
+ */
+export function shouldSurfaceUpdateError(message) {
+  return classifyUpdateError(message) !== "transient";
+}
+
+/**
+ * User-facing copy for a surfaced failure. Deliberately says what to DO —
+ * a banner that only says "update error" is barely better than the silence
+ * it replaces.
+ *
+ * @param {string | null | undefined} message
+ * @returns {string}
+ */
+export function describeUpdateError(message) {
+  switch (classifyUpdateError(message)) {
+    case "integrity":
+      return "An update was downloaded but failed its integrity check, so it wasn't installed. Download the latest version manually.";
+    case "permission":
+      return "An update is ready but couldn't be installed — Manta UI doesn't have permission to replace itself. Move the app to /Applications and try again.";
+    default:
+      return "Couldn't check for updates.";
+  }
+}

--- a/src/shared/updateError.test.ts
+++ b/src/shared/updateError.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyUpdateError,
+  shouldSurfaceUpdateError,
+  describeUpdateError,
+} from "./updateError.mjs";
+
+describe("classifyUpdateError", () => {
+  it("REGRESSION: the real checksum-mismatch message is integrity, not transient", () => {
+    // This is the error every 0.0.13/0.0.14 install hit on every launch while
+    // the published feed described the pre-staple DMG. It was swallowed into a
+    // console.warn, so two releases shipped undeliverable.
+    const real =
+      "sha512 checksum mismatch, expected TauhvBXmsr2WBSmYBPMiYQOEYaV9AzD5SsZ4DlVV7Mz…, got HWqkMAtj/VObVh9sj4TZYIputEKuIE/9WB69j/qXkIJ…";
+    expect(classifyUpdateError(real)).toBe("integrity");
+    expect(shouldSurfaceUpdateError(real)).toBe(true);
+  });
+
+  it.each([
+    ["checksum mismatch on download", "integrity"],
+    ["Integrity check failed", "integrity"],
+    ["code signature validation failed", "integrity"],
+    ["The application is not signed", "integrity"],
+  ])("classifies %j as %s", (msg, kind) => {
+    expect(classifyUpdateError(msg)).toBe(kind);
+  });
+
+  it.each([
+    ["EACCES: permission denied, rename '/Applications/Manta UI.app'", "permission"],
+    ["EPERM: operation not permitted", "permission"],
+    ["cannot write to read-only volume", "permission"],
+  ])("classifies %j as %s", (msg, kind) => {
+    expect(classifyUpdateError(msg)).toBe(kind);
+  });
+
+  it.each([
+    "net::ERR_INTERNET_DISCONNECTED",
+    "getaddrinfo ENOTFOUND mantaui.com",
+    "connect ETIMEDOUT 91.107.196.2:443",
+    "HttpError: 503 Service Unavailable",
+  ])("stays quiet for the transient failure %j", (msg) => {
+    expect(classifyUpdateError(msg)).toBe("transient");
+    expect(shouldSurfaceUpdateError(msg)).toBe(false);
+  });
+
+  it("defaults to transient for unknown/empty input rather than nagging", () => {
+    expect(classifyUpdateError("")).toBe("transient");
+    expect(classifyUpdateError(null)).toBe("transient");
+    expect(classifyUpdateError(undefined)).toBe("transient");
+    expect(classifyUpdateError("something weird happened")).toBe("transient");
+    expect(shouldSurfaceUpdateError(null)).toBe(false);
+  });
+});
+
+describe("describeUpdateError", () => {
+  it("tells the user to download manually on an integrity failure", () => {
+    const copy = describeUpdateError("sha512 checksum mismatch");
+    expect(copy).toMatch(/integrity check/i);
+    expect(copy).toMatch(/manually/i);
+  });
+
+  it("tells the user about /Applications on a permission failure", () => {
+    expect(describeUpdateError("EACCES: permission denied")).toMatch(/\/Applications/);
+  });
+});


### PR DESCRIPTION
Desktop auto-update has been broken in **every notarized release**. Three independent faults, each alone sufficient to stop updates — and all three silent, which is why they survived two releases.

## 1. The update feed describes a file that no longer exists

electron-builder writes `latest-mac.yml` with each artifact's sha512 + size. The workflow then signs, notarizes and **staples** the DMG — stapling rewrites the file in place, ~11KB larger, different hash. The feed was never regenerated, so electron-updater downloads the published DMG, fails verification, and refuses to install.

Verified against prod:

| Release | Feed says | Actual file |
|---|---|---|
| 0.0.13 | 98,214,660 | 98,226,318 |
| 0.0.14 | 97,241,753 | 97,253,264 |

**Fix:** `scripts/release/restamp-update-feed.mjs` recomputes digests from the artifacts on disk, run between staple and publish — plus a following step that re-verifies and **fails the build** on mismatch, so this is caught at build time rather than by a user reporting a shipped fix never arrived.

Verified end-to-end against the real published 0.0.14 DMG — the script reproduces its true digest exactly.

## 2. The update UI was wired to a stub

`httpApi`'s auto-update entries were hardcoded no-ops, commented *"desktop-only; no-op in http/mobile mode"*. That reasoning went stale when the SSH transport was removed: **desktop is now always in http mode**, so `window.api` IS `httpApi` on every paired desktop. Main downloaded updates and pushed `autoUpdate:*` IPC into a renderer subscribed to `() => () => {}`.

So the "Restart to update" banner could never render, and `autoUpdateInstall()` resolved without restarting. Even with fault 1 fixed, nothing would have reached the user.

**Fix:** expose the updater bridge on the preload; `httpApi` delegates to it when `window.__mantaPreload` is present (same pattern as `peekRemoteFile`), falling back to a real no-op on mobile/web.

## 3. Failures went to `console.warn` and nowhere else

Which is *why* 1 and 2 survived two releases. From the user's side the app just stopped updating — no error, no banner, nothing to report.

**Fix:** classify updater errors (`src/shared/updateError.mjs`) and surface only **terminal** ones — integrity and permission failures, which need the user to act. Transient network errors stay quiet so the banner can't nag about a flaky connection. The banner offers a manual download, since retrying an install that failed verification will fail identically.

## Rollout caveat

Bumps to **0.0.15**. Installs on 0.0.13/0.0.14 **cannot auto-update to this** — their updater is the broken one. Getting onto a working updater needs one manual download; every release after this can update itself.

## Tests

- 8 — restamp script (real pre/post-staple digests, idempotency, multi-artifact, no mutation)
- 12 — error classifier (verbatim checksum-mismatch message, transient cases stay quiet)
- 4 — httpApi delegation (both no-op regressions pinned)

`npm run typecheck` clean · 1098 renderer + 958 server green.