### PR TITLE
feat(scripts): reconcile merged-PR issues that never went terminal (BET-505)

### DIFF
--- a/.github/workflows/multica-close-on-merge.yml
+++ b/.github/workflows/multica-close-on-merge.yml
@@ -78,6 +78,24 @@ jobs:
         # Housekeeping must never fail a merge pipeline.
         continue-on-error: true
 
+      # ---------------------------------------------------------------------
+      # Catch merged PRs whose issue never went terminal (BET-505).
+      #
+      # The `close` job reacts to the pull_request_target CLOSE EVENT, which
+      # fires ONCE — if that single status write fails (BET-438: PR #397 merged,
+      # the write silently failed, the issue sat `blocked` until a human
+      # noticed), nothing ever re-checks. This pass runs inside THIS scheduled
+      # sweep (the hourly cron) and looks in the direction that actually failed:
+      # every non-terminal issue with a linked merged PR is set to `done` and
+      # recorded in metadata. It never comments (a comment on an agent-assigned
+      # issue dispatches a run), and it never moves an issue out of `done` or
+      # `cancelled`. A failed status write fails the job.
+      - name: Reconcile merged-PR issues that never went terminal
+        env:
+          MULTICA_TOKEN: ${{ secrets.MULTICA_TOKEN }}
+        run: node scripts/multica-pr-closed.mjs --reconcile --verbose
+        continue-on-error: true
+
       # Unblocking only changes a STATUS, and a status change dispatches
       # nobody — the issue sits `todo`, correctly labelled and untouched,
       # until a sweep re-fires its assignment. The scheduled sweep in

--- a/.github/workflows/multica-close-on-merge.yml
+++ b/.github/workflows/multica-close-on-merge.yml
@@ -89,12 +89,15 @@ jobs:
       # every non-terminal issue with a linked merged PR is set to `done` and
       # recorded in metadata. It never comments (a comment on an agent-assigned
       # issue dispatches a run), and it never moves an issue out of `done` or
-      # `cancelled`. A failed status write fails the job.
+      # `cancelled`. A failed status write fails the job — and unlike the
+      # housekeeping steps below, this step must NOT carry continue-on-error:
+      # swallowing the exit code would silently reintroduce the exact BET-438
+      # failure this reconcile exists to catch. If runReconcile exits non-zero,
+      # the job goes red; a dropped reconcile is visible.
       - name: Reconcile merged-PR issues that never went terminal
         env:
           MULTICA_TOKEN: ${{ secrets.MULTICA_TOKEN }}
         run: node scripts/multica-pr-closed.mjs --reconcile --verbose
-        continue-on-error: true
 
       # Unblocking only changes a STATUS, and a status change dispatches
       # nobody — the issue sits `todo`, correctly labelled and untouched,

--- a/scripts/multica-pr-closed.mjs
+++ b/scripts/multica-pr-closed.mjs
@@ -42,18 +42,20 @@
  * never suggested, because that is the word the PM acted on.
  *
  * USAGE
- *   node scripts/multica-pr-closed.mjs [--dry-run]
+ *   node scripts/multica-pr-closed.mjs [--dry-run]          (event path)
+ *   node scripts/multica-pr-closed.mjs --reconcile [--dry-run] [--verbose]
  *
  * ENV
- *   GITHUB_EVENT_PATH      required — the pull_request_target payload
+ *   GITHUB_EVENT_PATH      required (event path) — the pull_request_target payload
  *   GITHUB_TOKEN           required — reads branches/PRs to detect the stack
  *   MULTICA_TOKEN          required to mutate Multica; absent → log and skip
  *   MULTICA_WORKSPACE_ID   optional — defaults to the MantaUI (BET) workspace
  *   MULTICA_API_BASE       optional — defaults to https://api.multica.ai
  *   GITHUB_API_URL         optional — set by Actions
  *
- * Exit code is 0 unless the payload itself is unreadable. Every remote call
- * warns and continues: housekeeping must never fail a merge pipeline.
+ * Exit code is 0 unless the payload itself is unreadable, or a status / metadata
+ * WRITE fails (those fail the job — see runReconcile). Every remote read warns
+ * and continues: housekeeping must never fail a merge pipeline.
  */
 
 import { readFile } from "node:fs/promises";
@@ -131,6 +133,31 @@ export function classifyClosure({
 
   // Base branch is alive and unmerged — nothing took this PR down but a person.
   return { kind: "abandoned", reason: `its base branch \`${base}\` is still open` };
+}
+
+/** Statuses that mean an issue is finished and must never be moved out of. */
+export const TERMINAL_STATUSES = new Set(["done", "cancelled", "canceled"]);
+
+/**
+ * Should a merged-PR sweep reconcile THIS issue to `done`?
+ *
+ * Pure: `(issue, pullRequests) → boolean`. The rule is deliberately narrow —
+ * print it out, do not extend it:
+ *
+ *   - Throw a non-terminal issue away unless a LINKED PR merged.
+ *   - Never move an issue out of `done`/`cancelled` — a `cancelled` issue with
+ *     a merged PR stays cancelled (someone decided that deliberately).
+ *   - Pure-completion evidence only: a merged linked PR. No branch names, no
+ *     commit messages, no titles. "Closed" without `merged` is not evidence.
+ *
+ * @param {{status?:string}} issue
+ * @param {Array<{state?:string}>} pullRequests
+ * @returns {boolean}
+ */
+export function shouldReconcile(issue = {}, pullRequests = []) {
+  if (TERMINAL_STATUSES.has(issue?.status)) return false;
+  if (!Array.isArray(pullRequests)) return false;
+  return pullRequests.some((pr) => pr?.state === "merged");
 }
 
 /**
@@ -339,8 +366,159 @@ export async function run({
   return writeFailed ? 1 : 0;
 }
 
+/**
+ * Reconcile pass: catch issues whose linked PR merged but never went terminal.
+ *
+ * Runs inside the EXISTING scheduled sweep (the cron on the close-on-merge
+ * workflow), so a single dropped `done` write — the BET-438 shape, where the
+ * merge event fired once and the status write silently failed — is repaired on
+ * the next hourly tick instead of sitting wrong forever.
+ *
+ * For every non-terminal issue: fetch its linked PRs; if ANY has `state:
+ * merged`, set the issue `done` and record it in metadata. No comments ever
+ * (a comment on an agent-assigned issue dispatches a run). A failed status
+ * write fails the job, so a reconcile that does not land is visible.
+ *
+ * USAGE (no GITHUB_EVENT_PATH required)
+ *   MULTICA_TOKEN=… node scripts/multica-pr-closed.mjs --reconcile [--dry-run] [--verbose]
+ *
+ * @returns {Promise<number>} exit code — 1 iff a write failed
+ */
+export async function runReconcile({
+  token,
+  workspace = DEFAULT_WORKSPACE,
+  base = DEFAULT_API_BASE,
+  dryRun = false,
+  verbose = false,
+  pageSize = 100,
+  fetchImpl = fetch,
+} = {}) {
+  if (!token) {
+    console.error("MULTICA_TOKEN is not set — nothing to do.");
+    return 1;
+  }
+
+  // Enumerate every issue in the workspace (paginated) and keep only the
+  // non-terminal ones. This is the "who could have been missed" set.
+  const issues = [];
+  for (let offset = 0; ; offset += pageSize) {
+    const page = await api(
+      base,
+      token,
+      `/issues?workspace_id=${workspace}&limit=${pageSize}&offset=${offset}`,
+      {},
+      fetchImpl,
+    );
+    const batch = page.issues ?? [];
+    issues.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+
+  const candidates = issues.filter((i) => !TERMINAL_STATUSES.has(i?.status));
+  if (candidates.length === 0) {
+    console.log("No non-terminal issues. Nothing to reconcile.");
+    return 0;
+  }
+
+  let reconciled = 0;
+  let writeFailed = false;
+
+  for (const issue of candidates) {
+    const id = issue.identifier;
+    const uuid = issue.id;
+
+    let pullRequests = [];
+    try {
+      const prs = await api(
+        base,
+        token,
+        `/issues/${id}/pull-requests?workspace_id=${workspace}`,
+        {},
+        fetchImpl,
+      );
+      pullRequests = Array.isArray(prs.pull_requests) ? prs.pull_requests : [];
+    } catch (e) {
+      // A failed READ warns and continues — never fail the sweep on it.
+      if (verbose) console.log(`  ! ${id} PRs unreadable, leaving alone: ${e.message}`);
+      continue;
+    }
+
+    if (!shouldReconcile(issue, pullRequests)) {
+      if (verbose) console.log(`  · ${id} stays as-is (${issue.status}, no linked merged PR)`);
+      continue;
+    }
+
+    const merged = pullRequests.find((pr) => pr?.state === "merged");
+    const reason = `PR #${merged?.number ?? "?"} merged ${merged?.merged_at ?? "?"}; issue was ${issue.status}`;
+
+    if (dryRun) {
+      console.log(`  → ${id} WOULD reconcile (${reason})`);
+      reconciled++;
+      continue;
+    }
+
+    try {
+      await api(
+        base,
+        token,
+        `/issues/${id}?workspace_id=${workspace}`,
+        { method: "PUT", body: JSON.stringify({ status: "done" }) },
+        fetchImpl,
+      );
+    } catch (e) {
+      console.error(`Failed to set ${id} done (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+      writeFailed = true;
+      continue;
+    }
+    console.log(`  → ${id} reconciled (${reason})`);
+    reconciled++;
+
+    // Metadata only, never a comment. Mirrors how multica-unstick.mjs records
+    // its own actions: per-key PUTs, inert, invisible to dispatch.
+    const stamps = {
+      reconciled_last: new Date().toISOString(),
+      reconciled_reason: reason,
+    };
+    for (const [key, value] of Object.entries(stamps)) {
+      try {
+        await api(
+          base,
+          token,
+          `/issues/${uuid}/metadata/${key}?workspace_id=${workspace}`,
+          { method: "PUT", body: JSON.stringify({ value }) },
+          fetchImpl,
+        );
+      } catch (e) {
+        // A metadata write for a status change that already landed is still a
+        // write; surface it rather than silently dropping the ledger.
+        console.error(`Failed to write ${key} on ${id} (HTTP ${e.status ?? "?"}): ${e.body ?? e.message}`);
+        writeFailed = true;
+      }
+    }
+  }
+
+  console.log(
+    `${dryRun ? "[dry-run] " : ""}${reconciled} of ${candidates.length} non-terminal issue(s) ${dryRun ? "would be" : ""} reconciled.`,
+  );
+  return writeFailed ? 1 : 0;
+}
+
 async function main() {
   const dryRun = process.argv.includes("--dry-run");
+  const verbose = process.argv.includes("--verbose");
+
+  if (process.argv.includes("--reconcile")) {
+    const code = await runReconcile({
+      token: process.env.MULTICA_TOKEN,
+      workspace: process.env.MULTICA_WORKSPACE_ID,
+      base: process.env.MULTICA_API_BASE,
+      dryRun,
+      verbose,
+    });
+    if (code) process.exit(code);
+    return;
+  }
+
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
     console.error("GITHUB_EVENT_PATH is not set — nothing to react to.");

--- a/scripts/multica-pr-closed.test.mjs
+++ b/scripts/multica-pr-closed.test.mjs
@@ -1,6 +1,13 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { extractIssueKey, classifyClosure, buildComment, run as runPrClosed } from "./multica-pr-closed.mjs";
+import {
+  extractIssueKey,
+  classifyClosure,
+  buildComment,
+  shouldReconcile,
+  run as runPrClosed,
+  runReconcile,
+} from "./multica-pr-closed.mjs";
 import { run as runUnblock } from "./multica-unblock.mjs";
 import { api, ApiError } from "./lib/multicaApi.mjs";
 
@@ -154,6 +161,39 @@ describe("buildComment", () => {
   });
 });
 
+describe("shouldReconcile (BET-505)", () => {
+  const mergedPR = { state: "merged" };
+  const openPR = { state: "open" };
+  const closedUnmergedPR = { state: "closed" };
+
+  test("non-terminal issue + a merged PR → reconcile", () => {
+    assert.equal(shouldReconcile({ status: "todo" }, [mergedPR]), true);
+    assert.equal(shouldReconcile({ status: "in_progress" }, [mergedPR]), true);
+    assert.equal(shouldReconcile({ status: "blocked" }, [mergedPR]), true);
+  });
+
+  test("non-terminal issue + only open/closed-unmerged PRs → no change", () => {
+    assert.equal(shouldReconcile({ status: "todo" }, [openPR]), false);
+    assert.equal(shouldReconcile({ status: "todo" }, [closedUnmergedPR]), false);
+    assert.equal(shouldReconcile({ status: "todo" }, [openPR, closedUnmergedPR]), false);
+  });
+
+  test("non-terminal issue + no PRs → no change", () => {
+    assert.equal(shouldReconcile({ status: "todo" }, []), false);
+  });
+
+  test("done issue + merged PR → no change (idempotent)", () => {
+    assert.equal(shouldReconcile({ status: "done" }, [mergedPR]), false);
+  });
+
+  test("REGRESSION (BET-505): cancelled issue + merged PR → no change", () => {
+    // Cancelling is a deliberate human decision; a merged PR must not resurrect
+    // deliberately-killed work.
+    assert.equal(shouldReconcile({ status: "cancelled" }, [mergedPR]), false);
+    assert.equal(shouldReconcile({ status: "canceled" }, [mergedPR]), false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Fail-loud writes + the shared Multica API helper (BET-504).
 //
@@ -277,5 +317,88 @@ describe("BET-504 — a batch finishes before failing", () => {
     const puts = fetchImpl.calls.filter((c) => c.method === "PUT").map((c) => c.url);
     assert.ok(puts.some((u) => u.includes("/api/issues/BET-1")), "BET-1 write attempted");
     assert.ok(puts.some((u) => u.includes("/api/issues/BET-2")), "BET-2 write attempted");
+  });
+});
+
+describe("BET-505 — the reconcile sweep (pure-decision IO, no real HTTP)", () => {
+  const ws = "ws";
+  const B = "https://api.multica.ai";
+
+  function listPage(issues) {
+    return { method: "GET", match: "/api/issues?workspace_id=ws&limit=100&offset=0", status: 200, body: JSON.stringify({ issues, total: issues.length }) };
+  }
+
+  test("reconciles a non-terminal issue with a merged PR, writes done + metadata, never a comment", async () => {
+    const fetchImpl = stubFetch([
+      listPage([{ id: "u1", identifier: "BET-1", status: "blocked" }]),
+      { method: "GET", match: "/api/issues/BET-1/pull-requests", status: 200, body: JSON.stringify({ pull_requests: [{ number: 397, merged_at: "2026-08-01T09:51:46Z", state: "merged" }] }) },
+      { method: "PUT", match: "/api/issues/BET-1?workspace_id=ws", status: 200, body: "{}" },
+      { method: "PUT", match: "/metadata/reconciled_last", status: 200, body: "{}" },
+      { method: "PUT", match: "/metadata/reconciled_reason", status: 200, body: "{}" },
+    ]);
+    const code = await runReconcile({ token: "t", workspace: ws, base: B, fetchImpl });
+    assert.equal(code, 0);
+    const puts = fetchImpl.calls.filter((c) => c.method === "PUT");
+    assert.ok(puts.some((u) => u.url.includes("/api/issues/BET-1?")), "status write to done");
+    assert.ok(puts.some((u) => u.url.includes("/metadata/reconciled_last")), "reconciled_last written");
+    assert.ok(puts.some((u) => u.url.includes("/metadata/reconciled_reason")), "reconciled_reason written");
+    // No comment anywhere, on any issue.
+    assert.ok(!fetchImpl.calls.some((c) => c.method === "POST"), "no comment posted");
+  });
+
+  test("a merged PR on a done issue changes nothing (idempotent second run)", async () => {
+    const fetchImpl = stubFetch([
+      listPage([{ id: "u1", identifier: "BET-1", status: "done" }]),
+    ]);
+    const code = await runReconcile({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 0);
+    assert.ok(!fetchImpl.calls.some((c) => c.method === "PUT"), "no writes on a terminal issue");
+  });
+
+  test("a merged PR on a cancelled issue changes nothing", async () => {
+    const fetchImpl = stubFetch([
+      listPage([{ id: "u1", identifier: "BET-1", status: "cancelled" }]),
+    ]);
+    const code = await runReconcile({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 0);
+    assert.ok(!fetchImpl.calls.some((c) => c.method === "PUT"), "no writes on a cancelled issue");
+  });
+
+  test("no linked merged PR → no change", async () => {
+    const fetchImpl = stubFetch([
+      listPage([{ id: "u1", identifier: "BET-1", status: "todo" }]),
+      { method: "GET", match: "/api/issues/BET-1/pull-requests", status: 200, body: JSON.stringify({ pull_requests: [{ state: "open" }, { state: "closed" }] }) },
+    ]);
+    const code = await runReconcile({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 0);
+    assert.ok(!fetchImpl.calls.some((c) => c.method === "PUT"), "no writes without a merged PR");
+  });
+
+  test("a failed status write fails the job but does not write metadata", async () => {
+    const fetchImpl = stubFetch([
+      listPage([{ id: "u1", identifier: "BET-1", status: "blocked" }]),
+      { method: "GET", match: "/api/issues/BET-1/pull-requests", status: 200, body: JSON.stringify({ pull_requests: [{ state: "merged" }] }) },
+      { method: "PUT", match: "/api/issues/BET-1?workspace_id=ws", status: 500, body: "boom" },
+    ]);
+    const code = await runReconcile({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 1);
+    // Status write failed -> no metadata was attempted for this issue.
+    assert.ok(!fetchImpl.calls.some((c) => c.url.includes("/metadata/")), "no metadata after failed status write");
+  });
+
+  test("logs to a smaller page and continues (enumeration via pagination)", async () => {
+    // Two pages: one full page of a non-terminal + one cw. The sweep must page
+    // through both rather than rely on limit=100 returning everything.
+    const fetchImpl = stubFetch([
+      { method: "GET", match: "/api/issues?workspace_id=ws&limit=100&offset=0", status: 200, body: JSON.stringify({ issues: Array.from({ length: 100 }, (_, i) => ({ id: `u${i}`, identifier: `BET-${i}`, status: "todo" })) }) },
+      { method: "GET", match: "/api/issues?workspace_id=ws&limit=100&offset=100", status: 200, body: JSON.stringify({ issues: [{ id: "uA", identifier: "BET-A", status: "todo" }] }) },
+      { method: "GET", match: "/api/issues/BET-A/pull-requests", status: 200, body: JSON.stringify({ pull_requests: [{ state: "merged" }] }) },
+      { method: "PUT", match: "/api/issues/BET-A?workspace_id=ws", status: 200, body: "{}" },
+      { method: "PUT", match: "/metadata/reconciled_last", status: 200, body: "{}" },
+      { method: "PUT", match: "/metadata/reconciled_reason", status: 200, body: "{}" },
+    ]);
+    const code = await runReconcile({ token: "t", workspace: "ws", base: B, fetchImpl });
+    assert.equal(code, 0);
+    assert.ok(fetchImpl.calls.some((c) => c.url.includes("offset=100")), "paginated past the first 100");
   });
 });


### PR DESCRIPTION
**Base:** `origin/main` @ `ebc1cfe`

**Files changed:** 3 — `.github/workflows/multica-close-on-merge.yml`, `scripts/multica-pr-closed.mjs`, `scripts/multica-pr-closed.test.mjs`

**What & why (BET-505):** A merged PR whose issue never went terminal. The `close` job fires once on the `pull_request_target` close event; if that single status write fails (BET-438), nothing ever re-checks. This adds a reconciliation pass to the **existing scheduled sweep** — the hourly cron in `multica-close-on-merge.yml` — with **no new script, no new workflow, no new cron**.

For every non-terminal issue it fetches linked PRs and, if any is merged, sets the issue `done` and records `reconciled_last` / `reconciled_reason` in metadata. It never comments (a comment dispatches a run) and never moves an issue out of `done`/`cancelled`. A failed status write fails the job.

**Anti-spaghetti:** the pure rule is extracted as `shouldReconcile(issue, pullRequests)` and reuses the shared `api` helper from `lib/multicaApi.mjs` (the single Multica write path from BET-504). No new API-call code; the sweep reuses the existing enumeration/pagination and metadata-write patterns from `multica-unstick.mjs`.

**Verification results:**
- PR branch (`multica/BET-505-merged-pr-reconcile` @ `40a430b`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1320 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `ebc1cfe`):
  - typecheck: exit 0. Errors: none.
  - test: `multica-pr-closed.test.mjs` passes 24/24 (the 35-test count only appears on this branch once the 11 new BET-505 tests are added).
- **Conclusion:** 0 new failures, 0 pre-existing failures. The 11 new BET-505 tests (5 pure + 6 sweep) pass on the PR branch only.

**Idempotency:** Running the sweep twice produces no change on the second run — after the first pass sets an issue `done`, it is a terminal status and is filtered out of the candidate set on the next tick (verified by the "done issue + merged PR → no change" test). A `cancelled` issue with a merged PR also stays cancelled (regression test locks this).

**Red-before-green:** with `shouldReconcile` forced to always return false, 3 of the new suites fail (pure reconcile + sweep reconcile + fail-loud); they pass once the rule is implemented.
