### PR TITLE
fix(ci): resolve website-deploy releaseHost from channel.mjs (BET-401)

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -65,6 +65,12 @@ jobs:
       webroot: ${{ steps.resolve.outputs.webroot }}
       site: ${{ steps.resolve.outputs.site }}
     steps:
+      # The resolve step imports src/shared/channel.mjs to read releaseHost
+      # from the ONE per-channel table, so the repo must be checked out here.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - id: resolve
         name: Resolve channel + destinations
         env:
@@ -77,12 +83,20 @@ jobs:
           else
             channel="${INPUT_CHANNEL:-staging}"
           fi
+          # webroot is a filesystem path on the prod box, NOT a per-channel
+          # app value — it stays hardcoded here and does not belong in
+          # channel.mjs.
           if [ "$channel" = "staging" ]; then
             webroot="/var/www/mantaui/staging"
-            site="https://mantaui.com/staging"
           else
             webroot="/var/www/mantaui"
-            site="https://mantaui.com"
+          fi
+          # releaseHost comes from the ONE per-channel table
+          # (src/shared/channel.mjs) — never hardcode a second copy here.
+          site="$(node -e 'import("./src/shared/channel.mjs").then(m => process.stdout.write(m.channelConfig(process.argv[1]).releaseHost))' "$channel")"
+          if [ -z "$site" ]; then
+            echo "::error::could not resolve releaseHost for channel=${channel}"
+            exit 1
           fi
           echo "channel=$channel" >> "$GITHUB_OUTPUT"
           echo "webroot=$webroot" >> "$GITHUB_OUTPUT"
@@ -104,10 +118,6 @@ jobs:
             exit 1
           fi
           echo "✓ guard passed (channel=$CHANNEL, WEBROOT=$WEBROOT)"
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: Deploy static web assets
         env:


### PR DESCRIPTION
## BET-401 — resolve website-deploy `releaseHost` from `channel.mjs`

`website-deploy.yml` hardcoded a second copy of `channelConfig().releaseHost` (the per-channel public base URL) in its `resolve` step — duplicating `CHANNELS.<channel>.releaseHost` in `src/shared/channel.mjs`. Two copies, no sync: if the staging base URL ever changes in `channel.mjs`, the workflow would silently keep the old URL and the verify step could fetch the wrong endpoint and report green against a URL nothing real consumes. This is the exact same drift trap BET-389 just removed from `server-tarball-deploy.yml` (this issue's parent, deferred there as "a separate decision").

### Change (mirrors BET-389 1:1)
- Add `actions/checkout@v4` (`fetch-depth: 1`) **before** the `resolve` step so the `node -e` import resolves (the resolve step previously had no checkout).
- Read `releaseHost` from the ONE per-channel table: `site="$(node -e 'import("./src/shared/channel.mjs").then(m => process.stdout.write(m.channelConfig(process.argv[1]).releaseHost))' "$channel")"`.
- Keep `webroot` hardcoded — it is a filesystem path on the prod box, not a per-channel app value (same reasoning as `releases_dir` in BET-389).
- Fail red if `releaseHost` resolves empty (`::error::could not resolve releaseHost ...`).
- Drop the now-redundant later `actions/checkout` (the top-of-job checkout covers the whole `deploy` job; the workspace persists across steps).

### Verification (local equivalence)
- `node -e` resolves to the exact previously-hardcoded values: `prod` → `https://mantaui.com`, `staging` → `https://mantaui.com/staging`, `dev` → `https://mantaui.com`. No behavior change.
- YAML syntax valid (parsed).
- typecheck + full test suite green (see block below).
- `channel.mjs` **not modified**; `install.sh`, `server-tarball-deploy.yml`, `codemagic.yaml` untouched. Diff touches only `.github/workflows/website-deploy.yml`.

### Deferred verification (live staging publish)
The issue suggests `gh workflow run website-deploy.yml -f channel=staging` as the end-to-end check. That workflow runs on the self-hosted runner and SSHes to `root@<prod-box>` to write the `/staging/` subtree. Per Hard Rule 4 (no agent-initiated deploys to the prod box, no `ssh root@…`), I did not trigger a live deploy from the agent. The resolve-step guard (`if [ -z "$site" ] … exit 1`) is the negative check at the source; the existing verify step already fetches `$SITE` (now sourced from the table). Recommend a human trigger the staging run to confirm end-to-end.

**Files changed:** 1 file. `.github/workflows/website-deploy.yml` (+16 / −6)

**Verification results:**
- PR branch (`multica/BET-401-website-releasehost` @ `fdebfa9`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1143` pass / `0` fail / `0` skip. Failures: none. log sha256: `db3381e03fa9ca47f482be583baed6bde56c5f00bfe58f208fedb1cbd734fc5d`
- Base (`main` @ `d282633`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1143` pass / `0` fail / `0` skip. Failures: none. log sha256: `1cbb9cb41149b003ebe473ffe8792855419f30eda67a3d0955a100aab39e79a1`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. typecheck logs are byte-identical between branches (no code change affects the TS build); test suites are green on both.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Base: origin/main @ d282633
