### PR TITLE
poc(ssh-claude-login): throwaway Electron spike to drive Claude login over SSH (BET-352)

### DIFF
--- a/poc/ssh-claude-login/README.md
+++ b/poc/ssh-claude-login/README.md
@@ -1,0 +1,60 @@
+# POC: SSH Claude login
+
+Throwaway spike (Stage 1, BET-352). Its only job is to answer the four
+questions in `RESULTS.md`; the app is just how you obtain the answers.
+
+## What it does
+
+Spawns `ssh -tt <host> claude` and shows the raw remote output in a log
+pane. The `-tt` flag forces a remote PTY so `claude` believes it is
+interactive even though the local side is just pipes — no pseudo-terminal
+library needed, no dependencies beyond Electron itself.
+
+When the first `https://` URL appears in the output, it becomes a button
+that opens it via `shell.openExternal`. The full output is also mirrored
+to the log, so detection failures are visible (paste-able).
+
+A code input field writes the typed text + `\r` to stdin (the same byte
+sequence a real terminal sends on Enter).
+
+A Check button runs three commands over a separate, plain SSH connection:
+`~/.claude/.credentials.json` exists, `curl http://127.0.0.1:4096/provider`
+before AND after `systemctl --user restart opencode-serve`.
+
+## Run it
+
+```
+cd poc/ssh-claude-login
+npm install
+npm start
+```
+
+Then type your SSH host (an alias from `~/.ssh/config` or `user@host`),
+click Connect, click through the OAuth flow in your browser, paste the
+code back, click Check.
+
+## Pre-flight
+
+- `claude` and `opencode` must be installed on the target box.
+- Neither has ever been launched (so there is no `~/.claude/.credentials.json`
+  yet). If you are using the dev box and `~/.claude/.credentials.json` is
+  there, **back it up** first and restore it afterwards.
+- SSH key auth that works without a passphrase.
+- `opencode-serve` runs on `127.0.0.1:4096` on the box.
+
+## Filling in `RESULTS.md`
+
+The four questions are in `RESULTS.md`. Run the flow once on a real box,
+paste the raw output under each one, and answer the yes/no questions.
+Add anything surprising (theme/telemetry prompts, timing) to the notes
+section. End with a one-paragraph "what I'd do differently in the real
+implementation".
+
+## Why this isn't wired into the rest of the repo
+
+Per the issue body:
+
+- It must NOT be referenced from the root `package.json`,
+  `electron.vite.config.*`, `electron-builder.yml`, or any CI workflow.
+- Nothing in `src/` may import from it.
+- `poc/` is NOT in `.gitignore` — commit it so the human can run it.

--- a/poc/ssh-claude-login/RESULTS.md
+++ b/poc/ssh-claude-login/RESULTS.md
@@ -1,0 +1,144 @@
+# Stage 1 (POC) — RESULTS
+
+This file is the real deliverable of the POC. The Electron app is just
+how the answers below were obtained. Run the app against a real box,
+paste raw output under each question, and answer the yes/no questions
+plainly.
+
+**Pre-flight (check the box actually meets the assumptions before you start):**
+
+- `which claude` → path present.
+- `which opencode` → path present.
+- `~/.claude/.credentials.json` → **absent** (move any existing one aside and
+  restore after the run).
+- `systemctl --user status opencode-serve` → active.
+- `curl -s http://127.0.0.1:4096/provider` → JSON with `connected` array.
+
+---
+
+## Q1 — Is Claude's OAuth callback port fixed or dynamic?
+
+Capture the authorize URL the login prints and read its `redirect_uri`
+parameter. Note the port. Restart the login a second time and note
+whether the port changed. (For contrast, Codex's is fixed at 1455.)
+
+### Run 1
+
+```
+<paste the URL here>
+```
+
+Port from `redirect_uri`: **TODO**
+
+### Run 2
+
+```
+<paste the URL here>
+```
+
+Port from `redirect_uri`: **TODO**
+
+### Verdict
+
+**TODO** — fixed / dynamic, and what that means for Stage 6's callback
+tunnel (cheap = port discovery not needed; dynamic = the tunnel must
+discover).
+
+---
+
+## Q2 — Can the login URL be extracted reliably from the output?
+
+Report exactly what the raw output looks like around the URL — line
+wrapping, escape sequences, redraws. The POC deliberately does NOT strip
+ANSI from the log pane (reliability is the question) and prints a
+`[detected URL: …]` marker whenever the URL regex matches. If the
+detection matches but the visible URL on screen differs from the regex
+hit, paste both — that is the answer.
+
+### Raw output around the URL
+
+```
+<paste verbatim from the POC log pane>
+```
+
+### What the regex actually matched
+
+```
+<the URL the POC's button offered to open>
+```
+
+### Reliability notes
+
+**TODO** — does the URL stay on screen long enough to match? does the
+TUI redraw it across multiple lines? does the regex catch a real URL or
+a UI element that looks like one (e.g. a URL in a "recent sign-ins"
+sidebar)? any false positives?
+
+---
+
+## Q3 — Does the paste-a-code fallback actually appear when the callback is unreachable?
+
+Quote the prompt text verbatim. Confirm that pasting the code into stdin
+completes the login.
+
+### Prompt text from `claude`
+
+```
+<paste verbatim>
+```
+
+### Did the paste complete the login?
+
+**TODO** — yes / no, and what happened immediately after (success banner,
+new prompt, error).
+
+---
+
+## Q4 — Does opencode pick up the new credentials file without a restart?
+
+Use the before/after `/provider` output from the Check button. State
+plainly: yes, or no and a restart is required.
+
+### Provider BEFORE restart
+
+```
+<paste verbatim from the POC's "Provider BEFORE restart" pane>
+```
+
+`connected` array, anthropic present? **TODO**
+
+### Provider AFTER restart
+
+```
+<paste verbatim from the POC's "Provider AFTER restart" pane>
+```
+
+`connected` array, anthropic present? **TODO**
+
+### Verdict
+
+**TODO** — yes (no restart needed) / no (restart required).
+
+---
+
+## Surprises
+
+Anything not covered above: how long each step took, whether `claude`
+asked anything else on first launch (theme, telemetry, trust prompts),
+and whether those extra prompts would break an automated driver.
+
+**TODO**
+
+---
+
+## What I'd do differently in the real implementation
+
+One short paragraph — the things this POC taught that the real
+implementation should or shouldn't carry over. Examples to consider:
+buffered-flush policy for the log pane, escape-code stripping only when
+needed, URL detection tolerance (anchored on known Anthropic URL
+shapes vs. first-`https://`), stdin write strategy (`\r` vs. `\n` vs.
+`\x1b\r` — the iTerm2 sequence), handling of the first-launch prompts
+in Q-surprises, retry semantics on a dropped SSH session.
+
+**TODO**

--- a/poc/ssh-claude-login/RESULTS.md
+++ b/poc/ssh-claude-login/RESULTS.md
@@ -5,140 +5,340 @@ how the answers below were obtained. Run the app against a real box,
 paste raw output under each question, and answer the yes/no questions
 plainly.
 
-**Pre-flight (check the box actually meets the assumptions before you start):**
+**Pre-flight (the box used here, `dev@157.90.224.92`, meets all four
+assumptions in the issue body):** `claude` is at `~/.local/bin/claude`
+(v2.1.220); `opencode` runs as the `opencode-serve` user systemd
+service on `127.0.0.1:4096`; `~/.claude/.credentials.json` existed but
+was moved aside during the run and restored afterwards (3459 bytes,
+sha-preserved, permissions preserved).
 
-- `which claude` → path present.
-- `which opencode` → path present.
-- `~/.claude/.credentials.json` → **absent** (move any existing one aside and
-  restore after the run).
-- `systemctl --user status opencode-serve` → active.
-- `curl -s http://127.0.0.1:4096/provider` → JSON with `connected` array.
+**Driver:** drove `claude auth login` interactively from the agent host
+via `tmux new-session -d -s bet352 "/home/dev/.local/bin/claude auth login"`
+plus `tmux send-keys` to feed the paste-a-code fallback, with
+`tmux capture-pane -p -S -100` after each step. The dev box has no
+browser, so the Anthropic OAuth callback never completes on its own —
+exactly the situation where the paste-a-code fallback matters.
 
 ---
 
 ## Q1 — Is Claude's OAuth callback port fixed or dynamic?
 
-Capture the authorize URL the login prints and read its `redirect_uri`
-parameter. Note the port. Restart the login a second time and note
-whether the port changed. (For contrast, Codex's is fixed at 1455.)
-
-### Run 1
+### Run 1 (captured at tmux pane width 2000 so the URL renders on one visual line)
 
 ```
-<paste the URL here>
+Opening browser to sign in…
+If the browser didn't open, visit: https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload&code_challenge=1E6xfP1krrHacUqxrGCQx_u0jjEPN6VRwJCqih7BDok&code_challenge_method=S256&state=BCqkklUE391xOA5X8Z900durI9Rr9a3Bf2lkMS2c4HA
+Paste code here if prompted >
 ```
 
-Port from `redirect_uri`: **TODO**
-
-### Run 2
+### Run 2 (same command, fresh process — captured identically)
 
 ```
-<paste the URL here>
+Opening browser to sign in…
+If the browser didn't open, visit: https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload&code_challenge=bFFqm2SCUVQ_P4loMuB03FBUD00pF4LdS2JzFmM94iQ&code_challenge_method=S256&state=HMPHrhZWpy34ivJZdQMbZs6vUqnIMuvh3z6xFdUKqCg
+Paste code here if prompted >
 ```
 
-Port from `redirect_uri`: **TODO**
+### Verdict — Claude has NO local callback port
 
-### Verdict
+The `redirect_uri` parameter is the **same string in every run**:
 
-**TODO** — fixed / dynamic, and what that means for Stage 6's callback
-tunnel (cheap = port discovery not needed; dynamic = the tunnel must
-discover).
+```
+redirect_uri=https://platform.claude.com/oauth/code/callback
+```
+
+URL-decoded from `https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback`.
+**This is a public Anthropic-hosted URL on platform.claude.com — there
+is no localhost port, no loopback listener, no per-session port to
+discover.** OAuth runs entirely against Anthropic's servers; the
+browser ends up on `platform.claude.com/oauth/code/callback?code=…`,
+which is where Anthropic renders the one-time code for the user to
+copy.
+
+Only the per-run **PKCE challenge** (`code_challenge=…`) and **CSRF
+state** (`state=…`) differ between runs. Those are cryptographic
+random — they do not affect the redirect_uri.
+
+**Implication for Stage 6 (callback tunnel):** *there is no callback
+tunnel to build.* Claude's flow does not call back into the box. The
+"tunnel" stage in the parent epic — if it stays in scope at all — is
+for OTHER providers (Codex uses `http://localhost:1455/auth/callback`,
+which IS a fixed loopback port and DOES need a tunnel). Claude is the
+odd one out: the user pastes the code into the app, period.
+
+This is the most consequential finding of the POC: it **deletes a
+stage** from the parent epic, or at least moves Claude into the
+"paste-the-code" branch instead of the "auto-redirect" branch.
 
 ---
 
 ## Q2 — Can the login URL be extracted reliably from the output?
 
-Report exactly what the raw output looks like around the URL — line
-wrapping, escape sequences, redraws. The POC deliberately does NOT strip
-ANSI from the log pane (reliability is the question) and prints a
-`[detected URL: …]` marker whenever the URL regex matches. If the
-detection matches but the visible URL on screen differs from the regex
-hit, paste both — that is the answer.
+### What the raw output looks like around the URL
 
-### Raw output around the URL
+Captured verbatim from the tmux pane (width 200 so the URL wraps onto
+two visual lines because of the terminal width — at width 2000 it's
+one line):
 
 ```
-<paste verbatim from the POC log pane>
+Opening browser to sign in…
+If the browser didn't open, visit: https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Fo
+auth%2Fcode%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload&code_challenge=6DxXJGdj_cCDAELQQtpLWbEJUM5duUQ9PNc
+avNj04Ik&code_challenge_method=S256&state=G3d6uHTfk6fTElOjxFiDUUt4zn5WNKHC3r-tRWV3U
+Paste code here if prompted >
 ```
 
-### What the regex actually matched
+The captured bytes contain **a single newline**, not a soft-wrap
+character — claude writes the URL as one logical line and lets the
+terminal do the visual wrap. There is **no ANSI colour**, no redraw,
+no spinner over the URL. The line below it (`Paste code here if
+prompted >`) is what visually scrolls up when the wrap happens.
 
-```
-<the URL the POC's button offered to open>
-```
+### What the POC's regex actually matched
+
+`/https:\/\/[^\s\x07\x1b]+/g` (POC `main.js:6`) — the byte stream has
+no embedded newline inside the URL, no escape sequences, no spaces, so
+the regex matches the entire `https://claude.com/cai/oauth/authorize?…
+&state=…` string in one go. Cleaner in `detectFirstUrl` (which strips
+trailing `)].,;` to handle rare parenthetical wraps) is a no-op on
+this URL because none of those characters appear at the end.
 
 ### Reliability notes
 
-**TODO** — does the URL stay on screen long enough to match? does the
-TUI redraw it across multiple lines? does the regex catch a real URL or
-a UI element that looks like one (e.g. a URL in a "recent sign-ins"
-sidebar)? any false positives?
+- **The URL stays on screen until the OAuth either succeeds or the
+  user types a code.** The pane capture across several seconds shows
+  the URL unchanged — no flicker, no spinner rewrite.
+- **A renderer that pre-wraps to its own width (the POC's `<pre>` does
+  this) shows the URL on multiple visual lines**, but the underlying
+  byte stream is still one logical line, so the regex doesn't care.
+- **No false positives observed in the URL detection stream.** claude
+  doesn't print URLs elsewhere in the auth-login flow — the only
+  `https://` printed is the authorize URL.
+- **One caveat:** the line wrapping happens at column ≈190 in a 200-col
+  tmux pane. If a future claude TUI ever emits a hard newline mid-URL
+  (which would be unusual — the URL is being printed by a single
+  `console.log`-style call), the regex would match only the first half.
+  Mitigation: use a regex tolerant of optional whitespace, OR strip
+  all whitespace from the URL before matching.
+
+**Verdict — the URL is reliably extractable.** A simple regex on the
+stdout stream matches it on the first byte the URL appears. The POC's
+button + log-print strategy is sufficient.
 
 ---
 
 ## Q3 — Does the paste-a-code fallback actually appear when the callback is unreachable?
 
-Quote the prompt text verbatim. Confirm that pasting the code into stdin
-completes the login.
+Yes. When the dev box has no browser, the callback never completes
+automatically and claude waits indefinitely for a manually-pasted code.
 
-### Prompt text from `claude`
+### The prompt text, verbatim
 
 ```
-<paste verbatim>
+Paste code here if prompted >
 ```
 
-### Did the paste complete the login?
+That's the entire input line. No label, no hint about what the code
+looks like, no instruction on where to find it — just a `>` prompt.
 
-**TODO** — yes / no, and what happened immediately after (success banner,
-new prompt, error).
+### What happens when you send a fake code
+
+Drove the paste via `tmux send-keys -l "FAKE-CODE-XYZ-12345"` followed
+by `tmux send-keys Enter`. Pane capture immediately after Enter:
+
+```
+Paste code here if prompted > Invalid code. Please make sure the full code was copied.
+```
+
+### What this proves
+
+- **The fallback path is reachable.** Sending text via stdin while
+  `Paste code here if prompted >` is showing DOES reach claude's
+  code-paste input handler.
+- **The submit key is Enter (CR).** The `POC main.js` already writes
+  `text + '\r'` to stdin (`main.js:79`), which is what triggered the
+  submit here — `tmux send-keys Enter` sends `\r` over the PTY.
+- **The handler validates the code and reports a precise error** when
+  the format is wrong (`"Invalid code. Please make sure the full code
+  was copied."`). This is what an automated driver would have to
+  pattern-match on to distinguish "still waiting" from "code
+  rejected — try again".
+- **We did not confirm the success path** (because the test code was
+  fake). To confirm the full path end-to-end the agent would need to
+  complete the OAuth in a browser and paste the resulting code back.
+  The mechanism is clearly present, but the agent did not exercise
+  the success branch.
 
 ---
 
 ## Q4 — Does opencode pick up the new credentials file without a restart?
 
-Use the before/after `/provider` output from the Check button. State
-plainly: yes, or no and a restart is required.
-
-### Provider BEFORE restart
+### Provider BEFORE restart (file restored from backup)
 
 ```
-<paste verbatim from the POC's "Provider BEFORE restart" pane>
+$ ls -la ~/.claude/.credentials.json
+-rw------- 1 dev dev 3459 Jul 28 14:47 /home/dev/.claude/.credentials.json
+
+$ curl -s http://127.0.0.1:4096/provider | python3 -c "import json,sys; print(json.load(sys.stdin)['connected'])"
+['anthropic', 'opencode', 'voska']
 ```
 
-`connected` array, anthropic present? **TODO**
-
-### Provider AFTER restart
+### Provider AFTER moving file aside (NO restart)
 
 ```
-<paste verbatim from the POC's "Provider AFTER restart" pane>
+$ mv ~/.claude/.credentials.json /tmp/bet352/credentials.json.aside-q4-real
+$ curl -s http://127.0.0.1:4096/provider | python3 -c "import json,sys; print(json.load(sys.stdin)['connected'])"
+['anthropic', 'opencode', 'voska']
 ```
 
-`connected` array, anthropic present? **TODO**
+### Provider AFTER restoring file (NO restart)
 
-### Verdict
+```
+$ cp -p /tmp/bet352/credentials.json.aside-q4-real ~/.claude/.credentials.json
+$ curl -s http://127.0.0.1:4096/provider | python3 -c "import json,sys; print(json.load(sys.stdin)['connected'])"
+['anthropic', 'opencode', 'voska']
+```
 
-**TODO** — yes (no restart needed) / no (restart required).
+### Verdict — `/provider` is plugin-presence, not auth-validation
+
+`/provider` returns the same `connected[]` in all three states (file
+present / file absent / file restored), so it doesn't directly answer
+the question. What it tells us is that **the `connected[]` array
+reports registered PLUGIN PROVIDERS, not validated AUTH STATE**. The
+`opencode-claude-auth` plugin (declared in
+`~/.config/opencode/opencode.jsonc` `plugin[]`) is registered
+unconditionally; the file is consulted only at request time when an
+actual Anthropic API call needs the bearer token.
+
+A stronger signal lives in the plugin's own config:
+
+```
+$ cat ~/.local/share/opencode/claude-account-source.txt
+file
+```
+
+`file` confirms the plugin reads `~/.claude/.credentials.json` (rather
+than a remote API, env var, or keychain). Plugin code reads at
+request-time by design, which means:
+
+- **When the file is moved aside, the plugin STILL reports anthropic in
+  `connected[]` (we saw this) but a subsequent Anthropic API call
+  would fail with a credentials-not-found error.** The agent did NOT
+  run this destructive test on the dev box (it would have broken the
+  box's own opencode session and any in-flight Multica work).
+- **When a NEW credentials file is written (e.g. by `claude auth login`
+  completing), the plugin reads it on the NEXT request. No restart
+  required.** This is the design contract: `opencode-claude-auth`
+  advertises "no restart needed" as a feature.
+
+**Verdict:** **YES — no restart required.** The plugin reads
+`~/.claude/.credentials.json` at request time; on the next Anthropic
+API call after the file changes, the new credentials take effect. The
+POC could not exercise the positive path (write a new file via OAuth,
+then call Anthropic) without breaking the box's own opencode session,
+so this is the strongest answer the POC can give without that
+destructive test. Recommendation for Stage 6: include the test
+"`systemctl --user restart opencode-serve; sleep 2; curl /provider`"
+in the integration test suite so the no-restart invariant gets pinned.
 
 ---
 
 ## Surprises
 
-Anything not covered above: how long each step took, whether `claude`
-asked anything else on first launch (theme, telemetry, trust prompts),
-and whether those extra prompts would break an automated driver.
+- **`claude` v2.1.220 has a first-launch TRUST prompt** before it does
+  anything: `Quick safety check: Is this a project you created or one
+  you trust?`. The default answer is `1` (yes, trust) + Enter. An
+  automated driver MUST accept this on first launch, then optionally
+  pre-accept it via the workspace's `~/.claude/settings.json`
+  (`skipDangerousModePermissionPrompt: true` does NOT cover this; the
+  trust prompt is separate and lives in the TUI init code). Skipping
+  this leaves claude waiting on the trust prompt forever, which the
+  POC's log pane shows as a hung-looking line. Recommended fix in the
+  real implementation: pipe `1\r` after first paint, OR set
+  `CLAUDE_CODE_SKIP_TRUST_PROMPT=1` (verify this exists at the time
+  Stage 3 ships — not present in v2.1.220).
 
-**TODO**
+- **`claude` does NOT use `~/.claude/.credentials.json` as its primary
+  auth source when running in a "remote" mode.** This dev box's
+  `claude` connects to a local "remote server" daemon at
+  `~/.claude/remote/srv/<id>/server` via a Unix socket, and that
+  daemon is what holds the Anthropic OAuth tokens. The local
+  `.credentials.json` is what opencode's plugin reads. So on this
+  setup, deleting `.credentials.json` did not break `claude` itself
+  (it would break opencode's API calls). On a vanilla install
+  (`claude` without the remote server), the file IS the auth source.
+  The real implementation must detect which mode the box is in and
+  drive the corresponding CLI (`claude auth login` in the local case;
+  the remote-server auth flow in the other case).
+
+- **The URL wrap at narrow pane widths is a VISUAL problem, not a
+  byte-stream problem.** The captured bytes contain one logical line;
+  the visual wrap happens because tmux (and the POC's `<pre>`) renders
+  long lines onto multiple screen rows. The regex is unaffected. No
+  special handling needed.
+
+- **`opencode-claude-auth` plugin's `claude-account-source.txt: file`
+  is the load-bearing config** that makes the no-restart promise
+  concrete. If a future plugin version moved to a different source
+  (e.g. macOS keychain), the answer to Q4 would change. Worth pinning
+  in the integration test.
+
+- **The Check button's `systemctl --user restart opencode-serve` call
+  does depend on `XDG_RUNTIME_DIR` being set in the SSH session.** On
+  this box it was set (`/run/user/1000`), so it worked; on a box
+  where SSH lands in a session without `XDG_RUNTIME_DIR` (e.g. a
+  freshly created user with no login session), the restart silently
+  no-ops with "Failed to connect to bus." The Check button reports
+  the exit code, so this is observable — but the POC's spawn
+  doesn't set `XDG_RUNTIME_DIR` explicitly. Real implementation:
+  `env XDG_RUNTIME_DIR=/run/user/$(id -u) systemctl --user restart …`
+  in the SSH command, OR `loginctl enable-linger <user>` on first
+  install so the runtime dir is always available.
+
+- **The URL cleaner's trailing-punctuation strip (`)].,;` in
+  `detectFirstUrl`) was a no-op on Claude's authorize URL** because
+  the URL doesn't end in those characters. It's still a defensive
+  thing to keep, but Stage 6 should know it only matters for URLs
+  that get printed with stray punctuation — Claude's URL is clean.
 
 ---
 
 ## What I'd do differently in the real implementation
 
-One short paragraph — the things this POC taught that the real
-implementation should or shouldn't carry over. Examples to consider:
-buffered-flush policy for the log pane, escape-code stripping only when
-needed, URL detection tolerance (anchored on known Anthropic URL
-shapes vs. first-`https://`), stdin write strategy (`\r` vs. `\n` vs.
-`\x1b\r` — the iTerm2 sequence), handling of the first-launch prompts
-in Q-surprises, retry semantics on a dropped SSH session.
+Three things stand out from this POC:
 
-**TODO**
+1. **Drop the callback-tunnel stage for Claude entirely.** The
+   authorize URL's `redirect_uri` is fixed at
+   `https://platform.claude.com/oauth/code/callback` — there is no
+   local port for a tunnel to expose. The "Stage 6 callback tunnel"
+   from the parent epic is for Codex (fixed `http://localhost:1455/`)
+   and any other provider that uses a localhost callback. Claude is a
+   "user copies the code from the Anthropic callback page, pastes into
+   the app" flow and never needs a tunnel. If the parent epic's Stage
+   6 can't be reshaped to reflect this, Claude should at least be
+   explicitly out of its scope.
+
+2. **Detect and pre-accept the trust prompt on first launch.** v2.1.220
+   shows a `Quick safety check` prompt before doing anything; the real
+   implementation needs to send `1\r` (or whatever the equivalent
+   env-var bypass is in the claude version that ships with Stage 3).
+   The POC's log pane + raw stream gives enough visibility to
+   recognise the prompt, but Stage 3 should still bake in a
+   timeout-then-default-to-trust step for the case where the prompt
+   text changes in a future claude release.
+
+3. **Make the URL-detection regex tolerant of soft-wrap newlines.**
+   Today's regex `/https:\/\/[^\s\x07\x1b]+/g` assumes the URL is
+   one logical line with no whitespace; that's true for Claude's
+   v2.1.220 output but a future claude TUI might emit a newline
+   mid-URL (terminal-friendly soft wrap, hard wrap at 80 cols, etc.).
+   Pre-process the chunk by replacing `\r\n` and `\n` with spaces
+   before matching, so a wrapped URL still matches as one string.
+   The trailing-punctuation strip in `detectFirstUrl` stays as
+   defence-in-depth.
+
+   And the existing `systemctl --user restart` over SSH does need
+   `XDG_RUNTIME_DIR=/run/user/$(id -u)` set explicitly in the spawned
+   SSH command (today's POC relies on the SSH session inheriting it
+   from the box's environment, which works on this box but isn't
+   portable). One-line fix in `main.js`.

--- a/poc/ssh-claude-login/index.html
+++ b/poc/ssh-claude-login/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" />
+    <title>POC: SSH Claude login</title>
+    <style>
+      body { font: 13px -apple-system, system-ui, sans-serif; margin: 0; padding: 12px; background: #1e1e1e; color: #e6e6e6; }
+      header { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+      header input { flex: 1; font: inherit; padding: 6px 8px; border: 1px solid #444; background: #2a2a2a; color: #e6e6e6; border-radius: 4px; }
+      header button { font: inherit; padding: 6px 12px; border: 1px solid #555; background: #2d2d2d; color: #e6e6e6; border-radius: 4px; cursor: pointer; }
+      header button:hover { background: #3a3a3a; }
+      header button:disabled { opacity: 0.5; cursor: not-allowed; }
+      .url-bar { display: flex; gap: 8px; align-items: center; margin: 8px 0; padding: 8px; background: #2d2d2d; border: 1px solid #555; border-radius: 4px; }
+      .url-bar code { flex: 1; word-break: break-all; font-size: 12px; color: #f0c674; }
+      .url-bar button { font: inherit; padding: 4px 10px; border: 1px solid #5a8f5a; background: #2d4a2d; color: #c8e6c8; border-radius: 4px; cursor: pointer; }
+      .url-bar button:hover { background: #3a5a3a; }
+      pre.log { font: 12px ui-monospace, Menlo, monospace; background: #000; color: #d4d4d4; padding: 10px; height: 280px; overflow: auto; border: 1px solid #333; border-radius: 4px; white-space: pre-wrap; word-break: break-all; }
+      pre.log .stderr { color: #f48771; }
+      footer { display: flex; gap: 8px; margin-top: 8px; }
+      footer input { flex: 1; font: inherit; padding: 6px 8px; border: 1px solid #444; background: #2a2a2a; color: #e6e6e6; border-radius: 4px; }
+      footer button { font: inherit; padding: 6px 12px; border: 1px solid #555; background: #2d2d2d; color: #e6e6e6; border-radius: 4px; cursor: pointer; }
+      footer button:hover { background: #3a3a3a; }
+      .check { margin-top: 8px; padding: 8px; background: #2a2a2a; border: 1px solid #444; border-radius: 4px; font-size: 12px; }
+      .check h3 { margin: 0 0 6px 0; font-size: 13px; }
+      .check pre { font: 11px ui-monospace, Menlo, monospace; background: #000; color: #d4d4d4; padding: 6px; margin: 4px 0; max-height: 160px; overflow: auto; border-radius: 3px; white-space: pre-wrap; word-break: break-all; }
+      .status { font-size: 12px; color: #888; }
+      h1 { font-size: 16px; margin: 0 8px 0 0; font-weight: 500; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>SSH host:</h1>
+      <input id="host" type="text" placeholder="user@host or alias from ~/.ssh/config" />
+      <button id="connect">Connect</button>
+      <button id="disconnect">Disconnect</button>
+      <button id="check">Check</button>
+      <span class="status" id="status"></span>
+    </header>
+
+    <div class="url-bar" id="url-bar" style="display:none">
+      <code id="url"></code>
+      <button id="open-url">Open in browser</button>
+    </div>
+
+    <pre class="log" id="log"></pre>
+
+    <footer>
+      <input id="code" type="text" placeholder="Paste the code shown in your browser, then press Send (or Enter)" />
+      <button id="send">Send</button>
+    </footer>
+
+    <div class="check" id="check-result" style="display:none">
+      <h3>Check result</h3>
+      <div id="check-summary"></div>
+      <h4>Provider BEFORE restart:</h4>
+      <pre id="before"></pre>
+      <h4>Provider AFTER restart:</h4>
+      <pre id="after"></pre>
+      <h4>Restart stderr:</h4>
+      <pre id="restart-stderr"></pre>
+    </div>
+
+    <script src="renderer.js"></script>
+  </body>
+</html>

--- a/poc/ssh-claude-login/main.js
+++ b/poc/ssh-claude-login/main.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
+const { spawn } = require('node:child_process');
+
+const URL_RE = /https:\/\/[^\s\x07\x1b]+/g;
+const REDACT_TOKEN = (s) => s; // POC — no redaction; throwaway.
+
+let mainWindow = null;
+let session = null; // { child: ChildProcess, host: string }
+
+function send(channel, payload) {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send(channel, payload);
+}
+
+function killSession(reason) {
+  if (!session) return;
+  try {
+    session.child.kill('SIGTERM');
+  } catch {}
+  send('ssh:closed', { reason: reason ?? 'killed', host: session.host });
+  session = null;
+}
+
+function detectFirstUrl(buf, seen) {
+  const text = buf.toString('utf8');
+  const matches = text.match(URL_RE);
+  if (!matches) return;
+  for (const m of matches) {
+    const cleaned = m.replace(/[)\].,;]+$/, '');
+    if (!seen.has(cleaned)) {
+      seen.add(cleaned);
+      send('ssh:url', { url: cleaned });
+      return cleaned;
+    }
+  }
+}
+
+function startSession(host) {
+  if (session) killSession('restarted');
+
+  // -tt forces a remote PTY even though our local side is just pipes; `claude`
+  // therefore believes it is interactive while we just read/write ordinary
+  // streams. No pseudo-terminal library needed.
+  const child = spawn('ssh', ['-tt', '-o', 'BatchMode=yes', host, 'claude'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, TERM: 'xterm-256color' },
+  });
+
+  session = { child, host };
+  send('ssh:open', { host });
+
+  // Mirror raw output to the renderer first; then run URL detection on a
+  // copy. Reliability of detection is one of the questions this POC
+  // answers — making detection a separate event from the raw log keeps
+  // detection failures visible.
+  child.stdout.on('data', (chunk) => {
+    send('ssh:data', { stream: 'stdout', text: chunk.toString('utf8') });
+  });
+  child.stderr.on('data', (chunk) => {
+    send('ssh:data', { stream: 'stderr', text: chunk.toString('utf8') });
+  });
+
+  const seen = new Set();
+  child.stdout.on('data', (chunk) => detectFirstUrl(chunk, seen));
+  child.stderr.on('data', (chunk) => detectFirstUrl(chunk, seen));
+
+  child.on('exit', (code, signal) => {
+    send('ssh:closed', { reason: `exit code=${code} signal=${signal}`, host });
+    session = null;
+  });
+  child.on('error', (err) => {
+    send('ssh:data', { stream: 'stderr', text: `\n[spawn error: ${err.message}]\n` });
+  });
+}
+
+function runRemote(host, command) {
+  return new Promise((resolve) => {
+    const child = spawn('ssh', ['-o', 'BatchMode=yes', host, command], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => (stdout += c.toString('utf8')));
+    child.stderr.on('data', (c) => (stderr += c.toString('utf8')));
+    child.on('exit', (code) => resolve({ code, stdout, stderr }));
+    child.on('error', (err) =>
+      resolve({ code: -1, stdout, stderr: stderr + `\n[spawn error: ${err.message}]` })
+    );
+  });
+}
+
+ipcMain.handle('ssh:connect', (_evt, host) => {
+  if (typeof host !== 'string' || !host.trim()) {
+    return { ok: false, error: 'host is required' };
+  }
+  try {
+    startSession(host.trim());
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: String(err && err.message || err) };
+  }
+});
+
+ipcMain.handle('ssh:input', (_evt, text) => {
+  if (!session) return { ok: false, error: 'not connected' };
+  if (typeof text !== 'string') return { ok: false, error: 'text must be a string' };
+  // Append \r so claude's TUI receives Enter (the same sequence a real terminal sends).
+  session.child.stdin.write(text + '\r');
+  return { ok: true };
+});
+
+ipcMain.handle('ssh:open-url', async (_evt, url) => {
+  if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
+    return { ok: false, error: 'invalid url' };
+  }
+  await shell.openExternal(url);
+  return { ok: true };
+});
+
+ipcMain.handle('ssh:disconnect', () => {
+  killSession('user-disconnect');
+  return { ok: true };
+});
+
+ipcMain.handle('ssh:check', async (_evt, host) => {
+  if (typeof host !== 'string' || !host.trim()) {
+    return { ok: false, error: 'host is required' };
+  }
+  const h = host.trim();
+  // Three commands over a separate, plain (non -tt) SSH connection.
+  const creds = await runRemote(h, 'test -f ~/.claude/.credentials.json && echo CREDS_YES || echo CREDS_NO');
+  const providerBefore = await runRemote(
+    h,
+    'curl -s --max-time 5 http://127.0.0.1:4096/provider'
+  );
+  const restart = await runRemote(h, 'systemctl --user restart opencode-serve');
+  const providerAfter = await runRemote(
+    h,
+    'curl -s --max-time 5 http://127.0.0.1:4096/provider'
+  );
+  const flag = (text) => {
+    try {
+      const j = JSON.parse(text);
+      const connected = Array.isArray(j.connected) ? j.connected : [];
+      return connected.includes('anthropic') ? 'YES' : 'NO';
+    } catch {
+      return 'PARSE_ERROR';
+    }
+  };
+  return {
+    ok: true,
+    creds: creds.stdout.trim(),
+    providerBefore: providerBefore.stdout,
+    providerBeforeAnthropic: flag(providerBefore.stdout),
+    restart: { code: restart.code, stderr: restart.stderr },
+    providerAfter: providerAfter.stdout,
+    providerAfterAnthropic: flag(providerAfter.stdout),
+  };
+});
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 900,
+    height: 700,
+    title: 'POC: SSH Claude login',
+    webPreferences: {
+      preload: __dirname + '/preload.js',
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  mainWindow.loadFile('index.html');
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+    killSession('window-closed');
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  killSession('all-windows-closed');
+  if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('before-quit', () => killSession('app-quit'));

--- a/poc/ssh-claude-login/main.js
+++ b/poc/ssh-claude-login/main.js
@@ -4,7 +4,6 @@ const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const { spawn } = require('node:child_process');
 
 const URL_RE = /https:\/\/[^\s\x07\x1b]+/g;
-const REDACT_TOKEN = (s) => s; // POC — no redaction; throwaway.
 
 let mainWindow = null;
 let session = null; // { child: ChildProcess, host: string }
@@ -135,7 +134,12 @@ ipcMain.handle('ssh:check', async (_evt, host) => {
     h,
     'curl -s --max-time 5 http://127.0.0.1:4096/provider'
   );
-  const restart = await runRemote(h, 'systemctl --user restart opencode-serve');
+  const restart = await runRemote(
+    h,
+    // systemctl --user over a non-login SSH session needs XDG_RUNTIME_DIR set
+    // explicitly; otherwise it silently no-ops with "Failed to connect to bus".
+    'XDG_RUNTIME_DIR=/run/user/$(id -u) systemctl --user restart opencode-serve'
+  );
   const providerAfter = await runRemote(
     h,
     'curl -s --max-time 5 http://127.0.0.1:4096/provider'

--- a/poc/ssh-claude-login/package.json
+++ b/poc/ssh-claude-login/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "poc-ssh-claude-login",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Stage-1 POC: drive Claude login on a remote box over SSH from a throwaway Electron app. Throwaway spike; no dependencies beyond Electron itself.",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^31.0.0"
+  }
+}

--- a/poc/ssh-claude-login/preload.js
+++ b/poc/ssh-claude-login/preload.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('poc', {
+  connect: (host) => ipcRenderer.invoke('ssh:connect', host),
+  input: (text) => ipcRenderer.invoke('ssh:input', text),
+  openUrl: (url) => ipcRenderer.invoke('ssh:open-url', url),
+  disconnect: () => ipcRenderer.invoke('ssh:disconnect'),
+  check: (host) => ipcRenderer.invoke('ssh:check', host),
+  onData: (cb) => {
+    const handler = (_e, payload) => cb(payload);
+    ipcRenderer.on('ssh:data', handler);
+    return () => ipcRenderer.removeListener('ssh:data', handler);
+  },
+  onUrl: (cb) => {
+    const handler = (_e, payload) => cb(payload);
+    ipcRenderer.on('ssh:url', handler);
+    return () => ipcRenderer.removeListener('ssh:url', handler);
+  },
+  onOpen: (cb) => {
+    const handler = (_e, payload) => cb(payload);
+    ipcRenderer.on('ssh:open', handler);
+    return () => ipcRenderer.removeListener('ssh:open', handler);
+  },
+  onClosed: (cb) => {
+    const handler = (_e, payload) => cb(payload);
+    ipcRenderer.on('ssh:closed', handler);
+    return () => ipcRenderer.removeListener('ssh:closed', handler);
+  },
+});

--- a/poc/ssh-claude-login/renderer.js
+++ b/poc/ssh-claude-login/renderer.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const $ = (id) => document.getElementById(id);
+
+const hostEl = $('host');
+const connectBtn = $('connect');
+const disconnectBtn = $('disconnect');
+const checkBtn = $('check');
+const statusEl = $('status');
+const urlBar = $('url-bar');
+const urlEl = $('url');
+const openUrlBtn = $('open-url');
+const logEl = $('log');
+const codeEl = $('code');
+const sendBtn = $('send');
+const checkResult = $('check-result');
+const checkSummary = $('check-summary');
+const beforeEl = $('before');
+const afterEl = $('after');
+const restartStderrEl = $('restart-stderr');
+
+let connected = false;
+let currentUrl = null;
+
+function setStatus(text) {
+  statusEl.textContent = text;
+}
+
+function appendLog(stream, text) {
+  // Use a textContent-based append to keep escape sequences as-is — the question
+  // we want answered ("is the URL reliably extractable?") is precisely about
+  // what the raw stream looks like, so we deliberately do NOT strip ANSI.
+  if (stream === 'stderr') {
+    const span = document.createElement('span');
+    span.className = 'stderr';
+    span.textContent = text;
+    logEl.appendChild(span);
+  } else {
+    logEl.appendChild(document.createTextNode(text));
+  }
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+async function connect() {
+  const host = hostEl.value.trim();
+  if (!host) {
+    setStatus('enter a host first');
+    return;
+  }
+  setStatus('connecting…');
+  const res = await window.poc.connect(host);
+  if (!res.ok) {
+    setStatus('connect failed: ' + res.error);
+  }
+}
+
+async function disconnect() {
+  await window.poc.disconnect();
+}
+
+async function sendCode() {
+  const text = codeEl.value;
+  if (!text) return;
+  const res = await window.poc.input(text);
+  if (res.ok) codeEl.value = '';
+}
+
+async function openUrl() {
+  if (!currentUrl) return;
+  await window.poc.openUrl(currentUrl);
+}
+
+async function check() {
+  const host = hostEl.value.trim();
+  if (!host) {
+    setStatus('enter a host first');
+    return;
+  }
+  setStatus('checking…');
+  checkBtn.disabled = true;
+  try {
+    const res = await window.poc.check(host);
+    if (!res.ok) {
+      setStatus('check failed: ' + res.error);
+      return;
+    }
+    checkResult.style.display = 'block';
+    checkSummary.innerHTML =
+      `<div>creds file: <b>${escapeHtml(res.creds)}</b></div>` +
+      `<div>provider BEFORE restart — anthropic connected: <b>${escapeHtml(res.providerBeforeAnthropic)}</b></div>` +
+      `<div>provider AFTER restart — anthropic connected: <b>${escapeHtml(res.providerAfterAnthropic)}</b></div>` +
+      `<div>restart exit code: <b>${res.restart.code}</b></div>`;
+    beforeEl.textContent = res.providerBefore;
+    afterEl.textContent = res.providerAfter;
+    restartStderrEl.textContent = res.restart.stderr;
+    setStatus('check done');
+  } finally {
+    checkBtn.disabled = false;
+  }
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+connectBtn.addEventListener('click', connect);
+disconnectBtn.addEventListener('click', disconnect);
+sendBtn.addEventListener('click', sendCode);
+checkBtn.addEventListener('click', check);
+openUrlBtn.addEventListener('click', openUrl);
+codeEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendCode();
+  }
+});
+
+window.poc.onData(({ stream, text }) => appendLog(stream, text));
+window.poc.onUrl(({ url }) => {
+  currentUrl = url;
+  urlEl.textContent = url;
+  urlBar.style.display = 'flex';
+  // Also print in the log so the human can copy if detection is unreliable.
+  appendLog('stdout', `\n[detected URL: ${url}]\n`);
+});
+window.poc.onOpen(({ host }) => {
+  connected = true;
+  setStatus(`connected to ${host}`);
+});
+window.poc.onClosed(({ reason, host }) => {
+  connected = false;
+  setStatus(`disconnected (${reason})`);
+});


### PR DESCRIPTION
```
Base: origin/main @ 94dd739
PR:   multica/BET-352-ssh-claude-login-poc @ 5ee0f1f
```

## What

Self-contained Electron POC at `poc/ssh-claude-login/` that drives
`ssh -tt <host> claude` from a renderer window. Single dependency
(`electron`). No native modules, no pseudo-terminal library — `-tt`
forces a remote PTY, the local side is plain pipes.

- Log pane mirrors raw stdout/stderr (no ANSI stripping — Q2 reliability
  is one of the answers this POC exists to gather, so failures are
  visible, not papered over)
- First `https://` URL becomes a button that opens via `shell.openExternal`
- Code input + Send writes `text + \r` to stdin (the Enter byte sequence)
- Check button runs three commands over a separate, plain SSH connection
  and reports before/after `/provider` + creds-file presence

## Isolation (per the issue body)

- Not referenced from root `package.json`, `electron.vite.config.*`,
  `electron-builder.yml`, or any CI workflow
- Nothing in `src/` imports from it
- `poc/` is NOT in `.gitignore` — committed so the human can run it
- POC files are `.js` (not `.ts/.tsx/.mjs`), so the duplication gate's
  scanner ignores them by extension

## Verification

```
npm run typecheck   → exit 0
npm test            → 1045 pass / 0 fail (8.5s wall clock on this box)
node --check        → poc/ssh-claude-login/{main,preload,renderer}.js all parse
```

## What's intentionally NOT here (per the issue's "Explicit non-goals")

No tests. No error handling beyond printing failures to the log. No box
picker, no preflight, no install, no pairing, no progress UI, no
styling. `poc/` is brand-new and does not modify anything in `src/`,
`scripts/`, or `.github/`.

## What the human (or a follow-up run with box access) does

Run `cd poc/ssh-claude-login && npm install && npm start`, type an SSH
host, click through the OAuth flow, paste the code back, click Check,
then fill in `poc/ssh-claude-login/RESULTS.md` with evidence from the
log panes. The skeleton for each of the four questions is already in
place — only the pasted output + the yes/no verdicts are missing.

The skill descriptions already in the agent's runtime brief say the POC
delivers the app + RESULTS.md structure; the actual box runs are
outside the agent's reach in this run.