### PR TITLE
BET-510: baseline before/after diff + route baseline PRs to a human

### DIFF
--- a/.multica/agents/manta-reviewer.md
+++ b/.multica/agents/manta-reviewer.md
@@ -137,9 +137,14 @@ Therefore, before any PASS:
      - Set status back to `todo`: `multica issue status BET-<N> todo`
 
    - **Zero `Block`s + zero `Question`s** (clean, or only `Nit`s):
-     - Post a short Multica comment: *"Review passed (0 Blocks, 0 Questions, N nits — see PR). Routing to manta-pm for merge."*
-     - Reassign the issue to `manta-pm`: `multica issue assign BET-<N> --to manta-pm`
-     - Set status `in_review`: `multica issue status BET-<N> in_review`
+      - Post a short Multica comment: *"Review passed (0 Blocks, 0 Questions, N nits — see PR). Routing to manta-pm for merge."*
+      - Reassign the issue to `manta-pm`: `multica issue assign BET-<N> --to manta-pm`
+      - Set status `in_review`: `multica issue status BET-<N> in_review`
+
+      Exception — if this PR creates or re-records any visual baseline, the
+      hand-off goes to Antoine instead of `manta-pm` (see
+      `manta-pr-workflow` step 10); never route a baseline-routing PR back to
+      the PM.
 
     Do **NOT** flip the PR from draft to ready — that's the PM's call.
 

--- a/.multica/skills/manta-pr-workflow/SKILL.md
+++ b/.multica/skills/manta-pr-workflow/SKILL.md
@@ -100,6 +100,19 @@ The standard implementer workflow for the MANTA agents.
 
     Print the scores. If all 8+, you may submit.
 
+    > **If this PR creates or re-records ANY file under
+    > `tests/visual/screens.visual.ts-snapshots/`, the reviewer's hand-off goes
+    > to Antoine, not to the PM.** Run `npm run visual:baselines`, upload every
+    > generated `*.before-after.png` into a PR comment, and
+    > `multica issue assign <KEY> --to Antoine` with status `in_review`. Say in
+    > the comment what changed and what should have changed. A baseline is
+    > committed evidence and the two agents in this loop compare the app only
+    > to that evidence — a human looking at the picture once is the only thing
+    > that can catch a record taken from a broken render. Merging is his call;
+    > do not merge, and do not route back to the PM. Upload the images (a
+    > `raw.githubusercontent.com/.../<pr-branch>/...` branch link dies when
+    > `--delete-branch` runs at merge), never link them.
+
     Then: Post the PR URL on the Multica issue **with a structured
     `Verification results` block** (template below), stamp `loop_history`
     metadata (see below), and reassign to the reviewer via

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "video": "cd video && npm install && npm run build",
     "visual": "npm run build:mobile && playwright test --project=visual",
     "visual:update": "npm run build:mobile && playwright test --project=visual --update-snapshots",
-    "visual:compare": "npm run build:mobile && node scripts/visual/compare.mjs"
+    "visual:compare": "npm run build:mobile && node scripts/visual/compare.mjs",
+    "visual:baselines": "node scripts/visual/baseline-diff.mjs"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",

--- a/scripts/visual/baseline-diff.mjs
+++ b/scripts/visual/baseline-diff.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * scripts/visual/baseline-diff.mjs — one side-by-side before/after image per
+ * changed visual baseline.
+ *
+ * Recording a baseline is the moment of judgement in this system: layers 1
+ * and 2 compare the app to its own committed record, so both stay green when
+ * the record itself is wrong, and a baseline first recorded from a broken
+ * render locks the breakage in. The only defence is a person looking at the
+ * picture once — with the "before" beside the new one, since a lone "after"
+ * is nearly unreadable. This script turns "this PR re-recorded a baseline"
+ * into one labelled composite PNG per changed baseline, pulled straight from
+ * git (no hook into Playwright, no second capture run).
+ *
+ * Usage:
+ *   node scripts/visual/baseline-diff.mjs            # vs origin/main
+ *   node scripts/visual/baseline-diff.mjs --base HEAD~1
+ *
+ * Exit codes: 0 always — a no-change run prints "no baseline changes" and
+ * never fails a pipeline.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import sharp from "sharp";
+import { ROOT } from "./harness.mjs";
+import { writeComposite } from "./composite.mjs";
+
+const OUT_DIR = join(ROOT, ".visual-out");
+const SNAPSHOT_GLOB = "tests/visual/screens.visual.ts-snapshots/*.png";
+
+function log(msg) {
+  process.stdout.write(`[visual:baselines] ${msg}\n`);
+}
+
+function git(args) {
+  return execFileSync("git", args, { cwd: ROOT, encoding: "utf8" }).trim();
+}
+
+/** `git show <rev>:<path>` as a binary Buffer (the committed "before"). */
+function gitShow(rev, path) {
+  return execFileSync("git", ["show", `${rev}:${path}`], { cwd: ROOT });
+}
+
+/** List every baseline PNG modified and added against `base`, in git order. */
+function changedBaselines(base) {
+  const modified = git([
+    "diff",
+    "--name-only",
+    "--diff-filter=M",
+    base,
+    "--",
+    SNAPSHOT_GLOB,
+  ])
+    .split("\n")
+    .filter(Boolean);
+  const added = git([
+    "diff",
+    "--name-only",
+    "--diff-filter=A",
+    base,
+    "--",
+    SNAPSHOT_GLOB,
+  ])
+    .split("\n")
+    .filter(Boolean);
+  return [
+    ...modified.map((path) => ({ path, kind: "modified" })),
+    ...added.map((path) => ({ path, kind: "new" })),
+  ];
+}
+
+/** A plain mid-grey panel matching the image's dimensions — the "before" of a brand-new baseline. */
+async function greyPanelLike(png) {
+  const { width, height } = await sharp(png).metadata();
+  return sharp({
+    create: { width, height, channels: 3, background: "#808080" },
+  })
+    .png()
+    .toBuffer();
+}
+
+async function main() {
+  const baseIdx = process.argv.indexOf("--base");
+  const base = baseIdx !== -1 ? process.argv[baseIdx + 1] : "origin/main";
+
+  const changed = changedBaselines(base);
+
+  if (changed.length === 0) {
+    log("no baseline changes");
+    process.exit(0);
+  }
+
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  for (const { path, kind } of changed) {
+    const name = basename(path, ".png");
+    const after = readFileSync(join(ROOT, path));
+    let before;
+    let labels;
+    if (kind === "new") {
+      before = await greyPanelLike(after);
+      labels = ["(new — no prior baseline)", "after"];
+      log(`new baseline      → ${name}.png (no prior baseline, grey panel)`);
+    } else {
+      before = gitShow(base, path);
+      labels = ["before", "after"];
+      log(`re-recorded       → ${name}.png`);
+    }
+    const outPath = join(OUT_DIR, `${name}.before-after.png`);
+    const width = await writeComposite(before, after, outPath, labels);
+    log(`wrote composite   → .visual-out/${name}.before-after.png (${width}×…)`);
+  }
+}
+
+main().catch((e) => {
+  process.stderr.write(`[visual:baselines] FAILED: ${e?.stack ?? e}\n`);
+  process.exit(1);
+});

--- a/scripts/visual/compare.mjs
+++ b/scripts/visual/compare.mjs
@@ -26,7 +26,6 @@
  */
 
 import { chromium } from "playwright";
-import sharp from "sharp";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -38,12 +37,9 @@ import {
   startStaticServer,
 } from "./harness.mjs";
 import { SCREENS, getScreen } from "./screens.mjs";
+import { writeComposite } from "./composite.mjs";
 
 const OUT_DIR = join(ROOT, ".visual-out");
-
-// Composite compositing, done with sharp (already a direct dependency).
-const LABEL_H = 22; // dark label band above each half
-const GAP = 12; // gutter between the two halves
 
 function log(msg) {
   process.stdout.write(`[visual:compare] ${msg}\n`);
@@ -66,57 +62,6 @@ function describeRegionDelta(appBox, mockupBox) {
   if (dW !== 0) parts.push(`width ${dW > 0 ? "+" : ""}${dW}`);
   if (dH !== 0) parts.push(`height ${dH > 0 ? "+" : ""}${dH}`);
   return parts.length ? parts.join(", ") : "size matches";
-}
-
-/** Stamp a dark label band with `label` across the top of an image buffer. */
-async function withLabel(img, label) {
-  const { width } = await sharp(img).metadata();
-  const band = Buffer.from(
-    `<svg width="${width}" height="${LABEL_H}" xmlns="http://www.w3.org/2000/svg">
-      <rect width="100%" height="100%" fill="#131318"/>
-      <text x="8" y="15" fill="#e6e6ec" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12">${label}</text>
-    </svg>`,
-  );
-  return sharp(img)
-    .extend({ top: LABEL_H, background: "#131318" })
-    .composite([{ input: band, top: 0, left: 0 }])
-    .toBuffer();
-}
-
-/**
- * Join the app and mockup halves side by side at IDENTICAL scale (both scaled
- * to the taller half's height) and write the single `<id>.compare.png`.
- */
-async function writeComposite(appPng, mockupPng, outPath) {
-  const [aMeta, mMeta] = await Promise.all([
-    sharp(appPng).metadata(),
-    sharp(mockupPng).metadata(),
-  ]);
-  const targetH = Math.max(aMeta.height, mMeta.height);
-  const [appScaled, mockScaled] = await Promise.all([
-    sharp(appPng).resize({ height: targetH, withoutEnlargement: false }).toBuffer(),
-    sharp(mockupPng).resize({ height: targetH, withoutEnlargement: false }).toBuffer(),
-  ]);
-  const [appLabelled, mockLabelled] = await Promise.all([
-    withLabel(appScaled, "app"),
-    withLabel(mockScaled, "mockup"),
-  ]);
-  const [a, m] = await Promise.all([
-    sharp(appLabelled).metadata(),
-    sharp(mockLabelled).metadata(),
-  ]);
-  const canvasW = a.width + GAP + m.width;
-  const canvasH = a.height;
-  await sharp({
-    create: { width: canvasW, height: canvasH, channels: 4, background: "#000000" },
-  })
-    .composite([
-      { input: appLabelled, top: 0, left: 0 },
-      { input: mockLabelled, top: 0, left: a.width + GAP },
-    ])
-    .png()
-    .toFile(outPath);
-  return canvasW;
 }
 
 /** Capture one half (app or mockup), cropping to the region when declared. */

--- a/scripts/visual/composite.mjs
+++ b/scripts/visual/composite.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * scripts/visual/composite.mjs — shared side-by-side compositing for the
+ * visual scripts, built on sharp (already a direct dependency).
+ *
+ * Extracted from compare.mjs so both the app-vs-mockup comparison AND the
+ * baseline before/after diff use the same two helpers. compare.mjs must not
+ * define these itself — this file is the single source.
+ */
+
+import sharp from "sharp";
+
+const LABEL_H = 22; // dark label band above each half
+const GAP = 12; // gutter between the two halves
+
+/** Stamp a dark label band with `label` across the top of an image buffer. */
+export async function withLabel(img, label) {
+  const { width } = await sharp(img).metadata();
+  const band = Buffer.from(
+    `<svg width="${width}" height="${LABEL_H}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="100%" height="100%" fill="#131318"/>
+      <text x="8" y="15" fill="#e6e6ec" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12">${label}</text>
+    </svg>`,
+  );
+  return sharp(img)
+    .extend({ top: LABEL_H, background: "#131318" })
+    .composite([{ input: band, top: 0, left: 0 }])
+    .toBuffer();
+}
+
+/**
+ * Join the left and right halves side by side at IDENTICAL scale (both scaled
+ * to the taller half's height) and write the single composite to `outPath`.
+ * Labels default to "app"/"mockup" for the designer-comparison use; pass a
+ * two-element array (e.g. ["before", "after"]) for other halves.
+ */
+export async function writeComposite(leftPng, rightPng, outPath, labels = ["app", "mockup"]) {
+  const [aMeta, mMeta] = await Promise.all([
+    sharp(leftPng).metadata(),
+    sharp(rightPng).metadata(),
+  ]);
+  const targetH = Math.max(aMeta.height, mMeta.height);
+  const [leftScaled, rightScaled] = await Promise.all([
+    sharp(leftPng).resize({ height: targetH, withoutEnlargement: false }).toBuffer(),
+    sharp(rightPng).resize({ height: targetH, withoutEnlargement: false }).toBuffer(),
+  ]);
+  const [leftLabelled, rightLabelled] = await Promise.all([
+    withLabel(leftScaled, labels[0]),
+    withLabel(rightScaled, labels[1]),
+  ]);
+  const [a, m] = await Promise.all([
+    sharp(leftLabelled).metadata(),
+    sharp(rightLabelled).metadata(),
+  ]);
+  const canvasW = a.width + GAP + m.width;
+  const canvasH = a.height;
+  await sharp({
+    create: { width: canvasW, height: canvasH, channels: 4, background: "#000000" },
+  })
+    .composite([
+      { input: leftLabelled, top: 0, left: 0 },
+      { input: rightLabelled, top: 0, left: a.width + GAP },
+    ])
+    .png()
+    .toFile(outPath);
+  return canvasW;
+}


### PR DESCRIPTION
## BET-510 — Route baseline changes to a human, with a before/after image

**Base: origin/main @ `024d036`**

### Part 1 — `scripts/visual/baseline-diff.mjs`

New script turning "this PR re-recorded a baseline" into one labelled side-by-side composite per changed baseline, pulling the "before" straight from git (`git show <base>:<path>` — no Playwright hook, no second capture run).

**Extraction (not a copy):** `scripts/visual/composite.mjs` now owns `withLabel` / `writeComposite` (moved from `compare.mjs`, which imports them and no longer defines them). `writeComposite` gained a `labels` argument defaulting to `["app", "mockup"]` so the before/after use `["before", "after"]` without forking the function.

- Mariano-parity check: `grep -n 'function withLabel\|function writeComposite' scripts/visual/*.mjs` → matches only `scripts/visual/composite.mjs`.
- `compare.mjs` line delta: **1 added / 56 removed** (removed exceeds added). The extraction is behavior-preserving (identical bodies, default labels match the old hardcoded "app"/"mockup"), so `settings.compare.png` is unchanged.

**Behavior:**
- `node scripts/visual/baseline-diff.mjs` (vs `origin/main`) or `--base <ref>`.
- A **modified** baseline → `before`(git) | `after`(disk), labelled `before`/`after`.
- A **new** baseline → plain mid-grey panel of identical dimensions (no prior baseline), labelled `(new — no prior baseline)` | `after`. New baselines are highest-risk and are never skipped.
- No changes → prints `no baseline changes`, exits 0 (never fails a pipeline).
- `.visual-out/<name>.before-after.png` per changed baseline.
- `npm run visual:baselines` added beside the other `visual:*` scripts.

### Part 2 — route baseline PRs to a human

- `.multica/skills/manta-pr-workflow/SKILL.md` step 10: an added condition (not a new step, not a replacement for the reviewer pass) — a PR that creates/re-records any snapshot baseline routes its hand-off to **Antoine** (`--to Antoine`, status `in_review`), with `npm run visual:baselines` run, every `*.before-after.png` uploaded, and explicit "do not merge / do not route back to the PM". Also restates the upload-images-not-branch-links clause.
- `.multica/agents/manta-reviewer.md`: one-sentence mirror on the PASS hand-off pointing at the skill.

### Definition-of-done confirmations

1. `composite.mjs` exists; `compare.mjs` imports from it and no longer defines `withLabel`/`writeComposite` — grep matches exactly one file. `compare.mjs`: +1 / −56.
2. `npm run visual:compare settings` still produced `settings.compare.png` (7372×…, one file). Extraction is byte-behavior-preserving by construction (identical bodies, same defaults).
3. `npm run visual:baselines` demonstrated three ways (output below) — no change → `no baseline changes`/exit 0; modified → side-by-side labelled; new → grey panel + `(new — no prior baseline)`. Demo used a scratch commit, then dropped — **no baseline moved in this PR**.
4. One generated `before-after.png` is attached to the issue (uploaded image).
5. Both `.multica` files updated; the rule names `--to Antoine`, `in_review`, uploaded images, and "do not merge".
6. `git status` shows nothing under `tests/visual/screens.visual.ts-snapshots/` (pasted on issue).
7. `npm run typecheck && npm test` pass.

### Demo output (scratch commit, since dropped)

```
$ npm run visual:baselines            # clean tree → no baseline changes, exit 0
[visual:baselines] no baseline changes
exit 0

# after (scratch-committing) a modified + a brand-new baseline:
$ npm run visual:baselines
[visual:baselines] re-recorded       → settings-visual-linux.png
[visual:baselines] wrote composite   → .visual-out/settings-visual-linux.before-after.png (2892×…)
[visual:baselines] new baseline      → welcome-new-visual-linux.png (no prior baseline, grey panel)
[visual:baselines] wrote composite   → .visual-out/welcome-new-visual-linux.before-after.png (2892×…)
exit 0
```

### Verification results
- PR branch typecheck: exit 0, no errors.
- PR branch test: exit 0, 1309 pass / 0 fail / 0 skip.
- Base (`main` @ `024d036`): not re-run — extraction is script/`.multica`-only (no `src/`); typecheck+test green on PR branch.
- **Conclusion:** 0 new failures.
