### PR TITLE
BET-369: extend upgrade card to MobileApp

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,7 +15,7 @@ import {
   resolveLauncherFlags,
 } from "./chatShared";
 import { chooseUpdateSkewVariant, registerMountedTerminal, type MountedTerminal } from "./chatUtils";
-import { isCompatible } from "../shared/compatibility.mjs";
+import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { MOD_KEY } from "./platform";
 import { UpdateBar } from "./UpdateBar";
 import { ReconnectingBanner } from "./ReconnectingBanner";
@@ -401,55 +401,14 @@ export function App() {
   //   - "match"        → hide the card.
   // The `serverVersion` is the SAME field MobileSettings already reads
   // for "Server vX.Y.Z" under the URL field — single source of truth.
-  const [clientVersion, setClientVersion] = useState<string | null>(null);
-  const [serverMinClient, setServerMinClient] = useState<string | null>(null);
-  const [serverVersion, setServerVersion] = useState<string | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    void Promise.all([
-      window.api.getClientVersion?.().catch(() => null),
-      window.api.getServerVersion?.().catch(() => null),
-    ]).then(([client, server]) => {
-      if (cancelled) return;
-      if (client && typeof client.version === "string") {
-        setClientVersion(client.version);
-      }
-      if (server && typeof server.minClient === "string") {
-        setServerMinClient(server.minClient);
-      }
-      if (server && typeof server.version === "string") {
-        setServerVersion(server.version);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Desktop↔box compatibility variant (BET-357 §3 / BET-366). Pure
-  // derivation off the two versions already on hand; `isCompatible`
-  // collapses missing input to "unknown" so we never show a misleading
-  // upgrade card mid-bootstrap.
-  const compatibilityVariant = isCompatible({
-    desktopVersion: clientVersion,
-    boxVersion: serverVersion,
-  });
-  // The compatibility card is dismissible (unlike the MIN_CLIENT skew
-  // banner above): the "behind" path has a clear one-click action the
-  // user can re-trigger from the Settings card, and the "incompatible"
-  // path is informational. The dismiss is local state — clearing it
-  // re-shows the card if the variant re-evaluates (e.g. the user fixes
-  // the box remotely and the next version poll flips the variant).
-  const [compatibilityDismissed, setCompatibilityDismissed] = useState(false);
-  // Reset the dismiss latch when the variant changes (e.g. box was
-  // upgraded remotely, version refetch flipped match → behind). The
-  // user shouldn't have to reload to see the new "behind" card.
-  useEffect(() => {
-    setCompatibilityDismissed(false);
-  }, [compatibilityVariant]);
-  const showCompatibilityCard =
-    !compatibilityDismissed &&
-    (compatibilityVariant === "behind" || compatibilityVariant === "incompatible");
+  const {
+    clientVersion,
+    serverVersion,
+    serverMinClient,
+    variant: compatibilityVariant,
+    showCard: showCompatibilityCard,
+    dismiss,
+  } = useCompatibilityCard();
 
   // Sidebar status for chat-mode windows. The PTY-pane poller
   // (src/main/status.ts) can't see chat-mode state — the holder pane
@@ -903,7 +862,7 @@ export function App() {
                   void window.api.openExternal("https://mantaui.com/install");
                 }
               }}
-              onDismiss={() => setCompatibilityDismissed(true)}
+              onDismiss={dismiss}
             />
           )}
         {/* Reconnecting banner (BET-365 / BET-357 §1): full-width bar above

--- a/src/renderer/hooks/useCompatibilityCard.ts
+++ b/src/renderer/hooks/useCompatibilityCard.ts
@@ -1,0 +1,68 @@
+// useCompatibilityCard.ts — shared desktop↔box version matrix + dismiss state.
+// Extracted verbatim from App.tsx (BET-366) so MobileApp.tsx reuses the SAME
+// code path (BET-369) instead of duplicating the version-fetch + isCompatible
+// + dismiss logic. Behavior is byte-for-byte identical to the inline App.tsx
+// block it replaces.
+//
+// One fetch, one derivation, one dismiss latch — consumed by both the desktop
+// shell (App.tsx) and the mobile shell (MobileApp.tsx). Neither call site
+// owns version state or the matrix check anymore.
+
+import { useEffect, useState } from "react";
+import { isCompatible } from "../../shared/compatibility.mjs";
+
+export type CompatibilityVariant = "match" | "behind" | "incompatible" | "unknown";
+
+export type CompatibilityCard = {
+  clientVersion: string | null;
+  serverVersion: string | null;
+  serverMinClient: string | null;
+  variant: CompatibilityVariant;
+  dismissed: boolean;
+  dismiss: () => void;
+  showCard: boolean;
+};
+
+export function useCompatibilityCard(): CompatibilityCard {
+  const [clientVersion, setClientVersion] = useState<string | null>(null);
+  const [serverMinClient, setServerMinClient] = useState<string | null>(null);
+  const [serverVersion, setServerVersion] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      window.api.getClientVersion?.().catch(() => null),
+      window.api.getServerVersion?.().catch(() => null),
+    ]).then(([client, server]) => {
+      if (cancelled) return;
+      if (client && typeof client.version === "string") setClientVersion(client.version);
+      if (server && typeof server.minClient === "string") setServerMinClient(server.minClient);
+      if (server && typeof server.version === "string") setServerVersion(server.version);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const variant = isCompatible({
+    desktopVersion: clientVersion,
+    boxVersion: serverVersion,
+  });
+
+  useEffect(() => {
+    setDismissed(false);
+  }, [variant]);
+
+  const showCard = !dismissed && (variant === "behind" || variant === "incompatible");
+
+  return {
+    clientVersion,
+    serverVersion,
+    serverMinClient,
+    variant,
+    dismissed,
+    dismiss: () => setDismissed(true),
+    showCard,
+  };
+}

--- a/src/renderer/mobile/MobileApp.tsx
+++ b/src/renderer/mobile/MobileApp.tsx
@@ -12,6 +12,8 @@ import { AuthRequiredError, ServerNotConfiguredError, triggerResumeReconnect } f
 import { shouldReconnectOnAppStateChange } from "../chatUtils";
 import { getCapacitorApp, handlePairUrl } from "./deepLink";
 import { dlog, dwarn } from "./debugLog";
+import { UpdateBar } from "../UpdateBar";
+import { useCompatibilityCard } from "../hooks/useCompatibilityCard";
 
 type Nav =
   | { screen: "list" }
@@ -57,6 +59,7 @@ export function MobileApp() {
   const setScreenshotToast = useStore((s) => s.setScreenshotToast);
   const setAgentFileToast = useStore((s) => s.setAgentFileToast);
   const projects = useStore((s) => s.projects);
+  const compatibility = useCompatibilityCard();
 
   const [nav, setNav] = useState<Nav>({ screen: "list" });
   const [bootError, setBootError] = useState<string | null>(null);
@@ -696,6 +699,43 @@ export function MobileApp() {
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
     >
+      {compatibility.showCard && (
+        <UpdateBar
+          text={
+            compatibility.variant === "behind" ? (
+              <>
+                Box needs an upgrade:{" "}
+                <span className="font-medium text-text">
+                  {compatibility.serverVersion ?? "?"}
+                </span>
+              </>
+            ) : (
+              <>
+                This box (v
+                <span className="font-medium text-text">
+                  {compatibility.serverVersion ?? "?"}
+                </span>
+                ) is not supported by this app (v
+                <span className="font-medium text-text">
+                  {compatibility.clientVersion ?? "?"}
+                </span>
+                ).
+              </>
+            )
+          }
+          actionLabel={
+            compatibility.variant === "behind" ? "Upgrade box" : "Learn more"
+          }
+          onAction={() => {
+            if (compatibility.variant === "behind") {
+              void window.api.serverUpdateApply();
+            } else {
+              void window.api.openExternal("https://mantaui.com/install");
+            }
+          }}
+          onDismiss={compatibility.dismiss}
+        />
+      )}
       <div className="mobile-stack">
         <div
           className={


### PR DESCRIPTION
## BET-369: extend upgrade card to MobileApp

Extracts the inline version-fetch + `isCompatible` + dismiss block from `App.tsx` into a shared `useCompatibilityCard` hook so `MobileApp.tsx` reuses the same code path instead of duplicating it.

### Changes
- **CREATE** `src/renderer/hooks/useCompatibilityCard.ts` — the shared hook (lifted verbatim from `App.tsx`).
- **EDIT** `src/renderer/App.tsx` — removed the inline version/matrix/dismiss block, replaced with a `useCompatibilityCard()` destructure; dropped the `isCompatible` import; the JSX dismiss handler now calls `dismiss` from the hook. The skew banner's `chooseUpdateSkewVariant(clientVersion, serverMinClient)` and the compatibility card JSX are unchanged (names still in scope via the destructure).
- **EDIT** `src/renderer/mobile/MobileApp.tsx` — call `useCompatibilityCard()`, render `UpdateBar` at the top of the mobile shell (first child inside `.mobile`, before `.mobile-stack`).
- `UpdateBar.tsx` and `compatibility.mjs` untouched. No new tests (pure `isCompatible` already covered in `src/shared/compatibility.test.ts`; hook is thin wiring per repo convention).

Base: origin/main @ 0d9e608

**Files changed:** 3 files. `src/renderer/App.tsx` (-49/+9), `src/renderer/hooks/useCompatibilityCard.ts` (+68, new), `src/renderer/mobile/MobileApp.tsx` (+40).

**Verification results:**
- PR branch (`multica/BET-369-mobile-upgrade-card` @ 78671f7):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1582 pass (vitest) / 1192 pass (node:test) / 0 fail / 0 skip. Failures: none. log sha256: `132aeb236830b63edb23049bd24ec513886bbf3e1c627f38f1cf333db179e899`
- Base (`main` @ 0d9e608):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1582 pass / 1192 pass / 0 fail / 0 skip. Failures: none. log sha256: `958d79acbe005c7abf1a25072b4e7a95c1be56b280af8b56ab13fe5fad7baf20`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. Both branches green and identical on typecheck.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
