### PR TITLE
BET-518: stop a stale main failing unrelated PRs (path-gate PR drift, cover main nightly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,22 +198,36 @@ jobs:
       - name: Drift gate — regenerate website/shot-*.webp and diff against the committed set
         if: github.event_name == 'pull_request'
         run: |
-          npm run shots
-          npm run shots
-          # Scope is the SHOT ARTIFACTS this gate owns (website/shot-*.webp +
-          # hero-poster.webp). NOT the whole website/ dir — the npm test step
-          # regenerates website/sitemap.xml from git history, so including it
-          # here makes the gate measure the sitemap's lastmod against a stale
-          # committed copy and fail on an unrelated file (BET-444).
-          echo "::group::Post-capture shot diff against the committed set"
-          git status --porcelain -- website/shot-*.webp website/hero-poster.webp || true
-          git diff --name-status -- website/shot-*.webp website/hero-poster.webp || true
-          git diff --stat -- website/shot-*.webp website/hero-poster.webp || true
-          echo "::endgroup::"
-          if ! git diff --exit-code --quiet -- website/shot-*.webp website/hero-poster.webp; then
-            echo "::error file=website/shot-*.webp::drift detected — two consecutive runs differ from the committed set. Either the renderer changed or the capture is not byte-deterministic."
-            echo "::error::If the renderer intentionally changed, run 'npm run shots' locally and commit the regenerated files. If not, the capture pipeline is non-deterministic — investigate before merging."
-            exit 1
+          # A PR that touches none of the capture inputs cannot make the shots
+          # stale, and on a PR that can't affect them a red result would only
+          # inherit someone else's staleness. So run the gate only when the PR
+          # changes a file that feeds the capture — same mechanism as the
+          # conditional dependency audit in this job (diff against the merge
+          # base, gate on what the PR actually touched). The five paths are
+          # complete and specified by BET-518: the renderer paints the shots,
+          # website/ holds them, the two scripts capture them, and the lockfile
+          # pins the browser that renders them.
+          if git diff --name-only "$(git merge-base origin/main HEAD)" HEAD -- \
+               src/renderer/ website/ scripts/shots.mjs scripts/visual/harness.mjs package-lock.json | grep -q .; then
+            npm run shots
+            npm run shots
+            # Scope is the SHOT ARTIFACTS this gate owns (website/shot-*.webp +
+            # hero-poster.webp). NOT the whole website/ dir — the npm test step
+            # regenerates website/sitemap.xml from git history, so including it
+            # here makes the gate measure the sitemap's lastmod against a stale
+            # committed copy and fail on an unrelated file (BET-444).
+            echo "::group::Post-capture shot diff against the committed set"
+            git status --porcelain -- website/shot-*.webp website/hero-poster.webp || true
+            git diff --name-status -- website/shot-*.webp website/hero-poster.webp || true
+            git diff --stat -- website/shot-*.webp website/hero-poster.webp || true
+            echo "::endgroup::"
+            if ! git diff --exit-code --quiet -- website/shot-*.webp website/hero-poster.webp; then
+              echo "::error file=website/shot-*.webp::drift detected — two consecutive runs differ from the committed set. Either the renderer changed or the capture is not byte-deterministic."
+              echo "::error::If the renderer intentionally changed, run 'npm run shots' locally and commit the regenerated files. If not, the capture pipeline is non-deterministic — investigate before merging."
+              exit 1
+            fi
+          else
+            echo "PR touches neither the renderer, website/, the shot-capture scripts, nor the lockfile — the shots this gate owns cannot have gone stale from it. Skipping (main coverage is the shots job in dep-audit-nightly.yml)."
           fi
 
       # ── Visual gate — every screen in scripts/visual/screens.mjs is checked

--- a/.github/workflows/dep-audit-nightly.yml
+++ b/.github/workflows/dep-audit-nightly.yml
@@ -12,6 +12,16 @@ name: dep-audit-nightly
 # So: ci.yml audits a PR only when that PR changes the dependency set, and
 # this run covers main daily. A new advisory then surfaces as ONE red run on
 # main and one fix issue, instead of N blocked PRs.
+#
+# The same shape covers the shot drift gate (BET-518). That gate runs on pull
+# requests ONLY, on the assumption that every merge cleared it — so a push to
+# main never checks the shots, and if one merge lands red the committed set is
+# stale with nothing on main ever noticing, failing every later PR at once
+# for a file it never touched (this actually happened: #406 and #422 merged
+# red). ci.yml therefore gates the PR run on the five files that feed the
+# capture (see the drift-gate step), and this `shots-drift` job covers main on
+# the same schedule so staleness surfaces as ONE red run and one fix, mirroring
+# the dependency-audit reasoning above.
 
 on:
   schedule:
@@ -38,3 +48,56 @@ jobs:
       # breaking-change fixes; shipped-code advisories are the signal.
       - name: Audit production dependencies (high+)
         run: npm audit --omit=dev --audit-level=high
+
+  # Shot drift on main, on the same schedule (BET-518). The drift gate in ci.yml
+  # is PR-only by design and is now path-gated, so main is never checked there;
+  # this job covers it. One run is correct: distinguishing determinism from
+  # staleness is BET-519's job and must not be duplicated here.
+  #
+  # ffmpeg + Playwright's pinned Chromium are installed exactly as ci.yml does,
+  # so the capture drives the same browser/encoder the baselines were encoded
+  # under — a stale committed set must fail, not be masked by a browser that
+  # paints differently.
+  shots-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Cache node_modules
+        id: nm-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-nm-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+      # ffmpeg — `npm run shots` extracts website/hero-poster.webp from
+      # hero.mp4 (scripts/shots.mjs); ubuntu-24.04 images no longer ship it.
+      - name: Install ffmpeg (hero-poster extraction)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright Chromium
+        run: npx playwright install ${{ steps.pw-cache.outputs.cache-hit == 'true' && 'chromium' || '--with-deps chromium' }}
+      - name: Shot drift on main — regenerate website/shot-*.webp and diff against the committed set
+        run: |
+          npm run shots
+          # Scope is the SHOT ARTIFACTS this gate owns (website/shot-*.webp +
+          # hero-poster.webp), matching the PR gate; the npm test step
+          # regenerates website/sitemap.xml so it is deliberately excluded.
+          if ! git diff --exit-code --quiet -- website/shot-*.webp website/hero-poster.webp; then
+            echo "::error::main's committed website/shot-*.webp are stale. The PR drift gate never runs on main, so only this scheduled check covers them. Fix: run 'npm run shots' on main and commit the regenerated website/shot-*.webp + website/hero-poster.webp."
+            git diff --stat -- website/shot-*.webp website/hero-poster.webp || true
+            exit 1
+          fi


### PR DESCRIPTION
## BET-518 — A: stop a stale `main` failing unrelated PRs (Part 1 dropped, Parts 2 & 3)

Part 1 (regenerate stale shots) is **dropped** per the owner's correction: `npm run shots`
on current `main` produces **no diff** against the committed set — the shots are already
current. Only the two defensive CI changes are in this PR.

### Part 2 — path-condition the PR drift gate (`ci.yml`)
The `Drift gate` step now runs its capture+diff only when the PR touches one of the five
files that feed a changeable shot: `src/renderer/**`, `website/**`, `scripts/shots.mjs`,
`scripts/visual/harness.mjs`, `package-lock.json`. Expressed with the **same mechanism** as
the existing conditional dependency audit in the same job (`git diff --name-only
$(git merge-base origin/main HEAD) HEAD -- … | grep -q .`). A PR that touches none of them
prints a skip note instead of running (a stale `main` no longer fails it — but see Part 3).

The gate is still **blocking** on PRs that do touch those paths: the drift still ends in
`exit 1` inside the conditional, exactly as before — only the when is now narrower.

### Part 3 — cover `main` on the existing schedule (`dep-audit-nightly.yml`)
Added a second `shots-drift` job to the **existing** scheduled workflow (no new workflow
file): checks out `main`, installs `ffmpeg` + Playwright's pinned Chromium exactly as
`ci.yml` does, runs `npm run shots` once, and fails if the committed shots differ. The
failure message names the remedy (`run 'npm run shots' on main and commit`). One run —
distinguishing determinism from staleness is BET-519's job.

**Files changed:** 2 workflow files (no new file, no new job in `ci.yml`, no script change,
double-run untouched).

**Base:** `origin/main` @ `40d8773`

### Verification
- typecheck: **exit 0** (tsc x2)
- test: **exit 0** — 1346 pass / 0 fail / 0 skip / 0 todo (54 suites)

### Cross-cutting
- Touches `.github/**` → requires human Code Owner review (`@antoinedc`); cannot be
  agent-auto-merged.
- Re: BET-519 — during this work no new evidence about the #422 divergence surfaced beyond
  the owner's own observation; it remains the ambiguity BET-519 removes.
