### PR TITLE
chore(ci): re-indent the drift-gate comment block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,17 +169,17 @@ jobs:
       #    because Chrome 148 refused every loopback navigation (the captures
       #    could not run at all) and then, after moving to Playwright's pinned
       #    Chromium, two consecutive captures of the same UI were not
-#    byte-identical. Both are fixed: shots.mjs now uses the shared
-#    LAUNCH_OPTIONS (bundled Chromium pinned by package-lock.json). The gate
-#    captures twice and compares the two runs for byte-identity: the first
-#    `npm run shots` rebuilds + captures into the working tree, and a copy of
-#    its output is stashed in $RUNNER_TEMP; the second runs again into the same
-#    paths. If the two runs differ, the step fails as CAPTURE IS
-#    NON-DETERMINISTIC — the committed set is not the problem. Only when the two
-#    runs are byte-identical does the step diff the result against the committed
-#    set, failing as COMMITTED SHOTS ARE STALE with the remedy to run
-#    `npm run shots` and commit. A determinism regression fails HERE (as
-#    itself), not as a mystery diff on some unrelated PR.
+      #    byte-identical. Both are fixed: shots.mjs now uses the shared
+      #    LAUNCH_OPTIONS (bundled Chromium pinned by package-lock.json). The gate
+      #    captures twice and compares the two runs for byte-identity: the first
+      #    `npm run shots` rebuilds + captures into the working tree, and a copy of
+      #    its output is stashed in $RUNNER_TEMP; the second runs again into the same
+      #    paths. If the two runs differ, the step fails as CAPTURE IS
+      #    NON-DETERMINISTIC — the committed set is not the problem. Only when the two
+      #    runs are byte-identical does the step diff the result against the committed
+      #    set, failing as COMMITTED SHOTS ARE STALE with the remedy to run
+      #    `npm run shots` and commit. A determinism regression fails HERE (as
+      #    itself), not as a mystery diff on some unrelated PR.
       #
       #    The pinned Chromium must be present BEFORE the drift gate captures.
       #    After the 2026-07-31 Chrome-148 failure the gate ran cold against


### PR DESCRIPTION
Cosmetic, no behavioural change.

BET-519's comment rewrite landed with the block de-indented to column 0 while every neighbouring comment in the same step list sits at 6 spaces. Valid YAML — comments are position-independent — but it reads as though the block escaped its step.

Verified after: the workflow parses and `typecheck-test` still has all 18 steps, including the ffmpeg install, both Playwright cache/install pairs, the Swift token drift gate and the shots drift gate. The gate logic itself is untouched.

Context: this de-indentation arrived on `main` via PR #431, a docs-only change whose squash commit accidentally carried the BET-519 commit — agents share the `/home/dev/projects/better-ui` checkout, so a branch cut from local `main` picked up an in-progress commit from another session.