### PR TITLE
BET-420: settings — eight-section restructure

### DIFF
--- a/src/renderer/AddEndpointForm.tsx
+++ b/src/renderer/AddEndpointForm.tsx
@@ -1,0 +1,151 @@
+// BET-420 — ONE add-endpoint form with ONE validator, shared by Settings
+// (Accounts section) and onboarding (ProvidersStep). Both surfaces must
+// reject a scheme-less URL identically. Previously the Settings form
+// (ProvidersCard) accepted any non-empty string while only the onboarding
+// form checked the http(s):// scheme — they drifted.
+//
+// This file owns the form markup + the validator. The actual save (and
+// whether a restart follows) is the caller's job, passed as `onAdd`, so
+// Settings can route the restart through the panel-level banner while
+// onboarding restarts inline as it always has.
+
+import { useState } from "react";
+
+export type EndpointDraft = {
+  id: string;
+  name: string;
+  baseURL: string;
+  apiKey: string;
+};
+
+export const EMPTY_ENDPOINT_DRAFT: EndpointDraft = {
+  id: "",
+  name: "",
+  baseURL: "",
+  apiKey: "",
+};
+
+/**
+ * Validate an endpoint draft. Returns the reason it's invalid, or null when
+ * the draft is submittable. id + baseURL are required; key is optional (some
+ * self-hosted endpoints are keyless). The baseURL MUST carry an http:// or
+ * https:// scheme — this is the check that was missing on the Settings side.
+ */
+export function validateEndpointDraft(d: EndpointDraft): string | null {
+  if (!d.id.trim()) return "Provider id is required.";
+  if (!d.baseURL.trim()) return "Base URL is required.";
+  if (!/^https?:\/\//i.test(d.baseURL.trim())) {
+    return "Base URL must start with http:// or https://.";
+  }
+  return null;
+}
+
+export function AddEndpointForm({
+  onAdd,
+  busy,
+}: {
+  /** Save the draft. Return an error string on failure, or null on success. */
+  onAdd: (draft: EndpointDraft) => Promise<string | null>;
+  busy: boolean;
+}): JSX.Element {
+  const [draft, setDraft] = useState<EndpointDraft>(EMPTY_ENDPOINT_DRAFT);
+  const [error, setError] = useState<string | null>(null);
+
+  const set = (patch: Partial<EndpointDraft>) => {
+    setDraft((d) => ({ ...d, ...patch }));
+    setError(null);
+  };
+
+  const submit = async () => {
+    const draftErr = validateEndpointDraft(draft);
+    if (draftErr) {
+      setError(draftErr);
+      return;
+    }
+    setError(null);
+    const err = await onAdd(draft);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setDraft(EMPTY_ENDPOINT_DRAFT);
+  };
+
+  const canSubmit =
+    !busy && draft.id.trim().length > 0 && draft.baseURL.trim().length > 0;
+
+  return (
+    <div className="rounded-md border border-dashed border-border bg-bg-soft p-3 space-y-3">
+      <div className="text-micro font-semibold uppercase text-text-faint">
+        Add a custom endpoint
+      </div>
+      <EndpointInput
+        label="Provider id"
+        placeholder="e.g. groq"
+        value={draft.id}
+        disabled={busy}
+        onChange={(v) => set({ id: v })}
+      />
+      <EndpointInput
+        label="Name (optional)"
+        placeholder="e.g. Groq"
+        value={draft.name}
+        disabled={busy}
+        onChange={(v) => set({ name: v })}
+      />
+      <EndpointInput
+        label="Base URL"
+        placeholder="https://api.groq.com/openai/v1"
+        value={draft.baseURL}
+        disabled={busy}
+        onChange={(v) => set({ baseURL: v })}
+      />
+      <EndpointInput
+        label="API key (optional)"
+        placeholder="key"
+        value={draft.apiKey}
+        type="password"
+        disabled={busy}
+        onChange={(v) => set({ apiKey: v })}
+      />
+      {error && (
+        <div role="alert" className="text-meta text-danger">
+          {error}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => void submit()}
+        disabled={!canSubmit}
+        className="px-3 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {busy ? "Adding…" : "Add endpoint"}
+      </button>
+    </div>
+  );
+}
+
+function EndpointInput(props: {
+  label: string;
+  placeholder: string;
+  value: string;
+  type?: "text" | "password";
+  disabled: boolean;
+  onChange: (v: string) => void;
+}): JSX.Element {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-label text-text-muted">{props.label}</span>
+      <input
+        type={props.type ?? "text"}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={props.placeholder}
+        value={props.value}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value)}
+        className="w-full rounded bg-bg border border-border px-3 py-2 text-body text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+      />
+    </label>
+  );
+}

--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -54,6 +54,7 @@ import {
 } from "./chatUtils";
 import { CopyButton } from "./CopyButton";
 import { Terminal } from "./Terminal";
+import { useStore } from "./store";
 
 // Poll cadences (BET-312, BET-354): 3s for both the device-code wait and
 // the post-restart readiness poll. BET-354 adds a 1s tick for the
@@ -89,13 +90,11 @@ export function ConnectProvider({
   label,
   onDone,
   onCancel,
-  confirmRestart = false,
 }: {
   id: string;
   label: string;
   onDone: (connected: boolean) => void;
   onCancel: () => void;
-  confirmRestart?: boolean;
 }): JSX.Element {
   const [phase, setPhase] = useState<ConnectPhase>({ kind: "starting" });
   const mounted = useMounted();
@@ -306,7 +305,6 @@ export function ConnectProvider({
   // progress that completed before the second restart.
   useEffect(() => {
     if (phase.kind !== "applying") return;
-    if (confirmRestart && !phase.restartConfirmed) return;
     let cancelled = false;
     const startedAt = Date.now();
     const serverAlreadyRestarted = phase.restarted === true;
@@ -314,6 +312,9 @@ export function ConnectProvider({
       if (!serverAlreadyRestarted) {
         try {
           await window.api.opencodeRestart();
+          // BET-420: this restart satisfies any pending panel-level restart
+          // banner — clear it so the banner doesn't outlive the restart.
+          useStore.getState().setOpencodeRestartNeeded(false);
         } catch {
           /* poll below will catch a no-op restart on a reachable box */
         }
@@ -352,7 +353,7 @@ export function ConnectProvider({
     // `applying` variant; the ternary narrows `phase` for the access and
     // the `null` branch keeps the deps array a uniform value list (the
     // false branches never read the field).
-  }, [phase.kind, phase.kind === "applying" ? phase.restartConfirmed : null, phase.kind === "applying" ? phase.restarted : null, confirmRestart, id, safeSetPhase]);
+  }, [phase.kind, phase.kind === "applying" ? phase.restartConfirmed : null, phase.kind === "applying" ? phase.restarted : null, id, safeSetPhase]);
 
   // done is terminal — fire onDone exactly once when the phase KIND
   // becomes "done". Deps `[phase.kind, onDone]` so updates to fields
@@ -538,30 +539,9 @@ export function ConnectProvider({
         />
       )}
 
-      {phase.kind === "applying" && confirmRestart && !phase.restartConfirmed && (
-        <div className="flex items-center gap-2 bg-bg-soft border border-border rounded p-2">
-          <span className="flex-1 text-text-muted">
-            Restart opencode now to apply? (interrupts active sessions)
-          </span>
-          <button
-            onClick={() => safeSetPhase({ kind: "applying", restartConfirmed: true })}
-            className="px-2 py-1 bg-accent/20 border border-accent rounded text-text"
-          >
-            Apply Now
-          </button>
-          <button
-            onClick={onCancel}
-            className="px-2 py-1 border border-border rounded text-text-muted"
-          >
-            Apply Later
-          </button>
-        </div>
+      {phase.kind === "applying" && (
+        <div className="text-text-muted">Restarting opencode…</div>
       )}
-
-      {phase.kind === "applying" &&
-        (!confirmRestart || phase.restartConfirmed) && (
-          <div className="text-text-muted">Restarting opencode…</div>
-        )}
 
       {phase.kind === "done" && (
         <div className="text-ok">Connected.</div>

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -95,12 +95,6 @@ export function ModelsCard() {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
 
-  const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
-  const [restarting, setRestarting] = useState(false);
-  const [restartResult, setRestartResult] = useState<
-    { ok: boolean; message: string } | null
-  >(null);
-
   // Load models + config + reconcile subagents on mount. Mirrors the
   // SubagentsCard.refresh() flow (BET-123): every known model is auto-
   // registered as a named subagent; the user opts OUT via the Sub toggle.
@@ -137,24 +131,11 @@ export function ModelsCard() {
   }, [refresh]);
 
   // (Reused as-is from the prior SubagentsCard — subagent reconcile is the
-  // only opencode.jsonc writing the table triggers.)
-  const doRestart = useCallback(async () => {
-    if (restarting) return;
-    setRestarting(true);
-    setRestartResult(null);
-    try {
-      await window.api.opencodeRestart();
-      setRestartResult({ ok: true, message: "Restarted — subagent changes are now live." });
-    } catch (e) {
-      setRestartResult({
-        ok: false,
-        message: `Restart failed: ${e instanceof Error ? e.message : String(e)}`,
-      });
-    } finally {
-      setRestarting(false);
-      setRestartConfirmOpen(false);
-    }
-  }, [restarting]);
+  // only opencode.jsonc writing the table triggers.) A sub toggle change
+  // needs an opencode restart to take effect; rather than show a per-card
+  // restart prompt (BET-420 collapsed the three prompts into one panel-level
+  // banner), we raise the shared `opencodeRestartNeeded` flag and let the
+  // Settings panel offer the single restart button.
 
   // ---- Toggles ----
   //
@@ -225,6 +206,9 @@ export function ModelsCard() {
           deactivated: resolvedList,
         });
         setDeactivatedSub(new Set(resolvedList));
+        // Sub toggles write opencode.jsonc agent blocks — a restart is
+        // required for opencode to re-read them. Raise the panel banner.
+        useStore.getState().setOpencodeRestartNeeded(true);
       } catch (e) {
         setGlobalError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -419,53 +403,6 @@ export function ModelsCard() {
             })}
           </tbody>
         </table>
-      </div>
-
-      {/* Restart — Subagent changes still require a restart, so keep the
-          existing SubagentsCard restart button + destructive-confirm copy
-          verbatim (BET-123). */}
-      <div className="border border-border rounded p-3 space-y-2 bg-bg-elev">
-        {!restartConfirmOpen ? (
-          <button
-            onClick={() => { setRestartConfirmOpen(true); setRestartResult(null); }}
-            className="px-3 py-2 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text"
-          >
-            ⟳ Restart opencode
-          </button>
-        ) : (
-          <div className="space-y-2">
-            <div className="text-meta text-warn">
-              Restarting opencode applies subagent changes but STOPS all
-              running opencode sessions — any in-progress turns will be
-              interrupted. Continue?
-            </div>
-            <div className="flex gap-2">
-              <button
-                onClick={() => void doRestart()}
-                disabled={restarting}
-                className="px-3 py-1 text-meta bg-danger-bg border border-danger rounded text-danger hover:text-danger disabled:opacity-40"
-              >
-                {restarting ? "Restarting…" : "Restart"}
-              </button>
-              <button
-                onClick={() => setRestartConfirmOpen(false)}
-                disabled={restarting}
-                className="px-2 py-1 text-meta text-text-faint hover:text-text disabled:opacity-40"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        )}
-        {restartResult && (
-          <div className={`text-meta ${restartResult.ok ? "text-ok" : "text-danger"}`}>
-            {restartResult.message}
-          </div>
-        )}
-        <div className="text-meta text-text-faint">
-          Restart applies config to opencode's own service (systemctl --user
-          restart opencode-serve) — separate from manta-server itself.
-        </div>
       </div>
     </div>
   );

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -1,16 +1,25 @@
 import { useEffect, useState, useCallback } from "react";
 import { X } from "lucide-react";
 import type { ProviderEndpoint, DiscoverResult } from "../shared/types";
+import { AddEndpointForm, type EndpointDraft } from "./AddEndpointForm";
 
-type Draft = { id: string; name: string; baseURL: string; apiKey: string };
-const EMPTY_DRAFT: Draft = { id: "", name: "", baseURL: "", apiKey: "" };
+type Props = {
+  /**
+   * BET-420: raised when an endpoint mutation needs an opencode restart. When
+   * provided (desktop Settings), the card does NOT render its own restart
+   * banner — the Settings panel shows ONE shared restart banner instead. When
+   * omitted (mobile), the card keeps its inline "Apply Now / Apply Later"
+   * banner so mobile still has a restart affordance.
+   */
+  onRestartNeeded?: () => void;
+};
 
-export function ProvidersCard() {
+export function ProvidersCard({ onRestartNeeded }: Props = {}) {
   const [endpoints, setEndpoints] = useState<ProviderEndpoint[] | null>(null);
   const [discovered, setDiscovered] = useState<Record<string, { id: string }[]>>({});
   const [discoverError, setDiscoverError] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<string | null>(null); // endpoint id being mutated
-  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [adding, setAdding] = useState(false);
   const [restartNeeded, setRestartNeeded] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
 
@@ -48,6 +57,11 @@ export function ProvidersCard() {
     }
   }, [busy]);
 
+  const flagRestart = () => {
+    if (onRestartNeeded) onRestartNeeded();
+    else setRestartNeeded(true);
+  };
+
   const toggleModel = useCallback(async (ep: ProviderEndpoint, modelId: string) => {
     if (busy) return;
     const enabled = ep.enabledModels.includes(modelId)
@@ -60,38 +74,38 @@ export function ProvidersCard() {
         upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
       });
       if (!res.ok) { setGlobalError(res.error ?? "Save failed"); return; }
-      setRestartNeeded(true);
+      flagRestart();
       load();
     } catch (e) {
       setGlobalError(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(null);
     }
-  }, [busy, load]);
+  }, [busy, load, onRestartNeeded]);
 
-  const addEndpoint = useCallback(async () => {
-    if (busy) return;
-    const d = draft;
-    if (!d.id.trim() || !d.baseURL.trim()) return;
-    setBusy(d.id);
+  const addEndpoint = useCallback(async (draft: EndpointDraft): Promise<string | null> => {
+    if (busy || adding) return null;
+    setAdding(true);
     setGlobalError(null);
     try {
       const res = await window.api.opencodeSetProviders({
         upsert: [{
-          id: d.id.trim(), name: d.name.trim() || d.id.trim(),
-          baseURL: d.baseURL.trim(), apiKey: d.apiKey, enabledModels: [],
+          id: draft.id.trim(), name: draft.name.trim() || draft.id.trim(),
+          baseURL: draft.baseURL.trim(), apiKey: draft.apiKey, enabledModels: [],
         }],
       });
-      if (!res.ok) { setGlobalError(res.error ?? "Add failed"); return; }
-      setDraft(EMPTY_DRAFT);
-      setRestartNeeded(true);
+      if (!res.ok) { setGlobalError(res.error ?? "Add failed"); return res.error ?? "Add failed"; }
+      flagRestart();
       load();
+      return null;
     } catch (e) {
-      setGlobalError(e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
+      setGlobalError(msg);
+      return msg;
     } finally {
-      setBusy(null);
+      setAdding(false);
     }
-  }, [busy, draft, load]);
+  }, [busy, adding, load, onRestartNeeded]);
 
   const removeEndpoint = useCallback(async (ep: ProviderEndpoint) => {
     if (busy) return;
@@ -102,14 +116,14 @@ export function ProvidersCard() {
       if (!res.ok) { setGlobalError(res.error ?? "Remove failed"); return; }
       setDiscovered((d) => { const { [ep.id]: _drop, ...rest } = d; return rest; });
       setDiscoverError((er) => { const { [ep.id]: _drop, ...rest } = er; return rest; });
-      setRestartNeeded(true);
+      flagRestart();
       load();
     } catch (e) {
       setGlobalError(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(null);
     }
-  }, [busy, load]);
+  }, [busy, load, onRestartNeeded]);
 
   const [restarting, setRestarting] = useState(false);
   const applyRestart = useCallback(async () => {
@@ -129,10 +143,7 @@ export function ProvidersCard() {
   }, [restarting]);
 
   return (
-    <div className="space-y-2 pt-2 border-t border-border">
-      <label className="block text-micro font-semibold uppercase text-text-muted">
-        Providers
-      </label>
+    <div className="space-y-2">
       <div className="text-meta text-text-faint">
         OpenAI-compatible endpoints opencode can serve. Refresh to discover models,
         then enable the ones you want in the model picker.
@@ -181,30 +192,11 @@ export function ProvidersCard() {
         </div>
       ))}
 
-      <div className="border border-dashed border-border rounded p-2 space-y-1">
-        <div className="text-micro font-semibold uppercase text-text-faint">Add endpoint</div>
-        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded"
-          placeholder="id (e.g. voska)" value={draft.id}
-          onChange={(e) => setDraft((d) => ({ ...d, id: e.target.value }))} />
-        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded"
-          placeholder="name (e.g. VoskaAI)" value={draft.name}
-          onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))} />
-        <input className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded"
-          placeholder="baseURL (https://api.voska.org/v1)" value={draft.baseURL}
-          onChange={(e) => setDraft((d) => ({ ...d, baseURL: e.target.value }))} />
-        <input type="password" className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded"
-          placeholder="API key" value={draft.apiKey}
-          onChange={(e) => setDraft((d) => ({ ...d, apiKey: e.target.value }))} />
-        <button
-          onClick={addEndpoint}
-          disabled={!draft.id.trim() || !draft.baseURL.trim() || busy !== null}
-          className="px-3 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
-        >
-          Add
-        </button>
-      </div>
+      <AddEndpointForm onAdd={addEndpoint} busy={adding || busy !== null} />
 
-      {restartNeeded && (
+      {/* Mobile-only restart banner (desktop routes through the panel banner
+          via onRestartNeeded, so this never renders on desktop). */}
+      {!onRestartNeeded && restartNeeded && (
         <div className="flex items-center gap-2 text-meta bg-bg-soft border border-border rounded p-2">
           <span className="flex-1 text-text-muted">
             Restart opencode now to apply? (interrupts active sessions)

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -37,8 +37,8 @@ import { Check } from "lucide-react";
 import type { SubscriptionStatus } from "../shared/types";
 import { ConnectProvider } from "./ConnectProvider";
 import { StepFooter } from "./onboardingUi";
+import { AddEndpointForm, type EndpointDraft } from "./AddEndpointForm";
 
-const ACCENT_SOLID = "var(--accent-solid)";
 const DANGER = "var(--danger)";
 const SUCCESS = "var(--ok)";
 
@@ -51,17 +51,9 @@ export function canContinueProviders(statuses: SubscriptionStatus[]): boolean {
   return statuses.some((s) => s.connected);
 }
 
-// Validation for the custom-endpoint add form. id + baseURL are required;
-// key is optional (some self-hosted endpoints are keyless). Returns the
-// reason it's invalid, or null when the draft is submittable.
-type ProviderDraft = { id: string; name: string; baseURL: string; apiKey: string };
-
-export function customDraftError(draft: ProviderDraft): string | null {
-  if (!draft.id.trim()) return "Provider id is required.";
-  if (!draft.baseURL.trim()) return "Base URL is required.";
-  if (!/^https?:\/\//i.test(draft.baseURL.trim())) return "Base URL must start with http:// or https://.";
-  return null;
-}
+// BET-420: the custom-endpoint add form + its validator are shared with
+// Settings (Accounts) via AddEndpointForm / validateEndpointDraft, so a
+// scheme-less URL is rejected identically in onboarding and Settings.
 
 export function ProvidersStep({
   onBack,
@@ -125,9 +117,11 @@ export function ProvidersStep({
   );
 
   const submitCustom = async (
-    draft: ProviderDraft,
+    draft: EndpointDraft,
     onDone: () => Promise<void>,
   ): Promise<string | null> => {
+    // The shared AddEndpointForm already validated the draft (scheme check),
+    // so we only persist + restart here.
     try {
       const res = await window.api.opencodeSetProviders({
         upsert: [
@@ -249,12 +243,12 @@ export function ProvidersStep({
         </button>
         {showCustom && (
           <div className="mt-3">
-            <CustomForm
-              onDone={async () => {
+            <AddEndpointForm
+              onAdd={(draft) => submitCustom(draft, async () => {
                 setShowCustom(false);
                 await refresh();
-              }}
-              submit={submitCustom}
+              })}
+              busy={false}
             />
           </div>
         )}
@@ -270,113 +264,3 @@ export function ProvidersStep({
   );
 }
 
-function CustomForm({
-  onDone,
-  submit,
-}: {
-  onDone: () => Promise<void>;
-  submit: (draft: ProviderDraft, onDone: () => Promise<void>) => Promise<string | null>;
-}) {
-  const [draft, setDraft] = useState<ProviderDraft>({
-    id: "",
-    name: "",
-    baseURL: "",
-    apiKey: "",
-  });
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const set = (patch: Partial<ProviderDraft>) => {
-    setDraft((d) => ({ ...d, ...patch }));
-    setError(null);
-  };
-
-  const onSubmit = async () => {
-    const draftErr = customDraftError(draft);
-    if (draftErr) {
-      setError(draftErr);
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    const err = await submit(draft, onDone);
-    if (err) setError(err);
-    setBusy(false);
-  };
-
-  return (
-    <div className="rounded-md border border-border bg-bg-soft p-3 space-y-3">
-      <div className="text-micro font-semibold uppercase text-text-faint">
-        Add a custom provider
-      </div>
-      <CustomInput
-        label="Provider id"
-        placeholder="e.g. groq"
-        value={draft.id}
-        disabled={busy}
-        onChange={(v) => set({ id: v })}
-      />
-      <CustomInput
-        label="Name (optional)"
-        placeholder="e.g. Groq"
-        value={draft.name}
-        disabled={busy}
-        onChange={(v) => set({ name: v })}
-      />
-      <CustomInput
-        label="Base URL"
-        placeholder="https://api.groq.com/openai/v1"
-        value={draft.baseURL}
-        disabled={busy}
-        onChange={(v) => set({ baseURL: v })}
-      />
-      <CustomInput
-        label="API key (optional)"
-        placeholder="key"
-        value={draft.apiKey}
-        type="password"
-        disabled={busy}
-        onChange={(v) => set({ apiKey: v })}
-      />
-      {error && (
-        <div role="alert" className="text-meta" style={{ color: DANGER }}>
-          {error}
-        </div>
-      )}
-      <button
-        type="button"
-        onClick={() => void onSubmit()}
-        disabled={busy || !draft.id.trim() || !draft.baseURL.trim()}
-        className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
-        style={{ background: ACCENT_SOLID }}
-      >
-        {busy ? "Adding…" : "Add provider"}
-      </button>
-    </div>
-  );
-}
-
-function CustomInput(props: {
-  label: string;
-  placeholder: string;
-  value: string;
-  type?: "text" | "password";
-  disabled: boolean;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <label className="flex flex-col gap-1">
-      <span className="text-label text-text-muted">{props.label}</span>
-      <input
-        type={props.type ?? "text"}
-        autoComplete="off"
-        spellCheck={false}
-        placeholder={props.placeholder}
-        value={props.value}
-        disabled={props.disabled}
-        onChange={(e) => props.onChange(e.target.value)}
-        className="w-full rounded bg-bg border border-border px-3 py-2 text-body text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
-      />
-    </label>
-  );
-}

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -216,7 +216,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
 
   // Active tab + search — declared early so the plugins effect below can read
   // activeTab without a TDZ violation.
-  const [activeTab, setActiveTab] = useState<SettingSectionId>("connection");
+  const [activeTab, setActiveTab] = useState<SettingSectionId>("general");
   const [query, setQuery] = useState("");
   const inSearch = query.trim().length > 0;
   const searchHits = useMemo(() => searchSettings(SETTINGS, query, PLATFORM), [query]);
@@ -235,9 +235,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
       worktreeCleanOnClose: store.worktreeCleanOnClose,
       theme: store.theme,
       autoRenameSessions: store.autoRenameSessions,
-      shareAnalytics: store.shareAnalytics,
     }),
-    [store.cacheTtl, store.groqApiKey, store.voiceTranscriptionModel, store.voiceCommandModel, store.allowAgentPush, store.downloadsDir, store.worktreePerSession, store.worktreeCleanOnClose, store.theme, store.autoRenameSessions, store.shareAnalytics],
+    [store.cacheTtl, store.groqApiKey, store.voiceTranscriptionModel, store.voiceCommandModel, store.allowAgentPush, store.downloadsDir, store.worktreePerSession, store.worktreeCleanOnClose, store.theme, store.autoRenameSessions],
   );
 
   const commitKey = async (entry: SettingEntry, nextValue: unknown) => {
@@ -261,6 +260,29 @@ export function Settings({ onClose }: { onClose: () => void }) {
     });
     return () => { cancelled = true; };
   }, []);
+
+  // opencode port — exposed in the Box "Advanced" row (BET-420). Read via
+  // configGet (it's an AppConfig key with no store mirror) and committed via
+  // configUpdate. Not part of the schema-driven simple fields.
+  const [opencodePort, setOpencodePort] = useState<number | null>(null);
+  const [opencodePortDraft, setOpencodePortDraft] = useState("");
+  const [opencodePortSavedAt, setOpencodePortSavedAt] = useState<number | null>(null);
+  useEffect(() => {
+    window.api.configGet().then((c) => {
+      const port = typeof c.opencodePort === "number" ? c.opencodePort : 14096;
+      setOpencodePort(port);
+      setOpencodePortDraft(String(port));
+    }).catch(() => {});
+  }, []);
+  const commitOpencodePort = () => {
+    const n = Number(opencodePortDraft);
+    if (!Number.isFinite(n) || n <= 0 || n > 65535) return;
+    const prev = opencodePort;
+    setOpencodePort(n);
+    void window.api.configUpdate({ opencodePort: n })
+      .then((r) => { const saved = (r as Record<string, unknown>).opencodePort; setOpencodePort(typeof saved === "number" ? saved : n); setOpencodePortSavedAt(Date.now()); })
+      .catch((e: unknown) => { if (prev != null) setOpencodePort(prev); setOpencodePortDraft(prev != null ? String(prev) : ""); push({ id: `err-port-${Date.now()}`, message: errorDisclosure("Couldn't save the opencode port.", e) }); });
+  };
 
   // Registry URLs (custom control — instant apply on add/remove).
   const {
@@ -326,14 +348,14 @@ export function Settings({ onClose }: { onClose: () => void }) {
     if (!preload?.pluginsSetEnabled) return;
     try {
       await preload.pluginsSetEnabled(on);
-      push({ id: `plugins-${Date.now()}`, message: `Plugins ${on ? "enabled" : "disabled"} — restart MantaUI to apply.`, action: { label: "Undo", onClick: () => { setPluginsOn(prev); void preload.pluginsSetEnabled(prev); } } });
+      push({ id: `plugins-${Date.now()}`, message: `Plugins ${on ? "enabled" : "disabled"} — restart Manta to apply.`, action: { label: "Undo", onClick: () => { setPluginsOn(prev); void preload.pluginsSetEnabled(prev); } } });
     } catch (e) {
       setPluginsOn(prev);
       push({ id: `err-plugins-${Date.now()}`, message: errorDisclosure("Couldn't toggle plugins.", e) });
     }
   };
   useEffect(() => {
-    if (activeTab !== "plugins") return;
+    if (activeTab !== "extensions") return;
     let cancelled = false;
     const fetchOnce = () => {
       window.api.pluginsRegistry()
@@ -345,7 +367,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
     return () => { cancelled = true; clearInterval(timer); };
   }, [activeTab]);
 
-  // Mobile pairing (Connection tab).
+  // Mobile pairing (Box section).
   const [pairing, setPairing] = useState<AuthPairResult | null>(null);
   const [pairingExpiry, setPairingExpiry] = useState<Date | null>(null);
   const [pairingMinting, setPairingMinting] = useState(false);
@@ -411,6 +433,31 @@ export function Settings({ onClose }: { onClose: () => void }) {
     }
   };
 
+  // ===== BET-420: the ONE restart affordance =====
+  // ModelsCard (sub toggles) and ProvidersCard (endpoint changes) raise
+  // `opencodeRestartNeeded`; this banner is the single place the user is
+  // asked to restart. ConnectProvider's connect-completion restart is
+  // automatic (it must restart + poll to verify the credential came online),
+  // not a user-facing affordance, and clears this flag when it fires.
+  const restartNeeded = useStore((s) => s.opencodeRestartNeeded);
+  const setRestartNeeded = useStore((s) => s.setOpencodeRestartNeeded);
+  const [restarting, setRestarting] = useState(false);
+  const [restartError, setRestartError] = useState<string | null>(null);
+  const performRestart = async () => {
+    if (restarting) return;
+    setRestarting(true);
+    setRestartError(null);
+    try {
+      await window.api.opencodeRestart();
+      setRestartNeeded(false);
+    } catch (e) {
+      setRestartError(`Restart failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRestarting(false);
+    }
+  };
+  const requestRestart = () => setRestartNeeded(true);
+
   // Arrow-key navigation on the tab rail (BET-419 §C).
   const railRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const searchRef = useRef<HTMLInputElement | null>(null);
@@ -437,6 +484,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
   };
 
   const schemaEntries = settingsForSection(SETTINGS, activeTab, PLATFORM);
+  const simpleEntries = schemaEntries.filter((e) => e.control !== "custom");
 
   const renderField = (entry: SettingEntry): ReactNode => {
     const cur = entry.configKey ? values[entry.configKey] : undefined;
@@ -457,13 +505,62 @@ export function Settings({ onClose }: { onClose: () => void }) {
 
   // Per-section custom content (cards/lists the schema doesn't describe).
   const renderCustom = (section: SettingSectionId): ReactNode => {
-    if (section === "connection") {
+    if (section === "general") {
       return (
         <>
+          <div className="border-t border-border pt-6">
+            <h3 className="text-title font-semibold mb-4">About</h3>
+            <div className="text-body text-text-faint">Manta v{clientVersion ?? "…"}</div>
+            {serverVersion && <div className="text-meta text-text-faint mt-1">Box server v{serverVersion}</div>}
+            <div className="text-meta text-text-faint mt-1">Desktop client for remote Claude Code sessions.</div>
+            {store.updatePrompt && (
+              <div className="mt-4 rounded-lg border border-accent/30 bg-accent/10 px-3 py-2 flex items-center gap-2">
+                <span className="flex-1 text-meta text-text">Update ready: <span className="font-medium">{store.updatePrompt.releaseName || store.updatePrompt.version}</span></span>
+                <button onClick={() => { void window.api.autoUpdateInstall(); }} className="shrink-0 rounded bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium">Restart to update</button>
+              </div>
+            )}
+          </div>
+          <div className="border-t border-border pt-6">
+            <h3 className="text-title font-semibold mb-4">Reset all settings</h3>
+            <div className="text-body text-text-faint mb-3">Restore every setting below to its default. This does not remove your box pairing or projects.</div>
+            <button onClick={() => setConfirmReset(true)} className="text-body px-4 py-2 rounded border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
+          </div>
+        </>
+      );
+    }
+    if (section === "box") {
+      const connected = Boolean(store.boxToken);
+      return (
+        <>
+          {/* Read-only status card — the URL lives here; changing it means
+              re-pairing, so there is no editable Connection block (BET-420). */}
+          <div className="rounded-lg border border-border bg-bg-soft p-4 space-y-2">
+            <div className="flex items-center gap-2">
+              <span aria-hidden className={`inline-block w-2 h-2 rounded-full ${connected ? "bg-ok" : "bg-text-faint"}`} />
+              <span className="text-body font-medium text-text">{connected ? "Connected" : "Not paired"}</span>
+            </div>
+            <dl className="space-y-1 text-meta">
+              <div className="flex gap-2">
+                <dt className="text-text-faint shrink-0">Server URL</dt>
+                <dd className="text-text-muted font-mono break-all">{store.serverUrl || "—"}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="text-text-faint shrink-0">Box ID</dt>
+                <dd className="text-text-muted font-mono break-all">{store.boxId || "—"}</dd>
+              </div>
+              {serverVersion && (
+                <div className="flex gap-2">
+                  <dt className="text-text-faint shrink-0">Server</dt>
+                  <dd className="text-text-muted font-mono">v{serverVersion}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
           <div>
             <h3 className="text-title font-semibold mb-4">Pair phone</h3>
             <div className="text-body text-text-faint mb-4">
-              Scan this QR with the MANTA mobile app to connect it to your box. The code is one-time and valid for ~5 minutes. Generate a new code if the old one expires.
+              Scan this QR with the Manta mobile app to connect it to your box. The code is one-time and valid for ~5 minutes. Generate a new code if the old one expires.
             </div>
             {!pairing ? (
               <button onClick={mintPairingCode} disabled={pairingMinting} className="text-body px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">
@@ -489,13 +586,39 @@ export function Settings({ onClose }: { onClose: () => void }) {
               <div className="text-body text-danger">{pairing.error}</div>
             )}
           </div>
+
           <div className="border-t border-border pt-6">
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Re-run the guided setup (pairing, providers, first project).</div>
               <button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} className="text-body px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text shrink-0">Run setup again</button>
             </div>
           </div>
+
+          {/* Advanced — opencodePort, exposed in the UI for the first time
+              (BET-420). Collapsed by default; it's an infrequently-touched
+              knob. */}
+          <details className="border-t border-border pt-6">
+            <summary className="text-body text-text-muted cursor-pointer select-none">Advanced</summary>
+            <div className="mt-4 space-y-1">
+              <label htmlFor="setting-opencodePort" className="block text-micro font-semibold uppercase text-text-muted">opencode port</label>
+              <input
+                id="setting-opencodePort"
+                type="number"
+                min={1}
+                max={65535}
+                value={opencodePortDraft}
+                onChange={(e) => { setOpencodePortDraft(e.target.value); setOpencodePortSavedAt(null); }}
+                onBlur={commitOpencodePort}
+                spellCheck={false}
+                className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded focus:outline-none focus:border-accent font-mono"
+              />
+              <div className="text-meta text-text-faint">Local port forwarded to the box's opencode serve instance. Defaults to 14096 to avoid colliding with a local opencode on 4096.</div>
+              {opencodePortSavedAt && <div role="status" className="text-meta text-ok">Saved</div>}
+            </div>
+          </details>
+
           <div className="border-t border-border pt-6">
+            <h3 className="text-title font-semibold mb-3">Danger zone</h3>
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Forget this box on the desktop. If the box is reachable, its current token is revoked too.</div>
               <button onClick={() => setConfirmRemove(true)} disabled={removingBox} className="text-body px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-danger hover:border-danger disabled:opacity-40 disabled:cursor-not-allowed shrink-0">
@@ -507,51 +630,26 @@ export function Settings({ onClose }: { onClose: () => void }) {
         </>
       );
     }
-    if (section === "ai") {
+    if (section === "accounts") {
+      // Subscriptions + custom endpoints merged into one list (BET-420).
+      // Both are "a way to reach a model"; the shared AddEndpointForm lives
+      // inside ProvidersCard and rejects a scheme-less URL identically here
+      // and in onboarding.
       return (
         <>
-          <ModelsCard />
           <SubscriptionsCard />
-          <div className="border-t border-border pt-6"><ProvidersCard /></div>
-          {availableLaunchers.some((l) => l.flags.length > 0) && (
-            <div className="border-t border-border pt-6">
-              <h3 className="text-title font-semibold mb-1">AI CLI launch options</h3>
-              <div className="text-body text-text-faint mb-4">Flags used when launching an AI CLI (e.g. Claude Code) directly in a session's terminal. Only CLIs detected on this box are shown.</div>
-              <div className="space-y-4">
-                {availableLaunchers.filter((l) => l.flags.length > 0).map((l) => (
-                  <div key={l.id} className="space-y-2">
-                    <div className="text-body font-medium text-text">{l.label}</div>
-                    {l.flags.map((f) => (
-                      <label key={f.key} className="flex items-start gap-3 text-body cursor-pointer">
-                        <input type="checkbox" checked={resolveLauncherFlags(l.flags, launcherFlagValues[l.id])[f.key]} onChange={(e) => setLauncherFlag(l.id, f.key, e.target.checked)} className="mt-px" />
-                        <span>{f.label}</span>
-                      </label>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
           <div className="border-t border-border pt-6">
-            <h3 className="text-title font-semibold mb-4">Skill registries</h3>
-            <div className="text-body text-text-faint mb-3">Extra skill registry URLs fetched by opencode on startup. The default manta registry is always included.</div>
-            <div className="space-y-2">
-              {registryUrls.map((url) => (
-                <div key={url} className="flex items-center gap-2">
-                  <code className="flex-1 text-body bg-bg-soft border border-border rounded px-3 py-2 text-text-muted truncate">{url}</code>
-                  <button onClick={() => onRemoveRegistry(url)} className="text-body text-text-faint hover:text-text px-2 inline-flex items-center" aria-label="Remove registry URL"><X size={14} aria-hidden="true" /></button>
-                </div>
-              ))}
-            </div>
-            <div className="flex gap-2 mt-3">
-              <input placeholder="https://example.com/skills" value={newRegistryUrl} onChange={(e) => setNewRegistryUrl(e.target.value)} onKeyDown={(e) => e.key === "Enter" && onAddRegistry()} className="flex-1 bg-bg-soft border border-border px-3 py-2 text-body rounded focus:outline-none focus:border-accent" />
-              <button onClick={onAddRegistry} disabled={!newRegistryUrl.trim()} className="px-4 py-2 text-body bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">Add</button>
-            </div>
+            <h3 className="text-title font-semibold mb-1">Custom endpoints</h3>
+            <div className="text-body text-text-faint mb-3">OpenAI-compatible endpoints opencode can serve. Add one, refresh to discover models, then enable the ones you want in the model picker.</div>
+            <ProvidersCard onRestartNeeded={requestRestart} />
           </div>
         </>
       );
     }
-    if (section === "plugins") {
+    if (section === "models") {
+      return <ModelsCard />;
+    }
+    if (section === "extensions") {
       return (
         <>
           <div className="border-t border-border pt-6">
@@ -581,28 +679,40 @@ export function Settings({ onClose }: { onClose: () => void }) {
           <div className="border-t border-border pt-6">
             <button onClick={() => { const preload = getMantaPreload(); if (preload?.revealInFolder) void preload.revealInFolder("~/.manta/plugins"); }} className="text-body px-4 py-2 rounded bg-bg-soft border border-border text-text-muted hover:text-text">Open plugins folder</button>
           </div>
-        </>
-      );
-    }
-    if (section === "general") {
-      return (
-        <>
-          <div className="border-t border-border pt-6">
-            <h3 className="text-title font-semibold mb-4">About</h3>
-            <div className="text-body text-text-faint">Manta UI v{clientVersion ?? "…"}</div>
-            <div className="text-meta text-text-faint mt-1">Desktop client for remote Claude Code sessions.</div>
-            {serverVersion && <div className="text-meta text-text-faint mt-1">Box server v{serverVersion}</div>}
-            {store.updatePrompt && (
-              <div className="mt-4 rounded-lg border border-accent/30 bg-accent/10 px-3 py-2 flex items-center gap-2">
-                <span className="flex-1 text-meta text-text">Update ready: <span className="font-medium">{store.updatePrompt.releaseName || store.updatePrompt.version}</span></span>
-                <button onClick={() => { void window.api.autoUpdateInstall(); }} className="shrink-0 rounded bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium">Restart to update</button>
+          {availableLaunchers.some((l) => l.flags.length > 0) && (
+            <div className="border-t border-border pt-6">
+              <h3 className="text-title font-semibold mb-1">AI CLI launch options</h3>
+              <div className="text-body text-text-faint mb-4">Flags used when launching an AI CLI (e.g. Claude Code) directly in a session's terminal. Only CLIs detected on this box are shown.</div>
+              <div className="space-y-4">
+                {availableLaunchers.filter((l) => l.flags.length > 0).map((l) => (
+                  <div key={l.id} className="space-y-2">
+                    <div className="text-body font-medium text-text">{l.label}</div>
+                    {l.flags.map((f) => (
+                      <label key={f.key} className="flex items-start gap-3 text-body cursor-pointer">
+                        <input type="checkbox" checked={resolveLauncherFlags(l.flags, launcherFlagValues[l.id])[f.key]} onChange={(e) => setLauncherFlag(l.id, f.key, e.target.checked)} className="mt-px" />
+                        <span>{f.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                ))}
               </div>
-            )}
-          </div>
+            </div>
+          )}
           <div className="border-t border-border pt-6">
-            <h3 className="text-title font-semibold mb-4">Reset all settings</h3>
-            <div className="text-body text-text-faint mb-3">Restore every setting below to its default. This does not remove your box pairing or projects.</div>
-            <button onClick={() => setConfirmReset(true)} className="text-body px-4 py-2 rounded border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
+            <h3 className="text-title font-semibold mb-4">Skill registries</h3>
+            <div className="text-body text-text-faint mb-3">Extra skill registry URLs fetched by opencode on startup. The default Manta registry is always included.</div>
+            <div className="space-y-2">
+              {registryUrls.map((url) => (
+                <div key={url} className="flex items-center gap-2">
+                  <code className="flex-1 text-body bg-bg-soft border border-border rounded px-3 py-2 text-text-muted truncate">{url}</code>
+                  <button onClick={() => onRemoveRegistry(url)} className="text-body text-text-faint hover:text-text px-2 inline-flex items-center" aria-label="Remove registry URL"><X size={14} aria-hidden="true" /></button>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2 mt-3">
+              <input placeholder="https://example.com/skills" value={newRegistryUrl} onChange={(e) => setNewRegistryUrl(e.target.value)} onKeyDown={(e) => e.key === "Enter" && onAddRegistry()} className="flex-1 bg-bg-soft border border-border px-3 py-2 text-body rounded focus:outline-none focus:border-accent" />
+              <button onClick={onAddRegistry} disabled={!newRegistryUrl.trim()} className="px-4 py-2 text-body bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">Add</button>
+            </div>
           </div>
         </>
       );
@@ -612,8 +722,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
 
   // The plugins toggle is a schema entry but also drives the registry list,
   // so render it specially here (it's Mac-local, not a config key). We pull
-  // it out of schemaEntries and render it above the registry list.
-  const pluginsToggleEntry = schemaEntries.find((e) => e.id === "pluginsEnabled");
+  // it out of simpleEntries and render it at the top of the Extensions panel.
+  const pluginsToggleEntry = SETTINGS.find((e) => e.id === "pluginsEnabled");
+  const simpleEntriesExPlugins = simpleEntries.filter((e) => e.id !== "pluginsEnabled");
 
   return (
     <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="settings-title" className="fixed inset-0 bg-bg z-50 flex">
@@ -623,28 +734,34 @@ export function Settings({ onClose }: { onClose: () => void }) {
         <div className="p-4 border-b border-border">
           <h2 id="settings-title" tabIndex={-1} className="text-title font-semibold">Settings</h2>
         </div>
-        <nav className="flex-1 py-2" role="tablist" aria-label="Settings sections">
-          {SETTING_SECTIONS.map((tab) => {
+        <nav className="flex-1 py-2 overflow-y-auto" role="tablist" aria-label="Settings sections">
+          {SETTING_SECTIONS.map((tab, i) => {
             const modified = sectionIsModified(SETTINGS, tab.id, PLATFORM, values);
+            const prev = i > 0 ? SETTING_SECTIONS[i - 1] : null;
+            const showGroup = tab.group && (!prev || prev.group !== tab.group);
             return (
-              <button
-                key={tab.id}
-                ref={(el) => { railRefs.current[tab.id] = el; }}
-                role="tab"
-                aria-selected={activeTab === tab.id}
-                aria-controls={`panel-${tab.id}`}
-                id={`tab-${tab.id}`}
-                onClick={() => setActiveTab(tab.id)}
-                onKeyDown={onRailKeyDown}
-                className={`w-full text-left px-4 py-2 text-body transition-colors ${
-                  activeTab === tab.id ? "bg-accent/10 text-accent border-r-2 border-accent" : "text-text-muted hover:text-text hover:bg-bg-elev"
-                }`}
-              >
-                <span className="inline-flex items-center gap-2">
-                  {tab.label}
-                  {modified && <span aria-hidden="true" className="inline-block w-1.5 h-1.5 rounded-full bg-accent" title="Modified" />}
-                </span>
-              </button>
+              <div key={tab.id}>
+                {showGroup && (
+                  <div aria-hidden className="px-4 pt-3 pb-1 text-micro font-semibold uppercase tracking-wide text-text-quiet">── {tab.group} ──</div>
+                )}
+                <button
+                  ref={(el) => { railRefs.current[tab.id] = el; }}
+                  role="tab"
+                  aria-selected={activeTab === tab.id}
+                  aria-controls={`panel-${tab.id}`}
+                  id={`tab-${tab.id}`}
+                  onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={onRailKeyDown}
+                  className={`w-full text-left px-4 py-2 text-body transition-colors ${
+                    activeTab === tab.id ? "bg-accent/10 text-accent border-r-2 border-accent" : "text-text-muted hover:text-text hover:bg-bg-elev"
+                  }`}
+                >
+                  <span className="inline-flex items-center gap-2">
+                    {tab.label}
+                    {modified && <span aria-hidden="true" className="inline-block w-1.5 h-1.5 rounded-full bg-accent" title="Modified" />}
+                  </span>
+                </button>
+              </div>
             );
           })}
         </nav>
@@ -662,6 +779,21 @@ export function Settings({ onClose }: { onClose: () => void }) {
         </div>
 
         <div className="flex-1 overflow-y-auto p-6">
+          {/* The ONE restart affordance (BET-420). Sits above the panel so it
+              is visible regardless of which section is active. */}
+          {restartNeeded && (
+            <div role="status" className="mb-4 flex items-center gap-3 rounded-lg border border-warn/40 bg-warn-bg px-4 py-3">
+              <span className="flex-1 text-body text-text">
+                An opencode restart is needed to apply recent model or endpoint changes. Restarting interrupts all running sessions.
+              </span>
+              <button onClick={() => void performRestart()} disabled={restarting} className="shrink-0 px-3 py-2 text-body rounded bg-warn-bg border border-warn text-warn hover:bg-warn/20 disabled:opacity-40">
+                {restarting ? "Restarting…" : "Restart opencode"}
+              </button>
+              <button onClick={() => setRestartNeeded(false)} disabled={restarting} className="shrink-0 px-2 py-2 text-body text-text-muted hover:text-text disabled:opacity-40">Later</button>
+            </div>
+          )}
+          {restartError && <div role="alert" className="mb-4 text-body text-danger">{restartError}</div>}
+
           {inSearch ? (
             <div className="max-w-2xl space-y-4">
               <div className="text-body text-text-faint">{searchHits.length} match{searchHits.length === 1 ? "" : "es"} for “{query.trim()}”</div>
@@ -678,7 +810,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
             </div>
           ) : (
             <div role="tabpanel" id={`panel-${activeTab}`} aria-labelledby={`tab-${activeTab}`} className="max-w-2xl space-y-6">
-              {activeTab === "plugins" && pluginsToggleEntry ? (
+              {activeTab === "extensions" && pluginsToggleEntry ? (
                 <div className="space-y-1">
                   <label htmlFor={fieldId(pluginsToggleEntry)} className="flex items-start gap-3 text-body cursor-pointer">
                     <input id={fieldId(pluginsToggleEntry)} type="checkbox" checked={pluginsOn} onChange={(e) => void togglePlugins(e.target.checked)} className="mt-px" />
@@ -688,9 +820,8 @@ export function Settings({ onClose }: { onClose: () => void }) {
                     </span>
                   </label>
                 </div>
-              ) : (
-                schemaEntries.map((entry) => <div key={entry.id}>{renderField(entry)}</div>)
-              )}
+              ) : null}
+              {simpleEntriesExPlugins.map((entry) => <div key={entry.id}>{renderField(entry)}</div>)}
               {renderCustom(activeTab)}
             </div>
           )}

--- a/src/renderer/SubscriptionsCard.tsx
+++ b/src/renderer/SubscriptionsCard.tsx
@@ -159,7 +159,6 @@ export function SubscriptionsCard() {
             <ConnectProvider
               id={s.id}
               label={s.label}
-              confirmRestart={true}
               onDone={onConnectDone}
               onCancel={() => setConnectingId(null)}
             />

--- a/src/renderer/SubscriptionsCard.tsx
+++ b/src/renderer/SubscriptionsCard.tsx
@@ -90,7 +90,7 @@ export function SubscriptionsCard() {
       </label>
       <div className="text-meta text-text-faint space-y-1">
         <div>
-          Sign in with a subscription you already pay for. MantaUI never sees
+          Sign in with a subscription you already pay for. Manta never sees
           your password or your key after it is saved.
         </div>
       </div>

--- a/src/renderer/mobile/MobileSettings.tsx
+++ b/src/renderer/mobile/MobileSettings.tsx
@@ -267,10 +267,17 @@ export function MobileSettings({ onClose }: Props) {
   };
 
   // Server URL is a mobile-only schema entry with configKey null (localStorage).
-  const serverUrlEntry = SETTINGS.find((e) => e.id === "serverUrl") as SettingEntry;
+  const serverUrlEntry = SETTINGS.find((e) => e.id === "serverUrlMobile") as SettingEntry;
 
   // Group schema entries by their section for the single-scroll layout.
-  const sections = SETTING_SECTIONS.filter((s) => settingsForSection(SETTINGS, s.id, PLATFORM).length > 0 || s.id === "connection");
+  // BET-420: the schema now has 8 sections; mobile skips Files (no mobile
+  // entries, no mobile custom content) and keeps the rest.
+  const hasMobileCustom = (id: SettingSectionId): boolean =>
+    id === "general" || id === "box" || id === "accounts" ||
+    id === "models" || id === "extensions";
+  const sections = SETTING_SECTIONS.filter(
+    (s) => settingsForSection(SETTINGS, s.id, PLATFORM).length > 0 || hasMobileCustom(s.id),
+  );
 
   return (
     <div className="mobile-screen">
@@ -331,8 +338,11 @@ export function MobileSettings({ onClose }: Props) {
 
             {/* Schema-driven simple fields, grouped by section. */}
             {sections.map((section) => {
-              const entries = settingsForSection(SETTINGS, section.id, PLATFORM);
-              if (entries.length === 0) return null;
+              // Skip custom entries (rendered via renderMobileCustom) and the
+              // serverUrl entry (rendered specially above).
+              const entries = settingsForSection(SETTINGS, section.id, PLATFORM)
+                .filter((e) => e.control !== "custom" && e.id !== "serverUrlMobile");
+              if (entries.length === 0 && !hasMobileCustom(section.id)) return null;
               return (
                 <section key={section.id} className="space-y-3 pt-1 border-t border-border">
                   <div className="flex items-center gap-2">
@@ -374,30 +384,40 @@ export function MobileSettings({ onClose }: Props) {
     </div>
   );
 
-  // Per-section custom content for mobile (default model, providers,
-  // subscriptions, launcher flags, push, skill registries).
+  // Per-section custom content for mobile. BET-420 split the old AI section
+  // into accounts (subs + endpoints), models (default model) and extensions
+  // (launcher flags + skill registries); push moved from general to box.
   function renderMobileCustom(sectionId: SettingSectionId): ReactNode {
-    if (sectionId === "ai") {
+    if (sectionId === "models") {
+      return (
+        <div className="space-y-1">
+          <label htmlFor="setting-defaultModel" className="block text-micro font-semibold uppercase text-text-muted">Default model</label>
+          <select
+            id="setting-defaultModel"
+            value={selectedModel ? `${selectedModel.providerID}::${selectedModel.modelID}` : ""}
+            onChange={(e) => commitModel(e.target.value)}
+            className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded focus:outline-none focus:border-accent"
+          >
+            <option value="">opencode default</option>
+            {models && models.map((m) => (
+              <option key={`${m.providerID}::${m.id}`} value={`${m.providerID}::${m.id}`}>{m.name} ({m.providerID})</option>
+            ))}
+          </select>
+          <div className="text-meta text-text-faint">Used for every new and cleared session. Can be overridden per-session in the chat composer.</div>
+        </div>
+      );
+    }
+    if (sectionId === "accounts") {
       return (
         <>
-          {/* Default model */}
-          <div className="space-y-1">
-            <label htmlFor="setting-defaultModel" className="block text-micro font-semibold uppercase text-text-muted">Default model</label>
-            <select
-              id="setting-defaultModel"
-              value={selectedModel ? `${selectedModel.providerID}::${selectedModel.modelID}` : ""}
-              onChange={(e) => commitModel(e.target.value)}
-              className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded focus:outline-none focus:border-accent"
-            >
-              <option value="">opencode default</option>
-              {models && models.map((m) => (
-                <option key={`${m.providerID}::${m.id}`} value={`${m.providerID}::${m.id}`}>{m.name} ({m.providerID})</option>
-              ))}
-            </select>
-            <div className="text-meta text-text-faint">Used for every new and cleared session. Can be overridden per-session in the chat composer.</div>
-          </div>
           <SubscriptionsCard />
           <ProvidersCard />
+        </>
+      );
+    }
+    if (sectionId === "extensions") {
+      return (
+        <>
           {availableLaunchers.some((l) => l.flags.length > 0) && (
             <div role="group" aria-labelledby="setting-mobile-launchers" className="space-y-2">
               <span id="setting-mobile-launchers" className="text-micro font-semibold uppercase text-text-muted">AI CLI launch options</span>
@@ -418,7 +438,7 @@ export function MobileSettings({ onClose }: Props) {
           {/* Skill registries */}
           <div className="space-y-2">
             <label htmlFor="setting-mobile-skillRegistries" className="text-micro font-semibold uppercase text-text-muted">Skill registries</label>
-            <div className="text-meta text-text-faint">Extra opencode skill registry URLs. The default manta registry is always included.</div>
+            <div className="text-meta text-text-faint">Extra opencode skill registry URLs. The default Manta registry is always included.</div>
             <div className="space-y-1">
               {registryUrls.map((url) => (
                 <div key={url} className="flex items-center gap-2 bg-bg-soft border border-border rounded px-2 py-2">
@@ -435,35 +455,31 @@ export function MobileSettings({ onClose }: Props) {
         </>
       );
     }
-    if (sectionId === "voice") {
-      // The Groq key input is rendered by the schema (PasswordField) — but
-      // the schema's password renderer below needs the mobile-styled markup.
-      return null;
+    if (sectionId === "box") {
+      // Push notifications — per-device subscription, stays mobile-only under
+      // Box (BET-420: no Notifications section; push is a box-level concern).
+      if (!isPushSupported()) return null;
+      return (
+        <div role="group" aria-labelledby="setting-mobile-notifications" className="space-y-2">
+          <span id="setting-mobile-notifications" className="text-micro font-semibold uppercase text-text-muted">Notifications</span>
+          <div className="text-meta text-text-faint">Push alerts when Claude needs a permission/question, finishes a turn, or hits an error.{pushPermission() === "default" && " iOS only delivers these to the app installed on your home screen."}</div>
+          <button onClick={togglePush} disabled={pushBusy} className={`w-full px-3 py-2 text-body rounded border ${pushOn ? "bg-accent-soft text-white border-accent" : "bg-bg-soft text-text-muted border-border"} ${pushBusy ? "opacity-60" : ""}`}>
+            {pushBusy ? "Working…" : pushOn ? "Notifications on — tap to disable" : "Enable notifications"}
+          </button>
+          {pushOn && (
+            <button onClick={resubscribe} disabled={pushBusy} className={`w-full px-3 py-2 text-meta rounded border border-border bg-bg-soft text-text-muted ${pushBusy ? "opacity-60" : ""}`}>Not getting notifications? Re-subscribe</button>
+          )}
+          {pushErr && <div role="alert" className="text-meta text-danger">{errorDisclosure(pushErr, pushErrRaw)}</div>}
+        </div>
+      );
     }
     if (sectionId === "general") {
       return (
-        <>
-          {/* Push notifications — per-device subscription, not server config. */}
-          {isPushSupported() && (
-            <div role="group" aria-labelledby="setting-mobile-notifications" className="space-y-2">
-              <span id="setting-mobile-notifications" className="text-micro font-semibold uppercase text-text-muted">Notifications</span>
-              <div className="text-meta text-text-faint">Push alerts when Claude needs a permission/question, finishes a turn, or hits an error.{pushPermission() === "default" && " iOS only delivers these to the app installed on your home screen."}</div>
-              <button onClick={togglePush} disabled={pushBusy} className={`w-full px-3 py-2 text-body rounded border ${pushOn ? "bg-accent-soft text-white border-accent" : "bg-bg-soft text-text-muted border-border"} ${pushBusy ? "opacity-60" : ""}`}>
-                {pushBusy ? "Working…" : pushOn ? "Notifications on — tap to disable" : "Enable notifications"}
-              </button>
-              {pushOn && (
-                <button onClick={resubscribe} disabled={pushBusy} className={`w-full px-3 py-2 text-meta rounded border border-border bg-bg-soft text-text-muted ${pushBusy ? "opacity-60" : ""}`}>Not getting notifications? Re-subscribe</button>
-              )}
-              {pushErr && <div role="alert" className="text-meta text-danger">{errorDisclosure(pushErr, pushErrRaw)}</div>}
-            </div>
-          )}
-          {/* Reset all settings — danger zone (BET-419 §B.3). */}
-          <div className="space-y-2 pt-1 border-t border-border">
-            <span className="text-micro font-semibold uppercase text-text-muted">Reset all settings</span>
-            <div className="text-meta text-text-faint">Restore every setting to its default. This does not remove your box pairing or projects.</div>
-            <button onClick={() => setConfirmReset(true)} className="w-full px-3 py-2 text-body rounded border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
-          </div>
-        </>
+        <div className="space-y-2 pt-1 border-t border-border">
+          <span className="text-micro font-semibold uppercase text-text-muted">Reset all settings</span>
+          <div className="text-meta text-text-faint">Restore every setting to its default. This does not remove your box pairing or projects.</div>
+          <button onClick={() => setConfirmReset(true)} className="w-full px-3 py-2 text-body rounded border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
+        </div>
       );
     }
     return null;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -259,6 +259,16 @@ type State = {
   // (no `Date.now()` leakage in labels). Real apps leave it null and
   // `nowMs()` in src/renderer/clock.ts falls back to `Date.now()`.
   videoRenderNow: number | null;
+  // BET-420: raised by Settings cards whose changes need an opencode restart
+  // to take effect (subagent toggles, endpoint add/remove/toggle). The
+  // Settings panel renders ONE restart banner from this flag — replacing the
+  // three per-card restart prompts that used to live in ModelsCard,
+  // ProvidersCard and ConnectProvider. Cleared by the banner's restart button
+  // (and by any other path that restarts opencode, e.g. ConnectProvider's
+  // connect-completion restart). Desktop-only concept; mobile keeps its own
+  // inline restart prompt inside ProvidersCard.
+  opencodeRestartNeeded: boolean;
+  setOpencodeRestartNeeded: (v: boolean) => void;
   // ----- derived selectors -----
   activeSession: () => ActiveSession | null;
   // A minimal AppConfig-shaped snapshot of the onboarding-relevant fields,
@@ -408,6 +418,7 @@ export const useStore = create<State>((set, get) => ({
   connectionState: { state: "idle" },
   backgroundSyncing: false,
   videoRenderNow: null,
+  opencodeRestartNeeded: false,
 
   configSnapshot: () => {
     const s = get();
@@ -592,6 +603,7 @@ export const useStore = create<State>((set, get) => ({
   setUpdateError: (p) => set({ updateError: p }),
   setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),
   setConnectionState: (s) => set({ connectionState: s }),
+  setOpencodeRestartNeeded: (v) => set({ opencodeRestartNeeded: v }),
 
   applyStatusBatch: (batch) =>
     set((prev) => {

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -25,9 +25,14 @@ describe("settingsSchema shape", () => {
     for (const e of ALL) expect(known.has(e.section)).toBe(true);
   });
 
-  it("every non-custom entry has a configKey; custom entries have null", () => {
+  it("every entry declares a configKey field (null for Mac-local / presentational)", () => {
+    // configKey is null for Mac-local toggles (pluginsEnabled, rendered via
+    // the preload bridge) and presentational custom entries (accountsList);
+    // it is a real AppConfig key for everything else. opencodePort is custom-
+    // rendered inside the Box Advanced row but still carries its configKey so
+    // reset-all + the modified-dot work.
     for (const e of ALL) {
-      if (e.control === "custom") expect(e.configKey).toBeNull();
+      expect(typeof e.configKey === "string" || e.configKey === null).toBe(true);
     }
   });
 
@@ -66,7 +71,7 @@ describe("settingsForPlatform", () => {
 
   it("excludes mobile-only entries on desktop", () => {
     const desktop = settingsForPlatform(ALL, "desktop");
-    expect(desktop.some((e) => e.id === "serverUrl")).toBe(false); // mobile
+    expect(desktop.some((e) => e.id === "serverUrlMobile")).toBe(false); // mobile
     expect(desktop.some((e) => e.id === "chatAutoAllow")).toBe(false); // mobile
   });
 });
@@ -97,7 +102,7 @@ describe("searchSettings", () => {
 
   it("respects platform", () => {
     const hits = searchSettings(ALL, "server url", "desktop");
-    expect(hits).toEqual([]); // serverUrl is mobile-only
+    expect(hits).toEqual([]); // serverUrlMobile is mobile-only
   });
 });
 
@@ -129,7 +134,7 @@ describe("sectionIsModified", () => {
     // pluginsEnabled has configKey null — setting a value for it must not
     // mark the section modified.
     expect(
-      sectionIsModified(ALL, "plugins", "desktop", { pluginsEnabled: true }),
+      sectionIsModified(ALL, "extensions", "desktop", { pluginsEnabled: true }),
     ).toBe(false);
   });
 });
@@ -141,14 +146,14 @@ describe("resetAllPayload", () => {
     expect(payload.theme).toBe("system");
     expect(payload.groqApiKey).toBe("");
     expect(payload.autoRenameSessions).toBe(false);
-    expect(payload.shareAnalytics).toBe(true);
     expect(payload.allowAgentPush).toBe(false);
+    expect(payload.opencodePort).toBe(14096);
   });
 
   it("omits null-configKey entries", () => {
     const payload = resetAllPayload(ALL);
     expect(payload).not.toHaveProperty("pluginsEnabled");
-    expect(payload).not.toHaveProperty("serverUrl");
+    expect(payload).not.toHaveProperty("serverUrlMobile");
   });
 });
 

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -1,19 +1,29 @@
-// BET-419 §B — one settings schema, shared by desktop Settings.tsx and
-// mobile MobileSettings.tsx. Pure module: NO imports from `react` or
+// BET-419 §B / BET-420 — one settings schema, shared by desktop Settings.tsx
+// and mobile MobileSettings.tsx. Pure module: NO imports from `react` or
 // `electron`. Both surfaces render their simple fields from this schema;
-// complex cards (ModelsCard, ProvidersCard, SubscriptionsCard, plugins,
-// pairing, skill-registries list, launcher flags) stay as per-section
+// complex cards (ModelsCard, the merged Accounts list, plugins, skill-
+// registries list, launcher flags, pairing, box status) stay as per-section
 // custom content rendered alongside the schema-driven fields.
 //
-// Four things fall out of this schema for free (all implemented):
+// BET-420 restructured the six flat tabs into eight sections clustered as
+// three ideas:
+//
+//   General                    ← ungrouped, at the top (about THIS app)
+//   ── SETUP ──
+//   Box                        ← the thing you paired with
+//   Accounts                   ← ways to reach a model (subs + endpoints)
+//   Models                     ← which model, cache TTL
+//   ── AGENT ──
+//   Sessions                   ← per-session behaviour
+//   Files                      ← agent ↔ laptop file flow
+//   Extensions                 ← plugins, skill registries, AI-CLI flags
+//   Voice                      ← Groq STT
+//
+// Four things fall out of this schema (all implemented in BET-419):
 //   1. Search (label + help) across every section.
 //   2. "Modified" dot on a section containing a non-default value.
 //   3. Reset all settings (danger zone, General).
 //   4. `htmlFor`/`id` wiring on every field (a11y).
-//
-// The schema deliberately does NOT restructure the six tabs (sub-issue 14
-// owns that) and adds NO new config keys beyond `theme` (sub-issue 03) and
-// `pinnedWindows` (sub-issue 08).
 
 export type SettingControl =
   | "toggle"
@@ -26,12 +36,21 @@ export type SettingControl =
 export type SettingPlatform = "both" | "desktop" | "mobile";
 
 export type SettingSectionId =
-  | "connection"
-  | "ai"
-  | "voice"
+  | "general"
+  | "box"
+  | "accounts"
+  | "models"
+  | "sessions"
   | "files"
-  | "plugins"
-  | "general";
+  | "extensions"
+  | "voice";
+
+export type SettingSection = {
+  id: SettingSectionId;
+  label: string;
+  /** Optional cluster divider rendered above this entry in the nav. */
+  group?: "SETUP" | "AGENT";
+};
 
 export type SettingEntry = {
   /** Stable id used as the field's DOM id suffix and React key. */
@@ -55,22 +74,43 @@ export type SettingEntry = {
   placeholder?: string;
 };
 
-export const SETTING_SECTIONS: { id: SettingSectionId; label: string }[] = [
-  { id: "connection", label: "Connection" },
-  { id: "ai", label: "AI" },
-  { id: "voice", label: "Voice" },
-  { id: "files", label: "Files" },
-  { id: "plugins", label: "Plugins" },
+// General sits above the clusters because it is about this app, not the box
+// or the agent. The `group` markers drive the cluster dividers in the nav.
+export const SETTING_SECTIONS: SettingSection[] = [
   { id: "general", label: "General" },
+  { id: "box", label: "Box", group: "SETUP" },
+  { id: "accounts", label: "Accounts", group: "SETUP" },
+  { id: "models", label: "Models", group: "SETUP" },
+  { id: "sessions", label: "Sessions", group: "AGENT" },
+  { id: "files", label: "Files", group: "AGENT" },
+  { id: "extensions", label: "Extensions", group: "AGENT" },
+  { id: "voice", label: "Voice", group: "AGENT" },
 ];
 
 // The schema. `custom` entries are placeholders so search/section listing
 // stays consistent — the surface renders their real component in place.
 export const SETTINGS: SettingEntry[] = [
-  // ----- connection -----
+  // ----- general (about this app) -----
   {
-    id: "serverUrl",
-    section: "connection",
+    id: "theme",
+    section: "general",
+    label: "Theme",
+    help: "System follows your OS appearance and re-themes live.",
+    control: "segmented",
+    configKey: "theme",
+    platform: "desktop",
+    default: "system",
+    options: [
+      { value: "system", label: "System" },
+      { value: "light", label: "Light" },
+      { value: "dark", label: "Dark" },
+    ],
+  },
+
+  // ----- box (the paired box) -----
+  {
+    id: "serverUrlMobile",
+    section: "box",
     label: "Server URL",
     help: "Leave blank to use the page's own origin (default). Override only if your Manta server is on a different host.",
     control: "text",
@@ -79,13 +119,35 @@ export const SETTINGS: SettingEntry[] = [
     default: "",
     placeholder: "https://manta.example.com",
   },
+  {
+    id: "opencodePort",
+    section: "box",
+    label: "opencode port",
+    help: "Local port forwarded to the box's opencode serve instance. Defaults to 14096 to avoid colliding with a local opencode on 4096.",
+    control: "custom", // rendered inside the Box "Advanced" row (desktop)
+    configKey: "opencodePort",
+    platform: "desktop",
+    default: 14096,
+  },
 
-  // ----- ai -----
+  // ----- accounts (subscriptions + custom endpoints — one list) -----
+  {
+    id: "accountsList",
+    section: "accounts",
+    label: "Accounts",
+    help: "Sign in with a subscription you already pay for, or add your own OpenAI-compatible endpoint. Both are just a way to reach a model.",
+    control: "custom",
+    configKey: null,
+    platform: "both",
+    default: null,
+  },
+
+  // ----- models (default/main/sub table + cache TTL) -----
   {
     id: "cacheTtl",
-    section: "ai",
+    section: "models",
     label: "Prompt cache TTL",
-    help: "How long Anthropic keeps a session's prompt cache warm. Must match opencode's cache_control.ttl — manta only uses this to predict when a chat has gone stale.",
+    help: "How long Anthropic keeps a session's prompt cache warm. Must match opencode's cache_control.ttl — Manta only uses this to predict when a chat has gone stale.",
     control: "segmented",
     configKey: "cacheTtl",
     platform: "both",
@@ -96,7 +158,84 @@ export const SETTINGS: SettingEntry[] = [
     ],
   },
 
-  // ----- voice -----
+  // ----- sessions (per-session behaviour) -----
+  {
+    id: "autoRenameSessions",
+    section: "sessions",
+    label: "Auto-rename sessions",
+    help: "Every few turns, ask the model for a 1-2 word title and rename the chat window to match the current work. Overwrites the window name, including names you set by hand.",
+    control: "toggle",
+    configKey: "autoRenameSessions",
+    platform: "both",
+    default: false,
+  },
+  {
+    id: "worktreePerSession",
+    section: "sessions",
+    label: "Create git worktree for new sessions",
+    help: "When creating a new chat session in a project that's a git repo, automatically branch a sibling worktree and start the session on its own branch. Has no effect on non-git projects.",
+    control: "toggle",
+    configKey: "worktreePerSession",
+    platform: "desktop",
+    default: false,
+  },
+  {
+    id: "worktreeCleanOnClose",
+    section: "sessions",
+    label: "Remove worktree when a session is closed",
+    help: "Deletes the session's git worktree on close. Prompts before discarding uncommitted changes.",
+    control: "toggle",
+    configKey: "worktreeCleanOnClose",
+    platform: "desktop",
+    default: false,
+  },
+  {
+    id: "chatAutoAllow",
+    section: "sessions",
+    label: "Auto-allow tool permissions",
+    help: "Auto-reply \"always\" to every permission request — equivalent to opencode's --dangerously-skip-permissions. Question tool requests still require an explicit answer.",
+    control: "toggle",
+    configKey: "chatAutoAllow",
+    platform: "mobile",
+    default: false,
+  },
+
+  // ----- files (agent ↔ laptop file flow) -----
+  {
+    id: "allowAgentPush",
+    section: "files",
+    label: "Auto-save files the AI sends",
+    help: "When the AI drops a file in ~/.manta-outbox on the remote, save it to your downloads folder without asking. Off = a toast asks before each file is saved.",
+    control: "toggle",
+    configKey: "allowAgentPush",
+    platform: "desktop",
+    default: false,
+  },
+  {
+    id: "downloadsDir",
+    section: "files",
+    label: "Downloads directory",
+    help: "Destination for AI-sent files. Absolute path; leave empty for your OS Downloads folder.",
+    control: "path",
+    configKey: "downloadsDir",
+    platform: "desktop",
+    default: "",
+    placeholder: "~/Downloads (default)",
+  },
+
+  // ----- extensions (plugins, skill registries, AI-CLI flags) -----
+  {
+    id: "pluginsEnabled",
+    section: "extensions",
+    label: "Run plugins on this machine",
+    help: "Lets the AI trigger the plugins below — each is a YAML file on this machine; the AI can also create and edit them when this is on. Takes effect after restarting Manta.",
+    control: "toggle",
+    configKey: null, // Mac-local (preload bridge), not a server config key
+    platform: "desktop",
+    default: false,
+  },
+
+  // ----- voice (Groq STT) -----
   {
     id: "groqApiKey",
     section: "voice",
@@ -130,108 +269,6 @@ export const SETTINGS: SettingEntry[] = [
     platform: "both",
     default: "",
     placeholder: "llama-3.1-8b-instant",
-  },
-
-  // ----- files -----
-  {
-    id: "allowAgentPush",
-    section: "files",
-    label: "Auto-save files the AI sends",
-    help: "When the AI drops a file in ~/.manta-outbox on the remote, save it to your downloads folder without asking. Off = a toast asks before each file is saved.",
-    control: "toggle",
-    configKey: "allowAgentPush",
-    platform: "desktop",
-    default: false,
-  },
-  {
-    id: "downloadsDir",
-    section: "files",
-    label: "Downloads directory",
-    help: "Destination for AI-sent files. Absolute path; leave empty for your OS Downloads folder.",
-    control: "path",
-    configKey: "downloadsDir",
-    platform: "desktop",
-    default: "",
-    placeholder: "~/Downloads (default)",
-  },
-  {
-    id: "worktreePerSession",
-    section: "files",
-    label: "Create git worktree for new sessions",
-    help: "When creating a new chat session in a project that's a git repo, automatically branch a sibling worktree and start the session on its own branch. Has no effect on non-git projects.",
-    control: "toggle",
-    configKey: "worktreePerSession",
-    platform: "desktop",
-    default: false,
-  },
-  {
-    id: "worktreeCleanOnClose",
-    section: "files",
-    label: "Remove worktree when a session is closed",
-    help: "Deletes the session's git worktree on close. Prompts before discarding uncommitted changes.",
-    control: "toggle",
-    configKey: "worktreeCleanOnClose",
-    platform: "desktop",
-    default: false,
-  },
-
-  // ----- plugins (desktop-only; Mac-local toggle, not a config key) -----
-  {
-    id: "pluginsEnabled",
-    section: "plugins",
-    label: "Run plugins on this machine",
-    help: "Lets the AI trigger the plugins below — each is a YAML file on this machine; the AI can also create and edit them when this is on. Takes effect after restarting MantaUI.",
-    control: "toggle",
-    configKey: null, // Mac-local (preload bridge), not a server config key
-    platform: "desktop",
-    default: false,
-  },
-
-  // ----- general -----
-  {
-    id: "theme",
-    section: "general",
-    label: "Theme",
-    help: "System follows your OS appearance and re-themes live.",
-    control: "segmented",
-    configKey: "theme",
-    platform: "desktop",
-    default: "system",
-    options: [
-      { value: "system", label: "System" },
-      { value: "light", label: "Light" },
-      { value: "dark", label: "Dark" },
-    ],
-  },
-  {
-    id: "chatAutoAllow",
-    section: "general",
-    label: "Auto-allow tool permissions",
-    help: "Auto-reply \"always\" to every permission request — equivalent to opencode's --dangerously-skip-permissions. Question tool requests still require an explicit answer.",
-    control: "toggle",
-    configKey: "chatAutoAllow",
-    platform: "mobile",
-    default: false,
-  },
-  {
-    id: "autoRenameSessions",
-    section: "general",
-    label: "Auto-rename sessions",
-    help: "Every few turns, ask the model for a 1-2 word title and rename the chat window to match the current work. Overwrites the window name, including names you set by hand.",
-    control: "toggle",
-    configKey: "autoRenameSessions",
-    platform: "both",
-    default: false,
-  },
-  {
-    id: "shareAnalytics",
-    section: "general",
-    label: "Share anonymized analytics",
-    help: "Sends app and error logs to help improve Manta UI. On by default. Turn off to stop this instance from sending anything.",
-    control: "toggle",
-    configKey: "shareAnalytics",
-    platform: "desktop",
-    default: true,
   },
 ];
 


### PR DESCRIPTION
## BET-420 — Settings: eight-section restructure

Restructures the six flat tabs into eight sections clustered as three ideas
(General · SETUP: Box/Accounts/Models · AGENT: Sessions/Files/Extensions/Voice),
adds every section to `settingsSchema.ts`, and consolidates the three restart
affordances into one panel-level banner.

Base: `origin/main` @ `1a949c4`

### What changed

**Schema (`src/shared/settingsSchema.ts`)** — 8 sections with `group` markers
(SETUP / AGENT) driving nav dividers. `cacheTtl` → models; worktree toggles →
sessions; plugins → extensions; `theme` stays in general. Removed
`shareAnalytics` from the UI. Added `opencodePort` (custom, Box Advanced) and
`accountsList` (custom) entries.

**Desktop `Settings.tsx`** — renders the 8 sections:
- **General**: Theme + About (real client + server versions from package.json,
  replacing the old hardcoded `v0.0.1`) + Reset all (danger zone).
- **Box**: read-only status card (connected/URL/box ID/server version) + Pair
  phone + Re-run setup + collapsed **Advanced** exposing `opencodePort` (first
  UI for it) + Remove box (danger zone). No editable Connection block.
- **Accounts**: Subscriptions + custom endpoints merged into one list; the
  shared `AddEndpointForm` (with scheme validator) lives inside ProvidersCard.
- **Models**: ModelsCard + prompt-cache TTL.
- **Sessions**: auto-rename, worktree-per-session, worktree-clean-on-close.
- **Files**: auto-save agent files, downloads dir.
- **Extensions**: plugins toggle + installed list + open folder + AI-CLI launch
  flags + skill registries.
- **Voice**: Groq key + transcription/command models.
- Product name normalised to **Manta** (was MANTA / Manta UI / MantaUI).
- Stray leading `border-t` removed.

**Restart consolidation** — ONE panel-level banner driven by a new store flag
`opencodeRestartNeeded`. Removed the restart UI from `ModelsCard`,
`ProvidersCard` (desktop), and `ConnectProvider` (the `confirmRestart` confirm
bar). ConnectProvider's applying-phase restart stays automatic (it must
restart + poll to verify a credential came online — that's an internal
verification step, not a user-facing affordance) and clears the flag when it
fires. Mobile keeps ProvidersCard's inline restart banner (no panel banner on
mobile).

**Shared endpoint form (`AddEndpointForm.tsx`)** — one form + one validator
(`validateEndpointDraft`, rejects scheme-less URLs). Used by Settings
(ProvidersCard) AND onboarding (ProvidersStep), so both reject a scheme-less
URL identically.

**Mobile `MobileSettings.tsx`** — remapped to the 8 sections (models = default
model, accounts = subs + endpoints, extensions = launchers + registries, box =
push notifications, general = reset).

### Files changed
11 files, +684 / −540.

### Verification results
- PR branch (`multica/BET-420-settings-eight-sections` @ `2f7be5c`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65…`
  - test: exit 0, 1684 pass / 0 fail / 0 skip. log sha256: `8572c96…`
- Base (`main` @ `1a949c4`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65…`
  - test: exit 0, 1684 pass / 0 fail / 0 skip. log sha256: `e32e931…`
- **Conclusion:** 0 new failures, 0 resolved — both branches identical (1684
  pass). The test-log sha differs only by timestamps/duration lines.

**E2E smoke:** the Electron renderer smoke could not exercise Settings because
a fresh config launches the onboarding shell (Settings is only reachable from
the paired main shell). Confirmed the renderer launch itself introduces NO new
crash: the one page error (`window.api.opencodeModels is not a function`) is
**pre-existing on `origin/main`** — verified by checking out main, rebuilding,
and reproducing the identical error. It's a test-environment preload gap, not a
regression from this PR.

### Follow-ups filed (PM)
- **BET-427** — `uploadCleanupHours` UI: the config key AND its cleanup poller
  were removed in the SSH→direct migration; re-adding UI without the backing
  logic is dead code. PM to decide restore-vs-drop.
- **BET-428** — opencode version in About: no IPC exists to read the box's
  opencode version. Desktop + server versions shipped; opencode version needs
  a new server route.

### Notes on scope interpretation
- "Exactly one restart affordance": the panel banner is the single user-facing
  restart button. ConnectProvider's applying restart is automatic (status text
  only), which is load-bearing for credential verification — removing it would
  break the connect flow's "done" state and onboarding's auto-skip.
- `ModelsCard` behavior is unchanged (only its restart button moved to the
  panel banner); per "Do NOT change what ModelsCard does; only where it lives."
