### PR TITLE
BET-544: Add [data-density] scope for --row-* / wire sidebar rail density ancestor

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -493,6 +493,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         role="tree"
         aria-label="Sessions"
         tabIndex={-1}
+        data-density="comfortable"
         onKeyDown={onRailKeyDown}
       >
         {projects.length === 0 && (

--- a/src/renderer/tokens.css
+++ b/src/renderer/tokens.css
@@ -90,14 +90,6 @@
   --prose-lh: 1.55;
   --ui-lh: 1.45;
 
-  /* Session-row metrics (BET-451). The sidebar row is a fixed four-slot shape
-     ([dot] [name] [pin] [timer]); pinning these means the row cannot change
-     height or padding per variant, which is what stops the rail jittering when
-     a hover affordance appears. */
-  --row-h: 32px;
-  --row-px: 10px;
-  --row-py: 6px;
-
   /* One easing curve for every transition, so motion reads as one system. */
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 
@@ -110,6 +102,28 @@
      it is one decision living in two files. */
   --font-sans: "Inter Variable", Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+}
+
+/* Density scope (BET-544). Session-row metrics live on [data-density], NOT
+   :root (spec C2, docs/components.md). The sidebar rail renders inside a
+   density ancestor (Sidebar.tsx), so a row primitive consuming a --row-* token
+   must state that it requires a density ancestor. A component rendered outside
+   this scope gets none of these — the row collapses to an unpadded baseline.
+
+   `comfortable` is the app default and matches the prior :root values exactly
+   (no visual change to the rail). `compact` is the reduced variant the spec
+   defines (row-h 26px); it is not yet selected anywhere — the scope exists so
+   a future density setting can flip it. */
+[data-density="comfortable"] {
+  --row-h: 32px;
+  --row-px: 10px;
+  --row-py: 6px;
+}
+
+[data-density="compact"] {
+  --row-h: 26px;
+  --row-px: 8px;
+  --row-py: 4px;
 }
 
 /* Token substrate (BET-407). Colour literals moved out of tailwind.config.js


### PR DESCRIPTION
## BET-544 — Add `[data-density]` scope for `--row-*` / wire the sidebar rail density ancestor

Moves the session-row metrics off `:root` onto `[data-density="comfortable" | "compact"]` and renders the sidebar rail inside a density scope, per spec C2 (`docs/components.md`). This makes the density *feature* exercisable — before this, nobody defined a density scope, so the rail was functionally single-density regardless of any future density setting.

**Changes:**
- `src/renderer/tokens.css` — `--row-h`/`--row-px`/`--row-py` moved off `:root` onto `[data-density="comfortable"]` (values unchanged → default look identical) and `[data-density="compact"]` (`--row-h: 26px`). Scope placed after the `:root` block.
- `src/renderer/Sidebar.tsx` — the rail (the `role="tree"` scroll container, ~line 491) now renders with `data-density="comfortable"`, so any `--row-*` consumer resolves its tokens from a density ancestor. Default density (comfortable, 32px) unchanged.

**Notes:**
- No app code currently consumes `--row-*` (only `docs/screens/session/mockup.html` does), so this is scoped to establishing the density scope + ancestor, exactly as dispatched. The rail default (comfortable) is byte-identical in value to the prior `:root` definitions — no visual baseline moves.
- `compact` is not selected anywhere yet (the rail defaults to comfortable); the scope exists so a future density setting can flip it. `--row-px`/`--row-py` for compact are set to `8px`/`4px` as a sensible 26px-row fit — these are non-observable today (compact not wired); comfortable values are the load-bearing ones.

**Files changed:** `2` files. `src/renderer/tokens.css`, `src/renderer/Sidebar.tsx`

**Verification results:**
- PR branch (`multica/BET-544-density-scope` @ `172057c`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1346 pass / 0 fail / 0 skip. Failures: none. log sha256: `95ff488e7d75d67a7f33d12431dff9e75357bbe3b13701cd24edf74742caa8a4`
- Base (`main` @ `4e46d2e`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1346 pass / 0 fail / 0 skip. Failures: none. log sha256: `2534e36a2fff11297097d390f2318a0c500d383a5fd87390ba20034bcdae0df2`
- **Conclusion:** 0 new test failures, 0 pre-existing (identical between branches). Typecheck clean on both.

**Base: `origin/main` @ `4e46d2e`**
