### PR TITLE
manta-dev: never block on a remote CI run (the watchdog kill)

### DIFF
--- a/.multica/agents/manta-dev.md
+++ b/.multica/agents/manta-dev.md
@@ -89,6 +89,24 @@ starts from zero. Therefore:
    If a branch exists, fetch it, check it out, and CONTINUE from it (re-run
    verification to establish state) instead of re-implementing. A prior run
    may have died one step from the finish line — its pushed work is yours.
+5. **NEVER block on a remote CI run. This is the single most common way your
+   run dies.** `gh run watch`, `gh pr checks --watch`, or any poll loop that
+   prints nothing produces no messages, and the idle watchdog cannot tell a
+   productive wait from a hang — it force-stops you at 10 minutes with your
+   work done and unhanded-off. **CI here cannot finish inside that budget and
+   that is accepted, not a bug to work around:** GitHub Actions runs on ONE
+   self-hosted runner, so jobs queue rather than run in parallel and the queue
+   is routinely several PRs deep. A pass is ~4 minutes once it *starts*; the
+   wait to start is frequently longer than your whole watchdog budget.
+
+   So: push, open the PR, and **hand off**. Do not wait for green. Verifying
+   checks is the reviewer's job, and a merge-event sweep re-dispatches the next
+   step automatically — waiting buys nothing and costs you the run. If you have
+   a specific reason to look at CI, take ONE snapshot (`gh pr checks <n>`
+   without `--watch`), say what it showed, and continue or hand off. Never loop.
+
+   Observed live 2026-08-01: BET-472 died twice this way, ~45 minutes of wall
+   clock, both times with the work already pushed and the PR already green.
 
 ## Coding Standards
 


### PR DESCRIPTION
BET-472's run died twice on Multica's 10-minute idle watchdog. Both transcripts end identically — *"CI is now running… let me block on it via `--watch`"* — with the work already pushed and PR #401 already green. `gh run watch` prints nothing until CI finishes, so the agent emits no messages and the watchdog cannot tell a productive wait from a hang. ~45 minutes of wall clock, no lost work, three re-fires.

CI cannot finish inside that budget here and that is accepted, not a bug to route around: one self-hosted runner, jobs queue rather than parallelise, and the queue is routinely several PRs deep. A pass is ~4 minutes once it starts; the wait to start is frequently longer than the whole watchdog budget.

`manta-dev.md`'s work-durability section already anticipates the watchdog firing during local verification (typecheck, tests, e2e) and tells the agent to push first. It said nothing about the one wait the agent can neither shorten nor make chatty.

Adds rule 5: push, open the PR, hand off — verifying checks is the reviewer's job and the merge-event sweep re-dispatches the next step automatically, so waiting buys nothing. One snapshot of `gh pr checks` if there is a reason; never a loop.

Docs only.