### PR TITLE
BET-428: Show the opencode version in Settings → About

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -248,6 +248,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
   // Client + server versions for About.
   const [clientVersion, setClientVersion] = useState<string | null>(null);
   const [serverVersion, setServerVersion] = useState<string | null>(null);
+  const [opencodeVersion, setOpencodeVersion] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
     void Promise.all([
@@ -257,6 +258,12 @@ export function Settings({ onClose }: { onClose: () => void }) {
       if (cancelled) return;
       if (client && typeof client.version === "string") setClientVersion(client.version);
       if (server && typeof server.version === "string") setServerVersion(server.version);
+      // BET-428: opencode version ships in the same getServerVersion response
+      // (opencode's HTTP API has no version endpoint, so the server shells out
+      // to `opencode --version` once at startup). Only render when it's a real
+      // value — FALLBACK_VERSION ("0.0.0") means opencode isn't installed, so
+      // we hide the line rather than show a misleading "v0.0.0".
+      if (server && typeof server.opencodeVersion === "string" && server.opencodeVersion && server.opencodeVersion !== "0.0.0") setOpencodeVersion(server.opencodeVersion);
     });
     return () => { cancelled = true; };
   }, []);
@@ -512,6 +519,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
             <h3 className="text-title font-semibold mb-4">About</h3>
             <div className="text-body text-text-faint">Manta v{clientVersion ?? "…"}</div>
             {serverVersion && <div className="text-meta text-text-faint mt-1">Box server v{serverVersion}</div>}
+            {opencodeVersion && <div className="text-meta text-text-faint mt-1">Box opencode v{opencodeVersion}</div>}
             <div className="text-meta text-text-faint mt-1">Desktop client for remote Claude Code sessions.</div>
             {store.updatePrompt && (
               <div className="mt-4 rounded-lg border border-accent/30 bg-accent/10 px-3 py-2 flex items-center gap-2">

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -140,8 +140,8 @@ const launchersList = (): Promise<unknown[]> => Promise.resolve([]);
 const getClientVersion = (): Promise<{ version: string }> =>
   Promise.resolve({ version: "0.0.13" });
 
-const getServerVersion = (): Promise<{ version: string; minClient: string }> =>
-  Promise.resolve({ version: "0.0.13", minClient: "0.0.0" });
+const getServerVersion = (): Promise<{ version: string; minClient: string; opencodeVersion: string }> =>
+  Promise.resolve({ version: "0.0.13", minClient: "0.0.0", opencodeVersion: "0.0.0" });
 
 // Subscription provider auth (BET-308 / BET-309). Demo returns the three
 // disconnected rows so the connect-card UI still renders the registry

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -989,7 +989,7 @@ export const httpApi: Api = {
   claudeLoginCancel: (sessionKey: string) =>
     rpc<{ ok: boolean }>(IPC.claudeLoginCancel, sessionKey),
 
-  // -- server version (BET-180) --
+  // -- server version (BET-180, BET-428) --
   // Returns the manta-server's package.json version. In-process via the
   // `server:version` RPC channel (no HTTP round-trip; same value GET
   // /api/version returns for non-renderer clients). MobileSettings renders
@@ -1000,8 +1000,13 @@ export const httpApi: Api = {
   // (BET-225 stage 3) can compute `isClientTooOld` from a single round-trip
   // — no second endpoint, no parallel poll. The interface keeps `version`
   // only for backward compat with the BET-180 callers; new consumers
-  // should destructure both fields off the response.
-  getServerVersion: () => rpc<{ version: string; minClient: string }>(IPC.getServerVersion),
+  // should destructure all three fields off the response.
+  //
+  // BET-428: response also carries `opencodeVersion` — the box's
+  // `opencode --version` (read once at server startup; opencode's HTTP API
+  // has no version endpoint). Settings → About renders it in this same
+  // round-trip — no new IPC channel.
+  getServerVersion: () => rpc<{ version: string; minClient: string; opencodeVersion: string }>(IPC.getServerVersion),
 
   // -- client version (BET-225 stage 3) --
   // Returns the running client's own version. On desktop the preload bridge

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -91,7 +91,7 @@ import {
 } from "./pairPage.mjs";
 import * as push from "./push.mjs";
 import { registerWithGateway, publicBaseUrl } from "./gatewayRegister.mjs";
-import { readServerVersion, writeVersionResponse } from "./version.mjs";
+import { readServerVersion, readOpencodeVersion, writeVersionResponse } from "./version.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..", "..");
@@ -292,6 +292,13 @@ if (!authEnforced) {
 // (in-process, no HTTP round-trip); curl + future non-renderer clients use the
 // REST route.
 const SERVER_VERSION = await readServerVersion(PROJECT_ROOT);
+// BET-428: opencode's HTTP API exposes no version endpoint, so shell out to
+// `opencode --version` ONCE at startup (sync, cached here — never per-request).
+// Falls back to FALLBACK_VERSION if opencode isn't installed / errors, so the
+// boot sequence is never blocked. Surfaced in the same `server:version` RPC
+// response + `/api/version` body as `version` + `minClient` — no new IPC
+// channel; Settings → About reads it in the single getServerVersion trip.
+const OPENCODE_VERSION = readOpencodeVersion();
 rpcHandlers = buildHandlers({
   tmux,
   oc,
@@ -301,6 +308,7 @@ rpcHandlers = buildHandlers({
   authPair: () => authEngine.pair(),
   push,
   serverVersion: SERVER_VERSION,
+  opencodeVersion: OPENCODE_VERSION,
   delegate: delegateEngine,
   // BET-366 reviewer return: production wiring for the
   // `server:update-apply` IPC channel. The handler in rpc.mjs calls this
@@ -884,7 +892,7 @@ const handleRequest = async (req, res) => {
   // gating / banner / force-update logic lives behind this once skew is
   // visible.
   if (req.method === "GET" && path === "/api/version") {
-    writeVersionResponse(res, { version: SERVER_VERSION });
+    writeVersionResponse(res, { version: SERVER_VERSION, opencodeVersion: OPENCODE_VERSION });
     return;
   }
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -174,6 +174,11 @@ export async function dispatch(handlers, channel, args) {
 //                         value `GET /api/version` returns). The `server:version`
 //                         channel returns it in-process so the renderer avoids an
 //                         HTTP round-trip on every Settings mount.
+//   opencodeVersion     — string, the box's `opencode --version` output read once
+//                         at startup (BET-428). Surfaced in the same `server:version`
+//                         response so Settings → About can render it without a new
+//                         IPC channel; falls back to FALLBACK_VERSION when opencode
+//                         isn't installed.
 //   runServerSelfUpdate — the box's self-update spawner (BET-366 reviewer return).
 //                         Injected so the regression guard in rpc.test.mjs can
 //                         stub the spawn and assert the `server:update-apply`
@@ -193,6 +198,7 @@ export function buildHandlers({
   authPair,
   push,
   serverVersion,
+  opencodeVersion,
   runServerSelfUpdate,
   delegate,
 }) {
@@ -805,16 +811,19 @@ export function buildHandlers({
       }
     },
 
-    // ---- server version (BET-180, BET-225 stage 2) ----
+    // ---- server version (BET-180, BET-225 stage 2, BET-428) ----
     // Returns the cached package.json version (read once at startup, same
     // value the GET /api/version REST route returns). The renderer hits this
     // channel via window.api.getServerVersion() so it doesn't have to do an
     // HTTP round-trip just to render "Server vX.Y.Z" under the URL field in
     // MobileSettings. Also includes `minClient` so the version-skew guard
     // (BET-225 stage 3, renderer side) can compute `isClientTooOld` from a
-    // single response — no second poll, no parallel endpoint. The
-    // JSON-RPC envelope wraps the body as { result: { version, minClient } }.
-    "server:version": () => ({ version: serverVersion, minClient: MIN_CLIENT }),
+    // single response — no second poll, no parallel endpoint. BET-428 added
+    // `opencodeVersion` (the box's `opencode --version`, read once at startup)
+    // so Settings → About renders it in the same trip — no new IPC channel.
+    // The JSON-RPC envelope wraps the body as
+    // { result: { version, minClient, opencodeVersion } }.
+    "server:version": () => ({ version: serverVersion, minClient: MIN_CLIENT, opencodeVersion }),
 
     // ---- plugins (BET-189 / BET-190) ----
     // Read the current plugin registry the Mac executor has published.

--- a/src/server/version.mjs
+++ b/src/server/version.mjs
@@ -9,6 +9,7 @@
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 
 // Returned when package.json is unreadable / malformed / missing the `version`
 // field. Lets the server boot in broken packaging scenarios (a tarball that
@@ -48,15 +49,62 @@ export async function readServerVersion(repoRoot, fs = { readFile }) {
 }
 
 /**
+ * Read the running opencode CLI's version via `opencode --version`.
+ *
+ * opencode's HTTP API has no version endpoint (probed: `/api/health` returns
+ * only `{healthy:true}`, `/version`/`/api/version`/`/api/config`/`/api/info`
+ * all return the SPA HTML fallback), so a shell-out is the only viable
+ * source. Runs synchronously ONCE at server startup (never per-request) and
+ * is cached in `OPENCODE_VERSION` by src/server/index.mjs, mirroring the
+ * `readServerVersion` startup-read pattern.
+ *
+ * `exec` is injectable so the test can pass a stub (no real subprocess
+ * during the test, same resilience-injection contract as `readServerVersion`
+ * takes for `fs`). Production passes the real `execFileSync` from
+ * `node:child_process`. `opencode --version` prints a single line like
+ * `1.18.10`; we take the last whitespace-separated token so a future
+ * `opencode version 1.18.10`-style prefix won't silently break parsing.
+ * On any failure path — ENOENT (opencode not installed), non-zero exit,
+ * empty stdout — returns FALLBACK_VERSION rather than throwing, so the boot
+ * sequence is never blocked on a metadata read.
+ */
+export function readOpencodeVersion(exec = execFileSync) {
+  try {
+    const stdout = exec("opencode", ["--version"], { encoding: "utf8" });
+    const trimmed = String(stdout).trim();
+    if (!trimmed) return FALLBACK_VERSION;
+    const tokens = trimmed.split(/\s+/);
+    const v = tokens[tokens.length - 1];
+    return v || FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}
+
+/**
  * Write the /api/version JSON response. Pure: takes `res` (anything with
- * writeHead + end) and `deps` ({ version }) and emits the response body.
- * No IO. Tests pass a recorder `res` and assert on the captured calls.
+ * writeHead + end) and `deps` ({ version, opencodeVersion? }) and emits the
+ * response body. No IO. Tests pass a recorder `res` and assert on the
+ * captured calls.
  *
  * Includes `minClient` (the constant from `MIN_CLIENT`) so the
  * version-skew guard consumer (renderer stage 3) can check the client is
  * still supported in a single round-trip — no separate endpoint needed.
+ *
+ * Includes `opencodeVersion` (BET-428) so Settings → About can render the
+ * box's opencode CLI version alongside the desktop + server versions in the
+ * same `getServerVersion` round-trip — no new IPC channel. Defaults to
+ * FALLBACK_VERSION when omitted so the existing `{ version }`-only callers
+ * (and the BET-180 test) keep working; production always passes the cached
+ * startup value.
  */
-export function writeVersionResponse(res, { version }) {
+export function writeVersionResponse(res, { version, opencodeVersion = FALLBACK_VERSION }) {
   res.writeHead(200, { "content-type": "application/json" });
-  res.end(JSON.stringify({ version, minClient: MIN_CLIENT }));
+  res.end(
+    JSON.stringify({
+      version,
+      minClient: MIN_CLIENT,
+      opencodeVersion,
+    }),
+  );
 }

--- a/src/server/version.test.mjs
+++ b/src/server/version.test.mjs
@@ -18,6 +18,7 @@ import { createServer } from "node:http";
 import http from "node:http";
 import {
   readServerVersion,
+  readOpencodeVersion,
   writeVersionResponse,
   FALLBACK_VERSION,
   MIN_CLIENT,
@@ -83,10 +84,63 @@ test("readServerVersion returns FALLBACK_VERSION when version field is missing o
 });
 
 // ---------------------------------------------------------------------------
+// readOpencodeVersion (BET-428)
+// ---------------------------------------------------------------------------
+// opencode's HTTP API exposes no version endpoint, so the server shells out
+// to `opencode --version` once at startup. `exec` is injectable (mirrors the
+// fs-injection contract readServerVersion uses) so no real subprocess runs
+// during the test. The stub returns a Buffer/string the same way execFileSync
+// would; we assert parsing + every failure path falls back to FALLBACK_VERSION.
+
+test("readOpencodeVersion parses a clean version string from execFileSync stdout", () => {
+  const exec = () => "1.18.10\n";
+  assert.equal(readOpencodeVersion(exec), "1.18.10");
+});
+
+test("readOpencodeVersion takes the last token when stdout has a prefix", () => {
+  // Robust to a future `opencode version 1.18.10`-style output without
+  // coupling to a fixed format.
+  const exec = () => "opencode version 1.18.10\n";
+  assert.equal(readOpencodeVersion(exec), "1.18.10");
+});
+
+test("readOpencodeVersion trims trailing whitespace / newlines", () => {
+  const exec = () => "  1.2.3  \n\n";
+  assert.equal(readOpencodeVersion(exec), "1.2.3");
+});
+
+test("readOpencodeVersion returns FALLBACK_VERSION when the command throws (ENOENT — opencode not installed)", () => {
+  const exec = () => {
+    const err = new Error("spawn opencode ENOENT");
+    err.code = "ENOENT";
+    throw err;
+  };
+  assert.equal(readOpencodeVersion(exec), FALLBACK_VERSION);
+});
+
+test("readOpencodeVersion returns FALLBACK_VERSION when stdout is empty", () => {
+  const exec = () => "";
+  assert.equal(readOpencodeVersion(exec), FALLBACK_VERSION);
+});
+
+test("readOpencodeVersion returns FALLBACK_VERSION when stdout is only whitespace", () => {
+  const exec = () => "   \n\t\n";
+  assert.equal(readOpencodeVersion(exec), FALLBACK_VERSION);
+});
+
+test("readOpencodeVersion returns FALLBACK_VERSION on non-zero exit (child returns empty)", () => {
+  // execFileSync throws on non-zero exit; the catch maps it to FALLBACK.
+  const exec = () => {
+    throw new Error("Command failed: opencode --version");
+  };
+  assert.equal(readOpencodeVersion(exec), FALLBACK_VERSION);
+});
+
+// ---------------------------------------------------------------------------
 // writeVersionResponse (pure)
 // ---------------------------------------------------------------------------
 
-test("writeVersionResponse writes 200 + JSON { version, minClient }", () => {
+test("writeVersionResponse writes 200 + JSON { version, minClient, opencodeVersion }", () => {
   let captured = null;
   const fakeRes = {
     writeHead(status, headers) {
@@ -97,7 +151,7 @@ test("writeVersionResponse writes 200 + JSON { version, minClient }", () => {
       captured = { status: this._status, headers: this._headers, body };
     },
   };
-  writeVersionResponse(fakeRes, { version: "9.9.9" });
+  writeVersionResponse(fakeRes, { version: "9.9.9", opencodeVersion: "1.18.10" });
   assert.equal(captured.status, 200);
   assert.equal(captured.headers["content-type"], "application/json");
   const body = JSON.parse(captured.body);
@@ -108,6 +162,24 @@ test("writeVersionResponse writes 200 + JSON { version, minClient }", () => {
   assert.equal(body.minClient, MIN_CLIENT);
   assert.equal(typeof body.minClient, "string");
   assert.ok(body.minClient.length > 0);
+  // BET-428: opencodeVersion MUST be present so Settings → About renders it
+  // in the same getServerVersion round-trip — no new IPC channel.
+  assert.equal(body.opencodeVersion, "1.18.10");
+});
+
+test("writeVersionResponse defaults opencodeVersion to FALLBACK_VERSION when omitted", () => {
+  // Backward-compat: the BET-180 callers (and the existing route test below)
+  // pass only { version }. The response must still carry opencodeVersion so
+  // the renderer's destructure never hits `undefined`; it falls back to
+  // "0.0.0" which the About block hides.
+  let captured = null;
+  const fakeRes = {
+    writeHead() {},
+    end(body) { captured = body; },
+  };
+  writeVersionResponse(fakeRes, { version: "1.2.3" });
+  const body = JSON.parse(captured);
+  assert.equal(body.opencodeVersion, FALLBACK_VERSION);
 });
 
 // ---------------------------------------------------------------------------
@@ -143,7 +215,7 @@ function httpRequest(port, path, headers = {}) {
   });
 }
 
-async function startVersionServer(version) {
+async function startVersionServer(version, opencodeVersion = FALLBACK_VERSION) {
   // Real ensureAuth writes to ~/.manta/auth.json — avoid touching disk in
   // tests, so build an auth engine from a hand-rolled boxAuth with the
   // well-known HEX32 token. createAuthEngine doesn't care where the auth
@@ -187,7 +259,7 @@ async function startVersionServer(version) {
 
       // ---- /api/version route (mirrors src/server/index.mjs) ----
       if (req.method === "GET" && path === "/api/version") {
-        writeVersionResponse(res, { version });
+        writeVersionResponse(res, { version, opencodeVersion });
         return;
       }
 
@@ -223,8 +295,8 @@ test("/api/version returns 401 when Bearer is wrong", async () => {
   }
 });
 
-test("/api/version returns 200 + { version, minClient } when Bearer present", async () => {
-  const { server, port } = await startVersionServer("1.2.3-test");
+test("/api/version returns 200 + { version, minClient, opencodeVersion } when Bearer present", async () => {
+  const { server, port } = await startVersionServer("1.2.3-test", "1.18.10");
   try {
     const res = await httpRequest(port, "/api/version", {
       authorization: `Bearer ${HEY_HEX32}`,
@@ -237,6 +309,9 @@ test("/api/version returns 200 + { version, minClient } when Bearer present", as
     // surface MUST surface minClient to the renderer's `getServerVersion()`
     // consumer in stage 3.
     assert.equal(body.minClient, MIN_CLIENT);
+    // BET-428: opencodeVersion MUST be present so Settings → About renders it
+    // in the same round-trip — no new IPC channel.
+    assert.equal(body.opencodeVersion, "1.18.10");
   } finally {
     server.close();
   }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -396,7 +396,14 @@ export interface Api {
   // poll. The interface keeps `version` as the primary field for the
   // BET-180 callers (MobileSettings); new consumers should destructure
   // both.
-  getServerVersion(): Promise<{ version: string; minClient: string }>;
+  //
+  // BET-428: response also carries `opencodeVersion` — the box's
+  // `opencode --version` output, read once at server startup (opencode's
+  // HTTP API exposes no version endpoint, so a shell-out is the only
+  // source). Settings → About renders it alongside the desktop + server
+  // versions in this single round-trip — no new IPC channel. Falls back to
+  // "0.0.0" when opencode isn't installed.
+  getServerVersion(): Promise<{ version: string; minClient: string; opencodeVersion: string }>;
 
   // Client version (BET-225 stage 3): returns the desktop app's own version
   // via Electron's `app.getVersion()`. Combined with the server's

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -775,13 +775,15 @@ export const IPC = {
   // noticed — the app simply stopped updating without ever saying so.
   autoUpdateError: "autoUpdate:error",
 
-  // ---- server version (BET-180) ----
+  // ---- server version (BET-180, BET-428) ----
   // Returns the manta-server's package.json version (read once at server startup,
   // served by GET /api/version for non-renderer clients AND by this in-process
   // RPC channel for the renderer — single source of truth on the box, never
   // drifts between surfaces). Display-only foundation for client/server skew
   // detection; gating / banner / force-update logic lands in a later phase.
-  getServerVersion: "server:version",                 // () → { version: string }
+  // BET-428 added `opencodeVersion` (the box's `opencode --version`, read once
+  // at startup) so Settings → About can render it without a new IPC channel.
+  getServerVersion: "server:version",                 // () → { version: string, minClient: string, opencodeVersion: string }
 
   // ---- server self-update apply (BET-225 stage 3) ----
   // Trigger the server's `scripts/self-update.sh` (git fetch + reset --hard


### PR DESCRIPTION
## BET-428 — Show the opencode version in Settings → About

opencode's HTTP API exposes no version endpoint (probed: `/api/health` → `{healthy:true}` only; `/version`, `/api/version`, `/api/config`, `/api/info` all return the SPA HTML fallback). The only viable source is `opencode --version`, read **once at server startup** (sync shell-out, cached — never per-request) and surfaced in the **existing** `server:version` RPC response + `/api/version` body alongside `version` + `minClient`. No new IPC channel — Settings → About renders a third line in the same `getServerVersion` round-trip.

### Changes (9 files, +186 / −24)

- **`src/server/version.mjs`** — new `readOpencodeVersion()` (sync `execFileSync`, injectable `exec` for tests; parses last whitespace token of stdout; `FALLBACK_VERSION` on ENOENT / non-zero exit / empty stdout). `writeVersionResponse` now includes `opencodeVersion` (defaults to `FALLBACK_VERSION` for backward compat with `{ version }`-only callers).
- **`src/server/index.mjs`** — `const OPENCODE_VERSION = readOpencodeVersion();` at startup, threaded into `buildHandlers` + the `/api/version` REST route.
- **`src/server/rpc.mjs`** — `buildHandlers` accepts `opencodeVersion`; `server:version` returns `{ version, minClient, opencodeVersion }`.
- **`src/shared/types.ts`** / **`src/shared/api.ts`** — `getServerVersion` return type gains `opencodeVersion: string`.
- **`src/renderer/api/httpApi.ts`** / **`src/renderer/api/demoApi.ts`** — response type updated; demo returns `opencodeVersion: "0.0.0"`.
- **`src/renderer/Settings.tsx`** — destructure `opencodeVersion` from the `getServerVersion` response; render `Box opencode v{opencodeVersion}` in About (hidden when the value is the `0.0.0` fallback so a box without opencode installed never shows a misleading v0.0.0).
- **`src/server/version.test.mjs`** — 7 new `readOpencodeVersion` tests (clean parse, prefix-robust parse, trim, ENOENT fallback, empty stdout, whitespace-only, non-zero exit) + `writeVersionResponse` inclusion/default test + `/api/version` route body assertion.

### Design notes

- **No new IPC channel** — the spec preferred extending the existing `server:version` response over adding `opencode:version`. One round-trip serves all three versions.
- **Sync read at startup only** — `readOpencodeVersion` uses `execFileSync` (not `execFile` async) because it runs once at boot, before the server listens. Per-request handlers never shell out.
- **Fallback hides the line** — the renderer suppresses the About line when `opencodeVersion === "0.0.0"` (the `FALLBACK_VERSION`), so a box without opencode installed shows two lines, not a misleading three.
- **Parse robustness** — takes the last whitespace-separated token of stdout so a future `opencode version 1.18.10`-style prefix won't silently break parsing (today it's a bare `1.18.10`).
- Mobile (`MobileSettings.tsx`, `useCompatibilityCard`) reads only `{ version, minClient }` from the same response — adding `opencodeVersion` is additive and doesn't touch those surfaces (out of scope per the issue).

Base: `origin/main` @ `1e9915b` (BET-420 merged).

**Verification results:**
- PR branch (`multica/BET-428-opencode-version` @ `df38570`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1216` pass / `0` fail / `0` skip. Failures: none. log sha256: `fd0e0c0c4f5f0ea9d5c2de53c9cb89b3601b33b105315ff7522272b30b251d12`
- Base (`main` @ `1e9915b`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1208` pass / `0` fail / `0` skip. Failures: none. log sha256: `5c24de06d975cb321b439f2644af21f2246473bbfc47074cf23ad4583e8b4163`
- **Conclusion:** `8` new tests added by this PR (1208 → 1216), all passing. `0` pre-existing failures, `0` new failures, `0` failures resolved.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

### Self-check

- `readOpencodeVersion()` exists in `src/server/version.mjs` with tests → 10/10 (7 parsing/fallback tests + parse-robustness).
- `getServerVersion` IPC returns the opencode version → 10/10 (rpc.mjs `server:version` returns `opencodeVersion`; `/api/version` route + `writeVersionResponse` include it; types updated across shared/api/httpApi/demoApi).
- Settings → About shows three lines: Manta v{client}, Box server v{server}, Box opencode v{opencode} → 9/10 (line added with matching styling; hides on fallback — minor: only desktop Settings, mobile out of scope per issue).
- `npm run typecheck && npm test` passes → 10/10 (both green, 1216 pass).
- Push `multica/BET-428-*` branch, PR titled with issue key, reassign to manta-reviewer → 10/10 (this PR + reassign below).

No actionable follow-ups surfaced — the change is additive to a single RPC response and reuses the existing `readServerVersion` resilience pattern.
