### PR TITLE
BET-407: token substrate — Tailwind colours → CSS variables

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -39,6 +39,43 @@ html, body, #root {
   );
 }
 
+/* Token substrate (BET-407). Colour literals moved out of tailwind.config.js
+   into CSS custom properties so a theme is one attribute on <html>. Values are
+   a 1:1 rename of the previous hardcoded literals — no retune. Sub-issue 03
+   adds a light block; sub-issue 04 splits the intentionally-collapsed tokens
+   (border-subtle/border, tx3/tx4, the three accent tokens).
+
+   Each colour that is used with a Tailwind alpha modifier (e.g. bg-accent/20)
+   is paired with a `-rgb` channel variable so `rgb(var(--tok-rgb) / <alpha>)`
+   can apply opacity. The hex `--tok` variables hold the same values for direct
+   use in hand-written CSS (e.g. the scrollbar below) and are the substrate
+   sub-issue 04 will split. */
+[data-theme="dark"] {
+  --canvas: #0B1020;
+  --panel: #12182F;
+  --card: #171F3A;
+  --border-subtle: #253055;
+  --border: #253055;
+  --border-strong: #33406B;
+  --tx1: #F8FAFC;
+  --tx2: #A7B1C4;
+  --tx3: #5C6578;
+  --tx4: #5C6578;
+  --accent: #5A88FF;
+  --accent-tx: #5A88FF;
+  --accent-solid: #5A88FF;
+  --on-accent: #0B1020;
+  --accent-soft: #1740AE;
+
+  --canvas-rgb: 11 16 32;
+  --panel-rgb: 18 24 47;
+  --card-rgb: 23 31 58;
+  --border-rgb: 37 48 85;
+  --tx1-rgb: 248 250 252;
+  --accent-rgb: 90 136 255;
+  --accent-soft-rgb: 23 64 174;
+}
+
 /* Trailing spacer inside any header row that reaches the top-right of the
    window. Zero-width off Windows. */
 .titlebar-inset-right {
@@ -106,5 +143,5 @@ html, body, #root {
 /* Scrollbar */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: #253055; border-radius: 5px; }
-::-webkit-scrollbar-thumb:hover { background: #33406B; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 5px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,10 +4,24 @@ export default {
   theme: {
     extend: {
       colors: {
-        bg: { DEFAULT: "#0B1020", elev: "#12182F", soft: "#171F3A" },
-        border: { DEFAULT: "#253055", strong: "#33406B" },
-        text: { DEFAULT: "#F8FAFC", muted: "#A7B1C4", faint: "#5C6578" },
-        accent: { DEFAULT: "#5A88FF", soft: "#1740AE" },
+        bg: {
+          DEFAULT: "rgb(var(--canvas-rgb) / <alpha-value>)",
+          elev: "rgb(var(--panel-rgb) / <alpha-value>)",
+          soft: "rgb(var(--card-rgb) / <alpha-value>)",
+        },
+        border: {
+          DEFAULT: "rgb(var(--border-rgb) / <alpha-value>)",
+          strong: "var(--border-strong)",
+        },
+        text: {
+          DEFAULT: "rgb(var(--tx1-rgb) / <alpha-value>)",
+          muted: "var(--tx2)",
+          faint: "var(--tx3)",
+        },
+        accent: {
+          DEFAULT: "rgb(var(--accent-rgb) / <alpha-value>)",
+          soft: "rgb(var(--accent-soft-rgb) / <alpha-value>)",
+        },
       },
       fontFamily: {
         mono: ["JetBrains Mono", "SF Mono", "Menlo", "Consolas", "monospace"],


### PR DESCRIPTION
## What

Stage-1 substrate for the MantaUI 2.0 redesign (BET-407, sub-issue 01). Moves the 11 hardcoded colour literals out of `tailwind.config.js` into CSS custom properties scoped to `[data-theme=\"dark\"]` on `<html>`, so a future theme is one attribute swap. **No visual change** — every value is a 1:1 rename.

## Changes

- `src/renderer/index.html` — `data-theme=\"dark\"` added to `<html>` (so `document.documentElement.dataset.theme === \"dark\"` at runtime).
- `src/renderer/index.css` — a `[data-theme=\"dark\"]` block defining the hex tokens exactly as specified (`--canvas`, `--panel`, `--card`, `--border-subtle`/`--border`, `--border-strong`, `--tx1`–`--tx4`, `--accent`/`--accent-tx`/`--accent-solid`, `--on-accent`, `--accent-soft`) plus companion `-rgb` channel variables for the colours that are used with Tailwind alpha modifiers. The collapsed tokens (border-subtle/border, tx3/tx4, the three accent tokens) intentionally share a value — sub-issue 04 splits them. The hardcoded scrollbar hexes (`#253055`, `#33406B`) now reference `var(--border)` / `var(--border-strong)`.
- `tailwind.config.js` — colours reference the CSS variables; alpha-capable colours use `rgb(var(--tok-rgb) / <alpha-value>)` so opacity modifiers keep rendering. **No Tailwind class name was renamed** — all ~900 call sites are untouched.

## Why the `-rgb` channel variables (deviation from the literal `var(--tok)` form)

The sub-issue prescribes `colors.accent.DEFAULT = \"var(--accent)\"` with `--accent: #5A88FF`. With that literal form, Tailwind v3 cannot apply alpha to `bg-accent/20`, `bg-bg/70`, `border-text/25`, `bg-accent-soft/40`, etc. (24 usages) — `parseColor(\"var(--accent)\")` returns null, the `/20` is silently dropped, and the element renders at full opacity. That is a visual change, which the epic's stage-1 rule (\"zero visual diff\") forbids.

The standard Tailwind fix is the `<alpha-value>` channel form: `rgb(var(--accent-rgb) / <alpha-value>)` with `--accent-rgb: 90 136 255`. The hex `--accent` var is still defined exactly as specified (used by hand-written CSS like the scrollbar, and it is the substrate sub-issue 04 splits). This keeps every opacity-modified utility pixel-identical while still making the palette fully token-driven and theme-switchable via the `data-theme` attribute.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 1200/1200 green.
- Renderer build (`npm run build:mobile`) — succeeds; built CSS contains `rgb(var(--accent-rgb) …)` and `[data-theme=\"dark\"]`.
- **Pixel-identical CSS check**: generated the full utilities stylesheet from the old (hex) config and the new (var) config scanning the real `src/renderer` tree. Both produce the same 429 selectors — **0 dropped, 0 added**. Spot-checked every theme-colour utility (with and without alpha modifiers): declarations resolve to the original hex channels (e.g. `bg-accent/20` → `rgb(var(--accent-rgb) / 0.2)` ≡ old `rgb(90 136 255 / 0.2)`).
- `document.documentElement.dataset.theme === \"dark\"` at runtime (attribute on `<html>`).

## Step 5 (spacing-scale trim) — deferred

The sub-issue's step 5 asks to trim the Tailwind spacing scale to 11 steps and round off-grid usages. I did **not** do this here, because it is incompatible with the epic's mandatory stage-1 rule that this sub-issue ships with **zero visual diff** (epic BET-406: \"Stage 1 is pure mechanical substrate with zero visual diff\", verification #3: before/after screenshots must be identical).

The codebase uses off-grid spacing pervasively — `py-0.5` (46×), `gap-1.5` (29×), `py-1.5` (22×), `px-1.5` (24×), plus `0.5/1.5/2.5/3.5/7` across ~30 files **including `src/renderer/mobile/*`** (~190 pure-spacing sites, plus width/height values like `w-64`, `h-64`, `h-52`, `h-40` that derive from the spacing scale). Trimming the scale would either (a) silently drop those utilities (layout breakage) or (b) require rounding every site — which changes pixels (e.g. `py-0.5` 2px → 4px; `h-64` 256px would round to `h-12` 48px, an absurd collapse) and necessarily touches mobile `.tsx` + a `mobile/www` rebuild. Both outcomes violate the zero-visual-diff mandate and the \"don't touch mobile\" rule.

Recommend step 5 be split into its own sub-issue where the verify criterion is relaxed, width/height scales are decoupled from spacing, and mobile can be rebuilt deliberately.