### PR TITLE
refactor(server): listModels reuses getProviders() (BET-342)

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -893,23 +893,21 @@ export async function getProviders() {
 /**
  * List all models from CONNECTED providers only.
  * Strips raw API keys by reconstructing the model shape (normalizeProviderModel).
+ * Routes through `getProviders()` so the live `/provider` fetch lives in
+ * exactly one place (BET-342 — sibling of BET-320 for `getDefaultModel`).
  * @returns {Promise<Array<{ id: string, providerID: string, name: string, ... }>>}
  */
 export async function listModels() {
   const out = [];
   try {
-    const res = await ocFetch(apiUrl("/provider"));
-    if (res.ok) {
-      const data = await res.json();
-      const connected = new Set(data.connected ?? []);
-      for (const p of data.all ?? []) {
-        if (!p.id || !connected.has(p.id)) continue;
-        for (const modelId of Object.keys(p.models ?? {})) {
-          out.push(_normalizeProviderModel(p.id, modelId, (p.models ?? {})[modelId]));
-        }
+    const { connected: connectedIds, all } = await getProviders();
+    if (!Array.isArray(all)) return out;
+    const connected = new Set(connectedIds);
+    for (const p of all) {
+      if (!p.id || !connected.has(p.id)) continue;
+      for (const modelId of Object.keys(p.models ?? {})) {
+        out.push(_normalizeProviderModel(p.id, modelId, (p.models ?? {})[modelId]));
       }
-    } else {
-      await discardBody(res);
     }
   } catch {
     /* non-fatal */

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -30,6 +30,7 @@ import {
   discardBody,
   getProviders,
   getDefaultModel,
+  listModels,
 } from "./opencode.mjs";
 
 test("apiUrl targets local opencode port 4096", () => {
@@ -853,6 +854,86 @@ test("getDefaultModel returns null when default is missing from the payload", as
 });
 
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// listModels — flattens connected providers into a normalized model list.
+//
+// BET-342 follow-up: listModels used to inline its own `GET /provider` fetch
+// alongside `getProviders()`. The two paths were byte-identical for any 2xx
+// opencode response, but a future drift in defensive handling between them
+// would be a silent bug. The refactor routes listModels through
+// getProviders() so there is exactly one fetch site for /provider.
+// ---------------------------------------------------------------------------
+
+test("listModels returns normalized models for every connected provider", async () => {
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic", "openai"],
+          all: [
+            {
+              id: "anthropic",
+              models: {
+                "claude-sonnet-4-6": { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+              },
+            },
+            {
+              id: "openai",
+              models: {
+                "gpt-5": { id: "gpt-5", name: "GPT-5" },
+              },
+            },
+            {
+              id: "deepseek",
+              models: { "deepseek-chat": { id: "deepseek-chat" } },
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      const out = await listModels();
+      const ids = out.map((m) => `${m.providerID}/${m.id}`).sort();
+      // deepseek is in `all` but not in `connected` → must be filtered out.
+      assert.deepEqual(ids, ["anthropic/claude-sonnet-4-6", "openai/gpt-5"]);
+      const anthropic = out.find((m) => m.providerID === "anthropic");
+      assert.equal(anthropic.name, "Claude Sonnet 4.6");
+      const openai = out.find((m) => m.providerID === "openai");
+      assert.equal(openai.name, "GPT-5");
+    },
+  );
+});
+
+test("listModels returns [] when no providers are connected", async () => {
+  // `connected` empty → every provider in `all` is filtered out → empty out.
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: [],
+          all: [
+            { id: "anthropic", models: { "claude-sonnet-4-6": { id: "claude-sonnet-4-6" } } },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      const out = await listModels();
+      assert.deepEqual(out, []);
+    },
+  );
+});
+
+test("listModels returns [] on a transport throw (never re-throws)", async () => {
+  await withMockFetch(
+    async () => { throw new Error("ECONNREFUSED"); },
+    async () => {
+      const out = await listModels();
+      assert.deepEqual(out, []);
+    },
+  );
+});
+
 // Scoped-stream readiness gate (BET-115 fix C)
 //
 // sendPrompt (via getSessionDirectoryQuery) must not POST to opencode before


### PR DESCRIPTION
BET-342 closes the second half of the BET-318 drift trap. BET-320 (PR #289, merged at `5449aa6`) routes `getDefaultModel` through `getProviders()`; this PR routes `listModels` through the same. After this PR lands, the bare `GET /provider` call lives in exactly one place — `getProviders()`.

**Files changed:** 2 files. `src/server/opencode.mjs` (+9 / -11), `src/server/opencode.test.mjs` (+81).

`git diff --stat origin/main...HEAD`:
```
 src/server/opencode.mjs      | 20 +++++------
 src/server/opencode.test.mjs | 81 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 90 insertions(+), 11 deletions(-)
```

**Base:** `origin/main @ 5449aa6` (post-BET-320 merge). Rebased from prior base `0ec375f`; trivial test-file conflict resolved by keeping both BET-320's `getDefaultModel` section and BET-342's `listModels` section.

**Acceptance:**
- `grep -F 'apiUrl("/provider")' src/server/opencode.mjs` → **1 match** (`getProviders`, line 876). ✅ Both halves of the BET-318 drift trap closed.
- `listModels` had no existing tests; added 3 cases: 2xx with connected + unconnected providers (verifies filtering + normalization), 2xx with empty `connected[]`, transport throw → `[]`.
- `npm run typecheck && npm test` green on both branches.

**Verification results:**
- PR branch (`multica/BET-342-listmodels-reuse-getproviders` @ `d2c6155`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, **980** pass / **0** fail / 0 skip. (971 base + 6 BET-320 `getDefaultModel` + 3 BET-342 `listModels`. New tests `listModels returns normalized models for every connected provider`, `listModels returns [] when no providers are connected`, `listModels returns [] on a transport throw (never re-throws)`.)
- Base (`main` @ `5449aa6`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, **977** pass / **0** fail / 0 skip.
- **Conclusion:** 0 pre-existing failures. 0 new failures. +3 new tests from this PR.

**CI:**
- typecheck-test: PASS (the ONLY required check per `.github/workflows/required-checks.json`)
- E2E Smoke Test: PASS
- duplication-gate: FAIL (advisory, non-blocking — see note below)

**Note on duplication-gate:** the 4 clones jscpd flagged are all in pre-existing test scaffolding (`createSession`, `readiness gate: sendPrompt does not POST`, `subscribeEvents eagerly opens scoped streams` × 2). None of them involve the new `listModels` tests, and none share business logic — they're the same `withMockFetch(Response(JSON.stringify({...})), async () => {...})` pattern that the file uses for ~50+ other tests. Same pattern BET-320 hit; the reviewer (`antoinedc`) marked it "discounted — see Nit 2" and merged. Following the same precedent here. The `required-checks.json` commentary explicitly says duplication-gate "was de-required 2026-07-02 (flaky at token boundaries, blocked BET-57/PR#27, and agents cannot rerun CI)." Reassigning to PM for merge.