### PR TITLE
refactor(server): collapse five JSON store copies into jsonStore.mjs (BET-376)

### DIFF
--- a/src/server/capabilities.mjs
+++ b/src/server/capabilities.mjs
@@ -17,13 +17,11 @@
 // box reboot — the SSE+catch-up plumbing on the executor side picks them up
 // when the desktop comes back.
 
-import { readFile, mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import { normalizeHost } from "../shared/pluginManifest.mjs";
-import { atomicWrite } from "./storeUtils.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (single source of truth — see docs/mantaui-plugins.md §Constants)
@@ -53,18 +51,12 @@ const MAX_TERMINAL_JOBS = 50;
 // ---------------------------------------------------------------------------
 
 export async function loadJobs(path = STORE_PATH) {
-  try {
-    if (!existsSync(path)) return [];
-    const parsed = JSON.parse(await readFile(path, "utf-8"));
-    return Array.isArray(parsed?.jobs) ? parsed.jobs : [];
-  } catch {
-    return []; // corrupt/unreadable → start empty rather than crash the server
-  }
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed?.jobs) ? parsed.jobs : [];
 }
 
 export async function saveJobs(jobs, path = STORE_PATH) {
-  await mkdir(dirname(path), { recursive: true });
-  await atomicWrite(path, JSON.stringify({ jobs }, null, 2));
+  await writeJsonAtomic(path, JSON.stringify({ jobs }, null, 2));
 }
 
 function genId() {

--- a/src/server/jsonStore.mjs
+++ b/src/server/jsonStore.mjs
@@ -1,0 +1,49 @@
+// Single source of truth for the atomic JSON read/write dance used by every
+// durable store on the box (cap-jobs, schedule, webhooks, secrets, serve-page).
+// Promoted out of the five per-store copies in BET-376 — a pure collapse, no
+// behaviour change: each store keeps its own load/save wrapper (name, signature,
+// async-ness, record shape, default, fallback and mode are all preserved), only
+// the temp-file-then-rename core now lives here.
+//
+// `readJsonSync` is synchronous because `loadHooks`/`loadSecrets`/`loadPages`
+// are synchronous today and changing that would ripple into their callers. It
+// returns `fallback` on any failure — missing file, unreadable file, or invalid
+// JSON — and never throws.
+//
+// `writeJsonAtomic` keeps the existing temp-file-then-rename pattern, applies
+// `mode` to the final file when supplied (matching the 0600 stores), and
+// creates the parent directory if missing (matching what the existing copies
+// did before each write).
+
+import { readFileSync, existsSync } from "node:fs";
+import { writeFile, rename, chmod, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+// Read and parse `path` as JSON. Returns `fallback` when the file is missing,
+// unreadable, or contains invalid JSON. Never throws.
+export function readJsonSync(path, fallback) {
+  try {
+    if (!existsSync(path)) return fallback;
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return fallback;
+  }
+}
+
+// Write `data` (already-serialized bytes) to `path` atomically: write a temp
+// file alongside, then rename. The temp filename encodes pid + timestamp so a
+// crash mid-write can never clobber a sibling in-flight temp, and a stale temp
+// from a previous crash never overwrites a live `path`. When `mode` is supplied
+// it is applied to the temp file (and re-asserted via chmod, since writeFile's
+// mode is only honoured on create) so the renamed final file carries it.
+export async function writeJsonAtomic(path, data, { mode } = {}) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  if (mode !== undefined) {
+    await writeFile(tmp, data, { mode });
+    await chmod(tmp, mode).catch(() => {});
+  } else {
+    await writeFile(tmp, data);
+  }
+  await rename(tmp, path);
+}

--- a/src/server/jsonStore.test.mjs
+++ b/src/server/jsonStore.test.mjs
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, stat, readdir, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+
+async function tmpDir() {
+  const dir = await mkdtemp(join(tmpdir(), "manta-jsonstore-test-"));
+  return dir;
+}
+
+// 1. readJsonSync on a missing file returns the fallback.
+test("readJsonSync on a missing file returns the fallback", async () => {
+  const dir = await tmpDir();
+  const missing = join(dir, "nope.json");
+  assert.deepEqual(readJsonSync(missing, { ok: true }), { ok: true });
+  assert.deepEqual(readJsonSync(missing, []), []);
+  assert.equal(readJsonSync(missing, null), null);
+  await rm(dir, { recursive: true, force: true });
+});
+
+// 2. readJsonSync on a file containing invalid JSON returns the fallback and
+//    does not throw.
+test("readJsonSync on invalid JSON returns the fallback and does not throw", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "bad.json");
+  await writeFile(path, "{ this is not json }}}");
+  assert.deepEqual(readJsonSync(path, { fallback: true }), { fallback: true });
+  assert.deepEqual(readJsonSync(path, []), []);
+  await rm(dir, { recursive: true, force: true });
+});
+
+// 3. readJsonSync round-trips a value written by writeJsonAtomic.
+test("readJsonSync round-trips a value written by writeJsonAtomic", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "rt.json");
+  const value = { jobs: [{ id: "a", n: 1 }, { id: "b", n: 2 }] };
+  await writeJsonAtomic(path, JSON.stringify(value, null, 2));
+  assert.deepEqual(readJsonSync(path, null), value);
+  await rm(dir, { recursive: true, force: true });
+});
+
+// 4. writeJsonAtomic with mode: 0o600 produces a file whose mode is 0600.
+test("writeJsonAtomic with mode 0o600 produces a 0600 file", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "secret.json");
+  await writeJsonAtomic(path, JSON.stringify({ secrets: [] }, null, 2), { mode: 0o600 });
+  const mode = (await stat(path)).mode & 0o777;
+  assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+  await rm(dir, { recursive: true, force: true });
+});
+
+// 5. writeJsonAtomic creates a missing parent directory.
+test("writeJsonAtomic creates a missing parent directory", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "nested", "deep", "store.json");
+  await writeJsonAtomic(path, JSON.stringify({ x: 1 }));
+  assert.deepEqual(readJsonSync(path, null), { x: 1 });
+  await rm(dir, { recursive: true, force: true });
+});
+
+// 6. Writing over an existing file replaces it and leaves no temp file behind
+//    in the directory.
+test("writeJsonAtomic replaces an existing file and leaves no temp behind", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "store.json");
+  await writeJsonAtomic(path, JSON.stringify({ v: 1 }));
+  await writeJsonAtomic(path, JSON.stringify({ v: 2, more: true }));
+
+  // Content is the latest write.
+  assert.deepEqual(readJsonSync(path, null), { v: 2, more: true });
+
+  // No temp files remain alongside the final file.
+  const entries = await readdir(dir);
+  const temps = entries.filter((e) => e.startsWith("store.json.tmp"));
+  assert.deepEqual(temps, []);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+// Extra: a default-mode write (no mode supplied) does not throw and is
+// readable — guards the no-mode branch.
+test("writeJsonAtomic without a mode writes and is readable", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "plain.json");
+  await writeJsonAtomic(path, JSON.stringify({ hooks: [] }, null, 2));
+  assert.deepEqual(readJsonSync(path, null), { hooks: [] });
+  await rm(dir, { recursive: true, force: true });
+});

--- a/src/server/schedule.mjs
+++ b/src/server/schedule.mjs
@@ -20,12 +20,11 @@
 // (testable without timers or live opencode) + a startSchedulePoller() wrapper
 // with an inFlight guard and timer.unref().
 
-import { readFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
-import { atomicWrite } from "./storeUtils.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const STORE_PATH = statePath("schedule.json");
 
@@ -171,18 +170,12 @@ export function isJobFireable(job, { directoryExists } = {}) {
 // ---------------------------------------------------------------------------
 
 export async function loadJobs(path = STORE_PATH) {
-  try {
-    if (!existsSync(path)) return [];
-    const parsed = JSON.parse(await readFile(path, "utf-8"));
-    return Array.isArray(parsed?.jobs) ? parsed.jobs : [];
-  } catch {
-    return []; // corrupt/unreadable → start empty rather than crash the server
-  }
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed?.jobs) ? parsed.jobs : [];
 }
 
 export async function saveJobs(jobs, path = STORE_PATH) {
-  await mkdir(dirname(path), { recursive: true });
-  await atomicWrite(path, JSON.stringify({ jobs }, null, 2));
+  await writeJsonAtomic(path, JSON.stringify({ jobs }, null, 2));
 }
 
 function genId() {

--- a/src/server/secrets.mjs
+++ b/src/server/secrets.mjs
@@ -28,11 +28,11 @@
 // schedule.mjs / servePage.mjs. Store: ~/.manta/secrets.json (0600).
 // Materialized files: ~/.manta-secrets/ (dir 0700, files 0600).
 
-import { readFile, writeFile, rename, mkdir, chmod, rm } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
+import { writeFile, mkdir, chmod, rm } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { statePath, secretsRoot } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const STORE_PATH = statePath("secrets.json");
 // Where `secret_provide` writes the materialized value files. Shared secrets go
@@ -141,32 +141,13 @@ export function materializedPath(entry, dir = SECRETS_DIR) {
 // Store (atomic write + 0600, same shape as schedule.mjs / servePage.mjs)
 // ---------------------------------------------------------------------------
 
-async function atomicWrite(path, data, mode) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data, { mode });
-  // writeFile's mode is only applied on create; chmod is belt-and-suspenders
-  // in case the tmp file pre-existed with looser perms.
-  await chmod(tmp, mode).catch(() => {});
-  await rename(tmp, path);
-}
-
 export function loadSecrets(path = STORE_PATH) {
-  try {
-    if (existsSync(path)) {
-      const parsed = JSON.parse(readFileSync(path, "utf-8"));
-      return Array.isArray(parsed?.secrets) ? parsed.secrets : [];
-    }
-  } catch {
-    // corrupt/unreadable → start empty rather than crash the server. The file
-    // is never auto-overwritten unless a mutation happens, so a transient read
-    // error doesn't destroy data.
-  }
-  return [];
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed?.secrets) ? parsed.secrets : [];
 }
 
 export async function saveSecrets(secrets, path = STORE_PATH) {
-  await mkdir(dirname(path), { recursive: true });
-  await atomicWrite(path, JSON.stringify({ secrets }, null, 2), 0o600);
+  await writeJsonAtomic(path, JSON.stringify({ secrets }, null, 2), { mode: 0o600 });
 }
 
 function genId() {

--- a/src/server/servePage.mjs
+++ b/src/server/servePage.mjs
@@ -12,11 +12,12 @@
 // Pages expire after a configurable TTL (default 24h). A cleanup sweep
 // removes expired entries every 5 minutes.
 
-import { readFile, writeFile, rename, mkdir, copyFile, stat, rm } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
+import { readFile, mkdir, copyFile, stat, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const STORE_PATH = statePath("serve-page.json");
 const PAGES_DIR = statePath("pages");
@@ -28,36 +29,16 @@ const DEFAULT_TTL_HOURS = 24;
 const CLEANUP_MS = 5 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
-// Atomic write — same pattern as local.mjs / schedule.mjs
-// ---------------------------------------------------------------------------
-
-async function atomicWrite(path, data) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data);
-  await rename(tmp, path);
-}
-
-// ---------------------------------------------------------------------------
 // Store — durable registry in ~/.manta/serve-page.json
 // ---------------------------------------------------------------------------
 
 export function loadPages(path = STORE_PATH) {
-  try {
-    if (existsSync(path)) {
-      const raw = readFileSync(path, "utf-8");
-      const parsed = JSON.parse(raw);
-      return Array.isArray(parsed.pages) ? parsed.pages : [];
-    }
-  } catch {
-    // corrupt file — start fresh
-  }
-  return [];
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed.pages) ? parsed.pages : [];
 }
 
 export function savePages(pages, path = STORE_PATH) {
-  return mkdir(dirname(path), { recursive: true }).then(() =>
-    atomicWrite(path, JSON.stringify({ pages }, null, 2)),
-  );
+  return writeJsonAtomic(path, JSON.stringify({ pages }, null, 2));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/storeUtils.mjs
+++ b/src/server/storeUtils.mjs
@@ -1,18 +1,14 @@
-// Shared atomic-write helper for the on-disk JSON stores in src/server/.
-// Promoted out of src/server/schedule.mjs in BET-184 (consolidation; previously
-// duplicated logic lived next to schedule's loadJobs/saveJobs). Both schedule.mjs
-// and capabilities.mjs now import from here so there is exactly one
-// atomic-write implementation in src/server/.
+// Thin re-export of the atomic-write primitive. The temp-file-then-rename dance
+// now lives in src/server/jsonStore.mjs (BET-376), the single source of truth
+// for every on-disk JSON store's read/write. This wrapper is kept so existing
+// importers (src/server/tmux.mjs) keep compiling unchanged; new stores should
+// import readJsonSync / writeJsonAtomic from jsonStore.mjs directly.
 
-import { writeFile, rename } from "node:fs/promises";
+import { writeJsonAtomic } from "./jsonStore.mjs";
 
-// Write `data` to `path` atomically: write a temp file alongside, then rename.
-// The temp filename encodes pid + timestamp so a process crash mid-write can
-// never clobber a sibling in-flight temp from the same process (different ms),
-// and a stale temp left over from a previous crash never overwrites a live
-// `path` (it sits next to it as `path.tmp-<pid>-<ts>`).
+// Write `data` to `path` atomically (temp file + rename). Delegates to
+// jsonStore.writeJsonAtomic, which also creates the parent directory if missing
+// (idempotent — harmless for callers that already mkdir'd, like tmux.mjs).
 export async function atomicWrite(path, data) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data);
-  await rename(tmp, path);
+  await writeJsonAtomic(path, data);
 }

--- a/src/server/webhooks.mjs
+++ b/src/server/webhooks.mjs
@@ -26,11 +26,9 @@
 // Server-owned + durable (survives Mac-app-close / reboot), same pattern as
 // schedule.mjs / secrets.mjs. Store: ~/.manta/webhooks.json (0600).
 
-import { readFile, writeFile, rename, mkdir, chmod } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
 import { randomBytes, createHmac, timingSafeEqual } from "node:crypto";
-import { join, dirname } from "node:path";
 import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const STORE_PATH = statePath("webhooks.json");
 
@@ -150,28 +148,13 @@ export function deliveryUrl(token, base = process.env.MANTA_PUBLIC_URL || "https
 // Store (atomic write + 0600, same shape as schedule.mjs / secrets.mjs)
 // ---------------------------------------------------------------------------
 
-async function atomicWrite(path, data, mode) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data, { mode });
-  await chmod(tmp, mode).catch(() => {});
-  await rename(tmp, path);
-}
-
 export function loadHooks(path = STORE_PATH) {
-  try {
-    if (existsSync(path)) {
-      const parsed = JSON.parse(readFileSync(path, "utf-8"));
-      return Array.isArray(parsed?.hooks) ? parsed.hooks : [];
-    }
-  } catch {
-    // corrupt/unreadable → start empty rather than crash the server.
-  }
-  return [];
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed?.hooks) ? parsed.hooks : [];
 }
 
 export async function saveHooks(hooks, path = STORE_PATH) {
-  await mkdir(dirname(path), { recursive: true });
-  await atomicWrite(path, JSON.stringify({ hooks }, null, 2), 0o600);
+  await writeJsonAtomic(path, JSON.stringify({ hooks }, null, 2), { mode: 0o600 });
 }
 
 function genId() {


### PR DESCRIPTION
## One JSON store helper — collapse five copies of the atomic read/write pattern (BET-376)

Stage 1 pure refactor: no behaviour change, no new feature. Collapses the five
duplicated atomic read/write pairs into one `src/server/jsonStore.mjs`.

### What changed

**New:** `src/server/jsonStore.mjs` exports exactly two functions:
- `readJsonSync(path, fallback)` — synchronous; returns `fallback` on missing / unreadable / invalid-JSON, never throws.
- `writeJsonAtomic(path, data, { mode } = {})` — temp-file + rename; creates parent dir; applies `mode` (via writeFile + chmod) when supplied.

**Edited (load/save bodies only):** the five stores now delegate to jsonStore. Each keeps its name, signature, async-ness, record shape, default, fallback and mode unchanged:
- `capabilities.mjs` — `loadJobs`/`saveJobs` (async, no mode)
- `schedule.mjs` — `loadJobs`/`saveJobs` (async, no mode)
- `webhooks.mjs` — `loadHooks` (sync)/`saveHooks` (async, **0o600**)
- `secrets.mjs` — `loadSecrets` (sync)/`saveSecrets` (async, **0o600**)
- `servePage.mjs` — `loadPages` (sync)/`savePages` (returns promise, no mode)

**`storeUtils.mjs`:** its `atomicWrite` (the shared helper capabilities & schedule previously imported) now delegates to `jsonStore.writeJsonAtomic`. Kept as a thin re-export so `tmux.mjs` (the remaining importer, out of scope here) compiles unchanged. The temp-file-then-rename dance no longer lives in storeUtils.

### Tests

`src/server/jsonStore.test.mjs` (node:test, against a temp dir) covers all six required cases: missing-file fallback, invalid-JSON fallback, round-trip, 0o600 mode, parent-dir creation, overwrite-leaves-no-temp. Plus a no-mode-readable guard.

All existing tests in `capabilities/schedule/webhooks/secrets/servePage.test.mjs` pass **unchanged** — no edits to any existing test file.

### DoD

- `npm run typecheck && npm test` green (1150 pass, 0 fail).
- `grep -rn "renameSync|\.tmp" src/server/*.mjs` — the dance is gone from all five stores + storeUtils; it now lives only in `jsonStore.mjs`. **Caveat below.**
- Secrets store file on disk is still 0600 after a save (test 4 pins this).

### DoD grep caveat (needs a decision)

The DoD grep expects the atomic-write dance to appear **only** inside `jsonStore.mjs`. Five **other** modules carry the same `${path}.tmp-<pid>-<ts>` pattern and were **not** in this issue's explicit 5-file scope:

- `src/server/auth.mjs` (security-critical — `~/.manta/auth.json`)
- `src/server/local.mjs` (`~/.manta/config.json`)
- `src/server/providers.mjs` (opencode.jsonc writes)
- `src/server/push.mjs` (VAPID keys)
- `src/server/gatewayRegister.mjs` (gateway state)

Plus `opencodeRestart.test.mjs` (uses `renameSync` for its own fixture, unrelated).

I left these untouched per the issue's "Edit the load/save bodies only, in: [the 5 files]" instruction. Folding them in — especially `auth.mjs` — is a separate, risk-scoped change. **Recommend a follow-up issue** to collapse these five remaining copies into `jsonStore` so the DoD grep holds literally.

Base: origin/main @ d282633
