### PR TITLE
BET-405: Remove stale childFetchState doc reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1712,8 +1712,6 @@ ChatPanel:
   while expanded; ALSO refetched on re-expand when the child is still
   running (the cached snapshot would otherwise be stale until the next
   live event hits the now-expanded card).
-- `childFetchState: Map<childId, "loading"|"error">` — drives the
-  spinner / retry hint in collapsed-but-pending state.
 - `liveChildStatus: Map<childId, "running"|"idle">` — overrides the
   parent's stale `state.status` snapshot for the header badge.
 - `expandedTasks: Set<childId>` + `expandedTasksRef` mirror — the SSE


### PR DESCRIPTION
## BET-405 — Stale doc reference in AGENTS.md to deleted childFetchState

Follow-up to BET-402. BET-377 deleted the `childFetchState` field and its loading/error branches from `src/renderer/chatShared.tsx`, and BET-402 fixed the stale doc comment in that file. But the \"State pattern\" block in `AGENTS.md` (~line 1715) still documented `childFetchState` as a live state field.

### Change
- Removed the `childFetchState: Map<childId, \"loading\"|\"error\">` bullet from the ChatPanel state-pattern section in `AGENTS.md`.
- Verified the remaining bullets (`childSessionIds`, `childMessages`, `liveChildStatus`, `expandedTasks`) still accurately describe the live fields.

### Verification
- \`npm run typecheck && npm test\` — green (1192 tests pass).
- \`grep childFetchState AGENTS.md\` — no matches.

Doc-only change; no behaviour risk.