### PR TITLE
BET-467: Restore AI-CLI launcher entry point via session menu (stacked on BET-459)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1006,6 +1006,7 @@ export function App() {
                       winName={ownerWinName}
                       mode={mode}
                       onModeChange={setMode}
+                      availableLaunchers={availableLaunchers}
                     />
                   </div>
                 );

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -16,6 +16,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Clock, X } from "lucide-react";
 import type {
+  AvailableLauncher,
   DelegateApproval,
   DelegateApprovalTool,
   DelegateJob,
@@ -134,6 +135,10 @@ type Props = {
   winName?: string | null;
   mode?: SessionMode;
   onModeChange?: (m: SessionMode) => void;
+  // BET-467: the box's AI-CLI launchers for the session; forwarded to the
+  // header's session menu so a launcher mode is reachable from the running UI
+  // (the header glyph only toggles Chat ↔ Terminal).
+  availableLaunchers?: AvailableLauncher[];
 };
 
 export function ChatPanel({
@@ -146,6 +151,7 @@ export function ChatPanel({
   winName = null,
   mode = "chat",
   onModeChange,
+  availableLaunchers = [],
 }: Props) {
   const chatAutoAllow = useStore((s) => s.chatAutoAllow);
   const setChatAutoAllow = useStore((s) => s.setChatAutoAllow);
@@ -1957,6 +1963,7 @@ export function ChatPanel({
         breadcrumb={projectName ? { project: projectName, window: winName } : null}
         mode={mode}
         onModeChange={onModeChange}
+        availableLaunchers={availableLaunchers}
       />
 
       <Transcript

--- a/src/renderer/SessionHeader.menu.test.tsx
+++ b/src/renderer/SessionHeader.menu.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// BET-467: the AI-CLI launcher entry point (removed by BET-459's header
+// collapse) lives in the session ⋯ menu. These mount the real <ChatPanel> via
+// the render harness, open the session menu, and assert that the launcher
+// entries (a) render and (b) switching one calls onModeChange("tui:<id>").
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { ChatPanel } from "./ChatPanel";
+import {
+  installMockApi,
+  resetStore,
+  mount,
+  type Harness,
+} from "./testHarness";
+import type { AvailableLauncher } from "../shared/types";
+
+const PROPS = {
+  sessionId: "ses_test",
+  tmuxSession: "proj",
+  windowIndex: 1,
+  cwd: "/home/dev/projects/x",
+  isActive: true,
+  projectName: "proj",
+  winName: "chat-1",
+  mode: "chat" as const,
+  availableLaunchers: [
+    { id: "claude", label: "Claude", flags: [] },
+    { id: "opencode", label: "Opencode", flags: [] },
+  ] as AvailableLauncher[],
+};
+
+function openMenu(h: Harness) {
+  const trigger = h.container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Session actions"]',
+  );
+  expect(trigger).not.toBeNull();
+  act(() => trigger!.click());
+  return trigger!;
+}
+
+// The launcher button whose text begins with `label` (the icon renders no
+// text, the label text starts the button's text content).
+function launcherButton(h: Harness, label: string): HTMLButtonElement {
+  const btn = [...h.container.querySelectorAll<HTMLButtonElement>("button")].find(
+    (b) => b.textContent?.trim()?.startsWith(label),
+  );
+  expect(btn, `expected a "${label}" menu button`).not.toBeUndefined();
+  return btn!;
+}
+
+describe("SessionHeader session menu launcher entries (BET-467)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    installMockApi();
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("shows Chat / Terminal / each launcher when a session is active", async () => {
+    h = mount(<ChatPanel {...PROPS} onModeChange={() => {}} />);
+    await h!.flush();
+    openMenu(h!);
+
+    const text = h!.text();
+    expect(text).toContain("Mode");
+    expect(text).toContain("Chat");
+    expect(text).toContain("Terminal");
+    expect(text).toContain("AI-CLI");
+    expect(text).toContain("Claude");
+    expect(text).toContain("Opencode");
+  });
+
+  it("switching a launcher calls onModeChange with the tui:<id> mode", async () => {
+    let changed: unknown = null;
+    h = mount(
+      <ChatPanel
+        {...PROPS}
+        onModeChange={(m) => {
+          changed = m;
+        }}
+      />,
+    );
+    await h!.flush();
+    openMenu(h!);
+
+    act(() => launcherButton(h!, "Claude").click());
+    expect(changed).toBe("tui:claude");
+  });
+
+  it("marks the currently active mode in the menu", async () => {
+    h = mount(<ChatPanel {...PROPS} mode="tui:claude" onModeChange={() => {}} />);
+    await h!.flush();
+    openMenu(h!);
+
+    const active = launcherButton(h!, "Claude");
+    expect(active.textContent).toContain("✓");
+  });
+
+  it("omits the mode section when the caller owns mode elsewhere (mobile)", async () => {
+    h = mount(<ChatPanel {...PROPS} />);
+    await h!.flush();
+    openMenu(h!);
+
+    // No onModeChange → no Mode group, no launcher entries; the session
+    // actions still render.
+    expect(h!.text()).not.toContain("AI-CLI");
+    expect(h!.text()).not.toContain("Claude");
+    expect(h!.text()).toContain("Fork session");
+  });
+});

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -11,7 +11,7 @@
 // props by ChatPanel, which owns the session lifecycle.
 
 import { useRef, useState, type CSSProperties } from "react";
-import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal } from "lucide-react";
+import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare } from "lucide-react";
 import {
   ctxStageColor,
   cssVar,
@@ -20,6 +20,7 @@ import {
 } from "./chatUtils";
 import { useClickAway } from "./hooks/useClickAway";
 import type { SessionMode } from "./chatShared";
+import type { AvailableLauncher } from "../shared/types";
 
 // Cache-segment colors — same palette as ContextBar so the header pill and
 // the (retired) footer bar stay in sync visually.
@@ -57,6 +58,7 @@ export function SessionHeader({
   breadcrumb,
   mode,
   onModeChange,
+  availableLaunchers,
 }: {
   branch: string | null;
   ctxBreakdown: ContextBreakdown;
@@ -82,6 +84,11 @@ export function SessionHeader({
   breadcrumb: { project: string; window: string | null } | null;
   mode?: SessionMode;
   onModeChange?: (m: SessionMode) => void;
+  // BET-467: the box's AI-CLI launchers surfaced as switchable modes in the
+  // session menu (the header glyph only toggles Chat ↔ Terminal). Empty /
+  // omitted → no launcher entries (desktop callers supply it; mobile owns
+  // mode via its own <select> and passes neither this nor onModeChange).
+  availableLaunchers?: AvailableLauncher[];
 }) {
   const { pct, segments, freshInput, cacheRead, cacheWrite, totalInput } =
     ctxBreakdown;
@@ -170,13 +177,16 @@ export function SessionHeader({
           </button>
         )}
 
-        {/* Session menu — Fork / Compact / Clear / Delete. No badge on the
-            button (per BET-415 Do-NOT #2). Hidden when there is no owning
-            tmux window, and when the view is read-only (BET-418 §D: a
-            background-job session — Stop in ReadOnlyJobBar is the only live
-            action). */}
+        {/* Session menu — mode (Chat / Terminal / AI-CLI launchers) + Fork /
+            Compact / Clear / Delete. No badge on the button (per BET-415
+            Do-NOT #2). Hidden when there is no owning tmux window, and when
+            the view is read-only (BET-418 §D: a background-job session — Stop
+            in ReadOnlyJobBar is the only live action). */}
         {hasSession && !readOnly && (
           <SessionMenu
+            mode={mode}
+            onModeChange={onModeChange}
+            availableLaunchers={availableLaunchers}
             onFork={onFork}
             onCompact={onCompact}
             onClear={onClear}
@@ -402,13 +412,25 @@ function LegendRow({
 }
 
 // ===== Session menu (MoreHorizontal) =====
+//
+// Mode switching (Chat / Terminal / one entry per AI-CLI launcher) + the
+// session destruction/compact actions. The mode section is the menu's
+// functional replacement for the header `<select>` BET-459 removed (BET-467):
+// the header glyph only toggles Chat ↔ Terminal, so this is the entry point
+// for entering a launcher (`tui:<id>`) mode from the running UI.
 
 function SessionMenu({
+  mode,
+  onModeChange,
+  availableLaunchers,
   onFork,
   onCompact,
   onClear,
   onDelete,
 }: {
+  mode?: SessionMode;
+  onModeChange?: (m: SessionMode) => void;
+  availableLaunchers?: AvailableLauncher[];
   onFork: () => void;
   onCompact: () => void;
   onClear: () => void;
@@ -440,6 +462,42 @@ function SessionMenu({
     </button>
   );
 
+  // The menu closes after any action; a mode change just re-points mode
+  // (a no-op when already in that mode, so re-clicking the current row is a
+  // harmless close).
+  const switchMode = (m: SessionMode) => {
+    if (onModeChange) onModeChange(m);
+  };
+
+  const isActive = (m: SessionMode) => mode === m;
+
+  const modeItem = (
+    icon: React.ReactNode,
+    label: string,
+    m: SessionMode,
+  ) => {
+    const active = isActive(m);
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(false);
+          switchMode(m);
+        }}
+        className={
+          "w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-bg-soft text-meta " +
+          (active ? "text-accent" : "text-text")
+        }
+      >
+        {icon}
+        <span className="flex-1">{label}</span>
+        {active && <span className="text-text-faint" aria-hidden="true">✓</span>}
+      </button>
+    );
+  };
+
+  const hasMode = !!onModeChange;
+
   return (
     <div ref={rootRef} className="manta-session-menu relative shrink-0">
       <button
@@ -458,6 +516,31 @@ function SessionMenu({
           role="menu"
           className="manta-session-menu-dropdown absolute right-0 top-full mt-1 z-30 min-w-[180px] rounded-lg border border-border bg-bg-elev shadow-md py-1"
         >
+          {hasMode && (
+            <>
+              <div className="px-3 pt-1 pb-0.5 text-label text-text-faint select-none" role="presentation">
+                Mode
+              </div>
+              {modeItem(<MessageSquare size={14} aria-hidden="true" />, "Chat", "chat")}
+              {modeItem(<Terminal size={14} aria-hidden="true" />, "Terminal", "terminal")}
+              {availableLaunchers && availableLaunchers.length > 0 && (
+                <>
+                  <div className="px-3 pt-2 pb-0.5 text-label text-text-faint select-none" role="presentation">
+                    AI-CLI
+                  </div>
+                  {availableLaunchers.map((l) =>
+                    modeItem(
+                      <Bot size={14} aria-hidden="true" />,
+                      l.label,
+                      `tui:${l.id}` as SessionMode,
+                    ),
+                  )}
+                </>
+              )}
+              <div className="my-1 border-t border-border" />
+            </>
+          )}
+
           {item(
             <GitFork size={14} aria-hidden="true" />,
             "Fork session",


### PR DESCRIPTION
## BET-467 — Restore an entry point for AI-CLI launcher sessions (removed by BET-459 header collapse)

**Stacked on `multica/BET-459-collapse-session-header` (#395)** — this PR is the delta only. Base: `origin/main @ 36b0718`; parent branch base `origin/multica/BET-459-collapse-session-header @ 2c52c66`.

### What

BET-459 collapsed the header's mode `<select>` (Chat / Terminal / one option per AI-CLI launcher) to a single terminal glyph that only toggles Chat ↔ Terminal — deleting the only in-app entry point for entering a `tui:<launcherId>` mode.

This restores it in the ⋯ **Session actions** menu (`SessionHeader.tsx`), per the PM-confirmed design decision:

- A new **Mode** group (Chat / Terminal), current mode check-marked.
- A new **AI-CLI** group, one entry per available launcher — selecting one calls `onModeChange("tui:<id>")`.

The entries reuse the **existing** launcher-mode resolution — `onModeChange` flows through App's `setMode`, which `writeSavedMode`s + mounts the Terminal for `tui:<id>` via the `visitedModes` loop (the same `mode === "tui:${m.modeId}"` path the old `<select>` reached). No new mode path invented.

### Plumbing

`availableLaunchers` is threaded `App.tsx → ChatPanel → SessionHeader` (source of truth stays `window.api.launchersList` in `App.tsx`). `ChatPanel`/`SessionHeader` accept it as an optional prop; mobile is unaffected — it owns mode via its own header `<select>` and passes neither `onModeChange` nor `availableLaunchers`, so the menu's mode section is omitted there (`hasMode = !!onModeChange`).

### Files changed (3 + test)

- `src/renderer/App.tsx` — pass `availableLaunchers` to ChatPanel (1-line).
- `src/renderer/ChatPanel.tsx` — accept + forward `availableLaunchers` to SessionHeader.
- `src/renderer/SessionHeader.tsx` — add the Mode + AI-CLI groups to the session menu.
- `src/renderer/SessionHeader.menu.test.tsx` — new harness tests (4): entries render, switching a launcher calls `onModeChange("tui:<id>")`, current mode highlighted, mode section omitted without `onModeChange`.

### Verification results

**Files changed:** `4` files.

| Suite | Result |
|---|---|
| PR branch typecheck (`@ 0e74e3a`) | exit 0, no errors. log sha256 `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624` |
| PR branch test (`@ 0e74e3a`) | exit 0, `1274 pass / 0 fail / 0 skip`. log sha256 `74c3ced2a5163a702fe135c7843c563a19a6d67213cd4254acfca6cc0965d0aa` |

(PR branch includes the stacked BET-459 commits; the 4 new BET-467 tests are in `SessionHeader.menu.test.tsx`.)

**E2E smoke (Electron under Xvfb):** app launched via Playwright's Electron launcher, renderer mounted (onboarded shell), **0 console errors / 0 uncaught page errors**. Note: BootStrapped to onboarding (no paired box in this env) so the session menu itself is exercised by the 4 harness tests rather than the live shell.

**Conclusion:** no failures; 4 new tests added for BET-467.

No above-bar follow-ups surfaced for filing; the restoration reuses the existing launcher-mode path (no drift trap created). Mobile keeps its own `<select>` entry point and is out of BET-459's desktop scope.