### PR TITLE
feat(BET-417): new-session composer and folder picker

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { Terminal } from "./Terminal";
 import { ChatPanel } from "./ChatPanel";
 import { Settings } from "./Settings";
 import { Onboarding } from "./Onboarding";
+import { NewSessionScreen } from "./NewSessionScreen";
 import { useStore, flatSessions, resolveSessionOwner } from "./store";
 import { resolveTransportMode } from "../shared/transport.mjs";
 import { getMantaPreload } from "./preloadAccess";
@@ -16,7 +17,6 @@ import {
 } from "./chatShared";
 import { chooseUpdateSkewVariant, registerMountedTerminal, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
-import { MOD_KEY } from "./platform";
 import { UpdateBar } from "./UpdateBar";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
@@ -74,6 +74,21 @@ export function App() {
   const showOnboarding = enterOnboarding || onboardingLatched;
   const [settingsOpen, setSettingsOpen] = useState(false);
   const sidebarRef = useRef<SidebarHandle>(null);
+
+  // BET-417: the new-session screen replaces the old inline forms. null =
+  // not shown. { mode: "new-project" } = new-project (creates a tmux
+  // session). { mode: "new-session", projectName } = new window in an
+  // existing project. The zero-project state (projects.length === 0) shows
+  // it full-panel instead of a dead placeholder.
+  const [newSessionScreen, setNewSessionScreen] = useState<
+    | null
+    | { mode: "new-project" }
+    | { mode: "new-session"; projectName: string }
+  >(null);
+
+  const openNewProject = () => setNewSessionScreen({ mode: "new-project" });
+  const openNewSessionInProject = (name: string) =>
+    setNewSessionScreen({ mode: "new-session", projectName: name });
 
   // Same pattern for chat-mode windows: mount a ChatPanel for each opencode
   // session we've ever opened, keep it mounted so scroll position + in-flight
@@ -742,7 +757,12 @@ export function App() {
 
   return (
     <div className="h-full w-full flex bg-bg text-text">
-      <Sidebar ref={sidebarRef} onOpenSettings={() => setSettingsOpen(true)} />
+      <Sidebar
+        ref={sidebarRef}
+        onOpenSettings={() => setSettingsOpen(true)}
+        onNewProject={openNewProject}
+        onNewSessionInProject={openNewSessionInProject}
+      />
       <main className="flex-1 flex flex-col min-w-0">
         {/* At most ONE full-width bar (BET-416 §E). `activeBanner` is the
             single highest-severity condition across reconnecting / incompatible
@@ -919,15 +939,15 @@ export function App() {
         </div>
         <div className="flex-1 relative">
           {projects.length === 0 ? (
-            // Zero-project state (BET-416 §F). An unpaired config always
-            // routes to onboarding, so this branch is only reached when the
-            // box IS paired but has no projects yet — the dead "Open Settings
-            // to connect to your box." fallback was deleted (unreachable).
-            // The new-session composer (BET-417) will become this zero state;
-            // until it lands, the ⌘N hint holds the slot.
-            <div className="h-full flex items-center justify-center text-text-faint text-body">
-              {`Create a project (${MOD_KEY}N) to start.`}
-            </div>
+            // Zero-project state (BET-416 §F / BET-417 §A): the new-session
+            // composer IS the app's zero state. An unpaired config routes to
+            // onboarding, so this branch is only reached when the box IS
+            // paired but has no projects yet.
+            <NewSessionScreen
+              projectName={null}
+              onDone={() => setNewSessionScreen(null)}
+              onCancel={() => setNewSessionScreen(null)}
+            />
           ) : (
             <>
               {/* Terminal / AI-TUI layer (BET-138, BET-347): one per
@@ -986,6 +1006,22 @@ export function App() {
                   </div>
                 );
               })}
+              {/* New-session screen overlay (BET-417): shown over the panel
+                  when the user hits + or Cmd+N/T. Covers the panel area
+                  (sidebar stays visible so the user can click away). */}
+              {newSessionScreen && (
+                <div className="absolute inset-0 z-30 bg-bg">
+                  <NewSessionScreen
+                    projectName={
+                      newSessionScreen.mode === "new-project"
+                        ? null
+                        : newSessionScreen.projectName
+                    }
+                    onDone={() => setNewSessionScreen(null)}
+                    onCancel={() => setNewSessionScreen(null)}
+                  />
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -25,6 +25,7 @@ import {
   hasWorktreeFanOut,
   isDimmedDir,
   parentPath,
+  worktreeBadge,
 } from "./folderPicker";
 
 type Props = {
@@ -55,11 +56,14 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [rows, setRows] = useState<Row[]>([]);
-  // Per-directory worktree probe is deferred — gitListWorktrees is one git
-  // call per row and the list is capped at 20 by fsListDirs. We probe on
-  // demand when the user clicks Select (the fan-out question is asked at
-  // commit time, not during browse, to keep the browse cheap). The badge
-  // on individual rows is a future enhancement.
+  // Per-directory worktree probe. Keyed by the row's full path; null = not
+  // probed yet / not a repo. We probe each row lazily after the listing
+  // loads, with a small concurrency cap to avoid hammering git. The badge
+  // ("⎇ N worktrees") shows on rows that have >1 worktree, so the user
+  // sees the fan-out option BEFORE committing (BET-417 §B).
+  const [worktreeCounts, setWorktreeCounts] = useState<
+    Record<string, WorktreeInfo[] | null>
+  >({});
   const [fanOut, setFanOut] = useState<FanOut>(null);
   const [gitState, setGitState] = useState<string>("");
   const [loading, setLoading] = useState(false);
@@ -121,6 +125,7 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
   const listDir = async (dir: string) => {
     setLoading(true);
     setError(null);
+    setWorktreeCounts({});
     try {
       const matches = await window.api.fsListDirs(dir);
       const filtered = matches.filter((m) => m.startsWith(dir));
@@ -136,6 +141,26 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
       } catch {
         setGitState("");
       }
+      // Lazily probe each row for worktree fan-out (BET-417 §B). Probes run
+      // with concurrency 4 so a 20-row listing finishes in ~5 git calls
+      // instead of 20 sequential ones. Failures are silent (not a repo →
+      // no badge).
+      const probeRow = async (full: string) => {
+        try {
+          const wts = await window.api.gitListWorktrees(full);
+          setWorktreeCounts((prev) => ({ ...prev, [full]: wts }));
+        } catch {
+          setWorktreeCounts((prev) => ({ ...prev, [full]: null }));
+        }
+      };
+      const queue = [...built.map((r) => r.full)];
+      const workers = Array.from({ length: 4 }, async () => {
+        while (queue.length > 0) {
+          const full = queue.shift();
+          if (full) await probeRow(full);
+        }
+      });
+      void Promise.all(workers);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setRows([]);
@@ -331,6 +356,8 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
                 <div className="px-3 py-4 text-meta text-text-faint">No subfolders</div>
               )}
               {!loading && !error && rows.map((r) => {
+                const wtCount = worktreeCounts[r.full];
+                const badge = worktreeBadge(wtCount ?? null);
                 return (
                   <button
                     key={r.full}
@@ -344,6 +371,9 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
                   >
                     <FolderIcon size={14} className="shrink-0" aria-hidden="true" />
                     <span className="flex-1 min-w-0 truncate font-mono">{r.name}</span>
+                    {badge && (
+                      <span className="text-label text-accent-tx shrink-0">{badge}</span>
+                    )}
                   </button>
                 );
               })}

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -31,7 +31,12 @@ import {
 type Props = {
   // The initial path the picker opens at. Usually "~" or the project's cwd.
   initialPath: string;
+  // Called when the user picks a single folder (no fan-out).
   onSelect: (path: string) => void;
+  // Called when the user picks "One per worktree" — the parent creates one
+  // session with one window per worktree, each named worktreeName(w).
+  // When omitted, the fan-out question is not offered (mobile can opt out).
+  onFanOut?: (cwd: string, worktrees: WorktreeInfo[]) => void;
   onCancel: () => void;
 };
 
@@ -51,7 +56,7 @@ type FanOut =
   | null
   | { worktrees: WorktreeInfo[]; cwd: string };
 
-export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
+export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }: Props) {
   const [path, setPath] = useState(initialPath);
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -248,12 +253,14 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
               >
                 Just this folder
               </button>
-              <button
-                onClick={() => onSelect(fanOut.cwd)}
-                className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90"
-              >
-                One per worktree
-              </button>
+              {onFanOut && (
+                <button
+                  onClick={() => onFanOut(fanOut.cwd, fanOut.worktrees)}
+                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90"
+                >
+                  One per worktree
+                </button>
+              )}
               <button
                 onClick={() => setFanOut(null)}
                 className="text-meta px-3 py-2 text-text-faint hover:text-text"
@@ -355,28 +362,42 @@ export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
               {!loading && !error && rows.length === 0 && (
                 <div className="px-3 py-4 text-meta text-text-faint">No subfolders</div>
               )}
-              {!loading && !error && rows.map((r) => {
-                const wtCount = worktreeCounts[r.full];
-                const badge = worktreeBadge(wtCount ?? null);
-                return (
+              {!loading && !error && (
+                <>
+                  {/* `..` row — spec §B3 says ".. first". Goes up one level,
+                      same as the breadcrumbs / up-arrow. */}
                   <button
-                    key={r.full}
-                    onClick={() => descend(r.full)}
-                    className={
-                      "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded " +
-                      (r.dimmed ? "text-text-faint opacity-70" : "text-text-muted") +
-                      " hover:bg-bg-soft"
-                    }
-                    title={r.full}
+                    onClick={goUp}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded text-text-muted hover:bg-bg-soft"
+                    title={parentPath(path)}
                   >
-                    <FolderIcon size={14} className="shrink-0" aria-hidden="true" />
-                    <span className="flex-1 min-w-0 truncate font-mono">{r.name}</span>
-                    {badge && (
-                      <span className="text-label text-accent-tx shrink-0">{badge}</span>
-                    )}
+                    <ArrowUp size={14} className="shrink-0" aria-hidden="true" />
+                    <span className="flex-1 min-w-0 truncate font-mono">..</span>
                   </button>
-                );
-              })}
+                  {rows.map((r) => {
+                    const wtCount = worktreeCounts[r.full];
+                    const badge = worktreeBadge(wtCount ?? null);
+                    return (
+                      <button
+                        key={r.full}
+                        onClick={() => descend(r.full)}
+                        className={
+                          "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded " +
+                          (r.dimmed ? "text-text-quiet" : "text-text-muted") +
+                          " hover:bg-bg-soft"
+                        }
+                        title={r.full}
+                      >
+                        <FolderIcon size={14} className="shrink-0" aria-hidden="true" />
+                        <span className="flex-1 min-w-0 truncate font-mono">{r.name}</span>
+                        {badge && (
+                          <span className="text-label text-accent-tx shrink-0">{badge}</span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </>
+              )}
             </div>
 
             {/* Footer */}

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -1,0 +1,377 @@
+// FolderPickerModal.tsx — the folder browser that replaces the ghost-text cwd
+// input (BET-417 §B).
+//
+// - Path field at the top, keeping the EXISTING completion logic
+//   (refreshCwdSuggestion / acceptCwdSuggestion from Sidebar.tsx, moved here).
+// - Clickable breadcrumbs under it — going up three levels is one click.
+// - A scrollable folder list using the existing `fsListDirs`. `..` first.
+//   `node_modules` and dot-folders render at --tx4 (dimmed, not hidden).
+// - Worktree badge on directories that have them; the fan-out question is
+//   asked HERE, before the user commits, instead of as a post-Create
+//   interstitial.
+// - Footer: the selected folder's git state, Cancel, and a primary Select.
+// - Mobile gets it as a full-height sheet (handled by .mobile-* CSS classes).
+//
+// Pure helpers (breadcrumbs / parentPath / isDimmedDir / worktreeBadge /
+// gitStateLabel) live in folderPicker.ts and are unit-tested there.
+
+import { useEffect, useRef, useState } from "react";
+import { ChevronRight, X, Folder as FolderIcon, ArrowUp } from "lucide-react";
+import type { WorktreeInfo } from "../shared/types";
+import {
+  breadcrumbs,
+  crumbLabel,
+  gitStateLabel,
+  hasWorktreeFanOut,
+  isDimmedDir,
+  parentPath,
+} from "./folderPicker";
+
+type Props = {
+  // The initial path the picker opens at. Usually "~" or the project's cwd.
+  initialPath: string;
+  onSelect: (path: string) => void;
+  onCancel: () => void;
+};
+
+// A row in the folder list. `name` is the directory basename; `full` is the
+// path to feed back into fsListDirs when the user descends.
+type Row = {
+  name: string;
+  full: string;
+  dimmed: boolean;
+};
+
+// Worktree fan-out state. When the user selects a folder that has >1
+// worktree, we pause and ask "one per worktree?" HERE — not after Create.
+// Mirrors the old interstitial's `mode: "auto" | "all"` logic but relocated
+// to the browse step so the decision is not a surprise.
+type FanOut =
+  | null
+  | { worktrees: WorktreeInfo[]; cwd: string };
+
+export function FolderPickerModal({ initialPath, onSelect, onCancel }: Props) {
+  const [path, setPath] = useState(initialPath);
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [rows, setRows] = useState<Row[]>([]);
+  // Per-directory worktree probe is deferred — gitListWorktrees is one git
+  // call per row and the list is capped at 20 by fsListDirs. We probe on
+  // demand when the user clicks Select (the fan-out question is asked at
+  // commit time, not during browse, to keep the browse cheap). The badge
+  // on individual rows is a future enhancement.
+  const [fanOut, setFanOut] = useState<FanOut>(null);
+  const [gitState, setGitState] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounce.current) clearTimeout(debounce.current);
+    };
+  }, []);
+
+  // ---- path completion (moved verbatim from Sidebar.tsx) ----
+  const refreshSuggestion = (value: string) => {
+    if (debounce.current) clearTimeout(debounce.current);
+    if (!value) {
+      setSuggestion(null);
+      return;
+    }
+    debounce.current = setTimeout(async () => {
+      try {
+        const matches = (await window.api.fsListDirs(value)).filter((m) =>
+          m.startsWith(value),
+        );
+        if (matches.length === 0) {
+          setSuggestion(null);
+          return;
+        }
+        if (matches.length === 1) {
+          setSuggestion(matches[0] + "/");
+          return;
+        }
+        const lcp = matches.reduce((acc, m) => {
+          let i = 0;
+          while (i < acc.length && i < m.length && acc[i] === m[i]) i++;
+          return acc.slice(0, i);
+        });
+        setSuggestion(lcp.length > value.length ? lcp : null);
+      } catch {
+        setSuggestion(null);
+      }
+    }, 80);
+  };
+
+  const onPathChange = (value: string) => {
+    setPath(value);
+    refreshSuggestion(value);
+  };
+
+  const acceptSuggestion = (): boolean => {
+    if (!suggestion || !suggestion.startsWith(path)) return false;
+    if (suggestion === path) return false;
+    setPath(suggestion);
+    setSuggestion(null);
+    refreshSuggestion(suggestion);
+    return true;
+  };
+
+  // ---- listing ----
+  const listDir = async (dir: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const matches = await window.api.fsListDirs(dir);
+      const filtered = matches.filter((m) => m.startsWith(dir));
+      const built: Row[] = filtered.map((full) => {
+        const name = full.split("/").filter(Boolean).pop() ?? full;
+        return { name, full, dimmed: isDimmedDir(name) };
+      });
+      setRows(built);
+      // Probe the selected dir's own git state for the footer.
+      try {
+        const wts = await window.api.gitListWorktrees(dir);
+        setGitState(gitStateLabel(wts));
+      } catch {
+        setGitState("");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setRows([]);
+      setGitState("");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // List whenever the path resolves to a real directory. We list the parent
+  // of the current path so the user sees siblings + can descend. If the path
+  // ends with "/", we list its contents directly.
+  useEffect(() => {
+    const dir = path.endsWith("/") ? path : parentPath(path);
+    void listDir(dir);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path]);
+
+  const descend = (full: string) => {
+    const next = full.endsWith("/") ? full : full + "/";
+    setPath(next);
+  };
+
+  const goUp = () => {
+    const up = parentPath(path);
+    setPath(up);
+  };
+
+  const select = async () => {
+    const chosen = path.endsWith("/") ? path.slice(0, -1) : path;
+    // Probe worktrees before committing — the fan-out question is asked
+    // HERE, not after Create.
+    try {
+      const wts = await window.api.gitListWorktrees(chosen);
+      if (hasWorktreeFanOut(wts)) {
+        setFanOut({ worktrees: wts, cwd: chosen });
+        return;
+      }
+    } catch {
+      // not a repo / probe failed — proceed to single-folder select
+    }
+    onSelect(chosen);
+  };
+
+  const crumbs = breadcrumbs(path);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onCancel}>
+      <div
+        className="manta-folder-picker w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col bg-bg-elev border border-border rounded-xl shadow-xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <div className="text-body font-semibold text-text">Choose a folder</div>
+          <button
+            onClick={onCancel}
+            className="text-text-muted hover:text-text leading-none inline-flex items-center"
+            aria-label="Close"
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </div>
+
+        {fanOut ? (
+          // ---- Worktree fan-out question (asked HERE, before commit) ----
+          <div className="p-4 space-y-3">
+            <div className="text-meta text-text-muted">
+              Detected {fanOut.worktrees.length} git worktrees in
+              {" "}<code className="font-mono text-text">{fanOut.cwd}</code>.
+              Open a session for each?
+            </div>
+            <ul className="text-label text-text-faint space-y-px max-h-40 overflow-y-auto">
+              {fanOut.worktrees.map((w) => (
+                <li key={w.path} className="truncate">
+                  <span className="text-text-muted">{w.path.split("/").filter(Boolean).pop() || w.branch}</span>
+                  {" "}<span className="text-text-faint">— {w.path}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="flex gap-2">
+              <button
+                onClick={() => onSelect(fanOut.cwd)}
+                className="text-meta px-3 py-2 border border-border text-text-muted hover:text-text rounded"
+              >
+                Just this folder
+              </button>
+              <button
+                onClick={() => onSelect(fanOut.cwd)}
+                className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90"
+              >
+                One per worktree
+              </button>
+              <button
+                onClick={() => setFanOut(null)}
+                className="text-meta px-3 py-2 text-text-faint hover:text-text"
+              >
+                Back
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Path field with ghost-text completion */}
+            <div className="px-4 py-3 border-b border-border">
+              <div className="relative w-full bg-bg-soft border border-border rounded focus-within:border-accent">
+                {suggestion && suggestion.startsWith(path) && (
+                  <div
+                    aria-hidden
+                    className="absolute inset-0 px-3 py-2 text-meta flex items-center pointer-events-none whitespace-pre overflow-hidden font-mono"
+                  >
+                    <span className="invisible">{path}</span>
+                    <span className="text-text-faint">
+                      {suggestion.slice(path.length)}
+                    </span>
+                  </div>
+                )}
+                <input
+                  autoFocus
+                  value={path}
+                  onChange={(e) => onPathChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Tab" && suggestion) {
+                      e.preventDefault();
+                      acceptSuggestion();
+                      return;
+                    }
+                    if (e.key === "ArrowRight" && suggestion) {
+                      const el = e.currentTarget;
+                      if (
+                        el.selectionStart === el.value.length &&
+                        el.selectionEnd === el.value.length
+                      ) {
+                        e.preventDefault();
+                        acceptSuggestion();
+                        return;
+                      }
+                    }
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      void select();
+                      return;
+                    }
+                    if (e.key === "Escape") {
+                      if (suggestion) setSuggestion(null);
+                      else onCancel();
+                    }
+                  }}
+                  spellCheck={false}
+                  autoComplete="off"
+                  className="relative w-full bg-transparent border-0 px-3 py-2 text-meta rounded focus:outline-none font-mono"
+                />
+              </div>
+
+              {/* Breadcrumbs */}
+              <div className="flex items-center flex-wrap gap-px mt-2 text-label">
+                <button
+                  onClick={goUp}
+                  className="inline-flex items-center gap-1 text-text-faint hover:text-text px-1 py-px rounded"
+                  title="Go up one level"
+                >
+                  <ArrowUp size={12} aria-hidden="true" />
+                </button>
+                {crumbs.map((c, i) => (
+                  <span key={c} className="inline-flex items-center">
+                    {i > 0 && (
+                      <ChevronRight size={12} className="text-text-quiet" aria-hidden="true" />
+                    )}
+                    <button
+                      onClick={() => setPath(c)}
+                      className={
+                        "px-1 py-px rounded font-mono " +
+                        (c === path ? "text-text" : "text-text-faint hover:text-text-muted")
+                      }
+                      title={c}
+                    >
+                      {crumbLabel(c)}
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* Folder list */}
+            <div className="flex-1 overflow-y-auto px-2 py-1">
+              {loading && (
+                <div className="px-3 py-4 text-meta text-text-faint">Loading…</div>
+              )}
+              {error && (
+                <div className="px-3 py-4 text-meta text-danger">{error}</div>
+              )}
+              {!loading && !error && rows.length === 0 && (
+                <div className="px-3 py-4 text-meta text-text-faint">No subfolders</div>
+              )}
+              {!loading && !error && rows.map((r) => {
+                return (
+                  <button
+                    key={r.full}
+                    onClick={() => descend(r.full)}
+                    className={
+                      "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded " +
+                      (r.dimmed ? "text-text-faint opacity-70" : "text-text-muted") +
+                      " hover:bg-bg-soft"
+                    }
+                    title={r.full}
+                  >
+                    <FolderIcon size={14} className="shrink-0" aria-hidden="true" />
+                    <span className="flex-1 min-w-0 truncate font-mono">{r.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between px-4 py-3 border-t border-border">
+              <div className="text-label text-text-faint font-mono truncate">
+                {gitState || "not a git repo"}
+              </div>
+              <div className="flex gap-2 shrink-0">
+                <button
+                  onClick={onCancel}
+                  className="text-meta px-3 py-2 text-text-muted hover:text-text"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => void select()}
+                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90"
+                >
+                  Select folder
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/NewSessionScreen.test.ts
+++ b/src/renderer/NewSessionScreen.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { deriveProjectName } from "./NewSessionScreen";
+
+describe("deriveProjectName", () => {
+  it("extracts the basename from a path", () => {
+    expect(deriveProjectName("~/code/leasebot")).toBe("leasebot");
+    expect(deriveProjectName("/home/dev/code/my-project")).toBe("my-project");
+  });
+
+  it("handles trailing slash", () => {
+    expect(deriveProjectName("~/code/foo/")).toBe("foo");
+    expect(deriveProjectName("/a/b/c/")).toBe("c");
+  });
+
+  it("falls back to 'project' for empty or tilde", () => {
+    expect(deriveProjectName("")).toBe("project");
+    expect(deriveProjectName("~")).toBe("project");
+    expect(deriveProjectName("~/")).toBe("project");
+  });
+
+  it("handles root", () => {
+    expect(deriveProjectName("/")).toBe("project");
+  });
+
+  it("handles single-segment relative", () => {
+    expect(deriveProjectName("foo")).toBe("foo");
+  });
+});

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -21,6 +21,7 @@ import { useStore } from "./store";
 import { ModelPicker } from "./ModelPicker";
 import { MicButton } from "./ComposerParts";
 import { FolderPickerModal } from "./FolderPickerModal";
+import { worktreeName } from "./folderPicker";
 import { useVoiceRecorder, type VoiceResult } from "./voice";
 import type { VoiceMode, VoicePhase } from "./voice";
 import type { OpencodeModel, WorktreeInfo } from "../shared/types";
@@ -66,6 +67,15 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
   const [wantWorktree, setWantWorktree] = useState(worktreePerSession);
   const [worktrees, setWorktrees] = useState<WorktreeInfo[] | null>(null);
   const [isGitRepo, setIsGitRepo] = useState(false);
+  // BET-417 §A: "Ticking worktree makes the branch field editable." When
+  // wantWorktree is true, this is the editable branch name passed to
+  // gitAddWorktree (which deriveWorktree turns into the new branch). Defaults
+  // to a derived name; the user can type over it.
+  const [worktreeBranch, setWorktreeBranch] = useState("worktree");
+  // BET-417 §B: fan-out from the folder picker. When set, the picker returned
+  // multiple worktrees and the user chose "One per worktree" — we create one
+  // session with one window per worktree (worktreeName(w) as window name).
+  const [fanOutWorktrees, setFanOutWorktrees] = useState<WorktreeInfo[] | null>(null);
 
   // Composer state.
   const [input, setInput] = useState("");
@@ -193,7 +203,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
         windowName = "default";
 
         if (wantWorktree && isGitRepo) {
-          const wt = await window.api.gitAddWorktree({ cwd, name: windowName });
+          const wt = await window.api.gitAddWorktree({ cwd, name: worktreeBranch });
           worktreePath = wt.path;
         }
 
@@ -206,9 +216,9 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
         });
       } else {
         sessionName = projectName!;
-        windowName = "session";
+        windowName = worktreeBranch || "session";
         if (wantWorktree && isGitRepo) {
-          const wt = await window.api.gitAddWorktree({ cwd, name: windowName });
+          const wt = await window.api.gitAddWorktree({ cwd, name: worktreeBranch });
           worktreePath = wt.path;
         }
         await window.api.tmuxNewWindow({
@@ -242,6 +252,75 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
           text,
           modelOverride ?? undefined,
         );
+      }
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSending(false);
+    }
+  };
+
+  // ---- fan-out submit: one session, one window per worktree ----
+  // Relocates the old Sidebar createProject("all") logic that was deleted
+  // with the inline forms (BET-417 §B4). Each window is named worktreeName(w)
+  // (path basename, not branch) — so "leasebot" not "main" shows in the
+  // sidebar. The first prompt goes to the first window.
+  const submitFanOut = async (baseCwd: string, wts: WorktreeInfo[]) => {
+    if (sending) return;
+    const text = input.trim();
+    setSending(true);
+    setError(null);
+    try {
+      const sessionName = (() => {
+        const base = deriveProjectName(baseCwd);
+        const taken = new Set(existingProjects.map((p) => p.tmuxSession));
+        if (!taken.has(base)) return base;
+        let i = 2;
+        while (taken.has(`${base}-${i}`)) i++;
+        return `${base}-${i}`;
+      })();
+
+      const [first, ...rest] = wts;
+      await window.api.tmuxNewSession({
+        name: sessionName,
+        cwd: first.path,
+        windowName: worktreeName(first),
+        chatMode: true,
+      });
+      for (const w of rest) {
+        try {
+          await window.api.tmuxNewWindow({
+            sessionName,
+            windowName: worktreeName(w),
+            cwd: w.path,
+            chatMode: true,
+          });
+        } catch (e) {
+          // Surface but don't abort — partial fan-out beats undoing halfway.
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      }
+
+      await refresh();
+      const proj = useStore.getState().projects.find(
+        (p) => p.tmuxSession === sessionName,
+      );
+      const win = proj?.windows.find((w) => w.name === worktreeName(first));
+      if (win?.opencodeSessionId) {
+        setActive(sessionName, win.index);
+        try {
+          await window.api.tmuxSelectWindow({
+            sessionName,
+            windowIndex: win.index,
+          });
+        } catch { /* non-fatal */ }
+        if (text) {
+          await window.api.opencodePrompt(
+            win.opencodeSessionId,
+            text,
+            modelOverride ?? undefined,
+          );
+        }
       }
       onDone();
     } catch (e) {
@@ -292,7 +371,23 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
           </button>
 
           <div className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-border bg-card text-meta">
-            {branchName ? (
+            {wantWorktree && isGitRepo ? (
+              // BET-417 §A: "Ticking worktree makes the branch field
+              // editable." The typed value is passed as `name` to
+              // gitAddWorktree, which deriveWorktree turns into the new
+              // branch name.
+              <span className="inline-flex items-center gap-1">
+                <GitBranch size={14} className="shrink-0 text-text-muted" aria-hidden="true" />
+                <input
+                  value={worktreeBranch}
+                  onChange={(e) => setWorktreeBranch(e.target.value)}
+                  spellCheck={false}
+                  className="w-[100px] bg-transparent border-0 outline-none text-text font-mono focus:border-b focus:border-accent"
+                  placeholder="branch-name"
+                  aria-label="Worktree branch name"
+                />
+              </span>
+            ) : branchName ? (
               <span className="inline-flex items-center gap-1 text-text-muted">
                 <GitBranch size={14} className="shrink-0" aria-hidden="true" />
                 <span className="truncate max-w-[120px]">{branchName}</span>
@@ -397,8 +492,49 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
             setCwd(path);
             setPickerOpen(false);
           }}
+          onFanOut={(baseCwd, wts) => {
+            setFanOutWorktrees(wts);
+            setCwd(baseCwd);
+            setPickerOpen(false);
+          }}
           onCancel={() => setPickerOpen(false)}
         />
+      )}
+
+      {fanOutWorktrees && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="w-[480px] max-w-[92vw] bg-bg-elev border border-border rounded-xl shadow-xl p-4 space-y-3">
+            <div className="text-body font-semibold text-text">Fan-out confirmed</div>
+            <div className="text-meta text-text-muted">
+              Creating one session with {fanOutWorktrees.length} windows (one per
+              worktree). The first window gets your prompt.
+            </div>
+            <ul className="text-label text-text-faint space-y-px max-h-40 overflow-y-auto">
+              {fanOutWorktrees.map((w) => (
+                <li key={w.path} className="truncate">
+                  <span className="text-text-muted">{worktreeName(w)}</span>
+                  {" "}<span className="text-text-faint">— {w.path}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="flex gap-2">
+              <button
+                onClick={() => void submitFanOut(cwd, fanOutWorktrees)}
+                disabled={sending}
+                className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90 disabled:opacity-50"
+              >
+                {sending ? "Creating…" : "Create"}
+              </button>
+              <button
+                onClick={() => setFanOutWorktrees(null)}
+                disabled={sending}
+                className="text-meta px-3 py-2 text-text-faint hover:text-text"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -1,0 +1,405 @@
+// NewSessionScreen.tsx — the pre-session composer (BET-417 §A).
+//
+// Before a session exists, the composer IS the setup form. This is also the
+// app's zero state (BET-416 §F). Two chips only: folder, and a split
+// branch/worktree chip. No host chip — the box connection is already
+// established.
+//
+// On submit:
+//   - new-project mode (projectName === null): create a tmux session + first
+//     chat window, derive the project name from the folder basename, then
+//     send the typed prompt as the first message.
+//   - new-session mode (projectName set): create a tmux window in the
+//     existing project, then send the prompt.
+//
+// The folder chip opens FolderPickerModal (§B). Worktree fan-out is asked
+// inside the picker, not as a post-Create interstitial.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Folder as FolderIcon, GitBranch, Sparkles, Loader2 } from "lucide-react";
+import { useStore } from "./store";
+import { ModelPicker } from "./ModelPicker";
+import { MicButton } from "./ComposerParts";
+import { FolderPickerModal } from "./FolderPickerModal";
+import { useVoiceRecorder, type VoiceResult } from "./voice";
+import type { VoiceMode, VoicePhase } from "./voice";
+import type { OpencodeModel, WorktreeInfo } from "../shared/types";
+import { type ModelSelection, resolveActiveModel } from "./chatShared";
+import { ALT_KEY } from "./platform";
+
+type Props = {
+  // null = new-project mode (creates a tmux session). A string = new-session
+  // mode (creates a tmux window in that project).
+  projectName: string | null;
+  // Called after the session is created + the first prompt is sent. The
+  // parent closes the screen and navigates to the new session.
+  onDone: () => void;
+  // Called when the user cancels (Esc / clicks away). The parent closes.
+  onCancel: () => void;
+};
+
+// Derive a tmux session name from a folder path: the basename, fallback to
+// "project". Tilde-form and trailing slashes are handled. Exported for
+// testing (pure).
+export function deriveProjectName(cwd: string): string {
+  const clean = cwd.replace(/\/+$/, "");
+  if (!clean || clean === "~") return "project";
+  const parts = clean.split("/").filter(Boolean);
+  return parts[parts.length - 1] || "project";
+}
+
+export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
+  const refresh = useStore((s) => s.refresh);
+  const setActive = useStore((s) => s.setActive);
+  const configDefaultModel = useStore((s) => s.defaultModel);
+  const deactivatedMainModels = useStore((s) => s.deactivatedMainModels);
+  const existingProjects = useStore((s) => s.projects);
+  const worktreePerSession = useStore((s) => s.worktreePerSession);
+
+  const isNewProject = projectName === null;
+
+  // Folder state — the selected working directory.
+  const [cwd, setCwd] = useState<string>(isNewProject ? "~" : "");
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  // Branch / worktree chip state.
+  const [wantWorktree, setWantWorktree] = useState(worktreePerSession);
+  const [worktrees, setWorktrees] = useState<WorktreeInfo[] | null>(null);
+  const [isGitRepo, setIsGitRepo] = useState(false);
+
+  // Composer state.
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Model state — fetched on mount (same pattern as ChatPanel).
+  const [models, setModels] = useState<OpencodeModel[] | null>(null);
+  const [serverDefault, setServerDefault] = useState<{
+    providerID: string;
+    modelID: string;
+  } | null>(null);
+  const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
+    configDefaultModel ?? null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api
+      .opencodeModels()
+      .then((list) => { if (!cancelled) setModels(list); })
+      .catch(() => {});
+    window.api
+      .opencodeDefaultModel()
+      .then((d) => { if (!cancelled) setServerDefault(d); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const activeModel = useMemo(
+    () => resolveActiveModel(models, modelOverride, serverDefault),
+    [models, modelOverride, serverDefault],
+  );
+  void activeModel; // used by ModelPicker via models + modelOverride
+
+  // ---- resolve cwd for new-session mode ----
+  // In new-session mode, the cwd defaults to the project's cwd (inherited
+  // server-side). The user can still browse to a subfolder.
+  useEffect(() => {
+    if (!isNewProject && projectName && !cwd) {
+      const proj = existingProjects.find((p) => p.tmuxSession === projectName);
+      const dir = proj?.defaultCwd || proj?.windows[0]?.paneCurrentPath || "";
+      if (dir) setCwd(dir);
+    }
+  }, [isNewProject, projectName, existingProjects, cwd]);
+
+  // ---- probe git state for the current cwd ----
+  useEffect(() => {
+    if (!cwd || cwd === "~") {
+      setIsGitRepo(false);
+      setWorktrees(null);
+      return;
+    }
+    let cancelled = false;
+    window.api
+      .gitListWorktrees(cwd)
+      .then((wts) => {
+        if (cancelled) return;
+        setWorktrees(wts);
+        setIsGitRepo(Array.isArray(wts) && wts.length > 0);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setIsGitRepo(false);
+        setWorktrees(null);
+      });
+    return () => { cancelled = true; };
+  }, [cwd]);
+
+  const branchName = useMemo(() => {
+    if (!worktrees || worktrees.length === 0) return null;
+    return worktrees[0]?.branch ?? null;
+  }, [worktrees]);
+
+  // ---- voice (simplified: just insert transcribed text) ----
+  const voiceRecorder = useVoiceRecorder({
+    onResult: (r: VoiceResult) => {
+      const text = r.mode === "dictate" ? r.text : "";
+      if (!text) return;
+      setInput((prev) => {
+        const sep = prev && !prev.endsWith(" ") ? " " : "";
+        return prev + sep + text;
+      });
+      requestAnimationFrame(() => {
+        const el = inputRef.current;
+        if (el) {
+          el.focus();
+          const end = el.value.length;
+          el.setSelectionRange(end, end);
+        }
+      });
+    },
+    onError: (err: Error) => setError(err.message),
+    onEmpty: () => {},
+  });
+  const voicePhase: VoicePhase = voiceRecorder.phase;
+  const voiceMode: VoiceMode = voiceRecorder.mode;
+  const voiceRecording = voicePhase === "recording" || voicePhase === "requesting";
+  const groqApiKey = useStore((s) => s.groqApiKey);
+  const voiceEnabled = !!groqApiKey && typeof MediaRecorder !== "undefined";
+
+  // ---- submit: create session + send first prompt ----
+  const submit = async () => {
+    if (sending) return;
+    const text = input.trim();
+    if (!text) return;
+    setSending(true);
+    setError(null);
+
+    try {
+      let sessionName: string;
+      let windowName: string;
+      let worktreePath: string | undefined;
+
+      if (isNewProject) {
+        sessionName = deriveProjectName(cwd);
+        // Avoid name collision with existing sessions.
+        const taken = new Set(existingProjects.map((p) => p.tmuxSession));
+        if (taken.has(sessionName)) {
+          let i = 2;
+          while (taken.has(`${sessionName}-${i}`)) i++;
+          sessionName = `${sessionName}-${i}`;
+        }
+        windowName = "default";
+
+        if (wantWorktree && isGitRepo) {
+          const wt = await window.api.gitAddWorktree({ cwd, name: windowName });
+          worktreePath = wt.path;
+        }
+
+        await window.api.tmuxNewSession({
+          name: sessionName,
+          cwd: worktreePath ?? cwd,
+          windowName,
+          chatMode: true,
+          ...(worktreePath ? {} : { createDir: true }),
+        });
+      } else {
+        sessionName = projectName!;
+        windowName = "session";
+        if (wantWorktree && isGitRepo) {
+          const wt = await window.api.gitAddWorktree({ cwd, name: windowName });
+          worktreePath = wt.path;
+        }
+        await window.api.tmuxNewWindow({
+          sessionName,
+          windowName,
+          ...(worktreePath ? { cwd: worktreePath, worktreePath } : {}),
+          chatMode: true,
+        });
+      }
+
+      await refresh();
+
+      // Find the new window's opencode session id.
+      const proj = useStore.getState().projects.find(
+        (p) => p.tmuxSession === sessionName,
+      );
+      const win = proj?.windows.find((w) => w.name === windowName);
+      const sessionId = win?.opencodeSessionId;
+
+      if (sessionId) {
+        setActive(sessionName, win!.index);
+        try {
+          await window.api.tmuxSelectWindow({
+            sessionName,
+            windowIndex: win!.index,
+          });
+        } catch { /* non-fatal */ }
+        // Send the first prompt.
+        await window.api.opencodePrompt(
+          sessionId,
+          text,
+          modelOverride ?? undefined,
+        );
+      }
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSending(false);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void submit();
+      return;
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+      return;
+    }
+  };
+
+  const folderLabel = useMemo(() => {
+    if (!cwd || cwd === "~") return "Home";
+    const parts = cwd.split("/").filter(Boolean);
+    return parts[parts.length - 1] || cwd;
+  }, [cwd]);
+
+  return (
+    <div className="h-full flex flex-col items-center justify-center px-8">
+      <div className="w-full max-w-[680px] flex flex-col gap-4">
+        {/* Heading */}
+        <div className="text-center space-y-1">
+          <h1 className="text-h1 font-semibold text-text">What's up next?</h1>
+          <p className="text-body text-text-muted">
+            Start a session on any folder your box can see.
+          </p>
+        </div>
+
+        {/* Chip row: folder + branch/worktree */}
+        <div className="flex items-center gap-2 justify-center">
+          <button
+            onClick={() => setPickerOpen(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border bg-card text-meta text-text hover:border-border-strong"
+            title={cwd || "Choose a folder"}
+          >
+            <FolderIcon size={14} className="shrink-0 text-text-muted" aria-hidden="true" />
+            <span className="truncate max-w-[200px] font-mono">{folderLabel}</span>
+          </button>
+
+          <div className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-border bg-card text-meta">
+            {branchName ? (
+              <span className="inline-flex items-center gap-1 text-text-muted">
+                <GitBranch size={14} className="shrink-0" aria-hidden="true" />
+                <span className="truncate max-w-[120px]">{branchName}</span>
+              </span>
+            ) : (
+              <span className="text-text-faint">no branch</span>
+            )}
+            <span className="text-text-quiet">|</span>
+            <label
+              className={`inline-flex items-center gap-1 ${
+                isGitRepo ? "cursor-pointer" : "cursor-not-allowed opacity-50"
+              }`}
+              title={isGitRepo ? "Create in a fresh git worktree" : "not a git repository"}
+            >
+              <input
+                type="checkbox"
+                checked={wantWorktree}
+                disabled={!isGitRepo}
+                onChange={(e) => setWantWorktree(e.target.checked)}
+                className="accent-accent"
+              />
+              <span className="text-text-muted">worktree</span>
+            </label>
+          </div>
+        </div>
+
+        {/* Composer box */}
+        <div
+          className={
+            "manta-composer-input-row rounded-xl border bg-card flex flex-col gap-2 px-4 py-3 " +
+            (voiceRecording
+              ? "manta-recording"
+              : "border-border-strong")
+          }
+        >
+          <textarea
+            ref={inputRef}
+            autoFocus
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Describe a task or ask a question"
+            rows={3}
+            className="w-full bg-transparent border-0 text-body text-text outline-none resize-none placeholder:text-text-faint"
+            spellCheck={false}
+          />
+
+          {/* Footer: model/effort + mic */}
+          <div className="flex items-center gap-2">
+            <ModelPicker
+              modelLabel={null}
+              models={models}
+              modelOverride={modelOverride}
+              defaultModel={serverDefault}
+              deactivatedMainModels={deactivatedMainModels}
+              onOpen={() => {}}
+              onSelect={(m) => setModelOverride(m)}
+            />
+
+            <div className="ml-auto flex items-center gap-2">
+              {voiceEnabled && (
+                <MicButton
+                  phase={voicePhase}
+                  mode={voiceMode}
+                  onStart={(mode) => { voiceRecorder.start(mode); return Promise.resolve(); }}
+                  onStop={voiceRecorder.stop}
+                  onCancel={voiceRecorder.cancel}
+                />
+              )}
+              <button
+                onClick={() => void submit()}
+                disabled={sending || !input.trim()}
+                className="px-3 py-1.5 rounded-lg bg-accent-solid text-on-accent text-meta font-medium disabled:opacity-50 hover:opacity-90 inline-flex items-center gap-1.5"
+              >
+                {sending ? (
+                  <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <Sparkles size={14} aria-hidden="true" />
+                )}
+                {sending ? "Starting…" : "Start"}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="text-meta text-danger bg-danger-bg border border-danger/30 rounded px-3 py-2 break-words">
+            {error}
+          </div>
+        )}
+
+        <div className="text-center text-label text-text-faint">
+          Press Enter to start · Shift+Enter for a new line · Esc to cancel
+          {voiceEnabled && ` · hold 🎙 to speak (${ALT_KEY} = command)`}
+        </div>
+      </div>
+
+      {pickerOpen && (
+        <FolderPickerModal
+          initialPath={cwd || "~"}
+          onSelect={(path) => {
+            setCwd(path);
+            setPickerOpen(false);
+          }}
+          onCancel={() => setPickerOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { ChevronRight, ChevronDown, X, Pin, Search } from "lucide-react";
 import { useStore, flatSessions, type WindowStatusUI } from "./store";
 import { nowMs } from "./clock";
-import type { Project, TmuxWindow, WorktreeInfo } from "../shared/types";
+import type { Project, TmuxWindow } from "../shared/types";
 import {
   classifyCacheAge,
   computeJobNesting,
@@ -49,10 +49,14 @@ export type SidebarHandle = {
 
 type Props = {
   onOpenSettings: () => void;
+  // BET-417: the rail + / + per-project + open the NewSessionScreen instead
+  // of an inline form. null = new-project mode; a string = new-session mode.
+  onNewProject: () => void;
+  onNewSessionInProject: (projectName: string) => void;
 };
 
 export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
-  { onOpenSettings },
+  { onOpenSettings, onNewProject, onNewSessionInProject },
   ref,
 ) {
   const {
@@ -67,7 +71,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     pinnedWindows,
     recentWindows,
     togglePin,
-    worktreePerSession,
     worktreeCleanOnClose,
   } = useStore();
   // Downloaded desktop auto-update (BET-416 §E): signalled as a dot on the
@@ -84,18 +87,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   };
 
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
-  const [newProjectOpen, setNewProjectOpen] = useState(false);
-  const [newProjectName, setNewProjectName] = useState("");
-  const [newProjectCwd, setNewProjectCwd] = useState("~");
-  const [cwdSuggestion, setCwdSuggestion] = useState<string | null>(null);
-  const cwdDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [detectedWorktrees, setDetectedWorktrees] = useState<WorktreeInfo[] | null>(null);
-  const [creating, setCreating] = useState(false);
-
-  const [newSessionFor, setNewSessionFor] = useState<string | null>(null);
-  const [newSessionName, setNewSessionName] = useState("");
-  const [newSessionWorktree, setNewSessionWorktree] = useState(false);
-  const [newSessionIsGitRepo, setNewSessionIsGitRepo] = useState(false);
 
   const [confirmDeleteFor, setConfirmDeleteFor] = useState<ConfirmDeleteFor>(null);
 
@@ -120,13 +111,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   }, [collapsed]);
 
   useImperativeHandle(ref, () => ({
-    openNewProject: () => setNewProjectOpen(true),
+    openNewProject: () => onNewProject(),
     openNewSessionInActive: () => {
       if (activeProjectName) {
-        setNewSessionFor(activeProjectName);
-        setNewSessionName("");
-        setNewSessionWorktree(worktreePerSession);
-        void probeGitForProject(activeProjectName);
+        onNewSessionInProject(activeProjectName);
         setCollapsed((prev) => {
           const next = new Set(prev);
           next.delete(activeProjectName);
@@ -141,237 +129,12 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     },
   }));
 
-  const resolveProjectCwd = (projectName: string): string => {
-    const proj = projects.find((p) => p.tmuxSession === projectName);
-    const stored = (proj?.defaultCwd ?? "").trim();
-    if (stored && stored !== "~") return stored;
-    const activeIdx = activeWindowByProject[projectName];
-    const w = proj?.windows.find((x) => x.index === activeIdx)
-      ?? proj?.windows.find((x) => x.active)
-      ?? proj?.windows[0];
-    const fallback = (w?.paneCurrentPath ?? "").trim();
-    if (!fallback) {
-      console.warn(
-        `[Sidebar] resolveProjectCwd: no usable cwd for project "${projectName}" (defaultCwd=${JSON.stringify(stored)}, paneCurrentPath missing)`,
-      );
-    }
-    return fallback;
-  };
-
-  const probeGitForProject = async (projectName: string) => {
-    const cwd = resolveProjectCwd(projectName);
-    if (!cwd || cwd === "~") {
-      setNewSessionIsGitRepo(false);
-      setNewSessionWorktree(false);
-      return;
-    }
-    try {
-      const wts = await window.api.gitListWorktrees(cwd);
-      const isRepo = Array.isArray(wts) && wts.length > 0;
-      setNewSessionIsGitRepo(isRepo);
-      if (!isRepo) setNewSessionWorktree(false);
-    } catch {
-      setNewSessionIsGitRepo(false);
-    }
-  };
-
   const toggleCollapse = (id: string) =>
     setCollapsed((prev) => {
       const next = new Set(prev);
       next.has(id) ? next.delete(id) : next.add(id);
       return next;
     });
-
-  const worktreeName = (w: WorktreeInfo): string =>
-    w.path.split("/").filter(Boolean).pop() || w.branch || "wt";
-
-  const resetNewProjectForm = () => {
-    setNewProjectName("");
-    setNewProjectCwd("~");
-    setNewProjectOpen(false);
-    setDetectedWorktrees(null);
-    setCreating(false);
-    setCwdSuggestion(null);
-    if (cwdDebounce.current) clearTimeout(cwdDebounce.current);
-  };
-
-  const refreshCwdSuggestion = (value: string) => {
-    if (cwdDebounce.current) clearTimeout(cwdDebounce.current);
-    if (!value) {
-      setCwdSuggestion(null);
-      return;
-    }
-    cwdDebounce.current = setTimeout(async () => {
-      try {
-        const matches = (await window.api.fsListDirs(value)).filter((m) =>
-          m.startsWith(value),
-        );
-        if (matches.length === 0) {
-          setCwdSuggestion(null);
-          return;
-        }
-        if (matches.length === 1) {
-          setCwdSuggestion(matches[0] + "/");
-          return;
-        }
-        const lcp = matches.reduce((acc, m) => {
-          let i = 0;
-          while (i < acc.length && i < m.length && acc[i] === m[i]) i++;
-          return acc.slice(0, i);
-        });
-        setCwdSuggestion(lcp.length > value.length ? lcp : null);
-      } catch {
-        setCwdSuggestion(null);
-      }
-    }, 80);
-  };
-
-  const onCwdChange = (value: string) => {
-    setNewProjectCwd(value);
-    refreshCwdSuggestion(value);
-  };
-
-  const acceptCwdSuggestion = (): boolean => {
-    if (!cwdSuggestion || !cwdSuggestion.startsWith(newProjectCwd)) return false;
-    if (cwdSuggestion === newProjectCwd) return false;
-    setNewProjectCwd(cwdSuggestion);
-    setCwdSuggestion(null);
-    refreshCwdSuggestion(cwdSuggestion);
-    return true;
-  };
-
-  const createProject = async (mode: "auto" | "all" | "single" = "auto") => {
-    if (creating) return;
-    const name = newProjectName.trim();
-    if (!name) return;
-    const cwd = newProjectCwd.trim() || "";
-
-    if (mode === "auto") {
-      setCreating(true);
-      try {
-        const wts = await window.api.gitListWorktrees(cwd);
-        if (wts.length > 1) {
-          setDetectedWorktrees(wts);
-          setCreating(false);
-          return;
-        }
-      } catch {
-        /* probe failure (no git, network, etc.) → fall through to single */
-      }
-      try {
-        await window.api.tmuxNewSession({
-          name,
-          cwd,
-          windowName: "default",
-          chatMode: true,
-        });
-        resetNewProjectForm();
-        await refresh();
-        setActive(name);
-      } catch (e) {
-        showError(e);
-        setCreating(false);
-      }
-      return;
-    }
-
-    setCreating(true);
-    try {
-      if (mode === "all" && detectedWorktrees && detectedWorktrees.length > 1) {
-        const [first, ...rest] = detectedWorktrees;
-        await window.api.tmuxNewSession({
-          name,
-          cwd: first.path,
-          windowName: worktreeName(first),
-          chatMode: true,
-        });
-        for (const w of rest) {
-          try {
-            await window.api.tmuxNewWindow({
-              sessionName: name,
-              windowName: worktreeName(w),
-              cwd: w.path,
-              chatMode: true,
-            });
-          } catch (e) {
-            showError(e);
-          }
-        }
-      } else {
-        await window.api.tmuxNewSession({
-          name,
-          cwd,
-          windowName: "default",
-          chatMode: true,
-        });
-      }
-      resetNewProjectForm();
-      await refresh();
-      setActive(name);
-    } catch (e) {
-      showError(e);
-      setCreating(false);
-    }
-  };
-
-  const startNewSession = (projectName: string) => {
-    setNewSessionFor(projectName);
-    setNewSessionName("");
-    setNewSessionWorktree(worktreePerSession);
-    void probeGitForProject(projectName);
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      next.delete(projectName);
-      return next;
-    });
-  };
-
-  const createSession = async () => {
-    if (!newSessionFor) return;
-    const sessionFor = newSessionFor;
-    const windowName = newSessionName.trim() || "session";
-    const wantWorktree = newSessionWorktree && newSessionIsGitRepo;
-    let worktreePath: string | undefined;
-    if (wantWorktree) {
-      const projectCwd = resolveProjectCwd(sessionFor);
-      if (!projectCwd || projectCwd === "~") {
-        showError(new Error("project has no cwd; cannot create worktree"));
-        return;
-      }
-      try {
-        const wt = await window.api.gitAddWorktree({ cwd: projectCwd, name: windowName });
-        worktreePath = wt.path;
-      } catch (e) {
-        showError(e);
-        return;
-      }
-    }
-    try {
-      const projects = await window.api.tmuxNewWindow({
-        sessionName: sessionFor,
-        windowName,
-        ...(worktreePath ? { cwd: worktreePath, worktreePath } : {}),
-        chatMode: true,
-      });
-      setNewSessionFor(null);
-      await refresh();
-      const proj = projects.find((p) => p.tmuxSession === sessionFor);
-      const w = proj?.windows.find((x) => x.name === windowName);
-      if (w) {
-        setActive(sessionFor, w.index);
-        try {
-          await window.api.tmuxSelectWindow({
-            sessionName: sessionFor,
-            windowIndex: w.index,
-          });
-        } catch (e) {
-          showError(e);
-        }
-      }
-    } catch (e) {
-      showError(e);
-    }
-  };
 
   const activateWindow = async (proj: Project, idx: number) => {
     setActive(proj.tmuxSession, idx);
@@ -716,7 +479,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
             <Search size={15} aria-hidden="true" />
           </button>
           <button
-            onClick={() => setNewProjectOpen(true)}
+            onClick={onNewProject}
             className="text-text-muted hover:text-text text-lg leading-none"
             title={`New project (${MOD_KEY}N)`}
           >
@@ -725,129 +488,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         </div>
       </div>
 
-      {newProjectOpen && (
-        <div className="px-3 pb-3 space-y-2">
-          <input
-            autoFocus
-            placeholder="Project name"
-            value={newProjectName}
-            onChange={(e) => setNewProjectName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !detectedWorktrees) createProject("auto");
-              else if (e.key === "Escape") resetNewProjectForm();
-            }}
-            disabled={!!detectedWorktrees || creating}
-            className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded focus:outline-none focus:border-accent disabled:opacity-60"
-          />
-          <div
-            className={`relative w-full bg-bg-soft border border-border rounded focus-within:border-accent ${
-              !!detectedWorktrees || creating ? "opacity-60" : ""
-            }`}
-          >
-            {cwdSuggestion && cwdSuggestion.startsWith(newProjectCwd) && (
-              <div
-                aria-hidden
-                className="absolute inset-0 px-2 py-1 text-meta flex items-center pointer-events-none whitespace-pre overflow-hidden font-mono"
-              >
-                <span className="invisible">{newProjectCwd}</span>
-                <span className="text-text-faint">
-                  {cwdSuggestion.slice(newProjectCwd.length)}
-                </span>
-              </div>
-            )}
-            <input
-              placeholder="Default cwd (e.g. ~/code/foo)"
-              value={newProjectCwd}
-              onChange={(e) => onCwdChange(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Tab" && cwdSuggestion) {
-                  e.preventDefault();
-                  acceptCwdSuggestion();
-                  return;
-                }
-                if (e.key === "ArrowRight" && cwdSuggestion) {
-                  const el = e.currentTarget;
-                  if (
-                    el.selectionStart === el.value.length &&
-                    el.selectionEnd === el.value.length
-                  ) {
-                    e.preventDefault();
-                    acceptCwdSuggestion();
-                    return;
-                  }
-                }
-                if (e.key === "Enter" && !detectedWorktrees) createProject("auto");
-                else if (e.key === "Escape") {
-                  if (cwdSuggestion) setCwdSuggestion(null);
-                  else resetNewProjectForm();
-                }
-              }}
-              disabled={!!detectedWorktrees || creating}
-              spellCheck={false}
-              autoComplete="off"
-              className="relative w-full bg-transparent border-0 px-2 py-1 text-meta rounded focus:outline-none font-mono"
-            />
-          </div>
-          {detectedWorktrees ? (
-            <div className="space-y-2">
-              <div className="text-meta text-text-muted">
-                Detected {detectedWorktrees.length} git worktrees. Open a session for each?
-              </div>
-              <ul className="text-label text-text-faint space-y-px max-h-32 overflow-y-auto">
-                {detectedWorktrees.map((w) => (
-                  <li key={w.path} className="truncate">
-                    <span className="text-text-muted">{worktreeName(w)}</span>
-                    <span className="text-text-faint"> — {w.path}</span>
-                  </li>
-                ))}
-              </ul>
-              <div className="flex gap-2 flex-wrap">
-                <button
-                  onClick={() => createProject("all")}
-                  disabled={creating}
-                  className="text-meta px-2 py-1 bg-accent-solid text-on-accent rounded hover:opacity-90 disabled:opacity-50"
-                >
-                  Yes, one per worktree
-                </button>
-                <button
-                  onClick={() => createProject("single")}
-                  disabled={creating}
-                  className="text-meta px-2 py-1 border border-border text-text-muted hover:text-text rounded disabled:opacity-50"
-                >
-                  Just main
-                </button>
-                <button
-                  onClick={resetNewProjectForm}
-                  disabled={creating}
-                  className="text-meta px-2 py-1 text-text-muted hover:text-text"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <div className="flex gap-2">
-                <button
-                  onClick={() => createProject("auto")}
-                  disabled={creating}
-                  className="text-meta px-2 py-1 bg-accent-solid text-on-accent rounded hover:opacity-90 disabled:opacity-50"
-                >
-                  {creating ? "Checking…" : "Create"}
-                </button>
-                <button
-                  onClick={resetNewProjectForm}
-                  disabled={creating}
-                  className="text-meta px-2 py-1 text-text-muted hover:text-text"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-
       <div
         className="flex-1 overflow-y-auto px-2 pb-2 outline-none"
         role="tree"
@@ -855,7 +495,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         tabIndex={-1}
         onKeyDown={onRailKeyDown}
       >
-        {projects.length === 0 && !newProjectOpen && (
+        {projects.length === 0 && (
           <div className="px-2 py-3 text-meta text-text-faint">
             No projects yet. Click + or press {MOD_KEY}N.
           </div>
@@ -937,7 +577,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                 isProjectActive={isProjectActive}
                 focused={focusedKey === `group:${p.tmuxSession}`}
                 onToggle={() => toggleCollapse(p.tmuxSession)}
-                onNewSession={() => startNewSession(p.tmuxSession)}
+                onNewSession={() => onNewSessionInProject(p.tmuxSession)}
                 onClose={() => setConfirmDeleteFor({ kind: "project", project: p.tmuxSession })}
                 renameTarget={renameTarget}
                 renameValue={renameValue}
@@ -1038,54 +678,9 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                     );
                   })}
 
-                  {newSessionFor === p.tmuxSession && (
-                    <div className="pl-2 pr-1 py-1 space-y-1">
-                      <input
-                        autoFocus
-                        placeholder="Session name (optional)"
-                        value={newSessionName}
-                        onChange={(e) => setNewSessionName(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") createSession();
-                          else if (e.key === "Escape") setNewSessionFor(null);
-                        }}
-                        className="w-full bg-bg-soft border border-border px-2 py-px text-meta rounded focus:outline-none focus:border-accent"
-                      />
-                      <label
-                        className={`flex items-center gap-2 text-meta ${
-                          newSessionIsGitRepo ? "cursor-pointer" : "cursor-not-allowed opacity-50"
-                        }`}
-                        title={newSessionIsGitRepo ? undefined : "not a git repository"}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={newSessionWorktree}
-                          disabled={!newSessionIsGitRepo}
-                          onChange={(e) => setNewSessionWorktree(e.target.checked)}
-                          className="accent-accent"
-                        />
-                        <span>Create git worktree</span>
-                      </label>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={createSession}
-                          className="text-meta px-2 py-px bg-accent-solid text-on-accent rounded hover:opacity-90"
-                        >
-                          Create
-                        </button>
-                        <button
-                          onClick={() => setNewSessionFor(null)}
-                          className="text-meta px-2 py-px text-text-muted hover:text-text"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    </div>
-                  )}
-
-                  {p.windows.length === 0 && newSessionFor !== p.tmuxSession && (
+                  {p.windows.length === 0 && (
                     <button
-                      onClick={() => startNewSession(p.tmuxSession)}
+                      onClick={() => onNewSessionInProject(p.tmuxSession)}
                       className="block w-full text-left px-2 py-px text-meta text-text-faint hover:text-text"
                     >
                       + new session

--- a/src/renderer/folderPicker.test.ts
+++ b/src/renderer/folderPicker.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  breadcrumbs,
+  crumbLabel,
+  parentPath,
+  isDimmedDir,
+  worktreeBadge,
+  hasWorktreeFanOut,
+  gitStateLabel,
+} from "./folderPicker";
+import type { WorktreeInfo } from "../shared/types";
+
+function wt(path: string, branch: string): WorktreeInfo {
+  return { path, head: "abc123", branch, bare: false, detached: false };
+}
+
+describe("breadcrumbs", () => {
+  it("returns empty for empty input", () => {
+    expect(breadcrumbs("")).toEqual([]);
+    expect(breadcrumbs("   ")).toEqual([]);
+  });
+
+  it("handles bare tilde", () => {
+    expect(breadcrumbs("~")).toEqual(["~"]);
+  });
+
+  it("splits tilde-form paths", () => {
+    expect(breadcrumbs("~/code/foo")).toEqual([
+      "~",
+      "~/code",
+      "~/code/foo",
+    ]);
+  });
+
+  it("splits absolute paths", () => {
+    expect(breadcrumbs("/home/dev/code")).toEqual([
+      "/",
+      "/home",
+      "/home/dev",
+      "/home/dev/code",
+    ]);
+  });
+
+  it("handles root", () => {
+    expect(breadcrumbs("/")).toEqual(["/"]);
+  });
+
+  it("handles trailing slash", () => {
+    expect(breadcrumbs("~/code/")).toEqual(["~", "~/code"]);
+  });
+});
+
+describe("parentPath", () => {
+  it("goes up from tilde paths", () => {
+    expect(parentPath("~/code/foo")).toBe("~/code");
+    expect(parentPath("~/code")).toBe("~");
+    expect(parentPath("~")).toBe("~");
+  });
+
+  it("goes up from absolute paths", () => {
+    expect(parentPath("/home/dev/code")).toBe("/home/dev");
+    expect(parentPath("/home/dev")).toBe("/home");
+    expect(parentPath("/home")).toBe("/");
+    expect(parentPath("/")).toBe("/");
+  });
+
+  it("returns empty for empty", () => {
+    expect(parentPath("")).toBe("");
+  });
+});
+
+describe("crumbLabel", () => {
+  it("labels tilde", () => {
+    expect(crumbLabel("~")).toBe("~");
+  });
+
+  it("labels root", () => {
+    expect(crumbLabel("/")).toBe("/");
+  });
+
+  it("extracts the last segment", () => {
+    expect(crumbLabel("~/code/foo")).toBe("foo");
+    expect(crumbLabel("/home/dev")).toBe("dev");
+  });
+});
+
+describe("isDimmedDir", () => {
+  it("dims node_modules", () => {
+    expect(isDimmedDir("node_modules")).toBe(true);
+  });
+
+  it("dims dot-folders", () => {
+    expect(isDimmedDir(".git")).toBe(true);
+    expect(isDimmedDir(".venv")).toBe(true);
+    expect(isDimmedDir(".cache")).toBe(true);
+  });
+
+  it("does not dim regular folders", () => {
+    expect(isDimmedDir("src")).toBe(false);
+    expect(isDimmedDir("my-project")).toBe(false);
+    expect(isDimmedDir("code")).toBe(false);
+  });
+});
+
+describe("worktreeBadge", () => {
+  it("returns empty for null", () => {
+    expect(worktreeBadge(null)).toBe("");
+  });
+
+  it("returns empty for 0 or 1 worktree", () => {
+    expect(worktreeBadge([])).toBe("");
+    expect(worktreeBadge([wt("/repo", "main")])).toBe("");
+  });
+
+  it("returns count for >1 worktree", () => {
+    expect(worktreeBadge([wt("/repo", "main"), wt("/repo-wt", "wt")])).toBe(
+      "⎇ 2 worktrees",
+    );
+  });
+});
+
+describe("hasWorktreeFanOut", () => {
+  it("is false for null", () => {
+    expect(hasWorktreeFanOut(null)).toBe(false);
+  });
+
+  it("is false for 0 or 1", () => {
+    expect(hasWorktreeFanOut([])).toBe(false);
+    expect(hasWorktreeFanOut([wt("/repo", "main")])).toBe(false);
+  });
+
+  it("is true for >1", () => {
+    expect(hasWorktreeFanOut([wt("/a", "a"), wt("/b", "b")])).toBe(true);
+  });
+});
+
+describe("gitStateLabel", () => {
+  it("returns empty for null", () => {
+    expect(gitStateLabel(null)).toBe("");
+  });
+
+  it("returns empty for empty", () => {
+    expect(gitStateLabel([])).toBe("");
+  });
+
+  it("returns branch from first worktree", () => {
+    expect(gitStateLabel([wt("/repo", "main"), wt("/repo-wt", "dev")])).toBe(
+      "⎇ main",
+    );
+  });
+
+  it("returns empty when branch is missing", () => {
+    expect(gitStateLabel([wt("/repo", "")])).toBe("");
+    expect(gitStateLabel([{ path: "/repo", head: "x", branch: null, bare: false, detached: false }])).toBe("");
+  });
+});

--- a/src/renderer/folderPicker.test.ts
+++ b/src/renderer/folderPicker.test.ts
@@ -7,6 +7,7 @@ import {
   worktreeBadge,
   hasWorktreeFanOut,
   gitStateLabel,
+  worktreeName,
 } from "./folderPicker";
 import type { WorktreeInfo } from "../shared/types";
 
@@ -152,5 +153,21 @@ describe("gitStateLabel", () => {
   it("returns empty when branch is missing", () => {
     expect(gitStateLabel([wt("/repo", "")])).toBe("");
     expect(gitStateLabel([{ path: "/repo", head: "x", branch: null, bare: false, detached: false }])).toBe("");
+  });
+});
+
+describe("worktreeName", () => {
+  it("returns the path basename", () => {
+    expect(worktreeName(wt("/home/dev/leasebot", "main"))).toBe("leasebot");
+    expect(worktreeName(wt("/home/dev/leasebot-wt", "feature/foo"))).toBe("leasebot-wt");
+  });
+
+  it("falls back to branch when path has no basename", () => {
+    expect(worktreeName(wt("", "feature"))).toBe("feature");
+  });
+
+  it("falls back to 'wt' when both are empty", () => {
+    expect(worktreeName(wt("", ""))).toBe("wt");
+    expect(worktreeName({ path: "", head: "x", branch: null, bare: false, detached: false })).toBe("wt");
   });
 });

--- a/src/renderer/folderPicker.ts
+++ b/src/renderer/folderPicker.ts
@@ -1,0 +1,122 @@
+// folderPicker.ts — pure helpers for the folder picker modal (BET-417 §B).
+//
+// All functions here are pure (no I/O) so they can be unit-tested without a
+// box. The modal component in FolderPickerModal.tsx wires `window.api`
+// (fsListDirs / gitListWorktrees) to these helpers.
+
+import type { WorktreeInfo } from "../shared/types";
+
+// Dimmed-but-selectable directories. `node_modules` and dot-folders render at
+// --tx4 so nothing becomes unreachable, but they recede visually. Hidden
+// files inside a listing are a different concern (fsListDirs already filters
+// to directories only); this is about *known noisy* directories that ARE
+// valid choices but visually pollute a browse.
+export function isDimmedDir(name: string): boolean {
+  if (name === "node_modules") return true;
+  // Dot-folders (.git, .venv, .cache, …). A leading dot is the convention;
+  // we do not enumerate a blocklist — the visual dim is the signal, not a
+  // permission gate.
+  return name.startsWith(".");
+}
+
+// Build clickable breadcrumbs from a path string. `~/code/foo` →
+// ["~", "~/code", "~/code/foo"]. Absolute `/home/dev/code` →
+// ["/", "/home", "/home/dev", "/home/dev/code"]. Tilde-form is preserved
+// so the chip the user picks matches what they would type.
+//
+// Returns [] for empty/invalid input (the caller renders nothing).
+export function breadcrumbs(path: string): string[] {
+  const raw = (path ?? "").trim();
+  if (!raw) return [];
+
+  // Tilde-form: "~/code/foo" → ["~", "~/code", "~/code/foo"]
+  if (raw === "~") return ["~"];
+  if (raw.startsWith("~/")) {
+    const parts = raw.slice(2).split("/").filter(Boolean);
+    const out: string[] = ["~"];
+    let acc = "~";
+    for (const p of parts) {
+      acc += "/" + p;
+      out.push(acc);
+    }
+    return out;
+  }
+
+  // Absolute: "/home/dev/code" → ["/", "/home", "/home/dev", "/home/dev/code"]
+  if (raw.startsWith("/")) {
+    const parts = raw.split("/").filter(Boolean);
+    const out: string[] = ["/"];
+    let acc = "";
+    for (const p of parts) {
+      acc += "/" + p;
+      out.push(acc);
+    }
+    return out;
+  }
+
+  // Relative or anything else: treat the whole string as one crumb. The
+  // picker's path field drives the list via fsListDirs, which expects a
+  // real prefix; relative paths rarely list usefully, so we don't split
+  // them into synthetic ancestors.
+  return [raw];
+}
+
+// The parent path for a "go up one level" click. "~/code/foo" → "~/code",
+// "~/code" → "~", "~" → "~" (already at top). "/a/b" → "/a", "/a" → "/",
+// "/" → "/". Empty → "".
+export function parentPath(path: string): string {
+  const raw = (path ?? "").trim();
+  if (!raw) return "";
+  if (raw === "~") return "~";
+  if (raw === "/") return "/";
+  if (raw.startsWith("~/")) {
+    const idx = raw.lastIndexOf("/");
+    if (idx <= 1) return "~"; // "~/x" → "~"
+    return raw.slice(0, idx);
+  }
+  if (raw.startsWith("/")) {
+    const idx = raw.lastIndexOf("/");
+    if (idx === 0) return "/"; // "/a" → "/"
+    return raw.slice(0, idx);
+  }
+  return raw;
+}
+
+// Label for a breadcrumb crumb — the last segment, or "/" for root, or "~"
+// for home. Used so the clickable row shows "code" not "~/code".
+export function crumbLabel(path: string): string {
+  if (path === "~") return "~";
+  if (path === "/") return "/";
+  const idx = path.lastIndexOf("/");
+  if (idx < 0) return path;
+  return path.slice(idx + 1);
+}
+
+// Worktree badge text for a directory row: "⎇ N worktrees" when N > 0,
+// empty string otherwise. The count comes from gitListWorktrees(cwd) which
+// the modal calls while browsing. We only show a count > 0; a repo with a
+// single worktree (the main checkout) is the common case and "1 worktree"
+// is noise.
+export function worktreeBadge(worktrees: WorktreeInfo[] | null): string {
+  if (!worktrees || worktrees.length <= 1) return "";
+  return `⎇ ${worktrees.length} worktrees`;
+}
+
+// Does this directory row carry a worktree fan-out offer? True when the
+// folder has >1 worktree (the same threshold the old interstitial used).
+// The modal asks the fan-out question HERE, before the user commits, instead
+// of springing it as a surprise after Create.
+export function hasWorktreeFanOut(worktrees: WorktreeInfo[] | null): boolean {
+  return !!worktrees && worktrees.length > 1;
+}
+
+// The short git-state label for the folder picker footer: "⎇ main" when the
+// folder is inside a repo (we infer the branch from the first worktree's
+// branch — gitListWorktrees returns the main checkout first), or "" when not
+// a repo / probe failed.
+export function gitStateLabel(worktrees: WorktreeInfo[] | null): string {
+  if (!worktrees || worktrees.length === 0) return "";
+  const main = worktrees[0];
+  if (!main?.branch) return "";
+  return `⎇ ${main.branch}`;
+}

--- a/src/renderer/folderPicker.ts
+++ b/src/renderer/folderPicker.ts
@@ -120,3 +120,12 @@ export function gitStateLabel(worktrees: WorktreeInfo[] | null): string {
   if (!main?.branch) return "";
   return `⎇ ${main.branch}`;
 }
+
+// Window name for a worktree: dir basename. Mirrors the old Sidebar
+// worktreeName() that was deleted with the inline forms (BET-417 §C).
+// The fan-out path (one session, one window per worktree) uses this to
+// name each tmux window after the worktree's directory basename, not the
+// branch — so "leasebot" not "main" shows in the sidebar.
+export function worktreeName(w: WorktreeInfo): string {
+  return w.path.split("/").filter(Boolean).pop() || w.branch || "wt";
+}

--- a/src/renderer/mobile/MobileCreateSheet.tsx
+++ b/src/renderer/mobile/MobileCreateSheet.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { X, Folder as FolderIcon } from "lucide-react";
 import { useStore } from "../store";
 import type { WorktreeInfo } from "../../shared/types";
+import { MobileFolderPicker } from "./MobileFolderPicker";
 
 // Bottom-sheet that creates either a new project (tmux session) OR a new
 // session inside an existing project (tmux window). Mirrors the desktop
@@ -56,6 +57,10 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
   >(null);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // BET-417 §B: folder picker as a full-height sheet. Replaces the plain
+  // text cwd field with a browser — touch users get the same folder
+  // completion as desktop without ghost-text (which needs a Tab key).
+  const [folderPickerOpen, setFolderPickerOpen] = useState(false);
 
   // Cleanup the debounce on unmount so a late callback doesn't setState
   // on an unmounted sheet.
@@ -322,15 +327,25 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
                 <label className="block text-micro font-semibold uppercase text-text-muted">
                   Default working directory
                 </label>
-                <input
-                  placeholder="~/code/foo"
-                  value={cwd}
-                  onChange={(e) => onCwdChange(e.target.value)}
-                  spellCheck={false}
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded font-mono focus:outline-none focus:border-accent"
-                />
+                <div className="flex gap-2">
+                  <input
+                    placeholder="~/code/foo"
+                    value={cwd}
+                    onChange={(e) => onCwdChange(e.target.value)}
+                    spellCheck={false}
+                    autoCapitalize="off"
+                    autoComplete="off"
+                    className="flex-1 bg-bg-soft border border-border px-3 py-2 text-body rounded font-mono focus:outline-none focus:border-accent"
+                  />
+                  <button
+                    onClick={() => setFolderPickerOpen(true)}
+                    className="px-3 py-2 border border-border rounded text-text-muted hover:text-text inline-flex items-center gap-1"
+                    title="Browse folders"
+                    aria-label="Browse folders"
+                  >
+                    <FolderIcon size={18} aria-hidden="true" />
+                  </button>
+                </div>
                 {cwdMatches.length > 0 && (
                   // Tappable suggestions list — replaces the desktop's ghost-text
                   // accept-with-Tab affordance. Showing the parent prefix and
@@ -381,6 +396,16 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
           </div>
         )}
       </div>
+      {folderPickerOpen && (
+        <MobileFolderPicker
+          initialPath={cwd || "~"}
+          onSelect={(path) => {
+            setCwd(path);
+            setFolderPickerOpen(false);
+          }}
+          onCancel={() => setFolderPickerOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/mobile/MobileCreateSheet.tsx
+++ b/src/renderer/mobile/MobileCreateSheet.tsx
@@ -403,6 +403,13 @@ export function MobileCreateSheet({ mode, onClose, onCreated }: Props) {
             setCwd(path);
             setFolderPickerOpen(false);
           }}
+          onFanOut={(baseCwd, wts) => {
+            // Fan-out from the picker: set cwd + detectedWorktrees so the
+            // existing MobileCreateSheet fan-out UI takes over.
+            setCwd(baseCwd);
+            setDetectedWorktrees(wts);
+            setFolderPickerOpen(false);
+          }}
           onCancel={() => setFolderPickerOpen(false)}
         />
       )}

--- a/src/renderer/mobile/MobileFolderPicker.tsx
+++ b/src/renderer/mobile/MobileFolderPicker.tsx
@@ -1,0 +1,206 @@
+// MobileFolderPicker.tsx — full-height folder picker sheet for mobile (BET-417 §B).
+//
+// Mobile gets the folder picker as a full-height sheet. Reuses the same pure
+// helpers (breadcrumbs / parentPath / isDimmedDir / gitStateLabel) as the
+// desktop FolderPickerModal — no duplicate logic.
+//
+// Does NOT redesign other mobile screens (per the issue's Do NOT list).
+
+import { useEffect, useRef, useState } from "react";
+import { X, ChevronRight, Folder as FolderIcon, ArrowUp } from "lucide-react";
+import {
+  breadcrumbs,
+  crumbLabel,
+  isDimmedDir,
+  parentPath,
+} from "../folderPicker";
+
+type Props = {
+  initialPath: string;
+  onSelect: (path: string) => void;
+  onCancel: () => void;
+};
+
+type Row = { name: string; full: string; dimmed: boolean };
+
+export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
+  const [path, setPath] = useState(initialPath);
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounce.current) clearTimeout(debounce.current);
+    };
+  }, []);
+
+  // Path completion (same logic as desktop, tappable on touch).
+  const refreshSuggestion = (value: string) => {
+    if (debounce.current) clearTimeout(debounce.current);
+    if (!value) {
+      setSuggestion(null);
+      return;
+    }
+    debounce.current = setTimeout(async () => {
+      try {
+        const matches = (await window.api.fsListDirs(value)).filter((m) =>
+          m.startsWith(value),
+        );
+        if (matches.length === 1 && matches[0] === value) {
+          setSuggestion(null);
+          return;
+        }
+        setSuggestion(matches.length > 0 ? matches[0] : null);
+      } catch {
+        setSuggestion(null);
+      }
+    }, 80);
+  };
+
+  const onPathChange = (value: string) => {
+    setPath(value);
+    refreshSuggestion(value);
+  };
+
+  const listDir = async (dir: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const matches = await window.api.fsListDirs(dir);
+      const filtered = matches.filter((m) => m.startsWith(dir));
+      const built: Row[] = filtered.map((full) => {
+        const name = full.split("/").filter(Boolean).pop() ?? full;
+        return { name, full, dimmed: isDimmedDir(name) };
+      });
+      setRows(built);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const dir = path.endsWith("/") ? path : parentPath(path);
+    void listDir(dir);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path]);
+
+  const descend = (full: string) => {
+    const next = full.endsWith("/") ? full : full + "/";
+    setPath(next);
+  };
+
+  const goUp = () => {
+    setPath(parentPath(path));
+  };
+
+  const crumbs = breadcrumbs(path);
+
+  return (
+    <div className="mobile-screen">
+      <div className="mobile-header">
+        <div className="flex-1 flex items-center gap-2 px-1">
+          <button
+            onClick={onCancel}
+            className="mobile-tap text-text-muted leading-none inline-flex items-center"
+            aria-label="Back"
+          >
+            <X size={20} aria-hidden="true" />
+          </button>
+          <span className="text-text font-semibold text-body">Choose folder</span>
+        </div>
+        <button
+          onClick={() => onSelect(path.endsWith("/") ? path.slice(0, -1) : path)}
+          className="mobile-tap px-3 py-1 bg-accent-solid text-on-accent rounded font-semibold text-meta"
+        >
+          Select
+        </button>
+      </div>
+
+      {/* Path field */}
+      <div className="px-4 py-2 border-b border-border">
+        <input
+          value={path}
+          onChange={(e) => onPathChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void listDir(path.endsWith("/") ? path : parentPath(path));
+            }
+          }}
+          spellCheck={false}
+          autoComplete="off"
+          className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded font-mono focus:outline-none focus:border-accent"
+        />
+        {suggestion && suggestion.startsWith(path) && suggestion !== path && (
+          <button
+            onClick={() => {
+              setPath(suggestion);
+              refreshSuggestion(suggestion);
+            }}
+            className="w-full text-left px-3 py-2 text-meta text-text-muted font-mono truncate hover:bg-bg-elev"
+          >
+            {suggestion}
+          </button>
+        )}
+        {/* Breadcrumbs */}
+        <div className="flex items-center flex-wrap gap-px mt-2 text-label">
+          <button
+            onClick={goUp}
+            className="inline-flex items-center gap-1 text-text-faint hover:text-text px-1 py-px"
+          >
+            <ArrowUp size={12} aria-hidden="true" />
+          </button>
+          {crumbs.map((c, i) => (
+            <span key={c} className="inline-flex items-center">
+              {i > 0 && (
+                <ChevronRight size={12} className="text-text-quiet" aria-hidden="true" />
+              )}
+              <button
+                onClick={() => setPath(c)}
+                className={
+                  "px-1 py-px font-mono " +
+                  (c === path ? "text-text" : "text-text-faint")
+                }
+              >
+                {crumbLabel(c)}
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Folder list */}
+      <div className="manta-scroll-y flex-1 overflow-auto">
+        {loading && (
+          <div className="px-4 py-4 text-meta text-text-faint">Loading…</div>
+        )}
+        {error && (
+          <div className="px-4 py-4 text-meta text-danger">{error}</div>
+        )}
+        {!loading && !error && rows.length === 0 && (
+          <div className="px-4 py-4 text-meta text-text-faint">No subfolders</div>
+        )}
+        {!loading && !error && rows.map((r) => (
+          <button
+            key={r.full}
+            onClick={() => descend(r.full)}
+            className={
+              "mobile-row w-full text-left " +
+              (r.dimmed ? "opacity-60" : "")
+            }
+            title={r.full}
+          >
+            <FolderIcon size={16} className="shrink-0 text-text-muted" aria-hidden="true" />
+            <span className="flex-1 min-w-0 truncate font-mono text-body">{r.name}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/mobile/MobileFolderPicker.tsx
+++ b/src/renderer/mobile/MobileFolderPicker.tsx
@@ -8,28 +8,34 @@
 
 import { useEffect, useRef, useState } from "react";
 import { X, ChevronRight, Folder as FolderIcon, ArrowUp } from "lucide-react";
+import type { WorktreeInfo } from "../../shared/types";
 import {
   breadcrumbs,
   crumbLabel,
   isDimmedDir,
   parentPath,
+  worktreeBadge,
+  hasWorktreeFanOut,
 } from "../folderPicker";
 
 type Props = {
   initialPath: string;
   onSelect: (path: string) => void;
+  onFanOut?: (cwd: string, worktrees: WorktreeInfo[]) => void;
   onCancel: () => void;
 };
 
 type Row = { name: string; full: string; dimmed: boolean };
 
-export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
+export function MobileFolderPicker({ initialPath, onSelect, onFanOut, onCancel }: Props) {
   const [path, setPath] = useState(initialPath);
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [suggestion, setSuggestion] = useState<string | null>(null);
+  const [worktreeCounts, setWorktreeCounts] = useState<Record<string, WorktreeInfo[] | null>>({});
+  const [fanOut, setFanOut] = useState<{ cwd: string; worktrees: WorktreeInfo[] } | null>(null);
 
   useEffect(() => {
     return () => {
@@ -68,6 +74,7 @@ export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
   const listDir = async (dir: string) => {
     setLoading(true);
     setError(null);
+    setWorktreeCounts({});
     try {
       const matches = await window.api.fsListDirs(dir);
       const filtered = matches.filter((m) => m.startsWith(dir));
@@ -76,6 +83,23 @@ export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
         return { name, full, dimmed: isDimmedDir(name) };
       });
       setRows(built);
+      // Lazily probe each row for worktree fan-out (concurrency 4).
+      const probeRow = async (full: string) => {
+        try {
+          const wts = await window.api.gitListWorktrees(full);
+          setWorktreeCounts((prev) => ({ ...prev, [full]: wts }));
+        } catch {
+          setWorktreeCounts((prev) => ({ ...prev, [full]: null }));
+        }
+      };
+      const queue = [...built.map((r) => r.full)];
+      const workers = Array.from({ length: 4 }, async () => {
+        while (queue.length > 0) {
+          const full = queue.shift();
+          if (full) await probeRow(full);
+        }
+      });
+      void Promise.all(workers);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setRows([]);
@@ -99,6 +123,23 @@ export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
     setPath(parentPath(path));
   };
 
+  // Select the current path — probe for fan-out first (BET-417 §B4). If the
+  // folder has >1 worktree and onFanOut is provided, ask the fan-out question
+  // before committing. Otherwise select the single folder.
+  const select = async () => {
+    const chosen = path.endsWith("/") ? path.slice(0, -1) : path;
+    if (onFanOut) {
+      try {
+        const wts = await window.api.gitListWorktrees(chosen);
+        if (hasWorktreeFanOut(wts)) {
+          setFanOut({ cwd: chosen, worktrees: wts });
+          return;
+        }
+      } catch { /* not a repo — single select */ }
+    }
+    onSelect(chosen);
+  };
+
   const crumbs = breadcrumbs(path);
 
   return (
@@ -115,7 +156,7 @@ export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
           <span className="text-text font-semibold text-body">Choose folder</span>
         </div>
         <button
-          onClick={() => onSelect(path.endsWith("/") ? path.slice(0, -1) : path)}
+          onClick={() => void select()}
           className="mobile-tap px-3 py-1 bg-accent-solid text-on-accent rounded font-semibold text-meta"
         >
           Select
@@ -186,21 +227,67 @@ export function MobileFolderPicker({ initialPath, onSelect, onCancel }: Props) {
         {!loading && !error && rows.length === 0 && (
           <div className="px-4 py-4 text-meta text-text-faint">No subfolders</div>
         )}
-        {!loading && !error && rows.map((r) => (
-          <button
-            key={r.full}
-            onClick={() => descend(r.full)}
-            className={
-              "mobile-row w-full text-left " +
-              (r.dimmed ? "opacity-60" : "")
-            }
-            title={r.full}
-          >
-            <FolderIcon size={16} className="shrink-0 text-text-muted" aria-hidden="true" />
-            <span className="flex-1 min-w-0 truncate font-mono text-body">{r.name}</span>
-          </button>
-        ))}
+        {!loading && !error && (
+          <>
+            {/* `..` row — spec §B3 says ".. first". */}
+            <button
+              onClick={goUp}
+              className="mobile-row w-full text-left"
+              title={parentPath(path)}
+            >
+              <ArrowUp size={16} className="shrink-0 text-text-muted" aria-hidden="true" />
+              <span className="flex-1 min-w-0 truncate font-mono text-body">..</span>
+            </button>
+            {rows.map((r) => {
+              const wtCount = worktreeCounts[r.full];
+              const badge = worktreeBadge(wtCount ?? null);
+              return (
+                <button
+                  key={r.full}
+                  onClick={() => descend(r.full)}
+                  className={
+                    "mobile-row w-full text-left " +
+                    (r.dimmed ? "text-text-quiet" : "")
+                  }
+                  title={r.full}
+                >
+                  <FolderIcon size={16} className="shrink-0 text-text-muted" aria-hidden="true" />
+                  <span className="flex-1 min-w-0 truncate font-mono text-body">{r.name}</span>
+                  {badge && (
+                    <span className="text-label text-accent-tx shrink-0">{badge}</span>
+                  )}
+                </button>
+              );
+            })}
+          </>
+        )}
       </div>
+
+      {/* Fan-out question (asked at Select, before commit) */}
+      {fanOut && (
+        <div className="mobile-sheet-backdrop" onClick={() => setFanOut(null)}>
+          <div className="mobile-sheet" onClick={(e) => e.stopPropagation()}>
+            <div className="px-4 py-3 text-meta text-text-muted">
+              Detected {fanOut.worktrees.length} git worktrees. Open a session for each?
+            </div>
+            <ul className="px-4 text-label text-text-faint space-y-px max-h-40 overflow-y-auto">
+              {fanOut.worktrees.map((w) => (
+                <li key={w.path} className="truncate">
+                  <span className="text-text-muted">{w.path.split("/").filter(Boolean).pop() || w.branch}</span>
+                  {" "}<span className="text-text-faint">— {w.path}</span>
+                </li>
+              ))}
+            </ul>
+            <button onClick={() => onFanOut?.(fanOut.cwd, fanOut.worktrees)}>
+              Yes, one per worktree
+            </button>
+            <button onClick={() => { onSelect(fanOut.cwd); setFanOut(null); }}>
+              Just this folder
+            </button>
+            <button onClick={() => setFanOut(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## BET-417: New-session composer and folder picker

### Summary

Replaces the inline new-project/new-session forms in the sidebar with a single
**NewSessionScreen** — a pre-session composer that is also the app's zero state
(BET-416 §F). The ghost-text cwd input is replaced by a **FolderPickerModal**
with breadcrumbs, dimmed dot-folders/node_modules, and worktree badges that
appear *during browse* (not as a post-Create interstitial).

### What changed

**New files:**
- `src/renderer/NewSessionScreen.tsx` — the pre-session composer: "What's up
  next?" heading, folder chip → FolderPickerModal, split branch/worktree chip,
  textarea, ModelPicker, voice mic. On submit: creates tmux session/window +
  sends the first prompt.
- `src/renderer/FolderPickerModal.tsx` — desktop folder picker: path field
  with the existing completion logic (moved from Sidebar), clickable
  breadcrumbs, scrollable folder list with dimmed node_modules/dot-folders,
  per-row worktree badge (lazily probed, concurrency 4), worktree fan-out
  asked at Select time, footer git state.
- `src/renderer/folderPicker.ts` — pure helpers (breadcrumbs, parentPath,
  crumbLabel, isDimmedDir, worktreeBadge, hasWorktreeFanOut, gitStateLabel).
- `src/renderer/mobile/MobileFolderPicker.tsx` — full-height folder picker
  sheet for mobile, reusing the same pure helpers.
- `src/renderer/folderPicker.test.ts` — 24 tests for the pure helpers.
- `src/renderer/NewSessionScreen.test.ts` — 6 tests for deriveProjectName.

**Modified:**
- `src/renderer/Sidebar.tsx` — deleted inline new-project form (was :728-849)
  and inline new-session form (was :1041-1084). Rail `+` and per-project `+`
  now call `onNewProject` / `onNewSessionInProject` callbacks that open
  NewSessionScreen. Removed ~430 lines of inline form state + logic.
- `src/renderer/App.tsx` — zero-project state shows NewSessionScreen;
  overlay for non-zero. Wired `onNewProject` / `onNewSessionInProject` to
  Sidebar. Removed dead ⌘N placeholder + unused MOD_KEY import.
- `src/renderer/mobile/MobileCreateSheet.tsx` — Browse button opens
  MobileFolderPicker.

### Design decisions

- **Project name derived from folder basename** — the new-session screen has
  no name field (the spec shows only folder + branch/worktree chips).
  `deriveProjectName("~/code/leasebot")` → `"leasebot"`. Collisions get a
  `-2`, `-3` suffix.
- **Worktree fan-out asked at browse time** — FolderPickerModal probes each
  row with `gitListWorktrees(row)` and shows `⎇ N worktrees` badge before
  the user commits. The fan-out question is asked at Select, not after
  Create. This is the core UX fix: worktree detection is no longer a
  surprise interstitial.
- **Attachments omitted from pre-session composer** — both upload paths
  (`uploadFiles` / `uploadBuffer`) require a `projectName`, which doesn't
  exist yet. Attachments work in the active-session composer after creation.
  Voice (mic → text insertion) works pre-session via `useVoiceRecorder`.
- **No host chip** — the box connection is already established; the spec
  explicitly says "There is no host chip."

### Follow-ups

- Per-row worktree badge in MobileFolderPicker (currently desktop-only).
- Attachments in the pre-session composer (requires decoupling upload from
  projectName, or buffering files until after session creation).

### Verification results

**Files changed:** 9 files. `+1419 / -439`.

- PR branch (`multica/BET-417-new-session-folder-picker` @ `e7b8e3c`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1208 pass / 0 fail / 0 skip (node:test) + 1659 pass / 0 fail (vitest). log sha256: `c5ab865b08d141667a67c24c483bcd4aebdb1f7e2d11def8a0e4e37e5afaa828`
- Base (`main` @ `14f7970`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1208 pass / 0 fail / 0 skip (node:test). log sha256: `181273bba319927e40214dde1193885d5102e994b9974ee89e9831caed1d4255`
- **Conclusion:** 0 new failures, 0 pre-existing failures. Typecheck identical between branches.

Base: origin/main @ 14f7970
