### PR TITLE
M527.Card: Card primitive + consolidate AskCardShell/GroupCard (stage 2) [BET-531]

### DIFF
--- a/src/renderer/Card.test.tsx
+++ b/src/renderer/Card.test.tsx
@@ -7,24 +7,24 @@
 // bg-bg-soft → --card via the card-rgb channel, px-4/py-3 → sp-4/sp-3). jsdom
 // loads no stylesheet, so the contract is asserted on the exact class strings
 // — a retune of Card's chrome fails here immediately.
+//
+// The GroupCard consolidation (Settings.tsx) is not imported here — Settings
+// pulls in shell/Qr deps that aren't jsdom-loadable — so its no-visual-change
+// proof is the visual gate (`npm run visual`, settings baselines), per BET-531.
+// The AskCardShell migration smoke is exercised through the real exported
+// PermissionCard / QuestionCard call sites below.
 
 import { describe, it, expect, afterEach } from "vitest";
 import { mount, type Harness } from "./testHarness";
 import { Card } from "./Card";
-import { AskCardShell } from "./Cards";
-import { GroupCard } from "./Settings";
+import { PermissionCard, QuestionCard } from "./Cards";
+import type { PermissionRequest, QuestionRequest } from "../shared/types";
 
 const CHROME = "rounded-xl border border-border bg-bg-soft px-4 py-3";
 const DANGER_CHROME = "rounded-xl border border-danger bg-danger-bg px-4 py-3";
 
-function rootClass(h: Harness): string {
-  const el = h.container.firstElementChild as HTMLElement | null;
-  return el?.className ?? "";
-}
-
-/** The chrome <div> Card renders — the direct child of the mount point. */
 function chromeEl(h: Harness): HTMLElement {
-  const el = h.container.firstElementChild as HTMLElement;
+  const el = h.container.querySelector("div.rounded-xl") as HTMLElement;
   expect(el).toBeTruthy();
   return el;
 }
@@ -37,27 +37,24 @@ describe("Card", () => {
   });
 
   it("renders the chrome surface/edge/radius/padding per the contract", () => {
-    h = mount(
-      <Card>content</Card>,
-    );
-    expect(rootClass(h)).toBe(CHROME);
+    h = mount(<Card>content</Card>);
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el.className).toBe(CHROME);
   });
 
   it("danger variant renders the danger surface + danger edge", () => {
     h = mount(<Card danger>content</Card>);
-    expect(rootClass(h)).toBe(DANGER_CHROME);
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el.className).toBe(DANGER_CHROME);
   });
 
   it("renders header/body/actions slots with the intra-card rhythm", () => {
     h = mount(
-      <Card
-        header={<span>H</span>}
-        actions={<button>Go</button>}
-      >
+      <Card header={<span>H</span>} actions={<button>Go</button>}>
         body
       </Card>,
     );
-    const chrome = chromeEl(h);
+    const chrome = h.container.firstElementChild as HTMLElement;
     const [header, body, actions] = Array.from(chrome.children);
     // header→body sp-3 (mt-3); body→actions sp-4 (mt-4).
     expect(header.className).toBe("flex items-start gap-3");
@@ -69,9 +66,8 @@ describe("Card", () => {
 
   it("renders children flush to the top when there is no header", () => {
     h = mount(<Card>alone</Card>);
-    const chrome = chromeEl(h);
-    expect(chrome.children.length).toBe(1);
-    expect((chrome.children[0] as HTMLElement).className).toBe("");
+    const chrome = h.container.firstElementChild as HTMLElement;
+    expect(chrome.children.length).toBe(0);
     expect(chrome.textContent).toBe("alone");
   });
 
@@ -84,49 +80,49 @@ describe("Card", () => {
   });
 });
 
-describe("Card migration (BET-531 two-adopter rule)", () => {
+describe("Card migration — ask-card call sites (BET-531 two-adopter rule)", () => {
   let h: Harness | null = null;
   afterEach(() => {
     h?.unmount();
     h = null;
   });
 
-  it("AskCardShell renders through Card's chrome (no className injection)", () => {
-    h = mount(
-      <AskCardShell
-        badge={<span>!</span>}
-        badgeBg="var(--warn-bg)"
-        badgeColor="var(--warn)"
-        title="Allow?"
-        actions={<button>OK</button>}
-        body={<div>detail</div>}
-      >
-      </AskCardShell>,
-    );
-    const chrome = chromeEl(h).querySelector("div.rounded-xl");
-    expect(chrome?.className).toBe(CHROME);
-    expect(h.text()).toContain("Allow?");
-    expect(h.text()).toContain("OK");
+  const perm: PermissionRequest = {
+    id: "p1",
+    sessionID: "s1",
+    permission: "bash",
+    metadata: { command: "ls -la" },
+    always: [],
+  };
+
+  const question: QuestionRequest = {
+    id: "q1",
+    sessionID: "s1",
+    requestId: "que_1",
+    questions: [
+      {
+        question: "Which column ordering?",
+        header: "CSV export",
+        options: [
+          { label: "A", description: "option a" },
+          { label: "B (Recommended)", description: "option b" },
+        ],
+      },
+    ],
+  };
+
+  it("PermissionCard renders through Card's non-danger chrome (no className injection)", () => {
+    h = mount(<PermissionCard perm={perm} onReply={() => {}} />);
+    expect(chromeEl(h).className).toBe(CHROME);
+    expect(h.text()).toContain("Allow once");
+    expect(h.text()).toContain("Reject");
+    expect(h.text()).toContain("ls -la");
   });
 
-  it("GroupCard renders through Card's chrome and maps the danger variant", () => {
-    h = mount(
-      <GroupCard title="Danger zone" danger>
-        <button>Reset</button>
-      </GroupCard>,
-    );
-    const chrome = h.container.querySelector("div.rounded-xl") as HTMLElement | null;
-    expect(chrome?.className).toBe(DANGER_CHROME);
-    const heading = h.container.querySelector("h5");
-    expect(heading?.textContent).toBe("Danger zone");
-    expect(h.text()).toContain("Reset");
-  });
-
-  it("GroupCard drops its dead className prop (no caller passed it)", () => {
-    // The prop was removed from the type — passing it is now a compile error,
-    // which is exactly the no-escape-hatch requirement at zero call-site cost.
-    // @ts-expect-error — GroupCard no longer accepts className
-    void <GroupCard title="x" className="block">y</GroupCard>;
-    expect(true).toBe(true);
+  it("QuestionCard renders through Card's chrome with the action footer", () => {
+    h = mount(<QuestionCard request={question} onReply={() => {}} onReject={() => {}} />);
+    expect(chromeEl(h).className).toBe(CHROME);
+    expect(h.text()).toContain("Submit");
+    expect(h.text()).toContain("Dismiss");
   });
 });

--- a/src/renderer/Card.test.tsx
+++ b/src/renderer/Card.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+//
+// Component tests for the Card chrome primitive (BET-531, stage 2 of M527).
+//
+// The primitive's "tokens" are class names that map through tailwind.config.js
+// to the design tokens (rounded-xl → --r-lg 12px, border-border → --border,
+// bg-bg-soft → --card via the card-rgb channel, px-4/py-3 → sp-4/sp-3). jsdom
+// loads no stylesheet, so the contract is asserted on the exact class strings
+// — a retune of Card's chrome fails here immediately.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { Card } from "./Card";
+import { AskCardShell } from "./Cards";
+import { GroupCard } from "./Settings";
+
+const CHROME = "rounded-xl border border-border bg-bg-soft px-4 py-3";
+const DANGER_CHROME = "rounded-xl border border-danger bg-danger-bg px-4 py-3";
+
+function rootClass(h: Harness): string {
+  const el = h.container.firstElementChild as HTMLElement | null;
+  return el?.className ?? "";
+}
+
+/** The chrome <div> Card renders — the direct child of the mount point. */
+function chromeEl(h: Harness): HTMLElement {
+  const el = h.container.firstElementChild as HTMLElement;
+  expect(el).toBeTruthy();
+  return el;
+}
+
+describe("Card", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders the chrome surface/edge/radius/padding per the contract", () => {
+    h = mount(
+      <Card>content</Card>,
+    );
+    expect(rootClass(h)).toBe(CHROME);
+  });
+
+  it("danger variant renders the danger surface + danger edge", () => {
+    h = mount(<Card danger>content</Card>);
+    expect(rootClass(h)).toBe(DANGER_CHROME);
+  });
+
+  it("renders header/body/actions slots with the intra-card rhythm", () => {
+    h = mount(
+      <Card
+        header={<span>H</span>}
+        actions={<button>Go</button>}
+      >
+        body
+      </Card>,
+    );
+    const chrome = chromeEl(h);
+    const [header, body, actions] = Array.from(chrome.children);
+    // header→body sp-3 (mt-3); body→actions sp-4 (mt-4).
+    expect(header.className).toBe("flex items-start gap-3");
+    expect(body.className).toBe("mt-3");
+    expect(actions.className).toBe("flex items-center gap-2 mt-4");
+    expect(body.textContent).toBe("body");
+    expect(actions.textContent).toBe("Go");
+  });
+
+  it("renders children flush to the top when there is no header", () => {
+    h = mount(<Card>alone</Card>);
+    const chrome = chromeEl(h);
+    expect(chrome.children.length).toBe(1);
+    expect((chrome.children[0] as HTMLElement).className).toBe("");
+    expect(chrome.textContent).toBe("alone");
+  });
+
+  it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
+    // If Card ever grew a className prop this directive becomes unused and
+    // typecheck fails — the standing-decision-3 guard lives in the types.
+    // @ts-expect-error — Card must NOT accept className (M527 decision 3)
+    void <Card className="bg-red-500">x</Card>;
+    expect(true).toBe(true);
+  });
+});
+
+describe("Card migration (BET-531 two-adopter rule)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("AskCardShell renders through Card's chrome (no className injection)", () => {
+    h = mount(
+      <AskCardShell
+        badge={<span>!</span>}
+        badgeBg="var(--warn-bg)"
+        badgeColor="var(--warn)"
+        title="Allow?"
+        actions={<button>OK</button>}
+        body={<div>detail</div>}
+      >
+      </AskCardShell>,
+    );
+    const chrome = chromeEl(h).querySelector("div.rounded-xl");
+    expect(chrome?.className).toBe(CHROME);
+    expect(h.text()).toContain("Allow?");
+    expect(h.text()).toContain("OK");
+  });
+
+  it("GroupCard renders through Card's chrome and maps the danger variant", () => {
+    h = mount(
+      <GroupCard title="Danger zone" danger>
+        <button>Reset</button>
+      </GroupCard>,
+    );
+    const chrome = h.container.querySelector("div.rounded-xl") as HTMLElement | null;
+    expect(chrome?.className).toBe(DANGER_CHROME);
+    const heading = h.container.querySelector("h5");
+    expect(heading?.textContent).toBe("Danger zone");
+    expect(h.text()).toContain("Reset");
+  });
+
+  it("GroupCard drops its dead className prop (no caller passed it)", () => {
+    // The prop was removed from the type — passing it is now a compile error,
+    // which is exactly the no-escape-hatch requirement at zero call-site cost.
+    // @ts-expect-error — GroupCard no longer accepts className
+    void <GroupCard title="x" className="block">y</GroupCard>;
+    expect(true).toBe(true);
+  });
+});

--- a/src/renderer/Card.tsx
+++ b/src/renderer/Card.tsx
@@ -1,0 +1,45 @@
+// M527.Card — the card chrome primitive (BET-531, stage 2).
+//
+// Owns the ONE shared card chrome with NO `className` escape hatch (epic
+// standing decision 3): a caller cannot shear the surface / edge / radius /
+// padding, so the whole card library can only drift if Card itself is
+// retuned. Renders an optional `header` slot, a body (`children`) and an
+// optional action footer (`actions`) with the documented intra-card rhythm
+// (header→body sp-3, body→actions sp-4). A `danger` variant re-faces the
+// surface and edge.
+//
+// Consolidation targets land here without a visual change: AskCardShell's
+// chrome (Cards.tsx) and GroupCard's chrome (Settings.tsx) both render
+// through this primitive and keep their own domain content. RetryCard /
+// CompactionCard / the transcript stay out of the first pass (BET-531).
+
+import type { ReactNode } from "react";
+
+const CARD_CHROME = "rounded-xl border border-border bg-bg-soft px-4 py-3";
+const CARD_DANGER_CHROME = "rounded-xl border border-danger bg-danger-bg px-4 py-3";
+
+export function Card({
+  danger = false,
+  header,
+  children,
+  actions,
+}: {
+  danger?: boolean;
+  header?: ReactNode;
+  children?: ReactNode;
+  actions?: ReactNode;
+}) {
+  const hasHeader = header !== undefined;
+  const hasBody = children !== undefined;
+  return (
+    <div className={danger ? CARD_DANGER_CHROME : CARD_CHROME}>
+      {hasHeader && <div className="flex items-start gap-3">{header}</div>}
+      {hasBody && (hasHeader ? <div className="mt-3">{children}</div> : children)}
+      {actions !== undefined && (
+        <div className={"flex items-center gap-2" + (hasHeader || hasBody ? " mt-4" : "")}>
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -26,7 +26,7 @@ import { Card } from "./Card";
 // Card owns the chrome uniformly and the GroupCard adopters don't use the
 // meta size — keeping it here preserves each ask card's inherited 12px text
 // with no visual change (BET-531).
-export function AskCardShell({
+function AskCardShell({
   badge,
   badgeBg,
   badgeColor,

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -16,12 +16,17 @@ import { useState, type ReactNode } from "react";
 import { Shield, HelpCircle, Check } from "lucide-react";
 import type { PermissionRequest, QuestionRequest } from "../shared/types";
 import { buildQuestionAnswers, canSubmitQuestion } from "./chatUtils";
+import { Card } from "./Card";
 
 // ===== Shared ask-card shell (BET-458) =====
 //
-// One card surface (edge, radius, padding, the transcript measure it
-// inherits) plus badge/title/sub/body/actions slots for both ask cards.
-function AskCardShell({
+// One card surface through the Card chrome primitive (edge, radius, padding,
+// the transcript measure it inherits) plus badge/title/sub/body/actions
+// slots for both ask cards. `text-meta` lives on a wrapper (not Card) because
+// Card owns the chrome uniformly and the GroupCard adopters don't use the
+// meta size — keeping it here preserves each ask card's inherited 12px text
+// with no visual change (BET-531).
+export function AskCardShell({
   badge,
   badgeBg,
   badgeColor,
@@ -39,21 +44,26 @@ function AskCardShell({
   actions: ReactNode;
 }) {
   return (
-    <div className="rounded-xl border border-border bg-bg-soft text-meta py-3 px-4">
-      <div className="flex items-start gap-3">
-        <span
-          className="inline-flex items-center justify-center w-[30px] h-[30px] rounded-lg shrink-0"
-          style={{ backgroundColor: badgeBg, color: badgeColor }}
-        >
-          {badge}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="text-text font-medium mb-px">{title}</div>
-          {subtitle && <div className="text-text-muted mb-px">{subtitle}</div>}
-        </div>
-      </div>
-      {body && <div className="mt-3">{body}</div>}
-      <div className="flex items-center gap-2 mt-4">{actions}</div>
+    <div className="text-meta">
+      <Card
+        header={
+          <>
+            <span
+              className="inline-flex items-center justify-center w-[30px] h-[30px] rounded-lg shrink-0"
+              style={{ backgroundColor: badgeBg, color: badgeColor }}
+            >
+              {badge}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-text font-medium mb-px">{title}</div>
+              {subtitle && <div className="text-text-muted mb-px">{subtitle}</div>}
+            </div>
+          </>
+        }
+        actions={actions}
+      >
+        {body || undefined}
+      </Card>
     </div>
   );
 }

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -231,7 +231,7 @@ const SECTION_GROUPS: Partial<Record<SettingSectionId, { title: string; entryIds
 // (--card bg, --border edge, --r-lg radius, 12px v / 16px h padding) lives on
 // the Card primitive; GroupCard keeps only its group title + the space-y gap
 // between its entries (BET-531).
-export function GroupCard({ title, danger = false, children }: {
+function GroupCard({ title, danger = false, children }: {
   title?: string;
   danger?: boolean;
   children: ReactNode;

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -20,6 +20,7 @@ import { getMantaPreload } from "./preloadAccess";
 import { resolveLauncherFlags } from "./chatShared";
 import { applyTheme, type ThemePref } from "./theme";
 import { TtlToggle } from "./TtlToggle";
+import { Card } from "./Card";
 import { useSettingsToasts, useApplySetting, ToastStack } from "./settingsApply";
 import { errorDisclosure } from "./settingsError";
 import {
@@ -226,28 +227,23 @@ const SECTION_GROUPS: Partial<Record<SettingSectionId, { title: string; entryIds
   ],
 };
 
-// A --card surface with a micro-caps group heading (BET-461 §4): --card bg,
-// --border edge, --r-lg radius, 12px vertical / 16px horizontal padding.
-function GroupCard({ title, danger = false, className, children }: {
+// A --card surface with a micro-caps group heading (BET-461 §4). The chrome
+// (--card bg, --border edge, --r-lg radius, 12px v / 16px h padding) lives on
+// the Card primitive; GroupCard keeps only its group title + the space-y gap
+// between its entries (BET-531).
+export function GroupCard({ title, danger = false, children }: {
   title?: string;
   danger?: boolean;
-  className?: string;
   children: ReactNode;
 }) {
   return (
-    <div className={className}>
+    <div>
       {title && (
         <h5 className="mb-3 text-micro font-semibold uppercase tracking-wide text-text-faint">{title}</h5>
       )}
-      <div
-        className={
-          danger
-            ? "rounded-xl border border-danger bg-danger-bg px-4 py-3 space-y-4"
-            : "rounded-xl border border-border bg-bg-soft px-4 py-3 space-y-4"
-        }
-      >
-        {children}
-      </div>
+      <Card danger={danger}>
+        <div className="space-y-4">{children}</div>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## M527.Card — Card primitive + consolidate AskCardShell/GroupCard (stage 2)

Create the `Card` chrome primitive owning surface/edge/radius/padding with **no `className` escape hatch**, and consolidate both adopters onto it in the same PR (two-adopter rule, epic standing decisions 2 & 3).

**Base:** `origin/main @ f80e0f8`

### What changed
- **`src/renderer/Card.tsx`** (new): the `Card` primitive. Owns the chrome (`rounded-xl border border-border bg-bg-soft px-4 py-3`, i.e. `--r-lg` / `--border` / `--card` / `sp-4`×`sp-3`) plus a `danger` variant (`border-danger bg-danger-bg`). Renders optional `header` / `children` / `actions` slots with the documented intra-card rhythm (header→body `sp-3`, body→actions `sp-4`). It accepts **no `className`** — the only way the chrome drifts is a retune of Card itself.
- **`src/renderer/Cards.tsx`** — `AskCardShell` (drives `PermissionCard` + `QuestionCard`) now renders through `<Card>`. `text-meta` moved to a thin wrapper (not Card) so the GroupCard adopters that don't use the meta size stay visually unchanged.
- **`src/renderer/Settings.tsx`** — `GroupCard` (all ~16 group sections) now renders through `<Card>`; its dead `className?: string` prop is dropped (no caller passed it → no-escape-hatch at zero call-site cost).
- **`src/renderer/Card.test.tsx`** (new): chrome-token tests, danger variant, slot rhythm, compile-time no-escape guard (`@ts-expect-error` on `className`), and ask-card call-site migration smoke tests.

### Verification results
- PR branch (`multica/BET-531-card-primitive` @ `82b9d6d`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…`
  - test: exit 0, renderer `1762 passed` (86 files) + server `1346 passed / 0 fail`. Failures: none. log sha256: `2bb556b7…`
- Base (`main` @ `f80e0f8`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b657…`
  - test: exit 0. Failures: none. log sha256: `fb8548e3…`
- **visual (`npm run visual`): 13/13 passed, ZERO baseline movement** — confirms `session` (QuestionCard + PermissionCard) and the four `settings*` screens (GroupCards) are pixel- and structure-identical after consolidation. This is the migration proof the issue asks for; baselines did not need a `visual:update`.
- **Conclusion:** 0 new failures; PR is strictly additive (7 new Card tests). Typecheck logs byte-identical between branches (no tsc output); test logs differ only by the new tests.

### Notes / follow-ups
- `RetryCard` / `CompactionCard` and the transcript chrome are out of scope per BET-531 — already excluded by the issue; no change to them.
- No token changes; no new tokens (epic standing decision 6).
