### PR TITLE
feat(pair): carry box address in pairing link, private-only (BET-336)

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { STATE_DIRNAME } from "../src/shared/paths.mjs";
 import { loadAuth } from "../src/server/auth.mjs";
+import { isPrivateServerUrl } from "../src/shared/transport.mjs";
 
 // `qrcode-terminal` is CommonJS; we keep this module ESM. The local
 // `createRequire` shim is sync (no top-level await) and resolves the lib
@@ -942,32 +943,32 @@ export function formatPairingOutput(
     lines.push("");
     lines.push("  2. Pair it — click this link, or paste it into the app's Connect screen");
     // BET-267: when a non-public serverUrl is provided (tailscale path), the
-    // pair-page URL and the QR must point at THAT base. We also drop the
-    // `manta://pair?…` deep-link line: the resolver on the mobile/desktop side
-    // routes that link through `boxDirectUrl` → `https://<boxId>.boxes.mantaui.com`,
-    // which is unreachable on the tailscale path. The pair-page URL is the
-    // single source of truth for the connect block in tailscale mode.
+    // pair-page URL must point at THAT base. The pair-page URL is what the
+    // user opens in a browser; the deep link / QR below carry the listener
+    // verbatim for one-click.
+    //
+    // BET-336: the deep link now also carries the server URL when one was
+    // supplied (gated by `isPrivateServerUrl` inside `buildPairLink`, so a
+    // crafted install can't smuggle a public address past this function).
+    // ONE wire shape — no more manta:///pair-page fork.
     const useServerUrl = typeof serverUrl === "string" && serverUrl !== "";
+    const pairLinkOpts = useServerUrl ? { serverUrl } : {};
+    const pairLink = buildPairLink(box_id, pairing_code, pairLinkOpts);
     const pairPageUrl = buildPairPageUrl(box_id, pairing_code, {
       baseUrl: useServerUrl ? serverUrl : undefined,
     });
     lines.push(`       Pair page:     ${pairPageUrl}`);
-    if (!useServerUrl) {
-      // Public path keeps the manta:// deep link for one-tap mobile pairing.
-      const pairLink = buildPairLink(box_id, pairing_code);
-      lines.push(`       ${pairLink}`);
-    }
+    lines.push(`       ${pairLink}`);
     lines.push("");
     lines.push("  3. iPhone (optional) — scan the QR below with your camera");
     lines.push(`       App download: ${IOS_APP_URL}  (App Store link coming soon)`);
     lines.push("");
-    // QR encodes the pair-page URL when a serverUrl is in play (the QR has to
-    // open a URL the scanning device can actually reach), the manta:// link
-    // otherwise (preserves the old wire shape for the public install).
-    const qrPayload = useServerUrl ? pairPageUrl : buildPairLink(box_id, pairing_code);
+    // BET-336: the QR encodes the SAME deep link the user can paste — the
+    // one-tap path. The link itself already points at the right listener
+    // (with `&server=` on the tailscale path), so no separate conditional.
     let qr;
     try {
-      qr = qrRender(qrPayload);
+      qr = qrRender(pairLink);
     } catch {
       // qrcode-terminal missing / broken (e.g. a dev's stripped node_modules) —
       // degrade to text-only rather than crash the install. The QR is a
@@ -1029,16 +1030,35 @@ export function formatPairingOutput(
  * round-trips this against the renderer's `parsePairPayload` via subprocess
  * to enforce the contract.
  *
+ * BET-336 (Tailscale pair link): when an optional `serverUrl` is supplied
+ * it is appended as `&server=<url-encoded>` so the receiving device can
+ * claim against the private/tailnet listener instead of the derived
+ * public hostname. The supplied server URL MUST pass
+ * `isPrivateServerUrl` (the same single-source-of-truth gate the
+ * renderer-side parser uses); a non-private value throws — refusing is
+ * the intended behaviour, not silently dropping the param.
+ *
  * Cross-reference: keep in sync with src/renderer/mobile/pairPayload.ts
  * `buildPairPayload` (box-form branch). If the canonical shape changes,
  * BOTH helpers must change in lockstep — the test catches drift.
  */
-export function buildPairLink(boxId, code) {
+export function buildPairLink(boxId, code, { serverUrl } = {}) {
   if (typeof boxId !== "string" || !/^[0-9a-f]{32}$/.test(boxId)) {
     throw new Error("buildPairLink: boxId must be a 32-hex token");
   }
   if (!/^[0-9]{6}$/.test(String(code ?? ""))) {
     throw new Error("buildPairLink: code must be 6 digits");
+  }
+  if (serverUrl !== undefined) {
+    if (typeof serverUrl !== "string" || serverUrl === "") {
+      throw new Error("buildPairLink: serverUrl must be a non-empty string");
+    }
+    if (!isPrivateServerUrl(serverUrl)) {
+      throw new Error(
+        "buildPairLink: serverUrl must be a private/tailnet http(s) URL",
+      );
+    }
+    return `manta://pair?box=${encodeURIComponent(boxId)}&code=${code}&server=${encodeURIComponent(serverUrl)}`;
   }
   return `manta://pair?box=${encodeURIComponent(boxId)}&code=${code}`;
 }

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3179,14 +3179,14 @@ test("buildPairPageUrl with baseUrl embeds the box id in the fragment (BET-334)"
   );
 });
 
-test("formatPairingOutput uses serverUrl as the pair-page base on the tailnet path (BET-267)", () => {
+test("formatPairingOutput uses serverUrl as the pair-page base on the tailnet path (BET-267 + BET-336)", () => {
   // Headline acceptance criterion for BET-267 Branch A: when a non-public
-  // serverUrl is provided, the connect block must point at THAT base.
-  // The manta:// deep-link is dropped because the mobile/desktop resolver
-  // routes that link through `boxDirectUrl` → https://<boxId>.boxes.mantaui.com,
-  // which is unreachable on the tailnet path. The canonical
-  // boxes.mantaui.com hostname MUST NOT appear in the tailnet output
-  // (a stray one would mislead the device).
+  // serverUrl is provided, the pair-page URL must point at THAT base. The
+  // manta:// deep link (BET-336) also carries the server URL — one wire
+  // shape, one code path. The canonical boxes.mantaui.com hostname MUST
+  // NOT appear in the tailnet output (a stray one would mislead the
+  // device — and would never round-trip through parsePairPayload since
+  // `isPrivateServerUrl` rejects public addresses).
   const out = formatPairingOutput({
     pairing_code: "847291",
     box_id: HEX32,
@@ -3194,14 +3194,89 @@ test("formatPairingOutput uses serverUrl as the pair-page base on the tailnet pa
     serverUrl: "http://100.64.1.5:8787",
   });
   assert.match(out, /Pair page:     http:\/\/100\.64\.1\.5:8787\/pair#box=0123456789abcdef0123456789abcdef&code=847291/);
-  assert.doesNotMatch(out, /manta:\/\/pair/);
+  // BET-336: the deep link is present and carries the server URL.
+  assert.match(
+    out,
+    /manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291&server=http%3A%2F%2F100\.64\.1\.5%3A8787/,
+  );
   assert.doesNotMatch(out, /boxes\.mantaui\.com/);
   // The footer (Pairing code / Box ID / Server URL) stays identical to
-  // the public-path shape — only the pair-page URL + dropped deep link
+  // the public-path shape — only the pair-page URL + deep-link server
   // change.
   assert.match(out, /Server URL:    http:\/\/100\.64\.1\.5:8787/);
   assert.match(out, /Pairing code:  847291/);
   assert.match(out, /Box ID:        0123456789abcdef0123456789abcdef/);
+});
+
+test("formatPairingOutput refuses a non-private serverUrl (BET-336)", () => {
+  // `buildPairLink` (called by formatPairingOutput) gates the server URL
+  // through `isPrivateServerUrl`; a non-private value throws — refuses,
+  // does not silently drop. The guard prevents a misconfigured install
+  // from shipping a link that would round-trip to null on the receiver.
+  assert.throws(
+    () =>
+      formatPairingOutput({
+        pairing_code: "847291",
+        box_id: HEX32,
+        serverUrl: "https://attacker.example.com",
+      }),
+    /private\/tailnet/,
+  );
+});
+
+test("buildPairLink throws on a non-private serverUrl (BET-336)", () => {
+  // Pin the helper-level guard so a future caller that bypasses
+  // formatPairingOutput still gets the same refusal.
+  assert.throws(
+    () =>
+      buildPairLink(HEX32, "847291", { serverUrl: "https://attacker.example.com" }),
+    /private\/tailnet/,
+  );
+  assert.throws(
+    () =>
+      buildPairLink(HEX32, "847291", { serverUrl: "http://8.8.8.8:8787" }),
+    /private\/tailnet/,
+  );
+  assert.throws(
+    () =>
+      buildPairLink(HEX32, "847291", { serverUrl: "ftp://192.168.1.1" }),
+    /private\/tailnet/,
+  );
+  assert.throws(
+    () => buildPairLink(HEX32, "847291", { serverUrl: "" }),
+    /non-empty string/,
+  );
+});
+
+test("buildPairLink round-trips with a serverUrl through parsePairPayload (BET-336, install verification)", () => {
+  // Direct mirror of the verification snippet in the issue body: print
+  // the connect block with a tailnet serverUrl, and pin that the deep
+  // link in the output is EXACTLY the wire shape parsePairPayload (the
+  // mobile deep-link parser + the desktop QR panel) accepts and
+  // round-trips to a `{ boxId, code, serverUrl }` payload. We assert
+  // the literal here — the round-trip itself is enforced by the vitest
+  // tests at src/renderer/mobile/pairPayload.test.ts (Node has no TS
+  // loader in this Node:test run).
+  const out = formatPairingOutput({
+    pairing_code: "123456",
+    box_id: "0123456789abcdef0123456789abcdef",
+    serverUrl: "http://100.64.1.5:8787",
+  });
+  // The deep link must appear with the server URL appended (url-encoded).
+  const expectedLink =
+    "manta://pair?box=0123456789abcdef0123456789abcdef" +
+    "&code=123456" +
+    "&server=" + encodeURIComponent("http://100.64.1.5:8787");
+  assert.ok(out.includes(expectedLink), `expected deep link not found in:\n${out}`);
+  // Pin the literal helper output too — the assertion above would still
+  // pass if formatPairingOutput itself somehow stripped the server
+  // param, so check the helper directly.
+  assert.equal(
+    buildPairLink("0123456789abcdef0123456789abcdef", "123456", {
+      serverUrl: "http://100.64.1.5:8787",
+    }),
+    expectedLink,
+  );
 });
 
 test("formatPairingOutput keeps the manta:// deep-link on the public path (BET-267 regression guard)", () => {

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -10,7 +10,7 @@ import { claimBox } from "./pairClaim";
 import { useStore } from "./store";
 
 // PairStep.tsx — Step 1 (Pair) of the desktop onboarding shell (BET-49-T2,
-// BET-255, BET-268, BET-335).
+// BET-255, BET-268, BET-335, BET-336).
 //
 // Mounts into Onboarding.tsx's step-1 slot. Owns the pairing form:
 //   • a Box ID input (32-hex box id)
@@ -65,19 +65,24 @@ export function PairStep({
   onPaired: () => void;
   onSkip: () => void;
 }) {
-  // Deep-link prefill (BET-335): if App.tsx stashed a valid `manta://pair?…`
-  // URL into `pendingPairLink` before this step mounted, seed both fields
-  // from it. Lazy init via `useState(() => …)` so we read the store ONCE at
-  // mount — the user can then edit the fields freely without our re-reading
-  // the stashed URL on every keystroke. `prefillFromPairLink` returns null
-  // for any nullish/empty/invalid input (foreign URL, bad box, bad code),
-  // which falls through to empty fields — the same default the form already
+  // Deep-link prefill (BET-335; extended BET-336 for the server URL): if
+  // App.tsx stashed a valid `manta://pair?…` URL into `pendingPairLink`
+  // before this step mounted, seed the fields from it. Lazy init via
+  // `useState(() => …)` so we read the store ONCE at mount — the user can
+  // then edit the fields freely without our re-reading the stashed URL on
+  // every keystroke. `prefillFromPairLink` returns null for any
+  // nullish/empty/invalid input (foreign URL, bad box, bad code), which
+  // falls through to empty fields — the same default the form already
   // used for a non-deep-link open.
   const prefill = prefillFromPairLink(useStore.getState().pendingPairLink);
   const [boxId, setBoxId] = useState(() => prefill?.boxId ?? "");
   const [code, setCode] = useState(() => prefill?.code ?? "");
-  const [serverUrl, setServerUrl] = useState("");
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [serverUrl, setServerUrl] = useState(() => prefill?.serverUrl ?? "");
+  // BET-336: when the link supplied a server URL (Tailscale / private
+  // listener), open the Advanced section by default so the user can SEE
+  // the address they're about to pair against before clicking Connect —
+  // the deep-link confirmation screen promised exactly this visibility.
+  const [advancedOpen, setAdvancedOpen] = useState(() => Boolean(prefill?.serverUrl));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const codeRef = useRef<HTMLInputElement>(null);

--- a/src/renderer/mobile/deepLink.test.ts
+++ b/src/renderer/mobile/deepLink.test.ts
@@ -148,6 +148,21 @@ describe("handlePairUrl — box form (direct hostname, BET-198)", () => {
     expect(deps.persistCalls).toEqual([boxDirectUrl(BOX)]);
   });
 
+  it("claims + persists the link-supplied serverUrl verbatim (BET-336, Tailscale path)", async () => {
+    // The deep link carries a `server=` parameter (Tailscale path).
+    // `parsePairPayload` has already gated it through `isPrivateServerUrl`
+    // so the value reaching `handlePairUrl` is always a private/tailnet
+    // URL. Both the claim AND the persist must use that URL verbatim —
+    // never fall through to the public boxDirectUrl.
+    const SERVER = "http://100.64.1.5:8787";
+    const link = `manta://pair?box=${BOX}&code=847291&server=${encodeURIComponent(SERVER)}`;
+    const deps = makeDeps();
+    const out = await handlePairUrl(link, deps);
+    expect(out).toBe("paired");
+    expect(deps.authClaimCalls).toEqual([{ serverUrl: SERVER, code: "847291" }]);
+    expect(deps.persistCalls).toEqual([SERVER]);
+  });
+
   it("returns 'failed' when authClaim rejects with a classified failure (no persist)", async () => {
     const deps = makeDeps({
       authClaim: async () => failOutcome(),

--- a/src/renderer/mobile/deepLink.ts
+++ b/src/renderer/mobile/deepLink.ts
@@ -2,7 +2,12 @@
 //
 // Post-BET-198, phones connect DIRECTLY to https://<box_id>.boxes.mantaui.com
 // (Caddy on the box reverse-proxies 127.0.0.1:8787). The only live pair
-// payload shape is the box form `manta://pair?box=<box_id>&code=<6-digit>`.
+// payload shape is the box form `manta://pair?box=<box_id>&code=<6-digit>`,
+// optionally with a `server=<url>` for the Tailscale path (BET-336) — when
+// present, the link-supplied URL must be a private/tailnet address (gated by
+// `isPrivateServerUrl` in parsePairPayload) and is used verbatim for both
+// the claim and the persisted listener, so a Tailscale box with no public
+// hostname can still ship a working one-click / QR pair link.
 //
 // Phase 2 of BET-177: the iOS app registers the `manta://` custom scheme (see
 // Info.plist's CFBundleURLTypes + AndroidManifest.xml's intent-filter); the
@@ -29,8 +34,11 @@
 // Dep injection keeps handlePairUrl unit-testable without DOM / fetch / the
 // Capacitor bridge — see deepLink.test.ts beside this file.
 
-import { parsePairPayload, type PairPayload } from "./pairPayload";
-import { boxDirectUrl } from "../../shared/transport.mjs";
+import { parsePairPayload } from "./pairPayload";
+import {
+  buildSetupClaimInput,
+  resolveSetupServerUrl,
+} from "./setupLogic";
 import type { ClaimOutcome } from "../../shared/claim.mjs";
 import { dlog } from "./debugLog";
 
@@ -91,11 +99,13 @@ export type DeepLinkDeps = {
     code: string;
   }) => Promise<ClaimOutcome>;
   /** Persist the resolved server URL to localStorage["manta_server"]. Called
-   *  AFTER a successful claim — the URL is the shared direct hostname
-   *  `https://<boxId>.boxes.mantaui.com` (built by `boxDirectUrl`). The
-   *  deep-link handler is the only caller that needs this — direct pairing
-   *  flows (PairingScreen / SetupScreen) persist serverUrl directly because
-   *  the user already typed it. */
+   *  AFTER a successful claim — the URL is whatever `resolveSetupServerUrl`
+   *  returned for the parsed payload: the link-supplied `serverUrl` when
+   *  present (BET-336, Tailscale path) or the shared public hostname
+   *  `https://<boxId>.boxes.mantaui.com` otherwise. The deep-link handler is
+   *  the only caller that needs this — direct pairing flows (PairingScreen /
+   *  SetupScreen) persist serverUrl directly because the user already typed
+   *  it. */
   persistServer: (serverUrl: string) => void;
 };
 
@@ -108,11 +118,14 @@ export type DeepLinkDeps = {
  * - Foreign URLs (any non-manta scheme, or a manta:// URL that fails
  *   parsePairPayload) → "ignored" — no claim is attempted, no localStorage
  *   write happens.
- * - A box-form pair URL → claimAgainst with
- *   `https://<boxId>.boxes.mantaui.com`, then persistServer with the SAME
- *   string on success. The URL shape is produced by the SHARED `boxDirectUrl`
- *   helper so the desktop (PairStep.tsx) and the mobile deep-link handler
- *   write the EXACT same string.
+ * - A box-form pair URL → claim with the SHARED
+ *   `buildSetupClaimInput({boxId, code, serverUrl: payload.serverUrl})`
+ *   helper (the same one the desktop PairStep and the mobile setup screen
+ *   use). When the payload carries a `serverUrl` (BET-336 — Tailscale pair
+ *   link), that URL is used verbatim for both the claim AND the persisted
+ *   listener so the post-claim refresh points at the same box the claim
+ *   just succeeded against. With no `serverUrl`, the helper falls through
+ *   to the public hostname (`https://<boxId>.boxes.mantaui.com`).
  */
 export async function handlePairUrl(
   raw: string,
@@ -124,10 +137,16 @@ export async function handlePairUrl(
     return "ignored";
   }
   dlog(
-    `[deeplink] parsed: box=${payload.boxId.slice(0, 8)}… (direct) code=${payload.code}`,
+    payload.serverUrl
+      ? `[deeplink] parsed: box=${payload.boxId.slice(0, 8)}… server=${payload.serverUrl} code=${payload.code}`
+      : `[deeplink] parsed: box=${payload.boxId.slice(0, 8)}… (direct) code=${payload.code}`,
   );
 
-  const claimInput = buildClaimInput(payload);
+  const claimInput = buildSetupClaimInput({
+    boxId: payload.boxId,
+    code: payload.code,
+    serverUrl: payload.serverUrl,
+  });
   let outcome: ClaimOutcome;
   try {
     outcome = await deps.authClaim(claimInput);
@@ -149,33 +168,14 @@ export async function handlePairUrl(
   // Successful claim. Persist the resolved server URL to localStorage so the
   // next serverBase() call resolves correctly and doRefresh() finds the
   // bootstrap data path. The token is persisted by authClaim itself (single
-  // write-site in httpApi.saveClientToken).
-  const serverUrl = resolveServerUrl(payload);
+  // write-site in httpApi.saveClientToken). `resolveSetupServerUrl` honours
+  // the link-supplied `serverUrl` (BET-336) and otherwise falls through to
+  // the public hostname — same call site the desktop PairStep + manual
+  // mobile setup use, so all three flows write the EXACT same string.
+  const serverUrl = resolveSetupServerUrl({
+    boxId: payload.boxId,
+    serverUrl: payload.serverUrl,
+  });
   deps.persistServer(serverUrl);
   return "paired";
-}
-
-/**
- * Build the {serverUrl, code} input for httpApi.authClaim. The box-form URL
- * is built by the shared `boxDirectUrl` helper so the claim POSTs
- * `{pairing_code}` to the box's own /auth/claim against its public hostname
- * (`https://<boxId>.boxes.mantaui.com`). The same string is persisted by
- * `persistServer` below — single source of truth for the URL shape.
- */
-function buildClaimInput(payload: PairPayload): {
-  serverUrl: string;
-  code: string;
-} {
-  return { serverUrl: boxDirectUrl(payload.boxId), code: payload.code };
-}
-
-/**
- * Resolve the server URL to persist after a successful claim. The shared
- * `boxDirectUrl` helper is the single source of truth for the box-form URL
- * shape — it builds `https://<boxId>.boxes.mantaui.com` and validates the
- * boxId (callers MUST have shape-gated by parsePairPayload already, but the
- * helper is defensive).
- */
-function resolveServerUrl(payload: PairPayload): string {
-  return boxDirectUrl(payload.boxId);
 }

--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -67,10 +67,70 @@ describe("parsePairPayload", () => {
   });
 
   describe("rejects deprecated addressing forms", () => {
-    it("rejects the serverUrl form (?server=<url>&code=)", () => {
+    it("rejects a link with a PUBLIC serverUrl (BET-336 — crafted-link guard)", () => {
+      // BET-336: a `server=` carrying a public address is the exact attack
+      // vector the private-URL gate prevents — a link that points the app
+      // at an attacker-controlled host. The parser refuses the WHOLE
+      // payload (does not silently drop the param and fall through to the
+      // public hostname).
       expect(
         parsePairPayload("manta://pair?server=http://box:8787&code=123456"),
       ).toBeNull();
+      expect(
+        parsePairPayload(
+          "manta://pair?server=https://example.com&code=123456",
+        ),
+      ).toBeNull();
+      // Public IPv4, not in any accepted range.
+      expect(
+        parsePairPayload("manta://pair?server=http://8.8.8.8:8787&code=123456"),
+      ).toBeNull();
+    });
+
+    it("rejects a link with a malformed serverUrl (BET-336)", () => {
+      // Non-http(s) scheme → refusal.
+      expect(
+        parsePairPayload(
+          "manta://pair?server=ftp://192.168.1.1&code=123456",
+        ),
+      ).toBeNull();
+      // IPv6 literal → out of scope, refusal.
+      expect(
+        parsePairPayload(
+          "manta://pair?server=http://[::1]:8787&code=123456",
+        ),
+      ).toBeNull();
+    });
+
+    it("accepts a PRIVATE serverUrl (BET-336 — Tailscale pair link)", () => {
+      // The link now carries the listener; the receiver claims against it.
+      const r = parsePairPayload(
+        "manta://pair?box=" + BOX + "&code=123456&server=http://100.64.1.5:8787",
+      );
+      expect(r).toEqual({
+        boxId: BOX,
+        code: "123456",
+        serverUrl: "http://100.64.1.5:8787",
+      });
+      // Also for a 192.168.x and a .ts.net hostname.
+      expect(
+        parsePairPayload(
+          "manta://pair?box=" + BOX + "&code=123456&server=http://192.168.1.10:8787",
+        ),
+      ).toEqual({
+        boxId: BOX,
+        code: "123456",
+        serverUrl: "http://192.168.1.10:8787",
+      });
+      expect(
+        parsePairPayload(
+          "manta://pair?box=" + BOX + "&code=123456&server=https://mybox.ts.net:8787",
+        ),
+      ).toEqual({
+        boxId: BOX,
+        code: "123456",
+        serverUrl: "https://mybox.ts.net:8787",
+      });
     });
 
     it("rejects the legacy id/server alias (?id=<url>&token=)", () => {
@@ -151,6 +211,28 @@ describe("buildPairPayload", () => {
     const out = buildPairPayload({ boxId: BOX, code: "000000" });
     expect(out).toContain(encodeURIComponent(BOX));
   });
+
+  it("appends &server=<url-encoded serverUrl> when present (BET-336)", () => {
+    expect(
+      buildPairPayload({
+        boxId: BOX,
+        code: "847291",
+        serverUrl: "http://100.64.1.5:8787",
+      }),
+    ).toBe(
+      `manta://pair?box=${encodeURIComponent(BOX)}&code=847291&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+    );
+  });
+
+  it("omits the server param when serverUrl is absent or empty", () => {
+    // Mirrors the unchanged wire shape for the pre-BET-336 / public
+    // emitter — a regression here would break the round-trip for every
+    // existing emitter.
+    const without = buildPairPayload({ boxId: BOX, code: "847291" });
+    expect(without).not.toContain("server=");
+    const empty = buildPairPayload({ boxId: BOX, code: "847291", serverUrl: "" });
+    expect(empty).not.toContain("server=");
+  });
 });
 
 describe("round-trip", () => {
@@ -159,6 +241,10 @@ describe("round-trip", () => {
       { boxId: BOX, code: "111111" },
       { boxId: BOX, code: "000000" },
       { boxId: BOX, code: "987654" },
+      // BET-336: round-trip preserves the server URL through both directions.
+      { boxId: BOX, code: "111111", serverUrl: "http://100.64.1.5:8787" },
+      { boxId: BOX, code: "000000", serverUrl: "http://192.168.1.10:8787" },
+      { boxId: BOX, code: "987654", serverUrl: "https://mybox.ts.net" },
     ];
     for (const p of cases) {
       expect(parsePairPayload(buildPairPayload(p))).toEqual(p);

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -12,24 +12,47 @@
 //   • Deferred-deeplink https form (Branch/Firebase style):
 //       https://<host>/m/<payload>?box=<box_id>&code=<6-digit>
 //
-// The earlier direct-HTTPS `server=` form (and the ambiguous legacy `id=`
-// alias) are relay/pre-direct-era back-compat that no live emitter produces;
-// they are intentionally rejected here.
+// BET-336 (Tailscale pair link): the link MAY also carry an optional
+// `server=<url>` parameter — the box's listener URL, so a Tailscale box
+// (no public hostname) can ship a working one-click / QR pair link. The
+// server URL is gated by `isPrivateServerUrl` (../../shared/transport.mjs):
+// only loopback, RFC 1918 private, CGNAT/Tailscale (100.64/10), and
+// .ts.net MagicDNS hostnames are accepted. A link carrying a public
+// address is REFUSED outright (we return null for the whole payload,
+// never silently drop the parameter and fall back to the public hostname
+// — that fallback is exactly the "crafted link points the app at an
+// attacker's server" attack the gate prevents).
 //
-// The validation contract (32-hex boxId shape, 6-digit code) is SINGLE-SOURCED:
-// we delegate to normalizeCode (../../shared/claim.mjs) and isValidBoxToken
-// (../../shared/transport.mjs — the SAME 32-hex gate as
-// src/server/webhooks.mjs isValidToken, kept in sync there for exactly this
-// use case; the renderer cannot import from src/server/* because the box
-// server pulls Node built-ins, which Vite's renderer build externalizes
-// and the import then fails at build time).
+// The validation contract (32-hex boxId shape, 6-digit code, private
+// server URL) is SINGLE-SOURCED: we delegate to normalizeCode
+// (../../shared/claim.mjs), isValidBoxToken (../../shared/transport.mjs —
+// the SAME 32-hex gate as src/server/webhooks.mjs isValidToken, kept in
+// sync there for exactly this use case; the renderer cannot import from
+// src/server/* because the box server pulls Node built-ins, which Vite's
+// renderer build externalizes and the import then fails at build time),
+// and isPrivateServerUrl (../../shared/transport.mjs — single source of
+// truth for the ranges; every other consumer imports it from there).
 
 import { normalizeCode } from "../../shared/claim.mjs";
-import { isValidBoxToken } from "../../shared/transport.mjs";
+import {
+  isValidBoxToken,
+  isPrivateServerUrl,
+} from "../../shared/transport.mjs";
+import { normalizeServerUrl } from "./setupLogic";
 
 export type PairPayload = {
   boxId: string;
   code: string;
+  /**
+   * Optional server URL (BET-336, Tailscale path). When present, the
+   * pairing flow claims against THIS URL instead of the derived public
+   * hostname (`https://<boxId>.boxes.mantaui.com`) — so a Tailscale box
+   * (no public hostname) can ship a working one-click / QR link.
+   * Always set to the `normalizeServerUrl`-normalized form on the way
+   * out, and gated by `isPrivateServerUrl` on the way in. Absent on
+   * pre-BET-336 payloads and on any non-Tailscale emitter.
+   */
+  serverUrl?: string;
 };
 
 /**
@@ -94,6 +117,7 @@ export function parsePairPayload(raw: string): PairPayload | null {
   const q = url.searchParams;
   const rawBox = q.get("box") ?? "";
   const rawCode = q.get("code") ?? q.get("token") ?? "";
+  const rawServer = q.get("server") ?? "";
 
   const boxId = coerceBoxId(rawBox);
   if (!boxId) return null;
@@ -105,7 +129,20 @@ export function parsePairPayload(raw: string): PairPayload | null {
   if (!/^\d{6}$/.test(code)) return null;
   if ((String(rawCode).match(/\d/g) ?? []).length !== 6) return null;
 
-  return { boxId, code };
+  // BET-336 (Tailscale pair link): when the link carries a server URL, it
+  // MUST be a private / tailnet address — anything reachable from inside the
+  // user's own network. A non-private server URL means the link is asking us
+  // to point the app at an arbitrary host: we REFUSE the whole payload (not
+  // silently drop the param), so a crafted link can never smuggle an
+  // attacker-chosen address past the public-hostname default.
+  let serverUrl: string | undefined;
+  if (rawServer !== "") {
+    const normalized = normalizeServerUrl(rawServer);
+    if (normalized === null || !isPrivateServerUrl(normalized)) return null;
+    serverUrl = normalized;
+  }
+
+  return { boxId, code, serverUrl };
 }
 
 /**
@@ -116,7 +153,18 @@ export function parsePairPayload(raw: string): PairPayload | null {
  * install.sh heredoc. The boxId is URL-encoded so reserved characters
  * survive the query (32-hex has none today, but the encoder is the safe
  * default).
+ *
+ * BET-336: when the payload carries a `serverUrl` (Tailscale pair link),
+ * a `server=<url-encoded serverUrl>` query param is appended so the
+ * receiving device can claim against the private/tailnet listener instead
+ * of the derived public hostname. The current callers only feed this
+ * helper with server URLs that have already passed `isPrivateServerUrl`,
+ * so we do NOT re-validate here (the constructor is a thin encoder).
  */
 export function buildPairPayload(p: PairPayload): string {
-  return `manta://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+  const base = `manta://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+  if (p.serverUrl) {
+    return `${base}&server=${encodeURIComponent(p.serverUrl)}`;
+  }
+  return base;
 }

--- a/src/renderer/mobile/setupLogic.test.ts
+++ b/src/renderer/mobile/setupLogic.test.ts
@@ -247,4 +247,25 @@ describe("prefillFromPairLink (BET-335 deep-link prefill)", () => {
       prefillFromPairLink(`manta://pair?box=${VALID_BOX}&code=12345`),
     ).toBeNull();
   });
+
+  it("returns {boxId, code, serverUrl} for a valid link carrying a private server URL (BET-336)", () => {
+    // The Tailscale pair link carries a private/tailnet listener URL.
+    // The renderer-side prefill must surface that URL so PairStep can
+    // pre-fill the Advanced field and open it by default.
+    const link = `manta://pair?box=${VALID_BOX}&code=123456&server=${encodeURIComponent("http://100.64.1.5:8787")}`;
+    expect(prefillFromPairLink(link)).toEqual({
+      boxId: VALID_BOX,
+      code: "123456",
+      serverUrl: "http://100.64.1.5:8787",
+    });
+  });
+
+  it("returns null for a link carrying a PUBLIC server URL (BET-336, crafted-link guard)", () => {
+    // parsePairPayload refuses the whole payload when the server URL is
+    // not private; prefillFromPairLink is a thin wrapper so it must do
+    // the same — the desktop can't pre-fill a listener that the parser
+    // refused.
+    const link = `manta://pair?box=${VALID_BOX}&code=123456&server=${encodeURIComponent("https://attacker.example.com")}`;
+    expect(prefillFromPairLink(link)).toBeNull();
+  });
 });

--- a/src/renderer/mobile/setupLogic.ts
+++ b/src/renderer/mobile/setupLogic.ts
@@ -118,13 +118,23 @@ export function resolveConnectRoute(_serverBase: string): "direct" {
 }
 
 /**
- * Prefill helper for the deep-link pairing flow (BET-335).
+ * Prefill helper for the deep-link pairing flow (BET-335; extended BET-336
+ * for the optional server URL).
  *
  * PairStep lazily initializes its Box ID + code fields from this function so
  * clicking a `manta://pair?box=…&code=…` link opens the Connect screen with
  * both fields already filled — the user clicks Connect to confirm. Routing
  * through the existing screen (rather than auto-claiming) means the pair
  * page's "click Connect" copy is true.
+ *
+ * BET-336 (Tailscale pair link): when the link carries a `server=<url>`,
+ * that URL is returned as `serverUrl` so PairStep can pre-fill the Advanced
+ * "Server URL" field and open the Advanced section by default — the user
+ * sees the listener they are about to pair against BEFORE clicking Connect
+ * (the deep-link confirmation screen promises exactly this). The server URL
+ * is the SAME `isPrivateServerUrl`-gated value `parsePairPayload` already
+ * validated, so callers can pass it straight to `buildSetupClaimInput` /
+ * `resolveSetupServerUrl`.
  *
  * Pure — delegates to the canonical `parsePairPayload` parser (the same one
  * App.tsx uses to validate the deep-link URL) and returns `null` for any
@@ -135,7 +145,7 @@ export function resolveConnectRoute(_serverBase: string): "direct" {
  */
 export function prefillFromPairLink(
   raw: string | null | undefined,
-): { boxId: string; code: string } | null {
+): { boxId: string; code: string; serverUrl?: string } | null {
   if (raw == null) return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;

--- a/src/server/pair.html
+++ b/src/server/pair.html
@@ -206,13 +206,21 @@ function go(n){
   document.getElementById("kv-box").textContent=box||"—";
   document.getElementById("kv-code").textContent=code||"—";
   document.getElementById("kv-server").textContent=location.origin;
+  // BET-336 (Tailscale pair link): on a non-public origin (Tailscale IP,
+  // private hostname), append the page's own origin as `server=` so the
+  // deep link + QR point at a listener the scanning device can actually
+  // reach. On the public boxes.mantaui.com path, location.origin is a
+  // public address which the renderer refuses — appending it there would
+  // make every public link unparseable.
+  var isPublic=/\.boxes\.mantaui\.com$/.test(location.hostname);
+  var srv=isPublic?"":"&server="+encodeURIComponent(location.origin);
   if(box&&code){
-    var link="manta://pair?box="+box+"&code="+code;
+    var link="manta://pair?box="+box+"&code="+code+srv;
     document.getElementById("openlink").setAttribute("href",link);
     var dl=document.getElementById("deeplink");
     dl.setAttribute("href",link);
     dl.textContent=link;
-    document.getElementById("qr").src="/pair/qr.png?box="+box+"&code="+code;
+    document.getElementById("qr").src="/pair/qr.png?box="+box+"&code="+code+srv;
     document.getElementById("code-value").textContent=code.slice(0,3)+" "+code.slice(3);
   }else{
     document.body.classList.add("nocode");

--- a/src/server/pairPage.mjs
+++ b/src/server/pairPage.mjs
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import QRCode from "qrcode";
+import { isPrivateServerUrl } from "../shared/transport.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -23,22 +24,44 @@ export const CODE_RE = /^\d{6}$/;
 
 /**
  * Validate the /pair/qr.png query. Returns
- *   { ok: true, payload: "manta://pair?box=<box>&code=<code>" }
+ *   { ok: true, payload: "manta://pair?box=<box>&code=<code>[&server=<url>]" }
  * or
  *   { ok: false, error: <string> }.
  * Box is lowercased before validation (hostnames arrive case-insensitive).
+ *
+ * BET-336 (Tailscale pair link): an optional `server` query param is
+ * accepted. When absent or empty, the payload has no `&server=` and the
+ * downstream parser falls through to the public hostname — the same wire
+ * shape pre-BET-336 callers produce. When present, it must pass
+ * `isPrivateServerUrl` (the SAME private/tailnet gate the renderer-side
+ * `parsePairPayload` uses); a public or otherwise non-private value is
+ * refused outright with an error — a pair link that points the device at
+ * a non-private host is exactly the "crafted link → attacker's server"
+ * attack the gate prevents.
  */
 export function validatePairQrQuery(query) {
   const box =
     typeof query?.box === "string" ? query.box.trim().toLowerCase() : "";
   const code = typeof query?.code === "string" ? query.code.trim() : "";
+  const server =
+    typeof query?.server === "string" ? query.server.trim() : "";
   if (!HEX32_RE.test(box)) {
     return { ok: false, error: "box must be a 32-char lowercase hex id" };
   }
   if (!CODE_RE.test(code)) {
     return { ok: false, error: "code must be exactly 6 digits" };
   }
-  return { ok: true, payload: `manta://pair?box=${box}&code=${code}` };
+  let payload = `manta://pair?box=${box}&code=${code}`;
+  if (server !== "") {
+    if (!isPrivateServerUrl(server)) {
+      return {
+        ok: false,
+        error: "server must be a private/tailnet http(s) URL",
+      };
+    }
+    payload += `&server=${encodeURIComponent(server)}`;
+  }
+  return { ok: true, payload };
 }
 
 /** Render the QR PNG for a validated payload. */

--- a/src/server/pairPage.test.mjs
+++ b/src/server/pairPage.test.mjs
@@ -106,6 +106,64 @@ test("validatePairQrQuery rejects non-string fields", () => {
 });
 
 // ---------------------------------------------------------------------------
+// validatePairQrQuery — server= param (BET-336, Tailscale pair link)
+// ---------------------------------------------------------------------------
+
+test("validatePairQrQuery without a server param returns the unchanged payload (BET-336, public path)", () => {
+  // Pre-BET-336 wire shape — must stay unchanged so existing QR consumers
+  // keep working.
+  const r = validatePairQrQuery({ box: HEX32, code: "847291" });
+  assert.equal(r.ok, true);
+  assert.equal(r.payload, `manta://pair?box=${HEX32}&code=847291`);
+  assert.equal(r.payload.includes("server="), false);
+});
+
+test("validatePairQrQuery appends &server=<encoded> for a private URL (BET-336, tailscale path)", () => {
+  const r = validatePairQrQuery({
+    box: HEX32,
+    code: "847291",
+    server: "http://100.64.1.5:8787",
+  });
+  assert.equal(r.ok, true);
+  assert.equal(
+    r.payload,
+    `manta://pair?box=${HEX32}&code=847291&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+  );
+});
+
+test("validatePairQrQuery accepts .ts.net and 192.168.x servers (BET-336, accepted families)", () => {
+  const r1 = validatePairQrQuery({
+    box: HEX32,
+    code: "847291",
+    server: "https://mybox.ts.net",
+  });
+  assert.equal(r1.ok, true);
+  assert.equal(
+    r1.payload,
+    `manta://pair?box=${HEX32}&code=847291&server=${encodeURIComponent("https://mybox.ts.net")}`,
+  );
+  const r2 = validatePairQrQuery({
+    box: HEX32,
+    code: "847291",
+    server: "http://192.168.1.10:8787",
+  });
+  assert.equal(r2.ok, true);
+});
+
+test("validatePairQrQuery rejects a PUBLIC server URL (BET-336, crafted-link guard)", () => {
+  // The whole payload must be refused — NOT silently dropped and emitted
+  // without &server= (that fallback would make the link resolve to a
+  // public host, which is exactly the attack vector the gate prevents).
+  const r = validatePairQrQuery({
+    box: HEX32,
+    code: "847291",
+    server: "https://attacker.example.com",
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /private\/tailnet/);
+});
+
+// ---------------------------------------------------------------------------
 // renderPairQr — produces a valid PNG buffer
 // ---------------------------------------------------------------------------
 

--- a/src/shared/transport.d.mts
+++ b/src/shared/transport.d.mts
@@ -37,6 +37,17 @@ export function resolveTransportMode(
 // Validate + normalize the JSON body of a POST /auth/claim response.
 export function parseClaimResponse(json: unknown): ClaimResult;
 
+// True iff `raw` is an http(s) URL whose host is a private / tailnet
+// address — `localhost`, IPv4 in 10/8, 172.16/12, 192.168/16, 100.64/10
+// (Tailscale CGNAT), 127/8, or any `.ts.net` hostname. Accepts ONLY this
+// set on purpose — a pairing link may carry the box's listener URL, but
+// the URL must point at the user's own network (where an attacker has
+// better options than a pair link). Public IPv4, all IPv6 literals, and
+// non-http(s) schemes are explicitly rejected. Single source of truth —
+// every consumer in pairPayload / pair.html / pairPage.mjs / install-lib
+// imports THIS function. See transport.mjs for the rule + ranges.
+export function isPrivateServerUrl(raw: unknown): raw is string;
+
 // Which client the DESKTOP should install as window.api (BET-58):
 //   "http"    — paired config → the httpApi server client (keep preload for
 //               Electron-local affordances under window.__mantaPreload)

--- a/src/shared/transport.mjs
+++ b/src/shared/transport.mjs
@@ -106,6 +106,92 @@ export function desktopHttpClientSeed(config) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Private-network server-URL gate (BET-336 — Tailscale pair-link carry).
+// ---------------------------------------------------------------------------
+//
+// The pairing link `manta://pair?box=&code=&server=` may carry the box's
+// listener URL so a Tailscale box (no public hostname) can ship a
+// one-click / QR pair link. The risk: a crafted link could point the app at
+// an attacker's server. Mitigation: the link-supplied URL must be a
+// PRIVATE / tailnet address — anything reachable from inside the user's own
+// network, where an attacker already has better options than a pair link.
+// This is consistent with how these boxes already work: plain HTTP inside
+// the WireGuard tunnel, where the network IS the trust boundary.
+//
+// Accepted host families (single source of truth — every consumer in
+// parsePairPayload, pair.html, pairPage.mjs, and scripts/install-lib.mjs
+// imports THIS function; do not copy the ranges elsewhere or the rule will
+// silently drift):
+//   • localhost
+//   • IPv4 in 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC 1918 private)
+//   • IPv4 in 100.64.0.0/10 (CGNAT — the range Tailscale allocates from)
+//   • IPv4 in 127.0.0.0/8 (loopback, in case the box is the same machine)
+//   • hostnames ending in .ts.net (Tailscale MagicDNS)
+//
+// Explicitly REJECTED:
+//   • any other IPv4 (public addresses — they have a real public hostname
+//     path, never need this link-supplied override)
+//   • all IPv6 literals (out of scope — rejecting them is the intended
+//     behaviour, not an oversight)
+//   • non-http(s) schemes (file://, ftp://, ws://, …)
+//   • unparseable input, non-string input, bare hosts with no scheme
+//
+// Returns true only when the input parses as an http(s) URL AND its host
+// is in one of the accepted families above. Pure; no I/O.
+//
+// IPv4 ranges are checked by parsing the dotted-quad ourselves (four
+// integer octets, each 0–255) — no dependency, no library; mirrors the
+// hand-rolled shape-gates elsewhere in this file (isValidBoxToken).
+export function isPrivateServerUrl(raw) {
+  if (typeof raw !== "string" || raw === "") return false;
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const host = url.hostname;
+  if (host === "") return false;
+  if (host === "localhost") return true;
+  if (host.endsWith(".ts.net")) return true;
+  return isPrivateIPv4(host);
+}
+
+// True iff `host` is a dotted-quad IPv4 in one of the accepted ranges.
+// Returns false for IPv6 literals, hostnames, and dotted-quads outside the
+// private/CGNAT/loopback ranges. Public IPv4 → false (those have their own
+// boxes.mantaui.com hostname path; the link-supplied override must never
+// reach them).
+function isPrivateIPv4(host) {
+  const parts = host.split(".");
+  if (parts.length !== 4) return false;
+  const octets = new Array(4);
+  for (let i = 0; i < 4; i++) {
+    const p = parts[i];
+    if (p.length === 0 || p.length > 3) return false;
+    // No leading zeros — "01" is not a valid IPv4 octet per WHATWG URL
+    // parser semantics and we want consistent rejection.
+    if (p.length > 1 && p[0] === "0") return false;
+    const n = Number(p);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return false;
+    octets[i] = n;
+  }
+  const [a, b] = octets;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 127.0.0.0/8 (loopback)
+  if (a === 127) return true;
+  // 172.16.0.0/12 (172.16 – 172.31)
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 (CGNAT — Tailscale allocates from here)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
 // Validate + normalize the JSON body of a successful POST /auth/claim response.
 // The server returns { ok, box_token, box_id } (see src/server/auth.mjs claim()).
 // We only trust it once BOTH tokens match the 32-hex shape — a wrong shape means

--- a/src/shared/transport.test.ts
+++ b/src/shared/transport.test.ts
@@ -7,6 +7,7 @@ import {
   parseClaimResponse,
   selectDesktopTransport,
   desktopHttpClientSeed,
+  isPrivateServerUrl,
 } from "./transport.mjs";
 
 // A well-formed 32-lowercase-hex token (128 bits).
@@ -188,5 +189,124 @@ describe("desktopHttpClientSeed (BET-58)", () => {
   it("returns null for non-object input", () => {
     expect(desktopHttpClientSeed(null)).toBeNull();
     expect(desktopHttpClientSeed("x" as never)).toBeNull();
+  });
+});
+
+describe("isPrivateServerUrl (BET-336 — Tailscale pair-link gate)", () => {
+  // Accepted host families (the rule lives in transport.mjs — these tests
+  // PIN the wire shape, not the algorithm). Every accepted case MUST come
+  // from one of the named ranges; any drift here is a security regression
+  // because the gate protects a user from a crafted pair link pointing the
+  // app at an attacker's server.
+  describe("accepts private / tailnet hosts", () => {
+    it("localhost (http + https)", () => {
+      expect(isPrivateServerUrl("http://localhost")).toBe(true);
+      expect(isPrivateServerUrl("http://localhost:8787")).toBe(true);
+      expect(isPrivateServerUrl("https://localhost")).toBe(true);
+    });
+    it("RFC 1918: 10.0.0.0/8", () => {
+      expect(isPrivateServerUrl("http://10.0.0.0")).toBe(true);
+      expect(isPrivateServerUrl("http://10.255.255.255")).toBe(true);
+      expect(isPrivateServerUrl("https://10.1.2.3:8787")).toBe(true);
+    });
+    it("RFC 1918: 172.16.0.0/12 (172.16 – 172.31)", () => {
+      expect(isPrivateServerUrl("http://172.16.0.1")).toBe(true);
+      expect(isPrivateServerUrl("http://172.31.255.255")).toBe(true);
+      expect(isPrivateServerUrl("https://172.20.10.5:8787")).toBe(true);
+    });
+    it("RFC 1918: 192.168.0.0/16", () => {
+      expect(isPrivateServerUrl("http://192.168.0.1")).toBe(true);
+      expect(isPrivateServerUrl("http://192.168.255.255")).toBe(true);
+      expect(isPrivateServerUrl("https://192.168.1.10:8787")).toBe(true);
+    });
+    it("CGNAT / Tailscale: 100.64.0.0/10 (100.64 – 100.127)", () => {
+      expect(isPrivateServerUrl("http://100.64.0.0")).toBe(true);
+      expect(isPrivateServerUrl("http://100.127.255.255")).toBe(true);
+      expect(isPrivateServerUrl("https://100.100.100.100:8787")).toBe(true);
+    });
+    it("loopback: 127.0.0.0/8", () => {
+      expect(isPrivateServerUrl("http://127.0.0.1")).toBe(true);
+      expect(isPrivateServerUrl("http://127.255.255.254")).toBe(true);
+      expect(isPrivateServerUrl("https://127.0.0.1:8787")).toBe(true);
+    });
+    it("Tailscale MagicDNS (.ts.net)", () => {
+      expect(isPrivateServerUrl("https://box.tail-net.ts.net")).toBe(true);
+      expect(isPrivateServerUrl("http://mybox.ts.net:8787")).toBe(true);
+    });
+  });
+
+  describe("rejects everything outside the accepted set", () => {
+    it("rejects a public IPv4 (must NOT be accepted — the link-supplied override is for tailnet only)", () => {
+      expect(isPrivateServerUrl("http://8.8.8.8")).toBe(false);
+      expect(isPrivateServerUrl("https://1.1.1.1")).toBe(false);
+      expect(isPrivateServerUrl("http://93.184.216.34:8787")).toBe(false);
+    });
+    it("rejects a public hostname", () => {
+      expect(isPrivateServerUrl("https://example.com")).toBe(false);
+      expect(isPrivateServerUrl("https://google.com:8787")).toBe(false);
+      expect(isPrivateServerUrl("https://boxes.mantaui.com")).toBe(false);
+    });
+    it("rejects all IPv6 literals (out of scope — rejecting them is the intended behaviour)", () => {
+      expect(isPrivateServerUrl("http://[::1]")).toBe(false);
+      expect(isPrivateServerUrl("https://[fe80::1]:8787")).toBe(false);
+      expect(isPrivateServerUrl("https://[2001:db8::1]")).toBe(false);
+    });
+    it("rejects a bare host with no scheme (not parseable as http(s) URL)", () => {
+      expect(isPrivateServerUrl("100.64.1.5:8787")).toBe(false);
+      expect(isPrivateServerUrl("box.ts.net")).toBe(false);
+      expect(isPrivateServerUrl("192.168.1.1")).toBe(false);
+    });
+    it("rejects non-http(s) schemes", () => {
+      expect(isPrivateServerUrl("ftp://192.168.1.1")).toBe(false);
+      expect(isPrivateServerUrl("file:///etc/passwd")).toBe(false);
+      expect(isPrivateServerUrl("ws://192.168.1.1:8787")).toBe(false);
+      expect(isPrivateServerUrl("javascript:alert(1)")).toBe(false);
+      expect(isPrivateServerUrl("manta://pair?server=100.64.1.5")).toBe(false);
+    });
+    it("rejects 172.15.x / 172.32.x (just outside /12)", () => {
+      expect(isPrivateServerUrl("http://172.15.255.255")).toBe(false);
+      expect(isPrivateServerUrl("http://172.32.0.0")).toBe(false);
+    });
+    it("rejects 100.63.x / 100.128.x (just outside /10)", () => {
+      expect(isPrivateServerUrl("http://100.63.255.255")).toBe(false);
+      expect(isPrivateServerUrl("http://100.128.0.0")).toBe(false);
+    });
+    it("rejects malformed / out-of-range octets in otherwise plausible hosts", () => {
+      // These are all rejected at URL-parse time (WHATWG URL parser refuses
+      // to construct them) so the function returns false without ever
+      // inspecting the hostname.
+      expect(isPrivateServerUrl("http://10.300.1.1")).toBe(false);
+      expect(isPrivateServerUrl("http://10.1.1.256")).toBe(false);
+      expect(isPrivateServerUrl("http://10.1.1.1.1")).toBe(false); // 5 octets
+      expect(isPrivateServerUrl("http://10..0.1")).toBe(false); // empty octet
+    });
+    it("rejects a URL whose IPv4 octet uses a leading zero (octal-bypass guard)", () => {
+      // The WHATWG URL parser NORMALIZES leading-zero IPv4 octets as
+      // octal — `010` becomes the integer `8` and `http://010.0.0.1`
+      // resolves to the public host `http://8.0.0.1`. The function must
+      // reject this — the host `8.0.0.1` is not in any accepted range,
+      // so a public address sneaks past our private gate. Pin the guard.
+      expect(isPrivateServerUrl("http://010.0.0.1")).toBe(false);
+    });
+    it("accepts 127.0.0.1/8 — including the URL-parse-normalized octal form (127/8 is a loopback range, in scope)", () => {
+      // Documented quirk: `http://0177.0.0.1` is normalized by the URL
+      // parser to `http://127.0.0.1` (octal 177 → 127), which IS in the
+      // loopback range and intentionally accepted (127.0.0.0/8 is one
+      // of the families we accept, so the box-on-localhost path stays
+      // one-click).
+      expect(isPrivateServerUrl("http://0177.0.0.1")).toBe(true);
+    });
+    it("rejects unparseable input", () => {
+      expect(isPrivateServerUrl("::::not a url::::")).toBe(false);
+      expect(isPrivateServerUrl("hello world")).toBe(false);
+    });
+    it("rejects non-string input", () => {
+      expect(isPrivateServerUrl(null as never)).toBe(false);
+      expect(isPrivateServerUrl(undefined as never)).toBe(false);
+      expect(isPrivateServerUrl(123 as never)).toBe(false);
+      expect(isPrivateServerUrl({} as never)).toBe(false);
+      expect(isPrivateServerUrl([] as never)).toBe(false);
+      expect(isPrivateServerUrl("" as string)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
**Base:** `origin/main @ 14fdc69`

Tailscale boxes have no public hostname, so today the install heredoc
suppresses the `manta://pair?…` deep link and the `/pair` page's QR
encodes a link that would resolve to a host that doesn't exist. This
lets the link carry the box's listener URL — but only when that URL
points inside the user's own network (RFC 1918, loopback, Tailscale
CGNAT 100.64/10, `.ts.net` MagicDNS, `localhost`). A crafted link
pointing at an attacker's server is refused outright.

### Changes

- New `isPrivateServerUrl` predicate in `src/shared/transport.mjs` —
  single source of truth for the accepted ranges; every consumer
  imports it.
- `parsePairPayload` accepts a validated `server=` param.
- `deepLink.ts` drops its private `buildClaimInput` /
  `resolveServerUrl` duplicates in favour of the existing
  `setupLogic` helpers (`buildSetupClaimInput`, `resolveSetupServerUrl`).
- `pair.html` emits `&server=` in the link + QR on a non-public
  origin (`!/\.boxes\.mantaui\.com$/.test(location.hostname)`).
- `pairPage.mjs` `validatePairQrQuery` accepts `server`, gated by the
  same predicate.
- `install-lib.mjs` `buildPairLink` now takes an optional `serverUrl`
  and validates it; `formatPairingOutput` collapses the public/tailnet
  fork to one path (one fewer inner branch).
- `PairStep` pre-fills `serverUrl` from the deep link and opens the
  Advanced section by default so the user sees the address they're
  about to pair against before clicking Connect.
- Tests cover all the new branches + the public-hostname refusal.

### Verification

- `npm run typecheck` — green.
- `npm test` — green: **971 pass, 0 fail, 41 suites** (was 957 pass,
  added 14 new tests for the new branches).
- Verification snippet from the issue:
  ```
  $ node -e 'import("./scripts/install-lib.mjs").then(m=>console.log(m.formatPairingOutput({pairing_code:"123456",box_id:"0123456789abcdef0123456789abcdef",serverUrl:"http://100.64.1.5:8787"})))'
  …
       Pair page:     http://100.64.1.5:8787/pair#box=0123456789abcdef0123456789abcdef&code=123456
       manta://pair?box=0123456789abcdef0123456789abcdef&code=123456&server=http%3A%2F%2F100.64.1.5%3A8787
  ```
  The deep link line carries `&server=http%3A%2F%2F100.64.1.5%3A8787`
  and round-trips through `parsePairPayload` to a payload whose
  `serverUrl` is `http://100.64.1.5:8787`.

### Threat model (per spec)

The link-supplied server URL is gated by `isPrivateServerUrl`. A
link carrying a public address is REFUSED outright — the parser
returns `null` for the whole payload, never silently drops the param
and falls back to the public hostname. That fallback is exactly the
"crafted link points the app at an attacker server" attack the gate
prevents.