### PR TITLE
M527.Doc: docs/components.md + move the companion generator into the repo [BET-540]

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,73 @@
+# Component primitives — standing decisions & constraints
+
+## Purpose
+
+This is a primitive inventory with adopters — not a design system. Each primitive
+exists only because it replaces two or more real call sites, is owned by the owner,
+and is validated against the companion below. There is no showcase site, no
+documentation site, and no variants nobody uses. This document preserves the rules
+that were previously embedded in the BET-527 cell descriptions so they survive those
+cells closing; it is authoritative for future issues.
+
+## Source of truth
+
+- **The redesign spec** (component inventory, chrome, variants):
+  https://0d5784a7a43451f4ad70dd3d9ee5cf72.boxes.mantaui.com/pages/manta-redesign
+- **Tokens**: `src/renderer/tokens.css` (multi-consumer — BET-516 generates a Swift
+  theme from it, so a token change is no longer a local edit).
+- **Validation surface**: the component companion (`npm run visual:companion`), which
+  renders every candidate from the spec's own CSS, in **both themes**. Do not
+  re-derive a component's appearance from prose.
+
+## Standing decisions
+
+1. **The owner validates every component personally.** Each primitive is reviewed by
+   Antoine before it is adopted anywhere. Route to him; do not merge a primitive on
+   agent review alone.
+2. **Two-adopter rule.** A primitive is only introduced when it replaces **two or more
+   existing call sites**, and those call sites are migrated in the **same PR**. Never
+   land a primitive with no adopter. This is what keeps the inventory evidence-driven
+   instead of speculative.
+3. **No `className` escape hatch.** Primitives own their chrome. A component that
+   accepts arbitrary classes at call sites reintroduces exactly the drift it exists to
+   prevent.
+4. **This is not a design system.** No showcase site, no documentation site, no
+   variants nobody uses. It is a primitive inventory with adopters.
+5. **Chrome only in the first pass. The transcript is excluded.** It lives inside the
+   ChatPanel monolith and the mobile track is migrating its event wiring
+   (DECISIONS.md §17, desktop renderer first). Start with card, field, pill, icon
+   button, menu item — where both style-diff PoC screens live and where
+   `Settings.tsx` already holds half the primitives privately.
+6. **No new token.** If the spec needs a value the scale lacks, the scale changes
+   first, in its own change, with baselines regenerated.
+
+## Constraints C1–C5
+
+### C1 — Set a foreground whenever you set a background. Otherwise inherit. (NARROWED 2026-08-01)
+
+**Corrected after BET-531.** The original C1 said a primitive must always declare its own `color`. That was over-stated: the evidence came from the component companion, which renders TWO themes in ONE document, so a colour inherited from `<body>` resolved against the wrong theme. The app never does that — `data-theme` is set on `<html>` only (`src/renderer/theme.ts:73`), one theme per document, so inheritance always resolves correctly. `Card` correctly declares no text colour and was merged that way.
+
+The real rule that survives: **if a primitive sets a background that differs from the page surface, it must also set the matching foreground token**, because a surface change invalidates the contrast the inherited colour assumed. A primitive that sets no background inherits, and should.
+
+### C2 — Row metrics come from `[data-density]`, NOT `:root`.
+
+`--row-h` (32px comfortable / 26px compact), `--row-px`, `--row-py`, plus `--prose-lh` and `--ui-lh`, are defined on `[data-density="comfortable"]` and `[data-density="compact"]`. A component rendered outside a density scope gets **none** of them — measured live, a session row collapses from 32px with `6px 10px` padding to an unpadded **18.2px** line. Any primitive consuming a `--row-*` token must state that it requires a density ancestor.
+
+### C3 — Some insets belong to the CONTAINER, not the component.
+
+`.rail-scroll` owns the `--sp-2` horizontal inset, and `.srow.on::before` (the selection marker) sits at `left:-8px` — it hangs **outside** the row into that padding. A row primitive that owned its own left inset would clip its own selection marker.
+
+### C4 — An abstract base is not a variant.
+
+The bare `.pill` sets only padding, radius and font — no background, no colour — and **0 of its 81 uses in the spec omit a modifier**. Rendered bare it is invisible text. A primitive whose base is abstract must make the variant a **required prop with no default**, not an optional one.
+
+### C5 — The shadow scale is an open design decision. Do not silently pick a side.
+
+`--shadow-sm/md/lg` differ between the redesign spec and `src/renderer/tokens.css` in both themes (light `--shadow-md`: app `0 4px 12px` + a second layer vs spec `0 8px 24px` single-layer). Every other token agrees — dark 29/29, light 29/32. If your primitive needs a shadow, use the token and **report the divergence**; do not change `tokens.css` and do not hardcode the spec's value.
+
+## Inventory
+
+| Primitive | cls | Adopters migrated (PR) | Owner validated |
+| --- | --- | --- | --- |
+
+_Filled in as each primitive lands — see the last stage of BET-527._

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "visual:update": "npm run build:mobile && playwright test --project=visual --update-snapshots",
     "visual:compare": "npm run build:mobile && node scripts/visual/compare.mjs",
     "visual:styles": "npm run build:mobile && node scripts/visual/style-diff.mjs",
-    "visual:baselines": "node scripts/visual/baseline-diff.mjs"
+    "visual:baselines": "node scripts/visual/baseline-diff.mjs",
+    "visual:companion": "node scripts/visual/companion.mjs"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",

--- a/scripts/visual/companion.mjs
+++ b/scripts/visual/companion.mjs
@@ -1,0 +1,107 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { COMPONENTS } from "./components.mjs";
+
+// The redesign spec is the source of truth for the companion. Every candidate
+// primitive is rendered from the spec's own CSS, in both themes.
+const SPEC_URL =
+  "https://0d5784a7a43451f4ad70dd3d9ee5cf72.boxes.mantaui.com/pages/manta-redesign";
+
+const v = process.argv.indexOf("--source");
+const sourceUrl =
+  v !== -1
+    ? process.argv[v + 1]
+    : process.argv.find((a) => a.startsWith("--source="))?.slice("--source=".length) ??
+      SPEC_URL;
+
+// Fetch the spec. A non-200 or a network failure fails loudly with the URL and
+// exits 1 — a silently stale companion is worse than none. We deliberately do
+// NOT fall back to a cached copy.
+let res;
+try {
+  res = await fetch(sourceUrl);
+} catch (err) {
+  console.error(`companion: failed to fetch spec ${sourceUrl}: ${err.message}`);
+  process.exit(1);
+}
+if (!res.ok) {
+  console.error(`companion: failed to fetch spec ${sourceUrl} — HTTP ${res.status}`);
+  process.exit(1);
+}
+const src = await res.text();
+
+const css = [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n");
+const sprite = src.match(/<svg[^>]*(?:style="display:none"|hidden|aria-hidden="true")[^>]*>[\s\S]*?<\/svg>/)?.[0] ?? "";
+
+const count = (cls) =>
+  (src.match(new RegExp(`class="[^"]*\\b${cls}\\b[^"]*"`, "g")) || []).length;
+
+const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+
+const themePanel = (c, theme) => `
+  <div class="tp" data-theme="${theme}" data-density="comfortable">
+    <div class="tlabel">${theme}${theme === "light" ? " — the theme the visual gate captures" : ""}</div>
+    <div class="vs${c.full ? " one" : ""}">
+      ${c.variants.map(([n, html]) => `<div class="v"><div class="vn">${esc(n)}</div><div class="demo">${c.wrap ? c.wrap(html) : html}</div></div>`).join("")}
+    </div>
+  </div>`;
+
+const page = `<!doctype html><html data-theme="light"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>MantaUI — component companion (from the redesign spec)</title>
+<style>${css}</style>
+<style>
+  body{margin:0;background:var(--canvas);color:var(--tx1);font-family:var(--font-sans)}
+  .cwrap{max-width:1400px;margin:0 auto;padding:28px 22px 90px}
+  .chead h1{font-size:24px;margin:0 0 4px;letter-spacing:-.02em}
+  .chead p{color:var(--tx3);margin:0 0 18px;max-width:76ch;font-size:14px;line-height:1.6}
+  .comp{border:1px solid var(--border-subtle);border-radius:var(--r-lg);margin:0 0 22px;background:var(--panel);overflow:hidden}
+  .comp>header{display:flex;align-items:baseline;gap:10px;padding:12px 16px;border-bottom:1px solid var(--border-subtle);flex-wrap:wrap}
+  .comp h3{margin:0;font-size:15px}
+  .cnt{font:500 11px/1 var(--font-mono);color:var(--tx4)}
+  .appst{margin-left:auto;font-size:11.5px;color:var(--tx3)}
+  .appst.none{color:var(--warn)} .appst.priv{color:var(--accent-tx)}
+  .cnote{padding:10px 16px;border-bottom:1px solid var(--border-subtle);font-size:12.5px;line-height:1.6;color:var(--tx2);background:var(--raised)}
+  .cnote code{font-family:var(--font-mono);font-size:11.5px;color:var(--accent-tx)}
+  .themes{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border-subtle)}
+  .tp{background:var(--canvas);color:var(--tx1);padding:0 0 4px}
+  .tlabel{font:500 10.5px/1 var(--font-mono);text-transform:uppercase;letter-spacing:.09em;color:var(--tx4);padding:10px 14px 4px}
+  .vs{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr))}
+  .vs.one{grid-template-columns:1fr 1fr}
+  .vs.one .demo{display:block}
+  .v{padding:12px 14px 16px}
+  .vn{font:500 10px/1 var(--font-mono);color:var(--tx4);text-transform:uppercase;letter-spacing:.07em;margin-bottom:11px}
+  .demo{display:flex;align-items:center;gap:10px;flex-wrap:wrap;min-height:38px}
+  details{border-top:1px solid var(--border-subtle);background:var(--panel)}
+  summary{cursor:pointer;padding:9px 16px;font:500 11.5px/1 var(--font-sans);color:var(--tx3)}
+  pre{margin:0;padding:0 16px 14px;overflow:auto;font:11.5px/1.6 var(--font-mono);color:var(--tx3)}
+  .note{border:1px solid var(--border);border-radius:var(--r-md);padding:12px 14px;margin:0 0 22px;font-size:13px;color:var(--tx2);line-height:1.6}
+  .note b{color:var(--tx1)} .note code{font-family:var(--font-mono);font-size:12px;color:var(--accent-tx)}
+  @media(max-width:980px){.themes{grid-template-columns:1fr}}
+</style></head><body>
+${sprite}
+<div class="cwrap">
+<div class="chead">
+  <h1>Component companion</h1>
+  <p>Every candidate primitive from the redesign spec, rendered with the spec's own CSS, in <b>both themes side by side</b>. Each card shows how often the pattern appears in the spec and what exists in the app today.</p>
+</div>
+<div class="note">
+  <b>Token audit — the spec and <code>src/renderer/tokens.css</code> agree.</b> Dark 29/29 identical, light 29/32, root 18/21 (those 3 are whitespace and font-stack fallbacks). The spec defines <b>no token the app lacks</b>. The one real divergence is the shadow scale: <code>--shadow-sm/md/lg</code> differ in both themes — light <code>--shadow-md</code> is <code>0 4px 12px</code> plus a second layer in the app vs <code>0 8px 24px</code> single-layer in the spec. A design decision, not drift to fix silently.
+</div>
+${COMPONENTS.map((c) => `
+<div class="comp" id="${c.id}">
+  <header>
+    <h3>${c.name}</h3>
+    <span class="cnt">.${c.cls} × ${count(c.cls)} in spec</span>
+    <span class="appst ${c.app.startsWith("none") ? "none" : "priv"}">app: ${esc(c.app)}</span>
+  </header>
+  ${c.note ? `<div class="cnote">${c.note}</div>` : ""}
+  <div class="themes">${themePanel(c, "light")}${themePanel(c, "dark")}</div>
+  <details><summary>markup</summary><pre>${c.variants.map(([n, html]) => `/* ${n} */
+${esc(html)}`).join("\n\n")}</pre></details>
+</div>`).join("")}
+</div></body></html>`;
+
+mkdirSync(".visual-out", { recursive: true });
+writeFileSync(".visual-out/companion.html", page);
+console.log("wrote .visual-out/companion.html", (page.length / 1024).toFixed(0), "KB");
+console.log("counts:", COMPONENTS.map((c) => `${c.cls}=${count(c.cls)}`).join(" "));

--- a/scripts/visual/components.mjs
+++ b/scripts/visual/components.mjs
@@ -1,0 +1,96 @@
+/**
+ * scripts/visual/components.mjs — THE component registry.
+ *
+ * This file is data. It is the only thing you edit to add a candidate
+ * primitive to the component companion; no script change, no test and no
+ * CI step is touched. `scripts/visual/companion.mjs` loops over this list
+ * to render every candidate in both themes, and each adopter PR (BET-527
+ * epic) is validated against that output.
+ *
+ * The canonical markup in `variants` mirrors the CSS selectors verified in
+ * the redesign spec — not page-specific copies. Markup is the spec's own.
+ *
+ * Adding a component:
+ *   1. Owner-validate the primitive against the companion (BET-527 standing
+ *      decision 1) — never add an unvalidated candidate.
+ *   2. Add an entry here.
+ *   3. Adopt it at >= 2 call sites in the SAME PR (two-adopter rule).
+ *
+ * Field notes:
+ *   id        stable slug, used as the DOM id and the anchor
+ *   name      human label in the card header
+ *   cls       the spec's class name, counted to show usage
+ *   app       what exists in the app today, verbatim and honest
+ *   note      optional constraint shown on the card (HTML allowed)
+ *   full      optional; render one full-width column instead of the grid
+ *   wrap      optional (html) => html, to place the demo in its real container
+ *   variants  [label, html][] — canonical markup, mirroring the spec's selectors
+ */
+
+// Icons are referenced from the spec's sprite via `<use href="#i-…">`. The
+// markup embeds them at module load, so this helper must live here with the
+// data rather than in the companion.
+const ic = (n) => `<svg class="ic"><use href="#i-${n}"/></svg>`;
+
+// Canonical examples. Markup mirrors the CSS selectors verified in the spec
+// (e.g. `.setrow .lab b`, `.sw i`, `.srow .st.run`) — not page-specific copies.
+export const COMPONENTS = [
+  { id: "btn", name: "Button", cls: "btn", app: "none — every screen inlines utilities",
+    variants: [["default", `<button class="btn">Cancel</button>`],
+               ["primary", `<button class="btn pri">Create session</button>`],
+               ["ghost", `<button class="btn ghost">Skip</button>`],
+               ["small", `<button class="btn sm">${ic("plus")} Add</button>`]] },
+  { id: "pill", name: "Status pill", cls: "pill", app: "none — inline in ContextBar / SessionHeader",
+    note: "The bare <code>.pill</code> is an ABSTRACT base — 0 of its 81 uses in the spec omit a modifier, and the base sets no background or colour, so it renders as plain bold text. The React component should require a variant rather than defaulting to none.",
+    variants: [["base (abstract — never used alone)", `<span class="pill" style="outline:1px dashed var(--border);outline-offset:2px">draft</span>`],
+               ["good", `<span class="pill good">passing</span>`],
+               ["warn", `<span class="pill warn">stale</span>`],
+               ["bad", `<span class="pill bad">failed</span>`],
+               ["info", `<span class="pill info">default</span>`]] },
+  { id: "chip", name: "Chip", cls: "chip", app: "none — ModelPicker inlines its own",
+    variants: [["default", `<button class="chip">${ic("branch")} feat/orders-csv</button>`],
+               ["on", `<button class="chip on">${ic("terminal")} Terminal</button>`],
+               ["split", `<span class="chip split"><span>Opus 4.7</span><span>high</span></span>`]] },
+  { id: "tag", name: "Tag", cls: "tag", app: "none",
+    variants: [["default", `<span class="tag">${ic("key")} secret</span>`]] },
+  { id: "icard", name: "Icon card", cls: "icard", app: "none",
+    variants: [["default", `<div class="icard">${ic("folder")}<span>folder</span></div>`,
+      ], ["second", `<div class="icard">${ic("clock")}<span>clock</span></div>`]] },
+  { id: "callout", name: "Callout", cls: "callout", app: "none",
+    variants: [["default", `<div class="callout"><p>The box keeps running when the app is closed.</p></div>`],
+               ["ok", `<div class="callout ok"><p>Paired. Your box is reachable.</p></div>`],
+               ["warn", `<div class="callout warn"><p>Context is nearly full — consider /compact.</p></div>`],
+               ["danger", `<div class="callout danger"><p>This deletes the worktree and its uncommitted changes.</p></div>`]] },
+  { id: "card", name: "Card", cls: "card", app: "GroupCard — PRIVATE to Settings.tsx",
+    variants: [["default", `<div class="card"><h4>Appearance</h4><p>Theme, density and font size for this device.</p></div>`]] },
+  { id: "setrow", name: "Settings row", cls: "setrow", app: "SettingField — PRIVATE to Settings.tsx",
+    variants: [["with control", `<div class="setgrp"><h5>General</h5>
+      <div class="setrow"><span class="lab"><b>Trust this box</b><span class="h">Auto-approve tool runs in every session.</span></span><span class="ctl"><span class="sw on"><i></i></span></span></div>
+      <div class="setrow"><span class="lab"><b>Downloads folder</b></span><span class="ctl"><input class="inp" value="~/Downloads"></span></div></div>`]] },
+  { id: "inp", name: "Input", cls: "inp", app: "SettingField — PRIVATE to Settings.tsx",
+    variants: [["mono", `<input class="inp" value="~/projects/infra">`],
+               ["sans", `<input class="inp sans" value="Deploy new billing service">`]] },
+  { id: "sw", name: "Toggle", cls: "sw", app: "none — inline in Settings",
+    variants: [["off", `<span class="sw"><i></i></span>`], ["on", `<span class="sw on"><i></i></span>`]] },
+  { id: "srow", name: "Session row", cls: "srow", app: "none — inline in Sidebar.tsx",
+    note: "Two things this row does not own. Its <b>inset</b> belongs to <code>.rail-scroll</code> — the selection marker (<code>.srow.on::before</code>) sits at <code>left:-8px</code> and hangs outside the row into that padding, so a primitive owning its own left inset would clip it. Its <b>metrics</b> belong to <code>[data-density]</code> — <code>--row-h/--row-px/--row-py</code> are defined there, not on <code>:root</code>, so the row collapses to an 18px unpadded line if it is rendered outside a density scope.",
+    full: true,
+    variants: [["comfortable — 32px rows", `<div data-density="comfortable">` + `<div class="rail-scroll" style="width:264px;padding:var(--sp-1) var(--sp-2) var(--sp-3)">
+      <div class="grp" style="margin-top:0"><div class="grp-h">Sessions</div>
+      <div class="srow"><span class="st idle"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">now</span></div>
+      <div class="srow child"><span class="st ok"></span><span class="t">subagent · research</span><span class="age">1m</span></div>
+      <div class="srow"><span class="st att"></span><span class="t">Refactor auth middleware</span><span class="age">12m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Landing page copy</span><span class="age">2h</span></div>
+      </div></div>` + `</div>`],
+               ["compact — 26px rows", `<div data-density="compact">` + `<div class="rail-scroll" style="width:264px;padding:var(--sp-1) var(--sp-2) var(--sp-3)">
+      <div class="grp" style="margin-top:0"><div class="grp-h">Sessions</div>
+      <div class="srow"><span class="st idle"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">now</span></div>
+      <div class="srow child"><span class="st ok"></span><span class="t">subagent · research</span><span class="age">1m</span></div>
+      <div class="srow"><span class="st att"></span><span class="t">Refactor auth middleware</span><span class="age">12m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Landing page copy</span><span class="age">2h</span></div>
+      </div></div>` + `</div>`]] },
+  { id: "eyebrow", name: "Eyebrow", cls: "eyebrow", app: "none",
+    variants: [["default", `<div class="eyebrow">Section label</div>`]] },
+];


### PR DESCRIPTION
**BET-540** — M527.Doc: docs/components.md + move the companion generator into the repo.

Captures the two artefact that lived only outside the repo; no product code, no baseline moves.

## Changes
1. `scripts/visual/components.mjs` — the component registry (DATA only), mirroring `scripts/visual/screens.mjs`. All twelve owner-validated entries copied unchanged from the pasted generator.
2. `scripts/visual/companion.mjs` — imports `COMPONENTS` from the registry (0 component data in this file); fetches the redesign spec via `node:fetch` (constant `SPEC_URL` + `--source <url>` override); fails loudly (exit 1, names URL) on non-200 or network failure; writes `.visual-out/companion.html`. Kept the WHY-comments (theme-panel colour anchor, density wrapper, abstract-pill note).
3. `docs/components.md` — the five sections. C1 is the NARROWED wording from BET-534.
4. `package.json` — added `visual:companion` beside the other `visual:*` scripts.

## Verification results
- PR branch (`multica/BET-540-visual-doc` @ `HEAD`): typecheck exit 0 (no errors); test exit 0, 1346 pass / 0 fail / 0 skip.
- Base (`origin/main` @ `1554841`).
- `npm run visual`: 13 passed, baselines unchanged.
- `grep -c 'variants:' scripts/visual/companion.mjs` → 0.
- `git status` clean — nothing under `tests/visual/screens.visual.ts-snapshots/`, no change to `src/`.
- `npm run visual:companion` writes `.visual-out/companion.html` = **72 KB** (73634 bytes), 12 components, both themes.
- Bad-URL check: `node scripts/visual/companion.mjs --source https://example.invalid/x` → `companion: failed to fetch spec https://example.invalid/x: fetch failed`, exit 1.
- 404 check: `--source …/pages/does-not-exist` → `… — HTTP 404`, exit 1.

**Base: origin/main @ 1554841**
