### PR TITLE
BET-465: build mobile/www in e2e-smoke so the visual project passes

### DIFF
--- a/scripts/check-e2e-smoke.sh
+++ b/scripts/check-e2e-smoke.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # E2E smoke test gate for the MANTA Electron build.
 #
-# Builds the Electron bundles, then runs the Playwright e2e suite against the
-# built app. This is a HARD gate — exits non-zero on any failure.
+# Builds the bundles then runs the full Playwright suite against them. The
+# suite has two projects: `electron` (launches the built app via `out/`) and
+# `visual` (serves the built renderer via `mobile/www`, verified fresh by
+# scripts/visual/harness.mjs -> assertRendererFresh). So both bundles must be
+# built here before `npx playwright test`. This is a HARD gate — exits non-zero
+# on any failure.
 #
 # Designed to run on self-hosted CI runners. Requires:
 #   - Node.js 20+
@@ -19,6 +23,9 @@ cd "$ROOT"
 
 echo "==> Building Electron bundles..."
 npm run build
+
+echo "==> Building mobile renderer (the visual project needs mobile/www)..."
+npm run build:mobile
 
 echo
 echo "==> Running Playwright e2e smoke tests..."


### PR DESCRIPTION
## Summary

Fixes BET-465: `e2e-smoke` was red on every `main` run because its Playwright suite runs **both** projects (`electron` and `visual`) but `scripts/check-e2e-smoke.sh` only built the Electron bundles (`npm run build` → `out/`). The `visual` project serves `mobile/www` and its harness's `assertRendererFresh()` hard-fails when that bundle is missing, so the visual project threw `no built renderer at .../mobile/www` and the job exited 1 every time.

The fix adds `npm run build:mobile` before `npx playwright test`, so the smoke job provides every bundle its Playwright suite needs. **The visual-pixel gate is untouched and still runs** — this only fixes the wiring (the renderer is now built for the visual project in this job).

## Design choice

Took the "run `npm run build:mobile` in the script" direction from the issue (the first suggested option). It keeps the smoke suite identical (both configured projects still run) and repairs the missing prerequisite rather than changing which tests the job exercises. `scripts/check-e2e-smoke.sh` now mirrors the two bundles: `npm run build` → `out/` for `electron`, `npm run build:mobile` → `mobile/www` for `visual`. Header comment updated to document the two bundles.

The alternative (`--project=electron`) would have worked too — the visual gate is independently exercised by the `typecheck-test` job's `Visual gate` step — but it narrows the smoke run's coverage, which the issue's constraint ("the intent is that [the visual gate] runs") leans against.

## Verification

Ran the full gate exactly as CI does:

```
xvfb-run -a bash scripts/check-e2e-smoke.sh
```

The previously-red visual project now builds `mobile/www` and **7/7 tests pass** (4 electron bundle checks + 3 visual structure/pixel baseline checks).

**Files changed:** 1 file. `scripts/check-e2e-smoke.sh` (+9 / −2). `git diff origin/main...HEAD` confirms nothing else touched — no phantom renames/deletes.

**Verification results:**
- PR branch (`multica/BET-465-e2e-smoke-visual-build` @ `f074e99`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1274 pass / 0 fail / 0 skip. Failures: none. log sha256: `7224477ca18183d80b5964a62b78a342647e900bd374c6436e8af4e3751b1cd0`
  - e2e-smoke gate (`xvfb-run -a bash scripts/check-e2e-smoke.sh`): 7/7 pass (electron + visual)
- Base (`main` @ `6b8591d`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624` (identical to PR — script-only change, no code impact)
  - test: exit 0. Failures: none. log sha256: `25083010ba47a9ac520d93c5881837f8a192366ddece4f287ce3e70ee0fc38f3`
- **Conclusion:** 0 new failures. The script-only change cannot alter typecheck/test (identical typecheck sha256), and the e2e-smoke gate — previously red — is now green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log` for reviewer spot-check.

**Base: origin/main @ `6b8591d`**