### PR TITLE
Onboarding step 1: host picker refresh + always-available custom host (BET-384)

### DIFF
--- a/src/main/installer/_testFixtures.ts
+++ b/src/main/installer/_testFixtures.ts
@@ -77,7 +77,8 @@ export function makeProbeSpawn(
   responses: Record<string, ProbeResponse>,
 ): SpawnFn {
   return (_command, args) => {
-    // args layout: ["-o", "ConnectTimeout=10", "-o", "BatchMode=yes", alias, command]
+    // args layout: ["-o", "ConnectTimeout=10", "-o", "BatchMode=yes", "--", alias, command]
+    // (BET-384: "--" terminates option parsing before the destination)
     const cmd = args[args.length - 1];
     const found = Object.keys(responses).find((k) => cmd.includes(k));
     const r =

--- a/src/main/installer/handlers.ts
+++ b/src/main/installer/handlers.ts
@@ -26,6 +26,7 @@ import {
 import { buildDiagnostics, type DiagnosticsInput } from "./diagnostics.js";
 import type { InstallStageId } from "./stageMapper.js";
 import type { PreflightResult } from "./preflight.js";
+import { isEmptySshTarget, type SshTarget } from "../../shared/sshTarget.js";
 
 // ---------------------------------------------------------------------------
 // Per-install state (single-active; the renderer can re-mount and recover)
@@ -68,16 +69,19 @@ export function registerInstallerHandlers(
     preflight: activePreflight,
   }));
 
-  ipcMain.handle(IPC.installerStart, async (_e, input: { alias: string }) => {
+  ipcMain.handle(IPC.installerStart, async (_e, input: { alias: SshTarget }) => {
     if (activeHandle !== null) {
       // Single-active constraint — refuse to start a second install.
       // The renderer should call installCancel first (or wait for done).
       throw new Error("an install is already in progress");
     }
-    if (typeof input?.alias !== "string" || input.alias.trim() === "") {
+    if (input?.alias === undefined || isEmptySshTarget(input.alias)) {
       throw new Error("alias is required");
     }
-    const alias = input.alias.trim();
+    // Alias branch stays a trimmed string (unchanged); a custom target
+    // (BET-384) is already normalized by resolveInstallTarget on the
+    // renderer side, so there's nothing further to trim on an object.
+    const alias = typeof input.alias === "string" ? input.alias.trim() : input.alias;
     const handleId = `install-${++nextHandleSeq}-${Date.now()}`;
     activeStage = "preflight";
     logTail.length = 0;
@@ -155,7 +159,7 @@ export function registerInstallerHandlers(
 
   ipcMain.handle(IPC.installerMintAndClaim, async (
     _e,
-    input: { alias: string; claimUrlOverride?: string },
+    input: { alias: SshTarget; claimUrlOverride?: string },
   ) => {
     return mintAndClaim(input.alias, {
       persist,

--- a/src/main/installer/installer.ts
+++ b/src/main/installer/installer.ts
@@ -32,6 +32,7 @@ import {
   type SpawnFn,
 } from "./runner.js";
 import { parseSshConfig, type SshHostEntry } from "./sshConfig.js";
+import { isEmptySshTarget, type SshTarget } from "../../shared/sshTarget.js";
 import { isValidBoxToken } from "../../shared/transport.mjs";
 import {
   resolveChannel,
@@ -145,10 +146,10 @@ export type PreflightDeps = {
 };
 
 export async function preflightBox(
-  alias: string,
+  alias: SshTarget,
   deps: PreflightDeps = {},
 ): Promise<PreflightResult> {
-  if (typeof alias !== "string" || alias.trim() === "") {
+  if (isEmptySshTarget(alias)) {
     throw new Error("preflightBox: alias is required");
   }
   const spawn = deps.spawn;
@@ -176,7 +177,7 @@ export async function preflightBox(
 
 // ---------- individual probes ----------
 
-async function probeReachability(alias: string, spawn?: SpawnFn): Promise<PreflightProbes["reachability"]> {
+async function probeReachability(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["reachability"]> {
   // BatchMode=yes turns "no auth" into exit code 255 / stderr "Permission
   // denied (publickey)" — not a hang on a passphrase prompt.
   const r = await execRemote(alias, PROBE_REACHABILITY_CMD, {
@@ -200,7 +201,7 @@ async function probeReachability(alias: string, spawn?: SpawnFn): Promise<Prefli
   return "unreachable";
 }
 
-async function probeOs(alias: string, spawn?: SpawnFn): Promise<PreflightProbes["os"]> {
+async function probeOs(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["os"]> {
   const r = await execRemote(alias, PROBE_OS_CMD, { spawn, timeoutMs: 10_000 });
   if (r.code !== 0) {
     return { id: "unknown", arch: "unknown", release: null };
@@ -213,7 +214,7 @@ async function probeOs(alias: string, spawn?: SpawnFn): Promise<PreflightProbes[
   };
 }
 
-async function probeSudo(alias: string, spawn?: SpawnFn): Promise<boolean> {
+async function probeSudo(alias: SshTarget, spawn?: SpawnFn): Promise<boolean> {
   const r = await execRemote(alias, PROBE_SUDO_CMD, { spawn, timeoutMs: 10_000 });
   // `sudo -n true` exit 0 + no password prompt → passwordless sudo.
   // Anything else (exit != 0, or "password" in stderr) → not available.
@@ -221,7 +222,7 @@ async function probeSudo(alias: string, spawn?: SpawnFn): Promise<boolean> {
   return false;
 }
 
-async function probeTailscale(alias: string, spawn?: SpawnFn): Promise<PreflightProbes["tailscale"]> {
+async function probeTailscale(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["tailscale"]> {
   const r = await execRemote(alias, PROBE_TAILSCALE_CMD, { spawn, timeoutMs: 10_000 });
   if (r.code !== 0 || r.stdout.trim() === "") {
     return { running: false, ipv4: null };
@@ -230,7 +231,7 @@ async function probeTailscale(alias: string, spawn?: SpawnFn): Promise<Preflight
   return parsed ?? { running: false, ipv4: null };
 }
 
-async function probeClock(alias: string, spawn?: SpawnFn): Promise<number> {
+async function probeClock(alias: SshTarget, spawn?: SpawnFn): Promise<number> {
   const local = Math.floor(Date.now() / 1000);
   const r = await execRemote(alias, PROBE_CLOCK_CMD, { spawn, timeoutMs: 10_000 });
   if (r.code !== 0) return 0;
@@ -239,7 +240,7 @@ async function probeClock(alias: string, spawn?: SpawnFn): Promise<number> {
   return local - remote;
 }
 
-async function probeAuthFile(alias: string, spawn?: SpawnFn): Promise<boolean> {
+async function probeAuthFile(alias: SshTarget, spawn?: SpawnFn): Promise<boolean> {
   const r = await execRemote(alias, PROBE_AUTH_FILE_CMD, { spawn, timeoutMs: 10_000 });
   return r.code === 0 && r.stdout.trim() === "INSTALLED";
 }
@@ -291,11 +292,11 @@ export type InstallHandle = {
 };
 
 export function runInstall(
-  alias: string,
+  alias: SshTarget,
   sink: InstallSink,
   deps: InstallDeps = {},
 ): InstallHandle {
-  if (typeof alias !== "string" || alias.trim() === "") {
+  if (isEmptySshTarget(alias)) {
     throw new Error("runInstall: alias is required");
   }
   // Local name `cfg` (not `channelConfig`) so it doesn't shadow the imported
@@ -391,10 +392,10 @@ export type MintAndClaimDeps = {
  * {pairing_code, box_id, serverUrl} block the desktop parses.
  */
 export async function mintAndClaim(
-  alias: string,
+  alias: SshTarget,
   deps: MintAndClaimDeps,
 ): Promise<ClaimOutcome> {
-  if (typeof alias !== "string" || alias.trim() === "") {
+  if (isEmptySshTarget(alias)) {
     throw new Error("mintAndClaim: alias is required");
   }
   if (typeof deps.persist !== "function") {

--- a/src/main/installer/runner.test.ts
+++ b/src/main/installer/runner.test.ts
@@ -16,7 +16,7 @@ import { makeFakeChild } from "./_testFixtures.js";
 // ---------------------------------------------------------------------------
 
 describe("execRemote", () => {
-  it("builds the canonical ssh argv (ConnectTimeout + BatchMode + alias + cmd)", async () => {
+  it("builds the canonical ssh argv (ConnectTimeout + BatchMode + -- + alias + cmd)", async () => {
     const captured: { command: string; args: string[] } = { command: "", args: [] };
     const fake = makeFakeChild();
     const spawn: SpawnFn = (command, args) => {
@@ -29,17 +29,45 @@ describe("execRemote", () => {
     setImmediate(() => fake.fireExit(0));
     const r = await p;
     expect(captured.command).toBe(SSH_BIN);
+    // `--` terminates option parsing before the destination (BET-384
+    // review cycle 1 nit — a leading-`-` destination must never be read
+    // as an ssh(1) flag). See buildArgs's comment for the empirical proof.
     expect(captured.args).toEqual([
       "-o",
       "ConnectTimeout=10",
       "-o",
       "BatchMode=yes",
+      "--",
       "dev",
       "echo hi",
     ]);
     expect(r.code).toBe(0);
     expect(r.stdout).toBe("");
     expect(r.stderr).toBe("");
+  });
+
+  it("puts -- immediately before the destination even with a custom target's -p/-i", async () => {
+    const captured: { args: string[] } = { args: [] };
+    const fake = makeFakeChild();
+    const p = execRemote(
+      { kind: "custom", host: "-oProxyCommand=evil", port: 2222, identityFile: "~/.ssh/id_x" },
+      "echo hi",
+      {
+        spawn: (_c, args) => {
+          captured.args = args;
+          return fake.child as any;
+        },
+      },
+    );
+    setImmediate(() => fake.fireExit(0));
+    await p;
+    const dashDashIndex = captured.args.indexOf("--");
+    expect(dashDashIndex).toBeGreaterThan(-1);
+    expect(captured.args[dashDashIndex + 1]).toBe("-oProxyCommand=evil");
+    // -p/-i land before --, never after (they're real ssh options, not
+    // part of the destination).
+    expect(captured.args.indexOf("-p")).toBeLessThan(dashDashIndex);
+    expect(captured.args.indexOf("-i")).toBeLessThan(dashDashIndex);
   });
 
   it("returns non-zero exit without throwing", async () => {

--- a/src/main/installer/runner.ts
+++ b/src/main/installer/runner.ts
@@ -31,6 +31,12 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { parseSshG, type ResolvedSshConnection } from "./sshResolved.js";
+import {
+  isEmptySshTarget,
+  sshTargetDestination,
+  sshTargetExtraArgs,
+  type SshTarget,
+} from "../../shared/sshTarget.js";
 
 export type SpawnFn = (
   command: string,
@@ -75,11 +81,11 @@ export type ExecRemoteResult = {
 };
 
 export async function execRemote(
-  alias: string,
+  alias: SshTarget,
   command: string,
   options: ExecRemoteOptions = {},
 ): Promise<ExecRemoteResult> {
-  if (typeof alias !== "string" || alias.trim() === "") {
+  if (isEmptySshTarget(alias)) {
     throw new Error("execRemote: alias is required");
   }
   if (typeof command !== "string" || command === "") {
@@ -146,11 +152,11 @@ export type RemoteStreamHandle = {
 };
 
 export function streamRemote(
-  alias: string,
+  alias: SshTarget,
   command: string,
   options: StreamRemoteOptions,
 ): RemoteStreamHandle {
-  if (typeof alias !== "string" || alias.trim() === "") {
+  if (isEmptySshTarget(alias)) {
     throw new Error("streamRemote: alias is required");
   }
   if (typeof command !== "string" || command === "") {
@@ -220,14 +226,20 @@ export async function probeSshG(
 // can SEE the safety controls in one place (BatchMode=yes is the load-bearing
 // one — it forces ssh to NEVER prompt, so a half-configured box fails the
 // preflight cleanly instead of hanging the renderer on a passphrase prompt).
-function buildArgs(alias: string, command: string, opts: RemoteOptions): string[] {
+//
+// A custom target (BET-384) contributes `-p` / `-i` via sshTargetExtraArgs —
+// this is the ONE place that turns a resolved SshTarget into argv, so an
+// alias and a custom host produce an identical argv shape apart from those
+// two flags and the destination itself.
+function buildArgs(alias: SshTarget, command: string, opts: RemoteOptions): string[] {
   return [
     "-o",
     `ConnectTimeout=${opts.connectTimeoutSec ?? 10}`,
     "-o",
     "BatchMode=yes", // never prompt; non-zero exit on key auth failure
+    ...sshTargetExtraArgs(alias),
     ...(opts.forceTty ? ["-tt"] : []),
-    alias.trim(),
+    sshTargetDestination(alias),
     command,
   ];
 }

--- a/src/main/installer/runner.ts
+++ b/src/main/installer/runner.ts
@@ -231,6 +231,18 @@ export async function probeSshG(
 // this is the ONE place that turns a resolved SshTarget into argv, so an
 // alias and a custom host produce an identical argv shape apart from those
 // two flags and the destination itself.
+//
+// The `--` before the destination (review cycle 1 nit, defence in depth):
+// a custom target's Host-or-IP field is user-typed with no validation
+// against a leading `-`, and without a terminator ssh(1) reads a
+// destination like `-oProxyCommand=…` as another option rather than a
+// (bogus) hostname — verified empirically: `ssh -o … -oFoo=x true` fails
+// with "Bad configuration option: foobarbaz" (parsed as a flag), while
+// `ssh -o … -- -oFoo=x true` fails with "hostname contains invalid
+// characters" (correctly read as the destination). Not a live
+// vulnerability today (spawn runs without `shell: true`, so there's no
+// shell to inject into), but `--` closes the shape at zero cost and
+// covers both the alias and custom-target branches from this one site.
 function buildArgs(alias: SshTarget, command: string, opts: RemoteOptions): string[] {
   return [
     "-o",
@@ -239,6 +251,7 @@ function buildArgs(alias: SshTarget, command: string, opts: RemoteOptions): stri
     "BatchMode=yes", // never prompt; non-zero exit on key auth failure
     ...sshTargetExtraArgs(alias),
     ...(opts.forceTty ? ["-tt"] : []),
+    "--",
     sshTargetDestination(alias),
     command,
   ];

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,7 @@ import type { ClaimOutcome } from "../shared/claim.mjs";
 import type { UnpairOutcome } from "../shared/unpair.mjs";
 import type { PreflightResult } from "../main/installer/preflight.js";
 import type { SshHostEntry } from "../main/installer/sshConfig.js";
+import type { SshTarget } from "../shared/sshTarget.js";
 
 // This is the OS-bridge + pairing SUBSET of the full `Api` contract
 // (`src/shared/api.ts`) — the methods the desktop preload runtime actually
@@ -194,7 +195,7 @@ const api = {
   // (line / stage / preflight-failed / done / error). The renderer matches
   // events to its handle id so an out-of-band cancel doesn't lose events
   // mid-flight.
-  installerStart: (input: { alias: string }): Promise<{ handleId: string }> =>
+  installerStart: (input: { alias: SshTarget }): Promise<{ handleId: string }> =>
     ipcRenderer.invoke(IPC.installerStart, input),
 
   // Cancel the in-flight install. Idempotent: safe to call on a stale
@@ -209,7 +210,7 @@ const api = {
   // renderer treats success and failure the same way regardless of which
   // entry point produced them.
   installerMintAndClaim: (input: {
-    alias: string;
+    alias: SshTarget;
     claimUrlOverride?: string;
   }): Promise<ClaimOutcome> =>
     ipcRenderer.invoke(IPC.installerMintAndClaim, input),

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -52,6 +52,11 @@ const OK_GREEN = "#22C55E";
 // install grows the DOM without bound.
 const LOG_LINES_MAX = 500;
 
+// How long the count line's "· just now" suffix stays visible after a
+// manual refresh before decaying back to the plain count (BET-384 review
+// cycle 1 nit).
+const JUST_REFRESHED_DECAY_MS = 60_000;
+
 const INITIAL_STAGE: InstallStageId = "preflight";
 const INITIAL_STAGE_INFO = currentStageInfo(INITIAL_STAGE);
 
@@ -85,9 +90,10 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   );
   const [hostsLoaded, setHostsLoaded] = useState(false);
   const [hostsLoading, setHostsLoading] = useState(false);
-  // Set once a manual refresh has completed at least once — flips the count
-  // line's suffix from nothing to "· just now" (BET-384). Never reset back:
-  // the whole point is "this is fresher than the initial mount load".
+  // True right after a manual refresh completes — flips the count line's
+  // suffix to "· just now" (BET-384). Decays back to false on its own
+  // (JUST_REFRESHED_DECAY_MS below) — review cycle 1 nit: a "just now"
+  // that never expires is worse than no timestamp at all.
   const [justRefreshed, setJustRefreshed] = useState(false);
   // The <select> value: a real alias, or CUSTOM_HOST_VALUE. Starts on the
   // sentinel so the select always has a valid selected option (one of the
@@ -139,21 +145,37 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       aliveRef.current = false;
     };
   }, []);
+  // True once the FIRST load (success or failure) has completed. `alias`
+  // starts on CUSTOM_HOST_VALUE as a rendering bootstrap (see its own
+  // comment below) — that initial value is not a real user choice, so it
+  // must not be treated as "the user deliberately picked Custom host" the
+  // one time loadHosts's setAlias updater sees it. Caught while fixing the
+  // review cycle 1 Block: without this, a populated ~/.ssh/config would
+  // never auto-select the first alias — `prev === CUSTOM_HOST_VALUE` would
+  // always be true on that first pass and short-circuit before the
+  // list[0]-alias fallback ever ran.
+  const hasLoadedOnceRef = useRef(false);
 
   const loadHosts = useCallback(
     async (opts?: { manual?: boolean }) => {
       setHostsLoading(true);
+      const isFirstLoad = !hasLoadedOnceRef.current;
       try {
         const list = await preload.installerListHosts();
         if (!aliveRef.current) return;
         setHosts(list);
-        // Keep the current selection if it's still valid (still present in
-        // the refreshed list, or the custom sentinel — refresh never closes
-        // an open custom panel). Otherwise fall back to the first alias, or
-        // the custom sentinel when the config yields nothing at all —
-        // decision #3: the dropdown still renders, Custom host… pre-selected,
-        // panel already open. One code path, not an either/or branch.
         setAlias((prev) => {
+          if (isFirstLoad) {
+            // Bootstrap pass: `prev` is just the initial sentinel, not a
+            // real selection — pick the first alias when the config has
+            // entries, or fall back to the sentinel (decision #3) when it
+            // doesn't.
+            return list.length > 0 ? list[0].alias : CUSTOM_HOST_VALUE;
+          }
+          // A later refresh: keep the current selection if it's still
+          // valid (still present in the refreshed list, or the custom
+          // sentinel — refresh never closes an open custom panel the user
+          // deliberately opened). Otherwise fall back the same way.
           if (prev === CUSTOM_HOST_VALUE) return prev;
           if (list.some((h) => h.alias === prev)) return prev;
           return list.length > 0 ? list[0].alias : CUSTOM_HOST_VALUE;
@@ -161,13 +183,23 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         if (opts?.manual) setJustRefreshed(true);
       } catch {
         if (!aliveRef.current) return;
-        setHosts([]);
-        setAlias(CUSTOM_HOST_VALUE);
+        // First-load failure: hosts/alias are already at their
+        // [] / CUSTOM_HOST_VALUE initial state, so there's nothing to
+        // reset — the empty-config UI (decision #3) falls out for free.
+        // A LATER refresh's failure must NOT discard whatever host list
+        // and selection were already on screen — a transient read error
+        // is not license to yank the panel open out from under the user
+        // (review cycle 1 nit).
+        if (isFirstLoad) {
+          setHosts([]);
+          setAlias(CUSTOM_HOST_VALUE);
+        }
       } finally {
         if (aliveRef.current) {
           setHostsLoaded(true);
           setHostsLoading(false);
         }
+        hasLoadedOnceRef.current = true;
       }
     },
     [preload],
@@ -277,6 +309,15 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     const t = setInterval(() => setElapsedSeconds((s) => s + 1), 1000);
     return () => clearInterval(t);
   }, [running]);
+
+  // Decay "· just now" back to the plain count line after a while — a
+  // timestamp that never expires reads as wrong once enough time has
+  // actually passed (BET-384 review cycle 1 nit).
+  useEffect(() => {
+    if (!justRefreshed) return;
+    const t = setTimeout(() => setJustRefreshed(false), JUST_REFRESHED_DECAY_MS);
+    return () => clearTimeout(t);
+  }, [justRefreshed]);
 
   // ---------- Actions ----------
 
@@ -450,9 +491,20 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           </button>
         </div>
 
-        {/* Custom host panel — only rendered for the custom sentinel. No
-            second host control ever coexists with the select. */}
-        {alias === CUSTOM_HOST_VALUE && (
+        {/* Custom host panel — only rendered for the custom sentinel, AND
+            only once the host load has settled (review cycle 1 Block):
+            `alias` starts on the sentinel so the <select> always has a
+            valid selected option before installerListHosts() resolves,
+            but painting the panel during that window means a populated
+            ~/.ssh/config flashes the full four-field panel open and then
+            collapses once the real alias list lands. Gating on
+            `hostsLoaded` too keeps decision #3 intact — hostsLoaded is
+            true in both loadHosts' success and catch paths, so the
+            empty-config case still opens the panel pre-selected, exactly
+            as required — while a populated config never shows it before
+            the list is ready. No second host control ever coexists with
+            the select either way. */}
+        {hostsLoaded && alias === CUSTOM_HOST_VALUE && (
           <div className="rounded-md border border-border bg-bg-soft p-3.5 space-y-2.5">
             <div className="grid grid-cols-[1fr_90px] gap-2.5">
               <div className="flex flex-col gap-1">
@@ -547,12 +599,22 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               Leave a field empty to let OpenSSH decide. These are used for
               this box only — your ~/.ssh/config is never written to.
             </p>
-            {targetError && (
-              <p className="text-xs" style={{ color: DANGER }}>
-                {targetError}
-              </p>
-            )}
           </div>
+        )}
+
+        {/* Hoisted out of the custom panel (review cycle 1 nit): the panel
+            only renders for the custom branch, but resolveInstallTarget
+            can also reject the alias branch (defensive — unreachable
+            through this UI today since the <select>'s only values are a
+            parsed alias or the sentinel, but resolveInstallTarget is a
+            shared pure function and must not silently swallow a future
+            caller's bad input). Rendering the error here, outside the
+            panel, means it's never lost regardless of which branch
+            produced it. */}
+        {targetError && (
+          <p className="text-xs" style={{ color: DANGER }}>
+            {targetError}
+          </p>
         )}
 
         <div className="flex gap-2 pt-2">

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -1,5 +1,5 @@
 // SshInstallStep.tsx — SSH installer harness for the desktop onboarding
-// "Connect your box" step (BET-355 / BET-382 / BET-383).
+// "Connect your box" step (BET-355 / BET-382 / BET-383 / BET-384).
 //
 // PairStep renders this component inline as the primary surface when an
 // SSH installer preload is available and no deep-link is pending. The
@@ -15,16 +15,33 @@
 // The six-row checklist is gone in favour of one status line over an
 // always-mounted, auto-scrolling log that collapses on success.
 //
-// All decision logic lives in the main-process installer module. This
-// component is React state + per-event dispatch + JSX, nothing more.
+// BET-384: the host list can be re-read without an app restart (the
+// `loadHosts()` callback backs both the mount effect and the refresh
+// button), and "Custom host…" is a permanent last entry in the SAME
+// `<select>` — there is exactly one host control, never a select-or-input
+// branch. Selecting it reveals a small panel (host/port/user/identity
+// file); `resolveInstallTarget` (src/shared/sshTarget.ts) turns whichever
+// branch is active into the single value installerStart /
+// installerMintAndClaim consume — this component assembles no target
+// string of its own.
+//
+// All decision logic lives in the main-process installer module (plus the
+// pure src/shared/sshTarget.ts target resolver). This component is React
+// state + per-event dispatch + JSX, nothing more.
 
-import { useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import {
   getMantaPreload,
   type InstallerEvent,
   type PreflightFailure,
 } from "./preloadAccess";
 import { currentStageInfo, type InstallStageId } from "../shared/installStages";
+import {
+  CUSTOM_HOST_VALUE,
+  resolveInstallTarget,
+  sshTargetLabel,
+  type HostFieldSelection,
+} from "../shared/sshTarget";
 
 const ACCENT = "#5A88FF";
 const DANGER = "#FF7A88";
@@ -67,7 +84,23 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     [],
   );
   const [hostsLoaded, setHostsLoaded] = useState(false);
-  const [alias, setAlias] = useState("");
+  const [hostsLoading, setHostsLoading] = useState(false);
+  // Set once a manual refresh has completed at least once — flips the count
+  // line's suffix from nothing to "· just now" (BET-384). Never reset back:
+  // the whole point is "this is fresher than the initial mount load".
+  const [justRefreshed, setJustRefreshed] = useState(false);
+  // The <select> value: a real alias, or CUSTOM_HOST_VALUE. Starts on the
+  // sentinel so the select always has a valid selected option (one of the
+  // custom option, which is always rendered) even before the first
+  // installerListHosts() response lands — no empty-string flash.
+  const [alias, setAlias] = useState(CUSTOM_HOST_VALUE);
+  // Custom-host panel fields (BET-384) — only read when alias ===
+  // CUSTOM_HOST_VALUE. Never persisted, never written to ~/.ssh/config.
+  const [customHost, setCustomHost] = useState("");
+  const [customPort, setCustomPort] = useState("");
+  const [customUser, setCustomUser] = useState("");
+  const [customIdentityFile, setCustomIdentityFile] = useState("");
+  const [targetError, setTargetError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const [activeHandle, setActiveHandle] = useState<string | null>(null);
   const [stage, setStage] = useState<InstallStageId>(INITIAL_STAGE);
@@ -91,25 +124,63 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   const [claimError, setClaimError] = useState<string | null>(null);
   const logRef = useRef<HTMLDivElement | null>(null);
 
-  // ---------- One-shot loads on mount ----------
+  // ---------- Host list load (mount + manual refresh share this) ----------
+  //
+  // BET-384: editing ~/.ssh/config used to require restarting the whole app
+  // because the list was read once in a mount effect with no way back in.
+  // `loadHosts()` is the single fetch both the mount effect and the
+  // refresh button call — re-reads the config and nothing else (no
+  // preflight, no re-check; there is nothing left to re-run since BET-383
+  // folded preflight into the install click).
+  const aliveRef = useRef(true);
   useEffect(() => {
-    let alive = true;
-    (async () => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const loadHosts = useCallback(
+    async (opts?: { manual?: boolean }) => {
+      setHostsLoading(true);
       try {
         const list = await preload.installerListHosts();
-        if (!alive) return;
+        if (!aliveRef.current) return;
         setHosts(list);
-        setHostsLoaded(true);
-        if (list.length > 0 && list[0].alias) setAlias(list[0].alias);
+        // Keep the current selection if it's still valid (still present in
+        // the refreshed list, or the custom sentinel — refresh never closes
+        // an open custom panel). Otherwise fall back to the first alias, or
+        // the custom sentinel when the config yields nothing at all —
+        // decision #3: the dropdown still renders, Custom host… pre-selected,
+        // panel already open. One code path, not an either/or branch.
+        setAlias((prev) => {
+          if (prev === CUSTOM_HOST_VALUE) return prev;
+          if (list.some((h) => h.alias === prev)) return prev;
+          return list.length > 0 ? list[0].alias : CUSTOM_HOST_VALUE;
+        });
+        if (opts?.manual) setJustRefreshed(true);
       } catch {
-        if (!alive) return;
-        setHostsLoaded(true);
+        if (!aliveRef.current) return;
+        setHosts([]);
+        setAlias(CUSTOM_HOST_VALUE);
+      } finally {
+        if (aliveRef.current) {
+          setHostsLoaded(true);
+          setHostsLoading(false);
+        }
       }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [preload]);
+    },
+    [preload],
+  );
+
+  useEffect(() => {
+    void loadHosts();
+    // Mount-only — loadHosts is stable across the preload's lifetime (the
+    // preload accessor never changes after mount) and the refresh button
+    // calls it directly, so re-running this effect on every loadHosts
+    // identity change would just be the same fetch twice.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Recover any in-flight install on mount (a page refresh mid-install
   // shouldn't strand the user), or a preflight failure the user hasn't
@@ -208,7 +279,28 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   }, [running]);
 
   // ---------- Actions ----------
+
+  // Current host-picker selection in the shape resolveInstallTarget takes —
+  // one function, called wherever the resolved target is needed (BET-384:
+  // "the component contains no target-string assembly", only this
+  // pass-through into the pure resolver).
+  function currentSelection(): HostFieldSelection {
+    return {
+      alias,
+      host: customHost,
+      port: customPort,
+      user: customUser,
+      identityFile: customIdentityFile,
+    };
+  }
+
   async function startInstall() {
+    const resolved = resolveInstallTarget(currentSelection());
+    if (!resolved.ok) {
+      setTargetError(resolved.error);
+      return;
+    }
+    setTargetError(null);
     setInstallError(null);
     setPreflightFailure(null);
     setLines([]);
@@ -229,7 +321,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     // main process's response comes back.
     setRunning(true);
     try {
-      const { handleId } = await preload.installerStart({ alias: alias.trim() });
+      const { handleId } = await preload.installerStart({ alias: resolved.target });
       setActiveHandle(handleId);
     } catch (e) {
       setRunning(false);
@@ -243,11 +335,16 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   }
 
   async function runClaim() {
+    const resolved = resolveInstallTarget(currentSelection());
+    if (!resolved.ok) {
+      setClaimError(resolved.error);
+      return;
+    }
     setClaimRunning(true);
     setClaimError(null);
     try {
       const outcome = (await preload.installerMintAndClaim({
-        alias: alias.trim(),
+        alias: resolved.target,
       })) as { ok: boolean };
       if (outcome.ok) {
         // Mirror the manual PairStep onPaired — advances onboarding to
@@ -268,17 +365,26 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     // the time this button can be visible. No placeholder.
     const s = await preload.installerState();
     if (!s.preflight) return;
+    const resolved = resolveInstallTarget(currentSelection());
     const r = await preload.installerGetDiagnostics({
       preflight: s.preflight,
       stage,
       logTail: lines,
-      alias,
+      alias: resolved.ok ? sshTargetLabel(resolved.target) : alias,
     });
     await navigator.clipboard.writeText(r);
   }
 
   // ---------- Render ----------
-  const installDisabled = running || claimRunning || !alias.trim();
+  const installDisabled =
+    running || claimRunning || !resolveInstallTarget(currentSelection()).ok;
+  const hostCountLabel = hostsLoading
+    ? "reading ~/.ssh/config…"
+    : !hostsLoaded
+      ? ""
+      : hosts.length === 0
+        ? "No hosts in ~/.ssh/config"
+        : `${hosts.length} hosts from ~/.ssh/config${justRefreshed ? " · just now" : ""}`;
   // Keep the panel (status line + log) mounted through an install error too
   // — that's the log line the user needs most ("is it stuck, or just
   // slow?"). Only the preflight-failure card excludes it (nothing was
@@ -290,18 +396,27 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   return (
     <div className="space-y-5">
       {/* Host picker — PairStep owns the step-level heading + intro
-          (BET-382); this component drops straight into the picker. */}
+          (BET-382); this component drops straight into the picker.
+          BET-384: exactly one host control, always a <select> — "Custom
+          host…" is a permanent last option, present whether or not the
+          config has entries, never a second input rendered alongside it. */}
       <section className="space-y-2">
-        <label className="block text-sm font-medium" htmlFor="ssh-host">
-          Host
-        </label>
-        {hostsLoaded && hosts.length > 0 ? (
+        <div className="flex items-center justify-between gap-2">
+          <label className="text-sm font-medium" htmlFor="ssh-host">
+            Host
+          </label>
+          <span className="text-xs text-text-faint">{hostCountLabel}</span>
+        </div>
+        <div className="flex gap-2">
           <select
             id="ssh-host"
             value={alias}
-            onChange={(e) => setAlias(e.target.value)}
+            onChange={(e) => {
+              setAlias(e.target.value);
+              setTargetError(null);
+            }}
             disabled={running || claimRunning}
-            className="w-full rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+            className="flex-1 min-w-0 rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
           >
             {hosts.map((h) => (
               <option key={h.alias} value={h.alias}>
@@ -309,24 +424,137 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                 {h.patterns.length > 1 ? ` (${h.patterns.join(", ")})` : ""}
               </option>
             ))}
+            <option value={CUSTOM_HOST_VALUE}>Custom host…</option>
           </select>
-        ) : (
-          <input
-            id="ssh-host"
-            type="text"
-            value={alias}
-            onChange={(e) => setAlias(e.target.value)}
-            placeholder="user@box.example"
-            disabled={running || claimRunning}
-            className="w-full rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-          />
+          <button
+            type="button"
+            onClick={() => void loadHosts({ manual: true })}
+            disabled={hostsLoading || running || claimRunning}
+            aria-label="Refresh host list"
+            title="Re-read ~/.ssh/config"
+            className="w-[34px] h-[34px] shrink-0 flex items-center justify-center rounded-md bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={`w-3.5 h-3.5${hostsLoading ? " animate-spin" : ""}`}
+              aria-hidden
+            >
+              <path d="M21 12a9 9 0 1 1-2.6-6.4" />
+              <path d="M21 3v6h-6" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Custom host panel — only rendered for the custom sentinel. No
+            second host control ever coexists with the select. */}
+        {alias === CUSTOM_HOST_VALUE && (
+          <div className="rounded-md border border-border bg-bg-soft p-3.5 space-y-2.5">
+            <div className="grid grid-cols-[1fr_90px] gap-2.5">
+              <div className="flex flex-col gap-1">
+                <label
+                  className="text-[11px] font-medium text-text-muted"
+                  htmlFor="ssh-custom-host"
+                >
+                  Host or IP
+                </label>
+                <input
+                  id="ssh-custom-host"
+                  type="text"
+                  placeholder="box.example.com"
+                  value={customHost}
+                  onChange={(e) => {
+                    setCustomHost(e.target.value);
+                    setTargetError(null);
+                  }}
+                  disabled={running || claimRunning}
+                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  className="text-[11px] font-medium text-text-muted"
+                  htmlFor="ssh-custom-port"
+                >
+                  Port
+                </label>
+                <input
+                  id="ssh-custom-port"
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="22"
+                  value={customPort}
+                  onChange={(e) => {
+                    setCustomPort(e.target.value);
+                    setTargetError(null);
+                  }}
+                  disabled={running || claimRunning}
+                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2.5">
+              <div className="flex flex-col gap-1">
+                <label
+                  className="text-[11px] font-medium text-text-muted"
+                  htmlFor="ssh-custom-user"
+                >
+                  User
+                </label>
+                <input
+                  id="ssh-custom-user"
+                  type="text"
+                  placeholder="root"
+                  value={customUser}
+                  onChange={(e) => {
+                    setCustomUser(e.target.value);
+                    setTargetError(null);
+                  }}
+                  disabled={running || claimRunning}
+                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  className="text-[11px] font-medium text-text-muted"
+                  htmlFor="ssh-custom-identity"
+                >
+                  Identity file
+                </label>
+                {/* No Browse button — MantaPreload exposes no native file
+                    dialog bridge today. A plain text input is the whole
+                    control until that IPC channel exists (follow-up
+                    filed, BET-384 doesn't add it). */}
+                <input
+                  id="ssh-custom-identity"
+                  type="text"
+                  placeholder="~/.ssh/id_ed25519"
+                  value={customIdentityFile}
+                  onChange={(e) => {
+                    setCustomIdentityFile(e.target.value);
+                    setTargetError(null);
+                  }}
+                  disabled={running || claimRunning}
+                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-sm border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+            </div>
+            <p className="text-xs text-text-faint">
+              Leave a field empty to let OpenSSH decide. These are used for
+              this box only — your ~/.ssh/config is never written to.
+            </p>
+            {targetError && (
+              <p className="text-xs" style={{ color: DANGER }}>
+                {targetError}
+              </p>
+            )}
+          </div>
         )}
-        {hostsLoaded && hosts.length === 0 && (
-          <p className="text-xs text-text-muted">
-            No hosts found in ~/.ssh/config. Type the SSH alias or
-            user@host:port directly above.
-          </p>
-        )}
+
         <div className="flex gap-2 pt-2">
           <button
             onClick={startInstall}

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -9,6 +9,7 @@ import type { PreflightResult, PreflightFailure } from "../main/installer/prefli
 import type { SshHostEntry } from "../main/installer/sshConfig.js";
 import type { InstallerStageSnapshotRow } from "../shared/types.js";
 import type { UnpairOutcome } from "../shared/unpair.mjs";
+import type { SshTarget } from "../shared/sshTarget.js";
 
 // Re-export so the renderer can use the type names from the same accessor
 // module that exposes the preload methods — same pattern as the existing
@@ -131,7 +132,7 @@ export interface MantaPreload {
   // preflight channel. Returns the handle id the renderer uses to match
   // incoming installerEvent pushes; a failed preflight is reported via a
   // `preflight-failed` installerEvent, not a rejection.
-  installerStart(input: { alias: string }): Promise<{ handleId: string }>;
+  installerStart(input: { alias: SshTarget }): Promise<{ handleId: string }>;
 
   // SIGTERM the in-flight install. Idempotent: safe on a stale handle id
   // (one from a previous renderer mount) or on an already-done handle.
@@ -143,7 +144,7 @@ export interface MantaPreload {
   // same way regardless of which entry point produced them. Persists
   // credentials through main's existing claim path (single config writer).
   installerMintAndClaim(input: {
-    alias: string;
+    alias: SshTarget;
     claimUrlOverride?: string;
   }): Promise<unknown>;
 

--- a/src/shared/sshTarget.test.ts
+++ b/src/shared/sshTarget.test.ts
@@ -1,0 +1,248 @@
+// sshTarget.test.ts — resolveInstallTarget + the runner.ts argv helpers.
+// Pure: no fs, no ssh, no DOM.
+
+import { describe, it, expect } from "vitest";
+import {
+  CUSTOM_HOST_VALUE,
+  resolveInstallTarget,
+  isEmptySshTarget,
+  sshTargetDestination,
+  sshTargetExtraArgs,
+  sshTargetLabel,
+  type HostFieldSelection,
+} from "./sshTarget.js";
+
+function sel(overrides: Partial<HostFieldSelection> = {}): HostFieldSelection {
+  return {
+    alias: CUSTOM_HOST_VALUE,
+    host: "",
+    port: "",
+    user: "",
+    identityFile: "",
+    ...overrides,
+  };
+}
+
+describe("resolveInstallTarget", () => {
+  it("alias passthrough — returns the alias unchanged, no CustomSshTarget", () => {
+    const r = resolveInstallTarget(sel({ alias: "dev" }));
+    expect(r).toEqual({ ok: true, target: "dev" });
+  });
+
+  it("alias passthrough trims surrounding whitespace", () => {
+    const r = resolveInstallTarget(sel({ alias: "  dev  " }));
+    expect(r).toEqual({ ok: true, target: "dev" });
+  });
+
+  it("alias passthrough rejects an empty/whitespace-only alias", () => {
+    const r = resolveInstallTarget(sel({ alias: "   " }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("full custom target — every field populated", () => {
+    const r = resolveInstallTarget(
+      sel({
+        host: "box.example.com",
+        port: "2222",
+        user: "root",
+        identityFile: "~/.ssh/id_ed25519",
+      }),
+    );
+    expect(r).toEqual({
+      ok: true,
+      target: {
+        kind: "custom",
+        host: "box.example.com",
+        port: 2222,
+        user: "root",
+        identityFile: "~/.ssh/id_ed25519",
+      },
+    });
+  });
+
+  it("custom target trims every field", () => {
+    const r = resolveInstallTarget(
+      sel({
+        host: "  box.example.com  ",
+        port: " 2222 ",
+        user: " root ",
+        identityFile: "  ~/.ssh/id_ed25519  ",
+      }),
+    );
+    expect(r).toEqual({
+      ok: true,
+      target: {
+        kind: "custom",
+        host: "box.example.com",
+        port: 2222,
+        user: "root",
+        identityFile: "~/.ssh/id_ed25519",
+      },
+    });
+  });
+
+  it("omits port when empty — 'let OpenSSH decide', not a substituted default", () => {
+    const r = resolveInstallTarget(sel({ host: "box.example.com" }));
+    expect(r).toEqual({ ok: true, target: { kind: "custom", host: "box.example.com" } });
+    const target = r.ok && typeof r.target === "object" ? r.target : null;
+    expect(target && "port" in target).toBe(false);
+  });
+
+  it("omits user when empty", () => {
+    const r = resolveInstallTarget(sel({ host: "box.example.com", port: "22" }));
+    expect(r).toEqual({
+      ok: true,
+      target: { kind: "custom", host: "box.example.com", port: 22 },
+    });
+    const target = r.ok && typeof r.target === "object" ? r.target : null;
+    expect(target && "user" in target).toBe(false);
+  });
+
+  it("omits identityFile when empty", () => {
+    const r = resolveInstallTarget(
+      sel({ host: "box.example.com", user: "root" }),
+    );
+    expect(r).toEqual({
+      ok: true,
+      target: { kind: "custom", host: "box.example.com", user: "root" },
+    });
+    const target = r.ok && typeof r.target === "object" ? r.target : null;
+    expect(target && "identityFile" in target).toBe(false);
+  });
+
+  it("empty host → error, no target returned", () => {
+    const r = resolveInstallTarget(sel({ port: "22" }));
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error).toMatch(/host/i);
+  });
+
+  it("whitespace-only host → error", () => {
+    const r = resolveInstallTarget(sel({ host: "   " }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("invalid port — non-numeric → error", () => {
+    const r = resolveInstallTarget(sel({ host: "box.example.com", port: "abc" }));
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error).toMatch(/port/i);
+  });
+
+  it("invalid port — zero → error", () => {
+    const r = resolveInstallTarget(sel({ host: "box.example.com", port: "0" }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("invalid port — above 65535 → error", () => {
+    const r = resolveInstallTarget(sel({ host: "box.example.com", port: "70000" }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("invalid port — non-integer → error", () => {
+    const r = resolveInstallTarget(sel({ host: "box.example.com", port: "22.5" }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("boundary ports 1 and 65535 are valid", () => {
+    expect(resolveInstallTarget(sel({ host: "h", port: "1" })).ok).toBe(true);
+    expect(resolveInstallTarget(sel({ host: "h", port: "65535" })).ok).toBe(true);
+  });
+});
+
+describe("isEmptySshTarget", () => {
+  it("true for an empty/whitespace-only alias string", () => {
+    expect(isEmptySshTarget("")).toBe(true);
+    expect(isEmptySshTarget("   ")).toBe(true);
+  });
+
+  it("false for a non-empty alias string", () => {
+    expect(isEmptySshTarget("dev")).toBe(false);
+  });
+
+  it("true for a custom target with an empty host", () => {
+    expect(isEmptySshTarget({ kind: "custom", host: "" })).toBe(true);
+    expect(isEmptySshTarget({ kind: "custom", host: "   " })).toBe(true);
+  });
+
+  it("false for a custom target with a host", () => {
+    expect(isEmptySshTarget({ kind: "custom", host: "box.example.com" })).toBe(false);
+  });
+});
+
+describe("sshTargetDestination", () => {
+  it("returns the alias verbatim (trimmed) for a string target", () => {
+    expect(sshTargetDestination("  dev  ")).toBe("dev");
+  });
+
+  it("returns host only for a custom target with no user", () => {
+    expect(sshTargetDestination({ kind: "custom", host: "box.example.com" })).toBe(
+      "box.example.com",
+    );
+  });
+
+  it("returns user@host for a custom target with a user", () => {
+    expect(
+      sshTargetDestination({ kind: "custom", host: "box.example.com", user: "root" }),
+    ).toBe("root@box.example.com");
+  });
+
+  it("never includes the port — it is a separate -p flag, not part of the destination", () => {
+    const dest = sshTargetDestination({
+      kind: "custom",
+      host: "box.example.com",
+      port: 2222,
+    });
+    expect(dest).toBe("box.example.com");
+    expect(dest).not.toContain("2222");
+  });
+});
+
+describe("sshTargetExtraArgs", () => {
+  it("returns [] for a string (alias) target", () => {
+    expect(sshTargetExtraArgs("dev")).toEqual([]);
+  });
+
+  it("returns [] for a custom target with no port/identityFile", () => {
+    expect(sshTargetExtraArgs({ kind: "custom", host: "box.example.com" })).toEqual([]);
+  });
+
+  it("builds -p for a custom port", () => {
+    expect(
+      sshTargetExtraArgs({ kind: "custom", host: "h", port: 2222 }),
+    ).toEqual(["-p", "2222"]);
+  });
+
+  it("builds -i for a custom identity file", () => {
+    expect(
+      sshTargetExtraArgs({ kind: "custom", host: "h", identityFile: "~/.ssh/id_x" }),
+    ).toEqual(["-i", "~/.ssh/id_x"]);
+  });
+
+  it("builds both -p and -i, in that order, when both are set", () => {
+    expect(
+      sshTargetExtraArgs({
+        kind: "custom",
+        host: "h",
+        port: 2222,
+        identityFile: "~/.ssh/id_x",
+      }),
+    ).toEqual(["-p", "2222", "-i", "~/.ssh/id_x"]);
+  });
+});
+
+describe("sshTargetLabel", () => {
+  it("returns the alias verbatim for a string target", () => {
+    expect(sshTargetLabel("dev")).toBe("dev");
+  });
+
+  it("formats host/user/port for a custom target", () => {
+    expect(
+      sshTargetLabel({ kind: "custom", host: "box.example.com", user: "root", port: 2222 }),
+    ).toBe("root@box.example.com:2222");
+  });
+
+  it("omits user@ and :port when not set", () => {
+    expect(sshTargetLabel({ kind: "custom", host: "box.example.com" })).toBe(
+      "box.example.com",
+    );
+  });
+});

--- a/src/shared/sshTarget.ts
+++ b/src/shared/sshTarget.ts
@@ -106,9 +106,18 @@ export function resolveInstallTarget(
 /**
  * True when a target has no meaningful destination — the empty-alias /
  * empty-host case every runner.ts entry point rejects before spawning ssh.
+ *
+ * Every entry point this replaced did
+ * `typeof alias !== "string" || alias.trim() === ""` — deliberately
+ * defensive about a malformed caller (e.g. a bad IPC payload). Runtime
+ * values aren't guaranteed to match the static `SshTarget` type, so a
+ * non-string, non-object value (or `null`) must fail closed here too,
+ * not fall through to `target.host` and throw a TypeError one line later
+ * (review cycle 1 nit).
  */
 export function isEmptySshTarget(target: SshTarget): boolean {
   if (typeof target === "string") return target.trim() === "";
+  if (typeof target !== "object" || target === null) return true;
   return target.host.trim() === "";
 }
 

--- a/src/shared/sshTarget.ts
+++ b/src/shared/sshTarget.ts
@@ -1,0 +1,144 @@
+// sshTarget.ts — resolve the host-picker's selection into the single value
+// every install-path call site consumes (BET-384).
+//
+// WHY THIS LIVES IN src/shared/ (not src/main/installer/): the renderer must
+// compute the resolved value BEFORE it crosses the IPC boundary — main never
+// sees the raw form fields, only the resolved target — so this has to be
+// importable from BOTH processes without pulling Electron or DOM types into
+// either. Same reason installStages.ts lives here (BET-383): one source, not
+// two copies that can drift.
+//
+// ~/.ssh/config is still never written to (decision #1). A custom selection
+// configures ONE connection for this install only. The alias branch is
+// completely unchanged — resolveInstallTarget returns the alias string
+// verbatim, so every existing alias-based call site (execRemote, streamRemote,
+// preflightBox, runInstall, mintAndClaim — all of which already accept a
+// plain string) keeps working with zero changes for that branch. `SshTarget`
+// widens what those call sites accept (string | CustomSshTarget) rather than
+// adding a second parameter anywhere — see runner.ts's buildArgs, the actual
+// argv-construction site, for how a CustomSshTarget becomes `-p` / `-i` flags
+// plus a `[user@]host` destination.
+//
+// Pure: no fs, no ssh, no DOM. Tested in sshTarget.test.ts.
+
+/** Sentinel `<select>` value that reveals the custom-host panel. */
+export const CUSTOM_HOST_VALUE = "__custom__";
+
+/**
+ * A fully custom connection — never persisted, never written to
+ * ~/.ssh/config. Every field but `host` is optional: an omitted field means
+ * "let OpenSSH decide" (its own config / defaults apply), never a
+ * substituted default from this module or the renderer.
+ */
+export type CustomSshTarget = {
+  kind: "custom";
+  host: string;
+  port?: number;
+  user?: string;
+  identityFile?: string;
+};
+
+/**
+ * The single value every install-path call site consumes. A plain string is
+ * an ~/.ssh/config alias (the pre-existing, unchanged shape) — runner.ts
+ * passes it straight through as the `ssh <alias> <command>` destination. A
+ * `CustomSshTarget` is this-install-only connection info.
+ */
+export type SshTarget = string | CustomSshTarget;
+
+/** The host-picker's raw form state — one shape covers both branches. */
+export type HostFieldSelection = {
+  /** The `<select>` value: a real alias, or CUSTOM_HOST_VALUE. */
+  alias: string;
+  host: string;
+  port: string;
+  user: string;
+  identityFile: string;
+};
+
+export type ResolveInstallTargetResult =
+  | { ok: true; target: SshTarget }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a host-picker selection into the value the install path consumes.
+ *
+ * Alias selection → the alias, unchanged.
+ * Custom selection → the composed target; empty optional fields are omitted
+ * (never defaulted) so "let OpenSSH decide" is a real absence, not a
+ * substituted value this module invented.
+ *
+ * Validates: empty host → error; port (if given) must be 1-65535. Returns a
+ * structured error for the caller to render inline — never throws.
+ */
+export function resolveInstallTarget(
+  sel: HostFieldSelection,
+): ResolveInstallTargetResult {
+  if (sel.alias !== CUSTOM_HOST_VALUE) {
+    const alias = sel.alias.trim();
+    if (alias === "") return { ok: false, error: "Select a host." };
+    return { ok: true, target: alias };
+  }
+
+  const host = sel.host.trim();
+  if (host === "") return { ok: false, error: "Host or IP is required." };
+
+  const target: CustomSshTarget = { kind: "custom", host };
+
+  const portRaw = sel.port.trim();
+  if (portRaw !== "") {
+    const port = Number(portRaw);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return { ok: false, error: "Port must be between 1 and 65535." };
+    }
+    target.port = port;
+  }
+
+  const user = sel.user.trim();
+  if (user !== "") target.user = user;
+
+  const identityFile = sel.identityFile.trim();
+  if (identityFile !== "") target.identityFile = identityFile;
+
+  return { ok: true, target };
+}
+
+/**
+ * True when a target has no meaningful destination — the empty-alias /
+ * empty-host case every runner.ts entry point rejects before spawning ssh.
+ */
+export function isEmptySshTarget(target: SshTarget): boolean {
+  if (typeof target === "string") return target.trim() === "";
+  return target.host.trim() === "";
+}
+
+/**
+ * The `[user@]hostname` ssh(1) destination argument. Port and identity file
+ * are NOT part of the destination — OpenSSH takes them as separate `-p` /
+ * `-i` flags, built by `sshTargetExtraArgs`.
+ */
+export function sshTargetDestination(target: SshTarget): string {
+  if (typeof target === "string") return target.trim();
+  const user = target.user ? `${target.user}@` : "";
+  return `${user}${target.host}`;
+}
+
+/** The extra ssh(1) argv entries a custom target needs (`-p`, `-i`). An
+ * alias needs none — the alias's own ~/.ssh/config block already carries
+ * that connection detail. */
+export function sshTargetExtraArgs(target: SshTarget): string[] {
+  if (typeof target === "string") return [];
+  const args: string[] = [];
+  if (target.port !== undefined) args.push("-p", String(target.port));
+  if (target.identityFile) args.push("-i", target.identityFile);
+  return args;
+}
+
+/** Human-readable label for display (diagnostics, logs) — never fed back
+ * into an ssh argv. */
+export function sshTargetLabel(target: SshTarget): string {
+  if (typeof target === "string") return target;
+  const user = target.user ? `${target.user}@` : "";
+  const port = target.port !== undefined ? `:${target.port}` : "";
+  return `${user}${target.host}${port}`;
+}


### PR DESCRIPTION
Implements BET-384: adds a refresh affordance to the SSH host picker and makes "Custom host…" a permanent, always-selectable option instead of a mutually-exclusive select-or-input branch.

**Base:** `origin/main` @ `f120bec`

## What changed

**`src/renderer/SshInstallStep.tsx`**
- Deleted the `hostsLoaded && hosts.length > 0 ? <select> : <input>` ternary and the "No hosts found…" paragraph. One `<select>` always renders: discovered aliases + a permanent last `Custom host…` option.
- Extracted the mount effect's fetch into a named `loadHosts()`, shared by the mount effect and a new refresh button (34×34, `bg-bg-elev border border-border`, rotate-arrow SVG that spins while loading, no text label).
- Added the count line (`{n} hosts from ~/.ssh/config`, `· just now` after a manual refresh, `No hosts in ~/.ssh/config` when empty).
- Added the custom-host panel (Host/Port row, User/Identity-file row, footer hint verbatim from the spec) — rendered only when the sentinel is selected, never alongside a second host control.
- Dropped the `Browse` button for Identity file — no file-dialog bridge exists on `MantaPreload` today. Filed [BET-387](mention://issue/92a66c62-04bd-4d89-b9c2-eeec89dec1c0) (parked, `follow-up` label) instead of adding a new IPC channel in this PR, per the issue's own instruction.
- `startInstall` / `runClaim` / `copyDiagnostics` now resolve the selection through `resolveInstallTarget` and pass the resolved value straight through — no target-string assembly in the component.

**`src/shared/sshTarget.ts` (new)**
- `resolveInstallTarget(sel)` — pure, validates (empty host → error, port 1-65535), returns the alias unchanged for the alias branch or a `CustomSshTarget` for the custom branch.
- `SshTarget = string | CustomSshTarget` — widens what every install-path call site accepts. **No second parameter was added anywhere**: `installerStart` / `installerMintAndClaim` (`preflightBox`'s own IPC channel was already folded away in BET-383, so there are two call sites, not three) keep taking one `{ alias }` field, just typed as the union instead of `string`. The alias/string branch is byte-for-byte unchanged, so every existing test that passes a plain string alias keeps passing untouched.
- `sshTargetDestination` / `sshTargetExtraArgs` — the argv split: `[user@]host` as the ssh destination, `-p`/`-i` as separate flags (port cannot live in the destination string for the traditional `ssh <dest> <cmd>` form).

**`src/main/installer/runner.ts`** — `buildArgs` (the actual argv-construction site) now spreads `sshTargetExtraArgs` before the destination; `execRemote`/`streamRemote` accept `SshTarget`. `probeSshG` untouched (alias-only, doesn't apply to an already-fully-specified custom target).

**`src/main/installer/installer.ts` / `handlers.ts` / `preloadAccess.ts` / `preload/index.ts`** — type-only widening (`alias: string` → `alias: SshTarget`) plus swapping the ad-hoc `typeof x !== "string" || x.trim() === ""` checks for the shared `isEmptySshTarget`.

## Tests

`src/shared/sshTarget.test.ts` (new, 31 cases): alias passthrough (+trim, +empty-rejection), full custom target, every optional field omitted individually, invalid port (non-numeric/zero/>65535/non-integer), empty/whitespace host, boundary ports, plus the runner-facing helpers (`isEmptySshTarget`, `sshTargetDestination` — asserts port is never in the destination string, `sshTargetExtraArgs`, `sshTargetLabel`).

No new test file for `SshInstallStep.tsx` — consistent with existing precedent (the component has never had one across BET-355/382/383; its own header comment says it's "React state + per-event dispatch + JSX, nothing more").

## Verification results

- PR branch (`multica/BET-384-host-picker-refresh-custom` @ `08eeaaf`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`. vitest 1481 pass / 0 fail (69 files); node:test 1117 pass / 0 fail (43 suites). log sha256: `1456408b968adb5fded6c885c07b7809e6c465a047481dc23863230d8d8d7722`
- Base (`main` @ `f120bec`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624` (identical — no typecheck-affecting base drift)
  - test: exit `0`. vitest 1450 pass / 0 fail (68 files); node:test 1117 pass / 0 fail (43 suites). log sha256: `0692aecd35e53aeeeb964c514f4a97b70bb7790ba35ddaa27864fd6e14e458ca`
- **Conclusion:** 0 pre-existing failures, 0 new failures. The vitest delta is exactly +31 tests / +1 file (the new `sshTarget.test.ts`) — verified by diffing the full sorted test-title list between branches, not just the count. node:test is unchanged (0 delta).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

## Follow-up filed

- [BET-387](mention://issue/92a66c62-04bd-4d89-b9c2-eeec89dec1c0) (parked, `follow-up` label) — native file-dialog bridge for the Identity-file field's Browse button, deliberately out of scope per this issue's own text.
