### PR TITLE
BET-390: surface real claim outcome, drop fake Paired banner

### DIFF
--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -42,6 +42,7 @@ import {
   sshTargetLabel,
   type HostFieldSelection,
 } from "../shared/sshTarget";
+import type { ClaimOutcome } from "../shared/claim.mjs";
 
 const ACCENT = "#5A88FF";
 const DANGER = "#FF7A88";
@@ -57,6 +58,16 @@ const LOG_LINES_MAX = 500;
 // cycle 1 nit).
 const JUST_REFRESHED_DECAY_MS = 60_000;
 
+// BET-390 amendment: the install's final act starts/restarts the box service,
+// and the auto-claim fires the instant the install process exits — so the
+// first mint can race a service that isn't listening on loopback yet. A
+// single retry after this wait fixes the observed non-deterministic failure;
+// the retry is bounded to one extra attempt and the final failure still
+// surfaces the real message. Only transient kinds (network / server_error)
+// are retried — a wrong_code or invalid_response won't be fixed by trying
+// again.
+const CLAIM_RETRY_DELAY_MS = 3_000;
+
 const INITIAL_STAGE: InstallStageId = "preflight";
 const INITIAL_STAGE_INFO = currentStageInfo(INITIAL_STAGE);
 
@@ -64,6 +75,17 @@ function formatElapsed(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// BET-390: only failure kinds that can be caused by the box service not being
+// ready yet are worth a retry. A wrong/expired code or a malformed response
+// won't change on a second attempt.
+function isTransientClaimFailure(outcome: ClaimOutcome): boolean {
+  return !outcome.ok && (outcome.kind === "network" || outcome.kind === "server_error");
 }
 
 export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
@@ -384,15 +406,30 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     setClaimRunning(true);
     setClaimError(null);
     try {
-      const outcome = (await preload.installerMintAndClaim({
+      const outcome = await preload.installerMintAndClaim({
         alias: resolved.target,
-      })) as { ok: boolean };
+      });
       if (outcome.ok) {
         // Mirror the manual PairStep onPaired — advances onboarding to
         // step 2 exactly as a typed pairing code would.
         onPaired();
+        return;
+      }
+      // BET-390 amendment: a transient failure (the box service not yet
+      // listening) is retried once after a short wait. claimRunning stays
+      // true across the wait so the banner keeps reading "Pairing…".
+      if (isTransientClaimFailure(outcome)) {
+        await sleep(CLAIM_RETRY_DELAY_MS);
+        const retry = await preload.installerMintAndClaim({
+          alias: resolved.target,
+        });
+        if (retry.ok) {
+          onPaired();
+          return;
+        }
+        setClaimError(`Pairing failed: ${retry.message}`);
       } else {
-        setClaimError("Pairing failed — check the install log.");
+        setClaimError(`Pairing failed: ${outcome.message}`);
       }
     } catch (e) {
       setClaimError(e instanceof Error ? e.message : String(e));
@@ -713,9 +750,9 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       )}
 
       {/* Done / error / claim */}
-      {done && done.ok && (
+      {done && done.ok && !claimError && (
         <section className="text-sm" style={{ color: OK_GREEN }}>
-          Install finished successfully. {claimRunning ? "Pairing…" : "Paired."}
+          Install finished successfully. {claimRunning ? "Pairing…" : ""}
         </section>
       )}
       {done && !done.ok && (
@@ -749,8 +786,12 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         </section>
       )}
       {claimError && (
-        <section className="text-sm" style={{ color: DANGER }}>
-          {claimError}
+        <section className="text-sm space-y-1" style={{ color: DANGER }}>
+          <div>{claimError}</div>
+          <div>
+            Pair manually: run `manta pair` on the box and enter the 6-digit
+            code above.
+          </div>
         </section>
       )}
     </div>

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -57,7 +57,11 @@ function makeFakePreload(): MantaPreload {
     installerListHosts: vi.fn(async () => []),
     installerStart: vi.fn(async () => ({ handleId: "fake-handle" })),
     installerCancel: vi.fn(async () => {}),
-    installerMintAndClaim: vi.fn(async () => ({ ok: false })),
+    installerMintAndClaim: vi.fn(async () => ({
+      ok: false as const,
+      kind: "network" as const,
+      message: "manta pair exited 1 on the box",
+    })),
     installerState: vi.fn(async () => ({
       active: false,
       stage: "preflight" as const,

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -10,6 +10,7 @@ import type { SshHostEntry } from "../main/installer/sshConfig.js";
 import type { InstallerStageSnapshotRow } from "../shared/types.js";
 import type { UnpairOutcome } from "../shared/unpair.mjs";
 import type { SshTarget } from "../shared/sshTarget.js";
+import type { ClaimOutcome } from "../shared/claim.mjs";
 
 // Re-export so the renderer can use the type names from the same accessor
 // module that exposes the preload methods — same pattern as the existing
@@ -146,7 +147,7 @@ export interface MantaPreload {
   installerMintAndClaim(input: {
     alias: SshTarget;
     claimUrlOverride?: string;
-  }): Promise<unknown>;
+  }): Promise<ClaimOutcome>;
 
   // Returns the current install's { active, stage, logTail } — the renderer
   // calls this on mount to recover the install state after a page refresh


### PR DESCRIPTION
## BET-390 — Onboarding claims "Paired." when pairing failed

Fixes the two-banner contradiction on a failed auto-claim, and surfaces the
real failure reason instead of a discarded literal.

### Changes (`src/renderer/` only — main process untouched)

**Defect 1 — fake "Paired." literal removed.** The green banner now guards on
`!claimError`, so it can never render alongside the red claim-error banner.
The `Paired.` literal is gone (success calls `onPaired()` and unmounts, so a
success state was unreachable by construction).

**Defect 2 — real `ClaimOutcome.message` surfaced.** The `as { ok: boolean }`
cast is deleted; `installerMintAndClaim` is now typed `Promise<ClaimOutcome>`
in `preloadAccess.ts` (tightened from `Promise<unknown>` — the preload bridge
already returns `ClaimOutcome`, the accessor just declared it loose). The red
banner now reads `Pairing failed: <outcome.message>`.

**Recovery sentence.** The `claimError` block adds the plain-text manual-pairing
hint below the message (no button / IPC / copy handler added).

**Bounded retry (amendment).** A single retry after a 3s wait, only for
transient kinds (`network` / `server_error`) — fits the leading hypothesis
(the box service not yet listening when the auto-claim fires). `claimRunning`
stays true across the wait so the banner keeps reading "Pairing…"; the final
failure still surfaces the real message. No infinite retry, no silent swallow.

### Files changed
- `src/renderer/SshInstallStep.tsx` — banner guard, real message, retry, recovery sentence
- `src/renderer/preloadAccess.ts` — tighten `installerMintAndClaim` return type to `ClaimOutcome`
- `src/renderer/preloadAccess.test.ts` — mock returns a valid `ClaimOutcome` failure

### Verification results

**Files changed:** 3 files. `src/renderer/SshInstallStep.tsx`, `src/renderer/preloadAccess.ts`, `src/renderer/preloadAccess.test.ts`

- PR branch (`multica/BET-390-paired-banner-fix` @ `d69aebf`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1121 pass / 0 fail / 0 skip. log sha256: `bad015ccd791c549ce2df62ffa0a83215915b4d75eb37fe725119bd71bf06917`
- Base (`main` @ `10f67e5`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1121 pass / 0 fail / 0 skip. log sha256: `b8f4d626d42670437dd52ddad66b20ffa4ff1e88951b386241ae450bc035b609`
- **Conclusion:** 0 new failures, 0 resolved. Both branches identical (1121/1121). Typecheck logs identical (same hash).

Base: origin/main @ 10f67e5

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
