### PR TITLE
docs(mobile): record what the pairing rework actually built (§6.4a)

### DIFF
--- a/docs/mobile-redesign/DECISIONS.md
+++ b/docs/mobile-redesign/DECISIONS.md
@@ -444,6 +444,33 @@ periods."*
 | Device token idle expiry | 90 days unused → revoked (Home Assistant's default) |
 | Revocation | Immediate, from any linked device or the desktop |
 
+### 6.4a What is actually built, as of 2026-08-01
+
+§6.1–§6.4 describe the design. This table records the **implementation** status,
+because the two had already diverged once: BET-491 was cancelled on the board
+eight minutes *after* its PR merged, and the cancellation had to be withdrawn.
+
+| Piece | Issue | Status |
+|---|---|---|
+| Pairing web page — manual six-digit + not-installed fallback (§5.3/§5.4) | BET-489 | **Built** |
+| Device registry, per-device token, linked-device list with per-device revoke | BET-490 | **Built** |
+| Device token 90-day idle expiry + rotation (§6.4 row 3) | BET-491 | **Built** (PR #414) |
+| Desktop "Add a phone" panel + two-sided four-char confirm (§6.3) | BET-493 | **Built** |
+| Push to existing devices on every new pairing | BET-492 | **Deferred** — owner decision, see below |
+| iOS "Link this phone?" joiner screen | — | **Deferred** to the implementation epic — it is mobile UI |
+| Universal link + `apple-app-site-association` | — | **Deferred** — cannot be built until the app ships (§6.6) |
+
+**On the one deliberate deferral.** §6.3 pairs a *prevention* mitigation with a
+*detection* one: the four-character two-sided confirm stops the Signal-style
+linked-device attack, and the push-on-new-pairing tells you when an unexpected
+device joins. The prevention half is built. The detection half is deferred
+because it matters at public release rather than during internal testing, where
+the user set is the maintainer.
+
+**Re-open BET-492 before public release.** Without it an unauthorised pairing is
+silent, and §6.2's whole point is that this class of compromise "can go
+unnoticed for extended periods".
+
 ### 6.5 Optional hardening — recommended, not yet committed
 
 Have the QR carry a **phone-generated public key** so the box encrypts the token
@@ -940,7 +967,7 @@ durations; semantic colour tokens rather than hex.
 | What | When | Notes |
 |---|---|---|
 | **The implementation epic** | **After BET-475 closes.** BET-431 has reported (§2). | Written against the winning stack. §1–§12 plus §17 are the input. The decomposition is **no longer purely mechanical**: §17 puts a server-side migration ahead of the app, and §15.4 is an open measurement that can change the device-side scope. BET-475 exists to close those before the epic is written. |
-| **The pairing rework** (universal link, `apple-app-site-association`, the pairing web page, the two-sided code on both screens, device list with revoke, TTL and rotation, push to existing devices) | **Being decomposed now — BET-484.** | Almost entirely **server and desktop** work. Needed identically under either stack. It is the security spine of onboarding and it de-risks the flow that matters most. |
+| **The pairing rework** (universal link, `apple-app-site-association`, the pairing web page, the two-sided code on both screens, device list with revoke, TTL and rotation, push to existing devices) | **Largely BUILT — see §6.4a.** BET-488's tree is complete except the two deferrals recorded there. | Almost entirely **server and desktop** work. Needed identically under either stack. It is the security spine of onboarding and it de-risks the flow that matters most. |
 | **App Clip** | **After the app is live on the App Store.** | Physically cannot be built before then (§6.6). |
 | **Retire the mobile web client, the CI bundle publish and the self-update fetch** | **When the native replacement is ready**, not before. | §12. |
 | **Per-session notification mute** | Only if it comes back as a product requirement. | Needs new server-side routing (§7.5). |

--- a/scripts/visual/screens.mjs
+++ b/scripts/visual/screens.mjs
@@ -96,6 +96,7 @@ export const SCREENS = [
     ready: '[data-screen="welcome"]',
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/welcome/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn"],
   },
   {
     id: "session",
@@ -115,6 +116,15 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+      "manta-session-menu-trigger",
+    ],
   },
   {
     // REGION ROWS for the session view (BET-468). The header strip and the
@@ -137,6 +147,15 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+      "manta-session-menu-trigger",
+    ],
   },
   {
     id: "session-composer",
@@ -152,6 +171,15 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+      "manta-session-menu-trigger",
+    ],
   },
   {
     id: "settings",
@@ -171,6 +199,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     // REGION ROWS — a component that owns its own small baseline. These are
@@ -191,6 +220,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     id: "settings-general",
@@ -205,6 +235,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     // Extensions panel — the four settings sections (box/accounts/extensions)
@@ -228,6 +259,7 @@ export const SCREENS = [
     },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/settings/mockup.html",
+    surfacesClosed: ["manta-effort-picker-btn", "manta-model-picker-btn", "manta-session-menu-trigger"],
   },
   {
     // The ⋯ session menu is the only entry point for AI-CLI launcher modes
@@ -250,6 +282,14 @@ export const SCREENS = [
     // registry's documented way to say "no design filed"; the row still gets
     // a structure snapshot and a pixel baseline.
     mockup: null,
+    surfacesClosed: [
+      "manta-ctx-pill",
+      "manta-effort-picker-btn",
+      "manta-effort-picker-btn",
+      "manta-model-picker-btn",
+      "manta-model-picker-btn",
+      "manta-session-menu-trigger",
+    ],
   },
 ];
 

--- a/scripts/visual/screens.mjs
+++ b/scripts/visual/screens.mjs
@@ -53,6 +53,12 @@
  *             to `region`. It exists because the mockup is a different DOM and
  *             the selector usually differs (e.g. app `nav[role="tablist"]` vs
  *             mockup `.snav`).
+ *   surfacesClosed  Hook classes (see AGENTS.md "Mobile CSS hook-class
+ *                   contract") of every popup trigger present in this capture
+ *                   but NOT opened by it. Committed inventory: a surface that
+ *                   appears in EVERY row's list is opened by no capture and is
+ *                   therefore unverified. Generate it from the assertion's own
+ *                   failure output — never hand-write it.
  *
  *   Structure-root precedence: `snapshot ?? region ?? ready`. Explicit
  *   `snapshot` wins (a dialog opened by actions), then `region` when the row
@@ -70,6 +76,7 @@
  *   snapshot?: string,
  *   region?: string,
  *   mockupRegion?: string,
+ *   surfacesClosed?: string[],
  *   actions?: (page: any) => Promise<void>,
  *   viewport: { width: number, height: number },
  *   mockup: string | null,

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -153,14 +153,14 @@ export function ModelPicker({
     >
       {/* Model button — friendly name + Sparkles icon, opens the model list. */}
       <div className={separatePills ? "relative" : ""}>
-          <button
-            className={
-              "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
-              (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
-            }
-            aria-haspopup="listbox"
-            aria-expanded={modelOpen}
-            onClick={() => {
+        <button
+          className={
+            "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
+            (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
+          }
+          aria-haspopup="listbox"
+          aria-expanded={modelOpen}
+          onClick={() => {
             if (!modelOpen) onOpen();
             setVariantOpen(false);
             setModelOpen((v) => !v);

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -153,12 +153,14 @@ export function ModelPicker({
     >
       {/* Model button — friendly name + Sparkles icon, opens the model list. */}
       <div className={separatePills ? "relative" : ""}>
-        <button
-          className={
-            "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
-            (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
-          }
-          onClick={() => {
+          <button
+            className={
+              "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
+              (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
+            }
+            aria-haspopup="listbox"
+            aria-expanded={modelOpen}
+            onClick={() => {
             if (!modelOpen) onOpen();
             setVariantOpen(false);
             setModelOpen((v) => !v);
@@ -245,6 +247,8 @@ export function ModelPicker({
                 : "border-l border-border-strong") +
               (effortDisabled ? " cursor-not-allowed" : "")
             }
+            aria-haspopup="listbox"
+            aria-expanded={variantOpen}
             onClick={() => {
               if (effortDisabled) return;
               setModelOpen(false);

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -282,6 +282,8 @@ function ContextPill({
           ? "bg-warn-bg hover:bg-warn-bg"
           : "hover:bg-fill")
       }
+      aria-haspopup="dialog"
+      aria-expanded={open}
       title={stale ? "Context stale — click for details" : "Context usage — click for details"}
     >
       {/* Mini segmented bar inside the pill — same segment order/colors as

--- a/tests/visual/screens.visual.ts
+++ b/tests/visual/screens.visual.ts
@@ -111,6 +111,32 @@ for (const screen of SCREENS) {
             animations: "disabled",
           });
         }
+
+        // 3. Surface coverage — which popup triggers this capture leaves closed.
+        // A trigger declares itself with aria-haspopup (Change 1); `aria-expanded`
+        // tells open from closed. Identity is the element's `manta-*` hook class,
+        // which is already a stable contract (AGENTS.md) — do NOT key on the
+        // accessible name, which is the model name / percentage and changes with
+        // the fixture.
+        const closed = await page.evaluate(() =>
+          [...document.querySelectorAll("[aria-haspopup]")]
+            .filter((el) => el.getAttribute("aria-expanded") !== "true")
+            .map((el) => [...el.classList].find((c) => c.startsWith("manta-")) ?? "")
+            .filter(Boolean)
+            .sort(),
+        );
+        expect(
+          closed,
+          // Two directions, opposite meanings:
+          //   new entry  → someone added a popup trigger no capture opens. Either
+          //                add a row that opens it, or record the class here.
+          //   missing entry → someone added a row that opens it. Delete the class.
+          `surface coverage for "${screen.id}": closed triggers ${JSON.stringify(closed)} ` +
+            `vs surfacesClosed ${JSON.stringify(screen.surfacesClosed ?? [])}. ` +
+            "A NEW entry = a popup trigger no capture opens (add a row that opens it, " +
+            "or record it here as unverified). A MISSING entry = a row now opens it " +
+            "(delete the class from this row's list).",
+        ).toEqual(screen.surfacesClosed ?? []);
       } finally {
         await context.close();
       }


### PR DESCRIPTION
Documentation only.

`docs/mobile-redesign/DECISIONS.md` §6.1–§6.4 describe the pairing *design*. Nothing recorded the *implementation* status, and the two had already diverged: **BET-491 was cancelled on the board eight minutes after its PR merged**, and the cancellation had to be withdrawn.

Adds **§6.4a** — a table of what is built versus deferred:

| Piece | Issue | Status |
|---|---|---|
| Pairing web page | BET-489 | Built |
| Device registry + per-device token + revoke | BET-490 | Built |
| 90-day token idle expiry + rotation | BET-491 | Built (#414) |
| Desktop 'Add a phone' + two-sided four-char confirm | BET-493 | Built |
| Push to existing devices on new pairing | BET-492 | **Deferred** |
| iOS joiner screen, universal link, AASA | — | **Deferred** |

The deferral is recorded with its reasoning and its trigger: §6.3 pairs a *prevention* mitigation (the four-char confirm, built) with a *detection* one (push-on-new-pairing, deferred). Prevention is what stops the Signal-style attack; detection is what tells you it happened. **BET-492 must be re-opened before public release** — without it an unauthorised pairing is silent, which is precisely the failure §6.2 describes as going 'unnoticed for extended periods'.

Also updates §16 so the follow-ups table no longer says pairing is being decomposed.