### PR TITLE
refactor(scripts): collapse Multica API helpers, fail loud on writes (BET-504)

### DIFF
--- a/scripts/lib/multicaApi.mjs
+++ b/scripts/lib/multicaApi.mjs
@@ -1,36 +1,30 @@
-#!/usr/bin/env node
 /**
  * Single shared helper for talking to the Multica API.
  *
- * Before this existed, scripts/multica-pr-closed.mjs, scripts/multica-unblock.mjs
- * and scripts/multica-unstick.mjs each carried their own near-identical HTTP
- * call — two named `api(base, token, path, opts)` plus a set of bare `fetch`
- * calls in the third. Three copies of one thing is why a fix made once drifted
- * into three. This module is the ONLY place a Multica write happens, which is
- * what makes "a failed write must fail the job" a single change rather than
- * three.
+ * Previously scripts/multica-pr-closed.mjs, multica-unblock.mjs and
+ * multica-unstick.mjs each carried their own near-identical HTTP call — two
+ * named `api(base, token, path, opts)` plus many bare `fetch` calls in the
+ * third. Three copies is why a fix made once drifted into three. This module is
+ * now the ONLY place a Multica write happens, which makes "a failed write must
+ * fail the job" a single change rather than three.
  *
  * Policy: the helper throws an `ApiError` on ANY non-OK response, reads and
- * writes alike. A sweep decides separately whether a given call is a read
- * (warn and continue) or a write (fail the job) — write failures must never be
- * invisible. The error carries the HTTP status and response body so a sweep can
- * log the issue key, the status and the body on a failed write.
- *
- * The GitHub API calls in multica-pr-closed.mjs (branch/PR probes, PR comments)
- * deliberately do NOT go through here: they target api.github.com with a
- * different token, different headers, and must warn-and-continue rather than
- * throw. This helper is Multica-only.
+ * writes alike. A sweep decides separately whether a call is a read (warn and
+ * continue) or a write (fail the job) — write failures must never be invisible.
+ * The error carries the HTTP status + body so a sweep can log key + status +
+ * body on a failed write. The GitHub API calls in multica-pr-closed.mjs stay
+ * out of here on purpose: different API, different token/headers, and they must
+ * warn-and-continue rather than throw.
  *
  * ENV contract is unchanged and lives in the callers: MULTICA_TOKEN,
  * MULTICA_API_BASE (default https://api.multica.ai) and the workspace id each
- * script already reads. Nothing is renamed or added.
+ * script already reads.
  */
 
 export const DEFAULT_WORKSPACE = "264c89bb-4659-4570-af7b-5f8daaf87985";
 export const DEFAULT_API_BASE = "https://api.multica.ai";
 
-/** A non-OK response from the Multica API. Carries status + path + raw body so
- *  a sweep can log the key, the HTTP status and the response body. */
+/** A non-OK response from the Multica API; carries `status`, `path`, `body`. */
 export class ApiError extends Error {
   constructor({ status, path, body }) {
     const snippet = typeof body === "string" ? body.slice(0, 200) : "";

--- a/scripts/lib/multicaApi.mjs
+++ b/scripts/lib/multicaApi.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Single shared helper for talking to the Multica API.
+ *
+ * Before this existed, scripts/multica-pr-closed.mjs, scripts/multica-unblock.mjs
+ * and scripts/multica-unstick.mjs each carried their own near-identical HTTP
+ * call — two named `api(base, token, path, opts)` plus a set of bare `fetch`
+ * calls in the third. Three copies of one thing is why a fix made once drifted
+ * into three. This module is the ONLY place a Multica write happens, which is
+ * what makes "a failed write must fail the job" a single change rather than
+ * three.
+ *
+ * Policy: the helper throws an `ApiError` on ANY non-OK response, reads and
+ * writes alike. A sweep decides separately whether a given call is a read
+ * (warn and continue) or a write (fail the job) — write failures must never be
+ * invisible. The error carries the HTTP status and response body so a sweep can
+ * log the issue key, the status and the body on a failed write.
+ *
+ * The GitHub API calls in multica-pr-closed.mjs (branch/PR probes, PR comments)
+ * deliberately do NOT go through here: they target api.github.com with a
+ * different token, different headers, and must warn-and-continue rather than
+ * throw. This helper is Multica-only.
+ *
+ * ENV contract is unchanged and lives in the callers: MULTICA_TOKEN,
+ * MULTICA_API_BASE (default https://api.multica.ai) and the workspace id each
+ * script already reads. Nothing is renamed or added.
+ */
+
+export const DEFAULT_WORKSPACE = "264c89bb-4659-4570-af7b-5f8daaf87985";
+export const DEFAULT_API_BASE = "https://api.multica.ai";
+
+/** A non-OK response from the Multica API. Carries status + path + raw body so
+ *  a sweep can log the key, the HTTP status and the response body. */
+export class ApiError extends Error {
+  constructor({ status, path, body }) {
+    const snippet = typeof body === "string" ? body.slice(0, 200) : "";
+    super(`HTTP ${status} on ${path}${snippet ? `: ${snippet}` : ""}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.path = path;
+    this.body = body;
+  }
+}
+
+/**
+ * @param {string} base         API base URL (without trailing `/api`)
+ * @param {string} token        bearer token (MULTICA_TOKEN)
+ * @param {string} path         API path starting with `/` (e.g. `/issues/BET-1`)
+ * @param {object} [opts]       fetch options (method, body, headers)
+ * @param {typeof fetch} [fetchImpl]  injectable fetch for tests; defaults to global
+ * @returns {Promise<object>} parsed JSON body (or `{}` when empty)
+ * @throws {ApiError} on a non-OK response
+ */
+export async function api(base, token, path, opts = {}, fetchImpl = fetch) {
+  const res = await fetchImpl(`${base}/api${path}`, {
+    ...opts,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(opts.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  const body = await res.text().catch(() => "");
+  if (!res.ok) {
+    throw new ApiError({ status: res.status, path, body });
+  }
+  return body ? JSON.parse(body) : {};
+}

--- a/scripts/multica-pr-closed.mjs
+++ b/scripts/multica-pr-closed.mjs
@@ -298,8 +298,7 @@ export async function run({
       );
       log(`Set ${key} to done.`);
     } catch (e) {
-      // The exact failure this issue exists to make loud: a status write that
-      // never landed previously looked identical to one that did.
+      // The exact bug BET-504 exists to surface: a silent status-write failure.
       console.error(`Failed to set ${key} done (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
       writeFailed = true;
     }

--- a/scripts/multica-pr-closed.mjs
+++ b/scripts/multica-pr-closed.mjs
@@ -57,9 +57,8 @@
  */
 
 import { readFile } from "node:fs/promises";
+import { api, DEFAULT_WORKSPACE, DEFAULT_API_BASE } from "./lib/multicaApi.mjs";
 
-export const DEFAULT_WORKSPACE = "264c89bb-4659-4570-af7b-5f8daaf87985";
-export const DEFAULT_API_BASE = "https://api.multica.ai";
 export const DEFAULT_ISSUE_PREFIX = "BET";
 
 /**
@@ -229,30 +228,8 @@ async function probeBaseBranch({ owner, repo, baseRef, token, apiBase }) {
   return { baseBranchExists, baseMerged };
 }
 
-async function setIssueDone({ key, workspace, apiBase, token }) {
-  const resp = await fetch(`${apiBase}/api/issues/${key}?workspace_id=${workspace}`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ status: "done" }),
-  });
-  if (resp.ok) log(`Set ${key} to done.`);
-  else warn(`failed to set ${key} done (HTTP ${resp.status}): ${await resp.text()}`);
-}
-
-async function commentOnIssue({ key, workspace, apiBase, token, content }) {
-  // Two API quirks, both verified live (2026-07-27): workspace_id must be on
-  // the QUERY STRING (a body-only workspace 400s), and the field is `content`,
-  // not `body`.
-  const resp = await fetch(`${apiBase}/api/issues/${key}/comments?workspace_id=${workspace}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ workspace_id: workspace, content }),
-  });
-  if (resp.ok) log(`Posted comment to ${key}.`);
-  else warn(`Multica comment failed (HTTP ${resp.status}): ${await resp.text()}`);
-}
-
 async function commentOnPr({ owner, repo, number, token, apiBase, content }) {
+  // GitHub, not Multica — kept local (warn-and-continue, different headers).
   const resp = await fetch(`${apiBase}/repos/${owner}/${repo}/issues/${number}/comments`, {
     method: "POST",
     headers: {
@@ -266,34 +243,27 @@ async function commentOnPr({ owner, repo, number, token, apiBase, content }) {
   else warn(`GitHub comment failed (HTTP ${resp.status}): ${await resp.text()}`);
 }
 
-async function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) {
-    console.error("GITHUB_EVENT_PATH is not set — nothing to react to.");
-    process.exit(1);
-  }
-
-  const event = JSON.parse(await readFile(eventPath, "utf8"));
+export async function run({
+  event,
+  dryRun = false,
+  ghToken = "",
+  multicaToken = "",
+  workspace = DEFAULT_WORKSPACE,
+  multicaApi: apiBase = DEFAULT_API_BASE,
+  ghApi = "https://api.github.com",
+  fetchImpl = fetch,
+} = {}) {
   const pr = event?.pull_request;
-  if (!pr) {
-    console.error("payload has no pull_request — wrong trigger?");
-    process.exit(1);
-  }
+  if (!pr) throw new Error("payload has no pull_request — wrong trigger?");
 
   const owner = event.repository?.owner?.login;
   const repo = event.repository?.name;
   const defaultBranch = event.repository?.default_branch || "main";
-  const ghApi = process.env.GITHUB_API_URL || "https://api.github.com";
-  const ghToken = process.env.GITHUB_TOKEN || "";
-  const multicaToken = process.env.MULTICA_TOKEN || "";
-  const workspace = process.env.MULTICA_WORKSPACE_ID || DEFAULT_WORKSPACE;
-  const multicaApi = process.env.MULTICA_API_BASE || DEFAULT_API_BASE;
 
   const key = extractIssueKey({ title: pr.title, headRef: pr.head?.ref });
   if (!key) {
     log("No issue key in PR title or branch — nothing to do.");
-    return;
+    return 0;
   }
 
   const baseRef = pr.base?.ref ?? "";
@@ -314,20 +284,48 @@ async function main() {
     warn("MULTICA_TOKEN is not set — skipping every Multica call.");
   }
 
+  let writeFailed = false;
+
   if (kind === "merged") {
-    if (dryRun || !multicaToken) return;
-    await setIssueDone({ key, workspace, apiBase: multicaApi, token: multicaToken });
-    return;
+    if (dryRun || !multicaToken) return 0;
+    try {
+      await api(
+        apiBase,
+        multicaToken,
+        `/issues/${key}?workspace_id=${workspace}`,
+        { method: "PUT", body: JSON.stringify({ status: "done" }) },
+        fetchImpl,
+      );
+      log(`Set ${key} to done.`);
+    } catch (e) {
+      // The exact failure this issue exists to make loud: a status write that
+      // never landed previously looked identical to one that did.
+      console.error(`Failed to set ${key} done (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+      writeFailed = true;
+    }
+    return writeFailed ? 1 : 0;
   }
 
   const content = buildComment({ kind, key, reason, headRef: pr.head?.ref ?? "", defaultBranch });
   if (dryRun) {
     log("--- comment (dry run) ---");
     log(content);
-    return;
+    return 0;
   }
   if (multicaToken) {
-    await commentOnIssue({ key, workspace, apiBase: multicaApi, token: multicaToken, content });
+    try {
+      await api(
+        apiBase,
+        multicaToken,
+        `/issues/${key}/comments?workspace_id=${workspace}`,
+        { method: "POST", body: JSON.stringify({ workspace_id: workspace, content }) },
+        fetchImpl,
+      );
+      log(`Posted comment to ${key}.`);
+    } catch (e) {
+      console.error(`Failed to comment on ${key} (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+      writeFailed = true;
+    }
   }
   if (ghToken) {
     await commentOnPr({
@@ -339,6 +337,28 @@ async function main() {
       content,
     });
   }
+  return writeFailed ? 1 : 0;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    console.error("GITHUB_EVENT_PATH is not set — nothing to react to.");
+    process.exit(1);
+  }
+
+  const event = JSON.parse(await readFile(eventPath, "utf8"));
+  const code = await run({
+    event,
+    dryRun,
+    ghToken: process.env.GITHUB_TOKEN || "",
+    multicaToken: process.env.MULTICA_TOKEN || "",
+    workspace: process.env.MULTICA_WORKSPACE_ID,
+    multicaApi: process.env.MULTICA_API_BASE,
+    ghApi: process.env.GITHUB_API_URL,
+  });
+  if (code) process.exit(code);
 }
 
 // Only run when invoked directly, so the pure exports stay importable in tests.

--- a/scripts/multica-pr-closed.test.mjs
+++ b/scripts/multica-pr-closed.test.mjs
@@ -1,6 +1,8 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { extractIssueKey, classifyClosure, buildComment } from "./multica-pr-closed.mjs";
+import { extractIssueKey, classifyClosure, buildComment, run as runPrClosed } from "./multica-pr-closed.mjs";
+import { run as runUnblock } from "./multica-unblock.mjs";
+import { api, ApiError } from "./lib/multicaApi.mjs";
 
 describe("extractIssueKey", () => {
   test("reads the key from the PR title", () => {
@@ -149,5 +151,131 @@ describe("buildComment", () => {
   test("the abandoned comment does not claim a stack", () => {
     assert.doesNotMatch(abandoned, /stacked/i);
     assert.match(abandoned, /BET-430/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-loud writes + the shared Multica API helper (BET-504).
+//
+// These drive the sweep `run` loops with an injected fetch (the same injection
+// pattern the pure-function tests use) — no real HTTP. The three behaviours
+// BET-504 demands are locked in here: a failed WRITE fails the job, a failed
+// READ does not, and a batch with one failing write still processes the rest
+// before exiting non-zero.
+// ---------------------------------------------------------------------------
+
+/** A fetch stub that answers from a route table and records every call. */
+function stubFetch(routes) {
+  const calls = [];
+  const fn = async (url, opts = {}) => {
+    const method = (opts.method || "GET").toUpperCase();
+    calls.push({ method, url });
+    const hit = routes.find((r) => r.method === method && url.includes(r.match));
+    const status = hit ? hit.status : 404;
+    const body = hit?.body ?? "";
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => body,
+      json: async () => (body ? JSON.parse(body) : {}),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const B = "https://api.multica.ai";
+
+describe("multicaApi helper", () => {
+  test("a non-OK response makes the helper throw with the status and body", async () => {
+    const fetchImpl = stubFetch([
+      { method: "PUT", match: "/api/issues/BET-1", status: 500, body: "boom" },
+    ]);
+    await assert.rejects(
+      api(B, "t", "/issues/BET-1?workspace_id=ws", { method: "PUT" }, fetchImpl),
+      (e) => e instanceof ApiError && e.status === 500 && e.body === "boom",
+    );
+  });
+
+  test("a read returning non-OK also surfaces as an ApiError (the sweep decides), not a silent two-oh-oh", async () => {
+    const fetchImpl = stubFetch([
+      { method: "GET", match: "/api/issues/BET-9", status: 503, body: "down" },
+    ]);
+    await assert.rejects(
+      api(B, "t", "/issues/BET-9?workspace_id=ws", {}, fetchImpl),
+      (e) => e instanceof ApiError && e.status === 503,
+    );
+  });
+});
+
+describe("BET-504 — a failed Multica write fails the job", () => {
+  test("REGRESSION (BET-438): pr-closed's done-write failure exits non-zero", async () => {
+    // The incident: PR #397 merged, the status write warn'd and the script
+    // exited 0, so the issue sat `blocked` for 30 minutes looking healthy.
+    const fetchImpl = stubFetch([
+      { method: "PUT", match: "/api/issues/BET-99", status: 500, body: "nope" },
+    ]);
+    const code = await runPrClosed({
+      event: {
+        pull_request: {
+          merged: true,
+          title: "BET-99: wire x",
+          head: { ref: "multica/BET-99-x" },
+          base: { ref: "main" },
+          number: 99,
+        },
+        repository: { owner: { login: "o" }, name: "r", default_branch: "main" },
+      },
+      multicaToken: "t",
+      workspace: "ws",
+      fetchImpl,
+    });
+    assert.equal(code, 1);
+  });
+
+  test("unblock: a write that lands badly exits non-zero", async () => {
+    const fetchImpl = stubFetch([
+      { method: "GET", match: "/api/issues?workspace_id=ws&status=blocked", status: 200, body: JSON.stringify({ issues: [{ identifier: "BET-1", status: "blocked", metadata: { waiting_on: "BET-10" } }] }) },
+      { method: "GET", match: "/api/issues/BET-10", status: 200, body: JSON.stringify({ status: "done" }) },
+      { method: "PUT", match: "/api/issues/BET-1", status: 500, body: "conflict" },
+    ]);
+    const code = await runUnblock({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 1);
+  });
+});
+
+describe("BET-504 — a failed READ still warns and continues", () => {
+  test("unblock: an unresolvable blocker read stays blocked and exits 0", async () => {
+    const fetchImpl = stubFetch([
+      { method: "GET", match: "/api/issues?workspace_id=ws&status=blocked", status: 200, body: JSON.stringify({ issues: [{ identifier: "BET-1", status: "blocked", metadata: { waiting_on: "BET-10" } }] }) },
+      { method: "GET", match: "/api/issues/BET-10", status: 503, body: "down" },
+    ]);
+    // The blocker read fails -> BET-1 is treated as still blocked, so no write
+    // happens and the sweep must NOT fail. This is the "a single issue that
+    // cannot be fetched must not abort a sweep" rule.
+    const code = await runUnblock({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 0);
+  });
+});
+
+describe("BET-504 — a batch finishes before failing", () => {
+  test("unblock: one failing write still processes the rest, then exits non-zero", async () => {
+    const fetchImpl = stubFetch([
+      { method: "GET", match: "/api/issues?workspace_id=ws&status=blocked", status: 200, body: JSON.stringify({ issues: [
+        { identifier: "BET-1", status: "blocked", metadata: { waiting_on: "BET-10" } },
+        { identifier: "BET-2", status: "blocked", metadata: { waiting_on: "BET-20" } },
+      ] }) },
+      { method: "GET", match: "/api/issues/BET-10", status: 200, body: JSON.stringify({ status: "done" }) },
+      { method: "GET", match: "/api/issues/BET-20", status: 200, body: JSON.stringify({ status: "done" }) },
+      { method: "PUT", match: "/api/issues/BET-1", status: 200, body: "{}" },
+      { method: "PUT", match: "/api/issues/BET-2", status: 500, body: "db locked" },
+    ]);
+    const code = await runUnblock({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 1);
+    // Both writes were attempted: the failing BET-2 write did not stop BET-1,
+    // and neither was silently skipped after the other failed.
+    const puts = fetchImpl.calls.filter((c) => c.method === "PUT").map((c) => c.url);
+    assert.ok(puts.some((u) => u.includes("/api/issues/BET-1")), "BET-1 write attempted");
+    assert.ok(puts.some((u) => u.includes("/api/issues/BET-2")), "BET-2 write attempted");
   });
 });

--- a/scripts/multica-unblock.mjs
+++ b/scripts/multica-unblock.mjs
@@ -140,8 +140,7 @@ export async function run({
     return 0;
   }
 
-  // Resolve every referenced blocker once. A single unresolvable blocker is a
-  // READ: warn and keep sweeping — it must never abort the batch.
+  // Resolve every referenced blocker once. Unresolvable = READ, warn + continue.
   const statusByKey = new Map();
   const needed = new Set(blocked.flatMap((i) => parseBlockerKeys(i?.metadata?.waiting_on)));
   for (const key of needed) {
@@ -180,8 +179,7 @@ export async function run({
       console.log(`  → ${id} unblocked (${reason})`);
       unblocked++;
     } catch (e) {
-      // A failed WRITE is fatal to the job. Log the key + status + body, keep
-      // sweeping the rest of the batch, and exit non-zero at the end.
+      // Fail the job on a failed WRITE; keep sweeping the rest of the batch.
       console.error(`Failed to set ${id} todo (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
       writeFailed = true;
     }

--- a/scripts/multica-unblock.mjs
+++ b/scripts/multica-unblock.mjs
@@ -46,8 +46,7 @@
  * housekeeping and must never break a deploy pipeline.
  */
 
-const DEFAULT_WORKSPACE = "264c89bb-4659-4570-af7b-5f8daaf87985";
-const DEFAULT_API_BASE = "https://api.multica.ai";
+import { api, DEFAULT_WORKSPACE, DEFAULT_API_BASE } from "./lib/multicaApi.mjs";
 
 /** Statuses that mean a blocker is finished and no longer blocking. */
 export const TERMINAL_STATUSES = new Set(["done", "cancelled", "canceled"]);
@@ -115,48 +114,39 @@ export function decideUnblock(issue, statusByKey) {
  * IO below this line. Everything above is pure and unit-tested.
  * ------------------------------------------------------------------ */
 
-/** @param {string} path @param {object} opts */
-async function api(base, token, path, opts = {}) {
-  const res = await fetch(`${base}/api${path}`, {
-    ...opts,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      ...(opts.headers ?? {}),
-    },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status} on ${path}: ${(await res.text()).slice(0, 200)}`);
-  }
-  return res.json();
-}
-
-async function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const verbose = process.argv.includes("--verbose");
-  const token = process.env.MULTICA_TOKEN;
-  const ws = process.env.MULTICA_WORKSPACE_ID || DEFAULT_WORKSPACE;
-  const base = process.env.MULTICA_API_BASE || DEFAULT_API_BASE;
-
+export async function run({
+  token,
+  workspace = DEFAULT_WORKSPACE,
+  base = DEFAULT_API_BASE,
+  dryRun = false,
+  verbose = false,
+  fetchImpl = fetch,
+} = {}) {
   if (!token) {
     console.error("MULTICA_TOKEN is not set — nothing to do.");
-    process.exit(1);
+    return 1;
   }
 
-  const listed = await api(base, token, `/issues?workspace_id=${ws}&status=blocked&limit=200`);
+  const listed = await api(
+    base,
+    token,
+    `/issues?workspace_id=${workspace}&status=blocked&limit=200`,
+    {},
+    fetchImpl,
+  );
   const blocked = listed.issues ?? [];
   if (blocked.length === 0) {
     console.log("No blocked issues. Nothing to reconcile.");
-    return;
+    return 0;
   }
 
-  // Resolve every referenced blocker once.
+  // Resolve every referenced blocker once. A single unresolvable blocker is a
+  // READ: warn and keep sweeping — it must never abort the batch.
   const statusByKey = new Map();
   const needed = new Set(blocked.flatMap((i) => parseBlockerKeys(i?.metadata?.waiting_on)));
   for (const key of needed) {
     try {
-      const issue = await api(base, token, `/issues/${key}?workspace_id=${ws}`);
+      const issue = await api(base, token, `/issues/${key}?workspace_id=${workspace}`, {}, fetchImpl);
       statusByKey.set(key, issue?.status ?? null);
     } catch (e) {
       // Unresolvable → treated as still blocking. Never unblock on an error.
@@ -166,6 +156,7 @@ async function main() {
   }
 
   let unblocked = 0;
+  let writeFailed = false;
   for (const issue of blocked) {
     const { unblock, reason } = decideUnblock(issue, statusByKey);
     const id = issue.identifier;
@@ -179,20 +170,38 @@ async function main() {
       continue;
     }
     try {
-      await api(base, token, `/issues/${id}?workspace_id=${ws}`, {
-        method: "PUT",
-        body: JSON.stringify({ status: "todo" }),
-      });
+      await api(
+        base,
+        token,
+        `/issues/${id}?workspace_id=${workspace}`,
+        { method: "PUT", body: JSON.stringify({ status: "todo" }) },
+        fetchImpl,
+      );
       console.log(`  → ${id} unblocked (${reason})`);
       unblocked++;
     } catch (e) {
-      console.log(`  ! ${id} update failed, leaving blocked: ${e.message}`);
+      // A failed WRITE is fatal to the job. Log the key + status + body, keep
+      // sweeping the rest of the batch, and exit non-zero at the end.
+      console.error(`Failed to set ${id} todo (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+      writeFailed = true;
     }
   }
 
   console.log(
     `${dryRun ? "[dry-run] " : ""}${unblocked} of ${blocked.length} blocked issue(s) ${dryRun ? "would be" : ""} unblocked.`,
   );
+  return writeFailed ? 1 : 0;
+}
+
+async function main() {
+  const code = await run({
+    token: process.env.MULTICA_TOKEN,
+    workspace: process.env.MULTICA_WORKSPACE_ID,
+    base: process.env.MULTICA_API_BASE,
+    dryRun: process.argv.includes("--dry-run"),
+    verbose: process.argv.includes("--verbose"),
+  });
+  if (code) process.exit(code);
 }
 
 // Only run when invoked directly, so the pure exports stay importable in tests.

--- a/scripts/multica-unstick.mjs
+++ b/scripts/multica-unstick.mjs
@@ -309,24 +309,23 @@ export function decideUnstick({
  * IO below this line. Everything above is pure and unit-tested.
  * ------------------------------------------------------------------ */
 
-export async function run({
-  token,
-  workspace = DEFAULT_WORKSPACE,
-  base = DEFAULT_API_BASE,
-  dryRun = false,
-  verbose = false,
-  graceMs,
-  backoffMs,
-  maxActions,
-  fetchImpl = fetch,
-} = {}) {
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const verbose = process.argv.includes("--verbose");
+  const token = process.env.MULTICA_TOKEN;
+  const workspace = process.env.MULTICA_WORKSPACE_ID || DEFAULT_WORKSPACE;
+  const base = process.env.MULTICA_API_BASE || DEFAULT_API_BASE;
+  const graceMs = minutesEnv("MULTICA_UNSTICK_GRACE_MIN", 30);
+  const backoffMs = minutesEnv("MULTICA_UNSTICK_BACKOFF_MIN", 120);
+  const maxActions = Number(process.env.MULTICA_UNSTICK_MAX_ACTIONS) || 5;
+
   if (!token) {
     console.error("MULTICA_TOKEN is not set — nothing to do.");
-    return 1;
+    process.exit(1);
   }
 
   // Roles, resolved live so a renamed or newly added agent needs no code change.
-  const agents = await api(base, token, `/agents?workspace_id=${workspace}`, {}, fetchImpl);
+  const agents = await api(base, token, `/agents?workspace_id=${workspace}`);
   const roleById = new Map(
     (Array.isArray(agents) ? agents : (agents.agents ?? [])).map((a) => [
       a.id,
@@ -344,7 +343,7 @@ export async function run({
 
   const issues = [];
   for (const status of LIVE_STATUSES) {
-    const page = await api(base, token, `/issues?workspace_id=${workspace}&status=${status}&limit=200`, {}, fetchImpl);
+    const page = await api(base, token, `/issues?workspace_id=${workspace}&status=${status}&limit=200`, {});
     issues.push(...(page.issues ?? []));
   }
   if (issues.length === 0) {
@@ -370,8 +369,8 @@ export async function run({
     let runs = [];
     let pullRequests = [];
     try {
-      runs = await api(base, token, `/issues/${id}/task-runs?workspace_id=${workspace}`, {}, fetchImpl);
-      const prs = await api(base, token, `/issues/${id}/pull-requests?workspace_id=${workspace}`, {}, fetchImpl);
+      runs = await api(base, token, `/issues/${id}/task-runs?workspace_id=${workspace}`, {});
+      const prs = await api(base, token, `/issues/${id}/pull-requests?workspace_id=${workspace}`, {});
       pullRequests = prs.pull_requests ?? [];
     } catch (e) {
       // Unreadable state is a READ: never a reason to act. Skip and retry next
@@ -418,12 +417,12 @@ export async function run({
 
     try {
       if (decision.action === "rerun") {
-        await api(base, token, `/issues/${issue.id}/rerun?workspace_id=${workspace}`, { method: "POST", body: "{}" }, fetchImpl);
+        await api(base, token, `/issues/${issue.id}/rerun?workspace_id=${workspace}`, { method: "POST", body: "{}" });
       } else {
         await api(base, token, `/issues/${id}?workspace_id=${workspace}`, {
           method: "PUT",
           body: JSON.stringify({ assignee_id: target, assignee_type: "agent" }),
-        }, fetchImpl);
+        });
       }
       acted++;
       console.log(`  → ${id} ${what} (${decision.reason})`);
@@ -453,7 +452,7 @@ export async function run({
         await api(base, token, `/issues/${issue.id}/metadata/${key}?workspace_id=${workspace}`, {
           method: "PUT",
           body: JSON.stringify({ value }),
-        }, fetchImpl);
+        });
       } catch (e) {
         // A metadata write is a WRITE and must be visible too. The unstick
         // action itself already landed; keep the batch moving, fail at the end.
@@ -466,26 +465,15 @@ export async function run({
   console.log(
     `${dryRun ? "[dry-run] " : ""}${acted} of ${issues.length} live issue(s) ${dryRun ? "would be" : ""} unstuck.`,
   );
-  return writeFailed ? 1 : 0;
+
+  // A write that never landed must fail the job — invisible here means an
+  // issue left assigned-but-dead with a green-looking run.
+  if (writeFailed) process.exit(1);
 }
 
 function minutesEnv(name, fallback) {
   const raw = Number(process.env[name]);
   return (Number.isFinite(raw) && raw > 0 ? raw : fallback) * 60_000;
-}
-
-async function main() {
-  const code = await run({
-    token: process.env.MULTICA_TOKEN,
-    workspace: process.env.MULTICA_WORKSPACE_ID,
-    base: process.env.MULTICA_API_BASE,
-    dryRun: process.argv.includes("--dry-run"),
-    verbose: process.argv.includes("--verbose"),
-    graceMs: minutesEnv("MULTICA_UNSTICK_GRACE_MIN", 30),
-    backoffMs: minutesEnv("MULTICA_UNSTICK_BACKOFF_MIN", 120),
-    maxActions: Number(process.env.MULTICA_UNSTICK_MAX_ACTIONS) || 5,
-  });
-  if (code) process.exit(code);
 }
 
 // Only run when invoked directly, so the pure exports stay importable in tests.

--- a/scripts/multica-unstick.mjs
+++ b/scripts/multica-unstick.mjs
@@ -71,8 +71,7 @@
  * housekeeping and must never break a pipeline.
  */
 
-const DEFAULT_WORKSPACE = "264c89bb-4659-4570-af7b-5f8daaf87985";
-const DEFAULT_API_BASE = "https://api.multica.ai";
+import { api, DEFAULT_WORKSPACE, DEFAULT_API_BASE } from "./lib/multicaApi.mjs";
 
 /**
  * Statuses this sweep reasons about. `blocked` belongs to multica-unblock.
@@ -310,46 +309,24 @@ export function decideUnstick({
  * IO below this line. Everything above is pure and unit-tested.
  * ------------------------------------------------------------------ */
 
-/** @param {string} path @param {object} opts */
-async function api(base, token, path, opts = {}) {
-  const res = await fetch(`${base}/api${path}`, {
-    ...opts,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      ...(opts.headers ?? {}),
-    },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status} on ${path}: ${(await res.text()).slice(0, 200)}`);
-  }
-  const text = await res.text();
-  return text ? JSON.parse(text) : {};
-}
-
-function minutesEnv(name, fallback) {
-  const raw = Number(process.env[name]);
-  return (Number.isFinite(raw) && raw > 0 ? raw : fallback) * 60_000;
-}
-
-async function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const verbose = process.argv.includes("--verbose");
-  const token = process.env.MULTICA_TOKEN;
-  const ws = process.env.MULTICA_WORKSPACE_ID || DEFAULT_WORKSPACE;
-  const base = process.env.MULTICA_API_BASE || DEFAULT_API_BASE;
-  const graceMs = minutesEnv("MULTICA_UNSTICK_GRACE_MIN", 30);
-  const backoffMs = minutesEnv("MULTICA_UNSTICK_BACKOFF_MIN", 120);
-  const maxActions = Number(process.env.MULTICA_UNSTICK_MAX_ACTIONS) || 5;
-
+export async function run({
+  token,
+  workspace = DEFAULT_WORKSPACE,
+  base = DEFAULT_API_BASE,
+  dryRun = false,
+  verbose = false,
+  graceMs,
+  backoffMs,
+  maxActions,
+  fetchImpl = fetch,
+} = {}) {
   if (!token) {
     console.error("MULTICA_TOKEN is not set — nothing to do.");
-    process.exit(1);
+    return 1;
   }
 
   // Roles, resolved live so a renamed or newly added agent needs no code change.
-  const agents = await api(base, token, `/agents?workspace_id=${ws}`);
+  const agents = await api(base, token, `/agents?workspace_id=${workspace}`, {}, fetchImpl);
   const roleById = new Map(
     (Array.isArray(agents) ? agents : (agents.agents ?? [])).map((a) => [
       a.id,
@@ -367,16 +344,17 @@ async function main() {
 
   const issues = [];
   for (const status of LIVE_STATUSES) {
-    const page = await api(base, token, `/issues?workspace_id=${ws}&status=${status}&limit=200`);
+    const page = await api(base, token, `/issues?workspace_id=${workspace}&status=${status}&limit=200`, {}, fetchImpl);
     issues.push(...(page.issues ?? []));
   }
   if (issues.length === 0) {
     console.log("No in_progress/in_review issues. Nothing to reconcile.");
-    return;
+    return 0;
   }
 
   const now = Date.now();
   let acted = 0;
+  let writeFailed = false;
 
   for (const issue of issues) {
     const id = issue.identifier;
@@ -392,11 +370,12 @@ async function main() {
     let runs = [];
     let pullRequests = [];
     try {
-      runs = await api(base, token, `/issues/${id}/task-runs?workspace_id=${ws}`);
-      const prs = await api(base, token, `/issues/${id}/pull-requests?workspace_id=${ws}`);
+      runs = await api(base, token, `/issues/${id}/task-runs?workspace_id=${workspace}`, {}, fetchImpl);
+      const prs = await api(base, token, `/issues/${id}/pull-requests?workspace_id=${workspace}`, {}, fetchImpl);
       pullRequests = prs.pull_requests ?? [];
     } catch (e) {
-      // Unreadable state is never a reason to act. Skip and retry next tick.
+      // Unreadable state is a READ: never a reason to act. Skip and retry next
+      // tick — one issue's transient error must not abort the sweep.
       console.log(`  ! ${id} state unreadable, leaving alone: ${e.message}`);
       continue;
     }
@@ -439,20 +418,20 @@ async function main() {
 
     try {
       if (decision.action === "rerun") {
-        await api(base, token, `/issues/${issue.id}/rerun?workspace_id=${ws}`, {
-          method: "POST",
-          body: "{}",
-        });
+        await api(base, token, `/issues/${issue.id}/rerun?workspace_id=${workspace}`, { method: "POST", body: "{}" }, fetchImpl);
       } else {
-        await api(base, token, `/issues/${id}?workspace_id=${ws}`, {
+        await api(base, token, `/issues/${id}?workspace_id=${workspace}`, {
           method: "PUT",
           body: JSON.stringify({ assignee_id: target, assignee_type: "agent" }),
-        });
+        }, fetchImpl);
       }
       acted++;
       console.log(`  → ${id} ${what} (${decision.reason})`);
     } catch (e) {
-      console.log(`  ! ${id} could not ${what}: ${e.message}`);
+      // A failed WRITE (rerun/assign) is fatal to the job: log key + status +
+      // body, keep sweeping, exit non-zero at the end.
+      console.error(`Failed to ${what} ${id} (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+      writeFailed = true;
       continue;
     }
 
@@ -471,14 +450,15 @@ async function main() {
     };
     for (const [key, value] of Object.entries(stamps)) {
       try {
-        await api(base, token, `/issues/${issue.id}/metadata/${key}?workspace_id=${ws}`, {
+        await api(base, token, `/issues/${issue.id}/metadata/${key}?workspace_id=${workspace}`, {
           method: "PUT",
           body: JSON.stringify({ value }),
-        });
+        }, fetchImpl);
       } catch (e) {
-        // The unstick itself already landed; losing the ledger is not worth
-        // failing over. Backoff degrades to "may act again next tick".
-        if (verbose) console.log(`    (metadata ${key} failed: ${e.message})`);
+        // A metadata write is a WRITE and must be visible too. The unstick
+        // action itself already landed; keep the batch moving, fail at the end.
+        console.error(`Failed to write ${key} on ${id} (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+        writeFailed = true;
       }
     }
   }
@@ -486,6 +466,26 @@ async function main() {
   console.log(
     `${dryRun ? "[dry-run] " : ""}${acted} of ${issues.length} live issue(s) ${dryRun ? "would be" : ""} unstuck.`,
   );
+  return writeFailed ? 1 : 0;
+}
+
+function minutesEnv(name, fallback) {
+  const raw = Number(process.env[name]);
+  return (Number.isFinite(raw) && raw > 0 ? raw : fallback) * 60_000;
+}
+
+async function main() {
+  const code = await run({
+    token: process.env.MULTICA_TOKEN,
+    workspace: process.env.MULTICA_WORKSPACE_ID,
+    base: process.env.MULTICA_API_BASE,
+    dryRun: process.argv.includes("--dry-run"),
+    verbose: process.argv.includes("--verbose"),
+    graceMs: minutesEnv("MULTICA_UNSTICK_GRACE_MIN", 30),
+    backoffMs: minutesEnv("MULTICA_UNSTICK_BACKOFF_MIN", 120),
+    maxActions: Number(process.env.MULTICA_UNSTICK_MAX_ACTIONS) || 5,
+  });
+  if (code) process.exit(code);
 }
 
 // Only run when invoked directly, so the pure exports stay importable in tests.


### PR DESCRIPTION
## BET-504 — A failed Multica write fails the job; collapse the three duplicated API helpers

**Part 2 (helper) then Part 1 (fail-loud), per the issue's ordering.**

- New `scripts/lib/multicaApi.mjs` — the single Multica HTTP helper (`api` + `ApiError`), the ONLY place a Multica write happens. The three local copies are deleted.
- Every Multica **write** (status change, assignment, rerun, metadata, issue comment) now exits non-zero on a non-OK response, logging the issue key + HTTP status + response body. **Reads** still warn and continue. A batch finishes processing all issues before exiting non-zero.
- Each `api` call accepts an injectable `fetch` (5th arg, default = global) so the sweeps are testable without real HTTP — same injection pattern the existing pure-function tests use.
- No retry, no `--strict` flag, no second helper. Call-site behaviour unchanged.
- GitHub-only calls in `multica-pr-closed.mjs` (`gh` probes + `commentOnPr`) stay local intentionally: different API (api.github.com), different token headers, and they must warn-and-continue rather than throw. Forcing them through the Multica helper would change their behaviour, which the issue forbids ("stop and comment" — noted here rather than adding a flag/second function).

**Net line count:** whole diff `+333 / −128` (net `+205`); source only (helper + 3 scripts, excluding the new test file) `+204 / −127` (net `+77`). Not net-negative: the change necessarily adds the new helper module, a fetch-injection seam for the required tests, and fail-loud handling per sweep. The duplication removed (three local HTTP implementations ≈ 127 removed lines) is outweighed by those additive essentials. Per BET-503's standing constraint: "If a child's diff adds more than it deletes, say why" — this is it.

**Tests added** (in `scripts/multica-pr-closed.test.mjs`, the issue's permitted single home; `scripts/lib/*.test.mjs` is NOT matched by the `npm test` glob, so a test there would never run — red and each would fail to load / assert before the fix):
1. write non-OK → run exits non-zero (incl. the BET-438 done-write regression)
2. read non-OK → run exits 0
3. batch with one failing write → remaining issues still processed, exits non-zero at the end

**Verification results:**
- PR branch (`multica/BET-504-collapse-multica-api-helpers` @ `d4c0526`):
  - typecheck: exit 0, errors none, log sha256 `00a5b657…`
  - test: exit 0, 1285 pass / 0 fail / 0 skip. Failures: none. log sha256 `45fe1ff4…`
- Base (`main` @ `dfe2a56`):
  - typecheck: exit 0, errors none, log sha256 `00a5b657…`
  - test: exit 0, 1279 pass / 0 fail / 0 skip. Failures: none. log sha256 `835a9b16…`
- **Conclusion:** 0 test failures are pre-existing, 0 are new, and the PR adds 6 passing tests (1285 vs 1279). The new tests are red before the fix (the old code warn'd and exited 0 on write failure; there was no `run`/helper to call) and green after.
- Logs cached at `/tmp/tc-pr.log`, `/tmp/test-BET504.log`, `/tmp/tc-main.log`, `/tmp/test-main.log`.

Base: origin/main @ `dfe2a56`
