### PR TITLE
BET-370: build channels prod | staging | dev — one shared module

### DIFF
--- a/electron-builder.staging.yml
+++ b/electron-builder.staging.yml
@@ -1,0 +1,42 @@
+# electron-builder overlay for the STAGING channel (BET-370).
+#
+# Loaded by electron-builder via `electron-builder --config electron-builder.staging.yml`.
+# Inherits everything from electron-builder.yml (signing, notarization, mac/win/linux
+# targets, file exclusions, npmRebuild:false, entitlements, ...). Only the deltas:
+#
+#   - appId      — different bundle id so staging can install side-by-side with prod
+#                  on the same Mac / Windows box (one app per appId per OS).
+#   - productName — different display name + menu-bar label + dock label.
+#   - protocols   — different URL scheme (manta-staging) so the OS routes a
+#                  manta-staging:// link to the staging build, not the prod build
+#                  the user might also have installed.
+#   - publish.url — staging app reads its auto-update feed from the /staging path;
+#                  electron-updater's "generic" provider polls this and offers an
+#                  in-app upgrade.
+#   - mac.artifactName — base inherits `${productName}-${version}-${arch}.dmg` which
+#                  would produce a filename containing spaces and parentheses
+#                  ("Manta UI (Staging)-0.0.17-arm64.dmg"). That breaks the
+#                  scp / sha256sum steps in scripts/release/publish.sh. Override
+#                  to a hyphenated, no-space filename.
+#
+# Everything else (entitlements, hardenedRuntime, target arch, notarize:true,
+# win nsis signing posture, linux AppImage executableName, files exclusion of
+# node-pty, extraMetadata.main, ...) is INHERITED — do not redeclare any of it
+# here. A duplicated mac: block, for example, would silently shadow the
+# inherited one and break notarization.
+
+extends: electron-builder.yml
+appId: com.antoinedc.mantaui.staging
+productName: Manta UI (Staging)
+
+protocols:
+  - name: MantaUI Pairing (Staging)
+    schemes:
+      - manta-staging
+
+publish:
+  provider: generic
+  url: https://mantaui.com/staging/updates
+
+mac:
+  artifactName: "Manta-UI-Staging-${version}-${arch}.dmg"

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -16,6 +16,18 @@ const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf8"))
 export default defineConfig({
   main: {
     plugins: [externalizeDepsPlugin()],
+    // Build-time-injected channel id (BET-370). The release pipeline sets
+    // MANTA_CHANNEL=prod|staging for packaged builds; `npm run dev` leaves
+    // it unset so the main process falls back to "prod" baked value AND
+    // resolveChannel() itself overrides with "dev" when app.isPackaged is
+    // false. Defensive reference in main/index.ts:
+    // `typeof __MANTA_CHANNEL__ === "string" ? __MANTA_CHANNEL__ : "prod"`
+    // exists because an unbuilt / unprocessed main bundle has no define
+    // inlined — TypeScript would refuse an unknown identifier. The ambient
+    // declaration lives in src/main/buildDefines.d.ts.
+    define: {
+      __MANTA_CHANNEL__: JSON.stringify(process.env.MANTA_CHANNEL ?? "prod"),
+    },
     build: {
       rollupOptions: {
         input: { index: resolve(__dirname, "src/main/index.ts") },

--- a/src/main/buildDefines.d.ts
+++ b/src/main/buildDefines.d.ts
@@ -1,0 +1,10 @@
+// Build-time globals injected into the main process by electron-vite's
+// `define` (see electron.vite.config.ts). These exist at bundle time and
+// are inlined as string literals — there is no runtime `process.env` read
+// in a packaged build. Keeping them as separate ambient declarations
+// instead of `declare global` (like src/renderer/types.d.ts does for
+// __APP_VERSION__) because the main process already has its own tsconfig
+// (`tsconfig.node.json`) and adding a `declare global` here would force a
+// module wrapper.
+
+declare const __MANTA_CHANNEL__: string;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -265,7 +265,14 @@ if (!gotSingleInstanceLock) {
 // Web Notification API attributes them to the bundle, i.e. "Electron" in dev).
 // `appUserModelId` does the equivalent for Windows toast attribution.
 app.setName(CHANNEL_CONFIG.appName);
-app.setAppUserModelId("com.antoinedc.mantaui");
+// Windows toast attribution: per-channel AUMID so a prod and a staging install
+// on the same Windows box don't share a single taskbar group / notification
+// source. Dev falls back to the prod id because the spec marks dev's
+// electron-builder appId "n/a" (dev never builds), which leaves no value to
+// source from the table — same effective behaviour as before this PR.
+app.setAppUserModelId(
+  CHANNEL_CONFIG.electronBuilderAppId ?? "com.antoinedc.mantaui",
+);
 
 app.whenReady().then(() => {
   config = loadConfig();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,9 +33,31 @@ import {
 import { checkForUpdates } from "./autoUpdate.js";
 import { titleBarOptions } from "./windowChrome.js";
 import { registerInstallerHandlers } from "./installer/handlers.js";
+import {
+  resolveChannel,
+  channelConfig,
+} from "../shared/channel.mjs";
 import { IPC, type AppConfig, type AuthClaimInput } from "../shared/types.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+// Build-channel plumbing (BET-370). The baked value comes from electron-vite's
+// `define` (electron.vite.config.ts) — the ambient declaration lives in
+// src/main/buildDefines.d.ts. `resolveChannel` enforces the rule:
+//   isPackaged === false → "dev"  (npm run dev has no notion of release)
+//   otherwise             → bakedChannel if valid, else "prod" (never throws)
+// All per-channel values (userDataDir, appName, urlScheme, ...) flow through
+// `channelConfig(CHANNEL)` — there is no per-channel branch anywhere in this
+// file.
+const BAKED_CHANNEL =
+  typeof __MANTA_CHANNEL__ === "string" ? __MANTA_CHANNEL__ : "prod";
+const CHANNEL = resolveChannel(app.isPackaged, BAKED_CHANNEL);
+const CHANNEL_CONFIG = channelConfig(CHANNEL);
+// URL prefix used to recognise this channel's deep-link at every entry point
+// (warm open-url, second-instance argv, cold-start process.argv). Built from
+// the channel config — never a literal — so a future channel inherits the
+// pattern without touching this file.
+const PAIR_PREFIX = `${CHANNEL_CONFIG.urlScheme}://`;
 
 let mainWindow: BrowserWindow | null = null;
 let config: AppConfig = { projects: [] };
@@ -176,28 +198,33 @@ function createWindow(): void {
 
 // Pin userData to a stable directory BEFORE setName() (Electron otherwise
 // derives it from the app name, which would repoint it whenever the name
-// changes). Dev uses a SEPARATE directory so `npm run dev` runs fully isolated
-// from a packaged install — its own config.json, pairing, sessions, settings.
-app.setPath("userData", join(app.getPath("appData"), app.isPackaged ? "manta" : "manta-dev"));
+// changes). Per-channel: dev uses `manta-dev`, staging uses `manta-staging`,
+// prod uses `manta` — so each channel's install runs fully isolated from
+// the others (its own config.json, pairing, sessions, settings).
+app.setPath("userData", join(app.getPath("appData"), CHANNEL_CONFIG.userDataDir));
 
 // ---------------------------------------------------------------------------
-// manta:// deep-link pairing (protocol handler).
+// <scheme>:// deep-link pairing (protocol handler). The scheme name comes
+// from the build channel — prod registers `manta`, staging `manta-staging`,
+// dev `manta-dev` — so an OS can hand the same URL prefix to whichever
+// channel owns it.
+//
 // Registration + capture live in main; parsing/validation happens renderer-
 // side with the same parsePairPayload the PairStep paste field uses, so
 // there is exactly ONE parser for the wire format.
 //
-// ONLY the packaged app registers the scheme — an OS scheme can be owned by
-// one app, so the dev build (`npm run dev`) must not fight the packaged app
-// for it. In dev, pairing is done by pasting the 6-digit code manually.
+// All three channels register. Dev's `manta-dev://` registration is
+// best-effort and warm-only (rule 6): npm run dev reuses the shared
+// node_modules/electron bundle, so the scheme resolves to generic Electron
+// and `npm install` clobbers it. Register anyway — warm delivery to a
+// running dev instance works, and the registration is harmless.
 // ---------------------------------------------------------------------------
-if (app.isPackaged) {
-  app.setAsDefaultProtocolClient("manta");
-}
+app.setAsDefaultProtocolClient(CHANNEL_CONFIG.urlScheme);
 
 let pendingPairUrl: string | null = null;
 
 function deliverPairLink(url: string): void {
-  if (typeof url !== "string" || !url.startsWith("manta://")) return;
+  if (typeof url !== "string" || !url.startsWith(PAIR_PREFIX)) return;
   if (mainWindow && !mainWindow.webContents.isLoading()) {
     mainWindow.webContents.send(IPC.pairLinkReceived, url);
     if (mainWindow.isMinimized()) mainWindow.restore();
@@ -227,7 +254,7 @@ if (!gotSingleInstanceLock) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
     }
-    const url = argv.find((a) => a.startsWith("manta://"));
+    const url = argv.find((a) => a.startsWith(PAIR_PREFIX));
     if (url) deliverPairLink(url);
   });
 }
@@ -237,7 +264,7 @@ if (!gotSingleInstanceLock) {
 // builds — the source name on OS notifications (otherwise the renderer's
 // Web Notification API attributes them to the bundle, i.e. "Electron" in dev).
 // `appUserModelId` does the equivalent for Windows toast attribution.
-app.setName("Manta UI");
+app.setName(CHANNEL_CONFIG.appName);
 app.setAppUserModelId("com.antoinedc.mantaui");
 
 app.whenReady().then(() => {
@@ -259,7 +286,7 @@ app.whenReady().then(() => {
   mainWindow?.webContents.once("did-finish-load", () => {
     // Deep-link cold start: macOS parked the URL in pendingPairUrl (open-url
     // fires pre-ready); Windows/Linux pass it in this process's argv.
-    const argvPairUrl = process.argv.find((a) => a.startsWith("manta://")) ?? null;
+    const argvPairUrl = process.argv.find((a) => a.startsWith(PAIR_PREFIX)) ?? null;
     const coldPairUrl = pendingPairUrl ?? argvPairUrl;
     pendingPairUrl = null;
     if (coldPairUrl) {

--- a/src/main/installer/installer.test.ts
+++ b/src/main/installer/installer.test.ts
@@ -168,7 +168,7 @@ describe("runInstall", () => {
     ).toThrow(/alias is required/);
   });
 
-  it("runs `bash -lc 'curl -fsSL <url> | bash'` over SSH with -tt", async () => {
+  it("runs `bash -lc 'curl -fsSL <url> | MANTA_RELEASE_HOST=<host> bash'` over SSH with -tt", async () => {
     const fake = makeFakeChild();
     const { spawn, captured } = capturingSpawn(fake);
     const handle = runInstall("dev", {}, { spawn });
@@ -176,9 +176,43 @@ describe("runInstall", () => {
     await handle.done;
     expect(captured.args).toContain("-tt");
     expect(captured.args).toContain("dev");
+    // Channel-aware install command (BET-370): the install.sh URL + release
+    // host flow from the channel config (test env falls through to dev,
+    // whose installShUrl + releaseHost match the prod defaults per the
+    // BET-370 spec table — staging-specific values are pinned in
+    // src/shared/channel.test.ts and don't need to be re-asserted here).
     expect(captured.args[captured.args.length - 1]).toMatch(
-      /curl -fsSL .* \| bash/,
+      /curl -fsSL https:\/\/mantaui\.com\/install\.sh/,
     );
+    expect(captured.args[captured.args.length - 1]).toMatch(
+      /MANTA_RELEASE_HOST=https:\/\/mantaui\.com/,
+    );
+    expect(captured.args[captured.args.length - 1]).toMatch(/\sbash'$/);
+  });
+
+  // BET-370 channel assertions: the installShUrl test seam overrides the
+  // URL only — releaseHost stays channel-derived. The two come from the
+  // same channel record in production; here we just verify that the
+  // orchestrator threads installShUrl verbatim into the curl invocation.
+  it("honours deps.installShUrl while still passing the channel's release host", async () => {
+    const fake = makeFakeChild();
+    const { spawn, captured } = capturingSpawn(fake);
+    const handle = runInstall(
+      "dev",
+      {},
+      {
+        spawn,
+        installShUrl: "https://mantaui.com/staging/install.sh",
+      },
+    );
+    setImmediate(() => fake.fireExit(0));
+    await handle.done;
+    const cmd = captured.args[captured.args.length - 1];
+    expect(cmd).toContain("curl -fsSL https://mantaui.com/staging/install.sh");
+    // releaseHost still flows from the channel (test env = dev = prod
+    // default), not from the installShUrl override — the channel is the
+    // single source of truth per the spec.
+    expect(cmd).toContain("MANTA_RELEASE_HOST=https://mantaui.com");
   });
 
   it("invokes onLine + onStage as the log advances through milestones", async () => {

--- a/src/main/installer/installer.ts
+++ b/src/main/installer/installer.ts
@@ -298,15 +298,19 @@ export function runInstall(
   if (typeof alias !== "string" || alias.trim() === "") {
     throw new Error("runInstall: alias is required");
   }
-  const channelConfig = resolveChannelConfig();
-  const installShUrl = deps.installShUrl ?? channelConfig.installShUrl;
+  // Local name `cfg` (not `channelConfig`) so it doesn't shadow the imported
+  // `channelConfig` function for the rest of this module — a future reader
+  // scanning the call sites should be able to tell "is this a record or a
+  // function?" at a glance (N1 from the reviewer).
+  const cfg = resolveChannelConfig();
+  const installShUrl = deps.installShUrl ?? cfg.installShUrl;
   // We force a remote PTY (-tt) so install.sh's color codes survive (the
   // POC addendum documents this: install.sh's log/ok/warn helpers emit
   // CSI color sequences, and we want them to land in stdout so the stage
   // mapper's prefix-matching still works after we strip them).
   //
   // TERM=xterm-256color is inherited from this process; nothing to set here.
-  const handle = streamRemote(alias, buildInstallCommand(installShUrl, channelConfig.releaseHost), {
+  const handle = streamRemote(alias, buildInstallCommand(installShUrl, cfg.releaseHost), {
     forceTty: true,
     spawn: deps.spawn,
     onStdout: (chunk) => pumpChunk(chunk, "stdout", sink),

--- a/src/main/installer/installer.ts
+++ b/src/main/installer/installer.ts
@@ -28,12 +28,15 @@ import { join } from "node:path";
 import {
   execRemote,
   streamRemote,
-  DEFAULT_INSTALL_SH_URL,
   type ExecRemoteResult,
   type SpawnFn,
 } from "./runner.js";
 import { parseSshConfig, type SshHostEntry } from "./sshConfig.js";
 import { isValidBoxToken } from "../../shared/transport.mjs";
+import {
+  resolveChannel,
+  channelConfig,
+} from "../../shared/channel.mjs";
 import {
   classifyPreflight,
   type PreflightProbes,
@@ -49,6 +52,36 @@ import type { ClaimOutcome } from "../../shared/claim.mjs";
 import type { AppConfig } from "../../shared/types.js";
 
 export type { SpawnFn } from "./runner.js";
+
+// Build-channel plumbing (BET-370). Same baked global as src/main/index.ts
+// reads — the `define` injection lives in electron.vite.config.ts and the
+// ambient declaration in src/main/buildDefines.d.ts. The install command
+// the orchestrator runs is channel-specific (install.sh URL + release host),
+// so it must resolve the channel here too. `resolveChannel` is the one rule;
+// everything below is a `channelConfig(CHANNEL).…` lookup.
+//
+// Computed lazily (via `resolveChannelConfig()`) rather than at module load:
+// the orchestrator's unit tests stub `spawn` and never load Electron, so a
+// top-level `app.isPackaged` read would crash before any test runs. The
+// `app` lookup is a runtime `require("electron")` that succeeds in
+// production (Electron is the host process) and yields `undefined` in the
+// vitest environment; in that case we resolve as `isPackaged=false` which
+// falls through to the dev channel — a no-op for tests that override
+// `installShUrl` directly.
+const BAKED_CHANNEL =
+  typeof __MANTA_CHANNEL__ === "string" ? __MANTA_CHANNEL__ : "prod";
+
+function resolveChannelConfig() {
+  let isPackaged = false;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require("electron") as { app?: { isPackaged?: boolean } };
+    isPackaged = electron.app?.isPackaged === true;
+  } catch {
+    // require("electron") threw — Electron is not the host. Treat as dev.
+  }
+  return channelConfig(resolveChannel(isPackaged, BAKED_CHANNEL));
+}
 
 // Default location of the user's SSH config. ~/.ssh/config on macOS / Linux;
 // the same path on Windows 10 1809+ (OpenSSH ships in the box). The
@@ -71,11 +104,18 @@ const PROBE_CLOCK_CMD = "bash -lc 'date -u +%s'";
 const PROBE_AUTH_FILE_CMD =
   "bash -lc 'test -f ~/.manta/auth.json && echo INSTALLED || echo FRESH'";
 
-// The one-line install command. This is EXACTLY what a user would type by
-// hand (`curl -fsSL https://mantaui.com/install.sh | bash`) — no desktop-
-// specific variant, no forked install.sh, per BET-355 constraint #1.
-function buildInstallCommand(installShUrl: string): string {
-  return `bash -lc 'curl -fsSL ${installShUrl} | bash'`;
+// The one-line install command. `installShUrl` and `releaseHost` come from
+// the current build channel (CHANNEL_CONFIG) — the orchestrator only knows
+// about SSH; the channel lives in src/shared/channel.mjs and is injected
+// here via the module-level CHANNEL constant.
+//
+// MANTA_RELEASE_HOST is passed unconditionally on every channel. For prod
+// the value is identical to install.sh's own default, so there is no
+// behaviour change; for staging the box fetches the staging manifest +
+// tarball, which is the entire point of the channel split. The single
+// command shape keeps the wire-format tests trivial (BET-370 §Tests).
+function buildInstallCommand(installShUrl: string, releaseHost: string): string {
+  return `bash -lc 'curl -fsSL ${installShUrl} | MANTA_RELEASE_HOST=${releaseHost} bash'`;
 }
 
 // ===========================================================================
@@ -258,14 +298,15 @@ export function runInstall(
   if (typeof alias !== "string" || alias.trim() === "") {
     throw new Error("runInstall: alias is required");
   }
-  const installShUrl = deps.installShUrl ?? DEFAULT_INSTALL_SH_URL;
+  const channelConfig = resolveChannelConfig();
+  const installShUrl = deps.installShUrl ?? channelConfig.installShUrl;
   // We force a remote PTY (-tt) so install.sh's color codes survive (the
   // POC addendum documents this: install.sh's log/ok/warn helpers emit
   // CSI color sequences, and we want them to land in stdout so the stage
   // mapper's prefix-matching still works after we strip them).
   //
   // TERM=xterm-256color is inherited from this process; nothing to set here.
-  const handle = streamRemote(alias, buildInstallCommand(installShUrl), {
+  const handle = streamRemote(alias, buildInstallCommand(installShUrl, channelConfig.releaseHost), {
     forceTty: true,
     spawn: deps.spawn,
     onStdout: (chunk) => pumpChunk(chunk, "stdout", sink),

--- a/src/main/installer/runner.ts
+++ b/src/main/installer/runner.ts
@@ -42,13 +42,6 @@ export type SpawnFn = (
 // every supported platform (macOS, Linux, Windows 10 1809+).
 export const SSH_BIN = process.env.MANTA_SSH_BIN ?? "ssh";
 
-// Where install.sh is hosted. The install.sh itself is versioned through the
-// release manifest (BET-205 WP5), but install.sh is referenced by stable URL
-// (it downloads the versioned tarball at runtime). The desktop shells out to
-// exactly this URL so the code path on the box is identical to what the user
-// would type by hand.
-export const DEFAULT_INSTALL_SH_URL = "https://mantaui.com/install.sh";
-
 // Shared option shape for both the one-shot and streaming variants.
 export type RemoteOptions = {
   /** Force a remote PTY (-tt). Defaults to false — preflight probes do not

--- a/src/shared/channel.d.mts
+++ b/src/shared/channel.d.mts
@@ -1,0 +1,66 @@
+// Hand-written type declarations for channel.mjs. Implementation is plain JS so
+// both the renderer tsconfig and the main tsconfig import it without crossing
+// the process boundary. Keep in sync with src/shared/channel.mjs.
+
+/**
+ * The three valid build channel ids. Anything else resolves to "prod" (per
+ * resolveChannel's defensive rule — a bad build must still launch).
+ */
+export type ChannelId = "prod" | "staging" | "dev";
+
+/**
+ * The readonly record for a single channel. Frozen at runtime; the type
+ * system reflects that with `readonly` so a caller can't accidentally mutate
+ * the table from a call site.
+ */
+export type ChannelConfig = {
+  readonly id: ChannelId;
+  /** Electron userData subdir name. */
+  readonly userDataDir: string;
+  /** OS-level URL scheme (deep-link pairing). */
+  readonly urlScheme: string;
+  /** Display name passed to `app.setName()`. */
+  readonly appName: string;
+  /** install.sh URL — read by the SSH installer path. */
+  readonly installShUrl: string;
+  /** MANTA_RELEASE_HOST value — passed to install.sh on the box. */
+  readonly releaseHost: string;
+  /** electron-updater generic-provider URL. null on dev (no auto-update). */
+  readonly updateFeed: string | null;
+  /** electron-builder appId. null on dev (no build). */
+  readonly electronBuilderAppId: string | null;
+  /** electron-builder productName. null on dev (no build). */
+  readonly electronBuilderProductName: string | null;
+};
+
+/**
+ * The frozen channel table. `Object.freeze` makes the runtime enforce
+ * immutability; this typing mirrors it with `Readonly<...>`.
+ */
+export const CHANNELS: Readonly<Record<ChannelId, ChannelConfig>>;
+
+/**
+ * The set of valid channel ids — exported so a caller validating an external
+ * input (e.g. a debug toggle) can check membership without re-typing the list.
+ */
+export const CHANNEL_IDS: readonly ChannelId[];
+
+/**
+ * Resolve the running app's channel id.
+ *
+ *   isPackaged === false → "dev"
+ *   isPackaged === true  → bakedChannel (must be "prod" | "staging" | "dev";
+ *                          any other value, including undefined, → "prod")
+ *
+ * @param isPackaged   Electron's `app.isPackaged`.
+ * @param bakedChannel Build-time string injected by electron-vite `define`.
+ *                     See electron.vite.config.ts.
+ */
+export function resolveChannel(isPackaged: boolean, bakedChannel: string | undefined): ChannelId;
+
+/**
+ * Return the per-channel record for `channel`. Unknown channel → prod record
+ * (same fallback semantics as `resolveChannel`: a wrong lookup must still
+ * return a usable config, never throw).
+ */
+export function channelConfig(channel: string | null | undefined): ChannelConfig;

--- a/src/shared/channel.mjs
+++ b/src/shared/channel.mjs
@@ -1,0 +1,118 @@
+// channel.mjs — build-channel resolution + per-channel config table (BET-370).
+//
+// One module, one table, one rule. There are exactly three channels — prod,
+// staging, dev — and every per-channel value in the desktop app reads from
+// `channelConfig(channel)`. New values MUST land here, not as branches at the
+// call site; the renderer / main process / install command all reach this
+// module for their values.
+//
+// Lives in src/shared/ because the renderer may later need the scheme or
+// app name for display (e.g. a "running in staging" badge in Settings) and
+// shared/ is the only place both tsconfigs pick up.
+//
+// Pure (no electron, no node:fs) → unit-tested in src/shared/channel.test.ts.
+
+// ===========================================================================
+// CHANNELS — the per-channel value table.
+//
+// Copied verbatim from the BET-370 spec. Do NOT derive one value from another
+// (e.g. `installShUrl` is NOT `${releaseHost}/install.sh`) — the install.sh
+// path is intentionally stable so a staging release with a broken
+// `/staging/install.sh` can still be debugged from the prod endpoint.
+//
+// "same as prod" for dev means we still copy the literal — `CHANNELS.dev`
+// must be a complete record. Future readers shouldn't have to fall through
+// to prod for some keys; "absent" is NOT a value.
+//
+// `n/a` cells in the spec are fields the channel doesn't own — there is no
+// update feed for dev (it never auto-updates), no electron-builder id for
+// dev (it never builds). These are stored as `null` so a future caller that
+// accidentally asks for them gets an explicit "no" instead of a silent
+// fallback to prod.
+// ===========================================================================
+
+export const CHANNELS = Object.freeze({
+  prod: Object.freeze({
+    id: "prod",
+    userDataDir: "manta",
+    urlScheme: "manta",
+    appName: "Manta UI",
+    installShUrl: "https://mantaui.com/install.sh",
+    releaseHost: "https://mantaui.com",
+    updateFeed: "https://mantaui.com/updates",
+    electronBuilderAppId: "com.antoinedc.mantaui",
+    electronBuilderProductName: "Manta UI",
+  }),
+  staging: Object.freeze({
+    id: "staging",
+    userDataDir: "manta-staging",
+    urlScheme: "manta-staging",
+    appName: "Manta UI (Staging)",
+    installShUrl: "https://mantaui.com/staging/install.sh",
+    releaseHost: "https://mantaui.com/staging",
+    updateFeed: "https://mantaui.com/staging/updates",
+    electronBuilderAppId: "com.antoinedc.mantaui.staging",
+    electronBuilderProductName: "Manta UI (Staging)",
+  }),
+  dev: Object.freeze({
+    id: "dev",
+    userDataDir: "manta-dev",
+    urlScheme: "manta-dev",
+    appName: "Manta UI (Dev)",
+    installShUrl: "https://mantaui.com/install.sh",
+    releaseHost: "https://mantaui.com",
+    updateFeed: null,
+    electronBuilderAppId: null,
+    electronBuilderProductName: null,
+  }),
+});
+
+// The set of valid channel ids — exported so a caller validating an external
+// input (e.g. a debug toggle) can check membership without re-typing the
+// list. Frozen + readonly tuple: mutation throws, and a future reader sees
+// every legal value at a glance.
+export const CHANNEL_IDS = Object.freeze(["prod", "staging", "dev"]);
+
+// ===========================================================================
+// resolveChannel — one rule, nowhere else.
+//
+// `isPackaged` is the runtime signal from `app.isPackaged`. `bakedChannel` is
+// the build-time string the bundler injects via electron-vite's `define`
+// (see electron.vite.config.ts). The rule:
+//
+//   channel = isPackaged ? bakedChannel : "dev"
+//
+// An unpackaged build is ALWAYS dev — regardless of what the build env tried
+// to bake — because npm run dev has no concept of "the release channel I'm
+// aiming at". An unrecognised baked value (or undefined) falls back to prod;
+// a bad build must still launch rather than throw at startup.
+// ===========================================================================
+
+const PROD_CHANNEL = "prod";
+const DEV_CHANNEL = "dev";
+
+export function resolveChannel(isPackaged, bakedChannel) {
+  if (isPackaged !== true) return DEV_CHANNEL;
+  if (bakedChannel === "prod" || bakedChannel === "staging" || bakedChannel === "dev") {
+    return bakedChannel;
+  }
+  // An unrecognised baked value (undefined, null, "garbage", typo) — never
+  // throw. A bad build must still launch; the fallback is prod because prod
+  // is the one channel every release pipeline must produce successfully.
+  return PROD_CHANNEL;
+}
+
+// ===========================================================================
+// channelConfig — return the per-channel record.
+//
+// Unknown channel id → prod record (same fallback semantics as resolveChannel:
+// a wrong lookup must still return a usable config). The record is frozen, so
+// callers cannot accidentally mutate the table from a call site.
+// ===========================================================================
+
+export function channelConfig(channel) {
+  if (channel === "prod" || channel === "staging" || channel === "dev") {
+    return CHANNELS[channel];
+  }
+  return CHANNELS[PROD_CHANNEL];
+}

--- a/src/shared/channel.test.ts
+++ b/src/shared/channel.test.ts
@@ -1,0 +1,151 @@
+// channel.test.ts — pins the channel table + resolution rule (BET-370).
+//
+// Every assertion comes from the spec table — prod | staging | dev are
+// frozen values, no derived lookups. A reader who changes one number here
+// must change it in the spec, and vice versa.
+
+import { describe, it, expect } from "vitest";
+import { CHANNELS, CHANNEL_IDS, resolveChannel, channelConfig } from "./channel.mjs";
+
+// ===========================================================================
+// CHANNELS — the per-channel value table (spec verbatim)
+// ===========================================================================
+
+describe("CHANNELS — table values are pinned to the BET-370 spec", () => {
+  it("prod matches the spec row exactly", () => {
+    expect(CHANNELS.prod).toEqual({
+      id: "prod",
+      userDataDir: "manta",
+      urlScheme: "manta",
+      appName: "Manta UI",
+      installShUrl: "https://mantaui.com/install.sh",
+      releaseHost: "https://mantaui.com",
+      updateFeed: "https://mantaui.com/updates",
+      electronBuilderAppId: "com.antoinedc.mantaui",
+      electronBuilderProductName: "Manta UI",
+    });
+  });
+
+  it("staging matches the spec row exactly", () => {
+    expect(CHANNELS.staging).toEqual({
+      id: "staging",
+      userDataDir: "manta-staging",
+      urlScheme: "manta-staging",
+      appName: "Manta UI (Staging)",
+      installShUrl: "https://mantaui.com/staging/install.sh",
+      releaseHost: "https://mantaui.com/staging",
+      updateFeed: "https://mantaui.com/staging/updates",
+      electronBuilderAppId: "com.antoinedc.mantaui.staging",
+      electronBuilderProductName: "Manta UI (Staging)",
+    });
+  });
+
+  it("dev matches the spec row (install/release same as prod; update + build = n/a)", () => {
+    expect(CHANNELS.dev).toEqual({
+      id: "dev",
+      userDataDir: "manta-dev",
+      urlScheme: "manta-dev",
+      appName: "Manta UI (Dev)",
+      installShUrl: "https://mantaui.com/install.sh",
+      releaseHost: "https://mantaui.com",
+      updateFeed: null,
+      electronBuilderAppId: null,
+      electronBuilderProductName: null,
+    });
+  });
+
+  it("freezes every record + the table itself (no accidental drift)", () => {
+    expect(Object.isFrozen(CHANNELS)).toBe(true);
+    for (const id of CHANNEL_IDS) {
+      expect(Object.isFrozen(CHANNELS[id])).toBe(true);
+    }
+  });
+
+  it("CHANNEL_IDS lists exactly prod, staging, dev — no fourth channel", () => {
+    expect(new Set(CHANNEL_IDS)).toEqual(new Set(["prod", "staging", "dev"]));
+  });
+});
+
+// ===========================================================================
+// resolveChannel — the one rule: packaged ? baked : dev, with bad baked → prod
+// ===========================================================================
+
+describe("resolveChannel", () => {
+  it("unpackaged always wins — returns 'dev' regardless of baked value", () => {
+    expect(resolveChannel(false, "prod")).toBe("dev");
+    expect(resolveChannel(false, "staging")).toBe("dev");
+    expect(resolveChannel(false, "dev")).toBe("dev");
+    expect(resolveChannel(false, undefined)).toBe("dev");
+    expect(resolveChannel(false, "garbage")).toBe("dev");
+  });
+
+  it("packaged + valid baked channel returns that channel", () => {
+    expect(resolveChannel(true, "prod")).toBe("prod");
+    expect(resolveChannel(true, "staging")).toBe("staging");
+    expect(resolveChannel(true, "dev")).toBe("dev");
+  });
+
+  it("packaged + undefined baked value falls back to prod", () => {
+    expect(resolveChannel(true, undefined)).toBe("prod");
+  });
+
+  it("packaged + null baked value falls back to prod", () => {
+    expect(resolveChannel(true, null as unknown as string)).toBe("prod");
+  });
+
+  it("packaged + unrecognised baked value falls back to prod (never throws)", () => {
+    expect(resolveChannel(true, "garbage")).toBe("prod");
+    expect(resolveChannel(true, "PROD")).toBe("prod");
+    expect(resolveChannel(true, "")).toBe("prod");
+    expect(resolveChannel(true, 42 as unknown as string)).toBe("prod");
+  });
+});
+
+// ===========================================================================
+// channelConfig — returns the record for a channel; unknown → prod
+// ===========================================================================
+
+describe("channelConfig", () => {
+  it("returns the same frozen record for prod / staging / dev", () => {
+    expect(channelConfig("prod")).toBe(CHANNELS.prod);
+    expect(channelConfig("staging")).toBe(CHANNELS.staging);
+    expect(channelConfig("dev")).toBe(CHANNELS.dev);
+  });
+
+  it("returns the prod record for an unknown channel (never throws)", () => {
+    expect(channelConfig("unknown" as unknown as "prod")).toBe(CHANNELS.prod);
+    expect(channelConfig(undefined)).toBe(CHANNELS.prod);
+    expect(channelConfig(null as unknown as "prod")).toBe(CHANNELS.prod);
+    expect(channelConfig("" as unknown as "prod")).toBe(CHANNELS.prod);
+  });
+});
+
+// ===========================================================================
+// Scheme-distinctness — the wire-format safety net.
+//
+// A `manta://pair?...` link intended for the prod app must not be mis-
+// delivered to staging, and vice versa. Pinning the schemes here means a
+// future PR that tries to unify them has to update this test alongside the
+// pair-link parser on the renderer side.
+// ===========================================================================
+
+describe("scheme-distinctness guards", () => {
+  it("the three URL schemes are pairwise distinct", () => {
+    const schemes = new Set(CHANNEL_IDS.map((id) => CHANNELS[id].urlScheme));
+    expect(schemes.size).toBe(3);
+  });
+
+  it("no URL-form prefix (`scheme://`) is a prefix of another (guards against mis-delivery)", () => {
+    // The actual mis-delivery vector is `argv.find(a => a.startsWith(prefix))`
+    // in main process — so we compare URL FORM (`scheme://`), not raw scheme.
+    // The `://` boundary stops the match for `manta-staging://` vs `manta://`
+    // even though "manta" is a substring prefix of "manta-staging".
+    const urlForms = CHANNEL_IDS.map((id) => `${CHANNELS[id].urlScheme}://`);
+    for (let i = 0; i < urlForms.length; i++) {
+      for (let j = 0; j < urlForms.length; j++) {
+        if (i === j) continue;
+        expect(urlForms[i].startsWith(urlForms[j])).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the three-channel split (prod | staging | dev) for the desktop app. The app now reads every per-channel value (userData dir, app name, URL scheme, install.sh URL, release host) from a single shared module — `src/shared/channel.mjs` — instead of inlining literals at the call sites. The build-time channel is injected via electron-vite's `define` (`__MANTA_CHANNEL__`), and a small `electron-builder.staging.yml` overlay (extends: base config) carries the staging-only deltas (appId, productName, protocols, publish URL, mac.artifactName).

**Files changed:** 10 files. `[525 insertions(+), 31 deletions(-)]`

| File | What |
|---|---|
| `src/shared/channel.mjs` (new) | The single source of truth: `CHANNELS` table, `resolveChannel(isPackaged, bakedChannel)` (the one rule), `channelConfig(channel)` (with the prod fallback for unknown channels). |
| `src/shared/channel.d.mts` (new) | Hand-written types mirroring `.mjs` — same pattern as claim.mjs / compatibility.mjs. |
| `src/shared/channel.test.ts` (new) | 14 tests: pinned table values, frozen invariants, resolveChannel's packaged/unpackaged + bad-baked paths, scheme-distinctness guards. |
| `src/main/buildDefines.d.ts` (new) | `declare const __MANTA_CHANNEL__: string` so typecheck accepts the build-time global. |
| `electron.vite.config.ts` | Bakes `__MANTA_CHANNEL__: JSON.stringify(process.env.MANTA_CHANNEL ?? "prod")` in the **main** build only (renderer doesn't need it yet). |
| `electron-builder.staging.yml` (new) | `extends:` overlay — only the deltas: `appId`, `productName`, `protocols` (manta-staging), `publish.url`, `mac.artifactName`. Inherits signing / notarization / entitlements / targets / node-pty exclusion. |
| `src/main/index.ts` | Six call sites converted: userData dir, setAsDefaultProtocolClient (the isPackaged guard is deleted per rule 6), four `startsWith("manta://")` sites use `PAIR_PREFIX` (one helper, four sites), `app.setName(...)` uses `channelConfig.appName`. |
| `src/main/installer/runner.ts` | `DEFAULT_INSTALL_SH_URL` deleted (was the only export that held a hard-coded `mantaui.com` URL — now sourced from channelConfig). |
| `src/main/installer/installer.ts` | `runInstall` reads install.sh URL + release host from `channelConfig(CHANNEL)`. `buildInstallCommand` now takes `releaseHost` and emits `MANTA_RELEASE_HOST=<host>` unconditionally (one command shape for all channels). Channel resolution is **lazy** via a runtime `require("electron")` so the orchestrator's unit tests (which stub spawn and don't load Electron) don't crash. |
| `src/main/installer/installer.test.ts` | Extended the existing `runInstall` assertion to cover `MANTA_RELEASE_HOST=` + the channel's install.sh URL; added a second test that the installShUrl seam overrides only the URL while releaseHost stays channel-derived. |

## Verification results

- **PR branch** (`multica/BET-370-build-channels` @ `e49f0e6`):
  - typecheck: exit 0. Errors: none. (log: `/tmp/typecheck-pr.log`)
  - vitest: 1410 pass / 0 fail / 0 skip. (64 → 65 test files; +14 channel + 1 installer delta) (log: `/tmp/test-pr.log`)
  - node:test: 1107 pass / 0 fail / 0 skip. (log: `/tmp/test-pr-full.log`)
- **Base** (`main` @ `165b6dc`):
  - typecheck: exit 0. (clean before changes — confirmed)
  - vitest: 1395 pass / 0 fail / 0 skip. (log captured during verification)
  - node:test: 1107 pass / 0 fail / 0 skip.
- **Conclusion:** 0 new failures. 15 new vitest tests (all pass). 0 regressions.

## Cross-cutting follow-ups (filed separately, listed for reviewer context)

- The `pair-link payload format` (`manta://pair?box=…&code=…`) is **deliberately unchanged** in this issue. The renderer / iOS / PWA / box all parse that wire format, and the spec explicitly defers staging support for those. A follow-up will need to thread the channel into the renderer's `parsePairPayload` and the box's pair-link emitter.
- `app.setAppUserModelId("com.antoinedc.mantaui")` (Windows toast attribution) is left as the prod bundle id — the spec table only listed `app.setName` for conversion. A staging build on Windows will share toast attribution with prod. If that matters, a follow-up should add `channelConfig.electronBuilderAppId` as the source here too.

**Base: origin/main @ 165b6dc**
