### PR TITLE
BET-338: remove dead pairLinkClaims / notePairLinkClaimed machinery

### DIFF
--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -34,7 +34,7 @@
 // Those components own their own footers; the shell hides its generic
 // footer and lets each step drive advancement (`onPaired` / `onContinue`).
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   ONBOARDING_STEPS,
   STEP_LABELS,
@@ -252,17 +252,6 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   useEffect(() => {
     if (pendingPairLink) setPos(1);
   }, [pendingPairLink]);
-
-  // Deep-link pairing: a manta:// link that SUCCEEDS must move the flow off
-  // step 1. Re-derive from the freshly re-read config rather than calling
-  // goNext(): a re-pair from an already-configured box should land on the
-  // first step that's still incomplete, not blindly on step 2.
-  const pairLinkClaims = useStore((s) => s.pairLinkClaims);
-  const claimsAtMountRef = useRef(pairLinkClaims);
-  useEffect(() => {
-    if (pairLinkClaims === claimsAtMountRef.current) return;
-    setPos(resolveInitialStep(useStore.getState().configSnapshot()));
-  }, [pairLinkClaims]);
 
   const isSuccess = pos === "success";
 

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -712,33 +712,9 @@ describe("setPendingPairLink (BET-240 deep-link pairing)", () => {
   });
 });
 
-describe("deep-link claim outcome (stuck-on-pair-step regression)", () => {
+describe("deep-link pairing error", () => {
   beforeEach(() => {
-    useStore.setState({ pairLinkClaims: 0, pairLinkError: null, pendingPairLink: null });
-  });
-
-  it("notePairLinkClaimed bumps the counter so a mounted Onboarding re-derives", () => {
-    useStore.getState().notePairLinkClaimed();
-    expect(useStore.getState().pairLinkClaims).toBe(1);
-  });
-
-  it("REGRESSION: the counter changes identity on EVERY claim — a second link is not a no-op", () => {
-    // A boolean would latch true here and the second deep link would never
-    // move the flow off step 1 (the exact shape of the original bug).
-    useStore.getState().notePairLinkClaimed();
-    const first = useStore.getState().pairLinkClaims;
-    useStore.getState().notePairLinkClaimed();
-    expect(useStore.getState().pairLinkClaims).toBe(first + 1);
-  });
-
-  it("a successful claim clears the stale pending link + error from an earlier failure", () => {
-    useStore.setState({
-      pendingPairLink: "manta://pair?box=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&code=111111",
-      pairLinkError: "That code has expired.",
-    });
-    useStore.getState().notePairLinkClaimed();
-    expect(useStore.getState().pendingPairLink).toBeNull();
-    expect(useStore.getState().pairLinkError).toBeNull();
+    useStore.setState({ pairLinkError: null, pendingPairLink: null });
   });
 
   it("setPairLinkError carries the failure reason, and null consumes it", () => {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -113,22 +113,6 @@ type State = {
   // by Onboarding (to force step 1) and PairStep (to prefill the paste field).
   // Cleared once consumed. Not persisted — purely transient routing state.
   pendingPairLink: string | null;
-  // Deep-link pairing: monotonic counter bumped by App.tsx after a manta://
-  // link auto-claim SUCCEEDS and the config re-read has landed.
-  //
-  // Why a counter and not a boolean: Onboarding must re-derive its step from
-  // the FRESH config every time a link lands, including a second link in the
-  // same session. A counter changes identity on every claim; a boolean would
-  // latch true and the second link would be a no-op.
-  //
-  // This exists because a successful auto-claim used to leave the shell
-  // pinned on the onboarding flow at step 1. `finishOnboarding()` clears
-  // `onboardingForced` and re-reads config, but App keeps the flow MOUNTED
-  // behind a local latch (so steps 2-4 stay reachable after step 1 writes a
-  // boxToken). Nothing advanced the step, so a successful pairing rendered
-  // as an untouched pair form with the code field focused — indistinguishable
-  // from "the deep link did nothing".
-  pairLinkClaims: number;
   // Deep-link pairing: why the last auto-claim failed, surfaced inline by
   // PairStep. The auto-claim runs with no visible UI, so without this the
   // failure reason (wrong/expired code, unreachable box, malformed link) was
@@ -347,11 +331,6 @@ type State = {
   // null to consume (PairStep clears on use); App.tsx writes the URL when
   // the preload's pair:link-received IPC fires.
   setPendingPairLink: (url: string | null) => void;
-  // Record a SUCCESSFUL deep-link auto-claim. Call AFTER the config re-read
-  // (finishOnboarding) so any listener that re-derives from config sees the
-  // post-pairing state. Also clears any stale pendingPairLink/pairLinkError
-  // left by an earlier failed attempt.
-  notePairLinkClaimed: () => void;
   setPairLinkError: (message: string | null) => void;
   setConnectionState: (s: ConnectionState) => void;
 };
@@ -364,7 +343,6 @@ export const useStore = create<State>((set, get) => ({
   onboardingSkipped: false,
   onboardingForced: false,
   pendingPairLink: null,
-  pairLinkClaims: 0,
   pairLinkError: null,
   chatAutoAllow: false,
   autoRenameSessions: false,
@@ -485,13 +463,6 @@ export const useStore = create<State>((set, get) => ({
   },
 
   setPendingPairLink: (url) => set({ pendingPairLink: url }),
-
-  notePairLinkClaimed: () =>
-    set((s) => ({
-      pairLinkClaims: s.pairLinkClaims + 1,
-      pendingPairLink: null,
-      pairLinkError: null,
-    })),
 
   setPairLinkError: (message) => set({ pairLinkError: message }),
 


### PR DESCRIPTION
Closes [BET-338](mention://issue/a8d919e3-8b07-45b1-84a9-334ef085584c).

After BET-335 deleted the auto-claim branch in `App.tsx`, the `pairLinkClaims` counter, `notePairLinkClaimed` action, the `Onboarding` `useEffect` that watched the counter, and the three counter tests have no remaining caller.

**Removed**
- `src/renderer/store.ts` — `pairLinkClaims` field + initial value, `notePairLinkClaimed` action and its comment blocks.
- `src/renderer/Onboarding.tsx` — the `pairLinkClaims` `useEffect` + `claimsAtMountRef`, and the now-unused `useRef` import.
- `src/renderer/store.test.ts` — the three `notePairLinkClaimed` tests.

**Kept live** (still used by the malformed-link branch in `App.tsx`)
- `pairLinkError` / `setPairLinkError` and its test (describe renamed to `deep-link pairing error`).

**Verification**
- `npm run typecheck` — green.
- `npm test` — 1186 pass, 0 fail.