### PR TITLE
docs: stale Mac executor prose on plugins.ts:17 (BET-325 follow-up)

### DIFF
--- a/docs/opencode-tools/plugins.ts
+++ b/docs/opencode-tools/plugins.ts
@@ -14,7 +14,7 @@
 // job queue (src/server/capabilities.mjs) and the plugin registry
 // (src/server/plugins.mjs). The tools do NOT block on plugin runs:
 // plugin_run returns immediately with the job id, and a completion turn is
-// injected back into this session when the Mac executor finishes.
+// injected back into this session when the desktop executor finishes.
 //
 // A "plugin" is a YAML manifest at ~/.manta/plugins/<name>.yaml on the
 // machine the user wants to drive (today: host:"desktop" — the connected


### PR DESCRIPTION
## Summary

BET-337 (BET-325 follow-up): stale "Mac executor" prose on `docs/opencode-tools/plugins.ts:17`. One-line comment fix — replace `Mac executor` with `desktop executor`, the single occurrence missed by the BET-325 host-vocabulary rename.

**Files changed:** 1 file — `docs/opencode-tools/plugins.ts` (comment-only, line 17).

This file is source-of-truth, copied into `~/.config/opencode/tools/` on the box separately, so the next install picks up the prose fix automatically.

## Done-when

- `grep -n "Mac executor" docs/opencode-tools/plugins.ts` → no matches (verified).
- `npm run typecheck && npm test` green (both branches identical).
- Branch `multica/BET-325-followup-plugins-ts-prose` pushed; this PR opened.
- Reassigning to `manta-reviewer` on completion.

## Verification results

- PR branch (`multica/BET-325-followup-plugins-ts-prose` @ `9b62e06`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…c05b5624`
  - test: exit 0, 1186 pass / 0 fail / 0 skip. log sha256: `129fde80…ad37c2ada`
- Base (`main` @ `9547fd6`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…c05b5624` (identical to PR)
  - test: exit 0, 1186 pass / 0 fail / 0 skip. log sha256: `50aaba35…ea863d8d3`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. Diff is a comment-only one-liner; suites are identical between branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Base: origin/main @ 9547fd6**

No actionable follow-ups surfaced — single comment-only edit, no behavioral change.
