### PR TITLE
BET-393: route onboarding post-pair phase through one runPhase helper

### DIFF
--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -165,59 +165,71 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     }
   }, []);
 
-  // The post-pair orchestrator. Auto-creates the welcome project + chat
-  // window, sends a probe prompt, waits for a real assistant response. On
-  // success the shell advances to "success" so the user sees the
-  // terminal screen; on failure the error surfaces inline at the step
-  // that triggered it (the step's own onPaired/onContinue handler catches
-  // the throw via setVerifyError and stays put).
-  //
-  // Two call sites:
-  //   - onPaired (step 1): skips to step 2 if no provider is connected,
-  //     otherwise calls finalizeOnboarding directly. The "skip if no
-  //     provider" branch is the dual of ProvidersStep's mount-time
-  //     auto-skip, so either side arriving at finalizeOnboarding means
-  //     ≥1 provider is connected.
-  //   - onContinue (step 2): always calls finalizeOnboarding.
-  const finalize = useCallback(async () => {
+  // The ONE place that manages verifying/verifyError. Every async onboarding
+  // phase goes through it — a phase that throws surfaces inline and the user
+  // stays put, never a silent stall.
+  const runPhase = useCallback(async (fn: () => Promise<void>) => {
     setVerifying(true);
     setVerifyError(null);
     try {
-      await refreshAndInstallTransport();
-      await finalizeOnboarding({
-        api: window.api as unknown as VerifyApi,
-        store: useStore.getState() as unknown as VerifyStore,
-      });
-      setPos("success");
+      await fn();
     } catch (e) {
       setVerifyError(e instanceof Error ? e.message : String(e));
     } finally {
       setVerifying(false);
     }
+  }, []);
+
+  // The post-pair orchestrator body WITHOUT state management — runPhase owns
+  // that. Auto-creates the welcome project + chat window, sends a probe
+  // prompt, waits for a real assistant response. On success the shell
+  // advances to "success". Kept separate from runPhase so onPaired can run
+  // it inline without nesting two runPhase calls (which would clear
+  // verifying early).
+  //
+  // Two entry points route here through runPhase:
+  //   - onPaired (step 1): skips to step 2 if no provider is connected,
+  //     otherwise runs doFinalize. The "skip if no provider" branch is the
+  //     dual of ProvidersStep's mount-time auto-skip, so either side
+  //     arriving at finalizeOnboarding means ≥1 provider is connected.
+  //   - onProviderContinue (step 2): always runs doFinalize.
+  const doFinalize = useCallback(async () => {
+    await refreshAndInstallTransport();
+    await finalizeOnboarding({
+      api: window.api as unknown as VerifyApi,
+      store: useStore.getState() as unknown as VerifyStore,
+    });
+    setPos("success");
   }, [refreshAndInstallTransport]);
 
-  // Step 1 → step 2 (provider needed) OR step 1 → finalize (provider
+  // Step 1 → step 2 (provider needed) OR step 1 → doFinalize (provider
   // already connected). Detecting the latter before stepping forward keeps
   // the user from blinking through an empty step-2 frame.
   //
   // refreshAndInstallTransport FIRST so the hasConnectedProvider probe
-  // (and the upcoming finalize) actually reach the box.
-  const onPaired = useCallback(async () => {
-    await refreshAndInstallTransport();
-    const connected = await hasConnectedProvider(
-      window.api as unknown as VerifyApi,
-    );
-    if (connected) {
-      await finalize();
-    } else {
-      setPos(2);
-    }
-  }, [refreshAndInstallTransport, finalize]);
+  // (and the upcoming finalize) actually reach the box. The whole body runs
+  // inside runPhase so a rejection surfaces inline instead of stalling.
+  const onPaired = useCallback(
+    () =>
+      runPhase(async () => {
+        await refreshAndInstallTransport();
+        const connected = await hasConnectedProvider(
+          window.api as unknown as VerifyApi,
+        );
+        if (connected) {
+          await doFinalize();
+        } else {
+          setPos(2);
+        }
+      }),
+    [runPhase, refreshAndInstallTransport, doFinalize],
+  );
 
   // Step 2 → finalize (provider connect just landed → run the verify).
-  const onProviderContinue = useCallback(async () => {
-    await finalize();
-  }, [finalize]);
+  const onProviderContinue = useCallback(() => runPhase(doFinalize), [
+    runPhase,
+    doFinalize,
+  ]);
 
   const goBack = () => setPos((p) => prevPosition(p));
 


### PR DESCRIPTION
## BET-393 — Route the post-pair onboarding phase through one `runPhase` helper

**Symptom:** a successful pair could stall indefinitely on step 1. `onPaired`'s two `await`s ran outside any `try`, set neither `verifying` nor `verifyError`, and was invoked fire-and-forget — so a rejection from `refreshAndInstallTransport` (a network call on a freshly-paired box) became an unhandled promise rejection and the flow sat still with no spinner, no error, no step change.

**Fix (scoped to `src/renderer/Onboarding.tsx` only):**
- Extract one `runPhase(fn)` helper that owns `verifying`/`verifyError` (set → try → catch into `verifyError` → clear in `finally`).
- Split the old `finalize` into `runPhase` + a bare `doFinalize` body (no state management), so `onPaired` can call `doFinalize` inline without nesting two `runPhase` calls (which would clear `verifying` early).
- Route all three entry points through `runPhase`: `onPaired`, `doFinalize` (via `onProviderContinue`), and `onPaired`'s inner connected-branch.

**Acceptance check:**
```
$ grep -n 'setVerifying(\|setVerifyError(' src/renderer/Onboarding.tsx
172:    setVerifying(true);
173:    setVerifyError(null);
177:      setVerifyError(e instanceof Error ? e.message : String(e));
179:      setVerifying(false);
```
All four setter calls are inside `runPhase`. `onPaired` can no longer reject.

**Conflict avoidance:** no edits to `SshInstallStep.tsx` / `PairStep.tsx` — the fix lives at the definition, not at each call site. Parallel issues BET-383/384/390 touch `SshInstallStep.tsx` only; no textual overlap.

**Out of scope (per issue):** retry/backoff (BET-390), changes to `onboardingVerify.ts` / `refreshAndInstallTransport` / `finalizeOnboarding`, spinner restyle, copy changes. The existing "Verifying your box…" spinner text is reused unchanged.

---

**Files changed:** 1 file. `src/renderer/Onboarding.tsx` (+49 / -37)

**Verification results:**
- PR branch (`multica/BET-393-onboarding-phase-runner` @ `c7e9dad`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1119 pass / 0 fail / 0 skip. log sha256: `cb852a4d8c51df07ba6c6c5bc952cd6dd607b3c7240cde1740c7933736839bb5`
- Base (`main` @ `eb9e827`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1119 pass / 0 fail / 0 skip. log sha256: `768a35f49136c8f4398a17034785f5bcd6de69b3b106b0db1cf40d853fd48660`
- **Conclusion:** 0 new failures, 0 resolved, 0 pre-existing failures — suites are identical (typecheck logs hash-equal).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ eb9e827
