### PR TITLE
BET-403: gate question refetch + cache jobs read

### DIFF
--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -629,3 +629,81 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
     expect(promptCalls.length).toBe(1);
   });
 });
+
+// BET-403 nit 1 — gate the question.asked refetch to job-origin asks only.
+// The parent session's own question.asked carries a complete live payload, so
+// the GET round-trip was wasted work. A job-origin ask (sessionID is a known
+// related child) still refetches so the server-stamped fromJobName replaces
+// the live record.
+describe("useSseBus question.asked refetch gating (BET-403)", () => {
+  let api: MockApi;
+  let bus: MockEventBus;
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("does NOT refetch questions for the viewed session's own question.asked", async () => {
+    ({ api, bus } = installMockApi());
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const before = (api.calls.opencodeQuestions ?? []).length;
+
+    await emitAndFlush(bus, h, {
+      type: "question.asked",
+      properties: {
+        sessionID: "ses_test",
+        id: "que_1",
+        tool: { messageID: "msg_1", callID: "toolu_1" },
+        questions: [["pick one"]],
+      },
+    });
+
+    const after = (api.calls.opencodeQuestions ?? []).length;
+    expect(after).toBe(before);
+  });
+
+  it("DOES refetch questions for a background-job child's question.asked", async () => {
+    // Seed the related-id set: a server record carrying fromJobName for a
+    // child session. server.connected triggers refreshQuestions, which both
+    // populates the set and records one opencodeQuestions call.
+    ({ api, bus } = installMockApi({
+      opencodeQuestions: async () => [
+        {
+          id: "que_child",
+          sessionID: "ses_child",
+          fromJobName: "fix-the-bug",
+          questions: [["pick one"]],
+        },
+      ],
+    }));
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    await emitAndFlush(bus, h, { type: "server.connected", properties: {} });
+    const seeded = (api.calls.opencodeQuestions ?? []).length;
+    expect(seeded).toBeGreaterThanOrEqual(1);
+
+    // A job-origin ask (child session is in the related set) must refetch so
+    // the fromJobName-stamped record replaces the live one.
+    await emitAndFlush(bus, h, {
+      type: "question.asked",
+      properties: {
+        sessionID: "ses_child",
+        id: "que_child_live",
+        tool: { messageID: "msg_c", callID: "toolu_c" },
+        questions: [["pick one"]],
+      },
+    });
+
+    const after = (api.calls.opencodeQuestions ?? []).length;
+    expect(after).toBeGreaterThan(seeded);
+  });
+});

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -689,13 +689,22 @@ export function useSseBus(params: {
         setQuestions((prev) =>
           applyQuestionEvent(prev, ev.type, props, sessionId, relatedSessionIdsRef.current) as QuestionRequest[],
         );
-        // Re-fetch so the fromJobName-stamped record (server-side only) replaces
-        // the live record — the live event payload carries no job name. The
-        // server filter is now scoped to the viewed session + its job children,
-        // so the GET no longer stacks unrelated backlog (BET-380). Mirrors the
-        // permission path, which already refreshes on permission.asked.
+        // Re-fetch ONLY when the ask originates from a background job the
+        // viewed session owns: the live event payload carries no job name, so
+        // the GET must replace the live record with the server-stamped
+        // fromJobName one (BET-380). For the viewed session's OWN questions the
+        // live payload is already complete, so the round-trip was wasted work
+        // (BET-403 nit 1). A job-origin ask is one whose sessionID is a known
+        // related child (applyQuestionEvent already gated acceptance on the
+        // same set, so an unknown child is dropped before reaching here).
         if (ev.type === "question.asked") {
-          void refreshQuestions();
+          const isJobOrigin =
+            evSessionID.length > 0 &&
+            evSessionID !== sessionId &&
+            relatedSessionIdsRef.current.has(evSessionID);
+          if (isJobOrigin) {
+            void refreshQuestions();
+          }
         }
         if (ev.type === "question.replied" || ev.type === "question.rejected") {
           scheduleRefetch();

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -74,6 +74,39 @@ function genId() {
 }
 
 // ---------------------------------------------------------------------------
+// Jobs cache (BET-403 nit 2)
+// ---------------------------------------------------------------------------
+// `opencode:permissions` / `opencode:questions` only need the job list to
+// compute ownership (relatedSessionIds / jobNameForSession), which depends on
+// status/parentSessionID/childSessionID/name — fields that only change on a
+// job lifecycle transition. Reading the delegate-jobs.json file on every RPC
+// was wasted work for a single-user box; this wraps the load in a short-TTL
+// in-memory cache that is also invalidated by every engine mutation
+// (startJob/stopJob/deleteJob/observeEvent/sweep). The activity poller's
+// 10s saves mutate `activity` only (ownership-irrelevant), so it intentionally
+// does NOT invalidate — the cache stays warm through activity ticks.
+//
+// `delegate:list` (the UI jobs card) bypasses the cache and reads fresh, so a
+// `delegate.updated`-driven refetch still shows live status instantly.
+export function createJobsCache({ load = loadJobs, ttlMs = 2000, now = () => Date.now() } = {}) {
+  let cached = null;
+  let expiresAt = 0;
+  return {
+    async get() {
+      const t = now();
+      if (cached !== null && t < expiresAt) return cached;
+      cached = await load();
+      expiresAt = t + ttlMs;
+      return cached;
+    },
+    invalidate() {
+      cached = null;
+      expiresAt = 0;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Pure helpers (exported for unit tests)
 // ---------------------------------------------------------------------------
 
@@ -818,14 +851,37 @@ export async function deleteJob(id, deps = {}) {
 
 export function createDelegateEngine(deps) {
   const sawBusy = new Map();
+  const jobsCache = createJobsCache({
+    load: deps.load ?? (() => loadJobs(deps.storePath ?? STORE_PATH)),
+  });
+  // Invalidate the cache after any mutation so the next ownership read sees
+  // fresh status. Wrapping the bound methods (rather than poking the pure
+  // fns) keeps the pure functions testable and untouched (BET-403 nit 2).
+  const invalidate = () => jobsCache.invalidate();
+  const withInvalidate = (fn) => async (...args) => {
+    const r = await fn(...args);
+    invalidate();
+    return r;
+  };
   const bound = {
-    startJob: (input) => startJob(input, deps),
-    stopJob: (id) => stopJob(id, deps),
-    deleteJob: (id) => deleteJob(id, deps),
+    startJob: withInvalidate((input) => startJob(input, deps)),
+    stopJob: withInvalidate((id) => stopJob(id, deps)),
+    deleteJob: withInvalidate((id) => deleteJob(id, deps)),
+    observeEvent: withInvalidate((evt) => observeEvent(evt, deps, sawBusy)),
+    sweep: withInvalidate(() => sweepDelegateJobs(deps)),
     listJobs: (filter) => listJobs(filter, deps),
+    // Cached read for the permissions/questions RPC handlers (BET-403 nit 2).
+    // Mirrors listJobs' filter semantics (no filter → all jobs; sessionID →
+    // narrow to that parent's children) but serves from the TTL cache. The
+    // UI jobs card uses the uncached `listJobs` so it stays live.
+    cachedListJobs: async (filter = {}) => {
+      const jobs = await jobsCache.get();
+      if (filter?.sessionID === undefined) return jobs.map((j) => ({ ...j }));
+      return jobs
+        .filter((j) => j.parentSessionID === filter.sessionID)
+        .map((j) => ({ ...j }));
+    },
     getJob: (id) => getJob(id, deps),
-    observeEvent: (evt) => observeEvent(evt, deps, sawBusy),
-    sweep: () => sweepDelegateJobs(deps),
     startSweeper: (opts) => startSweeper(deps, opts),
     startActivityPoller: (opts) => startActivityPoller(deps, opts),
   };

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -13,6 +13,8 @@ import {
   MAX_RUNNING_JOBS,
   relatedSessionIds,
   jobNameForSession,
+  createJobsCache,
+  createDelegateEngine,
 } from "./delegate.mjs";
 
 // ----------------------------------------------------------------------------
@@ -581,4 +583,106 @@ test("jobNameForSession returns the job name, and null when unknown or terminal"
   assert.equal(jobNameForSession("", jobs), null);
   assert.equal(jobNameForSession("child_a", []), null);
   assert.equal(jobNameForSession("child_a", null), null);
+});
+
+// ----------------------------------------------------------------------------
+// createJobsCache — TTL + invalidation (BET-403 nit 2)
+// ----------------------------------------------------------------------------
+
+test("createJobsCache serves a cached load within the TTL window", async () => {
+  let loadCount = 0;
+  const load = async () => { loadCount += 1; return [{ id: "a", status: "running" }]; };
+  let nowMs = 1000;
+  const cache = createJobsCache({ load, ttlMs: 2000, now: () => nowMs });
+
+  const a = await cache.get();
+  const b = await cache.get();
+  assert.equal(loadCount, 1, "second get within TTL hits the cache");
+  assert.deepEqual(a, b);
+
+  nowMs = 4000; // past TTL
+  await cache.get();
+  assert.equal(loadCount, 2, "expired entry re-loads");
+});
+
+test("createJobsCache invalidate forces the next get to reload", async () => {
+  let loadCount = 0;
+  const load = async () => { loadCount += 1; return [{ id: "a" }]; };
+  const cache = createJobsCache({ load, ttlMs: 100000, now: () => 0 });
+  await cache.get();
+  await cache.get();
+  assert.equal(loadCount, 1);
+  cache.invalidate();
+  await cache.get();
+  assert.equal(loadCount, 2, "invalidate busts the cache even inside TTL");
+});
+
+// ----------------------------------------------------------------------------
+// createDelegateEngine.cachedListJobs — filter + invalidation on mutation
+// (BET-403 nit 2). The permissions/questions RPC handlers read jobs through
+// this path instead of re-reading delegate-jobs.json on every call.
+// ----------------------------------------------------------------------------
+
+function engineHarness(initialJobs = []) {
+  let jobs = initialJobs.map((j) => ({ ...j }));
+  let loadCount = 0;
+  const deps = {
+    load: async () => { loadCount += 1; return jobs.map((j) => ({ ...j })); },
+    save: async (next) => { jobs = next.map((j) => ({ ...j })); },
+    publish: () => {},
+    deliver: async () => ({ delivered: true }),
+    listMessages: async () => [],
+    gitRun: async () => ({ stdout: "" }),
+    now: () => 1_700_000_000_000,
+  };
+  const engine = createDelegateEngine(deps);
+  return { engine, get loadCount() { return loadCount; }, get jobs() { return jobs; }, setJobs(n) { jobs = n.map((j) => ({ ...j })); } };
+}
+
+test("cachedListJobs mirrors listJobs filter semantics", async () => {
+  const h = engineHarness([
+    { id: "1", parentSessionID: "ses_p", childSessionID: "c1", status: "running", name: "job1" },
+    { id: "2", parentSessionID: "ses_other", childSessionID: "c2", status: "running", name: "job2" },
+  ]);
+  const all = await h.engine.cachedListJobs();
+  assert.equal(all.length, 2);
+  const narrowed = await h.engine.cachedListJobs({ sessionID: "ses_p" });
+  assert.deepEqual(narrowed.map((j) => j.id), ["1"]);
+});
+
+test("cachedListJobs serves the cache across repeated reads", async () => {
+  const h = engineHarness([{ id: "1", status: "running" }]);
+  await h.engine.cachedListJobs();
+  await h.engine.cachedListJobs();
+  await h.engine.cachedListJobs();
+  // One load to warm the cache; subsequent reads hit it (TTL not elapsed).
+  assert.equal(h.loadCount, 1);
+});
+
+test("cachedListJobs returns copies, not the live store array", async () => {
+  const h = engineHarness([{ id: "1", status: "running" }]);
+  const a = await h.engine.cachedListJobs();
+  a[0].mutated = true;
+  const b = await h.engine.cachedListJobs();
+  assert.equal(b[0].mutated, undefined, "caller mutations must not leak into the cache");
+});
+
+test("a mutation invalidates the cache so the next cachedListJobs reloads", async () => {
+  const h = engineHarness([{ id: "1", status: "running" }]);
+  await h.engine.cachedListJobs();
+  const warmCount = h.loadCount; // 1: cache warm
+  // stopJob on a running job transitions it to "stopped" (one internal load)
+  // and busts the cache via the engine's withInvalidate wrapper.
+  await h.engine.stopJob("1");
+  const afterMutation = h.loadCount;
+  assert.equal(afterMutation, warmCount + 1, "stopJob performed its own load");
+
+  // First read after invalidation must reload and reflect the new status.
+  const jobs = await h.engine.cachedListJobs();
+  assert.equal(h.loadCount, afterMutation + 1, "cache was invalidated → reloaded");
+  assert.equal(jobs[0].status, "stopped");
+
+  // Second read hits the now-warm cache (no further load).
+  await h.engine.cachedListJobs();
+  assert.equal(h.loadCount, afterMutation + 1, "cache served the second read");
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -405,7 +405,7 @@ export function buildHandlers({
     // non-terminal background-job child sessions and stamp `fromJobName`
     // (BET-380): a job's asks surface in the PARENT's panel.
     "opencode:permissions": async (sessionId) => {
-      const jobs = await delegate.listJobs();
+      const jobs = delegate ? await delegate.cachedListJobs() : [];
       return oc.listPermissions(sessionId, jobs);
     },
 
@@ -417,7 +417,7 @@ export function buildHandlers({
     // Job records passed so a background job's questions surface in the
     // parent's panel with `fromJobName` (BET-380) — see opencode:permissions.
     "opencode:questions": async (sessionId) => {
-      const jobs = await delegate.listJobs();
+      const jobs = delegate ? await delegate.cachedListJobs() : [];
       return oc.listQuestions(sessionId, jobs);
     },
 


### PR DESCRIPTION
Closes BET-403. Two non-blocking perf nits from the BET-380 review.

## Nit 1 — gate the `question.asked` refetch
`useSseBus.ts` fired `refreshQuestions()` on every `question.asked` event.
It only needs to refetch when the ask originates from a background-job
child (so the server-stamped `fromJobName` replaces the live record). The
viewed session's own questions carry a complete live payload, so the GET
round-trip was wasted. Gated to job-origin asks only (sessionID in the
related-id set — the same set `applyQuestionEvent` already gates
acceptance on).

## Nit 2 — cache the `listJobs()` disk read
`opencode:permissions` / `opencode:questions` RPC handlers re-read
`delegate-jobs.json` on every call. Added `createJobsCache` (short TTL +
invalidation) and wired `cachedListJobs` into the delegate engine; the two
RPC handlers read through it. The cache is invalidated on every job
lifecycle mutation (start/stop/delete/observeEvent/sweep). `delegate:list`
(the UI jobs card) stays uncached so it remains live. The activity poller's
10s saves mutate `activity` only (ownership-irrelevant), so it intentionally
does not invalidate — the cache stays warm through activity ticks.

## Tests
- `useSseBus.test.tsx`: gated-refetch unit tests — parent-session
  `question.asked` does NOT trigger `refreshQuestions`; a job-child ask DOES.
- `delegate.test.mjs`: `createJobsCache` TTL + invalidation;
  `cachedListJobs` filter semantics, copy isolation, and mutation-driven
  invalidation.

## Verification results
**Files changed:** 5 files. `src/renderer/hooks/useSseBus.ts`, `src/renderer/hooks/useSseBus.test.tsx`, `src/server/delegate.mjs`, `src/server/delegate.test.mjs`, `src/server/rpc.mjs`

- PR branch (`multica/BET-403-perf-nits` @ `90d0292`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1192 pass / 0 fail / 0 skip. log sha256: `e29f795c54de23d227c763f793d2c46f2b02da4c422fc5c8da74ffb59a02a540`
- Base (`main` @ `7db1b97`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1186 pass / 0 fail / 0 skip. log sha256: `95b1a821e2c7bbf2a6c6a5d2e884ab2d227ea1570b67337533828d2df878c7b8`
- **Conclusion:** 0 test failures pre-existing; 6 new tests added by this PR (1186 → 1192), all green. 0 new failures, 0 resolved.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ 7db1b97