### PR TITLE
fix(renderer): register fill colour utility and activate hover fills (BET-539)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -906,7 +906,7 @@ export function App() {
             <button
               type="button"
               onClick={() => setMode(mode === "terminal" ? "chat" : "terminal")}
-              className="text-text-faint hover:text-text hover:bg-fill rounded p-1 inline-flex items-center ml-auto"
+              className="text-text-faint hover:text-text hover:bg-fill-hover rounded p-1 inline-flex items-center ml-auto"
               style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
               title={`Switch to ${mode === "terminal" ? "Chat" : "Terminal"}`}
               aria-label={mode === "terminal" ? "Chat" : "Terminal"}

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -155,7 +155,7 @@ export function ModelPicker({
       <div className={separatePills ? "relative" : ""}>
         <button
           className={
-            "manta-model-picker-btn truncate text-meta text-text hover:bg-fill flex items-center gap-1 px-2 py-1 " +
+            "manta-model-picker-btn truncate text-meta text-text hover:bg-fill-hover flex items-center gap-1 px-2 py-1 " +
             (separatePills ? "rounded-lg border border-border-strong bg-card" : "")
           }
           aria-haspopup="listbox"
@@ -241,7 +241,7 @@ export function ModelPicker({
         <div className={separatePills ? "relative" : ""}>
           <button
             className={
-              "manta-effort-picker-btn truncate text-meta hover:bg-fill flex items-center gap-1 px-2 py-1 " +
+              "manta-effort-picker-btn truncate text-meta hover:bg-fill-hover flex items-center gap-1 px-2 py-1 " +
               (separatePills
                 ? "rounded-lg border border-border-strong bg-card"
                 : "border-l border-border-strong") +

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -169,7 +169,7 @@ export function SessionHeader({
           <button
             type="button"
             onClick={() => onModeChange(targetMode)}
-            className="manta-session-mode-toggle text-text-faint hover:text-text hover:bg-fill rounded p-1 inline-flex items-center"
+            className="manta-session-mode-toggle text-text-faint hover:text-text hover:bg-fill-hover rounded p-1 inline-flex items-center"
             title={`Switch to ${modeLabel}`}
             aria-label={modeLabel}
           >
@@ -280,7 +280,7 @@ function ContextPill({
         "manta-ctx-pill inline-flex items-center gap-2 rounded-full px-2 py-px text-meta transition-colors " +
         (stale
           ? "bg-warn-bg hover:bg-warn-bg"
-          : "hover:bg-fill")
+          : "hover:bg-fill-hover")
       }
       aria-haspopup="dialog"
       aria-expanded={open}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -17,13 +17,6 @@
   overflow-wrap: anywhere;
 }
 
-/* Hover fill for the settings rail chip — Tailwind has no color utility for
-   --fill-hover (only --panel, which is a visibly heavier block), so expose the
-   token as a single utility. Uses an existing token; no new colour. */
-.bg-fill-hover {
-  background-color: var(--fill-hover);
-}
-
 html, body, #root {
   height: 100%;
   margin: 0;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -91,6 +91,14 @@ export default {
           elev: "rgb(var(--panel-rgb) / <alpha-value>)",
           soft: "rgb(var(--card-rgb) / <alpha-value>)",
         },
+        // Hover/active fill token (BET-539). `bg-fill-hover` and `bg-fill-active`
+        // resolve to --fill-hover / --fill-active; `bg-fill` resolves to the
+        // DEFAULT --fill base.
+        fill: {
+          DEFAULT: "var(--fill)",
+          hover: "var(--fill-hover)",
+          active: "var(--fill-active)",
+        },
         border: {
           DEFAULT: "rgb(var(--border-rgb) / <alpha-value>)",
           subtle: "var(--border-subtle)",


### PR DESCRIPTION
## BET-539 — bg-fill / bg-fill-hover were dead Tailwind utilities

`fill` was never registered as a Tailwind colour, so `bg-fill` / `bg-fill-hover` compiled to nothing — hover action fills across the app silently never rendered.

**Chosen direction: Option A** (the dispatch recommendation; the hover fill is clearly the intended affordance, and BET-532 had to work around its absence with an arbitrary value).

### Changes
- `tailwind.config.js` — register a `fill` colour utility (`DEFAULT: var(--fill)`, `hover: var(--fill-hover)`, `active: var(--fill-active)`), matching the `--fill*` tokens already in `tokens.css`.
- Activated the previously-dead hover fills, converting `hover:bg-fill` → `hover:bg-fill-hover` (the correct hover shade, consistent with BET-532's `--fill-hover`) at:
  - `src/renderer/App.tsx:909` (mode toggle button)
  - `src/renderer/ModelPicker.tsx:158` (model picker button)
  - `src/renderer/ModelPicker.tsx:244` (effort picker button)
  - `src/renderer/SessionHeader.tsx:172` (mode toggle — extra site not listed in the issue but same dead pattern, fixed as part of the root cause)
  - `src/renderer/SessionHeader.tsx:283` (ContextPill)
  - `src/renderer/Settings.tsx:805` (settings rail chip — already `hover:bg-fill-hover`, now live with no class change needed)
- `src/renderer/index.css` — removed the manual `.bg-fill-hover` workaround and its comment; Tailwind now generates the utility it was papering over.

**Files changed:** 5.

**Base:** `origin/main @ 1554841`

**Verification:**
- typecheck: exit 0, no errors.
- test: 1346 pass / 0 fail / 0 skip.
- visual: 13/13 passed against existing baselines — no `.hover` state is captured in the static screenshot baselines, so no baseline re-recording was required. Confirmed `hover\:bg-fill-hover:hover{background-color:var(--fill-hover)}` now emits in the built CSS (previously absent).
