### PR TITLE
feat: Desktop 'Add a phone' panel + two-sided four-char confirm (BET-493)

### DIFF
--- a/src/renderer/AddPhonePanel.tsx
+++ b/src/renderer/AddPhonePanel.tsx
@@ -1,0 +1,122 @@
+// AddPhonePanel — the desktop "Add a phone" pairing card (BET-493).
+//
+// Shows the pairing code + a four-character verification code (§5.3 "Scan"),
+// auto-rotates the code on expiry while the panel is open (§6.4), and carries
+// the manual six-digit path (§5.2.9/§5.2.10). The joiner (phone) echoes the
+// four characters back in /auth/claim as the two-sided confirm (§6.3) — the
+// human is the comparator, so this panel never tries to know what a phone
+// shows; it only displays the characters and rotates.
+//
+// Presentational glue: the expiry/refresh logic lives in the pure, unit-tested
+// helpers in ./pairPanel.ts (repo pattern: chatUtils.ts). This component only
+// mints via the existing `auth:pair` RPC channel and renders.
+
+import { useCallback, useEffect, useState } from "react";
+import type { AuthPairResult } from "../shared/types";
+import { PairingQR, PairingCountdown } from "./PairingQR";
+import {
+  formatVerifyCode,
+  shouldRefreshPairCode,
+} from "./pairPanel";
+
+// 1s tick drives the live countdown + re-evaluates expiry so the code
+// auto-rotates the moment it elapses while the panel stays open (§6.4). The
+// server is the authority; rotation never happens client-side-minted (the
+// `auth:pair` RPC channel is the loopback-only mint).
+const TICK_MS = 1000;
+
+export function AddPhonePanel() {
+  const [pairing, setPairing] = useState<AuthPairResult | null>(null);
+  const [minting, setMinting] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  const mint = useCallback(async () => {
+    setMinting(true);
+    try {
+      const result = await window.api.authPair();
+      setPairing(result);
+    } catch (e) {
+      setPairing({
+        ok: false,
+        error: (e as { message?: string })?.message ?? String(e),
+      });
+    } finally {
+      setMinting(false);
+    }
+  }, []);
+
+  // Mint on open so the card always shows a fresh code, not a stale one.
+  useEffect(() => {
+    void mint();
+  }, [mint]);
+
+  // A 1s tick keeps the "expires in" pill live and re-evaluates rotation.
+  useEffect(() => {
+    const t = setInterval(() => setTick((x) => x + 1), TICK_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  // Auto-rotate on expiry while the panel is open (§6.4 row 2).
+  useEffect(() => {
+    if (!pairing?.ok) return;
+    const expiresAt = new Date(pairing.expiresAt).getTime();
+    if (Number.isNaN(expiresAt)) return;
+    if (shouldRefreshPairCode(expiresAt, Date.now())) {
+      void mint();
+    }
+  }, [tick, pairing, mint]);
+
+  return (
+    <div className="space-y-4">
+      <div className="text-body text-text-faint">
+        Add a phone. Point its camera at this code — it refreshes on its own
+        every five minutes.
+      </div>
+
+      {!pairing ? (
+        <div className="flex items-center gap-2 text-body text-text-muted">
+          <span>Generating pairing code…</span>
+        </div>
+      ) : pairing.ok ? (
+        <div className="space-y-4">
+          <div className="flex items-start gap-4">
+            <div className="bg-white p-2 rounded border border-border shrink-0">
+              <PairingQR boxId={pairing.boxId} pairingCode={pairing.pairingCode} />
+            </div>
+            <div className="flex-1 space-y-2">
+              <div className="text-body">
+                <span className="text-text-muted">Code:</span>{" "}
+                <span className="font-mono text-text">{pairing.pairingCode}</span>
+              </div>
+              <div className="text-body">
+                <span className="text-text-muted">Verification code:</span>{" "}
+                <span className="font-mono text-lg text-text">
+                  {formatVerifyCode(pairing.verify)}
+                </span>
+              </div>
+              <div className="text-body text-text-muted">
+                Your phone will show the same four characters. Only tap Link if
+                they match.
+              </div>
+              <PairingCountdown expiry={new Date(pairing.expiresAt)} />
+            </div>
+          </div>
+          <button
+            onClick={() => void mint()}
+            disabled={minting}
+            className="text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {minting ? "Refreshing…" : "Refresh code"}
+          </button>
+        </div>
+      ) : (
+        <div className="shrink-0 text-body text-danger">{pairing.error}</div>
+      )}
+
+      <div className="text-body text-text-faint">
+        Prefer to type it? Enter the {pairing?.ok ? "six digits above" : "six-digit code"} on
+        your phone instead of scanning.
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -15,7 +15,7 @@ import { useStore } from "./store";
 import { ProvidersCard } from "./ProvidersCard";
 import { ModelsCard } from "./ModelsCard";
 import { SubscriptionsCard } from "./SubscriptionsCard";
-import { PairingQR, PairingCountdown } from "./PairingQR";
+import { AddPhonePanel } from "./AddPhonePanel";
 import { getMantaPreload } from "./preloadAccess";
 import { resolveLauncherFlags } from "./chatShared";
 import { applyTheme, type ThemePref } from "./theme";
@@ -28,7 +28,6 @@ import {
   useRegistryUrls,
 } from "./settingsShared";
 import type {
-  AuthPairResult,
   PluginRegistryRow,
 } from "../shared/types";
 import {
@@ -442,23 +441,6 @@ export function Settings({ onClose }: { onClose: () => void }) {
     return () => { cancelled = true; clearInterval(timer); };
   }, [activeTab]);
 
-  // Mobile pairing (Box section).
-  const [pairing, setPairing] = useState<AuthPairResult | null>(null);
-  const [pairingExpiry, setPairingExpiry] = useState<Date | null>(null);
-  const [pairingMinting, setPairingMinting] = useState(false);
-  const mintPairingCode = async () => {
-    setPairingMinting(true);
-    try {
-      const result = await window.api.authPair();
-      setPairing(result);
-      if (result.ok) setPairingExpiry(new Date(result.expiresAt));
-    } catch (e) {
-      push({ id: `err-pair-${Date.now()}`, message: errorDisclosure("Couldn't generate a pairing code. Try again.", e) });
-    } finally {
-      setPairingMinting(false);
-    }
-  };
-
   // Remove box — in-app confirm replaces window.confirm (BET-419 §D).
   const [removingBox, setRemovingBox] = useState(false);
   const [removeResult, setRemoveResult] = useState<{ ok: boolean; message: string } | null>(null);
@@ -635,32 +617,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
           </GroupCard>
 
           <GroupCard title="Devices">
-            <div className="flex items-start justify-between gap-4">
-              <div className="text-body text-text-faint">Scan this QR with the Manta mobile app to connect it to your box. The code is one-time and valid for ~5 minutes.</div>
-              {!pairing ? (
-                <button onClick={mintPairingCode} disabled={pairingMinting} className="shrink-0 text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">
-                  {pairingMinting ? "Generating…" : "Generate pairing code"}
-                </button>
-              ) : pairing.ok ? (
-                <div className="shrink-0 space-y-4">
-                  <div className="flex items-start gap-4">
-                    <div className="bg-white p-2 rounded border border-border shrink-0">
-                      <PairingQR boxId={pairing.boxId} pairingCode={pairing.pairingCode} />
-                    </div>
-                    <div className="flex-1 space-y-2">
-                      <div className="text-body"><span className="text-text-muted">Code:</span> <span className="font-mono text-text">{pairing.pairingCode}</span></div>
-                      <div className="text-body"><span className="text-text-muted">Box ID:</span> <span className="font-mono text-text break-all" title={pairing.boxId}>{pairing.boxId}</span></div>
-                      {pairingExpiry && <PairingCountdown expiry={pairingExpiry} />}
-                    </div>
-                  </div>
-                  <button onClick={mintPairingCode} disabled={pairingMinting} className="text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">
-                    {pairingMinting ? "Generating…" : "Refresh code"}
-                  </button>
-                </div>
-              ) : (
-                <div className="shrink-0 text-body text-danger">{pairing.error}</div>
-              )}
-            </div>
+            <AddPhonePanel />
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Re-run the guided setup (pairing, providers, first project).</div>
               <button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} className="text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text shrink-0">Run setup again</button>

--- a/src/renderer/pairPanel.test.ts
+++ b/src/renderer/pairPanel.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  isPairCodeExpired,
+  shouldRefreshPairCode,
+  msUntilRefresh,
+  formatVerifyCode,
+  isValidManualPairCode,
+} from "./pairPanel";
+
+describe("isPairCodeExpired", () => {
+  it("is alive before expiry", () => {
+    expect(isPairCodeExpired(1000, 999)).toBe(false);
+  });
+  it("expires exactly at the boundary", () => {
+    expect(isPairCodeExpired(1000, 1000)).toBe(true);
+  });
+  it("is expired after", () => {
+    expect(isPairCodeExpired(1000, 1001)).toBe(true);
+  });
+});
+
+describe("shouldRefreshPairCode (auto-rotation on expiry)", () => {
+  it("does not refresh well before expiry", () => {
+    expect(shouldRefreshPairCode(1000, 500)).toBe(false);
+  });
+  it("refreshes exactly at expiry", () => {
+    expect(shouldRefreshPairCode(1000, 1000)).toBe(true);
+  });
+  it("refreshes after expiry", () => {
+    expect(shouldRefreshPairCode(1000, 1500)).toBe(true);
+  });
+  it("grace refreshes slightly before expiry, not before the grace window", () => {
+    expect(shouldRefreshPairCode(1000, 995, 10)).toBe(true); // within grace
+    expect(shouldRefreshPairCode(1000, 990, 10)).toBe(true); // at the refresh point
+    expect(shouldRefreshPairCode(1000, 989, 10)).toBe(false); // before grace
+    expect(shouldRefreshPairCode(1000, 601, 10)).toBe(false);
+  });
+});
+
+describe("msUntilRefresh", () => {
+  it("is the remaining time before refresh", () => {
+    expect(msUntilRefresh(1000, 500)).toBe(500);
+  });
+  it("is zero at and after the refresh point", () => {
+    expect(msUntilRefresh(1000, 1000)).toBe(0);
+    expect(msUntilRefresh(1000, 1100)).toBe(0);
+  });
+  it("respects grace", () => {
+    expect(msUntilRefresh(1000, 500, 50)).toBe(450);
+  });
+});
+
+describe("formatVerifyCode", () => {
+  it("formats a 4-char code as two pairs with a space", () => {
+    expect(formatVerifyCode("K7Q2")).toBe("K7 Q2");
+  });
+  it("strips whitespace + uppercases", () => {
+    expect(formatVerifyCode("k7 q2")).toBe("K7 Q2");
+    expect(formatVerifyCode("  k7  q2  ")).toBe("K7 Q2");
+  });
+  it("passes through non-4-char input defensively", () => {
+    expect(formatVerifyCode("A")).toBe("A");
+    expect(formatVerifyCode("ABC")).toBe("ABC");
+    expect(formatVerifyCode("")).toBe("");
+  });
+  it("handles null/undefined", () => {
+    expect(formatVerifyCode(null as unknown as string)).toBe("");
+    expect(formatVerifyCode(undefined as unknown as string)).toBe("");
+  });
+});
+
+describe("isValidManualPairCode (manual six-digit path)", () => {
+  it("accepts exactly 6 digits", () => {
+    expect(isValidManualPairCode("123456")).toBe(true);
+    expect(isValidManualPairCode("000001")).toBe(true);
+  });
+  it("rejects short / long / non-digit / empty", () => {
+    expect(isValidManualPairCode("12345")).toBe(false);
+    expect(isValidManualPairCode("1234567")).toBe(false);
+    expect(isValidManualPairCode("12345a")).toBe(false);
+    expect(isValidManualPairCode(" 123456")).toBe(false);
+    expect(isValidManualPairCode("")).toBe(false);
+  });
+});

--- a/src/renderer/pairPanel.ts
+++ b/src/renderer/pairPanel.ts
@@ -1,0 +1,54 @@
+// pairPanel.ts — pure panel-state helpers for the desktop "Add a phone"
+// pairing card (BET-493). The server mints a pairing code plus a four-character
+// verification code (§5.3 "K7 Q2"); the joiner echoes the four characters in
+// /auth/claim as the two-sided confirm (§6.3), and the panel auto-rotates the
+// code on expiry while it is open (§6.4).
+//
+// Everything here is deterministic + clock-injectable so the expiry/refresh
+// edge cases are unit-tested (repo pattern: chatUtils.ts → chatUtils.test.ts)
+// without DOM or timers. The React component (AddPhonePanel) calls these.
+
+// Is the code expired at `now`? Expiry is inclusive: at/after expiresAt it's
+// dead (a joiner claiming it would get 403).
+export function isPairCodeExpired(expiresAt: number, now: number): boolean {
+  return now >= expiresAt;
+}
+
+// Should the panel rotate the code now, while it is open? Auto-rotation happens
+// on expiry (§6.4 row 2). `graceMs` lets a caller rotate slightly EARLY to hide
+// mint latency; default 0 rotates exactly on expiry so a still-valid code is
+// never wasted by a premature re-mint that would orphan a phone mid-scan.
+export function shouldRefreshPairCode(
+  expiresAt: number,
+  now: number,
+  graceMs = 0,
+): boolean {
+  return now >= expiresAt - graceMs;
+}
+
+// Milliseconds until the code should be refreshed (0 when it already has).
+export function msUntilRefresh(
+  expiresAt: number,
+  now: number,
+  graceMs = 0,
+): number {
+  return Math.max(0, expiresAt - graceMs - now);
+}
+
+// Render the 4-char verification code as the two pairs a human reads: "K7Q2"
+// → "K7 Q2". Strips whitespace + folds case so arbitrary (including server-
+// normalized) input displays consistently with what the phone shows. Any
+// non-4-char input passes through unchanged (defensive — the server always
+// sends 4).
+export function formatVerifyCode(verify: string): string {
+  if (typeof verify !== "string") return "";
+  const s = verify.replace(/\s+/g, "").toUpperCase();
+  if (s.length !== 4) return s;
+  return `${s.slice(0, 2)} ${s.slice(2, 4)}`;
+}
+
+// Manual six-digit path (§5.2.9/§5.2.10): the desktop shows the six digits; a
+// phone types them. Validate the exact 6-digit code shape.
+export function isValidManualPairCode(code: string): boolean {
+  return typeof code === "string" && /^\d{6}$/.test(code);
+}

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -256,6 +256,31 @@ function genPairingCode() {
   return String(randomInt(0, 1_000_000)).padStart(6, "0");
 }
 
+// Letters for the two-sided four-character verification code. Unambiguous
+// alphabet (no I/L/O that read like 1/0), uppercase. Digits likewise avoid
+// 0/1. The code is four chars grouped as two pairs — "K7 Q2" (§5.3) — stored
+// contiguously ("K7Q2"); the panel renders the space.
+const VERIFY_LETTERS = "ABCDEFGHJKMNPQRSTUVWXYZ";
+const VERIFY_DIGITS = "23456789";
+
+export function genVerifyCode() {
+  // Two pairs of [letter][digit] draw — e.g. "K7Q2" → displayed "K7 Q2".
+  let s = "";
+  for (let pair = 0; pair < 2; pair++) {
+    s += VERIFY_LETTERS[randomInt(0, VERIFY_LETTERS.length)];
+    s += VERIFY_DIGITS[randomInt(0, VERIFY_DIGITS.length)];
+  }
+  return s;
+}
+
+// Normalize a presented verification code for comparison: strip whitespace +
+// fold case so "K7 Q2", "k7 q2" and "K7Q2" all match the same minted code.
+// The human reads the pair form on both screens, so we never want a stray
+// space or case to break the two-factor confirm.
+export function normalizeVerifyCode(s) {
+  return typeof s === "string" ? s.replace(/\s+/g, "").toUpperCase() : "";
+}
+
 // ---------------------------------------------------------------------------
 // Store (atomic write + 0600 via jsonStore.mjs — single source of truth)
 // ---------------------------------------------------------------------------
@@ -329,12 +354,11 @@ export async function ensureAuth({
  * `now` injectable for deterministic tests.
  */
 export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date.now() } = {}) {
-  let active = null; // { code, expiresAt }
+  let active = null; // { code, verify, expiresAt }
 
   function issue() {
-    const code = genPairingCode();
-    active = { code, expiresAt: now() + ttlMs };
-    return { code, expiresAt: active.expiresAt };
+    active = { code: genPairingCode(), verify: genVerifyCode(), expiresAt: now() + ttlMs };
+    return { code: active.code, verify: active.verify, expiresAt: active.expiresAt };
   }
 
   // Try to consume `code`. Returns true only if it matches the single active,
@@ -354,6 +378,27 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
     return ok;
   }
 
+  // Two-factor confirm check (the "matches" affordance carried back in the
+  // claim): does `verify` match the four characters minted alongside `code`?
+  // Non-consumeing — a mismatch must NOT burn the one-time code (a wrong
+  // verify is a human/typo error on the deferred phone screen, not an attack),
+  // so the joiner can correct and retry within the code's window.
+  function verifyMatches(code, verify) {
+    if (!isValidPairingCode(code) || typeof verify !== "string" || verify === "") return false;
+    if (!active) return false;
+    if (now() > active.expiresAt) {
+      active = null;
+      return false;
+    }
+    const ca = Buffer.from(active.code, "utf-8");
+    const cbCode = Buffer.from(String(code), "utf-8");
+    const codeMatches = ca.length === cbCode.length && timingSafeEqual(ca, cbCode);
+    if (!codeMatches) return false;
+    const va = Buffer.from(active.verify, "utf-8");
+    const vb = Buffer.from(normalizeVerifyCode(verify), "utf-8");
+    return va.length === vb.length && timingSafeEqual(va, vb);
+  }
+
   function clear() {
     active = null;
   }
@@ -362,7 +407,7 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
     return !!active && now() <= active.expiresAt;
   }
 
-  return { issue, consume, clear, hasActive };
+  return { issue, consume, verifyMatches, clear, hasActive };
 }
 
 // ---------------------------------------------------------------------------
@@ -467,30 +512,60 @@ export function createAuthEngine({
 
   // Handle GET /auth/pair — mint a one-time pairing code. Rate-limiting is
   // applied by the caller (index.mjs) via the shared limiter; here we just
-  // issue. Returns the code + box_id so the desktop can render it / a QR.
+  // issue. Returns the code + the four-character verification code + box_id so
+  // the desktop can render it / a QR and the joiner can two-factor confirm (§5.3).
   function pair() {
-    const { code, expiresAt } = pairing.issue();
-    return { ok: true, pairing_code: code, box_id: auth.box_id, expiresAt };
+    const { code, verify, expiresAt } = pairing.issue();
+    return { ok: true, pairing_code: code, box_id: auth.box_id, expiresAt, verify };
   }
 
-  // Handle POST /auth/claim {pairing_code, device_id?, name?} — exchange a
-  // valid code for a device credential. One-time: a correct code is consumed.
-  // Returns 400 on a missing/invalid code and 403 on a wrong/expired/already-
-  // used code (so a guesser learns only "no", never partial progress).
+  // Handle POST /auth/claim — exchange a valid code for a device credential.
+  // One-time: a correct code is consumed. Returns 400 on a missing/invalid
+  // code and 403 on a wrong/expired/already-used code (so a guesser learns only
+  // "no", never partial progress).
   //
-  // Back-compat / coexistence: a claim with NO device_id resumes the PRIMARY
-  // (shared box_token) device and returns `box_token = auth.box_token` exactly
-  // as before — existing clients keep working unchanged. A claim WITH a
-  // device_id provisions (or resumes) that distinct device and returns its own
-  // per-device token. Either way the response keeps the `{ box_token, box_id }`
-  // shape existing clients already persist; `device_id` is additive.
-  function claim({ pairing_code, device_id = null, name = null } = {}) {
+  // TWO PATHS, keyed by the two-factor confirm (`verify`):
+  //   • verify ABSENT  → legacy first-pair path: resume the PRIMARY (shared
+  //     box_token) device and return `box_token = auth.box_token` exactly as
+  //     before — existing paired clients keep working unchanged.
+  //   • verify PRESENT → joiner path (§6.1/§6.3): the caller echoes the four
+  //     characters the desktop panel shows (the "matches" confirmation). A
+  //     mismatch → 403 WITHOUT consuming the code (retryable). On a match the
+  //     claim PROVISIONS A DISTINCT device in the Stage-2 registry — never the
+  //     desktop's own token — so a joiner can never impersonate the desktop or
+  //     an existing device.
+  //
+  // Either way the response keeps the `{ box_token, box_id }` shape existing
+  // clients already persist; `device_id` is additive.
+  function claim({ pairing_code, verify = null, device_id = null, name = null } = {}) {
     if (!isValidPairingCode(pairing_code)) {
       return { ok: false, status: 400, error: "invalid pairing code" };
+    }
+    const twoFactor = typeof verify === "string" && verify !== "";
+    if (twoFactor && !pairing.verifyMatches(pairing_code, verify)) {
+      return { ok: false, status: 403, error: "verification failed" };
     }
     if (!pairing.consume(pairing_code)) {
       return { ok: false, status: 403, error: "pairing failed" };
     }
+
+    if (twoFactor) {
+      // Joiner path — a DISTINCT device, never the primary. A device_id we're
+      // given resumes that device (its own distinct token, which by definition
+      // is a per-device entry, not the desktop's); absent, mint a fresh id.
+      const joinerId =
+        device_id && typeof device_id === "string" && device_id !== "" ? device_id : genToken();
+      const { entry } = devices.claim({ deviceId: joinerId, name });
+      maybePersistDevices(true);
+      return {
+        ok: true,
+        box_token: entry.token,
+        box_id: auth.box_id,
+        device_id: entry.device_id,
+      };
+    }
+
+    // Legacy path — resume the PRIMARY (shared box_token) device.
     const { entry } = devices.claim({ deviceId: device_id, name });
     maybePersistDevices(true);
     return {

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -21,6 +21,8 @@ import {
   queryTokenAllowedForPath,
   authorizationForRequest,
   QUERY_TOKEN_PATHS,
+  genVerifyCode,
+  normalizeVerifyCode,
 } from "./auth.mjs";
 import { createDeviceRegistry } from "./devices.mjs";
 
@@ -684,4 +686,127 @@ test("REGRESSION: loopback + proxy forwarding headers is NOT local (cloudflared)
     isLocalDirectRequest({ ...base, headers: { "x-forwarded-for": "" } }),
     true,
   );
+});
+
+// ----------------------------------------------------------------------------
+// BET-493 — two-sided four-character confirm (Desktop "Add a phone" panel)
+// ----------------------------------------------------------------------------
+//
+// The joiner's confirm claim provisions a DISTINCT device in the Stage-2
+// registry (never the desktop's own token); a refresh on expiry / auto-rotate
+// invalidates the prior code; nothing already-paired is disturbed.
+
+test("genVerifyCode produces 4 unambiguous uppercase letters + digits", () => {
+  const v = genVerifyCode();
+  assert.equal(typeof v, "string");
+  assert.equal(v.length, 4);
+  assert.match(v, /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{4}$/);
+});
+
+test("normalizeVerifyCode strips whitespace + folds case", () => {
+  assert.equal(normalizeVerifyCode("K7 Q2"), "K7Q2");
+  assert.equal(normalizeVerifyCode("k7 q2"), "K7Q2");
+  assert.equal(normalizeVerifyCode("K7Q2"), "K7Q2");
+  assert.equal(normalizeVerifyCode("  k7  q2  "), "K7Q2");
+  assert.equal(normalizeVerifyCode(null), "");
+  assert.equal(normalizeVerifyCode(""), "");
+});
+
+test("pair mints a verification code alongside the pairing code", () => {
+  const eng = engine({ auth: AUTH });
+  const p = eng.pair();
+  assert.equal(p.ok, true);
+  assert.equal(typeof p.verify, "string");
+  assert.equal(p.verify.length, 4);
+});
+
+test("BET-493: two-factor confirm claim provisions a DISTINCT device, never the desktop's token", () => {
+  const devices = createDeviceRegistry({ load: () => null, save: async () => {}, now: () => 0 });
+  const eng = engine({ auth: AUTH, devices });
+  const before = new Set(devices.serialize().devices.map((d) => d.device_id));
+
+  const p = eng.pair();
+  const c = eng.claim({ pairing_code: p.pairing_code, verify: p.verify });
+  assert.equal(c.ok, true);
+  // distinct token, not the desktop's shared box_token
+  assert.equal(c.box_token !== AUTH.box_token, true);
+  assert.equal(isValidToken(c.box_token), true);
+  // a NEW device_id was provisioned (not a resumed one)
+  assert.equal(before.has(c.device_id), false);
+  // the joiner's credential is live and distinct
+  assert.equal(devices.authorize(c.box_token) != null, true);
+  assert.notEqual(c.device_id, devices.primary().device_id);
+});
+
+test("BET-493: a claim WITHOUT the confirm resumes the PRIMARY (back-compat)", () => {
+  const eng = engine({ auth: AUTH });
+  const p = eng.pair();
+  const c = eng.claim({ pairing_code: p.pairing_code });
+  assert.equal(c.ok, true);
+  // legacy path returns the desktop's own shared token, unchanged
+  assert.equal(c.box_token, AUTH.box_token);
+});
+
+test("BET-493: a wrong verify → 403 WITHOUT consuming the code (retryable)", () => {
+  const eng = engine({ auth: AUTH });
+  const p = eng.pair();
+  const wrong = p.verify === "K7Q2" ? "AB12" : "K7Q2";
+  const r = eng.claim({ pairing_code: p.pairing_code, verify: wrong });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 403);
+  assert.equal(r.error, "verification failed");
+  // the one-time code is NOT burned — a corrected retry succeeds
+  const ok = eng.claim({ pairing_code: p.pairing_code, verify: p.verify });
+  assert.equal(ok.ok, true);
+});
+
+test("BET-493: whitespace/case-normalized verify still matches (human comparator)", () => {
+  const eng = engine({ auth: AUTH });
+  const p = eng.pair();
+  const spaced = `${p.verify.slice(0, 2)} ${p.verify.slice(2)}`;
+  const c = eng.claim({ pairing_code: p.pairing_code, verify: spaced.toLowerCase() });
+  assert.equal(c.ok, true);
+});
+
+test("BET-493: minting a replacement code supersedes a still-valid prior code (panel auto-rotate)", () => {
+  const eng = engine({ auth: AUTH });
+  const first = eng.pair();
+  const second = eng.pair(); // panel re-mint before the first timed out
+  // the prior code is dead even though it hadn't expired
+  const old = eng.claim({ pairing_code: first.pairing_code, verify: first.verify });
+  assert.equal(old.ok, false);
+  const ok = eng.claim({ pairing_code: second.pairing_code, verify: second.verify });
+  assert.equal(ok.ok, true);
+});
+
+test("BET-493: a refresh on expiry invalidates the prior code", () => {
+  let t = 0;
+  const eng = engine({ auth: AUTH, ttlMs: 100, now: () => t });
+  const first = eng.pair();
+  t = 200; // past TTL — first code has expired
+  const expired = eng.claim({ pairing_code: first.pairing_code, verify: first.verify });
+  assert.equal(expired.ok, false);
+  const second = eng.pair(); // panel refresh while open
+  assert.notEqual(second.pairing_code, first.pairing_code);
+  const ok = eng.claim({ pairing_code: second.pairing_code, verify: second.verify });
+  assert.equal(ok.ok, true);
+});
+
+test("BET-493: confirm claim leaves the primary (desktop) and existing devices undisturbed", () => {
+  const devices = createDeviceRegistry({ load: () => null, save: async () => {}, now: () => 0 });
+  const eng = engine({ auth: AUTH, devices });
+  assert.equal(devices.authorize(AUTH.box_token) != null, true); // desktop works pre-join
+  const p = eng.pair();
+  const c = eng.claim({ pairing_code: p.pairing_code, verify: p.verify });
+  assert.equal(c.ok, true);
+  // the desktop's own token still authorizes after the joiner joined
+  assert.equal(devices.authorize(AUTH.box_token) != null, true);
+  assert.equal(
+    eng.authorize({ method: "GET", path: "/api/projects", authorization: `Bearer ${AUTH.box_token}` }).ok,
+    true,
+  );
+  // listDevices shows both the primary and the joiner (public metadata)
+  const list = eng.listDevices();
+  assert.equal(list.some((d) => d.primary), true);
+  assert.equal(list.some((d) => d.device_id === c.device_id), true);
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -708,13 +708,17 @@ const handleRequest = async (req, res) => {
   }
 
   // ---------- Auth pairing handshake (UNAUTHENTICATED, rate-limited) ----------
-  // GET    /auth/pair            → {pairing_code, box_id, expiresAt}
-  //                                Mint a one-time, ~5-min code. The desktop
-  //                                shows it (and encodes box_id+code in a QR
-  //                                for mobile).
-  // POST   /auth/claim {pairing_code} → {box_token, box_id}
-  //                                Exchange a valid code for the bearer token.
+  // GET    /auth/pair            → {pairing_code, box_id, expiresAt, verify}
+  //                                Mint a one-time, ~5-min code + the four-
+  //                                character verification code (§5.3/§6.4). The
+  //                                desktop shows both (and encodes box_id+code
+  //                                in a QR for mobile).
+  // POST   /auth/claim {pairing_code, verify?} → {box_token, box_id, device_id}
+  //                                Exchange a valid code for a device credential.
   //                                One-time; 403 on wrong/expired/reused code.
+  //                                `verify` (BET-493): when the joiner echoes the
+  //                                four characters it provisions a DISTINCT
+  //                                Stage-2 device; absent → legacy primary token.
   // DELETE /auth/revoke           → 200 on success; 400/401 on bad token.
   //                                "Remove this box from the device that holds
   //                                the current box_token" (BET-357 §2). Mints

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -758,6 +758,7 @@ const handleRequest = async (req, res) => {
           pairing_code: result.pairing_code,
           box_id: result.box_id,
           expiresAt: result.expiresAt,
+          verify: result.verify,
         });
         return;
       }
@@ -772,7 +773,11 @@ const handleRequest = async (req, res) => {
         // primary box_token exactly as before (back-compat).
         const device_id = body?.device_id ?? body?.deviceId ?? null;
         const name = body?.name ?? null;
-        const result = authEngine.claim({ pairing_code, device_id, name });
+        // Two-factor confirm (BET-493): the joiner echoes the four verification
+        // characters shown on the desktop panel. Its PRESENCE switches the
+        // claim onto the distinct-joiner-device path (see authEngine.claim).
+        const verify = body?.verify ?? body?.verify_code ?? null;
+        const result = authEngine.claim({ pairing_code, verify, device_id, name });
         if (!result.ok) {
           respondJson(res, result.status ?? 400, { error: result.error });
           return;

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -833,7 +833,13 @@ export function buildHandlers({
     "auth:pair": async () => {
       try {
         const r = await authPair();
-        return { ok: true, pairingCode: r.pairing_code, boxId: r.box_id, expiresAt: r.expiresAt };
+        return {
+          ok: true,
+          pairingCode: r.pairing_code,
+          boxId: r.box_id,
+          expiresAt: r.expiresAt,
+          verify: r.verify,
+        };
       } catch (e) {
         return { ok: false, error: e instanceof Error ? e.message : String(e) };
       }

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -256,6 +256,7 @@ test("auth:pair translates snake_case authEngine.pair() output to AuthPairResult
     pairing_code: "123456",
     box_id: "abc",
     expiresAt: "2026-01-01T00:00:00Z",
+    verify: "K7Q2",
   });
   const handlers = buildHandlers(deps);
   const result = await dispatch(handlers, "auth:pair", []);
@@ -264,6 +265,7 @@ test("auth:pair translates snake_case authEngine.pair() output to AuthPairResult
     pairingCode: "123456",
     boxId: "abc",
     expiresAt: "2026-01-01T00:00:00Z",
+    verify: "K7Q2",
   });
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1075,10 +1075,12 @@ export type AuthClaimInput = {
 // Result of GET /auth/pair — a one-time pairing code the desktop renders as a
 // QR for mobile scanning. `expiresAt` is an ISO-8601 timestamp (server-side
 // clock); the desktop computes the remaining seconds for the UI countdown.
+// `verify` is the four-character two-sided-confirm code (§5.3) shown on the
+// desktop ("K7 Q2"); the joiner echoes it in /auth/claim to carry the confirm.
 // `error` is non-null only on failure (network, 403 from a non-loopback
 // address, 429 rate limit, 5xx).
 export type AuthPairResult =
-  | { ok: true; pairingCode: string; boxId: string; expiresAt: string }
+  | { ok: true; pairingCode: string; boxId: string; expiresAt: string; verify: string }
   | { ok: false; error: string };
 
 // One row of the plugin registry (BET-189 / BET-190). The Mac executor


### PR DESCRIPTION
## BET-493 — Desktop "Add a phone" panel + two-sided four-char confirm (Stage 5 of 5)

Reuses `/auth/pair` + `/auth/claim` — no exempt-route list change.

### What this does

**Desktop "Add a phone" panel** (`AddPhonePanel.tsx`, mounted in Settings → Devices):
- Shows the pairing code + the four-character verification code (§5.3 "K7 Q2").
- Live expiry countdown + **auto-rotation on expiry while the panel stays open** (§6.4) via the existing `auth:pair` RPC mint (loopback-only — no client-side mint).
- Manual six-digit path copy (§5.2.9/§5.2.10).
- No auto-match — the human is the comparator (§5.4). The panel only *displays* the four characters; it never tries to know what a phone shows.

Pure panel-state helpers in `pairPanel.ts` (expiry / rotation / pair formatting / manual-six-digit validation) + vitest coverage, following the `chatUtils.ts` pattern.

**Server** (`auth.mjs`, `devices.mjs` reuse, `index.mjs`, `rpc.mjs`):
- `/auth/pair` now returns `verify` — the four-char code minted alongside the 6-digit nonce.
- `/auth/claim` accepts `verify`: when the joiner echoes it (the two-factor "matches" confirmation), the claim **provisions a DISTINCT Stage-2 device — never the desktop's own token**. A wrong verify → 403 **without consuming** the one-time code (retryable). Absent verify → legacy primary-token path, unchanged (existing paired devices keep working).
- Auto-rotation semantics: re-mint supersedes the prior code; a code is invalidated on expiry.

**Tests:** `auth.test.mjs` (+10: distinct-device confirm claim, wrong-verify retry, whitespace/case-normalized verify, supersede-on-rerotate, refresh-on-expiry invalidates prior, nothing-already-paired-disturbed) and `pairPanel.test.ts` (+16).

### Explicitly out of scope (per issue)
- The phone/iOS "Link this phone?" confirm screen + camera scan — deferred to the implementation epic, not built here.
- Universal link + `apple-app-site-association` — deferred.

### Self-check
- Panel shows code + four chars, auto-rotates on expiry while open → 9/10 (covered by pure-helper tests + CI e2e smoke; no live-device iPhone).
- Confirm claim provisions distinct device; existing devices unaffected → 10/10 (server tests).
- No auto-match; human is the comparator; joiner-side confirm correctly deferred → 10/10.
- `npm run typecheck && npm test` green on PR + main → gate passed.

**Follow-up filed (parked):** BET-513 — surface `verify` in the `manta pair` CLI + `pair.html` so CLI/web-driven pairing can also carry the two-sided confirm (today they claim legacy → primary).

**Files changed:** 10.

**Verification results:**
- PR branch (`multica/BET-493-add-phone-panel` @ `1c11848`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1319 pass / 0 fail / 0 skip. log sha256: `084ead49325789ee4ee7f7497480dd9718d0b52fcc9b947bcccf9fda86a2647f`
- Base (`main` @ `ecfda62`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1309 pass / 0 fail / 0 skip. log sha256: `5f7d8cd8f141bd0a68bca3a18910e11f0840da9231541d3c0b1950668019c608`
- Conclusion: 0 new failures. PR adds 10 server + 16 renderer tests, all green.
- **Base: `main` @ `ecfda62`** (origin/main has since advanced; merge-base diff shows only the 10 intended files — no phantom deletions).
