### PR TITLE
refactor(ci): dedupe ffmpeg + pinned Chromium install into shared composite actions (BET-522)

### DIFF
--- a/.github/actions/cache-playwright-browsers/action.yml
+++ b/.github/actions/cache-playwright-browsers/action.yml
@@ -1,0 +1,19 @@
+name: Cache and install Playwright pinned Chromium
+description: |
+  Caches Playwright's browser download (keyed on the Playwright version via
+  package-lock.json) and installs the pinned Chromium. --with-deps needs sudo
+  apt and is only required the first time on a given runner. Single source for
+  the drift and visual/E2E gates, so every capture drives the same renderer.
+runs:
+  using: composite
+  steps:
+    - name: Cache Playwright browsers
+      id: pw-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+    - name: Install Playwright Chromium
+      shell: bash
+      run: npx playwright install ${{ steps.pw-cache.outputs.cache-hit == 'true' && 'chromium' || '--with-deps chromium' }}

--- a/.github/actions/install-ffmpeg/action.yml
+++ b/.github/actions/install-ffmpeg/action.yml
@@ -1,0 +1,11 @@
+name: Install ffmpeg
+description: |
+  Installs ffmpeg via apt. `npm run shots` extracts website/hero-poster.webp
+  from hero.mp4 (scripts/shots.mjs); ubuntu-24.04 images no longer ship it.
+  Single source for both workflows that drive the shots capture.
+runs:
+  using: composite
+  steps:
+    - name: Install ffmpeg (hero-poster extraction)
+      shell: bash
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,9 @@ jobs:
       #    NOTE: shots.mjs hardcodes that absolute path rather than resolving
       #    the binary from PATH. apt installs to /usr/bin so this works, but
       #    the hardcode is still wrong (a Homebrew ffmpeg lands in
-      #    /opt/homebrew/bin and would not be found) — tracked separately;
-      #    not fixed here because main is red and this PR is the unblock.
-      - name: Install ffmpeg (hero-poster extraction in the drift gate)
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
+      #    /opt/homebrew/bin and would not be found) — tracked separately
+      #    (BET-522 does not change shots.mjs). Shared with dep-audit-nightly.
+      - uses: ./.github/actions/install-ffmpeg
 
       - name: Typecheck
         run: npm run typecheck
@@ -181,23 +180,15 @@ jobs:
 #    `npm run shots` and commit. A determinism regression fails HERE (as
 #    itself), not as a mystery diff on some unrelated PR.
       #
-      #    The pinned Chromium must be present BEFORE the drift gate captures.
-      #    After the 2026-07-31 Chrome-148 failure the gate ran cold against
-      #    whatever browser was already in the runner cache — the visual gate's
-      #    browser install step sat AFTER this step — so a stale cache could
-      #    launch a browser that paints differently from the committed set.
-      #    The lockfile-pinned browser is installed here, first, so both this
-      #    gate and the visual gate below drive the exact renderer the
-      #    baselines were encoded under.
-      - name: Cache Playwright browsers
-        id: pw-cache-drift
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright Chromium
-        run: npx playwright install ${{ steps.pw-cache-drift.outputs.cache-hit == 'true' && 'chromium' || '--with-deps chromium' }}
+      # The pinned Chromium must be present BEFORE the drift gate captures.
+      # After the 2026-07-31 Chrome-148 failure the gate ran cold against
+      # whatever browser was already in the runner cache — the visual gate's
+      # browser install step sat AFTER this step — so a stale cache could
+      # launch a browser that paints differently from the committed set.
+      # The lockfile-pinned browser is installed here, first, so both this
+      # gate and the visual gate below drive the exact renderer the
+      # baselines were encoded under. Shared with the E2E job + dep-audit-nightly.
+      - uses: ./.github/actions/cache-playwright-browsers
 
       - name: Drift gate — regenerate website/shot-*.webp and diff against the committed set
         if: github.event_name == 'pull_request'
@@ -429,18 +420,10 @@ jobs:
         if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      # Playwright's browser download is the slowest part of this job and only
-      # changes when the Playwright version does. `--with-deps` needs sudo apt
-      # and is only required the first time on a given runner.
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browsers
-        run: npx playwright install ${{ steps.pw-cache.outputs.cache-hit == 'true' && 'chromium' || '--with-deps chromium' }}
+      # Playwright's pinned Chromium — same shared unit the drift gate uses,
+      # so both capture gates drive the identical browser. --with-deps needs
+      # sudo apt and is only required the first time on a given runner.
+      - uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run E2E smoke tests
         # xvfb-run: script needs a display for headless Electron but does not

--- a/.github/workflows/dep-audit-nightly.yml
+++ b/.github/workflows/dep-audit-nightly.yml
@@ -78,18 +78,11 @@ jobs:
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
-      # ffmpeg — `npm run shots` extracts website/hero-poster.webp from
-      # hero.mp4 (scripts/shots.mjs); ubuntu-24.04 images no longer ship it.
-      - name: Install ffmpeg (hero-poster extraction)
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-      - name: Install Playwright Chromium
-        run: npx playwright install ${{ steps.pw-cache.outputs.cache-hit == 'true' && 'chromium' || '--with-deps chromium' }}
+      # ffmpeg + Playwright's pinned Chromium are the same shared units ci.yml
+      # uses, so the capture drives the same browser/encoder the baselines were
+      # encoded under.
+      - uses: ./.github/actions/install-ffmpeg
+      - uses: ./.github/actions/cache-playwright-browsers
       - name: Shot drift on main — regenerate website/shot-*.webp and diff against the committed set
         run: |
           npm run shots


### PR DESCRIPTION
Dedupes the shots-capture toolchain install across `ci.yml` and `dep-audit-nightly.yml` into two reusable composite actions.

**Problem (per reviewer scope correction — THREE copies, not two):** the Playwright cache+install existed at three sites and ffmpeg at two, so a browser-pin / install change in one file could silently drift from the others — including between the two `ci.yml` capture gates that must drive the *same* renderer.

**Chosen single source of truth:**
- `.github/actions/cache-playwright-browsers/action.yml` — caches + installs the lockfile-pinned Chromium (the subtle `cache-hit` conditional lives here once). Replaces: ci.yml drift gate (`pw-cache-drift`), ci.yml E2E job (`pw-cache`), nightly `shots-drift` (`pw-cache`).
- `.github/actions/install-ffmpeg/action.yml` — the ffmpeg one-liner. Replaces: ci.yml drift gate + nightly `shots-drift`.

**Duplicate-site accounting (anti-spaghetti):**
| Old site | File | Replaced by |
|---|---|---|
| ffmpeg (124) | ci.yml drift gate | `install-ffmpeg` |
| Cache+install `pw-cache-drift` (192/200) | ci.yml drift gate | `cache-playwright-browsers` |
| Cache+install `pw-cache` (435/443) | ci.yml E2E job | `cache-playwright-browsers` |
| ffmpeg (83) | nightly | `install-ffmpeg` |
| Cache+install `pw-cache` (85/92) | nightly | `cache-playwright-browsers` |

3/3 Playwright copies and 2/2 ffmpeg copies removed. Distinct composite actions (not one combined) keep each job installing exactly what it installed before — the E2E job still gets only the browser, the two capture jobs get browser + ffmpeg — so behaviour is identical per job, no new job added.

Each composite-action invocation gets its own isolated `steps` context, so the `pw-cache` step id does not collide across the three call sites.

No source code touched — `.github/**` only.

Base: origin/main @ `1062c9d`