### PR TITLE
docs(tools): reflect per-box URL shape in serve_page tool + AI guidance (BET-344)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2287,10 +2287,9 @@ box-local and unchanged — it doesn't touch the gateway.
 - **Caddyfile is NOT in the repo** — it lives only on the box (`/etc/caddy/`),
   unversioned. `gateway.mantaui.com` (gateway) and one
   `<box_id>.boxes.mantaui.com` per registered box have their own Caddy
-  blocks there. (The old `*.pages.mantaui.com` serve-page vhost was retired
-  in BET-343 — pages now share the box's own hostname on the
-  `/pages/<sub>` path, so no wildcard DNS record, no OVH DNS-01 cert, no
-  extra port.)
+  blocks there. (The old dedicated serve-page vhost was retired in BET-343 —
+  pages now share the box's own hostname on the `/pages/<sub>` path, so no
+  wildcard DNS record, no OVH DNS-01 cert, no extra port.)
 - **`scripts/release/publish.sh`** is the OLDER manual all-in-one deploy
   (tarball + desktop + server + install.sh, run from a laptop over
   `MANTA_PROD_HOST`). The tag-driven workflows above supersede it for

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -30,15 +30,22 @@ the manta UI (the ⏰ schedules card), so keep labels short and descriptive.
 
 You have `serve_page`, `stop_page`, and `list_pages` tools to host standalone
 HTML pages publicly. When you generate a web page (design preview, demo,
-mockup), call `serve_page(subdomain, filePath)` to get a public URL under
-*.pages.mantaui.com. The page auto-expires after 24h (configurable via
-`ttlHours`, or `0` for no expiry). To update a page, call `serve_page` again
-with the same subdomain and a new file. Call `stop_page(subdomain)` to take
-it down early. `list_pages` shows all active pages.
+mockup), call `serve_page(subdomain, filePath)` and use the returned URL
+verbatim — the tool serves the page on this box's own public URL, so the
+exact hostname differs from box to box. The page auto-expires after 24h
+(configurable via `ttlHours`, or `0` for no expiry). To update a page, call
+`serve_page` again with the same subdomain and a new file. Call
+`stop_page(subdomain)` to take it down early. `list_pages` shows all active
+pages.
 
-- `serve_page(subdomain, filePath, ttlHours?)` -> "Page served at https://<sub>.pages.mantaui.com"
-- `stop_page(subdomain)` -> "Page <sub>.pages.mantaui.com has been taken down."
+- `serve_page(subdomain, filePath, ttlHours?)` -> "Page served at <url>"
+- `stop_page(subdomain)` -> "Page \"<sub>\" has been taken down."
 - `list_pages` -> bullet list of active pages with URLs and expiry times
+
+If this box never registered with the gateway (Tailscale-only / offline
+install), page hosting is unavailable and `serve_page` returns a clear error
+rather than a URL — relay the error to the user instead of retrying with a
+different file path.
 
 ## manta peer-session awareness
 

--- a/docs/opencode-tools/serve-page.ts
+++ b/docs/opencode-tools/serve-page.ts
@@ -7,9 +7,9 @@
 //
 // This tool is a THIN registrar. It validates the request and POSTs it to
 // manta-server (127.0.0.1:8787, same box — no SSH hop), which copies the page
-// into a stable directory and serves it via an in-process HTTP server. Caddy
-// reverse-proxies *.pages.mantaui.com to this server. The tool does NOT sleep
-// or run the page itself — execute() must return promptly.
+// into a stable directory and serves it from `/pages/<subdomain>` under the
+// box's own public hostname. The tool does NOT sleep or run the page itself —
+// execute() must return promptly.
 //
 // See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
 
@@ -69,12 +69,13 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
 
 export const serve_page = tool({
   description: [
-    "Host a standalone HTML webpage publicly under *.pages.mantaui.com.",
+    "Host a standalone HTML webpage publicly on this box's own public URL.",
     "Use when you generate a web page (design preview, demo, mockup, interactive",
     "prototype) and want it accessible from anywhere — especially from the",
-    "machine where the manta UI is running. The page is served at",
-    "https://<subdomain>.pages.mantaui.com and auto-expires after 24h by",
-    "default (configurable via ttlHours). To update a page, call this tool",
+    "machine where the manta UI is running. The tool returns the full public",
+    "URL from the server — echo `result.url` verbatim, NEVER construct one",
+    "yourself (the hostname differs per box). The page auto-expires after 24h",
+    "by default (configurable via ttlHours). To update a page, call this tool",
     "again with the same subdomain and a new file path.",
   ].join(" "),
   args: {
@@ -83,8 +84,8 @@ export const serve_page = tool({
       .describe(
         "Subdomain for the page (e.g. 'preview', 'my-design'). " +
           "Must be 1-63 lowercase alphanumeric characters or hyphens, no " +
-          "leading/trailing hyphens. The page will be served at " +
-          "https://<subdomain>.pages.mantaui.com",
+          "leading/trailing hyphens — it becomes a single URL path segment " +
+          "under /pages/, so no dots, no slashes.",
       ),
     filePath: z
       .string()
@@ -133,7 +134,7 @@ export const stop_page = tool({
       `/api/serve-page?subdomain=${encodeURIComponent(args.subdomain)}`,
     );
     return result.deleted
-      ? `Page ${args.subdomain}.pages.mantaui.com has been taken down.`
+      ? `Page "${args.subdomain}" has been taken down.`
       : `No page found for subdomain "${args.subdomain}".`;
   },
 });


### PR DESCRIPTION
BET-344 follow-up to BET-343 (PR #294).

BET-343 moved page hosting from the `*.pages.mantaui.com` wildcard vhost to `/pages/<sub>` on the box's own public hostname. The AI-facing copy still promised the dead domain — a model reading the tool description would keep telling users the wrong hostname.

This PR rewrites the descriptions so the model uses the URL returned by the server verbatim and never constructs one itself.

## Files changed
`docs/opencode-tools/serve-page.ts`, `docs/opencode-tools/AGENTS.md`, `AGENTS.md` — 3 files, 29 insertions, 22 deletions.

## What changed

- `docs/opencode-tools/serve-page.ts`:
  - Header comment: drop the "Caddy reverse-proxies `*.pages.mantaui.com`" line; replace with "manta-server serves it from `/pages/<subdomain>` under the box's own public hostname".
  - `serve_page` description: remove both `*.pages.mantaui.com` literals. Say the page is hosted on this box's own public URL and that the tool returns the full URL — the model must use the returned URL verbatim and must not construct one itself.
  - `subdomain` arg description: remove the `https://<subdomain>.pages.mantaui.com` literal. Keep the format rule (1-63 chars, lowercase alphanumeric or hyphens, no leading/trailing hyphen) and reframe the justification from "matches the wildcard certificate" to "single URL path segment under /pages/".
  - `stop_page` success string: `Page ${args.subdomain}.pages.mantaui.com has been taken down.` → `Page "${args.subdomain}" has been taken down.`. The tool must never rebuild a URL it does not own.
  - `serve_page`'s success line already echoes `result.url` from the server — left alone.

- `docs/opencode-tools/AGENTS.md`:
  - Rewrite `## manta serve page` so it does not name a domain.
  - Three `->` example lines: `https://<sub>.pages.mantaui.com` → `<url>` (per-box); `<sub>.pages.mantaui.com` → `"<sub>"`.
  - New sentence: page hosting is unavailable on an unregistered box (Tailscale-only / offline install); `serve_page` returns a clear error rather than a URL — relay the error, don't retry with a different file path.

- `AGENTS.md` (root):
  - One-line cleanup of the historical note in "Prod box topology" that still named the dead domain — acceptance grep requires it gone.

## Deployment note (maintainer step, not part of this PR)

The tool file is **copied**, not symlinked, into `~/.config/opencode/tools/` on each box. A copied tool only takes effect after `systemctl --user restart opencode-serve` on the box. Whoever merges this should follow the standard pull-and-restart loop on each box; this PR does not run that.

## Acceptance

- `grep -rn "pages\.mantaui\.com" docs/opencode-tools/ AGENTS.md` → no hits. ✅ verified on this branch.
- `npm run typecheck && npm test` → green. ✅ 1034 pass / 0 fail.

Base: origin/main @ `07ec769`