### PR TITLE
feat(visual): style-diff PoC — app-vs-mockup computed-style diff in token names (BET-523)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "visual": "npm run build:mobile && playwright test --project=visual",
     "visual:update": "npm run build:mobile && playwright test --project=visual --update-snapshots",
     "visual:compare": "npm run build:mobile && node scripts/visual/compare.mjs",
+    "visual:styles": "npm run build:mobile && node scripts/visual/style-diff.mjs",
     "visual:baselines": "node scripts/visual/baseline-diff.mjs"
   },
   "dependencies": {

--- a/scripts/visual/style-diff.mjs
+++ b/scripts/visual/style-diff.mjs
@@ -328,7 +328,7 @@ async function captureSide(page, baseURL, { url, ready, final, actions, region }
 function fmtValue(value, map) {
   const toks = resolveToken(value, map);
   return toks && toks.length
-    ? `${toks.map((t) => `--${t}`).join("|")} (${value})`
+    ? `${toks.join("|")} (${value})`
     : `[no token] (${value})`;
 }
 
@@ -350,7 +350,7 @@ function renderSectionA(appRecords, mockRecords, map) {
         if (isDefault(prop, value)) continue;
         const toks = resolveToken(value, map);
         if (!toks) continue;
-        for (const t of toks) bump(GROUP_OF[prop], side, `--${t}`);
+        for (const t of toks) bump(GROUP_OF[prop], side, t);
       }
     }
   }

--- a/scripts/visual/style-diff.mjs
+++ b/scripts/visual/style-diff.mjs
@@ -1,0 +1,575 @@
+#!/usr/bin/env node
+/**
+ * scripts/visual/style-diff.mjs — app-vs-mockup COMPUTED-STYLE diff in token
+ * names (layer 4 of the visual toolchain).
+ *
+ * compare.mjs writes two PNGs that a text-only agent cannot read; this script
+ * is the conformance judgement rendered as text a model can act on. It captures
+ * the app and its mockup under the exact same conditions as compare.mjs (same
+ * viewport, deviceScaleFactor, reducedMotion, colorScheme, same harness), reads
+ * back the COMPUTED STYLES of every tracked element inside the region, resolves
+ * each value through the design-token reverse-map built from
+ * src/renderer/tokens.css, and reports the deltas in TOKEN NAMES.
+ *
+ * Why token names and not pixel values: the two blocking layers are blind to a
+ * misapplied token. The accessibility tree sees elements, order and labels; the
+ * pixel baseline diffs the app against itself and was recorded from whatever
+ * render (right or wrong) was current when it was baselined. Neither sees
+ * "the design says --border-strong, the app uses --border". This tool's job is
+ * to surface exactly that.
+ *
+ * Output: .visual-out/<id>.styles.md (already gitignored — the report is the
+ * deliverable of this PoC, NOT a committed artifact).
+ *
+ * Usage:
+ *   npm run visual:styles                    # every screen with a mockup
+ *   node scripts/visual/style-diff.mjs session-header settings-general
+ *
+ * Exit codes: 0 = reports written; 1 = a capture or report failed.
+ *
+ * This is a PoC (BET-523) — deliberately no product-code change, no width
+ * normalisation (the width confound is REPORTED, not corrected), no decision
+ * about which side is right (the mockup is the design; the redo issue acts).
+ */
+
+import { chromium } from "playwright";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  LAUNCH_OPTIONS,
+  RENDERER_DIR,
+  ROOT,
+  preparePage,
+  startStaticServer,
+} from "./harness.mjs";
+import { SCREENS, getScreen } from "./screens.mjs";
+
+const OUT_DIR = join(ROOT, ".visual-out");
+const TOKENS_CSS = join(ROOT, "src/renderer/tokens.css");
+
+/**
+ * The property list — explicit, not "spacing and a few things". Exactly these
+ * properties are extracted on every examined element, and no others.
+ */
+const PROPERTIES = [
+  "color",
+  "background-color",
+  "border-top-color",
+  "border-right-color",
+  "border-bottom-color",
+  "border-left-color",
+  "border-top-width",
+  "border-right-width",
+  "border-bottom-width",
+  "border-left-width",
+  "border-radius",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "gap",
+  "row-gap",
+  "column-gap",
+  "font-family",
+  "font-size",
+  "font-weight",
+  "line-height",
+  "letter-spacing",
+  "box-shadow",
+  "opacity",
+];
+
+/** Group a property for Section A's per-group token counts. */
+const GROUP_OF = {
+  color: "color",
+  "background-color": "background-color",
+  "border-top-color": "border-*-color",
+  "border-right-color": "border-*-color",
+  "border-bottom-color": "border-*-color",
+  "border-left-color": "border-*-color",
+  "border-top-width": "border-*-width",
+  "border-right-width": "border-*-width",
+  "border-bottom-width": "border-*-width",
+  "border-left-width": "border-*-width",
+  "border-radius": "border-radius",
+  "padding-top": "padding-*",
+  "padding-right": "padding-*",
+  "padding-bottom": "padding-*",
+  "padding-left": "padding-*",
+  gap: "gap",
+  "row-gap": "gap",
+  "column-gap": "gap",
+  "font-family": "font-*",
+  "font-size": "font-*",
+  "font-weight": "font-*",
+  "line-height": "font-*",
+  "letter-spacing": "font-*",
+  "box-shadow": "box-shadow",
+  opacity: "opacity",
+};
+
+/**
+ * The browser-default sentinel per property. A property is SKIPPED when BOTH
+ * sides sit at the default (otherwise the report is thousands of lines of
+ * transparent/0px/normal noise). `null` = never default-skippable (inherited
+ * values like color and font-* are meaningful wherever they appear).
+ */
+const DEFAULTS = {
+  color: null,
+  "background-color": "rgba(0, 0, 0, 0)",
+  "border-top-color": "rgba(0, 0, 0, 0)",
+  "border-right-color": "rgba(0, 0, 0, 0)",
+  "border-bottom-color": "rgba(0, 0, 0, 0)",
+  "border-left-color": "rgba(0, 0, 0, 0)",
+  "border-top-width": "0px",
+  "border-right-width": "0px",
+  "border-bottom-width": "0px",
+  "border-left-width": "0px",
+  "border-radius": "0px",
+  "padding-top": "0px",
+  "padding-right": "0px",
+  "padding-bottom": "0px",
+  "padding-left": "0px",
+  gap: "normal",
+  "row-gap": "normal",
+  "column-gap": "normal",
+  "font-family": null,
+  "font-size": null,
+  "font-weight": null,
+  "line-height": "normal",
+  "letter-spacing": "normal",
+  "box-shadow": "none",
+  opacity: "1",
+};
+
+function log(msg) {
+  process.stdout.write(`[visual:styles] ${msg}\n`);
+}
+
+/* ------------------------------------------------------------------ *
+ *  Colour normalisation — getComputedStyle returns rgb(...) while
+ *  tokens.css is hex; both are reduced to the same lowercase rgb() form
+ *  before matching, or every colour looks like a mismatch.
+ * ------------------------------------------------------------------ */
+
+function fmtRgb(r, g, b, a) {
+  r = Math.round(r);
+  g = Math.round(g);
+  b = Math.round(b);
+  if (a == null || a >= 0.999) return `rgb(${r}, ${g}, ${b})`;
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+/**
+ * Normalise ANY colour spelling to one lowercase rgb()/rgba() string, or
+ * `null` when it is not a colour we can parse.
+ */
+export function canonColor(s) {
+  s = String(s).trim().replace(/\s+/g, " ");
+  let m;
+  if ((m = s.match(/^#([0-9a-f]{3,8})$/i))) {
+    let h = m[1];
+    if (h.length === 3 || h.length === 4) h = [...h].map((c) => c + c).join("");
+    if (h.length === 6) h += "ff";
+    const r = parseInt(h.slice(0, 2), 16);
+    const g = parseInt(h.slice(2, 4), 16);
+    const b = parseInt(h.slice(4, 6), 16);
+    const a = parseInt(h.slice(6, 8), 16) / 255;
+    return fmtRgb(r, g, b, a);
+  }
+  const pct = (v) => (v.endsWith("%") ? (parseFloat(v) / 100) * 255 : +v);
+  if (
+    (m = s.match(
+      /^rgba?\(\s*([\d.]+%?)\s*,\s*([\d.]+%?)\s*,\s*([\d.]+%?)(?:\s*,\s*([\d.]+))?\s*\)$/i,
+    ))
+  ) {
+    const a = m[4] != null ? +m[4] : 1;
+    return fmtRgb(pct(m[1]), pct(m[2]), pct(m[3]), a);
+  }
+  if (
+    (m = s.match(
+      /^rgba?\(\s*([\d.]+%?)\s+([\d.]+%?)\s+([\d.]+%?)(?:\s*\/\s*([\d.]+%?))?\s*\)$/i,
+    ))
+  ) {
+    let a = m[4] != null ? parseFloat(m[4]) : 1;
+    if (m[4] != null && m[4].endsWith("%")) a /= 100;
+    return fmtRgb(pct(m[1]), pct(m[2]), pct(m[3]), a);
+  }
+  return null;
+}
+
+function isColorLike(value) {
+  return /^(#|rgba?\()/i.test(value.trim());
+}
+
+/* ------------------------------------------------------------------ *
+ *  Token reverse-map — parse tokens.css once into value → token names.
+ * ------------------------------------------------------------------ */
+
+/**
+ * Build `canonical-key → Set<tokenName>` from every `--name: value` in
+ * tokens.css (both themes + :root). Keys are the raw value for lengths /
+ * numbers (a computed "8px" matches "--sp-3: 8px" verbatim), and the
+ * canonicalised colour for hex/rgb values.
+ */
+export function buildTokenMap(css) {
+  const map = new Map();
+  const add = (key, name) => {
+    if (key == null || key === "") return;
+    if (!map.has(key)) map.set(key, new Set());
+    map.get(key).add(name);
+  };
+  const re = /(--[\w-]+)\s*:\s*([^;]+);/g;
+  let m;
+  while ((m = re.exec(css))) {
+    const value = m[2].trim();
+    add(value, m[1]);
+    if (isColorLike(value)) add(canonColor(value), m[1]);
+  }
+  return map;
+}
+
+/**
+ * Resolve a computed value through the map → array of token names, or
+ * `null` for a raw literal with no matching token (`[no token]`).
+ */
+export function resolveToken(value, map) {
+  const v = String(value).trim();
+  if (map.has(v)) return [...map.get(v)];
+  if (isColorLike(v)) {
+    const c = canonColor(v);
+    if (c && map.has(c)) return [...map.get(c)];
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------ *
+ *  In-page extraction — walk a region, tagging each tracked element with
+ *  its computed ARIA role and its ordinal within that role.
+ * ------------------------------------------------------------------ */
+
+function isDefault(prop, value) {
+  const d = DEFAULTS[prop];
+  if (d == null) return false;
+  return value === d;
+}
+
+async function extractRegion(page, selector) {
+  const loc = page.locator(selector).first();
+  await loc.waitFor({ state: "visible", timeout: 30_000 });
+  const box = await loc.boundingBox();
+  const records = await loc.evaluate(
+    (root, propList) => {
+      // Resolve a tracked role (the pairing key + report label), else null.
+      function roleOf(el) {
+        const explicit = el.getAttribute && el.getAttribute("role");
+        if (explicit) return explicit;
+        const tag = el.tagName ? el.tagName.toLowerCase() : "";
+        if (tag === "button") return "button";
+        if (tag === "nav") return "nav";
+        if (/^h[1-6]$/.test(tag)) return "heading";
+        if (tag === "input" || tag === "textarea") return "textbox";
+        if (tag === "ul" || tag === "ol") return "list";
+        if (tag === "li") return "listitem";
+        if (tag === "a") return "link";
+        if (tag === "img") return "img";
+        if (tag === "div" || tag === "span") {
+          const cs = getComputedStyle(el);
+          const hasBg = cs.backgroundColor !== "rgba(0, 0, 0, 0)";
+          const hasBorder =
+            parseFloat(cs.borderTopWidth) +
+              parseFloat(cs.borderRightWidth) +
+              parseFloat(cs.borderBottomWidth) +
+              parseFloat(cs.borderLeftWidth) >
+            0;
+          if (hasBg || hasBorder) return "generic";
+        }
+        return null;
+      }
+
+      const out = [];
+      const ordinals = Object.create(null);
+      function walk(el) {
+        const role = roleOf(el);
+        if (role) {
+          ordinals[role] = (ordinals[role] || 0) + 1;
+          const cs = getComputedStyle(el);
+          const props = {};
+          for (const p of propList) props[p] = cs.getPropertyValue(p);
+          out.push({ role, ordinal: ordinals[role], props });
+        }
+        for (const child of el.children) walk(child);
+      }
+      walk(root);
+      return out;
+    },
+    PROPERTIES,
+  );
+  return { box, records };
+}
+
+async function captureSide(page, baseURL, { url, ready, final, actions, region }) {
+  await preparePage(page, {
+    url: `${baseURL}${url}`,
+    readySelector: ready,
+    finalSelector: final,
+    actions,
+  });
+  return extractRegion(page, region);
+}
+
+/* ------------------------------------------------------------------ *
+ *  Report rendering.
+ * ------------------------------------------------------------------ */
+
+/** `--border (rgb(51, 64, 107))` or `[no token] (rgb(...))`. */
+function fmtValue(value, map) {
+  const toks = resolveToken(value, map);
+  return toks && toks.length
+    ? `${toks.map((t) => `--${t}`).join("|")} (${value})`
+    : `[no token] (${value})`;
+}
+
+function renderSectionA(appRecords, mockRecords, map) {
+  const counts = new Map(); // group -> side -> token -> count
+  const bump = (group, side, token) => {
+    if (!counts.has(group)) counts.set(group, new Map());
+    const bySide = counts.get(group);
+    if (!bySide.has(side)) bySide.set(side, new Map());
+    const byTok = bySide.get(side);
+    byTok.set(token, (byTok.get(token) || 0) + 1);
+  };
+  for (const [side, records] of [
+    ["app", appRecords],
+    ["mockup", mockRecords],
+  ]) {
+    for (const rec of records) {
+      for (const [prop, value] of Object.entries(rec.props)) {
+        if (isDefault(prop, value)) continue;
+        const toks = resolveToken(value, map);
+        if (!toks) continue;
+        for (const t of toks) bump(GROUP_OF[prop], side, `--${t}`);
+      }
+    }
+  }
+
+  const lines = [];
+  const GROUP_ORDER = [
+    "color",
+    "background-color",
+    "border-*-color",
+    "border-*-width",
+    "border-radius",
+    "padding-*",
+    "gap",
+    "font-*",
+    "box-shadow",
+    "opacity",
+  ];
+  for (const group of GROUP_ORDER) {
+    const bySide = counts.get(group);
+    const total = [
+      ...(bySide?.get("app")?.values() ?? []),
+      ...(bySide?.get("mockup")?.values() ?? []),
+    ].reduce((a, b) => a + b, 0);
+    if (!bySide || total === 0) continue;
+    lines.push(group);
+    for (const side of ["app", "mockup"]) {
+      const toks = bySide.get(side);
+      if (!toks || toks.size === 0) {
+        lines.push(`  ${side}: (none)`);
+        continue;
+      }
+      const parts = [...toks.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([t, c]) => `${t} ×${c}`);
+      lines.push(`  ${side}: ${parts.join(", ")}`);
+    }
+  }
+  return lines.length ? lines.join("\n") : "No token-mapped styling on either side.";
+}
+
+function renderSectionB(appRecords, mockRecords, map) {
+  const lines = [];
+  const key = (r) => `${r.role}#${r.ordinal}`;
+  const appIdx = new Map(appRecords.map((r) => [key(r), r]));
+  const mockIdx = new Map(mockRecords.map((r) => [key(r), r]));
+
+  const matched = new Set();
+  for (const rec of appRecords) {
+    const other = mockIdx.get(key(rec));
+    if (!other) continue;
+    matched.add(key(rec));
+    const deltas = [];
+    for (const prop of PROPERTIES) {
+      const av = rec.props[prop];
+      const mv = other.props[prop];
+      if (isDefault(prop, av) && isDefault(prop, mv)) continue;
+      if (av !== mv) {
+        deltas.push(
+          `  ${prop.padEnd(20)} app ${fmtValue(av, map)}   mockup ${fmtValue(mv, map)}`,
+        );
+      }
+    }
+    if (deltas.length) {
+      lines.push(`[${rec.ordinal}] ${rec.role}`);
+      lines.push(...deltas);
+    }
+  }
+
+  const appUnmatched = appRecords
+    .filter((r) => !matched.has(key(r)))
+    .map((r) => `[${r.ordinal}] ${r.role}`);
+  const mockUnmatched = mockRecords
+    .filter((r) => !appIdx.has(key(r)))
+    .map((r) => `[${r.ordinal}] ${r.role}`);
+
+  if (appUnmatched.length) {
+    lines.push("");
+    lines.push(`Unmatched (app only): ${appUnmatched.join(", ")}`);
+  }
+  if (mockUnmatched.length) {
+    lines.push("");
+    lines.push(`Unmatched (mockup only): ${mockUnmatched.join(", ")}`);
+  }
+  return lines.length ? lines.join("\n") : "No paired style deltas.";
+}
+
+function fmtBox(box) {
+  if (!box) return "(no box)";
+  return `${Math.round(box.width)}×${Math.round(box.height)} @ (${Math.round(
+    box.x,
+  )},${Math.round(box.y)})`;
+}
+
+function renderReport({ id, appRecords, mockRecords, appBox, mockBox, map }) {
+  const sA = renderSectionA(appRecords, mockRecords, map);
+  const sB = renderSectionB(appRecords, mockRecords, map);
+  return [
+    `# ${id} — computed-style diff (app vs mockup)`,
+    ``,
+    `## Geometry (read first)`,
+    `app region ${fmtBox(appBox)} · mockup region ${fmtBox(mockBox)}`,
+    `The region captures are systematically wider on the mockup side. LAYOUT-DEPENDENT VALUES (padding, insets, gaps, line-height) may differ for that reason alone. COLOUR, border-width, border-radius, font-weight and font-size are unaffected by the width difference.`,
+    ``,
+    `## Section A — token usage per property group`,
+    sA,
+    ``,
+    `## Section B — paired element deltas`,
+    sB,
+    ``,
+  ].join("\n");
+}
+
+/* ------------------------------------------------------------------ *
+ *  Main.
+ * ------------------------------------------------------------------ */
+
+async function main() {
+  const only = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  const screenIds = only.length
+    ? only
+    : SCREENS.filter((s) => s.mockup).map((s) => s.id);
+  const screens = screenIds.map(getScreen);
+
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  if (!existsSync(join(RENDERER_DIR, "index.html"))) {
+    throw new Error(
+      `no built renderer at ${RENDERER_DIR} — run \`npm run build:mobile\` first`,
+    );
+  }
+
+  const tokenMap = buildTokenMap(readFileSync(TOKENS_CSS, "utf8"));
+  log(`reverse-map: ${tokenMap.size} canonical values → token names`);
+
+  const { server, baseURL } = await startStaticServer({
+    "/app": RENDERER_DIR,
+    "/": ROOT,
+  });
+  const browser = await chromium.launch(LAUNCH_OPTIONS);
+  try {
+    for (const screen of screens) {
+      log(`--- ${screen.id}: ${screen.title}`);
+      if (!screen.mockup) continue;
+      if (!existsSync(join(ROOT, screen.mockup))) {
+        throw new Error(
+          `screen "${screen.id}" points at a missing mockup: ${screen.mockup}`,
+        );
+      }
+
+      const appCtx = await browser.newContext({
+        viewport: screen.viewport,
+        deviceScaleFactor: 2,
+        reducedMotion: "reduce",
+        colorScheme: "light",
+      });
+      const appPage = await appCtx.newPage();
+      let app;
+      try {
+        await preparePage(appPage, {
+          url: `${baseURL}${screen.url}`,
+          readySelector: screen.ready,
+          finalSelector: screen.final,
+          actions: screen.actions,
+        });
+        app = await extractRegion(appPage, screen.region ?? "[data-screen]");
+      } finally {
+        await appCtx.close();
+      }
+
+      const mockCtx = await browser.newContext({
+        viewport: screen.viewport,
+        deviceScaleFactor: 2,
+        reducedMotion: "reduce",
+        colorScheme: "light",
+      });
+      const mockPage = await mockCtx.newPage();
+      let mock;
+      try {
+        await preparePage(mockPage, {
+          url: `${baseURL}/${screen.mockup}`,
+          readySelector: "[data-screen]",
+          actions: screen.mockupActions,
+        });
+        mock = await extractRegion(
+          mockPage,
+          screen.mockupRegion ?? screen.region ?? "[data-screen]",
+        );
+      } finally {
+        await mockCtx.close();
+      }
+
+      log(
+        `  app ${app.records.length} tracked elements · mockup ${mock.records.length}`,
+      );
+      const md = renderReport({
+        id: screen.id,
+        appRecords: app.records,
+        mockRecords: mock.records,
+        appBox: app.box,
+        mockBox: mock.box,
+        map: tokenMap,
+      });
+      const outPath = join(OUT_DIR, `${screen.id}.styles.md`);
+      await writeFile(outPath, md);
+      log(`  wrote → .visual-out/${screen.id}.styles.md`);
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isMain) {
+  main().catch((e) => {
+    process.stderr.write(`[visual:styles] FAILED: ${e?.stack ?? e}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
**BET-523 — PoC: diff computed styles app-vs-mockup and report deltas in token names**

A tool that captures the app and its design mockup under identical conditions (same browser, viewport, deviceScaleFactor, reducedMotion, colorScheme — the exact `compare.mjs` recipe), reads back the **computed styles** of every tracked element in the region, resolves each value through a `value → token-name` reverse-map built from `src/renderer/tokens.css`, and reports deltas **in token names**.

The deliverable is the two reports below — the code (`scripts/visual/style-diff.mjs` + the `visual:styles` npm entry) is only how they were produced. No product code, component, token, baseline or `screens.mjs` entry was touched.

**The tool proved the blind spot is real.** BET-459 rebuilt `session-header` three hours ago and it was "believed conformant" — and the tool immediately found deltas (the app's controls hardcode `border-radius: 9999px` instead of `--r-full`, and draw `--border`/a raw `rgb(229,231,235)` where the mockup specifies `--border-subtle`/`--tx1`). Both blocking layers (aria tree + pixel baseline) were, by definition, green on exactly this.

**What runs it:**
```
npm run visual:styles                          # every screen with a mockup
node scripts/visual/style-diff.mjs session-header settings-general
```
Writes `.visual-out/<id>.styles.md` (gitignored — reports are not committed, per the issue's durability stance).

**A named visible delta in each report:**
- `session-header` `[2] generic` — the app's pill/tag control resolves `border-radius` to a raw `9999px` (`[no token]`) where the mockup specifies `--r-full` (999px), and draws its borders with `--border` / a raw `rgb(229,231,235)` where the mockup uses `--border-subtle`. Visible as the header border + pill-shape difference.
- `settings-general` `[3] generic` — the Danger-zone row: app fills with a raw `rgba(190,47,60,0.08)` + `--danger` 1px borders + `--r-lg` radius + `--sp-4` padding; the mockup draws `--raised` background, `--tx1` border, `--sp-3` padding. Visible as the Reset danger-box looking different between app and mockup.

**Generalisation answer (does Section A suffice, or was Section B's pairing necessary?):**
Section A alone is enough to **detect** the defect and drive a fix — the systemic block deltas jump out of the aggregate counts (e.g. `settings-general` `border-*-color`: app is *all* `--border ×24`, mockup mixes `--border ×6` with `--tx3/accent-*`; `border-radius`: app `--r-lg`/`--sp-3`, mockup `--r-full`; `padding-*`: app heavy `--sp-4|--r-xl` ×14, mockup `--sp-3`/`--r-sm`). But Section B's pairing is **necessary for the work order** — it names the exact control + property + token to change, and it catches per-element divergence that aggregate counts hide (same count on both sides, different elements). **Recommend keeping both**: Section A as rapid triage, Section B as the actionable enumeration.

**`git status` on the branch** (clean apart from the two intended files):
```
 M package.json
?? scripts/visual/style-diff.mjs
```

**Base:** `origin/main @ 9e92c12`

---

## Report: session-header

# session-header — computed-style diff (app vs mockup)

## Geometry (read first)
app region 1184×44 @ (256,0) · mockup region 1188×46 @ (252,0)
The region captures are systematically wider on the mockup side. LAYOUT-DEPENDENT VALUES (padding, insets, gaps, line-height) may differ for that reason alone. COLOUR, border-width, border-radius, font-weight and font-size are unaffected by the width difference.

## Section A — token usage per property group
color
  app: --tx1 ×5, --tx3 ×2
  mockup: --tx1 ×3, --tx3 ×3
background-color
  app: --card ×1, --on-accent ×1, --ok ×1, --info ×1
  mockup: --fill ×2, --fill-active ×1
border-*-color
  app: --border ×4
  mockup: --border ×8, --tx3 ×8, --tx1 ×7, --border-subtle ×1
border-*-width
  app: --sp-px ×1
  mockup: --sp-px ×9
border-radius
  app: --sp-1 ×2, --r-xs ×2
  mockup: --r-full ×2, --r-sm ×2, --row-py ×2
padding-*
  app: --sp-1 ×8, --r-xs ×8, --sp-3 ×2, --r-lg ×2, --sp-px ×2, --sp-2 ×2, --r-md ×2
  mockup: --sp-px ×4, --r-sm ×4, --row-py ×4, --sp-3 ×2, --r-lg ×2, --sp-2 ×2, --r-md ×2
gap
  app: --sp-2 ×6, --r-md ×6
  mockup: --sp-2 ×3, --r-md ×3
font-*
  app: --font-sans ×7, --sp-3 ×4, --r-lg ×4
  mockup: --font-sans ×3, --font-mono ×1

## Section B — paired element deltas
[1] generic
  border-top-color     app --border (rgb(218, 213, 204))   mockup --tx1 (rgb(26, 24, 21))
  border-right-color   app --border (rgb(218, 213, 204))   mockup --tx1 (rgb(26, 24, 21))
  border-bottom-color  app --border (rgb(218, 213, 204))   mockup --border-subtle (rgb(232, 228, 221))
  border-left-color    app --border (rgb(218, 213, 204))   mockup --tx1 (rgb(26, 24, 21))
  line-height          app [no token] (23.25px)   mockup [no token] (21.75px)
[1] button
  color                app --tx1 (rgb(26, 24, 21))   mockup --tx3 (rgb(102, 95, 85))
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-radius        app [no token] (9999px)   mockup --r-sm|--row-py (6px)
  padding-right        app --sp-2|--r-md (8px)   mockup --r-sm|--row-py (6px)
  padding-left         app --sp-2|--r-md (8px)   mockup --r-sm|--row-py (6px)
  gap                  app --sp-2|--r-md (8px)   mockup [no token] (normal)
  row-gap              app --sp-2|--r-md (8px)   mockup [no token] (normal)
  column-gap           app --sp-2|--r-md (8px)   mockup [no token] (normal)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup [no token] (Arial)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (13.3333px)
  line-height          app [no token] (16.8px)   mockup [no token] (normal)
[2] generic
  color                app --tx1 (rgb(26, 24, 21))   mockup --tx3 (rgb(102, 95, 85))
  background-color     app --card|--on-accent (rgb(255, 255, 255))   mockup --fill (rgba(26, 24, 21, 0.035))
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-top-width     app [no token] (0px)   mockup --sp-px (1px)
  border-right-width   app [no token] (0px)   mockup --sp-px (1px)
  border-bottom-width  app [no token] (0px)   mockup --sp-px (1px)
  border-left-width    app [no token] (0px)   mockup --sp-px (1px)
  border-radius        app [no token] (9999px)   mockup --r-full (999px)
  padding-right        app [no token] (0px)   mockup --sp-2|--r-md (8px)
  padding-left         app [no token] (0px)   mockup --sp-2|--r-md (8px)
  gap                  app [no token] (normal)   mockup [no token] (5px)
  row-gap              app [no token] (normal)   mockup [no token] (5px)
  column-gap           app [no token] (normal)   mockup [no token] (5px)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup --font-mono ("JetBrains Mono Variable", "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (11.5px)
  font-weight          app [no token] (400)   mockup [no token] (500)
  line-height          app [no token] (16.8px)   mockup [no token] (11.5px)
[3] generic
  background-color     app --ok (rgb(10, 122, 83))   mockup --fill (rgba(26, 24, 21, 0.035))
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --border (rgb(218, 213, 204))
  border-top-width     app [no token] (0px)   mockup --sp-px (1px)
  border-right-width   app [no token] (0px)   mockup --sp-px (1px)
  border-bottom-width  app [no token] (0px)   mockup --sp-px (1px)
  border-left-width    app [no token] (0px)   mockup --sp-px (1px)
  border-radius        app [no token] (0px)   mockup --r-full (999px)
  padding-right        app [no token] (0px)   mockup [no token] (9px)
  padding-left         app [no token] (0px)   mockup [no token] (9px)
  gap                  app [no token] (normal)   mockup [no token] (7px)
  row-gap              app [no token] (normal)   mockup [no token] (7px)
  column-gap           app [no token] (normal)   mockup [no token] (7px)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (15px)
  line-height          app [no token] (16.8px)   mockup [no token] (21.75px)
[4] generic
  background-color     app --info (rgb(73, 215, 245))   mockup --fill-active (rgba(26, 24, 21, 0.09))
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --tx1 (rgb(26, 24, 21))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --tx1 (rgb(26, 24, 21))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --tx1 (rgb(26, 24, 21))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --tx1 (rgb(26, 24, 21))
  border-radius        app [no token] (0px)   mockup [no token] (3px)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (15px)
  line-height          app [no token] (16.8px)   mockup [no token] (21.75px)
  box-shadow           app [no token] (rgba(0, 0, 0, 0.35) 1px 0px 0px 0px inset)   mockup [no token] (none)
[2] button
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-radius        app --sp-1|--r-xs (4px)   mockup --r-sm|--row-py (6px)
  padding-top          app --sp-1|--r-xs (4px)   mockup --sp-px (1px)
  padding-right        app --sp-1|--r-xs (4px)   mockup --r-sm|--row-py (6px)
  padding-bottom       app --sp-1|--r-xs (4px)   mockup --sp-px (1px)
  padding-left         app --sp-1|--r-xs (4px)   mockup --r-sm|--row-py (6px)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup [no token] (Arial)
  font-size            app [no token] (15px)   mockup [no token] (13.3333px)
  line-height          app [no token] (23.25px)   mockup [no token] (normal)

Unmatched (app only): [3] button

## Report: settings-general

# settings-general — computed-style diff (app vs mockup)

## Geometry (read first)
app region 672×346 @ (216,96) · mockup region 1188×379 @ (232,66)
The region captures are systematically wider on the mockup side. LAYOUT-DEPENDENT VALUES (padding, insets, gaps, line-height) may differ for that reason alone. COLOUR, border-width, border-radius, font-weight and font-size are unaffected by the width difference.

## Section A — token usage per property group
color
  app: --tx1 ×6, --tx3 ×3, --tx2 ×2, --danger ×1
  mockup: --tx3 ×5, --tx1 ×3, --accent-tx ×2, --accent-solid ×2, --accent-soft ×2
background-color
  app: --card ×2, --on-accent ×2, --raised ×1
  mockup: --card ×1, --on-accent ×1, --raised ×1
border-*-color
  app: --border ×24, --danger ×8
  mockup: --tx3 ×18, --accent-tx ×8, --accent-solid ×8, --accent-soft ×8, --border ×6, --tx1 ×4
border-*-width
  app: --sp-px ×22
  mockup: --sp-px ×14
border-radius
  app: --sp-3 ×3, --r-lg ×3, --sp-2 ×1, --r-md ×1, --sp-1 ×1, --r-xs ×1
  mockup: --r-full ×2, --sp-2 ×1, --r-md ×1, --sp-3 ×1, --r-lg ×1
padding-*
  app: --sp-4 ×14, --r-xl ×14, --sp-2 ×8, --r-md ×8, --sp-3 ×6, --r-lg ×6
  mockup: --r-sm ×8, --row-py ×8, --sp-3 ×8, --r-lg ×8, --sp-2 ×4, --r-md ×4, --sp-4 ×2, --r-xl ×2, --sp-px ×2
font-*
  app: --font-sans ×12, --sp-4 ×5, --r-xl ×5, --sp-6 ×5
  mockup: --font-sans ×10, --sp-3 ×6, --r-lg ×6

## Section B — paired element deltas
[1] heading
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  line-height          app [no token] (14.3px)   mockup [no token] (11px)
  letter-spacing       app [no token] (0.275px)   mockup [no token] (0.88px)
[1] generic
  color                app --tx1 (rgb(26, 24, 21))   mockup --accent-tx|--accent-solid|--accent-soft (rgb(31, 85, 214))
  background-color     app --card|--on-accent (rgb(255, 255, 255))   mockup [no token] (rgba(46, 107, 255, 0.08))
  border-top-color     app --border (rgb(218, 213, 204))   mockup --accent-tx|--accent-solid|--accent-soft (rgb(31, 85, 214))
  border-right-color   app --border (rgb(218, 213, 204))   mockup --accent-tx|--accent-solid|--accent-soft (rgb(31, 85, 214))
  border-bottom-color  app --border (rgb(218, 213, 204))   mockup --accent-tx|--accent-solid|--accent-soft (rgb(31, 85, 214))
  border-left-color    app --border (rgb(218, 213, 204))   mockup --accent-tx|--accent-solid|--accent-soft (rgb(31, 85, 214))
  border-top-width     app --sp-px (1px)   mockup [no token] (0px)
  border-right-width   app --sp-px (1px)   mockup [no token] (0px)
  border-bottom-width  app --sp-px (1px)   mockup [no token] (0px)
  border-left-width    app --sp-px (1px)   mockup [no token] (0px)
  border-radius        app --sp-3|--r-lg (12px)   mockup --r-full (999px)
  padding-top          app --sp-3|--r-lg (12px)   mockup [no token] (2px)
  padding-right        app --sp-4|--r-xl (16px)   mockup --sp-2|--r-md (8px)
  padding-bottom       app --sp-3|--r-lg (12px)   mockup [no token] (2px)
  padding-left         app --sp-4|--r-xl (16px)   mockup --sp-2|--r-md (8px)
  font-size            app --sp-4|--r-xl (16px)   mockup [no token] (11px)
  font-weight          app [no token] (400)   mockup [no token] (600)
  line-height          app --sp-6 (24px)   mockup [no token] (16.5px)
[1] button
  color                app --tx1 (rgb(26, 24, 21))   mockup [no token] (rgb(0, 0, 0))
  background-color     app --raised (rgb(234, 231, 225))   mockup [no token] (rgb(239, 239, 239))
  border-top-color     app --border (rgb(218, 213, 204))   mockup [no token] (color(srgb 0.745098 0.184314 0.235294 / 0.4))
  border-right-color   app --border (rgb(218, 213, 204))   mockup [no token] (color(srgb 0.745098 0.184314 0.235294 / 0.4))
  border-bottom-color  app --border (rgb(218, 213, 204))   mockup [no token] (color(srgb 0.745098 0.184314 0.235294 / 0.4))
  border-left-color    app --border (rgb(218, 213, 204))   mockup [no token] (color(srgb 0.745098 0.184314 0.235294 / 0.4))
  border-top-width     app [no token] (0px)   mockup --sp-px (1px)
  border-bottom-width  app [no token] (0px)   mockup --sp-px (1px)
  border-left-width    app [no token] (0px)   mockup --sp-px (1px)
  padding-top          app --sp-2|--r-md (8px)   mockup --sp-px (1px)
  padding-right        app --sp-4|--r-xl (16px)   mockup --r-sm|--row-py (6px)
  padding-bottom       app --sp-2|--r-md (8px)   mockup --sp-px (1px)
  padding-left         app --sp-4|--r-xl (16px)   mockup --r-sm|--row-py (6px)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup [no token] (Arial)
  font-size            app [no token] (14px)   mockup [no token] (13.3333px)
  font-weight          app [no token] (600)   mockup [no token] (400)
  line-height          app [no token] (21px)   mockup [no token] (normal)
[2] heading
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  line-height          app [no token] (14.3px)   mockup [no token] (11px)
  letter-spacing       app [no token] (0.275px)   mockup [no token] (0.88px)
[2] generic
  border-radius        app --sp-3|--r-lg (12px)   mockup --sp-2|--r-md (8px)
  padding-top          app --sp-3|--r-lg (12px)   mockup [no token] (0px)
  padding-right        app --sp-4|--r-xl (16px)   mockup [no token] (0px)
  padding-bottom       app --sp-3|--r-lg (12px)   mockup [no token] (0px)
  padding-left         app --sp-4|--r-xl (16px)   mockup [no token] (0px)
  font-size            app --sp-4|--r-xl (16px)   mockup [no token] (15px)
  line-height          app --sp-6 (24px)   mockup [no token] (21.75px)
[3] heading
  border-top-color     app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-right-color   app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-bottom-color  app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  border-left-color    app [no token] (rgb(229, 231, 235))   mockup --tx3 (rgb(102, 95, 85))
  line-height          app [no token] (14.3px)   mockup [no token] (11px)
  letter-spacing       app [no token] (0.275px)   mockup [no token] (0.88px)
[3] generic
  background-color     app [no token] (rgba(190, 47, 60, 0.08))   mockup --raised (rgb(234, 231, 225))
  border-top-color     app --danger (rgb(190, 47, 60))   mockup --tx1 (rgb(26, 24, 21))
  border-right-color   app --danger (rgb(190, 47, 60))   mockup --tx1 (rgb(26, 24, 21))
  border-bottom-color  app --danger (rgb(190, 47, 60))   mockup --tx1 (rgb(26, 24, 21))
  border-left-color    app --danger (rgb(190, 47, 60))   mockup --tx1 (rgb(26, 24, 21))
  border-top-width     app --sp-px (1px)   mockup [no token] (0px)
  border-right-width   app --sp-px (1px)   mockup [no token] (0px)
  border-bottom-width  app --sp-px (1px)   mockup [no token] (0px)
  border-left-width    app --sp-px (1px)   mockup [no token] (0px)
  border-radius        app --sp-3|--r-lg (12px)   mockup [no token] (0px)
  padding-top          app --sp-3|--r-lg (12px)   mockup --r-sm|--row-py (6px)
  padding-right        app --sp-4|--r-xl (16px)   mockup --sp-3|--r-lg (12px)
  padding-bottom       app --sp-3|--r-lg (12px)   mockup --r-sm|--row-py (6px)
  padding-left         app --sp-4|--r-xl (16px)   mockup --sp-3|--r-lg (12px)
  font-size            app --sp-4|--r-xl (16px)   mockup --sp-3|--r-lg (12px)
  font-weight          app [no token] (400)   mockup [no token] (600)
  line-height          app --sp-6 (24px)   mockup --sp-3|--r-lg (12px)

Unmatched (app only): [1] tabpanel, [1] group, [2] button, [3] button, [4] button

Unmatched (mockup only): [4] generic, [5] generic, [6] generic, [7] generic
