### PR TITLE
chore(release): bump iOS to 1.0.15 and desktop to 0.0.16

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.14;
+				MARKETING_VERSION = 1.0.15;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -375,7 +375,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.14;
+				MARKETING_VERSION = 1.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "hasInstallScript": true,
       "dependencies": {
         "node-pty": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump so the pending iOS and desktop releases can be tagged.

- iOS `MARKETING_VERSION` 1.0.14 → 1.0.15 (auto-tags `ios-v1.0.15` on merge, which triggers Codemagic)
- Desktop `package.json` / lockfile 0.0.15 → 0.0.16 (for `mac-v0.0.16` + `win-v0.0.14`)

No code changes.