### PR TITLE
fix(server): publicBaseUrl falls back to ingress.json on Tailscale-only boxes

### DIFF
--- a/src/server/gatewayRegister.mjs
+++ b/src/server/gatewayRegister.mjs
@@ -63,16 +63,29 @@ export function loadAuthFile(path) {
   }
 }
 
-// The box's own public base URL, or "" when the box has never registered with
-// the gateway (Tailscale-only / offline install) and therefore has no publicly
-// resolvable hostname. Read fresh on each call: registerWithGateway() may
-// write gateway_host AFTER the server has booted, so a value cached at module
-// scope would be permanently empty on a box's first run. Reuses loadAuthFile
+// The box's own public base URL, or "" when the box has no reachable
+// hostname. Resolves in order:
+//   1. gateway_host from auth.json → https://<host> (published FQDN wins)
+//   2. serverUrl from ingress.json, only when mode === "tailscale"
+//      (Tailscale-only box — the tailnet address IS reachable from the tailnet)
+//   3. "" (unaddressable — caller must refuse rather than return a 404 URL)
+//
+// Reads both files fresh on each call: registerWithGateway() may write
+// gateway_host AFTER the server has booted, and install.sh may rewrite
+// ingress.json in the same window, so a module-scope cache would lock in
+// stale values. Reuses loadAuthFile (a plain JSON reader, not auth-specific)
 // rather than auth.mjs's loadAuth() because the latter deliberately drops
 // gateway_host (only returns {box_id, box_token, created_at}).
 export function publicBaseUrl(path = DEFAULT_AUTH_PATH) {
-  const host = loadAuthFile(path)?.gateway_host;
-  return typeof host === "string" && host ? `https://${host}` : "";
+  const auth = loadAuthFile(path);
+  const host = auth?.gateway_host;
+  if (typeof host === "string" && host) return `https://${host}`;
+
+  const ingress = loadAuthFile(join(dirname(path), "ingress.json"));
+  if (ingress?.mode === "tailscale" && typeof ingress.serverUrl === "string" && ingress.serverUrl) {
+    return ingress.serverUrl;
+  }
+  return "";
 }
 
 /**

--- a/src/server/gatewayRegister.test.mjs
+++ b/src/server/gatewayRegister.test.mjs
@@ -417,6 +417,65 @@ test("publicBaseUrl reads fresh on each call (no module-scope cache)", async () 
   assert.equal(publicBaseUrl(path), `https://${BOX_ID}.boxes.mantaui.com`);
 });
 
+// ----------------------------------------------------------------------------
+// publicBaseUrl — tailscale fallback (BET-349). A Tailscale-only box never
+// registers with the gateway (no gateway_host), but it has a reachable
+// tailnet address recorded in ~/.manta/ingress.json. The resolver MUST fall
+// back to ingress.json's serverUrl when mode === "tailscale", else serve_page
+// refuses to register a page on what is in fact a reachable box.
+// ----------------------------------------------------------------------------
+
+test("publicBaseUrl: gateway_host wins over a tailscale ingress.json", async () => {
+  const path = tmpAuthPath("public-base-gateway-wins");
+  await writeAuth(path, {
+    box_id: BOX_ID,
+    box_token: PRIOR_TOKEN,
+    gateway_host: `${BOX_ID}.boxes.mantaui.com`,
+  });
+  // ingress.json in the same directory as auth.json
+  await writeFile(join(path, "..", "ingress.json"), JSON.stringify({
+    mode: "tailscale",
+    tailnetIp: "100.64.0.1",
+    serverUrl: "http://100.64.0.1:8787",
+  }, null, 2), { mode: 0o600 });
+  assert.equal(publicBaseUrl(path), `https://${BOX_ID}.boxes.mantaui.com`);
+});
+
+test("publicBaseUrl: tailscale ingress.json when no gateway_host (BET-349 regression)", async () => {
+  const path = tmpAuthPath("public-base-tailscale");
+  await writeAuth(path, { box_id: BOX_ID, box_token: PRIOR_TOKEN });
+  await writeFile(join(path, "..", "ingress.json"), JSON.stringify({
+    mode: "tailscale",
+    tailnetIp: "100.64.0.1",
+    serverUrl: "http://100.64.0.1:8787",
+  }, null, 2), { mode: 0o600 });
+  assert.equal(publicBaseUrl(path), "http://100.64.0.1:8787");
+});
+
+test("publicBaseUrl: public-mode ingress.json is NOT a fallback", async () => {
+  const path = tmpAuthPath("public-base-public-mode");
+  await writeAuth(path, { box_id: BOX_ID, box_token: PRIOR_TOKEN });
+  await writeFile(join(path, "..", "ingress.json"), JSON.stringify({
+    mode: "public",
+  }, null, 2), { mode: 0o600 });
+  assert.equal(publicBaseUrl(path), "");
+});
+
+test("publicBaseUrl: no gateway_host and no ingress.json → ''", async () => {
+  const path = tmpAuthPath("public-base-no-ingress");
+  await writeAuth(path, { box_id: BOX_ID, box_token: PRIOR_TOKEN });
+  // No ingress.json written alongside auth.json
+  assert.equal(publicBaseUrl(path), "");
+});
+
+test("publicBaseUrl: malformed ingress.json does not throw, returns ''", async () => {
+  const path = tmpAuthPath("public-base-bad-ingress");
+  await writeAuth(path, { box_id: BOX_ID, box_token: PRIOR_TOKEN });
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(join(path, "..", "ingress.json"), "not json {", { mode: 0o600 });
+  assert.equal(publicBaseUrl(path), "");
+});
+
 // Cleanup any stray tmp dirs. Best-effort; safe to ignore errors.
 test("cleanup tmp auth files", async () => {
   // No-op assertion: each test already uses its own unique tmp path. This


### PR DESCRIPTION
## What

`publicBaseUrl()` in `src/server/gatewayRegister.mjs:73` returned `""` for any
box that never registered with the gateway. Tailscale-only boxes have no
`gateway_host`, so `serve_page` refused with
*"This box has no published public hostname"* — even though the box is
reachable over its tailnet address.

The fix: fall back to `serverUrl` from `~/.manta/ingress.json` when
`mode === "tailscale"` and no `gateway_host` is set. The state already
exists on disk (written by `scripts/install.sh` via `buildIngressJson`),
and it is exactly the right answer for a tailnet-only install.

## Changes

**`src/server/gatewayRegister.mjs`** — `publicBaseUrl()` now resolves in order:
1. `gateway_host` from `auth.json` → `https://<host>` (unchanged, still wins)
2. `serverUrl` from `ingress.json`, only when `mode === "tailscale"`
3. `""`

- Reuses `loadAuthFile()` (plain JSON reader, not auth-specific).
- Ingress path derived via `join(dirname(path), "ingress.json")` — same
  `path` injection point as the auth path, no new parameter.
- Reads fresh on every call (matches the existing no-cache rationale).
- `mode === "public"` with no `gateway_host` still returns `""` —
  genuinely unaddressable.
- JSDoc updated to describe the new resolution order.

**`src/server/gatewayRegister.test.mjs`** — five regression tests added
next to the existing four `publicBaseUrl` tests, covering every case in
the issue:
1. `gateway_host` set + tailscale `ingress.json` → gateway wins
2. No `gateway_host` + tailscale `ingress.json` → returns `serverUrl` *(regression test)*
3. No `gateway_host` + `mode: "public"` `ingress.json` → `""`
4. No `gateway_host` + no `ingress.json` → `""` (existing behavior)
5. Malformed `ingress.json` → `""`, no throw

## Out of scope (per spec)

- `scripts/install.sh` / `scripts/install-lib.mjs` — untouched.
- `src/server/servePage.mjs` — untouched (the empty-`baseUrl` guard stays).
- The `/pages/<sub>` route / CSP / auth exemption — untouched. On a
  tailnet the page is reachable only from inside the tailnet, which is
  itself the auth boundary.
- AI-facing tool description updates — separate follow-up.

## Red/green check

Commenting out the `ingress.json` fallback makes test #2 fail with the
expected `"expected 'http://100.64.0.1:8787' to equal ''"`. Restoring it
makes all 25 tests pass.

## Verification results

**Files changed:** 2 files, +79 / −7

- PR branch (`multica/BET-349-tailscale-publicBaseUrl` @ `c026741`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1045` pass / `0` fail / `0` skip. log sha256: `6d307a1cd9ffc0f9e173d8e9300e27cd86c0cfbd64042c112f6e235d503c36fa`
- Base (`main` @ `16133cb`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1040` pass / `0` fail / `0` skip. log sha256: `6dc365342e88b2056eb1e1c29c323302a1d67fa4edaa42c6ee3dff45fd98ebb9`
- **Conclusion:** 0 failures pre-existing. 5 new tests added, all pass.
  Test count went from 1040 (main) to 1045 (PR), zero failures on either side.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`,
`/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Base: origin/main @ 16133cb