### PR TITLE
BET-340: dedupe useSseBus.test.tsx setup prologue

### DIFF
--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -484,13 +484,21 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
     });
   }
 
-  it("aborts and drains at the next completed tool part, not at full idle", async () => {
+  // Shared 4-line setup prologue for the drain tests: install the mock API
+  // with a no-op opencodePrompt, reset the store, mount ChatPanel, and flush.
+  // Returns the harness so each test's `h =` assignment keeps TS narrowing.
+  async function mountDrainHarness(): Promise<Harness> {
     ({ api, bus } = installMockApi({
       opencodePrompt: () => Promise.resolve({ ok: true }),
     }));
     resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
+    const harness = mount(<ChatPanel {...PROPS} />);
+    await harness.flush();
+    return harness;
+  }
+
+  it("aborts and drains at the next completed tool part, not at full idle", async () => {
+    h = await mountDrainHarness();
 
     // Turn is already running.
     await emitAndFlush(bus, h, {
@@ -519,12 +527,7 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
   });
 
   it("does not abort on a running (non-boundary) tool part", async () => {
-    ({ api, bus } = installMockApi({
-      opencodePrompt: () => Promise.resolve({ ok: true }),
-    }));
-    resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
+    h = await mountDrainHarness();
 
     await emitAndFlush(bus, h, {
       type: "session.status",
@@ -546,12 +549,7 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
   });
 
   it("does not drain the parent queue on a subagent child's tool completion", async () => {
-    ({ api, bus } = installMockApi({
-      opencodePrompt: () => Promise.resolve({ ok: true }),
-    }));
-    resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
+    h = await mountDrainHarness();
 
     // Register a subagent child session under the main session.
     await emitAndFlush(bus, h, {
@@ -591,12 +589,7 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
   // effect is the sole owner. If a duplicate is ever reintroduced this test
   // sees two opencodePrompt calls for "second message".
   it("submits a queued message exactly once when it drains (no double send)", async () => {
-    ({ api, bus } = installMockApi({
-      opencodePrompt: () => Promise.resolve({ ok: true }),
-    }));
-    resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
+    h = await mountDrainHarness();
 
     // Turn running; queue a second message mid-turn.
     await emitAndFlush(bus, h, {


### PR DESCRIPTION
## BET-340 — Dedupe useSseBus.test.tsx setup prologue

Extracts the repeated 4-line setup prologue (`installMockApi({opencodePrompt}) + resetStore() + mount + flush`) in the "queued-message drain on tool step boundary" describe block into a local `mountDrainHarness()` helper. Each of the 4 drain `it(...)` blocks now collapses to `h = await mountDrainHarness();`.

Clears the `duplication-gate` advisory (4 clones). No behavior change, no test renames, no assertions removed. Helper is local to `useSseBus.test.tsx` (no new top-level test util file). No production code touched.

The helper returns the harness rather than assigning the closure `h` internally, so each test's `h =` assignment preserves TypeScript null-narrowing (`Harness | null` → `Harness`).

**Files changed:** 1 file — `src/renderer/hooks/useSseBus.test.tsx` (+14 / −21).

Base: `origin/main` @ `7db1b97`

**Verification results:**
- PR branch (`multica/BET-340-dedupe-ssebus-test-prologue` @ `899c678`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: vitest exit 0, 1583 pass / 0 fail / 0 skip; node:test exit 0, 1186 pass / 0 fail. Failures: none. log sha256: `3103394863bace5e0fb209c860b721ed5deae9e67f6c6dd0155ebcded3cc8545`
- Base (`main` @ `7db1b97`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: vitest exit 0, 1583 pass / 0 fail / 0 skip; node:test exit 0, 1186 pass / 0 fail. Failures: none. log sha256: `cfe4278f6abaf370ad03eddf70454b5d25c08143489bde0e190a280d66159887`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. Both branches are identical green.

`useSseBus.test.tsx` specifically: 23 tests pass (verified via `npx vitest run src/renderer/hooks/useSseBus.test.tsx`).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
