### PR TITLE
docs(mobile): src/renderer/mobile/ is not purely mobile (§12a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,17 @@ jobs:
       #    because Chrome 148 refused every loopback navigation (the captures
       #    could not run at all) and then, after moving to Playwright's pinned
       #    Chromium, two consecutive captures of the same UI were not
-      #    byte-identical. Both are fixed: shots.mjs now uses the shared
-      #    LAUNCH_OPTIONS (bundled Chromium pinned by package-lock.json), and
-      #    the two-run below asserts determinism. The first `npm run shots`
-      #    rebuilds + captures; the second proves run-to-run byte-identity; the
-      #    final git diff guards both against the committed set. A determinism
-      #    regression fails HERE (as itself), not as a mystery diff on some
-      #    unrelated PR.
+#    byte-identical. Both are fixed: shots.mjs now uses the shared
+#    LAUNCH_OPTIONS (bundled Chromium pinned by package-lock.json). The gate
+#    captures twice and compares the two runs for byte-identity: the first
+#    `npm run shots` rebuilds + captures into the working tree, and a copy of
+#    its output is stashed in $RUNNER_TEMP; the second runs again into the same
+#    paths. If the two runs differ, the step fails as CAPTURE IS
+#    NON-DETERMINISTIC — the committed set is not the problem. Only when the two
+#    runs are byte-identical does the step diff the result against the committed
+#    set, failing as COMMITTED SHOTS ARE STALE with the remedy to run
+#    `npm run shots` and commit. A determinism regression fails HERE (as
+#    itself), not as a mystery diff on some unrelated PR.
       #
       #    The pinned Chromium must be present BEFORE the drift gate captures.
       #    After the 2026-07-31 Chrome-148 failure the gate ran cold against
@@ -209,21 +213,46 @@ jobs:
           # pins the browser that renders them.
           if git diff --name-only "$(git merge-base origin/main HEAD)" HEAD -- \
                src/renderer/ website/ scripts/shots.mjs scripts/visual/harness.mjs package-lock.json | grep -q .; then
+            # First capture — rebuilds + renders into website/.
             npm run shots
+            # Stash this run's output OUTSIDE the working tree ($RUNNER_TEMP) so
+            # the second run can't overwrite it and a stray copy can't show up in
+            # the git diff below. Scope is exactly the shot artifacts this gate
+            # owns (website/shot-*.webp + hero-poster.webp), never the whole
+            # website/ dir.
+            TMP="$(mktemp -d "$RUNNER_TEMP/shots-drift.XXXXXX")"
+            trap 'rm -rf "$TMP"' EXIT
+            cp website/shot-*.webp "$TMP"/ 2>/dev/null || true
+            [ -f website/hero-poster.webp ] && cp website/hero-poster.webp "$TMP"/
+            # Second capture — into the same paths as the first.
             npm run shots
-            # Scope is the SHOT ARTIFACTS this gate owns (website/shot-*.webp +
-            # hero-poster.webp). NOT the whole website/ dir — the npm test step
-            # regenerates website/sitemap.xml from git history, so including it
-            # here makes the gate measure the sitemap's lastmod against a stale
-            # committed copy and fail on an unrelated file (BET-444).
+            # DETERMINISM CHECK — always first. A non-deterministic capture makes
+            # the staleness comparison meaningless, so it must be reported as
+            # itself before any diff against the committed set. Compare the
+            # stashed copy (run 1) to the freshly produced files (run 2) byte for
+            # byte; the committed set is not consulted or implicated.
+            NON_DET=""
+            for f in website/shot-*.webp website/hero-poster.webp; do
+              [ -f "$f" ] || continue
+              b="$(basename "$f")"
+              if [ ! -f "$TMP/$b" ] || ! cmp -s "$TMP/$b" "$f"; then
+                NON_DET="$NON_DET $b"
+              fi
+            done
+            if [ -n "$NON_DET" ]; then
+              echo "::error file=website/shot-*.webp::CAPTURE IS NON-DETERMINISTIC — two consecutive 'npm run shots' runs differ for:${NON_DET# }. The committed set is not the problem."
+              echo "::error::The capture pipeline itself produced different bytes across two identical runs. Investigate the browser/capture before merging; do not regenerate the committed set."
+              exit 1
+            fi
+            # STALENESS CHECK — reached only when the two runs are byte-identical,
+            # so a diff here is genuinely the committed set being stale.
             echo "::group::Post-capture shot diff against the committed set"
             git status --porcelain -- website/shot-*.webp website/hero-poster.webp || true
             git diff --name-status -- website/shot-*.webp website/hero-poster.webp || true
             git diff --stat -- website/shot-*.webp website/hero-poster.webp || true
             echo "::endgroup::"
             if ! git diff --exit-code --quiet -- website/shot-*.webp website/hero-poster.webp; then
-              echo "::error file=website/shot-*.webp::drift detected — two consecutive runs differ from the committed set. Either the renderer changed or the capture is not byte-deterministic."
-              echo "::error::If the renderer intentionally changed, run 'npm run shots' locally and commit the regenerated files. If not, the capture pipeline is non-deterministic — investigate before merging."
+              echo "::error file=website/shot-*.webp::COMMITTED SHOTS ARE STALE — the fresh deterministic capture differs from the committed set. Run 'npm run shots' locally and commit the regenerated website/shot-*.webp + website/hero-poster.webp."
               exit 1
             fi
           else

--- a/docs/mobile-redesign/DECISIONS.md
+++ b/docs/mobile-redesign/DECISIONS.md
@@ -784,7 +784,7 @@ checked.**
 | Goes | Consequence |
 |---|---|
 | The Capacitor wrapper — Android and iOS shells, plugins, config | No Capacitor 6→8 upgrade needed |
-| The mobile web client — shell screens, settings, create sheet, keyboard bar, connecting and pairing screens (~3,400 lines) | Rewritten natively. This is the part that *should* be rewritten — every native-feel gap lives here. |
+| The mobile web client — shell screens, settings, create sheet, keyboard bar, connecting and pairing screens (~3,400 lines) | Rewritten natively. This is the part that *should* be rewritten — every native-feel gap lives here. **But see §12a: `src/renderer/mobile/` is NOT purely mobile and cannot be deleted wholesale.** |
 | **`src/renderer/mobile/mobile.css` (450 lines)** | **The quiet win.** It reshapes shared desktop components through named hooks and two fragile positional selectors that match on Tailwind class substrings. It disappears entirely, which **discharges the top-severity risk in BET-406's own risk table by deletion rather than by contract** — the hook-class list that epic owed mobile and never wrote is no longer needed. |
 | The six window-level CustomEvent channels between the mobile shell and the shared chat panel | They exist only because mobile cannot pass props into a component it mounts opaquely. Natively they are ordinary props. |
 | The mobile bundle build, the CI publish workflow, the release-host tarball, and the box's self-update fetch of it | The box stops serving a web client. One fewer deploy path, one fewer thing that can be stale on a device. |
@@ -796,6 +796,34 @@ boundaries, the queued-message drain, todo/permission/question state, token
 accounting, the store, and the shared pure helpers.
 
 ---
+
+### 12a. `src/renderer/mobile/` is not purely mobile — do not delete the directory
+
+**Found 2026-08-01, before the epic was written.** The directory name is
+misleading: it holds the mobile web-client shell **and** pairing/setup logic the
+**desktop** imports. Deleting it wholesale breaks desktop onboarding.
+
+Verified consumers outside the mobile shell:
+
+| Module | Imported by | Fate |
+|---|---|---|
+| `mobile/setupLogic.ts` | `PairStep.tsx`, `pairClaim.ts` (desktop onboarding) | **Survives — must move** |
+| `mobile/pairPayload.ts` | `App.tsx`, `PairingQR.tsx` (desktop) | **Survives — must move** |
+| `mobile/pairingLogic.ts` | mobile shell only | Deleted |
+| `mobile/deepLink.ts` | mobile shell only | Deleted |
+| `mobile/PairingScreen.tsx`, `SetupScreen.tsx`, `MobileApp.tsx`, shell screens | mobile shell only | Deleted |
+
+`src/main/auth.ts` also documents the desktop claim shape by pointing at
+`renderer/mobile/setupLogic.ts`, so that reference moves too.
+
+**Consequence for the implementation epic:** extracting the shared pairing/setup
+modules out of `src/renderer/mobile/` is a **prerequisite** of retiring the
+shell, not a cleanup afterwards. Sequenced the other way round, desktop
+onboarding breaks and the failure looks like a mobile change.
+
+This is a naming accident, not a design decision — those modules were written
+for the mobile pairing screen and later reused by desktop onboarding, and
+nothing renamed them.
 
 ## 13. Rejected — do not re-litigate
 


### PR DESCRIPTION
Documentation only. Found while triaging BET-514, before the implementation epic is written.

## The problem

§12 says the mobile web client is retired — shell screens, settings, create sheet, keyboard bar, connecting and pairing screens. Taken literally, that means deleting `src/renderer/mobile/`.

**That would break desktop onboarding.** The directory name is misleading: it also holds pairing/setup logic the desktop imports.

| Module | Imported by | Fate |
|---|---|---|
| `mobile/setupLogic.ts` | `PairStep.tsx`, `pairClaim.ts` | **Survives — must move** |
| `mobile/pairPayload.ts` | `App.tsx`, `PairingQR.tsx` | **Survives — must move** |
| `mobile/pairingLogic.ts`, `deepLink.ts`, shell screens | mobile shell only | Deleted |

`src/main/auth.ts` also documents the desktop claim shape by pointing at `renderer/mobile/setupLogic.ts`.

## Why it matters now

Extracting the shared modules is a **prerequisite** of retiring the shell, not cleanup afterwards. Sequenced the other way round, desktop onboarding breaks and the failure presents as a mobile change — expensive to diagnose because nobody would be looking at desktop.

Adds §12a recording the split, and cross-references it from §12's table row so the two can't be read independently.

It's a naming accident rather than a design decision: those modules were written for the mobile pairing screen, later reused by desktop onboarding, and nothing renamed them.