### PR TITLE
BET-394: fix recovery sentence direction (above -> below)

### DIFF
--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -790,7 +790,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           <div>{claimError}</div>
           <div>
             Pair manually: run `manta pair` on the box and enter the 6-digit
-            code above.
+            code in the "Pair to an existing box" form below.
           </div>
         </section>
       )}


### PR DESCRIPTION
BET-394 — BET-390 follow-up: fix recovery sentence direction ("above" → below)

## What

The manual-pairing recovery sentence in the `claimError` block of `src/renderer/SshInstallStep.tsx` told users to "enter the 6-digit code **above**", but the manual pairing form actually sits **below** the SSH install step, behind the "Pair to an existing box" disclosure. A user following the instruction looks up when the form is down.

## Change

One-line copy fix, plain text, no UI/logic changes:

```
- Pair manually: run `manta pair` on the box and enter the 6-digit code above.
+ Pair manually: run `manta pair` on the box and enter the 6-digit code in the "Pair to an existing box" form below.
```

## Scope

- Only the recovery sentence string in the `claimError` block.
- No banner/claim/retry logic, no restructuring or restyle.

## Verification

- `npm run typecheck`: green (exit 0).
- `npm test`: 1121 pass / 0 fail / 0 skip.
- Diff: `1 file changed, 1 insertion(+), 1 deletion(-)`.

Base: origin/main @ a871a15

## Self-check

- Recovery sentence no longer says "above": 10/10 — replaced with explicit "in the 'Pair to an existing box' form below".
- Points to the actual layout: 10/10 — names the disclosure the form lives behind.
- No other changes (banner/claim/retry/restyle): 10/10 — single-string edit.
- typecheck && test green: 10/10 — both pass.
- Every actionable follow-up filed: N/A — none surfaced; this is a verbatim one-line copy fix.
