### PR TITLE
BET-388: Delete channel conditional on staging release pointer name

### DIFF
--- a/.github/workflows/server-tarball-deploy.yml
+++ b/.github/workflows/server-tarball-deploy.yml
@@ -19,8 +19,7 @@
 #   dist/manta-<v>-linux-arm64.tar.gz   → <RELEASES_DIR>/
 #   dist/manta-<v>-darwin-arm64.tar.gz  → <RELEASES_DIR>/
 #   dist/manta-<v>.txt                  → <RELEASES_DIR>/
-#   (then cp manta-<v>.txt → manta-latest.txt  for prod,
-#    or   cp manta-<v>.txt → manta-staging-latest.txt for staging — atomicity)
+#   (then cp manta-<v>.txt → manta-latest.txt — LAST, for atomicity)
 #
 # BUILD HOST CHOICE
 #   GitHub-hosted ubuntu-latest (x64) + ubuntu-24.04-arm (linux-arm64) +
@@ -38,14 +37,13 @@
 #   verbatim.
 #
 # ATOMICITY
-#   tarballs + versioned manifest are uploaded FIRST; the channel's *-latest.txt
-#   pointer (manta-latest.txt for prod, manta-staging-latest.txt for staging)
-#   is copied LAST. A client therefore either sees the OLD pointer (and the
+#   tarballs + versioned manifest are uploaded FIRST; manta-latest.txt is
+#   copied LAST. A client therefore either sees the OLD pointer (and the
 #   OLD tarballs are still served) OR the NEW pointer (and the NEW tarballs are
 #   already uploaded). Drift between manifest and tarballs is impossible.
 #   (Same rule publish.sh documents — generalized to both arches via a loop.)
-#   Staging refreshes its OWN pointer only — it must NEVER overwrite the prod
-#   manta-latest.txt.
+#   Channel separation is by directory (RELEASES_DIR), enforced by the
+#   /staging/ guard above — both channels publish the same filename.
 #
 # VERIFY
 #   After publish, fail red on:
@@ -259,24 +257,17 @@ jobs:
           echo "▸ Uploading ${manifest}"
           $SCP "$manifest" "$PROD_HOST:$RELEASES_DIR/"
 
-          # Channel-specific pointer. prod refreshes manta-latest.txt (the
-          # canonical install.sh pointer). staging refreshes
-          # manta-staging-latest.txt — it MUST NOT touch prod's latest.txt,
-          # or every install.sh fetch returns a staging build to a prod user.
-          channel="${{ needs.resolve.outputs.channel }}"
-          if [ "$channel" = "staging" ]; then
-            pointer="manta-staging-latest.txt"
-          else
-            pointer="manta-latest.txt"
-          fi
-          echo "▸ Publishing ${pointer} (LAST — atomicity)"
-          $SSH "$PROD_HOST" "cd $RELEASES_DIR && cp -f manta-${VERSION}.txt ${pointer}"
+          # Pointer is ALWAYS manta-latest.txt — install.sh appends
+          # /releases/manta-latest.txt to whatever MANTA_RELEASE_HOST it is
+          # given, and has no channel concept. The channel lives in
+          # RELEASES_DIR (guarded above), never in the filename.
+          echo "▸ Publishing manta-latest.txt (LAST — atomicity)"
+          $SSH "$PROD_HOST" "cd $RELEASES_DIR && cp -f manta-${VERSION}.txt manta-latest.txt"
 
       - name: Verify deploy (both arches)
         env:
           VERSION: ${{ steps.vars.outputs.version }}
           SITE: ${{ needs.resolve.outputs.site }}
-          CHANNEL: ${{ needs.resolve.outputs.channel }}
         run: |
           set -euo pipefail
           fail=0
@@ -293,14 +284,8 @@ jobs:
             fi
           done
 
-          # Channel-specific *-latest.txt pointer — same atomicity invariant.
-          if [ "$CHANNEL" = "staging" ]; then
-            pointer="manta-staging-latest.txt"
-          else
-            pointer="manta-latest.txt"
-          fi
-          echo "▸ Fetch served ${pointer} and assert version"
-          served=$(curl -fsSL "$SITE/releases/${pointer}")
+          echo "▸ Fetch served manta-latest.txt and assert version"
+          served=$(curl -fsSL "$SITE/releases/manta-latest.txt")
           served_version=$(printf '%s\n' "$served" | grep '^version=' | head -n1 | cut -d= -f2-)
           if [ "$served_version" != "$VERSION" ]; then
             echo "::error::served version='${served_version}' expected='${VERSION}'"


### PR DESCRIPTION
## Summary

Deletes the channel conditional on the staging release pointer name. Staging
installs were 404-ing at `manifest fetch failed:
https://mantaui.com/staging/releases/manta-latest.txt` because
`server-tarball-deploy.yml` was publishing `manta-staging-latest.txt`
instead — a name `install.sh` never requests and nothing else reads.

`install.sh` has no channel concept: it always appends
`/releases/manta-latest.txt` to whatever `MANTA_RELEASE_HOST` it was given.
Channel separation is already fully enforced by `RELEASES_DIR` (different
directory per channel) plus the `/staging/` hard guard — the filename never
needed to carry the channel too.

**The whole change is deletion**: two `if/else` blocks (publish + verify
steps) and the stale header comments collapse to a single unconditional
`manta-latest.txt` reference. No new logic added.

Base: `origin/main @ f120bec`

## Changes

All in `.github/workflows/server-tarball-deploy.yml`:
- Publish step: deleted the `if [ "$channel" = "staging" ]` pointer-name
  branch; always `cp -f manta-${VERSION}.txt manta-latest.txt`. Removed the
  now-unused `channel=` local.
- Verify step: deleted the matching `if [ "$CHANNEL" = "staging" ]` branch;
  always fetches `manta-latest.txt`. Removed the now-unused `CHANNEL` env
  entry from that step (still resolved/used in the earlier guard step).
- Header comments (top-of-file `WHAT IT DEPLOYS` and `ATOMICITY` sections):
  updated to describe the single canonical pointer name and state that
  channel separation is by directory + the `/staging/` guard.

Out of scope (per issue, untouched): the `/staging/` hard guard,
`website-deploy.yml`, `codemagic.yaml`, `scripts/install.sh`, tarball/manifest
naming.

## Verification results

- PR branch (`multica/BET-388-staging-pointer-fix` @ `f0db9aa`):
  - typecheck: exit `0`. Errors: none. log sha256:
    `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1117` pass / `0` fail / `0` skip. log sha256:
    `276cc27d5ee35dfb1ff7799a17ad41b18dac18baa0b462f942dc371862319550`
- **Conclusion:** the diff touches only `.github/workflows/server-tarball-deploy.yml`
  (a GitHub Actions workflow with no JS/TS source or test path referencing it —
  confirmed by `grep -rn "manta-staging-latest" .` returning zero hits after
  the edit, and no `npm test`/`typecheck` target covers workflow YAML). A
  base-branch re-run is not meaningful for a workflow-only change; skipped per
  the acceptance criteria in the issue, which specify the grep check and a
  real `workflow_dispatch` run as the actual verification (see below).

## Acceptance check

`grep -rn "manta-staging-latest" .` (excluding `node_modules`, `.git`) →
**zero hits.**

## Follow-up (not yet done — needs a human with prod SSH access)

The issue's "One-line cleanup on the prod box" step (removing the stale
`manta-staging-latest.txt` from
`/var/www/mantaui/staging/releases/`) and the real
`workflow_dispatch -f channel=staging` end-to-end run were **not** run by
this agent — they require live SSH access to the prod deploy box
(`~/.manta-deploy/prod_key` on the self-hosted runner) and triggering a real
GitHub Actions workflow run, which is out of scope for an agent session per
workspace rules ("No production deploy from agents"). These should be run by
a human (or the reviewer/PM flow, if it has that access) before/at merge
time to close out the `Done when` criteria fully.
