### PR TITLE
fix(visual): style-diff phantom border-colour rows + Section A double-count (BET-525)

### DIFF
--- a/scripts/visual/style-diff.mjs
+++ b/scripts/visual/style-diff.mjs
@@ -250,10 +250,31 @@ export function resolveToken(value, map) {
  *  its computed ARIA role and its ordinal within that role.
  * ------------------------------------------------------------------ */
 
+/** Which border-*-width property gates each border-*-color property. */
+const BORDER_WIDTH_OF_COLOR = {
+  "border-top-color": "border-top-width",
+  "border-right-color": "border-right-width",
+  "border-bottom-color": "border-bottom-width",
+  "border-left-color": "border-left-width",
+};
+
 function isDefault(prop, value) {
   const d = DEFAULTS[prop];
   if (d == null) return false;
   return value === d;
+}
+
+/**
+ * A border-*-color is PHANTOM — CSS computes it to the element's own text
+ * colour (currentColor) even when the border doesn't exist — unless that
+ * side actually renders a border. Gate on the computed border-*-width being
+ * `0px`: the width is the ground truth for whether a border exists, not the
+ * colour spelling and not any token-name heuristic.
+ */
+function isPhantomBorderColor(prop, props) {
+  const widthProp = BORDER_WIDTH_OF_COLOR[prop];
+  if (!widthProp) return false;
+  return props[widthProp] === "0px";
 }
 
 async function extractRegion(page, selector) {
@@ -348,9 +369,14 @@ function renderSectionA(appRecords, mockRecords, map) {
     for (const rec of records) {
       for (const [prop, value] of Object.entries(rec.props)) {
         if (isDefault(prop, value)) continue;
+        if (isPhantomBorderColor(prop, rec.props)) continue;
         const toks = resolveToken(value, map);
         if (!toks) continue;
-        for (const t of toks) bump(GROUP_OF[prop], side, t);
+        // A value that maps to several colliding tokens is ONE observation —
+        // count the candidate set as a single bucket (`--sp-3|--r-lg`), not
+        // each token separately (which would multiply one element into N).
+        const bucket = toks.length > 1 ? toks.join("|") : toks[0];
+        bump(GROUP_OF[prop], side, bucket);
       }
     }
   }
@@ -407,6 +433,11 @@ function renderSectionB(appRecords, mockRecords, map) {
       const av = rec.props[prop];
       const mv = other.props[prop];
       if (isDefault(prop, av) && isDefault(prop, mv)) continue;
+      // Skip a border-colour delta when either side has no border on that
+      // side: the border doesn't render, so the colour is phantom (a
+      // borderless element still computes currentColor). The width delta —
+      // when both widths differ — already reports the real structural gap.
+      if (isPhantomBorderColor(prop, rec.props) || isPhantomBorderColor(prop, other.props)) continue;
       if (av !== mv) {
         deltas.push(
           `  ${prop.padEnd(20)} app ${fmtValue(av, map)}   mockup ${fmtValue(mv, map)}`,


### PR DESCRIPTION
Fixes two accuracy defects in `scripts/visual/style-diff.mjs` from BET-523. No product code, no baselines, no new deps.

## Defect 1 — phantom border-colour rows
`border-*-color` was reported even when the element has no border: CSS computes `border-color` to `currentColor` (the element's text colour) when `border-width` is `0`, so borderless elements leaked `--tx1`/`--tx3` (TEXT tokens) as if they were borders. Now gate each `border-<side>-color` on that side's computed `border-<side>-width`: if it is `0px`, the border does not exist and the colour is skipped. Applied in both Section A and Section B. The width is the ground truth — no token-name heuristic.

## Defect 2 — Section A double-counts collided tokens
A value that maps to several tokens (the reverse-map is value→tokens, and the scale collides: `--sp-3`/`--r-lg` = 12px, `--sp-1`/`--r-xs` = 4px) was incremented once per token, turning one element into N buckets (`--sp-4 ×14, --r-xl ×14`). Section A now counts the candidate set as ONE bucket, rendered `--sp-4|--r-xl ×14` — matching Section B's existing `toks.join("|")`. Collisions are reported honestly, not disambiguated (that's the separate, explicitly out-of-scope decision).

## Evidence (re-run on the two screens)

**How many Section B rows the border-width gate removed:**
- `session-header`: `border-*-color` delta rows **24 → 1** (**23 removed**)
- `settings-general`: `border-*-color` delta rows **24 → 1** (**23 removed**)

The single surviving row in each is a genuine border (both sides have a real `border-width != 0`) with a differing colour — correctly retained.

**How Section A totals changed** (sum of recorded token counts):
- `session-header`: **151 → 95** recorded counts (**56 fewer**)
- `settings-general`: **321 → 190** recorded counts (**131 fewer**)

The drop is the combination of (a) the width gate removing phantom `border-*-color` counts (settings-general `border-*-color`: `app --border ×24 --danger ×8` → `--border ×14 --danger ×8`; mockup's `--tx3 ×18, --tx1 ×4, --accent-* ×24` phantom counts gone) and (b) multi-token observations counting once instead of N (`padding-* app --sp-4|--r-xl ×14` now a single bucket where before it was `--sp-4 ×14, --r-xl ×14`).

Note on the collision tokens still visible under `font-*` (e.g. `session-header app: --font-sans ×7, --sp-3|--r-lg ×4`): that is a real 12px font-size colliding with the 12px spacing/radius step. It now reports as one honest `--sp-3|--r-lg` candidate bucket rather than two phantom separate `--sp-3` and `--r-lg` entries. Making it disappear entirely would require the property-type disambiguation the issue explicitly excludes ("report the collision, do not resolve it").

## Corrected reports (full)

### session-header
```md
# session-header — computed-style diff (app vs mockup)

## Geometry (read first)
app region 1184×44 @ (256,0) · mockup region 1188×46 @ (252,0)
The region captures are systematically wider on the mockup side. LAYOUT-DEPENDENT VALUES (padding, insets, gaps, line-height) may differ for that reason alone. COLOUR, border-width, border-radius, font-weight and font-size are unaffected by the width difference.

## Section A — token usage per property group
color
  app: --tx1 ×5, --tx3 ×2
  mockup: --tx1 ×3, --tx3 ×3
background-color
  app: --card|--on-accent ×1, --ok ×1, --info ×1
  mockup: --fill ×2, --fill-active ×1
border-*-color
  app: --border ×1
  mockup: --border ×8, --border-subtle ×1
border-*-width
  app: --sp-px ×1
  mockup: --sp-px ×9
border-radius
  app: --sp-1|--r-xs ×2
  mockup: --r-full ×2, --r-sm|--row-py ×2
padding-*
  app: --sp-1|--r-xs ×8, --sp-3|--r-lg ×2, --sp-px ×2, --sp-2|--r-md ×2
  mockup: --sp-px ×4, --r-sm|--row-py ×4, --sp-3|--r-lg ×2, --sp-2|--r-md ×2
gap
  app: --sp-2|--r-md ×6
  mockup: --sp-2|--r-md ×3
font-*
  app: --font-sans ×7, --sp-3|--r-lg ×4
  mockup: --font-sans ×3, --font-mono ×1

## Section B — paired element deltas
[1] generic
  border-bottom-color  app --border (rgb(218, 213, 204))   mockup --border-subtle (rgb(232, 228, 221))
  line-height          app [no token] (23.25px)   mockup [no token] (21.75px)
[1] button
  color                app --tx1 (rgb(26, 24, 21))   mockup --tx3 (rgb(102, 95, 85))
  border-radius        app [no token] (9999px)   mockup --r-sm|--row-py (6px)
  padding-right        app --sp-2|--r-md (8px)   mockup --r-sm|--row-py (6px)
  padding-left         app --sp-2|--r-md (8px)   mockup --r-sm|--row-py (6px)
  gap                  app --sp-2|--r-md (8px)   mockup [no token] (normal)
  row-gap              app --sp-2|--r-md (8px)   mockup [no token] (normal)
  column-gap           app --sp-2|--r-md (8px)   mockup [no token] (normal)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup [no token] (Arial)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (13.3333px)
  line-height          app [no token] (16.8px)   mockup [no token] (normal)
[2] generic
  color                app --tx1 (rgb(26, 24, 21))   mockup --tx3 (rgb(102, 95, 85))
  background-color     app --card|--on-accent (rgb(255, 255, 255))   mockup --fill (rgba(26, 24, 21, 0.035))
  border-top-width     app [no token] (0px)   mockup --sp-px (1px)
  border-right-width   app [no token] (0px)   mockup --sp-px (1px)
  border-bottom-width  app [no token] (0px)   mockup --sp-px (1px)
  border-left-width    app [no token] (0px)   mockup --sp-px (1px)
  border-radius        app [no token] (9999px)   mockup --r-full (999px)
  padding-right        app [no token] (0px)   mockup --sp-2|--r-md (8px)
  padding-left         app [no token] (0px)   mockup --sp-2|--r-md (8px)
  gap                  app [no token] (normal)   mockup [no token] (5px)
  row-gap              app [no token] (normal)   mockup [no token] (5px)
  column-gap           app [no token] (normal)   mockup [no token] (5px)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup --font-mono ("JetBrains Mono Variable", "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (11.5px)
  font-weight          app [no token] (400)   mockup [no token] (500)
  line-height          app [no token] (16.8px)   mockup [no token] (11.5px)
[3] generic
  background-color     app --ok (rgb(10, 122, 83))   mockup --fill (rgba(26, 24, 21, 0.035))
  border-top-width     app [no token] (0px)   mockup --sp-px (1px)
  border-right-width   app [no token] (0px)   mockup --sp-px (1px)
  border-bottom-width  app [no token] (0px)   mockup --sp-px (1px)
  border-left-width    app [no token] (0px)   mockup --sp-px (1px)
  border-radius        app [no token] (0px)   mockup --r-full (999px)
  padding-right        app [no token] (0px)   mockup [no token] (9px)
  padding-left         app [no token] (0px)   mockup [no token] (9px)
  gap                  app [no token] (normal)   mockup [no token] (7px)
  row-gap              app [no token] (normal)   mockup [no token] (7px)
  column-gap           app [no token] (normal)   mockup [no token] (7px)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (15px)
  line-height          app [no token] (16.8px)   mockup [no token] (21.75px)
[4] generic
  background-color     app --info (rgb(73, 215, 245))   mockup --fill-active (rgba(26, 24, 21, 0.09))
  border-radius        app [no token] (0px)   mockup [no token] (3px)
  font-size            app --sp-3|--r-lg (12px)   mockup [no token] (15px)
  line-height          app [no token] (16.8px)   mockup [no token] (21.75px)
  box-shadow           app [no token] (rgba(0, 0, 0, 0.35) 1px 0px 0px 0px inset)   mockup [no token] (none)
[2] button
  border-radius        app --sp-1|--r-xs (4px)   mockup --r-sm|--row-py (6px)
  padding-top          app --sp-1|--r-xs (4px)   mockup --sp-px (1px)
  padding-right        app --sp-1|--r-xs (4px)   mockup --r-sm|--row-py (6px)
  padding-bottom       app --sp-1|--r-xs (4px)   mockup --sp-px (1px)
  padding-left         app --sp-1|--r-xs (4px)   mockup --r-sm|--row-py (6px)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup [no token] (Arial)
  font-size            app [no token] (15px)   mockup [no token] (13.3333px)
  line-height          app [no token] (23.25px)   mockup [no token] (normal)

Unmatched (app only): [3] button
```

### settings-general
```md
# settings-general — computed-style diff (app vs mockup)

## Geometry (read first)
app region 672×346 @ (216,96) · mockup region 1188×379 @ (232,66)
The region captures are systematically wider on the mockup side. LAYOUT-DEPENDENT VALUES (padding, insets, gaps, line-height) may differ for that reason alone. COLOUR, border-width, border-radius, font-weight and font-size are unaffected by the width difference.

## Section A — token usage per property group
color
  app: --tx1 ×6, --tx3 ×3, --tx2 ×2, --danger ×1
  mockup: --tx3 ×5, --tx1 ×3, --accent-tx|--accent-solid|--accent-soft ×2
background-color
  app: --card|--on-accent ×2, --raised ×1
  mockup: --card|--on-accent ×1, --raised ×1
border-*-color
  app: --border ×14, --danger ×8
  mockup: --border ×6
border-*-width
  app: --sp-px ×22
  mockup: --sp-px ×14
border-radius
  app: --sp-3|--r-lg ×3, --sp-2|--r-md ×1, --sp-1|--r-xs ×1
  mockup: --r-full ×2, --sp-2|--r-md ×1, --sp-3|--r-lg ×1
padding-*
  app: --sp-4|--r-xl ×14, --sp-2|--r-md ×8, --sp-3|--r-lg ×6
  mockup: --r-sm|--row-py ×8, --sp-3|--r-lg ×8, --sp-2|--r-md ×4, --sp-4|--r-xl ×2, --sp-px ×2
font-*
  app: --font-sans ×12, --sp-4|--r-xl ×5, --sp-6 ×5
  mockup: --font-sans ×10, --sp-3|--r-lg ×6

## Section B — paired element deltas
[1] heading
  line-height          app [no token] (14.3px)   mockup [no token] (11px)
  letter-spacing       app [no token] (0.275px)   mockup [no token] (0.88px)
[1] generic
  color                app --tx1 (rgb(26, 24, 21))   mockup --accent-tx|--accent-solid|--accent-soft (rgb(31, 85, 214))
  background-color     app --card|--on-accent (rgb(255, 255, 255))   mockup [no token] (rgba(46, 107, 255, 0.08))
  border-top-width     app --sp-px (1px)   mockup [no token] (0px)
  border-right-width   app --sp-px (1px)   mockup [no token] (0px)
  border-bottom-width  app --sp-px (1px)   mockup [no token] (0px)
  border-left-width    app --sp-px (1px)   mockup [no token] (0px)
  border-radius        app --sp-3|--r-lg (12px)   mockup --r-full (999px)
  padding-top          app --sp-3|--r-lg (12px)   mockup [no token] (2px)
  padding-right        app --sp-4|--r-xl (16px)   mockup --sp-2|--r-md (8px)
  padding-bottom       app --sp-3|--r-lg (12px)   mockup [no token] (2px)
  padding-left         app --sp-4|--r-xl (16px)   mockup --sp-2|--r-md (8px)
  font-size            app --sp-4|--r-xl (16px)   mockup [no token] (11px)
  font-weight          app [no token] (400)   mockup [no token] (600)
  line-height          app --sp-6 (24px)   mockup [no token] (16.5px)
[1] button
  color                app --tx1 (rgb(26, 24, 21))   mockup [no token] (rgb(0, 0, 0))
  background-color     app --raised (rgb(234, 231, 225))   mockup [no token] (rgb(239, 239, 239))
  border-right-color   app --border (rgb(218, 213, 204))   mockup [no token] (color(srgb 0.745098 0.184314 0.235294 / 0.4))
  border-top-width     app [no token] (0px)   mockup --sp-px (1px)
  border-bottom-width  app [no token] (0px)   mockup --sp-px (1px)
  border-left-width    app [no token] (0px)   mockup --sp-px (1px)
  padding-top          app --sp-2|--r-md (8px)   mockup --sp-px (1px)
  padding-right        app --sp-4|--r-xl (16px)   mockup --r-sm|--row-py (6px)
  padding-bottom       app --sp-2|--r-md (8px)   mockup --sp-px (1px)
  padding-left         app --sp-4|--r-xl (16px)   mockup --r-sm|--row-py (6px)
  font-family          app --font-sans ("Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif)   mockup [no token] (Arial)
  font-size            app [no token] (14px)   mockup [no token] (13.3333px)
  font-weight          app [no token] (600)   mockup [no token] (400)
  line-height          app [no token] (21px)   mockup [no token] (normal)
[2] heading
  line-height          app [no token] (14.3px)   mockup [no token] (11px)
  letter-spacing       app [no token] (0.275px)   mockup [no token] (0.88px)
[2] generic
  border-radius        app --sp-3|--r-lg (12px)   mockup --sp-2|--r-md (8px)
  padding-top          app --sp-3|--r-lg (12px)   mockup [no token] (0px)
  padding-right        app --sp-4|--r-xl (16px)   mockup [no token] (0px)
  padding-bottom       app --sp-3|--r-lg (12px)   mockup [no token] (0px)
  padding-left         app --sp-4|--r-xl (16px)   mockup [no token] (0px)
  font-size            app --sp-4|--r-xl (16px)   mockup [no token] (15px)
  line-height          app --sp-6 (24px)   mockup [no token] (21.75px)
[3] heading
  line-height          app [no token] (14.3px)   mockup [no token] (11px)
  letter-spacing       app [no token] (0.275px)   mockup [no token] (0.88px)
[3] generic
  background-color     app [no token] (rgba(190, 47, 60, 0.08))   mockup --raised (rgb(234, 231, 225))
  border-top-width     app --sp-px (1px)   mockup [no token] (0px)
  border-right-width   app --sp-px (1px)   mockup [no token] (0px)
  border-bottom-width  app --sp-px (1px)   mockup [no token] (0px)
  border-left-width    app --sp-px (1px)   mockup [no token] (0px)
  border-radius        app --sp-3|--r-lg (12px)   mockup [no token] (0px)
  padding-top          app --sp-3|--r-lg (12px)   mockup --r-sm|--row-py (6px)
  padding-right        app --sp-4|--r-xl (16px)   mockup --sp-3|--r-lg (12px)
  padding-bottom       app --sp-3|--r-lg (12px)   mockup --r-sm|--row-py (6px)
  padding-left         app --sp-4|--r-xl (16px)   mockup --sp-3|--r-lg (12px)
  font-size            app --sp-4|--r-xl (16px)   mockup --sp-3|--r-lg (12px)
  font-weight          app [no token] (400)   mockup [no token] (600)
  line-height          app --sp-6 (24px)   mockup --sp-3|--r-lg (12px)

Unmatched (app only): [1] tabpanel, [1] group, [2] button, [3] button, [4] button

Unmatched (mockup only): [4] generic, [5] generic, [6] generic, [7] generic
```

---
**Files changed:** `1` (`scripts/visual/style-diff.mjs`)

```
$ git status
```
```
 M scripts/visual/style-diff.mjs
```
(clean under `tests/visual/screens.visual.ts-snapshots/` — 0 changes; no baselines moved)

**Base: `origin/main` @ `5670fc8`**

**Verification results:**
- PR branch (`multica/BET-525-style-diff-defects` @ `d9c72d9`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1420 pass / 0 fail / 0 skip. log sha256: `ae47ebce17078398b745e36195cd3154a6676661e22fb3d6c0f60c98e0c5c163`
- Base (`main` @ `5670fc8`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624` (byte-identical to PR)
  - test: exit 0, 1420 pass / 0 fail / 0 skip. log sha256: `1fbf9881f835ce34302da47264d494d4bbd7505f3b5d3e70e0011efa0c25a522`
- `npm run visual`: **13 passed (8.5s)**, no snapshot changes
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved. This change touches one standalone script (`style-diff.mjs`) that tsc/tests do not import.
