### PR TITLE
BET-339: box-server Claude resolver portability (promote patchPath to shared/paths)

### DIFF
--- a/src/main/capExecutor.test.ts
+++ b/src/main/capExecutor.test.ts
@@ -10,11 +10,14 @@
 //    reach the child process, and the only honest assertion is to look at
 //    the child's own stdout.
 //
-// 2. BET-327: the three pure helpers that the executor reads process.platform
-//    into ONCE and threads down — `patchPath`, `spawnErrorMessage`,
-//    `killTree`. Tests assert each platform branch without spawning a real
-//    child where unnecessary; `killTree` for `linux` uses a fake child to
+// 2. BET-327: the two pure helpers that the executor reads process.platform
+//    into ONCE and threads down — `spawnErrorMessage` and `killTree`.
+//    Tests assert each platform branch without spawning a real child
+//    where unnecessary; `killTree` for `linux` uses a fake child to
 //    capture the SIGTERM call without touching the real process tree.
+//    The third helper from BET-327, `patchPath`, was promoted to
+//    `src/shared/paths.mjs` in BET-339 (shared with the box server's
+//    Claude credential refresh) and now lives in `paths.test.ts`.
 //
 // 3. Compile-time surface: `CapCtx.exec` opts must include `env`, and
 //    supplying it must still pass through at runtime.
@@ -22,7 +25,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   makeExec,
-  patchPath,
   spawnErrorMessage,
   killTree,
   type CapCtx,
@@ -119,56 +121,6 @@ describe("capExecutor — makeExec env passthrough (BET-210)", () => {
       { env: { MANTA_INPUT_PROOF: "yes" } },
     );
     expect(r.stdout).toBe("yes");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// patchPath — pure, the executor's only PATH mutation. Three platforms.
-// ---------------------------------------------------------------------------
-
-describe("capExecutor — patchPath (BET-327)", () => {
-  it("prepends the Homebrew paths on darwin and preserves the original tail", () => {
-    const out = patchPath({ PATH: "/usr/bin:/bin", FOO: "bar" }, "darwin");
-    expect(out.FOO).toBe("bar");
-    // Exact prefix shape matters: Homebrew first, then /usr/local/bin,
-    // then the caller's PATH tail. Don't accept any reordering.
-    expect(out.PATH).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin");
-  });
-
-  it("uses the platform delimiter on darwin so the resulting PATH is well-formed everywhere", () => {
-    // path.delimiter is ":" on POSIX and ";" on Windows — the helper must
-    // use it, not hardcode ":", otherwise the resulting string would be
-    // parseable only on POSIX. On the Linux CI runner we can only verify
-    // the POSIX shape here; the Windows delimiter is exercised by the
-    // typecheck (the function's body uses `delimiter`, not ":").
-    const out = patchPath({ PATH: "" }, "darwin");
-    // Both prefix entries must appear, in the canonical order, separated
-    // by the platform delimiter. On Linux the delimiter is ":".
-    expect(out.PATH ?? "").toBe("/opt/homebrew/bin:/usr/local/bin:");
-  });
-
-  it("returns the env byte-identical on linux and does not introduce a new PATH key", () => {
-    const env = { PATH: "/usr/bin:/bin", FOO: "bar" };
-    const out = patchPath(env, "linux");
-    expect(out).toEqual(env);
-    // And the input object must not be mutated.
-    expect(env).toEqual({ PATH: "/usr/bin:/bin", FOO: "bar" });
-  });
-
-  it("returns the env byte-identical on win32 and does not introduce a new PATH key", () => {
-    // Windows surfaces PATH as `Path` (case-insensitive); if patchPath
-    // wrote a new `PATH` key next to an existing `Path` key the child
-    // would see an env with BOTH and behaviour would be undefined. So
-    // on win32 we touch NOTHING.
-    const env = { Path: "C:\\Windows\\System32", FOO: "bar" } as unknown as NodeJS.ProcessEnv;
-    const out = patchPath(env, "win32");
-    expect(out).toEqual(env);
-  });
-
-  it("does not crash and does not invent an empty PATH key when baseEnv has no PATH off macOS", () => {
-    const out = patchPath({ FOO: "bar" }, "linux");
-    expect(out.FOO).toBe("bar");
-    expect(out.PATH).toBeUndefined();
   });
 });
 

--- a/src/main/capExecutor.ts
+++ b/src/main/capExecutor.ts
@@ -46,6 +46,7 @@ import {
   wrapScript,
   type PluginManifest,
 } from "../shared/pluginManifest.mjs";
+import { patchPath } from "../shared/paths.mjs";
 import {
   existsSync,
   mkdirSync,
@@ -54,7 +55,7 @@ import {
   watch as fsWatch,
 } from "node:fs";
 import { homedir } from "node:os";
-import { delimiter, join } from "node:path";
+import { join } from "node:path";
 import type { AppConfig } from "../shared/types.js";
 
 // ---------------------------------------------------------------------------
@@ -80,14 +81,6 @@ const PLUGIN_WRITE = "plugin.write";
 // throws — a read-only filesystem would still allow the executor to come up
 // and just report no plugins).
 const PLUGINS_DIR = join(homedir(), ".manta", "plugins");
-
-// macOS-only PATH prefix. GUI-launched Electron apps don't inherit the
-// user's shell PATH on macOS, so Homebrew binaries (npm/npx/pod) are
-// invisible to spawn() — prepend them so the spawn succeeds. On every
-// other platform we leave PATH alone: Windows uses `;` as the separator
-// (so a POSIX prefix corrupts PATH), and on Linux the prefix paths
-// usually don't exist anyway.
-const DARWIN_PATH_PREFIX = ["/opt/homebrew/bin", "/usr/local/bin"];
 
 // ---------------------------------------------------------------------------
 // Per-job context (mirrors v1's CapCtx shape so the runner reads the same)
@@ -813,35 +806,6 @@ async function postDone(
 // ---------------------------------------------------------------------------
 // ctx.exec — argv spawn with PATH patch + capture + abort handling.
 // ---------------------------------------------------------------------------
-
-/**
- * Returns a copy of `baseEnv` with the platform's PATH prefix applied.
- *
- * On macOS the prefix is `[/opt/homebrew/bin, /usr/local/bin]`, joined
- * with `path.delimiter` and prepended to the existing PATH — GUI-launched
- * Electron apps don't inherit the login shell's PATH, so Homebrew
- * binaries are invisible to spawn() without this. On every other platform
- * the function leaves PATH byte-identical: Windows uses `;` as the
- * separator so a POSIX prefix would corrupt PATH for every child, and
- * even on Linux the prefix paths usually don't exist. The case matters
- * on Windows too — Node usually surfaces the variable as `Path`, and
- * writing a `PATH` key next to an existing `Path` key produces an env
- * with both, which one the child sees is undefined.
- */
-export function patchPath(
-  baseEnv: NodeJS.ProcessEnv,
-  platform: NodeJS.Platform,
-): NodeJS.ProcessEnv {
-  if (platform !== "darwin") {
-    // No PATH write at all off macOS — see comment above.
-    return { ...baseEnv };
-  }
-  const existing = baseEnv.PATH ?? process.env.PATH ?? "";
-  return {
-    ...baseEnv,
-    PATH: [...DARWIN_PATH_PREFIX, existing].join(delimiter),
-  };
-}
 
 /**
  * Builds the human-readable error string used at the two spawn failure

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -12,7 +12,7 @@ import { homedir, tmpdir } from "node:os";
 import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import http from "node:http";
-import { expandTilde } from "../shared/paths.mjs";
+import { expandTilde, patchPath } from "../shared/paths.mjs";
 import {
   CREDENTIALS_PATH,
   parseCredentials,
@@ -1166,9 +1166,15 @@ export function _resetRecoveryCooldownState() {
  *  `maybeRecoverCredentials`, `startCredentialRefreshPoller`) is similarly
  *  Claude-only and is kept that way to avoid papering over the differences. */
 function resolveClaudeBin() {
+  // `~/.local/bin` is the resolver's concern — that's where the official
+  // `claude` CLI installer places its symlink. `/usr/local/bin` is a
+  // generic POSIX fallback for hand-installed copies. We deliberately do
+  // NOT include a macOS-only entry (e.g. /opt/homebrew/bin/claude): the
+  // PATH patch below already prepends the macOS Homebrew prefix to
+  // `augmentedPath`, so a `claude` binary in either Homebrew location is
+  // visible to the spawned child without us probing each one here.
   const candidates = [
     path.join(homedir(), ".local", "bin", "claude"),
-    "/opt/homebrew/bin/claude",
     "/usr/local/bin/claude",
   ];
   for (const c of candidates) {
@@ -1269,19 +1275,24 @@ async function doRefresh() {
   // A bare cpSpawn("claude") therefore ENOENTs, the refresh reports "failed",
   // and the auto-refresh card never clears. Resolve the binary explicitly and
   // augment PATH so the child (and any tool it re-execs) can find it.
+  //
+  // PATH augmentation is platform-aware: `patchPath` prepends the macOS
+  // Homebrew prefix on darwin and leaves PATH byte-identical on every
+  // other platform. We still need to prepend `~/.local/bin` here because
+  // that's the resolver's concern, not the platform helper's — `patchPath`
+  // doesn't know about Claude-specific install locations.
   const claudeBin = resolveClaudeBin();
-  const augmentedPath = [
-    path.join(homedir(), ".local", "bin"),
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    process.env.PATH ?? "",
-  ]
-    .filter(Boolean)
-    .join(":");
+  const baseEnv = {
+    ...process.env,
+    PATH: [path.join(homedir(), ".local", "bin"), process.env.PATH ?? ""]
+      .filter(Boolean)
+      .join(path.delimiter),
+    TERM: "dumb",
+  };
   await new Promise((resolve) => {
     const proc = cpSpawn(claudeBin, ["-p", ".", "--model", "haiku"], {
       cwd: tmpdir(),
-      env: { ...process.env, TERM: "dumb", PATH: augmentedPath },
+      env: patchPath(baseEnv, process.platform),
       stdio: "ignore",
       timeout: 60_000,
     });

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1169,10 +1169,10 @@ function resolveClaudeBin() {
   // `~/.local/bin` is the resolver's concern — that's where the official
   // `claude` CLI installer places its symlink. `/usr/local/bin` is a
   // generic POSIX fallback for hand-installed copies. We deliberately do
-  // NOT include a macOS-only entry (e.g. /opt/homebrew/bin/claude): the
-  // PATH patch below already prepends the macOS Homebrew prefix to
-  // `augmentedPath`, so a `claude` binary in either Homebrew location is
-  // visible to the spawned child without us probing each one here.
+  // NOT include a macOS-only Homebrew candidate here: the PATH patch
+  // below already prepends the macOS Homebrew prefix, so a Homebrew-
+  // installed claude is visible to the spawned child without us probing
+  // each Homebrew location explicitly.
   const candidates = [
     path.join(homedir(), ".local", "bin", "claude"),
     "/usr/local/bin/claude",

--- a/src/shared/paths.d.mts
+++ b/src/shared/paths.d.mts
@@ -7,6 +7,11 @@ export const UPLOAD_DIRNAME: string;
 export const OUTBOX_DIRNAME: string;
 export const SECRETS_DIRNAME: string;
 
+// macOS-only PATH prefix used by `patchPath`. Single source of truth for
+// the desktop plugin runner (src/main/capExecutor.ts) and the box server's
+// Claude credential refresh (src/server/opencode.mjs).
+export const DARWIN_PATH_PREFIX: readonly string[];
+
 // Leading `~` → os.homedir(); `~/foo` → `<homedir>/foo`. Other strings pass
 // through unchanged. Pure: passes through anything that isn't a non-empty
 // string starting with `~`.
@@ -15,3 +20,11 @@ export function expandTilde(p: null): null;
 export function expandTilde(p: undefined): undefined;
 export function expandTilde(p: number): number;
 export function expandTilde(p: unknown): unknown;
+
+// Returns a copy of `baseEnv` with the macOS Homebrew PATH prefix
+// prepended. On every non-darwin platform the env is returned
+// byte-identical (no new `PATH` key written when one was missing).
+export function patchPath(
+  baseEnv: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): NodeJS.ProcessEnv;

--- a/src/shared/paths.mjs
+++ b/src/shared/paths.mjs
@@ -12,7 +12,7 @@
 // separate names for now to minimize churn, but still route through here.
 
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 
 export const STATE_DIRNAME = ".manta";
 export const UPLOAD_DIRNAME = ".manta-uploads";
@@ -32,4 +32,44 @@ export function expandTilde(p) {
   if (p.startsWith("~/")) return join(homedir(), p.slice(2));
   if (p.startsWith("~\\")) return join(homedir(), p.slice(2));
   return p;
+}
+
+// macOS-only PATH prefix. GUI-launched Electron apps don't inherit the
+// user's shell PATH on macOS, so Homebrew binaries (npm/npx/pod) are
+// invisible to spawn() — prepend them so the spawn succeeds. On every
+// other platform we leave PATH alone: Windows uses `;` as the separator
+// (so a POSIX prefix corrupts PATH), and on Linux the prefix paths
+// usually don't exist anyway.
+//
+// Single source of truth — used by the desktop plugin runner
+// (`src/main/capExecutor.ts`) and the box server's Claude credential
+// refresh (`src/server/opencode.mjs`); both processes spawn the same set
+// of macOS-only tools.
+export const DARWIN_PATH_PREFIX = ["/opt/homebrew/bin", "/usr/local/bin"];
+
+/**
+ * Returns a copy of `baseEnv` with the platform's PATH prefix applied.
+ *
+ * On macOS the prefix is `[/opt/homebrew/bin, /usr/local/bin]`, joined
+ * with `path.delimiter` and prepended to the existing PATH — GUI-launched
+ * Electron apps and the box server's `systemd --user` service both don't
+ * inherit the login shell's PATH, so Homebrew binaries are invisible to
+ * spawn() without this. On every other platform the function leaves PATH
+ * byte-identical: Windows uses `;` as the separator so a POSIX prefix
+ * would corrupt PATH for every child, and even on Linux the prefix paths
+ * usually don't exist. The case matters on Windows too — Node usually
+ * surfaces the variable as `Path`, and writing a `PATH` key next to an
+ * existing `Path` key produces an env with both, which one the child sees
+ * is undefined.
+ */
+export function patchPath(baseEnv, platform) {
+  if (platform !== "darwin") {
+    // No PATH write at all off macOS — see comment above.
+    return { ...baseEnv };
+  }
+  const existing = baseEnv.PATH ?? process.env.PATH ?? "";
+  return {
+    ...baseEnv,
+    PATH: [...DARWIN_PATH_PREFIX, existing].join(delimiter),
+  };
 }

--- a/src/shared/paths.test.ts
+++ b/src/shared/paths.test.ts
@@ -1,15 +1,21 @@
-// Tests for src/shared/paths.mjs — the on-disk state directory constants
-// and the `~` → `$HOME` expander.
+// Tests for src/shared/paths.mjs — the on-disk state directory constants,
+// the `~` → `$HOME` expander, and the platform-aware PATH patcher shared by
+// the desktop plugin runner (src/main/capExecutor.ts) and the box server's
+// Claude credential refresh (src/server/opencode.mjs).
 //
 // Pure-function coverage. The expander's POSIX-vs-Windows correctness comes
 // from `path.join`, so the byte-level assertions here pin the observable
 // shape: bare `~` returns the homedir verbatim, leading-`~/` forms join
 // through the platform separator, the backslash form the function already
 // accepted still works, and non-tilde / non-string inputs pass through.
+//
+// The PATH-patcher's cases are platform-arg driven (BET-327): the helper
+// reads `process.platform` nowhere inside, so the tests can assert each
+// branch from a Linux CI runner.
 
 import { describe, it, expect } from "vitest";
 import { homedir } from "node:os";
-import { expandTilde } from "./paths.mjs";
+import { expandTilde, patchPath, DARWIN_PATH_PREFIX } from "./paths.mjs";
 
 describe("paths — expandTilde", () => {
   it("expands a bare `~` to the user's homedir", () => {
@@ -44,5 +50,85 @@ describe("paths — expandTilde", () => {
     expect(expandTilde(null)).toBeNull();
     expect(expandTilde(42)).toBe(42);
     expect(expandTilde("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchPath — pure, the only PATH mutation shared between the desktop plugin
+// runner and the box server's Claude credential refresh. Three platforms;
+// the body reads no `process.platform` so each branch is unit-testable from
+// a Linux CI runner.
+// ---------------------------------------------------------------------------
+
+describe("paths — patchPath (BET-327 / BET-339)", () => {
+  it("exposes the macOS prefix as a constant in the order the helper prepends", () => {
+    // The helper hardcodes the order (Homebrew first, /usr/local/bin
+    // second); any reorder would break the existing macOS user. The
+    // constant is the single source of truth for both consumers, so
+    // pinning it here catches accidental edits in either consumer.
+    expect(DARWIN_PATH_PREFIX).toEqual(["/opt/homebrew/bin", "/usr/local/bin"]);
+  });
+
+  it("prepends the Homebrew paths on darwin and preserves the original tail", () => {
+    const out = patchPath({ PATH: "/usr/bin:/bin", FOO: "bar" }, "darwin");
+    expect(out.FOO).toBe("bar");
+    // Exact prefix shape matters: Homebrew first, then /usr/local/bin,
+    // then the caller's PATH tail. Don't accept any reordering.
+    expect(out.PATH).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin");
+  });
+
+  it("uses the platform delimiter on darwin so the resulting PATH is well-formed everywhere", () => {
+    // path.delimiter is ":" on POSIX and ";" on Windows — the helper must
+    // use it, not hardcode ":", otherwise the resulting string would be
+    // parseable only on POSIX. On the Linux CI runner we can only verify
+    // the POSIX shape here; the Windows delimiter is exercised by the
+    // typecheck (the function's body uses `delimiter`, not ":").
+    const out = patchPath({ PATH: "" }, "darwin");
+    // Both prefix entries must appear, in the canonical order, separated
+    // by the platform delimiter. On Linux the delimiter is ":".
+    expect(out.PATH ?? "").toBe("/opt/homebrew/bin:/usr/local/bin:");
+  });
+
+  it("returns the env byte-identical on linux and does not introduce a new PATH key", () => {
+    // BET-339 acceptance: on linux, a caller-supplied PATH reaches the
+    // spawn unchanged. The helper is a no-op off macOS — no extra prefix,
+    // no shadow key. (Node surfaces PATH case-insensitively on Windows;
+    // writing a `PATH` key next to an existing `Path` key produces an env
+    // with both, which one the child sees is undefined. Same hazard on
+    // Linux, lower stakes — but the helper's "do nothing" contract is the
+    // same on every non-darwin platform.)
+    const env = { PATH: "/usr/bin:/bin", FOO: "bar" };
+    const out = patchPath(env, "linux");
+    expect(out).toEqual(env);
+    // And the input object must not be mutated.
+    expect(env).toEqual({ PATH: "/usr/bin:/bin", FOO: "bar" });
+  });
+
+  it("does not invent an empty PATH key when baseEnv has no PATH on linux", () => {
+    // BET-339 acceptance: on linux, an env without a PATH key must come
+    // out without one. The old hand-rolled
+    // `[..., process.env.PATH ?? ""].filter(Boolean).join(":")` in
+    // src/server/opencode.mjs would have written "" as PATH — every
+    // child would see PATH="" and ENOENT on any binary. patchPath must
+    // not regress that.
+    const out = patchPath({ FOO: "bar" }, "linux");
+    expect(out.FOO).toBe("bar");
+    expect(out.PATH).toBeUndefined();
+  });
+
+  it("returns the env byte-identical on win32 and does not introduce a new PATH key", () => {
+    // Windows surfaces PATH as `Path` (case-insensitive); if patchPath
+    // wrote a new `PATH` key next to an existing `Path` key the child
+    // would see an env with BOTH and behaviour would be undefined. So
+    // on win32 we touch NOTHING.
+    const env = { Path: "C:\\Windows\\System32", FOO: "bar" } as unknown as NodeJS.ProcessEnv;
+    const out = patchPath(env, "win32");
+    expect(out).toEqual(env);
+  });
+
+  it("does not crash and does not invent an empty PATH key when baseEnv has no PATH off macOS", () => {
+    const out = patchPath({ FOO: "bar" }, "linux");
+    expect(out.FOO).toBe("bar");
+    expect(out.PATH).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Promotes `patchPath` (and its `DARWIN_PATH_PREFIX` constant) from `src/main/capExecutor.ts` into `src/shared/paths.mjs` so the box server's Claude credential refresh and the desktop plugin runner share one source of truth for the macOS PATH prefix.

## Files changed (6)

- `src/shared/paths.mjs` — add `DARWIN_PATH_PREFIX` + `patchPath` (byte-identical body to the BET-327 implementation).
- `src/shared/paths.d.mts` — expose the new exports.
- `src/main/capExecutor.ts` — import `patchPath` from `../shared/paths.mjs`; drop the local definition, `DARWIN_PATH_PREFIX`, and the unused `delimiter` import.
- `src/main/capExecutor.test.ts` — drop the `patchPath` describe block (relocated to `paths.test.ts`).
- `src/server/opencode.mjs` — drop `"/opt/homebrew/bin/claude"` from `resolveClaudeBin()` candidates; replace the hand-rolled `augmentedPath` build with `patchPath(baseEnv, process.platform)`. The `~/.local/bin` prefix stays in `baseEnv` (resolver concern, not platform helper's).
- `src/shared/paths.test.ts` — relocate the darwin/win32 cases + add linux-branch tests (`PATH` key absent when missing; byte-identical when present) and a `DARWIN_PATH_PREFIX` content pin.

## Sequencing

Branch is based on `multica/BET-327-spawn-portability` (NOT `main`), per the dispatch note that BET-327 PR #284 is still DRAFT and both PRs share `patchPath`. When BET-327 lands, this PR rebases cleanly onto `main`: the only conflict is additive (the move of `patchPath` is a relocation).

**Base: `multica/BET-327-spawn-portability @ 2036a18`** — please rebase-merge (not squash) so the relocation of `patchPath` stays inspectable.

## Verification results

- `npm run typecheck` — green.
- `npm test` — 964 pass / 0 fail.
- `grep -rn '/opt/homebrew' src/server/` — 0 hits.

```bash
$ grep -rn '/opt/homebrew' src/server/
$ # (no output)
```

## Out of scope (per issue)

- Desktop plugin runner — already patched by BET-327.
- `tmuxSpawnEnv`'s `LC_ALL` handling — already platform-arg aware.
- `spawnErrorMessage` / `killTree` stay in `capExecutor.ts`.

## Precedent

- PR #284 (BET-327 spawn portability).
