### PR TITLE
Terminal: add tmux-attach spawn primitive (tmuxTarget) to the pty layer (BET-346)

### DIFF
--- a/src/server/pty.mjs
+++ b/src/server/pty.mjs
@@ -19,6 +19,7 @@
 import { spawn as ptySpawnNative } from "node-pty";
 import { expandTilde } from "../shared/paths.mjs";
 import { findLauncher } from "./launcherRegistry.mjs";
+import { tmuxSpawnEnv } from "./tmux.mjs";
 
 // Single-quote a token so it survives a `$SHELL -lc "<cmd>"` re-parse intact.
 // Bin names + registry flags are trusted (no user input), but quoting keeps
@@ -28,17 +29,55 @@ export function shellQuote(token) {
   return `'${String(token).replace(/'/g, `'\\''`)}'`;
 }
 
+// Decide what to exec for a pty. Pure — returns { file, args }; the caller
+// does the spawning. Exported for testing so the three-way branch can be
+// pinned without a live node-pty. `shell` is injected (defaults to the
+// server's `$SHELL` or "bash") so tests don't depend on the host env.
+//
+// Branches (in priority order):
+//   1. tmuxTarget set      → `tmux attach-session -t <target>`. Wins over
+//                            any `launcher`; attaching is not a launcher
+//                            choice (BET-346).
+//   2. launcher with a     → `$SHELL -lc "<bin> [args…]>"`. Reproduces the
+//      registered def         login-shell PATH the availability probe saw
+//                            so AI CLIs at ~/.local/bin/ are reachable.
+//   3. fallback            → `$SHELL -l`. Plain interactive login shell.
+//                            Unknown launcher ids fall through here too.
+export function resolvePtyCommand({ launcher, tmuxTarget, shell }) {
+  const effectiveShell = shell || process.env.SHELL || "bash";
+  if (tmuxTarget) {
+    return { file: "tmux", args: ["attach-session", "-t", tmuxTarget] };
+  }
+  if (launcher && launcher.id) {
+    const def = findLauncher(launcher.id);
+    if (def) {
+      const args = def.buildArgs(launcher.flags || {});
+      const cmd = [def.bin, ...args].map(shellQuote).join(" ");
+      return { file: effectiveShell, args: ["-l", "-c", cmd] };
+    }
+    // Unknown launcher id -> fall through to a plain shell.
+  }
+  return { file: effectiveShell, args: ["-l"] };
+}
+
 // ---------- shared low-level spawn helper ----------
 //
-// Spawns either a login shell (no launcher) OR an AI CLI TUI (launcher given)
-// in `cwd`. Ephemeral, no tmux. Returns the raw IPty object. Does NOT
-// register it in the registry below.
+// Spawns one of three things (decided by resolvePtyCommand):
+//   - `tmux attach-session -t <target>` for a window Manta didn't create
+//     (tmuxTarget).
+//   - a login shell launching an AI CLI TUI (launcher with a registered def).
+//   - a plain interactive login shell (base "terminal" mode).
 //
-// opts: { cwd, cols, rows, launcher? }
+// Ephemeral, no scrollback recovery — the PTY dies with whatever it spawned.
+// Returns the raw IPty object. Does NOT register it in the registry below.
+//
+// opts: { cwd, cols, rows, launcher?, tmuxTarget? }
 // launcher, if given: { id: string, flags?: Record<string, boolean> }.
+// tmuxTarget, if given: "<session>:<windowIndex>" — the exact format
+//   killWindow/selectWindow/renameWindow in src/server/tmux.mjs already use.
 // Unknown launcher ids fall through to a plain shell (defensive — e.g. a
 // stale localStorage mode referencing a launcher that no longer exists).
-export function spawnShellPty({ cwd, cols, rows, launcher }) {
+export function spawnShellPty({ cwd, cols, rows, launcher, tmuxTarget }) {
   const dir = expandTilde(cwd && cwd.trim() ? cwd : "~");
   const size = {
     name: "xterm-256color",
@@ -49,38 +88,25 @@ export function spawnShellPty({ cwd, cols, rows, launcher }) {
   };
 
   const shell = process.env.SHELL || "bash";
+  const { file, args } = resolvePtyCommand({ launcher, tmuxTarget, shell });
 
-  if (launcher && launcher.id) {
-    const def = findLauncher(launcher.id);
-    if (def) {
-      const args = def.buildArgs(launcher.flags || {});
-      // Run the CLI through a LOGIN shell (`$SHELL -lc "<cmd>"`), NOT a bare
-      // execFile of the binary. The availability probe in launchers.mjs uses
-      // `command -v` inside a login shell, so a launcher only ever appears in
-      // the dropdown when it resolves in the interactive PATH (claude lives at
-      // ~/.local/bin/claude, which is NOT on the systemd --user service PATH).
-      // Spawning the bin directly would inherit the server's bare PATH and
-      // exit immediately (127 → surfaced to the user as "[shell exited: 1]").
-      // The login shell reproduces the same PATH the probe saw, so the CLI is
-      // found. When it exits, the login shell exits, so the PTY still dies with
-      // the CLI (ephemeral lifecycle preserved).
-      const cmd = [def.bin, ...args].map(shellQuote).join(" ");
-      return ptySpawnNative(shell, ["-l", "-c", cmd], size);
-    }
-    // Unknown launcher id -> fall through to a plain shell.
-  }
+  // Env is selected per branch (matches the three cases in resolvePtyCommand):
+  //  - tmux attach: tmuxSpawnEnv() supplies the UTF-8 locale tmux needs —
+  //    without it tmux mangles its own -F output under a non-UTF-8 locale
+  //    (see AGENTS.md, "A service gets no LOCALE").
+  //  - login shell with `-lc <cmd>` launcher: non-interactive, so the
+  //    user's rc file cannot trigger an auto-attach block — no
+  //    MANTA_TERMINAL needed.
+  //  - plain interactive login shell: MANTA_TERMINAL=1 so a user's rc
+  //    file can skip a tmux auto-attach block that would otherwise hijack
+  //    this shell into a blank tmux alternate-screen.
+  const env = tmuxTarget
+    ? { ...tmuxSpawnEnv(), TERM: "xterm-256color" }
+    : launcher && launcher.id && findLauncher(launcher.id)
+      ? size.env
+      : { ...size.env, MANTA_TERMINAL: "1" };
 
-  // Plain shell-in-cwd (base "terminal" mode): an interactive LOGIN shell.
-  // MANTA_TERMINAL=1 marks this as a manta embedded terminal so a user's rc file
-  // can skip hostile interactive-login behaviour — notably a tmux auto-attach
-  // block (common in ~/.bashrc), which would otherwise hijack this shell into a
-  // blank tmux alternate-screen and the terminal would look frozen/empty. The
-  // login launcher path above is unaffected: it's `-lc <cmd>` (non-interactive)
-  // so it never triggers such blocks.
-  return ptySpawnNative(shell, ["-l"], {
-    ...size,
-    env: { ...size.env, MANTA_TERMINAL: "1" },
-  });
+  return ptySpawnNative(file, args, { ...size, env });
 }
 
 // ---------- RPC registry ----------
@@ -98,11 +124,11 @@ const ptys = new Map(); // sessionKey → IPty
 
 /**
  * Spawn (or silently reuse) a shell/launcher pty for opts.sessionKey.
- * @param {{ sessionKey: string, cwd: string, cols: number, rows: number, launcher?: { id: string, flags?: Record<string, boolean> } }} opts
+ * @param {{ sessionKey: string, cwd: string, cols: number, rows: number, launcher?: { id: string, flags?: Record<string, boolean> }, tmuxTarget?: string }} opts
  * @param {(e) => void} onEvent
  */
 export function spawn(opts, onEvent) {
-  const { sessionKey, cwd, cols, rows, launcher } = opts;
+  const { sessionKey, cwd, cols, rows, launcher, tmuxTarget } = opts;
   if (!sessionKey) throw new Error("pty:spawn — sessionKey required");
 
   // Mirror desktop: if already exists, do not respawn (avoids disconnect
@@ -111,7 +137,7 @@ export function spawn(opts, onEvent) {
   // (bus.publish, a module singleton).
   if (ptys.has(sessionKey)) return;
 
-  const pty = spawnShellPty({ cwd, cols, rows, launcher });
+  const pty = spawnShellPty({ cwd, cols, rows, launcher, tmuxTarget });
   ptys.set(sessionKey, pty);
 
   pty.onData((data) => {

--- a/src/server/pty.test.mjs
+++ b/src/server/pty.test.mjs
@@ -1,10 +1,11 @@
-// Tests for src/server/pty.mjs pure helpers (BET-138 follow-up). Only
-// shellQuote is unit-testable without a real PTY spawn; the login-shell launch
-// path itself is exercised manually (it requires node-pty + a real binary).
+// Tests for src/server/pty.mjs pure helpers (BET-138 + BET-346). Only
+// shellQuote + resolvePtyCommand are unit-testable without a real PTY spawn;
+// the login-shell launch path itself is exercised manually (it requires
+// node-pty + a real binary).
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { shellQuote } from "./pty.mjs";
+import { shellQuote, resolvePtyCommand } from "./pty.mjs";
 
 describe("shellQuote", () => {
   it("leaves safe tokens unquoted", () => {
@@ -32,3 +33,71 @@ describe("shellQuote", () => {
     assert.equal(shellQuote("it's"), `'it'\\''s'`);
   });
 });
+
+describe("resolvePtyCommand", () => {
+  const SHELL = "bash";
+
+  it("returns the tmux attach-session argv when tmuxTarget is set", () => {
+    // Case 1: plain tmuxTarget → tmux attach-session -t <target>.
+    assert.deepEqual(
+      resolvePtyCommand({ tmuxTarget: "main:0", shell: SHELL }),
+      { file: "tmux", args: ["attach-session", "-t", "main:0"] },
+    );
+  });
+
+  it("wins over launcher when both tmuxTarget and launcher are set", () => {
+    // Case 2: tmuxTarget is set AND launcher is set → tmux still wins.
+    // The renderer/CLI never supply both today, but the priority is locked.
+    assert.deepEqual(
+      resolvePtyCommand({
+        tmuxTarget: "main:1",
+        launcher: { id: "claude", flags: {} },
+        shell: SHELL,
+      }),
+      { file: "tmux", args: ["attach-session", "-t", "main:1"] },
+    );
+  });
+
+  it("returns the login-shell-with-command shape for a registered launcher", () => {
+    // Case 3: launcher set, tmuxTarget absent → unchanged `-l -c <cmd>`
+    // login-shell-with-command behaviour (the existing Claude/Codex path).
+    const out = resolvePtyCommand({
+      launcher: { id: "claude", flags: {} },
+      shell: SHELL,
+    });
+    assert.equal(out.file, SHELL);
+    assert.equal(out.args[0], "-l");
+    assert.equal(out.args[1], "-c");
+    // The actual command string includes the bin; assert it's a string and
+    // mentions the bin (don't pin every argv — the registry may grow).
+    assert.equal(typeof out.args[2], "string");
+    assert.match(out.args[2], /\bclaude\b/);
+  });
+
+  it("returns the plain login shell when neither launcher nor tmuxTarget is set", () => {
+    // Case 4: unchanged plain login shell (the base "terminal" mode).
+    assert.deepEqual(
+      resolvePtyCommand({ shell: SHELL }),
+      { file: SHELL, args: ["-l"] },
+    );
+    // Also: explicit empty launcher (no id) falls through to plain shell.
+    assert.deepEqual(
+      resolvePtyCommand({ launcher: { id: "", flags: {} }, shell: SHELL }),
+      { file: SHELL, args: ["-l"] },
+    );
+  });
+
+  it("falls through to the plain shell for an unknown launcher id", () => {
+    // Case 5: unknown launcher id (stale localStorage mode, deleted registry
+    // entry, typo) → falls through to plain shell — pin the defensive
+    // behaviour that was already there before BET-346.
+    assert.deepEqual(
+      resolvePtyCommand({
+        launcher: { id: "nonexistent-launcher", flags: {} },
+        shell: SHELL,
+      }),
+      { file: SHELL, args: ["-l"] },
+    );
+  });
+});
+

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -599,8 +599,14 @@ export function buildHandlers({ tmux, oc, pty, bus, local, authPair, push, serve
     // attach — keyed by sessionKey (`${opencodeSessionId}:${modeId}`), not
     // projectName. See src/server/pty.mjs.
     //
+    // BET-346: SpawnOptions now also accepts `tmuxTarget?: string`. When
+    // set, the server spawns `tmux attach-session -t <target>` instead,
+    // letting Manta open a pre-existing tmux window (one it did not create).
+    // `tmuxTarget` wins over `launcher`; nothing sets it yet (renderer
+    // follow-up is a separate issue).
+    //
     // IPC.ptySpawn   = "pty:spawn"   preload: ipcRenderer.invoke(IPC.ptySpawn, opts)
-    //   → args[0] = SpawnOptions { sessionKey, cwd, cols, rows, launcher? }
+    //   → args[0] = SpawnOptions { sessionKey, cwd, cols, rows, launcher?, tmuxTarget? }
     //   Side-effect: data/exit events flow to bus as { kind:"pty", payload: PtyEvent }
     //   where PtyEvent = { kind:"data"|"exit", sessionKey, data? / code? }
     //   (matches src/shared/types.ts PtyEvent)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -222,6 +222,13 @@ export type WorktreeInfo = {
 // `${opencodeSessionId}:${modeId}` (modeId = "terminal" or a launcher id from
 // src/server/launcherRegistry.mjs) so Terminal mode and each TUI launcher
 // mode of the same chat session get independent, kept-warm PTYs.
+//
+// BET-346: when `tmuxTarget` is set, the server spawns `tmux attach-session
+// -t <target>` instead — for a window Manta did NOT create (a pre-existing
+// tmux session the user wants to view). Format is `<session>:<windowIndex>`,
+// matching killWindow/selectWindow/renameWindow in src/server/tmux.mjs.
+// `tmuxTarget` wins over `launcher` if both are supplied. Nothing sets this
+// field yet; the renderer follow-up is a separate issue.
 export type SpawnOptions = {
   sessionKey: string; // stable per-session-mode id: see comment above
   cwd: string;        // working dir for the shell/CLI (may be tilde-prefixed)
@@ -229,6 +236,10 @@ export type SpawnOptions = {
   rows: number;
   // Present only for a TUI launch mode (absent = plain login shell).
   launcher?: { id: string; flags: Record<string, boolean> };
+  // Present only when attaching to an existing tmux window (a window Manta
+  // did not create). WINS over `launcher`. Server-only behavior today; the
+  // renderer half to wire this through is the follow-up issue.
+  tmuxTarget?: string;
 };
 
 export type PtyEvent =


### PR DESCRIPTION
## Summary

Adds an optional `tmuxTarget` field to `SpawnOptions` so the server can spawn a pty that attaches to an existing tmux window — the server-side primitive that lets Manta open pre-existing tmux sessions (sessions that show up in the sidebar today but render as a blank pane). Renderer follow-up is a separate issue; nothing sets `tmuxTarget` yet, so there is no behaviour change from this PR alone.

## Changes

- `src/server/pty.mjs`
  - New `resolvePtyCommand({launcher, tmuxTarget, shell})` — pure, returns `{file, args}`. Contains the three-way branch (tmux attach > launcher > plain shell).
  - `spawnShellPty` shrunk to env construction + one spawn call. Imports `tmuxSpawnEnv` from `./tmux.mjs` (the single existing helper — no copy, no new helper).
  - `spawn` threads `tmuxTarget` through to `spawnShellPty`.
- `src/shared/types.ts` — `tmuxTarget?: string` added to `SpawnOptions`. Cascades through `Api` (`src/shared/api.ts`) and `httpApi` automatically.
- `src/server/rpc.mjs` — comment-only update documenting the new field in `SpawnOptions` (handler body unchanged; it already forwards the whole opts object).
- `src/server/pty.test.mjs` — 5 new tests for `resolvePtyCommand` covering the 5 cases from the spec:
  1. `tmuxTarget` → tmux attach-session argv.
  2. both → tmux still wins.
  3. launcher → unchanged `-l -c` login-shell-with-command shape.
  4. neither → unchanged plain login shell (`["-l"]`).
  5. unknown launcher id → falls through to plain shell.

## Decisions pinned (per the issue)

- `tmuxTarget` wins over `launcher`. If both are supplied, tmux runs.
- `-d` is NOT passed to `attach-session` (would detach other clients — sharing a session is the desired behaviour).
- Target format is `<session>:<windowIndex>` (matches `killWindow`/`selectWindow`/`renameWindow` in `tmux.mjs`). Argv array, never a shell string.
- Env cascade preserved: tmux uses `tmuxSpawnEnv()` (UTF-8 locale fix), launcher uses `size.env` (no `MANTA_TERMINAL` because `-lc` is non-interactive), plain shell adds `MANTA_TERMINAL=1` to skip user rc-file tmux auto-attach blocks.

## Out of scope (renderer follow-up)

- Wiring through the renderer so a sidebar entry for a pre-existing tmux window passes `tmuxTarget` to `ptySpawn`.

## Verification

- `npm run typecheck` → clean.
- `npm test` → 1000/1000 pass (8 in pty.test.mjs: 3 existing shellQuote + 5 new resolvePtyCommand).