### PR TITLE
BET-446: installer — guard $OPENCODE_CLAUDE_AUTH_PLUGIN against set -u

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -755,22 +755,27 @@ main() {
   OPENCODE_CONFIG="$OPENCODE_CONFIG_DIR/opencode.jsonc"
   mkdir -p "$OPENCODE_CONFIG_DIR"
   OPENCODE_CONFIG_BACKUP="$OPENCODE_CONFIG.pre-manta"
-  # ${MANTA_CLAUDE_AUTH_PLUGIN:-} — the installer runs under `set -u`, so the
-  # bare expansion of an unset var is a hard error (the macOS CI job caught
-  # this: every public install crashes because end users never set the
-  # override). The `:-` default keeps the test safe when the var is unset.
+  # The installer runs under `set -u`, so a bare expansion of an unset var is a
+  # hard error. Both plugin vars are therefore guarded with `${VAR:-}`:
+  #   - MANTA_CLAUDE_AUTH_PLUGIN — the dev/CI override; unset for every end
+  #     user. The macOS CI job caught this once (BET-319): every public
+  #     install crashed because end users never set the override.
+  #   - OPENCODE_CLAUDE_AUTH_PLUGIN — the LOG-ONLY default name, emitted by the
+  #     `print-config` eval above (line ~659). It is pure cosmetic output for
+  #     the seeding message here; it must never be able to abort the install,
+  #     so the (should-be-unreachable-in-practice) empty default is fine.
   if [ -f "$OPENCODE_CONFIG" ]; then
     if [ -n "${MANTA_CLAUDE_AUTH_PLUGIN:-}" ]; then
       log "Seeding Claude auth plugin (override: ${MANTA_CLAUDE_AUTH_PLUGIN}) — merging into existing ${OPENCODE_CONFIG}…"
     else
-      log "Seeding Claude auth plugin ($OPENCODE_CLAUDE_AUTH_PLUGIN) — merging into existing ${OPENCODE_CONFIG}…"
+      log "Seeding Claude auth plugin (${OPENCODE_CLAUDE_AUTH_PLUGIN:-}) — merging into existing ${OPENCODE_CONFIG}…"
     fi
     existing="$(cat "$OPENCODE_CONFIG" 2>/dev/null || true)"
   else
     if [ -n "${MANTA_CLAUDE_AUTH_PLUGIN:-}" ]; then
       log "Seeding Claude auth plugin (override: ${MANTA_CLAUDE_AUTH_PLUGIN}) — no existing ${OPENCODE_CONFIG}, creating…"
     else
-      log "Seeding Claude auth plugin ($OPENCODE_CLAUDE_AUTH_PLUGIN) — no existing ${OPENCODE_CONFIG}, creating…"
+      log "Seeding Claude auth plugin (${OPENCODE_CLAUDE_AUTH_PLUGIN:-}) — no existing ${OPENCODE_CONFIG}, creating…"
     fi
     existing=""
   fi

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1429,6 +1429,32 @@ test("install.sh guards every MANTA_CLAUDE_AUTH_PLUGIN use against set -u (BET-3
   );
 });
 
+test("install.sh guards every OPENCODE_CLAUDE_AUTH_PLUGIN use against set -u (BET-446 regression)", () => {
+  // BET-319 guarded MANTA_CLAUDE_AUTH_PLUGIN (the override) but missed the
+  // parallel LOG-ONLY var OPENCODE_CLAUDE_AUTH_PLUGIN, which install.sh
+  // references at the two "Seeding Claude auth plugin (...)" messages inside
+  // the then/else branches for the `-n "${MANTA_CLAUDE_AUTH_PLUGIN:-}"`
+  // checks. That var is normally set by the `print-config` eval earlier in
+  // main(), but the installer runs under `set -u`, and a bare expansion of an
+  // unset var is a hard abort mid-install — the same class of failure
+  // BET-319 fixed for the override. This static guard pins the fix: every
+  // non-comment reference must use the `${VAR:-}` default-expansion form.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  const lines = src.split("\n");
+  const offenders = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*#/.test(line)) continue; // skip comment lines
+    const bare = /\$OPENCODE_CLAUDE_AUTH_PLUGIN(?!\{)/.test(line);
+    if (bare) offenders.push(`line ${i + 1}: ${line.trim()}`);
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `install.sh references OPENCODE_CLAUDE_AUTH_PLUGIN without the \${VAR:-} set -u guard:\n${offenders.join("\n")}`,
+  );
+});
+
 test("install.sh brace-delimits every $VAR adjacent to the … ellipsis (BET-319 bash 3.2 regression)", () => {
   // macOS ships bash 3.2, which under a UTF-8 locale absorbs the multibyte
   // `…` (U+2026) bytes into the variable-name lookup when `$VAR` is directly
@@ -5429,4 +5455,96 @@ test("missing Caddyfile under pipefail yields empty stdin and a created block, n
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// ----------------------------------------------------------------------------
+// BET-446 — `$OPENCODE_CLAUDE_AUTH_PLUGIN` must be `set -u` safe in the seeding
+// block.
+// ----------------------------------------------------------------------------
+//
+// install.sh runs under `set -euo pipefail`. BET-319 guarded the
+// MANTA_CLAUDE_AUTH_PLUGIN override but missed the parallel LOG-ONLY var
+// OPENCODE_CLAUDE_AUTH_PLUGIN, referenced in the two "Seeding Claude auth
+// plugin (...)" messages that are reached exactly when NO override is set —
+// i.e. the default install path. A bare `$OPENCODE_CLAUDE_AUTH_PLUGIN` there
+// would abort the whole install the instant the var is unset.
+//
+// These tests run the REAL extracted seeding block out of the REAL install.sh
+// under the real `set -eu` semantics against a fake box, rather than
+// replicating the branch logic in a test copy, so a regression in the shipped
+// source is what goes red.
+
+// Extract the "B. opencode config seeding" block from install.sh (inline in
+// main(), so slice it out of the source between its comment marker and the
+// `ok "opencode.jsonc seeded."` line). Returns the literal shell source — the
+// `${...}` / `$VAR` tokens inside are intended for the SHELL, so must never be
+// JS-interpolated by the caller.
+function extractSeedClaudeAuthBlock() {
+  const lines = readFileSync(INSTALL_SH, "utf-8").split("\n");
+  const start = lines.findIndex((l) => l.includes("# --- B. opencode config seeding"));
+  const end = lines.findIndex((l) => /ok "opencode\.jsonc seeded\."/.test(l));
+  assert.ok(start !== -1, "must find the '# --- B. opencode config seeding' comment in install.sh");
+  assert.ok(end > start, "must find the \\`ok \"opencode.jsonc seeded.\"\\` line after the block start");
+  return lines.slice(start, end + 1).join("\n");
+}
+
+// Run the real seeding block under `set -euo pipefail` with a fake $HOME and
+// the real merge lib. `pluginVar`:
+//   - undefined → the var is absent from the env (the BET-446 failure mode)
+//   - a string  → the var is set (regression: must still seed normally)
+// Returns { code, out, config } where `config` is the merged opencode.jsonc
+// content under the fake home (for the set case) or null (for the unset case,
+// where the else branch still writes a fresh file).
+function runSeedClaudeAuthBlock(pluginVar) {
+  const block = extractSeedClaudeAuthBlock();
+  const fakeHome = mkdtempSync(join(tmpdir(), "manta-seed-home-"));
+  const script = join(tmpdir(), `manta-seed-${process.pid}.sh`);
+  const body =
+    "#!/usr/bin/env bash\n" +
+    "set -euo pipefail\n" + // exactly the real installer's flag set
+    "export MANTA_INSTALL_TEST_MODE=1\n" +
+    "set +e\n" + // source install.sh (test-mode guard returns cleanly under set +e)
+    "source '" + INSTALL_SH + "'\n" +
+    "set -euo pipefail\n" + // re-assert the real flags after sourcing
+    "NODE=node\n" +
+    "LIB='" + join(__dirname, "install-lib.mjs") + "'\n" +
+    block + "\n" +
+    'echo "SEED_COMPLETE"\n'; // only reached if the block did not abort under set -u
+  writeFileSync(script, body, { mode: 0o755 });
+  const env = { ...process.env, HOME: fakeHome };
+  if (pluginVar === undefined) {
+    delete env.OPENCODE_CLAUDE_AUTH_PLUGIN;
+  } else {
+    env.OPENCODE_CLAUDE_AUTH_PLUGIN = pluginVar;
+  }
+  try {
+    const res = spawnSync("bash", [script], { env, encoding: "utf8" });
+    const out = (res.stdout ?? "") + (res.stderr ?? "");
+    let config = null;
+    const cfgPath = join(fakeHome, ".config", "opencode", "opencode.jsonc");
+    try {
+      config = readFileSync(cfgPath, "utf8");
+    } catch {
+      /* no config written (shouldn't happen — the else branch writes one) */
+    }
+    return { code: res.status, out, config };
+  } finally {
+    rmSync(script, { force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+}
+
+test("BET-446: seeding block does NOT abort under set -u when OPENCODE_CLAUDE_AUTH_PLUGIN is unset", () => {
+  const { code, out } = runSeedClaudeAuthBlock(undefined);
+  assert.equal(code, 0, `seeding block must complete when the var is unset:\n${out}`);
+  assert.match(out, /SEED_COMPLETE/, `seeding block must reach completion:\n${out}`);
+  assert.doesNotMatch(out, /unbound variable/, `no bare-expansion abort under set -u:\n${out}`);
+});
+
+test("BET-446: seeding still merges the plugin when OPENCODE_CLAUDE_AUTH_PLUGIN is set", () => {
+  const { code, out, config } = runSeedClaudeAuthBlock("opencode-claude-auth@latest");
+  assert.equal(code, 0, `seeding block must complete when the var is set:\n${out}`);
+  assert.match(out, /opencode\.jsonc seeded\./, `must print the success line:\n${out}`);
+  assert.ok(config !== null, "the merged opencode.jsonc must be written");
+  assert.match(config, /opencode-claude-auth@latest/, "the plugin must still be seeded into the config");
 });


### PR DESCRIPTION
## BET-446 — installer: hard-fail risk under `set -u` for `$OPENCODE_CLAUDE_AUTH_PLUGIN`

**Base: origin/main @ `47f8784`** (rebased onto latest main; includes BET-441's Caddyfile upsert)

### Problem
`scripts/install.sh` runs under `set -euo pipefail`. BET-319 guarded `MANTA_CLAUDE_AUTH_PLUGIN` (the dev/CI override) but missed the parallel LOG-ONLY var `OPENCODE_CLAUDE_AUTH_PLUGIN`, referenced bare in the two "Seeding Claude auth plugin (...)" `log` messages (the branches reached exactly when NO override is set — i.e. the default install path). A bare `$OPENCODE_CLAUDE_AUTH_PLUGIN` aborts the whole install the instant the var is unset (bash `unbound variable`).

### Fix
Trace: `OPENCODE_CLAUDE_AUTH_PLUGIN` is emitted by the `print-config` eval in `main()` (line ~659), so it is set in the happy path — but it is **log-only** (the actual merge reads `MANTA_CLAUDE_AUTH_PLUGIN` or the JS default) and not guaranteed under a partial/failed config eval. Both references are therefore guarded with the `${VAR:-}` default-expansion form, matching BET-319's treatment of the sibling var. Behavior is unchanged when the var IS present.

### Tests (scripts/install.test.mjs)
- Static guard (BET-446): every non-comment reference to `OPENCODE_CLAUDE_AUTH_PLUGIN` must use `${VAR:-}`.
- Behavioral — real extracted seeding block run under real `set -euo pipefail` against a fake box:
  - var **unset** → install completes past the previously-fatal line (exit 0, no `unbound variable`). Proven red against the pre-fix source.
  - var **set** → still seeds normally (success line + plugin present in the merged opencode.jsonc).

**Verification results:**
- PR branch (`multica/BET-446-installer/plugin-var-set-u-guard` @ `dbe2add`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, **1274 pass / 0 fail / 0 skip**. Failures: none. log sha256: `6a83225e9c59dbd106b62597cf0ef76b6fa39dc89c6b3ac76026b4a979021553`
- Base (`main` @ `47f8784`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, **1271 pass / 0 fail / 0 skip**. Failures: none. log sha256: `d29100bcf832a0e291ee2858b6536080095d4837d7431049de11e13dcb702adc`
- **Conclusion:** 0 new failures; the PR adds the 3 BET-446 tests (1271 → 1274). No cross-cutting follow-ups.