### PR TITLE
feat(scripts): verify opt-in deliverable declarations on done issues (BET-506)

### DIFF
--- a/scripts/multica-unblock.mjs
+++ b/scripts/multica-unblock.mjs
@@ -20,6 +20,14 @@
  * named in `waiting_on`, and if ALL of them are terminal (`done`/`cancelled`),
  * flip the issue to `todo`.
  *
+ * The same sweep also runs a second, opt-in pass (BET-506): for every `done`
+ * issue carrying BOTH `deliverable_branch` and `deliverable_paths` metadata, it
+ * verifies the declared file(s) actually exist on that branch (via git against
+ * this checkout). A `done` issue whose deliverable never landed — the artefact
+ * left on an orphan branch the issue never named — is set to `in_review` with
+ * `deliverable_missing` + `deliverable_checked` recorded. Issues without the
+ * declaration are never touched.
+ *
  * SCOPE — deliberately conservative
  *   - Only ever moves `blocked` → `todo`. It never blocks, closes, reassigns or
  *     reprioritises anything.
@@ -46,10 +54,85 @@
  * housekeeping and must never break a deploy pipeline.
  */
 
+import { execFileSync } from "node:child_process";
 import { api, DEFAULT_WORKSPACE, DEFAULT_API_BASE } from "./lib/multicaApi.mjs";
 
 /** Statuses that mean a blocker is finished and no longer blocking. */
 export const TERMINAL_STATUSES = new Set(["done", "cancelled", "canceled"]);
+
+/**
+ * Split a `deliverable_paths` metadata value into its paths.
+ *
+ * The value is newline-separated (the declaration format agreed in BET-506).
+ * Whitespace is trimmed and empty lines dropped so a trailing newline cannot
+ * quietly turn into a phantom path that never exists.
+ *
+ * @param {string|null|undefined} raw
+ * @returns {string[]}
+ */
+export function parseDeliverablePaths(raw) {
+  if (typeof raw !== "string") return [];
+  return raw
+    .split("\n")
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Decide whether a `done` issue's declared deliverable is actually on its
+ * branch, and what (if anything) to do about it.
+ *
+ * Opt-in: an issue is only ever checked when BOTH `deliverable_branch` and
+ * `deliverable_paths` metadata keys are set. An incomplete declaration (only
+ * one key) must never trip the check, and issues not `done` are never touched.
+ *
+ * `existingPaths` is the set of declared deliverable paths that exist on the
+ * branch, as resolved by the git check; `null` means the branch itself could
+ * not be found on the remote. Existence is the entire check — no contents, no
+ * size, no authorship.
+ *
+ * @param {{identifier?:string, status?:string, metadata?:{deliverable_branch?:string, deliverable_paths?:string}}} issue
+ * @param {Set<string>|null} existingPaths
+ * @returns {{act:false, reason:string} |
+ *           {act:true, status:"in_review", missing:string[], reason:string}}
+ */
+export function decideDeliverable(issue, existingPaths) {
+  const meta = issue?.metadata ?? {};
+  const branch = meta?.deliverable_branch;
+  const hasBranch = typeof branch === "string" && branch.trim() !== "";
+  const declared = parseDeliverablePaths(meta?.deliverable_paths);
+  const hasPaths = declared.length > 0;
+
+  // An incomplete or absent declaration is not a deliverable issue. Never trip
+  // the check on it.
+  if (!hasBranch || !hasPaths) {
+    return { act: false, reason: "no complete deliverable declaration" };
+  }
+  if (issue?.status !== "done") {
+    return { act: false, reason: "not done" };
+  }
+
+  // Branch missing on the remote is a failed check, not a skip.
+  if (existingPaths == null) {
+    return {
+      act: true,
+      status: "in_review",
+      missing: ["branch not found"],
+      reason: `deliverable branch \`${branch}\` not found on remote`,
+    };
+  }
+
+  const missing = declared.filter((p) => !existingPaths.has(p));
+  if (missing.length === 0) {
+    return { act: false, reason: `all deliverables present on \`${branch}\`` };
+  }
+  return {
+    act: true,
+    status: "in_review",
+    missing,
+    reason: `missing on \`${branch}\`: ${missing.join(", ")}`,
+  };
+}
 
 /**
  * Extract issue keys (BET-123) named in a free-text waiting_on note.
@@ -114,6 +197,46 @@ export function decideUnblock(issue, statusByKey) {
  * IO below this line. Everything above is pure and unit-tested.
  * ------------------------------------------------------------------ */
 
+/**
+ * Resolve which of the declared paths exist on a branch, using the git CLI
+ * against the already-checked-out repository the sweep runs in.
+ *
+ * Returns `null` when the branch itself cannot be resolved on the remote (the
+ * failed-check case), otherwise a Set of the declared paths present on it.
+ * Nothing is checked out and nothing is cloned — reading the remote tree is
+ * enough and leaves the working copy untouched.
+ *
+ * @param {{branch:string, paths:string[]}} args
+ * @returns {Promise<Set<string>|null>}
+ */
+export async function resolveDeliverablePaths({ branch, paths }) {
+  const ref = `refs/remotes/origin/${branch}`;
+  try {
+    // Fetch only the branch; failure means it does not exist on the remote.
+    execFileSync("git", ["fetch", "origin", branch], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      cwd: process.cwd(),
+    });
+    // Verify the fetched ref resolves.
+    execFileSync("git", ["rev-parse", "--verify", ref], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      cwd: process.cwd(),
+    });
+  } catch {
+    return null;
+  }
+
+  const tree = execFileSync("git", ["ls-tree", "-r", "--name-only", ref], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    cwd: process.cwd(),
+  });
+  const present = new Set(tree.split("\n").filter(Boolean));
+  return new Set(paths.filter((p) => present.has(p)));
+}
+
 export async function run({
   token,
   workspace = DEFAULT_WORKSPACE,
@@ -121,12 +244,16 @@ export async function run({
   dryRun = false,
   verbose = false,
   fetchImpl = fetch,
+  resolveDeliverable = resolveDeliverablePaths,
 } = {}) {
   if (!token) {
     console.error("MULTICA_TOKEN is not set — nothing to do.");
     return 1;
   }
 
+  let writeFailed = false;
+
+  // --- Pass 1: clear stale `blocked` statuses ------------------------------
   const listed = await api(
     base,
     token,
@@ -135,59 +262,144 @@ export async function run({
     fetchImpl,
   );
   const blocked = listed.issues ?? [];
-  if (blocked.length === 0) {
-    console.log("No blocked issues. Nothing to reconcile.");
-    return 0;
+  if (blocked.length > 0) {
+    // Resolve every referenced blocker once. Unresolvable = READ, warn + continue.
+    const statusByKey = new Map();
+    const needed = new Set(blocked.flatMap((i) => parseBlockerKeys(i?.metadata?.waiting_on)));
+    for (const key of needed) {
+      try {
+        const issue = await api(base, token, `/issues/${key}?workspace_id=${workspace}`, {}, fetchImpl);
+        statusByKey.set(key, issue?.status ?? null);
+      } catch (e) {
+        // Unresolvable → treated as still blocking. Never unblock on an error.
+        statusByKey.set(key, null);
+        if (verbose) console.log(`  ! could not resolve ${key}: ${e.message}`);
+      }
+    }
+
+    let unblocked = 0;
+    for (const issue of blocked) {
+      const { unblock, reason } = decideUnblock(issue, statusByKey);
+      const id = issue.identifier;
+      if (!unblock) {
+        if (verbose) console.log(`  · ${id} stays blocked (${reason})`);
+        continue;
+      }
+      if (dryRun) {
+        console.log(`  → ${id} WOULD unblock (${reason})`);
+        unblocked++;
+        continue;
+      }
+      try {
+        await api(
+          base,
+          token,
+          `/issues/${id}?workspace_id=${workspace}`,
+          { method: "PUT", body: JSON.stringify({ status: "todo" }) },
+          fetchImpl,
+        );
+        console.log(`  → ${id} unblocked (${reason})`);
+        unblocked++;
+      } catch (e) {
+        // Fail the job on a failed WRITE; keep sweeping the rest of the batch.
+        console.error(`Failed to set ${id} todo (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+        writeFailed = true;
+      }
+    }
+    console.log(
+      `${dryRun ? "[dry-run] " : ""}${unblocked} of ${blocked.length} blocked issue(s) ${dryRun ? "would be" : ""} unblocked.`,
+    );
+  } else {
+    console.log("No blocked issues.");
   }
 
-  // Resolve every referenced blocker once. Unresolvable = READ, warn + continue.
-  const statusByKey = new Map();
-  const needed = new Set(blocked.flatMap((i) => parseBlockerKeys(i?.metadata?.waiting_on)));
-  for (const key of needed) {
-    try {
-      const issue = await api(base, token, `/issues/${key}?workspace_id=${workspace}`, {}, fetchImpl);
-      statusByKey.set(key, issue?.status ?? null);
-    } catch (e) {
-      // Unresolvable → treated as still blocking. Never unblock on an error.
-      statusByKey.set(key, null);
-      if (verbose) console.log(`  ! could not resolve ${key}: ${e.message}`);
-    }
+  // --- Pass 2: verify opt-in deliverable declarations on `done` issues ------
+  let doneIssues = [];
+  try {
+    const done = await api(
+      base,
+      token,
+      `/issues?workspace_id=${workspace}&status=done&limit=200`,
+      {},
+      fetchImpl,
+    );
+    doneIssues = done.issues ?? [];
+  } catch (e) {
+    // List read failure is a READ: warn and continue, never abort the sweep.
+    console.log(`  ! could not list done issues, skipping deliverable check: ${e.message}`);
   }
-
-  let unblocked = 0;
-  let writeFailed = false;
-  for (const issue of blocked) {
-    const { unblock, reason } = decideUnblock(issue, statusByKey);
-    const id = issue.identifier;
-    if (!unblock) {
-      if (verbose) console.log(`  · ${id} stays blocked (${reason})`);
-      continue;
-    }
-    if (dryRun) {
-      console.log(`  → ${id} WOULD unblock (${reason})`);
-      unblocked++;
-      continue;
-    }
-    try {
-      await api(
-        base,
-        token,
-        `/issues/${id}?workspace_id=${workspace}`,
-        { method: "PUT", body: JSON.stringify({ status: "todo" }) },
-        fetchImpl,
-      );
-      console.log(`  → ${id} unblocked (${reason})`);
-      unblocked++;
-    } catch (e) {
-      // Fail the job on a failed WRITE; keep sweeping the rest of the batch.
-      console.error(`Failed to set ${id} todo (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
-      writeFailed = true;
-    }
-  }
-
-  console.log(
-    `${dryRun ? "[dry-run] " : ""}${unblocked} of ${blocked.length} blocked issue(s) ${dryRun ? "would be" : ""} unblocked.`,
+  const withDeliverable = doneIssues.filter(
+    (i) =>
+      typeof i?.metadata?.deliverable_branch === "string" &&
+      i.metadata.deliverable_branch.trim() !== "" &&
+      parseDeliverablePaths(i.metadata.deliverable_paths).length > 0,
   );
+  if (withDeliverable.length === 0) {
+    console.log("No done issues with a deliverable declaration.");
+  } else {
+    let checked = 0;
+    const nowIso = new Date().toISOString();
+    for (const issue of withDeliverable) {
+      const id = issue.identifier;
+      const branch = issue.metadata.deliverable_branch.trim();
+      const paths = parseDeliverablePaths(issue.metadata.deliverable_paths);
+      let existing;
+      try {
+        existing = await resolveDeliverable({ branch, paths });
+      } catch (e) {
+        // A git failure is a READ problem: never act on an unverifiable issue.
+        console.log(`  ! ${id} deliverable unverifiable, leaving alone: ${e.message}`);
+        continue;
+      }
+      const decision = decideDeliverable(issue, existing);
+      if (!decision.act) {
+        if (verbose) console.log(`  · ${id} deliverable ok (${decision.reason})`);
+        continue;
+      }
+      if (dryRun) {
+        console.log(`  → ${id} WOULD flag deliverable missing (${decision.reason})`);
+        checked++;
+        continue;
+      }
+      try {
+        await api(
+          base,
+          token,
+          `/issues/${id}?workspace_id=${workspace}`,
+          { method: "PUT", body: JSON.stringify({ status: decision.status }) },
+          fetchImpl,
+        );
+      } catch (e) {
+        console.error(`Failed to set ${id} ${decision.status} (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+        writeFailed = true;
+        continue;
+      }
+      const stamps = {
+        deliverable_missing: decision.missing.join("\n"),
+        deliverable_checked: nowIso,
+      };
+      for (const [key, value] of Object.entries(stamps)) {
+        try {
+          await api(
+            base,
+            token,
+            `/issues/${issue.id}/metadata/${key}?workspace_id=${workspace}`,
+            { method: "PUT", body: JSON.stringify({ value }) },
+            fetchImpl,
+          );
+        } catch (e) {
+          console.error(`Failed to write ${key} on ${id} (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+          writeFailed = true;
+        }
+      }
+      console.log(`  → ${id} marked ${decision.status}, deliverable missing (${decision.reason})`);
+      checked++;
+    }
+    console.log(
+      `${dryRun ? "[dry-run] " : ""}${checked} of ${withDeliverable.length} deliverable declaration(s) ${dryRun ? "would be" : ""} flagged.`,
+    );
+  }
+
   return writeFailed ? 1 : 0;
 }
 

--- a/scripts/multica-unblock.test.mjs
+++ b/scripts/multica-unblock.test.mjs
@@ -4,6 +4,8 @@ import {
   parseBlockerKeys,
   decideUnblock,
   TERMINAL_STATUSES,
+  parseDeliverablePaths,
+  decideDeliverable,
 } from "./multica-unblock.mjs";
 
 describe("parseBlockerKeys", () => {
@@ -153,5 +155,88 @@ describe("TERMINAL_STATUSES", () => {
     for (const s of ["todo", "in_progress", "in_review", "blocked"]) {
       assert.ok(!TERMINAL_STATUSES.has(s), `${s} must not be terminal`);
     }
+  });
+});
+
+describe("parseDeliverablePaths", () => {
+  test("splits a newline-separated metadata value touching real BET-481 shape", () => {
+    assert.deepEqual(
+      parseDeliverablePaths("spike/native-visual/SCROLL-FINDING.md\nspike/native-visual/capture.sh"),
+      ["spike/native-visual/SCROLL-FINDING.md", "spike/native-visual/capture.sh"],
+    );
+  });
+
+  test("trims whitespace and drops empty lines", () => {
+    assert.deepEqual(
+      parseDeliverablePaths("  a/b.md \n\n c/d.sh \n"),
+      ["a/b.md", "c/d.sh"],
+    );
+  });
+
+  test("returns empty for a non-string value", () => {
+    assert.deepEqual(parseDeliverablePaths(null), []);
+    assert.deepEqual(parseDeliverablePaths(undefined), []);
+    assert.deepEqual(parseDeliverablePaths(42), []);
+  });
+
+  test("returns empty for a blank string", () => {
+    assert.deepEqual(parseDeliverablePaths("   \n  "), []);
+  });
+});
+
+describe("decideDeliverable", () => {
+  const done = (branch, paths) => ({
+    identifier: "BET-481",
+    status: "done",
+    metadata: {
+      ...(branch ? { deliverable_branch: branch } : {}),
+      ...(paths ? { deliverable_paths: paths } : {}),
+    },
+  });
+
+  test("REGRESSION: both keys set and every path present → no change", () => {
+    const r = decideDeliverable(done("spike/native-visual", "spike/native-visual/SCROLL-FINDING.md"), new Set(["spike/native-visual/SCROLL-FINDING.md"]));
+    assert.equal(r.act, false);
+    assert.match(r.reason, /present/);
+  });
+
+  test("both keys set, one path missing → in_review + deliverable_missing", () => {
+    const paths = "a/b.md\nc/d.md";
+    const r = decideDeliverable(done("feat/x", paths), new Set(["a/b.md"]));
+    assert.equal(r.act, true);
+    assert.equal(r.status, "in_review");
+    assert.deepEqual(r.missing, ["c/d.md"]);
+  });
+
+  test("both keys set, branch missing → in_review + branch not found", () => {
+    const r = decideDeliverable(done("spike/native-visual", "a/b.md"), null);
+    assert.equal(r.act, true);
+    assert.equal(r.status, "in_review");
+    assert.deepEqual(r.missing, ["branch not found"]);
+  });
+
+  test("REGRESSION: only one of the two keys set → no change", () => {
+    const branchOnly = done("spike/native-visual", null);
+    assert.equal(decideDeliverable(branchOnly, new Set()).act, false);
+    const pathsOnly = done(null, "a/b.md");
+    assert.equal(decideDeliverable(pathsOnly, new Set()).act, false);
+  });
+
+  test("neither key set → no change", () => {
+    assert.equal(decideDeliverable({ identifier: "BET-1", status: "done", metadata: {} }, new Set()).act, false);
+    assert.equal(decideDeliverable({ identifier: "BET-1", status: "done", metadata: undefined }, new Set()).act, false);
+  });
+
+  test("issue not done → no change, even with keys set", () => {
+    const r = decideDeliverable(
+      { identifier: "BET-1", status: "in_review", metadata: { deliverable_branch: "x", deliverable_paths: "a/b.md" } },
+      null,
+    );
+    assert.equal(r.act, false);
+  });
+
+  test("tolerates a malformed issue object", () => {
+    assert.equal(decideDeliverable(null, new Set()).act, false);
+    assert.equal(decideDeliverable({}, new Set()).act, false);
   });
 });


### PR DESCRIPTION
Implements BET-506: an opt-in sweep check for issues marked `done` whose deliverable was never pushed to the branch they named.

## What

Extends the **existing** `multica-unblock.mjs` sweep (no new script/workflow/cron) with a second, opt-in pass:

- For every `done` issue carrying **both** `deliverable_branch` + `deliverable_paths` metadata, resolve the branch on the remote (`git fetch` + `git ls-tree` against the checkout) and check each declared path's **existence only**.
  - all present → no change
  - branch missing OR any path missing → set `in_review`, record `deliverable_missing` + `deliverable_checked`
- Incomplete declarations (only one key), absent declarations, and non-`done` issues are never touched. No content/size/authorship/recency checks. Never reverts to `todo`.
- Writes route through the shared `multicaApi` helper so a failed write fails the job (BET-504 guarantee stands); list reads warn and continue.

## BET-481 positive case (live)

`BET-481` now carries `deliverable_branch=spike/native-visual` and `deliverable_paths=spike/native-visual/SCROLL-FINDING.md`. The branch exists with the file, so the sweep passes it:

```
· BET-481 deliverable ok (all deliverables present on `spike/native-visual`)
[dry-run] 0 of 1 deliverable declaration(s) would be flagged.
```

Idempotent: a run only ever moves `done → in_review`; a re-run sees the issue no longer `done` and leaves it alone. No comments posted anywhere.

**Base:** `origin/main` @ `6728732` (advanced to `ebc1cfe` after branching).

**Net diff:** +343/−46. This child necessarily adds lines (a new pass + its tests); there was no existing code to delete here, unlike BET-504's helper-collapse. It reuses `multicaApi`, the existing metadata-write and fail-loud patterns. (Parent BET-503's net-negative constraint — stated for the record.)

**Files changed:** 2 — `scripts/multica-unblock.mjs`, `scripts/multica-unblock.test.mjs`

**Verification results:**
- PR branch (`multica/BET-506-deliverable-sweep` @ `889e420`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1320 pass / 0 fail / 0 skip. Failures: none. log sha256: `39cd43d7998ce5a408517d8d9bd9b99ba5138b658164f84169867b12d1ced585`
- Base (`main` @ `ebc1cfe`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1309 pass / 0 fail / 0 skip. Failures: none. log sha256: `e36288d62b5d1f0a5de6e8f6a0062efc052e530c609b46fa497b0e5354a8e9d8`
- **Red before green:** the new tests fail against `origin/main` (module lacks `decideDeliverable`); the pre-existing BET-504 `run()` tests still pass on the PR (the done-list read is guarded so an unmatched stub route no longer aborts the sweep).
- **Conclusion:** 0 new failures; +11 tests added by this PR.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log`.
