### PR TITLE
BET-392: bake MANTA_CHANNEL into manta-server systemd unit + LaunchAgent plist

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,6 +67,12 @@
 #   MANTA_REPO_URL      git URL the deploy is initialised against for `scripts/self-update.sh`
 #                       (default https://github.com/antoinedc/MantaUI.git)
 #   MANTA_HOME          where code is unpacked (default ~/manta)
+#   MANTA_CHANNEL       build channel — prod|staging|dev (default prod). Baked
+#                       into the manta-server systemd unit / LaunchAgent plist
+#                       as Environment/EnvironmentVariables so the box's own
+#                       long-lived process resolves the right pair-link URL
+#                       scheme (resolveBoxChannel() in src/server/pairPage.mjs,
+#                       BET-373). Not persisted anywhere.
 #   MANTA_MOBILE_PORT   server port (default 8787)
 #   MANTA_VERSION       version to fetch when MANTA_TARBALL_URL is unset (default: latest)
 #   MANTA_GATEWAY_BASE  push-gateway base URL (default https://gateway.mantaui.com)
@@ -545,6 +551,13 @@ main() {
   # ---------------------------------------------------------------------------
   MANTA_HOME="${MANTA_HOME:-$HOME/manta}"
   AUTH_DIR="$HOME/.manta"
+  # BET-392: resolve + export MANTA_CHANNEL here (same "unset/unrecognised ->
+  # prod" fallback resolveBoxChannel() applies) so it's available below when
+  # the manta-server systemd unit / LaunchAgent plist get rendered. Not
+  # persisted to disk — channel is a property of the build/install, not
+  # box state.
+  MANTA_CHANNEL="${MANTA_CHANNEL:-prod}"
+  export MANTA_CHANNEL
 
   rm -rf "$MANTA_HOME.prev"
   if [ -d "$MANTA_HOME" ]; then mv "$MANTA_HOME" "$MANTA_HOME.prev"; fi
@@ -832,6 +845,7 @@ main() {
       -e "s|@@OPENCODE_BIN@@|${OPENCODE_BIN:-}|g" \
       -e "s|@@AUTH_DIR@@|$AUTH_DIR|g" \
       -e "s|@@AGENT_PATH@@|$(launchd_agent_path)|g" \
+      -e "s|@@MANTA_CHANNEL@@|${MANTA_CHANNEL:-prod}|g" \
       "$src" > "$dest"
     local uid; uid="$(id -u)"
     # bootout first (ignore failure if not loaded), then bootstrap for a clean
@@ -1056,6 +1070,7 @@ main() {
       -e "s|@@MANTA_PORT@@|$MANTA_PORT|g" \
       -e "s|@@MANTA_TAILNET_HOST@@|$TAILNET_IP|g" \
       -e "s|@@AGENT_PATH@@|$(launchd_agent_path)|g" \
+      -e "s|@@MANTA_CHANNEL@@|${MANTA_CHANNEL:-prod}|g" \
       "$UNIT_SRC" > "$UNIT_DIR/manta-server.service"
 
     # Survive logout/reboot without an active session.

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4127,6 +4127,24 @@ test("install.sh: scripts/systemd/*.service carries @@AGENT_PATH@@ placeholder (
   }
 });
 
+test("install.sh: scripts/systemd/manta-server.service + scripts/launchd/com.mantaui.server.plist carry @@MANTA_CHANNEL@@ placeholder (BET-392)", () => {
+  // Belt-and-braces: without the placeholder in the template, install.sh's
+  // sed substitution has nothing to replace and the box's own server
+  // process would silently fall back to resolveBoxChannel()'s "prod"
+  // default on every install, regardless of MANTA_CHANNEL.
+  const serverUnit = readFileSync(join(__dirname, "systemd", "manta-server.service"), "utf-8");
+  assert.match(serverUnit, /Environment=MANTA_CHANNEL=@@MANTA_CHANNEL@@/);
+  const serverPlist = readFileSync(join(__dirname, "launchd", "com.mantaui.server.plist"), "utf-8");
+  assert.match(serverPlist, /<key>MANTA_CHANNEL<\/key>\s*<string>@@MANTA_CHANNEL@@<\/string>/);
+  // opencode-serve.service / com.mantaui.opencode.plist are NOT
+  // pair-link-emitting processes — MANTA_CHANNEL is deliberately scoped to
+  // manta-server only.
+  const opencodeUnit = readFileSync(join(__dirname, "systemd", "opencode-serve.service"), "utf-8");
+  assert.doesNotMatch(opencodeUnit, /MANTA_CHANNEL/);
+  const opencodePlist = readFileSync(join(__dirname, "launchd", "com.mantaui.opencode.plist"), "utf-8");
+  assert.doesNotMatch(opencodePlist, /MANTA_CHANNEL/);
+});
+
 test("install.sh systemd render: AGENT_PATH substitution materialises ~/.local/bin in both units (BET-353)", () => {
   // Pin the Linux render: install.sh substitutes @@AGENT_PATH@@ via the
   // lib's render-systemd-unit call (opencode-serve.service) AND via the
@@ -4156,7 +4174,8 @@ NODE="node"
 MANTA_PORT="8787"
 TAILNET_IP=""
 OPENCODE_BIN="/usr/local/bin/opencode"
-export MANTA_HOME NODE MANTA_PORT TAILNET_IP OPENCODE_BIN
+MANTA_CHANNEL="staging"
+export MANTA_HOME NODE MANTA_PORT TAILNET_IP OPENCODE_BIN MANTA_CHANNEL
 OC_UNIT_SRC="\${INSTALL_SH%/*}/systemd/opencode-serve.service"
 SERVER_UNIT_SRC="\${INSTALL_SH%/*}/systemd/manta-server.service"
 
@@ -4174,6 +4193,7 @@ sed \\
   -e "s|@@MANTA_PORT@@|\$MANTA_PORT|g" \\
   -e "s|@@MANTA_TAILNET_HOST@@|\${TAILNET_IP:-}|g" \\
   -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
+  -e "s|@@MANTA_CHANNEL@@|\${MANTA_CHANNEL:-prod}|g" \\
   "\$SERVER_UNIT_SRC" > "${SERVER_RENDERED}"
 
 echo "SYSTEMD_RENDER_DONE=1"
@@ -4192,6 +4212,52 @@ echo "SYSTEMD_RENDER_DONE=1"
       // service can't find `claude` for credential refresh.
       assert.match(text, new RegExp(`${homeRe}/\\.local/bin`));
     }
+    // BET-392: manta-server.service (not opencode-serve.service — MANTA_CHANNEL
+    // is only relevant to the pairing-QR-emitting process) must carry the
+    // resolved channel so resolveBoxChannel() sees it at runtime, not the
+    // "unset -> prod" fallback.
+    const serverText = readFileSync(SERVER_RENDERED, "utf-8");
+    assert.doesNotMatch(serverText, /@@MANTA_CHANNEL@@/, "unsubstituted @@MANTA_CHANNEL@@ leaked into manta-server.service");
+    assert.match(serverText, /Environment=MANTA_CHANNEL=staging/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("install.sh systemd render: MANTA_CHANNEL defaults to prod when unset (BET-392)", () => {
+  // Mirrors the MANTA_PORT/MANTA_TAILNET_HOST default-substitution coverage:
+  // an install that never sets MANTA_CHANNEL must still render a valid unit
+  // with the "prod" fallback baked in, not a literal @@MANTA_CHANNEL@@ token.
+  const dir = mkdtempSync(join(tmpdir(), "manta-systemd-channel-default-"));
+  try {
+    const SERVER_RENDERED = join(dir, "server-rendered.service");
+    const out = runMain({
+      stubs: `
+INSTALL_SH="${INSTALL_SH}"
+export INSTALL_SH
+MANTA_HOME="/tmp/fake-manta-home"
+NODE="node"
+MANTA_PORT="8787"
+TAILNET_IP=""
+unset MANTA_CHANNEL
+export MANTA_HOME NODE MANTA_PORT TAILNET_IP
+SERVER_UNIT_SRC="\${INSTALL_SH%/*}/systemd/manta-server.service"
+sed \\
+  -e "s|@@MANTA_HOME@@|\$MANTA_HOME|g" \\
+  -e "s|@@NODE_BIN@@|\$NODE|g" \\
+  -e "s|@@MANTA_PORT@@|\$MANTA_PORT|g" \\
+  -e "s|@@MANTA_TAILNET_HOST@@|\${TAILNET_IP:-}|g" \\
+  -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
+  -e "s|@@MANTA_CHANNEL@@|\${MANTA_CHANNEL:-prod}|g" \\
+  "\$SERVER_UNIT_SRC" > "${SERVER_RENDERED}"
+echo "SYSTEMD_CHANNEL_DEFAULT_DONE=1"
+`,
+      preBody: `: # run stubs above`,
+    });
+    assert.match(out, /SYSTEMD_CHANNEL_DEFAULT_DONE=1/);
+    const text = readFileSync(SERVER_RENDERED, "utf-8");
+    assert.doesNotMatch(text, /@@MANTA_CHANNEL@@/, "unsubstituted @@MANTA_CHANNEL@@ leaked into manta-server.service");
+    assert.match(text, /Environment=MANTA_CHANNEL=prod/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -4266,7 +4332,8 @@ MANTA_PORT="8787"
 TAILNET_IP="100.64.1.5"
 OPENCODE_BIN="/usr/local/bin/opencode"
 AUTH_DIR="/tmp/fake-manta-home/.manta"
-export MANTA_HOME NODE MANTA_PORT TAILNET_IP OPENCODE_BIN AUTH_DIR
+MANTA_CHANNEL="staging"
+export MANTA_HOME NODE MANTA_PORT TAILNET_IP OPENCODE_BIN AUTH_DIR MANTA_CHANNEL
 SERVER_PLIST_SRC="\${INSTALL_SH%/*}/launchd/com.mantaui.server.plist"
 export SERVER_PLIST_SRC
 sed \\
@@ -4277,6 +4344,7 @@ sed \\
   -e "s|@@OPENCODE_BIN@@|\${OPENCODE_BIN:-}|g" \\
   -e "s|@@AUTH_DIR@@|\$AUTH_DIR|g" \\
   -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
+  -e "s|@@MANTA_CHANNEL@@|\${MANTA_CHANNEL:-prod}|g" \\
   "\$SERVER_PLIST_SRC" > "${rendered}"
 echo "SUBST_DONE=1"
 `,
@@ -4295,6 +4363,10 @@ echo "SUBST_DONE=1"
     assert.match(text, /<string>8787<\/string>/);
     assert.match(text, /<string>100\.64\.1\.5<\/string>/);
     assert.match(text, /\/tmp\/fake-manta-home\/\.manta\/server\.log/);
+    // BET-392: MANTA_CHANNEL must land in EnvironmentVariables so
+    // resolveBoxChannel() sees the install's actual channel, not the
+    // "unset -> prod" fallback.
+    assert.match(text, /<key>MANTA_CHANNEL<\/key>\s*<string>staging<\/string>/);
     // PATH must be materialised: launchd hands an agent only
     // /usr/bin:/bin:/usr/sbin:/sbin, so a Homebrew tmux is invisible to
     // manta-server and every tmux call fails on a real Mac box.
@@ -4344,6 +4416,7 @@ sed \\
   -e "s|@@OPENCODE_BIN@@|\${OPENCODE_BIN:-}|g" \\
   -e "s|@@AUTH_DIR@@|\$AUTH_DIR|g" \\
   -e "s|@@AGENT_PATH@@|\$(launchd_agent_path)|g" \\
+  -e "s|@@MANTA_CHANNEL@@|\${MANTA_CHANNEL:-prod}|g" \\
   "\$OC_PLIST_SRC" > "${rendered}"
 echo "EMPTY_SUBST_DONE=1"
 `,
@@ -4386,6 +4459,9 @@ test("scripts/launchd/*.plist XML is well-formed (BET-277 lint gate)", () => {
   // tailnet listener keeps working after the supervisor swap. Pin the
   // key so a future rename doesn't silently break the tailnet path.
   assert.match(server, /<key>MANTA_TAILNET_HOST<\/key>/);
+  // BET-392: the server plist must carry MANTA_CHANNEL so resolveBoxChannel()
+  // (src/server/pairPage.mjs) sees the install's actual channel at runtime.
+  assert.match(server, /<key>MANTA_CHANNEL<\/key>/);
 });
 
 // ----------------------------------------------------------------------------

--- a/scripts/launchd/com.mantaui.server.plist
+++ b/scripts/launchd/com.mantaui.server.plist
@@ -39,6 +39,15 @@
     <string>127.0.0.1</string>
     <key>MANTA_MOBILE_PORT</key>
     <string>@@MANTA_PORT@@</string>
+    <!-- BET-392: the box's own long-lived server process reads MANTA_CHANNEL
+         to pick the pair-link URL scheme it emits from /pair/qr.png
+         (resolveBoxChannel() in src/server/pairPage.mjs, BET-373). Without
+         this key the process only ever sees the "prod" fallback regardless
+         of what channel the box was actually installed for. install.sh
+         substitutes the value it resolved for THIS install (default prod)
+         — see MANTA_CHANNEL in main(). -->
+    <key>MANTA_CHANNEL</key>
+    <string>@@MANTA_CHANNEL@@</string>
     <!-- Optional second listener bound to the Tailscale interface (BET-266).
          Set to a Tailscale IPv4 by install.sh on the tailnet ingress path;
          left empty on the public path so the server's tailnet listener is

--- a/scripts/systemd/manta-server.service
+++ b/scripts/systemd/manta-server.service
@@ -27,6 +27,13 @@ WorkingDirectory=@@MANTA_HOME@@
 ExecStart=@@NODE_BIN@@ @@MANTA_HOME@@/src/server/index.mjs
 Environment=MANTA_MOBILE_HOST=127.0.0.1
 Environment=MANTA_MOBILE_PORT=@@MANTA_PORT@@
+# BET-392: the box's own long-lived server process reads MANTA_CHANNEL to
+# pick the pair-link URL scheme it emits from /pair/qr.png
+# (resolveBoxChannel() in src/server/pairPage.mjs, BET-373). Without this,
+# the process only ever sees the "prod" fallback regardless of what channel
+# the box was actually installed for. install.sh substitutes the value it
+# resolved for THIS install (default prod) — see MANTA_CHANNEL in main().
+Environment=MANTA_CHANNEL=@@MANTA_CHANNEL@@
 # Same PATH the LaunchAgent plists get — systemd --user services inherit a
 # minimal default PATH that excludes ~/.local/bin (claude CLI) and Homebrew
 # dirs (tmux). Without this, `tmux:new-session` ENOENTs and


### PR DESCRIPTION
## Summary

`resolveBoxChannel()` in `src/server/pairPage.mjs` reads `process.env.MANTA_CHANNEL`, but neither the systemd unit nor the macOS LaunchAgent plist for `manta-server` supplied it, and `install.sh`'s substitution block didn't set it either — so on every real install the server resolves the prod channel and `/pair/qr.png` emits a `manta://pair?…` payload even on a staging/dev box.

**Base:** `origin/main @ f120bec`

## Changes

- `scripts/systemd/manta-server.service`: added `Environment=MANTA_CHANNEL=@@MANTA_CHANNEL@@` alongside the existing `Environment=` lines.
- `scripts/launchd/com.mantaui.server.plist`: added the equivalent `MANTA_CHANNEL` key to `EnvironmentVariables`.
- `scripts/install.sh`:
  - Resolves + exports `MANTA_CHANNEL` in `main()` (default `prod`, same fallback `resolveBoxChannel()` applies) right where `MANTA_HOME`/`AUTH_DIR` are resolved.
  - Substitutes `@@MANTA_CHANNEL@@` in the systemd sed block and in the shared `install_launchd_agent()` sed pipeline (used by both `com.mantaui.server.plist` and `com.mantaui.opencode.plist` — harmless no-op on the opencode plist since it doesn't carry the placeholder).
  - Added a short doc line under the env-var overrides comment block.
- `scripts/install.test.mjs`: extended/added tests —
  - Template placeholder-presence guard (server carries it, opencode-serve does NOT — scoped deliberately to the pair-link-emitting process only).
  - Substitution assertion with `MANTA_CHANNEL=staging` on both the systemd sed render and the launchd plist render (mirrors the existing `MANTA_PORT`/`MANTA_TAILNET_HOST` assertions).
  - Default-to-`prod` fallback assertion when `MANTA_CHANNEL` is unset.
  - XML-lint gate test now also pins `<key>MANTA_CHANNEL</key>` on the server plist template.

Scope intentionally excludes `opencode-serve.service`/`com.mantaui.opencode.plist` — that process doesn't serve `/pair/qr.png`.

## Verified end-to-end

Ran the real template through the actual `install.sh` sed pipeline with `MANTA_CHANNEL=staging`:

```
Environment=MANTA_CHANNEL=staging
```

Combined with the pre-existing (unmodified, still green) `pairPage.test.mjs` coverage of `resolveBoxChannel()`/`validatePairQrQuery` honoring `MANTA_CHANNEL=staging` → `manta-staging://`, the full chain from install-time env to QR payload is covered.

## Heads-up for merge ordering

[BET-386](mention://issue/7ae0d6d7-c862-40e6-95f5-62e7431a566a) (still draft, PR #324) also resolves+exports `MANTA_CHANNEL` in `install.sh`'s `main()` at essentially the same insertion point (right after `MANTA_HOME`/`AUTH_DIR`). Whichever of these two PRs merges second will hit a small, easy-to-resolve conflict there (drop the duplicate `MANTA_CHANNEL="${MANTA_CHANNEL:-prod}"; export MANTA_CHANNEL` pair). No action needed now — flagging so the reviewer isn't surprised.

## Verification results

- PR branch (`multica/BET-392-manta-channel-service-env` @ `605eb1f`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1119` pass / `0` fail / `0` skip. log sha256: `1c39ea49b17107c41d30519cda07046fb99ef295e397a352abfda69c4598b144`
- Base (`main` @ `f120bec`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1117` pass / `0` fail / `0` skip. log sha256: `7760fc6cb0ba1e1cca6e79190da62f40b98fc41bc582bebeb1a51273d8187f49`
- **Conclusion:** 0 pre-existing failures, 0 new failures, 2 new tests added (1119 vs 1117) by this PR.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
