### PR TITLE
feat(server): push to existing devices on every new pairing (BET-492)

### DIFF
--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -491,13 +491,21 @@ export function createAuthEngine({
     if (!pairing.consume(pairing_code)) {
       return { ok: false, status: 403, error: "pairing failed" };
     }
-    const { entry } = devices.claim({ deviceId: device_id, name });
+    // `resumed` reports whether this claim re-used an existing device entry
+    // (true) or provisioned a brand-new one (false). A resumed claim — an
+    // existing device re-pairing, or the legacy no-device_id path which resumes
+    // the PRIMARY (shared box_token) device — is NOT a new pairing, so the
+    // caller (index.mjs) uses this to decide whether to fire a "new device
+    // paired" notice to the other devices (§6.3, BET-492). Only a genuinely new
+    // provision (resumed === false) is a new device.
+    const { entry, resumed } = devices.claim({ deviceId: device_id, name });
     maybePersistDevices(true);
     return {
       ok: true,
       box_token: entry.token,
       box_id: auth.box_id,
       device_id: entry.device_id,
+      resumed,
     };
   }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -777,6 +777,25 @@ const handleRequest = async (req, res) => {
           respondJson(res, result.status ?? 400, { error: result.error });
           return;
         }
+        // BET-492 (§6.3 "Audit linked devices regularly" mitigation): a
+        // GENUINELY new device just paired (resumed === false — an existing
+        // device re-pairing or the legacy primary path is NOT a new pairing,
+        // so it doesn't spam the other devices). Tell every EXISTING paired
+        // device so a rogue/unknown link is visible to the devices already on
+        // the box. The existing set is read from the Stage 2 registry minus the
+        // joiner (never the new device itself). Best-effort + non-blocking:
+        // delivery must never delay or fail the token return.
+        if (result.resumed === false) {
+          const existingDevices = authEngine
+            .listDevices()
+            .filter((d) => d.device_id !== result.device_id);
+          push
+            .fireNewDevicePaired(existingDevices, {
+              device_id: result.device_id,
+              name: body?.name ?? null,
+            })
+            .catch(() => {});
+        }
         respondJson(res, 200, {
           box_token: result.box_token,
           box_id: result.box_id,

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -676,6 +676,59 @@ export async function fireNotify({ message, title, urgent, sessionID } = {}) {
   return { ok: true };
 }
 
+/**
+ * §6.3 "Audit linked devices regularly" mitigation (BET-492, Stage 4): the
+ * moment a genuinely NEW device pairs, every EXISTING paired device is told —
+ * the Google/Signal row that makes a rogue/unknown link visible to the devices
+ * already on the box instead of silently succeeding.
+ *
+ * Reuses the SAME single router as every other notification
+ * (dispatchNotification → routeNotification → desktop sink / sendPush), so
+ * this is ONE informational push subject to the exact router rules — an active
+ * desktop suppresses the mobile leg exactly like "done" (no bypass).
+ *
+ * `existingDevices` is the Stage 2 registry MINUS the joiner: the new device is
+ * never told it just paired (it performed the pairing itself, and it has no
+ * push subscription to receive a "new device" notice anyway). An empty set
+ * means there is nothing to notify → no-op.
+ *
+ * Non-blocking / best-effort, mirroring the pipeline's posture: any failure is
+ * logged and swallowed, so the pairing claim (which returns the token) never
+ * awaits or fails on push delivery.
+ *
+ * @param {Array<{device_id?:string, name?:string}>} existingDevices
+ *   live devices from the registry, the joiner excluded.
+ * @param {{device_id?:string|null, name?:string|null}} [joined]
+ *   the new device's identity, used only for notification copy.
+ */
+export async function fireNewDevicePaired(existingDevices, joined = {}) {
+  try {
+    const existing = Array.isArray(existingDevices) ? existingDevices : [];
+    if (existing.length === 0) {
+      console.log(
+        "[push] new-device: no existing devices to notify — skipping (joiner excluded)",
+      );
+      return;
+    }
+    const devName =
+      joined?.name && joined.name !== "" ? joined.name : "A new device";
+    const deviceId = joined?.device_id ?? null;
+    const payload = {
+      kind: "device-paired",
+      title: "New device paired",
+      body: `${devName} just linked to your box.`,
+      sessionId: null,
+      // Carry the joiner id so a consumer (e.g. the linked-devices list) can
+      // flag which device was added; distinct tag per device for dedup.
+      deviceId,
+      tag: `device-paired-${deviceId ?? Date.now()}`,
+    };
+    await dispatchNotification(payload);
+  } catch (e) {
+    console.warn("[push] new-device push failed:", e?.message ?? e);
+  }
+}
+
 async function sendPush(payload) {
   // APNs is the PRIMARY (native iOS) leg and MUST NOT be gated on the Web Push
   // (PWA) leg. Previously this function awaited webpush.sendNotification for

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -11,6 +11,7 @@ import {
   routeNotification,
   notifTier,
   fireNotify,
+  fireNewDevicePaired,
   setDesktopPresence,
   setDesktopSink,
   cancelEscalationsForSession,
@@ -585,6 +586,89 @@ test("escalation: re-notify same tag supersedes (no duplicate timer)", async () 
   await fireNotify({ message: "second", sessionID: "ses_s" });
   assert.deepEqual(_pendingEscalationTags(), ["notify-ses_s"]);
   cancelAllEscalations();
+  _resetPushState();
+});
+
+// ---------------------------------------------------------------------------
+// New-device-paired push (BET-492, Stage 4 of the pairing rework §6.3)
+// ---------------------------------------------------------------------------
+//
+// The mitigation row "plus a push to existing devices on every new pairing":
+// a genuinely new device joining is surfaced to every EXISTING paired device
+// through the SAME cross-device router as every other notification. These tests
+// pin: (1) it routes to existing devices and never the joiner, (2) it is
+// informational — an active desktop suppresses the mobile leg exactly like
+// "done", and (3) delivery failure never rejects (so the pairing claim, which
+// returns the token, is never blocked or failed by a push).
+
+test("new-device: routes to existing devices, never the joiner, via the shared router", async () => {
+  _resetPushState();
+  const sink = [];
+  setDesktopSink((p) => sink.push(p));
+  setDesktopPresence({ visible: false }); // fresh heartbeat, idle/away
+  // The joiner is deliberately NOT in existingDevices — the caller (the claim
+  // path) passes the registry minus the joiner.
+  await fireNewDevicePaired(
+    [{ device_id: "dev-desktop", name: "desktop" }],
+    { device_id: "dev-iphone", name: "iPhone" },
+  );
+  // Idle/away desktop → informational push routes desktop-first + escalates
+  // the mobile leg, exactly like "done". The desktop (an existing device) is
+  // told; the joiner never is.
+  assert.equal(sink.length, 1, "one informational push to the existing device");
+  assert.equal(sink[0].kind, "device-paired");
+  assert.match(sink[0].title ?? "", /New device paired/);
+  assert.match(sink[0].body ?? "", /iPhone/);
+  assert.equal(sink[0].deviceId, "dev-iphone");
+  assert.deepEqual(_pendingEscalationTags(), ["device-paired-dev-iphone"]);
+  _resetPushState();
+});
+
+test("new-device: no existing devices → no push (never tells the joiner)", async () => {
+  _resetPushState();
+  let sinkCalls = 0;
+  setDesktopSink(() => sinkCalls++);
+  setDesktopPresence({ visible: false });
+  await fireNewDevicePaired([], { device_id: "dev-solo", name: "solo" });
+  assert.equal(sinkCalls, 0, "nothing to notify when no existing device exists");
+  assert.deepEqual(_pendingEscalationTags(), []);
+  _resetPushState();
+});
+
+test("new-device: ACTIVE desktop suppresses the mobile leg like any informational kind", async () => {
+  _resetPushState();
+  const sink = [];
+  setDesktopSink((p) => sink.push(p));
+  setDesktopPresence({ visible: true }); // at the desk
+  await fireNewDevicePaired(
+    [{ device_id: "dev-desktop", name: "desktop" }],
+    { device_id: "dev-iphone", name: "iPhone" },
+  );
+  // routeNotification for an informational kind + active desktop → desktop
+  // only, no mobile push and NO escalation. Same row as "done".
+  assert.equal(sink.length, 1);
+  assert.deepEqual(
+    _pendingEscalationTags(),
+    [],
+    "active desktop suppresses the mobile leg + escalation",
+  );
+  _resetPushState();
+});
+
+test("new-device: delivery failure is swallowed (claim token unaffected)", async () => {
+  _resetPushState();
+  setDesktopSink(() => {
+    throw new Error("sink down");
+  });
+  setDesktopPresence({ visible: true });
+  // Even with the desktop leg throwing, the call must NOT reject — the claim
+  // (which returns the token) must never block or fail on push delivery.
+  await assert.doesNotReject(() =>
+    fireNewDevicePaired(
+      [{ device_id: "dev-desktop", name: "desktop" }],
+      { device_id: "dev-iphone", name: "iPhone" },
+    ),
+  );
   _resetPushState();
 });
 


### PR DESCRIPTION
## BET-492 — Push to existing devices on every new pairing

Stage 4 of the pairing rework (parent BET-488). On a successful `/auth/claim`
that provisions a **genuinely new** device, every existing paired device is told
via the existing push pipeline — the §6.3 "audit linked devices" mitigation that
makes a rogue link visible to the devices already on the box.

**Base:** `origin/main @ ecfda62`

### What changed
- `src/server/push.mjs`: new `fireNewDevicePaired(existingDevices, joined)` —
  builds a `device-paired` informational payload and runs it through the SAME
  cross-device router (`dispatchNotification` → `routeNotification` →
  desktop sink / `sendPush`) as every other notification, so desktop-presence
  suppression + desktop-first escalation apply untouched (no bypass). Best-effort:
  any failure is logged and swallowed, so the claim never blocks or fails on push.
  No-op when there are no existing devices (never tells the joiner).
- `src/server/auth.mjs`: the claim handler now surfaces `resumed` so the caller
  can distinguish a genuinely-new provisioning from an existing device re-pairing
  or the legacy primary resume (those are NOT new pairings and don't spam).
- `src/server/index.mjs`: on a successful claim with `resumed === false`, reads
  the existing-device set from the Stage 2 registry minus the joiner and calls
  `fireNewDevicePaired` fire-and-forget (non-blocking to the token return).
- `src/server/push.test.mjs`: 4 new tests (routes to existing devices + never the
  joiner; no-op with zero existing devices; active desktop suppresses the mobile
  leg exactly like an informational kind; delivery failure never rejects).

### Verification results
- typecheck: pass (no errors)
- test:server: 930 pass / 0 fail
- vitest: 84 files / 1737 pass / 0 fail

No exempt-route or token-store changes (the push is fire-and-forget on the
existing authenticated claim path), so no PR-title flag needed there.
