### PR TITLE
M527.Pill: Pill primitive + migrate ContextPill/Recommended tag (stage 5) [BET-534]

### DIFF
--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -17,6 +17,7 @@ import { Shield, HelpCircle, Check } from "lucide-react";
 import type { PermissionRequest, QuestionRequest } from "../shared/types";
 import { buildQuestionAnswers, canSubmitQuestion } from "./chatUtils";
 import { Card } from "./Card";
+import { Pill } from "./Pill";
 
 // ===== Shared ask-card shell (BET-458) =====
 //
@@ -385,14 +386,13 @@ export function QuestionCard({
                         </span>
                         <span className="text-text min-w-0">{opt.displayLabel}</span>
                         {opt.recommended && (
-                          <span
-                            className="ml-auto shrink-0 px-2 rounded-sm text-label"
-                            style={{
-                              backgroundColor: "var(--accent-bg)",
-                              color: "var(--accent)",
-                            }}
-                          >
-                            Recommended
+                          // The accent "Recommended" standing tag — a Pill.
+                          // `ml-auto shrink-0` is the flex-row placement (a
+                          // site concern, wrapped here); Pill owns the chrome.
+                          <span className="ml-auto shrink-0">
+                            <Pill tone="accent" size="label">
+                              Recommended
+                            </Pill>
                           </span>
                         )}
                         <input

--- a/src/renderer/Pill.test.tsx
+++ b/src/renderer/Pill.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+//
+// Component tests for the Pill chrome primitive (BET-534, stage 5 of M527).
+//
+// As with Card/Field/IconButton, the primitive's "tokens" are class names
+// that map through tailwind.config.js to the design tokens (rounded-full →
+// --r-full, bg-accent-bg → --accent-bg, text-text-muted → --tx2,
+// text-accent → --accent, px-2/py-px → sp-2 / the pill's 1px breathing room,
+// text-meta → 12px). jsdom loads no stylesheet, so the contract is asserted
+// on the exact class strings — a retune of Pill's chrome fails here.
+//
+// The two-stage C4 guard is load-bearing: `tone` is a REQUIRED prop with no
+// default (a bare `<Pill>` must be a TYPE error, not invisible text), and
+// Pill must not accept `className` (standing decision 3).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { Zap } from "lucide-react";
+import { mount, type Harness } from "./testHarness";
+import { Pill } from "./Pill";
+import { SessionHeader } from "./SessionHeader";
+import { QuestionCard } from "./Cards";
+import type { QuestionRequest } from "../shared/types";
+
+const PILL_BASE = "inline-flex items-center gap-2 rounded-full px-2 py-px font-semibold";
+
+function pillEl(h: Harness): HTMLElement {
+  const el = h.container.querySelector("span.rounded-full") as HTMLElement;
+  expect(el).toBeTruthy();
+  return el;
+}
+
+describe("Pill", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders the capsule --r-full radius, sp-2 padding and gap per the contract", () => {
+    h = mount(<Pill tone="neutral">meta</Pill>);
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el.className).toBe(`${PILL_BASE} text-meta text-text-muted`);
+    expect(el.className).toContain("rounded-full");
+    expect(el.className).toContain("px-2");
+    expect(el.className).toContain("py-px");
+    expect(el.className).toContain("gap-2");
+  });
+
+  it("accent tone renders the --accent-bg surface with a matching --accent foreground (C1)", () => {
+    h = mount(<Pill tone="accent">Recommended</Pill>);
+    const el = pillEl(h);
+    expect(el.className).toContain("bg-accent-bg");
+    expect(el.className).toContain("text-accent");
+  });
+
+  it("warn tone renders the --warn-bg surface with a matching --warn foreground (C1)", () => {
+    h = mount(<Pill tone="warn">stale</Pill>);
+    const el = pillEl(h);
+    expect(el.className).toContain("bg-warn-bg");
+    expect(el.className).toContain("text-warn");
+  });
+
+  it("neutral tone sets no background and reads as a muted label (inherits its surface)", () => {
+    h = mount(<Pill tone="neutral">label</Pill>);
+    const el = pillEl(h);
+    expect(el.className).not.toContain("bg-");
+    expect(el.className).toContain("text-text-muted");
+  });
+
+  it("border flag adds the optional --border edge", () => {
+    h = mount(<Pill tone="neutral" border>edge</Pill>);
+    const el = pillEl(h);
+    expect(el.className).toContain("border");
+    expect(el.className).toContain("border-border");
+  });
+
+  it("renders a leading icon at 14px, hidden from the a11y tree", () => {
+    h = mount(
+      <Pill tone="neutral" icon={<Zap />}>
+        active
+      </Pill>,
+    );
+    const svg = h.container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("14");
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    expect(pillEl(h).textContent).toContain("active");
+  });
+
+  it("size=label renders the 13px standing-tag size (vs meta default)", () => {
+    h = mount(<Pill tone="accent" size="label">Recommended</Pill>);
+    expect((h.container.firstElementChild as HTMLElement).className).toContain("text-label");
+  });
+
+  it("tone is REQUIRED with no default — a bare Pill is a type error (C4)", () => {
+    // If Pill ever grew a default tone this directive becomes unused and
+    // typecheck fails — the abstract-base-is-not-a-variant guard (C4) lives
+    // in the types.
+    // @ts-expect-error — Pill MUST NOT default tone (M527 C4)
+    void <Pill>invisible text</Pill>;
+    expect(true).toBe(true);
+  });
+
+  it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
+    // If Pill ever grew a className prop this directive becomes unused and
+    // typecheck fails — the standing-decision-3 guard lives in the types.
+    // @ts-expect-error — Pill must NOT accept className (M527 decision 3)
+    void <Pill tone="neutral" className="bg-red-500">x</Pill>;
+    expect(true).toBe(true);
+  });
+});
+
+describe("Pill migration — ContextPill call site (BET-534 two-adopter rule)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function renderHeader(stale: boolean) {
+    return mount(
+      <SessionHeader
+        branch={null}
+        ctxBreakdown={{ freshInput: 1, cacheRead: 1, cacheWrite: 1, totalInput: 100, pct: 12, segments: [] }}
+        ctxLimit={200000}
+        staleCache={{ isStale: stale, idleMs: 0, staleTokens: 0, ttlMs: 0 }}
+        modelName={null}
+        hasSession
+        onFork={() => {}}
+        onCompact={() => {}}
+        onClear={() => {}}
+        onDelete={() => {}}
+        breadcrumb={null}
+        mode="chat"
+        onModeChange={() => {}}
+      />,
+    );
+  }
+
+  function pillSpan(): HTMLElement {
+    const btn = h!.container.querySelector("button.manta-ctx-pill") as HTMLElement;
+    expect(btn).toBeTruthy();
+    // The Pill is the button's root child (the popover span only mounts when
+    // open). Its chrome is the pill's, distinct from the button's interaction
+    // wrapper.
+    const pill = btn.querySelector("span") as HTMLElement;
+    expect(pill).toBeTruthy();
+    return pill;
+  }
+
+  it("non-stale ContextPill renders through Pill's neutral chrome with no tint", () => {
+    h = renderHeader(false);
+    const pill = pillSpan();
+    expect(pill.className).toContain("rounded-full");
+    expect(pill.className).toContain("px-2");
+    expect(pill.className).toContain("text-text-muted");
+    expect(pill.className).not.toContain("bg-");
+    // The % metric still renders.
+    expect(pill.textContent).toContain("12%");
+  });
+
+  it("stale ContextPill renders through Pill's warn chrome (the canonical warn pill)", () => {
+    h = renderHeader(true);
+    const pill = pillSpan();
+    expect(pill.className).toContain("bg-warn-bg");
+    expect(pill.className).toContain("text-warn");
+  });
+
+  it("does not inject arbitrary classes into the migrated context-pill call site", () => {
+    h = renderHeader(false);
+    const btn = h!.container.querySelector("button.manta-ctx-pill") as HTMLElement;
+    // Button keeps only identity + the interactive wrapper (no old hand-rolled
+    // pill chrome), and the Pill span carries only Pill-owned classes.
+    expect(btn.className).not.toContain("inline-flex");
+    expect(btn.className).not.toContain("py-px");
+    expect(pillSpan().className).not.toContain("bg-red-500");
+  });
+});
+
+describe("Pill migration — Recommended option tag (BET-534 two-adopter rule)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  const question: QuestionRequest = {
+    id: "q1",
+    sessionID: "s1",
+    requestId: "que_1",
+    questions: [
+      {
+        question: "Pick one",
+        header: "CSV export",
+        options: [
+          { label: "A", description: "option a" },
+          // The "(Recommended)" suffix convention drives `recommended: true`
+          // (Cards.tsx parses it off and badges the option).
+          { label: "B (Recommended)", description: "option b" },
+        ],
+      },
+    ],
+  };
+
+  it("Recommended tag renders through Pill's accent chrome with the --r-full radius (was rounded-sm)", () => {
+    h = mount(<QuestionCard request={question} onReply={() => {}} onReject={() => {}} />);
+    const pill = Array.from(h.container.querySelectorAll("span.rounded-full")).find(
+      (el) => el.textContent === "Recommended",
+    ) as HTMLElement;
+    expect(pill).toBeTruthy();
+    // The intended delta is exactly the radius: --r-full replaces --r-sm
+    // (rounded-sm), while the accent surface, --accent foreground and the
+    // label size are preserved.
+    expect(pill.className).toContain("rounded-full");
+    expect(pill.className).not.toContain("rounded-sm");
+    expect(pill.className).toContain("bg-accent-bg");
+    expect(pill.className).toContain("text-accent");
+    expect(pill.className).toContain("text-label");
+    expect(pill.className).toContain("px-2");
+  });
+});

--- a/src/renderer/Pill.tsx
+++ b/src/renderer/Pill.tsx
@@ -1,0 +1,77 @@
+// M527.Pill — the status-pill chrome primitive (BET-534, stage 5).
+//
+// Owns the ONE shared pill chrome with NO `className` escape hatch (epic
+// standing decision 3): a caller cannot shear the capsule radius, the tone
+// surface, the optional edge or the padding, so the pill family can only
+// drift if Pill itself is retuned.
+//
+// Chrome contract (BET-529 inventory):
+//   - capsule `--r-full` (`rounded-full`).
+//   - `sp-2` padding — `px-2 py-px` (the vertical step is the pill's 1px
+//     breathing room, matching the canonical ContextPill; the horizontal is
+//     `sp-2` = 8px).
+//   - gap-2 between the icon and the metric/label.
+//   - a leading icon at 14px (the chrome contract's "icon 14px");
+//     label/mono content is free-form `children`.
+//
+// Tone + C1 (validated constraints). The tone carries the surface decision
+// and is a REQUIRED prop with no default (C4): the spec's bare `.pill` is an
+// abstract base — 0 of its 81 uses omit a modifier — so a `<Pill>` without a
+// tone must be a TYPE ERROR, not invisible text.
+//   - `neutral` sets no background (it inherits the surface it sits on) and
+//     therefore may inherit its foreground — a muted `--tx2` is declared as
+//     the resting label colour so a bare neutral pill reads as a label.
+//   - `accent` / `warn` set a surface (`--accent-bg` / `--warn-bg`) that
+//     differs from the page, so C1 makes them declare the matching foreground
+//     token (`text-accent` / `text-warn`) to keep contrast valid.
+//
+// An optional `border` flag adds the `--border` edge. `size` is a separate
+// axis from the tone — "meta" (12px, the ContextPill size) is the default,
+// "label" (13px) covers the larger standing tag — and is optional because it
+// is not the abstract-variant trap C4 guards against; only `tone` is.
+
+import type { ReactElement, ReactNode } from "react";
+import { cloneElement } from "react";
+
+type PillTone = "neutral" | "accent" | "warn";
+type PillSize = "meta" | "label";
+
+const PILL_BASE = "inline-flex items-center gap-2 rounded-full px-2 py-px font-semibold";
+const TONE: Record<PillTone, string> = {
+  neutral: "text-text-muted",
+  accent: "bg-accent-bg text-accent",
+  warn: "bg-warn-bg text-warn",
+};
+const SIZE: Record<PillSize, string> = {
+  meta: "text-meta",
+  label: "text-label",
+};
+const EDGE = "border border-border";
+
+export function Pill({
+  tone,
+  border = false,
+  size = "meta",
+  icon,
+  children,
+}: {
+  /**
+   * Which surface + foreground the pill carries. REQUIRED with no default
+   * (C4) — a pill that omitted a tone would render as invisible text.
+   */
+  tone: PillTone;
+  /** Optional `--border` edge around the pill. */
+  border?: boolean;
+  /** meta = 12px (default, the ContextPill size); label = 13px (standing tag). */
+  size?: PillSize;
+  /** Optional leading icon, rendered at 14px per the chrome contract. */
+  icon?: ReactElement;
+  children?: ReactNode;
+}) {
+  return (
+    <span className={`${PILL_BASE} ${SIZE[size]} ${TONE[tone]}${border ? ` ${EDGE}` : ""}`}>
+      {icon && cloneElement(icon, { size: 14, "aria-hidden": true })}
+      {children}
+    </span>
+  );
+}

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -22,6 +22,7 @@ import { useClickAway } from "./hooks/useClickAway";
 import type { SessionMode } from "./chatShared";
 import type { AvailableLauncher } from "../shared/types";
 import { IconButton } from "./IconButton";
+import { Pill } from "./Pill";
 
 // Cache-segment colors — same palette as ContextBar so the header pill and
 // the (retired) footer bar stay in sync visually.
@@ -276,28 +277,31 @@ function ContextPill({
       type="button"
       onClick={() => setOpen((v) => !v)}
       className={
-        "manta-ctx-pill inline-flex items-center gap-2 rounded-full px-2 py-px text-meta transition-colors " +
-        (stale
-          ? "bg-warn-bg hover:bg-warn-bg"
-          : "hover:bg-fill-hover")
+        // The button is the interactive host (click + popover + hover fill);
+        // the pill chrome itself lives on the Pill below. `rounded-full`
+        // keeps the resting-transparent hover fill capsule-shaped.
+        "manta-ctx-pill text-meta rounded-full p-0 border-0 bg-transparent transition-colors " +
+        (stale ? "" : "hover:bg-fill-hover")
       }
       aria-haspopup="dialog"
       aria-expanded={open}
       title={stale ? "Context stale — click for details" : "Context usage — click for details"}
     >
-      {/* Mini segmented bar inside the pill — same segment order/colors as
-          ContextBar but at pill scale (w-16 h-2). */}
-      <SegmentedBar
-        segments={segments}
-        segColor={segColor}
-        className="manta-ctx-track inline-block w-16 h-2 rounded-full overflow-hidden align-middle"
-      />
-      <span
-        className="tabular-nums text-meta font-mono font-semibold"
-        style={{ color: stale ? CACHE_WRITE_COLOR : fill }}
-      >
-        {pct}%
-      </span>
+      <Pill tone={stale ? "warn" : "neutral"}>
+        {/* Mini segmented bar inside the pill — same segment order/colors as
+            ContextBar but at pill scale (w-16 h-2). */}
+        <SegmentedBar
+          segments={segments}
+          segColor={segColor}
+          className="manta-ctx-track inline-block w-16 h-2 rounded-full overflow-hidden align-middle"
+        />
+        <span
+          className="tabular-nums font-mono font-semibold"
+          style={{ color: stale ? CACHE_WRITE_COLOR : fill }}
+        >
+          {pct}%
+        </span>
+      </Pill>
 
       {open && (
         <span


### PR DESCRIPTION
## M527.Pill — Pill primitive + migrate ContextPill / Recommended tag (stage 5)

Closes BET-534.

### What

A `Pill` chrome primitive in `src/renderer/Pill.tsx` owning the one shared
status-pill chrome with **no `className` escape hatch** (standing decision 3),
plus migration of the two mandated adopters in this same PR.

**Settled design decisions (was "settle the tone/variant decision in this cell"):**
- **Tone is a REQUIRED `tone` prop with no default (C4).** A `<Pill>` with no
  tone is a type error — the spec's bare `.pill` is an abstract base (0 of its
  81 uses omit a modifier, sets no bg/colour), so it renders as invisible text.
  The compile-time guard is in `Pill.test.tsx` via `@ts-expect-error`.
- **Tones settled to `neutral | accent | warn`** (matching the two adopters + the
  spec's `info`→accent and `warn` mapping):
  - `neutral` — no background (inherits the surface it sits on) with a muted
    `--tx2` label colour. C1: no bg set → foreground may inherit; `text-text-muted`
    is declared so a bare neutral pill reads as a label.
  - `accent` — `bg-accent-bg text-accent`: sets a surface differing from the page,
    so C1 makes it declare the matching foreground.
  - `warn` — `bg-warn-bg text-warn` (same C1 pairing).
- **Optional `border` flag** adds the `--border` edge.
- **`size` (`meta` default 12px / `label` 13px)** — a separate axis from the tone
  (not the C4 abstract-variant trap). It exists because the two adopters render at
  different sizes (ContextPill `text-meta`, Recommended `text-label`).
- **`icon` slot** at 14px per the BET-529 chrome contract ("icon 14px");
  label/mono content is free-form `children`.
- Chrome: `inline-flex items-center gap-2 rounded-full px-2 py-px font-semibold`
  — capsule `--r-full`, `sp-2` horizontal padding (px-2) with the pill's 1px
  vertical breathing room (py-px) and the canonical pill weight (600), matching
  the companion's `.pill { font:600 11px/1.5; padding:2px 8px; }`.

### Migration (two-adopter rule)

- **`ContextPill`** (`SessionHeader.tsx`) — the % context pill, warn-tinted when
  stale. Its chrome now comes from Pill: the `<button>` keeps only the identity +
  interaction + hover-fill wrapper (`manta-ctx-pill … rounded-full p-0 border-0
  bg-transparent … hover:bg-fill-hover`); the pill chrome itself lives on
  `<Pill tone={stale ? "warn" : "neutral"}>` wrapping the segmented bar + `%`
  metric. **Pixel-identical** — verified by the visual gate (ctx-pill baselines
  unchanged; the pill's `font-semibold` is inert here because the `%` metric
  already asserts its own weight/colour, and the segmented bar has no text).

- **"Recommended" option tag** (`Cards.tsx`) — the accent standing tag. Previously
  a `rounded-sm` span with inline `--accent-bg`/`--accent` styles; now
  `<Pill tone="accent" size="label">` wrapped in a `ml-auto shrink-0` span
  (flex-row placement is a site concern, not pill chrome), so the tag **adopts the
  canonical pill chrome**. **Deltas vs the previous markup (all confirmed
  intended — this is the tag joining the pill):**
  1. radius `rounded-sm → rounded-full` (`--r-full`) — the delta the issue named;
  2. font weight `400 → 600` (`font-semibold`, the canonical pill weight);
  3. vertical padding `0 → 1px` (`py-px`, the pill's 1px breathing room).
  The accent surface (`--accent-bg`), `--accent` foreground and 13px label size
  are preserved via the primitive. All three align the tag with the companion's
  canonical `.pill` and are visible to the owner's visual validation of the
  component companion (BET-510 baselines gate).

### Anti-spaghetti / scope notes

- `Cards.tsx` was already using the `Card` primitive; this adds `Pill` for the
  tag. No parallel copies introduced — `Pill` is the single source of pill chrome.
- Status dots (`Sidebar.tsx`) are dot glyphs, not pills — untouched (out of scope).
- `NewSessionScreen` branch/worktree chips were left for the canonical two adopters
  to avoid scope creep (explicitly optional in the issue).
- No new tokens (standing decision 6) — reused `--accent-bg`, `--warn-bg`,
  `--accent`, `--warn`, `--border`, `--tx2`, `--r-full`, `sp-2`.
- C5 (shadow scale): Pill uses no shadow — nothing to report.

### Tests

`src/renderer/Pill.test.tsx` (13) — component tests pinning the chrome class
strings (capsule radius, sp-2 padding, neutral/accent/warn surface+foreground
tokens, optional border, 14px icon, label size) + the two compile-time guards
(C4 required tone, no-`className` escape hatch) + migration smoke tests for both
call sites asserting no arbitrary class injection.

**Files changed:** `4` files. `[Pill.tsx (+), Pill.test.tsx (+), SessionHeader.tsx, Cards.tsx]`

**Verification results:**
- PR branch (`multica/BET-534-pill-primitive` @ `0f50de9`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1346` pass / `0` fail / `0` skip. Failures: none. log sha256: `840f3ef192cf9a5ff012d5bf29a0007696b5a6622601ae0866232e2a3a1713b4`
  - visual gate (`npx playwright test --project=visual`): **13 passed** — ctx-pill + session + session-header baselines unchanged (ContextPill migration pixel-identical).
- Base (`main` @ `c3579c2`):
  - typecheck: exit `0`. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit `0`, `1346` pass / `0` fail / `0` skip. Failures: none. log sha256: `d1ee3aa6d5e185c56eb7ef3c2ad4de70c56befe31ec86a61d5038a3a2d374b01`
- **Conclusion:** `0` new failures — identical pass counts between branches; the test-log sha256 differ only in per-subtest timing (`duration_ms`) lines, not in assertions.

**Base: `origin/main` @ `c3579c2`**

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
