### PR TITLE
feat(visual): durable conformance records + visual:compare reminder (BET-509)

### DIFF
--- a/docs/screens/session/conformance.md
+++ b/docs/screens/session/conformance.md
@@ -1,0 +1,17 @@
+# Conformance — session
+
+App vs `docs/screens/session/mockup.html`, from `npm run visual:compare session`.
+Advisory: nothing here blocks a merge. Findings are recorded so they survive
+the PR that found them.
+
+Last reviewed: 2026-08-01 (3802bc0)
+
+## Open divergences
+
+_None recorded._
+
+## Accepted divergences
+
+- **Pinned vs inline ask card** — the app pins a pending permission card above
+  the composer, while the mockup draws the ask inline in the scrollback (PR
+  #392). The pinned placement is deliberate and will not be changed.

--- a/docs/screens/settings/conformance.md
+++ b/docs/screens/settings/conformance.md
@@ -1,0 +1,17 @@
+# Conformance — settings
+
+App vs `docs/screens/settings/mockup.html`, from `npm run visual:compare settings`.
+Advisory: nothing here blocks a merge. Findings are recorded so they survive
+the PR that found them.
+
+Last reviewed: 2026-08-01 (3802bc0)
+
+## Open divergences
+
+- **Extensions launcher card** — the heading text and card ordering of the
+  launcher card differ between `Settings.tsx` and the mockup's `.ext` panel.
+  `tracked: BET-473`
+
+## Accepted divergences
+
+_None recorded._

--- a/docs/screens/welcome/conformance.md
+++ b/docs/screens/welcome/conformance.md
@@ -1,0 +1,15 @@
+# Conformance — welcome
+
+App vs `docs/screens/welcome/mockup.html`, from `npm run visual:compare welcome`.
+Advisory: nothing here blocks a merge. Findings are recorded so they survive
+the PR that found them.
+
+Last reviewed: 2026-08-01 (3802bc0)
+
+## Open divergences
+
+_None recorded._
+
+## Accepted divergences
+
+_None recorded._

--- a/docs/visual-verification.md
+++ b/docs/visual-verification.md
@@ -142,8 +142,10 @@ user gestures — a click a person could make — not for reaching into internal
    cause of the composer defect, and no tooling substitutes for it.
 2. The screen is a row in `scripts/visual/screens.mjs`.
 3. `npm run visual` is green, with the baselines committed.
-4. `npm run visual:compare` has been run and its findings addressed or
-   explicitly deferred in the PR description.
+4. `npm run visual:compare` has been run and its findings addressed, or
+   recorded in `docs/screens/<id>/conformance.md` with the "Last reviewed"
+   line updated. A finding that lives only in a PR description is lost the
+   moment the PR is merged.
 5. **Any baseline this PR creates or re-records is in the PR body as an
    image.** Not a filename, not "regenerated" — the picture. A baseline is
    committed *evidence*, and a reviewer who cannot see it is approving a hash.

--- a/scripts/visual/compare.mjs
+++ b/scripts/visual/compare.mjs
@@ -183,6 +183,18 @@ async function main() {
   log("  5. Emphasis — is the same element the loudest one on the screen?");
   log("  6. States — is the empty/placeholder state the one the design shows?");
   log("Findings are advisory. Nothing here blocks a merge.");
+
+  const withMockup = screens.filter(
+    (s) => s.mockup && s.mockup === `docs/screens/${s.id}/mockup.html`,
+  );
+  for (const s of withMockup) {
+    const record = `docs/screens/${s.id}/conformance.md`;
+    if (existsSync(join(ROOT, record))) {
+      log(`  Record findings in ${record} (update "Last reviewed").`);
+    } else {
+      log(`  NO conformance record for "${s.id}" — create ${record}.`);
+    }
+  }
 }
 
 main().catch((e) => {


### PR DESCRIPTION
# BET-509 — conformance records get a durable home

Gives layer-3 (app-vs-mockup) conformance findings somewhere durable to live:
one `conformance.md` per mocked-up screen, plus a reminder in `visual:compare`
and an updated definition-of-done.

## Changes

1. **`docs/screens/<id>/conformance.md`** created for every registry screen with
   a mockup, derived from `scripts/visual/screens.mjs` (distinct own-directory
   mockup — `mockup === docs/screens/<id>/mockup.html`; `mockup: null` rows and
   region rows that reuse a parent's mockup are excluded). Three files:
   - `docs/screens/welcome/conformance.md` — seeded `_None recorded._` under
     both headings (no finding in its PR history; no fresh review run).
   - `docs/screens/session/conformance.md` — the pinned-vs-inline ask-card
     placement difference from PR #392 recorded under **Accepted** (deliberate).
   - `docs/screens/settings/conformance.md` — the Extensions launcher-card
     divergence (heading text + card ordering vs the mockup's `.ext` panel)
     recorded under **Open**, `tracked: BET-473`.
   Files match the template exactly (no added/reordered sections).
2. **`scripts/visual/compare.mjs`** — the closing checklist now prints, per
   mocked-up screen, either `Record findings in docs/screens/<id>/conformance.md
   (update "Last reviewed").` or `NO conformance record for "<id>" — create
   ...` when the file is missing. The script never writes/creates/mutates the
   file. **`compare.mjs` grows by 12 lines** (DoD 6).
3. **`docs/visual-verification.md`** — Definition-of-done item 4 extended to
   point at `conformance.md`; no new numbered item, no restructuring.

## Files changed

- `docs/screens/welcome/conformance.md` (new)
- `docs/screens/session/conformance.md` (new)
- `docs/screens/settings/conformance.md` (new)
- `scripts/visual/compare.mjs`
- `docs/visual-verification.md`

**Base: origin/main @ `40d8773` (rebased)**

## Verification results

- PR branch (`multica/BET-509-conformance-records` @ `HEAD`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1346 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `3802bc0`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1346 pass / 0 fail / 0 skip. Failures: none.
- **Conclusion:** 0 new failures, 0 pre-existing — both branches identical.

### `visual:compare` output demo (DoD 2)

With all files present, per screen:
```
[visual:compare]   Record findings in docs/screens/welcome/conformance.md (update "Last reviewed").
[visual:compare]   Record findings in docs/screens/session/conformance.md (update "Last reviewed").
[visual:compare]   Record findings in docs/screens/settings/conformance.md (update "Last reviewed").
```
With a file missing (renamed `docs/screens/settings/conformance.md`):
```
[visual:compare]   NO conformance record for "settings" — create docs/screens/settings/conformance.md.
```
(renamed file restored afterward)

**No baseline moves:** `git status` shows nothing under
`tests/visual/screens.visual.ts-snapshots/` (verified clean).

