### PR TITLE
refactor(server): shared defer-while-busy prompt-delivery engine (BET-375)

### DIFF
--- a/src/server/capNotifier.mjs
+++ b/src/server/capNotifier.mjs
@@ -1,27 +1,40 @@
 // Capability-job completion notification: bridges the queue's field naming
 // to opencode's. capabilities.mjs calls notifySession({sessionID, text})
 // (the queue's natural shape — matches the job shape it persists);
-// oc.sendPrompt expects camelCase `sessionId`. This module OWNS the
-// field-name translation so there is exactly one definition (shared by
-// /api/cap/:id/done and the startCapSweeper deps in index.mjs), and so the
-// translation is unit-tested in isolation — a regression here would
-// silently strand the completion turn on /session/undefined/prompt_async
+// the shared prompt-delivery engine expects camelCase `sessionId`. This
+// module OWNS the field-name translation so there is exactly one definition
+// (shared by /api/cap/:id/done and the startCapSweeper deps in index.mjs),
+// and so the translation is unit-tested in isolation — a regression here
+// would silently strand the completion turn on /session/undefined/prompt_async
 // (the bug BET-184 review-return flagged).
 //
-// Keep this file the ONLY place that translates sessionID → sessionId; the
-// pass-through wiring elsewhere would let a field-name typo silently drop
-// the session id and never reach opencode.
+// The actual send now routes through the shared defer-while-busy engine
+// (src/server/promptDelivery.mjs) so a completion notice never aborts the
+// user's in-flight turn (BET-375). The translation stays HERE — do not move
+// it; a field-name typo elsewhere would silently drop the session id.
+//
+// Keep this file the ONLY place that translates sessionID → sessionId.
 
 import * as oc from "./opencode.mjs";
+
+// Default deliver: a direct passthrough to oc.sendPrompt. Used by the unit
+// tests (which assert the field translation by capturing the HTTP request)
+// and as a fallback when no shared engine is wired. Production wires the
+// shared engine's `deliver` via the { deliver } dep.
+function defaultDeliver({ sessionId, text }) {
+  return oc.sendPrompt({ sessionId, text });
+}
 
 /**
  * Bridge a capability job's terminal notification into an opencode
  * session prompt. Field-name translation: sessionID (caps) → sessionId
- * (opencode). Errors are propagated (caller is expected to swallow + log).
+ * (delivery engine / opencode). Errors are propagated (caller is expected
+ * to swallow + log).
  *
  * @param {{sessionID: string, text: string}} args
+ * @param {{deliver?: (args:{sessionId:string, text:string})=>Promise<unknown>}} [deps]
  * @returns {Promise<unknown>}
  */
-export function notifyCapSession({ sessionID, text }) {
-  return oc.sendPrompt({ sessionId: sessionID, text });
+export function notifyCapSession({ sessionID, text }, { deliver = defaultDeliver } = {}) {
+  return deliver({ sessionId: sessionID, text });
 }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -65,6 +65,7 @@ import {
 } from "./servePage.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
+import { createPromptDelivery } from "./promptDelivery.mjs";
 import {
   createWebhookEngine,
   createHook,
@@ -160,16 +161,30 @@ const { stop: stopStatusPoller } = startStatusPoller(bus, { intervalMs: 2000 });
 // eslint-disable-next-line no-unused-vars
 const { stop: stopOutboxPoller } = startOutboxPoller(bus, { intervalMs: 3000 });
 
+// Shared prompt-delivery engine (BET-375). ONE instance, shared by every
+// sender that injects a prompt into an opencode session: the scheduled-prompt
+// poller, the capability-job notifier, peer messages, and inbound webhooks.
+// It tracks per-session busy state from the opencode event firehose
+// (observeEvent, called in the pump below) and DEFERS a delivery when its
+// target session is mid-turn — so a scheduled tick, a peer agent, a plugin
+// job finishing, or an external webhook can NEVER abort the user's in-flight
+// model turn. See src/server/promptDelivery.mjs.
+const promptDelivery = createPromptDelivery({
+  sendPrompt: (args) => oc.sendPrompt(args),
+});
+
 // Scheduled-prompt engine: durable jobs in ~/.manta/schedule.json, fired
-// by re-submitting the stored prompt into its opencode session via
-// oc.sendPrompt — the scheduled work then streams into the user's open
-// ChatPanel as a new turn. Server-owned (survives Mac-app-close / reboot).
-// The remote AI creates jobs via the global opencode `schedule` tool →
-// POST /api/schedule (below). See src/server/schedule.mjs + docs/.
+// by re-submitting the stored prompt into its opencode session — the
+// scheduled work then streams into the user's open ChatPanel as a new turn.
+// Server-owned (survives Mac-app-close / reboot). The remote AI creates jobs
+// via the global opencode `schedule` tool → POST /api/schedule (below). See
+// src/server/schedule.mjs + docs/. Delivery routes through the shared
+// prompt-delivery engine so a firing while the session is busy is deferred,
+// not aborted.
 // eslint-disable-next-line no-unused-vars
 const { stop: stopSchedulePoller } = startSchedulePoller(
   {
-    sendPrompt: (args) => oc.sendPrompt(args),
+    sendPrompt: (args) => promptDelivery.deliver(args),
     publish: (evt) => bus.publish(evt),
   },
   { intervalMs: 30000 },
@@ -178,26 +193,28 @@ const { stop: stopSchedulePoller } = startSchedulePoller(
 // Capability-job sweeper: same shape as startSchedulePoller — fails out stale
 // `running` jobs (30 min) and expired `queued` jobs (24h), then prunes terminal
 // jobs past retention/cap. Notifies the originating session on every
-// transition via the SAME oc.sendPrompt leg the scheduler uses, so the user
-// sees a fresh turn when a job times out. See src/server/capabilities.mjs +
-// docs/mantaui-plugins.md §Layer 1.
+// transition, so the user sees a fresh turn when a job times out. See
+// src/server/capabilities.mjs + docs/mantaui-plugins.md §Layer 1.
 // Capability-job completion → opencode session notification. Wired via
 // src/server/capNotifier.mjs (see that file for why the field translation
 // lives in one place). Shared by the sweeper and the /api/cap/:id/done REST
-// handler below — one definition, two callers.
+// handler below — one definition, two callers. The notifier routes through
+// the shared prompt-delivery engine so a completion notice defers while busy.
+const capNotify = (args) => notifyCapSession(args, { deliver: promptDelivery.deliver });
 // eslint-disable-next-line no-unused-vars
 const { stop: stopCapSweeper } = startCapSweeper({
   publish: (evt) => bus.publish(evt),
-  notifySession: notifyCapSession,
+  notifySession: capNotify,
 });
 
 // Inbound webhook engine: external actors POST to the public /hook/<token>
 // route (below) to wake a chat session with an event — the push counterpart to
-// the schedule poller. The engine owns the rate limiter + the defer-until-idle
-// queue, and tracks per-session busy state from the opencode event firehose
-// (observeEvent, called in the pump below). See src/server/webhooks.mjs + docs.
+// the schedule poller. The engine owns the per-token rate limiter and delegates
+// busy-tracking + the defer-until-idle queue to the shared prompt-delivery
+// engine. See src/server/webhooks.mjs + docs.
 const webhookEngine = createWebhookEngine({
   sendPrompt: (args) => oc.sendPrompt(args),
+  delivery: promptDelivery,
   publish: (evt) => bus.publish(evt),
 });
 
@@ -319,8 +336,14 @@ try {
 
 // eslint-disable-next-line no-unused-vars
 const stopOpencodePump = oc.subscribeEvents((evt) => {
-  // Track per-session busy state for the webhook defer-until-idle queue. Cheap,
-  // runs for every event; never throws into the pump.
+  // Track per-session busy state for the defer-until-idle queue shared by all
+  // prompt senders (schedule, capability, peer, webhook). Cheap, runs for
+  // every event; never throws into the pump.
+  try {
+    promptDelivery.observeEvent(evt);
+  } catch (e) {
+    console.warn("[promptDelivery] observeEvent failed:", e?.message ?? e);
+  }
   try {
     webhookEngine.observeEvent(evt);
   } catch (e) {
@@ -1026,7 +1049,7 @@ const handleRequest = async (req, res) => {
             { status: body?.status, result: body?.result, error: body?.error },
             {
               ...BUS_PUBLISH_DEPS,
-              notifySession: notifyCapSession,
+              notifySession: capNotify,
             },
           );
           if (!result.ok) {
@@ -1356,12 +1379,15 @@ const handleRequest = async (req, res) => {
       }
       if (req.method === "POST") {
         const body = await readJsonBody(req);
-        const result = await sendPeerMessage({
-          sessionID: body?.sessionID,
-          directory: body?.directory,
-          target: body?.target,
-          message: body?.message,
-        });
+        const result = await sendPeerMessage(
+          {
+            sessionID: body?.sessionID,
+            directory: body?.directory,
+            target: body?.target,
+            message: body?.message,
+          },
+          { sendPrompt: (args) => promptDelivery.deliver(args) },
+        );
         if (!result.ok) {
           respondJson(res, 400, { error: result.error });
           return;

--- a/src/server/peers.mjs
+++ b/src/server/peers.mjs
@@ -344,6 +344,13 @@ export async function inspectPeer({ sessionID, directory, target }, deps = {}) {
 // peer agent. Only chat-mode peers (opencodeSessionId set) can receive a
 // message; a claude-TUI peer has no opencode session to inject into.
 //
+// The injected `sendPrompt` is wired in src/server/index.mjs (the /api/peers
+// POST handler) to the shared prompt-delivery engine
+// (src/server/promptDelivery.mjs), so a peer message that lands while the
+// target session is mid-turn is DEFERRED until idle rather than aborting the
+// peer's in-flight model turn (BET-375). This module stays ignorant of busy
+// state — the single injected delivery function handles it.
+//
 // deps.listProjects / deps.sendPrompt are injectable for tests; they default
 // to the live tmux + opencode implementations.
 export async function sendPeerMessage({ sessionID, directory, target, message }, deps = {}) {

--- a/src/server/promptDelivery.mjs
+++ b/src/server/promptDelivery.mjs
@@ -1,0 +1,103 @@
+// promptDelivery.mjs — the single defer-while-busy prompt-delivery engine.
+//
+// Every path that injects a prompt into an opencode session — webhook
+// delivery, scheduled-prompt firing, peer messages, capability-job
+// completion — routes through ONE instance of this engine (constructed in
+// src/server/index.mjs). The engine tracks per-session busy state from the
+// opencode event firehose and defers a delivery when its target session is
+// mid-turn, so an external event, a scheduled tick, a peer agent, or a
+// plugin job finishing can NEVER abort the user's in-flight model turn.
+//
+// The busy/pending mechanics were lifted verbatim from the webhook engine
+// (src/server/webhooks.mjs), which was the only sender that already deferred.
+// See BET-375 for the full rationale. `deliver` NEVER rejects — three of the
+// four callers today swallow errors and must keep doing so; a rejection here
+// would surface as an unhandled promise in a timer-driven poll loop.
+//
+// The queue is in-memory only; a server restart with prompts queued loses
+// them (accepted — matches the prior webhook behaviour). Draining is FIFO,
+// one prompt at a time, awaited in sequence (never batched into one message).
+
+/**
+ * Build the shared prompt-delivery engine.
+ *
+ * @param {object} deps
+ * @param {(args:{sessionId:string, text:string})=>Promise<unknown>} deps.sendPrompt
+ *        The underlying opencode prompt injector (oc.sendPrompt).
+ * @returns {{deliver: (args:{sessionId:string, text:string})=>Promise<{delivered:boolean, queued:boolean}>, observeEvent:(evt:unknown)=>void, isBusy:(sessionId:string)=>boolean}}
+ */
+export function createPromptDelivery({ sendPrompt }) {
+  const busy = new Set(); // sessionIds currently running a turn
+  const pending = new Map(); // sessionId -> [text, ...] queued while busy
+
+  async function drain(sessionId) {
+    const queue = pending.get(sessionId);
+    if (!queue || queue.length === 0) return;
+    // Pop the whole queue before sending so a prompt queued during the drain
+    // itself (e.g. a second webhook arriving while we flush) is not lost —
+    // it lands in a fresh queue rather than being iterated mid-flush.
+    pending.delete(sessionId);
+    for (const text of queue) {
+      try {
+        await sendPrompt({ sessionId, text });
+      } catch (e) {
+        // Warn and continue: one wedged delivery must not strand the rest of
+        // the queued prompts behind it.
+        console.warn(
+          `[promptDelivery] deferred send for ${sessionId} failed:`,
+          e?.message ?? e,
+        );
+      }
+    }
+  }
+
+  // Observe the opencode event firehose to know which sessions are busy.
+  // Mirrors the renderer's running derivation:
+  //   session.status{status.type:"busy"|"retry"} → busy
+  //   session.status{status.type:"idle"} / session.idle / session.error → idle (drain)
+  // Every other event type is ignored.
+  function observeEvent(evt) {
+    const sid = evt?.properties?.sessionID;
+    if (typeof sid !== "string" || !sid) return;
+    if (evt.type === "session.idle" || evt.type === "session.error") {
+      if (busy.delete(sid)) void drain(sid);
+      else void drain(sid); // also drain if we never saw a busy (defensive)
+      return;
+    }
+    if (evt.type === "session.status") {
+      const t = evt.properties?.status?.type;
+      if (t === "busy" || t === "retry") busy.add(sid);
+      else if (t === "idle") {
+        busy.delete(sid);
+        void drain(sid);
+      }
+    }
+  }
+
+  function isBusy(sessionId) {
+    return busy.has(sessionId);
+  }
+
+  async function deliver({ sessionId, text }) {
+    if (busy.has(sessionId)) {
+      const q = pending.get(sessionId) ?? [];
+      q.push(text);
+      pending.set(sessionId, q);
+      return { delivered: false, queued: true };
+    }
+    try {
+      await sendPrompt({ sessionId, text });
+      return { delivered: true, queued: false };
+    } catch (e) {
+      // Never reject: callers swallow errors and a rejection would surface as
+      // an unhandled promise in timer-driven loops. Log and report not-delivered.
+      console.warn(
+        `[promptDelivery] sendPrompt for ${sessionId} failed:`,
+        e?.message ?? e,
+      );
+      return { delivered: false, queued: false };
+    }
+  }
+
+  return { deliver, observeEvent, isBusy };
+}

--- a/src/server/promptDelivery.test.mjs
+++ b/src/server/promptDelivery.test.mjs
@@ -1,0 +1,149 @@
+// Tests for src/server/promptDelivery.mjs — the single defer-while-busy
+// prompt-delivery engine shared by all four senders (webhook, schedule,
+// peer, capability). The busy/pending mechanics were lifted verbatim from
+// the webhook engine; these tests pin that behaviour so a future change to
+// the shared engine can't silently regress the three senders that just
+// gained deferral (BET-375).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { createPromptDelivery } from "./promptDelivery.mjs";
+
+// Build an engine with a fake sendPrompt that records every call in order.
+// `rejectTexts` is a Set of texts whose sendPrompt call should reject.
+function makeEngine({ rejectTexts = new Set() } = {}) {
+  const calls = [];
+  const sendPrompt = async (args) => {
+    calls.push(args);
+    if (rejectTexts.has(args?.text)) {
+      throw new Error(`synthetic sendPrompt failure for "${args?.text}"`);
+    }
+  };
+  const engine = createPromptDelivery({ sendPrompt });
+  return { engine, calls };
+}
+
+test("1. idle session → deliver calls sendPrompt once and reports delivered:true", async () => {
+  const { engine, calls } = makeEngine();
+  const res = await engine.deliver({ sessionId: "s1", text: "hi" });
+  assert.equal(res.delivered, true);
+  assert.equal(res.queued, false);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { sessionId: "s1", text: "hi" });
+});
+
+test("2. busy session → sendPrompt NOT called; reports queued:true", async () => {
+  const { engine, calls } = makeEngine();
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  const res = await engine.deliver({ sessionId: "s1", text: "deferred" });
+  assert.equal(res.delivered, false);
+  assert.equal(res.queued, true);
+  assert.equal(calls.length, 0);
+});
+
+test("3. busy then two delivers then idle → both sent, in submission order", async () => {
+  const { engine, calls } = makeEngine();
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  await engine.deliver({ sessionId: "s1", text: "first" });
+  await engine.deliver({ sessionId: "s1", text: "second" });
+  assert.equal(calls.length, 0, "nothing sent while busy");
+  engine.observeEvent({ type: "session.idle", properties: { sessionID: "s1" } });
+  // drain is async — let it settle.
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].text, "first");
+  assert.equal(calls[1].text, "second");
+});
+
+test("4. session.status{type:\"retry\"} also marks busy", async () => {
+  const { engine, calls } = makeEngine();
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "retry" } },
+  });
+  assert.equal(engine.isBusy("s1"), true);
+  const res = await engine.deliver({ sessionId: "s1", text: "x" });
+  assert.equal(res.queued, true);
+  assert.equal(calls.length, 0);
+});
+
+test("5. session.error clears busy and drains", async () => {
+  const { engine, calls } = makeEngine();
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  await engine.deliver({ sessionId: "s1", text: "queued-on-error" });
+  engine.observeEvent({ type: "session.error", properties: { sessionID: "s1" } });
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(engine.isBusy("s1"), false);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].text, "queued-on-error");
+});
+
+test("6. session.status{type:\"idle\"} clears busy and drains", async () => {
+  const { engine, calls } = makeEngine();
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  await engine.deliver({ sessionId: "s1", text: "queued-on-idle" });
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "idle" } },
+  });
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(engine.isBusy("s1"), false);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].text, "queued-on-idle");
+});
+
+test("7. a sendPrompt rejection does not reject deliver and does not stop the queue draining", async () => {
+  const { engine, calls } = makeEngine({ rejectTexts: new Set(["will-fail", "boom"]) });
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  await engine.deliver({ sessionId: "s1", text: "will-fail" });
+  await engine.deliver({ sessionId: "s1", text: "after-fail" });
+  engine.observeEvent({ type: "session.idle", properties: { sessionID: "s1" } });
+  await new Promise((r) => setTimeout(r, 5));
+  // Both attempted; the first threw but the second still ran.
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].text, "will-fail");
+  assert.equal(calls[1].text, "after-fail");
+  // A direct deliver to an idle session that rejects must not reject.
+  const res = await engine.deliver({ sessionId: "s2", text: "boom" });
+  assert.equal(res.delivered, false);
+  assert.equal(res.queued, false);
+});
+
+test("8. events with no properties.sessionID are ignored without throwing", async () => {
+  const { engine } = makeEngine();
+  assert.doesNotThrow(() => engine.observeEvent({ type: "session.idle" }));
+  assert.doesNotThrow(() => engine.observeEvent({ type: "session.status", properties: {} }));
+  assert.doesNotThrow(() => engine.observeEvent(undefined));
+  assert.doesNotThrow(() => engine.observeEvent(null));
+  assert.doesNotThrow(() =>
+    engine.observeEvent({ type: "session.status", properties: { sessionID: 123 } }),
+  );
+});
+
+test("9. isBusy reflects the tracked state", async () => {
+  const { engine } = makeEngine();
+  assert.equal(engine.isBusy("s1"), false);
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  assert.equal(engine.isBusy("s1"), true);
+  engine.observeEvent({ type: "session.idle", properties: { sessionID: "s1" } });
+  assert.equal(engine.isBusy("s1"), false);
+});

--- a/src/server/schedule.mjs
+++ b/src/server/schedule.mjs
@@ -2,8 +2,14 @@
 // process on the Linux box). The remote AI calls the global opencode `schedule`
 // tool (docs/opencode-tools/schedule.ts), which POSTs to manta-server's
 // /api/schedule. Jobs are stored here durably and fired by a periodic tick that
-// re-submits the prompt into the SAME opencode session via oc.sendPrompt — the
-// scheduled work then streams back into the user's open ChatPanel as a new turn.
+// re-submits the prompt into the SAME opencode session — the scheduled work
+// then streams back into the user's open ChatPanel as a new turn.
+//
+// The injected `sendPrompt` is wired in src/server/index.mjs to the shared
+// prompt-delivery engine (src/server/promptDelivery.mjs), so a firing that
+// lands while the target session is mid-turn is DEFERRED until idle rather
+// than aborting the user's in-flight model turn (BET-375). This module stays
+// ignorant of busy state — the single injected delivery function handles it.
 //
 // Server-owned (NOT duplicated in desktop main) so jobs survive Mac-app-close,
 // session navigation, and box reboot. This is strictly more durable than Claude

--- a/src/server/webhooks.mjs
+++ b/src/server/webhooks.mjs
@@ -338,52 +338,27 @@ export async function deliverWebhook(
 // ---------------------------------------------------------------------------
 
 /**
- * Build the stateful delivery engine used by index.mjs. Tracks per-session busy
- * state from the opencode event stream (observeEvent), owns the rate limiter and
- * the defer-until-idle queue, and exposes deliver() for the public /hook route.
+ * Build the stateful delivery engine used by index.mjs. Owns the per-token
+ * rate limiter and delegates busy-tracking + the defer-until-idle queue to
+ * the SHARED prompt-delivery engine (src/server/promptDelivery.mjs), which
+ * every prompt sender now routes through (BET-375). `deliver` exposes the
+ * webhook route's `{ok, status, queued}` shape (preserving the 202-queued
+ * branch); `observeEvent` is a pass-through to the shared engine so the
+ * opencode pump calls it once for all senders.
  *
- * @param {object} deps { sendPrompt, publish, storePath, now }
+ * @param {object} deps
+ * @param {(args:{sessionId:string, text:string})=>Promise<unknown>} deps.sendPrompt
+ *        Raw opencode injector, used for the non-busy direct-delivery path.
+ * @param {{isBusy:(sessionId:string)=>boolean, observeEvent:(evt:unknown)=>void, deliver:(args:{sessionId:string, text:string})=>Promise<unknown>}} deps.delivery
+ *        The shared prompt-delivery engine — supplies busy state, the defer
+ *        queue (via deliver), and the event observer.
+ * @param {object} deps.publish
+ * @param {string} [deps.storePath]
+ * @param {() => number} [deps.now]
  */
-export function createWebhookEngine({ sendPrompt, publish, storePath, now = () => Date.now() } = {}) {
+export function createWebhookEngine({ sendPrompt, delivery, publish, storePath, now = () => Date.now() } = {}) {
   const path = storePath ?? STORE_PATH;
-  const busy = new Set(); // sessionIDs currently running a turn
-  const pending = new Map(); // sessionID -> [text, ...] queued while busy
   const take = createRateLimiter({ now });
-
-  async function drain(sessionID) {
-    const queue = pending.get(sessionID);
-    if (!queue || queue.length === 0) return;
-    pending.delete(sessionID);
-    for (const text of queue) {
-      try {
-        await sendPrompt({ sessionId: sessionID, text });
-      } catch (e) {
-        console.warn(`[webhook] deferred send for ${sessionID} failed:`, e?.message ?? e);
-      }
-    }
-  }
-
-  // Observe the opencode event firehose to know which sessions are busy. Mirrors
-  // App.tsx's running derivation:
-  //   session.status{status.type:"busy"|"retry"} → busy
-  //   session.status{status.type:"idle"} / session.idle / session.error → idle
-  function observeEvent(evt) {
-    const sid = evt?.properties?.sessionID;
-    if (typeof sid !== "string" || !sid) return;
-    if (evt.type === "session.idle" || evt.type === "session.error") {
-      if (busy.delete(sid)) void drain(sid);
-      else void drain(sid); // also drain if we never saw a busy (defensive)
-      return;
-    }
-    if (evt.type === "session.status") {
-      const t = evt.properties?.status?.type;
-      if (t === "busy" || t === "retry") busy.add(sid);
-      else if (t === "idle") {
-        busy.delete(sid);
-        void drain(sid);
-      }
-    }
-  }
 
   function deliver({ token, rawBody, signatureHeader }) {
     return deliverWebhook(
@@ -395,15 +370,16 @@ export function createWebhookEngine({ sendPrompt, publish, storePath, now = () =
         publish,
         now,
         take,
-        isBusy: (sid) => busy.has(sid),
+        isBusy: (sid) => delivery.isBusy(sid),
         enqueue: (sid, text) => {
-          const q = pending.get(sid) ?? [];
-          q.push(text);
-          pending.set(sid, q);
+          // Route the deferred webhook through the shared engine so the
+          // queued prompt drains in FIFO order alongside any other sender's
+          // deferred prompt for the same session.
+          void delivery.deliver({ sessionId: sid, text });
         },
       },
     );
   }
 
-  return { deliver, observeEvent };
+  return { deliver, observeEvent: delivery.observeEvent };
 }


### PR DESCRIPTION
## BET-375 — One prompt-delivery path: extract the defer-while-busy engine

Extracts the busy/pending mechanics from the webhook engine into a shared `src/server/promptDelivery.mjs` and routes all four prompt senders (webhook, schedule, peer, capability) through one instance. A scheduled tick, peer message, plugin-job completion, or external webhook that fires while a session is mid-turn is now **deferred** until idle instead of aborting the in-flight model turn.

### What changed
- **New `src/server/promptDelivery.mjs`** — `createPromptDelivery({ sendPrompt })` → `{ deliver, observeEvent, isBusy }`. `deliver` never rejects. Busy/pending/drain lifted verbatim from the webhook engine.
- **`webhooks.mjs`** — `createWebhookEngine` delegates `isBusy`/`enqueue`/`observeEvent` to the shared engine; keeps its `{deliver, observeEvent}` shape and the 202-queued branch. No second engine instance.
- **`index.mjs`** — constructs ONE shared instance; pump calls `promptDelivery.observeEvent` in its own try/catch alongside the existing `webhookEngine.observeEvent` call. Schedule poller, `capNotify`, and the `/api/peers` POST handler wired to delivery-backed functions.
- **`capNotifier.mjs`** — routes through `deliver` (field translation stays here). Default fallback to `oc.sendPrompt` keeps unit tests green.
- **`schedule.mjs` / `peers.mjs`** — header comments updated; no logic changes.

### Tests
- 9 new tests in `src/server/promptDelivery.test.mjs` (all 9 spec cases).
- All existing tests pass unchanged (1134 → 1143, +9 new).

**Files changed:** 7 files (`+363 / -83`)

**Verification results:**
- PR branch (`multica/BET-375-prompt-delivery` @ `a6a9456`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1143 pass / 0 fail / 0 skip. log sha256: `3d838b36e35562307f68ed2dcfc8d6233bab26ebc49fe4e2d637a092ee9d8ac1`
- Base (`main` @ `0cc21ea`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1134 pass / 0 fail / 0 skip. log sha256: `1c2f395826c08127a619b94ab954093d61004a51ed707bbc80232e50c001cd06`
- **Conclusion:** 0 test failures on either branch. 9 new tests added by this PR; 0 pre-existing failures, 0 new failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ 0cc21ea
