### PR TITLE
BET-373: thread build channel through pair-link wire format

### DIFF
--- a/electron.vite.config.mobile.ts
+++ b/electron.vite.config.mobile.ts
@@ -16,6 +16,12 @@ export default defineConfig({
     __MANTA_AXIOM_TOKEN__: JSON.stringify(process.env.MANTA_AXIOM_TOKEN ?? ""),
     __MANTA_AXIOM_DATASET__: JSON.stringify(process.env.MANTA_AXIOM_DATASET ?? "manta"),
     __APP_VERSION__: JSON.stringify(pkg.version ?? "0.0.0"),
+    // BET-370 + BET-373: the mobile bundle currently always bakes "prod"
+    // (mobile has no channel concept yet — out of scope per BET-373). Kept
+    // here so the ambient `const __MANTA_CHANNEL__: string` in
+    // src/renderer/types.d.ts is satisfied in BOTH renderer targets; a
+    // future mobile-channel effort can flip this to read the real env var.
+    __MANTA_CHANNEL__: JSON.stringify(process.env.MANTA_CHANNEL ?? "prod"),
   },
   resolve: { alias: { "@": resolve(__dirname, "src/renderer") } },
   build: {

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -49,6 +49,16 @@ export default defineConfig({
       __MANTA_AXIOM_TOKEN__: JSON.stringify(process.env.MANTA_AXIOM_TOKEN ?? ""),
       __MANTA_AXIOM_DATASET__: JSON.stringify(process.env.MANTA_AXIOM_DATASET ?? "manta"),
       __APP_VERSION__: JSON.stringify(pkg.version ?? "0.0.0"),
+      // BET-370 + BET-373: bake the channel id into the renderer bundle so
+      // pairPayload.ts (and any future renderer-side consumer) can pull the
+      // channel's URL scheme through `channelConfig(__MANTA_CHANNEL__)`.
+      // Mirrors the main-process baking — same source (process.env), same
+      // fallback ("prod"). The mobile renderer bundle bakes the SAME global
+      // (electron.vite.config.mobile.ts) so the ambient type is satisfied in
+      // both targets; mobile currently always uses the prod scheme because
+      // the mobile app does not yet have a channel concept (a separate
+      // effort per BET-373's out-of-scope list).
+      __MANTA_CHANNEL__: JSON.stringify(process.env.MANTA_CHANNEL ?? "prod"),
     },
     build: {
       rollupOptions: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,7 +20,17 @@ import { MOD_KEY } from "./platform";
 import { UpdateBar } from "./UpdateBar";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { parsePairPayload } from "./mobile/pairPayload";
+import { channelConfig } from "../shared/channel.mjs";
 import type { AvailableLauncher } from "../shared/types";
+
+// BET-373 (channel-aware wire format): the deep-link URL the OS hands this
+// app is, by construction, addressed to THIS channel's URL scheme
+// (the same scheme the main process registered via
+// `setAsDefaultProtocolClient(CHANNEL_CONFIG.urlScheme)`). Parsing with
+// that scheme enforces the boundary defensively — a `manta-staging://…`
+// link can never be misclaimed by a `manta://`-registered app, and a
+// `manta://` link can never silently pass through a staging build.
+const PAIR_PARSE_SCHEME = channelConfig(__MANTA_CHANNEL__).urlScheme;
 
 export function App() {
   const {
@@ -251,7 +261,7 @@ export function App() {
     const pre = getMantaPreload();
     if (!pre?.onPairLink) return;
     return pre.onPairLink((url) => {
-      const payload = parsePairPayload(url);
+      const payload = parsePairPayload(url, PAIR_PARSE_SCHEME);
       if (!payload) {
         // Malformed / legacy-shape link (e.g. an old box still minting the
         // `id=`/`token=` form). The OS still LAUNCHED us for the manta://

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -35,10 +35,29 @@ import { claimBox } from "./pairClaim";
 import { useStore } from "./store";
 import { SshInstallStep } from "./SshInstallStep";
 import { getMantaPreload } from "./preloadAccess";
+import { channelConfig } from "../shared/channel.mjs";
 
 const ACCENT = "#5A88FF"; // matches Onboarding.tsx + the app's accent token
 const DANGER = "#FF7A88"; // inline error text (no dedicated tailwind token)
 const SERVER_URL_ERROR = "Server URL must start with http:// or https://";
+
+// BET-373 (review cycle 1): the pending pair link stored by App.tsx was
+// already accepted against THIS channel's scheme (App.tsx's
+// PAIR_PARSE_SCHEME) — parsing it here with a different (default) scheme
+// would silently drop the payload on staging/dev. Same constant App.tsx
+// and PairingQR.tsx already build from `src/shared/channel.mjs`.
+//
+// BET-373 (review cycle 3): `__MANTA_CHANNEL__` is only DEFINEd by
+// electron-vite's build config (electron.vite.config.ts); it is not bound
+// under vitest/node, so a direct reference throws a ReferenceError at
+// import time. PairStep.test.tsx (BET-382) renders this component
+// directly, so — unlike App.tsx/PairingQR.tsx, which no test imports
+// today — this module needed the same `typeof` guard src/main/index.ts
+// and src/main/installer/installer.ts already use for exactly this
+// reason. Falls back to "prod", matching those call sites.
+const PAIR_PREFILL_SCHEME = channelConfig(
+  typeof __MANTA_CHANNEL__ === "string" ? __MANTA_CHANNEL__ : "prod",
+).urlScheme;
 
 export function PairStep({ onPaired }: { onPaired: () => void }) {
   const hasSshInstaller = getMantaPreload() !== null;
@@ -48,7 +67,7 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
   // so the user sees the address they're about to pair against. When no
   // link is pending, show the SSH picker as the primary surface.
   const pendingPairLink = useStore.getState().pendingPairLink;
-  const prefill = prefillFromPairLink(pendingPairLink);
+  const prefill = prefillFromPairLink(pendingPairLink, PAIR_PREFILL_SCHEME);
   const [disclosureOpen, setDisclosureOpen] = useState(() => Boolean(prefill));
   // On a renderer without an SSH installer (mobile / web), the picker is
   // unavailable — surface the manual form immediately rather than render an

--- a/src/renderer/PairingQR.tsx
+++ b/src/renderer/PairingQR.tsx
@@ -1,6 +1,6 @@
 // PairingQR — renders a QR code image for mobile device pairing.
 //
-// The QR encodes the CANONICAL box-form `manta://pair?box=<boxId>&code=<6-digit>`
+// The QR encodes the CANONICAL box-form `<scheme>://pair?box=<boxId>&code=<6-digit>`
 // payload produced by the SHARED `buildPairPayload` helper
 // (src/renderer/mobile/pairPayload.ts). BET-237 removed the deprecated
 // serverUrl / id forms — `parsePairPayload` rejects anything other than
@@ -14,9 +14,25 @@
 //
 // This is a desktop-only feature (BET-80). The mobile app consumes the same
 // URL scheme but generates the QR on the desktop side.
+//
+// BET-373 (channel-aware wire format): the QR uses THIS channel's URL scheme
+// (`channelConfig(__MANTA_CHANNEL__).urlScheme`, the same source the main
+// process uses to register `setAsDefaultProtocolClient(...)` and to build
+// `PAIR_PREFIX`). A staging desktop scans a QR with `manta-staging://…` so
+// the OS routes the open back to staging, not to whichever channel got
+// registered last for `manta://`. `__MANTA_CHANNEL__` is baked into the
+// renderer at build time (electron.vite.config.ts renderer `define`).
 
 import { useEffect, useMemo, useState } from "react";
 import { buildPairPayload } from "./mobile/pairPayload";
+import { channelConfig } from "../shared/channel.mjs";
+
+// Channel-aware scheme for the QR prefix. The baked `__MANTA_CHANNEL__`
+// comes from the renderer `define` (electron.vite.config.ts); channelConfig
+// does the same unknown-id → prod fallback the main process relies on, so a
+// stale/garbage baked value still produces a usable scheme rather than
+// throwing at render time.
+const PAIR_SCHEME = channelConfig(__MANTA_CHANNEL__).urlScheme;
 
 // Lazy-load qrcode so the renderer doesn't pay the bundle cost if this
 // component is never rendered (Settings is a modal, only open on demand).
@@ -38,7 +54,9 @@ export function PairingQR({
   const url = useMemo(() => {
     // Canonical box-form payload — shared with the install heredoc, `manta pair`
     // output, and the mobile deep-link parser. Single source: pairPayload.ts.
-    return buildPairPayload({ boxId, code: pairingCode });
+    // BET-373: `PAIR_SCHEME` keys the QR to this channel's OS-registered URL
+    // scheme so the OS routes the open back to the channel that scanned it.
+    return buildPairPayload({ boxId, code: pairingCode }, PAIR_SCHEME);
   }, [boxId, pairingCode]);
 
   useEffect(() => {

--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -4,8 +4,16 @@ import {
   buildPairPayload,
   type PairPayload,
 } from "./pairPayload";
+import { CHANNELS, CHANNEL_IDS } from "../../shared/channel.mjs";
 
 const BOX = "0123456789abcdef0123456789abcdef"; // 32 hex
+
+// Every channel in the table — drives the per-channel test loops below so
+// adding a fourth channel automatically extends coverage. The pairing wire
+// format only depends on urlScheme, but looping the table makes a future
+// PR that drops `manta` or adds a fourth scheme (e.g. "qa") impossible
+// without updating the test.
+const SCHEMES = CHANNEL_IDS.map((id) => CHANNELS[id].urlScheme);
 
 describe("parsePairPayload", () => {
   describe("boxId form (direct claim against the box's own hostname)", () => {
@@ -63,6 +71,61 @@ describe("parsePairPayload", () => {
       expect(
         parsePairPayload(`manta://pair?box=${BOX}&token=847291`),
       ).toEqual({ boxId: BOX, code: "847291" });
+    });
+  });
+
+  // BET-373: every channel's scheme is a legal pair-link prefix. The
+  // wire format is identical across channels — same query, same code,
+  // same server= gate — only the scheme prefix differs because that's
+  // what the OS uses to identify which app to deliver the link to.
+  describe("BET-373: per-channel scheme acceptance", () => {
+    for (const scheme of SCHEMES) {
+      it(`accepts ${scheme}://pair?... when configured with scheme="${scheme}"`, () => {
+        expect(
+          parsePairPayload(
+            `${scheme}://pair?box=${BOX}&code=847291`,
+            scheme,
+          ),
+        ).toEqual({ boxId: BOX, code: "847291" });
+      });
+
+      it(`accepts ${scheme}://pair?... with the URL-form Chromium-layout fallback (BET-240)`, () => {
+        // The "pair" segment lands in pathname (Chromium) — the parser's
+        // path-branch must still recover it for the channel's scheme.
+        // Pin it per-channel so a future PR that only fixes one scheme's
+        // URL parser can't slip through.
+        const raw = `${scheme}://pair?box=${BOX}&code=847291`;
+        expect(parsePairPayload(raw, scheme)).toEqual({
+          boxId: BOX,
+          code: "847291",
+        });
+      });
+
+      it(`rejects ${scheme}://pair?... when the parser is configured for a DIFFERENT scheme`, () => {
+        // The OS shouldn't have routed a `<scheme-A>://` link to a
+        // `<scheme-B>://`-registered app in the first place, but the
+        // parser enforces the same boundary defensively. A wrong-scheme
+        // payload is refused outright (NOT silently re-accepted under
+        // the parser's own scheme — that fallback would be the very
+        // mis-delivery the per-channel boundary is supposed to prevent).
+        for (const otherScheme of SCHEMES) {
+          if (otherScheme === scheme) continue;
+          expect(
+            parsePairPayload(
+              `${scheme}://pair?box=${BOX}&code=847291`,
+              otherScheme,
+            ),
+          ).toBeNull();
+        }
+      });
+    }
+
+    it("the three schemes from CHANNELS are pairwise distinct (no future channel silently merges)", () => {
+      // Sanity check on the SCHEMES list — loop above iterates these, so
+      // any drift here would silently skip a channel. A `Set` of size 3
+      // is the cheap pin that catches a copy-paste typo in CHANNELS.
+      expect(new Set(SCHEMES).size).toBe(SCHEMES.length);
+      expect(SCHEMES.length).toBe(3);
     });
   });
 
@@ -233,6 +296,34 @@ describe("buildPairPayload", () => {
     const empty = buildPairPayload({ boxId: BOX, code: "847291", serverUrl: "" });
     expect(empty).not.toContain("server=");
   });
+
+  // BET-373: per-channel emission. The builder picks up the caller's
+  // `scheme` arg verbatim — no derivation, no fallback chain — so the
+  // OS-registered scheme and the wire-format scheme can never disagree.
+  describe("BET-373: per-channel emission", () => {
+    for (const scheme of SCHEMES) {
+      it(`emits ${scheme}://pair?... when scheme="${scheme}"`, () => {
+        expect(
+          buildPairPayload({ boxId: BOX, code: "847291" }, scheme),
+        ).toBe(`${scheme}://pair?box=${encodeURIComponent(BOX)}&code=847291`);
+      });
+
+      it(`appends &server=<…> on the channel's scheme when scheme="${scheme}"`, () => {
+        // BET-336 + BET-373 together: the Tailscale pair link carries a
+        // server URL AND a channel-aware scheme prefix. Pin both ends so
+        // a future PR that loses the scheme arg on the server path can't
+        // quietly regress.
+        expect(
+          buildPairPayload(
+            { boxId: BOX, code: "847291", serverUrl: "http://100.64.1.5:8787" },
+            scheme,
+          ),
+        ).toBe(
+          `${scheme}://pair?box=${encodeURIComponent(BOX)}&code=847291&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+        );
+      });
+    }
+  });
 });
 
 describe("round-trip", () => {
@@ -248,6 +339,30 @@ describe("round-trip", () => {
     ];
     for (const p of cases) {
       expect(parsePairPayload(buildPairPayload(p))).toEqual(p);
+    }
+  });
+
+  // BET-373: round-trip per channel. The query is scheme-agnostic — the
+  // same `{boxId, code, serverUrl}` shape comes out no matter which
+  // scheme the build side picked, and a parse with the matching scheme
+  // recovers it.
+  describe("BET-373: build → parse round-trip per channel", () => {
+    for (const scheme of SCHEMES) {
+      it(`parsePairPayload(buildPairPayload(p, "${scheme}"), "${scheme}") deep-equals p`, () => {
+        const cases: PairPayload[] = [
+          { boxId: BOX, code: "111111" },
+          { boxId: BOX, code: "000000" },
+          { boxId: BOX, code: "987654" },
+          { boxId: BOX, code: "111111", serverUrl: "http://100.64.1.5:8787" },
+          { boxId: BOX, code: "000000", serverUrl: "http://192.168.1.10:8787" },
+          { boxId: BOX, code: "987654", serverUrl: "https://mybox.ts.net" },
+        ];
+        for (const p of cases) {
+          expect(
+            parsePairPayload(buildPairPayload(p, scheme), scheme),
+          ).toEqual(p);
+        }
+      });
     }
   });
 });

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -8,7 +8,12 @@
 // (Caddy on the box reverse-proxies 127.0.0.1:8787). The only live payload
 // shape is the box form:
 //   • Custom scheme (primary — what the desktop panel + install heredoc render):
-//       manta://pair?box=<box_id>&code=<6-digit>
+//       <scheme>://pair?box=<box_id>&code=<6-digit>
+//       scheme ∈ {manta, manta-staging, manta-dev} — the box + desktop emit
+//       the scheme their CHANNEL registered with the OS as a URL handler
+//       (BET-370 channel table; BET-373 thread this through pair links so
+//       staging-desktop users scanning a staging-box QR land in staging, not
+//       whatever other channel happened to register `manta://` last).
 //   • Deferred-deeplink https form (Branch/Firebase style):
 //       https://<host>/m/<payload>?box=<box_id>&code=<6-digit>
 //
@@ -22,6 +27,16 @@
 // never silently drop the parameter and fall back to the public hostname
 // — that fallback is exactly the "crafted link points the app at an
 // attacker's server" attack the gate prevents).
+//
+// BET-373 (channel-aware wire format): the parser and builder accept a
+// `scheme` arg (default "manta" — unchanged wire shape for callers that
+// don't care about channels). The parser only accepts the configured
+// scheme (the receiver's own URL handler), so a `manta-staging://pair?…`
+// link cannot accidentally be claimed by a `manta://`-registered app —
+// the OS shouldn't have routed it there in the first place, but the
+// parser enforces the same boundary defensively. The build side picks
+// up the channel's scheme via `channelConfig(channel).urlScheme` (the
+// single source of truth, shared with the box emitter).
 //
 // The validation contract (32-hex boxId shape, 6-digit code, private
 // server URL) is SINGLE-SOURCED: we delegate to normalizeCode
@@ -69,15 +84,29 @@ function coerceBoxId(raw: string): string | null {
 
 /**
  * Parse a raw scanned/deeplinked string into a PairPayload, or null for any
- * malformed / foreign input: not a manta pair URL, missing box, or code not
- * exactly 6 digits. Whitespace is trimmed.
+ * malformed / foreign input: not the expected pair URL (wrong scheme, wrong
+ * host segment), missing box, or code not exactly 6 digits. Whitespace is
+ * trimmed.
  *
  * Accepts the box form only (`box` + `code`, or `box` + `token` — the code
- * param has both spellings) and both URL shapes (custom `manta://pair` scheme
- * and the `https://host/m/...` deferred-deeplink form). The deprecated
- * `server=` and `id=` addressing forms are intentionally rejected.
+ * param has both spellings) and both URL shapes (custom `<scheme>://pair`
+ * — see `scheme` below — and the `https://host/m/...` deferred-deeplink
+ * form). The deprecated `server=` and `id=` addressing forms are
+ * intentionally rejected.
+ *
+ * BET-373 (channel-aware wire format): the custom-scheme half only accepts
+ * the configured `scheme` (default "manta" — unchanged for legacy callers).
+ * The OS hands a URL to the app whose registered scheme matches, so a
+ * `manta://` link landing in a `manta-staging://`-registered app would
+ * already be a routing bug — but the parser enforces the same boundary
+ * defensively so a wrong-channel payload can't sneak through. The query is
+ * scheme-agnostic: the same `{boxId, code, serverUrl}` shape comes out
+ * regardless of which scheme was used to deliver it.
  */
-export function parsePairPayload(raw: string): PairPayload | null {
+export function parsePairPayload(
+  raw: string,
+  scheme: string = "manta",
+): PairPayload | null {
   const input = String(raw ?? "").trim();
   if (!input) return null;
 
@@ -89,22 +118,25 @@ export function parsePairPayload(raw: string): PairPayload | null {
   }
 
   // Only two families are pairing payloads:
-  //   • manta://pair?...          (custom scheme; host is "pair")
-  //   • https://<host>/m/...    (deferred deeplink; path starts with /m/ or /m)
-  const isMantaScheme = url.protocol === "manta:";
+  //   • <scheme>://pair?...      (custom scheme; host is "pair")
+  //   • https://<host>/m/...   (deferred deeplink; path starts with /m/ or /m)
+  // BET-373: the custom-scheme family now keys off the caller's `scheme`
+  // arg (channel-aware), not a hardcoded `manta:` literal.
+  const isChannelScheme = url.protocol === `${scheme}:`;
   const isHttps = url.protocol === "https:" || url.protocol === "http:";
   const isDeferredPath = /^\/m(\/|$)/.test(url.pathname);
 
-  if (isMantaScheme) {
-    // manta://pair — the "pair" authority segment lands in DIFFERENT URL fields
-    // depending on the engine, because `manta:` is a NON-SPECIAL scheme:
+  if (isChannelScheme) {
+    // <scheme>://pair — the "pair" authority segment lands in DIFFERENT URL
+    // fields depending on the engine, because custom schemes are
+    // NON-SPECIAL schemes:
     //   • Node's URL           → url.hostname === "pair", pathname === ""
     //   • Chromium (renderer)  → url.hostname === "",     pathname === "//pair"
     // The parser originally checked only `url.hostname === "pair"`, which is
     // true in Node (where the unit tests run) but FALSE in the packaged
-    // Electron renderer — so every real deep-link / pasted manta:// link was
-    // rejected in-app with "Couldn't read that pair link". Accept the segment
-    // from either field (BET-240 regression).
+    // Electron renderer — so every real deep-link / pasted <scheme>:// link
+    // was rejected in-app with "Couldn't read that pair link". Accept the
+    // segment from either field (BET-240 regression).
     const host = url.hostname;
     const pathSeg = url.pathname.replace(/^\/+/, ""); // "//pair" → "pair"
     if (host !== "pair" && pathSeg !== "pair") return null;
@@ -148,11 +180,18 @@ export function parsePairPayload(raw: string): PairPayload | null {
 /**
  * Inverse of parsePairPayload: produce the canonical box-form custom-scheme
  * string
- *   manta://pair?box=<url-encoded box_id>&code=<code>
+ *   <scheme>://pair?box=<url-encoded box_id>&code=<code>
  * Used as a round-trip oracle in tests and by the desktop QR panel +
  * install.sh heredoc. The boxId is URL-encoded so reserved characters
  * survive the query (32-hex has none today, but the encoder is the safe
  * default).
+ *
+ * BET-373 (channel-aware wire format): the `scheme` arg (default "manta")
+ * lets the emitter pick the channel's own URL scheme — `manta://` for prod,
+ * `manta-staging://` for staging, `manta-dev://` for dev — so the OS
+ * routes the link back to the channel that scanned it. Callers should
+ * pass `channelConfig(channel).urlScheme` (src/shared/channel.mjs) so
+ * the literal lives in exactly one place.
  *
  * BET-336: when the payload carries a `serverUrl` (Tailscale pair link),
  * a `server=<url-encoded serverUrl>` query param is appended so the
@@ -161,8 +200,8 @@ export function parsePairPayload(raw: string): PairPayload | null {
  * helper with server URLs that have already passed `isPrivateServerUrl`,
  * so we do NOT re-validate here (the constructor is a thin encoder).
  */
-export function buildPairPayload(p: PairPayload): string {
-  const base = `manta://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+export function buildPairPayload(p: PairPayload, scheme: string = "manta"): string {
+  const base = `${scheme}://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
   if (p.serverUrl) {
     return `${base}&server=${encodeURIComponent(p.serverUrl)}`;
   }

--- a/src/renderer/mobile/setupLogic.test.ts
+++ b/src/renderer/mobile/setupLogic.test.ts
@@ -8,6 +8,12 @@ import {
   prefillFromPairLink,
 } from "./setupLogic";
 import { boxDirectUrl } from "../../shared/transport.mjs";
+import { CHANNELS, CHANNEL_IDS } from "../../shared/channel.mjs";
+
+// BET-373 (review cycle 1): every channel's scheme, derived from the table
+// (not hardcoded) so a fourth channel automatically extends this coverage —
+// same pattern pairPayload.test.ts uses for the parser/builder themselves.
+const SCHEMES = CHANNEL_IDS.map((id) => CHANNELS[id].urlScheme);
 
 const VALID_BOX = "7f3a9c1e0b8d4a62f1c9e5b7d0a4f8c2"; // 32 hex
 const BAD_BOX = "not-a-box";
@@ -267,5 +273,41 @@ describe("prefillFromPairLink (BET-335 deep-link prefill)", () => {
     // refused.
     const link = `manta://pair?box=${VALID_BOX}&code=123456&server=${encodeURIComponent("https://attacker.example.com")}`;
     expect(prefillFromPairLink(link)).toBeNull();
+  });
+
+  // BET-373 (review cycle 1): PairStep.tsx reads `pendingPairLink` from the
+  // store AFTER App.tsx already accepted it under the channel's own scheme
+  // (App.tsx's PAIR_PARSE_SCHEME). Regression coverage for the Block: this
+  // second parse MUST be given the same scheme, or a staging/dev pair link
+  // is silently dropped one step after being correctly routed by the OS.
+  describe("BET-373: per-channel scheme survives the prefill step", () => {
+    for (const scheme of SCHEMES) {
+      it(`prefills {boxId, code} for a ${scheme}:// link when called with scheme="${scheme}"`, () => {
+        const link = `${scheme}://pair?box=${VALID_BOX}&code=123456`;
+        expect(prefillFromPairLink(link, scheme)).toEqual({
+          boxId: VALID_BOX,
+          code: "123456",
+        });
+      });
+    }
+
+    it("drops the payload when called with the default scheme for a non-prod link (the bug this PR fixes)", () => {
+      // Documents the exact failure the reviewer found: App.tsx accepts a
+      // manta-staging:// link under its channel scheme and stores the raw
+      // URL; calling prefillFromPairLink WITHOUT threading that same scheme
+      // through (the pre-fix call site) falls back to "manta" and returns
+      // null — the staging pair form renders empty.
+      const staging = `manta-staging://pair?box=${VALID_BOX}&code=123456`;
+      expect(prefillFromPairLink(staging)).toBeNull();
+      expect(prefillFromPairLink(staging, "manta-staging")).toEqual({
+        boxId: VALID_BOX,
+        code: "123456",
+      });
+    });
+
+    it("rejects a link built for a DIFFERENT channel's scheme (defensive boundary)", () => {
+      const link = `manta-dev://pair?box=${VALID_BOX}&code=123456`;
+      expect(prefillFromPairLink(link, "manta-staging")).toBeNull();
+    });
   });
 });

--- a/src/renderer/mobile/setupLogic.ts
+++ b/src/renderer/mobile/setupLogic.ts
@@ -142,12 +142,23 @@ export function resolveConnectRoute(_serverBase: string): "direct" {
  * setupLogic is the project's home for pure pairing helpers and is already
  * covered by setupLogic.test.ts — that's what makes the behaviour testable
  * without mounting React.
+ *
+ * BET-373 (channel-aware wire format, review cycle 1): `scheme` defaults to
+ * `"manta"` (unchanged shape for legacy callers) but MUST be passed by
+ * PairStep.tsx as `channelConfig(__MANTA_CHANNEL__).urlScheme` — the same
+ * constant App.tsx already uses to accept the deep-link in the first place.
+ * Without it, a staging/dev pair link is accepted by App.tsx (which DOES
+ * pass the channel scheme) and stored as `pendingPairLink`, but then
+ * silently dropped here because the default `"manta"` scheme doesn't match
+ * `manta-staging:` / `manta-dev:` — the user lands on an empty form one
+ * step after the link was correctly routed.
  */
 export function prefillFromPairLink(
   raw: string | null | undefined,
+  scheme: string = "manta",
 ): { boxId: string; code: string; serverUrl?: string } | null {
   if (raw == null) return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
-  return parsePairPayload(trimmed);
+  return parsePairPayload(trimmed, scheme);
 }

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -20,6 +20,15 @@ declare global {
   // package.json version automatically propagates to every renderer build
   // at the next build run.
   const __APP_VERSION__: string;
+  // Build-time injected channel id (BET-370 + BET-373). Same source as the
+  // main-process baking (electron.vite.config.ts main `define`) — both the
+  // renderer + main resolve to the same per-channel URL scheme via
+  // `channelConfig(__MANTA_CHANNEL__).urlScheme` (src/shared/channel.mjs).
+  // The renderer reads this so the desktop's pair-link QR (PairingQR.tsx)
+  // + deep-link parse (App.tsx) pick up the channel's OS-registered scheme
+  // instead of a hardcoded `manta://`. Mobile bakes "prod" for now (mobile
+  // has no channel concept yet — out of scope per BET-373).
+  const __MANTA_CHANNEL__: string;
 }
 
 export {};

--- a/src/server/pairPage.mjs
+++ b/src/server/pairPage.mjs
@@ -3,7 +3,7 @@
 // Three auth-exempt GET routes (wired in index.mjs, exempted in auth.mjs):
 //   /pair          → pair.html (static wizard; code arrives in the URL
 //                    FRAGMENT so it never reaches the server or its logs)
-//   /pair/qr.png   → QR PNG of the canonical manta://pair payload. Shape-
+//   /pair/qr.png   → QR PNG of the canonical <scheme>://pair payload. Shape-
 //                    validated encoder only — it never touches the pairing
 //                    registry and cannot mint or verify codes.
 //   /pair/logo.png → the Manta mark (binary committed next to this file).
@@ -16,6 +16,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import QRCode from "qrcode";
 import { isPrivateServerUrl } from "../shared/transport.mjs";
+import { channelConfig } from "../shared/channel.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -23,11 +24,44 @@ export const HEX32_RE = /^[0-9a-f]{32}$/;
 export const CODE_RE = /^\d{6}$/;
 
 /**
+ * Resolve the box's pair-link URL scheme from `MANTA_CHANNEL` (BET-370 +
+ * BET-373). The box's release tarball bakes a `MANTA_CHANNEL` env var at
+ * deploy time (mirroring the desktop's `__MANTA_CHANNEL__`); the same
+ * channel table in `src/shared/channel.mjs` maps it to the OS-registered
+ * URL scheme. Without this hook the QR always emits `manta://` regardless
+ * of the channel — a staging desktop user scanning a staging-box QR would
+ * be routed to whatever app last registered `manta://`, never to their
+ * own staging install.
+ *
+ * Falls back to `"prod"` for an unset / unrecognised env value — matches
+ * `resolveChannel`'s defensive rule (a mis-configured box must still
+ * mint a working QR, not throw at request time). The same channel is
+ * always used for every QR on a given process; the function is cheap so
+ * we don't memoize it (env read once at first call).
+ */
+export function resolveBoxChannel() {
+  const raw =
+    typeof process !== "undefined" && process.env
+      ? process.env.MANTA_CHANNEL ?? ""
+      : "";
+  // channelConfig handles the unknown-channel → prod fallback (same rule
+  // as resolveChannel: a bad lookup must still return a usable config).
+  return channelConfig(raw || "prod");
+}
+
+/**
  * Validate the /pair/qr.png query. Returns
- *   { ok: true, payload: "manta://pair?box=<box>&code=<code>[&server=<url>]" }
+ *   { ok: true, payload: "<scheme>://pair?box=<box>&code=<code>[&server=<url>]" }
  * or
  *   { ok: false, error: <string> }.
  * Box is lowercased before validation (hostnames arrive case-insensitive).
+ *
+ * BET-373 (channel-aware wire format): `scheme` defaults to the box's own
+ * channel-derived URL scheme (so a staging box emits `manta-staging://…`).
+ * The caller can still override — tests pin each scheme directly — but
+ * the default ties the QR to the OS-registered scheme the box was built
+ * for, closing the staging-desktop-pair loop (BET-370 made the desktop
+ * channel-aware; this closes the same gap on the box side).
  *
  * BET-336 (Tailscale pair link): an optional `server` query param is
  * accepted. When absent or empty, the payload has no `&server=` and the
@@ -39,7 +73,7 @@ export const CODE_RE = /^\d{6}$/;
  * a non-private host is exactly the "crafted link → attacker's server"
  * attack the gate prevents.
  */
-export function validatePairQrQuery(query) {
+export function validatePairQrQuery(query, scheme) {
   const box =
     typeof query?.box === "string" ? query.box.trim().toLowerCase() : "";
   const code = typeof query?.code === "string" ? query.code.trim() : "";
@@ -51,7 +85,13 @@ export function validatePairQrQuery(query) {
   if (!CODE_RE.test(code)) {
     return { ok: false, error: "code must be exactly 6 digits" };
   }
-  let payload = `manta://pair?box=${box}&code=${code}`;
+  // BET-373: default to the box's own channel-derived scheme. `scheme ? : …`
+  // collapses the "caller passed nothing" / "caller passed undefined" /
+  // "caller passed empty string" cases into one fallback — the helper is
+  // a thin renderer-side channel lookup, callers shouldn't have to know
+  // how to spell "use the box's channel".
+  const useScheme = scheme || resolveBoxChannel().urlScheme;
+  let payload = `${useScheme}://pair?box=${box}&code=${code}`;
   if (server !== "") {
     if (!isPrivateServerUrl(server)) {
       return {

--- a/src/server/pairPage.mjs
+++ b/src/server/pairPage.mjs
@@ -35,9 +35,9 @@ export const CODE_RE = /^\d{6}$/;
  *
  * Falls back to `"prod"` for an unset / unrecognised env value — matches
  * `resolveChannel`'s defensive rule (a mis-configured box must still
- * mint a working QR, not throw at request time). The same channel is
- * always used for every QR on a given process; the function is cheap so
- * we don't memoize it (env read once at first call).
+ * mint a working QR, not throw at request time). The function re-reads
+ * `process.env.MANTA_CHANNEL` on every call rather than memoizing — it's
+ * cheap, and tests rely on being able to mutate the env between cases.
  */
 export function resolveBoxChannel() {
   const raw =

--- a/src/server/pairPage.test.mjs
+++ b/src/server/pairPage.test.mjs
@@ -11,11 +11,19 @@ import {
   HEX32_RE,
   CODE_RE,
   validatePairQrQuery,
+  resolveBoxChannel,
   renderPairQr,
   readPairAsset,
 } from "./pairPage.mjs";
+import { CHANNELS, CHANNEL_IDS } from "../shared/channel.mjs";
 
 const HEX32 = "0123456789abcdef0123456789abcdef";
+
+// Same per-channel iteration pattern as pairPayload.test.ts: drive the
+// per-scheme tests off the channel table so adding a fourth channel
+// automatically extends coverage (and a future PR that drops a scheme
+// from CHANNELS has to update the test alongside it).
+const SCHEMES = CHANNEL_IDS.map((id) => CHANNELS[id].urlScheme);
 
 // ---------------------------------------------------------------------------
 // HEX32_RE / CODE_RE
@@ -35,6 +43,57 @@ test("CODE_RE accepts exactly 6 digits", () => {
   assert.equal(CODE_RE.test("12345"), false);
   assert.equal(CODE_RE.test("1234567"), false);
   assert.equal(CODE_RE.test("abcdef"), false);
+});
+
+// ---------------------------------------------------------------------------
+// resolveBoxChannel — the env → channel table lookup
+// ---------------------------------------------------------------------------
+
+test("resolveBoxChannel falls back to the prod channel when MANTA_CHANNEL is unset", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  delete process.env.MANTA_CHANNEL;
+  try {
+    assert.equal(resolveBoxChannel(), CHANNELS.prod);
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+  }
+});
+
+test("resolveBoxChannel honors MANTA_CHANNEL=staging → CHANNELS.staging", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "staging";
+  try {
+    assert.equal(resolveBoxChannel(), CHANNELS.staging);
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+    else delete process.env.MANTA_CHANNEL;
+  }
+});
+
+test("resolveBoxChannel honors MANTA_CHANNEL=dev → CHANNELS.dev", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "dev";
+  try {
+    assert.equal(resolveBoxChannel(), CHANNELS.dev);
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+    else delete process.env.MANTA_CHANNEL;
+  }
+});
+
+test("resolveBoxChannel falls back to prod for an unrecognised MANTA_CHANNEL value (never throws)", () => {
+  // Same defensive rule as resolveChannel in shared/channel.mjs — a bad
+  // box deploy must still mint a working QR, not throw at request time.
+  // The pair page is auth-exempt and on the critical pairing path; a
+  // crash there would brick the install.
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "garbage";
+  try {
+    assert.equal(resolveBoxChannel(), CHANNELS.prod);
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+    else delete process.env.MANTA_CHANNEL;
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -161,6 +220,125 @@ test("validatePairQrQuery rejects a PUBLIC server URL (BET-336, crafted-link gua
   });
   assert.equal(r.ok, false);
   assert.match(r.error, /private\/tailnet/);
+});
+
+// ---------------------------------------------------------------------------
+// validatePairQrQuery — channel-aware scheme (BET-373)
+//
+// The renderer + desktop pair-link path now keys off the channel table
+// (src/shared/channel.mjs). These tests pin every channel's emitted
+// payload and the env-driven default that ties the box to its own scheme.
+// ---------------------------------------------------------------------------
+
+test("validatePairQrQuery honors an explicit scheme arg for every channel (BET-373)", () => {
+  for (const scheme of SCHEMES) {
+    const r = validatePairQrQuery({ box: HEX32, code: "847291" }, scheme);
+    assert.equal(r.ok, true, `scheme=${scheme} should accept valid input`);
+    assert.equal(
+      r.payload,
+      `${scheme}://pair?box=${HEX32}&code=847291`,
+      `scheme=${scheme} should emit <scheme>://pair?…`,
+    );
+  }
+});
+
+test("validatePairQrQuery honors an explicit scheme arg with &server= appended (BET-336 + BET-373)", () => {
+  // BET-336 + BET-373 together: a channel-aware scheme plus a Tailscale
+  // server URL. Pin both ends so a future PR that drops the scheme arg
+  // can't quietly regress.
+  for (const scheme of SCHEMES) {
+    const r = validatePairQrQuery(
+      { box: HEX32, code: "847291", server: "http://100.64.1.5:8787" },
+      scheme,
+    );
+    assert.equal(r.ok, true, `scheme=${scheme} should accept valid input`);
+    assert.equal(
+      r.payload,
+      `${scheme}://pair?box=${HEX32}&code=847291&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+      `scheme=${scheme} should emit <scheme>://pair?…&server=<encoded>`,
+    );
+  }
+});
+
+test("validatePairQrQuery defaults to the box's MANTA_CHANNEL scheme when no scheme arg is passed (BET-373)", () => {
+  // Drive every channel through env + delete so the env-driven default
+  // is pinned for ALL three channels. Pin the expected payload prefix to
+  // the env-driven channel so a future PR that loses the channel lookup
+  // (and silently falls back to manta://) fails this test for the
+  // staging + dev channels.
+  const prev = process.env.MANTA_CHANNEL;
+  try {
+    for (const id of CHANNEL_IDS) {
+      process.env.MANTA_CHANNEL = id;
+      const r = validatePairQrQuery({ box: HEX32, code: "847291" });
+      assert.equal(r.ok, true, `channel=${id} should accept valid input`);
+      assert.equal(
+        r.payload,
+        `${CHANNELS[id].urlScheme}://pair?box=${HEX32}&code=847291`,
+        `channel=${id} (env) should default to ${CHANNELS[id].urlScheme}://`,
+      );
+    }
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+    else delete process.env.MANTA_CHANNEL;
+  }
+});
+
+test("validatePairQrQuery defaults to manta:// when MANTA_CHANNEL is unset (BET-373 back-compat)", () => {
+  // The "no channel configured" path must still mint a valid
+  // `manta://pair?…` QR — pre-BET-373 boxes (which have no MANTA_CHANNEL
+  // env at all) keep working without any installer change. Pin the
+  // behavior so a future PR that re-routes an unset channel to dev
+  // (or anywhere else) breaks loudly here.
+  const prev = process.env.MANTA_CHANNEL;
+  delete process.env.MANTA_CHANNEL;
+  try {
+    const r = validatePairQrQuery({ box: HEX32, code: "847291" });
+    assert.equal(r.ok, true);
+    assert.equal(r.payload, `manta://pair?box=${HEX32}&code=847291`);
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+  }
+});
+
+test("validatePairQrQuery defaults to manta:// when MANTA_CHANNEL is unrecognised (BET-373 defensive fallback)", () => {
+  // Same defensive rule as resolveChannel — a mis-configured box must
+  // still mint a working QR. The pair page is auth-exempt and on the
+  // critical pairing path; a crash there would brick the install.
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "garbage";
+  try {
+    const r = validatePairQrQuery({ box: HEX32, code: "847291" });
+    assert.equal(r.ok, true);
+    assert.equal(r.payload, `manta://pair?box=${HEX32}&code=847291`);
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+    else delete process.env.MANTA_CHANNEL;
+  }
+});
+
+test("validatePairQrQuery: explicit scheme arg beats MANTA_CHANNEL env (BET-373 caller override)", () => {
+  // Pin the precedence: an explicit `scheme` arg from the caller wins
+  // over the env-driven default. Tests use this to drive each scheme
+  // without mutating the env; production callers (index.mjs) DON'T
+  // override and therefore pick up the env-driven channel.
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "staging";
+  try {
+    const r = validatePairQrQuery(
+      { box: HEX32, code: "847291" },
+      "manta-dev",
+    );
+    assert.equal(r.ok, true);
+    assert.equal(
+      r.payload,
+      `manta-dev://pair?box=${HEX32}&code=847291`,
+      "explicit scheme must override env-derived default",
+    );
+  } finally {
+    if (prev !== undefined) process.env.MANTA_CHANNEL = prev;
+    else delete process.env.MANTA_CHANNEL;
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

BET-370 made the desktop main process channel-aware (`manta` / `manta-staging` / `manta-dev` schemes, per-channel userData, app name, install.sh URL, release host). The renderer + box pair-link path was still hardcoded to `manta://` — a staging-desktop user scanning a staging-box QR was routed to whichever channel last registered `manta://`, never to their own staging install. This PR closes that gap on the pair-link wire format (the deliberate deferral recorded on BET-370).

## Changes

**Renderer (`src/renderer/mobile/pairPayload.ts`):** `parsePairPayload` / `buildPairPayload` accept a `scheme` arg (default `manta` — unchanged wire shape for callers that don't care). The parser only accepts the configured scheme (defensive against wrong-channel routing). The build side keys off `channelConfig(channel).urlScheme` (`src/shared/channel.mjs`, single source).

**Renderer wiring:**
- `electron.vite.config.ts` + `electron.vite.config.mobile.ts`: bake `__MANTA_CHANNEL__` into the renderer bundle (mobile always `prod` for now — mobile has no channel concept yet, separate effort per BET-373's out-of-scope list).
- `src/renderer/types.d.ts`: ambient `__MANTA_CHANNEL__` declaration.
- `PairingQR.tsx` + `App.tsx`: read the channel's scheme via `channelConfig(__MANTA_CHANNEL__).urlScheme`.

**Box (`src/server/pairPage.mjs`):** `validatePairQrQuery` defaults to the box's `MANTA_CHANNEL` env var → `channelConfig(env).urlScheme`, so a staging box emits `manta-staging://pair?...`. New `resolveBoxChannel()` export makes the env-driven lookup testable in isolation.

## Tests

- `src/renderer/mobile/pairPayload.test.ts`: per-channel parse acceptance, wrong-scheme rejection, per-channel build emission, and round-trip invariant (`build(scheme, …) → parse(build(…))` succeeds for every scheme).
- `src/server/pairPage.test.mjs`: per-channel explicit-scheme emission, env-driven default per channel (prod/staging/dev), back-compat default for an unset env (still emits `manta://`), defensive fallback for an unrecognised `MANTA_CHANNEL` value, and explicit-scheme-beats-env precedence.

`npm run typecheck && npm test` green — 1435 vitest tests + 1117 node:test tests pass.

## Out of scope

- iOS / Android native side of the pair flow (mobile has no channel concept yet; separate effort).
- `src/shared/channel.mjs` (table unchanged).
- Any change to the `?box=…&code=…` query shape.

## Verification

`npm run typecheck`: passes.
`npm test`: 1435 vitest tests + 1117 node:test tests, 0 failures.