### PR TITLE
fix(renderer): enumerate demo-fixture coverage gaps + de-dup session stubs (BET-471)

### DIFF
--- a/docs/visual-verification.md
+++ b/docs/visual-verification.md
@@ -151,10 +151,17 @@ user gestures — a click a person could make — not for reaching into internal
    merged with `--delete-branch`. The picture is the evidence for the *record*,
    which outlives the branch by definition — a review trail that 404s six weeks
    later cannot be re-read when someone asks why a baseline looks like that.
-   Drag the PNG into the GitHub comment box (it rewrites to a
-   `github.com/user-attachments/…` URL, hosted independently of any ref), or
-   link a permalink pinned to the merge commit SHA. Either survives; a branch
-   path does not.
+    Drag the PNG into the GitHub comment box (it rewrites to a
+    `github.com/user-attachments/…` URL, hosted independently of any ref), or
+    link a permalink pinned to the merge commit SHA. Either survives; a branch
+    path does not.
+6. **If the control you are changing renders data-driven content — a list, a
+   menu, a set of options — state in the PR which fixture state it was
+   specified against, and whether that state is representative.** A control
+   that renders a variable number of items looks fixed-size when the fixture
+   supplies zero or one, and the mockup, the structure snapshot and the pixel
+   baseline will all agree with the fixture. This is how the AI-CLI launcher
+   options were specified away in BET-459 and had to be restored in BET-467.
 
 Steps 4 and 5 apply **whenever a baseline moves**, not only when the issue is a
 design issue. A refactor that shifts a pixel is exactly the case where nobody

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -79,16 +79,15 @@ const onStatusEvent = (
   return () => {};
 };
 
-// `opencodeMessages` is the chat-panel mount-time transcript fetch. We
-// return the demo transcript for the active session; empty arrays for
-// anything else (a future consumer would only ever ask for the active
-// session at first render).
-const opencodeMessages = (sessionId: string): Promise<unknown[]> => {
-  if (sessionId === demoState.activeSessionId) {
-    return Promise.resolve(demoState.messages);
-  }
-  return Promise.resolve([]);
-};
+// Session-scoped fixture read. The active session carries content; every
+// other session is legitimately empty — this is NOT a coverage gap, it is
+// the product's real behaviour. An absent id means "the active one": the
+// pending-ask channels may omit it, and `opencodeMessages`' signature makes
+// it required, so unifying the two shapes cannot change behaviour.
+const forActiveSession = <T>(sessionId: string | undefined, value: T[]): Promise<T[]> =>
+  Promise.resolve(!sessionId || sessionId === demoState.activeSessionId ? value : []);
+
+const opencodeMessages = (sessionId: string) => forActiveSession(sessionId, demoState.messages);
 
 // The renderer uses `opencodeMessagesCached` as a fast first paint; a null
 // cache miss means "fall through to opencodeMessages". Match that exact
@@ -96,22 +95,8 @@ const opencodeMessages = (sessionId: string): Promise<unknown[]> => {
 const opencodeMessagesCached = (_sessionId: string): Promise<unknown[] | null> =>
   Promise.resolve(null);
 
-// Pending question + permission lists are session-scoped (see
-// opencodePermissions/opencodeQuestions in shared/api.ts). The active
-// session has both pending in the fixture; other sessions have none.
-const opencodePermissions = (sessionId?: string): Promise<unknown[]> => {
-  if (!sessionId || sessionId === demoState.activeSessionId) {
-    return Promise.resolve([demoState.permission]);
-  }
-  return Promise.resolve([]);
-};
-
-const opencodeQuestions = (sessionId?: string): Promise<unknown[]> => {
-  if (!sessionId || sessionId === demoState.activeSessionId) {
-    return Promise.resolve([demoState.question]);
-  }
-  return Promise.resolve([]);
-};
+const opencodePermissions = (sessionId?: string) => forActiveSession(sessionId, [demoState.permission]);
+const opencodeQuestions = (sessionId?: string) => forActiveSession(sessionId, [demoState.question]);
 
 // Footer branch chip — single string for the active window's cwd.
 const opencodeVcsBranch = (_directory?: string): Promise<string | null> =>
@@ -188,7 +173,7 @@ const claudeLoginCancel = (_sessionKey: string): Promise<{ ok: boolean }> => {
 // `demoApi` — the explicit methods exposed by name. Everything else falls
 // through the Proxy in the `unknown` handler.
 // ===========================================================================
-const explicitMethods = {
+export const explicitMethods = {
   configGet,
   tmuxList,
   onStatusEvent,

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -1,0 +1,147 @@
+// demoCoverage.test.ts — the demo transport's coverage-bound inventory
+// (BET-471).
+//
+// The demo transport implements a subset of the `Api` contract explicitly;
+// every other method is served by a Proxy fallback returning
+// `Promise.resolve(null)`. A capability the demo does not stub renders as
+// nothing in every mockup, structure snapshot and pixel baseline — the three
+// verification layers all agree with the fixture, so the gap is invisible to
+// the gate AND absent from the design spec the gate checks conformance to.
+// That already shipped a regression: BET-459 collapsed the session-header
+// mode `<select>` into a two-state toggle because the fixture only ever
+// exercised two options, and it had to be restored in BET-467. This test
+// makes the fallback-bound enumerable: it pins the exact set of unimplemented
+// `Api` keys so adding one is a deliberate, recorded act instead of a silent
+// gap, and when a capture does start exercising a capability the name must be
+// deleted from `DEMO_UNIMPLEMENTED`.
+//
+// `Api` is a TypeScript type and cannot be enumerated at runtime, but
+// `httpApi` is a plain object literal implementing the same contract, so its
+// keys are enumerable. The bound is therefore the set of `httpApi` keys the
+// demo transport does not implement.
+
+import { describe, it, expect } from "vitest";
+import { httpApi } from "./httpApi.js";
+import { explicitMethods } from "./demoApi.js";
+
+// Capabilities absent from every captured state, generated from this test's
+// own first failure against the post-BET-470 fixture shape — not hand-written.
+// Sorted for readable diffs. A change to this list means one of two opposite
+// things; the assertion message below distinguishes them:
+//   - a NEW key here → an `Api` method was added without a demo stub. Either
+//     add a stub, or keep the name here to record that no capture exercises it.
+//   - a key removed → someone added a demo stub (or deleted the Api method).
+//     Delete the name from this list.
+export const DEMO_UNIMPLEMENTED = [
+  "agentPullFile",
+  "authClaim",
+  "authPair",
+  "autoUpdateDownload",
+  "autoUpdateInstall",
+  "clipboardReadImage",
+  "clipboardWriteText",
+  "configUpdate",
+  "connectionRetryNow",
+  "delegateApprove",
+  "delegateDecline",
+  "delegateDelete",
+  "delegateList",
+  "delegatePendingApprovals",
+  "delegateStop",
+  "fsListDirs",
+  "getPathForFile",
+  "gitAddWorktree",
+  "gitListWorktrees",
+  "gitRemoveWorktree",
+  "onAgentFileReady",
+  "onAutoUpdateAvailable",
+  "onAutoUpdateDownloaded",
+  "onAutoUpdateError",
+  "onDelegateUpdated",
+  "onDesktopNotify",
+  "onPtyEvent",
+  "onScreenshotDetected",
+  "onServerUpdateAvailable",
+  "openExternal",
+  "opencodeAbort",
+  "opencodeAgents",
+  "opencodeClaudeCliStatus",
+  "opencodeClearSession",
+  "opencodeCommands",
+  "opencodeCompactSession",
+  "opencodeCreateEphemeralSession",
+  "opencodeDeleteSession",
+  "opencodeDeleteSessionRaw",
+  "opencodeDiscoverModels",
+  "opencodeFindFiles",
+  "opencodeForkSession",
+  "opencodeGenerateTitle",
+  "opencodeGetProviders",
+  "opencodeGetSubagents",
+  "opencodeMessage",
+  "opencodeMessagesReconcile",
+  "opencodePermissionReply",
+  "opencodePrompt",
+  "opencodeQuestionReject",
+  "opencodeQuestionReply",
+  "opencodeRestart",
+  "opencodeRunCommand",
+  "opencodeSetProviders",
+  "opencodeSetSubagents",
+  "opencodeSyncSubagents",
+  "peekRemoteFile",
+  "pluginsRegistry",
+  "projectMetaDelete",
+  "ptyKill",
+  "ptyResize",
+  "ptySpawn",
+  "ptyWrite",
+  "pushRegisterApns",
+  "revealInFolder",
+  "scheduleDelete",
+  "scheduleList",
+  "secretsDelete",
+  "secretsList",
+  "secretsSet",
+  "serverUpdateApply",
+  "tmuxConfigStatus",
+  "tmuxKillSession",
+  "tmuxKillWindow",
+  "tmuxNewSession",
+  "tmuxNewWindow",
+  "tmuxRenameSession",
+  "tmuxRenameWindow",
+  "tmuxRestoreConfig",
+  "tmuxSelectWindow",
+  "tmuxSetupConfig",
+  "uploadBuffer",
+  "uploadFiles",
+  "voiceClassifyCommand",
+  "voiceTranscribe",
+  "webhookDelete",
+  "webhookList",
+];
+
+describe("demo transport — coverage-bound inventory", () => {
+  it("documents exactly which opencode/Api capabilities the demo does not stub", () => {
+    const unimplemented = Object.keys(httpApi)
+      .filter((k) => !(k in explicitMethods))
+      .sort();
+
+    const message =
+      `The demo transport's Proxy fallback silently serves every Api method it ` +
+      `does not stub. This test keeps an honest inventory of those gaps.\n\n` +
+      `Actual unimplemented keys:\n  ${JSON.stringify(unimplemented)}\n\n` +
+      `How to reconcile (the two directions mean OPPOSITE things):\n` +
+      `  - a key is in "actual" but NOT in DEMO_UNIMPLEMENTED → someone added an ` +
+      `Api method with no demo stub. Either add a stub, or add the name to ` +
+      `DEMO_UNIMPLEMENTED to record that no capture exercises it.\n` +
+      `  - a key is in DEMO_UNIMPLEMENTED but NOT in "actual" → someone added a ` +
+      `demo stub (or deleted the Api method). Delete the name from ` +
+      `DEMO_UNIMPLEMENTED.`;
+
+    // `expect(actual, message)` — the custom message on failure (not a second
+    // arg to toEqual) is how vitest surfaces a matcher-specific message.
+    expect(unimplemented, message).toEqual(DEMO_UNIMPLEMENTED);
+  });
+});


### PR DESCRIPTION
## BET-471 — Make demo-fixture coverage gaps enumerable + de-dup session stubs

Fully-specified implementer cell. Three parts; two delete code.

**Files changed:** 3
- `src/renderer/api/demoApi.ts` — export `explicitMethods` (+0 semantic), de-duplicate the three session-scoped stubs into one `forActiveSession` helper (Part 2).
- `src/renderer/api/demoCoverage.test.ts` — new coverage-bound inventory test (Part 1).
- `docs/visual-verification.md` — one added numbered DoD item about data-driven controls (Part 3).

**Base: origin/main @ `03f6759`**

### Part 1 — the inventory test
- `export const explicitMethods` (1a). All other methods served by the Proxy fallback are now enumerated by `Object.keys(httpApi).filter(k => !(k in explicitMethods))` and pinned to the committed `DEMO_UNIMPLEMENTED`.
- **`DEMO_UNIMPLEMENTED` was generated from the test's own first failure** (empty list → pasted the actual array) against the post-BET-470 fixture shape. **Length: 87.**
- The assertion carries a dual-direction message (new key = added stub or Api method w/o stub; removed key = delete the name), as required — pasted in the issue, not just this PR.

### Failure-message demonstration (done-when 1)
Temporarily added a fake key `zzzFakeKey` to `DEMO_UNIMPLEMENTED` — the test fails with the custom message:
```
AssertionError: The demo transport's Proxy fallback silently serves every Api method it does not stub. This test keeps an honest inventory of those gaps.

Actual unimplemented keys:
  ["agentPullFile","authClaim",…]

How to reconcile (the two directions mean OPPOSITE things):
  - a key is in "actual" but NOT in DEMO_UNIMPLEMENTED → someone added an Api method with no demo stub. Either add a stub, or add the name to DEMO_UNIMPLEMENTED to record that no capture exercises it.
  - a key is in DEMO_UNIMPLEMENTED but NOT in "actual" → someone added a demo stub (or deleted the Api method). Delete the name from DEMO_UNIMPLEMENTED.: expected [ 'agentPullFile', 'authClaim', …(85) ] to deeply equal [ 'agentPullFile', 'authClaim', …(86) ]
- Expected
+ Received
@@ -79,11 +79,10 @@
   "tmuxSetupConfig",
   "uploadBuffer",
-  "zzzFakeKey",
   "uploadFiles",
```
Reverted immediately after capturing.

### Part 2 — net-negative de-dup (done-when 4)
`demoApi.ts`: **+12 added / −27 removed** → **net −15** (removed > added). `opencodeMessagesCached` untouched (its `null`-cache-miss contract is a separate concern, not an empty collection).

### Done-when verification
1. `npm test` green (1274 pass / 0 fail). Failure message demonstrated above.
2. `DEMO_UNIMPLEMENTED` committed, generated from the test; length **87**.
3. `git status --porcelain -- tests/visual/screens.visual.ts-snapshots/` → empty (no snapshot moved).
4. Part 2 diff net-negative: +12/−27 demoApi.ts.
5. `npm run typecheck` green; `npm test` green; `npm run visual` → **6 passed** (untouched rendering).
6. No new dependency.

### Verification results
- PR branch (`multica/BET-471-demo-coverage-inventory` @ `c9090da`):
  - typecheck: exit 0, no errors
  - test: exit 0, 1274 pass / 0 fail / 0 skip
  - visual: 6 passed
- Base (`main` @ `03f6759`): unchanged code paths; only additive test + de-dup + docs.
- **Conclusion:** 0 new failures.

No follow-ups filed — the issue explicitly scopes closing the gaps to later, one at a time.
