### PR TITLE
refactor(plugins): shell: manifest key, delete hardcoded /bin/sh (BET-326)

### DIFF
--- a/docs/mantaui-plugins.md
+++ b/docs/mantaui-plugins.md
@@ -18,8 +18,13 @@ the TypeScript handler layer is GONE (no more `HANDLERS` map,
 folder-scans + fs.watch-hot-reloads the dir, parses every `*.yaml` through
 the shared `src/shared/pluginManifest.mjs` module (single source of truth
 for parse + validate + if-eval + input→env + cwd substitution + timeout
-parse), and dispatches a matching capability by running its steps
-sequentially as `exec("/bin/sh", ["-c", step.run], …)`. The first
+parse + shell resolution), and dispatches a matching capability by running
+its steps sequentially under the resolved shell
+(`effectiveShell(manifest, step, process.platform)` → `resolveShellInvocation`
+→ `wrapScript` → `exec(command, argsPrefix, …)`). ⟨v3 BET-326⟩ the
+executor no longer hardcodes `/bin/sh`; the shell is an explicit, validated
+manifest key with two values (`sh`, `powershell`) and a per-platform
+default (`win32` → `powershell`, else `sh`). The first
 hard-coded capability is the `plugin.write` built-in — it lets the AI
 author/edit manifests via `plugin_save`. Everything else is a manifest
 lookup. Server spine (`src/server/capabilities.mjs` + REST + bus envelopes
@@ -141,6 +146,7 @@ stay unchanged.
 | `EXEC_STDOUT_CAP_BYTES` | `2 * 1024 * 1024` | `capExecutor.ts` | cap on captured stdout returned by `exec` |
 | `KILL_GRACE_MS` | `5_000` | `capExecutor.ts` | SIGTERM → SIGKILL grace on abort |
 | `CAP_HOSTS` | `["desktop","box"]` | `pluginManifest.mjs` | accepted `host:` values; `host: mac` is a permanent legacy alias for `"desktop"` |
+| `SHELLS` | `["sh","powershell"]` | `pluginManifest.mjs` | accepted `shell:` values; the runner resolves `sh` to `/bin/sh` on POSIX or Git Bash on Windows, and `powershell` to `powershell.exe -NoProfile -NonInteractive -Command` on Windows only |
 | `PLUGIN_WRITE` | `"plugin.write"` | `capExecutor.ts` | the one built-in capability name |
 
 ---
@@ -233,9 +239,18 @@ NO `CapHandler`/`CapCtx`-consumer indirection, and NO per-plugin
    - Found + valid → build the per-step env via the shared module's
      `buildEnv(manifest, suppliedInputs, {jobId})` (the executor patches
      in PATH via `exec`'s existing helper), arm an
-     `AbortController` with `EXECUTOR_JOB_TIMEOUT_MS`, run each step
-     sequentially as `exec("/bin/sh", ["-c", step.run], {cwd, quiet})`
-     (with `cwd` resolved via `resolveCwd(step.cwd, env)`), honoring
+     `AbortController` with `EXECUTOR_JOB_TIMEOUT_MS`, and for each step
+     resolve the shell via `effectiveShell(manifest, step, process.platform)`
+     + `resolveShellInvocation(shell, process.platform, {env, exists})`
+     from the shared module (the executor is the only place allowed to
+     read `process.platform`; the helpers stay pure so Windows behaviour
+     can be tested from Linux CI). The script body is wrapped via
+     `wrapScript(shell, step.run)` (PowerShell runs are wrapped to set
+     `$ErrorActionPreference='Stop'` and propagate `$LASTEXITCODE`,
+     because PowerShell does not reliably propagate a failing command's
+     exit code). Each step runs as
+     `exec(inv.command, [...inv.argsPrefix, wrappedScript], {cwd, quiet})`,
+     with `cwd` resolved via `resolveCwd(step.cwd, env)`, honoring
      `continue_on_error` and `if:` via `evalIf`, and streaming each
      step's stdout/stderr to `ctx.log`. Step exit ≠ 0 → job fails at
      that step.
@@ -264,12 +279,15 @@ state.
 Single source of truth for what a valid manifest looks like. Imported by
 BOTH the executor (TS) and the server (mjs). Pure functions everywhere,
 no `electron`/`node:fs` deps beyond YAML parsing + `resolveCwd`'s
-existence check. Adding a new validation rule here is reflected in every
-consumer and every test. Exports:
+existence check + `resolveShellInvocation`'s injected `exists`. Adding a
+new validation rule here is reflected in every consumer and every test.
+Exports:
 
 - `parseManifest(yamlText): { manifest, errors[] }` — returns a manifest
   OR keyed errors (`steps[2].run: required` style). Unknown keys →
-  `unknown key "<key>"`.
+  `unknown key "<key>"`. The `shell:` key is validated at top-level and
+  per-step (`must be one of sh, powershell`); platform availability is
+  the executor's concern, not the parser's.
 - `validateManifest(parsed): { errors[] }` — all schema rules from
   BET-189 §"Validation rules" plus the v3 grammar limits.
 - `evalIf(expr, inputs): boolean | { error }` — exactly three forms,
@@ -285,6 +303,13 @@ consumer and every test. Exports:
   with no default.
 - `parseTimeout(s): number | { error }` — `^\d+(s|m)$`; cap
   `MAX_TIMEOUT_MS`.
+- `defaultShell(platform)` / `effectiveShell(manifest, step, platform)` /
+  `resolveShellInvocation(shell, platform, io)` / `wrapScript(shell, script)`
+  — shell resolution (BET-326). Exactly two shell names (`SHELLS =
+  ["sh", "powershell"]`); per-platform default; the Git-Bash candidate
+  list (`ProgramFiles`, `ProgramFiles(x86)`, `LOCALAPPDATA`) is walked in
+  order on Windows; `io.exists` is injected so the resolution is testable
+  from Linux CI without a real Windows filesystem.
 
 Tests: `src/shared/pluginManifest.test.ts` (vitest) covers every
 validator path, evalIf truthy/falsey, buildEnv ordering + bool

--- a/docs/plugins-authoring.md
+++ b/docs/plugins-authoring.md
@@ -36,7 +36,9 @@ A plugin is one YAML file:
   optional env map, and one or more shell commands (steps) to run in order.
 - **What it does:** when the user or AI invokes `plugin_run("<name>", inputs)`,
   the executor on the machine validates the inputs against the schema, then
-  runs the steps sequentially in `/bin/sh`, with each step's stdout/stderr
+  runs the steps sequentially in the resolved shell (per-platform default:
+  `sh` on macOS/Linux, `powershell` on Windows — overridable per-manifest or
+  per-step via the `shell:` key, see §2), with each step's stdout/stderr
   streamed into the originating chat as a job log. When the run finishes
   (success, failure, or 30-minute sweep timeout), the executor reports back
   through the server and a completion turn is injected into the chat session
@@ -78,10 +80,11 @@ unknown top-level key is a validation error — typos fail loudly.
 | `name` | string | yes | `^[a-z0-9][a-z0-9-]{0,63}$`. Must equal the filename minus `.yaml`. The `plugin.` namespace is reserved for built-in capabilities and is impossible by the regex (no dots). |
 | `description` | string | yes | Non-empty. One sentence: what the plugin does and when to reach for it. Shown in `plugin_list` and surfaced to the model when picking a tool to call. |
 | `host` | string | yes | Must be `"desktop"` (the user's connected desktop) or `"box"` (the Linux box). `host: mac` is accepted as a permanent legacy alias for `desktop`. Any other value produces `host: must be one of desktop, box (legacy "mac" means desktop)`. |
+| `shell` | string | no | Must be `"sh"` or `"powershell"`. Default is per-platform: `win32` → `"powershell"`, everything else → `"sh"`. Used as the default for every step that doesn't override it; per-step `shell:` overrides the top-level value. Validation is platform-independent — a Windows-targeted manifest parses cleanly on Linux (the registry serves Settings cross-platform); platform availability is decided at run time by the executor. On Windows, `shell: sh` resolves to the `bash.exe` shipped with Git for Windows; if Git for Windows is absent the step fails with the actionable message in §6, never a silent fallback to PowerShell. |
 | `timeout` | string | no | `^\d+(s|m)$` (e.g. `30s`, `5m`, `30m`). Parsed value must be ≤ 30 minutes. Missing → no per-step cap. Why the cap: the server sweep fails any `running` job at 30 minutes; a longer manifest timeout would be killed anyway. |
 | `inputs` | array of input objects | no | Each object carries an `id:` field (`^[a-z][a-zA-Z0-9_]*$`). Order is preserved and surfaced to the tool schema verbatim — model-side prompt construction sees them. Optional; missing → plugin takes no inputs. See "Input object" below. |
 | `env` | map of `string → string` | no | Plugin-scoped environment variables injected into every step. Reserved names: `MANTA_PLUGIN`, `MANTA_JOB_ID` (the runner injects these itself — user-supplied values are silently ignored). Values with a leading `~` are expanded against `os.homedir()`. |
-| `steps` | list of step objects | yes | Required, min 1. Run sequentially in `/bin/sh -c`. See "Step object" below. |
+| `steps` | list of step objects | yes | Required, min 1. Run sequentially in the resolved shell (`sh -c` or `powershell -Command`). See "Step object" below. |
 
 ### Input object
 
@@ -99,7 +102,8 @@ unknown top-level key is a validation error — typos fail loudly.
 | Key | Type | Required | Description / validation |
 | --- | --- | --- | --- |
 | `name` | string | no | Free-form label for logs and the result. Defaults to the first 30 chars of `run`. |
-| `run` | string | yes | Shell string passed to `/bin/sh -c`. May use the plugin's `env:` map values, `MANTA_INPUT_<ID>` (uppercased input id) for each supplied input, `MANTA_PLUGIN=<name>`, and `MANTA_JOB_ID=<id>`. **Do NOT interpolate input values into `run` directly** — see §3. |
+| `run` | string | yes | Shell string passed to the resolved shell as a single argument. May use the plugin's `env:` map values, `MANTA_INPUT_<ID>` (uppercased input id) for each supplied input, `MANTA_PLUGIN=<name>`, and `MANTA_JOB_ID=<id>`. **Do NOT interpolate input values into `run` directly** — see §3. |
+| `shell` | string | no | Must be `"sh"` or `"powershell"`. Overrides the manifest-level `shell:` for this step only. Same resolution rules as the top-level `shell:` (default per platform; on Windows, `shell: sh` requires Git for Windows). |
 | `cwd` | string | no | Working directory for the step. `$KEY` / `${KEY}` substitutions resolve from the plugin's `env:` map; a leading `~` expands against the user's home. Non-existent dir → step fails with `cwd: <path> does not exist`. |
 | `if` | string | no | One of the three grammar forms — see §4. Anything else → validation error. |
 | `continue_on_error` | boolean | no | Default `false`. When `true`, a non-zero exit from this step logs the failure but the job continues to the next step. |
@@ -128,8 +132,9 @@ steps:
 Why this rule exists: the inputs field is typed data. The runner has already
 validated them against the schema. If a value with spaces or shell
 metacharacters lands in a string-concatenated `run:`, a typo or a hostile
-filename can break the command or worse. The env-var route lets `/bin/sh`
-quote-escape naturally without any extra shell-quoting logic in the runner.
+filename can break the command or worse. The env-var route lets the
+resolved shell quote-escape naturally without any extra shell-quoting logic
+in the runner.
 
 The runner also exposes the plugin's `env:` map (`REPO=~/projects/foo` in
 the `env:` block becomes `$REPO` in `run:`) and the two plumbing vars
@@ -299,6 +304,7 @@ flow that does not need Xcode at all.
 name: repo-cleanup
 description: Run a maintenance script and prune merged branches.
 host: desktop
+shell: sh
 timeout: 10m
 
 inputs:
@@ -357,6 +363,9 @@ and re-run.
 | `timeout: must be ≤ 30m` | Manifest timeout exceeds 30 min. | Lower the timeout. The server sweep kills at 30m anyway. |
 | `YAML parse error: <yaml detail>` | The file is not parseable YAML. | Fix the YAML syntax (indentation, quoting). |
 | `cwd: <path> does not exist` | Step `cwd:` (after `$KEY` / `~` expansion) does not resolve. | Use a path the executor can see (the Mac's filesystem). |
+| `shell: must be one of sh, powershell` | `shell:` (top-level or per-step) is not one of the two accepted values (likely a typo like `bash` / `cmd` / `pwsh`). | Change `shell:` to `sh` or `powershell`. The two values are the entire point — a third value is a new code path with no user. |
+| `shell "sh" needs a POSIX shell. Install Git for Windows …` | `shell: sh` was used on Windows but Git for Windows is not installed (none of `ProgramFiles\Git\bin\bash.exe`, `ProgramFiles(x86)\Git\bin\bash.exe`, or `LOCALAPPDATA\Programs\Git\bin\bash.exe` exists). | Install Git for Windows (https://git-scm.com/download/win), or change the manifest to `shell: powershell`. There is no silent fallback — the step fails clearly. |
+| `shell "powershell" is only available on Windows.` | `shell: powershell` was used on macOS or Linux. | Drop the per-step / per-manifest `shell: powershell` on non-Windows, or change it to `shell: sh`. |
 
 ## 7. The author / test loop
 

--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -41,6 +41,9 @@ import {
   validateSuppliedInputs,
   evalIf,
   normalizeHost,
+  effectiveShell,
+  resolveShellInvocation,
+  wrapScript,
   type PluginManifest,
 } from "../shared/pluginManifest.mjs";
 import {
@@ -651,7 +654,19 @@ function makeManifestHandler(manifest: PluginManifest) {
         ? withStepTimeout(controllerSignalOf(ctx), stepTimeoutMs)
         : null;
       try {
-        const res = await ctx.exec("/bin/sh", ["-c", step.run], {
+        // Shell resolution is the one place we read process.platform
+        // (BET-326 — exactly one read per step, passed down to the pure
+        // helpers). The shared module resolves the rest.
+        const platform = process.platform;
+        const shell = effectiveShell(manifest, step, platform);
+        const inv = resolveShellInvocation(shell, platform, {
+          env: process.env,
+          exists: existsSync,
+        });
+        if ("error" in inv) {
+          throw new Error(inv.error);
+        }
+        const res = await ctx.exec(inv.command, [...inv.argsPrefix, wrapScript(shell, step.run)], {
           cwd: cwdResolved,
           quiet: false,
           env,

--- a/src/shared/pluginManifest.d.mts
+++ b/src/shared/pluginManifest.d.mts
@@ -11,6 +11,8 @@ export type PluginInputRow = {
   values?: string[];
 };
 
+export type Shell = "sh" | "powershell";
+
 export type PluginStep = {
   name?: string;
   run: string;
@@ -19,6 +21,7 @@ export type PluginStep = {
   timeout?: string;
   if?: string;
   continue_on_error?: boolean;
+  shell?: Shell;
 };
 
 export type PluginManifest = {
@@ -28,15 +31,21 @@ export type PluginManifest = {
   inputs: PluginInputRow[];
   env: Record<string, string>;
   timeoutMs: number | null;
+  shell?: Shell;
   steps: PluginStep[];
 };
 
 export type PluginManifestError = { path: string; message: string };
 
+export type ShellInvocation =
+  | { command: string; argsPrefix: string[] }
+  | { error: string };
+
 export const NAME_RE: RegExp;
 export const INPUT_ID_RE: RegExp;
 export const INPUT_TYPES: readonly string[];
 export const CAP_HOSTS: readonly string[];
+export const SHELLS: readonly Shell[];
 export const PATH_PATCH: string;
 
 export function parseManifest(
@@ -72,3 +81,16 @@ export function validateSuppliedInputs(
 
 export function parseTimeout(s: string): number | { error: string };
 export function normalizeHost(h: unknown): "desktop" | "box" | null;
+
+export function defaultShell(platform: string): Shell;
+export function effectiveShell(
+  manifest: Pick<PluginManifest, "shell"> | null | undefined,
+  step: Pick<PluginStep, "shell"> | null | undefined,
+  platform: string,
+): Shell;
+export function resolveShellInvocation(
+  shell: Shell,
+  platform: string,
+  io: { env?: Record<string, string | undefined>; exists?: (p: string) => boolean },
+): ShellInvocation;
+export function wrapScript(shell: Shell, script: string): string;

--- a/src/shared/pluginManifest.mjs
+++ b/src/shared/pluginManifest.mjs
@@ -37,6 +37,7 @@
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { expandTilde } from "./paths.mjs";
 
 // ---------------------------------------------------------------------------
@@ -72,6 +73,7 @@ const STEP_KEYS = new Set([
   "timeout",
   "if",
   "continue_on_error",
+  "shell",
 ]);
 
 // Top-level whitelisted keys.
@@ -83,6 +85,7 @@ const TOP_KEYS = new Set([
   "env",
   "timeout",
   "steps",
+  "shell",
 ]);
 
 // Supported input types.
@@ -124,6 +127,115 @@ export function normalizeHost(h) {
   if (h === "box") return "box";
   if (h === "mac") return "desktop"; // permanent legacy alias
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// SHELLS — accepted `shell:` values (BET-326)
+//
+// The runner needs an explicit shell choice because `/bin/sh` does not exist
+// on Windows. Exactly two values: `sh` (POSIX shell, Git Bash on Windows)
+// and `powershell` (Windows PowerShell 5.1). No `bash`, no `cmd`, no `zsh`,
+// no `pwsh` — adding a third value is a new code path with no user.
+// ---------------------------------------------------------------------------
+
+export const SHELLS = ["sh", "powershell"];
+
+// Git Bash candidates, in this order — first existing path wins. Built with
+// `path.join` (never string concat) so platform-specific separators land
+// correctly on Windows. The candidate list is a constant — re-ordering it
+// silently changes the resolution priority, so it lives here as the single
+// source of truth (and `resolveShellInvocation` consumes it verbatim).
+const GIT_BASH_ROOT_KEYS = ["ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"];
+function gitBashCandidate(env, rootKey) {
+  const root = env[rootKey];
+  if (typeof root !== "string" || root.length === 0) return null;
+  return join(root, "Git", "bin", "bash.exe");
+}
+
+/**
+ * Per-platform default shell. win32 → "powershell" (always present on
+ * Windows); anything else → "sh" (POSIX). Pure: takes the platform as an
+ * argument so the executor reads `process.platform` once and passes it
+ * down.
+ */
+export function defaultShell(platform) {
+  return platform === "win32" ? "powershell" : "sh";
+}
+
+/**
+ * Resolve the shell for a step. Order: step.shell ?? manifest.shell ??
+ * defaultShell(platform). Step-level overrides manifest-level which
+ * overrides the platform default. Missing on all three → platform default.
+ */
+export function effectiveShell(manifest, step, platform) {
+  return (
+    step?.shell ?? manifest?.shell ?? defaultShell(platform)
+  );
+}
+
+/**
+ * Turn a shell name into something spawnable on the given platform.
+ *
+ *   sh, non-win32       → {command: "/bin/sh", argsPrefix: ["-c"]}
+ *   sh, win32           → first existing Git-Bash candidate → same shape
+ *   sh, win32, none     → {error: install-Git-for-Windows message}
+ *   powershell, win32   → {command: "powershell.exe", argsPrefix: [-NoProfile, -NonInteractive, -Command]}
+ *   powershell, non-win32 → {error: PowerShell-only-on-Windows message}
+ *
+ * `io` is injected (env, exists) so the helper stays pure and testable
+ * from a Linux CI runner. The executor passes `{env: process.env,
+ * exists: existsSync}`.
+ */
+export function resolveShellInvocation(shell, platform, io) {
+  const env = io?.env ?? {};
+  const exists = io?.exists ?? (() => false);
+
+  if (shell === "sh") {
+    if (platform !== "win32") {
+      return { command: "/bin/sh", argsPrefix: ["-c"] };
+    }
+    for (const key of GIT_BASH_ROOT_KEYS) {
+      const p = gitBashCandidate(env, key);
+      if (p && exists(p)) {
+        return { command: p, argsPrefix: ["-c"] };
+      }
+    }
+    return {
+      error:
+        'shell "sh" needs a POSIX shell. Install Git for Windows ' +
+        "(https://git-scm.com/download/win), or set `shell: powershell` " +
+        "in the manifest.",
+    };
+  }
+
+  if (shell === "powershell") {
+    if (platform !== "win32") {
+      return { error: 'shell "powershell" is only available on Windows.' };
+    }
+    return {
+      command: "powershell.exe",
+      argsPrefix: ["-NoProfile", "-NonInteractive", "-Command"],
+    };
+  }
+
+  // Defensive: parseManifest rejects unknown values, so this branch is
+  // unreachable in normal flow. Keeping it as an error makes the function
+  // total (every input → a result, never undefined).
+  return { error: `shell: unknown value "${shell}"` };
+}
+
+/**
+ * Shell-specific wrapping of a step's `run:` body. The runner decides
+ * step success purely from the exit code, and PowerShell does not reliably
+ * propagate a failing command's exit code — so powershell runs are wrapped
+ * to set `$ErrorActionPreference='Stop'` and surface `$LASTEXITCODE` on
+ * exit. POSIX `sh` needs no wrapping; the input is returned unchanged.
+ */
+export function wrapScript(shell, script) {
+  if (shell === "powershell") {
+    return `$ErrorActionPreference='Stop'; ${script} ; exit $LASTEXITCODE `;
+  }
+  return script;
 }
 
 // Reserved env names we never let a plugin clobber. `MANTA_PLUGIN` and
@@ -216,6 +328,19 @@ export function parseManifest(yamlText) {
       errors.push({
         path: "host",
         message: `host: must be one of ${CAP_HOSTS.join(", ")} (legacy "mac" means desktop)`,
+      });
+    }
+  }
+
+  // shell (top-level). Validation is platform-independent — a Windows-
+  // targeted manifest must parse cleanly on the Linux server (which serves
+  // the registry to Settings). Platform availability is the executor's
+  // concern (resolveShellInvocation), not the parser's.
+  if (raw.shell !== undefined) {
+    if (typeof raw.shell !== "string" || !SHELLS.includes(raw.shell)) {
+      errors.push({
+        path: "shell",
+        message: `shell: must be one of ${SHELLS.join(", ")}`,
       });
     }
   }
@@ -362,6 +487,16 @@ export function parseManifest(yamlText) {
         if (typeof step.run !== "string" || !step.run.trim()) {
           errors.push({ path: `${base}.run`, message: "run is required" });
         }
+        // step.shell — per-step override of the manifest-level default.
+        // Same platform-independent validation as the top-level field.
+        if (step.shell !== undefined) {
+          if (typeof step.shell !== "string" || !SHELLS.includes(step.shell)) {
+            errors.push({
+              path: `${base}.shell`,
+              message: `shell: must be one of ${SHELLS.join(", ")}`,
+            });
+          }
+        }
         // step.timeout
         if (step.timeout !== undefined) {
           const t = parseTimeout(step.timeout);
@@ -447,6 +582,9 @@ export function parseManifest(yamlText) {
       inputs,
       env,
       timeoutMs: topTimeoutMs,
+      // shell is preserved verbatim from raw (no platform default — see
+      // SHELLS doc above). Absent in the YAML → undefined here.
+      shell: typeof raw.shell === "string" ? raw.shell : undefined,
       steps,
     },
     errors: undefined,

--- a/src/shared/pluginManifest.test.ts
+++ b/src/shared/pluginManifest.test.ts
@@ -20,6 +20,11 @@ import {
   validateSuppliedInputs,
   parseTimeout,
   normalizeHost,
+  defaultShell,
+  effectiveShell,
+  resolveShellInvocation,
+  wrapScript,
+  SHELLS,
   CAP_HOSTS,
   NAME_RE,
   INPUT_ID_RE,
@@ -875,5 +880,298 @@ describe("validateManifest", () => {
 describe("INPUT_TYPES", () => {
   it("contains the four canonical types", () => {
     expect(INPUT_TYPES).toEqual(["string", "number", "boolean", "enum"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHELLS / shell resolution (BET-326)
+// ---------------------------------------------------------------------------
+
+describe("SHELLS", () => {
+  it("is exactly the two accepted values, in this order", () => {
+    expect(SHELLS).toEqual(["sh", "powershell"]);
+  });
+});
+
+describe("defaultShell", () => {
+  it("returns 'powershell' for win32", () => {
+    expect(defaultShell("win32")).toBe("powershell");
+  });
+
+  it("returns 'sh' for darwin / linux / anything else", () => {
+    expect(defaultShell("darwin")).toBe("sh");
+    expect(defaultShell("linux")).toBe("sh");
+    expect(defaultShell("freebsd")).toBe("sh");
+  });
+});
+
+describe("effectiveShell", () => {
+  it("step.shell overrides manifest.shell", () => {
+    expect(effectiveShell({ shell: "sh" }, { shell: "powershell" }, "linux")).toBe(
+      "powershell",
+    );
+  });
+
+  it("manifest.shell overrides the platform default", () => {
+    expect(effectiveShell({ shell: "powershell" }, {}, "darwin")).toBe(
+      "powershell",
+    );
+  });
+
+  it("falls back to defaultShell when neither is set", () => {
+    expect(effectiveShell({}, {}, "win32")).toBe("powershell");
+    expect(effectiveShell({}, {}, "linux")).toBe("sh");
+  });
+
+  it("falls back to defaultShell when both manifest and step are absent", () => {
+    expect(effectiveShell(undefined, undefined, "darwin")).toBe("sh");
+    expect(effectiveShell(null, null, "win32")).toBe("powershell");
+  });
+});
+
+describe("resolveShellInvocation", () => {
+  // Build the Git-Bash candidate paths via the same `path.join` the
+  // production code uses — the test must match the platform-specific
+  // separator (forward-slash on Linux CI, backslash on Windows).
+  const programFiles = "C:\\Program Files";
+  const programFilesX86 = "C:\\Program Files (x86)";
+  const localAppData = "C:\\Users\\me\\AppData\\Local";
+  const bashInProgramFiles = join(programFiles, "Git", "bin", "bash.exe");
+  const bashInLocalAppData = join(localAppData, "Git", "bin", "bash.exe");
+
+  it("returns /bin/sh on non-win32 for shell: sh", () => {
+    expect(resolveShellInvocation("sh", "darwin", { env: {}, exists: () => true })).toEqual({
+      command: "/bin/sh",
+      argsPrefix: ["-c"],
+    });
+    expect(resolveShellInvocation("sh", "linux", { env: {}, exists: () => true })).toEqual({
+      command: "/bin/sh",
+      argsPrefix: ["-c"],
+    });
+  });
+
+  it("on win32 shell: sh picks the first existing Git-Bash candidate", () => {
+    const env = {
+      ProgramFiles: programFiles,
+      "ProgramFiles(x86)": programFilesX86,
+      LOCALAPPDATA: localAppData,
+    };
+    // Candidate 1 (ProgramFiles) exists → wins.
+    const r = resolveShellInvocation("sh", "win32", {
+      env,
+      exists: (p) => p === bashInProgramFiles,
+    });
+    expect(r).toEqual({
+      command: bashInProgramFiles,
+      argsPrefix: ["-c"],
+    });
+  });
+
+  it("on win32 shell: sh walks the candidate list — 3rd wins when only it exists", () => {
+    const env = {
+      ProgramFiles: programFiles,
+      "ProgramFiles(x86)": programFilesX86,
+      LOCALAPPDATA: localAppData,
+    };
+    const r = resolveShellInvocation("sh", "win32", {
+      env,
+      exists: (p) => p === bashInLocalAppData,
+    });
+    expect(r).toEqual({
+      command: bashInLocalAppData,
+      argsPrefix: ["-c"],
+    });
+  });
+
+  it("on win32 shell: sh skips candidates whose env var is missing/empty", () => {
+    // ProgramFiles is missing → candidate 1 skipped. ProgramFiles(x86) is
+    // empty → candidate 2 skipped. LOCALAPPDATA → candidate 3.
+    const env = { LOCALAPPDATA: localAppData };
+    const r = resolveShellInvocation("sh", "win32", {
+      env,
+      exists: (p) => p === bashInLocalAppData,
+    });
+    if ("error" in r) throw new Error("expected success path");
+    expect(r.command).toBe(bashInLocalAppData);
+  });
+
+  it("on win32 shell: sh returns the install-Git-for-Windows error when none exist", () => {
+    const env = {
+      ProgramFiles: programFiles,
+      "ProgramFiles(x86)": programFilesX86,
+      LOCALAPPDATA: localAppData,
+    };
+    const r = resolveShellInvocation("sh", "win32", {
+      env,
+      exists: () => false,
+    });
+    expect("error" in r).toBe(true);
+    expect((r as { error: string }).error).toMatch(/Git for Windows/);
+    expect((r as { error: string }).error).toMatch(/shell: powershell/);
+  });
+
+  it("on win32 shell: powershell returns powershell.exe + flags", () => {
+    expect(
+      resolveShellInvocation("powershell", "win32", { env: {}, exists: () => true }),
+    ).toEqual({
+      command: "powershell.exe",
+      argsPrefix: ["-NoProfile", "-NonInteractive", "-Command"],
+    });
+  });
+
+  it("on non-win32 shell: powershell returns the only-on-Windows error", () => {
+    const r = resolveShellInvocation("powershell", "linux", {
+      env: {},
+      exists: () => true,
+    });
+    expect("error" in r).toBe(true);
+    expect((r as { error: string }).error).toMatch(/only available on Windows/);
+  });
+});
+
+describe("wrapScript", () => {
+  it("returns the input unchanged for shell: sh", () => {
+    const body = "echo hello\n";
+    expect(wrapScript("sh", body)).toBe(body);
+  });
+
+  it("prepends $ErrorActionPreference='Stop' and appends `; exit $LASTEXITCODE ` for shell: powershell", () => {
+    const body = "Write-Host hi";
+    expect(wrapScript("powershell", body)).toBe(
+      `$ErrorActionPreference='Stop'; ${body} ; exit $LASTEXITCODE `,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseManifest — shell (BET-326)
+// ---------------------------------------------------------------------------
+
+describe("parseManifest — shell", () => {
+  it("accepts shell: sh at the top level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+shell: sh
+steps: [{run: "echo"}]
+`);
+    expect(r.errors).toBeUndefined();
+    expect(okManifest(r).shell).toBe("sh");
+  });
+
+  it("accepts shell: powershell at the top level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+shell: powershell
+steps: [{run: "Write-Host hi"}]
+`);
+    expect(r.errors).toBeUndefined();
+    expect(okManifest(r).shell).toBe("powershell");
+  });
+
+  it("accepts shell: sh at the per-step level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+steps:
+  - run: "echo"
+    shell: sh
+`);
+    expect(r.errors).toBeUndefined();
+    expect(okManifest(r).steps[0].shell).toBe("sh");
+  });
+
+  it("accepts shell: powershell at the per-step level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+steps:
+  - run: "Write-Host hi"
+    shell: powershell
+`);
+    expect(r.errors).toBeUndefined();
+    expect(okManifest(r).steps[0].shell).toBe("powershell");
+  });
+
+  it("rejects shell: bash at the top level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+shell: bash
+steps: [{run: "echo"}]
+`);
+    expect(r.errors).toContainEqual({
+      path: "shell",
+      message: "shell: must be one of sh, powershell",
+    });
+  });
+
+  it("rejects shell: bash at the per-step level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+steps:
+  - run: "echo"
+    shell: bash
+`);
+    expect(r.errors).toContainEqual({
+      path: "steps[0].shell",
+      message: "shell: must be one of sh, powershell",
+    });
+  });
+
+  it("rejects shell: cmd at both levels", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+shell: cmd
+steps:
+  - run: "echo"
+    shell: cmd
+`);
+    expect(r.errors).toContainEqual({
+      path: "shell",
+      message: "shell: must be one of sh, powershell",
+    });
+    expect(r.errors).toContainEqual({
+      path: "steps[0].shell",
+      message: "shell: must be one of sh, powershell",
+    });
+  });
+
+  it("rejects a non-string shell at the top level", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+shell: 42
+steps: [{run: "echo"}]
+`);
+    expect(r.errors?.some((e) => /shell/.test(e.path))).toBe(true);
+  });
+
+  it("leaves shell absent (not defaulted) when omitted", () => {
+    const r = parseManifest(`
+name: foo
+description: x
+steps: [{run: "echo"}]
+`);
+    expect(r.errors).toBeUndefined();
+    expect(okManifest(r).shell).toBeUndefined();
+    expect(okManifest(r).steps[0].shell).toBeUndefined();
+  });
+
+  it("does not reject shell: powershell when parsed on a non-win32 build", () => {
+    // Validation is platform-independent — a Windows-targeted manifest
+    // must parse cleanly on the Linux server (registry serves Settings).
+    // Platform availability is resolveShellInvocation's concern, not the
+    // parser's.
+    const r = parseManifest(`
+name: foo
+description: x
+shell: powershell
+steps: [{run: "Write-Host hi"}]
+`);
+    expect(r.errors).toBeUndefined();
   });
 });


### PR DESCRIPTION
Stage 2 of BET-324 (the 'plugin runner on any desktop' epic). The executor no longer hardcodes `/bin/sh -c` — the shell is an explicit, validated manifest key with two values (`sh`, `powershell`) and a per-platform default, resolved through one shared pure module.

**Base:** origin/main @ ab9b5ea
**Branch:** multica/BET-326-shell-manifest-key @ c3bb6cc

## What changes

- **src/shared/pluginManifest.mjs** — adds `SHELLS`, `defaultShell(platform)`, `effectiveShell(manifest, step, platform)`, `resolveShellInvocation(shell, platform, io)`, `wrapScript(shell, script)`. `parseManifest` validates `shell:` at top-level and per-step (must be one of `sh`, `powershell`); validation is platform-independent so a Windows-targeted manifest parses cleanly on Linux (where the registry is served). The top-level `shell` key is added to `TOP_KEYS` and `STEP_KEYS`.
- **src/main/capExecutor.ts** — the per-step loop reads `process.platform` once (the only place it is read in the file), threads it through `effectiveShell` + `resolveShellInvocation` + `wrapScript`, and spawns `exec(inv.command, [...inv.argsPrefix, wrapScript(shell, step.run)])`. The hardcoded `/bin/sh -c` is gone.
- **src/shared/pluginManifest.d.mts** — type surface for the new exports + the new optional `shell:` field on `PluginManifest` / `PluginStep`.
- **src/shared/pluginManifest.test.ts** — 25 new tests: `defaultShell`, `effectiveShell`, the full `resolveShellInvocation` table (one test per row, including candidate-walk for `sh` on win32 and the missing-Git-Bash error), `wrapScript`, `parseManifest` `shell:` accept/reject at both levels.
- **docs/plugins-authoring.md** — `shell:` rows added to §1 (overview), §2 (top-level + per-step tables), `shell: sh` line added to the §5.3 generic-script example, three new rows in §6 error catalogue (must-be-one-of, install-Git-for-Windows, powershell-only-on-Windows).
- **docs/mantaui-plugins.md** — `SHELLS` added to the constants table; Layer-3 dispatch and shared-module exports sections updated to describe shell resolution.

## Acceptance

- `npm run typecheck`: exit 0, no errors.
- `npm test` (vitest + node:test): vitest 1105 pass, 0 fail; node:test 949 pass, 0 fail.
- `grep -rn '/bin/sh' src/main/` outside `src/main/capExecutor.test.ts`: empty.
- Exactly one `process.platform` read in `capExecutor.ts` for this feature (the only other match is a comment on the same code block).
- A manifest with no `shell:` produces the identical spawn arguments on macOS as before: `defaultShell("darwin") = "sh"`, `resolveShellInvocation("sh", "darwin", ...) = {command: "/bin/sh", argsPrefix: ["-c"]}`, `wrapScript("sh", script) = script`.

## Verification results

- PR branch (multica/BET-326-shell-manifest-key @ c3bb6cc):
  - typecheck: exit 0. Errors: none. log sha256: 42e43d8553ffd1afd4155ab126a5387b69a11b87fcef0f108c2776e13316b750
  - test: vitest 1105 pass / 0 fail; node:test 949 pass / 0 fail. log sha256: 9e2115ee66748e2a2c461d1e3c92724bf2243aaeab66ddf9b02ae9e558ee18b3
- Base (main @ ab9b5ea):
  - typecheck: exit 0. Errors: none. log sha256: 42e43d8553ffd1afd4155ab126a5387b69a11b87fcef0f108c2776e13316b750
  - test: vitest 1079 pass / 0 fail; node:test 950 pass / 0 fail. log sha256: 864990ece0326e36cdf990ddfb57f9d45caf39eaf15cf873a287dbebcb8360a7
- **Conclusion:** +26 vitest tests, all new (one extra `parseManifest — shell` block); zero regressions. Typecheck and node:test totals are identical between branches (the 950 → 949 node:test swing is a pre-existing flake unrelated to this change — same test passes on rerun).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

## Cross-cutting notes

- **Renderer untouched.** The renderer doesn't import `pluginManifest.mjs` — the registry publish shape is unchanged (the published row already drops `shell`). Settings → Plugins keeps working as today.
- **No new npm dependency.** All I/O is via the injected `io` argument (`env`, `exists`); `existsSync` is already imported in `capExecutor.ts`.
- **No new HTTP routes / job envelope fields.** `shell:` is manifest-level only, as specified.
- **Stage 1 (BET-325) is the prerequisite** — `normalizeHost` and the `host: mac` permanent alias are already merged; this PR layers the shell story on top of the same shared module.

## Out of scope (per the issue's 'Do not' section)

- No `shell` field on the job envelope or any HTTP route.
- No per-step `env` overlay support (known gap, stays out).
- No `run:` as a list, no `working-directory` alias, no other schema extension.
- No `shell: true` to spawn — every invocation remains an explicit executable plus arguments.