### PR TITLE
BET-404: widen duplication-gate ignore list for BET-381 spec-mandated mirrors

### DIFF
--- a/scripts/duplication-gate-ignore.txt
+++ b/scripts/duplication-gate-ignore.txt
@@ -4,7 +4,15 @@
 # other"). Everything else must pass the strict gate.
 #
 # This file is HUMAN-approval class (scripts/**): agent PRs cannot widen it.
+# Widened for BET-404 (human-approved on 2026-07-30) per AGENTS.md mirror pattern.
 src/server/opencode.mjs
 src/main/opencode.ts
 src/server/rpc.mjs
 src/renderer/api/httpApi.ts
+# BET-404: AGENTS.md desktop↔mobile mirror + BET-381 decision 3 — the app-level
+# 10s delegateList() job poll is shared by both transports (identical call).
+src/renderer/App.tsx
+src/renderer/mobile/MobileApp.tsx
+# BET-404: BET-381 decision 7 — BackgroundJobsCard mirrors ScheduledTasksCard
+# (copy the existing card pattern exactly).
+src/renderer/PanelCards.tsx


### PR DESCRIPTION
## What

Widens `scripts/duplication-gate-ignore.txt` (human-approved 2026-07-30, Option A) for two spec-mandated intentional mirrors from BET-381 that tripped the advisory `duplication-gate` on PR #347:

- **`src/renderer/App.tsx`** + **`src/renderer/mobile/MobileApp.tsx`** — the app-level 10s `delegateList()` job poll, shared verbatim by desktop and mobile transports. BET-381 decision 3 mandates the identical call in both.
- **`src/renderer/PanelCards.tsx`** — `BackgroundJobsCard` mirrors `ScheduledTasksCard`. BET-381 decision 7 mandates copying the existing card pattern exactly.

Each path is preceded by a comment referencing the AGENTS.md mirror pattern and the specific BET-381 decision. Existing header and entries are unchanged.

## Why not extraction (Option B)

Antoine approved widening (Option A) over extracting shared helpers/hooks. The mirrors are deliberate and spec-mandated, follow the same pattern the ignore list already documents (opencode.mjs/tsx, rpc.mjs, httpApi.ts), and the gate is advisory. Card-pattern extraction carried regression risk on `ScheduledTasksCard` for marginal benefit.

## Verification

- `npm run typecheck && npm test` — pass (1186/1186).
- `scripts/check-duplication-gate.sh` — PASS (no scannable changed files; only the ignore list itself changed).
- Scope: only `scripts/duplication-gate-ignore.txt` edited.

Closes BET-404.