### PR TITLE
Visual gate: record which popup surfaces no capture opens (BET-486)

### DIFF
--- a/scripts/visual/screens.mjs
+++ b/scripts/visual/screens.mjs
@@ -96,6 +96,7 @@ export const SCREENS = [
     ready: '[data-screen="welcome"]',
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/welcome/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn"],
   },
   {
     id: "session",
@@ -115,6 +116,15 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+      "manta-session-menu-trigger",
+    ],
   },
   {
     // REGION ROWS for the session view (BET-468). The header strip and the
@@ -137,6 +147,15 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+      "manta-session-menu-trigger",
+    ],
   },
   {
     id: "session-composer",
@@ -152,6 +171,15 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+      "manta-session-menu-trigger",
+    ],
   },
   {
     id: "settings",
@@ -171,6 +199,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     // REGION ROWS — a component that owns its own small baseline. These are
@@ -191,6 +220,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     id: "settings-general",
@@ -205,6 +235,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     // Extensions panel — the four settings sections (box/accounts/extensions)
@@ -228,6 +259,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     // The ⋯ session menu is the only entry point for AI-CLI launcher modes
@@ -250,6 +282,14 @@ export const SCREENS = [
     // registry's documented way to say "no design filed"; the row still gets
     // a structure snapshot and a pixel baseline.
     mockup: null,
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+    ],
   },
 ];
 

--- a/scripts/visual/screens.mjs
+++ b/scripts/visual/screens.mjs
@@ -53,6 +53,12 @@
  *             to `region`. It exists because the mockup is a different DOM and
  *             the selector usually differs (e.g. app `nav[role="tablist"]` vs
  *             mockup `.snav`).
+ *   surfacesClosed  Hook classes (see AGENTS.md "Mobile CSS hook-class
+ *                   contract") of every popup trigger present in this capture
+ *                   but NOT opened by it. Committed inventory: a surface that
+ *                   appears in EVERY row's list is opened by no capture and is
+ *                   therefore unverified. Generate it from the assertion's own
+ *                   failure output — never hand-write it.
  *
  *   Structure-root precedence: `snapshot ?? region ?? ready`. Explicit
  *   `snapshot` wins (a dialog opened by actions), then `region` when the row
@@ -70,6 +76,7 @@
  *   snapshot?: string,
  *   region?: string,
  *   mockupRegion?: string,
+ *   surfacesClosed?: string[],
  *   actions?: (page: any) => Promise<void>,
  *   viewport: { width: number, height: number },
  *   mockup: string | null,

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -153,14 +153,14 @@ export function ModelPicker({
     >
       {/* Model button — friendly name + Sparkles icon, opens the model list. */}
       <div className={separatePills ? "relative" : ""}>
-          <button
-            className={
-              "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
-              (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
-            }
-            aria-haspopup="listbox"
-            aria-expanded={modelOpen}
-            onClick={() => {
+        <button
+          className={
+            "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
+            (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
+          }
+          aria-haspopup="listbox"
+          aria-expanded={modelOpen}
+          onClick={() => {
             if (!modelOpen) onOpen();
             setVariantOpen(false);
             setModelOpen((v) => !v);

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -153,12 +153,14 @@ export function ModelPicker({
     >
       {/* Model button — friendly name + Sparkles icon, opens the model list. */}
       <div className={separatePills ? "relative" : ""}>
-        <button
-          className={
-            "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
-            (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
-          }
-          onClick={() => {
+          <button
+            className={
+              "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
+              (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
+            }
+            aria-haspopup="listbox"
+            aria-expanded={modelOpen}
+            onClick={() => {
             if (!modelOpen) onOpen();
             setVariantOpen(false);
             setModelOpen((v) => !v);
@@ -245,6 +247,8 @@ export function ModelPicker({
                 : "border-l border-border-strong") +
               (effortDisabled ? " cursor-not-allowed" : "")
             }
+            aria-haspopup="listbox"
+            aria-expanded={variantOpen}
             onClick={() => {
               if (effortDisabled) return;
               setModelOpen(false);

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -282,6 +282,8 @@ function ContextPill({
           ? "bg-warn-bg hover:bg-warn-bg"
           : "hover:bg-fill")
       }
+      aria-haspopup="dialog"
+      aria-expanded={open}
       title={stale ? "Context stale — click for details" : "Context usage — click for details"}
     >
       {/* Mini segmented bar inside the pill — same segment order/colors as

--- a/tests/visual/screens.visual.ts
+++ b/tests/visual/screens.visual.ts
@@ -111,6 +111,32 @@ for (const screen of SCREENS) {
             animations: "disabled",
           });
         }
+
+        // 3. Surface coverage — which popup triggers this capture leaves closed.
+        // A trigger declares itself with aria-haspopup (Change 1); `aria-expanded`
+        // tells open from closed. Identity is the element's `manta-*` hook class,
+        // which is already a stable contract (AGENTS.md) — do NOT key on the
+        // accessible name, which is the model name / percentage and changes with
+        // the fixture.
+        const closed = await page.evaluate(() =>
+          [...document.querySelectorAll("[aria-haspopup]")]
+            .filter((el) => el.getAttribute("aria-expanded") !== "true")
+            .map((el) => [...el.classList].find((c) => c.startsWith("manta-")) ?? "")
+            .filter(Boolean)
+            .sort(),
+        );
+        expect(
+          closed,
+          // Two directions, opposite meanings:
+          //   new entry  → someone added a popup trigger no capture opens. Either
+          //                add a row that opens it, or record the class here.
+          //   missing entry → someone added a row that opens it. Delete the class.
+          `surface coverage for "${screen.id}": closed triggers ${JSON.stringify(closed)} ` +
+            `vs surfacesClosed ${JSON.stringify(screen.surfacesClosed ?? [])}. ` +
+            "A NEW entry = a popup trigger no capture opens (add a row that opens it, " +
+            "or record it here as unverified). A MISSING entry = a row now opens it " +
+            "(delete the class from this row's list).",
+        ).toEqual(screen.surfacesClosed ?? []);
       } finally {
         await context.close();
       }


### PR DESCRIPTION
## BET-486 — Visual gate: record which popup surfaces no capture opens

**Files changed:** 4 files, 79 insertions, 0 deletions.

- `scripts/visual/screens.mjs` | 47 +
- `src/renderer/ModelPicker.tsx` | 4 +
- `src/renderer/SessionHeader.tsx` | 2 +
- `tests/visual/screens.visual.ts` | 26 +

**Component added/removed counts (per the issue's Definition of done #5):**
- `src/renderer/ModelPicker.tsx`: **+4 / −0** (`aria-haspopup` + `aria-expanded` on the model button and the effort button)
- `src/renderer/SessionHeader.tsx`: **+2 / −0** (`aria-haspopup` + `aria-expanded` on the context pill)
- Exactly six added attribute lines across the two files; nothing else touched.

### What changed

**Change 1 — declare the popup triggers (a11y fix).** The three controls that open a transient surface (model picker, effort picker, context pill) now carry `aria-haspopup` + `aria-expanded`, mirroring the already-correct session menu trigger. Models/effort pickers are `listbox`; the context pill is `dialog`. No renames, no restructure, no wrapper.

**Change 2 — surface-coverage assertion.** Added a third assertion to the existing visual loop: it collects every `[aria-haspopup]` element whose `aria-expanded !== "true"`, keys them by the `manta-*` hook class, and compares to each row's new optional `surfacesClosed` field. `screens.mjs` gained the field in the `Screen` typedef + field notes. Every row's `surfacesClosed` was **seeded from the assertion's own first failure output**, then re-run green.

The committed inventory now records what this issue is about: the model picker, effort picker, and context pill appear in **every** row's closed list, i.e. no capture opens them — they are unverified. Recording that is the deliverable; closing the gap is a separate per-surface decision (explicitly out of scope here).

### Definition-of-done confirmation

1. `npm run visual` green — 9/9 passed, `surfacesClosed` committed on all 9 rows (seeded from failure output).
2. No baselines moved — `git status` clean; no `*-visual-linux.png` and no `*.aria.yml` changed (the closed triggers add no snapshot lines).
3. Assertion fails usefully both directions — demonstrated: (a) NEW-entry direction from the unseeded run; (b) MISSING-entry direction by temporarily re-adding the open session-menu trigger to the session-menu row (failure: `- Expected -1 / + Received +0`), then reverted.
4. `npm run typecheck && npm test` pass (see Verification results).
5. Component diff exactly six added attribute lines (counts above).
6. No new file under `scripts/`, `tests/`, or `.github/`.

```
Base: origin/main @ ebf8213
```

**Verification results:**
- PR branch (`multica/BET-486-popup-surface-coverage` @ `ba4993f`):
  - typecheck: exit 0, no errors
  - test: 1301 pass / 0 fail / 0 skip
  - visual: 9/9 passed
- Base (`main` @ `ebf8213`):
  - typecheck: exit 0, no errors
  - test: 1301 pass / 0 fail / 0 skip
- **Conclusion:** 0 new test failures; the PR is purely additive (no production code path altered).
