### PR TITLE
feat(auth): remove box → unpair it (BET-357 §2)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { loadConfig, saveConfig } from "./config.js";
 import { claimPairing } from "./auth.js";
+import { unpairBox } from "./unpair.js";
 import {
   startDesktopPresence,
   stopDesktopPresence,
@@ -402,6 +403,30 @@ function registerHandlers(): void {
   ipcMain.handle(IPC.authClaim, (_e, input: AuthClaimInput) =>
     claimPairing(input, (patch) => commit(patch)),
   );
+
+  // BET-357 §2: "Remove this box from the device that holds the current
+  // box_token". Reads the live { serverUrl, boxToken } from config (so the
+  // renderer never holds a stale copy), DELETEs <serverUrl>/auth/revoke, and
+  // — REGARDLESS of the remote outcome — clears the local config entry.
+  // The unreachable-box path still succeeds locally per the spec; the
+  // returned UnpairOutcome lets the renderer's Settings panel surface a
+  // structured note when the remote revocation didn't happen.
+  ipcMain.handle(IPC.authUnpair, async () => {
+    const serverUrl = config.serverUrl ?? "";
+    const boxToken = config.boxToken ?? "";
+    const outcome = await unpairBox({ serverUrl, boxToken });
+    // ALWAYS clear locally: config.ts is the single token writer (BET-355 §4).
+    // Empty strings (not delete) so the field shape on disk stays stable
+    // across saves — the schema migration in loadConfig doesn't need to
+    // chase removed keys.
+    commit({
+      serverUrl: "",
+      boxId: "",
+      boxToken: "",
+      projects: [],
+    });
+    return outcome;
+  });
 
   // BET-355 (Stage 4): SSH installer flow. The channels exposed by
   // registerInstallerHandlers are the renderer's ONLY handle on the

--- a/src/main/unpair.test.ts
+++ b/src/main/unpair.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { unpairBox } from "./unpair.js";
+
+const HEX32 = "0123456789abcdef0123456789abcdef";
+const SERVER = `https://${HEX32}.boxes.mantaui.com`;
+
+function fakeResponse(status: number): Response {
+  return { status } as unknown as Response;
+}
+
+function stubFetch(res: Response | { throw: true }): {
+  fetch: typeof fetch;
+  urls: string[];
+  headers: Record<string, string>[];
+} {
+  const urls: string[] = [];
+  const headers: Record<string, string>[] = [];
+  const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+    urls.push(url);
+    const hdr: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) hdr[k.toLowerCase()] = h[k];
+    }
+    headers.push(hdr);
+    if ("throw" in res) throw new Error("ECONNREFUSED");
+    return res;
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, urls, headers };
+}
+
+describe("unpairBox — wire call to DELETE /auth/revoke (BET-357 §2)", () => {
+  it("200 → ok and sends DELETE + Bearer to <serverUrl>/auth/revoke", async () => {
+    const { fetch, urls, headers } = stubFetch(fakeResponse(200));
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(true);
+    expect(urls).toEqual([`${SERVER}/auth/revoke`]);
+    // Request is DELETE with the box_token in the Authorization header.
+    expect(headers[0]).toEqual({ authorization: `Bearer ${HEX32}` });
+  });
+
+  it("trims trailing slash off serverUrl before the request", async () => {
+    const { fetch, urls } = stubFetch(fakeResponse(200));
+    await unpairBox({ serverUrl: `${SERVER}/`, boxToken: HEX32 }, fetch);
+    expect(urls).toEqual([`${SERVER}/auth/revoke`]);
+  });
+
+  it("401 → auth_rejected", async () => {
+    const { fetch } = stubFetch(fakeResponse(401));
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.kind).toBe("auth_rejected");
+      expect(out.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("400 → bad_request (malformed-token shape, per server's manual gate)", async () => {
+    const { fetch } = stubFetch(fakeResponse(400));
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("bad_request");
+  });
+
+  it("429 → rate_limited", async () => {
+    const { fetch } = stubFetch(fakeResponse(429));
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("rate_limited");
+  });
+
+  it("5xx → server_error", async () => {
+    for (const status of [500, 502, 503]) {
+      const { fetch } = stubFetch(fakeResponse(status));
+      const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.kind).toBe("server_error");
+    }
+  });
+
+  it("fetch rejected (network failure) → network without crashing", async () => {
+    const { fetch } = stubFetch({ throw: true });
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("network");
+  });
+
+  it("empty serverUrl → network, no fetch", async () => {
+    const { fetch, urls } = stubFetch(fakeResponse(200));
+    const out = await unpairBox({ serverUrl: "", boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("network");
+    expect(urls).toEqual([]);
+  });
+
+  it("empty boxToken → network, no fetch (can't present a token)", async () => {
+    const { fetch, urls } = stubFetch(fakeResponse(200));
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: "" }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("network");
+    expect(urls).toEqual([]);
+  });
+
+  it("404 → unexpected (server doesn't recognize this route)", async () => {
+    const { fetch } = stubFetch(fakeResponse(404));
+    const out = await unpairBox({ serverUrl: SERVER, boxToken: HEX32 }, fetch);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.kind).toBe("unexpected");
+  });
+});

--- a/src/main/unpair.ts
+++ b/src/main/unpair.ts
@@ -1,0 +1,71 @@
+// unpair.ts (desktop) — the "Remove box" wire call (BET-357 §2).
+//
+// The desktop Settings → Connection → "Remove box" action invokes the
+// `authUnpair` IPC channel, which lands here. We DELETE <serverUrl>/auth/revoke
+// with the current box_token as a Bearer header. The box rotates its identity
+// in place (see src/server/auth.mjs revoke) and the OLD token is dead from
+// that instant.
+//
+// The IPC handler in src/main/index.ts ALWAYS clears the local config entry
+// (serverUrl / boxId / boxToken / projects) regardless of the remote outcome —
+// the unreachable-box path must still succeed locally per the spec. This
+// function returns ONLY the classified remote outcome so the caller can decide
+// whether to surface a "remote revocation didn't happen" note.
+
+import { classifyUnpairHttp } from "../shared/unpair.mjs";
+import type { UnpairOutcome } from "../shared/unpair.mjs";
+
+/**
+ * Perform the wire call to remove this box from the device that holds the
+ * current box_token. Pure of side effects (no FS, no config mutation) — the
+ * IPC handler is responsible for the local config clear so the policy lives
+ * in exactly one place.
+ *
+ * @param input        { serverUrl, boxToken } — the box's direct-HTTPS URL
+ *                     and the current device-held bearer token. The renderer
+ *                     reads both from the store at click time; no caching
+ *                     here.
+ * @param fetchImpl    Injectable for tests; defaults to global fetch.
+ * @param now          Injectable clock (currently unused — reserved for
+ *                     future timing instrumentation).
+ * @returns the classified {@link UnpairOutcome}. A wrong token, a rate limit,
+ *          an unreachable host, etc. are all normal `{ ok:false }` results —
+ *          this function never throws for an expected auth/transport failure.
+ *          Unexpected exceptions (e.g. fetch throwing for a non-network
+ *          reason) ARE propagated so the IPC handler can decide how to
+ *          handle them; the caller will translate the throw into a
+ *          `{ ok:false, kind:"network" }` so the Settings panel still has a
+ *          structured outcome to render.
+ */
+export async function unpairBox(
+  input: { serverUrl: string; boxToken: string },
+  fetchImpl: typeof fetch = fetch,
+): Promise<UnpairOutcome> {
+  const serverUrl = (input?.serverUrl ?? "").trim();
+  const boxToken = (input?.boxToken ?? "").trim();
+  if (serverUrl === "" || boxToken === "") {
+    // Local drift: no URL or token cached → can't even attempt the call.
+    // Surface as "network" so the Settings panel doesn't have to branch on a
+    // distinct "missing creds" shape — the unreachable-box fallback is the
+    // right UX either way (clear locally, show the note).
+    return { ok: false, kind: "network", message: "" };
+  }
+  const url = `${serverUrl.replace(/\/+$/, "")}/auth/revoke`;
+  let status: number | null = null;
+  let networkError: string | null = null;
+  try {
+    const res = await fetchImpl(url, {
+      method: "DELETE",
+      headers: {
+        authorization: `Bearer ${boxToken}`,
+      },
+    });
+    status = res.status;
+  } catch (e) {
+    // fetch rejected (offline / DNS / TLS / connection refused / timeout).
+    // Map to a generic network tag; the classifier collapses all fetch-level
+    // failures into one outcome for the UI.
+    networkError = e instanceof Error ? e.message : String(e);
+  }
+  return classifyUnpairHttp({ status, networkError });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,7 @@ import {
   type InstallerStageSnapshotRow,
 } from "../shared/types.js";
 import type { ClaimOutcome } from "../shared/claim.mjs";
+import type { UnpairOutcome } from "../shared/unpair.mjs";
 import type { PreflightResult } from "../main/installer/preflight.js";
 import type { SshHostEntry } from "../main/installer/sshConfig.js";
 
@@ -49,6 +50,16 @@ const api = {
   // { ok:false } result, NOT a rejected promise.
   authClaim: (input: AuthClaimInput): Promise<ClaimOutcome> =>
     ipcRenderer.invoke(IPC.authClaim, input),
+
+  // BET-357 §2: "Remove this box from the device that holds the current
+  // box_token". Main reads the live { serverUrl, boxToken } from config
+  // (never trusting a renderer-supplied copy — those would be stale the
+  // instant the config changes), DELETEs <serverUrl>/auth/revoke, and
+  // ALWAYS clears the local config entry as a single transactional step.
+  // The unreachable-box path therefore still succeeds locally; the
+  // UnpairOutcome is the structured note the Settings panel renders
+  // ("removed locally — remote revocation didn't reach the box").
+  authUnpair: (): Promise<UnpairOutcome> => ipcRenderer.invoke(IPC.authUnpair),
 
   clipboardWriteText: (text: string): Promise<void> =>
     ipcRenderer.invoke(IPC.clipboardWriteText, text),

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -102,6 +102,16 @@ export function Settings({ onClose }: { onClose: () => void }) {
   const [pairingExpiry, setPairingExpiry] = useState<Date | null>(null);
   const [pairingMinting, setPairingMinting] = useState(false);
 
+  // Remove-box (BET-357 §2): the in-flight flag plus the latest outcome so
+  // the Settings panel can render a structured note when remote revocation
+  // didn't reach the box (the unreachable-box fallback is honored regardless
+  // — the local config IS cleared, the note is just informational).
+  const [removingBox, setRemovingBox] = useState(false);
+  const [removeResult, setRemoveResult] = useState<{
+    ok: boolean;
+    message: string;
+  } | null>(null);
+
   // Active tab
   const [activeTab, setActiveTab] = useState<TabId>("connection");
 
@@ -266,6 +276,74 @@ export function Settings({ onClose }: { onClose: () => void }) {
     }
   };
 
+  // Remove this box (BET-357 §2): DELETE <serverUrl>/auth/revoke with the
+  // current box_token, then clear the local config entry regardless of the
+  // remote outcome (the unreachable-box path still succeeds locally per the
+  // spec). On a remote failure we surface a structured note so the user
+  // knows the box's own token is still alive until the next device re-pairs.
+  const removeBox = async () => {
+    if (removingBox) return;
+    // Native confirm — same simplicity the existing "Run setup again" uses
+    // for an irreversible action. The user is about to drop their pairing
+    // and any saved projects; we don't want a one-click accident.
+    const confirmed = window.confirm(
+      "Remove this box from the desktop?\n\n" +
+        "The desktop will forget its pairing and saved projects. " +
+        "If the box is reachable, its current token is also revoked. " +
+        "If the box is offline, the local credentials are cleared and the " +
+        "box's token will be rotated the next time it starts.\n\n" +
+        "Continue?",
+    );
+    if (!confirmed) return;
+    setRemovingBox(true);
+    setRemoveResult(null);
+    // authUnpair is a desktop-only IPC channel (mobile/web have no preload
+    // and therefore can't trigger a remote revoke) — null-check the bridge
+    // so the Settings panel still renders cleanly on those platforms.
+    const preload = getMantaPreload();
+    if (!preload?.authUnpair) {
+      setRemovingBox(false);
+      setRemoveResult({
+        ok: false,
+        message: "Removing a box is only supported in the desktop app.",
+      });
+      return;
+    }
+    try {
+      const outcome = await preload.authUnpair();
+      // Always reflect the cleared state in the store so subsequent Save
+      // calls don't try to re-persist the (now-empty) box identity.
+      await refresh().catch(() => {
+        /* refresh is best-effort; config.json is already cleared */
+      });
+      if (outcome.ok) {
+        // Clean exit: nothing to surface besides the dialog closing.
+        setRemoveResult({ ok: true, message: "" });
+        onClose();
+        return;
+      }
+      // Remote revocation didn't reach the box. The local credentials are
+      // gone — surface the UnpairOutcome.message so the user knows what
+      // happened (and can re-pair from scratch on next launch if they want
+      // to start over cleanly).
+      setRemoveResult({
+        ok: false,
+        message:
+          outcome.message ||
+          "The box's token could not be revoked remotely. Local credentials were cleared.",
+      });
+    } catch (e) {
+      // IPC crash — the local clear also didn't happen. Bail out without
+      // closing so the user can retry.
+      setRemoveResult({
+        ok: false,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setRemovingBox(false);
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-bg z-50 flex">
       {/* Left sidebar navigation */}
@@ -401,6 +479,32 @@ export function Settings({ onClose }: { onClose: () => void }) {
                     Run setup again
                   </button>
                 </div>
+              </div>
+
+              {/* Remove box (BET-357 §2): clears the local pairing triple and
+                  asks the box (when reachable) to revoke the current box_token.
+                  Always clears locally — the unreachable-box path is honored
+                  per the spec, with the UnpairOutcome surfaced as a note when
+                  remote revocation didn't reach the box. */}
+              <div className="border-t border-border pt-6">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-text-faint">
+                    Forget this box on the desktop. If the box is reachable,
+                    its current token is revoked too.
+                  </div>
+                  <button
+                    onClick={removeBox}
+                    disabled={removingBox}
+                    className="text-sm px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-red-400 hover:border-red-400 disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+                  >
+                    {removingBox ? "Removing…" : "Remove box"}
+                  </button>
+                </div>
+                {removeResult && !removeResult.ok && (
+                  <div className="text-sm text-amber-400 mt-3">
+                    {removeResult.message}
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -79,6 +79,11 @@ function makeFakePreload(): MantaPreload {
     })),
     installerGetDiagnostics: vi.fn(async () => ""),
     onInstallerEvent: vi.fn(() => vi.fn()),
+    // BET-357 §2: "remove this box" — desktop-only IPC, no-op on
+    // mobile/web. The fake matches the MantaPreload shape; per-method
+    // behavior is exercised by src/renderer/Settings.tsx + the main
+    // process unpairBox tests.
+    authUnpair: vi.fn(async () => ({ ok: true as const })),
   };
 }
 

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -8,6 +8,7 @@ import type { InstallerEvent, InstallerState } from "../shared/types.js";
 import type { PreflightResult } from "../main/installer/preflight.js";
 import type { SshHostEntry } from "../main/installer/sshConfig.js";
 import type { InstallerStageSnapshotRow } from "../shared/types.js";
+import type { UnpairOutcome } from "../shared/unpair.mjs";
 
 // Re-export so the renderer can use the type names from the same accessor
 // module that exposes the preload methods — same pattern as the existing
@@ -72,6 +73,16 @@ export interface MantaPreload {
   // pluginsSetEnabled; both are no-ops on mobile/web (no preload).
   pluginsGetEnabled(): Promise<boolean>;
   pluginsSetEnabled(value: boolean): Promise<void>;
+
+  // BET-357 §2: "Remove this box from the device that holds the current
+  // box_token". Main reads the live { serverUrl, boxToken } from config
+  // (never trusting a renderer-supplied copy — those would be stale the
+  // instant the config changes), DELETEs <serverUrl>/auth/revoke, and
+  // ALWAYS clears the local config entry as a single transactional step.
+  // The unreachable-box path therefore still succeeds locally; the
+  // UnpairOutcome is the structured note the Settings panel renders
+  // ("removed locally — remote revocation didn't reach the box").
+  authUnpair(): Promise<UnpairOutcome>;
   // Client version (BET-225 stage 3): returns the running desktop app's own
   // version via main → `app.getVersion()`. Combined with the server's
   // `minClient` (from getServerVersion) by the renderer's isClientTooOld

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -31,7 +31,7 @@
 // the mobile QR scanner (M3) are separate issues; they consume /auth/pair +
 // /auth/claim built here.
 
-import { writeFile, rename, mkdir, chmod } from "node:fs/promises";
+import { writeFile, rename, mkdir, chmod, unlink } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { homedir } from "node:os";
@@ -95,13 +95,20 @@ export function parseBearer(headerValue) {
 }
 
 // Decide whether a request path is EXEMPT from auth (reachable without a
-// box_token). Only the pairing handshake and the public webhook delivery leg
-// (which carries its own per-hook token+HMAC) are exempt. Everything else —
-// /rpc, /events, /pty, /api/*, /push/*, static assets — is gated.
+// box_token). Only the pairing handshake, the per-device revocation handshake,
+// and the public webhook delivery leg (which carries its own per-hook
+// token+HMAC) are exempt. Everything else — /rpc, /events, /pty, /api/*,
+// /push/*, static assets — is gated.
 //
 // Rationale for each exemption:
 //   /auth/pair, /auth/claim — bootstrap; you can't present a token you don't
 //     have yet. Rate-limited + code-gated instead.
+//   /auth/revoke            — per-device "remove this box" handshake (BET-357 §2).
+//     The caller MUST present a valid token, but the standard gate collapses
+//     malformed-token and missing-token into the same 401, which loses a
+//     useful signal for the desktop's classifier (400 vs 401). This route
+//     does its own validation (see authEngine.revoke), distinguishing shape
+//     errors from auth errors so the UI can surface a more actionable note.
 //   /pair, /pair/qr.png, /pair/logo.png — the pairing onboarding page; a
 //     visitor by definition has no token yet. The page carries no secrets
 //     (code is in the URL fragment; qr.png is a shape-validated encoder).
@@ -118,7 +125,7 @@ export function parseBearer(headerValue) {
 // caller's token is valid, so it must run through the gate.
 export function isExemptPath(path) {
   if (typeof path !== "string") return false;
-  if (path === "/auth/pair" || path === "/auth/claim") return true;
+  if (path === "/auth/pair" || path === "/auth/claim" || path === "/auth/revoke") return true;
   if (path === "/pair" || path === "/pair/qr.png" || path === "/pair/logo.png") return true;
   if (path === "/hook/" || path.startsWith("/hook/")) return true;
   if (path === "/pages/" || path.startsWith("/pages/")) return true;
@@ -280,6 +287,22 @@ export async function saveAuth(auth, path = STORE_PATH) {
   await atomicWrite(path, JSON.stringify(auth, null, 2), 0o600);
 }
 
+// Delete the persisted auth file. Idempotent — a missing file is not an error
+// (the caller is racing for "delete a box" semantics where concurrent revokes
+// are fine, and a not-yet-created store on a fresh install is irrelevant).
+// Used by revoke() to satisfy the BET-357 §2 contract: "the old box_token no
+// longer works" is enforced by regenerating a fresh identity (see revoke),
+// but the on-disk file is rewritten by the regenerate step so the store shape
+// stays consistent across revocation.
+export async function deleteAuth(path = STORE_PATH) {
+  try {
+    await unlink(path);
+  } catch (e) {
+    if (e && e.code === "ENOENT") return;
+    throw e;
+  }
+}
+
 // Load the box identity, generating + persisting a fresh one on first run.
 // Returns { box_id, box_token, created_at }. I/O injectable for tests.
 export async function ensureAuth({
@@ -360,15 +383,23 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
  * only so an existing self-hoster who upgrades isn't instantly locked out of
  * their own box before they've paired. The DEFAULT is enforce=true.
  *
- * @param {object} deps { auth, enforce, ttlMs, now }
- *   auth    — { box_id, box_token } from ensureAuth()
- *   enforce — gate on (default true)
+ * @param {object} deps
+ *   auth        — { box_id, box_token, created_at } from ensureAuth()
+ *   enforce     — gate on (default true)
+ *   ttlMs       — pairing-code TTL (default 5 minutes)
+ *   now         — injectable clock for tests
+ *   saveAuth    — injectable writer (default saveAuth) for the post-revoke
+ *                 regenerate step
+ *   deleteAuth  — injectable unlink (default deleteAuth) for the post-revoke
+ *                 "wipe + regenerate" path. The default also runs in tests.
  */
 export function createAuthEngine({
   auth,
   enforce = true,
   ttlMs = PAIRING_TTL_MS,
   now = () => Date.now(),
+  saveAuth: saveAuthFn = saveAuth,
+  deleteAuth: deleteAuthFn = deleteAuth,
 } = {}) {
   if (!auth || !isValidToken(auth.box_id) || !isValidToken(auth.box_token)) {
     throw new Error("createAuthEngine: valid { box_id, box_token } required");
@@ -411,12 +442,71 @@ export function createAuthEngine({
     return { ok: true, box_token: auth.box_token, box_id: auth.box_id };
   }
 
+  // Handle DELETE /auth/revoke — "remove this box from the device that holds
+  // the current box_token". Three distinct failure shapes for the desktop's
+  // classifier (BET-357 §2):
+  //   • no token presented           → 401 (the standard "unauthorized")
+  //   • token is not 32-hex          → 400 (malformed; the device's own value
+  //                                    was wrong before it ever reached us)
+  //   • token is well-shaped but the box's own token is different → 401
+  //   • token matches                → delete the on-disk auth file, mint a
+  //                                    fresh identity (box_id + box_token),
+  //                                    and mutate the in-memory `auth` so the
+  //                                    next request — by ANY device — is
+  //                                    forced to pair+claim the new pair.
+  //                                    Returns 200.
+  // Why a fresh identity (not just a no-op-after-delete): a literal "delete
+  // the file" leaves the engine's `auth.box_token` stale until the server
+  // restarts and re-runs ensureAuth(); during that window the engine would
+  // still issue the OLD token from /auth/claim (because `claim` reads from the
+  // in-memory `auth`). Regenerating in place collapses the gap: the device
+  // that called revoke immediately loses access (its old token is dead) AND
+  // a fresh /auth/pair → /auth/claim returns the new token to whoever pairs
+  // next. This matches the spec's "next install mints a new one" semantics
+  // without leaving the engine in a "no token at all" stuck state.
+  async function revoke({ token } = {}) {
+    if (typeof token !== "string" || token === "") {
+      return { ok: false, status: 401, error: "unauthorized" };
+    }
+    if (!isValidToken(token)) {
+      return { ok: false, status: 400, error: "malformed token" };
+    }
+    if (!tokenMatches(auth.box_token, token)) {
+      return { ok: false, status: 401, error: "unauthorized" };
+    }
+    // Caller is the legitimate holder of the current box_token. Mint a fresh
+    // identity, write it, and swap it into the closed-over `auth` so the
+    // very next /authorize and /auth/claim use the new token. The OLD token
+    // is dead from this instant.
+    const fresh = {
+      box_id: genToken(),
+      box_token: genToken(),
+      created_at: now(),
+    };
+    // Clear any active pairing: the code minted under the old identity is
+    // moot now (it would authorize the old token, which nothing holds).
+    pairing.clear();
+    // Wipe the on-disk file first so a power-fail between writes can't leave
+    // a stale token behind, then write the fresh identity atomically. Best-
+    // effort on the unlink (an absent file is fine — the write below re-
+    // creates it).
+    await deleteAuthFn();
+    await saveAuthFn(fresh);
+    // Mutate the closed-over `auth` in place. The caller (index.mjs) holds a
+    // reference to the same object via `boxAuth`, so it sees the new values.
+    auth.box_id = fresh.box_id;
+    auth.box_token = fresh.box_token;
+    auth.created_at = fresh.created_at;
+    return { ok: true, box_id: fresh.box_id };
+  }
+
   return {
     box_id: auth.box_id,
     enforce,
     authorize,
     pair,
     claim,
+    revoke,
     // exposed for /auth/status and tests
     hasActivePairing: () => pairing.hasActive(),
     clearPairing: () => pairing.clear(),

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { rm, readFile, stat } from "node:fs/promises";
+import { rm, readFile, stat, writeFile } from "node:fs/promises";
 import {
   isValidToken,
   isValidPairingCode,
@@ -12,6 +12,7 @@ import {
   isPublicAssetPath,
   loadAuth,
   saveAuth,
+  deleteAuth,
   ensureAuth,
   createPairingRegistry,
   createAuthEngine,
@@ -414,6 +415,177 @@ test("claim rejects an expired code", () => {
   const r = eng.claim({ pairing_code });
   assert.equal(r.ok, false);
   assert.equal(r.status, 403);
+});
+
+// ----------------------------------------------------------------------------
+// auth engine — revoke (BET-357 §2: "remove this box from the device")
+// ----------------------------------------------------------------------------
+//
+// revoke() is the per-device "forget this box" handshake. The contract
+// (from the issue spec + the DELETE /auth/revoke handler in index.mjs):
+//
+//   no token presented           → 401 unauthorized
+//   token is not 32-hex          → 400 malformed token
+//   token is 32-hex but wrong    → 401 unauthorized
+//   token is 32-hex and matches  → 200, deletes box_token from
+//                                   ~/.manta/auth.json, mints a fresh
+//                                   identity in place so the engine's
+//                                   subsequent authorize/claim calls use
+//                                   the new token (the OLD one is dead
+//                                   from this instant).
+
+test("revoke: no token presented → 401", async () => {
+  const eng = createAuthEngine({ auth: AUTH });
+  const r = await eng.revoke({});
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 401);
+});
+
+test("revoke: empty-string token → 401", async () => {
+  const eng = createAuthEngine({ auth: AUTH });
+  const r = await eng.revoke({ token: "" });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 401);
+});
+
+test("revoke: malformed token (not 32-hex) → 400", async () => {
+  const eng = createAuthEngine({ auth: AUTH });
+  const r = await eng.revoke({ token: "not-32-hex" });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+  // The malformed path returns BEFORE the token compare — so the box's
+  // own token is NOT exposed to a malformed-token caller (no partial leak).
+  // We assert that by checking that the engine's authorize() gate still
+  // accepts the real token afterwards (no rotation happened).
+  const gate = eng.authorize({
+    method: "GET",
+    path: "/api/projects",
+    authorization: `Bearer ${AUTH.box_token}`,
+  });
+  assert.equal(gate.ok, true);
+});
+
+test("revoke: 32-hex token that doesn't match → 401, no rotation", async () => {
+  const eng = createAuthEngine({ auth: AUTH });
+  const wrong = "a".repeat(32);
+  const r = await eng.revoke({ token: wrong });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 401);
+  // Same leak guard as the malformed case: the engine's token is intact.
+  const gate = eng.authorize({
+    method: "GET",
+    path: "/api/projects",
+    authorization: `Bearer ${AUTH.box_token}`,
+  });
+  assert.equal(gate.ok, true);
+});
+
+test("revoke: valid token deletes box_token from auth.json (BET-357 §2)", async () => {
+  // Live FS round-trip: write a real auth.json, build the engine around it,
+  // revoke, and assert the file no longer authenticates the OLD token. The
+  // engine's in-memory state is also rotated (verified by subsequent
+  // authorize() calls).
+  const path = tmpPath("revoke-roundtrip");
+  const initial = { box_id: HEX32, box_token: HEX32B, created_at: 1000 };
+  await saveAuth(initial, path);
+  const eng = createAuthEngine({
+    auth: initial,
+    saveAuth: (a) => saveAuth(a, path),
+    deleteAuth: () => deleteAuth(path),
+  });
+
+  const r = await eng.revoke({ token: HEX32B });
+  assert.equal(r.ok, true);
+  assert.equal(isValidToken(r.box_id), true);
+  // The new box_id MUST differ from the old one — otherwise we'd be reusing
+  // the identity, which defeats the point of "remove this box".
+  assert.notEqual(r.box_id, HEX32);
+
+  // On-disk file: the OLD token must no longer authorize. We re-read the
+  // file (instead of trusting the in-memory mutation) so the test pins the
+  // actual persistence behavior, not just the engine's bookkeeping.
+  const onDisk = JSON.parse(await readFile(path, "utf-8"));
+  assert.equal(onDisk.box_id, r.box_id);
+  assert.notEqual(onDisk.box_token, HEX32B);
+  assert.equal(isValidToken(onDisk.box_token), true);
+
+  // In-memory rotation: subsequent authorize() with the OLD token fails.
+  const blocked = eng.authorize({
+    method: "GET",
+    path: "/api/projects",
+    authorization: `Bearer ${HEX32B}`,
+  });
+  assert.equal(blocked.ok, false);
+  // ...and the NEW token (whatever was just written) authorizes.
+  const ok2 = eng.authorize({
+    method: "GET",
+    path: "/api/projects",
+    authorization: `Bearer ${onDisk.box_token}`,
+  });
+  assert.equal(ok2.ok, true);
+
+  await rm(path, { force: true });
+});
+
+test("revoke: pair + claim after revoke returns the NEW identity, not the old one", async () => {
+  // End-to-end: a real revoke is followed by a fresh pair+claim. The claim
+  // must surface the new identity (so any device that re-pairs next gets a
+  // working token, not the dead old one). This pins the "next install mints
+  // a new one" semantics from the spec.
+  const path = tmpPath("revoke-claim-roundtrip");
+  const initial = { box_id: HEX32, box_token: HEX32B, created_at: 1000 };
+  await saveAuth(initial, path);
+  const eng = createAuthEngine({
+    auth: initial,
+    saveAuth: (a) => saveAuth(a, path),
+    deleteAuth: () => deleteAuth(path),
+  });
+
+  await eng.revoke({ token: HEX32B });
+
+  // Now mint a code and claim it — must yield the NEW token (which the
+  // engine wrote to disk during the revoke).
+  const { pairing_code } = eng.pair();
+  const claimed = eng.claim({ pairing_code });
+  assert.equal(claimed.ok, true);
+  assert.notEqual(claimed.box_token, HEX32B);
+  assert.equal(isValidToken(claimed.box_token), true);
+
+  await rm(path, { force: true });
+});
+
+test("revoke: clears any active pairing code (the old identity's code is moot)", async () => {
+  // Issue a code before revoke, then revoke. The pre-existing code must be
+  // invalidated — otherwise a code minted under the OLD identity would
+  // authorize the OLD token (which nothing holds anymore).
+  const eng = createAuthEngine({ auth: AUTH });
+  const { pairing_code: stale } = eng.pair();
+  assert.equal(eng.hasActivePairing(), true);
+
+  await eng.revoke({ token: AUTH.box_token });
+
+  assert.equal(eng.hasActivePairing(), false);
+  const staleClaim = eng.claim({ pairing_code: stale });
+  assert.equal(staleClaim.ok, false);
+});
+
+test("deleteAuth: idempotent — missing file is not an error", async () => {
+  const path = tmpPath("delete-missing");
+  // Should not throw, even though the file doesn't exist.
+  await deleteAuth(path);
+  await deleteAuth(path); // twice for good measure
+});
+
+test("deleteAuth: removes the file and the next loadAuth returns null", async () => {
+  const path = tmpPath("delete-roundtrip");
+  try {
+    await writeFile(path, JSON.stringify({ box_id: HEX32, box_token: HEX32B }), "utf-8");
+    assert.equal(loadAuth(path)?.box_token, HEX32B);
+    await deleteAuth(path);
+    assert.equal(loadAuth(path), null);
+  } finally {
+    await rm(path, { force: true });
+  }
 });
 
 // ----------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -76,6 +76,7 @@ import {
   ensureAuth,
   createAuthEngine,
   isLocalDirectRequest,
+  parseBearer,
   authorizationForRequest,
   AUTH_RL_CAPACITY,
   AUTH_RL_REFILL_PER_SEC,
@@ -609,15 +610,25 @@ const handleRequest = async (req, res) => {
   }
 
   // ---------- Auth pairing handshake (UNAUTHENTICATED, rate-limited) ----------
-  // GET  /auth/pair            → {pairing_code, box_id, expiresAt}
-  //                              Mint a one-time, ~5-min code. The desktop shows
-  //                              it (and encodes box_id+code in a QR for mobile).
-  // POST /auth/claim {pairing_code} → {box_token, box_id}
-  //                              Exchange a valid code for the bearer token.
-  //                              One-time; 403 on wrong/expired/reused code.
+  // GET    /auth/pair            → {pairing_code, box_id, expiresAt}
+  //                                Mint a one-time, ~5-min code. The desktop
+  //                                shows it (and encodes box_id+code in a QR
+  //                                for mobile).
+  // POST   /auth/claim {pairing_code} → {box_token, box_id}
+  //                                Exchange a valid code for the bearer token.
+  //                                One-time; 403 on wrong/expired/reused code.
+  // DELETE /auth/revoke           → 200 on success; 400/401 on bad token.
+  //                                "Remove this box from the device that holds
+  //                                the current box_token" (BET-357 §2). Mints
+  //                                a fresh identity and clears the pairing
+  //                                cache so the next device must pair again.
   // These are the ONLY pre-token surface, so they're the brute-force target and
   // are throttled by a shared token-bucket limiter (per client IP). See auth.mjs.
-  if (path === "/auth/pair" || path === "/auth/claim") {
+  if (
+    path === "/auth/pair" ||
+    path === "/auth/claim" ||
+    path === "/auth/revoke"
+  ) {
     const ip =
       (typeof req.headers["x-forwarded-for"] === "string" &&
         req.headers["x-forwarded-for"].split(",")[0].trim()) ||
@@ -663,6 +674,20 @@ const handleRequest = async (req, res) => {
           return;
         }
         respondJson(res, 200, { box_token: result.box_token, box_id: result.box_id });
+        return;
+      }
+      if (req.method === "DELETE" && path === "/auth/revoke") {
+        // Manual auth check (this route is exempt from the standard gate so
+        // we can distinguish malformed-token → 400 from missing-token → 401;
+        // the gate collapses both into 401). The shape of the response is
+        // whatever authEngine.revoke returns: { ok, status?, error? }.
+        const token = parseBearer(req.headers["authorization"]);
+        const result = await authEngine.revoke({ token });
+        if (!result.ok) {
+          respondJson(res, result.status ?? 401, { error: result.error });
+          return;
+        }
+        respondJson(res, 200, { ok: true, box_id: result.box_id });
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -615,6 +615,17 @@ export const IPC = {
   // and lets the mobile app scan it. Main owns the fetch over the SSH tunnel.
   // Result: { pairingCode, boxId, expiresAt } or { error }.
   authPair: "auth:pair",
+  // BET-357 §2: "Remove this box from the device that holds the current
+  // box_token". The desktop Settings → Connection → "Remove box" action
+  // triggers this channel. Main does DELETE <serverUrl>/auth/revoke with the
+  // current box_token as Bearer (see src/main/unpair.ts + src/server/auth.mjs
+  // revoke), then ALWAYS clears the local config entry — including the
+  // unreachable-box path, which still succeeds locally per the spec.
+  // Input: none (main reads serverUrl/boxToken from the live config). Result:
+  // an UnpairOutcome (src/shared/unpair.mjs) — a structured note that the
+  // renderer's Settings panel surfaces as either a clean success or a
+  // "remote revocation didn't happen, but local credentials are gone" note.
+  authUnpair: "auth:unpair",
 
   // ---- scheduled prompts (manta-server owned) ----
   // Schedules are a manta-SERVER concept (durable jobs fired by the always-on

--- a/src/shared/unpair.d.mts
+++ b/src/shared/unpair.d.mts
@@ -1,0 +1,46 @@
+// Hand-written type declarations for unpair.mjs. Implementation is plain JS so
+// both the renderer tsconfig and the main tsconfig import it without crossing
+// the process boundary. Keep in sync with src/shared/unpair.mjs.
+
+// Why an unpair (DELETE /auth/revoke) attempt failed, mapped to a stable UI
+// category. The renderer decides whether to surface the note inline (a
+// transient "couldn't reach the box" is normal during network blips) versus
+// forcing the user through a re-pair flow.
+export type UnpairFailureKind =
+  | "network" // fetch rejected — offline, DNS, TLS, connection refused, timeout
+  | "bad_request" // 400 — the presented token wasn't 32-hex (desktop drift)
+  | "auth_rejected" // 401 — the box didn't recognize the device's token
+  | "method_not_allowed" // 405 — server doesn't support revoke on this path
+  | "rate_limited" // 429 — too many attempts
+  | "server_error" // 5xx — server-side error
+  | "unexpected"; // any other status (404, 418, ...)
+
+// The outcome of a DELETE /auth/revoke, classified for the UI. On success the
+// desktop MUST clear its local config (serverUrl/boxId/boxToken/projects) —
+// see src/main/unpair.ts and the "Remove box" Settings action. On a failure
+// the desktop also clears locally (the unreachable-box path) but surfaces the
+// remoteError kind so the user sees a structured note that remote revocation
+// didn't happen.
+export type UnpairOutcome =
+  | { ok: true }
+  | { ok: false; kind: UnpairFailureKind; message: string };
+
+// Map an (remoteOk, remoteError) tuple to a typed UnpairOutcome. The literal
+// signature from the issue spec — callers classify the raw fetch result into
+// the two args, then hand them here.
+export function classifyUnpairResult(
+  remoteOk: boolean,
+  remoteError: string | null | undefined,
+): UnpairOutcome;
+
+// One-step convenience: pass the raw HTTP outcome (status + optional
+// networkError tag) and get a UnpairOutcome. Mirrors classifyClaimResult's
+// shape so the two classifier entry points read the same way. `status` is
+// optional in the type because the implementation falls back to "network"
+// for `{}` / `{ status: undefined }` — the desktop's Settings panel relies
+// on this defensive behavior so a half-broken fetch can't crash the
+// renderer.
+export function classifyUnpairHttp(args?: {
+  status?: number | null;
+  networkError?: string | null;
+}): UnpairOutcome;

--- a/src/shared/unpair.mjs
+++ b/src/shared/unpair.mjs
@@ -1,0 +1,138 @@
+// unpair.mjs — pure, framework-free classification of a "remove box" outcome.
+//
+// One wire shape (BET-357 §2): the desktop sends DELETE <serverUrl>/auth/revoke
+// with the current box_token as a Bearer header, and the box server (see
+// src/server/auth.mjs revoke() + index.mjs DELETE /auth/revoke handler) does
+// one of:
+//
+//   200 { ok: true, box_id }       — revoke succeeded; the box rotated its
+//                                    identity and the old token is dead. The
+//                                    desktop's local config is cleared.
+//   400 { error: "malformed token"} — the presented token wasn't 32-hex. The
+//                                    desktop couldn't have produced this from
+//                                    its own stored token (which the store
+//                                    validates on write), so this signals
+//                                    drift between desktop and box config
+//                                    shapes — a manual debug aid, not a
+//                                    normal flow.
+//   401 { error: "unauthorized" }   — no Authorization header, or the
+//                                    presented token doesn't match. The desktop
+//                                    surfaces this as "auth rejected" so the
+//                                    user knows their local token is stale and
+//                                    a re-pair is the only path forward.
+//   429 { error: "rate limited" }   — too many attempts. The /auth/* surface
+//                                    is rate-limited per client IP.
+//   5xx                              — server-side error.
+//   fetch rejected (no response)    — offline, DNS, TLS, connection refused,
+//                                    timeout. The "unreachable box" path that
+//                                    the desktop must handle gracefully
+//                                    (BET-357 §2 — "still succeed locally with
+//                                    a note").
+//
+// Reached from two places that must agree on how an HTTP outcome maps to a
+// user-facing result:
+//   • the desktop main process (src/main/unpair.ts) — does the fetch, then
+//     classifies via this helper.
+//   • any future mobile or web caller — same wire, same shape.
+//
+// Pure (no fetch, no DOM, no Node built-ins) → unit-tested in
+// src/shared/unpair.test.ts.
+
+// User-facing copy for each failure category. Kept short — rendered inline
+// next to the "Remove box" action.
+const FAILURE_MESSAGE = {
+  network: "Couldn't reach the box. The box's token will be cleared locally only — re-pair to use it again.",
+  bad_request: "The local token is malformed. Remove this box and re-pair from scratch.",
+  auth_rejected: "The box rejected this device's token. Clear locally and re-pair.",
+  server_error: "The box had a problem. Clear locally and try again later.",
+  unexpected: "Unexpected response from the box. Clear locally and try again.",
+  rate_limited: "Too many attempts. Wait a moment and try again.",
+  method_not_allowed: "The box doesn't support removing boxes this way.",
+};
+
+function fail(kind) {
+  return { ok: false, kind, message: FAILURE_MESSAGE[kind] };
+}
+
+/**
+ * Classify a DELETE /auth/revoke outcome into a typed UnpairOutcome.
+ *
+ * The signature follows the issue spec (`remoteOk, remoteError`) so the
+ * caller's job is purely "translate the fetch result into these two values":
+ *
+ *   on HTTP 200                 → classifyUnpairResult(true, null)
+ *   on HTTP 400 (malformed)     → classifyUnpairResult(false, "bad_request")
+ *   on HTTP 401 (no/wrong tok)  → classifyUnpairResult(false, "auth_rejected")
+ *   on HTTP 429                 → classifyUnpairResult(false, "rate_limited")
+ *   on HTTP 405                 → classifyUnpairResult(false, "method_not_allowed")
+ *   on HTTP 5xx                 → classifyUnpairResult(false, "server_error")
+ *   on fetch rejected (any)     → classifyUnpairResult(false, "network")
+ *   on any other status         → classifyUnpairResult(false, "unexpected")
+ *
+ * @param {boolean} remoteOk     True ONLY for a successful 200. A successful
+ *                                revoke means the server rotated its identity
+ *                                and the desktop's local credentials are dead
+ *                                on the box side too.
+ * @param {string|null} remoteError  The classified error kind. One of
+ *                                "network" | "bad_request" | "auth_rejected"
+ *                                | "server_error" | "unexpected" |
+ *                                "rate_limited" | "method_not_allowed".
+ *                                Ignored when remoteOk is true (defensive —
+ *                                a buggy caller that passes both true and an
+ *                                error still gets a clean ok result).
+ * @returns {UnpairOutcome}
+ */
+export function classifyUnpairResult(remoteOk, remoteError) {
+  if (remoteOk === true) return { ok: true };
+  if (remoteError == null) {
+    // remoteOk=false but no error tag → treat as network (the safest
+    // fallback — never mis-attribute a "no response" as a server-side fault).
+    return fail("network");
+  }
+  switch (remoteError) {
+    case "network":
+    case "bad_request":
+    case "auth_rejected":
+    case "server_error":
+    case "unexpected":
+    case "rate_limited":
+    case "method_not_allowed":
+      return fail(remoteError);
+    default:
+      // Unknown error tag → surface as "unexpected" rather than crashing the
+      // renderer's Settings panel with an unmapped kind.
+      return fail("unexpected");
+  }
+}
+
+/**
+ * Convenience: produce the (remoteOk, remoteError) tuple from a raw fetch
+ * result. The caller performs the fetch, then hands the parsed pieces here
+ * to get a UnpairOutcome in one step. Mirrors `classifyClaimResult`'s shape
+ * (status + body) so the two classifier entry points look the same to readers.
+ *
+ * @param {object} args
+ *   @param {number|null} args.status       HTTP status, or null when fetch
+ *                                          never produced a response.
+ *   @param {string|null} [args.networkError] Optional tag for the fetch-level
+ *                                          failure ("timeout", "connection_refused",
+ *                                          "dns", "tls", …). Surfaced as
+ *                                          "network" regardless of the tag —
+ *                                          the desktop's UX collapses all
+ *                                          fetch failures into one outcome.
+ * @returns {UnpairOutcome}
+ */
+export function classifyUnpairHttp({ status, networkError } = {}) {
+  // A non-null networkError means fetch rejected BEFORE producing an HTTP
+  // response (TLS / DNS / connection refused / timeout). It trumps any status
+  // — even a coincidental 200 wouldn't be trustworthy when the request never
+  // reached the wire.
+  if (status == null || networkError) return fail("network");
+  if (status === 200) return { ok: true };
+  if (status === 400) return fail("bad_request");
+  if (status === 401) return fail("auth_rejected");
+  if (status === 405) return fail("method_not_allowed");
+  if (status === 429) return fail("rate_limited");
+  if (status >= 500 && status < 600) return fail("server_error");
+  return fail("unexpected");
+}

--- a/src/shared/unpair.test.ts
+++ b/src/shared/unpair.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyUnpairResult,
+  classifyUnpairHttp,
+} from "./unpair.mjs";
+
+// classifyUnpairResult — the literal (remoteOk, remoteError) signature from
+// the issue spec (BET-357 §2). Covers the success branch and every failure
+// shape the desktop's Settings "Remove box" action needs to render.
+describe("classifyUnpairResult", () => {
+  it("remoteOk=true → ok regardless of remoteError", () => {
+    expect(classifyUnpairResult(true, null)).toEqual({ ok: true });
+    // Defensive: a buggy caller that passes both true and a non-null error
+    // still gets a clean ok result (the remoteError is ignored on success).
+    expect(classifyUnpairResult(true, "network")).toEqual({ ok: true });
+    expect(classifyUnpairResult(true, "auth_rejected")).toEqual({ ok: true });
+  });
+
+  it("remoteOk=false + null remoteError → network (safe default)", () => {
+    const r = classifyUnpairResult(false, null);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("remoteOk=false + undefined remoteError → network", () => {
+    const r = classifyUnpairResult(false, undefined);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("each known error kind maps to itself with a user-facing message", () => {
+    const kinds = [
+      "network",
+      "bad_request",
+      "auth_rejected",
+      "method_not_allowed",
+      "rate_limited",
+      "server_error",
+      "unexpected",
+    ] as const;
+    for (const kind of kinds) {
+      const r = classifyUnpairResult(false, kind);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.kind).toBe(kind);
+        expect(typeof r.message).toBe("string");
+        expect(r.message.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("unknown error kind → 'unexpected' (don't crash the renderer)", () => {
+    const r = classifyUnpairResult(false, "made-up-kind");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("unexpected");
+  });
+
+  it("each failure message is meaningful and unique enough to debug", () => {
+    const r1 = classifyUnpairResult(false, "network");
+    const r2 = classifyUnpairResult(false, "auth_rejected");
+    const r3 = classifyUnpairResult(false, "server_error");
+    if (r1.ok || r2.ok || r3.ok) throw new Error("expected all failures");
+    expect(r1.message).not.toBe(r2.message);
+    expect(r2.message).not.toBe(r3.message);
+    // The network message must mention the unreachable-box graceful-fallback
+    // ("locally only") so the UI can be honest about what the user is seeing.
+    expect(r1.message.toLowerCase()).toMatch(/locally|unreachable|reach/);
+  });
+});
+
+// classifyUnpairHttp — the one-step convenience that takes a raw fetch result
+// (status + optional network tag). This is what the desktop main process
+// actually uses (src/main/unpair.ts); the two-classifier shape lets the
+// existing tests assert on the issue-spec signature while production code
+// benefits from the structured-input variant.
+describe("classifyUnpairHttp", () => {
+  it("200 → ok", () => {
+    expect(classifyUnpairHttp({ status: 200 })).toEqual({ ok: true });
+  });
+
+  it("400 → bad_request", () => {
+    const r = classifyUnpairHttp({ status: 400 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("bad_request");
+  });
+
+  it("401 → auth_rejected", () => {
+    const r = classifyUnpairHttp({ status: 401 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("auth_rejected");
+  });
+
+  it("405 → method_not_allowed", () => {
+    const r = classifyUnpairHttp({ status: 405 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("method_not_allowed");
+  });
+
+  it("429 → rate_limited", () => {
+    const r = classifyUnpairHttp({ status: 429 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("rate_limited");
+  });
+
+  it("5xx → server_error", () => {
+    for (const status of [500, 502, 503, 504]) {
+      const r = classifyUnpairHttp({ status });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.kind).toBe("server_error");
+    }
+  });
+
+  it("null status (no response) → network", () => {
+    const r = classifyUnpairHttp({ status: null });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("any status + networkError tag → network (fetch-level failure wins)", () => {
+    for (const status of [200, 401, 500, null]) {
+      const r = classifyUnpairHttp({ status, networkError: "connection_refused" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.kind).toBe("network");
+    }
+  });
+
+  it("unexpected status (404, 418, ...) → unexpected, not network", () => {
+    for (const status of [404, 418, 422]) {
+      const r = classifyUnpairHttp({ status });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.kind).toBe("unexpected");
+    }
+  });
+
+  it("empty args object (defensive) → network", () => {
+    const r = classifyUnpairHttp({});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+});
+
+// The unreachable-box fallback (BET-357 §2): the helper must always classify
+// to a user-facing message, even when called with the degenerate inputs a
+// half-broken fetch could produce. The renderer's Settings panel relies on
+// `r.message` being a non-empty string so the "couldn't revoke remotely" note
+// renders inline below the action button.
+describe("unpair classifier — unreachable-box fallback contract", () => {
+  it("any null/undefined status collapses to network (the safe default)", () => {
+    expect(classifyUnpairHttp({ status: undefined }).ok).toBe(false);
+    expect(classifyUnpairHttp({ status: null as unknown as number }).ok).toBe(false);
+    expect(classifyUnpairHttp().ok).toBe(false);
+  });
+
+  it("every failure kind carries a non-empty message (UI sanity)", () => {
+    const failures = [
+      classifyUnpairResult(false, "network"),
+      classifyUnpairResult(false, "bad_request"),
+      classifyUnpairResult(false, "auth_rejected"),
+      classifyUnpairResult(false, "method_not_allowed"),
+      classifyUnpairResult(false, "rate_limited"),
+      classifyUnpairResult(false, "server_error"),
+      classifyUnpairResult(false, "unexpected"),
+    ];
+    for (const f of failures) {
+      if (!f.ok) {
+        expect(typeof f.message).toBe("string");
+        expect(f.message.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a 'Remove box' action in Settings → Connection that revokes the device's box_token on the box and clears the local pairing triple, honoring the unreachable-box graceful-fallback from the spec.

- **Server**: new `DELETE /auth/revoke` route, exempt from the standard gate so it can distinguish malformed-token (400) from missing/wrong-token (401). The new `authEngine.revoke({ token })` validates the presented token, deletes auth.json, mints a fresh identity, and mutates the in-memory engine state in place — the old token is dead from the very next authorize/claim call (no server restart needed); the next /auth/pair → /auth/claim returns the fresh identity.
- **Shared classifier**: `classifyUnpairResult(remoteOk, remoteError)` (the literal issue spec) plus `classifyUnpairHttp({ status, networkError })` as a one-step convenience for the main process.
- **Main**: `unpairBox()` does the DELETE and classifies the outcome. The `IPC.authUnpair` handler reads the live { serverUrl, boxToken } from config (never trusting a renderer-supplied copy), calls `unpairBox`, then ALWAYS commits an empty config entry — `config.ts` remains the single token writer.
- **Renderer**: new section in the Connection tab, gated by a native confirm dialog for the irreversible action. Surfaces the UnpairOutcome message in amber when remote revocation didn't reach the box. Preload bridge is desktop-only — mobile/web callers get a friendly inline note.

## Files changed

```
14 files changed, 1006 insertions(+), 16 deletions(-)
```

`src/main/index.ts`                — IPC.authUnpair handler (reads live config, unpairBox, commit empty)
`src/main/unpair.ts` (new)         — wire-call wrapper, classifyUnpairHttp entry
`src/main/unpair.test.ts` (new)    — 10 vitest cases (URL/headers/status/network)
`src/preload/index.ts`             — authUnpair bridge on the preload
`src/renderer/Settings.tsx`        — new 'Remove box' section + state
`src/renderer/preloadAccess.ts`    — authUnpair on MantaPreload interface
`src/renderer/preloadAccess.test.ts` — fake-preload update
`src/server/auth.mjs`              — isExemptPath includes /auth/revoke; deleteAuth helper; revoke() method
`src/server/auth.test.mjs`         — 9 node:test cases (revoke, deleteAuth, post-revoke pair+claim)
`src/server/index.mjs`             — DELETE /auth/revoke handler with manual token validation
`src/shared/types.ts`               — IPC.authUnpair channel name + comment
`src/shared/unpair.mjs` (new)      — classifyUnpairResult + classifyUnpairHttp
`src/shared/unpair.d.mts` (new)    — TS declarations
`src/shared/unpair.test.ts` (new)  — 18 vitest cases (literal signature + http convenience + every failure kind)

## Verification results

- PR branch (`multica/BET-357-unpair-box` @ `2604452`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1086 pass / 0 fail / 0 skip (node:test). Vitest: 1335 pass. log sha256: `f0469b44b2036b63d0731f77bad4f88eb681bf3bbb6c8b46d09f343ecbdfb53b`
- Base (`main` @ `23a12bc`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1077 pass / 0 fail / 0 skip (node:test). log sha256: `557d7534acd002f9c809272547256380921a271b60c2aaa54d64bfd5a7a45ad9`
- **Conclusion:** 0 pre-existing failures, 0 new failures, 0 regressions. PR adds 9 node:test cases + 28 vitest cases; both suites remain green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

## Base

Base: `origin/main` @ `23a12bc` (the SHA branched from — verified by `git diff --stat origin/main...HEAD`; no phantom deletions).

## Out of scope (intentionally)

- Reconnect logic — stage 3 of BET-357.
- Token re-issue / rotation as a separate operation — `revoke()` mints fresh as part of the same action, which already covers the 'next install mints a new one' semantics.
- Anything that touches the on-disk credentials file `~/.claude/.credentials.json` — stage 5 of BET-357.

## Notes

- The DELETE /auth/revoke route is intentionally exempt from the standard auth gate so we can distinguish malformed-token (400) from missing/wrong-token (401). The gate collapses both into 401, which loses a useful signal for the desktop's classifier.
- The MantaPreload `authUnpair` returns `UnpairOutcome` (not `unknown`) so the Settings UI gets a typed result without a cast. Mobile/web callers see no bridge and get an inline 'only supported in the desktop app' note instead of a crash.