### PR TITLE
fix(renderer): address terminals by tmux window so pre-existing tmux sessions open instead of a black pane

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,18 +14,11 @@ import {
   writeSavedMode,
   resolveLauncherFlags,
 } from "./chatShared";
-import { chooseUpdateSkewVariant } from "./chatUtils";
+import { chooseUpdateSkewVariant, registerMountedTerminal, type MountedTerminal } from "./chatUtils";
 import { MOD_KEY } from "./platform";
 import { UpdateBar } from "./UpdateBar";
 import { parsePairPayload } from "./mobile/pairPayload";
 import type { AvailableLauncher } from "../shared/types";
-
-// mode -> the composite-key "modeId" segment used for the PTY sessionKey and
-// the visitedModes tracking set. "chat" has no PTY, so it's never called with
-// mode==="chat" (callers guard first).
-function modeIdFor(m: SessionMode): string {
-  return m === "terminal" ? "terminal" : m.slice("tui:".length);
-}
 
 export function App() {
   const {
@@ -76,7 +69,10 @@ export function App() {
   // session we've ever opened, keep it mounted so scroll position + in-flight
   // streaming state are preserved when switching back.
   const visitedChats = useRef<Set<string>>(new Set());
-  // Active chat session id (set if active window is chat-mode, else null).
+  // Active window — every tmux window has this; only manta-created windows
+  // additionally carry opencodeSessionId, so the terminal layer uses
+  // (tmuxSession, windowIndex) directly to avoid the black-pane bug for
+  // adopted windows (BET-347).
   const activeWin = activeProjectName
     ? projects
         .find((p) => p.tmuxSession === activeProjectName)
@@ -85,65 +81,21 @@ export function App() {
   const activeChatSessionId = activeWin?.opencodeSessionId ?? null;
   if (activeChatSessionId) visitedChats.current.add(activeChatSessionId);
 
-  // Resolved before the BET-348 block below so the non-Manta detection
-  // can read the project's `mantaOwned` flag.
+  // Resolved early so it can be reused at the activeWinName display site
+  // (line ~695) and anywhere else that needs the active project's metadata.
   const activeProject = activeProjectName
     ? projects.find((p) => p.tmuxSession === activeProjectName) ?? null
     : null;
 
-  // BET-348: active window in a NON-Manta session — there is no
-  // opencode session id (the user started this session in their own
-  // terminal, before opening Manta). We render a Terminal that does
-  // `tmux attach-session -t <session>:<windowIndex>` instead of
-  // spawning a fresh shell. A "non-Manta session" is one whose
-  // `mantaOwned` field is false on the project record (set by the
-  // server's `~/.manta/tmux-sessions.json` sidecar, stamped onto
-  // every listing — see src/server/tmux.mjs listProjects()).
-  //
-  // visitedNonManta keeps one entry per (session, windowIndex) so a
-  // Terminal stays warm across remounts, mirroring visitedModes /
-  // visitedChats above. Each key is "<session>:<windowIndex>" — the
-  // exact format `ptySpawn`'s tmuxTarget expects, which keeps the
-  // server-side PTY reuse key aligned with the click target.
-  const visitedNonManta = useRef<Set<string>>(new Set());
-  const isActiveNonManta =
-    !!activeProject &&
-    activeProject.mantaOwned === false &&
-    // Defensive: a non-Manta session with a stamped opencode session
-    // id is unusual but possible (a session the user shared with
-    // opencode before opening Manta). Treat the opencode-stamped
-    // windows as Manta sessions for routing — they go through the
-    // existing chat flow.
-    activeChatSessionId === null &&
-    activeWin !== undefined;
-  const activeNonMantaTarget = isActiveNonManta && activeWin
-    ? `${activeProject.tmuxSession}:${activeWin.index}`
-    : null;
-  if (activeNonMantaTarget) visitedNonManta.current.add(activeNonMantaTarget);
-  // Garbage-collect visitedNonManta against the live projects tree —
-  // sessions / windows that disappeared from the listing can't be
-  // reattached to.
-  for (const key of visitedNonManta.current) {
-    const [sess, winStr] = key.split(":");
-    const winIdx = Number(winStr);
-    const proj = projects.find((p) => p.tmuxSession === sess);
-    if (
-      !proj ||
-      proj.mantaOwned !== false || // session transitioned to Manta-owned (rename, etc.)
-      !proj.windows.find((w) => w.index === winIdx)
-    ) {
-      visitedNonManta.current.delete(key);
-    }
-  }
-
-  // Session-mode toggle (BET-138): each chat session shows Chat, a bare
-  // shell-in-cwd Terminal, or an AI CLI TUI launcher (e.g. Claude Code).
-  // `mode` tracks the ACTIVE chat session's current mode; other sessions'
-  // last-used modes stay in localStorage (read lazily when they're
-  // activated). `visitedModes` tracks every `${sessionId}:${modeId}`
-  // composite key ever opened, so its Terminal is mounted lazily on first
-  // use and then kept warm (mirrors visitedChats above).
-  const visitedModes = useRef<Set<string>>(new Set());
+  // Session-mode toggle (BET-138). `mode` tracks the active window's
+  // current mode; other windows' last-used modes stay in localStorage. The
+  // visitedModes Map is keyed by terminalMountKey so its Terminal is
+  // mounted lazily on first use and kept warm (BET-347) — the value carries
+  // the fields, the loop never parses the key back apart. The single
+  // terminal mount loop below also handles adopted (pre-existing) tmux
+  // windows via the `tmuxTarget` field — supersedes BET-348's parallel
+  // visitedNonManta loop, removed.
+  const visitedModes = useRef<Map<string, MountedTerminal>>(new Map());
   const [mode, setModeState] = useState<SessionMode>("chat");
   const [availableLaunchers, setAvailableLaunchers] = useState<AvailableLauncher[]>([]);
 
@@ -166,22 +118,42 @@ export function App() {
       .catch(() => setAvailableLaunchers([]));
   }, [activeChatSessionId]);
 
-  // Reset to the persisted mode whenever the active chat session changes. A
-  // saved `tui:<id>` whose launcher isn't in `availableLaunchers` downgrades
-  // to "chat" (readSavedMode's fallback).
+  // Reset to the persisted mode whenever the active window changes. Adopted
+  // windows (no opencodeSessionId) are forced to "terminal" — the dropdown
+  // is hidden for them and there's no opencode session id to key
+  // localStorage on. Primitive deps so a freshly-derived activeWin per
+  // render doesn't re-fire this.
   useEffect(() => {
-    const m = activeChatSessionId ? readSavedMode(activeChatSessionId, availableLaunchers) : "chat";
+    const m: SessionMode = activeChatSessionId
+      ? readSavedMode(activeChatSessionId, availableLaunchers)
+      : activeWin && activeProjectName
+        ? "terminal"
+        : "chat";
     setModeState(m);
-    if (activeChatSessionId && m !== "chat") {
-      visitedModes.current.add(`${activeChatSessionId}:${modeIdFor(m)}`);
+    if (activeWin && activeProjectName && m !== "chat") {
+      registerMountedTerminal(
+        visitedModes.current,
+        activeProjectName,
+        activeWin.index,
+        m,
+        activeWin.paneCurrentPath || "",
+        activeChatSessionId,
+      );
     }
-  }, [activeChatSessionId, availableLaunchers]);
+  }, [activeChatSessionId, availableLaunchers, activeProjectName, activeWin?.index, activeWin?.paneCurrentPath]);
 
   const setMode = (m: SessionMode) => {
-    if (activeChatSessionId) {
+    if (activeChatSessionId && activeWin && activeProjectName) {
       writeSavedMode(activeChatSessionId, m);
       if (m !== "chat") {
-        visitedModes.current.add(`${activeChatSessionId}:${modeIdFor(m)}`);
+        registerMountedTerminal(
+          visitedModes.current,
+          activeProjectName,
+          activeWin.index,
+          m,
+          activeWin.paneCurrentPath || "",
+          activeChatSessionId,
+        );
       }
     }
     setModeState(m);
@@ -870,21 +842,18 @@ export function App() {
             </div>
           ) : (
             <>
-              {/* Terminal / AI-TUI layer (BET-138): one per `${sessionId}:${modeId}` */}
-              {/* composite key ever opened, kept mounted so the shell/CLI */}
-              {/* stays warm across mode toggles. Visible only when it's the */}
-              {/* active session's CURRENT mode. modeId is "terminal" (bare */}
-              {/* shell) or an available launcher's id (AI CLI TUI). */}
-              {[...visitedModes.current].map((key) => {
-                const sepIdx = key.lastIndexOf(":");
-                const sid = key.slice(0, sepIdx);
-                const modeId = key.slice(sepIdx + 1);
-                const owner = resolveSessionOwner(projects, sid);
-                const wantMode: SessionMode =
-                  modeId === "terminal" ? "terminal" : `tui:${modeId}`;
-                const isActiveThisMode = sid === activeChatSessionId && mode === wantMode;
-                const launcherDef =
-                  modeId === "terminal" ? undefined : availableLaunchers.find((l) => l.id === modeId);
+              {/* Terminal / AI-TUI layer (BET-138, BET-347): one per
+                  (tmuxSession, windowIndex, modeId) triple, kept mounted so
+                  the shell/CLI stays warm. Adopted + manta-created windows
+                  share this loop — `tmuxTarget` is the only diff (BET-347). */}
+              {[...visitedModes.current.entries()].map(([key, m]) => {
+                const isActiveThisMode =
+                  activeProjectName === m.tmuxSession &&
+                  activeWin?.index === m.windowIndex &&
+                  mode === (m.modeId === "terminal" ? "terminal" : `tui:${m.modeId}`);
+                const launcherDef = m.modeId === "terminal"
+                  ? undefined
+                  : availableLaunchers.find((l) => l.id === m.modeId);
                 const launcher = launcherDef
                   ? { id: launcherDef.id, flags: resolveLauncherFlags(launcherDef.flags, launcherFlags[launcherDef.id]) }
                   : undefined;
@@ -896,8 +865,9 @@ export function App() {
                   >
                     <Terminal
                       sessionKey={key}
-                      cwd={owner?.cwd ?? ""}
+                      cwd={m.cwd}
                       launcher={launcher}
+                      tmuxTarget={m.tmuxTarget}
                       active={isActiveThisMode}
                     />
                   </div>
@@ -924,41 +894,6 @@ export function App() {
                       windowIndex={owner?.windowIndex ?? null}
                       cwd={owner?.cwd ?? ""}
                       isActive={isActiveChat}
-                    />
-                  </div>
-                );
-              })}
-              {/* BET-348: tmux-attach Terminals for non-Manta windows. One
-                  Terminal per (session, windowIndex); only the active one
-                  is visible. Keyed on "<session>:<windowIndex>" so the
-                  sessionKey passed to Terminal — and therefore the PTY
-                  key on the server — matches the tmuxTarget verbatim.
-                  The Terminal mounts a `tmux attach-session -t
-                  <session>:<windowIndex>` PTY (server branch 1 of
-                  resolvePtyCommand), which is exactly the pre-existing
-                  window's output — no blank pane, no detached other
-                  clients (the server explicitly does NOT pass `-d`,
-                  see BET-346 / pty.test.mjs). */}
-              {[...visitedNonManta.current].map((key) => {
-                const [sess, winStr] = key.split(":");
-                const winIdx = Number(winStr);
-                const proj = projects.find((p) => p.tmuxSession === sess);
-                const w = proj?.windows.find((x) => x.index === winIdx);
-                const isActiveNonMantaHere =
-                  isActiveNonManta && activeNonMantaTarget === key;
-                // sessionKey is the same string as tmuxTarget so the
-                // server's PTY reuse key stays stable across remounts.
-                return (
-                  <div
-                    key={`tmux:${key}`}
-                    className="absolute inset-0"
-                    style={{ display: isActiveNonMantaHere ? "block" : "none" }}
-                  >
-                    <Terminal
-                      sessionKey={`tmux:${key}`}
-                      cwd={w?.paneCurrentPath || proj?.defaultCwd || ""}
-                      tmuxTarget={key}
-                      active={isActiveNonMantaHere}
                     />
                   </div>
                 );

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -44,13 +44,10 @@ type Props = {
   // Present only when this Terminal is an AI CLI TUI launch mode (BET-138
   // refinement). Absent = plain login shell (base "terminal" mode).
   launcher?: { id: string; flags: Record<string, boolean> };
-  // BET-348: when set, the server spawns `tmux attach-session -t <target>`
-  // instead of a fresh shell — for a window Manta did NOT create (a
-  // pre-existing tmux session the user wants to view). Format is
-  // `<session>:<windowIndex>`, matching killWindow/selectWindow in
-  // src/server/tmux.mjs. WINS over `launcher` when both are set (server
-  // branch 1 of resolvePtyCommand). Omit for a Manta-owned window — the
-  // server falls through to the launcher / plain-shell branch.
+  // BET-347: set iff this Terminal is a window Manta did not create (a
+  // pre-existing tmux session). The server then runs `tmux attach-session
+  // -t <target>` instead of spawning a fresh shell. Format matches
+  // killWindow/selectWindow/renameWindow in src/server/tmux.mjs.
   tmuxTarget?: string;
 };
 

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -73,9 +73,91 @@ import {
   terminalShortcut,
   authErrorAdvice,
   AUTH_PROVIDER_LABELS,
+  terminalMountKey,
+  registerMountedTerminal,
 } from "./chatUtils";
 
 // ===== formatTokens =====
+
+// ===== terminalMountKey =====
+
+describe("terminalMountKey", () => {
+  it("is stable for the same inputs", () => {
+    expect(terminalMountKey("proj", 0, "terminal")).toBe(
+      terminalMountKey("proj", 0, "terminal"),
+    );
+  });
+
+  it("different window indexes in the same session produce different keys", () => {
+    expect(terminalMountKey("proj", 0, "terminal")).not.toBe(
+      terminalMountKey("proj", 1, "terminal"),
+    );
+  });
+
+  it("a session name containing `:` does not collide with a different session/index pair", () => {
+    // Without the NUL separator, a `:` in the session name would let two
+    // distinct (session, index, modeId) tuples produce the same string.
+    // Pin the separator behaviour: tmux session names may contain `:`,
+    // so the key must not be parseable on `:`. Two tuples that would
+    // collide under a `:` separator must produce distinct keys here.
+    const colonInSession = terminalMountKey("proj:0", 1, "terminal");
+    const parsedAcrossColon = terminalMountKey("proj", 0, "1:terminal");
+    expect(colonInSession).not.toBe(parsedAcrossColon);
+    // The key is opaque (NUL-separated) by design — splitting on NUL must
+    // yield exactly the input triple for the colon-in-session case.
+    expect(colonInSession.split("\u0000")).toEqual(["proj:0", "1", "terminal"]);
+  });
+
+  it("different modeIds for the same window produce different keys", () => {
+    expect(terminalMountKey("proj", 0, "terminal")).not.toBe(
+      terminalMountKey("proj", 0, "claude"),
+    );
+  });
+});
+
+// ===== registerMountedTerminal =====
+
+describe("registerMountedTerminal", () => {
+  it("is a no-op for chat mode (no PTY is needed)", () => {
+    const visited = new Map();
+    registerMountedTerminal(visited, "proj", 0, "chat", "/tmp", "sid");
+    expect(visited.size).toBe(0);
+  });
+
+  it("records a terminal mount with tmuxTarget for adopted windows", () => {
+    const visited = new Map();
+    registerMountedTerminal(visited, "proj", 0, "terminal", "/tmp", null);
+    const entry = visited.get(terminalMountKey("proj", 0, "terminal"));
+    expect(entry).toEqual({
+      tmuxSession: "proj",
+      windowIndex: 0,
+      modeId: "terminal",
+      cwd: "/tmp",
+      tmuxTarget: "proj:0",
+    });
+  });
+
+  it("records a terminal mount WITHOUT tmuxTarget for manta-created windows", () => {
+    const visited = new Map();
+    registerMountedTerminal(visited, "proj", 0, "terminal", "/tmp", "sid-abc");
+    const entry = visited.get(terminalMountKey("proj", 0, "terminal"));
+    expect(entry).toEqual({
+      tmuxSession: "proj",
+      windowIndex: 0,
+      modeId: "terminal",
+      cwd: "/tmp",
+    });
+    expect(entry?.tmuxTarget).toBeUndefined();
+  });
+
+  it("strips the tui: prefix from launcher modes", () => {
+    const visited = new Map();
+    registerMountedTerminal(visited, "proj", 0, "tui:claude", "/tmp", "sid");
+    const entry = visited.get(terminalMountKey("proj", 0, "claude"));
+    expect(entry?.modeId).toBe("claude");
+    expect(entry?.tmuxTarget).toBeUndefined();
+  });
+});
 
 describe("formatTokens", () => {
   it("shows raw count below 1k", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,12 +5,69 @@
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
 import type { SubscriptionStatus } from "../shared/types";
+import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
 // shared/versionCompare.mjs so both src/server/*.mjs and the renderer share
 // one source of truth; re-imported here so chooseUpdateSkewVariant is
 // testable in isolation (no DOM/network, just the compare).
 import { isClientTooOld } from "../shared/versionCompare.mjs";
+
+// Stable identity for a mounted Terminal in App.tsx's visitedModes map. A
+// tmux window is identified by its session name + index, which EVERY window
+// has — unlike the opencode session id, which only manta-created windows
+// carry. Without this, opening a pre-existing tmux session in the sidebar
+// renders a black pane (BET-347).
+//
+// The NUL separator is deliberate: tmux session names may contain `:` (the
+// only character tmux forbids in a session name is `.`), and the key is
+// NEVER parsed back apart — the map value carries the fields. Do not write a
+// matching parse function; if you find yourself needing one, you have kept a
+// string where the map value should be used instead.
+export function terminalMountKey(
+  tmuxSession: string,
+  windowIndex: number,
+  modeId: string,
+): string {
+  return `${tmuxSession}\u0000${windowIndex}\u0000${modeId}`;
+}
+
+// One mounted Terminal record (BET-347). `tmuxTarget` is set iff the window
+// has no opencodeSessionId (a window Manta did not create) — the server's
+// pty:spawn then runs `tmux attach-session -t <target>` so the user sees
+// the live contents of their pre-existing tmux window instead of a blank
+// pane.
+export type MountedTerminal = {
+  tmuxSession: string;
+  windowIndex: number;
+  modeId: string;
+  cwd: string;
+  tmuxTarget?: string;
+};
+
+// Record (or refresh) a Terminal mount for the given window + mode in
+// App.tsx's visitedModes map. Sets `tmuxTarget` iff chatSessionId is null
+// (adopted window) so the server spawns `tmux attach-session` instead of a
+// fresh shell. Centralising this keeps the mode-reset effect and setMode
+// from drifting (BET-347).
+export function registerMountedTerminal(
+  visited: Map<string, MountedTerminal>,
+  tmuxSession: string,
+  windowIndex: number,
+  m: SessionMode,
+  cwd: string,
+  chatSessionId: string | null,
+): void {
+  if (m === "chat") return;
+  const modeId = m === "terminal" ? "terminal" : m.slice("tui:".length);
+  visited.set(terminalMountKey(tmuxSession, windowIndex, modeId), {
+    tmuxSession,
+    windowIndex,
+    modeId,
+    cwd,
+    tmuxTarget: chatSessionId ? undefined : `${tmuxSession}:${windowIndex}`,
+  });
+}
 
 // Fallback context size used when the active model has no `limit.context`
 // (or no active model is known yet). 200k is the lowest common denominator


### PR DESCRIPTION
Pre-existing tmux sessions (those Manta did not create) appeared in the sidebar but rendered a black pane that ignored keystrokes. Root cause: every Terminal mount was gated on `activeChatSessionId` (the `@manta-session-id` tmux user-option), which only windows Manta created carry. The terminal layer is now keyed by `(tmuxSession, windowIndex)`, which every window has.

**Rebased onto current main (post-BET-348)**

This PR was rebased onto `origin/main` after BET-348 landed (PR #296). BET-348 took a different approach: a parallel `[...visitedNonManta.current].map(...)` mount loop in `App.tsx` for non-Manta windows, with `mantaOwned` on `Project`/`TmuxSession` (server sidecar) as the "adopted" signal. BET-347 takes a unified approach: a single mount loop over a `Map<string, MountedTerminal>` keyed by `(tmuxSession, windowIndex, modeId)`, where the map value carries `tmuxTarget` set iff the window has no `opencodeSessionId`.

The unified BET-347 approach replaces BET-348's renderer half:

- **Kept from BET-348**: `mantaOwned` sidecar (`~/.manta/tmux-sessions.json`), `listProjects()` reconciliation, `parseSessions({owned})` testability, server-side `pty:spawn tmuxTarget` forwarding (already there from BET-346), `Terminal.tsx`'s `tmuxTarget` prop (BET-347 added an identical one — resolved to the BET-348 comment + BET-347 wording).
- **Removed from BET-348 (superseded)**: the parallel `visitedNonManta` `Set<string>` derivation, the parallel `[...visitedNonManta.current].map(...)` mount loop at the bottom of `App.tsx`, the early-`activeProject` block (kept a 1-liner reuse at the activeWinName site). BET-347's unified loop handles the same adopted windows via the map value's `tmuxTarget` field.
- **`activeProject` is kept** (BET-348 promoted it earlier in the file) — only its later re-declaration at line ~619 was dropped. The activeWinName display site at line ~695 still consumes it.

**Net App.tsx change against current main is now -65 lines** (was +12 against the stale base). The spec's "fewer lines" intent is satisfied once the base is current, as the reviewer predicted.

**Nit addressed: `activeWindowRef` is not a named variable**

The previous PR description claimed a new `activeWindowRef` was added (memoized on primitives). It is not — the spec's intent (every window has an address, adopted windows included) is met by inlining the `activeWin && activeProjectName` check at the two consumer sites (the mount loop's `isActiveThisMode` check, and the mode-reset effect's terminal-only branch). No consumer actually reads a named `{tmuxSession, windowIndex, cwd}` shape — both consumers only check existence or read scalar fields off `activeWin`/`activeProjectName` directly. The intermediate object has no callers; introducing it would be dead code per AGENTS.md "no speculative abstraction".

**Fix**

- `visitedModes`: `Set<string>` of `${opencodeSessionId}:${modeId}` → `Map<string, MountedTerminal>` keyed by `terminalMountKey` (NUL-separated; tmux session names may contain `:` so a colon separator is unsafe). The map value carries the fields — the mount loop no longer round-trips through `lastIndexOf`/`slice` + `resolveSessionOwner`.
- The mode-reset effect reads `activeWin && activeProjectName` to detect "every active window" and forces `"terminal"` mode for adopted windows; the mode dropdown stays gated on `activeChatSessionId` so the chat/launcher options stay hidden for them.
- `MountedTerminal` carries `tmuxTarget` for adopted windows (`<tmuxSession>:<windowIndex>`); the server (BET-346) spawns `tmux attach-session -t <target>` so the user sees the live contents of their pre-existing tmux window.
- `Terminal.tsx` (BET-348 already added the prop; BET-347 kept the equivalent definition) passes `tmuxTarget` straight through to `ptySpawn`.

**Tests**

8 new tests in `src/renderer/chatUtils.test.ts` (4 `terminalMountKey` + 4 `registerMountedTerminal`):

- terminalMountKey is stable for same inputs
- different window indexes produce different keys
- session name containing `:` does not collide (the NUL-separator pin)
- different modeIds for the same window produce different keys
- registerMountedTerminal: chat-mode no-op
- registerMountedTerminal: adopted window → tmuxTarget set
- registerMountedTerminal: manta-created window → tmuxTarget absent
- registerMountedTerminal: `tui:` prefix stripped from launcher modes

**Verification results**

- PR branch (`multica/BET-347-terminal-adopt-pre-existing-windows` @ `70112bc`):
  - typecheck: exit 0. Errors: none. log sha256: `afcc5676e88a9717b0c29864a0d6731ff33a64328b7fd7f5c6f9f6666b518e5d`
  - vitest: exit 0, **1209** pass / 0 fail / 0 skip. log sha256: `493f40b00069de2ae799500a36386fe6cd51101c6fb784ac666739aa76eca1be`
  - node:test: exit 0, **1034** pass / 0 fail / 0 skip. log sha256: `493f40b00069de2ae799500a36386fe6cd51101c6fb784ac666739aa76eca1be` (combined log)
- Base (`main` @ `07ec769`):
  - typecheck: exit 0. Errors: none. log sha256: `afcc5676e88a9717b0c29864a0d6731ff33a64328b7fd7f5c6f9f6666b518e5d`
  - vitest: exit 0, **1201** pass / 0 fail / 0 skip. log sha256: `4d3f41b83abadccfdb08e57b3f2c87e11f08ab2fa049870a5d52054764f7846d`
  - node:test: exit 0, **1034** pass / 0 fail / 0 skip. log sha256: `4d3f41b83abadccfdb08e57b3f2c87e11f08ab2fa049870a5d52054764f7846d` (combined log)
- **Conclusion:** 0 failures (pre-existing or new). vitest delta = +8 (the new tests). node:test unchanged (I didn't touch server code; BET-348's 14 new server tests are on main already).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Files changed:** 4 files, +202/-131 against current `main` @ `07ec769`:
- `src/renderer/App.tsx` — +60/-125 (net -65): visitedModes Map + adopted-window mode logic; BET-348's parallel `visitedNonManta` loop removed.
- `src/renderer/Terminal.tsx` — +2/-9 (BET-348's tmuxTarget prop kept; BET-347's added one resolved to BET-348's comment).
- `src/renderer/chatUtils.ts` — +57/-0: `terminalMountKey` + `MountedTerminal` + `registerMountedTerminal` + type imports.
- `src/renderer/chatUtils.test.ts` — +82/-0: 8 new tests (4 `terminalMountKey` + 4 `registerMountedTerminal`).

**Base:** origin/main @ `07ec769`.
