### PR TITLE
fix(sitemap): emit UTC lastmod so test runs don't dirty sitemap.xml

### DIFF
--- a/scripts/build-website-sitemap.mjs
+++ b/scripts/build-website-sitemap.mjs
@@ -25,13 +25,20 @@ const SCHEMA_PATH = join(ROOT, "website/schema/meta.json");
 const SITEMAP_PATH = join(ROOT, "website/sitemap.xml");
 
 function lastmodIsoFor(relFile) {
+  // Always emit UTC so re-running the generator on any machine/CI timezone
+  // produces byte-identical output. `%cI` carries the committer's stored
+  // timezone offset, which varies across machines and dirties sitemap.xml on
+  // every test run; `%ct` is a timezone-independent unix epoch we normalize
+  // to an ISO-8601 UTC string (`...Z`).
   try {
-    const iso = execFileSync(
+    const unix = execFileSync(
       "git",
-      ["log", "-1", "--format=%cI", "--", relFile],
+      ["log", "-1", "--format=%ct", "--", relFile],
       { cwd: ROOT, encoding: "utf8" },
     ).trim();
-    return iso || new Date().toISOString();
+    const sec = Number(unix);
+    if (!Number.isFinite(sec) || sec <= 0) return new Date().toISOString();
+    return new Date(sec * 1000).toISOString();
   } catch {
     return new Date().toISOString();
   }

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-07-27T16:51:21+00:00</lastmod>
+    <lastmod>2026-07-27T16:51:21.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## BET-385

The sitemap generator used git's `%cI` (committer date, strict ISO 8601), which carries the committer's **stored timezone offset**. Commits made on the dev box (+02:00) produced `lastmod` values like `2026-07-28T09:33:17+02:00`, while a UTC runner produced `+00:00` — so every test run that regenerated `website/sitemap.xml` left a noisy, unrelated diff on a tracked file that had to be manually dropped from feature PRs (as happened on BET-383 / PR #322).

## Fix

Switch `lastmodIsoFor` from `%cI` to `%ct` (unix epoch, timezone-independent) and normalize via `Date#toISOString()` (UTC, `...Z`). Output is now byte-identical across machines/CI/timezones and only changes when content actually changes.

This is the issue's suggested option B (pin generator to UTC) over option A (gitignore), because the file is intentionally tracked and deployed by the website workflow.

## Verification

- `npm run typecheck` — clean
- `npm test` — 1134 pass, 0 fail
- Idempotency test (`build-website-sitemap.mjs is idempotent on identical input`) — pass
- `sitemap.xml parses` (XML) — pass
- Regenerated `website/sitemap.xml` committed; the only diff is the format (`+00:00` → `.000Z`) and the corrected `index.html` lastmod (its real last commit was `2026-07-28T07:33:17Z`, previously stale at `2026-07-27T16:51:21+00:00`).