### PR TITLE
docs(serve_page): teach the AI tool + guidance that a Tailscale-only box can now host pages (BET-350)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -650,9 +650,11 @@ generates on the box. Follows the same "MantaUI tools" pattern as the scheduler
   one Caddy already reverse-proxies to `127.0.0.1:8787` for the SPA, with an
   automatic LE cert — nothing new to provision. `gateway_host` is read fresh
   per call from `~/.manta/auth.json` via `publicBaseUrl()` in
-  `gatewayRegister.mjs`. **An unregistered box (Tailscale-only / offline
-  install) fails `registerPage` loudly with a clear error** — never hands
-  back a URL that would silently 404 (BET-343).
+  `gatewayRegister.mjs`. **Resolution order (BET-349):** `gateway_host`
+  wins; a Tailscale-only box with no `gateway_host` falls back to the
+  tailnet `serverUrl` in `~/.manta/ingress.json`; otherwise `registerPage`
+  fails loudly with a clear error — never hands back a URL that would
+  silently 404 (BET-343).
 - **Sandbox CSP is load-bearing.** Pages now share an origin with the SPA
   (which keeps the box_token in localStorage), so the response carries
   `Content-Security-Policy: sandbox allow-scripts allow-forms allow-popups

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -31,21 +31,22 @@ the manta UI (the ⏰ schedules card), so keep labels short and descriptive.
 You have `serve_page`, `stop_page`, and `list_pages` tools to host standalone
 HTML pages publicly. When you generate a web page (design preview, demo,
 mockup), call `serve_page(subdomain, filePath)` and use the returned URL
-verbatim — the tool serves the page on this box's own public URL, so the
-exact hostname differs from box to box. The page auto-expires after 24h
-(configurable via `ttlHours`, or `0` for no expiry). To update a page, call
-`serve_page` again with the same subdomain and a new file. Call
-`stop_page(subdomain)` to take it down early. `list_pages` shows all active
-pages.
+verbatim — the tool returns the box's own URL, which may be a public
+`https://` hostname or a private tailnet `http://` address depending on how
+the box is reached. A tailnet URL only works from inside the user's tailnet;
+if it doesn't open, that is the likely reason — not a bug to retry. The
+page auto-expires after 24h (configurable via `ttlHours`, or `0` for no
+expiry). To update a page, call `serve_page` again with the same subdomain
+and a new file. Call `stop_page(subdomain)` to take it down early.
+`list_pages` shows all active pages.
 
 - `serve_page(subdomain, filePath, ttlHours?)` -> "Page served at <url>"
 - `stop_page(subdomain)` -> "Page \"<sub>\" has been taken down."
 - `list_pages` -> bullet list of active pages with URLs and expiry times
 
-If this box never registered with the gateway (Tailscale-only / offline
-install), page hosting is unavailable and `serve_page` returns a clear error
-rather than a URL — relay the error to the user instead of retrying with a
-different file path.
+If the box has neither a public hostname nor a tailnet address,
+`serve_page` returns a clear error instead of a URL — relay the error to
+the user instead of retrying with a different file path.
 
 ## manta peer-session awareness
 

--- a/docs/opencode-tools/serve-page.ts
+++ b/docs/opencode-tools/serve-page.ts
@@ -69,14 +69,19 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
 
 export const serve_page = tool({
   description: [
-    "Host a standalone HTML webpage publicly on this box's own public URL.",
-    "Use when you generate a web page (design preview, demo, mockup, interactive",
-    "prototype) and want it accessible from anywhere — especially from the",
-    "machine where the manta UI is running. The tool returns the full public",
-    "URL from the server — echo `result.url` verbatim, NEVER construct one",
-    "yourself (the hostname differs per box). The page auto-expires after 24h",
-    "by default (configurable via ttlHours). To update a page, call this tool",
-    "again with the same subdomain and a new file path.",
+    "Host a standalone HTML webpage on the box's own URL and return it.",
+    "Use when you generate a web page (design preview, demo, mockup,",
+    "interactive prototype) and want it accessible from anywhere —",
+    "especially from the machine where the manta UI is running. The returned",
+    "URL may be a public `https://` hostname OR a private tailnet `http://`",
+    "address depending on how the box is reached — echo `result.url`",
+    "verbatim, NEVER construct one yourself. A tailnet URL is only reachable",
+    "from inside the user's tailnet (if the link doesn't open, that is the",
+    "likely reason — not a bug to retry). If the box has neither a public",
+    "hostname nor a tailnet address, `serve_page` returns a clear error",
+    "instead of a URL — relay it to the user. The page auto-expires after",
+    "24h by default (configurable via ttlHours). To update a page, call this",
+    "tool again with the same subdomain and a new file path.",
   ].join(" "),
   args: {
     subdomain: z


### PR DESCRIPTION
## Summary

Follow-up to [BET-349](https://github.com/antoinedc/MantaUI/pull/303) (merged `87a4e56`): the AI-facing copy from [BET-344](https://github.com/antoinedc/MantaUI/pull/298) still tells the model that a Tailscale-only / unregistered box returns a clear error and that page hosting is unavailable there. BET-349 changed that — `publicBaseUrl()` now falls back to the tailnet `serverUrl` in `~/.manta/ingress.json`, so page hosting **works** on Tailscale-only boxes (at the tailnet address).

Without this PR, the model will tell users `serve_page` is unavailable on exactly the boxes where it now works. Text-only fix to three files.

## Files changed

```
 AGENTS.md                         |  8 +++++---
 docs/opencode-tools/AGENTS.md     | 21 +++++++++++----------
 docs/opencode-tools/serve-page.ts | 21 +++++++++++++--------
 3 files changed, 29 insertions(+), 21 deletions(-)
```

**`docs/opencode-tools/serve-page.ts`** — rewrites the `serve_page` description so the model knows:
- The returned URL may be a public `https://` hostname OR a private tailnet `http://` address.
- Echo `result.url` verbatim, NEVER construct one yourself (the existing rule — preserved).
- A tailnet URL only works from inside the user's tailnet; if the link doesn't open, that is the likely reason — not a bug to retry.
- Hosting is unavailable only when the box has neither; in that case relay the server's error unchanged.

Tool name, args, descriptions, and return shape unchanged. No new argument.

**`docs/opencode-tools/AGENTS.md`** — same correction in the `## manta serve page` section, replacing the existing 'this box's own public URL' sentence and the closing Tailscale-only paragraph with the post-BET-349 view. Roughly the same length (file is injected into every session on every box, so the cost of added words compounds).

**`AGENTS.md`** — replaces the BET-343 'unregistered box fails registerPage loudly' sentence in the Serve page section with the post-BET-349 resolution order: `gateway_host` → tailscale `ingress.json` `serverUrl` → loud error. One or two sentences, per the issue body.

## Acceptance

- `grep -rn 'pages.mantaui.com' docs/opencode-tools/ AGENTS.md` returns nothing (BET-344's acceptance criterion — must stay clean). Verified on this branch.
- Only the three target files were modified. (One stray `website/sitemap.xml` lastmod tickled by an unrelated background process during `npm ci` was reverted before commit.)
- `npm run typecheck` → exit 0.
- `npm test` → exit 0, 1045 pass / 0 fail / 0 skip.

## Verification results

**Files changed:** 3 files. `AGENTS.md`, `docs/opencode-tools/AGENTS.md`, `docs/opencode-tools/serve-page.ts`.

**Verification results:**
- PR branch (`multica/BET-350-serve-page-tailnet-copy` @ `a41167c`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, 1045 pass / 0 fail / 0 skip. log sha256: `00522fa585d49ebed76572594992fd35cdc2eb2fa34a9b2293e035d41640d7d5`
- Base (`main` @ `87a4e56`): identical surface — text-only docs change, no logic.
- **Conclusion:** 0 new failures, 0 pre-existing. Text-only docs change — typecheck and tests pass on the PR branch exactly as on `main`.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.

## Note for the reviewer

The tool file is COPIED into `~/.config/opencode/tools/`, not symlinked, so this change reaches a box only after that copy is refreshed and opencode is restarted. That refresh now happens during self-update (shipped 2026-07-28, PR #302) — nothing extra is needed in this PR, but don't expect to see the new text on a running box the moment the PR merges.

Base: `origin/main` @ `87a4e56`
