### PR TITLE
BET-429: wire lazy Claude CLI install into the connect card

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -181,6 +181,13 @@ resolve_arch() {
 #                          Dedup'd against the existing base (a Homebrew-
 #                          installed claude that also lives in /usr/local/bin
 #                          must not appear twice).
+#                          BET-421 §E: install.sh no longer installs the
+#                          claude CLI — the app does it lazily on first
+#                          Claude sign-in. KEEP this entry anyway: a later
+#                          lazy install (by the app) places the binary here,
+#                          and both supervisors must be able to find it.
+#                          Deleting it "because claude is gone from install"
+#                          would break the whole design.
 #   2. the directory `tmux` was actually resolved from when it lives
 #      somewhere else entirely (MacPorts, /usr/local/opt, a hand-built
 #      binary) — the prereq check already proved that copy exists.
@@ -294,7 +301,7 @@ print_provider_detection_summary() {
     # when the app is genuinely unreachable. The same caveat applies to
     # Codex/Kimi but those already had opencode-native OAuth, so only the
     # Claude-specific copy changes.
-    warn "Fallback (if the app is unavailable): connect providers from inside opencode (Claude: 'claude auth login'; Codex: '/auth' command)."
+    warn "Fallback (if the app is unavailable): connect providers from inside opencode (Codex: '/auth' command; Claude: install the claude CLI from https://claude.ai then run 'claude auth login')."
     return 0
   fi
 
@@ -349,7 +356,7 @@ print_provider_detection_summary() {
     # a fallback for boxes where the app is unreachable. Codex/Kimi
     # already had opencode-native OAuth, so the original copy just lost
     # its Claude-specific invocation.
-    warn "Fallback (if the app is unavailable): connect providers from inside opencode (Claude: 'claude auth login'; Codex: '/auth' command)."
+    warn "Fallback (if the app is unavailable): connect providers from inside opencode (Codex: '/auth' command; Claude: install the claude CLI from https://claude.ai then run 'claude auth login')."
   fi
 }
 
@@ -715,63 +722,14 @@ main() {
     ok "opencode installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
   fi
 
-  # --- A2. claude CLI install (idempotent via official installer). ----------
-  # opencode's "anthropic" provider is a passthrough that reads
-  # ~/.claude/.credentials.json — a file only the `claude` CLI writes. Without
-  # the binary, Claude cannot work on a fresh box at all (BET-353). Same
-  # shape as the opencode install above: curl-to-file + bash </dev/null +
-  # PATH probe + non-fatal-on-failure (a box without Claude must still finish
-  # installing, still pair, and still be usable with Codex).
-  #
-  # The official installer places the binary in $HOME/.local/bin/claude —
-  # SAME dir we prepend to launchd_agent_path above so the supervisor-managed
-  # services can spawn it for credential refresh
-  # (src/server/opencode.mjs doRefresh / refreshClaudeCredentials). Reuses
-  # the opencode install's stdin dance because the SAME `curl | bash` pipe-
-  # truncation footgun applies (install.sh itself is run as `curl | bash`,
-  # so the child's stdin must be /dev/null AND the script must come from a
-  # file, not stdin).
-  #
-  # PLATFORM: macOS arm64 + Linux x64/arm64 — same matrix install.sh ships
-  # tarballs for (resolve_arch). The official installer honours that matrix
-  # directly.
-  if [ "$DRY_RUN" = "1" ]; then
-    if command -v claude >/dev/null 2>&1; then
-      dry_log "claude CLI already installed ($(command -v claude)) — would skip install step"
-    else
-      dry_log "would install claude CLI (official installer https://claude.ai/install.sh); idempotent on PATH probe"
-    fi
-  elif command -v claude >/dev/null 2>&1; then
-    ok "claude CLI already installed ($(command -v claude))."
-  else
-    log "Installing claude CLI (official installer)…"
-    _claude_installer="$WORK/claude-install.sh"
-    curl -fsSL https://claude.ai/install.sh -o "$_claude_installer" \
-      || { warn "claude installer download failed — skipping. Connect Codex/Kimi from the MantaUI app, or install manually: https://claude.ai"; rm -f "$_claude_installer"; }
-    if [ -f "$_claude_installer" ]; then
-      bash "$_claude_installer" </dev/null \
-        || warn "claude install failed — skipping. Connect Codex/Kimi from the MantaUI app, or install manually: https://claude.ai"
-      rm -f "$_claude_installer"
-      # Mirror the opencode install's PATH recovery: source .bashrc if the
-      # installer wrote to it, then probe the well-known install location
-      # as a safety net.
-      if [ -f "$HOME/.bashrc" ]; then
-        set +e
-        # shellcheck disable=SC1090
-        . "$HOME/.bashrc" 2>/dev/null || true
-        set -e
-      fi
-      if [ -x "$HOME/.local/bin/claude" ]; then
-        export PATH="$HOME/.local/bin:$PATH"
-      fi
-      CLAUDE_BIN="$(command -v claude || true)"
-      if [ -n "$CLAUDE_BIN" ]; then
-        ok "claude CLI installed ($("$CLAUDE_BIN" --version 2>/dev/null | head -n1 || echo "$CLAUDE_BIN"))."
-      else
-        warn "claude installer ran but the binary is not on PATH — non-fatal: Claude auth will be unavailable until you install it manually (https://claude.ai). Connect Codex/Kimi from the MantaUI app in the meantime."
-      fi
-    fi
-  fi
+  # --- A2. claude CLI install — REMOVED (BET-421 §E). -----------------------
+  # The app now owns the Claude CLI: it installs the binary lazily, the
+  # first time the user picks Claude, via the official installer — no
+  # confirmation step, straight into sign-in. A box that never picks Claude
+  # never gets the binary, which is fine (Codex / Kimi / custom need no
+  # binary). Nothing here is a flag or opt-in; the whole block is deleted.
+  # The box is usable without claude — its own comment (below, at A2's old
+  # site) already anticipated that.
 
   # --- B. opencode config seeding — MERGE the plugin entry, never clobber. --
   # Target: ~/.config/opencode/opencode.jsonc. Required:

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4383,78 +4383,32 @@ command() {
   assert.equal(out.match(/\/opt\/homebrew\/bin/g).length, 1);
 });
 
-test("install.sh claude install step: dry-run shows the install branch when claude is absent (BET-353)", () => {
-  // Stage-2 acceptance: a fresh box has no claude binary; the installer's
-  // dry-run mode must show that it WOULD install it (not silently skip it).
-  // Pin the dry-run shape so a future regression that drops the step is
-  // caught here instead of on a real box.
-  const out = runBootstrap({
-    preBody: `
-# Force claude to be absent (the test runner itself may have claude
-# installed — see the same stub used in print_provider_detection_summary's
-# CLI-probe test).
-command() {
-  case "$1" in
-    -v) case "$2" in claude) return 1 ;; *) builtin command "$@" ;; esac ;;
-    *) builtin command "$@" ;;
-  esac
-}
-export -f command
-
-# claude is NOT on PATH for this test; dry-run must emit the install branch.
-DRY_RUN=1
-dry_log() { [ "$DRY_RUN" = "1" ] && printf '\\033[36m▸\\033[0m [dry-run] %s\\n' "$*"; }
-# Inline the Claude install branch from install.sh (the helper lives inside
-# main() so we can't call it directly).
-if [ "$DRY_RUN" = "1" ]; then
-  if command -v claude >/dev/null 2>&1; then
-    dry_log "claude CLI already installed ($(command -v claude)) — would skip install step"
-  else
-    dry_log "would install claude CLI (official installer https://claude.ai/install.sh); idempotent on PATH probe"
-  fi
-elif command -v claude >/dev/null 2>&1; then
-  echo "BRANCH=already-installed"
-else
-  echo "BRANCH=install"
-fi
-echo "DONE"
-`,
-    func: ":",
-  });
-  assert.match(out, /\[dry-run\] would install claude CLI/);
-  assert.doesNotMatch(out, /already installed/);
-  assert.match(out, /DONE/);
+test("install.sh no longer installs the claude CLI — the app owns it now (BET-421 §E)", () => {
+  // BET-421 §E: the A2 claude-CLI install block was deleted from install.sh.
+  // The app installs the binary lazily on first Claude sign-in instead. This
+  // test pins the deletion so a future regression that re-adds the block is
+  // caught here. Acceptance (issue Verify): `grep -n 'claude' install.sh`
+  // shows no install block.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  // The official-installer invocation must be gone.
+  assert.doesNotMatch(src, /curl -fsSL https:\/\/claude\.ai\/install\.sh -o/);
+  assert.doesNotMatch(src, /would install claude CLI/);
+  // The A2 heading now documents the removal, not the install.
+  assert.match(src, /A2\. claude CLI install — REMOVED/);
 });
 
-test("install.sh claude install step: dry-run reports skip when claude is on PATH (BET-353)", () => {
-  // Mirror of the previous test: when `command -v claude` succeeds, the
-  // dry-run output must say "already installed … would skip" — never the
-  // install branch. This is the BET-353 idempotency acceptance: re-running
-  // the installer must not re-download or re-install.
-  const out = runBootstrap({
-    preBody: `
-DRY_RUN=1
-dry_log() { [ "$DRY_RUN" = "1" ] && printf '\\033[36m▸\\033[0m [dry-run] %s\\n' "$*"; }
-command() {
-  case "$1" in
-    -v) case "$2" in claude) echo "/home/tester/.local/bin/claude"; return 0 ;; *) builtin command "$@" ;; esac ;;
-    *) builtin command "$@" ;;
-  esac
-}
-if [ "$DRY_RUN" = "1" ]; then
-  if command -v claude >/dev/null 2>&1; then
-    dry_log "claude CLI already installed ($(command -v claude)) — would skip install step"
-  else
-    dry_log "would install claude CLI (official installer https://claude.ai/install.sh); idempotent on PATH probe"
-  fi
-fi
-echo "DONE"
-`,
-    func: ":",
-  });
-  assert.match(out, /claude CLI already installed/);
-  assert.match(out, /would skip install step/);
-  assert.doesNotMatch(out, /\[dry-run\] would install claude CLI \(official/);
+test("install.sh launchd_agent_path still prepends ~/.local/bin after the claude install removal (BET-421 §E)", () => {
+  // BET-421 §E: do NOT touch launchd_agent_path. It appends $HOME/.local/bin
+  // unconditionally — that's what makes a later lazy install (by the app)
+  // visible to both supervisors. Deleting it "because claude is gone" would
+  // break the whole design. Acceptance (issue Verify): launchd_agent_path
+  // still contains .local/bin.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  assert.match(src, /\$HOME\/\.local\/bin/);
+  // The function body must still prepend it.
+  const fn = src.match(/launchd_agent_path\(\) \{[\s\S]*?\n\}/);
+  assert.ok(fn, "launchd_agent_path function not found");
+  assert.match(fn[0], /HOME\/\.local\/bin/);
 });
 
 test("install.sh: scripts/systemd/*.service carries @@AGENT_PATH@@ placeholder (BET-353 wiring)", () => {

--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -48,6 +48,8 @@ import { X } from "lucide-react";
 import type { OpencodeProviderAuthRequest } from "../shared/types";
 import {
   connectPhaseLabel,
+  deviceCodeFallback,
+  formatRemaining,
   isPollExpired,
   parseDeviceCode,
   type ConnectPhase,
@@ -98,6 +100,23 @@ export function ConnectProvider({
   confirmRestart?: boolean;
 }): JSX.Element {
   const [phase, setPhase] = useState<ConnectPhase>({ kind: "starting" });
+  // BET-421 §D: device-code wait elapsed + remaining countdown. Ticked once
+  // a second while `phase.kind === "waiting"` so the user sees how long is
+  // left on the code instead of a bare "Waiting for sign-in".
+  const [waitingElapsed, setWaitingElapsed] = useState(0);
+  const waitingStartedRef = useRef<number>(0);
+  useEffect(() => {
+    if (phase.kind !== "waiting") {
+      setWaitingElapsed(0);
+      return;
+    }
+    waitingStartedRef.current = Date.now();
+    setWaitingElapsed(0);
+    const t = setInterval(() => {
+      setWaitingElapsed(Math.floor((Date.now() - waitingStartedRef.current) / 1000));
+    }, 1000);
+    return () => clearInterval(t);
+  }, [phase.kind, phase.kind === "waiting" ? phase.methodIndex : null]);
   const mounted = useMounted();
 
   // Wraps setPhase to guard against late-firing async paths (status polls,
@@ -395,7 +414,12 @@ export function ConnectProvider({
       )}
 
       {phase.kind === "waiting" && (
-        <WaitingBlock url={phase.url} instructions={phase.instructions} />
+        <WaitingBlock
+          url={phase.url}
+          instructions={phase.instructions}
+          elapsedSeconds={waitingElapsed}
+          onCancel={onCancel}
+        />
       )}
 
       {phase.kind === "needsCode" && (
@@ -582,41 +606,90 @@ export function ConnectProvider({
   );
 }
 
-// Device-code block: instructions verbatim + a clickable URL + a copyable
-// code (when one is present in the instructions). Matches the OAuth shape
-// the server reports: "oauth-auto" only ships the URL + instructions, the
-// device code is a token embedded inside the instructions string that
-// parseDeviceCode extracts.
+// Device-code block (BET-421 §D). Two labelled steps the user works through:
+//   1. Open the URL (copy + open).
+//   2. Enter the code shown on that page.
+// The device code is regex-scraped out of the `instructions` string by
+// parseDeviceCode. When nothing parses (the provider reformatted the
+// sentence), deviceCodeFallback points the user at the verbatim instructions
+// instead of rendering an empty code slot — the chip silently vanishing was
+// the exact fragility the issue calls out.
+//
+// The upstream `instructions` text is demoted to a collapsed
+// "Message from ChatGPT" disclosure — it's upstream text we render verbatim,
+// not our framing; we own the card's headline. While waiting, an elapsed +
+// remaining countdown + a real Cancel replace the old bare "Waiting for
+// sign-in" that could sit for five minutes with no feedback.
 function WaitingBlock({
   url,
   instructions,
+  elapsedSeconds,
+  onCancel,
 }: {
   url: string;
   instructions: string;
+  elapsedSeconds: number;
+  onCancel: () => void;
 }) {
   const code = parseDeviceCode(instructions);
+  const fallback = deviceCodeFallback(instructions);
+  const remaining = formatRemaining(0, elapsedSeconds * 1000, DEVICE_POLL_LIMIT_MS);
   return (
-    <div className="space-y-1">
-      <div className="text-text">{instructions || "Open the URL below on any device."}</div>
-      {url && (
-        <div className="flex items-center gap-2 min-w-0">
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-text-muted underline decoration-dotted truncate min-w-0"
-            title={url}
-          >
-            {url.replace(/^https?:\/\//, "")}
-          </a>
-          <CopyButton text={url} />
-        </div>
-      )}
-      {code && (
-        <div className="flex items-center gap-2">
-          <code className="font-mono text-text bg-bg px-2 py-px rounded">{code}</code>
-          <CopyButton text={code} />
-        </div>
+    <div className="space-y-2">
+      <div className="text-text">
+        <div className="text-label font-medium text-text-faint mb-1">Step 1 — open this link</div>
+        {url ? (
+          <div className="flex items-center gap-2 min-w-0">
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text-muted underline decoration-dotted truncate min-w-0"
+              title={url}
+            >
+              {url.replace(/^https?:\/\//, "")}
+            </a>
+            <CopyButton text={url} />
+          </div>
+        ) : (
+          <span className="text-text-muted">Open the sign-in page on any device.</span>
+        )}
+      </div>
+      <div className="text-text">
+        <div className="text-label font-medium text-text-faint mb-1">Step 2 — enter the code</div>
+        {code ? (
+          <div className="flex items-center gap-2">
+            <code className="font-mono text-text bg-bg px-2 py-px rounded">{code}</code>
+            <CopyButton text={code} />
+          </div>
+        ) : fallback ? (
+          <p className="text-text-muted">{fallback}</p>
+        ) : (
+          <p className="text-text-muted">The code will appear on the page above.</p>
+        )}
+      </div>
+      <div className="flex items-center gap-3 text-text-faint">
+        <span
+          aria-hidden
+          className="inline-block w-2.5 h-2.5 rounded-full border-2 border-accent border-t-transparent animate-spin"
+        />
+        <span>Waiting for sign-in · {remaining}</span>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="ml-auto px-2 py-1 rounded text-meta"
+          style={{ border: "1px solid var(--danger)", color: "var(--danger)" }}
+        >
+          Cancel
+        </button>
+      </div>
+      {instructions && (
+        <details className="text-meta">
+          <summary className="text-text-faint cursor-pointer hover:text-text-muted">
+            Message from ChatGPT
+          </summary>
+          <pre className="whitespace-pre-wrap text-text-muted mt-1">{instructions}</pre>
+        </details>
       )}
     </div>
   );
@@ -795,17 +868,24 @@ function ClaudeLoginBlock({
             error={inputError}
             onSubmit={onSubmitCode}
           />
-          {/* Live terminal pane — renders the raw escape sequences from
-              `claude auth login`. Sized small enough to live inside the
-              connect card without dominating the onboarding step. */}
-          <div className="rounded border border-border overflow-hidden h-40 bg-[var(--inset)]">
-            <Terminal
-              sessionKey={ptySessionKey}
-              cwd={cwd}
-              active={true}
-              launcher={{ id: "claude-auth-login", flags: {} }}
-            />
-          </div>
+          {/* BET-421 §D: demote the live terminal to a collapsed disclosure.
+              It always being visible at h-40 reads as something going wrong;
+              the two labelled steps (URL, then code) above are the card's
+              real surface. The raw escape sequences from `claude auth login`
+              still render through xterm for users who want to watch. */}
+          <details className="text-meta">
+            <summary className="text-text-faint cursor-pointer hover:text-text-muted">
+              Show what's happening on the box
+            </summary>
+            <div className="rounded border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
+              <Terminal
+                sessionKey={ptySessionKey}
+                cwd={cwd}
+                active={true}
+                launcher={{ id: "claude-auth-login", flags: {} }}
+              />
+            </div>
+          </details>
         </>
       )}
     </div>

--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -69,6 +69,30 @@ const RESTART_POLL_INTERVAL_MS = 3_000;
 const RESTART_POLL_LIMIT_MS = 30_000;
 const CLAUDE_POLL_INTERVAL_MS = 1_000;
 const CLAUDE_POLL_LIMIT_MS = 5 * 60 * 1_000;
+// BET-429: lazy Claude CLI install poll. The installer is a one-shot
+// `curl … | bash` over the pty bus; the renderer can't observe its exit
+// code across the WS boundary reliably (the pty stays open for scrollback),
+// so it polls `opencodeClaudeCliStatus()` for the binary to appear. 2s is
+// a comfortable cadence — the install takes seconds to minutes, and a
+// sub-second poll would hammer the box's filesystem stat for no benefit.
+// 5-minute cap matches the device-code / Claude-login caps (same
+// rationale: an unbounded poll would leave the user staring at a stale
+// installer forever; the failure card's "Try again" re-runs it on demand).
+const CLI_INSTALL_POLL_INTERVAL_MS = 2_000;
+const CLI_INSTALL_POLL_LIMIT_MS = 5 * 60 * 1_000;
+
+// BET-429: client-generated session key for the installer pty. Distinct
+// from the server-minted claude-login sessionKey (which never spawns in
+// the install phase — startClaudeLogin only stamps metadata) so the two
+// ptys never collide on the bus. Mirrors the att-id shape used elsewhere
+// in the renderer (Date.now + Math.random) — `crypto.randomUUID` is not
+// guaranteed in the renderer's secure-context on every box, and this key
+// only needs to be unique within the session, not cryptographically so.
+function makeInstallSessionKey(): string {
+  return `claude-cli-install-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+}
 
 // Track the in-flight action so an unmounted / unmounting component cannot
 // call setPhase on an unmounted tree (React's "set state on unmounted
@@ -129,83 +153,187 @@ export function ConnectProvider({
     [mounted],
   );
 
-  // Fire `{action:"start"}` on mount. The server's resolveAuthMethod picks
-  // the right opencode method index (NEVER a literal) and returns one of
-  // four shapes that drive the next state directly. Errors fall back to
-  // the API-key path so a transient box-unreachable still gives the user a
-  // way forward.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const req: OpencodeProviderAuthRequest = { action: "start", id };
-      let res;
+  // BET-429: factor the `{action:"start"}` dispatch into a callable so the
+  // post-install re-fire (when the lazy CLI installer reports installed)
+  // re-enters the SAME branch logic the mount-time call uses — no second
+  // copy of the shape switch. A generation ref guards against a stale
+  // in-flight start overwriting a newer one (e.g. the post-install re-fire
+  // landing while a retry-driven start is still pending); safeSetPhase's
+  // mounted guard covers the unmount case.
+  const startGenRef = useRef(0);
+  const runStart = useCallback(async () => {
+    const gen = ++startGenRef.current;
+    const req: OpencodeProviderAuthRequest = { action: "start", id };
+    let res;
+    try {
+      res = await window.api.opencodeProviderAuth(req);
+    } catch {
+      if (startGenRef.current === gen)
+        safeSetPhase({ kind: "failed", message: "Couldn't reach the box. Try again." });
+      return;
+    }
+    if (startGenRef.current !== gen) return;
+    if (res.action !== "start") {
+      safeSetPhase({ kind: "failed", message: "Unexpected response from the box." });
+      return;
+    }
+    // BET-354: claude-login shape carries a sessionKey for the live
+    // terminal pane + the server-side startedAt timestamp the renderer
+    // passes back to the claude-status poll. The server has already
+    // stamped the metadata; the actual pty:spawn is below (in the
+    // Terminal's own useEffect) so the IPty sizes to the rendered
+    // cols/rows rather than a fixed 80x24.
+    if (res.shape === "claude-login") {
+      const sessionKey = typeof res.sessionKey === "string" ? res.sessionKey : "";
+      const startedAt = typeof res.startedAt === "number" ? res.startedAt : Date.now();
+      const cwd = typeof res.cwd === "string" ? res.cwd : "~";
+      // BET-429: probe the CLI BEFORE sign-in. Installed → straight to
+      // the existing needsClaudeLogin flow. Not installed → install
+      // phase; the login sessionKey is held so the post-install re-fire
+      // can cancel it before minting a fresh one. A probe failure is
+      // treated as "not installed" — the install phase will re-probe
+      // on its poll and recover, so a transiently-unreachable box does
+      // not block the flow.
+      let cli: { installed: boolean; path: string } | null = null;
       try {
-        res = await window.api.opencodeProviderAuth(req);
+        cli = await window.api.opencodeClaudeCliStatus();
       } catch {
-        if (!cancelled) safeSetPhase({ kind: "failed", message: "Couldn't reach the box. Try again." });
-        return;
+        cli = null;
       }
-      if (cancelled) return;
-      if (res.action !== "start") {
-        safeSetPhase({ kind: "failed", message: "Unexpected response from the box." });
-        return;
-      }
-      // BET-354: claude-login shape carries a sessionKey for the live
-      // terminal pane + the server-side startedAt timestamp the renderer
-      // passes back to the claude-status poll. The server has already
-      // stamped the metadata; the actual pty:spawn is below (in the
-      // Terminal's own useEffect) so the IPty sizes to the rendered
-      // cols/rows rather than a fixed 80x24.
-      if (res.shape === "claude-login") {
+      if (startGenRef.current !== gen) return;
+      if (cli?.installed) {
         safeSetPhase({
           kind: "needsClaudeLogin",
-          ptySessionKey: typeof res.sessionKey === "string" ? res.sessionKey : "",
-          startedAt: typeof res.startedAt === "number" ? res.startedAt : Date.now(),
-          cwd: typeof res.cwd === "string" ? res.cwd : "~",
+          ptySessionKey: sessionKey,
+          startedAt,
+          cwd,
           url: "",
           inputError: undefined,
           preExisting: false,
         });
-        return;
-      }
-      if (res.shape === "oauth-auto") {
+      } else {
         safeSetPhase({
-          kind: "waiting",
-          url: typeof res.url === "string" ? res.url : "",
-          instructions: typeof res.instructions === "string" ? res.instructions : "",
-          methodIndex: typeof res.methodIndex === "number" ? res.methodIndex : 0,
+          kind: "installingClaudeCli",
+          installSessionKey: makeInstallSessionKey(),
+          loginSessionKey: sessionKey,
+          startedAt: Date.now(),
+          cwd,
         });
-        return;
       }
-      if (res.shape === "oauth-code") {
-        safeSetPhase({
-          kind: "needsCode",
-          url: typeof res.url === "string" ? res.url : "",
-          instructions: typeof res.instructions === "string" ? res.instructions : "",
-          methodIndex: typeof res.methodIndex === "number" ? res.methodIndex : 0,
-        });
-        return;
+      return;
+    }
+    if (res.shape === "oauth-auto") {
+      safeSetPhase({
+        kind: "waiting",
+        url: typeof res.url === "string" ? res.url : "",
+        instructions: typeof res.instructions === "string" ? res.instructions : "",
+        methodIndex: typeof res.methodIndex === "number" ? res.methodIndex : 0,
+      });
+      return;
+    }
+    if (res.shape === "oauth-code") {
+      safeSetPhase({
+        kind: "needsCode",
+        url: typeof res.url === "string" ? res.url : "",
+        instructions: typeof res.instructions === "string" ? res.instructions : "",
+        methodIndex: typeof res.methodIndex === "number" ? res.methodIndex : 0,
+      });
+      return;
+    }
+    // api-key path. Fetch the console URL from the status action so the
+    // "Get a key" link can appear when the registry provides one; the
+    // start response itself doesn't carry it (server-side scope: the
+    // resolver returns the connect shape, not the meta).
+    let consoleUrl: string | null = null;
+    try {
+      const s = await window.api.opencodeProviderAuth({ action: "status" });
+      if (startGenRef.current !== gen) return;
+      if (s.action === "status") {
+        const row = s.providers.find((p) => p.id === id);
+        consoleUrl = row?.console ?? null;
       }
-      // api-key path. Fetch the console URL from the status action so the
-      // "Get a key" link can appear when the registry provides one; the
-      // start response itself doesn't carry it (server-side scope: the
-      // resolver returns the connect shape, not the meta).
-      let consoleUrl: string | null = null;
-      try {
-        const s = await window.api.opencodeProviderAuth({ action: "status" });
-        if (s.action === "status") {
-          const row = s.providers.find((p) => p.id === id);
-          consoleUrl = row?.console ?? null;
-        }
-      } catch {
-        // Console link is optional; degrade silently to "no link".
-      }
-      safeSetPhase({ kind: "needsKey", consoleUrl });
-    })();
-    return () => {
-      cancelled = true;
-    };
+    } catch {
+      // Console link is optional; degrade silently to "no link".
+    }
+    if (startGenRef.current !== gen) return;
+    safeSetPhase({ kind: "needsKey", consoleUrl });
   }, [id, safeSetPhase]);
+
+  // Fire `{action:"start"}` on mount. The server's resolveAuthMethod picks
+  // the right opencode method index (NEVER a literal) and returns one of
+  // four shapes that drive the next state directly. Errors fall back to
+  // the API-key path so a transient box-unreachable still gives the user a
+  // way forward. BET-429: the body lives in `runStart` so the post-install
+  // re-fire reuses the exact same branch logic.
+  useEffect(() => {
+    void runStart();
+  }, [runStart]);
+
+  // BET-429: lazy Claude CLI install poll. Fires every 2s while
+  // `installingClaudeCli`. The installer pty is owned by the Terminal
+  // below (claude-cli-install launcher); this poll watches for the binary
+  // to appear via opencodeClaudeCliStatus(). On installed → kill the
+  // installer pty (the Terminal's own cleanup deliberately does NOT kill
+  // ptys — it keeps them alive across remounts), cancel the original
+  // login sessionKey, and re-fire runStart() so the server mints a fresh
+  // claude-login sessionKey + takes a fresh credential backup right
+  // before the real OAuth. On 5-min timeout → failure card with three
+  // actions (Try again / Use a different model / Install manually),
+  // carrying loginSessionKey + cwd so "Try again" can re-enter the
+  // install phase without re-firing start.
+  useEffect(() => {
+    if (phase.kind !== "installingClaudeCli") return;
+    const installKey = phase.installSessionKey;
+    const loginKey = phase.loginSessionKey;
+    const cwd = phase.cwd;
+    const startedWall = phase.startedAt;
+    const handle = window.setInterval(async () => {
+      if (!mounted.current) return;
+      if (isPollExpired(startedWall, Date.now(), CLI_INSTALL_POLL_LIMIT_MS)) {
+        window.clearInterval(handle);
+        // Best-effort: stop the installer pty so a "Try again" doesn't
+        // leave a second curl|bash running alongside the new one.
+        window.api.ptyKill(installKey).catch(() => {
+          /* best-effort — the pty may already be gone */
+        });
+        safeSetPhase({
+          kind: "failed",
+          message:
+            "The Claude CLI didn't install in time. The box is fine — only the Claude binary didn't appear.",
+          installFailure: { loginSessionKey: loginKey, cwd },
+        });
+        return;
+      }
+      let cli: { installed: boolean; path: string } | null = null;
+      try {
+        cli = await window.api.opencodeClaudeCliStatus();
+      } catch {
+        /* keep polling; box may be transiently unreachable */
+        return;
+      }
+      if (!mounted.current) return;
+      if (cli?.installed) {
+        window.clearInterval(handle);
+        // Kill the installer pty — Terminal's cleanup keeps ptys alive
+        // across remounts by design, so without this the finished
+        // installer would linger on the bus.
+        window.api.ptyKill(installKey).catch(() => {
+          /* best-effort */
+        });
+        // Cancel the original login session so the re-fire doesn't
+        // orphan its entry in the server's _claudeLoginSessions map.
+        // The re-fire mints a fresh sessionKey + takes a fresh backup.
+        try {
+          await window.api.claudeLoginCancel(loginKey);
+        } catch {
+          /* best-effort — the re-fire mints a fresh key regardless */
+        }
+        if (!mounted.current) return;
+        void runStart();
+      }
+    }, CLI_INSTALL_POLL_INTERVAL_MS);
+    return () => window.clearInterval(handle);
+  }, [phase, safeSetPhase, mounted, runStart]);
 
   // BET-354: claude-status poll. Fires every 1s while `needsClaudeLogin`.
   // The server checks the credentials file mtime + probes opencode's
@@ -393,6 +521,23 @@ export function ConnectProvider({
   const retry = useCallback(() => {
     safeSetPhase({ kind: "starting" });
   }, [safeSetPhase]);
+
+  // BET-429: re-run the lazy installer after an install failure. Reuses
+  // the original loginSessionKey + cwd (carried in installFailure) so the
+  // retry does NOT re-fire `{action:"start"}` — the server-side metadata
+  // is still valid (startClaudeLogin only stamps metadata + backs up
+  // credentials, it does not spawn). A fresh installSessionKey ensures
+  // the new installer pty doesn't collide with the killed one's bus entry.
+  const retryInstall = useCallback(() => {
+    if (phase.kind !== "failed" || !phase.installFailure) return;
+    safeSetPhase({
+      kind: "installingClaudeCli",
+      installSessionKey: makeInstallSessionKey(),
+      loginSessionKey: phase.installFailure.loginSessionKey,
+      startedAt: Date.now(),
+      cwd: phase.installFailure.cwd,
+    });
+  }, [phase, safeSetPhase]);
 
   return (
     <div className="rounded-md border bg-bg-elev px-3 py-2 text-meta space-y-2">
@@ -591,15 +736,76 @@ export function ConnectProvider({
         <div className="text-ok">Connected.</div>
       )}
 
+      {/* BET-429: lazy Claude CLI install. The box has no `claude` binary;
+          the connect card spawned the official installer (`curl … | bash`)
+          over the pty bus and is polling opencodeClaudeCliStatus() for the
+          binary to appear. The live terminal is demoted to a collapsed
+          disclosure — same pattern as the Claude login terminal — so the
+          card's headline is the status line, not a wall of curl output.
+          Once the binary appears, the poll kills the installer pty and
+          re-fires start to enter sign-in. */}
+      {phase.kind === "installingClaudeCli" && (
+        <div className="space-y-2">
+          <div className="text-text-muted">
+            Installing the Claude CLI on the box. Sign-in will start
+            automatically once it's ready.
+          </div>
+          <details className="text-meta">
+            <summary className="text-text-faint cursor-pointer hover:text-text-muted">
+              Show what's happening on the box
+            </summary>
+            <div className="rounded border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
+              <Terminal
+                sessionKey={phase.installSessionKey}
+                cwd={phase.cwd}
+                active={true}
+                launcher={{ id: "claude-cli-install", flags: {} }}
+              />
+            </div>
+          </details>
+        </div>
+      )}
+
       {phase.kind === "failed" && (
         <div className="space-y-2">
           <div className="text-danger break-words">{phase.message}</div>
-          <button
-            onClick={retry}
-            className="px-2 py-1 border border-border rounded text-text-muted hover:text-text"
-          >
-            Retry
-          </button>
+          {phase.installFailure ? (
+            // BET-429: install failure gets three actions, not the single
+            // Retry. "Use a different model" closes the card — Codex, Kimi,
+            // and custom providers need no binary, so the user can pivot
+            // without revisiting the box. "Install manually" links to the
+            // official installer page for a user-driven install outside
+            // the app.
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={retryInstall}
+                className="px-2 py-1 border border-border rounded text-text-muted hover:text-text"
+              >
+                Try again
+              </button>
+              <button
+                onClick={onCancel}
+                className="px-2 py-1 border border-border rounded text-text-muted hover:text-text"
+              >
+                Use a different model
+              </button>
+              <a
+                href="https://claude.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-2 py-1 border border-border rounded text-text-muted hover:text-text inline-flex items-center"
+              >
+                Install manually
+              </a>
+            </div>
+          ) : (
+            <button
+              onClick={retry}
+              className="px-2 py-1 border border-border rounded text-text-muted hover:text-text"
+            >
+              Retry
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -1,28 +1,26 @@
-// Onboarding.tsx — full-screen M6.6 onboarding shell (BET-356).
+// Onboarding.tsx — full-screen M6.6 onboarding shell (BET-356, BET-421).
 //
 // Owns the full-screen container (no sidebar / header / footer), the progress
 // rail (numbered dots + connecting lines), fade+slide step transitions, and
 // the terminal success screen.
 //
-// The user-visible flow collapses from four steps (Pair → Providers → Model
-// → Project, BET-49) to two (Connect → Connect a provider, BET-356). Model
-// is global config (edited in Settings), and the first project is auto-
-// created on pair success — no dedicated onboarding step for either.
+// The user-visible flow is two steps (Connect → Connect a provider). Model is
+// global config (edited in Settings); no dedicated onboarding step for it.
 //
 // Onboarding's responsibilities beyond the step machine:
 //
-//   1. Verify by working (BET-356 §4). After both steps complete (or after
-//      step 1 alone, when step 2 auto-skipped because a provider was
-//      already connected), `finalizeOnboarding` auto-creates the welcome
-//      project + chat window, sends a probe prompt, and waits for a real
-//      assistant response. An install that exits zero but cannot answer
-//      is a failure the user sees immediately, not later.
+//   1. Verify by working (BET-421 §B). After both steps complete (or after
+//      step 1 alone, when step 2 auto-skipped because a provider was already
+//      connected), `verifyOnboarding` spins up an EPHEMERAL opencode session
+//      (no project, no sidebar entry), sends one probe prompt, waits for a
+//      real assistant reply, and deletes the session. Three named stages
+//      drive a ProcessPanel; on failure the user sees which stage failed +
+//      Try again / Back to the provider step / Copy diagnostics. No "continue
+//      anyway" — a working model is mandatory.
 //
-//   2. Failure and resumption (BET-356 §5). Every failure shows a plain-
-//      language cause + one action. The shell re-derives the resume point
-//      from config so a quit-mid-flow reopens at the first incomplete
-//      step (the underlying `resolveInitialStep` already has this
-//      property; the shell just re-uses it on every mount).
+//   2. Failure and resumption. Every failure shows a plain-language cause +
+//      one way forward. The shell re-derives the resume point from config so
+//      a quit-mid-flow reopens at the first incomplete step.
 //
 // Per-step bodies:
 //   - Step 1 (Connect)          → PairStep.tsx (SSH picker primary, manual
@@ -34,7 +32,7 @@
 // Those components own their own footers; the shell hides its generic
 // footer and lets each step drive advancement (`onPaired` / `onContinue`).
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ONBOARDING_STEPS,
   STEP_LABELS,
@@ -47,17 +45,21 @@ import { useStore } from "./store";
 import { PairStep } from "./PairStep";
 import { ProvidersStep } from "./ProvidersStep";
 import {
-  finalizeOnboarding,
+  verifyOnboarding,
   hasConnectedProvider,
+  pickVerifyLabels,
+  verifyStageLabels,
   type VerifyApi,
-  type VerifyStore,
+  type VerifyProgress,
+  type VerifyStageIndex,
 } from "./onboardingVerify";
 import { installHttpTransport } from "./transportInstall";
-import { ArrowRight, CheckIcon } from "./onboardingUi";
-import mantaMark from "./assets/manta-mark-128.png";
+import { ArrowRight, CheckIcon, MantaMark } from "./onboardingUi";
+import { ProcessPanel } from "./ProcessPanel";
 
 const ACCENT = "var(--accent)"; // the app's accent token (borders/tints)
 const ACCENT_SOLID = "var(--accent-solid)"; // filled buttons (BET-409: darker in light for AA)
+const DANGER = "var(--danger)";
 
 // Progress rail — one dot + connector per step. Reads every numbered step as
 // completed on the success screen.
@@ -117,39 +119,34 @@ function ProgressRail({ current }: { current: OnboardingPosition }) {
 }
 
 // Props:
-//   onDone — called when onboarding completes (success screen "Open manta") OR
-//            is skipped. The parent (App.tsx) re-reads config and drops back
-//            to the normal shell WITHOUT an app restart.
+//   onDone — called when onboarding completes (success screen "Open manta").
 export function Onboarding({ onDone }: { onDone: () => void }) {
   // Derive the resume point once from the current config so a quit-mid-flow
-  // reopens at the first incomplete step. Read straight from the store's
-  // config snapshot (App gates on `loaded`, so config is present by mount).
-  //
-  // Deep-link pairing (BET-240): if a manta://pair?... URL is pending in the
-  // store, force step 1 regardless of the resume point — re-pairing to a new
-  // box is a legitimate flow that resolveInitialStep would otherwise skip.
+  // reopens at the first incomplete step. Deep-link pairing forces step 1.
   const [pos, setPos] = useState<OnboardingPosition>(() =>
     useStore.getState().pendingPairLink
       ? 1
       : resolveInitialStep(useStore.getState().configSnapshot()),
   );
 
-  // Verification state — the orchestrator runs after a successful pair +
-  // (optional) provider step, before the success screen. The user sees an
-  // inline "Verifying your box…" panel while it polls; success replaces it
-  // with the "You're all set!" screen.
-  const [verifying, setVerifying] = useState(false);
-  const [verifyError, setVerifyError] = useState<string | null>(null);
+  // Verification state (BET-421 §B). The ProcessPanel is driven by
+  // `verifyProgress`; a failure populates `verifyError` with the stage +
+  // message so the failure card can render the three actions.
+  const [verifyProgress, setVerifyProgress] = useState<VerifyProgress | null>(null);
+  const [verifyError, setVerifyError] = useState<{
+    failedStage: VerifyStageIndex;
+    message: string;
+    labels: [string, string, string];
+  } | null>(null);
+  const [verifyElapsed, setVerifyElapsed] = useState(0);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
 
   // Pre-flight for everything that runs AFTER a successful pair: refresh
   // the store from main's config + seed localStorage / swap window.api to
   // httpApi. The SSH claim path persists credentials via main's commit()
-  // but does NOT seed localStorage or swap window.api to httpApi (only
-  // the manual path's claimBox does). Without this pre-flight, the
-  // window.api.opencode* / .tmuxNewSession / .opencodeProviderAuth calls
-  // in finalize + hasConnectedProvider fail — the preload has no such
-  // surface. The manual path's claimBox already did the install; this
-  // re-run is idempotent (localStorage entries + window.api swap).
+  // but does NOT seed localStorage or swap window.api to httpApi. Without
+  // this pre-flight, the window.api.opencode* / .opencodeProviderAuth calls
+  // in verify + hasConnectedProvider fail.
   const refreshAndInstallTransport = useCallback(async () => {
     await useStore.getState().refresh();
     const cfg = useStore.getState().configSnapshot();
@@ -166,103 +163,132 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     }
   }, []);
 
-  // The ONE place that manages verifying/verifyError. Every async onboarding
-  // phase goes through it — a phase that throws surfaces inline and the user
-  // stays put, never a silent stall.
-  const runPhase = useCallback(async (fn: () => Promise<void>) => {
-    setVerifying(true);
-    setVerifyError(null);
-    try {
-      await fn();
-    } catch (e) {
-      setVerifyError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setVerifying(false);
-    }
-  }, []);
-
-  // The post-pair orchestrator body WITHOUT state management — runPhase owns
-  // that. Auto-creates the welcome project + chat window, sends a probe
-  // prompt, waits for a real assistant response. On success the shell
-  // advances to "success". Kept separate from runPhase so onPaired can run
-  // it inline without nesting two runPhase calls (which would clear
-  // verifying early).
-  //
-  // Two entry points route here through runPhase:
-  //   - onPaired (step 1): skips to step 2 if no provider is connected,
-  //     otherwise runs doFinalize. The "skip if no provider" branch is the
-  //     dual of ProvidersStep's mount-time auto-skip, so either side
-  //     arriving at finalizeOnboarding means ≥1 provider is connected.
-  //   - onProviderContinue (step 2): always runs doFinalize.
-  const doFinalize = useCallback(async () => {
+  // The post-pair verify. Runs an ephemeral opencode session through three
+  // named stages; on success the shell advances to "success", on failure
+  // the failure card renders with Try again / Back to the provider step /
+  // Copy diagnostics.
+  const runVerify = useCallback(async () => {
     await refreshAndInstallTransport();
-    await finalizeOnboarding({
+    // Resolve the connected provider label + the configured default model
+    // so the stage labels name them. If the status probe fails or nothing
+    // is connected, fall back to generic labels — the verify still runs.
+    let providerLabel = "your provider";
+    let modelLabel: string | undefined;
+    try {
+      const status = await (window.api as unknown as VerifyApi).opencodeProviderAuth({
+        action: "status",
+      });
+      const cfg = useStore.getState().configSnapshot();
+      const labels = pickVerifyLabels(status, cfg.defaultModel ?? null);
+      if (labels) {
+        providerLabel = labels.providerLabel;
+        modelLabel = labels.modelLabel;
+      }
+    } catch {
+      /* best-effort — verify with generic labels */
+    }
+    const stages = verifyStageLabels(providerLabel, modelLabel);
+    setVerifyError(null);
+    setVerifyElapsed(0);
+    setVerifyProgress({ stage: 0, status: "running" });
+    const outcome = await verifyOnboarding({
       api: window.api as unknown as VerifyApi,
-      store: useStore.getState() as unknown as VerifyStore,
+      providerLabel,
+      modelLabel,
+      onProgress: (p) => setVerifyProgress(p),
     });
-    setPos("success");
+    if (outcome.ok) {
+      setVerifyProgress(null);
+      setPos("success");
+      return;
+    }
+    setVerifyProgress({ stage: outcome.failedStage, status: "error" });
+    setVerifyError({
+      failedStage: outcome.failedStage,
+      message: outcome.message,
+      labels: stages,
+    });
   }, [refreshAndInstallTransport]);
 
-  // Step 1 → step 2 (provider needed) OR step 1 → doFinalize (provider
+  // Step 1 → step 2 (provider needed) OR step 1 → runVerify (provider
   // already connected). Detecting the latter before stepping forward keeps
   // the user from blinking through an empty step-2 frame.
-  //
-  // refreshAndInstallTransport FIRST so the hasConnectedProvider probe
-  // (and the upcoming finalize) actually reach the box. The whole body runs
-  // inside runPhase so a rejection surfaces inline instead of stalling.
-  const onPaired = useCallback(
-    () =>
-      runPhase(async () => {
-        await refreshAndInstallTransport();
-        const connected = await hasConnectedProvider(
-          window.api as unknown as VerifyApi,
-        );
-        if (connected) {
-          await doFinalize();
-        } else {
-          setPos(2);
-        }
-      }),
-    [runPhase, refreshAndInstallTransport, doFinalize],
-  );
+  const onPaired = useCallback(async () => {
+    await refreshAndInstallTransport();
+    const connected = await hasConnectedProvider(window.api as unknown as VerifyApi);
+    if (connected) {
+      await runVerify();
+    } else {
+      setPos(2);
+    }
+  }, [refreshAndInstallTransport, runVerify]);
 
-  // Step 2 → finalize (provider connect just landed → run the verify).
-  const onProviderContinue = useCallback(() => runPhase(doFinalize), [
-    runPhase,
-    doFinalize,
-  ]);
+  // Step 2 → verify (provider connect just landed → run the verify).
+  const onProviderContinue = useCallback(() => {
+    void runVerify();
+  }, [runVerify]);
 
   const goBack = () => setPos((p) => prevPosition(p));
 
-  // Skip: persist onboardingSkipped so the flow doesn't re-trigger on every
-  // launch of an otherwise-empty config, then hand control back to the shell.
-  // Reserved for future Settings-driven "Skip setup" re-runs (BET-382 §A.3);
-  // today the renderer's `Skip setup` button is gone, so the only caller is
-  // a future Settings affordance that hasn't landed yet. `void skip;` keeps
-  // the function referenced for TS while we wait.
-  const skip = async () => {
-    await useStore.getState().skipOnboarding();
-    onDone();
-  };
-  void skip;
+  // BET-421 §C: skip / onboardingSkipped are deliberately NOT wired. A
+  // model is mandatory; there is no skip button on any platform.
 
-  // Deep-link pairing (BET-240): a link that arrives WHILE onboarding is
-  // already open (e.g. user clicked the link from Terminal after the app
-  // was running) must also jump to step 1.
+  // Deep-link pairing: a link that arrives WHILE onboarding is already open
+  // must also jump to step 1.
   const pendingPairLink = useStore((s) => s.pendingPairLink);
   useEffect(() => {
     if (pendingPairLink) setPos(1);
   }, [pendingPairLink]);
 
+  // BET-421 §F: move focus to the new step's heading on advance. The
+  // refocus-on-error pattern already exists in these files; this is the
+  // same idea applied when advancing. The step components own their own
+  // <h2>; we focus the first heading inside the step body so a screen
+  // reader / keyboard user lands on the new step's title.
+  useEffect(() => {
+    if (verifyProgress) return; // verify overlay owns focus while running
+    const h2 = bodyRef.current?.querySelector("h2");
+    if (h2 instanceof HTMLHeadingElement) {
+      h2.setAttribute("tabindex", "-1");
+      h2.focus();
+    }
+  }, [pos, verifyProgress]);
+
+  // Tick the verify elapsed-time display once a second while running.
+  useEffect(() => {
+    if (!verifyProgress || verifyProgress.status !== "running") return;
+    const t = setInterval(() => setVerifyElapsed((s) => s + 1), 1000);
+    return () => clearInterval(t);
+  }, [verifyProgress]);
+
   const isSuccess = pos === "success";
+  const isVerifying = verifyProgress !== null && !verifyError;
+
+  const copyVerifyDiagnostics = useCallback(async () => {
+    if (!verifyError) return;
+    const stageLabel = verifyError.labels[verifyError.failedStage] ?? "verification";
+    const text = [
+      "Manta onboarding verification failed",
+      `Stage: ${verifyError.failedStage + 1} of ${verifyError.labels.length} — ${stageLabel}`,
+      `Elapsed: ${verifyElapsed}s`,
+      `Error: ${verifyError.message}`,
+    ].join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      /* clipboard may be unavailable; the text is also shown inline */
+    }
+  }, [verifyError, verifyElapsed]);
 
   return (
     <div className="fixed inset-0 z-50 bg-bg text-text flex items-center justify-center overflow-y-auto">
       <div className="w-full max-w-[720px] px-6 py-8">
-        {/* Header: logo + progress rail (hidden on the success screen). */}
+        {/* Header: brand mark + progress rail (hidden on the success screen). */}
         <div className="text-center mb-10">
           <div className="inline-flex items-center gap-3 mb-8">
-            <img src={mantaMark} alt="" className="w-9 h-9 object-contain" />
+            {/* BET-421 §F: one brand mark for desktop and mobile — the
+                inline MantaMark SVG (current page text color), not a PNG. */}
+            <MantaMark className="w-9 h-9 text-accent" />
             <span className="text-title font-semibold tracking-tight">Manta</span>
           </div>
           {!isSuccess && <ProgressRail current={pos} />}
@@ -270,43 +296,79 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
 
         {/* Step body. `key` on the wrapper restarts the fade+slide animation on
             every position change. */}
-        <div className="relative overflow-hidden">
+        <div className="relative overflow-hidden" ref={bodyRef}>
           <div key={String(pos)} className="onboarding-step-enter">
             {isSuccess ? (
               <SuccessPanel onOpen={onDone} />
             ) : pos === 1 ? (
-              <PairStep onPaired={onPaired} />
+              <PairStep onPaired={() => void onPaired()} />
             ) : pos === 2 ? (
-              <ProvidersStep
-                onBack={goBack}
-                onContinue={onProviderContinue}
-              />
+              <ProvidersStep onBack={goBack} onContinue={onProviderContinue} />
             ) : null}
           </div>
         </div>
 
-        {/* Verification overlay — sits below the step body so it doesn't
-            obscure the active step's controls. Only visible mid-finalize. */}
-        {verifying && (
-          <div
-            role="status"
-            aria-live="polite"
-            className="mt-6 rounded-md border border-border bg-bg-soft px-4 py-3 text-body text-text-muted flex items-center gap-3"
-          >
-            <span
-              aria-hidden
-              className="inline-block w-3 h-3 rounded-full border-2 border-accent border-t-transparent animate-spin"
+        {/* Verification panel (BET-421 §B). Sits below the step body so it
+            doesn't obscure the active step's controls. Mounted mid-verify
+            and on failure; cleared on success. */}
+        {verifyProgress && verifyError && (
+          <div className="mt-6 space-y-4">
+            <ProcessPanel
+              stages={verifyError.labels}
+              activeIndex={verifyError.failedStage}
+              status="error"
+              elapsedSeconds={verifyElapsed}
+              logLines={[]}
+              onCopyDiagnostics={copyVerifyDiagnostics}
             />
-            Verifying your box…
+            <div
+              role="alert"
+              className="rounded-md border px-4 py-3 text-body"
+              style={{ borderColor: DANGER, color: DANGER }}
+            >
+              {verifyError.message}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void runVerify()}
+                className="px-4 py-2 rounded-md text-body font-medium"
+                style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
+              >
+                Try again
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setVerifyProgress(null);
+                  setVerifyError(null);
+                  setPos(2);
+                }}
+                className="px-4 py-2 rounded-md text-body font-medium"
+                style={{ border: `1px solid ${ACCENT}`, color: ACCENT }}
+              >
+                Back to the provider step
+              </button>
+              <button
+                type="button"
+                onClick={() => void copyVerifyDiagnostics()}
+                className="px-4 py-2 rounded-md text-body font-medium"
+                style={{ border: `1px solid ${DANGER}`, color: DANGER }}
+              >
+                Copy diagnostics
+              </button>
+            </div>
           </div>
         )}
-        {verifyError && (
-          <div
-            role="alert"
-            className="mt-6 rounded-md border px-4 py-3 text-body"
-            style={{ borderColor: "var(--danger)", color: "var(--danger)" }}
-          >
-            {verifyError}
+        {isVerifying && verifyProgress && (
+          <div className="mt-6">
+            <ProcessPanel
+              stages={verifyStageLabels("your provider")}
+              activeIndex={verifyProgress.stage}
+              status={verifyProgress.status}
+              elapsedSeconds={verifyElapsed}
+              logLines={[]}
+            />
           </div>
         )}
       </div>
@@ -328,8 +390,8 @@ function SuccessPanel({ onOpen }: { onOpen: () => void }) {
       </div>
       <h2 className="text-display font-semibold mb-2">You're all set!</h2>
       <p className="text-body text-text-muted leading-relaxed max-w-sm mx-auto mb-8">
-        Your box is paired, a provider is connected, and your first project is
-        ready. Start chatting with your AI assistant.
+        Your box is paired and a provider is connected. Start chatting with
+        your AI assistant.
       </p>
       <button
         onClick={onOpen}

--- a/src/renderer/ProcessPanel.tsx
+++ b/src/renderer/ProcessPanel.tsx
@@ -1,0 +1,168 @@
+// ProcessPanel.tsx — reusable "long opaque operation" surface (BET-421 §A).
+//
+// The SSH installer's progress section (SshInstallStep.tsx) is the best-
+// designed thing in the product: named stages, an N-of-M counter, elapsed
+// time, a progress bar, a live log, and a Copy diagnostics button. Every
+// other slow operation (provider sign-in, verification, opencode restarts)
+// showed a bare spinner instead. This component extracts that surface into
+// one reusable element so all four render the same way.
+//
+// Render-only. The parent owns the stage list, the active index, the log
+// buffer, and the elapsed timer — ProcessPanel just lays them out. Inline
+// prompts (the SSH installer's fingerprint / passphrase cards) are passed
+// as children and render between the bar and the log, exactly where they
+// lived before.
+//
+// Props:
+//   stages          ordered list of stage labels (drives "N of M" + bar width).
+//   activeIndex     0-based index of the stage currently running. `stages.length`
+//                   means "past the last stage" (done → full bar + check). Any
+//                   index < stages.length while `status === "running"` shows the
+//                   spinner on that stage.
+//   status          "running" | "done" | "error". Done shows a check and fills
+//                   the bar; error shows an X and freezes the bar at the failed
+//                   stage.
+//   elapsedSeconds  seconds since the operation started (parent ticks it).
+//   logLines        live log lines (auto-scrolls while open).
+//   onCopyDiagnostics  optional — renders a "Copy diagnostics" button. Present
+//                      for every operation that can fail opaquely (installer,
+//                      verify, restart).
+//   children         optional inline prompts rendered between the bar and the
+//                    log (the SSH installer's fingerprint / passphrase cards).
+//   logHeight        log pane height in px (defaults to the SSH installer's 172).
+//   copyLabel        override the Copy diagnostics button label.
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Check, X, ChevronUp, ChevronDown } from "lucide-react";
+
+const ACCENT = "var(--accent)";
+const ACCENT_SOLID = "var(--accent-solid)";
+const DANGER = "var(--danger)";
+const OK_GREEN = "var(--ok)";
+
+export type ProcessPanelStatus = "running" | "done" | "error";
+
+export function ProcessPanel({
+  stages,
+  activeIndex,
+  status,
+  elapsedSeconds,
+  logLines,
+  onCopyDiagnostics,
+  children,
+  logHeight = 172,
+  copyLabel = "Copy diagnostics",
+}: {
+  stages: string[];
+  activeIndex: number;
+  status: ProcessPanelStatus;
+  elapsedSeconds: number;
+  logLines: string[];
+  onCopyDiagnostics?: () => void | Promise<void>;
+  children?: ReactNode;
+  logHeight?: number;
+  copyLabel?: string;
+}): JSX.Element {
+  const [logOpen, setLogOpen] = useState(false);
+  const logRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll the log to the bottom while it's open — matches a terminal
+  // user's "stick to the tail" expectation.
+  useEffect(() => {
+    if (logOpen && logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [logLines, logOpen]);
+
+  const total = stages.length;
+  // Clamp the displayed index for the "N of M" line. While running, it's the
+  // current stage (1-based); when done we show the last stage as completed.
+  const displayIndex = Math.min(Math.max(activeIndex + 1, 1), total);
+  const stageLabel =
+    status === "done"
+      ? stages[total - 1] ?? "Done"
+      : (stages[activeIndex] ?? stages[0] ?? "");
+  // Bar width: fraction of stages completed. Done → full. Error → frozen at
+  // the failed stage's progress (displayIndex/total).
+  const barFraction =
+    status === "done" ? 1 : total > 0 ? displayIndex / total : 0;
+
+  // The log only renders when there's something to show AND no inline prompt
+  // is currently monopolizing the panel (mirrors the SSH installer, which
+  // hides the log while a fingerprint / passphrase card is up).
+  const showLog = logOpen && !children;
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-2 text-body">
+        {status === "done" ? (
+          <span aria-hidden style={{ color: OK_GREEN }} className="inline-flex items-center">
+            <Check size={14} aria-hidden="true" />
+          </span>
+        ) : status === "error" ? (
+          <span aria-hidden style={{ color: DANGER }} className="inline-flex items-center">
+            <X size={14} aria-hidden="true" />
+          </span>
+        ) : (
+          <span
+            aria-hidden
+            className="inline-block w-3 h-3 rounded-full border-2 animate-spin"
+            style={{ borderColor: ACCENT, borderTopColor: "transparent" }}
+          />
+        )}
+        <span>{stageLabel}</span>
+        <span className="text-text-muted">
+          {displayIndex} of {total} · {formatElapsed(elapsedSeconds)}
+        </span>
+        <button
+          onClick={() => setLogOpen((o) => !o)}
+          className="ml-auto text-meta text-text-muted hover:text-text inline-flex items-center gap-1"
+          aria-expanded={logOpen}
+        >
+          {logOpen ? (
+            <>Hide log <ChevronUp size={12} aria-hidden="true" /></>
+          ) : (
+            <>Show log <ChevronDown size={12} aria-hidden="true" /></>
+          )}
+        </button>
+      </div>
+      <div className="h-0.5 rounded-full overflow-hidden bg-bg-elev" aria-hidden>
+        <div
+          className="h-full"
+          style={{
+            width: `${barFraction * 100}%`,
+            background: status === "error" ? DANGER : ACCENT_SOLID,
+          }}
+        />
+      </div>
+      {children}
+      {showLog && (
+        <div
+          ref={logRef}
+          style={{ height: logHeight, overflowY: "auto" }}
+          className="rounded-md bg-bg-elev px-3 py-2 text-meta font-mono whitespace-pre-wrap"
+        >
+          {logLines.join("\n")}
+        </div>
+      )}
+      {onCopyDiagnostics && (
+        <div className="pt-px">
+          <button
+            type="button"
+            onClick={() => void onCopyDiagnostics()}
+            className="px-3 py-2 rounded-md text-meta"
+            style={{ border: `1px solid ${DANGER}`, color: DANGER }}
+          >
+            {copyLabel}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function formatElapsed(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  return `${m}:${String(s % 60).padStart(2, "0")}`;
+}

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -30,13 +30,13 @@
 // state + per-event dispatch + JSX, nothing more.
 
 import { useCallback, useEffect, useState, useRef } from "react";
-import { Check, X, ChevronUp, ChevronDown } from "lucide-react";
 import {
   getMantaPreload,
   type InstallerEvent,
   type PreflightFailure,
 } from "./preloadAccess";
-import { currentStageInfo, type InstallStageId } from "../shared/installStages";
+import { currentStageInfo, INSTALL_STAGES, type InstallStageId } from "../shared/installStages";
+import { ProcessPanel } from "./ProcessPanel";
 import {
   CUSTOM_HOST_VALUE,
   resolveInstallTarget,
@@ -73,11 +73,11 @@ const CLAIM_RETRY_DELAY_MS = 3_000;
 const INITIAL_STAGE: InstallStageId = "preflight";
 const INITIAL_STAGE_INFO = currentStageInfo(INITIAL_STAGE);
 
-function formatElapsed(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}:${String(s).padStart(2, "0")}`;
-}
+// The installer's ProcessPanel stages — the ordered INSTALL_STAGES labels.
+// `currentStageInfo` is 1-based, so the panel's 0-based activeIndex is
+// `stageIndex - 1`. Using all six entries preserves the original "N of 6"
+// counter (the SSH installer always showed six steps).
+const INSTALL_STAGE_LABELS: string[] = INSTALL_STAGES.map((s) => s.label);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -134,11 +134,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   const [running, setRunning] = useState(false);
   const [activeHandle, setActiveHandle] = useState<string | null>(null);
   const [stage, setStage] = useState<InstallStageId>(INITIAL_STAGE);
-  const [stageLabel, setStageLabel] = useState(INITIAL_STAGE_INFO.label);
   const [stageIndex, setStageIndex] = useState(INITIAL_STAGE_INFO.index);
-  const [stageTotal, setStageTotal] = useState(INITIAL_STAGE_INFO.total);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const [logOpen, setLogOpen] = useState(false);
   const [lines, setLines] = useState<string[]>([]);
   const [done, setDone] = useState<
     | { ok: boolean; code: number | null; signal: NodeJS.Signals | null }
@@ -168,7 +165,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   const [passphraseInput, setPassphraseInput] = useState("");
   const [claimRunning, setClaimRunning] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
-  const logRef = useRef<HTMLDivElement | null>(null);
 
   // ---------- Host list load (mount + manual refresh share this) ----------
   //
@@ -270,10 +266,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         setRunning(true);
         setActiveHandle(s.trustHandleId);
         setStage(INITIAL_STAGE);
-        setStageLabel(INITIAL_STAGE_INFO.label);
         setStageIndex(INITIAL_STAGE_INFO.index);
-        setStageTotal(INITIAL_STAGE_INFO.total);
-        setLogOpen(true);
         setFingerprintPrompt({
           handleId: s.trustHandleId,
           algo: s.pendingFingerprint.algo,
@@ -286,10 +279,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         setRunning(true);
         setActiveHandle(s.passphraseHandleId);
         setStage(INITIAL_STAGE);
-        setStageLabel(INITIAL_STAGE_INFO.label);
         setStageIndex(INITIAL_STAGE_INFO.index);
-        setStageTotal(INITIAL_STAGE_INFO.total);
-        setLogOpen(true);
         setPassphrasePrompt({
           handleId: s.passphraseHandleId,
           prompt: "Enter the passphrase for your SSH key:",
@@ -301,11 +291,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         const info = currentStageInfo(s.stage);
         setRunning(true);
         setStage(s.stage);
-        setStageLabel(info.label);
         setStageIndex(info.index);
-        setStageTotal(info.total);
         setLines(s.logTail);
-        setLogOpen(true);
       } else if (s.preflight && !s.preflight.ok) {
         setPreflightFailure({ failures: s.preflight.failures });
       }
@@ -335,9 +322,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         case "stage": {
           const info = currentStageInfo(evt.stage);
           setStage(evt.stage);
-          setStageLabel(info.label);
           setStageIndex(info.index);
-          setStageTotal(info.total);
           break;
         }
         case "preflight-failed":
@@ -375,8 +360,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setPassphrasePrompt(null);
           setPassphraseInput("");
           if (evt.ok) {
-            // Collapse the log back to the single status line on success.
-            setLogOpen(false);
             // Auto-claim on success — the whole point of the flow. The
             // user typed a host, nothing else.
             void runClaim();
@@ -395,14 +378,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     return unsub;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preload, activeHandle]);
-
-  // Auto-scroll the log pane on new lines while it's open — matches what a
-  // terminal user expects (Tail-style: stick to the bottom while streaming).
-  useEffect(() => {
-    if (logOpen && logRef.current) {
-      logRef.current.scrollTop = logRef.current.scrollHeight;
-    }
-  }, [lines, logOpen]);
 
   // Tick the elapsed-time display once a second while running.
   useEffect(() => {
@@ -457,11 +432,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     // filtering against a prior, now-dead handle.
     setActiveHandle(null);
     setStage(INITIAL_STAGE);
-    setStageLabel(INITIAL_STAGE_INFO.label);
     setStageIndex(INITIAL_STAGE_INFO.index);
-    setStageTotal(INITIAL_STAGE_INFO.total);
     setElapsedSeconds(0);
-    setLogOpen(true);
     // Mount the progress panel immediately on click — no gap before the
     // main process's response comes back.
     setRunning(true);
@@ -846,50 +818,21 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       )}
 
       {/* Status line + progress bar + live log — mounted on click, streams,
-          auto-scrolls, collapses to the single line on success. */}
+          auto-scrolls, collapses to the single line on success. The shared
+          ProcessPanel (BET-421 §A) renders the chrome; the fingerprint and
+          passphrase prompts pass as children so they render between the bar
+          and the log, exactly where they lived before the extraction. */}
       {showProgress && (
-        <section className="space-y-2">
-          <div className="flex items-center gap-2 text-body">
-            {done ? (
-              <span aria-hidden style={{ color: done.ok ? OK_GREEN : DANGER }} className="inline-flex items-center">
-                {done.ok ? <Check size={14} aria-hidden="true" /> : <X size={14} aria-hidden="true" />}
-              </span>
-            ) : (
-              <span
-                aria-hidden
-                className="inline-block w-3 h-3 rounded-full border-2 animate-spin"
-                style={{ borderColor: ACCENT, borderTopColor: "transparent" }}
-              />
-            )}
-            <span>
-              {fingerprintPrompt
-                ? "Waiting for host trust…"
-                : passphrasePrompt
-                ? "Waiting for SSH key passphrase…"
-                : stageLabel}
-            </span>
-            <span className="text-text-muted">
-              {stageIndex} of {stageTotal} · {formatElapsed(elapsedSeconds)}
-            </span>
-            <button
-              onClick={() => setLogOpen((o) => !o)}
-              className="ml-auto text-meta text-text-muted hover:text-text inline-flex items-center gap-1"
-            >
-              {logOpen ? <>Hide log <ChevronUp size={12} aria-hidden="true" /></> : <>Show log <ChevronDown size={12} aria-hidden="true" /></>}
-            </button>
-          </div>
-          <div
-            className="h-0.5 rounded-full overflow-hidden bg-bg-elev"
-            aria-hidden
-          >
-            <div
-              className="h-full"
-              style={{
-                width: `${(stageIndex / stageTotal) * 100}%`,
-                background: done && !done.ok ? DANGER : ACCENT_SOLID,
-              }}
-            />
-          </div>
+        <ProcessPanel
+          stages={INSTALL_STAGE_LABELS}
+          activeIndex={Math.max(0, stageIndex - 1)}
+          status={
+            done ? (done.ok ? "done" : "error") : installError ? "error" : "running"
+          }
+          elapsedSeconds={elapsedSeconds}
+          logLines={lines}
+          onCopyDiagnostics={copyDiagnostics}
+        >
           {/* BET-361: inline fingerprint prompt. The install is paused — the
               log has nothing new to show, so the card takes the place of
               attention until the user answers. */}
@@ -984,16 +927,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               </form>
             </div>
           )}
-          {logOpen && !fingerprintPrompt && !passphrasePrompt && (
-            <div
-              ref={logRef}
-              style={{ height: 172, overflowY: "auto" }}
-              className="rounded-md bg-bg-elev px-3 py-2 text-meta font-mono whitespace-pre-wrap"
-            >
-              {lines.join("\n")}
-            </div>
-          )}
-        </section>
+        </ProcessPanel>
       )}
 
       {/* Done / error / claim */}

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -970,8 +970,9 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         <section className="text-body space-y-1" style={{ color: DANGER }}>
           <div>{claimError}</div>
           <div>
-            Pair manually: run `manta pair` on the box and enter the 6-digit
-            code in the "Pair to an existing box" form below.
+            Pair manually: run <code>manta pair</code> on the box for a fresh
+            6-digit code, then open the "Pair to an existing box" form on this
+            page and enter it.
           </div>
         </section>
       )}

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -993,6 +993,8 @@ export const httpApi: Api = {
   // (server-side) so a fresh start can register under the SAME name.
   claudeLoginCancel: (sessionKey: string) =>
     rpc<{ ok: boolean }>(IPC.claudeLoginCancel, sessionKey),
+  // BET-421 §E: claude CLI presence probe for the lazy install.
+  opencodeClaudeCliStatus: () => rpc(IPC.opencodeClaudeCliStatus),
 
   // -- server version (BET-180) --
   // Returns the manta-server's package.json version. In-process via the

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -884,6 +884,11 @@ export const httpApi: Api = {
   opencodeCompactSession: (sessionId) =>
     rpc(IPC.opencodeCompactSession, sessionId),
   opencodeDeleteSession: (input) => rpc(IPC.opencodeDeleteSession, input),
+  // BET-421: ephemeral session lifecycle for the onboarding verifier.
+  opencodeCreateEphemeralSession: (input) =>
+    rpc(IPC.opencodeCreateEphemeralSession, input),
+  opencodeDeleteSessionRaw: (sessionId) =>
+    rpc(IPC.opencodeDeleteSessionRaw, sessionId),
 
   // -- scheduled prompts (manta-server owned; in-process on mobile) --
   scheduleList: (sessionId) => rpc(IPC.scheduleList, sessionId),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3189,6 +3189,33 @@ describe("connectPhaseLabel", () => {
       }),
     ).toBe("Already signed in");
   });
+
+  // BET-429: the lazy-install phase has its own label so the status chip
+  // tells the user the box is installing the Claude CLI (not waiting on
+  // sign-in). Pins the copy so a future change is an explicit decision.
+  it("labels installingClaudeCli 'Installing Claude CLI…'", () => {
+    expect(
+      connectPhaseLabel({
+        kind: "installingClaudeCli",
+        installSessionKey: "claude-cli-install-abc",
+        loginSessionKey: "claude-login-1",
+        startedAt: 0,
+        cwd: "~",
+      }),
+    ).toBe("Installing Claude CLI…");
+  });
+
+  // BET-429: an install failure still labels "Failed" — the three-action
+  // card is the distinguishing surface, not the status chip.
+  it("labels failed 'Failed' even when installFailure is set", () => {
+    expect(
+      connectPhaseLabel({
+        kind: "failed",
+        message: "The install didn't finish.",
+        installFailure: { loginSessionKey: "claude-login-1", cwd: "~" },
+      }),
+    ).toBe("Failed");
+  });
 });
 
 // ===== isPollExpired (BET-312) =====

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -68,6 +68,8 @@ import {
   arrowUpNavigatesHistory,
   arrowDownNavigatesHistory,
   parseDeviceCode,
+  deviceCodeFallback,
+  formatRemaining,
   connectPhaseLabel,
   isPollExpired,
   describeSubscriptionStatus,
@@ -3097,6 +3099,39 @@ describe("parseDeviceCode", () => {
     expect(parseDeviceCode(undefined as unknown as string)).toBeNull();
     expect(parseDeviceCode(null as unknown as string)).toBeNull();
     expect(parseDeviceCode(42 as unknown as string)).toBeNull();
+  });
+});
+
+// ===== deviceCodeFallback + formatRemaining (BET-421 §D) =====
+
+describe("deviceCodeFallback", () => {
+  it("returns null when a code parsed (caller shows the chip)", () => {
+    expect(deviceCodeFallback("Enter code: TOQR-BUA7Z")).toBeNull();
+  });
+  it("points at the instructions when no code parses", () => {
+    expect(deviceCodeFallback("Sign in to your account to continue")).toBe(
+      "The code is in the message below — copy it from there.",
+    );
+  });
+  it("returns null for empty instructions", () => {
+    expect(deviceCodeFallback("")).toBeNull();
+    expect(deviceCodeFallback("   ")).toBeNull();
+  });
+});
+
+describe("formatRemaining", () => {
+  it("formats the remaining minutes:seconds on a device-code poll", () => {
+    // 5 min limit, 90s elapsed → 3:30 remaining.
+    expect(formatRemaining(0, 90_000, 300_000)).toBe("3:30 remaining");
+  });
+  it("clamps at 0 when the deadline has passed", () => {
+    expect(formatRemaining(0, 400_000, 300_000)).toBe("0:00 remaining");
+  });
+  it("is NaN-safe", () => {
+    expect(formatRemaining(NaN, 0, 0)).toBe("0:00 remaining");
+  });
+  it("handles the full-limit case at start", () => {
+    expect(formatRemaining(0, 0, 300_000)).toBe("5:00 remaining");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2245,6 +2245,24 @@ export type ConnectPhase =
       preExisting?: boolean;
     }
   | {
+      // BET-429: lazy Claude CLI install. The box has no `claude` binary,
+      // so the connect card spawned the official installer over the pty
+      // bus (installSessionKey, client-generated) and is polling
+      // opencodeClaudeCliStatus() every 2s. loginSessionKey is the
+      // claude-login sessionKey minted by the initial `{action:"start"}`
+      // response — held so the post-install re-fire can cancel it before
+      // minting a fresh one (the server's startClaudeLogin always
+      // generates a new key; the orphaned entry would otherwise leak in
+      // the server's _claudeLoginSessions map). startedAt is the wall
+      // clock the 5-min cap ticks against; cwd is the installer's cwd
+      // (the home dir the start response carried).
+      kind: "installingClaudeCli";
+      installSessionKey: string;
+      loginSessionKey: string;
+      startedAt: number;
+      cwd: string;
+    }
+  | {
       // BET-354: `restarted` is true when the server already called
       // `restartOpencode()` for this transition (the Claude "completed"
       // path). When true, the `applying` effect skips the renderer's
@@ -2258,7 +2276,23 @@ export type ConnectPhase =
       restarted?: boolean;
     }
   | { kind: "done" }
-  | { kind: "failed"; message: string };
+  | {
+      kind: "failed";
+      message: string;
+      // BET-429: when present, the failure was the lazy Claude CLI
+      // install — NOT the box (the box itself is fine; only the Claude
+      // binary didn't appear). The card renders three actions instead
+      // of the single Retry: Try again (re-run the installer with a
+      // fresh installSessionKey, reusing loginSessionKey), Use a
+      // different model (close the card — Codex/Kimi/custom need no
+      // binary), and Install manually (link to claude.ai). loginSessionKey
+      // + cwd are carried so "Try again" can re-enter installingClaudeCli
+      // without re-firing start.
+      installFailure?: {
+        loginSessionKey: string;
+        cwd: string;
+      };
+    };
 
 /**
  * Pull the device code out of an opencode OAuth instructions string, e.g.
@@ -2335,6 +2369,8 @@ export function connectPhaseLabel(state: ConnectPhase): string {
       return state.preExisting
         ? "Already signed in"
         : "Awaiting Claude sign-in";
+    case "installingClaudeCli":
+      return "Installing Claude CLI…";
     case "applying":
       return "Applying…";
     case "done":

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2278,6 +2278,45 @@ export function parseDeviceCode(instructions: string): string | null {
 }
 
 /**
+ * BET-421 §D: when parseDeviceCode returns null (the provider reformatted
+ * the sentence and the chip would silently vanish), point the user at the
+ * verbatim instructions block instead of rendering an empty code slot.
+ * Returns the hint string the waiting card renders under the URL; null when
+ * a code WAS parsed (caller shows the chip instead).
+ */
+export function deviceCodeFallback(instructions: string): string | null {
+  if (parseDeviceCode(instructions) !== null) return null;
+  if (typeof instructions === "string" && instructions.trim().length > 0) {
+    return "The code is in the message below — copy it from there.";
+  }
+  return null;
+}
+
+/**
+ * BET-421 §D: format the remaining time on a device-code poll as
+ * "M:SS remaining". Clamped at 0; NaN-safe. Pure so the countdown display
+ * is unit-testable.
+ */
+export function formatRemaining(
+  startedAt: number,
+  now: number,
+  limitMs: number,
+): string {
+  if (
+    !Number.isFinite(startedAt) ||
+    !Number.isFinite(now) ||
+    !Number.isFinite(limitMs)
+  ) {
+    return "0:00 remaining";
+  }
+  const ms = Math.max(0, limitMs - (now - startedAt));
+  const totalSec = Math.ceil(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, "0")} remaining`;
+}
+
+/**
  * Single source of user-facing status text for every phase of the connect
  * flow. Centralised so no string is duplicated across branches and so a
  * future i18n pass replaces one place, not five.

--- a/src/renderer/mobile/SetupScreen.tsx
+++ b/src/renderer/mobile/SetupScreen.tsx
@@ -8,6 +8,7 @@ import {
   clearDebugLog,
 } from "./debugLog";
 import { isValidBoxToken } from "../../shared/transport.mjs";
+import { MantaMark } from "../onboardingUi";
 import {
   canConnectSetup,
   buildSetupClaimInput,
@@ -113,21 +114,9 @@ export function SetupScreen({ onConnected, pairStatus }: Props) {
             }}
             aria-hidden
           >
-            <svg width="30" height="30" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M3 17c3-6 6-9 9-9s6 3 9 9"
-                stroke="#fff"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-              <path
-                d="M7 17c2-3.5 3.4-5 5-5s3 1.5 5 5"
-                stroke="#fff"
-                strokeWidth="2"
-                strokeLinecap="round"
-                opacity=".6"
-              />
-            </svg>
+            {/* BET-421 §F: one brand mark for desktop and mobile — the shared
+                MantaMark SVG (same arcs), white on the pair-screen circle. */}
+            <MantaMark className="w-[30px] h-[30px] text-white" />
           </div>
           <div className="flex flex-col gap-2">
             <div className="text-text text-display font-semibold">Pair your phone</div>
@@ -143,7 +132,7 @@ export function SetupScreen({ onConnected, pairStatus }: Props) {
             <b className="text-text font-semibold">Settings &rsaquo; Connection</b>.
           </Step>
           <Step n={2}>
-            Tap <b className="text-text font-semibold">Generate Pairing Code</b> to show a QR code.
+            Tap <b className="text-text font-semibold">Generate pairing code</b> to show a QR code.
           </Step>
           <Step n={3}>
             Point your iPhone <b className="text-text font-semibold">Camera</b> at the QR code. This

--- a/src/renderer/onboardingUi.tsx
+++ b/src/renderer/onboardingUi.tsx
@@ -8,6 +8,37 @@
 
 const ACCENT_SOLID = "var(--accent-solid)";
 
+// ── Brand mark ───────────────────────────────────────────────────────────────
+//
+// BET-421 §F: first-run used a PNG on desktop and an inline SVG on mobile.
+// One mark for both. The two-arc manta shape is the same path the mobile
+// SetupScreen already drew; rendering it with `currentColor` lets the
+// caller pick accent/white without a second asset.
+
+export function MantaMark({ className = "w-9 h-9" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 17c3-6 6-9 9-9s6 3 9 9"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M7 17c2-3.5 3.4-5 5-5s3 1.5 5 5"
+        strokeWidth="2"
+        strokeLinecap="round"
+        opacity=".6"
+      />
+    </svg>
+  );
+}
+
 // ── Icons ────────────────────────────────────────────────────────────────────
 
 export function ArrowRight({ className = "w-4 h-4" }: { className?: string }) {

--- a/src/renderer/onboardingVerify.test.ts
+++ b/src/renderer/onboardingVerify.test.ts
@@ -1,338 +1,165 @@
 import { describe, it, expect, vi } from "vitest";
 import {
-  WELCOME_PROJECT_NAME,
-  WELCOME_PROJECT_CWD,
-  firstChatSessionId,
-  ensureWelcomeProject,
-  verifyBoxAnswers,
-  finalizeOnboarding,
+  VERIFY_PROBE_TEXT,
+  VERIFY_DIRECTORY,
+  verifyStageLabels,
+  verifyOnboarding,
   hasConnectedProvider,
+  pickVerifyLabels,
   type VerifyApi,
-  type VerifyStore,
 } from "./onboardingVerify";
 
 function makeApi(over: Partial<VerifyApi> = {}): VerifyApi {
   return {
-    tmuxNewSession: vi.fn(async () => ({ ok: true as const, sessionName: "welcome" })),
-    opencodeProviderAuth: vi.fn(async () => ({ action: "status", providers: [] })),
+    opencodeCreateEphemeralSession: vi.fn(async () => ({
+      ok: true,
+      sessionId: "eph-1",
+    })),
+    opencodeDeleteSessionRaw: vi.fn(async () => ({ ok: true })),
     opencodePrompt: vi.fn(async () => ({ ok: true })),
     opencodeMessages: vi.fn(async () => []),
+    opencodeProviderAuth: vi.fn(async () => ({ action: "status", providers: [] })),
     ...over,
   };
 }
 
-function makeStore(over: Partial<VerifyStore> = {}): VerifyStore {
-  // Default projects + refresh hook that simulates the post-create store
-  // re-sync: once refresh() runs, the projects list carries the new
-  // welcome project + chat window. Tests that don't simulate the create
-  // can pre-populate `projects` and skip refresh().
-  let projects: VerifyStore["projects"] = over.projects ?? [];
-  const refresh = over.refresh ?? vi.fn(async () => {
-    // Simulate the real store after tmuxNewSession("welcome", chatMode:true):
-    // a new "welcome" project with one chat-mode window appears. The
-    // append (not replace) covers both the fresh-box case (empty → adds
-    // welcome) and the "projects exist but no chat window" case (existing
-    // list → adds welcome alongside).
-    if (!projects.some((p) => p.tmuxSession === "welcome")) {
-      projects = [
-        ...projects,
-        {
-          tmuxSession: "welcome",
-          windows: [{ opencodeSessionId: "sid-welcome" }],
-        },
-      ];
-    }
+// A completed assistant message that appears after the probe prompt. The
+// first poll returns [] (baseline + first tick), the second returns the
+// completed reply — mirroring the real opencode message timeline.
+function messagesSequence() {
+  const calls: unknown[][] = [];
+  const steps: unknown[] = [[], [{ info: { id: "a1", role: "assistant", time: { completed: 123 } } }]];
+  const fn = vi.fn(async (sid: string) => {
+    calls.push([sid]);
+    return steps[Math.min(calls.length - 1, steps.length - 1)];
   });
-  const setActive = over.setActive ?? vi.fn(() => undefined);
-  return {
-    get projects() {
-      return projects;
-    },
-    refresh,
-    setActive,
-  };
+  return fn;
 }
 
-describe("firstChatSessionId", () => {
-  it("returns null for an empty project list", () => {
-    expect(firstChatSessionId([])).toBeNull();
+describe("verifyStageLabels", () => {
+  it("builds the three named stages with provider and model", () => {
+    expect(verifyStageLabels("Claude", "claude-sonnet-4")).toEqual([
+      "Reached opencode on your box",
+      "Claude credentials accepted",
+      "Getting a reply from claude-sonnet-4",
+    ]);
   });
 
-  it("returns the first chat-mode session id in declaration order", () => {
-    const projects = [
-      {
-        tmuxSession: "a",
-        windows: [{ opencodeSessionId: null }, { opencodeSessionId: "sid-1" }],
-      },
-      {
-        tmuxSession: "b",
-        windows: [{ opencodeSessionId: "sid-2" }],
-      },
-    ];
-    expect(firstChatSessionId(projects)).toBe("sid-1");
-  });
-
-  it("skips projects that have only terminal-mode windows", () => {
-    const projects = [
-      { tmuxSession: "a", windows: [{ opencodeSessionId: null }] },
-      { tmuxSession: "b", windows: [{ opencodeSessionId: "sid-x" }] },
-    ];
-    expect(firstChatSessionId(projects)).toBe("sid-x");
+  it("falls back to 'the model' when no model label is supplied", () => {
+    expect(verifyStageLabels("Codex")[2]).toBe("Getting a reply from the model");
   });
 });
 
-describe("ensureWelcomeProject", () => {
-  it("creates a welcome project when none exists", async () => {
-    const api = makeApi();
-    const store = makeStore({ projects: [] });
-    await ensureWelcomeProject({ api, store });
-    expect(api.tmuxNewSession).toHaveBeenCalledWith({
-      name: WELCOME_PROJECT_NAME,
-      cwd: WELCOME_PROJECT_CWD,
-      windowName: "default",
-      chatMode: true,
-      createDir: true,
-    });
-    expect(store.refresh).toHaveBeenCalledTimes(1);
-    expect(store.setActive).toHaveBeenCalledWith("welcome");
-  });
-
-  it("skips creation when a project with a chat session already exists", async () => {
-    const api = makeApi();
-    const store = makeStore({
-      projects: [
-        {
-          tmuxSession: "preexisting",
-          windows: [{ opencodeSessionId: "sid-pre" }],
-        },
-      ],
-    });
-    await ensureWelcomeProject({ api, store });
-    expect(api.tmuxNewSession).not.toHaveBeenCalled();
-    expect(store.refresh).not.toHaveBeenCalled();
-  });
-
-  it("creates a project when projects exist but none has a chat window", async () => {
-    const api = makeApi();
-    const store = makeStore({
-      projects: [
-        { tmuxSession: "preexisting", windows: [{ opencodeSessionId: null }] },
-      ],
-    });
-    await ensureWelcomeProject({ api, store });
-    expect(api.tmuxNewSession).toHaveBeenCalledTimes(1);
-  });
-
-  it("throws when the box rejects the create request", async () => {
-    const api = makeApi({
-      tmuxNewSession: vi.fn(async () => ({ ok: false as const, error: "permission denied" })),
-    });
-    const store = makeStore({ projects: [] });
-    await expect(ensureWelcomeProject({ api, store })).rejects.toThrow(
-      /permission denied/,
-    );
-  });
-});
-
-describe("verifyBoxAnswers", () => {
-  it("returns ok when a new assistant message with time.completed appears", async () => {
-    let pollCount = 0;
-    const api = makeApi({
-      opencodeMessages: vi.fn(async () => {
-        pollCount += 1;
-        // First poll: just the user message. Second poll: assistant message with completion.
-        if (pollCount < 2) return [{ info: { id: "u-1", role: "user" } }];
-        return [
-          { info: { id: "u-1", role: "user" } },
-          { info: { id: "a-1", role: "assistant", time: { completed: 1700000000000 } } },
-        ];
-      }),
-    });
-    const outcome = await verifyBoxAnswers({
+describe("verifyOnboarding", () => {
+  it("reports stage progress and deletes the ephemeral session on success", async () => {
+    const api = makeApi({ opencodeMessages: messagesSequence() });
+    const progress: string[] = [];
+    const out = await verifyOnboarding({
       api,
-      sessionId: "s-1",
-      // Use real Date.now() (no injected clock) so the loop's deadline math
-      // actually advances; the second-poll success returns well within the
-      // default 15s budget.
-      pollIntervalMs: 5,
+      providerLabel: "Claude",
+      modelLabel: "claude-sonnet-4",
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
+      now: () => 0,
+      onProgress: (p) => progress.push(`${p.stage}:${p.status}`),
     });
-    expect(outcome).toEqual({ ok: true });
-    expect(api.opencodePrompt).toHaveBeenCalledWith("s-1", "hi");
+    expect(out).toEqual({ ok: true });
+    expect(progress).toEqual(["0:running", "1:running", "2:running", "2:done"]);
+    expect(api.opencodeCreateEphemeralSession).toHaveBeenCalledWith({
+      directory: VERIFY_DIRECTORY,
+      title: "manta-verify",
+    });
+    expect(api.opencodePrompt).toHaveBeenCalledWith("eph-1", VERIFY_PROBE_TEXT);
+    // The ephemeral session is always deleted.
+    expect(api.opencodeDeleteSessionRaw).toHaveBeenCalledWith("eph-1");
   });
 
-  it("does not pass on an assistant message that existed BEFORE the prompt", async () => {
-    // The transcript already contains a completed assistant message; the
-    // baseline filter must keep this from being a false positive. The poll
-    // keeps returning the same list (no NEW assistant message), so the
-    // helper times out within the small budget.
+  it("fails at stage 0 when opencode is unreachable, and still cleans up", async () => {
     const api = makeApi({
-      opencodeMessages: vi.fn(async () => [
-        { info: { id: "a-existing", role: "assistant", time: { completed: 1699999000000 } } },
-      ]),
+      opencodeCreateEphemeralSession: vi.fn(async () => ({ ok: false, error: "ECONNREFUSED" })),
     });
-    const outcome = await verifyBoxAnswers({
+    const out = await verifyOnboarding({
       api,
-      sessionId: "s-1",
-      pollIntervalMs: 5,
-      timeoutMs: 50,
+      providerLabel: "Claude",
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
     });
-    expect(outcome.ok).toBe(false);
-  });
-
-  it("returns a failure message when the prompt send is rejected", async () => {
-    const api = makeApi({
-      opencodePrompt: vi.fn(async () => ({ ok: false, error: "no_provider" })),
-    });
-    const outcome = await verifyBoxAnswers({
-      api,
-      sessionId: "s-1",
-      pollIntervalMs: 5,
-      timeoutMs: 100,
-    });
-    expect(outcome).toMatchObject({ ok: false });
-    if (outcome.ok === false) {
-      expect(outcome.message).toMatch(/no_provider/);
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.failedStage).toBe(0);
+      expect(out.message).toContain("ECONNREFUSED");
     }
+    // No session was created, so no delete call.
+    expect(api.opencodeDeleteSessionRaw).not.toHaveBeenCalled();
   });
 
-  it("does not pass on a NEW assistant message without time.completed", async () => {
-    let pollCount = 0;
+  it("fails at stage 1 when the prompt is rejected, and deletes the session", async () => {
     const api = makeApi({
-      opencodeMessages: vi.fn(async () => {
-        pollCount += 1;
-        if (pollCount < 2) return [];
-        // New assistant message but no completion stamp — turn is still in flight.
-        return [
-          { info: { id: "u-1", role: "user" } },
-          { info: { id: "a-1", role: "assistant", time: {} } },
-        ];
-      }),
+      opencodePrompt: vi.fn(async () => ({ ok: false, error: "unauthorized" })),
     });
-    const outcome = await verifyBoxAnswers({
+    const out = await verifyOnboarding({
       api,
-      sessionId: "s-1",
-      pollIntervalMs: 5,
-      timeoutMs: 50,
+      providerLabel: "Codex",
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
     });
-    expect(outcome.ok).toBe(false);
-  });
-
-  it("times out when no assistant response arrives within the budget", async () => {
-    const api = makeApi({
-      opencodeMessages: vi.fn(async () => []),
-    });
-    const outcome = await verifyBoxAnswers({
-      api,
-      sessionId: "s-1",
-      pollIntervalMs: 5,
-      timeoutMs: 25,
-    });
-    expect(outcome.ok).toBe(false);
-    if (outcome.ok === false) {
-      expect(outcome.message).toMatch(/didn't answer the test prompt/);
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.failedStage).toBe(1);
+      expect(out.message).toContain("Codex");
     }
+    expect(api.opencodeDeleteSessionRaw).toHaveBeenCalledWith("eph-1");
   });
 
-  it("ignores transient fetch failures (keeps polling)", async () => {
-    let pollCount = 0;
-    const api = makeApi({
-      opencodeMessages: vi.fn(async () => {
-        pollCount += 1;
-        if (pollCount === 1) throw new Error("network blip");
-        return [
-          { info: { id: "u-1", role: "user" } },
-          { info: { id: "a-1", role: "assistant", time: { completed: 1700000000000 } } },
-        ];
-      }),
-    });
-    const outcome = await verifyBoxAnswers({
+  it("fails at stage 2 on timeout (no reply), and deletes the session", async () => {
+    const api = makeApi({ opencodeMessages: vi.fn(async () => []) });
+    // now() jumps past the deadline on the first poll so the loop exits fast.
+    let t = 0;
+    const out = await verifyOnboarding({
       api,
-      sessionId: "s-1",
-      pollIntervalMs: 5,
-      timeoutMs: 5000,
+      providerLabel: "Kimi",
+      timeoutMs: 1_000,
+      pollIntervalMs: 1,
+      now: () => (t += 10_000),
     });
-    expect(outcome).toEqual({ ok: true });
-  });
-});
-
-describe("finalizeOnboarding", () => {
-  it("creates a project, sends the probe, and resolves on a real response", async () => {
-    let pollCount = 0;
-    const api = makeApi({
-      tmuxNewSession: vi.fn(async () => ({ ok: true as const, sessionName: "welcome" })),
-      opencodeMessages: vi.fn(async () => {
-        pollCount += 1;
-        // First poll is the BASELINE snapshot taken BEFORE the prompt is
-        // sent — only the user message is present. Subsequent polls return
-        // the assistant reply, which is what `verifyBoxAnswers` is waiting
-        // for. Without this split the baseline filter would never see a
-        // new assistant message and the verify would time out.
-        if (pollCount === 1) return [{ info: { id: "u-1", role: "user" } }];
-        return [
-          { info: { id: "u-1", role: "user" } },
-          { info: { id: "a-1", role: "assistant", time: { completed: 1700000000000 } } },
-        ];
-      }),
-    });
-    // Pre-populate the store with the post-create project so the verify
-    // path has a chat session to send the probe against. The default
-    // refresh() in makeStore would also populate this — using an explicit
-    // pre-population here keeps the test intent obvious.
-    const store = makeStore({
-      projects: [
-        {
-          tmuxSession: "welcome",
-          windows: [{ opencodeSessionId: "sid-welcome" }],
-        },
-      ],
-    });
-    await expect(
-      finalizeOnboarding({
-        api,
-        store,
-        pollIntervalMs: 5,
-      }),
-    ).resolves.toBeUndefined();
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.failedStage).toBe(2);
+      expect(out.message).toContain("didn't reply");
+    }
+    expect(api.opencodeDeleteSessionRaw).toHaveBeenCalledWith("eph-1");
   });
 
-  it("rejects with the verify-box message when no assistant response arrives", async () => {
-    const api = makeApi({
-      opencodeMessages: vi.fn(async () => []),
+  it("does not count a pre-existing assistant message as the reply", async () => {
+    // Baseline already has a completed assistant message; the poll returns
+    // the SAME message — the verifier must keep waiting (and time out).
+    const pre = [{ info: { id: "old", role: "assistant", time: { completed: 1 } } }];
+    const api = makeApi({ opencodeMessages: vi.fn(async () => pre) });
+    let t = 0;
+    const out = await verifyOnboarding({
+      api,
+      providerLabel: "Claude",
+      timeoutMs: 1_000,
+      pollIntervalMs: 1,
+      now: () => (t += 10_000),
     });
-    const store = makeStore({
-      projects: [
-        {
-          tmuxSession: "welcome",
-          windows: [{ opencodeSessionId: "sid-welcome" }],
-        },
-      ],
-    });
-    await expect(
-      finalizeOnboarding({
-        api,
-        store,
-        pollIntervalMs: 5,
-        timeoutMs: 25,
-      }),
-    ).rejects.toThrow(/didn't answer/);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.failedStage).toBe(2);
   });
 });
 
 describe("hasConnectedProvider", () => {
-  it("returns true when any row is connected", async () => {
+  it("returns true when at least one provider is connected", async () => {
     const api = makeApi({
       opencodeProviderAuth: vi.fn(async () => ({
         action: "status",
-        providers: [
-          { id: "anthropic", connected: false },
-          { id: "openai", connected: true },
-        ],
+        providers: [{ id: "anthropic", connected: false }, { id: "openai", connected: true }],
       })),
     });
     expect(await hasConnectedProvider(api)).toBe(true);
   });
 
-  it("returns false when every row is disconnected", async () => {
+  it("returns false when nothing is connected", async () => {
     const api = makeApi({
       opencodeProviderAuth: vi.fn(async () => ({
         action: "status",
@@ -341,20 +168,18 @@ describe("hasConnectedProvider", () => {
     });
     expect(await hasConnectedProvider(api)).toBe(false);
   });
+});
 
-  it("returns false on a malformed response", async () => {
-    const api = makeApi({
-      opencodeProviderAuth: vi.fn(async () => null),
-    });
-    expect(await hasConnectedProvider(api)).toBe(false);
+describe("pickVerifyLabels", () => {
+  it("returns the first connected provider label + the default model", () => {
+    const res = pickVerifyLabels(
+      { providers: [{ id: "anthropic", label: "Claude", connected: true }] },
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    );
+    expect(res).toEqual({ providerLabel: "Claude", modelLabel: "claude-sonnet-4" });
   });
 
-  it("returns false on an IPC throw (treat as unreachable, not a fatal)", async () => {
-    const api = makeApi({
-      opencodeProviderAuth: vi.fn(async () => {
-        throw new Error("network");
-      }),
-    });
-    expect(await hasConnectedProvider(api)).toBe(false);
+  it("returns null when nothing is connected", () => {
+    expect(pickVerifyLabels({ providers: [{ connected: false }] })).toBeNull();
   });
 });

--- a/src/renderer/onboardingVerify.ts
+++ b/src/renderer/onboardingVerify.ts
@@ -1,24 +1,27 @@
-// onboardingVerify.ts — pure orchestrator for the final onboarding actions
-// (BET-356 §4 "Verify by working, not by exit code").
+// onboardingVerify.ts — pure orchestrator for the onboarding verification
+// (BET-421 §B "Verify by working, not by exit code").
 //
-// Two responsibilities, kept together because they always run in this order:
+// Replaces the old finalizeOnboarding, which created a real ~/projects/welcome
+// project, opened a chat window, sent "hi", and left all of it behind. Every
+// install therefore billed a model turn, littered the box, and put a junk
+// session in the sidebar before the user had done anything.
 //
-//   1. ensureWelcomeProject — auto-create a "welcome" project on the box the
-//      user just paired with, so they land somewhere real (the sidebar shows
-//      a project, the chat panel mounts against an existing session). No
-//      dedicated onboarding step — BET-356 demotes the project step out of
-//      onboarding. Skips if any project already exists on the box.
+// The new flow spins up an EPHEMERAL opencode session (no tmux project, no
+// sidebar entry), sends one probe prompt, waits for a real assistant reply,
+// and deletes the session the moment the reply lands. Nothing is left on
+// the box. Three named stages drive the ProcessPanel:
 //
-//   2. verifyBoxAnswers — send a one-line prompt to the box's opencode and
-//      wait for a real assistant response. An install that exits zero but
-//      cannot answer is a failure the user must know about immediately, not
-//      discover later. The check is intentionally a real round-trip: any
-//      cheaper proxy (TCP probe, /provider ping) would pass on a misconfigured
-//      provider that cannot serve a turn.
+//   1. Reached opencode on your box       — createEphemeralSession succeeds.
+//   2. <Provider> credentials accepted    — the probe prompt is accepted.
+//   3. Getting a reply from <model>       — a completed assistant reply.
 //
-// Both helpers are framework-free + pure (deps injected); the renderer wires
-// `window.api` and `useStore.getState()` into them at the call site. Tests
-// stub the deps so the orchestrator can be exercised without a real box.
+// The failure state always names which stage failed; the caller renders
+// Try again / Back to the model step / Copy diagnostics. There is no
+// "continue anyway" — a working model is mandatory.
+//
+// Pure + framework-free (deps injected); the renderer wires `window.api`
+// into it at the call site. Tests stub the deps so the orchestrator can be
+// exercised without a real box.
 
 // ---------- Types injected from the renderer ----------
 
@@ -26,17 +29,11 @@
 // here as a type so the test fixture doesn't need to construct the whole
 // preload surface — see onboardingVerify.test.ts.
 export type VerifyApi = {
-  tmuxNewSession: (input: {
-    name: string;
-    cwd: string;
-    windowName?: string;
-    chatMode?: boolean;
-    createDir?: boolean;
-  }) => Promise<TmuxNewSessionResult>;
-  opencodeProviderAuth: (input: {
-    action: string;
-    [k: string]: unknown;
-  }) => Promise<unknown>;
+  opencodeCreateEphemeralSession: (input: {
+    directory: string;
+    title?: string;
+  }) => Promise<{ ok: boolean; sessionId?: string; error?: string }>;
+  opencodeDeleteSessionRaw: (sessionId: string) => Promise<{ ok: boolean }>;
   opencodePrompt: (
     sessionId: string,
     text: string,
@@ -45,169 +42,195 @@ export type VerifyApi = {
     mentions?: unknown,
   ) => Promise<{ ok: boolean; error?: string }>;
   opencodeMessages: (sessionId: string) => Promise<unknown>;
+  opencodeProviderAuth: (input: {
+    action: string;
+    [k: string]: unknown;
+  }) => Promise<unknown>;
 };
 
-// TmuxNewSessionResult — the relevant fields only. The renderer reads the
-// full object from `useStore.getState().projects`, but for our purposes we
-// only need to know "did creation succeed and what session name was used".
-export type TmuxNewSessionResult =
-  | { ok: true; sessionName: string }
-  | { ok: false; error: string };
+// A verify stage index (0-based) the caller feeds to ProcessPanel.activeIndex.
+export type VerifyStageIndex = 0 | 1 | 2;
 
-// Minimal store surface — provides `projects` (the live projects list) and
-// `refresh`/`setActive` actions to re-sync after auto-creating a project.
-export type VerifyStore = {
-  projects: Array<{
-    tmuxSession: string;
-    windows: Array<{ opencodeSessionId: string | null }>;
-  }>;
-  refresh: () => Promise<void>;
-  setActive: (projectName: string, windowIndex?: number) => void;
+export type VerifyProgress = {
+  // 0-based index of the stage that is currently running (or that failed).
+  stage: VerifyStageIndex;
+  status: "running" | "done" | "error";
 };
 
-// ---------- ensureWelcomeProject ----------
-
-export const WELCOME_PROJECT_NAME = "welcome";
-export const WELCOME_PROJECT_CWD = "~/projects/welcome";
-
-// Create a "welcome" project + chat-mode window if none exists yet. Returns
-// the opencode session id of the new project's first chat-mode window, or
-// `null` if no auto-create was needed (a project already exists) AND none
-// of the existing projects carry a chat-mode session id (caller will not
-// have anything to verify against — see verifyBoxAnswers for the empty-
-// projects early return).
-//
-// Pure orchestrator: the only I/O is `api.tmuxNewSession` and
-// `store.refresh`/`store.setActive`. Both deps are injected.
-export async function ensureWelcomeProject(deps: {
-  api: VerifyApi;
-  store: VerifyStore;
-}): Promise<string | null> {
-  // Skip when a project already exists. The sidebar shows real things; the
-  // user can rename / move them later. This is the common resume path: the
-  // user already had a project from a previous run.
-  if (deps.store.projects.length > 0) {
-    const existing = firstChatSessionId(deps.store.projects);
-    if (existing) return existing;
-    // Projects exist but none has a chat-mode window — fall through and
-    // create one anyway, so the verify path has somewhere to send the
-    // probe prompt. (The user will see their existing project with one
-    // new chat-mode window added.)
-  }
-
-  const result = await deps.api.tmuxNewSession({
-    name: WELCOME_PROJECT_NAME,
-    cwd: WELCOME_PROJECT_CWD,
-    windowName: "default",
-    chatMode: true,
-    createDir: true,
-  });
-  if (!result.ok) {
-    throw new Error(`Couldn't create a starter project: ${result.error}`);
-  }
-  // Refresh the store so the new project + window is visible, then select
-  // the new session so the user lands on it. setActive's windowIndex is
-  // omitted on purpose — the project's first window is the chat-mode one
-  // we just minted, and the store's setActive defaults to index 0.
-  await deps.store.refresh();
-  deps.store.setActive(result.sessionName);
-
-  // After refresh, the store carries the new project. Find its chat session.
-  const refreshed = firstChatSessionId(deps.store.projects);
-  if (!refreshed) {
-    throw new Error("Welcome project created but no chat session was opened.");
-  }
-  return refreshed;
-}
-
-// Pick the first chat-mode opencode session id across all projects + windows.
-// Used by both `ensureWelcomeProject` and the verify helper so they agree on
-// "what counts as the chat session we're verifying against".
-export function firstChatSessionId(
-  projects: VerifyStore["projects"],
-): string | null {
-  for (const p of projects) {
-    for (const w of p.windows) {
-      if (typeof w.opencodeSessionId === "string" && w.opencodeSessionId.length > 0) {
-        return w.opencodeSessionId;
-      }
-    }
-  }
-  return null;
-}
-
-// ---------- verifyBoxAnswers ----------
-
-export const VERIFY_DEFAULT_TIMEOUT_MS = 15_000;
-export const VERIFY_POLL_INTERVAL_MS = 1_000;
-export const VERIFY_PROBE_TEXT = "hi";
-
-// Outcome of a single verification attempt. The caller surfaces `message` to
-// the user (Plain-language cause + one action, per BET-356 §5 failure UX).
 export type VerifyOutcome =
   | { ok: true }
-  | { ok: false; message: string };
+  | { ok: false; failedStage: VerifyStageIndex; message: string };
 
-// Send the probe prompt + wait for a real assistant response. Polls
-// `opencodeMessages` at 1Hz; an assistant message with `time.completed`
-// set is the success signal (the turn has fully ended server-side, so an
-// empty/timed-out reply won't false-positive).
+export const VERIFY_DEFAULT_TIMEOUT_MS = 30_000;
+export const VERIFY_POLL_INTERVAL_MS = 1_000;
+export const VERIFY_PROBE_TEXT = "hi";
+// The ephemeral session is created in the box's home dir — no project, no
+// worktree, nothing to clean up beyond the session itself.
+export const VERIFY_DIRECTORY = "~";
+
+// Build the three stage labels the ProcessPanel renders. Provider and model
+// labels come from the caller (the onboarding shell reads them from the
+// connected-provider status + the configured default model). Pure so the
+// test can assert the exact strings.
+export function verifyStageLabels(
+  providerLabel: string,
+  modelLabel?: string,
+): [string, string, string] {
+  return [
+    "Reached opencode on your box",
+    `${providerLabel} credentials accepted`,
+    `Getting a reply from ${modelLabel ?? "the model"}`,
+  ];
+}
+
+// Send the probe prompt + wait for a real assistant reply inside an
+// EPHEMERAL session that is deleted the moment the function returns (success
+// OR failure). Reports stage progress via `onProgress` so the caller can
+// advance its ProcessPanel live.
 //
 // `now` is injected so the deadline math is pure-testable; production wires
 // `Date.now`.
-export async function verifyBoxAnswers(deps: {
+export async function verifyOnboarding(deps: {
   api: VerifyApi;
-  sessionId: string;
-  now?: () => number;
+  providerLabel: string;
+  modelLabel?: string;
+  directory?: string;
+  probeText?: string;
   timeoutMs?: number;
   pollIntervalMs?: number;
+  now?: () => number;
+  onProgress?: (p: VerifyProgress) => void;
 }): Promise<VerifyOutcome> {
   const now = deps.now ?? Date.now;
   const timeoutMs = deps.timeoutMs ?? VERIFY_DEFAULT_TIMEOUT_MS;
   const pollIntervalMs = deps.pollIntervalMs ?? VERIFY_POLL_INTERVAL_MS;
+  const directory = deps.directory ?? VERIFY_DIRECTORY;
+  const probeText = deps.probeText ?? VERIFY_PROBE_TEXT;
+  const onProgress = deps.onProgress ?? (() => {});
 
-  // Snapshot the transcript BEFORE we send so we can detect "a NEW assistant
-  // message appeared after the prompt" rather than "any assistant message
-  // is present" (the latter would falsely pass on a project that already
-  // had a turn before onboarding was re-entered).
-  const baseline = await safeFetchMessages(deps.api, deps.sessionId);
-  const baselineAssistantIds = new Set(extractAssistantIds(baseline));
-
-  const send = await deps.api.opencodePrompt(deps.sessionId, VERIFY_PROBE_TEXT);
-  if (!send || send.ok === false) {
+  // Stage 1 — reach opencode by creating an ephemeral session.
+  onProgress({ stage: 0, status: "running" });
+  const created = await deps.api.opencodeCreateEphemeralSession({
+    directory,
+    title: "manta-verify",
+  });
+  if (!created.ok || typeof created.sessionId !== "string" || !created.sessionId) {
+    onProgress({ stage: 0, status: "error" });
     return {
       ok: false,
+      failedStage: 0,
       message:
-        send && typeof send.error === "string"
-          ? `Couldn't send the test prompt: ${send.error}`
-          : "Couldn't send the test prompt to the box.",
+        created && typeof created.error === "string" && created.error.length > 0
+          ? `Couldn't reach opencode on your box: ${created.error}`
+          : "Couldn't reach opencode on your box. Check that the box service is running and try again.",
     };
   }
+  const sessionId = created.sessionId;
 
-  const deadline = now() + timeoutMs;
-  while (true) {
-    if (now() >= deadline) {
+  try {
+    // Stage 2 — send the probe prompt (credentials accepted by the provider).
+    onProgress({ stage: 1, status: "running" });
+    const send = await deps.api.opencodePrompt(sessionId, probeText);
+    if (!send || send.ok === false) {
+      onProgress({ stage: 1, status: "error" });
       return {
         ok: false,
+        failedStage: 1,
         message:
-          "The box accepted the install but didn't answer the test prompt. Open the chat and try sending a message to diagnose.",
+          send && typeof send.error === "string" && send.error.length > 0
+            ? `${deps.providerLabel} rejected the request: ${send.error}`
+            : `${deps.providerLabel} isn't ready. Reconnect the provider and try again.`,
       };
     }
-    await sleep(pollIntervalMs, deps.api);
-    const msgs = await safeFetchMessages(deps.api, deps.sessionId);
-    if (!msgs) {
-      // Transient fetch failure — keep polling until the deadline.
-      continue;
-    }
-    for (const id of extractAssistantIds(msgs)) {
-      if (baselineAssistantIds.has(id)) continue;
-      // New assistant message found. Verify it has actually completed
-      // (time.completed is server-stamped only when the turn fully ended).
-      if (hasCompletedAssistantMessage(msgs, id)) {
-        return { ok: true };
+
+    // Stage 3 — wait for a completed assistant reply.
+    onProgress({ stage: 2, status: "running" });
+    const baseline = await safeFetchMessages(deps.api, sessionId);
+    const baselineAssistantIds = new Set(extractAssistantIds(baseline));
+
+    const deadline = now() + timeoutMs;
+    while (true) {
+      if (now() >= deadline) {
+        onProgress({ stage: 2, status: "error" });
+        return {
+          ok: false,
+          failedStage: 2,
+          message:
+            "The box accepted the install but the model didn't reply. Open the chat and try sending a message to diagnose — a bad credential or a misconfigured provider shows up here.",
+        };
+      }
+      await sleep(pollIntervalMs);
+      const msgs = await safeFetchMessages(deps.api, sessionId);
+      if (!msgs) continue; // transient fetch failure — keep polling.
+      for (const id of extractAssistantIds(msgs)) {
+        if (baselineAssistantIds.has(id)) continue;
+        if (hasCompletedAssistantMessage(msgs, id)) {
+          onProgress({ stage: 2, status: "done" });
+          return { ok: true };
+        }
       }
     }
+  } finally {
+    // Delete the ephemeral session no matter the outcome — success or
+    // failure. A session that fails to delete is non-fatal (the caller
+    // still surfaces the real verify result); best-effort, never throws.
+    try {
+      await deps.api.opencodeDeleteSessionRaw(sessionId);
+    } catch {
+      /* ignore — nothing left behind that the user would see */
+    }
   }
+}
+
+// ---------- pre-connect provider check ----------
+
+// Quick `is there at least one provider connected` probe — used by the
+// Connect step to decide whether to skip step 2 entirely. Same source
+// (`opencodeProviderAuth({action:"status"})`) that ProvidersStep consumes
+// for its Continue gate, so the two paths agree by construction.
+export async function hasConnectedProvider(api: VerifyApi): Promise<boolean> {
+  try {
+    const res = await api.opencodeProviderAuth({ action: "status" });
+    if (!res || typeof res !== "object") return false;
+    const providers = (res as { providers?: unknown }).providers;
+    if (!Array.isArray(providers)) return false;
+    return providers.some(
+      (p) =>
+        typeof p === "object" &&
+        p !== null &&
+        (p as { connected?: unknown }).connected === true,
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Resolve a (providerLabel, modelLabel) pair for the stage labels from the
+// status probe. The first connected provider's label + the configured
+// default model. Pure so the test can assert; returns nulls when nothing
+// is connected (the caller shouldn't call verify without a provider, but
+// the resolver is defensive).
+export function pickVerifyLabels(
+  statusResult: unknown,
+  defaultModel?: { providerID: string; modelID: string } | null,
+): { providerLabel: string; modelLabel: string } | null {
+  if (!statusResult || typeof statusResult !== "object") return null;
+  const providers = (statusResult as { providers?: unknown }).providers;
+  if (!Array.isArray(providers)) return null;
+  const connected = providers.find(
+    (p) =>
+      typeof p === "object" &&
+      p !== null &&
+      (p as { connected?: unknown }).connected === true,
+  );
+  if (!connected) return null;
+  const providerLabel =
+    (connected as { label?: unknown }).label ?? "the provider";
+  const modelLabel = defaultModel?.modelID ?? "the model";
+  return {
+    providerLabel: String(providerLabel),
+    modelLabel: String(modelLabel),
+  };
 }
 
 // ---------- helpers ----------
@@ -223,9 +246,7 @@ async function safeFetchMessages(
   }
 }
 
-function sleep(ms: number, _api: VerifyApi): Promise<void> {
-  // Pure setTimeout; the api param is in the signature so future tests can
-  // swap in a fake clock without rewriting call sites.
+function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
@@ -270,69 +291,4 @@ function hasCompletedAssistantMessage(
     return typeof completed === "number" && Number.isFinite(completed) && completed > 0;
   }
   return false;
-}
-
-// ---------- orchestrator: finalizeOnboarding ----------
-
-// Compose the two helpers above into the single "we're done" transition
-// from the onboarding shell. Called when:
-//   - step 1 (Connect) onPaired fires AND the box already has a provider
-//     connected (skip step 2, jump straight to finalization), or
-//   - step 2 (Provider) onContinue fires after a fresh provider connect.
-//
-// Throws on failure — the caller renders the message in the same inline
-// error slot a manual claim failure uses (BET-356 §5).
-export async function finalizeOnboarding(deps: {
-  api: VerifyApi;
-  store: VerifyStore;
-  now?: () => number;
-  timeoutMs?: number;
-  pollIntervalMs?: number;
-}): Promise<void> {
-  const sessionId = await ensureWelcomeProject({
-    api: deps.api,
-    store: deps.store,
-  });
-  if (!sessionId) {
-    // No project and no chat session to verify against. This shouldn't
-    // happen on a fresh box (ensureWelcomeProject creates one), but if a
-    // user closed onboarding mid-create we treat it as a verification
-    // failure rather than a silent pass.
-    throw new Error(
-      "Couldn't open a chat session to verify the box. Try again from the welcome project in the sidebar.",
-    );
-  }
-  const outcome = await verifyBoxAnswers({
-    api: deps.api,
-    sessionId,
-    now: deps.now,
-    timeoutMs: deps.timeoutMs,
-    pollIntervalMs: deps.pollIntervalMs,
-  });
-  if (!outcome.ok) {
-    throw new Error(outcome.message);
-  }
-}
-
-// ---------- pre-connect provider check ----------
-
-// Quick `is there at least one provider connected` probe — used by the
-// Connect step to decide whether to skip step 2 entirely. Same source
-// (`opencodeProviderAuth({action:"status"})`) that ProvidersStep consumes
-// for its Continue gate, so the two paths agree by construction.
-export async function hasConnectedProvider(api: VerifyApi): Promise<boolean> {
-  try {
-    const res = await api.opencodeProviderAuth({ action: "status" });
-    if (!res || typeof res !== "object") return false;
-    const providers = (res as { providers?: unknown }).providers;
-    if (!Array.isArray(providers)) return false;
-    return providers.some(
-      (p) =>
-        typeof p === "object" &&
-        p !== null &&
-        (p as { connected?: unknown }).connected === true,
-    );
-  } catch {
-    return false;
-  }
 }

--- a/src/server/launcherRegistry.mjs
+++ b/src/server/launcherRegistry.mjs
@@ -67,6 +67,24 @@ export const LAUNCHERS = [
     hidden: true,
     buildArgs: () => ["auth", "login"],
   },
+  // BET-421 §E: lazy Claude CLI install. The app owns the binary now —
+  // install.sh no longer installs it. When the user picks Claude and the
+  // binary isn't on the box, the connect card spawns this launcher (via the
+  // same pty bus as claude-auth-login) to run the official installer, then
+  // flows straight into sign-in. Hidden from the dropdown; one-shot.
+  // `bash -c "curl … | bash"` mirrors the install.sh shape that worked
+  // before the deletion (stdin from /dev/null is the curl|bash pipe itself).
+  {
+    id: "claude-cli-install",
+    label: "Claude CLI install",
+    bin: "bash",
+    flags: [],
+    hidden: true,
+    buildArgs: () => [
+      "-c",
+      "curl -fsSL https://claude.ai/install.sh | bash",
+    ],
+  },
 ];
 
 export function findLauncher(id) {

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1207,6 +1207,36 @@ function resolveClaudeBin() {
   return "claude";
 }
 
+/**
+ * BET-421 §E: is the `claude` CLI installed on this box? Used by the
+ * connect card to decide whether to run the lazy installer before sign-in.
+ * Pure over an injected `existsFn` so the decision is unit-testable.
+ * Returns `{ installed, path }` — `path` is the resolved binary path, or
+ * `"claude"` (the bare-name fallback) when nothing is on disk.
+ */
+export function claudeCliStatus({ existsFn = existsSync } = {}) {
+  const bin = resolveClaudeBinExists(existsFn);
+  return { installed: bin.installed, path: bin.path };
+}
+
+// Separated from resolveClaudeBin so claudeCliStatus can report the resolved
+// path AND whether it actually exists (resolveClaudeBin returns "claude" as
+// a last-resort bare name, which is NOT "installed").
+function resolveClaudeBinExists(existsFn) {
+  const candidates = [
+    path.join(homedir(), ".local", "bin", "claude"),
+    "/usr/local/bin/claude",
+  ];
+  for (const c of candidates) {
+    try {
+      if (existsFn(c)) return { installed: true, path: c };
+    } catch {
+      // ignore and try the next candidate
+    }
+  }
+  return { installed: false, path: "claude" };
+}
+
 /** Best-effort read + parse of ~/.claude/.credentials.json. Null on any
  *  read or parse failure (file missing, permissions, malformed JSON). */
 function readCredsSnapshot() {

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -31,6 +31,7 @@ import {
   getProviders,
   getDefaultModel,
   listModels,
+  claudeCliStatus,
 } from "./opencode.mjs";
 
 test("apiUrl targets local opencode port 4096", () => {
@@ -1534,3 +1535,27 @@ test("subscribeEvents default (no eagerDirectories) opens NO scoped stream at st
   }
 });
 
+
+// ===== claudeCliStatus (BET-421 §E) =====
+
+test("claudeCliStatus reports installed when a candidate binary exists", () => {
+  const status = claudeCliStatus({
+    existsFn: (p) => p === "/usr/local/bin/claude",
+  });
+  assert.equal(status.installed, true);
+  assert.equal(status.path, "/usr/local/bin/claude");
+});
+
+test("claudeCliStatus reports not-installed when no candidate exists", () => {
+  const status = claudeCliStatus({ existsFn: () => false });
+  assert.equal(status.installed, false);
+  // Falls back to the bare name, which is NOT "installed".
+  assert.equal(status.path, "claude");
+});
+
+test("claudeCliStatus prefers ~/.local/bin/claude over /usr/local/bin/claude", () => {
+  const status = claudeCliStatus({ existsFn: () => true });
+  // resolveClaudeBinExists walks candidates in order; the home-dir path wins.
+  assert.match(status.path, /\.local\/bin\/claude$/);
+  assert.equal(status.installed, true);
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -19,7 +19,7 @@ import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
 import * as subscriptionProviders from "./subscriptionProviders.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
-import { pollClaudeLogin } from "./opencode.mjs";
+import { pollClaudeLogin, claudeCliStatus } from "./opencode.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
@@ -734,7 +734,11 @@ export function buildHandlers({
       const key = String(sessionKey ?? "");
       cancelClaudeLogin(key);
       return { ok: true };
-    },    // ---- scheduled prompts (manta-server owned; in-process on mobile) ----
+    },
+    // BET-421 §E: is the `claude` CLI installed on this box? The connect
+    // card asks before sign-in so it can run the lazy installer when it
+    // isn't. Pure probe over resolveClaudeBin — never spawns anything.
+    "opencode:claude-cli-status": () => claudeCliStatus(),    // ---- scheduled prompts (manta-server owned; in-process on mobile) ----
     // Mirror of desktop IPC.scheduleList / scheduleDelete. The store + firing
     // loop live in src/server/schedule.mjs; these just read/mutate it. Delete
     // publishes schedule.updated so the ScheduledTasksCard refetches live.

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -563,6 +563,30 @@ export function buildHandlers({
       return tmux.listProjects();
     },
 
+    // BET-421: bare session lifecycle for the onboarding verifier. create
+    // makes a fresh opencode session in `directory` (no tmux window, no
+    // project) — mirrors the throwaway session generateSessionTitle uses.
+    // deleteRaw drops it by id alone (no tmux window to kill). Together
+    // they let the verifier probe the box and leave nothing behind.
+    "opencode:create-ephemeral-session": async ({ directory, title }) => {
+      try {
+        const sess = await oc.createSession({ directory, title });
+        return { ok: true, sessionId: sess.id };
+      } catch (e) {
+        return { ok: false, error: e?.message ? String(e.message) : String(e) };
+      }
+    },
+    "opencode:delete-session-raw": async ({ sessionId }) => {
+      try {
+        await oc.deleteSessionRaw(sessionId);
+        return { ok: true };
+      } catch {
+        // Best-effort — a session that failed to create, or one already
+        // reaped, must not fail the verify flow's cleanup.
+        return { ok: true };
+      }
+    },
+
     // opencode:generate-title
     // Auto-rename: throwaway-session title generation. Mirror of desktop
     // IPC.opencodeGenerateTitle. Returns the RAW model reply (caller sanitizes).

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -390,6 +390,9 @@ export interface Api {
   // ptyKill(sessionKey). Both calls together release the full session so
   // a fresh start can register under the SAME name.
   claudeLoginCancel(sessionKey: string): Promise<{ ok: boolean }>;
+  // BET-421 §E: is the `claude` CLI installed on the box? The connect card
+  // runs the lazy installer before sign-in when it isn't.
+  opencodeClaudeCliStatus(): Promise<{ installed: boolean; path: string }>;
 
   // Server version (BET-180): returns the manta-server's package.json version,
   // served in-process via the `server:version` RPC channel (no HTTP round

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -262,6 +262,15 @@ export interface Api {
     sessionName: string;
     windowIndex: number;
   }): Promise<Project[]>;
+  // BET-421: bare session lifecycle for the ephemeral onboarding verifier.
+  // create makes a fresh opencode session in `directory` (no tmux window,
+  // no project); deleteRaw drops it by id alone. Together they let the
+  // verifier probe the box and leave nothing behind.
+  opencodeCreateEphemeralSession(input: {
+    directory: string;
+    title?: string;
+  }): Promise<{ ok: boolean; sessionId?: string; error?: string }>;
+  opencodeDeleteSessionRaw(sessionId: string): Promise<{ ok: boolean }>;
 
   // Scheduled prompts (manta-server owned; desktop reaches it over -L 18787).
   scheduleList(sessionId?: string): Promise<ScheduledJob[]>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -664,6 +664,10 @@ export const IPC = {
   // shared with every other terminal, so cancellation here + pty:kill
   // there = full teardown).
   claudeLoginCancel: "claude:login-cancel",
+  // BET-421 §E: probe whether the `claude` CLI is installed on the box, so
+  // the connect card can run the lazy installer before sign-in when it
+  // isn't. Returns { installed, path }.
+  opencodeClaudeCliStatus: "opencode:claude-cli-status",
 
   // ---- voice (Groq STT + lightweight classifier) ----
   // Renderer captures audio via MediaRecorder, ships the ArrayBuffer to

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -631,6 +631,14 @@ export const IPC = {
   // @manta-session-id user-option. The renderer notices the new id and
   // unmounts/remounts ChatPanel.
   opencodeClearSession: "opencode:clear-session",
+  // BET-421: bare opencode session create/delete with NO tmux window. Used
+  // by the onboarding verifier to spin up an ephemeral session, send one
+  // probe prompt, confirm a real assistant reply, and delete the session
+  // — leaving no project and no session behind on the box. Mirrors the
+  // throwaway-session pattern opencode:generate-title already uses
+  // server-side, exposed here so the renderer can drive the staged UI.
+  opencodeCreateEphemeralSession: "opencode:create-ephemeral-session",
+  opencodeDeleteSessionRaw: "opencode:delete-session-raw",
   // Auto-rename: generate a short 1-2 word title for a session by spawning a
   // throwaway opencode session, prompting it to summarize the conversation,
   // then deleting it. Returns the RAW model reply (renderer sanitizes). Used


### PR DESCRIPTION
## BET-429 — Wire lazy Claude CLI install into the connect card

BET-421 §E parts 3–4 (deferred from the parent). The server-side foundation (hidden `claude-cli-install` launcher, `claudeCliStatus()`, `opencode:claude-cli-status` RPC) shipped on the parent branch; this PR is the connect-card wiring only.

### What it does

When the `{action:"start"}` response is the `claude-login` shape, the connect card now probes `window.api.opencodeClaudeCliStatus()` **before** transitioning to `needsClaudeLogin`:

- **Installed** → existing `needsClaudeLogin` flow, unchanged.
- **Not installed** → new `installingClaudeCli` phase:
  - A collapsed `<details>` Terminal (mirroring the Claude login terminal) runs the `claude-cli-install` launcher (`curl … | bash`) over the pty bus with a client-generated session key.
  - Polls `opencodeClaudeCliStatus()` every 2s (5-min cap). On `installed` → kills the installer pty, cancels the original login sessionKey, and **re-fires `runStart()`** so the server mints a fresh claude-login sessionKey + takes a fresh credential backup right before the real OAuth.
  - On timeout → failure card with three actions: **Try again** (re-run the installer, reusing the held loginSessionKey/cwd — no re-fire), **Use a different model** (closes the card — Codex/Kimi/custom need no binary), **Install manually** (link to claude.ai). The message states plainly the box is fine.

The mount-time `{action:"start"}` dispatch is factored into a `runStart` callable so the post-install re-fire reuses the exact same branch logic (a generation ref guards against a stale in-flight start overwriting a newer one).

### Design note on "already-minted sessionKey"

The spec says "re-fire `{action:\"start\"}` … using the already-minted `sessionKey`". The server's `startClaudeLogin` always mints a fresh `claude-login-${uuid}` per call, so a re-fire returns a **new** sessionKey. This PR re-fires (per the explicit instruction) and uses the fresh key; the original loginSessionKey is cancelled first so its entry in the server's `_claudeLoginSessions` map doesn't leak. A fresh backup snapshot is taken as close to the real OAuth as possible — the correct moment for the rollback target. The `installFailure`-driven "Try again" path does NOT re-fire (it re-enters `installingClaudeCli` with the held loginSessionKey), matching "the server-side metadata is still valid".

### Files

- `src/renderer/ConnectProvider.tsx` — `runStart` callable + CLI-status probe, `installingClaudeCli` phase + 2s poll, three-action install-failure card.
- `src/renderer/chatUtils.ts` — `installingClaudeCli` variant on `ConnectPhase`, `installFailure` payload on `failed`, exhaustive `connectPhaseLabel` case.
- `src/renderer/chatUtils.test.ts` — label tests for the new phase + install-failure shape.

### Verification results

**Files changed:** 3 files. `src/renderer/ConnectProvider.tsx`, `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts`.

- PR branch (`multica/BET-429-claude-cli-install-connect` @ `7c3cecd`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…`
  - vitest: 1685 pass / 0 fail / 0 skip. log sha256: `572b8a67…`
  - node:test: 1211 pass / 0 fail. log sha256: `ba539587…`
- Base (`multica/BET-421-onboarding-processpanel` @ `1d15cf5`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…` (identical)
  - vitest: 1683 pass / 0 fail / 0 skip. log sha256: `19af9313…`
  - node:test: 1211 pass / 0 fail. log sha256: `2c99c5ea…`
- **Conclusion:** 0 failures new or pre-existing. +2 vitest tests are the new label tests this PR adds (1683 → 1685).

### E2E smoke (Electron launch)

The built app launched standalone (Playwright `electron.launch` + `xvfb-run`) crashes identically on **both** branches with `TypeError: window.api.opencodeModels is not a function` — the renderer's bootstrap model-fetch fires before any box connection is configured, and `window.api` is not wired in a standalone launch with no live box server. This is a **pre-existing** environment limitation, not a regression: the error is byte-identical on the base commit (`1d15cf5`). My change is renderer-only, touches a component (`ConnectProvider`) that mounts only on a user "Connect" click, and cannot affect the bootstrap model-fetch. typecheck + unit tests are the load-bearing gates here; the smoke gate cannot pass in this environment for any branch.

Base: `origin/multica/BET-421-onboarding-processpanel` @ `1d15cf5` (parent PR #373 still open; this PR targets that branch so the diff is the BET-429 delta only — retarget to `main` once #373 lands).
