### PR TITLE
BET-371: add staging channel to publish + trigger workflows

### DIFF
--- a/.github/workflows/server-tarball-deploy.yml
+++ b/.github/workflows/server-tarball-deploy.yml
@@ -1,5 +1,6 @@
 # Server tarball deploy — build ALL arch tarballs (x64 + arm64 + darwin-arm64)
-# and publish them + a combined multi-arch manifest on a `server-v*` git tag.
+# and publish them + a combined multi-arch manifest on a `server-v*` git tag,
+# or to a `/staging/releases/` subtree on demand.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -14,11 +15,12 @@
 # runner (native Mach-O binding for node-pty).
 #
 # WHAT IT DEPLOYS
-#   dist/manta-<v>-linux-x64.tar.gz     → <PROD_HOST>:/var/www/mantaui/releases/
-#   dist/manta-<v>-linux-arm64.tar.gz   → <PROD_HOST>:/var/www/mantaui/releases/
-#   dist/manta-<v>-darwin-arm64.tar.gz  → <PROD_HOST>:/var/www/mantaui/releases/
-#   dist/manta-<v>.txt                  → <PROD_HOST>:/var/www/mantaui/releases/
-#   (then cp manta-<v>.txt → manta-latest.txt, last — atomicity guarantee)
+#   dist/manta-<v>-linux-x64.tar.gz     → <RELEASES_DIR>/
+#   dist/manta-<v>-linux-arm64.tar.gz   → <RELEASES_DIR>/
+#   dist/manta-<v>-darwin-arm64.tar.gz  → <RELEASES_DIR>/
+#   dist/manta-<v>.txt                  → <RELEASES_DIR>/
+#   (then cp manta-<v>.txt → manta-latest.txt  for prod,
+#    or   cp manta-<v>.txt → manta-staging-latest.txt for staging — atomicity)
 #
 # BUILD HOST CHOICE
 #   GitHub-hosted ubuntu-latest (x64) + ubuntu-24.04-arm (linux-arm64) +
@@ -36,22 +38,25 @@
 #   verbatim.
 #
 # ATOMICITY
-#   tarballs + versioned manifest are uploaded FIRST; manta-latest.txt is the
-#   pointer that install.sh fetches by default, and it is copied LAST. A client
-#   therefore either sees the OLD latest.txt (and the OLD tarballs are still
-#   served) OR the NEW latest.txt (and the NEW tarballs are already uploaded).
-#   Drift between manifest and tarballs is impossible. (Same rule publish.sh
-#   documents — generalized to both arches via a loop.)
+#   tarballs + versioned manifest are uploaded FIRST; the channel's *-latest.txt
+#   pointer (manta-latest.txt for prod, manta-staging-latest.txt for staging)
+#   is copied LAST. A client therefore either sees the OLD pointer (and the
+#   OLD tarballs are still served) OR the NEW pointer (and the NEW tarballs are
+#   already uploaded). Drift between manifest and tarballs is impossible.
+#   (Same rule publish.sh documents — generalized to both arches via a loop.)
+#   Staging refreshes its OWN pointer only — it must NEVER overwrite the prod
+#   manta-latest.txt.
 #
 # VERIFY
 #   After publish, fail red on:
 #     - any tarball URL returning non-200
-#     - served manta-latest.txt's version != the version we just published
+#     - served *-latest.txt's version != the version we just published
 #     - any arch's served tarball sha256 != the manifest's sha256_<archkey>
 #   This is the two-arch generalization of publish.sh's existing drift check.
 #
-# TRIGGER: push a tag matching server-v* (e.g. server-v1). Also runnable
-#   manually via workflow_dispatch (deploys current main).
+# TRIGGER: push a tag matching server-v* (e.g. server-v1) → ALWAYS resolves to
+#   prod. Also runnable manually via workflow_dispatch with the `channel`
+#   input (default staging, since a manual run is nearly always staging).
 
 name: Server tarball deploy
 
@@ -60,6 +65,15 @@ on:
     tags:
       - "server-v*"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Deploy channel. prod = /var/www/mantaui/releases (the live tarballs). staging = /var/www/mantaui/staging/releases (on-demand QA channel; never auto-fires)."
+        type: choice
+        required: true
+        default: staging
+        options:
+          - prod
+          - staging
 
 # Serialize: two quick tags must not race two deploys that overwrite each
 # other's manifests / tarballs. Same group shape as build-mobile-bundle.yml +
@@ -71,10 +85,57 @@ concurrency:
 env:
   PROD_HOST: root@91.107.196.2
   SSH_KEY: /home/dev/.manta-deploy/prod_key
-  RELEASES_DIR: /var/www/mantaui/releases
-  SITE: https://mantaui.com
 
 jobs:
+  # Resolve channel ONCE at the entrypoint. Downstream steps read the resolved
+  # outputs and never re-derive — same shape as website-deploy.yml.
+  resolve:
+    runs-on: self-hosted
+    timeout-minutes: 2
+    outputs:
+      channel: ${{ steps.resolve.outputs.channel }}
+      releases_dir: ${{ steps.resolve.outputs.releases_dir }}
+      site: ${{ steps.resolve.outputs.site }}
+    steps:
+      - id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            channel="prod"
+          else
+            channel="${INPUT_CHANNEL:-staging}"
+          fi
+          if [ "$channel" = "staging" ]; then
+            releases_dir="/var/www/mantaui/staging/releases"
+            site="https://mantaui.com/staging"
+          else
+            releases_dir="/var/www/mantaui/releases"
+            site="https://mantaui.com"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "releases_dir=$releases_dir" >> "$GITHUB_OUTPUT"
+          echo "site=$site" >> "$GITHUB_OUTPUT"
+          echo "▸ Resolved channel=$channel releases_dir=$releases_dir site=$site"
+
+      # HARD GUARD: a staging run that silently writes to the prod releases
+      # directory is the only truly dangerous failure mode here, and it must
+      # be impossible rather than unlikely. Same guard shape as
+      # website-deploy.yml + mac-desktop.
+      - name: Guard — staging destination must contain /staging/
+        env:
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
+          RELEASES_DIR: ${{ steps.resolve.outputs.releases_dir }}
+        run: |
+          set -euo pipefail
+          if [ "$CHANNEL" = "staging" ] && [[ "$RELEASES_DIR" != */staging* ]]; then
+            echo "::error::channel=staging but RELEASES_DIR='$RELEASES_DIR' does not contain /staging/"
+            exit 1
+          fi
+          echo "✓ guard passed (channel=$CHANNEL, RELEASES_DIR=$RELEASES_DIR)"
+
   build:
     name: pack (${{ matrix.arch }})
     # One job per arch — node-pty's native binding cannot be cross-compiled,
@@ -123,7 +184,7 @@ jobs:
 
   publish:
     name: publish + verify
-    needs: build
+    needs: [resolve, build]
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
@@ -175,16 +236,19 @@ jobs:
           echo "✓ combined manifest: dist/manta-${VERSION}.txt"
 
       # Same scp/ssh plumbing as website-deploy.yml — no new secrets, no new
-      # key path. tarballs + versioned manifest first; manta-latest.txt pointer
-      # LAST so a client either sees old (and old tarballs) or new (and new
-      # tarballs are already uploaded) — drift is impossible.
-      - name: Upload tarballs + combined manifest to prod
+      # key path. tarballs + versioned manifest first; channel *-latest.txt
+      # pointer LAST so a client either sees old (and old tarballs) or new
+      # (and new tarballs are already uploaded) — drift is impossible.
+      - name: Upload tarballs + combined manifest to channel destination
         env:
           VERSION: ${{ steps.vars.outputs.version }}
+          RELEASES_DIR: ${{ needs.resolve.outputs.releases_dir }}
         run: |
           set -euo pipefail
           SSH="ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
           SCP="scp -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+
+          $SSH "$PROD_HOST" "mkdir -p $RELEASES_DIR"
 
           for arch in linux-x64 linux-arm64 darwin-arm64; do
             tarball="dist/manta-${VERSION}-${arch}.tar.gz"
@@ -195,12 +259,24 @@ jobs:
           echo "▸ Uploading ${manifest}"
           $SCP "$manifest" "$PROD_HOST:$RELEASES_DIR/"
 
-          echo "▸ Publishing manta-latest.txt pointer (LAST — atomicity)"
-          $SSH "$PROD_HOST" "cd $RELEASES_DIR && cp -f manta-${VERSION}.txt manta-latest.txt"
+          # Channel-specific pointer. prod refreshes manta-latest.txt (the
+          # canonical install.sh pointer). staging refreshes
+          # manta-staging-latest.txt — it MUST NOT touch prod's latest.txt,
+          # or every install.sh fetch returns a staging build to a prod user.
+          channel="${{ needs.resolve.outputs.channel }}"
+          if [ "$channel" = "staging" ]; then
+            pointer="manta-staging-latest.txt"
+          else
+            pointer="manta-latest.txt"
+          fi
+          echo "▸ Publishing ${pointer} (LAST — atomicity)"
+          $SSH "$PROD_HOST" "cd $RELEASES_DIR && cp -f manta-${VERSION}.txt ${pointer}"
 
       - name: Verify deploy (both arches)
         env:
           VERSION: ${{ steps.vars.outputs.version }}
+          SITE: ${{ needs.resolve.outputs.site }}
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
         run: |
           set -euo pipefail
           fail=0
@@ -217,8 +293,14 @@ jobs:
             fi
           done
 
-          echo "▸ Fetch served manta-latest.txt and assert version"
-          served=$(curl -fsSL "$SITE/releases/manta-latest.txt")
+          # Channel-specific *-latest.txt pointer — same atomicity invariant.
+          if [ "$CHANNEL" = "staging" ]; then
+            pointer="manta-staging-latest.txt"
+          else
+            pointer="manta-latest.txt"
+          fi
+          echo "▸ Fetch served ${pointer} and assert version"
+          served=$(curl -fsSL "$SITE/releases/${pointer}")
           served_version=$(printf '%s\n' "$served" | grep '^version=' | head -n1 | cut -d= -f2-)
           if [ "$served_version" != "$VERSION" ]; then
             echo "::error::served version='${served_version}' expected='${VERSION}'"

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -132,15 +132,19 @@ jobs:
             done
           fi
 
-          echo "▸ Copying installer + AI install doc"
+          echo "▸ Copying installer + AI install doc (shared — staging needs both)"
           $SCP scripts/install.sh "$PROD_HOST:$WEBROOT/install.sh"
           $SCP llms-install.md "$PROD_HOST:$WEBROOT/llms-install.md"
-          $SCP docs/plugins-authoring.md "$PROD_HOST:$WEBROOT/llms-plugins.md"
 
-          # Version manifest + .well-known/ — prod only. These are the
-          # AI-crawler discovery surface (llms.txt / sitemap.xml / agent-skills);
-          # staging must not be advertised.
+          # Version manifest, .well-known/ + llms-plugins.md — prod only. The
+          # spec's decision 4 names the staging artifact set as install.sh +
+          # llms-install.md only; llms-plugins.md (= docs/plugins-authoring.md)
+          # is part of the prod AI-crawler discovery surface and must not be
+          # advertised on the staging subtree.
           if [ "$CHANNEL" = "prod" ]; then
+            echo "▸ Copying llms-plugins.md (BET-300 — prod AI-crawler surface only)"
+            $SCP docs/plugins-authoring.md "$PROD_HOST:$WEBROOT/llms-plugins.md"
+
             echo "▸ Copying version manifest (BET-225)"
             $SSH "$PROD_HOST" "mkdir -p $WEBROOT/updates"
             if ls website/updates/*.json >/dev/null 2>&1; then
@@ -211,13 +215,16 @@ jobs:
             check "og.png" website/og.png
             check ".well-known/agent-skills/index.json" .well-known/agent-skills/index.json
             check ".well-known/agent-skills/manta/SKILL.md" .well-known/agent-skills/manta/SKILL.md
+            # llms-plugins.md is part of the prod AI-crawler discovery surface
+            # (see decision 4 — staging publishes install.sh + llms-install.md
+            # only); the verify step must follow the publish scope.
+            check "llms-plugins.md" docs/plugins-authoring.md
           fi
 
           # Shared across channels — install.sh + docs are what a staging
           # installer (or a /staging/ llms-read) actually fetches.
           check "install.sh" scripts/install.sh
           check "llms-install.md" llms-install.md
-          check "llms-plugins.md" docs/plugins-authoring.md
 
           if [ "$fail" -ne 0 ]; then
             echo "::error::One or more web assets are not live or are stale."

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,5 +1,5 @@
 # Website deploy — publish the marketing site + install assets to the prod box
-# on a `web-v*` git tag.
+# on a `web-v*` git tag, or to a `/staging/` subtree on demand.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -12,10 +12,10 @@
 #
 # WHAT IT DEPLOYS (glob-driven — adding a file to website/ deploys + verifies it)
 #   website/*.html + website/*.{png,css,txt,xml,svg,webp,jpg,mp4,webm}
-#                                                → /var/www/mantaui/ (each ext optional)
+#                                                → <WEBROOT>/ (each ext optional)
 #   website/updates/*.json, scripts/install.sh, llms-install.md,
-#     docs/plugins-authoring.md                  → /var/www/mantaui/ + subpaths
-#   .well-known/                                 → /var/www/mantaui/.well-known/  (EXPLICIT copy — dotfile dirs are NOT picked up by the website/ globs)
+#     docs/plugins-authoring.md                  → <WEBROOT>/ + subpaths
+#   .well-known/                                 → <WEBROOT>/.well-known/  (EXPLICIT copy — dotfile dirs are NOT picked up by the website/ globs; PROD ONLY)
 # Verify follows the copy — no hand-maintained file list, so no silent 404.
 #
 # RUNNER + AUTH
@@ -23,8 +23,10 @@
 #   box over SSH with the deploy key at ~/.manta-deploy/prod_key (public half is
 #   in the prod box's authorized_keys). No GitHub secret needed.
 #
-# TRIGGER: push a tag matching web-v* (e.g. web-v1, web-v2026-07-19). Also
-#   runnable manually via workflow_dispatch (deploys current main).
+# TRIGGER: push a tag matching web-v* (e.g. web-v1, web-v2026-07-19) → ALWAYS
+#   resolves to `prod`. Also runnable manually via workflow_dispatch with the
+#   `channel` input (default `staging`, since a manual run is nearly always a
+#   staging run — prod goes out by tag).
 
 name: Website deploy
 
@@ -33,6 +35,15 @@ on:
     tags:
       - "web-v*"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Deploy channel. prod = /var/www/mantaui (the live site). staging = /var/www/mantaui/staging (on-demand QA channel; never auto-fires)."
+        type: choice
+        required: true
+        default: staging
+        options:
+          - prod
+          - staging
 
 concurrency:
   group: website-deploy
@@ -40,20 +51,68 @@ concurrency:
 
 env:
   PROD_HOST: root@91.107.196.2
-  WEBROOT: /var/www/mantaui
   SSH_KEY: /home/dev/.manta-deploy/prod_key
-  SITE: https://mantaui.com
 
 jobs:
   deploy:
     runs-on: self-hosted
     timeout-minutes: 10
+    # Resolve channel ONCE here: a tag push is always prod; a workflow_dispatch
+    # honours its input (default staging). Downstream steps read the resolved
+    # `channel` / `WEBROOT` / `SITE` outputs and never re-derive.
+    outputs:
+      channel: ${{ steps.resolve.outputs.channel }}
+      webroot: ${{ steps.resolve.outputs.webroot }}
+      site: ${{ steps.resolve.outputs.site }}
     steps:
+      - id: resolve
+        name: Resolve channel + destinations
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            channel="prod"
+          else
+            channel="${INPUT_CHANNEL:-staging}"
+          fi
+          if [ "$channel" = "staging" ]; then
+            webroot="/var/www/mantaui/staging"
+            site="https://mantaui.com/staging"
+          else
+            webroot="/var/www/mantaui"
+            site="https://mantaui.com"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "webroot=$webroot" >> "$GITHUB_OUTPUT"
+          echo "site=$site" >> "$GITHUB_OUTPUT"
+          echo "▸ Resolved channel=$channel webroot=$webroot site=$site"
+
+      # HARD GUARD: a staging run that silently writes to the prod webroot is
+      # the only truly dangerous failure mode here, and it must be impossible
+      # rather than unlikely. The three workflows share this contract — any
+      # divergence is a reviewer Block.
+      - name: Guard — staging destination must contain /staging/
+        env:
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
+          WEBROOT: ${{ steps.resolve.outputs.webroot }}
+        run: |
+          set -euo pipefail
+          if [ "$CHANNEL" = "staging" ] && [[ "$WEBROOT" != */staging* ]]; then
+            echo "::error::channel=staging but WEBROOT='$WEBROOT' does not contain /staging/"
+            exit 1
+          fi
+          echo "✓ guard passed (channel=$CHANNEL, WEBROOT=$WEBROOT)"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Deploy static web assets to prod
+      - name: Deploy static web assets
+        env:
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
+          WEBROOT: ${{ steps.resolve.outputs.webroot }}
         run: |
           set -euo pipefail
           SSH="ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
@@ -62,30 +121,40 @@ jobs:
           echo "▸ Ensuring webroot exists"
           $SSH "$PROD_HOST" "mkdir -p $WEBROOT"
 
-          echo "▸ Copying marketing site (website/*.html + optional assets)"
-          $SCP website/*.html "$PROD_HOST:$WEBROOT/"
-          for ext in png css txt xml svg webp jpg mp4 webm; do
-            ls website/*."$ext" >/dev/null 2>&1 && $SCP website/*."$ext" "$PROD_HOST:$WEBROOT/"
-          done
+          # Marketing site (HTML + assets) — prod only. Staging does NOT mirror
+          # the marketing site; a staging copy of it is dead weight and a
+          # drift trap if someone edits website/* while pointing at staging.
+          if [ "$CHANNEL" = "prod" ]; then
+            echo "▸ Copying marketing site (website/*.html + optional assets)"
+            $SCP website/*.html "$PROD_HOST:$WEBROOT/"
+            for ext in png css txt xml svg webp jpg mp4 webm; do
+              ls website/*."$ext" >/dev/null 2>&1 && $SCP website/*."$ext" "$PROD_HOST:$WEBROOT/"
+            done
+          fi
 
           echo "▸ Copying installer + AI install doc"
           $SCP scripts/install.sh "$PROD_HOST:$WEBROOT/install.sh"
           $SCP llms-install.md "$PROD_HOST:$WEBROOT/llms-install.md"
           $SCP docs/plugins-authoring.md "$PROD_HOST:$WEBROOT/llms-plugins.md"
 
-          echo "▸ Copying version manifest (BET-225)"
-          $SSH "$PROD_HOST" "mkdir -p $WEBROOT/updates"
-          if ls website/updates/*.json >/dev/null 2>&1; then
-            $SCP website/updates/*.json "$PROD_HOST:$WEBROOT/updates/"
-          fi
+          # Version manifest + .well-known/ — prod only. These are the
+          # AI-crawler discovery surface (llms.txt / sitemap.xml / agent-skills);
+          # staging must not be advertised.
+          if [ "$CHANNEL" = "prod" ]; then
+            echo "▸ Copying version manifest (BET-225)"
+            $SSH "$PROD_HOST" "mkdir -p $WEBROOT/updates"
+            if ls website/updates/*.json >/dev/null 2>&1; then
+              $SCP website/updates/*.json "$PROD_HOST:$WEBROOT/updates/"
+            fi
 
-          echo "▸ Copying .well-known/agent-skills/ (BET-300 — dotfile dirs are NOT picked up by website/* globs)"
-          $SSH "$PROD_HOST" "mkdir -p $WEBROOT/.well-known/agent-skills/manta"
-          if [ -f .well-known/agent-skills/index.json ]; then
-            $SCP .well-known/agent-skills/index.json "$PROD_HOST:$WEBROOT/.well-known/agent-skills/index.json"
-          fi
-          if [ -f .well-known/agent-skills/manta/SKILL.md ]; then
-            $SCP .well-known/agent-skills/manta/SKILL.md "$PROD_HOST:$WEBROOT/.well-known/agent-skills/manta/SKILL.md"
+            echo "▸ Copying .well-known/agent-skills/ (BET-300 — dotfile dirs are NOT picked up by website/* globs)"
+            $SSH "$PROD_HOST" "mkdir -p $WEBROOT/.well-known/agent-skills/manta"
+            if [ -f .well-known/agent-skills/index.json ]; then
+              $SCP .well-known/agent-skills/index.json "$PROD_HOST:$WEBROOT/.well-known/agent-skills/index.json"
+            fi
+            if [ -f .well-known/agent-skills/manta/SKILL.md ]; then
+              $SCP .well-known/agent-skills/manta/SKILL.md "$PROD_HOST:$WEBROOT/.well-known/agent-skills/manta/SKILL.md"
+            fi
           fi
 
           echo "▸ Keeping /opt/manta clone current (source-of-truth parity)"
@@ -93,6 +162,9 @@ jobs:
             echo "⚠ /opt/manta pull skipped (non-fatal — webroot already updated)"
 
       - name: Verify each asset is live + matches the repo
+        env:
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
+          SITE: ${{ steps.resolve.outputs.site }}
         run: |
           set -euo pipefail
           fail=0
@@ -109,34 +181,44 @@ jobs:
               fail=1
             fi
           }
-          for f in website/*.html; do
-            base=$(basename "$f" .html)
-            if [ "$base" = "index" ]; then check "" "$f"; else check "$base" "$f"; fi
-          done
-          for f in website/*.css; do
-            [ -e "$f" ] || continue
-            check "$(basename "$f")" "$f"
-          done
-          # Hero video artefacts (BET-304 stage 1). The webp is also covered by
-          # the *.webp copy glob above (no duplicate rule needed), but listed
-          # explicitly here so the verify step confirms the poster is live.
-          for f in website/hero.mp4 website/hero.webm website/hero-poster.webp; do
-            [ -e "$f" ] || continue
-            check "$(basename "$f")" "$f"
-          done
+
+          # Marketing-site + GEO layer files are prod-only; on staging they would
+          # not exist and the verify would produce a hard fail. Same for
+          # .well-known/.
+          if [ "$CHANNEL" = "prod" ]; then
+            for f in website/*.html; do
+              base=$(basename "$f" .html)
+              if [ "$base" = "index" ]; then check "" "$f"; else check "$base" "$f"; fi
+            done
+            for f in website/*.css; do
+              [ -e "$f" ] || continue
+              check "$(basename "$f")" "$f"
+            done
+            # Hero video artefacts (BET-304 stage 1). The webp is also covered by
+            # the *.webp copy glob above (no duplicate rule needed), but listed
+            # explicitly here so the verify step confirms the poster is live.
+            for f in website/hero.mp4 website/hero.webm website/hero-poster.webp; do
+              [ -e "$f" ] || continue
+              check "$(basename "$f")" "$f"
+            done
+            check "updates/server.json" website/updates/server.json
+            # GEO layer (BET-300) — every file the marketing site advertises
+            # to AI / search crawlers must be live and byte-equal to the repo.
+            check "robots.txt" website/robots.txt
+            check "sitemap.xml" website/sitemap.xml
+            check "llms.txt" website/llms.txt
+            check "llms-full.txt" website/llms-full.txt
+            check "og.png" website/og.png
+            check ".well-known/agent-skills/index.json" .well-known/agent-skills/index.json
+            check ".well-known/agent-skills/manta/SKILL.md" .well-known/agent-skills/manta/SKILL.md
+          fi
+
+          # Shared across channels — install.sh + docs are what a staging
+          # installer (or a /staging/ llms-read) actually fetches.
           check "install.sh" scripts/install.sh
           check "llms-install.md" llms-install.md
           check "llms-plugins.md" docs/plugins-authoring.md
-          check "updates/server.json" website/updates/server.json
-          # GEO layer (BET-300) — every file the marketing site advertises
-          # to AI / search crawlers must be live and byte-equal to the repo.
-          check "robots.txt" website/robots.txt
-          check "sitemap.xml" website/sitemap.xml
-          check "llms.txt" website/llms.txt
-          check "llms-full.txt" website/llms-full.txt
-          check "og.png" website/og.png
-          check ".well-known/agent-skills/index.json" .well-known/agent-skills/index.json
-          check ".well-known/agent-skills/manta/SKILL.md" .well-known/agent-skills/manta/SKILL.md
+
           if [ "$fail" -ne 0 ]; then
             echo "::error::One or more web assets are not live or are stale."
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2315,7 +2315,7 @@ meaning **prod**; staging is triggered by hand after the spec change lands.
 | `install.sh`, `llms-install.md` | `/var/www/mantaui/` | `/var/www/mantaui/staging/` |
 | server tarballs + manifest | `/var/www/mantaui/releases/` | `/var/www/mantaui/staging/releases/` |
 | desktop update feed + DMG | `/var/www/mantaui/updates/` | `/var/www/mantaui/staging/updates/` |
-| desktop canonical download | `Manta-latest.dmg` (under `downloads/`) | `Manta-UI-Staging-latest.dmg` (under `staging/downloads/`) |
+| desktop canonical download | `Manta-latest.dmg` (under `downloads/`) | `Manta-Staging-latest.dmg` (under `staging/downloads/`) |
 
 **Triggers (three commands, no new workflow files):**
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2301,6 +2301,43 @@ APNs via `POST gateway.mantaui.com/push` with a `gateway_token` it got back
 from `POST /register` at install time. Web Push (VAPID, for the PWA) stays
 box-local and unchanged — it doesn't touch the gateway.
 
+### Staging channel — ON DEMAND ONLY, never auto-fires (BET-371)
+
+A parallel `staging/` subtree on the SAME prod webroot (`/var/www/mantaui/staging/...`),
+served as `https://mantaui.com/staging/...` from the existing Caddy vhost —
+no new host, no DNS, no TLS cert. Staging is **manual-only**: it never fires on
+a push, merge, or tag. Tag triggers (`web-v*`, `server-v*`, `mac-v*`) keep
+meaning **prod**; staging is triggered by hand after the spec change lands.
+
+**URL layout** (one prefix, three artifact dirs, mirroring prod):
+| Artifact | prod destination | staging destination |
+|---|---|---|
+| `install.sh`, `llms-install.md` | `/var/www/mantaui/` | `/var/www/mantaui/staging/` |
+| server tarballs + manifest | `/var/www/mantaui/releases/` | `/var/www/mantaui/staging/releases/` |
+| desktop update feed + DMG | `/var/www/mantaui/updates/` | `/var/www/mantaui/staging/updates/` |
+| desktop canonical download | `Manta-latest.dmg` (under `downloads/`) | `Manta-UI-Staging-latest.dmg` (under `staging/downloads/`) |
+
+**Triggers (three commands, no new workflow files):**
+```
+# Website — current main → /var/www/mantaui/staging
+gh workflow run website-deploy.yml -f channel=staging
+# Server tarballs — rebuilds all arches natively + publishes
+gh workflow run server-tarball-deploy.yml -f channel=staging
+# Desktop DMG — Codemagic REST API (no GitHub action); overrides MANTA_CHANNEL=staging
+CMK=$(secret_provide CODEMAGIC_API_KEY)
+curl -s -X POST -H "x-auth-token: $(cat $CMK)" -H "Content-Type: application/json" \
+  -d '{"appId":"6a5bfe08d7050a29d2f33802","workflowId":"mac-desktop","branch":"main",\
+       "environment":{"variables":{"MANTA_CHANNEL":"staging"}}}' \
+  https://api.codemagic.io/builds
+```
+Each workflow carries a `/staging/` guard step that fails RED if `channel=staging`
+and the resolved destination path lacks `/staging/` — a staging run that
+silently writes to prod is the only dangerous failure mode, and the guard makes
+it impossible rather than unlikely. The mac-desktop build's overlay
+(`electron-builder.staging.yml`, created in BET-370) changes appId +
+productName + URL scheme + update-feed URL + dmg filename so staging can
+install side-by-side with prod on the same Mac.
+
 ### Prod box topology (why deploys are shaped this way)
 
 - **Prod box** `root@91.107.196.2` (Hetzner "manta"), zone `mantaui.com`.

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -236,7 +236,7 @@ workflows:
           if [ "$CHANNEL" = "staging" ]; then
             FEED_DIR='/var/www/mantaui/staging/updates'
             DOWNLOADS_DIR='/var/www/mantaui/staging/downloads'
-            LATEST_DMG='Manta-UI-Staging-latest.dmg'
+            LATEST_DMG='Manta-Staging-latest.dmg'
           else
             FEED_DIR='/var/www/mantaui/updates'
             DOWNLOADS_DIR='/var/www/mantaui/downloads'
@@ -452,7 +452,7 @@ workflows:
           # CHANNEL (BET-371): all paths + the canonical *-latest.dmg name come
           # from the "Resolve + guard channel" step above (FEED_DIR,
           # DOWNLOADS_DIR, LATEST_DMG). Staging writes under /staging/ and
-          # refreshes Manta-UI-Staging-latest.dmg; prod stays on the original
+          # refreshes Manta-Staging-latest.dmg; prod stays on the original
           # /var/www/mantaui/{updates,downloads}/ + Manta-latest.dmg. The guard
           # step would already have failed RED if the resolved paths were
           # inconsistent with MANTA_CHANNEL — this step just trusts them.

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -145,6 +145,15 @@ workflows:
   # key, then the DMG + latest-mac.yml auto-update feed are published to the
   # prod box (mantaui.com/downloads + /updates).
   #
+  # CHANNEL (prod | staging): `MANTA_CHANNEL` env var drives the channel.
+  # Defaults to `prod`; tag triggers keep meaning prod and resolve via the
+  # default. Staging is on-demand ONLY — the box triggers a staging build by
+  # setting `environment.variables.MANTA_CHANNEL=staging` on the Codemagic
+  # REST API start call. When staging, the build is overlaid with
+  # `electron-builder.staging.yml` (different appId / productName / protocol /
+  # update feed) and the publish step writes to /var/www/mantaui/staging/...
+  # instead of /var/www/mantaui/... (BET-371).
+  #
   # ONE-TIME SETUP IN THE CODEMAGIC WEB UI (see docs/mac-beta-distribution.md):
   #   1. Create a "Developer ID Application" cert on a Mac (Xcode → Settings →
   #      Accounts → Manage Certificates → + → Developer ID Application), export
@@ -184,6 +193,13 @@ workflows:
         # app-store-connect CLI implicitly and does NOT expose the full key as a
         # shell variable). APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD are unused.
         - mantaui
+      # Channel resolution (BET-371). Codemagic env vars default to "" when
+      # unset; we coerce to `prod` so a tag-triggered run is unambiguously prod
+      # regardless of how the REST API was last invoked. The REST API override
+      # (for staging) passes environment.variables.MANTA_CHANNEL=staging — see
+      # AGENTS.md "Staging channel" subsection.
+      vars:
+        MANTA_CHANNEL: "prod"
       node: 22
       xcode: latest
     triggering:
@@ -204,6 +220,44 @@ workflows:
       - name: Install deps
         script: |
           npm ci
+      - name: Resolve + guard channel (BET-371)
+        script: |
+          # Coerce the channel here too (env.vars default is "" on Codemagic if
+          # unset, even with vars: { MANTA_CHANNEL: prod }) and fail RED if a
+          # staging build is asked to write to a non-staging destination. This
+          # is the codemagic.yaml analogue of the /staging/ guard in
+          # website-deploy.yml / server-tarball-deploy.yml — same contract.
+          set -euo pipefail
+          CHANNEL="${MANTA_CHANNEL:-prod}"
+          case "$CHANNEL" in
+            prod|staging) ;;
+            *) echo "::error::MANTA_CHANNEL='$CHANNEL' must be 'prod' or 'staging'"; exit 1 ;;
+          esac
+          if [ "$CHANNEL" = "staging" ]; then
+            FEED_DIR='/var/www/mantaui/staging/updates'
+            DOWNLOADS_DIR='/var/www/mantaui/staging/downloads'
+            LATEST_DMG='Manta-UI-Staging-latest.dmg'
+          else
+            FEED_DIR='/var/www/mantaui/updates'
+            DOWNLOADS_DIR='/var/www/mantaui/downloads'
+            LATEST_DMG='Manta-latest.dmg'
+          fi
+          # Guard: prod destinations must NOT contain /staging/; staging
+          # destinations MUST contain /staging/. Belt-and-braces against a
+          # future refactor that accidentally drops the channel suffix.
+          if [ "$CHANNEL" = "staging" ]; then
+            [[ "$FEED_DIR" == */staging* ]] || { echo "::error::staging but FEED_DIR='$FEED_DIR' lacks /staging/"; exit 1; }
+            [[ "$DOWNLOADS_DIR" == */staging* ]] || { echo "::error::staging but DOWNLOADS_DIR='$DOWNLOADS_DIR' lacks /staging/"; exit 1; }
+          else
+            [[ "$FEED_DIR" != */staging* ]] || { echo "::error::prod but FEED_DIR='$FEED_DIR' contains /staging/"; exit 1; }
+            [[ "$DOWNLOADS_DIR" != */staging* ]] || { echo "::error::prod but DOWNLOADS_DIR='$DOWNLOADS_DIR' contains /staging/"; exit 1; }
+          fi
+          echo "▸ channel=$CHANNEL feed=$FEED_DIR downloads=$DOWNLOADS_DIR latest=$LATEST_DMG"
+          # Export for the rest of the script (electron-builder, publish, ...).
+          echo "MANTA_CHANNEL=$CHANNEL"               >> "$CM_ENV"
+          echo "MANTA_FEED_DIR=$FEED_DIR"             >> "$CM_ENV"
+          echo "MANTA_DOWNLOADS_DIR=$DOWNLOADS_DIR"   >> "$CM_ENV"
+          echo "MANTA_LATEST_DMG=$LATEST_DMG"         >> "$CM_ENV"
       - name: Decode + import Developer ID cert into the keychain
         script: |
           # electron-builder reads CSC_LINK as a FILE PATH or a base64 string; we
@@ -280,13 +334,28 @@ workflows:
           # but Gatekeeper REJECTS it on open ("source=no usable signature")
           # because there is no code signature to anchor the ticket to. This was
           # THE mac-desktop notarization bug.
+          #
+          # CHANNEL (BET-371): MANTA_CHANNEL=staging is exported into the env by
+          # the "Resolve + guard channel" step ABOVE this one — electron.vite
+          # reads it via `__MANTA_CHANNEL__` (see electron.vite.config.ts). On
+          # staging, we ALSO overlay `electron-builder.staging.yml` (which
+          # changes appId/productName/protocol/publish.url + dmg filename —
+          # created in BET-370); prod stays on `electron-builder.yml`. The
+          # overlay uses `extends:` so signing/notarization/entitlements are
+          # inherited unchanged.
           set -e
           export APPLE_API_KEY="$ASC_KEY_FILE"
           export APPLE_API_KEY_ID="$ASC_API_KEY_ID"
           export APPLE_API_ISSUER="$ASC_ISSUER_ID"
           export APPLE_TEAM_ID="$APPLE_TEAM_ID"
+          export MANTA_CHANNEL="${MANTA_CHANNEL:-prod}"
           npm run build
-          npx electron-builder --mac --publish never -c.mac.notarize=true
+          if [ "$MANTA_CHANNEL" = "staging" ]; then
+            npx electron-builder --mac --publish never -c.mac.notarize=true \
+              --config electron-builder.staging.yml
+          else
+            npx electron-builder --mac --publish never -c.mac.notarize=true
+          fi
       - name: Sign + notarize + staple the DMG itself
         script: |
           # The missing steps. Sign the DMG with the Developer ID cert, submit it
@@ -379,32 +448,43 @@ workflows:
         script: |
           # Skips cleanly if no deploy key is configured, so the workflow still
           # produces downloadable Codemagic artifacts without prod access.
+          #
+          # CHANNEL (BET-371): all paths + the canonical *-latest.dmg name come
+          # from the "Resolve + guard channel" step above (FEED_DIR,
+          # DOWNLOADS_DIR, LATEST_DMG). Staging writes under /staging/ and
+          # refreshes Manta-UI-Staging-latest.dmg; prod stays on the original
+          # /var/www/mantaui/{updates,downloads}/ + Manta-latest.dmg. The guard
+          # step would already have failed RED if the resolved paths were
+          # inconsistent with MANTA_CHANNEL — this step just trusts them.
           if [ -z "${PROD_SSH_KEY:-}" ]; then
             echo "No PROD_SSH_KEY — skipping publish. DMG is in Codemagic artifacts."
             exit 0
           fi
           set -e
+          : "${MANTA_FEED_DIR:?MANTA_FEED_DIR not set — guard step must run first}"
+          : "${MANTA_DOWNLOADS_DIR:?MANTA_DOWNLOADS_DIR not set — guard step must run first}"
+          : "${MANTA_LATEST_DMG:?MANTA_LATEST_DMG not set — guard step must run first}"
           mkdir -p ~/.ssh
           echo "$PROD_SSH_KEY" | base64 --decode > ~/.ssh/prod_key
           chmod 600 ~/.ssh/prod_key
           SSH="ssh -i ~/.ssh/prod_key -o StrictHostKeyChecking=accept-new"
           HOST="root@91.107.196.2"
-          $SSH "$HOST" 'mkdir -p /var/www/mantaui/updates /var/www/mantaui/downloads'
-          # Upload feed + binaries to the update channel.
-          scp -i ~/.ssh/prod_key dist/desktop/latest-mac.yml "$HOST:/var/www/mantaui/updates/"
-          scp -i ~/.ssh/prod_key dist/desktop/*.dmg "$HOST:/var/www/mantaui/updates/"
-          # Human-facing downloads + refresh the canonical Manta-latest.dmg
+          $SSH "$HOST" "mkdir -p $MANTA_FEED_DIR $MANTA_DOWNLOADS_DIR"
+          # Upload feed + binaries to the channel's update directory.
+          scp -i ~/.ssh/prod_key dist/desktop/latest-mac.yml "$HOST:$MANTA_FEED_DIR/"
+          scp -i ~/.ssh/prod_key dist/desktop/*.dmg "$HOST:$MANTA_FEED_DIR/"
+          # Human-facing downloads + refresh the channel's canonical latest.dmg
           # (arm64 preferred; falls back to whatever single dmg exists).
           # MUST pick the HIGHEST version, not the alphabetically-first —
           # `ls | head -1` returned 0.0.1 once both 0.0.1 and 0.0.4 were in the
           # dir, so Manta-latest.dmg silently served the OLDEST build (BET-252
           # shipped in 0.0.4 but the download link stayed on 0.0.1). Always
           # version-sort and take the tail.
-          scp -i ~/.ssh/prod_key dist/desktop/*.dmg "$HOST:/var/www/mantaui/downloads/"
-          $SSH "$HOST" 'cd /var/www/mantaui/downloads && \
-            latest=$(ls -1 *arm64*.dmg 2>/dev/null | sort -V | tail -1); \
-            [ -z "$latest" ] && latest=$(ls -1 *.dmg | sort -V | tail -1); \
-            cp -f "$latest" Manta-latest.dmg && echo "Manta-latest.dmg -> $latest"'
+          scp -i ~/.ssh/prod_key dist/desktop/*.dmg "$HOST:$MANTA_DOWNLOADS_DIR/"
+          $SSH "$HOST" "cd $MANTA_DOWNLOADS_DIR && \
+            latest=\$(ls -1 *arm64*.dmg 2>/dev/null | sort -V | tail -1); \
+            [ -z \"\$latest\" ] && latest=\$(ls -1 *.dmg | sort -V | tail -1); \
+            cp -f \"\$latest\" $MANTA_LATEST_DMG && echo \"$MANTA_LATEST_DMG -> \$latest\""
     artifacts:
       - dist/desktop/*.dmg
       - dist/desktop/latest-mac.yml


### PR DESCRIPTION
Base: origin/main @ 2b47f8d

Adds an on-demand staging channel to the three existing publish+trigger
workflows (website-deploy, server-tarball-deploy, codemagic mac-desktop)
without duplicating any workflow file. Tag triggers (web-v*, server-v*,
mac-v*) keep meaning prod; staging fires by hand via
`gh workflow run ... -f channel=staging` or the Codemagic REST API with
`environment.variables.MANTA_CHANNEL=staging`.

**Resolution shape (same in all three):** a single `resolve` step / job
sets `WEBROOT` / `RELEASES_DIR` / `FEED_DIR` / `SITE` / `LATEST_DMG` from
the channel and exposes them via step or job outputs; downstream steps
read those and never re-derive. A `/staging/` guard step before any
write fails RED if `channel=staging` but the resolved destination lacks
`/staging/`.

**Prod value diff (behaviourally empty):**
| Resolved variable | Before (always prod) | After (channel=prod) |
|---|---|---|
| `WEBROOT` (website) | `/var/www/mantaui` | `/var/www/mantaui` |
| `SITE` (website) | `https://mantaui.com` | `https://mantaui.com` |
| `RELEASES_DIR` (server) | `/var/www/mantaui/releases` | `/var/www/mantaui/releases` |
| `SITE` (server) | `https://mantaui.com` | `https://mantaui.com` |
| `FEED_DIR` (mac) | `/var/www/mantaui/updates` | `/var/www/mantaui/updates` |
| `DOWNLOADS_DIR` (mac) | `/var/www/mantaui/downloads` | `/var/www/mantaui/downloads` |
| `LATEST_DMG` (mac) | `Manta-latest.dmg` | `Manta-latest.dmg` |

Same strings, just reached through a parameter instead of literals.

**Files changed:**
- `.github/workflows/website-deploy.yml` — `channel` input (default
  `staging`), `WEBROOT`/`SITE` resolved in one step, prod-only gates on
  marketing site / `.well-known/agent-skills/` / `website/updates/*.json`
  copy steps, verify reads resolved `SITE`.
- `.github/workflows/server-tarball-deploy.yml` — `channel` input, new
  `resolve` job exposes `channel` / `releases_dir` / `site` outputs,
  publish reads them; staging refreshes `manta-staging-latest.txt`,
  never `manta-latest.txt`.
- `codemagic.yaml` (mac-desktop) — `MANTA_CHANNEL` env var defaulting
  `prod`, `Resolve + guard channel` step exports `MANTA_FEED_DIR` /
  `MANTA_DOWNLOADS_DIR` / `MANTA_LATEST_DMG`; the build step passes
  `--config electron-builder.staging.yml` when staging; publish uses
  the exported channel paths.
- `AGENTS.md` — new "Staging channel — ON DEMAND ONLY" subsection with
  the URL layout table and the three trigger recipes (two `gh workflow
  run`, one Codemagic `curl`).

**Verification results:**
- PR branch (`multica/BET-371-staging-channel` @ `f3e7425`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1107` pass / `0` fail / `0` skip. log sha256: `4de48cf2b7b3bd14985cebae6ef91dd3d8c8dfbda3241291cfeca061d90ffc9d`
- Base (`main` @ `2b47f8d`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1107` pass / `0` fail / `0` skip. log sha256: `dfcb9003c5d4cc6caa41519f4f7f87bbfa72ce4fca4144856137b7f3cd572351`
- **Conclusion:** `0` new failures, `0` pre-existing failures, `0` resolved.
  typecheck logs are byte-identical between PR and base; test logs differ
  only in timestamps.

YAML parse check (per the issue's "Tests" section):
- `.github/workflows/website-deploy.yml` — parses cleanly with `yaml@2.x`.
- `.github/workflows/server-tarball-deploy.yml` — parses cleanly.
- `codemagic.yaml` — parses cleanly.

**Out of scope (not done, per the spec):** no workflow was triggered, no
scp to prod, no tag pushed. The first staging publish is a human action
after this merges.

**Depends on:** BET-370 (already merged in PR #318 / commit `2b47f8d`):
`electron-builder.staging.yml` overlay and `MANTA_CHANNEL` baked via
`__MANTA_CHANNEL__` are already on `main` and resolve cleanly.