### PR TITLE
BET-402: remove stale fetchState doc comment in chatShared.tsx

### DIFF
--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -92,9 +92,9 @@ export type ToolState = {
 export type TaskContextValue = {
   expanded: Set<string>;
   toggle: (childSessionId: string) => void;
-  // Lazy-loaded child transcripts. Map.get(childSessionId) may be undefined
-  // (never fetched) — TaskBody shows a spinner or "expand to load" depending
-  // on fetchState.
+  // Child transcripts. Map.get(childSessionId) may be undefined if the child
+  // has no cached messages yet; TaskBody renders its collapsed header only in
+  // that case (no separate loading/fetch state is tracked here).
   childMessages: Map<string, OpencodeMessage[]>;
   // Live child running/idle from session.status / session.idle events.
   // Overrides the parent's stale `state.status` for the running pulse.


### PR DESCRIPTION
Follow-up to BET-377 (dead-code sweep in the subagent panel).

The doc comment above `childMessages` in `TaskContextValue` (`src/renderer/chatShared.tsx:95-97`) still described a `fetchState` loading/spinner state for subagent transcripts, but BET-377 deleted the `childFetchState` field and both unreachable loading/error branches it documented. The comment referenced code that no longer existed.

Updated the comment to describe `childMessages` as-is (may be undefined → collapsed-header-only rendering), with no `fetchState` reference. Verified the surrounding `TaskContextValue` doc block still accurately describes the remaining fields.

`grep -rn 'fetchState\|childFetchState' src/` → no matches.

Verification: `npm run typecheck && npm test` green (1186/1186).