### PR TITLE
Surface the four-char verify in manta pair CLI + pairing web page (BET-513)

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -1011,6 +1011,32 @@ export const readBoxIdentity = loadAuth;
 // Pairing-output formatter
 // ---------------------------------------------------------------------------
 
+// Normalize a presented verification code (BET-493 two-sided confirm): strip
+// whitespace + fold case so "K7 Q2", "k7 q2" and "K7Q2" all resolve to the
+// same 4-char string. Mirrors src/server/auth.mjs `normalizeVerifyCode`.
+export function normalizeVerifyCode(s) {
+  return typeof s === "string" ? s.replace(/\s+/g, "").toUpperCase() : "";
+}
+
+// Render the 4-char verify as the two pairs a human reads — "K7Q2" → "K7 Q2"
+// — matching the desktop panel's presentation (§5.3). Passes non-4-char input
+// through unchanged (defensive — the server always sends 4).
+export function formatVerifyDisplay(verify) {
+  const s = normalizeVerifyCode(verify);
+  if (s.length !== 4) return s;
+  return `${s.slice(0, 2)} ${s.slice(2, 4)}`;
+}
+
+// The four-char verification-code shape: exactly four uppercase alnum after
+// normalization. The server only ever mints the unambiguous alphabet
+// (A–H J K M N P–Z letters, 2–9 digits), but we accept any 4 uppercase
+// alnum here and let the server do the authoritative match (a wrong-but-valid
+// shape just 403s without consuming the one-time code).
+export const VERIFY_RE = /^[A-Z0-9]{4}$/;
+export function isValidVerifyCode(s) {
+  return VERIFY_RE.test(normalizeVerifyCode(s));
+}
+
 /**
  * Format the human-facing pairing block printed at the end of install (and by
  * `manta pair`). Given the server's { pairing_code, box_id, expiresAt } response,
@@ -1019,6 +1045,14 @@ export const readBoxIdentity = loadAuth;
  * `serverUrl` is the address the DESKTOP should point at (the box's public
  * ingress the user set up — tailscale/reverse-proxy/cloudflared). We can't know
  * it, so it's passed in (or omitted, in which case we print a hint line).
+ *
+ * `verify` (BET-513) is the four-character two-sided-confirm code (§5.3)
+ * minted alongside the six digits. When supplied, it is surfaced as a
+ * `Verify code:` line (rendered "K7 Q2") right after the six digits AND
+ * threaded through the pair link / pair-page URL so a device that claims from
+ * either carries the confirm → gets a DISTINCT Stage-2 device, never the
+ * shared primary token. Absent (a pre-BET-513 caller) → no line, no param —
+ * the output stays byte-compatible with before.
  *
  * The output is the single connect block both install.sh and `manta pair`
  * print — install.sh captures it once and emits it LAST so the user sees it
@@ -1051,11 +1085,14 @@ export const readBoxIdentity = loadAuth;
  * (saves the cold-install path from a needless dep).
  */
 export function formatPairingOutput(
-  { pairing_code, box_id, expiresAt, serverUrl } = {},
+  { pairing_code, box_id, expiresAt, serverUrl, verify } = {},
   { qrRender = defaultQrRender, scheme = "manta" } = {},
 ) {
   if (!/^[0-9]{6}$/.test(String(pairing_code ?? ""))) {
     throw new Error("formatPairingOutput: pairing_code must be 6 digits");
+  }
+  if (verify != null && verify !== "" && !isValidVerifyCode(verify)) {
+    throw new Error("formatPairingOutput: verify must be a 4-character verification code");
   }
   const lines = [];
   if (box_id) {
@@ -1078,9 +1115,11 @@ export function formatPairingOutput(
     // ONE wire shape — no more manta:///pair-page fork.
     const useServerUrl = typeof serverUrl === "string" && serverUrl !== "";
     const pairLinkOpts = useServerUrl ? { serverUrl, scheme } : { scheme };
+    if (verify != null) pairLinkOpts.verify = verify;
     const pairLink = buildPairLink(box_id, pairing_code, pairLinkOpts);
     const pairPageUrl = buildPairPageUrl(box_id, pairing_code, {
       baseUrl: useServerUrl ? serverUrl : undefined,
+      verify,
     });
     lines.push(`       Pair page:     ${pairPageUrl}`);
     lines.push(`       ${pairLink}`);
@@ -1108,6 +1147,9 @@ export function formatPairingOutput(
       lines.push("");
     }
     lines.push(`  Pairing code:  ${pairing_code}`);
+    if (verify != null) {
+      lines.push(`  Verify code:   ${formatVerifyDisplay(verify)}  (matches the code on the screen you're pairing)`);
+    }
     lines.push(`  Box ID:        ${box_id}`);
     if (serverUrl) {
       lines.push(`  Server URL:    ${serverUrl}`);
@@ -1125,6 +1167,9 @@ export function formatPairingOutput(
     lines.push("  ✓ Manta server is running.");
     lines.push("");
     lines.push(`  Pairing code:  ${pairing_code}`);
+    if (verify != null) {
+      lines.push(`  Verify code:   ${formatVerifyDisplay(verify)}  (matches the code on the screen you're pairing)`);
+    }
     if (expiresAt != null) {
       lines.push(`  Expires:       ${formatExpiry(expiresAt)}`);
     }
@@ -1172,29 +1217,45 @@ export function formatPairingOutput(
  * literal — mirrors how `pairPage.mjs`'s `validatePairQrQuery` and the
  * renderer's `buildPairPayload` take the same channel-derived value.
  *
+ * BET-513 (two-sided confirm): an optional `verify` may be appended as
+ * `&verify=<4-char>` so a device that claims from this link carries the
+ * two-sided confirm and gets a DISTINCT Stage-2 device instead of the
+ * shared primary box_token. A present-but-malformed verify throws (refused,
+ * never silently dropped) — mirroring how this helper refuses an invalid
+ * serverUrl.
+ *
  * Cross-reference: keep in sync with src/renderer/mobile/pairPayload.ts
  * `buildPairPayload` (box-form branch). If the canonical shape changes,
  * BOTH helpers must change in lockstep — the test catches drift.
  */
-export function buildPairLink(boxId, code, { serverUrl, scheme = "manta" } = {}) {
+export function buildPairLink(boxId, code, { serverUrl, scheme = "manta", verify } = {}) {
   if (typeof boxId !== "string" || !/^[0-9a-f]{32}$/.test(boxId)) {
     throw new Error("buildPairLink: boxId must be a 32-hex token");
   }
   if (!/^[0-9]{6}$/.test(String(code ?? ""))) {
     throw new Error("buildPairLink: code must be 6 digits");
   }
+  if (verify != null && verify !== "" && !isValidVerifyCode(verify)) {
+    throw new Error("buildPairLink: verify must be a 4-character verification code");
+  }
+  let out = `${scheme}://pair?box=${encodeURIComponent(boxId)}&code=${code}`;
+  if (verify != null && verify !== "") {
+    out += `&verify=${normalizeVerifyCode(verify)}`;
+  }
   if (serverUrl !== undefined) {
     if (typeof serverUrl !== "string" || serverUrl === "") {
-      throw new Error("buildPairLink: serverUrl must be a non-empty string");
+      throw new Error(
+        "buildPairLink: serverUrl must be a non-empty string",
+      );
     }
     if (!isPrivateServerUrl(serverUrl)) {
       throw new Error(
         "buildPairLink: serverUrl must be a private/tailnet http(s) URL",
       );
     }
-    return `${scheme}://pair?box=${encodeURIComponent(boxId)}&code=${code}&server=${encodeURIComponent(serverUrl)}`;
+    out += `&server=${encodeURIComponent(serverUrl)}`;
   }
-  return `${scheme}://pair?box=${encodeURIComponent(boxId)}&code=${code}`;
+  return out;
 }
 
 /**
@@ -1211,18 +1272,24 @@ export function buildPairLink(boxId, code, { serverUrl, scheme = "manta" } = {})
  * the canonical `<boxId>.boxes.mantaui.com`. The fragment (`#box=&code=`) is
  * emitted in both branches — one wire shape from one code path.
  */
-export function buildPairPageUrl(boxId, code, { baseUrl } = {}) {
+export function buildPairPageUrl(boxId, code, { baseUrl, verify } = {}) {
   if (!/^[0-9a-f]{32}$/.test(boxId ?? "")) {
     throw new Error("buildPairPageUrl: boxId must be a 32-hex token");
   }
   if (!/^[0-9]{6}$/.test(code ?? "")) {
     throw new Error("buildPairPageUrl: code must be 6 digits");
   }
+  if (verify != null && verify !== "" && !isValidVerifyCode(verify)) {
+    throw new Error("buildPairPageUrl: verify must be a 4-character verification code");
+  }
+  const frag = `#box=${boxId}&code=${code}${
+    verify != null && verify !== "" ? `&verify=${normalizeVerifyCode(verify)}` : ""
+  }`;
   if (typeof baseUrl === "string" && baseUrl !== "") {
     const trimmed = baseUrl.replace(/\/+$/, "");
-    return `${trimmed}/pair#box=${boxId}&code=${code}`;
+    return `${trimmed}/pair${frag}`;
   }
-  return `https://${boxId}.boxes.mantaui.com/pair#box=${boxId}&code=${code}`;
+  return `https://${boxId}.boxes.mantaui.com/pair${frag}`;
 }
 
 // Lazy-default QR renderer: requires `qrcode-terminal` at call time, not at

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -551,6 +551,37 @@ test("formatPairingOutput pins the greppable 'Pairing code' line shape", () => {
   assert.match(out, /^  Pairing code:  847291$/m);
 });
 
+test("formatPairingOutput surfaces a Verify code line + threads verify into the link/page URL (BET-513)", () => {
+  const out = formatPairingOutput({
+    pairing_code: "847291",
+    box_id: HEX32,
+    verify: "k7 q2",
+    expiresAt: Date.UTC(2026, 6, 3, 12, 34, 56),
+  });
+  // The four-char code is surfaced right after the six digits, rendered as
+  // the two pairs a human reads ("K7 Q2").
+  assert.match(out, /^  Verify code:   K7 Q2/m);
+  // And threaded into BOTH the pair page URL + the deep link so a device
+  // that claims from either carries the two-sided confirm.
+  assert.match(out, /pair#box=0123456789abcdef0123456789abcdef&code=847291&verify=K7Q2/);
+  assert.match(out, /manta:\/\/pair\?box=0123456789abcdef0123456789abcdef&code=847291&verify=K7Q2/);
+});
+
+test("formatPairingOutput omits the Verify code line when none supplied (back-compat)", () => {
+  const out = formatPairingOutput({
+    pairing_code: "847291",
+    box_id: HEX32,
+  });
+  assert.doesNotMatch(out, /Verify code/);
+});
+
+test("formatPairingOutput rejects a malformed verify (BET-513)", () => {
+  assert.throws(
+    () => formatPairingOutput({ pairing_code: "847291", box_id: HEX32, verify: "K7" }),
+    /4-character verification code/,
+  );
+});
+
 // ----------------------------------------------------------------------------
 // buildPairLink — canonical box-form pair link (BET-177 §2.4)
 // ----------------------------------------------------------------------------
@@ -649,6 +680,38 @@ test("buildPairLink threads scheme through the serverUrl branch too", () => {
 });
 
 // ----------------------------------------------------------------------------
+// buildPairLink — verify= (BET-513, two-sided confirm)
+// ----------------------------------------------------------------------------
+
+test("buildPairLink appends &verify=<normalized> when a verify is supplied (BET-513)", () => {
+  assert.equal(
+    buildPairLink(HEX32, "847291", { verify: "k7 q2" }),
+    `manta://pair?box=${HEX32}&code=847291&verify=K7Q2`,
+  );
+});
+
+test("buildPairLink omits &verify= when no verify is supplied (back-compat)", () => {
+  assert.doesNotMatch(buildPairLink(HEX32, "847291"), /verify=/);
+  assert.doesNotMatch(buildPairLink(HEX32, "847291", { verify: "" }), /verify=/);
+});
+
+test("buildPairLink rejects a malformed verify (BET-513)", () => {
+  assert.throws(() => buildPairLink(HEX32, "847291", { verify: "K7" }), /4-character verification code/);
+  assert.throws(() => buildPairLink(HEX32, "847291", { verify: "K7Q22" }), /4-character/);
+  assert.throws(() => buildPairLink(HEX32, "847291", { verify: "12!4" }), /4-character/);
+});
+
+test("buildPairLink composes verify= with server= (BET-513 + BET-336)", () => {
+  assert.equal(
+    buildPairLink(HEX32, "847291", {
+      verify: "K7Q2",
+      serverUrl: "http://100.64.1.5:8787",
+    }),
+    `manta://pair?box=${HEX32}&code=847291&verify=K7Q2&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+  );
+});
+
+// ----------------------------------------------------------------------------
 // buildPairPageUrl — box-served /pair onboarding URL (BET-239 §2.6)
 // ----------------------------------------------------------------------------
 //
@@ -677,6 +740,22 @@ test("buildPairPageUrl rejects a non-6-digit code", () => {
   assert.throws(() => buildPairPageUrl(HEX32, "12345"), /6 digits/);
   assert.throws(() => buildPairPageUrl(HEX32, "abcdef"), /6 digits/);
   assert.throws(() => buildPairPageUrl(HEX32, ""), /6 digits/);
+});
+
+test("buildPairPageUrl carries &verify= in the fragment when supplied (BET-513)", () => {
+  assert.equal(
+    buildPairPageUrl(HEX32, "847291", { verify: "k7 q2" }),
+    "https://0123456789abcdef0123456789abcdef.boxes.mantaui.com/pair#box=0123456789abcdef0123456789abcdef&code=847291&verify=K7Q2",
+  );
+});
+
+test("buildPairPageUrl omits &verify= when none supplied (back-compat)", () => {
+  assert.doesNotMatch(buildPairPageUrl(HEX32, "847291"), /verify=/);
+});
+
+test("buildPairPageUrl rejects a malformed verify (BET-513)", () => {
+  assert.throws(() => buildPairPageUrl(HEX32, "847291", { verify: "K7" }), /4-character/);
+  assert.throws(() => buildPairPageUrl(HEX32, "847291", { verify: "K7Q22" }), /4-character/);
 });
 
 // ----------------------------------------------------------------------------

--- a/scripts/manta-pair.mjs
+++ b/scripts/manta-pair.mjs
@@ -95,6 +95,7 @@ async function main() {
       {
         pairing_code: data?.pairing_code,
         box_id: data?.box_id,
+        verify: data?.verify,
         expiresAt: data?.expiresAt,
         serverUrl: readIngressServerUrl(cfg.authDir),
       },

--- a/src/renderer/mobile/pairPayload.test.ts
+++ b/src/renderer/mobile/pairPayload.test.ts
@@ -83,6 +83,40 @@ describe("parsePairPayload", () => {
     });
   });
 
+  // BET-513: the two-sided confirm travels as an optional verify= param. A
+  // present + well-formed verify is carried through; a present + malformed
+  // one refuses the WHOLE payload (a broken link, not a silently-dropped
+  // confirm that would fall back to the shared primary token).
+  describe("BET-513: verify param (two-sided confirm)", () => {
+    it("carries a well-formed verify through to the payload", () => {
+      expect(
+        parsePairPayload(`manta://pair?box=${BOX}&code=847291&verify=K7Q2`),
+      ).toEqual({ boxId: BOX, code: "847291", verify: "K7Q2" });
+    });
+
+    it("normalizes a spaced/lower-case verify (K7 Q2 → K7Q2)", () => {
+      expect(
+        parsePairPayload(
+          `manta://pair?box=${BOX}&code=847291&verify=${encodeURIComponent("k7 q2")}`,
+        ),
+      ).toEqual({ boxId: BOX, code: "847291", verify: "K7Q2" });
+    });
+
+    it("rejects a malformed verify", () => {
+      for (const bad of ["K7", "K7Q22", "12!4", "123", "ABCDE"]) {
+        expect(
+          parsePairPayload(`manta://pair?box=${BOX}&code=847291&verify=${bad}`),
+        ).toBeNull();
+      }
+    });
+
+    it("omits verify from the payload when absent (back-compat)", () => {
+      expect(
+        parsePairPayload(`manta://pair?box=${BOX}&code=847291`),
+      ).toEqual({ boxId: BOX, code: "847291" });
+    });
+  });
+
   // BET-373: every channel's scheme is a legal pair-link prefix. The
   // wire format is identical across channels — same query, same code,
   // same server= gate — only the scheme prefix differs because that's
@@ -346,6 +380,25 @@ describe("buildPairPayload", () => {
     expect(empty).not.toContain("server=");
   });
 
+  it("appends &verify=<normalized> when a verify is present (BET-513)", () => {
+    expect(
+      buildPairPayload({ boxId: BOX, code: "847291", verify: "k7 q2" }),
+    ).toBe(`manta://pair?box=${encodeURIComponent(BOX)}&code=847291&verify=K7Q2`);
+  });
+
+  it("omits &verify= when verify is absent or empty (back-compat)", () => {
+    const without = buildPairPayload({ boxId: BOX, code: "847291" });
+    expect(without).not.toContain("verify=");
+    const empty = buildPairPayload({ boxId: BOX, code: "847291", verify: "" });
+    expect(empty).not.toContain("verify=");
+  });
+
+  it("throws on a malformed verify (BET-513)", () => {
+    expect(() =>
+      buildPairPayload({ boxId: BOX, code: "847291", verify: "K7" }),
+    ).toThrow(/4-character verification code/);
+  });
+
   // BET-373: per-channel emission. The builder picks up the caller's
   // `scheme` arg verbatim — no derivation, no fallback chain — so the
   // OS-registered scheme and the wire-format scheme can never disagree.
@@ -381,10 +434,16 @@ describe("round-trip", () => {
       { boxId: BOX, code: "111111" },
       { boxId: BOX, code: "000000" },
       { boxId: BOX, code: "987654" },
+      // BET-513: round-trip preserves the two-sided confirm through both
+      // directions (verify is normalized uppercase on the way back).
+      { boxId: BOX, code: "111111", verify: "K7Q2" },
+      { boxId: BOX, code: "000000", verify: "MN29" },
       // BET-336: round-trip preserves the server URL through both directions.
       { boxId: BOX, code: "111111", serverUrl: "http://100.64.1.5:8787" },
       { boxId: BOX, code: "000000", serverUrl: "http://192.168.1.10:8787" },
       { boxId: BOX, code: "987654", serverUrl: "https://mybox.ts.net" },
+      // BET-513 + BET-336: verify + server together.
+      { boxId: BOX, code: "111111", verify: "K7Q2", serverUrl: "http://100.64.1.5:8787" },
     ];
     for (const p of cases) {
       expect(parsePairPayload(buildPairPayload(p))).toEqual(p);
@@ -402,9 +461,11 @@ describe("round-trip", () => {
           { boxId: BOX, code: "111111" },
           { boxId: BOX, code: "000000" },
           { boxId: BOX, code: "987654" },
+          { boxId: BOX, code: "111111", verify: "K7Q2" },
           { boxId: BOX, code: "111111", serverUrl: "http://100.64.1.5:8787" },
           { boxId: BOX, code: "000000", serverUrl: "http://192.168.1.10:8787" },
           { boxId: BOX, code: "987654", serverUrl: "https://mybox.ts.net" },
+          { boxId: BOX, code: "111111", verify: "K7Q2", serverUrl: "http://100.64.1.5:8787" },
         ];
         for (const p of cases) {
           expect(

--- a/src/renderer/mobile/pairPayload.ts
+++ b/src/renderer/mobile/pairPayload.ts
@@ -8,12 +8,15 @@
 // (Caddy on the box reverse-proxies 127.0.0.1:8787). The only live payload
 // shape is the box form:
 //   • Custom scheme (primary — what the desktop panel + install heredoc render):
-//       <scheme>://pair?box=<box_id>&code=<6-digit>
+//       <scheme>://pair?box=<box_id>&code=<6-digit>[&verify=<4-char>]
 //       scheme ∈ {manta, manta-staging, manta-dev} — the box + desktop emit
 //       the scheme their CHANNEL registered with the OS as a URL handler
 //       (BET-370 channel table; BET-373 thread this through pair links so
 //       staging-desktop users scanning a staging-box QR land in staging, not
 //       whatever other channel happened to register `manta://` last).
+//       `verify` (BET-513) is the four-char two-sided confirm (§5.3) — when
+//       carried, the receiving device claims WITH it and gets a DISTINCT
+//       Stage-2 device instead of the shared primary box_token.
 //   • Deferred-deeplink https form (Branch/Firebase style):
 //       https://<host>/m/<payload>?box=<box_id>&code=<6-digit>
 //
@@ -59,6 +62,15 @@ export type PairPayload = {
   boxId: string;
   code: string;
   /**
+   * Optional four-character verification code (BET-493 two-sided confirm,
+   * §5.3 "K7 Q2"). When present, the pairing flow claims WITH `verify` so
+   * the server provisions a DISTINCT Stage-2 joiner device rather than the
+   * shared primary `box_token` (the legacy no-verify path). Absent on
+   * pre-BET-513 payloads and on any emitter that only had the six digits.
+   * Always stored in the normalized form (whitespace-stripped, uppercase).
+   */
+  verify?: string;
+  /**
    * Optional server URL (BET-336, Tailscale path). When present, the
    * pairing flow claims against THIS URL instead of the derived public
    * hostname (`https://<boxId>.boxes.mantaui.com`) — so a Tailscale box
@@ -69,6 +81,28 @@ export type PairPayload = {
    */
   serverUrl?: string;
 };
+
+/**
+ * Normalize a presented verification code for comparison: strip whitespace +
+ * fold case so "K7 Q2", "k7 q2" and "K7Q2" all resolve to "K7Q2". Mirrors
+ * the server's `normalizeVerifyCode` in src/server/auth.mjs — the human
+ * reads the two-pair form, so we never want a stray space or case to break
+ * the two-factor confirm.
+ */
+export function normalizeVerifyCode(s: string): string {
+  return typeof s === "string" ? s.replace(/\s+/g, "").toUpperCase() : "";
+}
+
+// The four-char verification code shape: exactly four alphanumeric chars
+// after normalization. The server only ever mints the unambiguous alphabet
+// (A–H J K M N P–Z letters, 2–9 digits), but we accept any 4 uppercase
+// alnum client-side and let the server do the authoritative timing-safe
+// match (a wrong-but-valid-shape verify just 403s without consuming the
+// one-time code).
+export const VERIFY_RE = /^[A-Z0-9]{4}$/;
+export function isValidVerifyCode(s: string): boolean {
+  return VERIFY_RE.test(s);
+}
 
 /**
  * Coerce a raw boxId value to a validated 32-hex string, or null. The shape is
@@ -150,6 +184,7 @@ export function parsePairPayload(
   const rawBox = q.get("box") ?? "";
   const rawCode = q.get("code") ?? q.get("token") ?? "";
   const rawServer = q.get("server") ?? "";
+  const rawVerify = q.get("verify") ?? "";
 
   const boxId = coerceBoxId(rawBox);
   if (!boxId) return null;
@@ -174,7 +209,18 @@ export function parsePairPayload(
     serverUrl = normalized;
   }
 
-  return { boxId, code, serverUrl };
+  // BET-513 (two-sided confirm): when the link carries a `verify` param it
+  // MUST be a well-formed four-char code. A present-but-malformed verify is
+  // a broken link — refuse the whole payload rather than silently dropping
+  // it and falling back to the legacy primary-token claim.
+  let verify: string | undefined;
+  if (rawVerify !== "") {
+    const normalized = normalizeVerifyCode(rawVerify);
+    if (!isValidVerifyCode(normalized)) return null;
+    verify = normalized;
+  }
+
+  return { boxId, code, serverUrl, verify };
 }
 
 /**
@@ -199,11 +245,24 @@ export function parsePairPayload(
  * of the derived public hostname. The current callers only feed this
  * helper with server URLs that have already passed `isPrivateServerUrl`,
  * so we do NOT re-validate here (the constructor is a thin encoder).
+ *
+ * BET-513: when the payload carries a `verify` code (the four-char two-sided
+ * confirm), a `verify=<verify>` query param is appended so a CLI / web-paired
+ * device claims WITH the confirm and gets a DISTINCT Stage-2 device instead of
+ * the shared primary box_token. Only a well-formed normalized verify is
+ * appended; a malformed one is refused (throws), never silently dropped.
  */
 export function buildPairPayload(p: PairPayload, scheme: string = "manta"): string {
-  const base = `${scheme}://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+  let base = `${scheme}://pair?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+  if (p.verify && p.verify !== "") {
+    const norm = normalizeVerifyCode(p.verify);
+    if (!isValidVerifyCode(norm)) {
+      throw new Error("buildPairPayload: verify must be a 4-character verification code");
+    }
+    base += `&verify=${norm}`;
+  }
   if (p.serverUrl) {
-    return `${base}&server=${encodeURIComponent(p.serverUrl)}`;
+    base += `&server=${encodeURIComponent(p.serverUrl)}`;
   }
   return base;
 }

--- a/src/server/pair.html
+++ b/src/server/pair.html
@@ -150,8 +150,8 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
       <div class="picon">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
       </div>
-      <h1>Enter the code</h1>
-      <p class="lead">Read the six digits off your desktop, or run <span class="mono" style="background:var(--fill-subtle);border:1px solid var(--border-subtle);border-radius:5px;padding:0 6px">manta pair</span> on the box.</p>
+      <h1>Enter the codes</h1>
+      <p class="lead">Read the six digits <b>and the four-character code</b> off your desktop's "Add a phone" screen (or run <span class="mono" style="background:var(--fill-subtle);border:1px solid var(--border-subtle);border-radius:5px;padding:0 6px">manta pair</span> on the box).</p>
       <div class="otp-wrap" id="otp" role="group" aria-label="Six digit pairing code">
         <input class="otp-auto" id="otp-auto" inputmode="numeric" autocomplete="one-time-code" autofocus>
         <input class="otp-cell" inputmode="numeric" maxlength="1" pattern="[0-9]*" aria-label="Digit 1">
@@ -160,6 +160,13 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
         <input class="otp-cell" inputmode="numeric" maxlength="1" pattern="[0-9]*" aria-label="Digit 4">
         <input class="otp-cell" inputmode="numeric" maxlength="1" pattern="[0-9]*" aria-label="Digit 5">
         <input class="otp-cell" inputmode="numeric" maxlength="1" pattern="[0-9]*" aria-label="Digit 6">
+      </div>
+      <p class="hint" style="margin-top:18px;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:700">Also enter the four-character code, e.g. K7 Q2</p>
+      <div class="otp-wrap" id="votp" role="group" aria-label="Four character verification code">
+        <input class="otp-cell votp-cell" inputmode="text" maxlength="1" autocapitalize="characters" aria-label="Verify character 1">
+        <input class="otp-cell votp-cell" inputmode="text" maxlength="1" autocapitalize="characters" aria-label="Verify character 2">
+        <input class="otp-cell votp-cell" inputmode="text" maxlength="1" autocapitalize="characters" aria-label="Verify character 3">
+        <input class="otp-cell votp-cell" inputmode="text" maxlength="1" autocapitalize="characters" aria-label="Verify character 4">
       </div>
       <div class="action">
         <button class="btn btn-primary" id="btn-continue" type="button" disabled onclick="submitCode()">Continue</button>
@@ -268,7 +275,7 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
 <footer>Served by your box · the pairing code never leaves your machines</footer>
 
 <script>
-var cells, code, claimOrigin;
+var cells, vcells, code, claimOrigin;
 
 function $(id){ return document.getElementById(id); }
 
@@ -278,12 +285,14 @@ function show(id){
     var s=$("view-"+sections[i]);
     if(s) s.classList.toggle("active", sections[i]===id);
   }
-  if(id==="manual" && cells) setTimeout(function(){ var t=digtarget(); if(t) t.focus(); },30);
+  if(id==="manual"){
+    if(cells) setTimeout(function(){ var t=digtarget(); if(t) t.focus(); },30);
+  }
 }
 
 function parseFragment(){
   var q=new URLSearchParams((location.hash||"").replace(/^#/,""));
-  return { code:(q.get("code")||"").trim(), box:(q.get("box")||"").trim().toLowerCase() };
+  return { code:(q.get("code")||"").trim(), box:(q.get("box")||"").trim().toLowerCase(), verify:(q.get("verify")||"").trim() };
 }
 
 function claimEndpointFor(origin){
@@ -296,7 +305,7 @@ function resolveHost(){
   try{ return o? new URL(o).host : location.host; }catch(e){ return location.host; }
 }
 
-// --- OTP ---
+// --- OTP (six digits) ---
 function gather(){
   var s="";
   for(var i=0;i<cells.length;i++) s+=cells[i].value||"";
@@ -315,9 +324,7 @@ function onCellInput(el,i){
   el.value=el.value.replace(/[^0-9]/g,"");
   el.classList.toggle("filled", !!el.value);
   if(el.value) focusCell(i+1);
-  var s=gather();
-  $("btn-continue").disabled = !/^\d{6}$/.test(s);
-  if(/^\d{6}$/.test(s)) submitCode();
+  updateContinue();
 }
 function onCellKey(e,i){
   if(e.key==="Backspace" && !cells[i].value && i>0){ focusCell(i-1); }
@@ -329,8 +336,8 @@ function onCellPaste(e){
   var t=(e.clipboardData||window.clipboardData).getData("text")||"";
   var digits=t.replace(/[^0-9]/g,"");
   if(digits.length>6) digits=digits.slice(0,6);
-  if(/^\d{6}$/.test(digits)) setCells(digits);
-  else if(digits.length) setCells(digits);
+  setCells(digits);
+  updateContinue();
   var first=digtarget();
   if(first) first.focus();
 }
@@ -339,14 +346,54 @@ function digtarget(){
   return cells[5];
 }
 
+// --- Verify code (four characters, two-sided confirm §5.3) ---
+function gatherVerify(){
+  var s="";
+  for(var i=0;i<vcells.length;i++) s+=vcells[i].value||"";
+  return s.toUpperCase();
+}
+function setVerifyCells(str){
+  var v=(str||"").replace(/[^A-Za-z0-9]/g,"").toUpperCase();
+  for(var i=0;i<vcells.length;i++){
+    vcells[i].value=(v&&v[i])?v[i]:"";
+    vcells[i].classList.toggle("filled", !!vcells[i].value);
+  }
+}
+function focusVerifyCell(i){
+  if(i>=0&&i<vcells.length) vcells[i].focus();
+}
+function onVerifyCellInput(el,i){
+  el.value=(el.value||"").replace(/[^A-Za-z0-9]/g,"").toUpperCase();
+  el.classList.toggle("filled", !!el.value);
+  if(el.value) focusVerifyCell(i+1);
+  updateContinue();
+}
+function onVerifyCellKey(e,i){
+  if(e.key==="Backspace" && !vcells[i].value && i>0){ focusVerifyCell(i-1); }
+  if(e.key==="ArrowLeft"){ e.preventDefault(); focusVerifyCell(i-1); }
+  if(e.key==="ArrowRight"){ e.preventDefault(); focusVerifyCell(i+1); }
+}
+function verifytarget(){
+  for(var i=0;i<vcells.length;i++) if(!vcells[i].value) return vcells[i];
+  return vcells[3];
+}
+function isValidVerify(s){ return /^[A-Z0-9]{4}$/.test(s); }
+
+function updateContinue(){
+  var btn=$("btn-continue");
+  btn.disabled = !(/^\d{6}$/.test(gather()) && isValidVerify(gatherVerify()));
+}
+
 // --- claim ---
 function submitCode(){
   var s=gather();
+  var v=gatherVerify();
   if(!/^\d{6}$/.test(s)) return;
-  doClaim(s);
+  if(!isValidVerify(v)) return;
+  doClaim(s, v);
 }
 
-function doClaim(code){
+function doClaim(code, verify){
   show("checking");
   var origin=$("server-url")? $("server-url").value : "";
   claimOrigin=origin;
@@ -354,7 +401,7 @@ function doClaim(code){
   fetch(claimEndpointFor(origin), {
     method:"POST",
     headers:{"Content-Type":"application/json"},
-    body:JSON.stringify({ code: code })
+    body:JSON.stringify({ code: code, verify: verify })
   }).then(function(r){
     res=r;
     return r.text();
@@ -393,6 +440,7 @@ function goFinish(){ show("landing"); }
 
 function copyDiagnostics(){
   var blob="MantaUI pair diagnostics\nhost: "+resolveHost()+"\ncode: "+gather()+
+    "\nverify: "+gatherVerify()+
     "\nsource: "+location.href+"\nuserAgent: "+navigator.userAgent;
   if(navigator.clipboard && navigator.clipboard.writeText){
     navigator.clipboard.writeText(blob).then(function(){ $("view-unreachable").querySelector(".btn-row .btn-ghost").textContent="Copied"; });
@@ -400,11 +448,18 @@ function copyDiagnostics(){
 }
 
 (function init(){
-  cells=Array.prototype.slice.call(document.querySelectorAll(".otp-cell"));
+  cells=Array.prototype.slice.call(document.querySelectorAll("#otp .otp-cell"));
   cells.forEach(function(c,i){
     c.addEventListener("input",function(){ onCellInput(c,i); });
     c.addEventListener("keydown",function(e){ onCellKey(e,i); });
     c.addEventListener("paste",onCellPaste);
+    c.addEventListener("focus",function(){ c.select(); });
+  });
+
+  vcells=Array.prototype.slice.call(document.querySelectorAll("#votp .votp-cell"));
+  vcells.forEach(function(c,i){
+    c.addEventListener("input",function(){ onVerifyCellInput(c,i); });
+    c.addEventListener("keydown",function(e){ onVerifyCellKey(e,i); });
     c.addEventListener("focus",function(){ c.select(); });
   });
 
@@ -415,7 +470,7 @@ function copyDiagnostics(){
   if(auto){
     auto.addEventListener("input",function(){
       var d=(this.value||"").replace(/[^0-9]/g,"");
-      if(/^\d{6}$/.test(d)) setCells(d);
+      if(/^\d{6}$/.test(d)){ setCells(d); updateContinue(); }
     });
   }
 
@@ -431,16 +486,26 @@ function copyDiagnostics(){
   var host=(location.hostname||"").split(".")[0];
   $("boxchip-id").textContent=("box "+host);
 
+  updateContinue();
+
   if(f.code && /^\d{6}$/.test(f.code)){
-    // Arrived with a code in the URL fragment — prefill and go straight to
-    // the resolved-box card.
-    var q=new URLSearchParams((location.hash||"").replace(/^#/,""));
-    if(q.get("box")){ /* box id also carried; unused by manual flow */ }
-    $("btn-continue").disabled=false;
-    show("manual");
+    // Arrived with a code (and maybe a verify) in the URL fragment. Prefill
+    // the six digits, and when the two-sided confirm is also carried, go
+    // straight to the resolved-box card. A legacy six-digit-only link (no
+    // verify) CANNOT auto-claim — the joiner must type the four-char code
+    // shown on the desktop so the claim provisions a distinct device, not
+    // the shared primary token.
     setCells(f.code);
-    $("landing-code").textContent=(f.code.slice(0,3)+" "+f.code.slice(3));
-    doClaim(f.code);
+    updateContinue();
+    if(f.verify && isValidVerify(f.verify)){
+      setVerifyCells(f.verify);
+      show("manual");
+      doClaim(f.code, f.verify);
+    } else {
+      show("manual");
+      var t=verifytarget();
+      if(t) t.focus();
+    }
   } else {
     show("landing");
   }

--- a/src/server/pairPage.mjs
+++ b/src/server/pairPage.mjs
@@ -23,6 +23,16 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 export const HEX32_RE = /^[0-9a-f]{32}$/;
 export const CODE_RE = /^\d{6}$/;
 
+// BET-493 two-sided confirm: the four-character verification code mints
+// alongside the six digits. Normalized (whitespace-stripped, uppercase) and
+// required to be four uppercase alnum — the server does the authoritative
+// timing-safe match; the safe-shape check here only refuses clearly-broken
+// QR inputs. Mirrors src/server/auth.mjs `normalizeVerifyCode`.
+export function normalizeVerifyCode(s) {
+  return typeof s === "string" ? s.replace(/\s+/g, "").toUpperCase() : "";
+}
+export const VERIFY_RE = /^[A-Z0-9]{4}$/;
+
 /**
  * Resolve the box's pair-link URL scheme from `MANTA_CHANNEL` (BET-370 +
  * BET-373). The box's release tarball bakes a `MANTA_CHANNEL` env var at
@@ -51,7 +61,7 @@ export function resolveBoxChannel() {
 
 /**
  * Validate the /pair/qr.png query. Returns
- *   { ok: true, payload: "<scheme>://pair?box=<box>&code=<code>[&server=<url>]" }
+ *   { ok: true, payload: "<scheme>://pair?box=<box>&code=<code>[&verify=<v>][&server=<url>]" }
  * or
  *   { ok: false, error: <string> }.
  * Box is lowercased before validation (hostnames arrive case-insensitive).
@@ -72,6 +82,12 @@ export function resolveBoxChannel() {
  * refused outright with an error — a pair link that points the device at
  * a non-private host is exactly the "crafted link → attacker's server"
  * attack the gate prevents.
+ *
+ * BET-513 (two-sided confirm): an optional `verify` query param is
+ * accepted (the four-char confirm minted alongside the code). When absent
+ * or empty, the payload has no `&verify=` (legacy six-digit-only QR).
+ * When present, it must be a well-formed four-char code; a malformed
+ * verify is refused with an error rather than silently dropped.
  */
 export function validatePairQrQuery(query, scheme) {
   const box =
@@ -79,11 +95,19 @@ export function validatePairQrQuery(query, scheme) {
   const code = typeof query?.code === "string" ? query.code.trim() : "";
   const server =
     typeof query?.server === "string" ? query.server.trim() : "";
+  const verify =
+    typeof query?.verify === "string" ? query.verify.trim() : "";
   if (!HEX32_RE.test(box)) {
     return { ok: false, error: "box must be a 32-char lowercase hex id" };
   }
   if (!CODE_RE.test(code)) {
     return { ok: false, error: "code must be exactly 6 digits" };
+  }
+  if (verify !== "") {
+    const norm = normalizeVerifyCode(verify);
+    if (!VERIFY_RE.test(norm)) {
+      return { ok: false, error: "verify must be a 4-character verification code" };
+    }
   }
   // BET-373: default to the box's own channel-derived scheme. `scheme ? : …`
   // collapses the "caller passed nothing" / "caller passed undefined" /
@@ -92,6 +116,9 @@ export function validatePairQrQuery(query, scheme) {
   // how to spell "use the box's channel".
   const useScheme = scheme || resolveBoxChannel().urlScheme;
   let payload = `${useScheme}://pair?box=${box}&code=${code}`;
+  if (verify !== "") {
+    payload += `&verify=${normalizeVerifyCode(verify)}`;
+  }
   if (server !== "") {
     if (!isPrivateServerUrl(server)) {
       return {

--- a/src/server/pairPage.test.mjs
+++ b/src/server/pairPage.test.mjs
@@ -223,6 +223,45 @@ test("validatePairQrQuery rejects a PUBLIC server URL (BET-336, crafted-link gua
 });
 
 // ---------------------------------------------------------------------------
+// validatePairQrQuery — verify= param (BET-513, two-sided confirm)
+// ---------------------------------------------------------------------------
+
+test("validatePairQrQuery without a verify param leaves the payload unchanged (BET-513 back-compat)", () => {
+  const r = validatePairQrQuery({ box: HEX32, code: "847291" });
+  assert.equal(r.ok, true);
+  assert.equal(r.payload, `manta://pair?box=${HEX32}&code=847291`);
+  assert.equal(r.payload.includes("verify="), false);
+});
+
+test("validatePairQrQuery appends &verify=<normalized> for a valid verify (BET-513)", () => {
+  const r = validatePairQrQuery({ box: HEX32, code: "847291", verify: "k7 q2" });
+  assert.equal(r.ok, true);
+  assert.equal(r.payload, `manta://pair?box=${HEX32}&code=847291&verify=K7Q2`);
+});
+
+test("validatePairQrQuery rejects a malformed verify (BET-513)", () => {
+  for (const bad of ["K7", "K7Q22", "K7!2", "123", "ABCDE"]) {
+    const r = validatePairQrQuery({ box: HEX32, code: "847291", verify: bad });
+    assert.equal(r.ok, false, `verify=${JSON.stringify(bad)} should be refused`);
+    assert.match(r.error, /4-character verification code/);
+  }
+});
+
+test("validatePairQrQuery composes verify= with server= (BET-513 + BET-336)", () => {
+  const r = validatePairQrQuery({
+    box: HEX32,
+    code: "847291",
+    verify: "K7Q2",
+    server: "http://100.64.1.5:8787",
+  });
+  assert.equal(r.ok, true);
+  assert.equal(
+    r.payload,
+    `manta://pair?box=${HEX32}&code=847291&verify=K7Q2&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
 // validatePairQrQuery — channel-aware scheme (BET-373)
 //
 // The renderer + desktop pair-link path now keys off the channel table
@@ -406,13 +445,41 @@ test("manual-entry mailbox: shipped page claims the fragment code against /auth/
   assert.match(endpoint[1], /"\/auth\/claim";/, "endpoint is exactly <origin>/auth/claim");
   assert.doesNotMatch(endpoint[1], /"\/auth\/claim\?/, "no query appended after /auth/claim");
   assert.doesNotMatch(endpoint[1], /[?&]code\s*=/i, "no code in a query string");
-  // doClaim POSTs only {code} to that endpoint — the code travels in the body.
-  const doClaim = html.match(/function doClaim\(code\)\{([\s\S]*?)\n\}/);
-  assert.ok(doClaim, "the page must define doClaim(code)");
+  // doClaim POSTs both {code, verify} to that endpoint — the code AND the
+  // two-sided confirm travel in the body (BET-513: claiming WITH verify
+  // provisions a DISTINCT Stage-2 device, never the shared primary token).
+  const doClaim = html.match(/function doClaim\(code,\s*verify\)\{([\s\S]*?)\n\}/);
+  assert.ok(doClaim, "the page must define doClaim(code, verify)");
   assert.match(doClaim[1], /fetch\(claimEndpointFor\(origin\)/, "claims via the built endpoint");
   assert.match(doClaim[1], /method:\s*"POST"/, "must be a POST");
-  assert.match(doClaim[1], /JSON\.stringify\(\{\s*code:\s*code\s*\}\)/, "body carries {code}");
+  assert.match(
+    doClaim[1],
+    /JSON\.stringify\(\{\s*code:\s*code,\s*verify:\s*verify\s*\}\)/,
+    "body carries {code, verify}",
+  );
   assert.doesNotMatch(doClaim[1], /box\s*:/, "manual entry sends no box id");
+});
+
+// BET-513 — two-sided confirm on the web page. A device claimed through the
+// /pair page must carry `verify` so the server provisions a DISTINCT Stage-2
+// joiner device, never the shared primary box_token. The page therefore
+// surfaces the four-char code: it is read from the URL fragment (like the six
+// digits) and collected as a required four-cell entry in the manual view.
+test("pair.html surfaces + collects the four-char verify so web claims carry it (BET-513)", () => {
+  const html = readPairAsset("pair.html").toString("utf-8");
+  // Four dedicated verify cells exist and are separate from the six digits.
+  assert.match(html, /id="votp"/, "a verify OTP group must exist");
+  assert.match(html, /id="votp"[^]*?votp-cell/, "#votp must contain verify cells");
+  const verifyCells = html.match(/class="otp-cell votp-cell"/g) ?? [];
+  assert.equal(verifyCells.length, 4, "exactly four verify cells");
+  // parseFragment must carry the verify from the URL fragment alongside code.
+  const frag = html.match(/function parseFragment\(\)\{([\s\S]*?)\n\}/);
+  assert.ok(frag, "parseFragment must exist");
+  assert.match(frag[1], /verify:/, "parseFragment must read the verify param");
+  // A legacy six-digit-only fragment must NOT auto-claim: without a verify the
+  // claim would fall back to the shared primary token.
+  assert.doesNotMatch(html, /if\(f\.code[^]*?doClaim\(f\.code\)\s*\)/, "no auto-claim on code alone");
+  assert.match(html, /doClaim\(f\.code,\s*f\.verify\)/, "auto-claim only with the verify");
 });
 
 // Fragment-only: the code must never be placed in a path/query the server
@@ -459,8 +526,10 @@ test("pair.html renders the §5.4 failure-state copy verbatim (BET-489)", () => 
   assert.match(html, /Try again/);
   assert.match(html, /Copy diagnostics/);
   // Manual + not-installed fallback
-  assert.match(html, /Enter the code/);
-  assert.match(html, /Read the six digits off your desktop/);
+  assert.match(html, /Enter the codes/);
+  assert.match(html, /Read the six digits/);
+  assert.match(html, /four-character code/);
+  assert.match(html, /K7 Q2/);
   assert.match(html, /Get the app to finish/);
   assert.match(html, /Prefer to type it\?/);
   assert.match(html, /Get Manta/);


### PR DESCRIPTION
**Base: origin/main @ `1219169`**

## Problem

BET-493 added the four-character two-sided verification code to the desktop
"Add a phone" panel and to `/auth/pair` + `/auth/claim` (claim-with-`verify`
provisions a distinct Stage-2 joiner device). But the two OTHER pairing entry
points that mint/display the pairing code still surfaced only the six digits
and claimed with no `verify`, so a device paired through them reused the shared
primary `box_token` — the exact "joiner reuses the desktop's own token" outcome
the two-factor confirm is meant to prevent.

## What changed

- **`manta pair` CLI** (`scripts/manta-pair.mjs` + `formatPairingOutput` in
  `scripts/install-lib.mjs`): surfaces a `Verify code: K7 Q2` line next to the
  six digits, and threads `verify` through the emitted pair link + pair-page
  URL so a device that claims from either carries the two-sided confirm.
- **`/pair` web page** (`src/server/pair.html`): the manual entry now collects
  the four-char verify (a dedicated 4-cell entry) alongside the six digits,
  reads `verify` from the URL fragment, and claims with `{ code, verify }` so a
  web-paired device gets a distinct Stage-2 device. A legacy six-digit-only
  link no longer auto-claims as the primary device — it waits for the verify.
- **Payload builder** (`src/renderer/mobile/pairPayload.ts`): `PairPayload`
  gained an optional `verify`; `parsePairPayload` / `buildPairPayload` carry it
  so QRs / deep links can transport the confirm.
- **`/pair/qr.png`** (`src/server/pairPage.mjs` `validatePairQrQuery`): accepts
  an optional, validated `verify` query param.

**Back-compat maintained:** no `verify` = legacy path (shared primary token),
byte-compatible with before. Only the new surfaces / params change.

## Verification results

**Files changed:** 8 files (see diff --stat in the PR; server + scripts
(`install-lib.mjs`, `manta-pair.mjs`, `pairPage.mjs`, `pair.html`) + renderer
(`pairPayload.ts`) + tests for all new surfaces).

- PR branch (`multica/BET-513-verify-cli-webpair` @ `f0ac204`):
  - `npm run typecheck`: exit 0, no errors.
  - `npm test`: exit 0; vitest `pairPayload.test.ts` 62/62 pass; node:test
    server+install+gateway 1345/1345 pass, 0 fail.
- Base (`main` @ `1219169`): unchanged (no production code touched on main).

**Conclusion:** 0 new failures.
