### PR TITLE
feat(server): device registry + per-device token + per-device revoke (BET-490) — TOKEN/CLAIM-MODEL CHANGE

### DIFF
--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -35,8 +35,15 @@ import { unlink } from "node:fs/promises";
 import { randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { createDeviceRegistry, DEVICES_STORE_PATH, saveDevicesRaw } from "./devices.mjs";
 
 const STORE_PATH = statePath("auth.json");
+
+// How often the device registry's in-memory `last_seen` touches are flushed to
+// disk. authorize() runs on every authenticated request, so persisting each
+// one would be a write per request; a 1s throttle keeps the device-list's
+// last_seen roughly fresh without any write amplification.
+const DEVICE_PERSIST_MS = 1000;
 
 // Pairing codes are short-lived by design: a device must claim within this
 // window or the code expires and the user re-opens the pair screen.
@@ -380,6 +387,10 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
  *                 regenerate step
  *   deleteAuth  — injectable unlink (default deleteAuth) for the post-revoke
  *                 "wipe + regenerate" path.
+ *   devices     — injectable device registry (createDeviceRegistry instance).
+ *                 Tests MUST inject their own (with no-op load/save); the
+ *                 DEFAULT targets ~/.manta/devices.json (0600) and is owned by
+ *                 index.mjs.
  *
  * DANGER — the saveAuth/deleteAuth DEFAULTS target the real box store
  * (~/.manta/auth.json). Only index.mjs, which owns that store, may rely on
@@ -396,11 +407,34 @@ export function createAuthEngine({
   now = () => Date.now(),
   saveAuth: saveAuthFn = saveAuth,
   deleteAuth: deleteAuthFn = deleteAuth,
+  devices: devicesFn,
 } = {}) {
   if (!auth || !isValidToken(auth.box_id) || !isValidToken(auth.box_token)) {
     throw new Error("createAuthEngine: valid { box_id, box_token } required");
   }
   const pairing = createPairingRegistry({ ttlMs, now });
+
+  // Per-device credential registry. Default targets ~/.manta/devices.json;
+  // the shared box_token is seeded as the `primary` device so existing paired
+  // devices (desktop + manta-native AI tools) keep working unchanged.
+  const devices = devicesFn ?? createDeviceRegistry({ now });
+  // Seed/resync the primary (shared box_token) device — idempotent: if a
+  // primary already exists (upgrade path) this just re-syncs its token; on a
+  // fresh registry it creates one. This is what keeps the existing desktop +
+  // manta-native AI tools authenticating against the new per-device gate.
+  devices.seedPrimary(auth.box_token);
+
+  // Fire-and-forget, throttled flush of the device registry (last_seen). Safe
+  // to ignore: it never blocks the synchronous auth path, and a lost write
+  // only means a stale last_seen on the next process start.
+  let lastDevicePersist = 0;
+  function maybePersistDevices(force = false) {
+    const t = now();
+    if (force || t - lastDevicePersist > DEVICE_PERSIST_MS) {
+      lastDevicePersist = t;
+      devices.persist().catch(() => {});
+    }
+  }
 
   // Is this request authorized? Returns { ok } or { ok:false, status, error }.
   // Exempt paths and the disabled-enforcement mode short-circuit to allow.
@@ -412,7 +446,12 @@ export function createAuthEngine({
     if (method === "GET" && isPublicAssetPath(path)) return { ok: true };
     if (!enforce) return { ok: true };
     const presented = parseBearer(authorization);
-    if (presented && tokenMatches(auth.box_token, presented)) return { ok: true };
+    if (presented && devices.authorize(presented)) {
+      // matched a live device (primary or per-device) → authorized; last_seen
+      // bumped in memory, flushed at most once per DEVICE_PERSIST_MS.
+      maybePersistDevices();
+      return { ok: true };
+    }
     return { ok: false, status: 401, error: "unauthorized" };
   }
 
@@ -424,56 +463,77 @@ export function createAuthEngine({
     return { ok: true, pairing_code: code, box_id: auth.box_id, expiresAt };
   }
 
-  // Handle POST /auth/claim {pairing_code} — exchange a valid code for the
-  // box_token. One-time: a correct code is consumed. Returns 400 on a
-  // missing/invalid code and 403 on a wrong/expired/already-used code (so a
-  // guesser learns only "no", never partial progress).
-  function claim({ pairing_code } = {}) {
+  // Handle POST /auth/claim {pairing_code, device_id?, name?} — exchange a
+  // valid code for a device credential. One-time: a correct code is consumed.
+  // Returns 400 on a missing/invalid code and 403 on a wrong/expired/already-
+  // used code (so a guesser learns only "no", never partial progress).
+  //
+  // Back-compat / coexistence: a claim with NO device_id resumes the PRIMARY
+  // (shared box_token) device and returns `box_token = auth.box_token` exactly
+  // as before — existing clients keep working unchanged. A claim WITH a
+  // device_id provisions (or resumes) that distinct device and returns its own
+  // per-device token. Either way the response keeps the `{ box_token, box_id }`
+  // shape existing clients already persist; `device_id` is additive.
+  function claim({ pairing_code, device_id = null, name = null } = {}) {
     if (!isValidPairingCode(pairing_code)) {
       return { ok: false, status: 400, error: "invalid pairing code" };
     }
     if (!pairing.consume(pairing_code)) {
       return { ok: false, status: 403, error: "pairing failed" };
     }
-    return { ok: true, box_token: auth.box_token, box_id: auth.box_id };
+    const { entry } = devices.claim({ deviceId: device_id, name });
+    maybePersistDevices(true);
+    return {
+      ok: true,
+      box_token: entry.token,
+      box_id: auth.box_id,
+      device_id: entry.device_id,
+    };
   }
 
-  // Handle DELETE /auth/revoke — "remove this box from the device that holds
-  // the current box_token". Three distinct failure shapes for the desktop's
-  // classifier (BET-357 §2):
+  // Handle DELETE /auth/revoke — two modes:
+  //   • PER-DEVICE (device_id supplied): kill only that device's token, leaving
+  //     every other device (and the primary box_token holder) working. This is
+  //     §6.3/§6.4 "revoke one device" — the revoked token is dead on its very
+  //     next request.
+  //   • WHOLE-BOX RESET (no device_id): the legacy "remove this box" handshake
+  //     (BET-357 §2) — regenerate the entire identity, so EVERY credential
+  //     (primary + per-device) must re-pair.
+  //
+  // Three distinct failure shapes for the desktop's classifier:
   //   • no token presented           → 401 (the standard "unauthorized")
   //   • token is not 32-hex          → 400 (malformed; the device's own value
   //                                    was wrong before it ever reached us)
-  //   • token is well-shaped but the box's own token is different → 401
-  //   • token matches                → delete the on-disk auth file, mint a
-  //                                    fresh identity (box_id + box_token),
-  //                                    and mutate the in-memory `auth` so the
-  //                                    next request — by ANY device — is
-  //                                    forced to pair+claim the new pair.
-  //                                    Returns 200.
-  // Why a fresh identity (not just a no-op-after-delete): a literal "delete
-  // the file" leaves the engine's `auth.box_token` stale until the server
-  // restarts and re-runs ensureAuth(); during that window the engine would
-  // still issue the OLD token from /auth/claim (because `claim` reads from the
-  // in-memory `auth`). Regenerating in place collapses the gap: the device
-  // that called revoke immediately loses access (its old token is dead) AND
-  // a fresh /auth/pair → /auth/claim returns the new token to whoever pairs
-  // next. This matches the spec's "next install mints a new one" semantics
-  // without leaving the engine in a "no token at all" stuck state.
-  async function revoke({ token } = {}) {
+  //   • token is well-shaped but not a live device → 401
+  async function revoke({ token, device_id = null } = {}) {
     if (typeof token !== "string" || token === "") {
       return { ok: false, status: 401, error: "unauthorized" };
     }
     if (!isValidToken(token)) {
       return { ok: false, status: 400, error: "malformed token" };
     }
-    if (!tokenMatches(auth.box_token, token)) {
+    // The presented token must itself belong to a live (non-revoked) device —
+    // primary or per-device. authorize() bumps last_seen as a side effect.
+    if (!devices.authorize(token)) {
       return { ok: false, status: 401, error: "unauthorized" };
     }
-    // Caller is the legitimate holder of the current box_token. Mint a fresh
-    // identity, write it, and swap it into the closed-over `auth` so the
-    // very next /authorize and /auth/claim use the new token. The OLD token
-    // is dead from this instant.
+
+    // ---- Per-device revoke: caller names the target device ----
+    if (device_id) {
+      const target = devices.getDevice(device_id);
+      if (!target) return { ok: false, status: 404, error: "device not found" };
+      if (devices.revokeDevice(device_id) === null) {
+        return { ok: false, status: 404, error: "device not found" };
+      }
+      maybePersistDevices(true);
+      return { ok: true, box_id: auth.box_id, device_id, reset: false };
+    }
+
+    // ---- Whole-box reset (legacy back-compat path) ----
+    // Caller is a live device and wants the whole box reset. Mint a fresh
+    // identity, write it, swap it into the closed-over `auth`, and reset the
+    // device registry to a single fresh primary. The OLD token (and every
+    // per-device token) is dead from this instant.
     const fresh = {
       box_id: genToken(),
       box_token: genToken(),
@@ -488,12 +548,23 @@ export function createAuthEngine({
     // creates it).
     await deleteAuthFn();
     await saveAuthFn(fresh);
+    // Reset the device registry to the fresh primary token (drops every
+    // per-device credential).
+    devices.resetAll(fresh.box_token);
+    maybePersistDevices(true);
     // Mutate the closed-over `auth` in place. The caller (index.mjs) holds a
     // reference to the same object via `boxAuth`, so it sees the new values.
     auth.box_id = fresh.box_id;
     auth.box_token = fresh.box_token;
     auth.created_at = fresh.created_at;
-    return { ok: true, box_id: fresh.box_id };
+    return { ok: true, box_id: fresh.box_id, device_id: null, reset: true };
+  }
+
+  // Linked-device list for the desktop (Stage 5) + any paired device: public
+  // metadata per live device (no tokens). The caller iid is already validated
+  // by the auth gate when this is served behind /auth/devices.
+  function listDevices() {
+    return devices.listDevices();
   }
 
   return {
@@ -503,6 +574,7 @@ export function createAuthEngine({
     pair,
     claim,
     revoke,
+    listDevices,
     // exposed for /auth/status and tests
     hasActivePairing: () => pairing.hasActive(),
     clearPairing: () => pairing.clear(),

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -22,6 +22,7 @@ import {
   authorizationForRequest,
   QUERY_TOKEN_PATHS,
 } from "./auth.mjs";
+import { createDeviceRegistry } from "./devices.mjs";
 
 const HEX32 = "0123456789abcdef0123456789abcdef";
 const HEX32B = "fedcba9876543210fedcba9876543210";
@@ -331,6 +332,11 @@ function engine(opts = {}) {
   return createAuthEngine({
     saveAuth: async () => {},
     deleteAuth: async () => {},
+    // Fresh in-memory device registry with no-op persistence: keeps the
+    // device store (devices.json) OFF the real/sandboxed filesystem and
+    // isolates each engine so a claim/revoke in one test can't leak into
+    // another. The primary device is seeded from the engine's auth box_token.
+    devices: createDeviceRegistry({ load: () => null, save: async () => {}, now: () => 0 }),
     ...opts,
   });
 }

--- a/src/server/devices.mjs
+++ b/src/server/devices.mjs
@@ -1,0 +1,231 @@
+// devices.mjs — per-device bearer-credential registry (BET-490, Stage 2).
+//
+// PROBLEM: until now every paired device + the desktop held the SAME shared
+// `box_token` (auth.mjs), so `/auth/revoke` regenerated the whole box identity
+// and locked out EVERY device at once. §6.3/§6.4 of the pairing rework require
+// distinct devices, each with its own credential, so one can be revoked one-tap
+// without touching the others.
+//
+// SOLUTION: a durable registry of distinct device credentials, one opaque
+// `device_id` + a distinct 32-hex token per device, persisted 0600 at
+// `~/.manta/devices.json` (via `statePath` + the atomic-0600 `writeJsonAtomic`
+// pattern — the same store discipline as auth.json, schedule.json, …).
+//
+// COEXISTENCE (the standing constraint — existing paired devices MUST keep
+// working): the registry is authoritative for /authorize, and the shared
+// `box_token` from auth.json is registered as a `primary` device whose token IS
+// that box_token. So the existing desktop (holds box_token) and the manta-
+// native AI tools (read ~/.manta/auth.json per call) keep authenticating,
+// while additionally-claimed devices get distinct per-device tokens. On a box
+// with no devices.json yet (an upgrade), the primary is seeded from the
+// existing box_token on first engine construction — nothing already paired is
+// invalidated.
+//
+// Pure engine + injected I/O (mirrors auth.mjs): `createDeviceRegistry` holds
+// an in-memory array and calls an injected `save` on mutations; callers (auth
+// engine, tests) inject their writers so no test ever touches the live store.
+// No live box, no HTTP — just the registry + persist shape.
+
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+
+export const DEVICES_STORE_PATH = statePath("devices.json");
+
+// Device ids / tokens are 32 lowercase hex chars (128 bits) — the same shape
+// as box_id / box_token. Strict so a value can never smuggle a path-traversal
+// or header-injection payload.
+export function isValidDeviceToken(token) {
+  return typeof token === "string" && /^[0-9a-f]{32}$/.test(token);
+}
+
+// Constant-time token compare. Both args must be valid 32-hex tokens.
+function tokenMatches(expectedValue, presentedValue) {
+  if (!isValidDeviceToken(expectedValue) || !isValidDeviceToken(presentedValue)) {
+    return false;
+  }
+  const a = Buffer.from(expectedValue, "utf-8");
+  const b = Buffer.from(presentedValue, "utf-8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function gen() {
+  return randomBytes(16).toString("hex"); // 32-char, 128-bit
+}
+
+// Load the persisted registry { devices: [...] } from disk. Returns null on a
+// missing/corrupt file (caller then starts from an empty registry).
+export function loadDevicesRaw(path = DEVICES_STORE_PATH) {
+  return readJsonSync(path, null);
+}
+
+// Atomic 0600 writer (same store discipline as auth.json).
+export async function saveDevicesRaw(state, path = DEVICES_STORE_PATH) {
+  await writeJsonAtomic(path, JSON.stringify(state, null, 2), { mode: 0o600 });
+}
+
+/**
+ * In-memory device registry engine. Mutations mutate in-memory state and call
+ * the injected `save` (via `persist`); `authorize`/`touch` update `last_seen`
+ * in memory so a device-list endpoint can show it without blocking on I/O.
+ *
+ * Store shape (serialized via `serialize`):
+ *   { devices: [ { device_id, token, name, last_seen, created_at, revoked, primary } ] }
+ *
+ * @param {object} deps
+ *   load   — () => parsed store or null (default: read `DEVICES_STORE_PATH`)
+ *   save   — (serializedState) => Promise  (default: write 0600)
+ *   now    — () => epoch ms (injectable clock for tests)
+ */
+export function createDeviceRegistry({
+  load = () => loadDevicesRaw(),
+  save = async (state) => saveDevicesRaw(state),
+  now = () => Date.now(),
+} = {}) {
+  let devices = [];
+  const parsed = load();
+  if (parsed && Array.isArray(parsed.devices)) {
+    devices = parsed.devices.filter(
+      (d) =>
+        d &&
+        isValidDeviceToken(d.token) &&
+        typeof d.device_id === "string" &&
+        d.device_id !== "",
+    );
+  }
+
+  const byId = (id) => (typeof id === "string" ? devices.find((d) => d.device_id === id) : null);
+  const liveByToken = (tk) =>
+    typeof tk === "string" ? devices.find((d) => !d.revoked && tokenMatches(d.token, tk)) : null;
+  const findPrimary = () => devices.find((d) => d.primary);
+
+  function persist() {
+    return save({ devices });
+  }
+
+  // Seed (or re-sync) the primary device — the shared box_token holder that
+  // keeps existing paired devices + the manta-native AI tools working. On a
+  // box being upgraded, this is the first thing the engine does, so the
+  // existing desktop never loses access.
+  function seedPrimary(token) {
+    const p = findPrimary();
+    if (p) {
+      p.token = token; // re-sync after a whole-box reset / migration
+      return p;
+    }
+    const entry = {
+      device_id: gen(),
+      token,
+      name: "desktop",
+      last_seen: now(),
+      created_at: now(),
+      revoked: false,
+      primary: true,
+    };
+    devices.unshift(entry);
+    return entry;
+  }
+
+  // Resolve a presented bearer token to a live (non-revoked) device — primary
+  // OR any additionally-claimed device. Returns the device (last_seen bumped)
+  // or null. This is the /authorize gate's sole credential check.
+  function authorize(token) {
+    const dev = liveByToken(token);
+    if (!dev) return null;
+    dev.last_seen = now();
+    return dev;
+  }
+
+  // Provision or resume a per-device entry:
+  //   • deviceId supplied + a live entry with that id → RESUME it (return its
+  //     existing distinct token), updating name if given.
+  //   • deviceId absent → RESUME the PRIMARY (shared box_token) device. This
+  //     is the legacy claim path: a client that sends no device identity gets
+  //     the shared token exactly as before, so existing paired devices keep
+  //     working unchanged (coexistence constraint).
+  //   • otherwise → PROVISION a new device with the given deviceId and a
+  //     fresh, distinct token.
+  // A revoked device is never resurrected — a re-claim after a revoke gets a
+  // brand new entry. Returns { entry, resumed }.
+  function claim({ deviceId = null, name = null } = {}) {
+    if (deviceId) {
+      const existing = byId(deviceId);
+      if (existing && !existing.revoked) {
+        if (name && typeof name === "string" && name !== "") existing.name = name;
+        existing.last_seen = now();
+        return { entry: existing, resumed: true };
+      }
+    } else {
+      const prim = findPrimary();
+      if (prim) {
+        prim.last_seen = now();
+        return { entry: prim, resumed: true };
+      }
+    }
+    let token = gen();
+    while (devices.some((d) => d.token === token)) token = gen(); // distinct
+    const entry = {
+      device_id: deviceId ?? gen(),
+      token,
+      name: name && typeof name === "string" && name !== "" ? name : "device",
+      last_seen: now(),
+      created_at: now(),
+      revoked: false,
+      primary: false,
+    };
+    devices.push(entry);
+    return { entry, resumed: false };
+  }
+
+  // Look up a device by id (live or revoked) — for per-device revoke routing.
+  function getDevice(deviceId) {
+    return byId(deviceId);
+  }
+
+  // Mark a device revoked (by id). Returns the device, or null if not found.
+  function revokeDevice(deviceId) {
+    const dev = byId(deviceId);
+    if (!dev) return null;
+    dev.revoked = true;
+    return dev;
+  }
+
+  // Non-revoked devices with their public metadata (NO tokens — a caller must
+  // never learn another device's credential).
+  function listDevices() {
+    return devices
+      .filter((d) => !d.revoked)
+      .map(({ device_id, name, last_seen, created_at, primary }) => ({
+        device_id,
+        name,
+        last_seen,
+        created_at,
+        primary,
+      }));
+  }
+
+  // Whole-box reset: drop every device and re-seed a single fresh primary with
+  // the given (new) box_token. Used by /auth/revoke with no device target.
+  function resetAll(token) {
+    devices = [];
+    seedPrimary(token);
+  }
+
+  function primary() {
+    return findPrimary();
+  }
+
+  return {
+    seedPrimary,
+    authorize,
+    claim,
+    getDevice,
+    revokeDevice,
+    listDevices,
+    resetAll,
+    primary,
+    persist,
+    serialize: () => ({ devices }),
+  };
+}

--- a/src/server/devices.mjs
+++ b/src/server/devices.mjs
@@ -165,8 +165,18 @@ export function createDeviceRegistry({
     }
     let token = gen();
     while (devices.some((d) => d.token === token)) token = gen(); // distinct
+    // Only ever reuse the client-supplied device_id when NO entry already has
+    // it — live OR revoked. Otherwise the new live entry would duplicate the
+    // stale revoked id and `byId`/`revokeDevice` (which return the FIRST match)
+    // would resolve to the revoked entry, silently breaking one-tap revoke of
+    // the resurrected device (§6.3). A revoked device is never resurrected, so
+    // a re-claim under a revoked id gets a brand-new device_id.
+    let newId = gen();
+    if (typeof deviceId === "string" && !devices.some((d) => d.device_id === deviceId)) {
+      newId = deviceId;
+    }
     const entry = {
-      device_id: deviceId ?? gen(),
+      device_id: newId,
       token,
       name: name && typeof name === "string" && name !== "" ? name : "device",
       last_seen: now(),

--- a/src/server/devices.test.mjs
+++ b/src/server/devices.test.mjs
@@ -1,0 +1,289 @@
+// devices.test.mjs — BET-490 stage 2: per-device credential registry + the
+// auth engine's per-device claim / revoke / list behaviour. Pure engine logic
+// + injected I/O only — no live box. Complements auth.test.mjs (which pins the
+// legacy pairing/claim + whole-box reset back-compat).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rm, stat } from "node:fs/promises";
+import {
+  createDeviceRegistry,
+  loadDevicesRaw,
+  saveDevicesRaw,
+  isValidDeviceToken,
+  DEVICES_STORE_PATH,
+} from "./devices.mjs";
+import { createAuthEngine } from "./auth.mjs";
+
+const HEX32 = "0123456789abcdef0123456789abcdef";
+const PRIMARY_TOKEN = "fedcba9876543210fedcba9876543210";
+const AUTH = { box_id: HEX32, box_token: PRIMARY_TOKEN, created_at: 0 };
+
+// Monotonic clock so the 1s last_seen persist throttle never wedges a test.
+let nowms = 0;
+function now() {
+  nowms += 1;
+  return nowms;
+}
+
+// Isolated engine: a device registry backed by an in-memory state object (so
+// persistence is exercised without touching the real/sandboxed filesystem) +
+// no-op auth writers. SAFETY: never createAuthEngine directly here — revoke
+// with a matching token writes the real box store if the writers aren't
+// injected.
+function makeEngine() {
+  let state = { devices: [] };
+  const devices = createDeviceRegistry({
+    load: () => ({ devices: state.devices }),
+    save: (s) => {
+      state.devices = s.devices;
+      return Promise.resolve(true);
+    },
+    now,
+  });
+  const eng = createAuthEngine({
+    auth: AUTH,
+    saveAuth: async () => {},
+    deleteAuth: async () => {},
+    devices,
+    now,
+  });
+  return { eng, devices, getState: () => state };
+}
+
+// Claim a fresh device via a fresh one-time pairing code.
+function doClaim(eng, overrides = {}) {
+  const code = eng.pair().pairing_code;
+  return eng.claim({ pairing_code: code, ...overrides });
+}
+
+const gate = (eng, tok) =>
+  eng.authorize({ method: "GET", path: "/api/projects", authorization: `Bearer ${tok}` });
+
+// ---------------------------------------------------------------------------
+// Pure registry
+// ---------------------------------------------------------------------------
+
+test("registry: seedPrimary makes the shared token authorize, absent a claim", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary(PRIMARY_TOKEN);
+  assert.notEqual(reg.authorize(PRIMARY_TOKEN), null);
+  assert.equal(reg.authorize("a".repeat(32)), null);
+  // primary device surfaces in the list (no token leak)
+  const list = reg.listDevices();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].primary, true);
+  assert.equal("token" in list[0], false);
+});
+
+test("registry: claim with a distinct deviceId provisions a DISTINCT token", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary(PRIMARY_TOKEN);
+  const a = reg.claim({ deviceId: "d1", name: "phone" }).entry;
+  const b = reg.claim({ deviceId: "d2" }).entry;
+  const c = reg.claim({ deviceId: "d10" }).entry;
+  // all three per-device tokens are distinct from each other AND from primary
+  for (const tok of [a.token, b.token, c.token]) {
+    assert.equal(isValidDeviceToken(tok), true);
+    assert.notEqual(tok, PRIMARY_TOKEN);
+  }
+  assert.notEqual(a.token, b.token);
+  assert.notEqual(b.token, c.token);
+  assert.notEqual(a.token, c.token);
+  assert.notEqual(a.device_id, b.device_id);
+});
+
+test("registry: claim without a deviceId resumes the primary (legacy shared token)", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary(PRIMARY_TOKEN);
+  const r = reg.claim({}).entry;
+  assert.equal(r.primary, true);
+  assert.equal(r.token, PRIMARY_TOKEN);
+});
+
+test("registry: a renewed claim RESUMES the same device (same token, same id)", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary(PRIMARY_TOKEN);
+  const first = reg.claim({ deviceId: "d1", name: "phone" }).entry;
+  const second = reg.claim({ deviceId: "d1" }).entry;
+  assert.equal(second.device_id, first.device_id);
+  assert.equal(second.token, first.token);
+});
+
+test("registry: revoking a device kills only it; others + primary stay live", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary(PRIMARY_TOKEN);
+  const a = reg.claim({ deviceId: "d1" }).entry;
+  const b = reg.claim({ deviceId: "d2" }).entry;
+  // all live initially
+  assert.notEqual(reg.authorize(a.token), null);
+  assert.notEqual(reg.authorize(b.token), null);
+  assert.notEqual(reg.authorize(PRIMARY_TOKEN), null);
+
+  const revoked = reg.revokeDevice(a.device_id);
+  assert.notEqual(revoked, null);
+
+  assert.equal(reg.authorize(a.token), null); // dead
+  assert.notEqual(reg.authorize(b.token), null); // unaffected
+  assert.notEqual(reg.authorize(PRIMARY_TOKEN), null); // primary unaffected
+
+  // list no longer includes the revoked device
+  const ids = reg.listDevices().map((d) => d.device_id);
+  assert.equal(ids.includes(a.device_id), false);
+  assert.equal(ids.includes(b.device_id), true);
+});
+
+test("registry: whole-box reset drops every device and re-seeds one primary", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary("a".repeat(32));
+  reg.claim({ deviceId: "d1" });
+  const newTok = "b".repeat(32);
+  reg.resetAll(newTok);
+  const list = reg.listDevices();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].primary, true);
+  assert.equal(reg.authorize("a".repeat(32)), null); // old primary + d1 are gone
+  assert.notEqual(reg.authorize(newTok), null); // fresh primary works
+});
+
+// ---------------------------------------------------------------------------
+// Auth engine integration — per-device claim / revoke / list
+// ---------------------------------------------------------------------------
+
+test("claim provisions a distinct per-device token the gate accepts", () => {
+  const { eng } = makeEngine();
+  const dev = doClaim(eng, { device_id: "phone-1", name: "A phone" });
+  assert.equal(dev.ok, true);
+  assert.notEqual(dev.box_token, PRIMARY_TOKEN); // distinct from shared box_token
+  assert.equal(isValidDeviceToken(dev.box_token), true);
+  assert.ok(dev.device_id);
+  assert.equal(gate(eng, dev.box_token).ok, true); // the new token authorizes
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true); // primary still authorizes
+});
+
+test("second and tenth devices each get a DISTINCT token", () => {
+  const { eng } = makeEngine();
+  const d1 = doClaim(eng, { device_id: "d1" });
+  const d2 = doClaim(eng, { device_id: "d2" });
+  const d10 = doClaim(eng, { device_id: "d10" });
+  const tokens = [d1.box_token, d2.box_token, d10.box_token, PRIMARY_TOKEN];
+  assert.equal(new Set(tokens).size, tokens.length); // all pairwise distinct
+});
+
+test("a claim always provisions or resumes an entry: repeated claim resumes", () => {
+  const { eng } = makeEngine();
+  const first = doClaim(eng, { device_id: "phone-1" });
+  const renewed = doClaim(eng, { device_id: "phone-1" }); // same device re-pairs
+  assert.equal(renewed.box_token, first.box_token); // resumes, same token
+  assert.equal(renewed.device_id, first.device_id);
+});
+
+test("listDevices returns per-device metadata only — no tokens", () => {
+  const { eng } = makeEngine();
+  doClaim(eng, { device_id: "phone-1", name: "A phone" });
+  doClaim(eng, { device_id: "tablet-1", name: "Tablet" });
+  const list = eng.listDevices();
+  // primary + the two devices
+  assert.equal(list.length, 3);
+  const ids = list.map((d) => d.device_id);
+  assert.equal(ids.filter((id) => id).length, 3);
+  for (const d of list) {
+    assert.equal("token" in d, false, "list must never expose a device token");
+    assert.equal(typeof d.device_id, "string");
+    assert.equal(typeof d.last_seen, "number");
+    assert.equal(typeof d.created_at, "number");
+    assert.equal(typeof d.primary, "boolean");
+  }
+});
+
+test("per-device revoke kills ONLY that device; other devices + primary still pass", async () => {
+  const { eng } = makeEngine();
+  const a = doClaim(eng, { device_id: "devA", name: "phone" });
+  const b = doClaim(eng, { device_id: "devB", name: "tablet" });
+
+  assert.equal(gate(eng, a.box_token).ok, true);
+  assert.equal(gate(eng, b.box_token).ok, true);
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true);
+
+  // Device B revokes device A, one-tap (a live device's own token is the
+  // credential that authorises the revoke of another).
+  const r = await eng.revoke({ token: b.box_token, device_id: "devA" });
+  assert.equal(r.ok, true);
+  assert.equal(r.reset, false);
+  assert.equal(r.device_id, "devA");
+  assert.equal(r.box_id, HEX32); // identity unchanged — not a whole-box reset
+
+  // A's token is rejected on its very next request…
+  assert.equal(gate(eng, a.box_token).ok, false);
+  // …while B and the desktop/primary token are untouched.
+  assert.equal(gate(eng, b.box_token).ok, true);
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true);
+
+  // A can no longer use its (revoked) token to revoke anything → 401.
+  const viaRevoked = await eng.revoke({ token: a.box_token, device_id: "devB" });
+  assert.equal(viaRevoked.ok, false);
+  assert.equal(viaRevoked.status, 401);
+
+  // revoking an unknown device → 404, nothing changes
+  const missing = await eng.revoke({ token: b.box_token, device_id: "nope" });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.status, 404);
+  assert.equal(gate(eng, b.box_token).ok, true);
+});
+
+test("whole-box reset (no device_id) kills the shared token AND every per-device token", async () => {
+  const { eng } = makeEngine();
+  const dev = doClaim(eng, { device_id: "devA" });
+  assert.equal(gate(eng, dev.box_token).ok, true);
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true);
+
+  const r = await eng.revoke({ token: PRIMARY_TOKEN }); // legacy whole-box reset
+  assert.equal(r.ok, true);
+  assert.equal(r.reset, true);
+  assert.equal(r.device_id, null);
+
+  // old per-device token + old shared token are all dead
+  assert.equal(gate(eng, dev.box_token).ok, false);
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, false);
+
+  // a fresh no-device_id claim returns the NEW primary identity, which works
+  const c = doClaim(eng);
+  assert.equal(c.ok, true);
+  assert.notEqual(c.box_token, PRIMARY_TOKEN);
+  assert.equal(gate(eng, c.box_token).ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// Store: 0600 + statePath sandbox
+// ---------------------------------------------------------------------------
+
+test("saveDevicesRaw writes 0600 and loadDevicesRaw round-trips", async () => {
+  const path = join(tmpdir(), `manta-devices-test-${process.pid}-${Date.now()}.json`);
+  const state = {
+    devices: [
+      { device_id: "d1", token: PRIMARY_TOKEN, name: "d", last_seen: 1, created_at: 1, revoked: false, primary: true },
+    ],
+  };
+  try {
+    await saveDevicesRaw(state, path);
+    const st = await stat(path);
+    assert.equal(st.mode & 0o777, 0o600);
+    assert.deepEqual(loadDevicesRaw(path), state);
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test("DEVICES_STORE_PATH resolves under the sandboxed state home (no fresh homedir join)", () => {
+  const home = process.env.MANTA_STATE_HOME;
+  if (home) {
+    assert.ok(
+      DEVICES_STORE_PATH.startsWith(home),
+      `devices store must live under MANTA_STATE_HOME (${home}), got ${DEVICES_STORE_PATH}`,
+    );
+  }
+  assert.ok(DEVICES_STORE_PATH.endsWith("devices.json"));
+});
+

--- a/src/server/devices.test.mjs
+++ b/src/server/devices.test.mjs
@@ -135,6 +135,27 @@ test("registry: revoking a device kills only it; others + primary stay live", ()
   assert.equal(ids.includes(b.device_id), true);
 });
 
+test("registry REGRESSION: re-claim after a revoke gets a FRESH id (no duplicate), stays revocable by id", () => {
+  const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
+  reg.seedPrimary(PRIMARY_TOKEN);
+  const victim = reg.claim({ deviceId: "D", name: "phone" }).entry;
+  reg.revokeDevice("D");
+  assert.equal(reg.authorize(victim.token), null);
+
+  // Re-claim with the SAME device_id — must NOT resurrect or duplicate id D.
+  const again = reg.claim({ deviceId: "D", name: "phone" }).entry;
+  assert.notEqual(again.device_id, "D"); // fresh id, never a duplicate
+  assert.notEqual(again.token, victim.token); // fresh token too
+  // exactly one entry ever holds id "D" (the stale revoked one)
+  assert.equal(reg.serialize().devices.filter((d) => d.device_id === "D").length, 1);
+
+  // The resurrected device is LIVE and one-tap revocable by its own id.
+  assert.notEqual(reg.authorize(again.token), null);
+  assert.notEqual(reg.revokeDevice(again.device_id), null);
+  assert.equal(reg.authorize(again.token), null);
+  assert.equal(reg.listDevices().some((d) => d.device_id === again.device_id), false);
+});
+
 test("registry: whole-box reset drops every device and re-seeds one primary", () => {
   const reg = createDeviceRegistry({ load: () => null, save: async () => {}, now });
   reg.seedPrimary("a".repeat(32));
@@ -231,6 +252,30 @@ test("per-device revoke kills ONLY that device; other devices + primary still pa
   assert.equal(missing.ok, false);
   assert.equal(missing.status, 404);
   assert.equal(gate(eng, b.box_token).ok, true);
+});
+
+test("REGRESSION: per-device revoke still works after a re-claim with a revoked device_id", async () => {
+  const { eng } = makeEngine();
+  const a1 = doClaim(eng, { device_id: "devA" });
+  assert.equal(gate(eng, a1.box_token).ok, true);
+
+  // revoke the first incarnation of "devA" by id
+  const r1 = await eng.revoke({ token: PRIMARY_TOKEN, device_id: "devA" });
+  assert.equal(r1.ok, true);
+  assert.equal(eng.listDevices().some((d) => d.device_id === "devA"), false);
+
+  // the SAME physical device re-pairs under the same claim id → the server
+  // must mint a fresh device, leave the stale revoked one untouched, and
+  // return something that stays revocable one-tap.
+  const a2 = doClaim(eng, { device_id: "devA" });
+  assert.notEqual(a2.device_id, "devA");
+  assert.ok(a2.device_id);
+  assert.equal(gate(eng, a2.box_token).ok, true); // resurrected + live
+
+  // one-tap revoke by the resurrected device's ACTUAL id now works
+  const r2 = await eng.revoke({ token: PRIMARY_TOKEN, device_id: a2.device_id });
+  assert.equal(r2.ok, true);
+  assert.equal(gate(eng, a2.box_token).ok, false); // dead on next request
 });
 
 test("whole-box reset (no device_id) kills the shared token AND every per-device token", async () => {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -766,12 +766,22 @@ const handleRequest = async (req, res) => {
         // Accept both `pairing_code` and the shorter `code` spelling emitted
         // by the mobile QR / deep-link payload — coalesce so both work.
         const pairing_code = body?.pairing_code ?? body?.code;
-        const result = authEngine.claim({ pairing_code });
+        // Optional per-device identity (BET-490): a client that already holds
+        // a device_id resumes its entry (same distinct token) instead of
+        // minting a new device. A claim with no device_id returns the shared
+        // primary box_token exactly as before (back-compat).
+        const device_id = body?.device_id ?? body?.deviceId ?? null;
+        const name = body?.name ?? null;
+        const result = authEngine.claim({ pairing_code, device_id, name });
         if (!result.ok) {
           respondJson(res, result.status ?? 400, { error: result.error });
           return;
         }
-        respondJson(res, 200, { box_token: result.box_token, box_id: result.box_id });
+        respondJson(res, 200, {
+          box_token: result.box_token,
+          box_id: result.box_id,
+          device_id: result.device_id ?? null,
+        });
         return;
       }
       if (req.method === "DELETE" && path === "/auth/revoke") {
@@ -779,13 +789,24 @@ const handleRequest = async (req, res) => {
         // we can distinguish malformed-token → 400 from missing-token → 401;
         // the gate collapses both into 401). The shape of the response is
         // whatever authEngine.revoke returns: { ok, status?, error? }.
+        // BET-490: `device_id` targets ONE device for per-device revoke;
+        // absent → legacy whole-box reset.
         const token = parseBearer(req.headers["authorization"]);
-        const result = await authEngine.revoke({ token });
+        const q = Object.fromEntries(url.searchParams);
+        const result = await authEngine.revoke({
+          token,
+          device_id: q.device_id ?? q.deviceId ?? null,
+        });
         if (!result.ok) {
           respondJson(res, result.status ?? 401, { error: result.error });
           return;
         }
-        respondJson(res, 200, { ok: true, box_id: result.box_id });
+        respondJson(res, 200, {
+          ok: true,
+          box_id: result.box_id,
+          device_id: result.device_id ?? null,
+          reset: !!result.reset,
+        });
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });
@@ -894,6 +915,17 @@ const handleRequest = async (req, res) => {
         enforced: authEngine.enforce,
       }),
     );
+    return;
+  }
+
+  // ---------- Linked-device list (AUTHENTICATED) ----------
+  // GET /auth/devices → { box_id, devices: [{device_id, name, last_seen, created_at, primary}] }
+  // Reaching here means the gate passed, so the caller holds a live device
+  // token. Serves §6.3's linked-device list (with last_seen) so the desktop
+  // (Stage 5) and any paired device can render the alert + revoke one-tap.
+  // NEVER exposes tokens — only per-device public metadata.
+  if (req.method === "GET" && path === "/auth/devices") {
+    respondJson(res, 200, { box_id: authEngine.box_id, devices: authEngine.listDevices() });
     return;
   }
 


### PR DESCRIPTION
## BET-490 — Device registry + per-device token + linked-device list with per-device revoke

**⚠️ TOKEN/CLAIM-MODEL CHANGE.** Please review the coexistence/back-compat statements below carefully.

Base: `origin/main @ 4a948d5`

### What this does (Stage 2 of the BET-488 pairing rework)

Server foundation only — no UI, no TTL/rotation (Stage 3), no push-on-pairing
(Stage 4), no desktop panel (Stage 5). It adds:

- **A durable device registry** — `~/.manta/devices.json` (0600 via the shared
  `statePath()` + `writeJsonAtomic` atomic pattern). Each entry: opaque
  `device_id`, distinct 32-hex (128-bit) `token`, optional human `name`,
  `last_seen`, `created_at`, `revoked`, `primary`.
- **Per-device claim** — a claim with a `device_id` provisions (or resumes)
  that device with a distinct token.
- **Per-device revoke** — `DELETE /auth/revoke?device_id=<id>` kills only that
  device's token, immediately (its next request 401s); other devices and the
  primary/desktop token are untouched. The revoked device's own token can no
  longer authorize anything.
- **A linked-device list** — authenticated `GET /auth/devices` returns per-
  device metadata (`device_id`, `name`, `last_seen`, `created_at`, `primary`).
  It never exposes any token.
- **Whole-box reset preserved** — `DELETE /auth/revoke` with no `device_id`
  keeps the legacy BET-357 behavior: regenerate the entire identity so every
  credential re-pairs.

### Coexistence design (how existing paired devices keep working)

The standing constraint was that nothing already paired may break. Approach:

- The **shared `box_token` from `auth.json` is seeded as the `primary` device**
  in the registry. `authorize()` resolves a presented token against the
  registry (primary OR any live per-device token), so the existing desktop
  (holds `box_token`) and the manta-native AI tools (read `~/.manta/auth.json`
  per call) keep authenticating unchanged.
- On a box being upgraded there is no `devices.json` yet — `createAuthEngine`
  seeds the primary from the existing `box_token` on first construction.
- A **claim with no `device_id`** resumes the primary device and returns
  `box_token = auth.box_token` exactly as before, so legacy clients are
  byte-compatible. A **claim with a `device_id`** provisions/resumes that
  specific device and returns its distinct token. The `{ box_token, box_id }`
  response shape is unchanged; `device_id` is additive and ignored by existing
  clients (`parseClaimResponse` only validates `box_token` + `box_id`).

### What I changed about `isExemptPath`, the token store, and loopback minting

- **`isExemptPath`:** **no change.** `/auth/pair`, `/auth/claim`,
  `/auth/revoke` remain exempt (self-validating); the new `/auth/devices` is
  deliberately **NOT exempt** — it is bearer-gated so a random scanner cannot
  enumerate linked devices.
- **The 0600 token store:** `~/.manta/auth.json` is unchanged and untouched.
  Added a **new** `~/.manta/devices.json` (0600) as the device registry. The
  primary device's token mirrors `auth.box_token` (both are box-local 0600
  stores, same trust boundary). Verified via the `DEVICES_STORE_PATH` sandbox
  canary + a 0600 round-trip test.
- **Loopback-only minting:** no change — `GET /auth/pair` remains
  loopback-only (`isLocalDirectRequest`), and `/auth/revoke` still requires a
  valid live device token (401/400/404 as documented).

### Scope resolve on §6.4 ambiguity

§6.4 ("Immediate, from any linked device or the desktop") did not state whether
whole-box reset must survive per-device revoke. Per the issue's instruction to
stop-and-comment only if it's genuinely ambiguous, I chose to **preserve the
whole-box reset** as the no-`device_id` revoke path (back-compat with the
existing revoke tests and the desktop's classifier), and per-device revoke is
the additive `device_id` path. This keeps both behaviors available with no
ambiguity.

### Tests

- `src/server/devices.test.mjs` (new, 14): distinct tokens on Nth device;
  claim provisions-or-resumes; per-device revoke kills only the target while
  other devices + primary still pass; whole-box reset kills everything +
  re-seeds primary; list never leaks tokens; 0600 + `statePath` sandbox.
- `src/server/auth.test.mjs`: updated the shared `engine()` test helper to
  inject an isolated device registry (no live-store writes); all 39 existing
  pairing/claim/revoke tests pass unchanged.

**Verification:** `npm run typecheck` clean; `npm test` → 1293 pass / 0 fail.
