### PR TITLE
fix(ci): drift-failure gather step pixel-diff (BET-543)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,8 +337,9 @@ jobs:
               })().catch(() => {});
             '; } > "$ART/machine.txt" 2>/dev/null || true
           # Per-shot pixel diffs (regenerated vs committed) → report.txt + *.diff.png.
-          node scripts/shots-drift-diff.mjs "$ART" > "$ART/diff/report.txt" 2>/dev/null || \
-            { echo "diff tool failed; artifact carries raw byte sets only" > "$ART/diff/report.txt"; }
+          # The script creates diff/ itself (mkdirSync recursive) and writes
+          # report.txt, so no shell redirect to a pre-existing dir is needed.
+          node scripts/shots-drift-diff.mjs "$ART"
 
       - name: Drift gate failure — upload shot byte sets
         if: failure() && steps.drift_gate.outcome == 'failure'


### PR DESCRIPTION
Fixes **BET-543** — the `drift_gather` step always failed, so the drift-failure artifact never carried pixel-diff evidence.

**Root cause:** the step redirected the per-shot pixel-diff output into `$ART/diff/report.txt`, but only `mkdir`'d `$ART/committed` + `$ART/regenerated`. The shell opened the redirect target before the script ran → `No such file or directory`; the `|| { ... }` fallback hit the same missing path and the step exited 1.

**Fix (issue's preferred):** `scripts/shots-drift-diff.mjs` already creates `diff/` itself (`mkdirSync(outDir, {recursive:true})`) and writes `report.txt` + `*.diff.png`. Dropped the shell redirect and the fallback entirely; the step now just calls `node scripts/shots-drift-diff.mjs "$ART"`. The script's own stdout is the log. `scripts/shots-drift-diff.mjs` unchanged (out of scope).

**Files changed:** 1 (`.github/workflows/ci.yml`).

**Base:** `origin/main @ 503421e`