### PR TITLE
refactor(renderer): dead-code sweep in subagent panel + dedupe refreshPermissions/refreshQuestions (BET-377)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -32,7 +32,6 @@ import {
   buildTitlePromptInput,
   buildTitleInstruction,
   sanitizeGeneratedTitle,
-  hydrateQuestion,
   classifyScrollForPin,
   detectCommandFromText,
   formatBytes,
@@ -234,6 +233,8 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
     retryInfo,
     compactionState,
     rejectAllPendingQuestions,
+    refreshPermissions,
+    refreshQuestions,
   } = useSseBus({
     sessionId,
     cwd,
@@ -323,17 +324,9 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   const agentFileToast = useStore((s) => s.agentFileToast);
   const setAgentFileToast = useStore((s) => s.setAgentFileToast);
   const [agentFileSaving, setAgentFileSaving] = useState(false);
-  // Per-child loading/error state for the lazy fetch on expand.
-  const [childFetchState] = useState<
-    Map<string, "loading" | "error">
-  >(() => new Map());
-  // Ref mirrors of the child-state maps so `toggleTaskExpand` can read
+  // Ref mirror of the child-status map so `toggleTaskExpand` can read
   // current values synchronously without taking them as deps.
-  const childFetchStateRef = useRef<Map<string, "loading" | "error">>(new Map());
   const liveChildStatusRef = useRef<Map<string, "running" | "idle">>(new Map());
-  useEffect(() => {
-    childFetchStateRef.current = childFetchState;
-  }, [childFetchState]);
   useEffect(() => {
     liveChildStatusRef.current = liveChildStatus;
   }, [liveChildStatus]);
@@ -360,33 +353,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       clearInterval(branchPoll);
     };
   }, [sessionId, cwd, refreshBranch]);
-
-  // Refresh permissions list. Called on any permission event.
-  const refreshPermissions = useCallback(() => {
-    window.api
-      .opencodePermissions(sessionId)
-      .then((all) =>
-        setPermissions(all.filter((p) => p.sessionID === sessionId)),
-      )
-      .catch(() => { /* keep last-known */ });
-  }, [sessionId]);
-
-  // Refresh question list. Called on any question event.
-  // `hydrateQuestion` normalizes the server's QuestionRequest shape — in
-  // particular, it copies the server's `id` (the `que_…`) into our `requestId`
-  // field, which is required for the reply handler.
-  const refreshQuestions = useCallback(() => {
-    window.api
-      .opencodeQuestions(sessionId)
-      .then((all) =>
-        setQuestions(
-          all
-            .filter((q) => q.sessionID === sessionId)
-            .map(hydrateQuestion) as QuestionRequest[],
-        ),
-      )
-      .catch(() => { /* keep last-known — v2-only endpoint */ });
-  }, [sessionId]);
 
   // Ctrl+O toggles reasoning visibility. Matches Claude Code's TUI keybind.
   useEffect(() => {
@@ -1669,7 +1635,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       expanded: expandedTasks,
       toggle: toggleTaskExpand,
       childMessages,
-      childFetchState,
       liveStatus: liveChildStatus,
       showThinking,
     }),
@@ -1677,7 +1642,6 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
       expandedTasks,
       toggleTaskExpand,
       childMessages,
-      childFetchState,
       liveChildStatus,
       showThinking,
     ],

--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -339,7 +339,6 @@ function TaskBody({ state }: { state: ToolState }) {
   }
   const isExpanded = ctx?.expanded.has(info.childSessionId) ?? false;
   const childMsgs = childMsgsForSummary;
-  const childFetch = ctx?.childFetchState.get(info.childSessionId);
   const liveState = ctx?.liveStatus.get(info.childSessionId);
   // Prefer live SSE status over the parent's transcript snapshot (which
   // lags by one refetch cycle). Maps "running" → still going, "idle" →
@@ -428,14 +427,6 @@ function TaskBody({ state }: { state: ToolState }) {
           followed by the final output. While loading, a small spinner. */}
       {isExpanded && (
         <div className="mt-1 ml-4 pl-3 border-l-2 border-border">
-          {childFetch === "loading" && !childMsgs && (
-            <div className="text-text-faint italic">Loading subagent transcript…</div>
-          )}
-          {childFetch === "error" && !childMsgs && (
-            // Inline hex — theme has no `error` token; matches bulletStyle()'s
-            // red used for failed tool calls.
-            <div style={{ color: "#F0505F" }}>Failed to load subagent transcript.</div>
-          )}
           {childMsgs && childMsgs.length > 0 && (
             <div className="flex flex-col gap-2">
               {childMsgs.map((m) => (

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -96,9 +96,6 @@ export type TaskContextValue = {
   // (never fetched) — TaskBody shows a spinner or "expand to load" depending
   // on fetchState.
   childMessages: Map<string, OpencodeMessage[]>;
-  // "loading" while the initial fetch is in flight; "error" if it failed
-  // (TaskBody renders a small retry hint). Absent = idle.
-  childFetchState: Map<string, "loading" | "error">;
   // Live child running/idle from session.status / session.idle events.
   // Overrides the parent's stale `state.status` for the running pulse.
   liveStatus: Map<string, "running" | "idle">;

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -285,7 +285,9 @@ export function useSseBus(params: {
     try {
       const perms = await window.api.opencodePermissions?.(sessionId);
       if (Array.isArray(perms)) {
-        setPermissions(perms);
+        // Filter to the viewed session so a cumulative workspace-wide GET
+        // can't stack unrelated backlog — symmetric with refreshQuestions.
+        setPermissions(perms.filter((p) => p.sessionID === sessionId));
       }
     } catch { /* non-fatal */ }
   }, [sessionId]);


### PR DESCRIPTION
## BET-377 — Dead-code sweep in the subagent panel + one refetch path for permissions and questions

Stage 1 of the "Background delegation (v1)" epic: pure deletion and de-duplication, no new feature.

### What changed

**A. Deleted `childFetchState` entirely.** It was a `useState` with no setter, initialised empty, never mutated; its ref mirror `childFetchStateRef` was read nowhere. The two branches consuming it in `ToolCall.tsx` ("Loading…" / "Failed to load…") were unreachable. Removed:
- the `useState` declaration + `childFetchStateRef` + its assign effect in `ChatPanel.tsx`
- the `childFetchState` field on `TaskContextValue` in `chatShared.tsx`
- the `childFetch` local and both dead branches in `ToolCall.tsx`
- the entry in `taskContextValue` and its dep-array entry

An un-fetched subagent card now renders an empty body until the live transcript lands (the `childMsgs.length > 0` and `=== 0` branches already cover both outcomes). No spinner added — out of scope per the issue.

**B. Deduplicated `refreshPermissions` / `refreshQuestions`.** Deleted the older ChatPanel-local copies; `useSseBus`'s versions are the single survivors, now pulled via the hook's return and used at every call site (the `isActive` effect, the reply-error rollbacks). Added the `p.sessionID === sessionId` filter to the hook's `refreshPermissions` so it matches `refreshQuestions` and the deleted ChatPanel copy — keeps the panel correct when a stale workspace-wide response lands after a session switch.

Dropped the now-unused `hydrateQuestion` import from ChatPanel.

### Verification results

**Files changed:** 4 files.
```
 src/renderer/ChatPanel.tsx      | 42 +++--------------------------------------
 src/renderer/ToolCall.tsx       |  9 ---------
 src/renderer/chatShared.tsx     |  3 ---
 src/renderer/hooks/useSseBus.ts |  4 +++-
 4 files changed, 6 insertions(+), 52 deletions(-)
```

- PR branch (`multica/BET-377-deadcode-sweep` @ `0dad457`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1150 pass / 0 fail / 0 skip. Failures: none. log sha256: `82ff140c18f1b8b299d8460e752f10851bb719f3c2679dfaa9b461facfb926c4`
- Base (`main` @ `968559f`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1150 pass / 0 fail / 0 skip. Failures: none. log sha256: `bf5c6cbb2e448526b50f32798cbe7a54631bbbfc0745803da7ae52eb8cf7f45e`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved by this PR. Identical green on both branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

### Definition-of-done checks

- `npm run typecheck && npm test` green ✅
- `grep -rn "childFetchState\|childFetch" src/` returns nothing ✅ (exit 1)
- `grep -n "refreshPermissions\|refreshQuestions" src/renderer/ChatPanel.tsx` shows only call sites, no definitions ✅
- App builds; expanded subagent card still renders its transcript ✅ (live branches unchanged)

Base: origin/main @ 968559f
