### PR TITLE
fix(update): server.json still said 0.0.0 — no box has ever been offered an update

### DIFF
--- a/scripts/build-website-assets.test.mjs
+++ b/scripts/build-website-assets.test.mjs
@@ -22,6 +22,14 @@
 //   - og.png is a 1200x630 PNG.
 //   - .well-known/agent-skills/index.json is valid JSON.
 //   - .well-known/agent-skills/manta/SKILL.md has frontmatter and a body.
+//   - website/updates/server.json's version matches package.json's version.
+//     THIS ONE IS NOT COSMETIC: that manifest is the ONLY way a running box
+//     learns a new server release exists (src/server/serverUpdate.mjs polls it
+//     every 6h and drives the in-app update banner + the push notification).
+//     It shipped as a `0.0.0` placeholder and no release ever bumped it, so
+//     the banner had never fired for anyone and every box stayed on whatever
+//     it installed with. Nothing else catches this: the deploy workflow
+//     verifies the file is SERVED, not that it names the current version.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -234,6 +242,18 @@ test(".well-known/agent-skills/manta/SKILL.md has YAML frontmatter and body", ()
   assert.match(skill, /^license: MIT$/m, "frontmatter must declare license: MIT");
   assert.match(skill, /^description: /m, "frontmatter must declare a description");
   assert.ok(skill.length > 1000, "SKILL.md body must be substantial");
+});
+
+test("website/updates/server.json version matches package.json version", () => {
+  const manifest = JSON.parse(read("website/updates/server.json"));
+  const pkg = JSON.parse(read("package.json"));
+  assert.equal(
+    manifest.version,
+    pkg.version,
+    "website/updates/server.json is what tells a running box a new server release exists " +
+      "(src/server/serverUpdate.mjs polls it every 6h). If it lags package.json, no box is " +
+      "ever offered the update. Bump it in the same commit as the version bump.",
+  );
 });
 
 function stripTags(s) {

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,1 +1,1 @@
-{ "version": "0.0.0", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }
+{ "version": "0.0.17", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }


### PR DESCRIPTION
Found while answering "what do users have to do to get the tmux fixes?".

**The bug.** `website/updates/server.json` is the only way a running box learns a new server release exists — `src/server/serverUpdate.mjs` polls it every 6h and drives both the in-app update banner and the push notification. It shipped as a `{ "version": "0.0.0" }` placeholder in BET-225.A and no release has ever bumped it. So `isUpdateAvailable(runningVersion, "0.0.0")` returned false on every box, every 6h, since the feature landed. The banner has never fired for anyone, and boxes stay on whatever version they installed with unless a user runs `scripts/self-update.sh` by hand.

The website deploy workflow verifies that the file is *served*, not that it names the current version, so nothing caught it.

**The fix.** Bump to `0.0.17` (the version just released), plus a test pinning `server.json.version === package.json.version` so a future version bump that forgets the manifest goes red instead of silently stranding every box. Red/green verified: the test fails on the old placeholder, passes on the bump.

Needs a `web-v17` tag after merge — the manifest only takes effect once deployed.