### PR TITLE
fix(update): self-update never refreshed the opencode tool copies, so AI-facing fixes could not reach a box

### DIFF
--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4322,3 +4322,148 @@ echo "       \$(supervisor_hint status server)"
   // messages (the headline acceptance criterion).
   assert.doesNotMatch(out, /systemctl/);
 });
+
+// ----------------------------------------------------------------------------
+// scripts/self-update.sh — refresh_opencode_tools.
+// ----------------------------------------------------------------------------
+//
+// The manta-native opencode tools (docs/opencode-tools/*.ts) are COPIED into
+// ~/.config/opencode/tools/, never symlinked (opencode resolves a tool's
+// imports from the file's REAL path). install.sh does that copy on INSTALL;
+// nothing did it on UPDATE, so `git reset --hard origin/main` refreshed the
+// source while every box kept running the tool copy it was installed with —
+// making any change to what the AI is told about a tool undeliverable to an
+// existing box (BET-344 rewrote serve_page's description and no box would
+// ever have seen it).
+//
+// These tests run the REAL function out of the REAL script against a fake box
+// layout, rather than replicating its logic in a preBody, so a regression in
+// the shipped source is what goes red.
+
+function runRefreshOpencodeTools({ manthaHome, opencodeConfigDir }) {
+  const selfUpdate = join(__dirname, "self-update.sh");
+  const src = readFileSync(selfUpdate, "utf8");
+  const start = src.indexOf("refresh_opencode_tools() {");
+  assert.ok(start !== -1, "self-update.sh must define refresh_opencode_tools()");
+  const end = src.indexOf("\n}\n", start);
+  assert.ok(end !== -1, "refresh_opencode_tools() must be brace-terminated");
+  const fn = src.slice(start, end + 3);
+
+  const dir = mkdtempSync(join(tmpdir(), "manta-selfupd-fn-"));
+  const fnPath = join(dir, "fn.sh");
+  writeFileSync(fnPath, `set -euo pipefail\n${fn}\nrefresh_opencode_tools\n`);
+  try {
+    const res = spawnSync("bash", [fnPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        MANTA_HOME: manthaHome,
+        OPENCODE_CONFIG_DIR: opencodeConfigDir,
+      },
+    });
+    return `${res.stdout ?? ""}${res.stderr ?? ""}EXIT=${res.status}`;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeFakeBox() {
+  const root = mkdtempSync(join(tmpdir(), "manta-fakebox-"));
+  const srcDir = join(root, "repo", "docs", "opencode-tools");
+  const toolsDir = join(root, "home", ".config", "opencode", "tools");
+  mkdirSync(srcDir, { recursive: true });
+  mkdirSync(toolsDir, { recursive: true });
+  return { root, srcDir, toolsDir, manthaHome: join(root, "repo"), opencodeConfigDir: join(root, "home", ".config", "opencode") };
+}
+
+test("self-update.sh refresh_opencode_tools overwrites a stale installed tool (BET-344 deliverability)", () => {
+  const box = makeFakeBox();
+  try {
+    writeFileSync(join(box.srcDir, "serve-page.ts"), "NEW serve-page\n");
+    writeFileSync(join(box.toolsDir, "serve-page.ts"), "OLD serve-page\n");
+
+    const out = runRefreshOpencodeTools(box);
+
+    assert.equal(
+      readFileSync(join(box.toolsDir, "serve-page.ts"), "utf8"),
+      "NEW serve-page\n",
+      "the installed tool must be replaced by the repo's version",
+    );
+    assert.match(out, /opencode tools refreshed/);
+    assert.match(out, /EXIT=0/);
+  } finally {
+    rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("self-update.sh refresh_opencode_tools never copies *.test.ts into tools/", () => {
+  // opencode loads EVERY file in tools/ as a tool; a test file imports vitest
+  // (absent under ~/.config/opencode/node_modules), which makes tool
+  // resolution throw and every chat turn fail with "Cannot find package
+  // 'vitest'". Same exclusion install.sh carries.
+  const box = makeFakeBox();
+  try {
+    writeFileSync(join(box.srcDir, "serve-page.ts"), "tool\n");
+    writeFileSync(join(box.srcDir, "serve-page.test.ts"), "import 'vitest'\n");
+
+    runRefreshOpencodeTools(box);
+
+    const installed = readdirSync(box.toolsDir);
+    assert.ok(installed.includes("serve-page.ts"));
+    assert.deepEqual(
+      installed.filter((f) => f.endsWith(".test.ts")),
+      [],
+      "a *.test.ts must never land in tools/",
+    );
+  } finally {
+    rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("self-update.sh refresh_opencode_tools is idempotent — a second run reports no change", () => {
+  const box = makeFakeBox();
+  try {
+    writeFileSync(join(box.srcDir, "notify.ts"), "same\n");
+
+    const first = runRefreshOpencodeTools(box);
+    assert.match(first, /opencode tools refreshed/);
+
+    const second = runRefreshOpencodeTools(box);
+    assert.match(second, /already current/);
+    assert.doesNotMatch(second, /refreshed/);
+    assert.match(second, /EXIT=0/);
+  } finally {
+    rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("self-update.sh refresh_opencode_tools is non-fatal when the source dir is missing", () => {
+  // It runs AFTER the checkout has been reset and deps reinstalled. Aborting
+  // there would leave the box half-updated, so a missing source dir must warn
+  // and return 0.
+  const box = makeFakeBox();
+  try {
+    rmSync(join(box.root, "repo", "docs"), { recursive: true, force: true });
+    const out = runRefreshOpencodeTools(box);
+    assert.match(out, /skipping opencode tool refresh/);
+    assert.match(out, /EXIT=0/);
+  } finally {
+    rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("self-update.sh does NOT restart opencode — that would kill in-flight agent turns", () => {
+  // Loading a new tool needs an opencode restart, but restarting opencode ends
+  // every running agent turn on the box, which is exactly the "close the lid
+  // and the work carries on" guarantee. The script stages the files and tells
+  // the user how to restart; it must never do it itself.
+  const src = readFileSync(join(__dirname, "self-update.sh"), "utf8");
+  const commands = src
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("#") && !l.includes("echo "));
+  assert.deepEqual(
+    commands.filter((l) => /restart opencode-serve|kickstart .*com\.mantaui\.opencode/.test(l)),
+    [],
+    "self-update.sh must not execute an opencode restart (only print it as advice)",
+  );
+});

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -125,6 +125,81 @@ refresh_mobile_bundle() {
 
 refresh_mobile_bundle
 
+# --- Refresh the manta-native opencode tools --------------------------------
+# The AI-facing tool sources (docs/opencode-tools/*.ts) are COPIED into
+# ~/.config/opencode/tools/ rather than symlinked — opencode resolves a tool's
+# imports from the file's REAL path, so a symlink back into the checkout misses
+# ~/.config/opencode/node_modules/@opencode-ai/plugin and the tool silently
+# never registers.
+#
+# WHY THIS IS HERE: install.sh does that copy, but ONLY on install. Nothing in
+# the update path did, so `git reset --hard origin/main` refreshed the SOURCE
+# while every box kept running whatever tool copy it was installed with. Any
+# change to what the AI is told about a tool was therefore undeliverable to an
+# existing box — BET-344 rewrote serve_page's description to stop naming the
+# retired *.pages.mantaui.com domain, and no box would ever have seen it.
+#
+# Non-fatal throughout: a tool copy failing must never abort an update that has
+# already reset the checkout and reinstalled deps.
+#
+# NOTE: we deliberately do NOT restart opencode here. Picking up a new tool
+# needs an opencode restart, but that kills every in-flight agent turn on the
+# box — which is exactly the "close the lid and the work carries on" guarantee
+# the product is built on. Staging the files is safe and unconditional; they
+# take effect at the next opencode restart, and we say so.
+refresh_opencode_tools() {
+  local src="$MANTA_HOME/docs/opencode-tools"
+  local dest="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/tools"
+
+  if [ ! -d "$src" ]; then
+    echo "⚠ self-update: $src not found — skipping opencode tool refresh"
+    return 0
+  fi
+  if ! mkdir -p "$dest" 2>/dev/null; then
+    echo "⚠ self-update: cannot create $dest — skipping opencode tool refresh"
+    return 0
+  fi
+
+  # EXCLUDE *.test.ts: opencode loads EVERY file in tools/ as a tool, and a
+  # test file imports vitest (absent under ~/.config/opencode/node_modules),
+  # which makes tool resolution throw and every chat turn fail with
+  # "Cannot find package 'vitest'". Same exclusion as install.sh.
+  local copied=0 changed=0 tool base
+  for tool in "$src"/*.ts; do
+    case "$tool" in
+      *.test.ts) continue ;;
+    esac
+    [ -e "$tool" ] || continue
+    base="$(basename "$tool")"
+    if ! cmp -s "$tool" "$dest/$base" 2>/dev/null; then
+      changed=$((changed + 1))
+    fi
+    if cp -f "$tool" "$dest/" 2>/dev/null; then
+      copied=$((copied + 1))
+    else
+      echo "⚠ self-update: failed to copy opencode tool $base"
+    fi
+  done
+
+  if [ "$copied" = "0" ]; then
+    echo "⚠ self-update: no opencode tool sources found in $src"
+    return 0
+  fi
+  if [ "$changed" = "0" ]; then
+    echo "✓ self-update: opencode tools already current ($copied checked)"
+    return 0
+  fi
+  echo "✓ self-update: opencode tools refreshed ($changed of $copied changed)"
+  echo "  ↳ restart opencode to load them (this will end any running agent turn):"
+  if command -v systemctl >/dev/null 2>&1; then
+    echo "      systemctl --user restart opencode-serve"
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    echo "      launchctl kickstart -k gui/\$(id -u)/com.mantaui.opencode"
+  fi
+}
+
+refresh_opencode_tools
+
 # Restart the supervisor that runs manta-server. Linux uses the systemd
 # --user unit (default since v1); macOS (BET-277) uses the LaunchAgent
 # installed by install.sh — `launchctl kickstart -k` kills any running


### PR DESCRIPTION
Found while answering "what do users have to do to get the self-hosted pages fix?".

**The bug.** The manta-native opencode tools are COPIED into `~/.config/opencode/tools/`, never symlinked (opencode resolves imports from the file's real path, so a symlink into the checkout misses `@opencode-ai/plugin` and the tool silently never registers). `install.sh` does that copy on INSTALL — and nothing did it on UPDATE. `git reset --hard origin/main` refreshed the *source* while every box kept running the tool copy it was installed with.

So every AI-facing tool change is undeliverable to an existing box. BET-344 rewrote `serve_page`'s description to stop naming the retired `*.pages.mantaui.com` domain — no box would ever have seen it. Concretely, this dev box's installed copy still names the dead domain **5 times** while the repo names it **zero**.

This affects all six MantaUI-native tools, not just serve_page.

**The fix.** `refresh_opencode_tools()` in `self-update.sh`: copies changed tools only, excludes `*.test.ts` (opencode loads every file in `tools/` as a tool, and a vitest import there makes every chat turn fail), and is non-fatal — it runs after the checkout is already reset, so aborting would leave the box half-updated.

**Deliberately does NOT restart opencode.** Loading a new tool requires a restart, but that ends every in-flight agent turn on the box — precisely the "close the lid and the work carries on" guarantee. Files are staged unconditionally and take effect at the next restart; the script prints the command. A test pins that the script never runs the restart itself.

Tests run the real function out of the real script against a fake box layout, so a regression in the shipped source is what goes red. Red/green verified: removing the function fails 4 tests.

**Not fixed here, needs a decision:** the guidance blurb appended to `~/.config/opencode/AGENTS.md` is marker-guarded on `^## manta scheduled tasks`, so it never refreshes even on re-install — and because the marker changed across the bui→MantaUI→manta renames, boxes have accumulated **three** near-duplicate copies of the whole blurb. Cleaning that up means rewriting a user-owned config file, which I did not want to do unasked.