### PR TITLE
BET-507: one owner per decomposition issue (instructions only)

### DIFF
--- a/.multica/agents/manta-pm.md
+++ b/.multica/agents/manta-pm.md
@@ -264,6 +264,15 @@ assignee). At that point:
    when all its children are done) — do NOT try to "implement the milestone"
    directly. Its children are the buildable units.
 
+A decomposition issue — one whose deliverable is other issues — has exactly
+**one** assignee, and is never re-assigned or re-dispatched while a run is in
+flight. Before decomposing, check whether the children already exist: if any
+child of that parent is already filed, **stop and comment** rather than filing
+a second set, saying what you found. If two trees do exist, they are reconciled
+by a **human**, not by an agent picking one — an agent must not cancel another
+agent's issues. Both BET-484 and BET-475 produced duplicate trees this way and
+needed a human to sort them out.
+
 **Do NOT decompose a milestone before its stage is active.** Later-stage
 milestones stay `todo` + unassigned until their turn — decomposing early
 creates stale sub-issues that drift from the code that lands before them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2837,6 +2837,15 @@ and before a reassign it would wake the stalled agent being routed away from.
 Metadata writes are inert. Anything automated that touches an agent-assigned
 issue must account for this — a "harmless status comment" is an agent run.
 
+**A decomposition issue — one whose deliverable is other issues — has exactly
+one owner.** BET-484 and BET-475 both decomposed concurrently on 2026-08-01
+(two assignments, or an assignment plus a comment, fired two runs and produced
+two trees a human had to diff and cancel). Such an issue has one assignee and
+is never re-assigned or re-dispatched while a run is in flight; before
+decomposing, check whether the children already exist and stop rather than
+filing a second set. If two trees do exist, they are reconciled by a human, not
+by an agent picking one — an agent must not cancel another agent's issues.
+
 **`manta-ops` is NOT part of this.** It's an agent driven by a Multica autopilot
 that has been paused since 2026-07-21, so every recovery path its instructions
 describe (`manta-pm.md` cases D and E) currently routes to nobody. The CI


### PR DESCRIPTION
Implements BET-507 (child of BET-503). **Instructions-only change** — this issue changes instructions, not code. No script, no workflow, no test; the diff touches exactly two files and nothing under `scripts/` or `.github/`.

## What changed

Adds the rule for issues whose deliverable is *other issues* (decomposition): exactly one assignee, never re-assigned/re-dispatched while a run is in flight, check whether the children already exist before decomposing (stop + comment rather than filing a second set), and if two trees do exist they are reconciled by a **human**, not an agent picking one.

- `.multica/agents/manta-pm.md` — rule added to the milestone-decomposition section (manta-pm is the decomposer).
- `AGENTS.md` — one short paragraph added in the work-tracking section, next to the existing comment-dispatches-a-run gotcha.

Both instances name BET-484 and BET-475 as the observed 2026-08-01 failures. Per the issue, the rule appears in exactly these two places and nowhere else.

## Verification

- `git diff --name-only` → `.multica/agents/manta-pm.md`, `AGENTS.md` only; no `scripts/` or `.github/` changes.
- `npm run typecheck` → passes.
- `npm test` → 1309 pass, 0 fail.
- `manta-pm` instructions pushed to Multica with `multica agent update df781c72-9408-47e3-be9e-cfa317ed6bc9 --instructions "$(cat .multica/agents/manta-pm.md)"`.

Reviewer: please verify the DoD — rule in exactly two files (and no third), both name BET-484/BET-475, instructions pushed, checks green.