### PR TITLE
refactor(server): getDefaultModel reuses getProviders() (BET-320)

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -841,19 +841,19 @@ export async function rejectQuestion({ requestId, sessionId }) {
 
 /**
  * Get the default model from the first connected provider.
+ * Single source of truth for live provider state is `getProviders()`
+ * (BET-318). Keeping the inline `GET /provider` fetch out of here
+ * eliminates the latent drift trap between this caller and the
+ * `opencode:provider-auth` `status` action.
+ *
+ * Returns `null` when opencode is unreachable, returns a non-2xx,
+ * or when no connected provider has a default model recorded.
  * @returns {Promise<{ providerID: string, modelID: string }|null>}
  */
 export async function getDefaultModel() {
-  const res = await ocFetch(apiUrl("/provider"));
-  if (!res.ok) {
-    await discardBody(res);
-    return null;
-  }
-  const data = await res.json();
-  const connected = data.connected ?? [];
-  const defaults = data.default ?? {};
+  const { connected, default: defaults } = await getProviders();
   for (const id of connected) {
-    const modelID = defaults[id];
+    const modelID = defaults?.[id];
     if (modelID) return { providerID: id, modelID };
   }
   return null;

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -29,6 +29,7 @@ import {
   _pooledOcRequest,
   discardBody,
   getProviders,
+  getDefaultModel,
 } from "./opencode.mjs";
 
 test("apiUrl targets local opencode port 4096", () => {
@@ -749,6 +750,104 @@ test("getProviders coerces a non-array connected[] to []", async () => {
     async () => {
       const out = await getProviders();
       assert.deepEqual(out.connected, []);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultModel — picks the first connected provider with a default model.
+//
+// BET-320 follow-up: getDefaultModel used to inline its own `GET /provider`
+// fetch alongside `getProviders()`. The two paths were byte-identical for any
+// 2xx opencode response, but a future drift in defensive handling between
+// them would be a silent bug. The refactor routes getDefaultModel through
+// getProviders() so there is exactly one fetch site for /provider.
+// ---------------------------------------------------------------------------
+
+test("getDefaultModel returns the first connected provider's default", async () => {
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic", "openai"],
+          default: { anthropic: "claude-sonnet-4-6", openai: "gpt-5" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      assert.deepEqual(
+        await getDefaultModel(),
+        { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      );
+    },
+  );
+});
+
+test("getDefaultModel returns null when no connected provider has a default", async () => {
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic", "openai"],
+          default: {},
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      assert.equal(await getDefaultModel(), null);
+    },
+  );
+});
+
+test("getDefaultModel skips connected providers with no recorded default", async () => {
+  // anthropic is connected but has no default; openai does. We expect
+  // openai's model — proves we iterate, not just take the first key.
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic", "openai"],
+          default: { openai: "gpt-5" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      assert.deepEqual(
+        await getDefaultModel(),
+        { providerID: "openai", modelID: "gpt-5" },
+      );
+    },
+  );
+});
+
+test("getDefaultModel returns null on a non-2xx response", async () => {
+  await withMockFetch(
+    async () => new Response("server gone", { status: 503 }),
+    async () => {
+      assert.equal(await getDefaultModel(), null);
+    },
+  );
+});
+
+test("getDefaultModel returns null on a transport throw (never re-throws)", async () => {
+  await withMockFetch(
+    async () => { throw new Error("ECONNREFUSED"); },
+    async () => {
+      assert.equal(await getDefaultModel(), null);
+    },
+  );
+});
+
+test("getDefaultModel returns null when default is missing from the payload", async () => {
+  // `default` field absent — getProviders() returns { connected, default: undefined }.
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({ connected: ["anthropic"] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      assert.equal(await getDefaultModel(), null);
     },
   );
 });


### PR DESCRIPTION
## Summary

BET-318 added `getProviders()` as the single source of truth for live provider state from opencode's `GET /provider`. `getDefaultModel` still inlined its own fetch of the same endpoint — byte-identical today, but a silent drift trap the next time either path's defensive handling changed.

Route `getDefaultModel` through `getProviders()` and adjust the inner loop to the new shape (`default` may be `undefined`). Behavior is identical for any 2xx response opencode produces today; transport throws now yield `null` instead of propagating, matching `getProviders()`'s design as the safe single source of truth.

Base: `origin/main` @ `0ec375f`

## Files changed

`2` files, +108 / −9.

```
 src/server/opencode.mjs      | 16 +++++++++-------
 src/server/opencode.test.mjs | 101 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
```

## Verification results

- PR branch (`multica/BET-320-reuse-getproviders-in-getdefaultmodel` @ `6e03fbb`):
  - typecheck: exit `0`. Errors: none. log sha256: `c8bdf13fabf2e30a13dc1ee14650c4435b0db109f0ca4816045eccb4877901a3`
  - test: exit `0`, `977` pass / `0` fail / `0` skip (+6 from main's 971, from the new `getDefaultModel` cases). log sha256: `9ee310072bb5972b3a2839f6647d3b7e17da7f6e5f11c0ce16b9f1399b56376d`
- Base (`main` @ `0ec375f`):
  - typecheck: exit `0`. Errors: none. log sha256: `c8bdf13fabf2e30a13dc1ee14650c4435b0db109f0ca4816045eccb4877901a3`
  - test: exit `0`, `971` pass / `0` fail / `0` skip. log sha256: `55da5a9a777e700d4035bd3742a3ef21cf4ed14dc8462e83cf66aa40d432d9d5`
- **Conclusion:** 0 pre-existing failures, 0 new failures, 6 new tests added.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

## Notes on the grep acceptance criterion

The issue's acceptance says `grep "apiUrl.*/provider" src/server/opencode.mjs` returns **one** match. After this PR it returns **5** matches:

```
876:    const res = await ocFetch(apiUrl("/provider"));              // getProviders  (the named single source of truth)
901:    const res = await ocFetch(apiUrl("/provider"));              // listModels   (separate caller, separate shape)
969:    const res = await ocFetch(apiUrl("/provider/auth"));         // provider auth flow (different path entirely)
991:    const res = await ocFetch(apiUrl(`/provider/.../oauth/...`); // OAuth start
1021:    const res = await ocFetch(apiUrl(`/provider/.../oauth/...`); // OAuth callback
```

The regex `apiUrl.*/provider` matches `apiUrl("/provider")`, `apiUrl("/provider/auth")`, and `apiUrl(`/provider/...`)` alike. The issue's "one match" was over-stated — the only way to satisfy it literally would be to also refactor `listModels` and the auth-flow endpoints. `listModels` is a genuine sibling of `getDefaultModel` (same drift trap) and should be folded in next; the auth flows are intentionally distinct paths. Calling this out so the reviewer knows the divergence is between the issue's stated criterion and reality, not a missed fix on my part.

## Follow-ups

- `listModels` (line 901) still inlines its own `GET /provider` fetch using the same `data.connected` + `data.all` shape that `getProviders()` exposes. Same drift trap, same fix. Out of scope for the surgical BET-320 follow-up, parked as a sibling issue.

Refs BET-320 (this), BET-318 (parent fix), BET-308 (subscription providers epic).