### PR TITLE
ci: re-dispatch dropped hand-offs on the merge event, not on a throttled cron

### DIFF
--- a/.github/workflows/multica-close-on-merge.yml
+++ b/.github/workflows/multica-close-on-merge.yml
@@ -51,7 +51,8 @@ jobs:
   # observed live when BET-297 sat blocked on BET-294/BET-295 for an hour after
   # both had merged, stalling the whole website epic until a human noticed.
   #
-  # Runs after `close` so the just-merged issue is already `done` and counts.
+  # Runs after `close` so the just-merged issue is already `done` and counts,
+  # then re-dispatches any dropped hand-off it has made eligible.
   # ---------------------------------------------------------------------------
   unblock:
     name: Unblock issues whose blockers are done
@@ -75,4 +76,17 @@ jobs:
           MULTICA_TOKEN: ${{ secrets.MULTICA_TOKEN }}
         run: node scripts/multica-unblock.mjs --verbose
         # Housekeeping must never fail a merge pipeline.
+        continue-on-error: true
+
+      # Unblocking only changes a STATUS, and a status change dispatches
+      # nobody — the issue sits `todo`, correctly labelled and untouched,
+      # until a sweep re-fires its assignment. The scheduled sweep in
+      # multica-unstick.yml is the safety net, but GitHub throttles cron
+      # hard (observed 58-202 min between ticks), so the merge event is the
+      # only timely trigger. Runs AFTER the unblock step on purpose: the
+      # issue must already be `todo` for the unstick screen to pick it up.
+      - name: Re-dispatch dropped hand-offs
+        env:
+          MULTICA_TOKEN: ${{ secrets.MULTICA_TOKEN }}
+        run: node scripts/multica-unstick.mjs --verbose
         continue-on-error: true

--- a/.github/workflows/multica-unstick.yml
+++ b/.github/workflows/multica-unstick.yml
@@ -19,7 +19,11 @@ name: Multica Unstick
 #
 # WHY SCHEDULED: the stall lives entirely on the Multica platform. No GitHub
 # event fires for it, so a periodic scan is the only way a workflow can see it.
-# Every 15 minutes; most runs are a no-op costing one API call.
+# Scheduled every 15 minutes, but GitHub throttles cron heavily — ticks 58-202
+# minutes apart were observed on 2026-08-01. Treat this as the safety net, not
+# the mechanism: the timely trigger is the merge-event step in
+# multica-close-on-merge.yml, which runs this same script the moment an unblock
+# makes an issue eligible.
 #
 # Failure policy: housekeeping must never break a pipeline. The script logs and
 # exits 0 on per-issue failures; the job itself is continue-on-error.


### PR DESCRIPTION
**Files changed:** 2
```
 .github/workflows/multica-close-on-merge.yml | 16 +++++++++++++++-
 .github/workflows/multica-unstick.yml        |  6 +++++-
 2 files changed, 20 insertions(+), 2 deletions(-)
```

Adds `scripts/multica-unstick.mjs` as a **second step in the existing `unblock` job** of `multica-close-on-merge.yml`, running immediately after the `Reconcile blocked issues` (unblock) step. Order is load-bearing: unblock flips `blocked → todo`, unstick re-fires the pending assignment of a `todo` — sequential steps in one job guarantee the order without a `needs`. Both steps keep `continue-on-error: true`.

Also corrects the stale claim in `multica-unstick.yml`'s header ("Every 15 minutes; most runs are a no-op costing one API call."), replacing it with the throttling truth + the new merge-event arrangement. No script, test, or source file touched.

**Deliberately omitted (per issue):** no new workflow/job, no cron change, no changes to `multica-unstick.mjs`/`multica-unblock.mjs`, **no concurrency group** (per-issue 2h backoff + action cap in the script is the protection; a workflow-level `concurrency:` would wrongly serialise the `close` job against unrelated sweeps).

**Base: origin/main @ `c1d1a9b`**

**Verification results:**
- PR branch (`multica/BET-487-redispatch-on-merge`): typecheck exit 0 (no errors — pure YAML/comment change, no TS touched); test exit 0, 1274 pass / 0 fail / 0 skip.
- YAML validity: both files parse; `unblock` job's `if:` condition and both cron expressions unchanged.
- **Conclusion:** 0 failures; neither suite is affected by this diff (workflow files only).
