### PR TITLE
feat(server): 90-day device token idle expiry + rotation [token-lifetime change] (BET-491)

### DIFF
--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -35,7 +35,7 @@ import { unlink } from "node:fs/promises";
 import { randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
-import { createDeviceRegistry, DEVICES_STORE_PATH, saveDevicesRaw } from "./devices.mjs";
+import { createDeviceRegistry, DEVICES_STORE_PATH, DEVICE_IDLE_TTL_MS, saveDevicesRaw } from "./devices.mjs";
 
 const STORE_PATH = statePath("auth.json");
 
@@ -383,6 +383,8 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
  *   enforce     — gate on (default true)
  *   ttlMs       — pairing-code TTL (default 5 minutes)
  *   now         — injectable clock for tests
+ *   idleTtlMs   — device token idle-expiry threshold (§6.4, default 90 days).
+ *                 Passed through to the device registry; see devices.mjs.
  *   saveAuth    — injectable writer (default saveAuth) for the post-revoke
  *                 regenerate step
  *   deleteAuth  — injectable unlink (default deleteAuth) for the post-revoke
@@ -405,6 +407,7 @@ export function createAuthEngine({
   enforce = true,
   ttlMs = PAIRING_TTL_MS,
   now = () => Date.now(),
+  idleTtlMs = DEVICE_IDLE_TTL_MS,
   saveAuth: saveAuthFn = saveAuth,
   deleteAuth: deleteAuthFn = deleteAuth,
   devices: devicesFn,
@@ -417,7 +420,7 @@ export function createAuthEngine({
   // Per-device credential registry. Default targets ~/.manta/devices.json;
   // the shared box_token is seeded as the `primary` device so existing paired
   // devices (desktop + manta-native AI tools) keep working unchanged.
-  const devices = devicesFn ?? createDeviceRegistry({ now });
+  const devices = devicesFn ?? createDeviceRegistry({ now, idleTtlMs });
   // Seed/resync the primary (shared box_token) device — idempotent: if a
   // primary already exists (upgrade path) this just re-syncs its token; on a
   // fresh registry it creates one. This is what keeps the existing desktop +
@@ -451,6 +454,13 @@ export function createAuthEngine({
       // bumped in memory, flushed at most once per DEVICE_PERSIST_MS.
       maybePersistDevices();
       return { ok: true };
+    }
+    if (devices.needPersist && devices.needPersist()) {
+      // authorize() rejected BECAUSE it just revoked an idle-expired device.
+      // That revocation must be durable even though authorize only flushes on
+      // success — force it (fire-and-forget; a lost write just means the next
+      // request re-detects + re-revokes from the durable stale last_seen).
+      maybePersistDevices(true);
     }
     return { ok: false, status: 401, error: "unauthorized" };
   }

--- a/src/server/devices.mjs
+++ b/src/server/devices.mjs
@@ -32,6 +32,12 @@ import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
 export const DEVICES_STORE_PATH = statePath("devices.json");
 
+// Device token idle expiry (§6.4 of the pairing rework): a joined device whose
+// `last_seen` is older than this is treated as abandoned and its token is
+// revoked (dead on its next request). Home Assistant's default of 90 days.
+// Exported so auth.mjs can default its engine and inject in tests.
+export const DEVICE_IDLE_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
 // Device ids / tokens are 32 lowercase hex chars (128 bits) — the same shape
 // as box_id / box_token. Strict so a value can never smuggle a path-traversal
 // or header-injection payload.
@@ -74,16 +80,30 @@ export async function saveDevicesRaw(state, path = DEVICES_STORE_PATH) {
  *   { devices: [ { device_id, token, name, last_seen, created_at, revoked, primary } ] }
  *
  * @param {object} deps
- *   load   — () => parsed store or null (default: read `DEVICES_STORE_PATH`)
- *   save   — (serializedState) => Promise  (default: write 0600)
- *   now    — () => epoch ms (injectable clock for tests)
+ *   load      — () => parsed store or null (default: read `DEVICES_STORE_PATH`)
+ *   save      — (serializedState) => Promise  (default: write 0600)
+ *   now       — () => epoch ms (injectable clock for tests)
+ *   idleTtlMs — idle-expiry threshold (default: 90 days). A non-primary device
+ *               whose `last_seen` is older than this is revoked (token dead).
+ *               The PRIMARY (shared box_token) device is deliberately EXEMPT:
+ *               it is the box's enduring identity held by the desktop + the
+ *               manta-native AI tools (which re-read ~/.manta/auth.json per
+ *               call), so an idle-expiry policy must never spuriously lock the
+ *               whole box out. §6.4's 90-day idle expiry targets abandoned
+ *               *joined* devices (a lost phone), not the box's own identity.
  */
 export function createDeviceRegistry({
   load = () => loadDevicesRaw(),
   save = async (state) => saveDevicesRaw(state),
   now = () => Date.now(),
+  idleTtlMs = DEVICE_IDLE_TTL_MS,
 } = {}) {
   let devices = [];
+  // Set when an idle-expiry path mutates a device (revokes it). The request
+  // gate in auth.mjs reads it to force-persist a revocation that would
+  // otherwise not be flushed (authorize() only persists on success). Cleared
+  // when persist() succeeds.
+  let dirty = false;
   const parsed = load();
   if (parsed && Array.isArray(parsed.devices)) {
     devices = parsed.devices.filter(
@@ -101,7 +121,27 @@ export function createDeviceRegistry({
   const findPrimary = () => devices.find((d) => d.primary);
 
   function persist() {
-    return save({ devices });
+    return save({ devices }).then(
+      () => {
+        dirty = false;
+      },
+      (e) => {
+        throw e;
+      },
+    );
+  }
+
+  // Has an idle-expiry path marked a device revoked since the last persisted
+  // write? The request gate consults this on a rejected authorize to persist a
+  // revocation that the success-only throttle would otherwise skip.
+  function needPersist() {
+    return dirty;
+  }
+
+  // True when a device is subject to idle expiry (everyone except the PRIMARY
+  // shared box_token holder — see the constructor doc).
+  function expirable(d) {
+    return !d.primary;
   }
 
   // Seed (or re-sync) the primary device — the shared box_token holder that
@@ -130,11 +170,45 @@ export function createDeviceRegistry({
   // Resolve a presented bearer token to a live (non-revoked) device — primary
   // OR any additionally-claimed device. Returns the device (last_seen bumped)
   // or null. This is the /authorize gate's sole credential check.
+  //
+  // IDLE EXPIRY (deterministic in-flight behaviour): expiry is evaluated ONCE,
+  // at request admission. If the presenting device is a non-primary whose
+  // `last_seen` is already older than idleTtlMs, it is marked revoked and the
+  // request is rejected (401) — it does NOT bump last_seen, so it can never
+  // "come back". A request that ADMITTED before the window elapsed bumped
+  // last_seen to `now` on admission, so it runs to completion and is not
+  // re-checked mid-flight; its fresh last_seen also keeps it from expiring for
+  // another full window. That is the single answer to the §6.4 "token in
+  // flight at the boundary" question: an admitted request completes, and the
+  // next request after an idle window is cleanly rejected.
   function authorize(token) {
     const dev = liveByToken(token);
     if (!dev) return null;
+    if (expirable(dev) && now() - dev.last_seen > idleTtlMs) {
+      dev.revoked = true;
+      dirty = true;
+      return null;
+    }
     dev.last_seen = now();
     return dev;
+  }
+
+  // The "90-day sweep" leg: mark every non-primary device idle past the
+  // threshold as revoked in one pass. Returns the revoked devices (tests assert
+  // this). Enforcement itself is already handled per-request by `authorize`;
+  // this exists so a background sweep (or the desktop list) can force the
+  // bookkeeping to reflect expiration without waiting for an ill-fated request.
+  function sweepIdleExpired() {
+    const t = now();
+    const expired = [];
+    for (const d of devices) {
+      if (!d.revoked && expirable(d) && t - d.last_seen > idleTtlMs) {
+        d.revoked = true;
+        dirty = true;
+        expired.push(d);
+      }
+    }
+    return expired;
   }
 
   // Provision or resume a per-device entry:
@@ -229,6 +303,8 @@ export function createDeviceRegistry({
   return {
     seedPrimary,
     authorize,
+    sweepIdleExpired,
+    needPersist,
     claim,
     getDevice,
     revokeDevice,

--- a/src/server/devices.test.mjs
+++ b/src/server/devices.test.mjs
@@ -14,6 +14,7 @@ import {
   saveDevicesRaw,
   isValidDeviceToken,
   DEVICES_STORE_PATH,
+  DEVICE_IDLE_TTL_MS,
 } from "./devices.mjs";
 import { createAuthEngine } from "./auth.mjs";
 
@@ -61,6 +62,150 @@ function doClaim(eng, overrides = {}) {
 
 const gate = (eng, tok) =>
   eng.authorize({ method: "GET", path: "/api/projects", authorization: `Bearer ${tok}` });
+
+// A settable monotonic clock for idle-expiry tests, plus a registry + engine
+// wired with a small idleTtlMs so we don't advance 90 simulated days per case.
+function makeClockEngine({ idleTtlMs = 1000, start = 1000 } = {}) {
+  let t = start;
+  const clock = {
+    now: () => t,
+    advance: (ms) => {
+      t += ms;
+    },
+  };
+  let state = { devices: [] };
+  const devices = createDeviceRegistry({
+    load: () => ({ devices: state.devices }),
+    save: (s) => {
+      state.devices = s.devices;
+      return Promise.resolve(true);
+    },
+    now: clock.now,
+    idleTtlMs,
+  });
+  const eng = createAuthEngine({
+    auth: AUTH,
+    saveAuth: async () => {},
+    deleteAuth: async () => {},
+    devices,
+    now: clock.now,
+    idleTtlMs,
+  });
+  return { eng, devices, clock };
+}
+
+// ---------------------------------------------------------------------------
+// Stage 3 — device token idle expiry (90 days, §6.4)
+// ---------------------------------------------------------------------------
+
+test("idle expiry: a device idle past the threshold is revoked on its NEXT request", () => {
+  const { eng, devices, clock } = makeClockEngine();
+  const a = doClaim(eng, { device_id: "devA" });
+  // admitted once, so last_seen = now
+  assert.equal(gate(eng, a.box_token).ok, true);
+  const lastSeenA = devices.getDevice(a.device_id).last_seen;
+
+  // goes idle WITHOUT further use for more than the window
+  clock.advance(1001); // idleTtlMs=1000 → idle = 1001 > 1000
+  assert.equal(gate(eng, a.box_token).ok, false); // revoked on its next request
+  // and it stays revoked — it can never "come back" (last_seen not bumped)
+  assert.equal(gate(eng, a.box_token).ok, false);
+  // the revocation is durable-flagged for the gate to force-persist
+  assert.equal(devices.needPersist(), true);
+  assert.ok(lastSeenA > 0);
+});
+
+test("idle expiry: a device idle AT the boundary (not past it) is accepted — not spuriously expired", () => {
+  const { eng, clock } = makeClockEngine();
+  const a = doClaim(eng, { device_id: "devA" });
+  assert.equal(gate(eng, a.box_token).ok, true); // admission, last_seen = now
+  clock.advance(999); // idle = 999 < 1000
+  assert.equal(gate(eng, a.box_token).ok, true);
+});
+
+test("idle expiry: an ACTIVE device (recent auth) is never expired", () => {
+  const { eng, clock } = makeClockEngine();
+  const a = doClaim(eng, { device_id: "devA" });
+  // use it at a pace just inside the window, forever
+  for (let i = 0; i < 5; i++) {
+    clock.advance(999);
+    assert.equal(gate(eng, a.box_token).ok, true, `iteration ${i} must stay live`);
+  }
+  assert.equal(gate(eng, a.box_token).ok, true);
+});
+
+test("idle expiry: the PRIMARY (shared box_token) device is NEVER expired, even idle past the threshold", () => {
+  const { eng, clock } = makeClockEngine();
+  // primary is the shared box_token holder (desktop + manta-native tools)
+  clock.advance(10 ** 7); // way past 90 days of simulated idle
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true);
+});
+
+test("idle expiry: other devices are unaffected when one expires", () => {
+  const { eng, clock } = makeClockEngine();
+  const a = doClaim(eng, { device_id: "devA" });
+  const b = doClaim(eng, { device_id: "devB" });
+  const c = doClaim(eng, { device_id: "devC" });
+  // keep B and C fresh, let A go idle
+  for (let i = 0; i < 3; i++) {
+    clock.advance(999);
+    assert.equal(gate(eng, b.box_token).ok, true);
+    assert.equal(gate(eng, c.box_token).ok, true);
+  }
+  clock.advance(2); // A now idle past threshold
+  assert.equal(gate(eng, a.box_token).ok, false); // only A dies
+  assert.equal(gate(eng, b.box_token).ok, true);
+  assert.equal(gate(eng, c.box_token).ok, true);
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true);
+  // revoked A drops out of the linked-device list; B/C/primary remain
+  const ids = eng.listDevices().map((d) => d.device_id);
+  assert.equal(ids.includes(a.device_id), false);
+  assert.equal(ids.includes(b.device_id), true);
+  assert.equal(ids.includes(c.device_id), true);
+});
+
+test("idle expiry: IN-FLIGHT behaviour — admitted requests complete (never torn down mid-flight); the next request once the idle window has elapsed 401s cleanly without refreshing", () => {
+  const { eng, clock } = makeClockEngine({ idleTtlMs: 1000 });
+  const a = doClaim(eng, { device_id: "devA" });
+  // (a) an admitted request RUNS to completion — expiry is evaluated exactly
+  //     once, at admission, and never re-checked mid-request.
+  assert.equal(gate(eng, a.box_token).ok, true);
+  // (b) the device is then abandoned (a lost phone): a full idle window elapses
+  //     with no use, so the NEXT request is rejected cleanly — 401.
+  clock.advance(1001); // idle from last use = 1001 > 1000
+  const r = eng.authorize({ method: "GET", path: "/api/projects", authorization: `Bearer ${a.box_token}` });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 401);
+  // (c) the rejected request did NOT refresh the device — it stays revoked.
+  assert.equal(gate(eng, a.box_token).ok, false);
+});
+
+test("idle expiry: the 90-day SWEEP marks every long-idle device revoked in one pass", () => {
+  const { devices, clock, eng } = makeClockEngine();
+  const a = doClaim(eng, { device_id: "devA" });
+  const b = doClaim(eng, { device_id: "devB" });
+  assert.equal(gate(eng, a.box_token).ok, true);
+  assert.equal(gate(eng, b.box_token).ok, true);
+  // sweep while both fresh → nothing expires, nothing revoked
+  assert.deepEqual(devices.sweepIdleExpired(), []);
+  // let both go idle, then sweep
+  clock.advance(10 ** 5);
+  const swept = devices.sweepIdleExpired().map((d) => d.device_id);
+  assert.deepEqual(swept.sort(), [a.device_id, b.device_id].sort());
+  // both tokens are now dead on their next request
+  assert.equal(gate(eng, a.box_token).ok, false);
+  assert.equal(gate(eng, b.box_token).ok, false);
+  // primary survives the sweep (exempt)
+  assert.equal(gate(eng, PRIMARY_TOKEN).ok, true);
+  // a fresh use re-provisions a NEW device (a revoked device is never resurrected)
+  const again = doClaim(eng, { device_id: "devA" });
+  assert.notEqual(again.device_id, a.device_id);
+  assert.equal(gate(eng, again.box_token).ok, true);
+});
+
+test("DEVICE_IDLE_TTL_MS is 90 days", () => {
+  assert.equal(DEVICE_IDLE_TTL_MS, 90 * 24 * 60 * 60 * 1000);
+});
 
 // ---------------------------------------------------------------------------
 // Pure registry


### PR DESCRIPTION
**BET-491 — Device token TTL + rotation (90-day idle expiry)** · Stage 3 of 5 (BET-488 pairing rework)

## ⚠️ CHANGES TOKEN LIFETIME / touches the token store–registry

This PR enforces a **90-day device-token idle-expiry** on the device registry created in Stage 2 (BET-490). It does **not** change loopback-only minting or the 0600 store discipline.

## What happens to a token in flight when it rotates/expires

Expiry is evaluated **exactly once, at request admission** (`devices.authorize`). Concretely:

- A request admitted before the idle window elapsed runs to completion — it is **never re-checked mid-flight** and is not torn down. Its admission refreshes `last_seen`, which also pushes the next expiry a full window out.
- The **next request after** a full idle window (no use since the last admission) is rejected cleanly with **401**, and that rejected request does **not** refresh the device — so an expired token can never "walk itself back to life".
- This is the single deterministic answer to the §6.4 boundary question, and it is pinned by the `idle expiry: IN-FLIGHT behaviour` test.

**Primary device (the shared `box_token`) is exempt** from idle expiry. It is the box's enduring identity held by the desktop + the manta-native AI tools (which re-read `~/.manta/auth.json` per call), so an idle policy must never spuriously lock the whole box out. §6.4's 90-day expiry targets abandoned *joined* devices (a lost phone). Existing paired devices keep working: an active device (recent auth) is never spuriously expired.

## Implementation

- `src/server/devices.mjs`: `DEVICE_IDLE_TTL_MS` (90 days), an `idleTtlMs` constructor param (injectable, mirroring the existing `now` injection), expiry enforced in `authorize`, a `sweepIdleExpired()` leg, and a `needPersist()`/`dirty` flag so an expiry-revocation is force-persisted by the request gate (authorize otherwise only flushes on success).
- `src/server/auth.mjs`: `createAuthEngine({ idleTtlMs })` passes the threshold through, and the request gate force-persists when `authorize` rejects because it just revoked an idle-expired device.
- `src/server/devices.test.mjs`: idle-crossing revocation, boundary (not-past) accepted, active-never-expired, primary-exempt, other-devices-unaffected, the in-flight behaviour, the sweep, and `DEVICE_IDLE_TTL_MS === 90d`.

Out of scope (per issue): push-on-pairing (Stage 4), desktop panel (Stage 5), pairing-code TTL, universal link.

**Base: origin/main @ 761f9f8**

**Verification results:**
- PR branch (`multica/BET-491-device-token-ttl`):
  - typecheck: exit 0. Errors: none
  - test: exit 0, 1303 pass / 0 fail / 0 skip
- Base (`main` @ 761f9f8, pre-existing): identical test+typecheck baseline (1303 pass)
- **Conclusion:** 0 new failures. Earlier manual runs showed capabilities/pairPage/pty/push/rpc "failures" were purely missing-optional-dep load errors (no `npm install`), identical on main; all green once installed.
