### PR TITLE
BET-386: thread build channel through install.sh pair-link emitter

### DIFF
--- a/scripts/install-lib.d.mts
+++ b/scripts/install-lib.d.mts
@@ -1,0 +1,20 @@
+// Hand-written type declaration for install-lib.mjs — same pattern as
+// src/shared/channel.d.mts (a plain-JS module imported from a checked .ts
+// file needs a sibling .d.mts under "moduleResolution": "Bundler").
+//
+// install-lib.mjs's full surface is the install.sh CLI/pairing-format
+// helpers, exercised by the plain-Node scripts/install.test.mjs suite (no
+// type declarations needed there — node:test loads the .mjs directly).
+// This file declares ONLY the exports a checked .ts file actually imports
+// (currently: src/renderer/mobile/pairPayload.test.ts, for the BET-386
+// buildPairLink round-trip) — extend it if a future .ts file imports more.
+
+/**
+ * Build the canonical box-form pair link. See install-lib.mjs's JSDoc for
+ * the full contract (BET-177 §2.4, BET-336 serverUrl, BET-386 scheme).
+ */
+export function buildPairLink(
+  boxId: string,
+  code: string,
+  opts?: { serverUrl?: string; scheme?: string },
+): string;

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -22,6 +22,7 @@ import { createRequire } from "node:module";
 import { STATE_DIRNAME } from "../src/shared/paths.mjs";
 import { loadAuth } from "../src/server/auth.mjs";
 import { isPrivateServerUrl } from "../src/shared/transport.mjs";
+import { channelConfig } from "../src/shared/channel.mjs";
 
 // `qrcode-terminal` is CommonJS; we keep this module ESM. The local
 // `createRequire` shim is sync (no top-level await) and resolves the lib
@@ -85,6 +86,21 @@ function envVal(env, key) {
  *   releaseHost  — MANTA_RELEASE_HOST || DEFAULT_RELEASE_HOST
  *   port         — MANTA_MOBILE_PORT || DEFAULT_PORT
  *   healthUrl    — http://127.0.0.1:<port>/auth/status
+ *   channel      — MANTA_CHANNEL, resolved through channelConfig's id
+ *                  (BET-386; unset/unrecognised → "prod", same fallback as
+ *                  resolveBoxChannel() in src/server/pairPage.mjs)
+ *   urlScheme    — channelConfig(channel).urlScheme — the pair-link scheme
+ *                  formatPairingOutput/buildPairLink default to
+ *
+ * MANTA_CHANNEL follows the exact same wiring as MANTA_RELEASE_HOST: it is
+ * an env var the caller sets before invoking install.sh (mirrors
+ * `src/main/installer/installer.ts`'s SSH orchestrator, which already
+ * resolves the desktop's build channel and passes MANTA_RELEASE_HOST in the
+ * same curl-pipe command — MANTA_CHANNEL rides along there). install.sh
+ * itself is served byte-identical across channels (no build-time
+ * substitution — see scripts/release/publish.sh), so a channel can only be
+ * communicated at invocation time via this env var, not by the script
+ * content.
  */
 export function resolveConfig({ env = process.env, home = homedir() } = {}) {
   const mantaHome = envVal(env, "MANTA_HOME") ?? join(home, DEFAULT_HOME_DIRNAME);
@@ -95,6 +111,7 @@ export function resolveConfig({ env = process.env, home = homedir() } = {}) {
     envVal(env, "MANTA_RELEASE_HOST") ?? DEFAULT_RELEASE_HOST,
   );
   const port = parsePort(envVal(env, "MANTA_MOBILE_PORT")) ?? DEFAULT_PORT;
+  const channel = channelConfig(envVal(env, "MANTA_CHANNEL") ?? "prod");
   return {
     mantaHome,
     authDir,
@@ -103,6 +120,8 @@ export function resolveConfig({ env = process.env, home = homedir() } = {}) {
     releaseHost,
     port,
     healthUrl: `http://127.0.0.1:${port}${HEALTH_PATH}`,
+    channel: channel.id,
+    urlScheme: channel.urlScheme,
   };
 }
 
@@ -910,7 +929,7 @@ export const readBoxIdentity = loadAuth;
  * try/catch degradation), and the per-row QR indenting loop are all kept
  * intact — only the assembled line list changes.
  *
- * BET-177 §2.4: the pair link `manta://pair?box=<id>&code=<code>` is
+ * BET-177 §2.4: the pair link `<scheme>://pair?box=<id>&code=<code>` is
  * always included in the output (when a box_id + a valid 6-digit code are
  * present) as BOTH a copy-paste line AND a terminal-rendered QR. The QR is
  * for the user who wants to scan with the iOS Camera instead of pasting the
@@ -918,6 +937,12 @@ export const readBoxIdentity = loadAuth;
  * `buildPairLink` (local helper) — single source of truth, consumed
  * exclusively by this function now (install.sh's heredoc duplicate was
  * retired in BET-241).
+ *
+ * BET-386 (channel-aware wire format): `scheme` (default "manta") flows
+ * straight through to `buildPairLink` so a staging/dev install prints
+ * `manta-staging://…` / `manta-dev://…` instead of always `manta://`.
+ * Callers should pass `resolveConfig().urlScheme` — see `buildPairLink`'s
+ * doc comment for the single-source-of-truth rationale.
  *
  * The QR generator is injected (`qrRender`) so tests can capture the output
  * without pulling in `qrcode-terminal` at module-load. The default
@@ -927,7 +952,7 @@ export const readBoxIdentity = loadAuth;
  */
 export function formatPairingOutput(
   { pairing_code, box_id, expiresAt, serverUrl } = {},
-  { qrRender = defaultQrRender } = {},
+  { qrRender = defaultQrRender, scheme = "manta" } = {},
 ) {
   if (!/^[0-9]{6}$/.test(String(pairing_code ?? ""))) {
     throw new Error("formatPairingOutput: pairing_code must be 6 digits");
@@ -952,7 +977,7 @@ export function formatPairingOutput(
     // crafted install can't smuggle a public address past this function).
     // ONE wire shape — no more manta:///pair-page fork.
     const useServerUrl = typeof serverUrl === "string" && serverUrl !== "";
-    const pairLinkOpts = useServerUrl ? { serverUrl } : {};
+    const pairLinkOpts = useServerUrl ? { serverUrl, scheme } : { scheme };
     const pairLink = buildPairLink(box_id, pairing_code, pairLinkOpts);
     const pairPageUrl = buildPairPageUrl(box_id, pairing_code, {
       baseUrl: useServerUrl ? serverUrl : undefined,
@@ -1038,11 +1063,20 @@ export function formatPairingOutput(
  * renderer-side parser uses); a non-private value throws — refusing is
  * the intended behaviour, not silently dropping the param.
  *
+ * BET-386 (channel-aware wire format): `scheme` (default "manta" — same
+ * default as the renderer's `buildPairPayload`) lets the caller pick the
+ * channel's own URL scheme so an install run under a non-prod channel
+ * emits `manta-staging://…` / `manta-dev://…` instead of always `manta://`.
+ * Callers should pass `resolveConfig().urlScheme` (channel-derived, single
+ * source of truth in src/shared/channel.mjs) rather than typing a scheme
+ * literal — mirrors how `pairPage.mjs`'s `validatePairQrQuery` and the
+ * renderer's `buildPairPayload` take the same channel-derived value.
+ *
  * Cross-reference: keep in sync with src/renderer/mobile/pairPayload.ts
  * `buildPairPayload` (box-form branch). If the canonical shape changes,
  * BOTH helpers must change in lockstep — the test catches drift.
  */
-export function buildPairLink(boxId, code, { serverUrl } = {}) {
+export function buildPairLink(boxId, code, { serverUrl, scheme = "manta" } = {}) {
   if (typeof boxId !== "string" || !/^[0-9a-f]{32}$/.test(boxId)) {
     throw new Error("buildPairLink: boxId must be a 32-hex token");
   }
@@ -1058,9 +1092,9 @@ export function buildPairLink(boxId, code, { serverUrl } = {}) {
         "buildPairLink: serverUrl must be a private/tailnet http(s) URL",
       );
     }
-    return `manta://pair?box=${encodeURIComponent(boxId)}&code=${code}&server=${encodeURIComponent(serverUrl)}`;
+    return `${scheme}://pair?box=${encodeURIComponent(boxId)}&code=${code}&server=${encodeURIComponent(serverUrl)}`;
   }
-  return `manta://pair?box=${encodeURIComponent(boxId)}&code=${code}`;
+  return `${scheme}://pair?box=${encodeURIComponent(boxId)}&code=${code}`;
 }
 
 /**

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,12 +67,16 @@
 #   MANTA_REPO_URL      git URL the deploy is initialised against for `scripts/self-update.sh`
 #                       (default https://github.com/antoinedc/MantaUI.git)
 #   MANTA_HOME          where code is unpacked (default ~/manta)
-#   MANTA_CHANNEL       build channel — prod|staging|dev (default prod). Baked
-#                       into the manta-server systemd unit / LaunchAgent plist
-#                       as Environment/EnvironmentVariables so the box's own
-#                       long-lived process resolves the right pair-link URL
+#   MANTA_CHANNEL       build channel — prod|staging|dev (default prod). Drives
+#                       the pair-link URL scheme install.sh/`manta pair` print
+#                       (BET-386 — see scripts/install-lib.mjs's resolveConfig),
+#                       and baked into the manta-server systemd unit / LaunchAgent
+#                       plist as Environment/EnvironmentVariables so the box's
+#                       own long-lived process resolves the right pair-link URL
 #                       scheme (resolveBoxChannel() in src/server/pairPage.mjs,
-#                       BET-373). Not persisted anywhere.
+#                       BET-373/BET-392). Baked into the `manta` CLI shim at
+#                       install time so later `manta pair` re-runs agree. Not
+#                       persisted anywhere.
 #   MANTA_MOBILE_PORT   server port (default 8787)
 #   MANTA_VERSION       version to fetch when MANTA_TARBALL_URL is unset (default: latest)
 #   MANTA_GATEWAY_BASE  push-gateway base URL (default https://gateway.mantaui.com)
@@ -551,11 +555,13 @@ main() {
   # ---------------------------------------------------------------------------
   MANTA_HOME="${MANTA_HOME:-$HOME/manta}"
   AUTH_DIR="$HOME/.manta"
-  # BET-392: resolve + export MANTA_CHANNEL here (same "unset/unrecognised ->
-  # prod" fallback resolveBoxChannel() applies) so it's available below when
-  # the manta-server systemd unit / LaunchAgent plist get rendered. Not
-  # persisted to disk — channel is a property of the build/install, not
-  # box state.
+  # BET-386/BET-392: resolve + export MANTA_CHANNEL here (same
+  # "unset/unrecognised -> prod" fallback resolveBoxChannel() applies) so every
+  # downstream node invocation in THIS run sees it, so it's available below when
+  # the manta-server systemd unit / LaunchAgent plist get rendered, and so the
+  # value is available to bake into the `manta` CLI shim below for later
+  # re-runs. Never persisted to disk — channel is a property of the
+  # build/install, not box state (BET-370).
   MANTA_CHANNEL="${MANTA_CHANNEL:-prod}"
   export MANTA_CHANNEL
 
@@ -1644,6 +1650,14 @@ main() {
 set -euo pipefail
 MANTA_HOME="$MANTA_HOME"
 NODE="$NODE"
+# BET-386 (review cycle 2): bake the install-time channel in the same way
+# MANTA_HOME/NODE above are baked — a fresh shell running \`manta pair\`
+# months later has no other way to learn the channel (resolveConfig()
+# deliberately never persists it to disk). Exported so manta-pair.mjs's
+# child process (which reads process.env.MANTA_CHANNEL via resolveConfig())
+# actually sees it, not just this shim's own shell.
+MANTA_CHANNEL="$MANTA_CHANNEL"
+export MANTA_CHANNEL
 case "\${1:-}" in
   pair) exec "\$NODE" "\$MANTA_HOME/scripts/manta-pair.mjs" ;;
   ""|-h|--help|help)

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1462,6 +1462,115 @@ test("install.sh waits for the box id before rendering the Caddy vhost (first-ru
 });
 
 // ----------------------------------------------------------------------------
+// `manta` CLI shim — MANTA_CHANNEL propagation (BET-386 review cycle 2)
+// ----------------------------------------------------------------------------
+//
+// The reviewer's Block: resolveConfig() deliberately never persists the
+// channel to disk (BET-370), so the ONLY way a later `manta pair` re-run (in
+// a fresh shell, with no MANTA_CHANNEL in its environment) can still learn
+// the install-time channel is if install.sh bakes it into the CLI shim it
+// drops on PATH — the same way it already bakes MANTA_HOME and NODE. Two
+// tests: a static-layout guard (the heredoc's shape) and a dynamic
+// behavioral test that actually executes the extracted, unmodified
+// production heredoc and proves the value reaches a child process's env.
+
+test("install.sh's manta CLI shim heredoc bakes + exports MANTA_CHANNEL before the exec (static layout)", () => {
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  const shimStart = src.indexOf('cat > "$MANTA_SHIM" <<SHIM');
+  const shimEnd = src.indexOf("\nSHIM", shimStart);
+  assert.ok(
+    shimStart !== -1 && shimEnd !== -1,
+    "could not locate the manta CLI shim heredoc in install.sh — did it move?",
+  );
+  const heredoc = src.slice(shimStart, shimEnd);
+  // Baked the same way MANTA_HOME/NODE already are (unescaped $, expanded
+  // at heredoc-write time against install.sh's own resolved value).
+  assert.match(heredoc, /^MANTA_CHANNEL="\$MANTA_CHANNEL"$/m);
+  // Exported so the execed manta-pair.mjs child process (which reads
+  // process.env.MANTA_CHANNEL) actually sees it — a plain shell var set by
+  // a piped-in env var is not automatically exported once reassigned via
+  // ${VAR:-default} at the OUTER install.sh level, and the shim itself
+  // starts a fresh, unexported local var when it's baked as a literal.
+  assert.match(heredoc, /^export MANTA_CHANNEL$/m);
+  // Both must appear BEFORE the case/exec so the export is in effect when
+  // `manta pair` runs.
+  const bakedAt = heredoc.search(/^MANTA_CHANNEL="\$MANTA_CHANNEL"$/m);
+  const exportedAt = heredoc.search(/^export MANTA_CHANNEL$/m);
+  const execAt = heredoc.indexOf('exec "\\$NODE"');
+  assert.ok(bakedAt < execAt && exportedAt < execAt, "MANTA_CHANNEL must be baked + exported before the exec");
+});
+
+test("install.sh's manta CLI shim propagates MANTA_CHANNEL to `manta pair` re-runs (dynamic, BET-386 review cycle 2)", () => {
+  // Extracts and executes the REAL, unmodified shim-writing block (between
+  // its two stable anchor lines) rather than a hand-copied duplicate, so a
+  // future edit to the real heredoc can't silently drift out of sync with
+  // this test. Runs it with a fake $HOME (so the shim writes into a temp
+  // dir, never ~/.local/bin) and a fake $NODE (a stub that just echoes
+  // whether MANTA_CHANNEL reached its environment, standing in for the
+  // real manta-pair.mjs/resolveConfig() which reads process.env.MANTA_CHANNEL).
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  const startMarker = 'MANTA_BIN_DIR="$HOME/.local/bin"';
+  const endMarker = 'chmod +x "$MANTA_SHIM"';
+  const startIdx = src.indexOf(startMarker);
+  const endIdx = src.indexOf(endMarker, startIdx);
+  assert.ok(
+    startIdx !== -1 && endIdx !== -1,
+    "could not locate the manta CLI shim block in install.sh — did the anchor lines move?",
+  );
+  const block = src.slice(startIdx, endIdx + endMarker.length);
+
+  const dir = mkdtempSync(join(tmpdir(), "manta-shim-"));
+  try {
+    const fakeNode = join(dir, "fake-node");
+    writeFileSync(
+      fakeNode,
+      `#!/usr/bin/env bash\necho "MANTA_CHANNEL_SEEN=\${MANTA_CHANNEL:-<unset>}"\n`,
+      { mode: 0o755 },
+    );
+    const script = join(dir, "shim-test.sh");
+    writeFileSync(
+      script,
+      `#!/usr/bin/env bash
+set -euo pipefail
+HOME="${dir}"
+MANTA_HOME="/tmp/fake-manta-home"
+NODE="${fakeNode}"
+MANTA_CHANNEL="staging"
+${block}
+"\$MANTA_SHIM" pair
+`,
+      { mode: 0o755 },
+    );
+    const out = execSync(`bash ${script}`, { encoding: "utf8" });
+    // The child process (fake-node, standing in for manta-pair.mjs) saw
+    // MANTA_CHANNEL — the export actually worked, not just the assignment.
+    assert.match(out, /MANTA_CHANNEL_SEEN=staging/);
+
+    const shimContent = readFileSync(join(dir, ".local", "bin", "manta"), "utf-8");
+    assert.match(shimContent, /^MANTA_CHANNEL="staging"$/m);
+    assert.match(shimContent, /^export MANTA_CHANNEL$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("install.sh's manta CLI shim defaults MANTA_CHANNEL to prod when unset at install time", () => {
+  // Mirrors resolveConfig()'s own "unset -> prod" fallback contract — the
+  // shim must never be unbound (set -u in the shim would otherwise crash
+  // `manta pair` on a box installed without MANTA_CHANNEL in its env).
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  const startIdx = src.indexOf('MANTA_HOME="${MANTA_HOME:-$HOME/manta}"');
+  assert.ok(startIdx !== -1, "could not locate the MANTA_HOME resolution line in install.sh");
+  const nearby = src.slice(startIdx, startIdx + 600);
+  assert.match(
+    nearby,
+    /MANTA_CHANNEL="\$\{MANTA_CHANNEL:-prod\}"/,
+    "MANTA_CHANNEL must default to prod (same fallback as resolveConfig()) near the MANTA_HOME resolution",
+  );
+  assert.match(nearby, /export MANTA_CHANNEL/);
+});
+
+// ----------------------------------------------------------------------------
 // manifest_get — the bash helper install.sh uses to read key=value from the
 // release manifest BEFORE any node exists on the box.
 // ----------------------------------------------------------------------------

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -260,6 +260,45 @@ test("resolveConfig honors MANTA_MOBILE_PORT and derives healthUrl", () => {
 });
 
 // ----------------------------------------------------------------------------
+// resolveConfig — MANTA_CHANNEL (BET-386)
+// ----------------------------------------------------------------------------
+//
+// Mirrors src/server/pairPage.mjs's resolveBoxChannel() env-var contract:
+// same env var name, same "unset/unrecognised → prod" fallback, so a box
+// server AND the install-lib pairing emitter agree on the channel from the
+// same MANTA_CHANNEL value.
+
+test("resolveConfig defaults channel to prod when MANTA_CHANNEL is unset", () => {
+  const cfg = resolveConfig({ env: {}, home: HOME });
+  assert.equal(cfg.channel, "prod");
+  assert.equal(cfg.urlScheme, "manta");
+});
+
+test("resolveConfig honors MANTA_CHANNEL=staging", () => {
+  const cfg = resolveConfig({ env: { MANTA_CHANNEL: "staging" }, home: HOME });
+  assert.equal(cfg.channel, "staging");
+  assert.equal(cfg.urlScheme, "manta-staging");
+});
+
+test("resolveConfig honors MANTA_CHANNEL=dev", () => {
+  const cfg = resolveConfig({ env: { MANTA_CHANNEL: "dev" }, home: HOME });
+  assert.equal(cfg.channel, "dev");
+  assert.equal(cfg.urlScheme, "manta-dev");
+});
+
+test("resolveConfig falls back to prod for an unrecognised MANTA_CHANNEL (never throws)", () => {
+  const cfg = resolveConfig({ env: { MANTA_CHANNEL: "garbage" }, home: HOME });
+  assert.equal(cfg.channel, "prod");
+  assert.equal(cfg.urlScheme, "manta");
+});
+
+test("resolveConfig treats an empty-string MANTA_CHANNEL as unset (shell footgun)", () => {
+  const cfg = resolveConfig({ env: { MANTA_CHANNEL: "" }, home: HOME });
+  assert.equal(cfg.channel, "prod");
+  assert.equal(cfg.urlScheme, "manta");
+});
+
+// ----------------------------------------------------------------------------
 // parsePort
 // ----------------------------------------------------------------------------
 
@@ -554,7 +593,10 @@ test("buildPairLink produces the canonical box-form pair link (BET-177 §2.4)", 
   // heredoc duplicate) in lockstep with this helper. The install.test
   // suite is plain Node — we don't load the .ts parser here — but we CAN
   // enforce the wire shape on the install-lib helper so a future drift is
-  // caught here.
+  // caught here. (BET-386: the actual cross-module round-trip against the
+  // real `parsePairPayload`, for all three channel schemes, lives in
+  // src/renderer/mobile/pairPayload.test.ts — vitest, not plain Node,
+  // can load the .ts parser directly.)
   //
   // 1. install-lib's buildPairLink produces the canonical shape:
   const fromLib = buildPairLink(HEX32, "847291");
@@ -562,6 +604,45 @@ test("buildPairLink produces the canonical box-form pair link (BET-177 §2.4)", 
     fromLib,
     "manta://pair?box=0123456789abcdef0123456789abcdef&code=847291",
     "install-lib buildPairLink produces the canonical box-form URL",
+  );
+});
+
+// ----------------------------------------------------------------------------
+// buildPairLink — channel-aware scheme (BET-386)
+// ----------------------------------------------------------------------------
+//
+// `buildPairLink` no longer hardcodes the `manta` literal in its URL
+// template — the scheme comes from the `scheme` option (default "manta",
+// same default as the renderer's `buildPairPayload`). Callers pass
+// `resolveConfig().urlScheme`. See src/renderer/mobile/pairPayload.test.ts
+// for the round-trip-through-parsePairPayload coverage across all three
+// channel schemes.
+
+test("buildPairLink derives the scheme from the `scheme` option, not a hardcoded literal", () => {
+  assert.equal(
+    buildPairLink(HEX32, "847291", { scheme: "manta-staging" }),
+    `manta-staging://pair?box=${HEX32}&code=847291`,
+  );
+  assert.equal(
+    buildPairLink(HEX32, "847291", { scheme: "manta-dev" }),
+    `manta-dev://pair?box=${HEX32}&code=847291`,
+  );
+});
+
+test("buildPairLink defaults scheme to manta when no scheme option is passed (back-compat)", () => {
+  assert.equal(
+    buildPairLink(HEX32, "847291"),
+    `manta://pair?box=${HEX32}&code=847291`,
+  );
+});
+
+test("buildPairLink threads scheme through the serverUrl branch too", () => {
+  assert.equal(
+    buildPairLink(HEX32, "847291", {
+      scheme: "manta-staging",
+      serverUrl: "http://100.64.1.5:8787",
+    }),
+    `manta-staging://pair?box=${HEX32}&code=847291&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
   );
 });
 
@@ -667,6 +748,27 @@ test("formatPairingOutput still throws on a non-6-digit code", () => {
     () => formatPairingOutput({ pairing_code: "12345" }),
     /6 digits/,
   );
+});
+
+// ----------------------------------------------------------------------------
+// formatPairingOutput — channel-aware scheme (BET-386)
+// ----------------------------------------------------------------------------
+
+test("formatPairingOutput threads the scheme option into the printed pair link", () => {
+  const out = formatPairingOutput(
+    { pairing_code: "847291", box_id: HEX32 },
+    { scheme: "manta-staging" },
+  );
+  assert.match(out, new RegExp(`manta-staging://pair\\?box=${HEX32}&code=847291`));
+  // "manta-staging://" does not contain the substring "manta://", so this
+  // also guards against the scheme option being ignored and the literal
+  // prod prefix leaking through instead.
+  assert.doesNotMatch(out, /manta:\/\//);
+});
+
+test("formatPairingOutput defaults to manta:// when no scheme option is passed (back-compat)", () => {
+  const out = formatPairingOutput({ pairing_code: "847291", box_id: HEX32 });
+  assert.match(out, new RegExp(`manta://pair\\?box=${HEX32}&code=847291`));
 });
 
 test("formatExpiry handles epoch-ms, ISO string, and junk", () => {

--- a/scripts/manta-pair.mjs
+++ b/scripts/manta-pair.mjs
@@ -88,12 +88,18 @@ async function main() {
   }
 
   try {
-    const block = formatPairingOutput({
-      pairing_code: data?.pairing_code,
-      box_id: data?.box_id,
-      expiresAt: data?.expiresAt,
-      serverUrl: readIngressServerUrl(cfg.authDir),
-    });
+    // BET-386: scheme comes from cfg.urlScheme (MANTA_CHANNEL, resolved by
+    // resolveConfig()) so a staging/dev box prints its own channel's pair
+    // link rather than always `manta://`.
+    const block = formatPairingOutput(
+      {
+        pairing_code: data?.pairing_code,
+        box_id: data?.box_id,
+        expiresAt: data?.expiresAt,
+        serverUrl: readIngressServerUrl(cfg.authDir),
+      },
+      { scheme: cfg.urlScheme },
+    );
     process.stdout.write(block + "\n");
   } catch (e) {
     fail(`unexpected pairing response from manta-server (${e?.message ?? e})`);

--- a/src/main/installer/installer.test.ts
+++ b/src/main/installer/installer.test.ts
@@ -191,6 +191,11 @@ describe("runInstall", () => {
     expect(captured.args[captured.args.length - 1]).toMatch(
       /MANTA_RELEASE_HOST=https:\/\/mantaui\.com/,
     );
+    // BET-386: MANTA_CHANNEL rides the same curl-pipe invocation as
+    // MANTA_RELEASE_HOST so install.sh's pairing block emits the right
+    // pair-link scheme. Test env falls through to dev (see the BET-370
+    // comment above) — channelConfig("dev").id is "dev".
+    expect(captured.args[captured.args.length - 1]).toMatch(/MANTA_CHANNEL=dev/);
     expect(captured.args[captured.args.length - 1]).toMatch(/\sbash'$/);
   });
 
@@ -217,6 +222,9 @@ describe("runInstall", () => {
     // default), not from the installShUrl override — the channel is the
     // single source of truth per the spec.
     expect(cmd).toContain("MANTA_RELEASE_HOST=https://mantaui.com");
+    // BET-386: same story for MANTA_CHANNEL — it's the channel id, not
+    // derived from the installShUrl override.
+    expect(cmd).toContain("MANTA_CHANNEL=dev");
   });
 
   it("invokes onLine + onStage as the log advances through milestones", async () => {

--- a/src/main/installer/installer.ts
+++ b/src/main/installer/installer.ts
@@ -115,8 +115,18 @@ const PROBE_AUTH_FILE_CMD =
 // behaviour change; for staging the box fetches the staging manifest +
 // tarball, which is the entire point of the channel split. The single
 // command shape keeps the wire-format tests trivial (BET-370 §Tests).
-function buildInstallCommand(installShUrl: string, releaseHost: string): string {
-  return `bash -lc 'curl -fsSL ${installShUrl} | MANTA_RELEASE_HOST=${releaseHost} bash'`;
+//
+// MANTA_CHANNEL (BET-386) rides along the same curl-pipe invocation: it's
+// the only way install.sh (served byte-identical across channels — see
+// scripts/release/publish.sh) learns which channel it's running under, so
+// the pairing block it prints at the end (via scripts/manta-pair.mjs →
+// install-lib.mjs's formatPairingOutput/buildPairLink) emits the right
+// pair-link scheme (manta:// / manta-staging:// / manta-dev://) instead of
+// always manta://. Same env-var-at-invocation pattern as MANTA_RELEASE_HOST,
+// same channel record — no new plumbing needed on the box side beyond what
+// scripts/install-lib.mjs's resolveConfig() already reads.
+function buildInstallCommand(installShUrl: string, releaseHost: string, channel: string): string {
+  return `bash -lc 'curl -fsSL ${installShUrl} | MANTA_RELEASE_HOST=${releaseHost} MANTA_CHANNEL=${channel} bash'`;
 }
 
 // ===========================================================================
@@ -311,7 +321,7 @@ export function runInstall(
   // mapper's prefix-matching still works after we strip them).
   //
   // TERM=xterm-256color is inherited from this process; nothing to set here.
-  const handle = streamRemote(alias, buildInstallCommand(installShUrl, cfg.releaseHost), {
+  const handle = streamRemote(alias, buildInstallCommand(installShUrl, cfg.releaseHost, cfg.id), {
     forceTty: true,
     spawn: deps.spawn,
     onStdout: (chunk) => pumpChunk(chunk, "stdout", sink),

--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -5,6 +5,15 @@ import {
   type PairPayload,
 } from "./pairPayload";
 import { CHANNELS, CHANNEL_IDS } from "../../shared/channel.mjs";
+// BET-386: install-lib.mjs's buildPairLink is the OTHER emitter of this
+// wire shape (install.sh's pairing block, via scripts/manta-pair.mjs) —
+// plain .mjs, no Electron/DOM dependency, importable straight into vitest's
+// node environment (same as the CHANNELS import above). Cross-importing it
+// here lets us round-trip the install-lib emitter against THIS module's
+// parser in one place, rather than re-implementing the wire shape as a
+// literal string in scripts/install.test.mjs (which is plain Node and
+// can't load this .ts parser directly).
+import { buildPairLink } from "../../../scripts/install-lib.mjs";
 
 const BOX = "0123456789abcdef0123456789abcdef"; // 32 hex
 
@@ -126,6 +135,46 @@ describe("parsePairPayload", () => {
       // is the cheap pin that catches a copy-paste typo in CHANNELS.
       expect(new Set(SCHEMES).size).toBe(SCHEMES.length);
       expect(SCHEMES.length).toBe(3);
+    });
+  });
+
+  // BET-386: scripts/install-lib.mjs's buildPairLink (the emitter behind
+  // install.sh's printed pairing block / `manta pair`) must produce a link
+  // this parser accepts for EVERY channel — not just the prod default the
+  // pre-BET-386 test only covered. A future drift where the two emitters
+  // (this module's buildPairPayload and install-lib's buildPairLink)
+  // disagree on the scheme literal would fail here.
+  describe("BET-386: install-lib's buildPairLink round-trips for every channel", () => {
+    for (const scheme of SCHEMES) {
+      it(`buildPairLink(..., { scheme: "${scheme}" }) round-trips through parsePairPayload`, () => {
+        const link = buildPairLink(BOX, "847291", { scheme });
+        expect(link).toBe(`${scheme}://pair?box=${BOX}&code=847291`);
+        expect(parsePairPayload(link, scheme)).toEqual({
+          boxId: BOX,
+          code: "847291",
+        });
+      });
+    }
+
+    it("defaults to the manta:// scheme when no scheme is passed (back-compat)", () => {
+      const link = buildPairLink(BOX, "847291");
+      expect(link).toBe(`manta://pair?box=${BOX}&code=847291`);
+      expect(parsePairPayload(link)).toEqual({ boxId: BOX, code: "847291" });
+    });
+
+    it("composes with a Tailscale serverUrl (BET-336) under a non-prod scheme", () => {
+      const link = buildPairLink(BOX, "847291", {
+        scheme: "manta-staging",
+        serverUrl: "http://100.64.1.5:8787",
+      });
+      expect(parsePairPayload(link, "manta-staging")).toEqual({
+        boxId: BOX,
+        code: "847291",
+        serverUrl: "http://100.64.1.5:8787",
+      });
+      // And it must NOT be accepted under a different channel's scheme —
+      // same wrong-app-routing boundary as the prod-only case above.
+      expect(parsePairPayload(link, "manta")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## What

Threads the build channel through `scripts/install-lib.mjs`'s pair-link
emitter (`buildPairLink` / `formatPairingOutput`), closing the gap
[BET-373](https://github.com/antoinedc/MantaUI/pull/319) fixed on the QR
path but left open on install.sh's printed pairing block: a box installed
from the staging/dev channel printed a `manta://` (prod-scheme) pair link,
so the OS routed the click to whatever app last registered `manta://`,
never the channel that was actually installed.

## Design decision (channel source)

`MANTA_CHANNEL` env var, read via `resolveConfig()` — the exact same
wiring `MANTA_RELEASE_HOST` already uses for this same curl-pipe
invocation. Rejected the other two options the issue raised:

- **Build-time substitution** — `install.sh` is served byte-identical
  across channels (`scripts/release/publish.sh` — no per-channel
  templating), so the script itself has no channel-specific content to
  substitute into.
- **Persisting channel to disk** — [BET-370](https://github.com/antoinedc/MantaUI/pull/318)'s decision record is explicit: *"the channel is a
  property of the BUILD, never of user config — do not persist it to
  config.json"*. An env var at invocation time, no persistence, matches
  that precedent.

## Changes

- `scripts/install-lib.mjs`: `resolveConfig()` reads `MANTA_CHANNEL`
  (unset/unrecognised → `"prod"`, same fallback contract as
  `resolveBoxChannel()` in `pairPage.mjs`) and exposes `channel` +
  `urlScheme`. `buildPairLink`/`formatPairingOutput` take a `scheme`
  option (default `"manta"`) instead of a hardcoded `manta://` literal.
- `scripts/manta-pair.mjs`: passes `cfg.urlScheme` through — covers both
  install.sh's final step (which calls this script) **and** later manual
  `manta pair` re-runs (the latter only actually works as of the review
  cycle 2 fix below — see correction note).
- `src/main/installer/installer.ts`: the SSH orchestrator (desktop app's
  "Install" button) now passes `MANTA_CHANNEL=<channel>` alongside
  `MANTA_RELEASE_HOST` in the curl-pipe command — it already resolves the
  channel record for `releaseHost`, so this rides along for free.
- `scripts/install-lib.d.mts` (new): hand-written declaration for
  `buildPairLink`, same pattern as `src/shared/channel.d.mts`, so a
  checked `.ts` file can import the plain-`.mjs` module.
- **`scripts/install.sh` (review cycle 2 fix, see below):** resolves +
  exports `MANTA_CHANNEL` (default `"prod"`, same fallback as
  `resolveConfig()`) and bakes it into the `manta` CLI shim heredoc the
  same way `MANTA_HOME`/`NODE` already are, so a `manta pair` re-run in
  ANY later shell actually reads the install-time channel back out.

## Tests

- `scripts/install.test.mjs`: `resolveConfig`'s `channel`/`urlScheme`
  fields (prod default, staging, dev, unrecognised-value fallback,
  empty-string-is-unset); `buildPairLink`/`formatPairingOutput`'s `scheme`
  option (staging/dev output, back-compat default, composes with the
  BET-336 `serverUrl` branch).
- `src/main/installer/installer.test.ts`: asserts `MANTA_CHANNEL=dev`
  appears in the built SSH command alongside the existing
  `MANTA_RELEASE_HOST` assertion.
- `src/renderer/mobile/pairPayload.test.ts`: **the actual round-trip
  against the real `parsePairPayload`**, for all three channel schemes
  plus a Tailscale `serverUrl` composition — this is a first: it
  cross-imports `install-lib.mjs`'s `buildPairLink` into the vitest suite
  so the two emitters (`buildPairPayload` and `buildPairLink`) are
  verified to actually agree on the wire shape, not just asserted to by
  comment. `scripts/install.test.mjs` (plain Node, no TS loader) still
  pins the literal string shape for staging/dev, per the pre-existing
  pattern in that file (see the updated comment at the `BET-177 §2.4`
  test) — it cannot load the `.ts` parser directly, which is why the real
  round-trip lives in the vitest file instead.

## Review cycle 2 — correction + fix

The reviewer found the PR body's claim above ("later manual `manta pair`
re-runs" are covered) was **wrong**: `resolveConfig()` deliberately never
persists the channel to disk (BET-370's "channel is a property of the
build" ruling), so a `manta pair` re-run in a fresh shell had no source
for `MANTA_CHANNEL` at all and always resolved `prod` — printing
`manta://` on a staging/dev box, the exact bug this issue describes, on
the documented re-mint path.

**Fix (`Block (fix-here)`):** `scripts/install.sh` now resolves +
exports `MANTA_CHANNEL` right alongside `MANTA_HOME`, and bakes it into
the `manta` CLI shim heredoc the same way `MANTA_HOME`/`NODE` already
are — see the added `scripts/install.sh` diff. Three new tests in
`scripts/install.test.mjs`: a static-layout guard, a dynamic test that
extracts and *executes* the real (unmodified) shim-writing block from
install.sh's source and proves the value reaches a child process's env,
and a default-to-prod guard.

**Follow-up filed (`Block (followup-issue)`):**
[BET-392](mention://issue/f26083b4-0470-4aa8-b831-34eb16f8bfca) (assigned
`manta-pm`, high priority) — the box server's systemd/launchd env still
has no `MANTA_CHANNEL`, so BET-373's channel-aware `/pair/qr.png` stays
dormant on every real box. Out of scope here: it changes the server's
runtime environment (not the install-lib emitter this issue scopes) and
its own test surface (unit-template substitution tests).

## Verification results

- PR branch (`multica/BET-386-channel-install-lib-pair-link` @ `2d6f98a`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0` — vitest 1455 pass / 0 fail, node:test 1130 pass / 0 fail. log sha256: `a0185156db1bc33745169724e880e82328ffa2bd0aa33ee71197dbc9aa2207b2`
- Base (`main` @ `f120bec`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0` — vitest 1450 pass / 0 fail, node:test 1117 pass / 0 fail. log sha256: `e51581b527d804ed669da253f24fb1e057dfa2c554c9a5f24d54ce8f82e9f335`
- **Conclusion:** 0 pre-existing failures, 0 new failures. +5 vitest / +13 node:test tests added by this PR, all passing.

Base: `origin/main` @ `f120bec`

## Follow-ups filed

- [BET-391](mention://issue/7bf6a514-0ae1-40ab-8aa2-2aeea4777750) (parked,
  low) — the raw `curl -fsSL https://mantaui.com/staging/install.sh | bash`
  path (no SSH orchestrator involved) still needs `MANTA_CHANNEL=staging`
  exported manually since `install.sh` is served byte-identical across
  channels; nothing documents that today.
- [BET-392](mention://issue/f26083b4-0470-4aa8-b831-34eb16f8bfca)
  (assigned `manta-pm`, high) — box server systemd/launchd env needs
  `MANTA_CHANNEL` too (review cycle 1 `Block (followup-issue)`, see above).

