### PR TITLE
fix(installer): write Caddy config via install_root_file, never mv (BET-440)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,6 +117,20 @@ ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
 warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
+# Install a staged temp file as a root-owned, world-readable config file.
+#
+# ALWAYS use this instead of `mv` or `tee` for files a system service must
+# read. `mv` preserves the SOURCE file's mode + owner, and mktemp(1) creates
+# 0600 files owned by the invoking user — that is exactly what made
+# /etc/caddy/Caddyfile unreadable to the `caddy` service user and silently
+# broke TLS on every re-install. install(1) sets the destination mode and
+# owner explicitly, so the result never depends on the temp file.
+#
+#   $1 = staged source path   $2 = destination path
+install_root_file() {
+  sudo -n install -m 0644 -o root -g root "$1" "$2"
+}
+
 # Parse one key out of a key=value manifest body. Echoes the value, empty if
 # absent. Values may contain `=` (cut -d= -f2- preserves them). A repeated key
 # is reduced to the FIRST occurrence (head -n1) — the manifest writer emits
@@ -1377,7 +1391,7 @@ main() {
         printf 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/ubuntu %s main\n' "$_caddy_codename"
         printf 'deb-src [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/ubuntu %s main\n' "$_caddy_codename"
       } > "$_caddy_list_tmp"
-      sudo -n install -m 0644 "$_caddy_list_tmp" /etc/apt/sources.list.d/caddy-stable.list \
+      install_root_file "$_caddy_list_tmp" /etc/apt/sources.list.d/caddy-stable.list \
         || { rm -f "$_caddy_list_tmp"; die "failed to add Caddy apt repo"; }
       rm -f "$_caddy_list_tmp"
       sudo -n apt-get update \
@@ -1513,7 +1527,7 @@ main() {
             warn "failed to render the Caddy vhost (see /tmp/manta-caddy-render.err)"
             warn "  the rest of the install will proceed; re-run to write the Caddy vhost."
             CADDY_E_SKIP=1
-          elif ! sudo -n install -m 0644 "$_caddy_snippet_tmp" "$CADDY_DIR_D/manta.caddy" 2>/tmp/manta-caddy-tee.err; then
+          elif ! install_root_file "$_caddy_snippet_tmp" "$CADDY_DIR_D/manta.caddy" 2>/tmp/manta-caddy-tee.err; then
             warn "failed to write $CADDY_DIR_D/manta.caddy (sudo install failed — see /tmp/manta-caddy-tee.err)"
             warn "  the rest of the install will proceed; re-run after fixing sudo to write the Caddy vhost."
             CADDY_E_SKIP=1
@@ -1542,12 +1556,12 @@ main() {
               awk '/^# >>> manta >>>$/{skip=1; print; next} /^# <<< manta <<<$/{skip=0; print "REPLACE_HERE"; next} skip{next} {print}' "$CADDYFILE" \
                 | awk -v snippet="$SNIPPET" '/REPLACE_HERE/{print snippet; next} {print}' \
                 > "$tmp"
-              if ! sudo -n mv "$tmp" "$CADDYFILE" 2>/tmp/manta-caddy-mv.err; then
-                warn "could not update $CADDYFILE (sudo mv failed — see /tmp/manta-caddy-mv.err)"
+              if ! install_root_file "$tmp" "$CADDYFILE" 2>/tmp/manta-caddy-mv.err; then
+                warn "could not update $CADDYFILE (sudo install failed — see /tmp/manta-caddy-mv.err)"
                 warn "  the rest of the install will proceed; re-run after fixing sudo to write the Caddy vhost."
                 CADDY_E_SKIP=1
-                rm -f "$tmp" 2>/dev/null || true
               fi
+              rm -f "$tmp" 2>/dev/null || true
             else
               if ! sudo -n bash -c "printf '\n%s\n' \"\$1\" >> \"\$2\"" -- "$SNIPPET" "$CADDYFILE" 2>/tmp/manta-caddy-append.err; then
                 warn "could not append to $CADDYFILE (sudo bash failed — see /tmp/manta-caddy-append.err)"

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -5119,3 +5119,42 @@ test("self-update.sh does NOT restart opencode — that would kill in-flight age
     "self-update.sh must not execute an opencode restart (only print it as advice)",
   );
 });
+
+test("install.sh writes service-read config files via install_root_file, never `sudo -n mv` (BET-440)", () => {
+  // BET-440 outage: the marker-replace branch staged the new Caddyfile in a
+  // mktemp file then moved it into place with `sudo -n mv`. mktemp(1) makes
+  // 0600 files owned by the invoking user, and mv preserves the source file's
+  // mode + owner — so /etc/caddy/Caddyfile became unreadable to the `caddy`
+  // service user and the box's TLS silently died on every re-install. This
+  // asserts the fix: a single install_root_file helper (install(1) sets the
+  // destination mode + owner explicitly), no stray `sudo -n mv`, and no caller
+  // that bypasses the helper to write a config file.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+
+  // 1. install_root_file is defined exactly once.
+  const defs = (src.match(/^[ \t]*install_root_file\(\)[ \t]*\{/gm) || []).length;
+  assert.strictEqual(defs, 1, "install_root_file() must be defined exactly once");
+
+  // 2. Its body pins the destination mode + owner root:root.
+  const open = src.indexOf("install_root_file() {");
+  const close = src.indexOf("\n}", open);
+  assert.ok(open !== -1 && close !== -1, "could not locate install_root_file() body");
+  const helperBody = src.slice(open, close);
+  assert.match(
+    helperBody,
+    /install -m 0644 -o root -g root/,
+    "install_root_file body must set 0644 + root:root explicitly",
+  );
+
+  // 3. No `sudo -n mv` remains anywhere — the exact construct that caused the outage.
+  assert.doesNotMatch(src, /sudo -n mv/, "install.sh must not contain `sudo -n mv`");
+
+  // 4. Every `sudo -n install -m 0644 <src> <dst>` lives inside the helper.
+  const totalInstallCalls = (src.match(/sudo -n install -m 0644 /g) || []).length;
+  const helperInstallCalls = (helperBody.match(/sudo -n install -m 0644 /g) || []).length;
+  assert.strictEqual(
+    totalInstallCalls,
+    helperInstallCalls,
+    "every `sudo -n install -m 0644` call must go through the install_root_file helper",
+  );
+});


### PR DESCRIPTION
## What & why

BET-440 — re-running `install.sh` breaks a working box's TLS. The marker-replace branch staged the new Caddyfile in a `mktemp` file (0600, invoking-user owner) and moved it into place with `sudo -n mv`. `mv` preserves the source file's mode + owner, so `/etc/caddy/Caddyfile` became unreadable to the `caddy` service user (`User=caddy`), `caddy reload` failed, the vhost never activated, no ACME cert was issued, and `https://<box_id>.boxes.mantaui.com` failed the TLS handshake.

## Change

Add a single `install_root_file` helper (`sudo -n install -m 0644 -o root -g root`) and route every service-read config write through it:

- the `Caddyfile.d` snippet write (was already `install`, just unpinned owner)
- the marker-replace Caddyfile write (was the buggy `sudo -n mv`) — and the temp-file `rm` moved out of the failure branch since `install` copies rather than moves
- the apt `caddy-stable.list` write (a third config-file write a system service reads; converted so the issue's own test criterion #4 — *no* `sudo -n install -m 0644 ` outside the helper — holds)

The `printf … >> ` append branch and `tee` create branch are **untouched** (correct today, deleted wholesale by the follow-up marker-block restructure).

## Tests

New BET-440 regression test asserting the four guards the issue specifies: helper defined once, body pins `-m 0644 -o root -g root`, no `sudo -n mv` anywhere, no `sudo -n install -m 0644 ` outside the helper. It reads the script text only — runs unprivileged, never touches `/etc/caddy` or invokes sudo.

**Files changed:** `2` files. `scripts/install.sh` (+24/−5), `scripts/install.test.mjs` (+39/−0).

**Base: `origin/main` @ `0f734e4`**

**Verification results:**
- PR branch (`multica/BET-440-fix-caddyfile-perms` @ `10ed295`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1251` pass / `0` fail / `0` skip. Failures: none. log sha256: `01f533fbcbfbc1defe09ec07aeec759508ba0d51368791462226db19f0acfe10`
- Base (`main` @ `0f734e4`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1250` pass / `0` fail / `0` skip. Failures: none. log sha256: `63e2d2a6b9e8a13b81fc49e63c7e2a1d70bd62f1941175cd20dc83248a03cbc5`
- **Conclusion:** `0` test failures are pre-existing (identical between branches), `0` are new and caused by this PR, `1` new test was added (the BET-440 guard).

**Acceptance criteria met:**
- `npm run typecheck && npm test` pass ✓
- The four assertions pass ✓
- `grep -n "sudo -n mv" scripts/install.sh` returns nothing ✓
