### PR TITLE
feat(server): background job engine — delegate.mjs (BET-378)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -1,0 +1,802 @@
+// delegate.mjs — background job engine for the MantaUI server (BET-378).
+//
+// The core of "background delegation": a durable record of jobs plus the
+// machinery to start one (worktree → session → window → prompt), detect when
+// it finishes, assemble its result, and hand that result back to the parent
+// session WITHOUT interrupting the user.
+//
+// Modelled on src/server/capabilities.mjs (dependency-injected pure-logic +
+// injected I/O, an in-flight-guarded sweeper/poller with timer.unref()), but a
+// SEPARATE module and a SEPARATE store (~/.manta/delegate-jobs.json). Do NOT
+// extend capabilities.mjs: its records are plugin-capability shaped and
+// background jobs complete from a different signal (the opencode event stream,
+// not an executor POST).
+//
+// Completion is detected from the opencode event firehose via observeEvent,
+// which the pump in src/server/index.mjs calls alongside the existing
+// observers (promptDelivery, webhookEngine). A job completes on the first
+// idle transition for its childSessionID that occurs AFTER at least one busy
+// has been observed (per-job in-memory sawBusy flag) — that ordering is what
+// stops a stray pre-prompt idle from completing the job instantly.
+//
+// The result is assembled in finishJob (final assistant text + filesChanged
+// count) and delivered to the parent session through the shared
+// prompt-delivery engine (src/server/promptDelivery.mjs), which defers it
+// until the parent is idle so a completion notice never aborts the parent's
+// in-flight turn.
+
+import { randomBytes } from "node:crypto";
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { slugify } from "../shared/worktree.mjs";
+import {
+  parseGitStatus,
+  summarizeTranscript,
+  describeChatActivity,
+} from "./peers.mjs";
+
+// ---------------------------------------------------------------------------
+// Constants (mirrors capabilities.mjs exactly — reuse, do not diverge)
+// ---------------------------------------------------------------------------
+
+const STORE_PATH = statePath("delegate-jobs.json");
+
+// Max concurrently `running` jobs, counted box-wide. There is no `queued`
+// state — a job either starts immediately or is refused by the cap.
+export const MAX_RUNNING_JOBS = 5;
+// `running` jobs older than this → `failed "timed out after 30 minutes"`.
+const RUNNING_TIMEOUT_MS = 30 * 60_000;
+// Terminal jobs are retained this long, OR until 50 records, whichever bites
+// first. The window + worktree are NEVER removed by the sweeper — only by an
+// explicit delete.
+const TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60_000;
+const MAX_TERMINAL_JOBS = 50;
+// Activity-summary poller cadence (updates `activity` for running jobs only).
+const ACTIVITY_INTERVAL_MS = 10_000;
+// Sweeper cadence (matches capabilities.mjs SWEEP_INTERVAL_MS).
+const SWEEP_INTERVAL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Store (atomic, same pattern as capabilities.mjs / schedule.mjs)
+// ---------------------------------------------------------------------------
+
+export async function loadJobs(path = STORE_PATH) {
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed?.jobs) ? parsed.jobs : [];
+}
+
+export async function saveJobs(jobs, path = STORE_PATH) {
+  await writeJsonAtomic(path, JSON.stringify({ jobs }, null, 2));
+}
+
+function genId() {
+  return randomBytes(4).toString("hex"); // 8-char hex, matches capabilities/genId
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * The opening prompt injected into the child session. The git paragraph is
+ * omitted entirely when `worktree` is null (parent cwd was not a repo). Do not
+ * add anything else and do not make it configurable.
+ */
+export function buildJobPrompt({ prompt, worktree, branch }) {
+  const head = String(prompt ?? "").trim();
+  if (!worktree) {
+    return (
+      head +
+      "\n\n---\n" +
+      "You are running as a background job. The user is not watching this session and\n" +
+      "cannot see your intermediate output — only your final message is reported back.\n\n" +
+      "When you are done, end with a short summary of what you changed and why."
+    );
+  }
+  return (
+    head +
+    "\n\n---\n" +
+    "You are running as a background job. The user is not watching this session and\n" +
+    "cannot see your intermediate output — only your final message is reported back.\n\n" +
+    `You are working in an isolated git worktree at ${worktree}, on branch ${branch}.\n` +
+    "Commit your work to that branch before you finish. Do not push, do not open a\n" +
+    "pull request, do not merge, and do not touch any other checkout.\n\n" +
+    "When you are done, end with a short summary of what you changed and why."
+  );
+}
+
+/**
+ * The completion message delivered to the parent session. The Branch/Worktree
+ * lines are omitted when there is no worktree. On failure `<result>` is
+ * replaced by `Error: <error>`. On timeout the status word is `failed` and the
+ * error is `timed out after 30 minutes`.
+ */
+export function buildCompletionText(job) {
+  const name = job?.name ?? "";
+  const status = job?.status ?? "done";
+  const lines = [`[background job "${name}" ${status}]`];
+  if (job?.worktree) {
+    const changed = job?.filesChanged == null ? "0" : String(job.filesChanged);
+    lines.push(`Branch: ${job.branch ?? ""} (${changed} files changed)`);
+    lines.push(`Worktree: ${job.worktree}`);
+  }
+  lines.push("");
+  if (status === "failed" || status === "stopped") {
+    lines.push(`Error: ${job?.error ?? ""}`);
+  } else {
+    lines.push(String(job?.result ?? ""));
+  }
+  return lines.join("\n");
+}
+
+// Derive the job name from the first four whitespace-separated words of the
+// prompt, slugified. Pure.
+export function deriveName(prompt) {
+  const words = String(prompt ?? "").trim().split(/\s+/).slice(0, 4).join(" ");
+  return slugify(words || "background");
+}
+
+// Find the tmux session that owns a given opencode sessionID. Mirrors the
+// renderer's resolveSessionOwner (src/renderer/store.ts) — the server-side
+// equivalent the spec calls for. Returns { tmuxSession, windowIndex, cwd } or
+// null.
+export function resolveOwner(projects, sessionID) {
+  if (!Array.isArray(projects) || !sessionID) return null;
+  for (const p of projects) {
+    const w = (p.windows || []).find((x) => x.opencodeSessionId === sessionID);
+    if (w) {
+      return {
+        tmuxSession: p.tmuxSession,
+        windowIndex: w.index,
+        cwd: w.paneCurrentPath || p.defaultCwd || "~",
+      };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// List / get
+// ---------------------------------------------------------------------------
+
+export async function listJobs({ sessionID } = {}, { load = loadJobs } = {}) {
+  const jobs = await load();
+  if (sessionID === undefined) return jobs.map((j) => ({ ...j }));
+  return jobs.filter((j) => j.parentSessionID === sessionID).map((j) => ({ ...j }));
+}
+
+export async function getJob(id, { load = loadJobs } = {}) {
+  const jobs = await load();
+  const job = jobs.find((j) => j.id === id);
+  return job ? { ...job } : null;
+}
+
+// ---------------------------------------------------------------------------
+// startJob — performs the steps in the exact order the spec dictates. If any
+// step throws, undo the steps already done, in reverse, and return
+// {ok:false, error} — never leave a half-created job.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {{prompt:string, model?:string, parentSessionID:string, parentDirectory:string}} input
+ * @param {object} deps injected I/O (load/save/publish/deliver/listProjects/
+ *        newWindow/gitAddWorktree/gitRun/oc listMessages/now)
+ */
+export async function startJob(input, deps = {}) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    deliver,
+    listProjects,
+    newWindow,
+    gitAddWorktree,
+    gitRun,
+    now = () => Date.now(),
+  } = deps;
+
+  const prompt = String(input?.prompt ?? "");
+  const parentSessionID = input?.parentSessionID;
+  const parentDirectory = input?.parentDirectory;
+
+  if (!parentSessionID) return { ok: false, error: "parentSessionID is required" };
+  if (!parentDirectory) return { ok: false, error: "parentDirectory is required" };
+
+  // 1. Refuse if nesting.
+  {
+    const jobs = await load();
+    const nesting = jobs.find(
+      (j) => j.childSessionID === parentSessionID && j.status === "running",
+    );
+    if (nesting) {
+      return { ok: false, error: "a background job cannot start another background job" };
+    }
+  }
+
+  // 2. Refuse if at cap.
+  {
+    const jobs = await load();
+    const running = jobs.filter((j) => j.status === "running").length;
+    if (running >= MAX_RUNNING_JOBS) {
+      return {
+        ok: false,
+        error:
+          "too many background jobs running (5). Do not retry — either wait for one to finish, or do this work yourself.",
+      };
+    }
+  }
+
+  // 3. Derive the name.
+  const name = deriveName(prompt);
+
+  // 4. Create the worktree. On throw, catch and continue with
+  //    worktree = branch = baseSha = null and cwd = parentDirectory.
+  let worktree = null;
+  let branch = null;
+  let baseSha = null;
+  let cwd = parentDirectory;
+  try {
+    const wt = await gitAddWorktree({ cwd: parentDirectory, name });
+    worktree = wt.path;
+    branch = wt.branch;
+    cwd = wt.path;
+  } catch {
+    worktree = null;
+    branch = null;
+    baseSha = null;
+    cwd = parentDirectory;
+  }
+
+  // 5. Record baseSha — git -C <worktree> rev-parse HEAD, trimmed. Skip when
+  //    there is no worktree.
+  if (worktree) {
+    try {
+      const { stdout } = await gitRun(["-C", worktree, "rev-parse", "HEAD"]);
+      baseSha = String(stdout ?? "").trim() || null;
+    } catch {
+      baseSha = null;
+    }
+  }
+
+  // 6. Create the window. Because chatMode is true, newWindow already creates
+  //    the opencode session and stamps @manta-session-id; read the new
+  //    window's opencodeSessionId back out of the returned project list —
+  //    that is childSessionID. On throw, undo step 4 (remove the worktree)
+  //    and return {ok:false, error}.
+  let childSessionID = null;
+  let tmuxSession = null;
+  let windowIndex = null;
+  try {
+    const owner = resolveOwner(await listProjects(), parentSessionID);
+    if (!owner) {
+      throw new Error(`could not resolve the tmux session owning ${parentSessionID}`);
+    }
+    tmuxSession = owner.tmuxSession;
+    const projects = await newWindow({
+      sessionName: tmuxSession,
+      windowName: name,
+      cwd,
+      chatMode: true,
+      worktreePath: worktree,
+      oc: deps.oc,
+    });
+    const owner2 = resolveOwner(projects, parentSessionID);
+    const proj = (projects || []).find((p) => p.tmuxSession === tmuxSession);
+    const win = (proj?.windows || []).find(
+      (w) => w.name === name && w.opencodeSessionId,
+    );
+    childSessionID = win?.opencodeSessionId ?? null;
+    windowIndex = win?.index ?? null;
+    // Sanity: if we somehow failed to read the child session id back, abort.
+    if (!childSessionID) {
+      throw new Error("could not read the new window's opencode session id");
+    }
+    void owner2;
+  } catch (e) {
+    // Undo step 4 in reverse: remove the worktree (force:false, best-effort).
+    if (worktree && deps.gitRemoveWorktree) {
+      try {
+        await deps.gitRemoveWorktree({ path: worktree, force: false });
+      } catch {
+        /* best-effort cleanup; the start failure is the headline error */
+      }
+    }
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+
+  // 7. Persist the record with status "running", startedAt = now.
+  const id = genId();
+  const job = {
+    id,
+    name,
+    prompt,
+    model: input?.model ?? null,
+    parentSessionID,
+    parentDirectory,
+    childSessionID,
+    tmuxSession,
+    windowIndex,
+    worktree,
+    branch,
+    baseSha,
+    status: "running",
+    activity: null,
+    createdAt: now(),
+    startedAt: now(),
+    finishedAt: null,
+    result: null,
+    error: null,
+    filesChanged: null,
+  };
+  {
+    const jobs = await load();
+    jobs.push(job);
+    await save(jobs);
+  }
+  publish?.({ kind: "delegate.updated", payload: { id, status: "running" } });
+
+  // 8. Send the opening prompt via the shared delivery module's deliver.
+  try {
+    await deliver({
+      sessionId: childSessionID,
+      text: buildJobPrompt({ prompt, worktree, branch }),
+    });
+  } catch (e) {
+    // deliver never rejects in production, but guard anyway — the job is
+    // already persisted + running; a delivery failure surfaces as a normal
+    // completion (the child will idle immediately).
+    console.warn("[delegate] opening prompt delivery failed:", e?.message ?? e);
+  }
+
+  return { ok: true, job };
+}
+
+// ---------------------------------------------------------------------------
+// Completion detection — observeEvent, called by the opencode pump.
+//
+// A job completes on the first idle transition for its childSessionID that
+// occurs AFTER at least one busy has been observed for that session. Track a
+// per-job in-memory sawBusy flag (passed in so each engine instance owns its
+// own map).
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {object} evt an opencode event
+ * @param {object} deps { load, save, publish, deliver, listMessages, gitRun, now }
+ * @param {Map<string,boolean>} sawBusy per-childSessionID busy flag (engine-owned)
+ */
+export async function observeEvent(evt, deps = {}, sawBusy = new Map()) {
+  const sid = evt?.properties?.sessionID;
+  if (typeof sid !== "string" || !sid) return;
+  const { load = loadJobs } = deps;
+  const jobs = await load();
+  const job = jobs.find((j) => j.childSessionID === sid && j.status === "running");
+  if (!job) {
+    // Not a tracked background job — but still keep the sawBusy flag honest so
+    // a job that starts later in this same session id isn't instantly
+    // completed by a stale idle. (Session ids are unique per opencode
+    // session, so this is defensive only.)
+    return;
+  }
+
+  if (evt.type === "session.error") {
+    const errName = evt?.properties?.error?.name;
+    if (errName === "MessageAbortedError") return; // intentional abort — ignore
+    await finishJob(job, "failed", String(evt?.properties?.error?.message ?? "error"), deps, sawBusy);
+    return;
+  }
+
+  if (evt.type === "session.idle") {
+    if (sawBusy.get(sid)) {
+      await finishJob(job, "done", null, deps, sawBusy);
+    }
+    return;
+  }
+
+  if (evt.type === "session.status") {
+    const t = evt?.properties?.status?.type;
+    if (t === "busy" || t === "retry") {
+      sawBusy.set(sid, true);
+    } else if (t === "idle") {
+      if (sawBusy.get(sid)) {
+        await finishJob(job, "done", null, deps, sawBusy);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// finishJob — assemble the result, persist, and deliver the completion
+// message to the parent session through the shared delivery engine (which
+// defers until the parent is idle). If the parent session no longer exists,
+// deliver fails; swallow it, log, and still mark the job terminal.
+// ---------------------------------------------------------------------------
+
+async function lastAssistantText(messages) {
+  const msgs = Array.isArray(messages) ? messages : [];
+  for (let i = msgs.length - 1; i >= 0; i -= 1) {
+    const m = msgs[i];
+    if (m?.info?.role !== "assistant") continue;
+    let text = "";
+    for (const p of m?.parts || []) {
+      if (p?.type === "text" && typeof p.text === "string") text += p.text;
+    }
+    text = text.trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+async function countFilesChanged(job, deps) {
+  if (!job.worktree || !job.baseSha) return null;
+  const { gitRun } = deps;
+  let committed = 0;
+  try {
+    const { stdout } = await gitRun([
+      "-C", job.worktree, "diff", "--name-only", `${job.baseSha}..HEAD`,
+    ]);
+    committed = (String(stdout ?? "").split("\n").filter((l) => l.length > 0)).length;
+  } catch {
+    committed = 0;
+  }
+  let uncommitted = 0;
+  try {
+    const { stdout } = await gitRun(["-C", job.worktree, "status", "--porcelain"]);
+    uncommitted = parseGitStatus(stdout).count;
+  } catch {
+    uncommitted = 0;
+  }
+  return committed + uncommitted;
+}
+
+export async function finishJob(job, status, error, deps = {}, sawBusy) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    deliver,
+    listMessages,
+    now = () => Date.now(),
+  } = deps;
+
+  // Idempotent: if the job is already terminal, do nothing.
+  if (job.status === "done" || job.status === "failed" || job.status === "stopped") {
+    return { ok: true, alreadyTerminal: true };
+  }
+
+  let result = "";
+  let filesChanged = null;
+  if (status === "done") {
+    try {
+      const messages = listMessages ? await listMessages(job.childSessionID) : [];
+      result = await lastAssistantText(messages);
+    } catch (e) {
+      console.warn("[delegate] listMessages failed:", e?.message ?? e);
+      result = "";
+    }
+    filesChanged = await countFilesChanged(job, deps);
+  }
+
+  const finishedAt = now();
+  const updated = {
+    ...job,
+    status,
+    error: status === "done" ? null : (error ?? null),
+    result: status === "done" ? result : null,
+    filesChanged,
+    finishedAt,
+  };
+
+  // Persist.
+  {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === job.id);
+    if (idx !== -1) {
+      jobs[idx] = updated;
+      await save(jobs);
+    }
+  }
+  publish?.({
+    kind: "delegate.updated",
+    payload: { id: updated.id, status: updated.status, activity: updated.activity },
+  });
+  if (sawBusy) sawBusy.delete(job.childSessionID);
+
+  // Deliver the completion message to the parent session (deferred until idle
+  // by the shared delivery engine). Swallow a failure — the job is terminal
+  // regardless.
+  if (deliver && job.parentSessionID) {
+    try {
+      await deliver({
+        sessionId: job.parentSessionID,
+        text: buildCompletionText(updated),
+      });
+    } catch (e) {
+      console.warn(`[delegate] completion delivery failed for ${job.id}:`, e?.message ?? e);
+    }
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Activity summaries — a 10s poller updates `activity` for running jobs only.
+// Reuses summarizeTranscript(messages) then describeChatActivity(summary),
+// both from peers.mjs. No model call. No Groq. No new config.
+// ---------------------------------------------------------------------------
+
+async function tickActivity(deps) {
+  const { load = loadJobs, save = saveJobs, publish, listMessages, now = () => Date.now() } = deps;
+  const jobs = await load();
+  let changed = false;
+  await Promise.all(
+    jobs.map(async (job) => {
+      if (job.status !== "running") return;
+      let activity = null;
+      try {
+        const messages = listMessages ? await listMessages(job.childSessionID) : [];
+        activity = describeChatActivity(summarizeTranscript(messages));
+      } catch (e) {
+        console.warn(`[delegate] activity poll failed for ${job.id}:`, e?.message ?? e);
+        return;
+      }
+      if (activity !== job.activity) {
+        job.activity = activity;
+        changed = true;
+        publish?.({
+          kind: "delegate.updated",
+          payload: { id: job.id, status: job.status, activity },
+        });
+      }
+    }),
+  );
+  if (changed) await save(jobs);
+  void now;
+}
+
+export function startActivityPoller(deps = {}, { intervalMs = ACTIVITY_INTERVAL_MS } = {}) {
+  let inFlight = false;
+  const tick = async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await tickActivity(deps);
+    } catch (e) {
+      console.warn("[delegate] activity tick failed:", e?.message ?? e);
+    } finally {
+      inFlight = false;
+    }
+  };
+  void tick();
+  const timer = setInterval(() => void tick(), intervalMs);
+  timer.unref();
+  return { stop() { clearInterval(timer); } };
+}
+
+// ---------------------------------------------------------------------------
+// Sweeper — reuses the capability sweeper's constants and shape. Running jobs
+// older than 30 minutes become `failed` with error "timed out after 30
+// minutes". Terminal jobs are retained 7 days or 50 records, whichever bites
+// first. The window and worktree are NEVER removed by the sweeper — only by an
+// explicit delete.
+// ---------------------------------------------------------------------------
+
+export async function sweepDelegateJobs(deps = {}) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    deliver,
+    now = () => Date.now(),
+  } = deps;
+  try {
+    const jobs = await load();
+    if (jobs.length === 0) return;
+    const nowMs = now();
+    const transitioned = [];
+
+    for (const job of jobs) {
+      if (
+        job.status === "running" &&
+        job.startedAt != null &&
+        nowMs - job.startedAt > RUNNING_TIMEOUT_MS
+      ) {
+        transitioned.push(job);
+      }
+    }
+
+    if (transitioned.length === 0) {
+      const retained = applyRetention(jobs, nowMs);
+      if (retained.length !== jobs.length) await save(retained);
+      return;
+    }
+
+    for (const job of transitioned) {
+      // finishJob persists + publishes + delivers. Pass a fresh sawBusy map —
+      // the sweeper has no event-stream state.
+      await finishJob(job, "failed", "timed out after 30 minutes", { load, save, publish, deliver, now }, new Map());
+    }
+    const retained = applyRetention(await load(), nowMs);
+    await save(retained);
+  } catch (e) {
+    console.warn("[delegate] sweep failed:", e?.message ?? e);
+  }
+}
+
+function applyRetention(jobs, nowMs) {
+  const cutoff = nowMs - TERMINAL_RETENTION_MS;
+  let out = jobs.filter(
+    (j) =>
+      !(
+        (j.status === "done" || j.status === "failed" || j.status === "stopped") &&
+        j.finishedAt != null &&
+        j.finishedAt < cutoff
+      ),
+  );
+  const terminal = out.filter(
+    (j) => j.status === "done" || j.status === "failed" || j.status === "stopped",
+  );
+  if (terminal.length > MAX_TERMINAL_JOBS) {
+    const sorted = [...terminal].sort((a, b) => (a.finishedAt ?? 0) - (b.finishedAt ?? 0));
+    const dropped = new Set(
+      sorted.slice(0, terminal.length - MAX_TERMINAL_JOBS).map((j) => j.id),
+    );
+    out = out.filter((j) => !dropped.has(j.id));
+  }
+  return out;
+}
+
+export function startSweeper(deps = {}, { intervalMs = SWEEP_INTERVAL_MS } = {}) {
+  const pathBound = {
+    ...deps,
+    load: () => loadJobs(deps.storePath ?? STORE_PATH),
+    save: (jobs) => saveJobs(jobs, deps.storePath ?? STORE_PATH),
+  };
+  let inFlight = false;
+  const tick = async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await sweepDelegateJobs(pathBound);
+    } catch (e) {
+      console.warn("[delegate] sweep tick failed:", e?.message ?? e);
+    } finally {
+      inFlight = false;
+    }
+  };
+  void tick();
+  const timer = setInterval(() => void tick(), intervalMs);
+  timer.unref();
+  return { stop() { clearInterval(timer); } };
+}
+
+// ---------------------------------------------------------------------------
+// Stopping and deleting
+// ---------------------------------------------------------------------------
+
+/**
+ * stopJob aborts the child session with oc.abortSession, marks the job
+ * `stopped`, and sends a completion message. Window and worktree are kept.
+ */
+export async function stopJob(id, deps = {}) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    deliver,
+    abortSession,
+    listMessages,
+    now = () => Date.now(),
+  } = deps;
+  const jobs = await load();
+  const idx = jobs.findIndex((j) => j.id === id);
+  if (idx === -1) return { ok: false, error: "not found" };
+  const job = jobs[idx];
+  if (job.status !== "running") {
+    return { ok: false, error: "job not running", status: job.status };
+  }
+  if (abortSession && job.childSessionID) {
+    try {
+      await abortSession(job.childSessionID);
+    } catch (e) {
+      console.warn(`[delegate] abortSession failed for ${id}:`, e?.message ?? e);
+    }
+  }
+  const finishedAt = now();
+  const updated = {
+    ...job,
+    status: "stopped",
+    error: "stopped by user",
+    finishedAt,
+  };
+  jobs[idx] = updated;
+  await save(jobs);
+  publish?.({
+    kind: "delegate.updated",
+    payload: { id: updated.id, status: updated.status, activity: updated.activity },
+  });
+  if (deliver && job.parentSessionID) {
+    try {
+      await deliver({
+        sessionId: job.parentSessionID,
+        text: buildCompletionText(updated),
+      });
+    } catch (e) {
+      console.warn(`[delegate] stop completion delivery failed for ${id}:`, e?.message ?? e);
+    }
+  }
+  void listMessages;
+  return { ok: true };
+}
+
+/**
+ * deleteJob removes the tmux window, then calls
+ * local.gitRemoveWorktree({ path, force: false }), then removes the record.
+ * NEVER pass force: true. If gitRemoveWorktree returns {removed:false,
+ * reason:"dirty"}, keep the worktree AND keep the job record, and return that
+ * reason so the UI can explain it.
+ */
+export async function deleteJob(id, deps = {}) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    killWindow,
+    gitRemoveWorktree,
+  } = deps;
+  const jobs = await load();
+  const idx = jobs.findIndex((j) => j.id === id);
+  if (idx === -1) return { ok: false, error: "not found" };
+  const job = jobs[idx];
+
+  // 1. Remove the tmux window (best-effort).
+  if (killWindow && job.tmuxSession != null && job.windowIndex != null) {
+    try {
+      await killWindow({ sessionName: job.tmuxSession, windowIndex: job.windowIndex });
+    } catch (e) {
+      console.warn(`[delegate] killWindow failed for ${id}:`, e?.message ?? e);
+    }
+  }
+
+  // 2. Remove the worktree (force: false, NEVER force: true).
+  if (gitRemoveWorktree && job.worktree) {
+    try {
+      const res = await gitRemoveWorktree({ path: job.worktree, force: false });
+      if (res && res.removed === false && res.reason === "dirty") {
+        // Keep the worktree AND keep the job record; report `dirty`.
+        return { ok: false, error: "dirty", reason: "dirty" };
+      }
+    } catch (e) {
+      console.warn(`[delegate] gitRemoveWorktree failed for ${id}:`, e?.message ?? e);
+      // A failed remove leaves the worktree on disk; still drop the record so
+      // the UI isn't stuck, but surface the error.
+    }
+  }
+
+  // 3. Remove the record.
+  const next = jobs.filter((j) => j.id !== id);
+  await save(next);
+  publish?.({ kind: "delegate.updated", payload: { id, status: "deleted" } });
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Engine factory — wires the runtime deps once (in src/server/index.mjs) and
+// returns bound methods the REST/RPC handlers + the pump call. Mirrors the
+// createPromptDelivery / createWebhookEngine pattern.
+// ---------------------------------------------------------------------------
+
+export function createDelegateEngine(deps) {
+  const sawBusy = new Map();
+  const bound = {
+    startJob: (input) => startJob(input, deps),
+    stopJob: (id) => stopJob(id, deps),
+    deleteJob: (id) => deleteJob(id, deps),
+    listJobs: (filter) => listJobs(filter, deps),
+    getJob: (id) => getJob(id, deps),
+    observeEvent: (evt) => observeEvent(evt, deps, sawBusy),
+    sweep: () => sweepDelegateJobs(deps),
+    startSweeper: (opts) => startSweeper(deps, opts),
+    startActivityPoller: (opts) => startActivityPoller(deps, opts),
+  };
+  return bound;
+}

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -1,0 +1,529 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildJobPrompt,
+  buildCompletionText,
+  deriveName,
+  resolveOwner,
+  startJob,
+  observeEvent,
+  finishJob,
+  sweepDelegateJobs,
+  deleteJob,
+  MAX_RUNNING_JOBS,
+} from "./delegate.mjs";
+
+// ----------------------------------------------------------------------------
+// Harness: in-memory load/save on a closure-held array, recorded publish +
+// deliver. Mirrors the harness style of capabilities.test.mjs / schedule.test.
+// No real tmux, no real opencode, no real git.
+// ----------------------------------------------------------------------------
+
+function harness(initialJobs = [], fixedNow = 1_700_000_000_000) {
+  let jobs = initialJobs.map((j) => ({ ...j }));
+  const published = [];
+  const delivered = [];
+  let nowMs = fixedNow;
+  const deps = {
+    load: async () => jobs.map((j) => ({ ...j })),
+    save: async (next) => {
+      jobs = next.map((j) => ({ ...j }));
+    },
+    publish: (evt) => published.push(evt),
+    deliver: async (args) => {
+      delivered.push(args);
+      return { delivered: true, queued: false };
+    },
+    listMessages: async () => [],
+    gitRun: async () => ({ stdout: "" }),
+    now: () => nowMs,
+    setNow: (n) => { nowMs = n; },
+  };
+  return {
+    deps,
+    published,
+    delivered,
+    setNow: (n) => { nowMs = n; },
+    get jobs() { return jobs; },
+  };
+}
+
+const CAP_ERROR =
+  "too many background jobs running (5). Do not retry — either wait for one to finish, or do this work yourself.";
+
+// ----------------------------------------------------------------------------
+// 1. buildJobPrompt — with and without a worktree
+// ----------------------------------------------------------------------------
+
+test("buildJobPrompt includes the git paragraph when a worktree is present", () => {
+  const out = buildJobPrompt({
+    prompt: "Fix the login bug",
+    worktree: "/repo/wt-login",
+    branch: "fix-login",
+  });
+  assert.match(out, /^Fix the login bug\n\n---\n/);
+  assert.ok(out.includes("You are running as a background job."));
+  assert.ok(out.includes("/repo/wt-login"));
+  assert.ok(out.includes("branch fix-login"));
+  assert.ok(out.includes("Commit your work to that branch before you finish."));
+  assert.ok(out.includes("Do not push, do not open a"));
+  assert.ok(out.includes("When you are done, end with a short summary"));
+});
+
+test("buildJobPrompt omits the git paragraph when there is no worktree", () => {
+  const out = buildJobPrompt({ prompt: "Summarize the docs", worktree: null, branch: null });
+  assert.match(out, /^Summarize the docs\n\n---\n/);
+  assert.ok(out.includes("You are running as a background job."));
+  assert.ok(!out.includes("git worktree"));
+  assert.ok(!out.includes("Commit your work"));
+  assert.ok(out.includes("When you are done, end with a short summary"));
+});
+
+// ----------------------------------------------------------------------------
+// 2. buildCompletionText — done, failed, stopped, no-worktree
+// ----------------------------------------------------------------------------
+
+test("buildCompletionText done with a worktree", () => {
+  const text = buildCompletionText({
+    name: "fix-login", status: "done", branch: "fix-login",
+    worktree: "/repo/wt-login", filesChanged: 3, result: "fixed it",
+  });
+  assert.equal(text, [
+    '[background job "fix-login" done]',
+    "Branch: fix-login (3 files changed)",
+    "Worktree: /repo/wt-login",
+    "",
+    "fixed it",
+  ].join("\n"));
+});
+
+test("buildCompletionText failed replaces result with Error", () => {
+  const text = buildCompletionText({
+    name: "fix-login", status: "failed", branch: "b", worktree: "/w",
+    filesChanged: 0, error: "boom",
+  });
+  assert.ok(text.startsWith('[background job "fix-login" failed]'));
+  assert.ok(text.includes("Error: boom"));
+  assert.ok(!text.includes("undefined"));
+});
+
+test("buildCompletionText stopped uses Error too", () => {
+  const text = buildCompletionText({
+    name: "bg", status: "stopped", worktree: null, error: "stopped by user",
+  });
+  assert.ok(text.startsWith('[background job "bg" stopped]'));
+  assert.ok(text.includes("Error: stopped by user"));
+  // no worktree → no Branch/Worktree lines
+  assert.ok(!text.includes("Branch:"));
+  assert.ok(!text.includes("Worktree:"));
+});
+
+test("buildCompletionText no-worktree done omits Branch/Worktree lines", () => {
+  const text = buildCompletionText({
+    name: "sum", status: "done", worktree: null, result: "done summary",
+  });
+  assert.equal(text, [
+    '[background job "sum" done]',
+    "",
+    "done summary",
+  ].join("\n"));
+});
+
+test("buildCompletionText timeout status is failed with the timeout error", () => {
+  const text = buildCompletionText({
+    name: "bg", status: "failed", worktree: "/w", branch: "b", filesChanged: 0,
+    error: "timed out after 30 minutes",
+  });
+  assert.ok(text.startsWith('[background job "bg" failed]'));
+  assert.ok(text.includes("Error: timed out after 30 minutes"));
+});
+
+// ----------------------------------------------------------------------------
+// 8. Name derivation from a long prompt (placed early, pure)
+// ----------------------------------------------------------------------------
+
+test("deriveName takes the first four words and slugifies", () => {
+  assert.equal(
+    deriveName("Fix the login bug by updating auth.ts and the session store"),
+    "fix-the-login-bug",
+  );
+});
+
+test("deriveName falls back to a slug for symbol-heavy prompts", () => {
+  assert.equal(deriveName("!!! ??? @@@ something"), "something");
+  assert.equal(deriveName("   "), "background");
+});
+
+// ----------------------------------------------------------------------------
+// resolveOwner helper
+// ----------------------------------------------------------------------------
+
+test("resolveOwner finds the tmux session owning a session id", () => {
+  const projects = [
+    { tmuxSession: "proj-a", windows: [{ index: 0, opencodeSessionId: "ses_x", paneCurrentPath: "/a" }] },
+    { tmuxSession: "proj-b", windows: [{ index: 1, opencodeSessionId: "ses_parent", paneCurrentPath: "/b" }] },
+  ];
+  assert.deepEqual(resolveOwner(projects, "ses_parent"), {
+    tmuxSession: "proj-b", windowIndex: 1, cwd: "/b",
+  });
+  assert.equal(resolveOwner(projects, "ses_missing"), null);
+});
+
+// ----------------------------------------------------------------------------
+// 3. The cap: a sixth concurrent start is refused with the exact error string
+// ----------------------------------------------------------------------------
+
+function runningJob(i) {
+  return {
+    id: `r${i}`, name: `job${i}`, prompt: "p", model: null,
+    parentSessionID: `parent${i}`, parentDirectory: "/repo",
+    childSessionID: `child${i}`, tmuxSession: "s", windowIndex: i,
+    worktree: null, branch: null, baseSha: null,
+    status: "running", activity: null,
+    createdAt: 1, startedAt: 1, finishedAt: null,
+    result: null, error: null, filesChanged: null,
+  };
+}
+
+test("startJob refuses a sixth concurrent job with the exact cap error", async () => {
+  const h = harness(Array.from({ length: MAX_RUNNING_JOBS }, (_, i) => runningJob(i)));
+  const res = await startJob(
+    { prompt: "extra work", parentSessionID: "parentX", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.error, CAP_ERROR);
+  // nothing persisted
+  assert.equal(h.jobs.length, MAX_RUNNING_JOBS);
+  assert.equal(h.delivered.length, 0);
+});
+
+test("startJob allows a job when under the cap", async () => {
+  const h = harness(Array.from({ length: MAX_RUNNING_JOBS - 1 }, (_, i) => runningJob(i)));
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  const parentWin = { index: 0, name: "parent", opencodeSessionId: "parentX", paneCurrentPath: "/repo" };
+  const childWin = { index: 9, name: "extra-work", opencodeSessionId: "child-new", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  h.deps.newWindow = async (input) => [
+    { tmuxSession: input.sessionName, windows: [parentWin, childWin] },
+  ];
+  const res = await startJob(
+    { prompt: "extra work", parentSessionID: "parentX", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(res.job.status, "running");
+  assert.equal(h.jobs.length, MAX_RUNNING_JOBS);
+});
+
+// ----------------------------------------------------------------------------
+// 4. Nesting: a start whose parentSessionID is a live job's childSessionID
+// ----------------------------------------------------------------------------
+
+test("startJob refuses nesting when parentSessionID is a live job's childSessionID", async () => {
+  const live = { ...runningJob(0), childSessionID: "child_live", status: "running" };
+  const h = harness([live]);
+  const res = await startJob(
+    { prompt: "nested work", parentSessionID: "child_live", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.error, "a background job cannot start another background job");
+  assert.equal(h.jobs.length, 1);
+  assert.equal(h.delivered.length, 0);
+});
+
+test("startJob allows nesting when the blocking job is terminal", async () => {
+  const done = { ...runningJob(0), childSessionID: "child_done", status: "done", finishedAt: 2 };
+  const h = harness([done]);
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  const parentWin = { index: 1, name: "p", opencodeSessionId: "child_done", paneCurrentPath: "/repo" };
+  const childWin = { index: 5, name: "nested-work", opencodeSessionId: "c2", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  h.deps.newWindow = async (input) => [
+    { tmuxSession: input.sessionName, windows: [parentWin, childWin] },
+  ];
+  const res = await startJob(
+    { prompt: "nested work", parentSessionID: "child_done", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+});
+
+// ----------------------------------------------------------------------------
+// 7. Rollback: a throw at the window-creation step removes the worktree
+// ----------------------------------------------------------------------------
+
+test("startJob rolls back the worktree when window creation throws", async () => {
+  const h = harness([]);
+  let worktreeCreated = null;
+  h.deps.gitAddWorktree = async ({ cwd, name }) => {
+    worktreeCreated = { path: `/repo/wt-${name}`, branch: name };
+    return worktreeCreated;
+  };
+  h.deps.gitRun = async (args) => ({ stdout: "abc123\n" }); // baseSha
+  const parentWin = { index: 0, name: "parent", opencodeSessionId: "parent", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  h.deps.newWindow = async () => { throw new Error("tmux new-window exploded"); };
+  const removed = [];
+  h.deps.gitRemoveWorktree = async (input) => { removed.push(input); return { removed: true }; };
+
+  const res = await startJob(
+    { prompt: "do work", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, false);
+  assert.match(res.error, /tmux new-window exploded/);
+  // worktree was created then removed on rollback
+  assert.ok(worktreeCreated, "worktree was created");
+  assert.equal(removed.length, 1);
+  assert.equal(removed[0].path, worktreeCreated.path);
+  assert.equal(removed[0].force, false);
+  // no job persisted
+  assert.equal(h.jobs.length, 0);
+  assert.equal(h.delivered.length, 0);
+});
+
+// ----------------------------------------------------------------------------
+// 5. observeEvent: idle before any busy does NOT complete; busy then idle DOES
+// ----------------------------------------------------------------------------
+
+function runningObserverJob() {
+  return {
+    id: "j1", name: "bg", prompt: "p", model: null,
+    parentSessionID: "parent", parentDirectory: "/repo",
+    childSessionID: "child", tmuxSession: "s", windowIndex: 1,
+    worktree: null, branch: null, baseSha: null,
+    status: "running", activity: null,
+    createdAt: 1, startedAt: 1, finishedAt: null,
+    result: null, error: null, filesChanged: null,
+  };
+}
+
+test("observeEvent: idle before any busy does NOT complete the job", async () => {
+  const h = harness([runningObserverJob()]);
+  const sawBusy = new Map();
+  // stray idle arrives before the opening prompt lands
+  await observeEvent({ type: "session.idle", properties: { sessionID: "child" } }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.delivered.length, 0);
+});
+
+test("observeEvent: busy then idle DOES complete the job as done", async () => {
+  const h = harness([runningObserverJob()]);
+  const sawBusy = new Map();
+  h.deps.listMessages = async () => [
+    { info: { role: "assistant" }, parts: [{ type: "text", text: "all done" }] },
+  ];
+  h.deps.gitRun = async () => ({ stdout: "" }); // no worktree → filesChanged null
+  await observeEvent({ type: "session.status", properties: { sessionID: "child", status: { type: "busy" } } }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "running");
+  await observeEvent({ type: "session.idle", properties: { sessionID: "child" } }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "done");
+  assert.equal(h.jobs[0].result, "all done");
+  assert.equal(h.delivered.length, 1);
+  assert.equal(h.delivered[0].sessionId, "parent");
+  assert.match(h.delivered[0].text, /\[background job "bg" done\]/);
+});
+
+test("observeEvent: session.status idle (not session.idle) also completes after busy", async () => {
+  const h = harness([runningObserverJob()]);
+  const sawBusy = new Map();
+  await observeEvent({ type: "session.status", properties: { sessionID: "child", status: { type: "busy" } } }, h.deps, sawBusy);
+  await observeEvent({ type: "session.status", properties: { sessionID: "child", status: { type: "idle" } } }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "done");
+});
+
+// ----------------------------------------------------------------------------
+// 6. observeEvent: session.error fails the job, MessageAbortedError ignored
+// ----------------------------------------------------------------------------
+
+test("observeEvent: session.error fails the job", async () => {
+  const h = harness([runningObserverJob()]);
+  const sawBusy = new Map();
+  await observeEvent({ type: "session.status", properties: { sessionID: "child", status: { type: "busy" } } }, h.deps, sawBusy);
+  await observeEvent({
+    type: "session.error",
+    properties: { sessionID: "child", error: { name: "ProviderAuthError", message: "bad key" } },
+  }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "failed");
+  assert.equal(h.jobs[0].error, "bad key");
+  assert.equal(h.delivered.length, 1);
+  assert.match(h.delivered[0].text, /failed/);
+  assert.match(h.delivered[0].text, /Error: bad key/);
+});
+
+test("observeEvent: MessageAbortedError is ignored (intentional abort)", async () => {
+  const h = harness([runningObserverJob()]);
+  const sawBusy = new Map();
+  await observeEvent({ type: "session.status", properties: { sessionID: "child", status: { type: "busy" } } }, h.deps, sawBusy);
+  await observeEvent({
+    type: "session.error",
+    properties: { sessionID: "child", error: { name: "MessageAbortedError", message: "aborted" } },
+  }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.delivered.length, 0);
+});
+
+test("observeEvent ignores events for untracked sessions", async () => {
+  const h = harness([runningObserverJob()]);
+  const sawBusy = new Map();
+  await observeEvent({ type: "session.idle", properties: { sessionID: "other" } }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "running");
+});
+
+// ----------------------------------------------------------------------------
+// 9. Sweeper marks a 31-minute-old running job failed, leaves worktree intact
+// ----------------------------------------------------------------------------
+
+test("sweeper marks a 31-minute-old running job failed with the timeout error", async () => {
+  const started = 1_700_000_000_000;
+  const h = harness([{
+    ...runningObserverJob(),
+    id: "old", startedAt: started, worktree: "/repo/wt-old", branch: "old",
+    baseSha: "abc",
+  }], started + 31 * 60_000); // 31 minutes later
+  h.deps.gitRun = async () => ({ stdout: "" });
+  await sweepDelegateJobs(h.deps);
+  assert.equal(h.jobs[0].status, "failed");
+  assert.equal(h.jobs[0].error, "timed out after 30 minutes");
+  // worktree field left intact (sweeper NEVER removes the worktree)
+  assert.equal(h.jobs[0].worktree, "/repo/wt-old");
+  assert.equal(h.jobs[0].branch, "old");
+  // completion delivered to parent
+  assert.equal(h.delivered.length, 1);
+  assert.match(h.delivered[0].text, /timed out after 30 minutes/);
+});
+
+test("sweeper leaves a job younger than 30 minutes running", async () => {
+  const started = 1_700_000_000_000;
+  const h = harness([{
+    ...runningObserverJob(), id: "young", startedAt: started,
+  }], started + 10 * 60_000);
+  await sweepDelegateJobs(h.deps);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.delivered.length, 0);
+});
+
+// ----------------------------------------------------------------------------
+// 10. deleteJob on a dirty worktree keeps worktree + record, reports dirty
+// ----------------------------------------------------------------------------
+
+test("deleteJob on a dirty worktree keeps the worktree and the record", async () => {
+  const job = {
+    ...runningObserverJob(), id: "d1", status: "done",
+    worktree: "/repo/wt-dirty", branch: "dirty", finishedAt: 2,
+    tmuxSession: "s", windowIndex: 3,
+  };
+  const h = harness([job]);
+  const killed = [];
+  h.deps.killWindow = async (input) => { killed.push(input); };
+  h.deps.gitRemoveWorktree = async () => ({ removed: false, reason: "dirty" });
+
+  const res = await deleteJob("d1", h.deps);
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "dirty");
+  // window was killed (best-effort) ...
+  assert.equal(killed.length, 1);
+  // ... but the worktree removal refused, so the record MUST be kept
+  assert.equal(h.jobs.length, 1);
+  assert.equal(h.jobs[0].id, "d1");
+  assert.equal(h.jobs[0].worktree, "/repo/wt-dirty");
+});
+
+test("deleteJob removes the record when the worktree removes cleanly", async () => {
+  const job = {
+    ...runningObserverJob(), id: "d2", status: "done",
+    worktree: "/repo/wt-clean", branch: "clean", finishedAt: 2,
+    tmuxSession: "s", windowIndex: 4,
+  };
+  const h = harness([job]);
+  h.deps.killWindow = async () => {};
+  h.deps.gitRemoveWorktree = async () => ({ removed: true });
+  const res = await deleteJob("d2", h.deps);
+  assert.equal(res.ok, true);
+  assert.equal(h.jobs.length, 0);
+  assert.ok(h.published.some((e) => e.payload?.id === "d2" && e.payload?.status === "deleted"));
+});
+
+test("deleteJob on a job with no worktree just drops the record", async () => {
+  const job = { ...runningObserverJob(), id: "d3", status: "done", worktree: null, finishedAt: 2 };
+  const h = harness([job]);
+  h.deps.killWindow = async () => {};
+  const res = await deleteJob("d3", h.deps);
+  assert.equal(res.ok, true);
+  assert.equal(h.jobs.length, 0);
+});
+
+test("deleteJob returns not-found for an unknown id", async () => {
+  const h = harness([]);
+  h.deps.killWindow = async () => {};
+  const res = await deleteJob("nope", h.deps);
+  assert.equal(res.ok, false);
+  assert.equal(res.error, "not found");
+});
+
+// ----------------------------------------------------------------------------
+// startJob happy path (no worktree) persists + delivers the opening prompt
+// ----------------------------------------------------------------------------
+
+test("startJob happy path (non-git cwd) persists a running job and delivers the prompt", async () => {
+  const h = harness([]);
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  const parentWin = { index: 1, name: "parent-h", opencodeSessionId: "parent-h", paneCurrentPath: "/repo" };
+  const childWin = { index: 2, name: "fix-the-login-bug", opencodeSessionId: "child-h", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "proj", windows: [parentWin] }];
+  h.deps.newWindow = async (input) => [
+    { tmuxSession: input.sessionName, windows: [parentWin, childWin] },
+  ];
+  const res = await startJob(
+    { prompt: "Fix the login bug please", parentSessionID: "parent-h", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(res.job.name, "fix-the-login-bug");
+  assert.equal(res.job.worktree, null);
+  assert.equal(res.job.branch, null);
+  assert.equal(res.job.baseSha, null);
+  assert.equal(res.job.childSessionID, "child-h");
+  assert.equal(res.job.status, "running");
+  assert.equal(h.jobs.length, 1);
+  // opening prompt delivered to the child session
+  assert.equal(h.delivered.length, 1);
+  assert.equal(h.delivered[0].sessionId, "child-h");
+  assert.match(h.delivered[0].text, /Fix the login bug please/);
+  assert.doesNotMatch(h.delivered[0].text, /git worktree/);
+});
+
+// ----------------------------------------------------------------------------
+// finishJob filesChanged counts committed + uncommitted (with a worktree)
+// ----------------------------------------------------------------------------
+
+test("finishJob counts committed + uncommitted files when a worktree exists", async () => {
+  const job = {
+    ...runningObserverJob(), id: "fc", worktree: "/repo/wt", branch: "b", baseSha: "sha1",
+  };
+  const h = harness([job]);
+  const sawBusy = new Map();
+  h.deps.listMessages = async () => [
+    { info: { role: "assistant" }, parts: [{ type: "text", text: "done" }] },
+  ];
+  h.deps.gitRun = async (args) => {
+    if (args.includes("diff")) return { stdout: "a.ts\nb.ts\n" }; // 2 committed
+    if (args.includes("status")) return { stdout: " M c.ts\n?? d.ts\n" }; // 2 uncommitted
+    return { stdout: "" };
+  };
+  await finishJob(job, "done", null, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "done");
+  assert.equal(h.jobs[0].result, "done");
+  assert.equal(h.jobs[0].filesChanged, 4);
+});
+
+test("finishJob is idempotent for an already-terminal job", async () => {
+  const job = { ...runningObserverJob(), id: "idem", status: "done", finishedAt: 9 };
+  const h = harness([job]);
+  const res = await finishJob(job, "done", null, h.deps, new Map());
+  assert.equal(res.ok, true);
+  assert.equal(res.alreadyTerminal, true);
+  assert.equal(h.delivered.length, 0);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -54,6 +54,7 @@ import {
   startCapSweeper,
 } from "./capabilities.mjs";
 import { notifyCapSession } from "./capNotifier.mjs";
+import { createDelegateEngine } from "./delegate.mjs";
 import {
   startCleanupPoller,
   registerPage,
@@ -218,6 +219,33 @@ const webhookEngine = createWebhookEngine({
   publish: (evt) => bus.publish(evt),
 });
 
+// Background-job engine (BET-378): durable jobs that run in their own
+// worktree + chat-mode window, detect completion from the opencode event
+// stream, and report their result back to the parent session (deferred until
+// the parent is idle via the shared prompt-delivery engine). See
+// src/server/delegate.mjs. Completion detection runs in the opencode pump
+// below (delegateEngine.observeEvent); the sweeper fails out stale running
+// jobs (30 min) and prunes terminal retention; the 10s activity poller
+// refreshes the `activity` summary for running jobs. The AI tool + UI are
+// Stage 3 — this server wiring is Stage 2 only.
+const delegateEngine = createDelegateEngine({
+  publish: (evt) => bus.publish(evt),
+  deliver: (args) => promptDelivery.deliver(args),
+  listProjects: () => tmux.listProjects(),
+  newWindow: (input) => tmux.newWindow(input),
+  killWindow: (input) => tmux.killWindow(input),
+  gitAddWorktree: (input) => local.gitAddWorktree(input),
+  gitRemoveWorktree: (input) => local.gitRemoveWorktree(input),
+  gitRun: (args) => tmux.run("git", args),
+  listMessages: (sid) => oc.listMessages(sid),
+  abortSession: (sid) => oc.abortSession(sid),
+  oc,
+});
+// eslint-disable-next-line no-unused-vars
+const { stop: stopDelegateSweeper } = delegateEngine.startSweeper();
+// eslint-disable-next-line no-unused-vars
+const { stop: stopDelegateActivityPoller } = delegateEngine.startActivityPoller();
+
 // Single-box auth gate (M1, job zero). Every request must carry the box_token
 // as `Authorization: Bearer <token>` except the pairing handshake (/auth/*) and
 // the public webhook delivery leg (/hook/<token>, self-authenticated). The box
@@ -263,6 +291,7 @@ rpcHandlers = buildHandlers({
   authPair: () => authEngine.pair(),
   push,
   serverVersion: SERVER_VERSION,
+  delegate: delegateEngine,
   // BET-366 reviewer return: production wiring for the
   // `server:update-apply` IPC channel. The handler in rpc.mjs calls this
   // with SELF_UPDATE_SCRIPT (resolved at module load from `import.meta.url`).
@@ -348,6 +377,11 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
     webhookEngine.observeEvent(evt);
   } catch (e) {
     console.warn("[webhook] observeEvent failed:", e?.message ?? e);
+  }
+  try {
+    delegateEngine.observeEvent(evt);
+  } catch (e) {
+    console.warn("[delegate] observeEvent failed:", e?.message ?? e);
   }
   // Auto-recover expired Claude credentials (server-side; works with no client attached).
   oc.maybeRecoverCredentials(evt).catch(() => {});
@@ -1097,6 +1131,82 @@ const handleRequest = async (req, res) => {
         const host = url.searchParams.get("host") || undefined;
         const status = url.searchParams.get("status") || undefined;
         const jobs = await listCapJobs({ sessionID, host, status });
+        respondJson(res, 200, { jobs });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Background jobs (BET-378, server-side only) ----------
+  // POST   /api/delegate           body {prompt, model?, sessionID, directory}
+  //                               → 200 {ok, job} (400 refused: cap/nesting/bad input)
+  // GET    /api/delegate?sessionID= → {jobs:[...]} (jobs for that parent session)
+  // POST   /api/delegate/:id/stop  → 200 {ok} (409 not running / 404 not found)
+  // DELETE /api/delegate/:id       → 200 {ok} (409 dirty worktree → {error:"dirty"})
+  //
+  // Behind the existing Bearer auth gate (every route below the gate is
+  // gated wholesale). Jobs are created by the AI tool (Stage 3) — there is
+  // deliberately no `delegate:create` RPC channel; the UI only lists/stops/
+  // deletes via the delegate:* channels in rpc.mjs.
+  if (
+    path === "/api/delegate" ||
+    /^\/api\/delegate\/([0-9a-f]{8})(?:\/(stop))?$/.test(path)
+  ) {
+    const detailRe = /^\/api\/delegate\/([0-9a-f]{8})(?:\/(stop))?$/;
+    const detailMatch = path.match(detailRe);
+    try {
+      if (detailMatch) {
+        const [, id, action] = detailMatch;
+        if (action === "stop") {
+          if (req.method !== "POST") {
+            respondJson(res, 405, { error: "method not allowed" });
+            return;
+          }
+          const result = await delegateEngine.stopJob(id);
+          if (!result.ok) {
+            respondJson(res, 409, { error: result.error, status: result.status });
+            return;
+          }
+          respondJson(res, 200, { ok: true });
+          return;
+        }
+        // No action verb, DELETE /api/delegate/:id → delete the job.
+        if (req.method !== "DELETE") {
+          respondJson(res, 405, { error: "method not allowed" });
+          return;
+        }
+        const result = await delegateEngine.deleteJob(id);
+        if (!result.ok) {
+          // Dirty worktree → keep worktree + record; 409 so the UI explains it.
+          respondJson(res, 409, { error: result.error, reason: result.reason });
+          return;
+        }
+        respondJson(res, 200, { ok: true });
+        return;
+      }
+      // Collection routes (/api/delegate): create + list.
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await delegateEngine.startJob({
+          prompt: body?.prompt,
+          model: body?.model,
+          parentSessionID: body?.sessionID,
+          parentDirectory: body?.directory,
+        });
+        if (!result.ok) {
+          respondJson(res, 400, { error: result.error });
+          return;
+        }
+        respondJson(res, 200, { ok: true, id: result.job.id, job: result.job });
+        return;
+      }
+      if (req.method === "GET") {
+        const sessionID = url.searchParams.get("sessionID") || undefined;
+        const jobs = await delegateEngine.listJobs({ sessionID });
         respondJson(res, 200, { jobs });
         return;
       }

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -194,6 +194,7 @@ export function buildHandlers({
   push,
   serverVersion,
   runServerSelfUpdate,
+  delegate,
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -714,6 +715,20 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.scheduleDelete, id)  → args[0] = id
     "schedule:delete": (id) =>
       scheduleDeleteJob(id, { publish: (evt) => bus.publish(evt) }),
+
+    // ---- background jobs (manta-server owned; in-process on mobile) ----
+    // Mirror of the /api/delegate REST surface for the renderer. Jobs are
+    // CREATED by the AI tool (Stage 3), NOT by the UI — there is deliberately
+    // no `delegate:create` channel. list/stop/delete route to the engine
+    // wired in src/server/index.mjs (createDelegateEngine). Stop/delete
+    // publish delegate.updated so a future UI card refetches live.
+    // preload: ipcRenderer.invoke(IPC.delegateList, sessionId) → args[0] = sessionId?
+    "delegate:list": (sessionId) =>
+      delegate ? delegate.listJobs({ sessionID: sessionId || undefined }) : { jobs: [] },
+    // preload: ipcRenderer.invoke(IPC.delegateStop, id) → args[0] = id
+    "delegate:stop": (id) => (delegate ? delegate.stopJob(id) : { ok: false, error: "no engine" }),
+    // preload: ipcRenderer.invoke(IPC.delegateDelete, id) → args[0] = id
+    "delegate:delete": (id) => (delegate ? delegate.deleteJob(id) : { ok: false, error: "no engine" }),
 
     // ---- secrets (manta-server owned; in-process on mobile) ----
     // Mirror of desktop IPC.secretsList / secretsSet / secretsDelete. The store


### PR DESCRIPTION
## Background job engine — server-side only (BET-378)

Stage 2 of the background-delegation epic. New `src/server/delegate.mjs` + its own store `~/.manta/delegate-jobs.json`, modelled on `capabilities.mjs` but completing from the opencode event stream (not an executor POST). No AI tool, no UI (Stage 3).

### What
- `startJob` — worktree → session → window → opening prompt, ordered rollback on failure. Refuses nesting + a 5-job box-wide cap (exact error string). `buildJobPrompt` pure + exported.
- `observeEvent` — completes on the first idle after a busy for the child session (per-job `sawBusy` flag); `session.error` fails except `MessageAbortedError`. Wired into the opencode pump.
- `finishJob` — final assistant text + `filesChanged` (committed + uncommitted via `parseGitStatus`), delivered to the parent via the shared prompt-delivery engine (deferred until parent idle). `buildCompletionText` pure + exported.
- 10s activity poller (`summarizeTranscript` + `describeChatActivity`, no model call) + 30-min sweeper + 7-day/50-record retention. Window/worktree are NEVER removed by the sweeper.
- `stopJob` (`abortSession`) + `deleteJob` (`killWindow` + `gitRemoveWorktree force:false`, dirty → keep both + report).
- REST `/api/delegate` routes behind the auth gate + `delegate:list`/`stop`/`delete` RPC channels (no `delegate:create` — jobs are created by the AI tool, Stage 3).

### Verification results
- **Files changed:** 4. `src/server/delegate.mjs` (new, 802), `src/server/delegate.test.mjs` (new, 529), `src/server/index.mjs` (+110), `src/server/rpc.mjs` (+15).
- PR branch (`multica/BET-378-background-job-engine` @ `d02847f`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…`
  - test: exit 0, **1180 pass / 0 fail / 0 skip**. Failures: none. log sha256: `383432c7…`
- Base (`main` @ `156940b`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…` (identical to PR — typecheck is byte-identical).
  - test: exit 0, **1150 pass / 0 fail / 0 skip**. Failures: none. log sha256: `9d9c44c7…`
- **Conclusion:** 0 pre-existing failures. The PR branch adds exactly 30 tests (1180 − 1150), all green — the new `delegate.test.mjs` cases.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log` for reviewer spot-check. The 30 new cases cover all 10 required scenarios (buildJobPrompt w/ & w/o worktree; buildCompletionText done/failed/stopped/no-worktree; cap refusal w/ exact string; nesting refusal; observeEvent idle-before-busy no-op + busy-then-idle completes; session.error fails / MessageAbortedError ignored; rollback removes worktree on window-creation throw; name derivation; sweeper 31-min→failed w/ worktree intact; deleteJob dirty→keep both + report `dirty`).

### Self-check
All acceptance criteria from the issue score 9-10. Weakest (9/10): rollback on window-creation failure removes the worktree as required (test 7), but cannot clean the orphaned opencode session that `maybeCreateChatSession` creates *inside* `newWindow` — the spec forbids calling that module-private function, and test 7 only asserts worktree removal. This matches the desktop's existing worktree-dirty flow where a failed create leaves the session to be reaped by the next listing reconciliation.

Base: `origin/main` @ `156940b`
