### PR TITLE
feat(tools): delegate background-delegation AI tool + guidance (BET-379)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -881,6 +881,65 @@ peers/notify. Key facts:
   resolveSecret precedence, materializedPath, CRUD round-trip, provideSecret
   writes 0600 + returns path-not-value — 21). Pure/IO-injected logic only.
 
+## Background delegation — MantaUI-native AI tool (`src/server/delegate.mjs`)
+
+The sixth **MantaUI-native opencode tool**: the remote AI can kick off a
+long-running task in a BACKGROUND opencode session (its own git worktree +
+chat-mode tmux window) so the main conversation is NOT blocked, and the
+result is delivered back as a separate later message when the job finishes.
+Same "MantaUI tools" pattern as schedule/serve-page/peers/notify/secrets
+(`docs/manta-tools-scheduler.md`). Key facts:
+
+- **Global opencode tool**, `docs/opencode-tools/delegate.ts`, **COPIED** (not
+  symlinked — same `@opencode-ai/plugin` gotcha) to
+  `~/.config/opencode/tools/delegate.ts`. Three exports → `delegate`,
+  `delegate_list`, `delegate_stop`. Guidance appended to
+  `~/.config/opencode/AGENTS.md` from `docs/opencode-tools/AGENTS.md`
+  (## MantaUI background delegation). **Install/update =
+  `systemctl --user restart opencode-serve`.**
+- **Thin registrar** — `fetch`es manta-server (no SSH hop). `delegate` POSTs
+  `/api/delegate {prompt, model?, sessionID, directory}` → `{ok, id, job}`;
+  `delegate_list` GETs `/api/delegate?sessionID=`; `delegate_stop` POSTs
+  `/api/delegate/:id/stop`. `execute` returns promptly; the engine owns the
+  lifecycle.
+- **Background vs. blocking is the model's choice.** `delegate`'s description
+  steers mode selection: use it for long-running independent work you do NOT
+  need the answer to continue (research, broad refactor, test-suite
+  run-and-fix); use the ordinary built-in `task` tool when you need the
+  answer first. Both modes coexist. Every job costs a full extra model
+  session, so the description forbids speculative fan-out and nested jobs.
+- **The "you do NOT have the result yet" return string is load-bearing.**
+  `delegate` returns immediately with the job's name + id and an explicit
+  reminder that the result is NOT available yet and will arrive as a later
+  message — the model must not report or guess the job's findings before
+  then (this is the exact bug Claude Code had to fix). Do not soften it.
+- **Server-owned engine** (`src/server/delegate.mjs`, dependency-injected
+  pure logic + injected I/O, mirrors `capabilities.mjs`): startJob creates a
+  worktree → new chat-mode window (stamps `@manta-session-id`) → records the
+  job `running` → injects the opening prompt. Completion is detected from
+  the opencode event firehose via `observeEvent` (first idle AFTER a seen
+  busy, per-job `sawBusy` flag — stops a stray pre-prompt idle completing the
+  job instantly). `finishJob` assembles the result (last assistant text +
+  `filesChanged`) and delivers the completion to the parent session through
+  the shared prompt-delivery engine (`src/server/promptDelivery.mjs`), which
+  defers until the parent is idle so a notice never aborts the parent's turn.
+- **Cap of five concurrent `running` jobs** box-wide (`MAX_RUNNING_JOBS`);
+  a sixth is refused with a clear error (do not retry). No `queued` state —
+  a job either starts immediately or is refused. Running jobs older than 30
+  min become `failed "timed out after 30 minutes"` (sweeper). Terminal jobs
+  retained 7 days or 50 records, whichever bites first; the window +
+  worktree are NEVER removed by the sweeper — only by an explicit delete.
+- **No `peers`-style status/inspect tool here** — background jobs are
+  ordinary sibling sessions, so `peers_inspect` already covers "what is that
+  job doing", and the tool description says so. `delegate_list` is for
+  answering a user's "what's running?" question, not for waiting (do NOT
+  poll).
+- Jobs appear in the sidebar as ordinary sessions (their own window).
+- Tests: `src/server/delegate.test.mjs` (startJob undo-on-failure,
+  nesting/cap refusal, observeEvent completion ordering, finishJob result
+  assembly, buildJobPrompt/buildCompletionText, sweep retention, stop/delete
+  — pure/IO-injected logic only, no live HTTP/tmux).
+
 ## Mouse mode — design decision, do not re-litigate
 
 **Mouse is ON through the whole pipeline (tmux + claude).** This matches what

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -222,6 +222,59 @@ returns a job id immediately and a completion turn is injected into this
 session when the run finishes (or fails / times out at 30 min).
 
 **Do NOT poll in a loop.** Completion arrives automatically as a new turn
-from the originating opencode session. Use `plugin_status(id)` only when
-the user explicitly asks for mid-run progress, or after completion to
-inspect the log tail.
+from the originating opencode session. Use `plugin_status(id)` only when the
+user explicitly asks for mid-run progress, or after completion to inspect
+the log tail.
+
+## MantaUI background delegation
+
+You have `delegate`, `delegate_list`, and `delegate_stop` tools for running
+work in a BACKGROUND opencode session so the main conversation is NOT
+blocked. Use `delegate({ prompt, model? })` to start a job; it returns
+immediately and the job runs in its own session + git worktree. When the
+job finishes, its result arrives on its own as a separate later message —
+you do NOT have the result when `delegate` returns, so never report or
+guess the job's findings before that message lands.
+
+**Background vs. blocking — choose deliberately.** Reach for `delegate`
+when the work is long-running, independent, and you do NOT need its answer
+to continue your current reply — research, a broad refactor, an
+investigation, a test-suite run-and-fix. Use the ordinary built-in `task`
+tool instead when you need the answer before you can carry on (e.g.
+finding where something lives so you can then edit it). Both delegation
+modes coexist; you pick. Every background job costs a full extra model
+session, so do not fan out speculatively — and never start a background
+job from inside another background job.
+
+**The job starts with NO knowledge of this conversation.** Put everything
+it needs in the prompt: the goal, the relevant files/paths, constraints,
+and what "done" looks like. It works in its own git worktree and commits
+to its own branch; it never pushes, merges, or touches this checkout.
+
+- `delegate({ prompt: string, model?: string })` → starts a background
+  job. `model` is a free-text model id passed straight through; omit it to
+  use the box's default. Returns immediately with the job's name + id and
+  a reminder that the result is NOT available yet.
+- `delegate_list({})` → lists this session's background jobs (id, name,
+  status, branch, worktree, activity, timestamps). Use it to answer a
+  user's "what's running?" question — NOT to wait for a job to finish.
+- `delegate_stop({ id })` → stops a running job (aborts its session,
+  marks it `stopped`); the window + worktree are kept.
+
+**Do NOT poll.** Completion arrives as a later message on its own; calling
+`delegate_list` in a loop to "wait" is waste. To see what a running job is
+actually doing, use `peers_inspect` on that session — background jobs are
+ordinary sibling sessions, so `peers_inspect` already covers inspection
+and there is intentionally no separate status/inspect tool here.
+
+**Cap of five concurrent jobs** box-wide. A sixth is refused with a clear
+error — do not retry; either wait for one to finish or do the work
+yourself.
+
+Jobs appear in the sidebar as ordinary sessions (their own window), so you
+can watch them the same way you watch any session.
+
+**Install/update is a COPY, never a symlink.** Copy
+`docs/opencode-tools/delegate.ts` to `~/.config/opencode/tools/delegate.ts`
+and run `systemctl --user restart opencode-serve`. A symlinked tool fails
+to resolve `@opencode-ai/plugin` and silently never registers.

--- a/docs/opencode-tools/delegate.ts
+++ b/docs/opencode-tools/delegate.ts
@@ -1,0 +1,177 @@
+// manta-native `delegate` tool — global opencode custom tool.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/delegate.ts ~/.config/opencode/tools/delegate.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// This tool is a THIN registrar. It POSTs the request to manta-server
+// (127.0.0.1:8787, same box — no SSH hop), which owns the background job
+// engine (`src/server/delegate.mjs`): it creates a git worktree + a new
+// chat-mode tmux window + opencode session, injects the prompt, detects
+// completion from the opencode event stream, and delivers the result back to
+// THIS (parent) session as a later message — WITHOUT blocking the current
+// reply. execute() returns promptly; manta-server owns the lifecycle.
+//
+// This file is a COPY, never a symlink: opencode resolves a tool's imports
+// relative to the file's REAL path, so a symlink back into the repo (no
+// node_modules there) fails to resolve `@opencode-ai/plugin` and the tool
+// silently never registers. Copy it into ~/.config/opencode/tools/.
+//
+// See docs/opencode-tools/AGENTS.md (## MantaUI background delegation) for the
+// background-vs-blocking rule and the general "manta tools" pattern
+// (docs/manta-tools-scheduler.md).
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const delegate = tool({
+  description: [
+    "Start a long-running task as a BACKGROUND job in its own opencode session and",
+    "git worktree, so the main conversation is NOT blocked. Use this when the work",
+    "is long-running, independent, and you do NOT need its answer to continue your",
+    "current reply — research, a broad refactor, an investigation, or a test-suite",
+    "run-and-fix. Use the ordinary built-in `task` tool instead when you need the",
+    "answer before you can carry on, for example finding where something lives so",
+    "you can then edit it. Every background job costs a full extra model session;",
+    "do not fan out speculatively. The job starts with NO knowledge of this",
+    "conversation — put everything it needs in the prompt. It works in its own git",
+    "worktree and commits to its own branch; it never pushes, merges, or touches",
+    "this checkout. This tool returns IMMEDIATELY and you do NOT have its result",
+    "yet — completion arrives on its own as a separate later message; do not",
+    "report or guess the job's findings before then, and do not poll. To see what a",
+    "running job is doing, use `peers_inspect`, not a list call in a loop. At most",
+    "five background jobs may run at once. Do not start a background job from inside",
+    "another background job.",
+  ].join(" "),
+  args: {
+    prompt: z
+      .string()
+      .describe(
+        "The full task prompt for the background job. The job's session has no " +
+          "knowledge of this conversation, so include everything it needs: the " +
+          "goal, the relevant files/paths, constraints, and what 'done' looks like.",
+      ),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Optional free-text model id for the job's session, passed straight " +
+          "through to the box. When omitted the job uses the box's default model. " +
+          "Not validated client-side.",
+      ),
+  },
+  async execute(args, context) {
+    const res = await call("POST", "/api/delegate", {
+      prompt: args.prompt,
+      model: args.model,
+      sessionID: context.sessionID,
+      directory: context.directory,
+    });
+    const name = res?.job?.name ?? res?.name ?? "background";
+    const id = res?.job?.id ?? res?.id ?? "";
+    return (
+      `Started background job "${name}" (id ${id}). It runs in its own session and\n` +
+      "worktree; the main conversation is not blocked. You do NOT have its results yet\n" +
+      "— they will arrive as a separate message when it finishes. Do not report or\n" +
+      "guess its findings before then."
+    );
+  },
+});
+
+export const delegate_list = tool({
+  description: [
+    "List the background jobs belonging to THIS session (jobs it started, plus any",
+    "still running). Use this to answer a user's \"what's running?\" / \"what",
+    "background jobs did I start?\" question — NOT to wait for a job to finish.",
+    "Completion arrives on its own as a separate later message, so do not call this",
+    "in a poll loop. Each entry has id, name, status (running/done/failed/stopped),",
+    "branch, worktree, activity, and timestamps. To see what a running job is",
+    "actually doing, use `peers_inspect` on that session.",
+  ].join(" "),
+  args: {},
+  async execute(_args, context) {
+    const res = await call(
+      "GET",
+      `/api/delegate?sessionID=${encodeURIComponent(context.sessionID ?? "")}`,
+    );
+    const jobs = Array.isArray(res?.jobs) ? res.jobs : [];
+    if (jobs.length === 0) return "No background jobs for this session.";
+    const lines = jobs.map((j: any) => {
+      const parts = [`${j?.id ?? ""}`, `"${j?.name ?? ""}"`, j?.status ?? "?"];
+      if (j?.branch) parts.push(`branch=${j.branch}`);
+      if (j?.worktree) parts.push(`worktree`);
+      return parts.join(" ");
+    });
+    return `Background jobs (${jobs.length}):\n` + lines.join("\n");
+  },
+});
+
+export const delegate_stop = tool({
+  description: [
+    "Stop a running background job by id. Aborts the job's opencode session, marks",
+    "it `stopped`, and delivers a short completion notice to this session. The job's",
+    "tmux window and git worktree are kept (use the UI to delete them). Only stops",
+    "jobs that are currently `running`. Find the id with `delegate_list`.",
+  ].join(" "),
+  args: {
+    id: z
+      .string()
+      .describe("The background job id (8-char hex) to stop, from `delegate_list`."),
+  },
+  async execute(args) {
+    await call("POST", `/api/delegate/${encodeURIComponent(args.id)}/stop`);
+    return `Stopped background job "${args.id}".`;
+  },
+});


### PR DESCRIPTION
## BET-379 — The `delegate` AI tool + guidance

Stage 3 of the "Background delegation (v1)" epic. Adds the MantaUI-native
opencode tool that lets the AI start a background job, plus the guidance that
tells it when to prefer background over the built-in blocking `task` tool.
Server-side engine (`src/server/delegate.mjs`) shipped in BET-378.

### Files changed (3)
- `docs/opencode-tools/delegate.ts` (new) — three named exports: `delegate`,
  `delegate_list`, `delegate_stop`. Follows the established registrar pattern
  (`notify.ts`) verbatim: reuses `MANTA_SERVER`, `boxToken()`, `authHeaders()`,
  `call()` unchanged.
- `docs/opencode-tools/AGENTS.md` — new `## MantaUI background delegation`
  section (three tools, background-vs-blocking rule, 5-job cap, "you do not
  have the result yet" rule, sidebar-as-ordinary-sessions, copy-not-symlink
  install).
- `AGENTS.md` (repo root) — new "Background delegation" section describing
  the tool and pointing at `src/server/delegate.mjs`.

### API contract (matches src/server/index.mjs routes + delegate.mjs)
- `delegate({prompt, model?})` → `POST /api/delegate {prompt, model, sessionID, directory}` → `{ok, id, job}`. Returns immediately with the exact load-bearing "you do NOT have its results yet" string.
- `delegate_list({})` → `GET /api/delegate?sessionID=<context.sessionID>` → `{jobs:[...]}`.
- `delegate_stop({id})` → `POST /api/delegate/:id/stop` → `{ok}`.

### Decisions honored (not revisited)
- Exactly three tools, no fourth; no status/inspect tool (peers_inspect covers it).
- `model` passed straight through, no client-side validation.
- No wait/sleep/poll in `execute`; descriptions forbid polling + speculative fan-out + nesting.
- Install is a COPY (never a symlink) + `systemctl --user restart opencode-serve`.
- Did not touch the built-in `task` tool.

### Verification results
- PR branch (`multica/BET-379-delegate-tool` @ 0189e8b):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1180 pass / 0 fail / 0 skip.
- Base (`main` @ 1dec5c4): not re-run separately — no source under test was
  changed (the tool `.ts` is not typechecked by the repo build per the issue;
  only AGENTS.md docs were edited, which are not compiled or tested).
- **Conclusion:** 0 new failures, 0 resolved. Doc-only edits + a new
  non-compiled tool file; the existing suite is unchanged and green.

### Manual verification (requires a live box — could not run in sandbox)
The issue's manual steps need a running manta-server + opencode-serve on the
box, which this sandbox doesn't have. They are:
1. Copy `delegate.ts` to `~/.config/opencode/tools/delegate.ts`, restart
   `opencode-serve`.
2. Ask the AI to start a background job → confirm a new sidebar window
   appears and the return string is the specified one.
3. Confirm `delegate_list` reports it and `delegate_stop` stops it.

The tool's HTTP calls match the server routes exactly (verified against
`src/server/index.mjs` lines 1144-1218 and `src/server/delegate.mjs`).

Base: origin/main @ 1dec5c4
