### PR TITLE
BET-380: Route background job permission/question requests into the parent's panel

### DIFF
--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -137,7 +137,9 @@ export function PermissionCard({
     >
       <div className="flex items-center gap-2 mb-1">
         <span style={{ color: CLAUDE_ORANGE }}>✻</span>
-        <span className="text-text">Permission needed</span>
+        <span className="text-text">
+          {perm.fromJobName ? `${perm.fromJobName} · ` : ""}Permission needed
+        </span>
         <span className="text-text-faint">· {perm.permission}</span>
       </div>
       {detail && (
@@ -223,7 +225,9 @@ export function QuestionCard({
     >
       <div className="flex items-center gap-2 mb-2">
         <span style={{ color: CLAUDE_ORANGE }}>?</span>
-        <span className="text-text font-medium">Question</span>
+        <span className="text-text font-medium">
+          {request.fromJobName ? `${request.fromJobName} · ` : ""}Question
+        </span>
         <button
           onClick={onReject}
           className="ml-auto text-text-faint hover:text-text leading-none"

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -771,14 +771,23 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
   }, [sessionId, rejectAllPendingQuestions]);
 
   const replyPermission = useCallback(
-    async (requestId: string, reply: "once" | "always" | "reject") => {
+    async (
+      requestId: string,
+      reply: "once" | "always" | "reject",
+      recordSessionId?: string,
+    ) => {
       // Optimistically drop this request so the card disappears immediately.
       setPermissions((prev) => prev.filter((p) => p.id !== requestId));
       // Clear the sidebar attention dot immediately — the SSE round-trip can
       // be missed, leaving the red `!` stuck.
       useStore.getState().setChatAttention(sessionId, null);
+      // Route the reply to the request's OWN session, not the panel's. A
+      // background job's permission lives on the job's child session; the
+      // record carries that sessionID. Fall back to the viewed session for
+      // the panel's own requests (BET-380 decision #8).
+      const sid = recordSessionId ?? sessionId;
       try {
-        await window.api.opencodePermissionReply(requestId, reply, sessionId);
+        await window.api.opencodePermissionReply(requestId, reply, sid);
       } catch (e) {
         setSendError(String((e as Error)?.message ?? e));
         refreshPermissions();
@@ -1740,7 +1749,7 @@ export function ChatPanel({ sessionId, tmuxSession, windowIndex, cwd, isActive }
             <PermissionCard
               key={p.id}
               perm={p}
-              onReply={(reply) => replyPermission(p.id, reply)}
+              onReply={(reply) => replyPermission(p.id, reply, p.sessionID)}
             />
           ))}
         </div>

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -1441,6 +1441,62 @@ describe("applyQuestionEvent", () => {
       applyQuestionEvent([], "question.asked", { id: "que_x", sessionID: SID }, SID),
     ).toEqual([]); // no questions array
   });
+
+  // ----- BET-380: background-job child questions surface in the parent's panel -----
+  //
+  // applyQuestionEvent takes a related-id set (the background-job child
+  // sessions the viewed session owns) so a job's live question.asked event is
+  // accepted into the parent's panel. The set is passed in (pure), never read
+  // from module state. Reply/reject still clears regardless of session.
+
+  it("BET-380: keeps a question whose sessionID is in the related-id set", () => {
+    const childAsked = {
+      id: "que_child",
+      sessionID: "ses_child",
+      questions: [{ question: "which?", header: "h", options: [] }],
+      tool: { messageID: "msg_c", callID: "toolu_c" },
+    };
+    const related = new Set<string>(["ses_child"]);
+    const next = applyQuestionEvent([], "question.asked", childAsked, SID, related);
+    expect(next).toHaveLength(1);
+    expect(next[0].sessionID).toBe("ses_child");
+    expect(next[0].id).toBe("toolu_c");
+  });
+
+  it("BET-380: still drops a question from an unrelated session not in the set", () => {
+    const otherAsked = {
+      id: "que_other",
+      sessionID: "ses_other",
+      questions: [{ question: "q?", header: "h", options: [] }],
+      tool: { messageID: "msg_o", callID: "toolu_o" },
+    };
+    const related = new Set<string>(["ses_child"]);
+    expect(applyQuestionEvent([], "question.asked", otherAsked, SID, related)).toEqual([]);
+    // And with no set at all, an unrelated session is still dropped.
+    expect(applyQuestionEvent([], "question.asked", otherAsked, SID)).toEqual([]);
+  });
+
+  it("BET-380: a reply/reject event still removes the question regardless of session", () => {
+    const childAsked = {
+      id: "que_child",
+      sessionID: "ses_child",
+      questions: [{ question: "which?", header: "h", options: [] }],
+      tool: { messageID: "msg_c", callID: "toolu_c" },
+    };
+    const related = new Set<string>(["ses_child"]);
+    const prev = applyQuestionEvent([], "question.asked", childAsked, SID, related);
+    expect(prev).toHaveLength(1);
+    // replied echoes the que_ id; the card must clear even though the event's
+    // sessionID differs from the viewed session.
+    expect(
+      applyQuestionEvent(prev, "question.replied", { id: "que_child", sessionID: "ses_child" }, SID, related),
+    ).toEqual([]);
+    // rejected likewise.
+    const prev2 = applyQuestionEvent([], "question.asked", childAsked, SID, related);
+    expect(
+      applyQuestionEvent(prev2, "question.rejected", { id: "que_child", sessionID: "ses_child" }, SID, related),
+    ).toEqual([]);
+  });
 });
 
 describe("applyQuestionEvent — callID unification & defensive removal", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -905,6 +905,12 @@ export type QuestionLike = {
   // Kept ALONGSIDE the callID-keyed `id` so a replied/rejected event that
   // echoes only the `que_` id can still clear a callID-keyed card.
   requestId?: string;
+  // Present when this question came from a background delegation job the
+  // viewed session owns — see PermissionRequest.fromJobName (BET-380). Set
+  // by hydrateQuestion from the server-stamped field; the live event path
+  // has no name (only the related-id set), so the prefix appears once the
+  // GET refresh replaces the live record.
+  fromJobName?: string;
 };
 
 export function applyQuestionEvent(
@@ -912,6 +918,7 @@ export function applyQuestionEvent(
   eventType: string,
   properties: Record<string, unknown> | undefined,
   viewedSessionId: string,
+  relatedSessionIds: Set<string> = new Set(),
 ): QuestionLike[] {
   const p = properties ?? {};
   const sessionID = typeof p.sessionID === "string" ? p.sessionID : "";
@@ -948,8 +955,12 @@ export function applyQuestionEvent(
   }
   if (eventType === "question.asked") {
     if (!id) return prev; // need a stable key to store/dedupe
-    // Only surface questions for the session the user is viewing.
-    if (sessionID !== viewedSessionId) return prev;
+    // Surface questions for the viewed session OR a background job it owns.
+    // The related-id set is maintained in useSseBus from the GET refresh
+    // results (every record carrying fromJobName carries its own sessionID).
+    // Pure: the set is passed in, never read from module state (BET-380).
+    if (sessionID !== viewedSessionId && !relatedSessionIds.has(sessionID))
+      return prev;
     if (!Array.isArray(p.questions)) return prev;
     const next: QuestionLike = {
       id,
@@ -985,6 +996,7 @@ export function hydrateQuestion(server: {
   sessionID: string;
   questions: unknown[];
   tool?: { messageID: string; callID: string };
+  fromJobName?: string;
 }): QuestionLike {
   // Dedup key prefers tool.callID (matches applyQuestionEvent so a live
   // event arriving after GET hydrate updates the same row instead of
@@ -999,6 +1011,7 @@ export function hydrateQuestion(server: {
     questions: server.questions,
     tool: server.tool,
     requestId: server.id, // the `que_…` — what opencode's reply API requires
+    fromJobName: server.fromJobName,
   };
 }
 

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -200,6 +200,12 @@ export function useSseBus(params: {
   useEffect(() => {
     questionsRef.current = questions;
   }, [questions]);
+  // Background-job child session ids the viewed session owns — learned from
+  // the GET refresh results (every record carrying fromJobName carries its
+  // own sessionID). Used by applyQuestionEvent so a job's live question.asked
+  // event is accepted into the parent's panel. Reset per session. The
+  // renderer never queries the job list to compute ownership (BET-380).
+  const relatedSessionIdsRef = useRef<Set<string>>(new Set());
   const [stepTokens, setStepTokens] = useState<(TokenUsage & { cost: number }) | null>(null);
   const [compactionState, setCompactionState] = useState<{
     reason: string;
@@ -285,9 +291,19 @@ export function useSseBus(params: {
     try {
       const perms = await window.api.opencodePermissions?.(sessionId);
       if (Array.isArray(perms)) {
-        // Filter to the viewed session so a cumulative workspace-wide GET
-        // can't stack unrelated backlog — symmetric with refreshQuestions.
-        setPermissions(perms.filter((p) => p.sessionID === sessionId));
+        // The server now returns the viewed session's requests PLUS any
+        // non-terminal background-job child's, each stamped with fromJobName.
+        // Drop the client-side sessionID narrow so a job's asks surface in
+        // the parent's panel (BET-380). Learn the related-id set from the
+        // records that carry fromJobName.
+        const related = new Set<string>();
+        for (const p of perms) {
+          if (p.fromJobName && typeof p.sessionID === "string") {
+            related.add(p.sessionID);
+          }
+        }
+        relatedSessionIdsRef.current = related;
+        setPermissions(perms);
       }
     } catch { /* non-fatal */ }
   }, [sessionId]);
@@ -296,15 +312,22 @@ export function useSseBus(params: {
     try {
       const qs = await window.api.opencodeQuestions?.(sessionId);
       if (Array.isArray(qs)) {
-        // Mirror ChatPanel's original hydrate + sessionID-filter: hydrateQuestion
-        // copies the server's `que_…` id into `requestId` (required for reply),
-        // and the filter keeps only the viewed session's questions so a
-        // cumulative workspace-wide GET doesn't stack unrelated backlog.
-        setQuestions(
-          qs
-            .filter((q) => q.sessionID === sessionId)
-            .map(hydrateQuestion) as QuestionRequest[],
-        );
+        // hydrateQuestion copies the server's `que_…` id into `requestId`
+        // (required for reply) and fromJobName through for the card prefix.
+        // The server filter already narrows to the viewed session + its
+        // non-terminal job children, so no client-side sessionID narrow is
+        // needed (BET-380). Fold any newly-seen job child ids into the
+        // related-id set so live question.asked events from those sessions
+        // are accepted by applyQuestionEvent.
+        const related = new Set(relatedSessionIdsRef.current);
+        const hydrated = qs.map(hydrateQuestion) as QuestionRequest[];
+        for (const q of hydrated) {
+          if (q.fromJobName && typeof q.sessionID === "string") {
+            related.add(q.sessionID);
+          }
+        }
+        relatedSessionIdsRef.current = related;
+        setQuestions(hydrated);
       }
     } catch { /* non-fatal */ }
   }, [sessionId]);
@@ -336,6 +359,10 @@ export function useSseBus(params: {
 
   // SSE effect
   useEffect(() => {
+    // The related-id set is per-viewed-session (learned from the GET refresh
+    // results). Clear it on session switch so a prior session's job children
+    // can't accept live question.asked events for the new session (BET-380).
+    relatedSessionIdsRef.current = new Set();
     // Drain-abort helper
     const maybeDrainQueuedPrompt = () => {
       if (!shouldAbortForQueuedDrain(messageQueueRef.current.length, drainAbortRef.current)) {
@@ -656,12 +683,20 @@ export function useSseBus(params: {
         // Payload-driven live update (restored from BET-64 refactor regression).
         // Applying the event payload directly (a) hydrates `requestId` from the
         // asked payload so submit can send the reply, (b) upserts by callID so
-        // re-asks don't stack, and (c) filters to the viewed session — instead
-        // of re-polling GET /question which returns ALL cumulatively-pending
-        // questions for the workspace and dropped the requestId + filter.
+        // re-asks don't stack, and (c) accepts the viewed session OR a known
+        // background-job child (via the related-id set) so a job's ask surfaces
+        // in the parent's panel (BET-380).
         setQuestions((prev) =>
-          applyQuestionEvent(prev, ev.type, props, sessionId) as QuestionRequest[],
+          applyQuestionEvent(prev, ev.type, props, sessionId, relatedSessionIdsRef.current) as QuestionRequest[],
         );
+        // Re-fetch so the fromJobName-stamped record (server-side only) replaces
+        // the live record — the live event payload carries no job name. The
+        // server filter is now scoped to the viewed session + its job children,
+        // so the GET no longer stacks unrelated backlog (BET-380). Mirrors the
+        // permission path, which already refreshes on permission.asked.
+        if (ev.type === "question.asked") {
+          void refreshQuestions();
+        }
         if (ev.type === "question.replied" || ev.type === "question.rejected") {
           scheduleRefetch();
         }

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -136,6 +136,37 @@ export function deriveName(prompt) {
   return slugify(words || "background");
 }
 
+/**
+ * The childSessionIDs of every NON-TERMINAL job whose parentSessionID matches.
+ * Used by opencode.mjs listPermissions/listQuestions to widen their session
+ * filter so a background job's permission/question requests surface in the
+ * PARENT's panel (BET-380). Terminal jobs are excluded: once a job is done/
+ * failed/stopped its session is no longer interactive and its stale asks must
+ * not be pulled into the parent's panel. Pure.
+ */
+export function relatedSessionIds(parentSessionID, jobs) {
+  if (!parentSessionID || !Array.isArray(jobs)) return [];
+  return jobs
+    .filter((j) => j.parentSessionID === parentSessionID && j.status === "running")
+    .map((j) => j.childSessionID)
+    .filter((sid) => typeof sid === "string" && sid.length > 0);
+}
+
+/**
+ * The job name for a given childSessionID, or null when the session is not a
+ * known running job. Used by opencode.mjs to stamp `fromJobName` on each
+ * permission/question record so the renderer can prefix the card header with
+ * `<job name> · ` (BET-380). Only running jobs are considered — a terminal
+ * job's session is no longer owned. Pure.
+ */
+export function jobNameForSession(childSessionID, jobs) {
+  if (!childSessionID || !Array.isArray(jobs)) return null;
+  const job = jobs.find(
+    (j) => j.childSessionID === childSessionID && j.status === "running",
+  );
+  return job ? (job.name ?? null) : null;
+}
+
 // Find the tmux session that owns a given opencode sessionID. Mirrors the
 // renderer's resolveSessionOwner (src/renderer/store.ts) — the server-side
 // equivalent the spec calls for. Returns { tmuxSession, windowIndex, cwd } or

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -11,6 +11,8 @@ import {
   sweepDelegateJobs,
   deleteJob,
   MAX_RUNNING_JOBS,
+  relatedSessionIds,
+  jobNameForSession,
 } from "./delegate.mjs";
 
 // ----------------------------------------------------------------------------
@@ -526,4 +528,57 @@ test("finishJob is idempotent for an already-terminal job", async () => {
   assert.equal(res.ok, true);
   assert.equal(res.alreadyTerminal, true);
   assert.equal(h.delivered.length, 0);
+});
+
+// ----------------------------------------------------------------------------
+// relatedSessionIds / jobNameForSession — BET-380 ownership helpers
+//
+// Pure functions used by opencode.mjs listPermissions/listQuestions to widen
+// their session filter so a background job's asks surface in the PARENT's
+// panel. Non-terminal = "running"; terminal (done/failed/stopped) jobs are
+// excluded so a finished job's stale asks don't leak into the parent panel.
+// ----------------------------------------------------------------------------
+
+function jobRecord(overrides) {
+  return {
+    id: "j1",
+    name: "fix-login",
+    parentSessionID: "ses_parent",
+    childSessionID: "ses_child",
+    status: "running",
+    ...overrides,
+  };
+}
+
+test("relatedSessionIds returns children of running jobs only, not terminal ones", () => {
+  const jobs = [
+    jobRecord({ id: "a", childSessionID: "child_a", status: "running" }),
+    jobRecord({ id: "b", childSessionID: "child_b", status: "done", finishedAt: 1 }),
+    jobRecord({ id: "c", childSessionID: "child_c", status: "failed", finishedAt: 2 }),
+    jobRecord({ id: "d", childSessionID: "child_d", status: "stopped", finishedAt: 3 }),
+    jobRecord({ id: "e", childSessionID: "child_e", status: "running", parentSessionID: "ses_other" }),
+  ];
+  const related = relatedSessionIds("ses_parent", jobs);
+  assert.deepEqual(related, ["child_a"], "only the running job's child id is returned");
+});
+
+test("relatedSessionIds returns an empty array for an unknown parent", () => {
+  const jobs = [jobRecord({ id: "a", childSessionID: "child_a", status: "running" })];
+  assert.deepEqual(relatedSessionIds("ses_unknown", jobs), []);
+  assert.deepEqual(relatedSessionIds("", jobs), []);
+  assert.deepEqual(relatedSessionIds("ses_parent", []), []);
+  assert.deepEqual(relatedSessionIds("ses_parent", null), []);
+});
+
+test("jobNameForSession returns the job name, and null when unknown or terminal", () => {
+  const jobs = [
+    jobRecord({ id: "a", childSessionID: "child_a", name: "fix-the-bug", status: "running" }),
+    jobRecord({ id: "b", childSessionID: "child_b", name: "done-job", status: "done", finishedAt: 1 }),
+  ];
+  assert.equal(jobNameForSession("child_a", jobs), "fix-the-bug");
+  assert.equal(jobNameForSession("child_b", jobs), null, "terminal job is not owned");
+  assert.equal(jobNameForSession("child_unknown", jobs), null);
+  assert.equal(jobNameForSession("", jobs), null);
+  assert.equal(jobNameForSession("child_a", []), null);
+  assert.equal(jobNameForSession("child_a", null), null);
 });

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -26,6 +26,7 @@ import {
   defaultCredentialsValidator,
   restoreFromBackup,
 } from "./claudeAuth.mjs";
+import { relatedSessionIds, jobNameForSession } from "./delegate.mjs";
 
 const REMOTE_PORT = 4096;
 
@@ -730,6 +731,39 @@ function extractAssistantText(msgs) {
 // Permission flow (Write/Edit/Bash approval)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Background-job request surfacing (BET-380)
+//
+// A background delegation job runs in its OWN opencode session (a git worktree,
+// or the parent cwd when not a repo). Its permission/question requests must
+// surface in the PARENT's panel so the user can answer them — otherwise the
+// job hangs until the 30-minute sweeper kills it. Ownership is determined
+// server-side from the job records (src/server/delegate.mjs): the renderer
+// never recomputes it.
+//
+// `listPermissions`/`listQuestions` accept the parent's sessionID plus the
+// current job records, widen their filter to the parent OR any non-terminal
+// job child session, and stamp `fromJobName` on each record that came from a
+// job. `fromJobName` is the ONLY new field — the renderer keys everything off
+// its presence.
+//
+// opencode's /permission and /question are `?directory=`-scoped, and a job's
+// child session lives in a DIFFERENT directory than the parent, so the parent's
+// scoped query does not return the child's asks. Each related child's directory
+// is fetched and merged in (best-effort) before the single filter pass. The
+// allowed-id set is built ONCE per call, before filtering — never per record.
+// ---------------------------------------------------------------------------
+
+function buildAllowedSessionSet(sessionId, jobs) {
+  if (!sessionId) return null;
+  return new Set([sessionId, ...relatedSessionIds(sessionId, jobs)]);
+}
+
+function stampFromJobName(record, jobs) {
+  const name = jobNameForSession(record?.sessionID, jobs);
+  return name ? { ...record, fromJobName: name } : record;
+}
+
 /** List all pending tool-use permissions.
  *  Scoped to the session's directory when sessionId is provided. opencode's
  *  WorkspaceRoutingMiddleware makes the UNSCOPED endpoint return [] for
@@ -737,23 +771,46 @@ function extractAssistantText(msgs) {
  *  PermissionCard never appears on mobile and the turn hangs forever (the
  *  live `per_…` is sitting in the server's pending map, we just can't see
  *  it). Mirrors listQuestions above + desktop listPermissions.
+ *
+ *  When `jobs` is passed, the filter is widened to the requested session OR
+ *  any non-terminal background-job child session, and each record from a job
+ *  is stamped with `fromJobName` (BET-380). The child's directory is fetched
+ *  separately and merged, because a job runs in its own directory.
  *  @param {string} [sessionId]
- *  @returns {Promise<Array<{ id: string, sessionID: string, permission: string, ... }>>}
+ *  @param {Array<{childSessionID?:string, parentSessionID?:string, status?:string, name?:string}>} [jobs]
+ *  @returns {Promise<Array<{ id: string, sessionID: string, permission: string, fromJobName?: string, ... }>>}
  */
-export async function listPermissions(sessionId) {
+export async function listPermissions(sessionId, jobs = []) {
+  const allowed = buildAllowedSessionSet(sessionId, jobs);
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
   const res = await ocFetch(apiUrl(`/permission${dirQ}`));
   if (!res.ok) {
     throw new Error(`opencode listPermissions ${res.status}: ${await res.text()}`);
   }
   const all = await res.json();
-  // opencode's /permission endpoint is `?directory=`-scoped, not session-scoped:
-  // a directory can hold pending permissions from multiple sessions. Filter
-  // down to the requested sessionID so callers never see cross-session leaks.
-  if (sessionId && Array.isArray(all)) {
-    return all.filter((p) => p.sessionID === sessionId);
+  let list = Array.isArray(all) ? all : [];
+  // Pull in each related child job's directory — a job runs in its own
+  // directory, so the parent's scoped query never includes its asks.
+  if (allowed) {
+    for (const childId of relatedSessionIds(sessionId, jobs)) {
+      try {
+        const childDirQ = await getSessionDirectoryQuery(childId);
+        const childRes = await ocFetch(apiUrl(`/permission${childDirQ}`));
+        if (childRes.ok) {
+          const childAll = await childRes.json();
+          if (Array.isArray(childAll)) list = list.concat(childAll);
+        }
+      } catch {
+        /* best-effort: a failed child fetch does not discard the rest */
+      }
+    }
+    // Filter to the allowed-id set (parent + non-terminal children) so
+    // cross-session leaks from the directory-wide responses are dropped.
+    return list
+      .filter((p) => allowed.has(p.sessionID))
+      .map((p) => stampFromJobName(p, jobs));
   }
-  return all;
+  return list;
 }
 
 /** Approve or deny a permission request.
@@ -786,24 +843,42 @@ export async function replyPermission({ requestId, reply, sessionId }) {
  *  from the correct workspace are returned. Without scoping, opencode returns
  *  questions for the default workspace only — causing the QuestionCard to
  *  never appear for non-default sessions and the agent to hang forever.
+ *
+ *  When `jobs` is passed, the filter is widened to the requested session OR
+ *  any non-terminal background-job child session, and each record from a job
+ *  is stamped with `fromJobName` (BET-380). The child's directory is fetched
+ *  separately and merged, because a job runs in its own directory.
  *  @param {string} [sessionId]
- *  @returns {Promise<Array<{ id: string, sessionID: string, questions: Array<...>, ... }>>}
+ *  @param {Array<{childSessionID?:string, parentSessionID?:string, status?:string, name?:string}>} [jobs]
+ *  @returns {Promise<Array<{ id: string, sessionID: string, questions: Array<...>, fromJobName?: string, ... }>>}
  */
-export async function listQuestions(sessionId) {
+export async function listQuestions(sessionId, jobs = []) {
+  const allowed = buildAllowedSessionSet(sessionId, jobs);
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
   const res = await ocFetch(apiUrl(`/question${dirQ}`));
   if (!res.ok) {
     throw new Error(`opencode listQuestions ${res.status}: ${await res.text()}`);
   }
   const all = await res.json();
-  // opencode's /question endpoint is `?directory=`-scoped, not session-scoped:
-  // a directory can hold pending questions from multiple sessions (including
-  // orphan/subagent sessions). Filter down to the requested sessionID so
-  // callers never see cross-session leaks or stale/orphan asks.
-  if (sessionId && Array.isArray(all)) {
-    return all.filter((q) => q.sessionID === sessionId);
+  let list = Array.isArray(all) ? all : [];
+  if (allowed) {
+    for (const childId of relatedSessionIds(sessionId, jobs)) {
+      try {
+        const childDirQ = await getSessionDirectoryQuery(childId);
+        const childRes = await ocFetch(apiUrl(`/question${childDirQ}`));
+        if (childRes.ok) {
+          const childAll = await childRes.json();
+          if (Array.isArray(childAll)) list = list.concat(childAll);
+        }
+      } catch {
+        /* best-effort: a failed child fetch does not discard the rest */
+      }
+    }
+    return list
+      .filter((q) => allowed.has(q.sessionID))
+      .map((q) => stampFromJobName(q, jobs));
   }
-  return all;
+  return list;
 }
 
 /**

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -1533,3 +1533,164 @@ test("subscribeEvents default (no eagerDirectories) opens NO scoped stream at st
     _setEventStreamTransport(null);
   }
 });
+
+// ---------------------------------------------------------------------------
+// BET-380: listPermissions/listQuestions widen to background-job child sessions
+//
+// A background delegation job runs in its own opencode session (a git worktree
+// directory). Its asks must surface in the PARENT's panel. The list functions
+// accept the job records, widen the filter to the parent OR any non-terminal
+// child, fetch each child's directory (the parent's scoped query does not
+// return the child's asks), and stamp `fromJobName` on job-origin records.
+// ---------------------------------------------------------------------------
+
+test("listPermissions widens to a running job child and stamps fromJobName (separate directory)", async () => {
+  _resetSessionDirectoryCache();
+  const jobs = [
+    {
+      id: "j1",
+      name: "fix-login",
+      parentSessionID: "ses_parent",
+      childSessionID: "ses_child",
+      status: "running",
+    },
+  ];
+  await withMockFetch(
+    async (url) => {
+      const u = String(url);
+      // Parent + child directories are distinct; both lazy-fetched.
+      if (u === "http://127.0.0.1:4096/session/ses_parent") {
+        return new Response(JSON.stringify({ id: "ses_parent", directory: "/proj" }),
+          { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u === "http://127.0.0.1:4096/session/ses_child") {
+        return new Response(JSON.stringify({ id: "ses_child", directory: "/proj/wt" }),
+          { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u.startsWith("http://127.0.0.1:4096/permission?directory=")) {
+        // Parent dir returns parent + an unrelated session; child dir returns
+        // the child's ask.
+        if (u.includes("directory=%2Fproj%2Fwt")) {
+          return new Response(
+            JSON.stringify([
+              { id: "per_child", sessionID: "ses_child", permission: "Bash", reply: null },
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify([
+            { id: "per_parent", sessionID: "ses_parent", permission: "Write", reply: null },
+            { id: "per_other", sessionID: "ses_other", permission: "Bash", reply: null },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listPermissions("ses_parent", jobs);
+      assert.equal(result.length, 2, "parent + child asks, unrelated dropped");
+      const childRec = result.find((r) => r.sessionID === "ses_child");
+      const parentRec = result.find((r) => r.sessionID === "ses_parent");
+      assert.equal(childRec.fromJobName, "fix-login", "child record stamped with job name");
+      assert.equal(parentRec.fromJobName, undefined, "parent's own record is not stamped");
+      assert.equal(result.find((r) => r.sessionID === "ses_other"), undefined, "unrelated session dropped");
+    },
+  );
+});
+
+test("listQuestions widens to a running job child and stamps fromJobName", async () => {
+  _resetSessionDirectoryCache();
+  const jobs = [
+    {
+      id: "j1",
+      name: "add-tests",
+      parentSessionID: "ses_parent",
+      childSessionID: "ses_child",
+      status: "running",
+    },
+  ];
+  await withMockFetch(
+    async (url) => {
+      const u = String(url);
+      if (u === "http://127.0.0.1:4096/session/ses_parent") {
+        return new Response(JSON.stringify({ id: "ses_parent", directory: "/proj" }),
+          { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u === "http://127.0.0.1:4096/session/ses_child") {
+        return new Response(JSON.stringify({ id: "ses_child", directory: "/proj/wt" }),
+          { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u.startsWith("http://127.0.0.1:4096/question?directory=")) {
+        if (u.includes("directory=%2Fproj%2Fwt")) {
+          return new Response(
+            JSON.stringify([
+              { id: "que_child", sessionID: "ses_child", questions: [{ question: "which?" }] },
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify([
+            { id: "que_parent", sessionID: "ses_parent", questions: [{ question: "ok?" }] },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listQuestions("ses_parent", jobs);
+      assert.equal(result.length, 2);
+      const childRec = result.find((r) => r.sessionID === "ses_child");
+      assert.equal(childRec.fromJobName, "add-tests");
+      assert.equal(result.find((r) => r.sessionID === "ses_parent").fromJobName, undefined);
+    },
+  );
+});
+
+test("listPermissions excludes terminal jobs' children and does not fetch their directory", async () => {
+  _resetSessionDirectoryCache();
+  const jobs = [
+    {
+      id: "j1",
+      name: "done-job",
+      parentSessionID: "ses_parent",
+      childSessionID: "ses_child",
+      status: "done",
+      finishedAt: 1,
+    },
+  ];
+  let fetchedChild = false;
+  await withMockFetch(
+    async (url) => {
+      const u = String(url);
+      if (u === "http://127.0.0.1:4096/session/ses_parent") {
+        return new Response(JSON.stringify({ id: "ses_parent", directory: "/proj" }),
+          { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u === "http://127.0.0.1:4096/session/ses_child") {
+        fetchedChild = true;
+        return new Response(JSON.stringify({ id: "ses_child", directory: "/proj/wt" }),
+          { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (u.startsWith("http://127.0.0.1:4096/permission?directory=")) {
+        return new Response(
+          JSON.stringify([
+            { id: "per_parent", sessionID: "ses_parent", permission: "Write", reply: null },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listPermissions("ses_parent", jobs);
+      assert.equal(result.length, 1, "only the parent's own record");
+      assert.equal(result[0].sessionID, "ses_parent");
+      assert.equal(result[0].fromJobName, undefined);
+      assert.equal(fetchedChild, false, "terminal job's child directory is not fetched");
+    },
+  );
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -401,14 +401,25 @@ export function buildHandlers({
     // Scope the list to the session's directory — opencode returns [] for a
     // non-default-directory session on the unscoped endpoint, so an unpassed
     // sessionId made the PermissionCard never appear on mobile (turn hangs).
-    "opencode:permissions": (sessionId) => oc.listPermissions(sessionId),
+    // The job records are passed so the server can widen the filter to
+    // non-terminal background-job child sessions and stamp `fromJobName`
+    // (BET-380): a job's asks surface in the PARENT's panel.
+    "opencode:permissions": async (sessionId) => {
+      const jobs = await delegate.listJobs();
+      return oc.listPermissions(sessionId, jobs);
+    },
 
     // preload: ipcRenderer.invoke(IPC.opencodePermissionReply, { requestId, reply, sessionId })
     // → args[0] = { requestId, reply, sessionId }; opencode.mjs replyPermission expects same shape
     "opencode:permission-reply": (input) => oc.replyPermission(input),
 
     // preload: ipcRenderer.invoke(IPC.opencodeQuestions, sessionId?)  → args[0] = sessionId
-    "opencode:questions": (sessionId) => oc.listQuestions(sessionId),
+    // Job records passed so a background job's questions surface in the
+    // parent's panel with `fromJobName` (BET-380) — see opencode:permissions.
+    "opencode:questions": async (sessionId) => {
+      const jobs = await delegate.listJobs();
+      return oc.listQuestions(sessionId, jobs);
+    },
 
     // preload: ipcRenderer.invoke(IPC.opencodeQuestionReply, { requestId, answers, sessionId })
     // → opencode.mjs replyQuestion expects { requestId, answers, sessionId }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1163,6 +1163,11 @@ export type PermissionRequest = {
   always?: string[];
   metadata?: Record<string, unknown>;
   tool?: { messageID: string; callID: string };
+  // Present when this request originated from a background delegation job the
+  // viewed session owns. The renderer prefixes the card header with
+  // `<fromJobName> · ` so the user knows which job is asking. Absent for the
+  // session's own requests. Stamped server-side only (BET-380).
+  fromJobName?: string;
 };
 
 // Question tool — Claude asks the user structured multiple-choice questions
@@ -1186,6 +1191,9 @@ export type QuestionRequest = {
   // the ONLY id opencode's /question/{requestID}/reply|reject accepts. Absent
   // for transcript-only recovered questions (which are thus unanswerable).
   requestId?: string;
+  // Present when this question came from a background delegation job the
+  // viewed session owns — see PermissionRequest.fromJobName (BET-380).
+  fromJobName?: string;
 };
 
 // ----- Voice / speech-to-text (Groq) -----


### PR DESCRIPTION
## BET-380 — Route a background job's permission/question requests into its parent's panel

A background delegation job runs in its own opencode session (a git worktree directory), so its permission/question requests were filtered out at two layers and hung forever with no UI. Ownership is now determined server-side from the job records; the renderer never recomputes it.

### What changed

**Server (`src/server/delegate.mjs`)** — two pure helpers:
- `relatedSessionIds(parentSessionID, jobs)` → childSessionIDs of non-terminal (running) jobs owned by the parent.
- `jobNameForSession(childSessionID, jobs)` → the job name, or null.

**Server (`src/server/opencode.mjs`)** — `listPermissions`/`listQuestions` widen their filter to the requested session OR any related non-terminal child, build the allowed-id set once before filtering, and stamp `fromJobName` on each job-origin record. Each related child's directory is fetched and merged first — a job runs in its own directory, so the parent's scoped query never includes its asks.

**Server (`src/server/rpc.mjs`)** — `opencode:permissions` / `opencode:questions` pass the current job records.

**Renderer (`src/renderer/hooks/useSseBus.ts`)** — `refreshPermissions`/`refreshQuestions` drop the client-side sessionID narrow (the server now scopes correctly) and maintain the related-id set from records carrying `fromJobName`. `applyQuestionEvent` receives the set so a job's live `question.asked` event is accepted. `question.asked` also triggers a refresh so the server-stamped `fromJobName` reaches the card (the live event payload carries no job name; the server filter is now correctly scoped so the GET no longer stacks unrelated backlog — the original objection to GET-on-asked is resolved by this change).

**Renderer (`src/renderer/chatUtils.ts`)** — `applyQuestionEvent` takes a `relatedSessionIds: Set<string>` final arg (pure, no module state). `QuestionLike`/`hydrateQuestion` carry `fromJobName` through.

**Renderer (`src/renderer/Cards.tsx`)** — `PermissionCard`/`QuestionCard` prepend `<job name> · ` to the header when `fromJobName` is present. No new card type, no restyle, no icon.

**Renderer (`src/renderer/ChatPanel.tsx`)** — `replyPermission` routes the reply to the request's OWN session (the record's `sessionID`), not the panel's, so a job's permission reply lands on the job's child session (decision #8). Question reply/reject already used the record's sessionID.

**Types (`src/shared/types.ts`)** — `PermissionRequest`/`QuestionRequest` gain an optional `fromJobName` field (the only new field).

### Notes on decisions followed exactly
- `fromJobName` is the ONLY new field (no `isChild`/`origin`/etc.).
- `shouldDropEventForSessionFilter` / `isSelfFilteringLifecycleEvent` untouched (permission/question events are already exempt from the session guard).
- Denying/rejecting does not stop the job — no kill logic added.
- The renderer does not query the job list to compute ownership; it learns the related-id set from the records it already receives.
- `chatAutoAllow` behaviour unchanged.
- One necessary extension of decision #4: because a job runs in its own directory, the parent's single scoped query does not return the child's asks, so each related child's directory is fetched and merged before the single filter pass. The allowed-id set is still built once per call, before filtering. Without this, the DoD manual test (start a background job, which creates a worktree) could not pass.

### Tests
- `src/server/delegate.test.mjs`: `relatedSessionIds` (running-only, unknown-parent empty), `jobNameForSession` (name + null/terminal).
- `src/server/opencode.test.mjs`: widening + `fromJobName` stamping with a separate child directory; terminal-job exclusion (child dir not fetched).
- `src/renderer/chatUtils.test.ts`: `applyQuestionEvent` keeps a related-set question, drops an unrelated one, and still clears on reply/reject regardless of session.

### Manual verification (not run here — requires a live box)
Start a background job with trust mode OFF and a prompt that forces a permission request → the parent panel shows it prefixed with the job name; approve/deny lets the job continue. Repeat with a question → same, no indefinite hang.

---

**Files changed:** 11 — `src/server/delegate.mjs`, `src/server/delegate.test.mjs`, `src/server/opencode.mjs`, `src/server/opencode.test.mjs`, `src/server/rpc.mjs`, `src/renderer/hooks/useSseBus.ts`, `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts`, `src/renderer/Cards.tsx`, `src/renderer/ChatPanel.tsx`, `src/shared/types.ts`

**Verification results:**
- PR branch (`multica/BET-380-route-job-requests-to-parent-panel` @ `6a15773`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0. vitest 1573 pass / 0 fail / 0 skip (72 files); node --test 1186 pass / 0 fail. log sha256: `3e9ad76c73c90f15801f8751b216ace048c268657f905ed0d358c9cd802fa67`
- Base (`main` @ `d342d6e`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0. vitest 1570 pass / 0 fail; node --test 1180 pass / 0 fail. log sha256: `754b702b6da119a4900c0c8adb10e25d1539df0a1c2d47e8d8eea486182bd717`
- **Conclusion:** 0 new failures. +3 vitest and +6 node --test are the new tests added by this PR.

**E2E smoke (xvfb-run, Playwright electron launcher):** PASS — app launches, renderer mounts (fresh-install onboarding "Connect your box" screen, expected with no box config), zero uncaught renderer errors. Bundle includes the renderer changes.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ d342d6e
