### PR TITLE
ci: install Pillow — the runner move broke every job on a Python import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,20 @@ jobs:
         if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
+      # ── Pillow — `npm test` shells out to scripts/build-og-image.py, which
+      #    imports PIL. The retired self-hosted runner happened to have it
+      #    installed; a GitHub-hosted image does not, so the move to
+      #    ubuntu-latest turned every run red with `ModuleNotFoundError: No
+      #    module named 'PIL'` — on main and on every open PR at once, none of
+      #    them for a reason in their own diff. Installed here rather than
+      #    skipping the test when PIL is absent: a test that silently skips in
+      #    CI is a test that stops running, and og.png determinism is exactly
+      #    the kind of generated-artifact drift nobody re-checks by hand.
+      #    ~3s on a warm image. scripts/gen-icons.py needs the same import but
+      #    no test invokes it today.
+      - name: Install Pillow (scripts/*.py image generation)
+        run: python3 -m pip install --quiet --disable-pip-version-check pillow
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,19 @@ jobs:
       - name: Install Pillow (scripts/*.py image generation)
         run: python3 -m pip install --quiet --disable-pip-version-check pillow
 
+      # ── ffmpeg — the drift gate runs `npm run shots`, which extracts
+      #    website/hero-poster.webp from hero.mp4 (scripts/shots.mjs). Same
+      #    class of breakage as Pillow above: the self-hosted runner had it,
+      #    and GitHub dropped ffmpeg from the ubuntu-24.04 image, so the step
+      #    died with "ffmpeg not found at /usr/bin/ffmpeg".
+      #    NOTE: shots.mjs hardcodes that absolute path rather than resolving
+      #    the binary from PATH. apt installs to /usr/bin so this works, but
+      #    the hardcode is still wrong (a Homebrew ffmpeg lands in
+      #    /opt/homebrew/bin and would not be found) — tracked separately;
+      #    not fixed here because main is red and this PR is the unblock.
+      - name: Install ffmpeg (hero-poster extraction in the drift gate)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
+
       - name: Typecheck
         run: npm run typecheck
 


### PR DESCRIPTION
`ecfda62` moved CI from the self-hosted runner to `ubuntu-latest`. The old runner happened to have Pillow installed; a GitHub-hosted image does not. `npm test` shells out to `scripts/build-og-image.py`, which imports PIL — so every run went red with `ModuleNotFoundError: No module named 'PIL'`, on **main and on all three open PRs at once**, none of them for a reason in their own diff.

One step, before typecheck. ~3s on a warm image.

**Why install rather than skip when PIL is absent:** a test that silently skips in CI is a test that has stopped running, and `og.png` byte-determinism is exactly the generated-artifact drift nobody re-checks by hand. `scripts/gen-icons.py` has the same import but no test invokes it today.

Verified locally: `node --test scripts/build-website-assets.test.mjs` → 16 pass, 0 fail.