### PR TITLE
refactor(server): collapse remaining atomic-write copies into jsonStore.mjs (BET-400)

### DIFF
--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -31,11 +31,10 @@
 // the mobile QR scanner (M3) are separate issues; they consume /auth/pair +
 // /auth/claim built here.
 
-import { writeFile, rename, mkdir, chmod, unlink } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
+import { unlink } from "node:fs/promises";
 import { randomBytes, randomInt, timingSafeEqual } from "node:crypto";
-import { join, dirname } from "node:path";
 import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const STORE_PATH = statePath("auth.json");
 
@@ -251,39 +250,29 @@ function genPairingCode() {
 }
 
 // ---------------------------------------------------------------------------
-// Store (atomic write + 0600, same shape as webhooks.mjs / secrets.mjs)
+// Store (atomic write + 0600 via jsonStore.mjs — single source of truth)
 // ---------------------------------------------------------------------------
-
-async function atomicWrite(path, data, mode) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data, { mode });
-  await chmod(tmp, mode).catch(() => {});
-  await rename(tmp, path);
-}
 
 // Load the persisted { box_id, box_token, created_at }. Returns null if the
 // file is missing or corrupt (caller then generates a fresh identity).
 export function loadAuth(path = STORE_PATH) {
-  try {
-    if (existsSync(path)) {
-      const parsed = JSON.parse(readFileSync(path, "utf-8"));
-      if (isValidToken(parsed?.box_id) && isValidToken(parsed?.box_token)) {
-        return {
-          box_id: parsed.box_id,
-          box_token: parsed.box_token,
-          created_at: parsed.created_at ?? null,
-        };
-      }
-    }
-  } catch {
-    // corrupt/unreadable → regenerate rather than crash the server.
+  const parsed = readJsonSync(path, null);
+  if (
+    parsed &&
+    isValidToken(parsed.box_id) &&
+    isValidToken(parsed.box_token)
+  ) {
+    return {
+      box_id: parsed.box_id,
+      box_token: parsed.box_token,
+      created_at: parsed.created_at ?? null,
+    };
   }
   return null;
 }
 
 export async function saveAuth(auth, path = STORE_PATH) {
-  await mkdir(dirname(path), { recursive: true });
-  await atomicWrite(path, JSON.stringify(auth, null, 2), 0o600);
+  await writeJsonAtomic(path, JSON.stringify(auth, null, 2), { mode: 0o600 });
 }
 
 // Delete the persisted auth file. Idempotent — a missing file is not an error

--- a/src/server/gatewayRegister.mjs
+++ b/src/server/gatewayRegister.mjs
@@ -30,10 +30,9 @@
 // I/O INJECTION: authPath + fetchImpl + env + gatewayBase are all injectable
 // so unit tests never touch the real filesystem or hit a live gateway.
 
-import { writeFile, rename, mkdir, chmod } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const DEFAULT_GATEWAY_BASE = "https://gateway.mantaui.com";
 // Same path auth.mjs uses (STORE_PATH). Mirror here so this module has no
@@ -42,24 +41,17 @@ const DEFAULT_GATEWAY_BASE = "https://gateway.mantaui.com";
 // module that's already past its first use.
 export const DEFAULT_AUTH_PATH = statePath("auth.json");
 
-async function atomicWrite(path, data, mode) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data, { mode });
-  await chmod(tmp, mode).catch(() => {});
-  await rename(tmp, path);
-}
+// Atomic reads/writes route through jsonStore.mjs (single source of truth for
+// the temp-file-then-rename dance). `writeJsonAtomic` takes already-serialized
+// bytes, creates the parent dir, and applies 0600 when `mode` is supplied —
+// matching the security-critical auth.json contract.
 
 // Pure helper (tested). Read the persisted auth.json. Returns null on a
 // missing file or a corrupt payload — the caller decides what to do next
 // (treats "no auth at all" as "not registered yet").
 export function loadAuthFile(path) {
-  try {
-    if (!existsSync(path)) return null;
-    const parsed = JSON.parse(readFileSync(path, "utf-8"));
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
-    return null;
-  }
+  const parsed = readJsonSync(path, null);
+  return parsed && typeof parsed === "object" ? parsed : null;
 }
 
 // The box's own public base URL, or "" when the box has no reachable
@@ -194,8 +186,7 @@ export async function registerWithGateway({
   }
   if (changed) {
     try {
-      await mkdir(dirname(authPath), { recursive: true });
-      await atomicWrite(authPath, JSON.stringify(next, null, 2), 0o600);
+      await writeJsonAtomic(authPath, JSON.stringify(next, null, 2), { mode: 0o600 });
     } catch (e) {
       logger.warn?.(`[gateway-register] failed to persist auth.json: ${String(e?.message ?? e)}`);
       return { ok: false, skipped: "persist_failed" };

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -8,12 +8,13 @@
 // are no-ops documented below.
 
 import { run } from "./tmux.mjs";
-import { readdir, readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { statePath, expandTilde } from "../shared/paths.mjs";
 import { deriveWorktree, isWorktreeDirtyError } from "../shared/worktree.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 // ============================================================
 // Config persistence (real implementation — renderer depends on it)
@@ -31,14 +32,10 @@ import { deriveWorktree, isWorktreeDirtyError } from "../shared/worktree.mjs";
 
 const CONFIG_PATH = statePath("config.json");
 
-// atomicWrite — write to a temp file then rename over the target.
-// rename(2) is atomic on the same filesystem, so a crash mid-write
-// cannot leave the destination file truncated or empty.
-async function atomicWrite(path, data) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data);
-  await rename(tmp, path);
-}
+// atomic writes route through jsonStore.mjs (single source of truth for the
+// temp-file-then-rename dance). `writeJsonAtomic` takes already-serialized
+// bytes, so it works for the config JSON and the plain-text ~/.tmux.conf
+// rewrites alike.
 
 const DEFAULT_CONFIG = {
   projects: [],
@@ -53,30 +50,24 @@ let _config = null;
 
 async function getConfig() {
   if (_config) return _config;
-  try {
-    if (existsSync(CONFIG_PATH)) {
-      const raw = await readFile(CONFIG_PATH, "utf-8");
-      const parsed = JSON.parse(raw);
-      // Migrate old project shape (id/name) → { tmuxSession, defaultCwd }
-      if (parsed.projects) {
-        parsed.projects = parsed.projects.map((p) => {
-          if (p.tmuxSession) return p;
-          return { tmuxSession: p.name ?? "untitled", defaultCwd: p.defaultCwd ?? "~" };
-        });
-      }
-      _config = { ...DEFAULT_CONFIG, ...parsed };
-    } else {
-      _config = { ...DEFAULT_CONFIG };
+  const parsed = readJsonSync(CONFIG_PATH, null);
+  if (parsed) {
+    // Migrate old project shape (id/name) → { tmuxSession, defaultCwd }
+    if (parsed.projects) {
+      parsed.projects = parsed.projects.map((p) => {
+        if (p.tmuxSession) return p;
+        return { tmuxSession: p.name ?? "untitled", defaultCwd: p.defaultCwd ?? "~" };
+      });
     }
-  } catch {
+    _config = { ...DEFAULT_CONFIG, ...parsed };
+  } else {
     _config = { ...DEFAULT_CONFIG };
   }
   return _config;
 }
 
 async function saveConfig(cfg) {
-  await mkdir(dirname(CONFIG_PATH), { recursive: true });
-  await atomicWrite(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+  await writeJsonAtomic(CONFIG_PATH, JSON.stringify(cfg, null, 2));
   _config = cfg;
 }
 
@@ -365,10 +356,10 @@ export async function tmuxSetupConfig() {
   if (!current.includes(MANTA_BEGIN)) {
     // Backup original if not already backed up
     if (current && !existsSync(tmuxConfBak)) {
-      await atomicWrite(tmuxConfBak, current);
+      await writeJsonAtomic(tmuxConfBak, current);
     }
     // Append manta block (full-file rewrite — atomic to avoid blank tmux.conf on crash)
-    await atomicWrite(tmuxConf, current + MANTA_BLOCK);
+    await writeJsonAtomic(tmuxConf, current + MANTA_BLOCK);
     // Try to source it into the live tmux server (best-effort)
     await run("tmux", ["source-file", tmuxConf]).catch(() => {});
   }
@@ -383,7 +374,7 @@ export async function tmuxRestoreConfig() {
   if (existsSync(tmuxConfBak)) {
     // Restore original backup (full-file rewrite — atomic to avoid blank tmux.conf on crash)
     const original = await readFile(tmuxConfBak, "utf-8");
-    await atomicWrite(tmuxConf, original);
+    await writeJsonAtomic(tmuxConf, original);
   } else {
     // Strip manta block in place (full-file rewrite — atomic)
     try {
@@ -393,7 +384,7 @@ export async function tmuxRestoreConfig() {
         new RegExp(`\\n?${escapeRegex(MANTA_BEGIN)}[\\s\\S]*?${escapeRegex(MANTA_END)}\\n?`, "g"),
         "",
       );
-      await atomicWrite(tmuxConf, stripped);
+      await writeJsonAtomic(tmuxConf, stripped);
     } catch { /* no config to restore */ }
   }
 

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -10,11 +10,12 @@
 // This slice only adds the HTTP path. The RPC layer serves both (SSH + HTTP)
 // until SSH is removed.
 
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { reconcileSubagents } from "../shared/subagentSync.mjs";
+import { writeJsonAtomic } from "./jsonStore.mjs";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (ported from src/main/providers.ts)
@@ -78,14 +79,10 @@ const normBaseURL = (u) => stripUrlUserinfo(u).replace(/\/$/, "");
 // mobile server IS the box, so we read/write it directly (no SSH hop).
 const OPENCODE_JSONC = join(homedir(), ".config", "opencode", "opencode.jsonc");
 
-// Atomic write helper: write to a temp file then rename over the target.
-// rename(2) is atomic on the same filesystem, so a crash mid-write cannot
-// leave the destination file truncated or empty.
-async function atomicWrite(path, data) {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data);
-  await rename(tmp, path);
-}
+// Atomic writes route through jsonStore.mjs (single source of truth for the
+// temp-file-then-rename dance). The READ path stays here because opencode.jsonc
+// is JSONC (// comments), which the plain-JSON readJsonSync can't parse — the
+// comment-stripping readRemoteConfig below is the JSONC-aware loader.
 
 /**
  * Strip // line comments from JSONC without eating // inside strings.
@@ -353,8 +350,7 @@ export async function discoverModelsForEndpoint(baseURL, apiKey, readConfig = re
 async function writeOpencodeJsonc(cfg) {
   const content = JSON.stringify(cfg, null, 2);
   try {
-    await mkdir(dirname(OPENCODE_JSONC), { recursive: true });
-    await atomicWrite(OPENCODE_JSONC, content);
+    await writeJsonAtomic(OPENCODE_JSONC, content);
     return { ok: true };
   } catch (e) {
     console.warn("[providers] write failed:", e);

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -40,11 +40,10 @@
 // lives in firePush / the subscription helpers.
 
 import webpush from "web-push";
-import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import * as tmux from "./tmux.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 const DIR = statePath();
 const VAPID_PATH = join(DIR, "vapid.json");
@@ -57,12 +56,9 @@ const APNS_TOKENS_PATH = join(DIR, "apns-tokens.json");
 // VAPID `subject` must be a mailto: or https: URI identifying the sender.
 const VAPID_SUBJECT = "mailto:app@mantaui.com";
 
-async function atomicWrite(path, data) {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, data);
-  await rename(tmp, path);
-}
+// Atomic reads/writes route through jsonStore.mjs (single source of truth for
+// the temp-file-then-rename dance). `writeJsonAtomic` takes already-serialized
+// bytes and creates the parent dir, matching the old per-store copy.
 
 // ---------------------------------------------------------------------------
 // VAPID keys — load once, generate + persist on first run.
@@ -72,17 +68,11 @@ let _vapid = null;
 
 async function ensureVapid() {
   if (_vapid) return _vapid;
-  try {
-    if (existsSync(VAPID_PATH)) {
-      _vapid = JSON.parse(await readFile(VAPID_PATH, "utf-8"));
-    }
-  } catch {
-    _vapid = null;
-  }
+  _vapid = readJsonSync(VAPID_PATH, null);
   if (!_vapid?.publicKey || !_vapid?.privateKey) {
     _vapid = webpush.generateVAPIDKeys();
     try {
-      await atomicWrite(VAPID_PATH, JSON.stringify(_vapid, null, 2));
+      await writeJsonAtomic(VAPID_PATH, JSON.stringify(_vapid, null, 2));
     } catch (e) {
       console.warn("[push] failed to persist VAPID keys:", e?.message ?? e);
     }
@@ -102,19 +92,12 @@ export async function getVapidPublic() {
 // ---------------------------------------------------------------------------
 
 async function loadSubs() {
-  try {
-    if (existsSync(SUBS_PATH)) {
-      const arr = JSON.parse(await readFile(SUBS_PATH, "utf-8"));
-      return Array.isArray(arr) ? arr : [];
-    }
-  } catch {
-    /* corrupt file → start empty rather than crash the pump */
-  }
-  return [];
+  const arr = readJsonSync(SUBS_PATH, []);
+  return Array.isArray(arr) ? arr : [];
 }
 
 async function saveSubs(subs) {
-  await atomicWrite(SUBS_PATH, JSON.stringify(subs, null, 2));
+  await writeJsonAtomic(SUBS_PATH, JSON.stringify(subs, null, 2));
 }
 
 /** Add (or replace by endpoint) a PushSubscription. */
@@ -149,19 +132,12 @@ export async function removeSubscription(endpoint) {
 // ---------------------------------------------------------------------------
 
 async function loadApnsTokens(path = APNS_TOKENS_PATH) {
-  try {
-    if (existsSync(path)) {
-      const arr = JSON.parse(await readFile(path, "utf-8"));
-      return Array.isArray(arr) ? arr : [];
-    }
-  } catch {
-    /* corrupt file → start empty */
-  }
-  return [];
+  const arr = readJsonSync(path, []);
+  return Array.isArray(arr) ? arr : [];
 }
 
 async function saveApnsTokens(tokens, path = APNS_TOKENS_PATH) {
-  await atomicWrite(path, JSON.stringify(tokens, null, 2));
+  await writeJsonAtomic(path, JSON.stringify(tokens, null, 2));
 }
 
 /** Upsert a device token. De-dupes by token value; updates registeredAt.
@@ -769,18 +745,13 @@ const GATEWAY_BASE = process.env.MANTA_GATEWAY_BASE || "https://gateway.mantaui.
 const AUTH_PATH = statePath("auth.json");
 
 async function readBoxGatewayIdentity() {
-  try {
-    if (!existsSync(AUTH_PATH)) return null;
-    const raw = await readFile(AUTH_PATH, "utf-8");
-    const parsed = JSON.parse(raw);
-    const box_id = typeof parsed?.box_id === "string" ? parsed.box_id : null;
-    const gateway_token =
-      typeof parsed?.gateway_token === "string" ? parsed.gateway_token : null;
-    if (!box_id || !gateway_token) return null;
-    return { box_id, gateway_token };
-  } catch {
-    return null;
-  }
+  const parsed = readJsonSync(AUTH_PATH, null);
+  if (!parsed) return null;
+  const box_id = typeof parsed.box_id === "string" ? parsed.box_id : null;
+  const gateway_token =
+    typeof parsed.gateway_token === "string" ? parsed.gateway_token : null;
+  if (!box_id || !gateway_token) return null;
+  return { box_id, gateway_token };
 }
 
 // Test hooks — let unit tests inject fakes without touching globals.


### PR DESCRIPTION
Follow-up to BET-376. Routes the five remaining atomic-write copies through `src/server/jsonStore.mjs` (`readJsonSync` / `writeJsonAtomic`), the unfinished half of BET-376's "single source of truth for the atomic-write dance" goal.

## What changed

Each of the five modules' local `atomicWrite` (temp-file-then-rename) is removed; its load/save now routes through `jsonStore.mjs`:

- `src/server/auth.mjs` — `loadAuth` → `readJsonSync`, `saveAuth` → `writeJsonAtomic` **with `{mode:0o600}`** (security-critical, preserved). Validation of `box_id`/`box_token` kept.
- `src/server/local.mjs` — `getConfig` → `readJsonSync` (migration logic preserved), `saveConfig` → `writeJsonAtomic`; the plain-text `~/.tmux.conf` rewrites in `tmuxSetupConfig`/`tmuxRestoreConfig` also route through `writeJsonAtomic` (it takes pre-serialized bytes, so non-JSON content is fine).
- `src/server/providers.mjs` — `writeOpencodeJsonc` → `writeJsonAtomic`. The JSONC **read** (`readRemoteConfig`, with `//` comment stripping) stays here by design — `readJsonSync` does plain `JSON.parse` and can't parse JSONC; routing it would break. Only the atomic-write dance was duplicated here.
- `src/server/push.mjs` — VAPID/subs/apns-tokens load → `readJsonSync`, save → `writeJsonAtomic`; `readBoxGatewayIdentity` → `readJsonSync`. Array validation preserved.
- `src/server/gatewayRegister.mjs` — `loadAuthFile` → `readJsonSync`, persist step → `writeJsonAtomic` **with `{mode:0o600}`**.

Pure collapse — no behaviour change: each wrapper keeps its name, signature, async-ness, record shape, path, and mode.

## DoD grep

```
grep -rn "renameSync|\.tmp" src/server/*.mjs
src/server/jsonStore.mjs:41:  const tmp = …
src/server/jsonStore.test.mjs:76:  …store.json.tmp…
src/server/opencodeRestart.test.mjs:40/257/259:  (unrelated fixture)
```
The dance now lives only in `jsonStore.mjs` (and the unrelated `opencodeRestart.test.mjs` fixture, left alone as scoped).

## Verification results

- **Files changed:** 5 (`auth.mjs`, `gatewayRegister.mjs`, `local.mjs`, `providers.mjs`, `push.mjs`)
- PR branch (`multica/BET-400-collapse-atomic-writes` @ `96df31d`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1180 pass / 0 fail / 0 skip. Failures: none. log sha256: `12de2e1671c673fa181aaf00fa05c3da5d881d0f16c6d311c45af8c33db9288c`
- Base (`main` @ `1dec5c4`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624` (identical)
  - test: exit 0, 1180 pass / 0 fail / 0 skip. Failures: none. log sha256: `df12470ba01619c9fbe2219087f5ddb41f7238bc5ad24d8de227814309ed68c8`
- **Conclusion:** 0 new failures, 0 resolved, 0 pre-existing failures. Zero edits to existing tests.

Base: `origin/main @ 1dec5c4`

No follow-ups filed — this completes BET-376's single-source-of-truth goal; no dual source of truth remains and no new drift trap is introduced.