### PR TITLE
BET-372: fix(installer) — inject commit instead of require('../index.js')

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -433,6 +433,9 @@ function registerHandlers(): void {
   // installer module — main owns the SSH connection from start to
   // pairing-success, and the connection dies at pairing time. The
   // renderer never touches ssh itself (no preload API for it).
-  registerInstallerHandlers(() => mainWindow);
+  // BET-372: pass main's `commit` so the auto-pair path persists via
+  // the SAME writer as the manual claim path above (no circular
+  // require, no second config writer).
+  registerInstallerHandlers(() => mainWindow, commit);
 
 }

--- a/src/main/installer/handlers.test.ts
+++ b/src/main/installer/handlers.test.ts
@@ -1,0 +1,207 @@
+// handlers.test.ts — IPC wiring tests for src/main/installer/handlers.ts.
+//
+// These tests verify that:
+//   1. The mint-and-claim IPC handler funnels through the INJECTED
+//      `persist` callback (the same one main's manual claim path uses).
+//      This is the regression test for BET-372 — the production wiring
+//      used to `require("../index.js")` and destructure a non-exported
+//      `commit`, throwing `TypeError: commit is not a function` on every
+//      successful SSH claim.
+//   2. The handlers.ts source file contains no `require("../index")`
+//      (a simple source-level assertion that pins the circular require
+//      from sneaking back in).
+//
+// No SSH connection, no network: the installer module is mocked at the
+// boundary so the wiring — not the install — is what the tests exercise.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// --- electron mock ----------------------------------------------------------
+//
+// vi.mock factories are hoisted to the top of the file, so any variable
+// the factory closes over has to be declared with `vi.hoisted()` — or the
+// factory has to inline its state. We use a hoisted Map keyed by channel
+// so individual tests can invoke the handler the way the renderer's IPC
+// bridge would.
+
+const ipcState = vi.hoisted(() => {
+  const handlers = new Map<string, (e: unknown, payload: unknown) => unknown>();
+  const ipcMainHandle = vi.fn(
+    (channel: string, fn: (e: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, fn);
+    },
+  );
+  return { handlers, ipcMainHandle };
+});
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: ipcState.ipcMainHandle },
+}));
+
+// --- installer module mock --------------------------------------------------
+//
+// We don't want a real SSH connection; we want to assert that the handler
+// forwards `alias` + `claimUrlOverride` and threads the INJECTED persist
+// callback down to mintAndClaim unchanged.
+
+const mintState = vi.hoisted(() => ({
+  mintAndClaim: vi.fn(
+    async (
+      _alias: string,
+      deps: {
+        persist: (patch: unknown) => void;
+        claimUrlOverride?: string;
+      },
+    ) => {
+      // Simulate the post-claim persist that mintAndClaim performs on the
+      // box's success path — exactly what src/main/installer/installer.ts:387
+      // does after a successful /auth/claim response.
+      deps.persist({
+        serverUrl: "https://box.example",
+        boxId: "0123456789abcdef0123456789abcdef",
+        boxToken: "fedcba9876543210fedcba9876543210",
+      });
+      return {
+        ok: true,
+        boxId: "0123456789abcdef0123456789abcdef",
+        boxToken: "fedcba9876543210fedcba9876543210",
+      };
+    },
+  ),
+}));
+
+vi.mock("./installer.js", () => ({
+  mintAndClaim: mintState.mintAndClaim,
+  listSshHosts: vi.fn(),
+  preflightBox: vi.fn(),
+  runInstall: vi.fn(),
+  DEFAULT_SSH_CONFIG_PATH: "/dev/null",
+}));
+
+// Also stub the small support modules the handlers pull in but never call
+// during the mint-and-claim path.
+vi.mock("./diagnostics.js", () => ({
+  buildDiagnostics: vi.fn(),
+}));
+vi.mock("./stageMapper.js", () => ({
+  buildStageSnapshot: vi.fn(),
+}));
+
+import { IPC, type AppConfig } from "../../shared/types.js";
+import { registerInstallerHandlers } from "./handlers.js";
+
+beforeEach(() => {
+  ipcState.handlers.clear();
+  ipcState.ipcMainHandle.mockClear();
+  mintState.mintAndClaim.mockClear();
+});
+
+describe("registerInstallerHandlers — mint-and-claim (BET-372)", () => {
+  it("invokes the injected persist with the claimed credentials", async () => {
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+    registerInstallerHandlers(() => null, persist);
+
+    const handler = ipcState.handlers.get(IPC.installerMintAndClaim);
+    expect(handler).toBeDefined();
+
+    const out = await handler!(null, { alias: "dev" });
+    expect(out).toEqual({
+      ok: true,
+      boxId: "0123456789abcdef0123456789abcdef",
+      boxToken: "fedcba9876543210fedcba9876543210",
+    });
+
+    // mintAndClaim was called with the injected persist (not a wrapper that
+    // re-requires main/index.js) and with the renderer-provided input.
+    expect(mintState.mintAndClaim).toHaveBeenCalledTimes(1);
+    const [aliasArg, deps] = mintState.mintAndClaim.mock.calls[0];
+    expect(aliasArg).toBe("dev");
+    expect(deps.persist).toBe(persist);
+    expect(deps.claimUrlOverride).toBeUndefined();
+
+    // And the persist callback actually fires with the claimed patch —
+    // the exact regression BET-372 reported. Before the fix, the
+    // handler's persist wrapper threw before reaching this assertion.
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledWith({
+      serverUrl: "https://box.example",
+      boxId: "0123456789abcdef0123456789abcdef",
+      boxToken: "fedcba9876543210fedcba9876543210",
+    });
+  });
+
+  it("forwards claimUrlOverride through to mintAndClaim", async () => {
+    const persist = vi.fn((_patch: Partial<AppConfig>) => {});
+    registerInstallerHandlers(() => null, persist);
+
+    const handler = ipcState.handlers.get(IPC.installerMintAndClaim);
+    await handler!(null, { alias: "dev", claimUrlOverride: "https://override.example" });
+
+    const [, deps] = mintState.mintAndClaim.mock.calls[0];
+    expect(deps.claimUrlOverride).toBe("https://override.example");
+  });
+
+  it("registers every installer IPC channel on the handler bus", () => {
+    registerInstallerHandlers(() => null, vi.fn());
+    const registeredChannels = ipcState.ipcMainHandle.mock.calls.map((c) => c[0]);
+    expect(registeredChannels).toEqual(
+      expect.arrayContaining([
+        IPC.installerListHosts,
+        IPC.installerPreflight,
+        IPC.installerState,
+        IPC.installerStart,
+        IPC.installerCancel,
+        IPC.installerMintAndClaim,
+        IPC.installerGetDiagnostics,
+      ]),
+    );
+  });
+});
+
+// Source-level guard: the handlers.ts file MUST NOT pull main's index.js
+// back into the installer module's require graph. This catches a future
+// regression where someone re-adds the `require("../index.js")` to grab
+// `commit` — the same trap BET-372 fixed. A source-level assertion is
+// intentionally cheap and survives refactors that keep the function names
+// but rewrite the wiring.
+describe("handlers.ts — no circular require of main/index", () => {
+  const handlersPath = fileURLToPath(new URL("./handlers.ts", import.meta.url));
+  const source = readFileSync(handlersPath, "utf8");
+
+  it("does not require ../index.js", () => {
+    // Match either CommonJS require(...) of ../index or an ES import from
+    // "../index.js" (the issue's root cause was the former, but the assertion
+    // covers both — same trap).
+    expect(source).not.toMatch(/require\(["']\.\.\/index(\.js)?["']\)/);
+    expect(source).not.toMatch(/from\s+["']\.\.\/index(\.js)?["']/);
+  });
+
+  it("does not reference commit at all (it must be injected, not imported)", () => {
+    // The whole point of BET-372's fix: `commit` lives in main, and
+    // handlers.ts receives it as a parameter. Any executable reference to
+    // `commit` inside this file means someone snuck a binding back in.
+    // Comments may discuss the symbol (to explain the fix); only code
+    // matters, so strip block + line comments first.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    expect(code).not.toMatch(/\bcommit\b/);
+  });
+
+  it("takes persist as a parameter on registerInstallerHandlers", () => {
+    // Spot-check the function signature so a future refactor that drops
+    // the second argument fails this test instead of silently falling back
+    // to a require(). The signature is multi-line, so strip newlines + runs
+    // of whitespace before applying the regex. We anchor on the function
+    // name + persist + its callback type, in that order, with anything
+    // (including a getWindow arg) allowed between the opening `(` and the
+    // persist parameter — getWindow's `() => BrowserWindow | null` contains
+    // its own parens which a strict `[^)]*` would not cross.
+    const code = source.replace(/\s+/g, " ");
+    expect(code).toMatch(
+      /function\s+registerInstallerHandlers\s*\([\s\S]*persist\s*:\s*\(patch\s*:\s*Partial<AppConfig>\)\s*=>\s*void/,
+    );
+  });
+});

--- a/src/main/installer/handlers.test.ts
+++ b/src/main/installer/handlers.test.ts
@@ -4,12 +4,13 @@
 //   1. The mint-and-claim IPC handler funnels through the INJECTED
 //      `persist` callback (the same one main's manual claim path uses).
 //      This is the regression test for BET-372 — the production wiring
-//      used to `require("../index.js")` and destructure a non-exported
-//      `commit`, throwing `TypeError: commit is not a function` on every
-//      successful SSH claim.
-//   2. The handlers.ts source file contains no `require("../index")`
-//      (a simple source-level assertion that pins the circular require
-//      from sneaking back in).
+//      used to grab a non-exported `commit` via a circular require against
+//      the main entry module, yielding `undefined` and throwing
+//      `TypeError: commit is not a function` on every successful SSH claim.
+//   2. The handlers.ts source file does NOT pull the main entry module
+//      back into the installer module's require graph (a simple
+//      source-level assertion that pins the circular require from
+//      sneaking back in).
 //
 // No SSH connection, no network: the installer module is mocked at the
 // boundary so the wiring — not the install — is what the tests exercise.
@@ -162,10 +163,10 @@ describe("registerInstallerHandlers — mint-and-claim (BET-372)", () => {
 
 // Source-level guard: the handlers.ts file MUST NOT pull main's index.js
 // back into the installer module's require graph. This catches a future
-// regression where someone re-adds the `require("../index.js")` to grab
-// `commit` — the same trap BET-372 fixed. A source-level assertion is
-// intentionally cheap and survives refactors that keep the function names
-// but rewrite the wiring.
+// regression where someone re-adds a circular require to grab `commit`
+// — the same trap BET-372 fixed. A source-level assertion is intentionally
+// cheap and survives refactors that keep the function names but rewrite
+// the wiring.
 describe("handlers.ts — no circular require of main/index", () => {
   const handlersPath = fileURLToPath(new URL("./handlers.ts", import.meta.url));
   const source = readFileSync(handlersPath, "utf8");

--- a/src/main/installer/handlers.ts
+++ b/src/main/installer/handlers.ts
@@ -15,7 +15,7 @@
 // from an earlier renderer (e.g. after a refresh) can no-op cleanly.
 
 import { ipcMain, type BrowserWindow } from "electron";
-import { IPC } from "../../shared/types.js";
+import { IPC, type AppConfig } from "../../shared/types.js";
 import {
   listSshHosts,
   preflightBox,
@@ -48,9 +48,17 @@ function pushTail(line: string): void {
 // registerInstallerHandlers — wire the IPC channels for the installer module.
 // `getWindow` resolves the BrowserWindow that should receive push events
 // (null → no push, no error — the renderer can re-mount and read state).
+// `persist` is the SAME config writer main uses for the manual claim path
+// (see src/main/index.ts `commit`). Injected here so the installer module
+// stays out of the main module's require graph — same constraint that
+// keeps the manual pairing path from accidentally inventing a second
+// writer (BET-355 constraint #4: one config writer).
 // ---------------------------------------------------------------------------
 
-export function registerInstallerHandlers(getWindow: () => BrowserWindow | null): void {
+export function registerInstallerHandlers(
+  getWindow: () => BrowserWindow | null,
+  persist: (patch: Partial<AppConfig>) => void,
+): void {
   ipcMain.handle(IPC.installerListHosts, () => listSshHosts(DEFAULT_SSH_CONFIG_PATH));
 
   ipcMain.handle(IPC.installerPreflight, async (_e, input: { alias: string }) => {
@@ -145,12 +153,7 @@ export function registerInstallerHandlers(getWindow: () => BrowserWindow | null)
     input: { alias: string; claimUrlOverride?: string },
   ) => {
     return mintAndClaim(input.alias, {
-      persist: (patch) => {
-        // Persist via main's existing config writer — same one the manual
-        // claim path uses (BET-355 constraint #4: one config writer).
-        const { commit } = require("../index.js");
-        commit(patch);
-      },
+      persist,
       claimUrlOverride: input.claimUrlOverride,
     });
   });


### PR DESCRIPTION
Fixes BET-372.

## What

The automatic pairing handler (installerMintAndClaim) tried to pull main's `commit` out of `require('../index.js')` — but `commit` is a plain function declared at src/main/index.ts:43 and was never exported. The destructure yielded `undefined`, so every real auto-pair threw `TypeError: commit is not a function` AFTER the box had minted the code, accepted the claim, and handed back a real token. From the user's view the install succeeded and the app was still unpaired, with a token burned on the box side.

## Fix

Pass `commit` in via a second parameter — exactly how the manual claim path already does it at src/main/index.ts:403-405. Delete the circular `require('../index.js')` and the local wrapper. Both paths now share the same writer, preserving BET-355 constraint #4 (one config writer).

```ts
// src/main/installer/handlers.ts
-export function registerInstallerHandlers(getWindow: () => BrowserWindow | null): void {
+export function registerInstallerHandlers(
+  getWindow: () => BrowserWindow | null,
+  persist: (patch: Partial<AppConfig>) => void,
+): void {
   ...
   ipcMain.handle(IPC.installerMintAndClaim, async (
     _e, input: { alias: string; claimUrlOverride?: string },
   ) => {
     return mintAndClaim(input.alias, {
-      persist: (patch) => {
-        const { commit } = require("../index.js");
-        commit(patch);
-      },
+      persist,
       claimUrlOverride: input.claimUrlOverride,
     });
   });
```

```ts
// src/main/index.ts
-registerInstallerHandlers(() => mainWindow);
+registerInstallerHandlers(() => mainWindow, commit);
```

## Tests

New `src/main/installer/handlers.test.ts`:
- **Regression**: invoking installerMintAndClaim calls the INJECTED writer with the claimed credentials (the old wiring threw before reaching this assertion).
- **claimUrlOverride**: forwarded through unchanged.
- **Channel registration**: every installer IPC channel is registered on the bus.
- **Source guard**: handlers.ts has no `require('../index')` / import from `../index.js`.
- **Symbol guard**: the literal identifier `commit` does not appear in executable code (only in comments is fine).
- **Signature guard**: `registerInstallerHandlers` declares a `persist` parameter.

No SSH, no network — the installer module is mocked at the boundary.

## Verification

- **typecheck**: clean.
- **test**: 1107 pass / 0 fail (full suite).
- **Regression confirmation**: reverted handlers.ts/index.ts to `origin/main` and re-ran `handlers.test.ts` — 5 of 6 assertions failed (the wiring test, no-require guard, no-`commit`-in-code guard, signature guard, and the channel-overrides test caught the bug; only the channel-list test passed, since the bug doesn't change which channels are registered).

## Out of scope (per the issue)

- No other installer or onboarding behaviour touched.
- No changes to the manual pairing path (already correct at src/main/index.ts:403-405).
- No export of `commit`, no second config writer.

Base: origin/main @ 165b6dc