### PR TITLE
feat(installer): SSH_ASKPASS passphrase flow (BET-360)

### DIFF
--- a/src/main/installer/askpass.test.ts
+++ b/src/main/installer/askpass.test.ts
@@ -1,0 +1,135 @@
+// askpass.test.ts — unit tests for the SSH_ASKPASS session manager.
+//
+// No real filesystem: all I/O is injected. Tests verify the env-var
+// construction, the platform-specific helper script content, the 0600
+// passphrase file, and the idempotent cleanup.
+
+import { describe, it, expect } from "vitest";
+import {
+  createAskpassSession,
+  helperScriptContent,
+  helperScriptExtension,
+} from "./askpass.js";
+
+describe("helperScriptContent", () => {
+  it("returns a /bin/sh script on unix", () => {
+    const content = helperScriptContent("linux");
+    expect(content).toContain("#!/bin/sh");
+    expect(content).toContain('cat "$MANTA_ASKPASS_FILE"');
+  });
+
+  it("returns a cmd batch on win32", () => {
+    const content = helperScriptContent("win32");
+    expect(content).toContain("@echo off");
+    expect(content).toContain('type "%MANTA_ASKPASS_FILE%"');
+  });
+
+  it("guards against a missing MANTA_ASKPASS_FILE (unix)", () => {
+    const content = helperScriptContent("darwin");
+    expect(content).toMatch(/if.*-z.*MANTA_ASKPASS_FILE/);
+  });
+});
+
+describe("helperScriptExtension", () => {
+  it("returns .sh on unix", () => {
+    expect(helperScriptExtension("linux")).toBe(".sh");
+    expect(helperScriptExtension("darwin")).toBe(".sh");
+  });
+
+  it("returns .cmd on win32", () => {
+    expect(helperScriptExtension("win32")).toBe(".cmd");
+  });
+});
+
+describe("createAskpassSession", () => {
+  function makeDeps() {
+    const files: Record<string, string> = {};
+    const chmods: Record<string, number> = {};
+    const dirs: string[] = [];
+    return {
+      files,
+      chmods,
+      dirs,
+      deps: {
+        platform: "linux" as string,
+        tmpdirPath: "/tmp",
+        mkdtemp: (prefix: string) => {
+          const dir = `/tmp/${prefix}XYZ`;
+          dirs.push(dir);
+          return dir;
+        },
+        writeFile: (path: string, data: string) => {
+          files[path] = data;
+        },
+        chmod: (path: string, mode: number) => {
+          chmods[path] = mode;
+        },
+        rm: (path: string, _opts: { recursive: boolean; force: boolean }) => {
+          const idx = dirs.indexOf(path);
+          if (idx >= 0) dirs.splice(idx, 1);
+        },
+      },
+    };
+  }
+
+  it("writes the helper script and passphrase file, and returns the correct env", () => {
+    const { deps, files, chmods } = makeDeps();
+    const session = createAskpassSession("hunter2", deps);
+
+    expect(session.env.SSH_ASKPASS).toMatch(/askpass\.sh$/);
+    expect(session.env.SSH_ASKPASS_REQUIRE).toBe("force");
+    expect(session.env.MANTA_ASKPASS_FILE).toMatch(/passphrase$/);
+
+    // The helper script was written with the sh content.
+    const helperPath = session.env.SSH_ASKPASS;
+    expect(files[helperPath]).toContain("#!/bin/sh");
+    expect(files[helperPath]).toContain('cat "$MANTA_ASKPASS_FILE"');
+
+    // The passphrase file was written.
+    const pwPath = session.env.MANTA_ASKPASS_FILE;
+    expect(files[pwPath]).toBe("hunter2");
+
+    // The helper was chmod'd executable on unix.
+    expect(chmods[helperPath]).toBe(0o700);
+  });
+
+  it("chmods the helper on unix but not on win32", () => {
+    const { deps: unixDeps, chmods: unixChmods } = makeDeps();
+    unixDeps.platform = "linux";
+    createAskpassSession("pw", unixDeps);
+    const unixHelper = Object.keys(unixChmods)[0];
+    expect(unixHelper).toBeDefined();
+    expect(unixChmods[unixHelper]).toBe(0o700);
+
+    const winFixture = makeDeps();
+    winFixture.deps.platform = "win32";
+    createAskpassSession("pw", winFixture.deps);
+    // No chmod calls on win32.
+    expect(Object.keys(winFixture.chmods)).toHaveLength(0);
+  });
+
+  it("writes a .cmd helper on win32", () => {
+    const { deps, files } = makeDeps();
+    deps.platform = "win32";
+    const session = createAskpassSession("pw", deps);
+    expect(session.env.SSH_ASKPASS).toMatch(/askpass\.cmd$/);
+    expect(files[session.env.SSH_ASKPASS]).toContain("@echo off");
+  });
+
+  it("cleanup removes the temp dir and is idempotent", () => {
+    const { deps, dirs } = makeDeps();
+    const session = createAskpassSession("pw", deps);
+    expect(dirs).toHaveLength(1);
+    session.cleanup();
+    expect(dirs).toHaveLength(0);
+    // Second cleanup is a no-op.
+    session.cleanup();
+    expect(dirs).toHaveLength(0);
+  });
+
+  it("throws if passphrase is not a string", () => {
+    expect(() => createAskpassSession(null as never, makeDeps().deps)).toThrow(
+      /passphrase is required/,
+    );
+  });
+});

--- a/src/main/installer/askpass.ts
+++ b/src/main/installer/askpass.ts
@@ -1,0 +1,114 @@
+// askpass.ts — SSH_ASKPASS session manager for passphrase-protected keys.
+//
+// When the installer's preflight returns `auth-failed` because the user's SSH
+// key is passphrase-protected AND not loaded in ssh-agent, this module sets
+// up the OpenSSH SSH_ASKPASS mechanism so ssh can obtain the passphrase from
+// a helper script instead of hanging on a terminal prompt.
+//
+// OpenSSH 8.4+ supports `SSH_ASKPASS_REQUIRE=force`, which makes ssh invoke
+// the SSH_ASKPASS helper unconditionally — even when a controlling terminal
+// is present (Electron GUI apps have none, but this is belt-and-suspenders).
+// The helper is a tiny platform-native script that reads the passphrase from
+// a 0600 temp file and writes it to stdout. Main writes that file after
+// collecting the passphrase from the renderer's native dialog; it persists
+// for the duration of the install + claim so every ssh invocation (six
+// preflight probes + the install stream + `manta pair`) can reuse it without
+// re-prompting.
+//
+// WHY a runtime-generated script (not a shipped .mjs): electron-vite bundles
+// the main process into a single `out/main/index.js`. A loose .mjs file in
+// src/ would either be bundled (breaking it as a standalone script) or
+// require extra rollup/copy config. Generating the helper at runtime in a
+// temp dir sidesteps the bundler entirely — no build config changes, works
+// identically in `electron-vite dev` and in the packaged .app/.AppImage.
+//
+// The helper is cross-platform: `/bin/sh` on Unix, `.cmd` on Windows. Both
+// are one-liners that `cat`/`type` the passphrase file — no Node, no native
+// deps, no pty.
+
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export type AskpassSession = {
+  /** Env vars to merge into every ssh child's environment while this session
+   *  is active: SSH_ASKPASS, SSH_ASKPASS_REQUIRE, MANTA_ASKPASS_FILE. */
+  env: Record<string, string>;
+  /** Delete the temp dir (helper script + passphrase file). Idempotent.
+   *  Call in a finally / cleanup path — never leaves the passphrase on disk. */
+  cleanup: () => void;
+};
+
+// The helper script content per platform. ssh invokes the script with the
+// prompt text as argv[1]; we ignore it (we already know what the passphrase
+// is for) and just emit the file's contents.
+export function helperScriptContent(platform: string): string {
+  if (platform === "win32") {
+    return '@echo off\r\nif "%MANTA_ASKPASS_FILE%"=="" exit /b 1\r\ntype "%MANTA_ASKPASS_FILE%"';
+  }
+  return '#!/bin/sh\nif [ -z "$MANTA_ASKPASS_FILE" ]; then exit 1; fi\ncat "$MANTA_ASKPASS_FILE"';
+}
+
+export function helperScriptExtension(platform: string): string {
+  return platform === "win32" ? ".cmd" : ".sh";
+}
+
+export type AskpassDeps = {
+  platform?: string;
+  tmpdirPath?: string;
+  mkdtemp?: (prefix: string) => string;
+  writeFile?: (path: string, data: string) => void;
+  chmod?: (path: string, mode: number) => void;
+  rm?: (path: string, opts: { recursive: boolean; force: boolean }) => void;
+};
+
+/**
+ * Create an askpass session: a temp directory holding the helper script and
+ * the passphrase file, plus the env vars ssh needs to find them.
+ *
+ * `passphrase` is the user's key passphrase, collected from the renderer
+ * dialog BEFORE this function is called. It is written 0600 to a temp file
+ * and deleted on `cleanup()`.
+ */
+export function createAskpassSession(
+  passphrase: string,
+  deps: AskpassDeps = {},
+): AskpassSession {
+  if (typeof passphrase !== "string") {
+    throw new Error("createAskpassSession: passphrase is required");
+  }
+  const platform = deps.platform ?? process.platform;
+  const tmpBase = deps.tmpdirPath ?? tmpdir();
+  const mkdtemp = deps.mkdtemp ?? ((prefix: string) => mkdtempSync(join(tmpBase, prefix)));
+  const writeFile = deps.writeFile ?? ((p, d) => writeFileSync(p, d, { mode: 0o600 }));
+  const chmod = deps.chmod ?? ((p, m) => chmodSync(p, m));
+  const rm = deps.rm ?? ((p, opts) => rmSync(p, opts));
+
+  const dir = mkdtemp("manta-askpass-");
+  const helperPath = join(dir, `askpass${helperScriptExtension(platform)}`);
+  const passphrasePath = join(dir, "passphrase");
+
+  writeFile(helperPath, helperScriptContent(platform));
+  if (platform !== "win32") chmod(helperPath, 0o700);
+  writeFile(passphrasePath, passphrase);
+
+  const env: Record<string, string> = {
+    SSH_ASKPASS: helperPath,
+    SSH_ASKPASS_REQUIRE: "force",
+    MANTA_ASKPASS_FILE: passphrasePath,
+  };
+
+  let cleaned = false;
+  return {
+    env,
+    cleanup: () => {
+      if (cleaned) return;
+      cleaned = true;
+      try {
+        rm(dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
+    },
+  };
+}

--- a/src/main/installer/handlers.test.ts
+++ b/src/main/installer/handlers.test.ts
@@ -55,6 +55,7 @@ const mintState = vi.hoisted(() => ({
       deps: {
         persist: (patch: unknown) => void;
         claimUrlOverride?: string;
+        askpassEnv?: Record<string, string>;
       },
     ) => {
       // Simulate the post-claim persist that mintAndClaim performs on the
@@ -75,7 +76,10 @@ const mintState = vi.hoisted(() => ({
 }));
 
 const installerState = vi.hoisted(() => ({
-  preflightBox: vi.fn(async (): Promise<PreflightResult> => ({
+  preflightBox: vi.fn(async (
+    _alias?: unknown,
+    _deps?: unknown,
+  ): Promise<PreflightResult> => ({
     ok: true,
     ingressMode: "public-tls" as const,
     probes: {
@@ -92,7 +96,11 @@ const installerState = vi.hoisted(() => ({
     failures: [],
     unknownHost: null,
   })),
-  runInstall: vi.fn(() => ({
+  runInstall: vi.fn((
+    _alias?: unknown,
+    _sink?: unknown,
+    _deps?: unknown,
+  ) => ({
     // Resolves immediately so the handler's fire-and-forget `.finally()`
     // clears the module's `activeHandle` before the next test runs —
     // otherwise every later `installerStart` call in this file sees a
@@ -106,6 +114,20 @@ const installerState = vi.hoisted(() => ({
 // the handler test never touches ssh-keyscan or the filesystem.
 const knownHostsState = vi.hoisted(() => ({
   trustHost: vi.fn(async () => ({ ok: true as const, line: "box ssh-ed25519 AAAA" })),
+}));
+
+// BET-360: createAskpassSession creates a temp dir + helper script. Stubbed
+// so the handler test never touches the filesystem; cleanup is a spy so we
+// can assert it fires on the right paths.
+const askpassState = vi.hoisted(() => ({
+  createAskpassSession: vi.fn((_passphrase: string) => ({
+    env: {
+      SSH_ASKPASS: "/tmp/fake-askpass.sh",
+      SSH_ASKPASS_REQUIRE: "force",
+      MANTA_ASKPASS_FILE: "/tmp/fake-passphrase",
+    },
+    cleanup: vi.fn(),
+  })),
 }));
 
 /** Flush the microtask queue so handlers.ts's fire-and-forget
@@ -127,6 +149,10 @@ vi.mock("./knownHosts.js", () => ({
   trustHost: knownHostsState.trustHost,
 }));
 
+vi.mock("./askpass.js", () => ({
+  createAskpassSession: askpassState.createAskpassSession,
+}));
+
 // Also stub the small support module the handlers pull in but never call
 // during the mint-and-claim path. handlers.ts only imports a type from
 // stageMapper.js now (erased at compile time), so no mock needed for it.
@@ -144,6 +170,7 @@ beforeEach(() => {
   installerState.preflightBox.mockClear();
   installerState.runInstall.mockClear();
   knownHostsState.trustHost.mockClear();
+  askpassState.createAskpassSession.mockClear();
 });
 
 describe("registerInstallerHandlers — mint-and-claim (BET-372)", () => {
@@ -201,6 +228,7 @@ describe("registerInstallerHandlers — mint-and-claim (BET-372)", () => {
         IPC.installerStart,
         IPC.installerCancel,
         IPC.installerTrustHost,
+        IPC.installerAskpassRespond,
         IPC.installerMintAndClaim,
         IPC.installerGetDiagnostics,
       ]),
@@ -464,6 +492,253 @@ describe("registerInstallerHandlers — fingerprint pause/resume (BET-361)", () 
     expect(failed).toBeDefined();
   });
 });
+
+// BET-360: a passphrase-protected key (not in ssh-agent) pauses the install
+// for a passphrase, then re-runs preflight + install with SSH_ASKPASS.
+describe("registerInstallerHandlers — passphrase pause/resume (BET-360)", () => {
+  function authFailedPreflight(): PreflightResult {
+    return {
+      ok: false,
+      ingressMode: "no-root",
+      probes: {
+        reachability: "auth-failed",
+        hostFingerprint: null,
+        os: { id: "unknown", arch: "unknown", release: null },
+        passwordlessSudo: false,
+        tailscale: { running: false, ipv4: null },
+        clockSkewSeconds: 0,
+        alreadyInstalled: false,
+        windowsAgent: "not-windows",
+        keyFormat: "not-windows",
+      },
+      failures: [
+        {
+          cause: "SSH key authentication was rejected.",
+          action:
+            "Make sure your key is loaded (ssh-add) and listed in the box's ~/.ssh/authorized_keys.",
+        },
+      ],
+      unknownHost: null,
+    };
+  }
+
+  function okPreflight(): PreflightResult {
+    return {
+      ok: true,
+      ingressMode: "public-tls",
+      probes: {
+        reachability: "ok",
+        hostFingerprint: null,
+        os: { id: "linux", arch: "x64", release: "6.5.0" },
+        passwordlessSudo: true,
+        tailscale: { running: false, ipv4: null },
+        clockSkewSeconds: 0,
+        alreadyInstalled: false,
+        windowsAgent: "not-windows",
+        keyFormat: "not-windows",
+      },
+      failures: [],
+      unknownHost: null,
+    };
+  }
+
+  it("emits a passphrase event, creates an askpass session, re-runs preflight, and starts the install with askpassEnv", async () => {
+    installerState.preflightBox
+      .mockResolvedValueOnce(authFailedPreflight())
+      .mockResolvedValueOnce(okPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const respondHandler = ipcState.handlers.get(IPC.installerAskpassRespond);
+    const stateHandler = ipcState.handlers.get(IPC.installerState);
+
+    // installerStart does not resolve until the askpass loop finishes — drive
+    // it without awaiting so we can answer the prompt mid-flight.
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // While paused, installerState reports the passphrase wait.
+    const paused = (await stateHandler!(null, undefined)) as {
+      waitingForPassphrase: boolean;
+      passphraseHandleId: string | null;
+    };
+    expect(paused.waitingForPassphrase).toBe(true);
+    expect(paused.passphraseHandleId).toMatch(/^install-/);
+
+    // A passphrase event was pushed to the renderer.
+    const pwEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "passphrase",
+    ) as [string, { kind: string; handleId: string; prompt: string }];
+    expect(pwEvent).toBeDefined();
+    expect(pwEvent[1].prompt).toMatch(/passphrase/i);
+    const handleId = pwEvent[1].handleId;
+
+    // runInstall has NOT started yet — the install is paused.
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+
+    // User enters a passphrase and submits.
+    await respondHandler!(null, { handleId, passphrase: "hunter2" });
+    await startP;
+
+    // An askpass session was created with the user's passphrase.
+    expect(askpassState.createAskpassSession).toHaveBeenCalledTimes(1);
+    expect(askpassState.createAskpassSession).toHaveBeenCalledWith("hunter2");
+
+    // Preflight was called twice: once with no askpass, once with askpassEnv.
+    expect(installerState.preflightBox).toHaveBeenCalledTimes(2);
+    const [, secondCallArgs] = installerState.preflightBox.mock.calls[1];
+    expect(secondCallArgs).toEqual({ askpassEnv: expect.objectContaining({ SSH_ASKPASS_REQUIRE: "force" }) });
+
+    // runInstall was called with askpassEnv.
+    expect(installerState.runInstall).toHaveBeenCalledTimes(1);
+    const [, , installDeps] = installerState.runInstall.mock.calls[0];
+    expect(installDeps).toEqual({ askpassEnv: expect.objectContaining({ SSH_ASKPASS_REQUIRE: "force" }) });
+
+    // The passphrase wait is cleared.
+    const after = (await stateHandler!(null, undefined)) as { waitingForPassphrase: boolean };
+    expect(after.waitingForPassphrase).toBe(false);
+
+    await flushMicrotasks();
+  });
+
+  it("aborts with preflight-failed on a cancel (passphrase=null), never creates a session or starts the install", async () => {
+    installerState.preflightBox.mockResolvedValueOnce(authFailedPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const respondHandler = ipcState.handlers.get(IPC.installerAskpassRespond);
+
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const pwEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "passphrase",
+    ) as [string, { kind: string; handleId: string }];
+    await respondHandler!(null, { handleId: pwEvent[1].handleId, passphrase: null });
+    await startP;
+
+    expect(askpassState.createAskpassSession).not.toHaveBeenCalled();
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+    const failed = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "preflight-failed",
+    ) as [string, { kind: string; failures: { cause: string }[] }];
+    expect(failed).toBeDefined();
+    expect(failed[1].failures[0].cause).toMatch(/authentication was rejected/);
+  });
+
+  it("cleans up the askpass session when the second preflight still fails (wrong passphrase)", async () => {
+    installerState.preflightBox
+      .mockResolvedValueOnce(authFailedPreflight())
+      .mockResolvedValueOnce(authFailedPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const respondHandler = ipcState.handlers.get(IPC.installerAskpassRespond);
+
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const pwEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "passphrase",
+    ) as [string, { kind: string; handleId: string }];
+    await respondHandler!(null, { handleId: pwEvent[1].handleId, passphrase: "wrong" });
+    await startP;
+
+    // Session was created but then cleaned up (preflight still failed).
+    expect(askpassState.createAskpassSession).toHaveBeenCalledTimes(1);
+    const session = askpassState.createAskpassSession.mock.results[0].value;
+    expect(session.cleanup).toHaveBeenCalledTimes(1);
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+  });
+
+  it("installerCancel during the passphrase pause aborts the wait", async () => {
+    installerState.preflightBox.mockResolvedValueOnce(authFailedPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const cancelHandler = ipcState.handlers.get(IPC.installerCancel);
+
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+    const pwEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "passphrase",
+    ) as [string, { kind: string; handleId: string }];
+
+    await cancelHandler!(null, { handleId: pwEvent[1].handleId });
+    await startP;
+
+    expect(askpassState.createAskpassSession).not.toHaveBeenCalled();
+    expect(installerState.runInstall).not.toHaveBeenCalled();
+    const failed = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "preflight-failed",
+    );
+    expect(failed).toBeDefined();
+  });
+
+  it("refuses a second install while a passphrase prompt is paused", async () => {
+    installerState.preflightBox.mockResolvedValueOnce(authFailedPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const respondHandler = ipcState.handlers.get(IPC.installerAskpassRespond);
+
+    void startHandler!(null, { alias: "dev" });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    await expect(
+      startHandler!(null, { alias: "dev2" }),
+    ).rejects.toThrow(/already in progress/);
+
+    // Clean up: answer the paused prompt.
+    const pwEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "passphrase",
+    ) as [string, { kind: string; handleId: string }];
+    await respondHandler!(null, { handleId: pwEvent[1].handleId, passphrase: null });
+    await flushMicrotasks();
+  });
+
+  it("installerMintAndClaim passes askpassEnv and cleans up on success", async () => {
+    // Simulate a completed install with an active askpass session by running
+    // the full flow up to the install start, then calling mintAndClaim.
+    installerState.preflightBox
+      .mockResolvedValueOnce(authFailedPreflight())
+      .mockResolvedValueOnce(okPreflight());
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const respondHandler = ipcState.handlers.get(IPC.installerAskpassRespond);
+    const claimHandler = ipcState.handlers.get(IPC.installerMintAndClaim);
+
+    const startP = startHandler!(null, { alias: "dev" }) as Promise<{ handleId: string }>;
+    await flushMicrotasks();
+    await flushMicrotasks();
+    const pwEvent = win.webContents.send.mock.calls.find(
+      (c) => (c[1] as { kind: string }).kind === "passphrase",
+    ) as [string, { kind: string; handleId: string }];
+    await respondHandler!(null, { handleId: pwEvent[1].handleId, passphrase: "hunter2" });
+    await startP;
+
+    // The askpass session is active.
+    const session = askpassState.createAskpassSession.mock.results[0].value;
+    expect(session.cleanup).not.toHaveBeenCalled();
+
+    // Claim succeeds → mintAndClaim receives askpassEnv, session is cleaned up.
+    await claimHandler!(null, { alias: "dev" });
+    const [, claimDeps] = mintState.mintAndClaim.mock.calls[0];
+    expect(claimDeps.askpassEnv).toEqual(
+      expect.objectContaining({ SSH_ASKPASS_REQUIRE: "force" }),
+    );
+    expect(session.cleanup).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+  });
+});
+
 
 // Source-level guard: the handlers.ts file MUST NOT pull main's index.js
 // back into the installer module's require graph. This catches a future

--- a/src/main/installer/handlers.ts
+++ b/src/main/installer/handlers.ts
@@ -25,6 +25,7 @@ import {
 } from "./installer.js";
 import { buildDiagnostics, type DiagnosticsInput } from "./diagnostics.js";
 import { trustHost } from "./knownHosts.js";
+import { createAskpassSession, type AskpassSession } from "./askpass.js";
 import type { InstallStageId } from "./stageMapper.js";
 import type { PreflightResult } from "./preflight.js";
 import type { HostFingerprint } from "./fingerprint.js";
@@ -60,6 +61,32 @@ let trustDeferred: {
 // enough that a user reading the fingerprint isn't rushed; short enough
 // that a forgotten tab doesn't hold the single-active slot forever.
 const TRUST_WAIT_TIMEOUT_MS = 5 * 60_000;
+
+// BET-360: when preflight (BatchMode=yes) returns auth-failed because the
+// key is passphrase-protected and not in ssh-agent, the install PAUSES here
+// waiting for the renderer's passphrase input. The deferred is resolved by
+// the installerAskpassRespond handler (passphrase string) or rejected by
+// installerCancel / a timeout (both → null = cancelled). `waitingForPassphrase`
+// is mirrored into installerState so a renderer remount re-shows the prompt.
+let waitingForPassphrase: { handleId: string; prompt: string } | null = null;
+let passphraseDeferred: {
+  resolve: (passphrase: string | null) => void;
+} | null = null;
+const PASSPHRASE_WAIT_TIMEOUT_MS = 5 * 60_000;
+
+// The active askpass session (temp dir + helper script + passphrase file).
+// Created when the user enters a passphrase; persists through the preflight
+// retry + install + claim so every ssh invocation reuses the cached
+// passphrase without re-prompting. Cleaned up on claim success, install
+// failure, cancel, or a new install start.
+let activeAskpass: AskpassSession | null = null;
+
+function cleanupAskpass(): void {
+  if (activeAskpass) {
+    activeAskpass.cleanup();
+    activeAskpass = null;
+  }
+}
 
 function pushTail(line: string): void {
   logTail.push(line);
@@ -98,6 +125,34 @@ async function awaitTrustDecision(
   });
 }
 
+// awaitPassphrase — pause the install while the renderer shows a passphrase
+// input. Resolves with the passphrase string, or null if the user cancelled
+// / the wait timed out. A null resolution is rejection-free so the caller
+// has a single path: null → abort with the original auth-failed guidance.
+async function awaitPassphrase(
+  handleId: string,
+  prompt: string,
+  send: (payload: unknown) => void,
+): Promise<string | null> {
+  waitingForPassphrase = { handleId, prompt };
+  send({ kind: "passphrase", handleId, prompt });
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (passphrase: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      waitingForPassphrase = null;
+      passphraseDeferred = null;
+      resolve(passphrase);
+    };
+    const timer = setTimeout(() => finish(null), PASSPHRASE_WAIT_TIMEOUT_MS);
+    passphraseDeferred = {
+      resolve: (p) => finish(p),
+    };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // registerInstallerHandlers — wire the IPC channels for the installer module.
 // `getWindow` resolves the BrowserWindow that should receive push events
@@ -125,18 +180,25 @@ export function registerInstallerHandlers(
     waitingForTrust: waitingForTrust !== null,
     trustHandleId: waitingForTrust?.handleId ?? null,
     pendingFingerprint: waitingForTrust?.fingerprint ?? null,
+    // BET-360: mirror the passphrase-pause so a renderer remount re-shows
+    // the passphrase prompt.
+    waitingForPassphrase: waitingForPassphrase !== null,
+    passphraseHandleId: waitingForPassphrase?.handleId ?? null,
   }));
 
   ipcMain.handle(IPC.installerStart, async (_e, input: { alias: SshTarget }) => {
-    if (activeHandle !== null || waitingForTrust !== null) {
+    if (activeHandle !== null || waitingForTrust !== null || waitingForPassphrase !== null) {
       // Single-active constraint — refuse to start a second install. The
-      // trust-pause counts as "in progress": a paused install holds the
-      // slot until the user answers (BET-361).
+      // trust-pause and passphrase-pause both count as "in progress": a
+      // paused install holds the slot until the user answers (BET-361/360).
       throw new Error("an install is already in progress");
     }
     if (input?.alias === undefined || isEmptySshTarget(input.alias)) {
       throw new Error("alias is required");
     }
+    // Clear any stale askpass session from a previous (failed/cancelled)
+    // install — the passphrase temp file must not survive across installs.
+    cleanupAskpass();
     // Alias branch stays a trimmed string (unchanged); a custom target
     // (BET-384) is already normalized by resolveInstallTarget on the
     // renderer side, so there's nothing further to trim on an object.
@@ -195,6 +257,42 @@ export function registerInstallerHandlers(
       preflight = await preflightBox(alias);
       activePreflight = preflight;
     }
+
+    // BET-360: auth-failed on a reachable, trusted host means the key is
+    // passphrase-protected and not in ssh-agent. Pause for a passphrase,
+    // then re-run preflight with SSH_ASKPASS enabled. A cancel / timeout
+    // (null passphrase) aborts with the original auth-failed guidance —
+    // nothing was written to the box. We do NOT loop: a second auth-failed
+    // after askpass (wrong passphrase) is a normal preflight-failed.
+    if (!preflight.ok && preflight.probes.reachability === "auth-failed") {
+      const passphrase = await awaitPassphrase(
+        handleId,
+        "Enter the passphrase for your SSH key:",
+        send,
+      );
+      if (passphrase === null) {
+        send({ kind: "preflight-failed", handleId, failures: preflight.failures });
+        return { handleId };
+      }
+      const session = createAskpassSession(passphrase);
+      activeAskpass = session;
+      try {
+        preflight = await preflightBox(alias, { askpassEnv: session.env });
+        activePreflight = preflight;
+      } catch {
+        session.cleanup();
+        activeAskpass = null;
+        send({ kind: "preflight-failed", handleId, failures: preflight.failures });
+        return { handleId };
+      }
+      if (!preflight.ok) {
+        session.cleanup();
+        activeAskpass = null;
+        send({ kind: "preflight-failed", handleId, failures: preflight.failures });
+        return { handleId };
+      }
+    }
+
     if (!preflight.ok) {
       send({ kind: "preflight-failed", handleId, failures: preflight.failures });
       return { handleId };
@@ -212,6 +310,7 @@ export function registerInstallerHandlers(
           send({ kind: "stage", handleId, stage });
         },
       },
+      { askpassEnv: activeAskpass?.env },
     );
     activeHandle = { handleId, cancel: handle.cancel };
     // Fire-and-forget the done promise — we push the done event ourselves
@@ -226,6 +325,11 @@ export function registerInstallerHandlers(
           signal: r.signal,
           ok: r.code === 0,
         });
+        // On a FAILED install, the SSH connection is no longer needed —
+        // clean up the askpass session immediately. On success, keep it
+        // alive for the mint+claim phase (installerMintAndClaim cleans up
+        // after a successful claim).
+        if (r.code !== 0) cleanupAskpass();
       })
       .catch((err: unknown) => {
         send({
@@ -233,6 +337,7 @@ export function registerInstallerHandlers(
           handleId,
           message: err instanceof Error ? err.message : String(err),
         });
+        cleanupAskpass();
       })
       .finally(() => {
         // Only clear if THIS handle is still the active one — a cancel-then-
@@ -248,6 +353,13 @@ export function registerInstallerHandlers(
 
   ipcMain.handle(IPC.installerCancel, (_e, input: { handleId: string }) => {
     if (typeof input?.handleId !== "string" || input.handleId === "") return;
+    // BET-360: cancel during the passphrase-pause aborts the wait (treated
+    // as "cancelled" → null passphrase → the install aborts with the
+    // original auth-failed guidance). No child to SIGTERM yet.
+    if (waitingForPassphrase?.handleId === input.handleId && passphraseDeferred) {
+      passphraseDeferred.resolve(null);
+      return;
+    }
     // BET-361: cancel during the trust-pause aborts the wait (treated as
     // "not trusted" — the install never started, so there's no child to
     // SIGTERM).
@@ -257,6 +369,7 @@ export function registerInstallerHandlers(
     }
     if (activeHandle?.handleId === input.handleId) {
       activeHandle.cancel();
+      cleanupAskpass();
     }
     // If handleId doesn't match the active handle (already done / cancelled
     // / a stale renderer): no-op. cancel is idempotent by design.
@@ -271,14 +384,35 @@ export function registerInstallerHandlers(
     trustDeferred.resolve({ trust: input.trust });
   });
 
+  ipcMain.handle(
+    IPC.installerAskpassRespond,
+    (_e, input: { handleId: string; passphrase: string | null }) => {
+      if (typeof input?.handleId !== "string" || input.handleId === "") return;
+      // No paused passphrase prompt, or a stale renderer: no-op.
+      if (!waitingForPassphrase || !passphraseDeferred) return;
+      if (waitingForPassphrase.handleId !== input.handleId) return;
+      // null or empty string → user cancelled. A non-empty string → the
+      // passphrase to decrypt the SSH key.
+      const pw = input.passphrase;
+      passphraseDeferred.resolve(pw && pw.length > 0 ? pw : null);
+    },
+  );
+
   ipcMain.handle(IPC.installerMintAndClaim, async (
     _e,
     input: { alias: SshTarget; claimUrlOverride?: string },
   ) => {
-    return mintAndClaim(input.alias, {
+    const result = await mintAndClaim(input.alias, {
       persist,
       claimUrlOverride: input.claimUrlOverride,
+      askpassEnv: activeAskpass?.env,
     });
+    // After a successful claim the SSH connection is no longer needed —
+    // the app switches to HTTP. Clean up the askpass session (temp dir +
+    // passphrase file). On failure, keep it so the user can retry the
+    // claim without re-entering the passphrase.
+    if (result.ok) cleanupAskpass();
+    return result;
   });
 
   ipcMain.handle(IPC.installerGetDiagnostics, (_e, input: DiagnosticsInput) => {

--- a/src/main/installer/installer.ts
+++ b/src/main/installer/installer.ts
@@ -30,6 +30,7 @@ import {
   execLocal,
   streamRemote,
   type ExecRemoteResult,
+  type ExecRemoteOptions,
   type SpawnFn,
 } from "./runner.js";
 import { parseSshConfig, type SshHostEntry } from "./sshConfig.js";
@@ -162,6 +163,11 @@ export type PreflightDeps = {
   /** Override the local home directory for tests (defaults to os.homedir()).
    *  The key-format probe reads ~/.ssh/id_* under this path. */
   homeDir?: string;
+  /** Askpass env vars (BET-360). When set, probes run WITHOUT BatchMode so
+   *  ssh can invoke the SSH_ASKPASS helper for a passphrase-protected key.
+   *  Only the askpass retry path sets this (after the first preflight
+   *  returned auth-failed and the user entered a passphrase). */
+  askpassEnv?: Record<string, string>;
 };
 
 export async function preflightBox(
@@ -172,6 +178,15 @@ export async function preflightBox(
     throw new Error("preflightBox: alias is required");
   }
   const spawn = deps.spawn;
+  // Build the shared ssh options once — every probe gets the same askpass
+  // env (if any) so a passphrase-protected key works across all six probes
+  // without re-prompting (the passphrase is cached in the askpass temp file
+  // for the whole session). `allowPrompt` is derived from askpassEnv so
+  // BatchMode=yes is dropped only on the retry path.
+  const probeOpts: { spawn?: SpawnFn; askpassEnv?: Record<string, string> } = {
+    spawn,
+    askpassEnv: deps.askpassEnv,
+  };
   // Run the six remote probes in parallel — they're independent and each
   // bounded by execRemote's timeoutMs. The two Windows probes inspect the
   // LOCAL machine (no SSH round-trip) and run alongside; on non-Windows
@@ -187,12 +202,12 @@ export async function preflightBox(
     winAgentRes,
     keyFmtRes,
   ] = await Promise.all([
-    probeReachability(alias, spawn),
-    probeOs(alias, spawn),
-    probeSudo(alias, spawn),
-    probeTailscale(alias, spawn),
-    probeClock(alias, spawn),
-    probeAuthFile(alias, spawn),
+    probeReachability(alias, probeOpts),
+    probeOs(alias, probeOpts),
+    probeSudo(alias, probeOpts),
+    probeTailscale(alias, probeOpts),
+    probeClock(alias, probeOpts),
+    probeAuthFile(alias, probeOpts),
     probeWindowsAgent(deps),
     probeKeyFormat(deps),
   ]);
@@ -221,13 +236,28 @@ type ReachabilityProbe = {
   fingerprint: HostFingerprint | null;
 };
 
-async function probeReachability(alias: SshTarget, spawn?: SpawnFn): Promise<ReachabilityProbe> {
+// Shared options for the remote probes — each probe gets the same askpass
+// env (if any) so a passphrase-protected key works across all six probes
+// without re-prompting. `allowPrompt` is derived from askpassEnv so
+// BatchMode=yes is dropped only on the retry path.
+type ProbeOpts = {
+  spawn?: SpawnFn;
+  askpassEnv?: Record<string, string>;
+};
+
+function probeExecOpts(opts: ProbeOpts, timeoutMs: number): ExecRemoteOptions {
+  return {
+    spawn: opts.spawn,
+    timeoutMs,
+    env: opts.askpassEnv,
+    allowPrompt: !!opts.askpassEnv,
+  };
+}
+
+async function probeReachability(alias: SshTarget, opts: ProbeOpts): Promise<ReachabilityProbe> {
   // BatchMode=yes turns "no auth" into exit code 255 / stderr "Permission
   // denied (publickey)" — not a hang on a passphrase prompt.
-  const r = await execRemote(alias, PROBE_REACHABILITY_CMD, {
-    spawn,
-    timeoutMs: 15_000,
-  });
+  const r = await execRemote(alias, PROBE_REACHABILITY_CMD, probeExecOpts(opts, 15_000));
   if (r.code === 0 && r.stdout.trim() === "ok") {
     return { reachability: "ok", fingerprint: null };
   }
@@ -262,8 +292,8 @@ async function probeReachability(alias: SshTarget, spawn?: SpawnFn): Promise<Rea
   return { reachability: "unreachable", fingerprint: null };
 }
 
-async function probeOs(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["os"]> {
-  const r = await execRemote(alias, PROBE_OS_CMD, { spawn, timeoutMs: 10_000 });
+async function probeOs(alias: SshTarget, opts: ProbeOpts): Promise<PreflightProbes["os"]> {
+  const r = await execRemote(alias, PROBE_OS_CMD, probeExecOpts(opts, 10_000));
   if (r.code !== 0) {
     return { id: "unknown", arch: "unknown", release: null };
   }
@@ -275,16 +305,16 @@ async function probeOs(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProb
   };
 }
 
-async function probeSudo(alias: SshTarget, spawn?: SpawnFn): Promise<boolean> {
-  const r = await execRemote(alias, PROBE_SUDO_CMD, { spawn, timeoutMs: 10_000 });
+async function probeSudo(alias: SshTarget, opts: ProbeOpts): Promise<boolean> {
+  const r = await execRemote(alias, PROBE_SUDO_CMD, probeExecOpts(opts, 10_000));
   // `sudo -n true` exit 0 + no password prompt → passwordless sudo.
   // Anything else (exit != 0, or "password" in stderr) → not available.
   if (r.code === 0) return !/password/i.test(r.stderr);
   return false;
 }
 
-async function probeTailscale(alias: SshTarget, spawn?: SpawnFn): Promise<PreflightProbes["tailscale"]> {
-  const r = await execRemote(alias, PROBE_TAILSCALE_CMD, { spawn, timeoutMs: 10_000 });
+async function probeTailscale(alias: SshTarget, opts: ProbeOpts): Promise<PreflightProbes["tailscale"]> {
+  const r = await execRemote(alias, PROBE_TAILSCALE_CMD, probeExecOpts(opts, 10_000));
   if (r.code !== 0 || r.stdout.trim() === "") {
     return { running: false, ipv4: null };
   }
@@ -292,17 +322,17 @@ async function probeTailscale(alias: SshTarget, spawn?: SpawnFn): Promise<Prefli
   return parsed ?? { running: false, ipv4: null };
 }
 
-async function probeClock(alias: SshTarget, spawn?: SpawnFn): Promise<number> {
+async function probeClock(alias: SshTarget, opts: ProbeOpts): Promise<number> {
   const local = Math.floor(Date.now() / 1000);
-  const r = await execRemote(alias, PROBE_CLOCK_CMD, { spawn, timeoutMs: 10_000 });
+  const r = await execRemote(alias, PROBE_CLOCK_CMD, probeExecOpts(opts, 10_000));
   if (r.code !== 0) return 0;
   const remote = Number(r.stdout.trim());
   if (!Number.isFinite(remote)) return 0;
   return local - remote;
 }
 
-async function probeAuthFile(alias: SshTarget, spawn?: SpawnFn): Promise<boolean> {
-  const r = await execRemote(alias, PROBE_AUTH_FILE_CMD, { spawn, timeoutMs: 10_000 });
+async function probeAuthFile(alias: SshTarget, opts: ProbeOpts): Promise<boolean> {
+  const r = await execRemote(alias, PROBE_AUTH_FILE_CMD, probeExecOpts(opts, 10_000));
   return r.code === 0 && r.stdout.trim() === "INSTALLED";
 }
 
@@ -385,6 +415,11 @@ function parseTailscaleJson(text: string): PreflightProbes["tailscale"] | null {
 export type InstallDeps = {
   spawn?: SpawnFn;
   installShUrl?: string;
+  /** Askpass env vars (BET-360). When set, the install stream runs without
+   *  BatchMode so ssh can invoke the SSH_ASKPASS helper for a passphrase-
+   *  protected key. The session is created by the installer handler after
+   *  the user enters a passphrase; it persists through the install + claim. */
+  askpassEnv?: Record<string, string>;
 };
 
 export type InstallSink = {
@@ -422,6 +457,8 @@ export function runInstall(
   const handle = streamRemote(alias, buildInstallCommand(installShUrl, cfg.releaseHost, cfg.id), {
     forceTty: true,
     spawn: deps.spawn,
+    env: deps.askpassEnv,
+    allowPrompt: !!deps.askpassEnv,
     onStdout: (chunk) => pumpChunk(chunk, "stdout", sink),
     onStderr: (chunk) => pumpChunk(chunk, "stderr", sink),
   });
@@ -486,6 +523,11 @@ export type MintAndClaimDeps = {
   /** Optional override for the box's claim URL — defaults to the serverUrl
    *  parsed out of `manta pair` output. */
   claimUrlOverride?: string;
+  /** Askpass env vars (BET-360). When set, the `manta pair` SSH call runs
+   *  without BatchMode so a passphrase-protected key can be decrypted via
+   *  the SSH_ASKPASS helper. The session is owned by the installer handler
+   *  and cleaned up after the claim resolves. */
+  askpassEnv?: Record<string, string>;
 };
 
 /**
@@ -513,6 +555,8 @@ export async function mintAndClaim(
   const fetched = await execRemote(alias, "bash -lc 'manta pair'", {
     spawn,
     timeoutMs: 30_000,
+    env: deps.askpassEnv,
+    allowPrompt: !!deps.askpassEnv,
   });
   if (fetched.code !== 0) {
     return {

--- a/src/main/installer/runner.test.ts
+++ b/src/main/installer/runner.test.ts
@@ -294,3 +294,105 @@ describe("probeSshG", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// BET-360: askpass env-var construction + BatchMode suppression
+// ---------------------------------------------------------------------------
+
+describe("execRemote — askpass env (BET-360)", () => {
+  it("drops BatchMode=yes when allowPrompt is true", async () => {
+    const captured: { args: string[] } = { args: [] };
+    const fake = makeFakeChild();
+    const p = execRemote("dev", "echo hi", {
+      spawn: (_c, args) => {
+        captured.args = args;
+        return fake.child as any;
+      },
+      allowPrompt: true,
+    });
+    setImmediate(() => fake.fireExit(0));
+    await p;
+    // BatchMode=yes must NOT be in the args when allowPrompt is set.
+    expect(captured.args).not.toContain("BatchMode=yes");
+    // ConnectTimeout is still present.
+    expect(captured.args).toContain("ConnectTimeout=10");
+  });
+
+  it("keeps BatchMode=yes by default (allowPrompt unset)", async () => {
+    const captured: { args: string[] } = { args: [] };
+    const fake = makeFakeChild();
+    const p = execRemote("dev", "echo hi", {
+      spawn: (_c, args) => {
+        captured.args = args;
+        return fake.child as any;
+      },
+    });
+    setImmediate(() => fake.fireExit(0));
+    await p;
+    expect(captured.args).toContain("BatchMode=yes");
+  });
+
+  it("merges env into the spawn options (overlay, not replace)", async () => {
+    const captured: { opts: Parameters<SpawnFn>[2] | undefined } = { opts: undefined };
+    const fake = makeFakeChild();
+    const askpassEnv = {
+      SSH_ASKPASS: "/tmp/helper.sh",
+      SSH_ASKPASS_REQUIRE: "force",
+      MANTA_ASKPASS_FILE: "/tmp/pw",
+    };
+    const p = execRemote("dev", "echo hi", {
+      spawn: (_c, _a, opts) => {
+        captured.opts = opts;
+        return fake.child as any;
+      },
+      env: askpassEnv,
+    });
+    setImmediate(() => fake.fireExit(0));
+    await p;
+    // The env was passed through and contains the askpass vars.
+    expect(captured.opts?.env).toBeDefined();
+    expect(captured.opts?.env?.SSH_ASKPASS).toBe("/tmp/helper.sh");
+    expect(captured.opts?.env?.SSH_ASKPASS_REQUIRE).toBe("force");
+    // process.env is preserved (PATH must survive).
+    expect(captured.opts?.env?.PATH).toBe(process.env.PATH);
+  });
+
+  it("does not set env on spawn when no env option is provided", async () => {
+    const captured: { opts: Parameters<SpawnFn>[2] | undefined } = { opts: undefined };
+    const fake = makeFakeChild();
+    const p = execRemote("dev", "echo hi", {
+      spawn: (_c, _a, opts) => {
+        captured.opts = opts;
+        return fake.child as any;
+      },
+    });
+    setImmediate(() => fake.fireExit(0));
+    await p;
+    // No env key → child inherits process.env (Node default).
+    expect(captured.opts?.env).toBeUndefined();
+  });
+});
+
+describe("streamRemote — askpass env (BET-360)", () => {
+  it("drops BatchMode and merges env when allowPrompt + env are set", async () => {
+    const captured: { args: string[]; opts: Parameters<SpawnFn>[2] | undefined } = {
+      args: [],
+      opts: undefined,
+    };
+    const fake = makeFakeChild();
+    const handle = streamRemote("dev", "echo hi", {
+      spawn: (_c, args, opts) => {
+        captured.args = args;
+        captured.opts = opts;
+        return fake.child as any;
+      },
+      allowPrompt: true,
+      env: { SSH_ASKPASS: "/tmp/helper.sh", SSH_ASKPASS_REQUIRE: "force", MANTA_ASKPASS_FILE: "/tmp/pw" },
+      onStdout: () => {},
+    });
+    setImmediate(() => fake.fireExit(0));
+    await handle.done;
+    expect(captured.args).not.toContain("BatchMode=yes");
+    expect(captured.opts?.env?.SSH_ASKPASS).toBe("/tmp/helper.sh");
+  });
+});

--- a/src/main/installer/runner.ts
+++ b/src/main/installer/runner.ts
@@ -57,6 +57,18 @@ export type RemoteOptions = {
   connectTimeoutSec?: number;
   /** Inject for tests; defaults to child_process.spawn. */
   spawn?: SpawnFn;
+  /** Extra environment variables merged into the ssh child's env (BET-360).
+   *  Used to set SSH_ASKPASS / SSH_ASKPASS_REQUIRE / MANTA_ASKPASS_FILE for
+   *  the passphrase-protected-key flow. When present, the child inherits
+   *  process.env with these overlaid — a partial env does NOT erase the
+   *  rest of the parent environment. */
+  env?: Record<string, string>;
+  /** When true, omit `BatchMode=yes` so ssh can prompt via SSH_ASKPASS
+   *  (BET-360). Defaults to false — BatchMode=yes is the safe default that
+   *  turns an auth failure into a clean non-zero exit instead of hanging on
+   *  a passphrase prompt the user can't see. Only the askpass retry path
+   *  (preflight returned auth-failed, user entered a passphrase) sets this. */
+  allowPrompt?: boolean;
 };
 
 // execRemote — run one remote command and return its outcome.
@@ -93,7 +105,7 @@ export async function execRemote(
   }
   const spawn = options.spawn ?? nodeSpawn;
   const args: string[] = buildArgs(alias, command, options);
-  const child = spawn(SSH_BIN, args, { stdio: ["ignore", "pipe", "pipe"] });
+  const child = spawn(SSH_BIN, args, buildSpawnOptions(options));
   return collectChild(child, options.timeoutMs ?? 30_000);
 }
 
@@ -199,7 +211,7 @@ export function streamRemote(
   }
   const spawn = options.spawn ?? nodeSpawn;
   const args = buildArgs(alias, command, options);
-  const child = spawn(SSH_BIN, args, { stdio: ["ignore", "pipe", "pipe"] });
+  const child = spawn(SSH_BIN, args, buildSpawnOptions(options));
   if (child.stdout) {
     child.stdout.on("data", (c: Buffer) => options.onStdout(c.toString("utf8")));
   }
@@ -282,12 +294,29 @@ function buildArgs(alias: SshTarget, command: string, opts: RemoteOptions): stri
   return [
     "-o",
     `ConnectTimeout=${opts.connectTimeoutSec ?? 10}`,
-    "-o",
-    "BatchMode=yes", // never prompt; non-zero exit on key auth failure
+    // BatchMode=yes forces ssh to NEVER prompt — a half-configured box fails
+    // the preflight cleanly instead of hanging. The ONE exception is the
+    // askpass retry path (BET-360): when the key is passphrase-protected and
+    // not in ssh-agent, BatchMode would suppress the very SSH_ASKPASS prompt
+    // we need, so `allowPrompt` drops it for that retry only.
+    ...(opts.allowPrompt ? [] : ["-o", "BatchMode=yes"]),
     ...sshTargetExtraArgs(alias),
     ...(opts.forceTty ? ["-tt"] : []),
     "--",
     sshTargetDestination(alias),
     command,
   ];
+}
+
+// buildSpawnOptions — shared spawn options for every ssh child in this module.
+// Merges the askpass env (if any) over process.env so the child inherits the
+// full parent environment plus SSH_ASKPASS / SSH_ASKPASS_REQUIRE / etc.
+// Without the spread, Node's spawn replaces the env entirely when `env` is set
+// (e.g. PATH would be lost) — we always overlay, never replace.
+function buildSpawnOptions(opts: RemoteOptions): Parameters<typeof nodeSpawn>[2] {
+  const base: Parameters<typeof nodeSpawn>[2] = { stdio: ["ignore", "pipe", "pipe"] };
+  if (opts.env) {
+    base.env = { ...process.env, ...opts.env };
+  }
+  return base;
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -211,6 +211,15 @@ const api = {
   installerTrustHost: (input: { handleId: string; trust: boolean }): Promise<void> =>
     ipcRenderer.invoke(IPC.installerTrustHost, input),
 
+  // BET-360: the renderer's answer to a paused `passphrase` event.
+  // passphrase=non-empty → main creates an askpass session (SSH_ASKPASS
+  // helper + temp passphrase file) and re-runs preflight; passphrase=null
+  // → the user cancelled → the install aborts with a preflight-failed event.
+  installerAskpassRespond: (input: {
+    handleId: string;
+    passphrase: string | null;
+  }): Promise<void> => ipcRenderer.invoke(IPC.installerAskpassRespond, input),
+
   // Mint a fresh pairing code over the existing SSH connection + claim it
   // via the box's public URL. Persists credentials through main's existing
   // claim path (single config writer, per BET-355 constraint #4). The

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -156,6 +156,14 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     algo: string;
     sha256: string;
   } | null>(null);
+  // BET-360: a passphrase-protected key (not in ssh-agent) paused the
+  // install for a passphrase. Rendered INLINE in the progress panel (same
+  // pattern as the fingerprint card) — a password input + Submit/Cancel.
+  const [passphrasePrompt, setPassphrasePrompt] = useState<{
+    handleId: string;
+    prompt: string;
+  } | null>(null);
+  const [passphraseInput, setPassphraseInput] = useState("");
   const [claimRunning, setClaimRunning] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
   const logRef = useRef<HTMLDivElement | null>(null);
@@ -271,6 +279,22 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         });
         return;
       }
+      // BET-360: recover a paused passphrase prompt on remount.
+      if (s.waitingForPassphrase && s.passphraseHandleId) {
+        setRunning(true);
+        setActiveHandle(s.passphraseHandleId);
+        setStage(INITIAL_STAGE);
+        setStageLabel(INITIAL_STAGE_INFO.label);
+        setStageIndex(INITIAL_STAGE_INFO.index);
+        setStageTotal(INITIAL_STAGE_INFO.total);
+        setLogOpen(true);
+        setPassphrasePrompt({
+          handleId: s.passphraseHandleId,
+          prompt: "Enter the passphrase for your SSH key:",
+        });
+        setPassphraseInput("");
+        return;
+      }
       if (s.active) {
         const info = currentStageInfo(s.stage);
         setRunning(true);
@@ -321,6 +345,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setRunning(false);
           setActiveHandle(null);
           setFingerprintPrompt(null);
+          setPassphrasePrompt(null);
+          setPassphraseInput("");
           break;
         case "fingerprint":
           // The install is paused waiting for a trust decision — show the
@@ -333,11 +359,19 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
             sha256: evt.fingerprint.sha256,
           });
           break;
+        case "passphrase":
+          // BET-360: the install is paused waiting for the SSH key
+          // passphrase — show the passphrase input card inline.
+          setPassphrasePrompt({ handleId: evt.handleId, prompt: evt.prompt });
+          setPassphraseInput("");
+          break;
         case "done":
           setDone({ ok: evt.ok, code: evt.code, signal: evt.signal });
           setRunning(false);
           setActiveHandle(null);
           setFingerprintPrompt(null);
+          setPassphrasePrompt(null);
+          setPassphraseInput("");
           if (evt.ok) {
             // Collapse the log back to the single status line on success.
             setLogOpen(false);
@@ -351,6 +385,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setRunning(false);
           setActiveHandle(null);
           setFingerprintPrompt(null);
+          setPassphrasePrompt(null);
+          setPassphraseInput("");
           break;
       }
     });
@@ -408,6 +444,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     setInstallError(null);
     setPreflightFailure(null);
     setFingerprintPrompt(null);
+    setPassphrasePrompt(null);
+    setPassphraseInput("");
     setLines([]);
     setDone(null);
     setClaimError(null);
@@ -435,12 +473,12 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   }
 
   async function cancelInstall() {
-    // During the fingerprint trust pause, activeHandle is still null
-    // (installerStart hasn't returned) — but the install IS in flight and
-    // the Cancel button is visible. Route through the trust-prompt's
-    // handleId so installerCancel reaches the main-process trust-wait
-    // abort instead of silently no-oping (BET-361 review cycle 1 Block).
-    const handleId = activeHandle ?? fingerprintPrompt?.handleId;
+    // During the fingerprint trust pause OR the passphrase pause,
+    // activeHandle is still null (installerStart hasn't returned) — but the
+    // install IS in flight and the Cancel button is visible. Route through
+    // the paused prompt's handleId so installerCancel reaches the main-
+    // process abort instead of silently no-oping (BET-361/360).
+    const handleId = activeHandle ?? fingerprintPrompt?.handleId ?? passphrasePrompt?.handleId;
     if (!handleId) return;
     await preload.installerCancel({ handleId });
   }
@@ -460,6 +498,27 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     }
     try {
       await preload.installerTrustHost({ handleId, trust });
+    } catch (e) {
+      setInstallError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  // BET-360: submit the entered passphrase (or cancel). Submit → main
+  // creates an SSH_ASKPASS session and re-runs preflight; the install
+  // resumes streaming. Cancel → main aborts with a preflight-failed event;
+  // we drop the spinner immediately.
+  async function submitPassphrase(submit: boolean) {
+    if (!passphrasePrompt) return;
+    const handleId = passphrasePrompt.handleId;
+    const pw = submit ? passphraseInput : null;
+    setPassphrasePrompt(null);
+    setPassphraseInput("");
+    if (!submit) {
+      setRunning(false);
+      setActiveHandle(null);
+    }
+    try {
+      await preload.installerAskpassRespond({ handleId, passphrase: pw });
     } catch (e) {
       setInstallError(e instanceof Error ? e.message : String(e));
     }
@@ -782,7 +841,13 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                 style={{ borderColor: ACCENT, borderTopColor: "transparent" }}
               />
             )}
-            <span>{fingerprintPrompt ? "Waiting for host trust…" : stageLabel}</span>
+            <span>
+              {fingerprintPrompt
+                ? "Waiting for host trust…"
+                : passphrasePrompt
+                ? "Waiting for SSH key passphrase…"
+                : stageLabel}
+            </span>
             <span className="text-text-muted">
               {stageIndex} of {stageTotal} · {formatElapsed(elapsedSeconds)}
             </span>
@@ -847,7 +912,59 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               </div>
             </div>
           )}
-          {logOpen && !fingerprintPrompt && (
+          {/* BET-360: inline passphrase prompt. The install is paused —
+              the key is passphrase-protected and not in ssh-agent. The
+              user enters the passphrase once; main caches it in a temp
+              file for every ssh invocation in the rest of the flow. */}
+          {passphrasePrompt && (
+            <div
+              className="rounded-md p-3.5 space-y-2.5"
+              style={{ border: `1px solid ${ACCENT}` }}
+            >
+              <div className="text-sm font-medium">{passphrasePrompt.prompt}</div>
+              <p className="text-xs text-text-muted">
+                Your SSH key is passphrase-protected and not loaded in
+                ssh-agent. Enter the passphrase to decrypt it for this
+                install — it is used only in-memory and never stored.
+              </p>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void submitPassphrase(passphraseInput.length > 0);
+                }}
+                className="space-y-2"
+              >
+                <input
+                  type="password"
+                  value={passphraseInput}
+                  onChange={(e) => setPassphraseInput(e.target.value)}
+                  autoFocus
+                  placeholder="Passphrase"
+                  className="w-full rounded-md px-3 py-2 text-sm bg-bg-elev"
+                  style={{ border: `1px solid ${ACCENT}` }}
+                />
+                <div className="flex gap-2 pt-0.5">
+                  <button
+                    type="submit"
+                    disabled={passphraseInput.length === 0}
+                    className="px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-40"
+                    style={{ background: ACCENT, color: "#0B1020" }}
+                  >
+                    Unlock &amp; continue
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void submitPassphrase(false)}
+                    className="px-3 py-1.5 rounded-md text-sm font-medium"
+                    style={{ border: `1px solid ${DANGER}`, color: DANGER }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+          {logOpen && !fingerprintPrompt && !passphrasePrompt && (
             <div
               ref={logRef}
               style={{ height: 172, overflowY: "auto" }}

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -58,6 +58,7 @@ function makeFakePreload(): MantaPreload {
     installerStart: vi.fn(async () => ({ handleId: "fake-handle" })),
     installerCancel: vi.fn(async () => {}),
     installerTrustHost: vi.fn(async () => {}),
+    installerAskpassRespond: vi.fn(async () => {}),
     installerMintAndClaim: vi.fn(async () => ({
       ok: false as const,
       kind: "network" as const,
@@ -71,6 +72,8 @@ function makeFakePreload(): MantaPreload {
       waitingForTrust: false,
       trustHandleId: null,
       pendingFingerprint: null,
+      waitingForPassphrase: false,
+      passphraseHandleId: null,
     })),
     installerGetDiagnostics: vi.fn(async () => ""),
     onInstallerEvent: vi.fn(() => vi.fn()),

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -143,6 +143,14 @@ export interface MantaPreload {
   // host key to ~/.ssh/known_hosts and resumes; trust=false aborts.
   installerTrustHost(input: { handleId: string; trust: boolean }): Promise<void>;
 
+  // BET-360: answer a paused `passphrase` event. passphrase=non-empty →
+  // main creates an SSH_ASKPASS session and re-runs preflight; passphrase=
+  // null → the user cancelled → the install aborts.
+  installerAskpassRespond(input: {
+    handleId: string;
+    passphrase: string | null;
+  }): Promise<void>;
+
   // Mint a fresh pairing code over the existing SSH connection + claim it
   // via the box's public URL. Returns the SAME ClaimOutcome shape as the
   // manual PairStep claim — the renderer treats success and failure the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -356,6 +356,17 @@ export type InstallerEvent =
       handleId: string;
       fingerprint: HostFingerprint;
     }
+  // Preflight (BatchMode=yes) returned auth-failed: the key is passphrase-
+  // protected and not in ssh-agent. The install PAUSES here — the renderer
+  // shows a passphrase input; the user's answer comes back via
+  // installerAskpassRespond. On submit, main re-runs preflight with
+  // SSH_ASKPASS enabled (BET-360). A cancel / timeout aborts like a
+  // declined trust prompt.
+  | {
+      kind: "passphrase";
+      handleId: string;
+      prompt: string;
+    }
   | {
       kind: "done";
       handleId: string;
@@ -382,6 +393,12 @@ export type InstallerState = {
   // The fingerprint being awaited, or null. Mirrors the `fingerprint` event
   // payload so a remount recovers the prompt without a re-send.
   pendingFingerprint: HostFingerprint | null;
+  // BET-360: True while the install is PAUSED waiting for the user to enter
+  // an SSH key passphrase. The renderer re-shows the passphrase prompt on
+  // remount when this is set (mirrors waitingForTrust).
+  waitingForPassphrase: boolean;
+  // The handle id the paused passphrase prompt belongs to, or null.
+  passphraseHandleId: string | null;
 };
 
 // Desktop auto-update (electron-updater) payloads, shared by the preload
@@ -811,12 +828,19 @@ export const IPC = {
   // ~/.ssh/known_hosts and resumes the install; trust=false (or a cancel)
   // aborts with a preflight-failed event.
   installerTrustHost: "installer:trust-host",
+  // installerAskpassRespond (BET-360): the renderer's answer to a paused
+  // `passphrase` event. passphrase=non-empty string → main creates an
+  // askpass session and re-runs preflight with SSH_ASKPASS enabled;
+  // passphrase=null → the user cancelled → the install aborts with a
+  // preflight-failed event (same shape as a declined trust prompt).
+  installerAskpassRespond: "installer:askpass-respond",
   // installerEvent is the main → renderer push channel (mirrors the
   // pairLinkReceived pattern). Payload is a discriminated union:
   //   { kind: "line", handleId, text }
   //   { kind: "stage", handleId, stage }
   //   { kind: "preflight-failed", handleId, failures }
   //   { kind: "fingerprint", handleId, fingerprint }   (BET-361 — pause for trust)
+  //   { kind: "passphrase", handleId, prompt }         (BET-360 — pause for key passphrase)
   //   { kind: "done", handleId, code, signal }
   //   { kind: "error", handleId, message }
   installerEvent: "installer:event",

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-28T09:33:17+02:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-07-28T09:33:17+02:00</lastmod>
+    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## BET-360: SSH_ASKPASS passphrase flow for passphrase-protected keys

### What

When the installer's preflight (BatchMode=yes) returns `auth-failed` because the SSH key is passphrase-protected and not loaded in ssh-agent, the installer now pauses and prompts the user for the passphrase via an inline renderer card. On submit, main creates a runtime SSH_ASKPASS helper script + passphrase file in a temp dir, re-runs preflight and the install with `SSH_ASKPASS_REQUIRE=force` (dropping BatchMode), so ssh invokes the helper to decrypt the key. The session persists through the mint+claim phase and is cleaned up on success/failure/cancel.

### Why

The BET-355 installer flow used `BatchMode=yes` on every ssh invocation — correct for keys loaded in ssh-agent, but a dead end for passphrase-protected keys not in the agent. The DoD ("nothing typed but the host") requires the latter to work end-to-end. OpenSSH's `SSH_ASKPASS` + `SSH_ASKPASS_REQUIRE=force` (8.4+) is the canonical path.

### How

- **`askpass.ts`** (NEW) — Pure session manager: creates a temp dir, writes a platform-native helper script (sh on Unix, cmd on Windows) + the passphrase file (0600), returns the env vars (`SSH_ASKPASS`, `SSH_ASKPASS_REQUIRE`, `MANTA_ASKPASS_FILE`), and an idempotent `cleanup()`. Helper script is generated at runtime (not shipped) to sidestep the electron-vite bundler — no build config changes, works identically in dev and packaged mode.
- **`runner.ts`** — `RemoteOptions` gains `env` (merged into spawn env, overlaid on `process.env`) and `allowPrompt` (drops `BatchMode=yes` when true). Shared `buildSpawnOptions` helper.
- **`installer.ts`** — `askpassEnv` threaded through `PreflightDeps` (all 6 probes), `InstallDeps` (install stream), and `MintAndClaimDeps` (`manta pair`).
- **`handlers.ts`** — After preflight returns `auth-failed`, emits a `passphrase` event and pauses. On `installerAskpassRespond` with a non-empty passphrase: creates an askpass session, re-runs preflight with askpass, proceeds to install + claim with the session. On cancel/timeout: aborts with the original auth-failed guidance. Session cleaned up on install failure, claim success, cancel, or new install start.
- **`types.ts` / preload / renderer** — New `passphrase` InstallerEvent variant, `installerAskpassRespond` IPC channel, `waitingForPassphrase`/`passphraseHandleId` in InstallerState (for remount recovery). `SshInstallStep.tsx` renders an inline passphrase card (password input + Submit/Cancel) matching the BET-361 fingerprint card pattern.

### Flow

```
1. User clicks "Install & pair"
2. Preflight (BatchMode=yes) → auth-failed (passphrase-protected key, not in agent)
3. Renderer shows inline passphrase prompt
4. User enters passphrase → main creates askpass session (temp helper + pw file)
5. Preflight re-runs with SSH_ASKPASS + no BatchMode → ssh invokes helper → key decrypts → ok
6. Install streams with askpass session
7. mintAndClaim runs with askpass session → on success, session cleaned up
```

The user is prompted **once**; the passphrase is cached in a 0600 temp file for all subsequent ssh invocations (6 probes + install + `manta pair`).

### Files changed

12 files, 1033 insertions, 39 deletions.

### Verification results

- PR branch (`multica/BET-360-askpass-passphrase` @ `4601d7a`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1569 pass / 0 fail / 0 skip. log sha256: `96b9f5b04674c75c73e387b2260fa0b292808579641bd6eebabedd5e4d365004`
- Base (`main` @ `758da58`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1548 pass / 0 fail / 0 skip. log sha256: `593aca72783e4fb61c73df0f64bb19b0389a19d8b9d0728121fdafea7ce03602`
- **Conclusion:** 21 new tests added (1569 − 1548), all passing. 0 new failures, 0 pre-existing failures. Typecheck identical between branches.

Base: `origin/main @ 758da58`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log`.
