### PR TITLE
feat(installer): unknown-host fingerprint prompt (BET-361)

### DIFF
--- a/src/main/installer/diagnostics.test.ts
+++ b/src/main/installer/diagnostics.test.ts
@@ -11,6 +11,7 @@ import {
 function makeProbes(overrides: Partial<PreflightProbes> = {}): PreflightProbes {
   return {
     reachability: "ok",
+    hostFingerprint: null,
     os: { id: "linux", arch: "x64", release: "6.5.0" },
     passwordlessSudo: true,
     tailscale: { running: false, ipv4: null },

--- a/src/main/installer/fingerprint.test.ts
+++ b/src/main/installer/fingerprint.test.ts
@@ -1,0 +1,107 @@
+// fingerprint.test.ts — parseFingerprint / isHostKeyVerificationFailure.
+// Pure: feeds the canonical OpenSSH stderr snippets and asserts on the
+// structured result. No ssh, no I/O.
+
+import { describe, it, expect } from "vitest";
+import {
+  parseFingerprint,
+  isHostKeyVerificationFailure,
+} from "./fingerprint.js";
+
+describe("parseFingerprint", () => {
+  it("parses the modern OpenSSH stderr line (ED25519 key fingerprint is SHA256:…)", () => {
+    const stderr = [
+      "The authenticity of host 'box.example.com (203.0.113.5)' can't be established.",
+      "ED25519 key fingerprint is SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=.",
+      "Host key verification failed.",
+    ].join("\n");
+    const r = parseFingerprint(stderr);
+    expect(r.found).toBe(true);
+    if (!r.found) return;
+    expect(r.fingerprint.algo).toBe("ED25519");
+    expect(r.fingerprint.sha256).toBe("SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=");
+  });
+
+  it("parses the RSA variant", () => {
+    const stderr =
+      "RSA key fingerprint is SHA256:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=.";
+    const r = parseFingerprint(stderr);
+    expect(r.found).toBe(true);
+    if (!r.found) return;
+    expect(r.fingerprint.algo).toBe("RSA");
+    expect(r.fingerprint.sha256).toBe("SHA256:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=");
+  });
+
+  it("parses the ECDSA variant", () => {
+    const r = parseFingerprint(
+      "ECDSA key fingerprint is SHA256:EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE=.",
+    );
+    expect(r.found).toBe(true);
+    if (!r.found) return;
+    expect(r.fingerprint.algo).toBe("ECDSA");
+  });
+
+  it("parses the BET-361-issue variant 'ED25519 fingerprint: SHA256:…'", () => {
+    const r = parseFingerprint("ED25519 fingerprint: SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=");
+    expect(r.found).toBe(true);
+    if (!r.found) return;
+    expect(r.fingerprint.algo).toBe("ED25519");
+    expect(r.fingerprint.sha256).toBe("SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=");
+  });
+
+  it("normalizes the algorithm to upper-case", () => {
+    const r = parseFingerprint("ed25519 key fingerprint is SHA256:AAAA=");
+    expect(r.found).toBe(true);
+    if (!r.found) return;
+    expect(r.fingerprint.algo).toBe("ED25519");
+  });
+
+  it("returns found:false for an auth-failed stderr (Permission denied)", () => {
+    const stderr = "Permission denied (publickey).";
+    expect(parseFingerprint(stderr).found).toBe(false);
+  });
+
+  it("returns found:false for an unreachable stderr (Connection refused)", () => {
+    const stderr = "ssh: connect to host 203.0.113.5 port 22: Connection refused";
+    expect(parseFingerprint(stderr).found).toBe(false);
+  });
+
+  it("returns found:false for empty / non-string input", () => {
+    expect(parseFingerprint("").found).toBe(false);
+    expect(parseFingerprint("just some log output\nwith no fingerprint").found).toBe(false);
+  });
+
+  it("returns found:false when a SHA256 token appears without an algorithm name", () => {
+    // A stray base64-ish blob that isn't a host-key line.
+    expect(parseFingerprint("digest SHA256:abcd== for payload").found).toBe(false);
+  });
+
+  it("handles CRLF line endings", () => {
+    const stderr =
+      "ED25519 key fingerprint is SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=.\r\nHost key verification failed.\r\n";
+    const r = parseFingerprint(stderr);
+    expect(r.found).toBe(true);
+    if (!r.found) return;
+    expect(r.fingerprint.algo).toBe("ED25519");
+  });
+});
+
+describe("isHostKeyVerificationFailure", () => {
+  it("recognizes 'Host key verification failed'", () => {
+    expect(isHostKeyVerificationFailure("Host key verification failed.")).toBe(true);
+  });
+
+  it("recognizes 'authenticity of host'", () => {
+    expect(
+      isHostKeyVerificationFailure(
+        "The authenticity of host 'box (1.2.3.4)' can't be established.",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for auth / network failures", () => {
+    expect(isHostKeyVerificationFailure("Permission denied (publickey).")).toBe(false);
+    expect(isHostKeyVerificationFailure("Connection refused")).toBe(false);
+    expect(isHostKeyVerificationFailure("")).toBe(false);
+  });
+});

--- a/src/main/installer/fingerprint.ts
+++ b/src/main/installer/fingerprint.ts
@@ -1,0 +1,92 @@
+// fingerprint.ts — pure parser for the OpenSSH "unknown host" stderr block.
+//
+// WHY THIS EXISTS (BET-361): runner.ts runs every ssh invocation with
+// `BatchMode=yes`, which suppresses the interactive
+// "Are you sure you want to continue connecting (yes/no)?" prompt. On a
+// never-seen host ssh therefore prints the host-key fingerprint to stderr
+// and then FAILS (exit 255, "Host key verification failed.") instead of
+// waiting for input. The preflight reachability probe used to classify
+// that as a generic `unreachable` (or `auth-failed`), so the user was told
+// to "check the alias resolves" when what they actually wanted was to
+// trust the host.
+//
+// This module turns that stderr block into a structured fingerprint the
+// renderer can show next to a one-tap "Trust this host" button. Pure: it
+// takes a string and returns a typed result — no I/O, no ssh. Tested in
+// fingerprint.test.ts with the canonical OpenSSH snippets.
+//
+// NOTE on the fingerprint vs. the host key: the SHA256 fingerprint is a
+// HASH of the host's public key — it is NOT the key itself, so it cannot
+// be written straight into ~/.ssh/known_hosts. knownHosts.ts fetches the
+// real key with `ssh-keyscan` and verifies its fingerprint matches the one
+// this parser extracted (and the user therefore trusted) before persisting
+// the line. That closes the MITM gap: the key we add is provably the one
+// whose fingerprint the user saw.
+
+/** A parsed host-key fingerprint. `sha256` keeps the `SHA256:` prefix so it
+ *  matches the wire format ssh prints (and what knownHosts.ts compares). */
+export type HostFingerprint = {
+  /** Normalized upper-case: "ED25519" | "ECDSA" | "RSA" | "DSA". */
+  algo: string;
+  /** The full `SHA256:<base64>` token exactly as ssh printed it. */
+  sha256: string;
+};
+
+export type FingerprintParseResult =
+  | { found: true; fingerprint: HostFingerprint }
+  | { found: false };
+
+// The four host-key algorithm families OpenSSH names in the prompt. Order
+// is by frequency for the common case (ed25519 first).
+const ALGO_RE = /\b(ED25519|ECDSA|RSA|DSA)\b/i;
+// A SHA256 fingerprint token: `SHA256:` followed by standard base64 (may
+// include `+`, `/`, `=` padding). We do not anchor the end so a trailing
+// period (ssh prints `SHA256:….`) is tolerated.
+const SHA256_RE = /SHA256:[A-Za-z0-9+/=]+/i;
+
+/**
+ * Scan an ssh stderr string for the host-key fingerprint line.
+ *
+ * Matches every shape OpenSSH has shipped:
+ *   - `ED25519 key fingerprint is SHA256:base64.`        (modern default)
+ *   - `ED25519 fingerprint: SHA256:base64`               (variant in BET-361)
+ *   - `256 SHA256:base64 host (ED25519)`                 (ssh-keygen -l style)
+ *
+ * Returns `{ found: true, fingerprint }` for the first line that carries
+ * both an algorithm name and a `SHA256:` token, `{ found: false }` for
+ * unrelated stderr (Permission denied, Connection refused, etc.). The
+ * algorithm is normalized to upper-case; `sha256` preserves the
+ * `SHA256:` prefix verbatim.
+ */
+export function parseFingerprint(stderr: string): FingerprintParseResult {
+  if (typeof stderr !== "string" || stderr === "") return { found: false };
+  for (const rawLine of stderr.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "") continue;
+    const shaMatch = SHA256_RE.exec(line);
+    if (!shaMatch) continue;
+    const algoMatch = ALGO_RE.exec(line);
+    if (!algoMatch) continue;
+    return {
+      found: true,
+      fingerprint: {
+        algo: algoMatch[1].toUpperCase(),
+        sha256: shaMatch[0],
+      },
+    };
+  }
+  return { found: false };
+}
+
+/**
+ * True when stderr indicates ssh refused the connection over a HOST KEY
+ * (not auth, not network) — i.e. the "authenticity can't be established"
+ * / "Host key verification failed" block. Used as a fallback for ssh builds
+ * that fail without a parseable fingerprint line: those still belong to the
+ * unknown-host family rather than `auth-failed` or `unreachable`.
+ */
+export function isHostKeyVerificationFailure(stderr: string): boolean {
+  if (typeof stderr !== "string" || stderr === "") return false;
+  return /Host key verification failed/i.test(stderr)
+    || /authenticity of host/i.test(stderr);
+}

--- a/src/main/installer/handlers.test.ts
+++ b/src/main/installer/handlers.test.ts
@@ -80,6 +80,7 @@ const installerState = vi.hoisted(() => ({
     ingressMode: "public-tls" as const,
     probes: {
       reachability: "ok" as const,
+      hostFingerprint: null,
       os: { id: "linux" as const, arch: "x64" as const, release: "6.5.0" },
       passwordlessSudo: true,
       tailscale: { running: false, ipv4: null },
@@ -87,6 +88,7 @@ const installerState = vi.hoisted(() => ({
       alreadyInstalled: false,
     },
     failures: [],
+    unknownHost: null,
   })),
   runInstall: vi.fn(() => ({
     // Resolves immediately so the handler's fire-and-forget `.finally()`
@@ -96,6 +98,12 @@ const installerState = vi.hoisted(() => ({
     done: Promise.resolve({ code: 0, signal: null }),
     cancel: vi.fn(),
   })),
+}));
+
+// BET-361: trustHost writes the host key to known_hosts. Stubbed here so
+// the handler test never touches ssh-keyscan or the filesystem.
+const knownHostsState = vi.hoisted(() => ({
+  trustHost: vi.fn(async () => ({ ok: true as const, line: "box ssh-ed25519 AAAA" })),
 }));
 
 /** Flush the microtask queue so handlers.ts's fire-and-forget
@@ -111,6 +119,10 @@ vi.mock("./installer.js", () => ({
   preflightBox: installerState.preflightBox,
   runInstall: installerState.runInstall,
   DEFAULT_SSH_CONFIG_PATH: "/dev/null",
+}));
+
+vi.mock("./knownHosts.js", () => ({
+  trustHost: knownHostsState.trustHost,
 }));
 
 // Also stub the small support module the handlers pull in but never call
@@ -129,6 +141,7 @@ beforeEach(() => {
   mintState.mintAndClaim.mockClear();
   installerState.preflightBox.mockClear();
   installerState.runInstall.mockClear();
+  knownHostsState.trustHost.mockClear();
 });
 
 describe("registerInstallerHandlers — mint-and-claim (BET-372)", () => {
@@ -185,6 +198,7 @@ describe("registerInstallerHandlers — mint-and-claim (BET-372)", () => {
         IPC.installerState,
         IPC.installerStart,
         IPC.installerCancel,
+        IPC.installerTrustHost,
         IPC.installerMintAndClaim,
         IPC.installerGetDiagnostics,
       ]),
@@ -204,6 +218,7 @@ function failedPreflightFixture(cause: string): PreflightResult {
     ingressMode: "no-root",
     probes: {
       reachability: "unreachable",
+      hostFingerprint: null,
       os: { id: "unknown", arch: "unknown", release: null },
       passwordlessSudo: false,
       tailscale: { running: false, ipv4: null },
@@ -211,6 +226,7 @@ function failedPreflightFixture(cause: string): PreflightResult {
       alreadyInstalled: false,
     },
     failures: [{ cause, action: "Check the alias resolves." }],
+    unknownHost: null,
   };
 }
 
@@ -257,6 +273,187 @@ describe("registerInstallerHandlers — installerStart preflight fold (BET-383)"
     };
     expect(state.preflight?.ok).toBe(false);
     expect(state.preflight?.failures[0].cause).toMatch(/Could not connect/);
+  });
+});
+
+// BET-361: a never-seen host pauses the install for a trust decision.
+// The handler must (a) emit a `fingerprint` event, (b) hold the slot while
+// waiting, (c) resume into runInstall after a Trust answer + successful
+// trustHost, and (d) abort with preflight-failed on a decline.
+describe("registerInstallerHandlers — fingerprint pause/resume (BET-361)", () => {
+  function unknownHostPreflight(): PreflightResult {
+    return {
+      ok: false,
+      ingressMode: "no-root",
+      probes: {
+        reachability: "unknown-host",
+        hostFingerprint: {
+          algo: "ED25519",
+          sha256: "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=",
+        },
+        os: { id: "unknown", arch: "unknown", release: null },
+        passwordlessSudo: false,
+        tailscale: { running: false, ipv4: null },
+        clockSkewSeconds: 0,
+        alreadyInstalled: false,
+      },
+      failures: [
+        {
+          cause: "This host's identity is not yet trusted.",
+          action: "Review the host key fingerprint and choose Trust to continue, or pick a different host.",
+        },
+      ],
+      unknownHost: {
+        algo: "ED25519",
+        sha256: "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=",
+      },
+    };
+  }
+
+  it("emits a fingerprint event, then resumes into runInstall after Trust", async () => {
+    installerState.preflightBox
+      .mockResolvedValueOnce(unknownHostPreflight())
+      .mockResolvedValueOnce({
+        // Second preflight (after trust) — the host key is now known.
+        ok: true,
+        ingressMode: "public-tls",
+        probes: {
+          reachability: "ok",
+          hostFingerprint: null,
+          os: { id: "linux", arch: "x64", release: "6.5.0" },
+          passwordlessSudo: true,
+          tailscale: { running: false, ipv4: null },
+          clockSkewSeconds: 0,
+          alreadyInstalled: false,
+        },
+        failures: [],
+        unknownHost: null,
+      });
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const trustHandler = ipcState.handlers.get(IPC.installerTrustHost);
+    const stateHandler = ipcState.handlers.get(IPC.installerState);
+
+    // installerStart does not resolve until the trust loop finishes — drive
+    // it without awaiting so we can answer the prompt mid-flight.
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+
+    // Let the preflight + fingerprint event land.
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // While paused, installerState reports the trust wait.
+    const paused = (await stateHandler!(null, undefined)) as {
+      waitingForTrust: boolean;
+      trustHandleId: string | null;
+      pendingFingerprint: { algo: string; sha256: string } | null;
+    };
+    expect(paused.waitingForTrust).toBe(true);
+    expect(paused.trustHandleId).toMatch(/^install-/);
+    expect(paused.pendingFingerprint?.algo).toBe("ED25519");
+
+    // A fingerprint event was pushed to the renderer.
+    const fpEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "fingerprint",
+    ) as [string, { kind: string; handleId: string; fingerprint: { algo: string } }];
+    expect(fpEvent).toBeDefined();
+    expect(fpEvent[1].fingerprint.algo).toBe("ED25519");
+    const handleId = fpEvent[1].handleId;
+
+    // runInstall has NOT started yet — the install is paused.
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+
+    // User clicks Trust.
+    await trustHandler!(null, { handleId, trust: true });
+    await startP;
+
+    // trustHost wrote the host key, preflight re-ran, and the install started.
+    expect(knownHostsState.trustHost).toHaveBeenCalledTimes(1);
+    expect(installerState.preflightBox).toHaveBeenCalledTimes(2);
+    expect(installerState.runInstall).toHaveBeenCalledTimes(1);
+
+    // The trust wait is cleared.
+    const after = (await stateHandler!(null, undefined)) as { waitingForTrust: boolean };
+    expect(after.waitingForTrust).toBe(false);
+
+    await flushMicrotasks();
+  });
+
+  it("aborts with preflight-failed on a decline (Trust=false), never starts the install", async () => {
+    installerState.preflightBox.mockResolvedValueOnce(unknownHostPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const trustHandler = ipcState.handlers.get(IPC.installerTrustHost);
+
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const fpEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "fingerprint",
+    ) as [string, { handleId: string }];
+    await trustHandler!(null, { handleId: fpEvent[1].handleId, trust: false });
+    await startP;
+
+    expect(knownHostsState.trustHost).not.toHaveBeenCalled();
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+    const failed = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "preflight-failed",
+    ) as [string, { kind: string; failures: { cause: string }[] }];
+    expect(failed).toBeDefined();
+    expect(failed[1].failures[0].cause).toMatch(/not yet trusted/);
+  });
+
+  it("refuses a second install while a trust prompt is paused", async () => {
+    installerState.preflightBox.mockResolvedValueOnce(unknownHostPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const trustHandler = ipcState.handlers.get(IPC.installerTrustHost);
+
+    // Start the first install and let it pause.
+    void startHandler!(null, { alias: "dev" });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // A second start while paused must throw (single-active slot held).
+    await expect(
+      startHandler!(null, { alias: "dev2" }),
+    ).rejects.toThrow(/already in progress/);
+
+    // Clean up: answer the paused prompt so the slot is released.
+    const fpEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "fingerprint",
+    ) as [string, { handleId: string }];
+    await trustHandler!(null, { handleId: fpEvent[1].handleId, trust: false });
+    await flushMicrotasks();
+  });
+
+  it("installerCancel during the trust pause aborts the wait", async () => {
+    installerState.preflightBox.mockResolvedValueOnce(unknownHostPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const cancelHandler = ipcState.handlers.get(IPC.installerCancel);
+
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+    const fpEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "fingerprint",
+    ) as [string, { handleId: string }];
+
+    await cancelHandler!(null, { handleId: fpEvent[1].handleId });
+    await startP;
+
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+    expect(knownHostsState.trustHost).not.toHaveBeenCalled();
+    const failed = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "preflight-failed",
+    );
+    expect(failed).toBeDefined();
   });
 });
 

--- a/src/main/installer/handlers.ts
+++ b/src/main/installer/handlers.ts
@@ -24,8 +24,10 @@ import {
   DEFAULT_SSH_CONFIG_PATH,
 } from "./installer.js";
 import { buildDiagnostics, type DiagnosticsInput } from "./diagnostics.js";
+import { trustHost } from "./knownHosts.js";
 import type { InstallStageId } from "./stageMapper.js";
 import type { PreflightResult } from "./preflight.js";
+import type { HostFingerprint } from "./fingerprint.js";
 import { isEmptySshTarget, type SshTarget } from "../../shared/sshTarget.js";
 
 // ---------------------------------------------------------------------------
@@ -40,9 +42,60 @@ let nextHandleSeq = 0;
 // Most recent preflight verdict, read back by IPC.installerState.
 let activePreflight: PreflightResult | null = null;
 
+// BET-361: when preflight hits a never-seen host, the install PAUSES here
+// waiting for the renderer's "Trust this host" answer. The deferred is
+// resolved by the installerTrustHost handler (trust=true/false) or rejected
+// by installerCancel / a timeout. `waitingForTrust` is mirrored into
+// installerState so a renderer remount re-shows the prompt.
+let waitingForTrust: {
+  handleId: string;
+  fingerprint: HostFingerprint;
+  target: SshTarget;
+} | null = null;
+let trustDeferred: {
+  resolve: (decision: { trust: boolean }) => void;
+  reject: (err: Error) => void;
+} | null = null;
+// How long the install waits for a trust answer before giving up. Long
+// enough that a user reading the fingerprint isn't rushed; short enough
+// that a forgotten tab doesn't hold the single-active slot forever.
+const TRUST_WAIT_TIMEOUT_MS = 5 * 60_000;
+
 function pushTail(line: string): void {
   logTail.push(line);
   if (logTail.length > LOG_TAIL_MAX) logTail.splice(0, logTail.length - LOG_TAIL_MAX);
+}
+
+// awaitTrustDecision — pause the install while the renderer shows the host
+// fingerprint and a Trust button. Resolves with the user's answer
+// ({ trust: true|false }); a cancel or a timeout both resolve to
+// { trust: false } so the caller has a single, rejection-free path. The
+// module-level `waitingForTrust` is set for the duration so installerState
+// can recover the prompt after a renderer remount, and cleared on settle.
+async function awaitTrustDecision(
+  handleId: string,
+  fingerprint: HostFingerprint,
+  target: SshTarget,
+  send: (payload: unknown) => void,
+): Promise<{ trust: boolean }> {
+  waitingForTrust = { handleId, fingerprint, target };
+  send({ kind: "fingerprint", handleId, fingerprint });
+  return new Promise<{ trust: boolean }>((resolve) => {
+    let settled = false;
+    const finish = (decision: { trust: boolean }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      waitingForTrust = null;
+      trustDeferred = null;
+      resolve(decision);
+    };
+    const timer = setTimeout(() => finish({ trust: false }), TRUST_WAIT_TIMEOUT_MS);
+    trustDeferred = {
+      resolve: (d) => finish(d),
+      reject: () => finish({ trust: false }),
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -67,12 +120,18 @@ export function registerInstallerHandlers(
     stage: activeStage,
     logTail: [...logTail],
     preflight: activePreflight,
+    // BET-361: mirror the trust-pause so a renderer remount re-shows the
+    // fingerprint prompt and routes its answer to the right handle.
+    waitingForTrust: waitingForTrust !== null,
+    trustHandleId: waitingForTrust?.handleId ?? null,
+    pendingFingerprint: waitingForTrust?.fingerprint ?? null,
   }));
 
   ipcMain.handle(IPC.installerStart, async (_e, input: { alias: SshTarget }) => {
-    if (activeHandle !== null) {
-      // Single-active constraint — refuse to start a second install.
-      // The renderer should call installCancel first (or wait for done).
+    if (activeHandle !== null || waitingForTrust !== null) {
+      // Single-active constraint — refuse to start a second install. The
+      // trust-pause counts as "in progress": a paused install holds the
+      // slot until the user answers (BET-361).
       throw new Error("an install is already in progress");
     }
     if (input?.alias === undefined || isEmptySshTarget(input.alias)) {
@@ -92,11 +151,50 @@ export function registerInstallerHandlers(
       win.webContents.send(IPC.installerEvent, payload);
     };
 
-    // Phase 1 — preflight, run here in main. A failure aborts before
-    // anything is written to the box: activeHandle stays unset, runInstall
-    // is never called, nothing is spawned.
-    const preflight = await preflightBox(alias);
+    // Phase 1 — preflight, run here in main. On a never-seen host ssh
+    // offers a fingerprint and bails (BatchMode=yes); preflight surfaces
+    // that as `unknownHost`. We PAUSE for a trust decision, write the host
+    // key to ~/.ssh/known_hosts, then re-run preflight exactly once. A
+    // second failure after trust (different problem, or a key that
+    // changed) is reported as a normal preflight-failed — no retry loop.
+    let preflight = await preflightBox(alias);
     activePreflight = preflight;
+    if (!preflight.ok && preflight.unknownHost) {
+      const decision = await awaitTrustDecision(
+        handleId,
+        preflight.unknownHost,
+        alias,
+        send,
+      );
+      if (!decision.trust) {
+        // User declined, cancelled, or the trust wait timed out. Nothing
+        // was written to the box — the standard preflight-failed guidance
+        // (which already says "pick a different host") is the right call.
+        send({ kind: "preflight-failed", handleId, failures: preflight.failures });
+        return { handleId };
+      }
+      const trusted = await trustHost({
+        target: alias,
+        fingerprint: preflight.unknownHost,
+      });
+      if (!trusted.ok) {
+        send({
+          kind: "preflight-failed",
+          handleId,
+          failures: [
+            {
+              cause: "Could not trust this host.",
+              action: trusted.message,
+            },
+          ],
+        });
+        return { handleId };
+      }
+      // Host key is now in known_hosts — re-run preflight over the now-
+      // trusted connection.
+      preflight = await preflightBox(alias);
+      activePreflight = preflight;
+    }
     if (!preflight.ok) {
       send({ kind: "preflight-failed", handleId, failures: preflight.failures });
       return { handleId };
@@ -150,11 +248,27 @@ export function registerInstallerHandlers(
 
   ipcMain.handle(IPC.installerCancel, (_e, input: { handleId: string }) => {
     if (typeof input?.handleId !== "string" || input.handleId === "") return;
+    // BET-361: cancel during the trust-pause aborts the wait (treated as
+    // "not trusted" — the install never started, so there's no child to
+    // SIGTERM).
+    if (waitingForTrust?.handleId === input.handleId && trustDeferred) {
+      trustDeferred.reject(new Error("cancelled"));
+      return;
+    }
     if (activeHandle?.handleId === input.handleId) {
       activeHandle.cancel();
     }
     // If handleId doesn't match the active handle (already done / cancelled
     // / a stale renderer): no-op. cancel is idempotent by design.
+  });
+
+  ipcMain.handle(IPC.installerTrustHost, (_e, input: { handleId: string; trust: boolean }) => {
+    if (typeof input?.handleId !== "string" || input.handleId === "") return;
+    // No paused trust prompt, or a stale renderer answering an old prompt:
+    // no-op. The active install (if any) is unaffected.
+    if (!waitingForTrust || !trustDeferred) return;
+    if (waitingForTrust.handleId !== input.handleId) return;
+    trustDeferred.resolve({ trust: input.trust });
   });
 
   ipcMain.handle(IPC.installerMintAndClaim, async (

--- a/src/main/installer/installer.test.ts
+++ b/src/main/installer/installer.test.ts
@@ -106,6 +106,33 @@ describe("preflightBox", () => {
     expect(r.failures[0].action).toMatch(/ssh-add|authorized_keys/);
   });
 
+  it("classifies a never-seen host as unknown-host and surfaces the fingerprint (BET-361)", async () => {
+    const responses = happyLinuxProbes({
+      [PROBE_KEYS.REACHABILITY]: {
+        code: 255,
+        stderr: [
+          "The authenticity of host 'box (203.0.113.5)' can't be established.",
+          "ED25519 key fingerprint is SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=.",
+          "Host key verification failed.",
+        ].join("\n"),
+      },
+    });
+    const r = await preflightBox("dev", { spawn: makeProbeSpawn(responses) });
+    expect(r.ok).toBe(false);
+    expect(r.probes.reachability).toBe("unknown-host");
+    expect(r.probes.hostFingerprint).toEqual({
+      algo: "ED25519",
+      sha256: "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=",
+    });
+    expect(r.unknownHost).toEqual({
+      algo: "ED25519",
+      sha256: "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=",
+    });
+    // Short-circuited — no OS/unsupported noise on top of the trust prompt.
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0].cause).toMatch(/not yet trusted/);
+  });
+
   it("classifies tailscale-running → ingressMode=tailscale (wins over macOS)", async () => {
     const responses = happyLinuxProbes({
       [PROBE_KEYS.OS]: { code: 0, stdout: "Darwin\narm64\n23.0.0\n" },

--- a/src/main/installer/installer.ts
+++ b/src/main/installer/installer.ts
@@ -42,7 +42,9 @@ import {
   classifyPreflight,
   type PreflightProbes,
   type PreflightResult,
+  type Reachability,
 } from "./preflight.js";
+import { parseFingerprint, isHostKeyVerificationFailure, type HostFingerprint } from "./fingerprint.js";
 import {
   foldChunk,
   buildStageSnapshot,
@@ -165,7 +167,8 @@ export async function preflightBox(
     probeAuthFile(alias, spawn),
   ]);
   const probes: PreflightProbes = {
-    reachability: reach,
+    reachability: reach.reachability,
+    hostFingerprint: reach.fingerprint,
     os: osRes,
     passwordlessSudo: sudoRes,
     tailscale: tsRes,
@@ -177,28 +180,54 @@ export async function preflightBox(
 
 // ---------- individual probes ----------
 
-async function probeReachability(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["reachability"]> {
+// probeReachability returns BOTH the reachability verdict and, when ssh
+// offered a host-key fingerprint on a never-seen host, that fingerprint.
+// The fingerprint is what installerStart hands to the renderer's "Trust
+// this host" prompt (BET-361); without it the trust UI has nothing to show.
+type ReachabilityProbe = {
+  reachability: Reachability;
+  fingerprint: HostFingerprint | null;
+};
+
+async function probeReachability(alias: SshTarget, spawn?: SpawnFn): Promise<ReachabilityProbe> {
   // BatchMode=yes turns "no auth" into exit code 255 / stderr "Permission
   // denied (publickey)" — not a hang on a passphrase prompt.
   const r = await execRemote(alias, PROBE_REACHABILITY_CMD, {
     spawn,
     timeoutMs: 15_000,
   });
-  if (r.code === 0 && r.stdout.trim() === "ok") return "ok";
+  if (r.code === 0 && r.stdout.trim() === "ok") {
+    return { reachability: "ok", fingerprint: null };
+  }
+  // Never-seen host: ssh prints the fingerprint then fails with "Host key
+  // verification failed." Detect the fingerprint and surface it so the
+  // installer can pause for a trust decision instead of mislabeling this
+  // as a generic unreachable / auth-failed (BET-361).
+  const fp = parseFingerprint(r.stderr);
+  if (fp.found) {
+    return { reachability: "unknown-host", fingerprint: fp.fingerprint };
+  }
   // The two well-known BatchMode=yes failure modes:
   //   exit 255 + "Permission denied (publickey)" → auth-failed
   //   exit 255 + "Connection refused" / "No route to host" / "Could not
   //   resolve hostname" → unreachable
   if (r.code === 255 || r.code === null) {
+    if (isHostKeyVerificationFailure(r.stderr)) {
+      // Host-key refusal without a parseable fingerprint (rare ssh build):
+      // still unknown-host, but with no fingerprint to show — the trust UI
+      // cannot verify a key against nothing, so treat as unreachable and
+      // let the standard failure guidance surface.
+      return { reachability: "unreachable", fingerprint: null };
+    }
     const stderr = r.stderr;
     if (/Permission denied/i.test(stderr) || /publickey/i.test(stderr)) {
-      return "auth-failed";
+      return { reachability: "auth-failed", fingerprint: null };
     }
-    return "unreachable";
+    return { reachability: "unreachable", fingerprint: null };
   }
   // Any other exit → unreachable (network glitch mid-probe, ssh missing on
   // the box, etc.)
-  return "unreachable";
+  return { reachability: "unreachable", fingerprint: null };
 }
 
 async function probeOs(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["os"]> {

--- a/src/main/installer/knownHosts.test.ts
+++ b/src/main/installer/knownHosts.test.ts
@@ -1,0 +1,280 @@
+// knownHosts.test.ts — parseKeyScanOutput / computeFingerprint /
+// fingerprintsMatch / formatKnownHostsLine / appendKnownHostsLine /
+// scanHostKeys / resolveKnownHostsKey / trustHost.
+//
+// No real ssh-keyscan, no real network: spawn is stubbed with the shared
+// makeFakeChild helper, and appendKnownHostsLine writes to a tmp path.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseKeyScanOutput,
+  computeFingerprint,
+  fingerprintsMatch,
+  formatKnownHostsLine,
+  appendKnownHostsLine,
+  scanHostKeys,
+  resolveKnownHostsKey,
+  trustHost,
+} from "./knownHosts.js";
+import { makeFakeChild } from "./_testFixtures.js";
+import type { SpawnFn } from "./runner.js";
+import type { HostFingerprint } from "./fingerprint.js";
+
+// A throwaway "host key" — any base64 blob works because computeFingerprint
+// just hashes the decoded bytes; the match logic is what's under test.
+const KEY_ED25519 = "AAAAC3NzaC1lZDI1NTE5AAAAIEhbgP+4g5Fw2vQj9aQk7mZp";
+const KEY_RSA = "AAAAB3NzaC1yc2EAAAADAQABAAABAQCx1234fakeRsaKey==";
+
+let tmpDir: string;
+let knownHostsPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "manta-knownhosts-"));
+  knownHostsPath = join(tmpDir, "known_hosts");
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("parseKeyScanOutput", () => {
+  it("parses ed25519 + rsa lines, dropping comments and the host field", () => {
+    const stdout = [
+      "# 203.0.113.5:22 SSH-2.0-OpenSSH_9.0",
+      "203.0.113.5 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhbgP+4g5Fw2vQj9aQk7mZp",
+      "203.0.113.5 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCx1234fakeRsaKey==",
+      "# comment line",
+      "",
+    ].join("\n");
+    const keys = parseKeyScanOutput(stdout);
+    expect(keys).toEqual([
+      { algo: "ssh-ed25519", keyBase64: "AAAAC3NzaC1lZDI1NTE5AAAAIEhbgP+4g5Fw2vQj9aQk7mZp" },
+      { algo: "ssh-rsa", keyBase64: "AAAAB3NzaC1yc2EAAAADAQABAAABAQCx1234fakeRsaKey==" },
+    ]);
+  });
+
+  it("drops lines whose algo token is not a key type", () => {
+    const stdout = "host some-junk AAAA==\nhost ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhbgP+4g5Fw2vQj9aQk7mZp";
+    expect(parseKeyScanOutput(stdout)).toEqual([
+      { algo: "ssh-ed25519", keyBase64: "AAAAC3NzaC1lZDI1NTE5AAAAIEhbgP+4g5Fw2vQj9aQk7mZp" },
+    ]);
+  });
+
+  it("returns [] for empty / non-string input", () => {
+    expect(parseKeyScanOutput("")).toEqual([]);
+  });
+});
+
+describe("computeFingerprint / fingerprintsMatch", () => {
+  it("produces a SHA256: token", () => {
+    expect(computeFingerprint(KEY_ED25519)).toMatch(/^SHA256:[A-Za-z0-9+/=]+$/);
+  });
+
+  it("matches regardless of trailing base64 padding", () => {
+    const fp = computeFingerprint(KEY_ED25519);
+    // Same fingerprint with padding stripped should still match.
+    const stripped = fp.replace(/=+$/g, "");
+    expect(fingerprintsMatch(fp, stripped)).toBe(true);
+    expect(fingerprintsMatch(stripped, fp)).toBe(true);
+  });
+
+  it("does not match a different key's fingerprint", () => {
+    expect(
+      fingerprintsMatch(computeFingerprint(KEY_ED25519), computeFingerprint(KEY_RSA)),
+    ).toBe(false);
+  });
+});
+
+describe("formatKnownHostsLine", () => {
+  it("uses the bare hostname for port 22", () => {
+    expect(formatKnownHostsLine("box.example.com", 22, "ssh-ed25519", KEY_ED25519))
+      .toBe(`box.example.com ssh-ed25519 ${KEY_ED25519}`);
+  });
+
+  it("uses the [host]:port form for non-default ports", () => {
+    expect(formatKnownHostsLine("box.example.com", 2222, "ssh-ed25519", KEY_ED25519))
+      .toBe(`[box.example.com]:2222 ssh-ed25519 ${KEY_ED25519}`);
+  });
+});
+
+describe("appendKnownHostsLine", () => {
+  it("creates the file (and ~/.ssh dir) when missing, mode 0600", () => {
+    const nested = join(tmpDir, "sub", "known_hosts");
+    appendKnownHostsLine(nested, `box ssh-ed25519 ${KEY_ED25519}`);
+    expect(existsSync(nested)).toBe(true);
+    expect((statSync(nested).mode & 0o777)).toBe(0o600);
+    expect(readFileSync(nested, "utf8")).toBe(`box ssh-ed25519 ${KEY_ED25519}\n`);
+  });
+
+  it("preserves existing entries on a second append", () => {
+    appendKnownHostsLine(knownHostsPath, `boxA ssh-ed25519 ${KEY_ED25519}`);
+    appendKnownHostsLine(knownHostsPath, `boxB ssh-rsa ${KEY_RSA}`);
+    const content = readFileSync(knownHostsPath, "utf8");
+    expect(content).toContain(`boxA ssh-ed25519 ${KEY_ED25519}`);
+    expect(content).toContain(`boxB ssh-rsa ${KEY_RSA}`);
+  });
+
+  it("is idempotent — an identical line is not duplicated", () => {
+    const line = `box ssh-ed25519 ${KEY_ED25519}`;
+    appendKnownHostsLine(knownHostsPath, line);
+    appendKnownHostsLine(knownHostsPath, line);
+    const content = readFileSync(knownHostsPath, "utf8");
+    expect(content.split("\n").filter((l) => l === line)).toHaveLength(1);
+  });
+});
+
+describe("scanHostKeys", () => {
+  it("spawns ssh-keyscan with -t and -p for a non-default port, parses the keys", async () => {
+    const captured: { command: string; args: string[] } = { command: "", args: [] };
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = (command, args) => {
+      captured.command = command;
+      captured.args = args;
+      return fake.child as any;
+    };
+    setImmediate(() => {
+      fake.pushStdout(`box.example.com ssh-ed25519 ${KEY_ED25519}\n`);
+      fake.fireExit(0);
+    });
+    const keys = await scanHostKeys("box.example.com", 2222, { spawn });
+    expect(captured.args).toContain("-p");
+    expect(captured.args).toContain("2222");
+    expect(captured.args).toContain("-t");
+    expect(keys).toEqual([{ algo: "ssh-ed25519", keyBase64: KEY_ED25519 }]);
+  });
+
+  it("omits -p for the default port", async () => {
+    const captured: { args: string[] } = { args: [] };
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = (_c, args) => {
+      captured.args = args;
+      return fake.child as any;
+    };
+    setImmediate(() => {
+      fake.pushStdout(`box ssh-ed25519 ${KEY_ED25519}\n`);
+      fake.fireExit(0);
+    });
+    await scanHostKeys("box", 22, { spawn });
+    expect(captured.args).not.toContain("-p");
+  });
+
+  it("returns [] when ssh-keyscan exits with no output", async () => {
+    const fake = makeFakeChild();
+    setImmediate(() => fake.fireExit(1));
+    const keys = await scanHostKeys("box", 22, { spawn: () => fake.child as any });
+    expect(keys).toEqual([]);
+  });
+});
+
+describe("resolveKnownHostsKey", () => {
+  it("reads host + port directly from a custom target", async () => {
+    const r = await resolveKnownHostsKey({
+      kind: "custom",
+      host: "box.example.com",
+      port: 2222,
+    });
+    expect(r).toEqual({ hostname: "box.example.com", port: 2222 });
+  });
+
+  it("defaults a custom target's port to 22", async () => {
+    const r = await resolveKnownHostsKey({ kind: "custom", host: "box.example.com" });
+    expect(r.port).toBe(22);
+  });
+
+  it("resolves an alias through `ssh -G`", async () => {
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = () => fake.child as any;
+    setImmediate(() => {
+      fake.pushStdout("hostname 203.0.113.5\nport 2222\nuser root\n");
+      fake.fireExit(0);
+    });
+    const r = await resolveKnownHostsKey("dev", { spawn });
+    expect(r).toEqual({ hostname: "203.0.113.5", port: 2222 });
+  });
+
+  it("falls back to the alias string + port 22 when ssh -G yields no hostname", async () => {
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = () => fake.child as any;
+    setImmediate(() => fake.fireExit(1));
+    const r = await resolveKnownHostsKey("dev", { spawn });
+    expect(r).toEqual({ hostname: "dev", port: 22 });
+  });
+});
+
+describe("trustHost", () => {
+  const trustedFp: HostFingerprint = {
+    algo: "ED25519",
+    sha256: computeFingerprint(KEY_ED25519),
+  };
+
+  it("writes the matching key's line to known_hosts and returns ok", async () => {
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = () => fake.child as any;
+    setImmediate(() => {
+      fake.pushStdout(
+        `box.example.com ssh-rsa ${KEY_RSA}\nbox.example.com ssh-ed25519 ${KEY_ED25519}\n`,
+      );
+      fake.fireExit(0);
+    });
+    const r = await trustHost(
+      { target: { kind: "custom", host: "box.example.com" }, fingerprint: trustedFp, knownHostsPath },
+      { spawn },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.line).toBe(`box.example.com ssh-ed25519 ${KEY_ED25519}`);
+    expect(readFileSync(knownHostsPath, "utf8")).toContain(r.line);
+  });
+
+  it("uses [host]:port for a non-default port", async () => {
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = () => fake.child as any;
+    setImmediate(() => {
+      fake.pushStdout(`box ssh-ed25519 ${KEY_ED25519}\n`);
+      fake.fireExit(0);
+    });
+    const r = await trustHost(
+      {
+        target: { kind: "custom", host: "box.example.com", port: 2222 },
+        fingerprint: trustedFp,
+        knownHostsPath,
+      },
+      { spawn },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.line).toBe(`[box.example.com]:2222 ssh-ed25519 ${KEY_ED25519}`);
+  });
+
+  it("fails with fingerprint-mismatch when no scanned key matches", async () => {
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = () => fake.child as any;
+    setImmediate(() => {
+      fake.pushStdout(`box ssh-rsa ${KEY_RSA}\n`);
+      fake.fireExit(0);
+    });
+    const r = await trustHost(
+      { target: { kind: "custom", host: "box.example.com" }, fingerprint: trustedFp, knownHostsPath },
+      { spawn },
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("fingerprint-mismatch");
+    expect(existsSync(knownHostsPath)).toBe(false);
+  });
+
+  it("fails with keyscan-failed when ssh-keyscan returns no keys", async () => {
+    const fake = makeFakeChild();
+    const spawn: SpawnFn = () => fake.child as any;
+    setImmediate(() => fake.fireExit(1));
+    const r = await trustHost(
+      { target: { kind: "custom", host: "box.example.com" }, fingerprint: trustedFp, knownHostsPath },
+      { spawn },
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("keyscan-failed");
+  });
+});

--- a/src/main/installer/knownHosts.ts
+++ b/src/main/installer/knownHosts.ts
@@ -1,0 +1,302 @@
+// knownHosts.ts — persist a trusted host key into ~/.ssh/known_hosts.
+//
+// The fingerprint the user saw (fingerprint.ts) is a SHA256 HASH of the
+// host's public key, not the key itself — so it cannot be written directly
+// into known_hosts. To get the actual key we run `ssh-keyscan`, compute
+// each returned key's SHA256 fingerprint, and keep ONLY the key whose
+// fingerprint matches the one the user just trusted. That match is the
+// security-critical step: it guarantees the key we persist is provably the
+// one whose fingerprint was shown, closing the MITM gap that a blind
+// `ssh-keyscan >> known_hosts` (or `StrictHostKeyChecking=accept-new`)
+// would leave open.
+//
+// After the line lands, BatchMode=yes connections accept the host on the
+// next connect — so the preflight re-run and every later pairing flow
+// (manual PairStep, mobile) skip the prompt entirely.
+//
+// I/O is injectable: `spawn` (for ssh-keyscan and `ssh -G` alias
+// resolution) and the known_hosts path default to the real system values
+// but are overridable in tests. The atomic write (temp file + rename,
+// mode 0600) preserves existing entries and never leaves a half-written
+// file.
+
+import { spawn as nodeSpawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+import { probeSshG } from "./runner.js";
+import {
+  sshTargetDestination,
+  type SshTarget,
+} from "../../shared/sshTarget.js";
+import type { SpawnFn } from "./runner.js";
+import type { HostFingerprint } from "./fingerprint.js";
+
+export type { SpawnFn } from "./runner.js";
+
+export const DEFAULT_KNOWN_HOSTS_PATH = join(homedir(), ".ssh", "known_hosts");
+
+export type TrustHostInput = {
+  /** The host-picker target the install is running against. */
+  target: SshTarget;
+  /** The fingerprint the user just trusted (from parseFingerprint). */
+  fingerprint: HostFingerprint;
+  /** Override for tests; defaults to ~/.ssh/known_hosts. */
+  knownHostsPath?: string;
+};
+
+export type TrustHostResult =
+  | { ok: true; line: string }
+  | {
+      ok: false;
+      reason: "resolve-failed" | "keyscan-failed" | "fingerprint-mismatch" | "write-failed";
+      message: string;
+    };
+
+export type TrustHostDeps = {
+  spawn?: SpawnFn;
+};
+
+// ---------------------------------------------------------------------------
+// resolveKnownHostsKey — turn an SshTarget into the (hostname, port) ssh
+// uses to look up the host key. A custom target carries both fields; an
+// alias is resolved through `ssh -G <alias>` (the single source of truth
+// for the effective connection settings, after Includes / Match).
+// ---------------------------------------------------------------------------
+
+export type ResolvedHostKey = {
+  hostname: string;
+  port: number;
+};
+
+export async function resolveKnownHostsKey(
+  target: SshTarget,
+  deps: TrustHostDeps = {},
+): Promise<ResolvedHostKey> {
+  if (typeof target === "string") {
+    const resolved = await probeSshG(target, { spawn: deps.spawn });
+    return {
+      hostname: resolved.hostname ?? target,
+      port: resolved.port ?? 22,
+    };
+  }
+  return {
+    hostname: target.host,
+    port: target.port ?? 22,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// scanHostKeys — run `ssh-keyscan` and return every (algo, key) pair it
+// emits. Bounded by a timeout so a hung scan can't stall the trust step.
+// ---------------------------------------------------------------------------
+
+export type ScannedHostKey = { algo: string; keyBase64: string };
+
+const KEYSCAN_BIN = process.env.MANTA_SSH_KEYSCAN_BIN ?? "ssh-keyscan";
+const KEYSCAN_TIMEOUT_MS = 20_000;
+
+export function scanHostKeys(
+  hostname: string,
+  port: number,
+  deps: TrustHostDeps = {},
+): Promise<ScannedHostKey[]> {
+  const spawn = deps.spawn ?? nodeSpawn;
+  const args = [
+    "-t",
+    "ed25519,rsa,ecdsa",
+    ...(port !== 22 ? ["-p", String(port)] : []),
+    "--",
+    hostname,
+  ];
+  return new Promise<ScannedHostKey[]>((resolve) => {
+    const child = spawn(KEYSCAN_BIN, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const chunks: Buffer[] = [];
+    let done = false;
+    const finish = (out: ScannedHostKey[]) => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      resolve(out);
+    };
+    if (child.stdout) child.stdout.on("data", (c: Buffer) => chunks.push(c));
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already exited */
+      }
+      finish([]);
+    }, KEYSCAN_TIMEOUT_MS);
+    child.on("exit", () => finish(parseKeyScanOutput(Buffer.concat(chunks).toString("utf8"))));
+    child.on("error", () => finish([]));
+  });
+}
+
+/**
+ * Parse `ssh-keyscan` stdout into `{ algo, keyBase64 }` pairs. Comment
+ * lines (leading `#`) and any line without a recognized algo token are
+ * dropped. The host field ssh-keyscan emits is intentionally ignored —
+ * the caller rebuilds the known_hosts host field from the resolved
+ * (hostname, port) so the `[host]:port` bracketing is always correct
+ * regardless of how ssh-keyscan chose to print it.
+ */
+export function parseKeyScanOutput(stdout: string): ScannedHostKey[] {
+  if (typeof stdout !== "string" || stdout === "") return [];
+  const out: ScannedHostKey[] = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 3) continue;
+    // parts[0] = host field (ignored); parts[1] = algo; parts[2] = key.
+    const algo = parts[1];
+    const keyBase64 = parts[2];
+    if (!/^(ssh-|ecdsa-)/.test(algo)) continue;
+    if (!/^[A-Za-z0-9+/=]+$/.test(keyBase64)) continue;
+    out.push({ algo, keyBase64 });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// computeFingerprint — SHA256 fingerprint of a base64-encoded host key, in
+// the `SHA256:<base64>` form OpenSSH prints. Used to match a scanned key
+// against the fingerprint the user trusted.
+// ---------------------------------------------------------------------------
+
+export function computeFingerprint(keyBase64: string): string {
+  const keyBytes = Buffer.from(keyBase64, "base64");
+  const hash = createHash("sha256").update(keyBytes).digest("base64");
+  return `SHA256:${hash}`;
+}
+
+/** Compare two `SHA256:<base64>` fingerprints, ignoring base64 padding
+ *  (`=`) which OpenSSH emits inconsistently across versions. */
+export function fingerprintsMatch(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  return a.replace(/=+$/g, "") === b.replace(/=+$/g, "");
+}
+
+// ---------------------------------------------------------------------------
+// formatKnownHostsLine — the single known_hosts entry. Non-default ports
+// use the bracketed `[host]:port` form ssh looks up; port 22 is bare.
+// ---------------------------------------------------------------------------
+
+export function formatKnownHostsLine(
+  hostname: string,
+  port: number,
+  algo: string,
+  keyBase64: string,
+): string {
+  const hostField = port !== 22 ? `[${hostname}]:${port}` : hostname;
+  return `${hostField} ${algo} ${keyBase64}`;
+}
+
+// ---------------------------------------------------------------------------
+// appendKnownHostsLine — atomic, idempotent append. Reads the existing
+// file (if any), skips when the exact line is already present (so re-trust
+// is a no-op), and writes the full content through a temp file + rename
+// with mode 0600. The ~/.ssh directory is created if missing.
+// ---------------------------------------------------------------------------
+
+export function appendKnownHostsLine(
+  path: string,
+  line: string,
+): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const existing = existsSync(path) ? readFileSync(path, "utf8") : "";
+  const lines = existing.split(/\r?\n/).filter((l) => l.trim() !== "");
+  if (lines.includes(line)) return;
+  lines.push(line);
+  const content = lines.join("\n") + "\n";
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, content, { mode: 0o600 });
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    try {
+      // rename across filesystems can fail; fall back to a direct write.
+      writeFileSync(path, content, { mode: 0o600 });
+    } catch {
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// trustHost — the orchestrator. Resolve the host, scan its keys, find the
+// one whose fingerprint matches what the user trusted, write its
+// known_hosts line. Returns a structured result the installer handler
+// turns into either a resumed install or a preflight-failed event.
+// ---------------------------------------------------------------------------
+
+export async function trustHost(
+  input: TrustHostInput,
+  deps: TrustHostDeps = {},
+): Promise<TrustHostResult> {
+  const knownHostsPath = input.knownHostsPath ?? DEFAULT_KNOWN_HOSTS_PATH;
+  let resolved: ResolvedHostKey;
+  try {
+    resolved = await resolveKnownHostsKey(input.target, deps);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "resolve-failed",
+      message: `Could not resolve the host's address: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!resolved.hostname || resolved.hostname.trim() === "") {
+    return {
+      ok: false,
+      reason: "resolve-failed",
+      message: "Could not resolve the host's address from the selected target.",
+    };
+  }
+
+  const keys = await scanHostKeys(resolved.hostname, resolved.port, deps);
+  if (keys.length === 0) {
+    return {
+      ok: false,
+      reason: "keyscan-failed",
+      message: `ssh-keyscan returned no keys for ${sshTargetDestination(input.target)}.`,
+    };
+  }
+
+  const trusted = keys.find((k) =>
+    fingerprintsMatch(computeFingerprint(k.keyBase64), input.fingerprint.sha256),
+  );
+  if (!trusted) {
+    return {
+      ok: false,
+      reason: "fingerprint-mismatch",
+      message:
+        "The key the host presented does not match the fingerprint you were shown. Do not trust this host — it may be a different machine.",
+    };
+  }
+
+  const line = formatKnownHostsLine(
+    resolved.hostname,
+    resolved.port,
+    trusted.algo,
+    trusted.keyBase64,
+  );
+  try {
+    appendKnownHostsLine(knownHostsPath, line);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "write-failed",
+      message: `Could not write to ~/.ssh/known_hosts: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return { ok: true, line };
+}

--- a/src/main/installer/preflight.test.ts
+++ b/src/main/installer/preflight.test.ts
@@ -10,6 +10,12 @@ import {
   targetLabel,
   type PreflightProbes,
 } from "./preflight.js";
+import type { HostFingerprint } from "./fingerprint.js";
+
+const SAMPLE_FP: HostFingerprint = {
+  algo: "ED25519",
+  sha256: "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG=",
+};
 
 const OK_OS_LINUX_X64 = {
   id: "linux" as const,
@@ -30,6 +36,7 @@ const OK_OS_DARWIN_ARM64 = {
 function makeProbes(overrides: Partial<PreflightProbes> = {}): PreflightProbes {
   return {
     reachability: "ok",
+    hostFingerprint: null,
     os: OK_OS_LINUX_X64,
     passwordlessSudo: true,
     tailscale: { running: false, ipv4: null },
@@ -245,5 +252,44 @@ describe("classifyPreflight", () => {
     const probes = makeProbes({ alreadyInstalled: true });
     const r = classifyPreflight(probes);
     expect(r.probes).toEqual(probes);
+  });
+});
+
+// BET-361: unknown-host reachability short-circuits into a trust-pause
+// signal, not a hard failure list. The OS/clock checks are meaningless
+// until the host can be reached and would otherwise pile on "unsupported
+// unknown/unknown" noise the user cannot act on before trusting.
+describe("classifyPreflight — unknown host (BET-361)", () => {
+  it("surfaces the fingerprint and a single guidance failure, no OS noise", () => {
+    const r = classifyPreflight(
+      makeProbes({
+        reachability: "unknown-host",
+        hostFingerprint: SAMPLE_FP,
+        os: { id: "unknown", arch: "unknown", release: null },
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.unknownHost).toEqual(SAMPLE_FP);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0].cause).toMatch(/not yet trusted/);
+    // The unknown/unknown OS must NOT add a second failure here.
+    expect(r.failures.some((f) => /Unsupported target/.test(f.cause))).toBe(false);
+  });
+
+  it("still short-circuits when no fingerprint was parsed (degraded)", () => {
+    const r = classifyPreflight(
+      makeProbes({
+        reachability: "unknown-host",
+        hostFingerprint: null,
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.unknownHost).toBeNull();
+    expect(r.failures).toHaveLength(1);
+  });
+
+  it("a normal (reachable) verdict leaves unknownHost null", () => {
+    const r = classifyPreflight(makeProbes());
+    expect(r.unknownHost).toBeNull();
   });
 });

--- a/src/main/installer/preflight.ts
+++ b/src/main/installer/preflight.ts
@@ -23,6 +23,8 @@
 // Pure: takes the raw probe results, returns structured objects. Tested in
 // preflight.test.ts.
 
+import type { HostFingerprint } from "./fingerprint.js";
+
 export type OsId = "linux" | "darwin" | "unknown";
 export type Arch = "x64" | "arm64" | "unknown";
 
@@ -33,7 +35,7 @@ export type OsInfo = {
   release: string | null;
 };
 
-export type Reachability = "ok" | "auth-failed" | "unreachable";
+export type Reachability = "ok" | "auth-failed" | "unreachable" | "unknown-host";
 
 export type TailscaleState = {
   /** `command -v tailscale` succeeded AND `tailscale status --json` had BackendState=Running. */
@@ -44,6 +46,10 @@ export type TailscaleState = {
 
 export type PreflightProbes = {
   reachability: Reachability;
+  /** The host-key fingerprint ssh offered on a never-seen host, when
+   *  reachability is "unknown-host". Null in every other case. Populated by
+   *  probeReachability from the ssh stderr block (fingerprint.ts). */
+  hostFingerprint: HostFingerprint | null;
   os: OsInfo;
   /** `sudo -n true` exited 0 over the SSH connection. */
   passwordlessSudo: boolean;
@@ -135,6 +141,10 @@ export type PreflightResult = {
   probes: PreflightProbes;
   /** Structured failures the UI renders one-per-line with the cause + action. */
   failures: PreflightFailure[];
+  /** When the host is unknown and ssh offered a fingerprint, this carries it
+   *  so installerStart can pause for a trust decision instead of hard-failing.
+   *  Null for every other verdict (ok, unreachable, auth-failed, etc.). */
+  unknownHost: HostFingerprint | null;
 };
 
 // Clock skew: a wrong box clock silently breaks Let's Encrypt issuance and
@@ -160,6 +170,29 @@ const CLOCK_SKEW_FAIL_SECONDS = 60;
  */
 export function classifyPreflight(probes: PreflightProbes): PreflightResult {
   const failures: PreflightFailure[] = [];
+
+  // Unknown host: ssh printed a fingerprint and bailed (BatchMode=yes
+  // suppresses the interactive yes/no). This is NOT a hard failure — the
+  // installer pauses for a trust decision (BET-361) — so we short-circuit
+  // with a single guidance failure and surface the fingerprint. The OS /
+  // clock / sudo checks are meaningless until the host can be reached, so
+  // they are skipped here (they would otherwise pile on "unsupported
+  // unknown/unknown" noise the user cannot act on before trusting).
+  if (probes.reachability === "unknown-host") {
+    return {
+      ok: false,
+      ingressMode: decideIngressMode(probes),
+      probes,
+      failures: [
+        {
+          cause: "This host's identity is not yet trusted.",
+          action:
+            "Review the host key fingerprint and choose Trust to continue, or pick a different host.",
+        },
+      ],
+      unknownHost: probes.hostFingerprint,
+    };
+  }
 
   if (probes.reachability === "unreachable") {
     failures.push({
@@ -209,5 +242,6 @@ export function classifyPreflight(probes: PreflightProbes): PreflightResult {
     ingressMode: decideIngressMode(probes),
     probes,
     failures,
+    unknownHost: null,
   };
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,6 +203,14 @@ const api = {
   installerCancel: (input: { handleId: string }): Promise<void> =>
     ipcRenderer.invoke(IPC.installerCancel, input),
 
+  // BET-361: the renderer's answer to a paused `fingerprint` event. trust=true
+  // → main writes the host key to ~/.ssh/known_hosts (verifying it matches
+  // the shown fingerprint) and re-runs preflight; trust=false → the install
+  // aborts with a preflight-failed event. Resolves once main has acted on
+  // the decision; the renderer does NOT need to wait for a separate event.
+  installerTrustHost: (input: { handleId: string; trust: boolean }): Promise<void> =>
+    ipcRenderer.invoke(IPC.installerTrustHost, input),
+
   // Mint a fresh pairing code over the existing SSH connection + claim it
   // via the box's public URL. Persists credentials through main's existing
   // claim path (single config writer, per BET-355 constraint #4). The

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -435,8 +435,14 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   }
 
   async function cancelInstall() {
-    if (!activeHandle) return;
-    await preload.installerCancel({ handleId: activeHandle });
+    // During the fingerprint trust pause, activeHandle is still null
+    // (installerStart hasn't returned) — but the install IS in flight and
+    // the Cancel button is visible. Route through the trust-prompt's
+    // handleId so installerCancel reaches the main-process trust-wait
+    // abort instead of silently no-oping (BET-361 review cycle 1 Block).
+    const handleId = activeHandle ?? fingerprintPrompt?.handleId;
+    if (!handleId) return;
+    await preload.installerCancel({ handleId });
   }
 
   // BET-361: answer the paused fingerprint prompt. Trust → main writes the

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -148,6 +148,14 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   const [preflightFailure, setPreflightFailure] = useState<{
     failures: PreflightFailure[];
   } | null>(null);
+  // BET-361: a never-seen host paused the install for a trust decision.
+  // Rendered INLINE in the progress panel (the status line flips to
+  // "Waiting for host trust…" and the log pauses) — not a separate panel.
+  const [fingerprintPrompt, setFingerprintPrompt] = useState<{
+    handleId: string;
+    algo: string;
+    sha256: string;
+  } | null>(null);
   const [claimRunning, setClaimRunning] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
   const logRef = useRef<HTMLDivElement | null>(null);
@@ -244,6 +252,25 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     (async () => {
       const s = await preload.installerState();
       if (!alive) return;
+      // BET-361: a paused trust prompt recovers first — it's neither an
+      // active install nor a hard preflight failure, and the unknown-host
+      // verdict sitting in `s.preflight` must NOT be rendered as the
+      // failure card while we're waiting on the user.
+      if (s.waitingForTrust && s.trustHandleId && s.pendingFingerprint) {
+        setRunning(true);
+        setActiveHandle(s.trustHandleId);
+        setStage(INITIAL_STAGE);
+        setStageLabel(INITIAL_STAGE_INFO.label);
+        setStageIndex(INITIAL_STAGE_INFO.index);
+        setStageTotal(INITIAL_STAGE_INFO.total);
+        setLogOpen(true);
+        setFingerprintPrompt({
+          handleId: s.trustHandleId,
+          algo: s.pendingFingerprint.algo,
+          sha256: s.pendingFingerprint.sha256,
+        });
+        return;
+      }
       if (s.active) {
         const info = currentStageInfo(s.stage);
         setRunning(true);
@@ -293,11 +320,24 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setPreflightFailure({ failures: evt.failures });
           setRunning(false);
           setActiveHandle(null);
+          setFingerprintPrompt(null);
+          break;
+        case "fingerprint":
+          // The install is paused waiting for a trust decision — show the
+          // fingerprint card inline. The handleId on the event is what
+          // installerTrustHost needs (installerStart hasn't returned yet,
+          // so activeHandle is still null here).
+          setFingerprintPrompt({
+            handleId: evt.handleId,
+            algo: evt.fingerprint.algo,
+            sha256: evt.fingerprint.sha256,
+          });
           break;
         case "done":
           setDone({ ok: evt.ok, code: evt.code, signal: evt.signal });
           setRunning(false);
           setActiveHandle(null);
+          setFingerprintPrompt(null);
           if (evt.ok) {
             // Collapse the log back to the single status line on success.
             setLogOpen(false);
@@ -310,6 +350,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setInstallError(evt.message);
           setRunning(false);
           setActiveHandle(null);
+          setFingerprintPrompt(null);
           break;
       }
     });
@@ -366,6 +407,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     setTargetError(null);
     setInstallError(null);
     setPreflightFailure(null);
+    setFingerprintPrompt(null);
     setLines([]);
     setDone(null);
     setClaimError(null);
@@ -395,6 +437,26 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   async function cancelInstall() {
     if (!activeHandle) return;
     await preload.installerCancel({ handleId: activeHandle });
+  }
+
+  // BET-361: answer the paused fingerprint prompt. Trust → main writes the
+  // host key and resumes (running stays true, the install streams on).
+  // Decline → main aborts with a preflight-failed event; we drop the
+  // spinner immediately so the UI never hangs on a verdict that's already
+  // been decided.
+  async function trustHostDecision(trust: boolean) {
+    if (!fingerprintPrompt) return;
+    const handleId = fingerprintPrompt.handleId;
+    setFingerprintPrompt(null);
+    if (!trust) {
+      setRunning(false);
+      setActiveHandle(null);
+    }
+    try {
+      await preload.installerTrustHost({ handleId, trust });
+    } catch (e) {
+      setInstallError(e instanceof Error ? e.message : String(e));
+    }
   }
 
   async function runClaim() {
@@ -714,7 +776,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                 style={{ borderColor: ACCENT, borderTopColor: "transparent" }}
               />
             )}
-            <span>{stageLabel}</span>
+            <span>{fingerprintPrompt ? "Waiting for host trust…" : stageLabel}</span>
             <span className="text-text-muted">
               {stageIndex} of {stageTotal} · {formatElapsed(elapsedSeconds)}
             </span>
@@ -737,7 +799,49 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               }}
             />
           </div>
-          {logOpen && (
+          {/* BET-361: inline fingerprint prompt. The install is paused — the
+              log has nothing new to show, so the card takes the place of
+              attention until the user answers. */}
+          {fingerprintPrompt && (
+            <div
+              className="rounded-md p-3.5 space-y-2.5"
+              style={{ border: `1px solid ${ACCENT}` }}
+            >
+              <div className="text-sm font-medium">Trust this host?</div>
+              <p className="text-xs text-text-muted">
+                The host's identity can't be verified yet. Its{" "}
+                {fingerprintPrompt.algo} key fingerprint is:
+              </p>
+              <code
+                className="block text-xs font-mono break-all rounded px-2 py-1.5 bg-bg-elev"
+                style={{ color: ACCENT }}
+              >
+                {fingerprintPrompt.sha256}
+              </code>
+              <p className="text-xs text-text-faint">
+                Only trust this if you recognize the fingerprint (for example,
+                from your VPS console). The key is saved to
+                ~/.ssh/known_hosts so future connections skip this prompt.
+              </p>
+              <div className="flex gap-2 pt-0.5">
+                <button
+                  onClick={() => void trustHostDecision(true)}
+                  className="px-3 py-1.5 rounded-md text-sm font-medium"
+                  style={{ background: ACCENT, color: "#0B1020" }}
+                >
+                  Trust &amp; continue
+                </button>
+                <button
+                  onClick={() => void trustHostDecision(false)}
+                  className="px-3 py-1.5 rounded-md text-sm font-medium"
+                  style={{ border: `1px solid ${DANGER}`, color: DANGER }}
+                >
+                  Don't trust
+                </button>
+              </div>
+            </div>
+          )}
+          {logOpen && !fingerprintPrompt && (
             <div
               ref={logRef}
               style={{ height: 172, overflowY: "auto" }}

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -57,6 +57,7 @@ function makeFakePreload(): MantaPreload {
     installerListHosts: vi.fn(async () => []),
     installerStart: vi.fn(async () => ({ handleId: "fake-handle" })),
     installerCancel: vi.fn(async () => {}),
+    installerTrustHost: vi.fn(async () => {}),
     installerMintAndClaim: vi.fn(async () => ({
       ok: false as const,
       kind: "network" as const,
@@ -67,6 +68,9 @@ function makeFakePreload(): MantaPreload {
       stage: "preflight" as const,
       logTail: [],
       preflight: null,
+      waitingForTrust: false,
+      trustHandleId: null,
+      pendingFingerprint: null,
     })),
     installerGetDiagnostics: vi.fn(async () => ""),
     onInstallerEvent: vi.fn(() => vi.fn()),

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -139,6 +139,10 @@ export interface MantaPreload {
   // (one from a previous renderer mount) or on an already-done handle.
   installerCancel(input: { handleId: string }): Promise<void>;
 
+  // BET-361: answer a paused `fingerprint` event. trust=true writes the
+  // host key to ~/.ssh/known_hosts and resumes; trust=false aborts.
+  installerTrustHost(input: { handleId: string; trust: boolean }): Promise<void>;
+
   // Mint a fresh pairing code over the existing SSH connection + claim it
   // via the box's public URL. Returns the SAME ClaimOutcome shape as the
   // manual PairStep claim — the renderer treats success and failure the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,6 @@
 // Type-only, erased at compile time (preloadAccess.ts does the same).
 import type { PreflightResult, PreflightFailure } from "../main/installer/preflight.js";
+import type { HostFingerprint } from "../main/installer/fingerprint.js";
 
 // ----- Local app config -----
 // Source of truth for sessions/windows is tmux on the remote. We only persist
@@ -345,6 +346,16 @@ export type InstallerEvent =
       handleId: string;
       failures: PreflightFailure[];
     }
+  // Preflight hit a never-seen host: ssh offered a fingerprint and bailed
+  // (BatchMode=yes). The install PAUSES here — the renderer shows the
+  // fingerprint + a "Trust this host" button; the user's answer comes back
+  // via installerTrustHost. On trust, main writes the host key to
+  // ~/.ssh/known_hosts and re-runs preflight (BET-361).
+  | {
+      kind: "fingerprint";
+      handleId: string;
+      fingerprint: HostFingerprint;
+    }
   | {
       kind: "done";
       handleId: string;
@@ -361,6 +372,16 @@ export type InstallerState = {
   // Most recent preflight verdict, null before any install started — feeds
   // "Copy diagnostics" with the real values instead of a placeholder.
   preflight: PreflightResult | null;
+  // True while the install is PAUSED waiting for the user to trust an
+  // unknown host. The renderer re-shows the fingerprint prompt on remount
+  // when this is set (BET-361).
+  waitingForTrust: boolean;
+  // The handle id the paused trust prompt belongs to, or null. Lets a
+  // re-mounted renderer route its Trust/Cancel answer to the right install.
+  trustHandleId: string | null;
+  // The fingerprint being awaited, or null. Mirrors the `fingerprint` event
+  // payload so a remount recovers the prompt without a re-send.
+  pendingFingerprint: HostFingerprint | null;
 };
 
 // Desktop auto-update (electron-updater) payloads, shared by the preload
@@ -785,11 +806,17 @@ export const IPC = {
   installerMintAndClaim: "installer:mint-and-claim",
   installerState: "installer:state",
   installerGetDiagnostics: "installer:get-diagnostics",
+  // installerTrustHost (BET-361): the renderer's answer to a paused
+  // `fingerprint` event — trust=true writes the host key to
+  // ~/.ssh/known_hosts and resumes the install; trust=false (or a cancel)
+  // aborts with a preflight-failed event.
+  installerTrustHost: "installer:trust-host",
   // installerEvent is the main → renderer push channel (mirrors the
   // pairLinkReceived pattern). Payload is a discriminated union:
   //   { kind: "line", handleId, text }
   //   { kind: "stage", handleId, stage }
   //   { kind: "preflight-failed", handleId, failures }
+  //   { kind: "fingerprint", handleId, fingerprint }   (BET-361 — pause for trust)
   //   { kind: "done", handleId, code, signal }
   //   { kind: "error", handleId, message }
   installerEvent: "installer:event",


### PR DESCRIPTION
## BET-361 — unknown-host fingerprint prompt

When the desktop installer connects to a never-seen host, `BatchMode=yes` makes ssh print the host-key fingerprint to stderr and fail instead of prompting interactively. The preflight used to mislabel that as `unreachable`/`auth-failed`. This adds the prompt the user actually wants.

### Flow
1. `probeReachability` now parses the ssh stderr fingerprint (`fingerprint.ts`, pure) and returns a new `unknown-host` reachability + the fingerprint.
2. `classifyPreflight` short-circuits `unknown-host` into a trust-pause signal (`unknownHost` on the verdict) — no OS/clock noise piled on top.
3. `installerStart` (handlers.ts) pauses on `unknownHost`, emits a `fingerprint` installerEvent, and awaits the renderer's answer on a new `installerTrustHost` IPC channel.
4. On **Trust**, `knownHosts.trustHost` fetches the real key via `ssh-keyscan`, **verifies its SHA256 fingerprint matches the one the user was shown** (closes the MITM gap a blind `ssh-keyscan >> known_hosts` or `StrictHostKeyChecking=accept-new` would leave), and writes it atomically to `~/.ssh/known_hosts` (0600, temp+rename, idempotent). Preflight re-runs, then the install proceeds.
5. On **decline/cancel/timeout**, the install aborts with a `preflight-failed` event; nothing is written to the box.

The fingerprint card renders **inline** in the existing single-line + log layout (status line flips to "Waiting for host trust…", log pauses) — not a resurrected separate panel, per the post-BET-383 surface. Works for both an alias-selected host (resolved via `ssh -G`) and a custom host entry.

Host-key checking is **never** silently disabled — the whole point is to be the prompt the user answers, and the persisted key is provably the one whose fingerprint was shown.

### Files
- NEW `src/main/installer/fingerprint.ts` — pure stderr parser (ED25519/RSA/ECDSA, SHA256: form) + `isHostKeyVerificationFailure`.
- NEW `src/main/installer/knownHosts.ts` — `ssh-keyscan` + fingerprint-verify + atomic `known_hosts` write; `trustHost` orchestrator.
- MOD `src/main/installer/preflight.ts` — `unknown-host` reachability, `hostFingerprint` probe, `unknownHost` verdict.
- MOD `src/main/installer/installer.ts` — `probeReachability` detects the fingerprint.
- MOD `src/main/installer/handlers.ts` — pause/resume loop, `installerTrustHost` handler, cancel-during-trust, `installerState` recovery fields.
- MOD `src/shared/types.ts`, `src/preload/index.ts`, `src/renderer/preloadAccess.ts` — `fingerprint` event + `installerTrustHost` IPC.
- MOD `src/renderer/SshInstallStep.tsx` — inline fingerprint card + Trust/Don't-trust actions + remount recovery.

### Tests
- `fingerprint.test.ts` — canonical OpenSSH stderr snippets (modern, RSA, ECDSA, BET-361-issue variant, CRLF) + rejection of auth/network stderr.
- `knownHosts.test.ts` — parseKeyScanOutput, computeFingerprint, fingerprintsMatch (padding-insensitive), formatKnownHostsLine (port 22 vs `[host]:port`), atomic + idempotent append, scanHostKeys (stubbed spawn), resolveKnownHostsKey (custom + alias via `ssh -G`), trustHost (match / mismatch / keyscan-failed).
- `preflight.test.ts` — unknown-host short-circuits to a single trust-pause failure, no OS noise.
- `installer.test.ts` — `preflightBox` classifies a never-seen host from stderr and surfaces the fingerprint.
- `handlers.test.ts` — pause/resume integration: fingerprint event emitted, slot held while paused, Trust → trustHost + re-preflight + runInstall; decline → preflight-failed, no install; cancel-during-trust; second-start refused while paused.

### Verification results
- PR branch (`multica/BET-361-fingerprint-prompt` @ `ca40c59`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1b6bb2ebbe3c05b5624`
  - test: exit 0, 1529 pass / 0 fail / 0 skip. log sha256: `a4f20a78d939232bc651fda5a015dff6ec412163131d06e8f776ef1e7db25f93`
- Base (`main` @ `9dc1499`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1b6bb2ebbe3c05b5624` (identical)
  - test: exit 0, 1486 pass / 0 fail / 0 skip. log sha256: `0c03808d6ce0cffa4e672de15ac6c5194149e1d77268fe61b1f0bfc95762ff81`
- **Conclusion:** 0 new failures. 43 new tests added (1486 → 1529), all green. Base: origin/main @ `9dc1499`.

Electron renderer smoke (Playwright `electron.launch` under xvfb): app launches, the onboarding "Connect your box" step mounts `SshInstallStep` (host picker + "Install & pair" button), zero real console errors — 1 passed.

### Notes / deviations
- The issue sketched a separate `onInstallerFingerprint` subscription; I reused the existing `installerEvent` push channel with a new `fingerprint` kind, matching how `line`/`stage`/`preflight-failed`/`done`/`error` are already multiplexed. The fingerprint is a SHA256 *hash* of the host key, not the key itself — so `knownHosts.ts` fetches the real key with `ssh-keyscan` and verifies the fingerprint matches before persisting (the issue's "writes the trust line" can't be done from the fingerprint alone).
- Live-VPS end-to-end (DoD's "pick a never-seen host, watch the prompt, click Trust") can't run in this environment — the logic path is covered by the stubbed integration test in `handlers.test.ts`.

Base: origin/main @ `9dc1499`
