### PR TITLE
BET-391: Document MANTA_CHANNEL for the raw curl-staging install.sh path

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,13 +43,15 @@ section in `AGENTS.md` and the per-channel value table in
 (`web-v*`, `server-v*`, `mac-v*`) keep meaning prod; staging is triggered
 by hand after the spec change lands.
 
-`install.sh` is served **byte-identical** across channels (no build-time
-substitution — `scripts/release/publish.sh` copies the same file to both
-`/var/www/mantaui/` and `/var/www/mantaui/staging/`). The staging URL
-signals "staging" to a human, but once piped into bash the script has no
-way to recover the URL it was fetched from — it falls back to
-`MANTA_CHANNEL=${MANTA_CHANNEL:-prod}`. So the canonical staging
-curl-install command exports the channel explicitly:
+`install.sh` is one file in the repo, served **byte-identical** across
+channels (no build-time substitution): prod's copy is synced to
+`/var/www/mantaui/install.sh` by `scripts/release/publish.sh`; staging's
+copy is synced to `/var/www/mantaui/staging/install.sh` by the
+`website-deploy.yml` workflow (`channel=staging`, see the "Staging channel"
+section in `AGENTS.md`). The staging URL signals "staging" to a human, but
+once piped into bash the script has no way to recover the URL it was
+fetched from — it falls back to `MANTA_CHANNEL=${MANTA_CHANNEL:-prod}`. So
+the canonical staging curl-install command exports the channel explicitly:
 
 ```
 curl -fsSL https://mantaui.com/staging/install.sh | MANTA_CHANNEL=staging bash

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,6 +34,48 @@ In order. No decisions, no extra steps:
 
 Done.
 
+## Staging install
+
+Staging is a parallel `staging/` subtree on the same prod webroot,
+served as `https://mantaui.com/staging/...` (see the "Staging channel"
+section in `AGENTS.md` and the per-channel value table in
+`src/shared/channel.mjs`, BET-370). It is **manual-only** — tag triggers
+(`web-v*`, `server-v*`, `mac-v*`) keep meaning prod; staging is triggered
+by hand after the spec change lands.
+
+`install.sh` is served **byte-identical** across channels (no build-time
+substitution — `scripts/release/publish.sh` copies the same file to both
+`/var/www/mantaui/` and `/var/www/mantaui/staging/`). The staging URL
+signals "staging" to a human, but once piped into bash the script has no
+way to recover the URL it was fetched from — it falls back to
+`MANTA_CHANNEL=${MANTA_CHANNEL:-prod}`. So the canonical staging
+curl-install command exports the channel explicitly:
+
+```
+curl -fsSL https://mantaui.com/staging/install.sh | MANTA_CHANNEL=staging bash
+```
+
+Without `MANTA_CHANNEL=staging` the script defaults to prod: it pulls the
+tarball from the prod release host (`https://mantaui.com/releases/...`) and
+prints a `manta://` (not `manta-staging://`) pair link at the end — a
+staging URL that behaves identically to prod, including a prod pair-link
+scheme baked into the `manta` CLI shim and the manta-server systemd unit.
+
+The two callers that already set this correctly (BET-386):
+
+- **The desktop app's SSH orchestrator** (`src/main/installer/installer.ts`)
+  resolves the build channel and passes `MANTA_CHANNEL=<channel>` in the
+  same curl-pipe command as `MANTA_RELEASE_HOST`.
+- **An operator who manually exports `MANTA_CHANNEL`** before running or
+  piping `install.sh` — i.e. the command above.
+
+The raw `curl -fsSL https://mantaui.com/staging/install.sh | bash` path
+(without the env var) is the only gap: it's internal/QA-only (BET-370
+scoped "nothing about the box" out, and the primary user-facing paths —
+the SSH-orchestrated desktop install and prod's default curl command — are
+unaffected), so this section exists to close it before anyone writes a
+staging curl-install doc elsewhere.
+
 ## Rollback
 
 The atomic pointer is `manta-latest.txt` (the combined manifest), not

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,21 @@
 #
 #   curl -fsSL https://mantaui.com/install.sh | bash
 #
+# Staging channel (QA/internal only — see docs/releasing.md "Staging install"
+# and the channel table in src/shared/channel.mjs, BET-370):
+#
+#   curl -fsSL https://mantaui.com/staging/install.sh | MANTA_CHANNEL=staging bash
+#
+# install.sh is served byte-identical across channels (no build-time
+# substitution — see scripts/release/publish.sh), so the URL alone signals
+# "staging" to a human but the script itself has no way to know that once
+# piped into bash. You MUST export MANTA_CHANNEL=staging too: without it the
+# script defaults to prod (MANTA_CHANNEL=${MANTA_CHANNEL:-prod} below),
+# points at the prod release host, and prints a manta:// (not
+# manta-staging://) pair link at the end. The desktop app's SSH orchestrator
+# and any operator who manually exports MANTA_CHANNEL are the two callers
+# that already set this correctly (BET-386).
+#
 # On a fresh Linux box: gets manta-server running under systemd --user and
 # prints a 6-digit pairing code to enter in the desktop app.
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,10 +8,12 @@
 #
 #   curl -fsSL https://mantaui.com/staging/install.sh | MANTA_CHANNEL=staging bash
 #
-# install.sh is served byte-identical across channels (no build-time
-# substitution — see scripts/release/publish.sh), so the URL alone signals
-# "staging" to a human but the script itself has no way to know that once
-# piped into bash. You MUST export MANTA_CHANNEL=staging too: without it the
+# install.sh is one file in the repo, served byte-identical across channels
+# (no build-time substitution): prod's copy is synced to
+# /var/www/mantaui/install.sh by scripts/release/publish.sh; staging's copy
+# is synced to /var/www/mantaui/staging/install.sh by the website-deploy.yml
+# workflow (channel=staging). So the URL alone signals "staging" to a human
+# but the script itself has no way to know that once piped into bash. You MUST export MANTA_CHANNEL=staging too: without it the
 # script defaults to prod (MANTA_CHANNEL=${MANTA_CHANNEL:-prod} below),
 # points at the prod release host, and prints a manta:// (not
 # manta-staging://) pair link at the end. The desktop app's SSH orchestrator


### PR DESCRIPTION
## BET-391 — Document MANTA_CHANNEL for the raw curl-staging install.sh path

Doc-only. PM (manta-pm) picked **option 1**: document the canonical staging
curl-install command. The script is served byte-identical across channels
(no build-time substitution — `scripts/release/publish.sh`), so the channel
must be exported explicitly; nothing is inferable from the URL once piped
into bash.

### Changes
- **`scripts/install.sh`** header comment — added a staging-channel note
  right after the prod command, documenting
  `curl -fsSL https://mantaui.com/staging/install.sh | MANTA_CHANNEL=staging bash`
  and explaining *why* the env var is required (defaults to prod → prod
  release host + `manta://` not `manta-staging://` pair link).
- **`docs/releasing.md`** — new "Staging install" subsection (after the
  release runbook, before Rollback) documenting the same command, the
  byte-identical-across-channels constraint, and the two callers that
  already set `MANTA_CHANNEL` correctly (desktop SSH orchestrator +
  manual export), cross-referencing the channel table in
  `src/shared/channel.mjs` (BET-370) and the AGENTS.md "Staging channel"
  section.

No `install-lib.mjs` / `resolveConfig()` logic touched — the wiring is
already correct per BET-386. This is purely the doc gap for the
internal/QA-only raw-curl staging path.

**Base: origin/main @ 729af38**

**Files changed:** 2 files, +57/-0 (`scripts/install.sh`, `docs/releasing.md`)

**Verification results:**
- PR branch (`multica/BET-391-doc-manta-channel-staging` @ `d497806`):
  - typecheck: exit `0`. Errors: none. log sha256: see `/tmp/typecheck-pr.log`
  - test: exit `0`, `1192` pass / `0` fail / `0` skip. Failures: none. log sha256: see `/tmp/test-pr.log`
- Base (`main` @ `729af38`): not re-run — doc-only change (comments + markdown), no code paths touched, so the PR-branch run is representative. Both suites green on the PR branch.
- **Conclusion:** 0 new failures; doc-only, no behavioral change.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
