### PR TITLE
M527.Enforce: primitive rules as tests + fill the inventory (BET-541)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -67,7 +67,17 @@ The bare `.pill` sets only padding, radius and font — no background, no colour
 
 ## Inventory
 
-| Primitive | cls | Adopters migrated (PR) | Owner validated |
-| --- | --- | --- | --- |
+Primitives that exist today, their adopting files (matching the two-adopter
+count the enforce test asserts, `src/renderer/primitives.test.ts`), and the
+variant axes their props actually accept (read from the props, not the spec).
+A primitive with fewer than two adopting files is under-adopted — see the
+BET-541 findings.
 
-_Filled in as each primitive lands — see the last stage of BET-527._
+| Primitive | File | Adopters | Variants |
+| --- | --- | --- | --- |
+| Card | `src/renderer/Card.tsx` | 2 — `Cards.tsx`, `Settings.tsx` | `danger` (optional); `header`/`actions` slots |
+| IconButton | `src/renderer/IconButton.tsx` | 1 — `SessionHeader.tsx` | `size: md\|lg`; `ariaHaspopup`/`ariaExpanded`/`hook` |
+| Field | `src/renderer/Field.tsx` | 1 — `Settings.tsx` | `type: text\|password\|number`; `mono` (default true); `label`/`help`/`leading` |
+| Pill | `src/renderer/Pill.tsx` | 2 — `Cards.tsx`, `SessionHeader.tsx` | `tone: neutral\|accent\|warn` (required); `size: meta\|label`; `border` |
+| MenuItem | `src/renderer/MenuItem.tsx` | 1 — `SessionHeader.tsx` | `variant: normal\|danger\|active` |
+| SessionRow | `src/renderer/SessionRow.tsx` | 1 — `Sidebar.tsx` | `status: run\|att\|idle\|ok\|default` (required); `selected`; `child`; `ageStale` |

--- a/docs/visual-verification.md
+++ b/docs/visual-verification.md
@@ -174,6 +174,12 @@ Steps 4 and 5 apply **whenever a baseline moves**, not only when the issue is a
 design issue. A refactor that shifts a pixel is exactly the case where nobody
 thinks to look.
 
+> **A UI issue that renders card, field, pill, icon-button, menu-item or
+> session-row chrome uses the existing primitive** (`docs/components.md`).
+> Introducing a new primitive requires two or more adopters migrated in the
+> same PR; re-implementing one inline is rejected on sight. This is the rule
+> that stops the inventory eroding back into per-screen utilities.
+
 ## Commands
 
 ```

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -1,0 +1,171 @@
+// M527.Enforce — the epic's three mechanical rules, as tests (BET-541, last stage).
+//
+// These are the "a rule with no test decays" net for the M527 primitive layer,
+// mirroring the repo's three prior answers to that question
+// (`tailwindScale.test.ts`, `DEMO_UNIMPLEMENTED`, `surfacesClosed`): a cheap
+// test that fails naming the offender instead of a rule someone must remember.
+//
+// Three cases:
+//   1a. no `className` escape hatch  (epic standing decision 3)
+//   1b. two-adopter rule             (epic standing decision 2)
+//   1c. no raw colour / off-grid px  (the drift that started the epic)
+//
+// The per-component `@ts-expect-error` guards in each primitive's OWN test are
+// compile-time and stronger; this file is the net that catches a primitive
+// added WITHOUT one. The doc (`docs/components.md` inventory) follows this test,
+// never the reverse.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// Every primitive in the M527 inventory. Adding one here is the whole cost of
+// putting it under the epic's rules.
+const PRIMITIVES = ["Card", "IconButton", "Field", "Pill", "MenuItem", "SessionRow"] as const;
+
+const RENDERER = fileURLToPath(new URL(".", import.meta.url));
+
+function rendererFiles(): string[] {
+  const out: string[] = [];
+  const walk = (d: string) => {
+    for (const e of readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (/\.(tsx|ts)$/.test(e.name)) out.push(path.relative(RENDERER, p));
+    }
+  };
+  walk(RENDERER);
+  return out;
+}
+
+function source(p: string): string {
+  return readFileSync(path.join(RENDERER, `${p}.tsx`), "utf8");
+}
+
+/** Return the balanced `{ ... }` starting at `openIdx` (must be a `{`). */
+function balancedBrace(content: string, openIdx: number): string {
+  let depth = 0;
+  for (let i = openIdx; i < content.length; i++) {
+    if (content[i] === "{") depth++;
+    else if (content[i] === "}") {
+      depth--;
+      if (depth === 0) return content.slice(openIdx, i + 1);
+    }
+  }
+  return "";
+}
+
+/**
+ * Extract the props type literal of `export function <component>({ ... })`.
+ * Handles both forms used by the M527 primitives:
+ *   - inline: `}: { artA; artB }`  (Card, IconButton, Pill, MenuItem, SessionRow)
+ *   - name alias: `}: FieldProps)` with `type FieldProps = { ... }`  (Field)
+ * Returns null when neither form is parseable (caller skips, never lies).
+ */
+function propsLiteral(content: string, component: string): string | null {
+  const fn = content.indexOf(`export function ${component}(`);
+  if (fn === -1) return null;
+  const inline = content.indexOf(`}: {`, fn);
+  if (inline !== -1) return balancedBrace(content, inline + 3);
+  const alias = content.slice(fn).match(/\}\s*:\s*([A-Za-z_$]\w*)\s*\)\s*\{/);
+  if (alias) {
+    const typeIdx = content.indexOf(`type ${alias[1]} = {`);
+    if (typeIdx !== -1) return balancedBrace(content, content.indexOf("{", typeIdx));
+  }
+  return null;
+}
+
+/** Impoter filenames for `p` per the epic's rule (excludes own source + test). */
+function importers(p: string): string[] {
+  const re = new RegExp(`import\\s*\\{[^}]*\\b${p}\\b[^}]*\\}\\s*from\\s*["'][^"']*\\/${p}["']`);
+  return rendererFiles().filter((f) => {
+    if (f === `${p}.tsx` || f === `${p}.test.tsx`) return false;
+    return re.test(readFileSync(path.join(RENDERER, f), "utf8"));
+  });
+}
+
+/** The rendered code, with comments removed (comments legitimately document chrome). */
+function sourceCode(p: string): string {
+  return source(p).replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+// Genuine gaps this cell surfaces (reported as findings — the epic delivered
+// call-site adopters within a single file, and SessionRow carries spec-.srow
+// metrics). The tests below it.skip them with justifications; the doc's
+// adopter counts match these true numbers.
+const UNDER_ADOPTED: Record<string, string> = {
+  IconButton:
+    "1 adopting file (SessionHeader.tsx) today — BET-532 migrated two call sites IN that one file. A second file (NewSessionScreen) is already tracked in BET-538; un-skip when it lands.",
+  Field:
+    "1 adopting file (Settings.tsx) today — BET-533 migrated four call sites, all in Settings. Reaching 2 needs a Field call site migrated from another file (BET-533 named CustomProviderForm.tsx / ConnectProvider.tsx as future adopters).",
+  MenuItem:
+    "1 adopting file (SessionHeader.tsx) today — the three variants are all in the one session menu. Reaching 2 needs a second role=menu surface that adopts MenuItem.",
+  SessionRow:
+    "1 adopting file (Sidebar.tsx) today — BET-536 migrated top-level + child rows, both in Sidebar. Reaching 2 needs a row migrated in another screen.",
+};
+
+const RAW_PX_EXCEPTIONS: Record<string, string> = {
+  SessionRow:
+    "the .srow metrics (7px dot, 3px ring, 13px connector, 26px child indent, 20px age slot) are spec-authorized off-grid values, NOT on the spacing grid by design (BET-536 C6). Incapable of token-expression today; un-skip if/when a token or scale captures them.",
+};
+
+describe("M527 primitive rules", () => {
+  describe("1a — no className escape hatch (standing decision 3)", () => {
+    for (const p of PRIMITIVES) {
+      const props = propsLiteral(source(p), p);
+      const label = `${p} props type has no className member`;
+      if (props === null) {
+        // Defensive: if a future primitive's props shape defeats the extractor,
+        // skip explicitly rather than emit a fragile regex false negative.
+        it.skip(label, () => {});
+      } else {
+        it(label, () => {
+          expect(props.match(/className\??:/), `${p}: no className in its props type`).toBeNull();
+        });
+      }
+    }
+  });
+
+  describe("1b — two-adopter rule (standing decision 2)", () => {
+    for (const p of PRIMITIVES) {
+      const adopters = importers(p);
+      const label = `${p} has at least two adopting files (got ${adopters.length})`;
+      if (adopters.length < 2) {
+        // Under-adopted today — an epic finding, NOT fixed in this cell
+        // (explicitly out of scope: "If a primitive has fewer than two, report
+        // it"). Documented in the PR + filed as follow-up; un-skip when a
+        // second adopting file lands.
+        it.skip(label, () => {});
+      } else {
+        it(label, () => {
+          expect(
+            adopters,
+            `${p}: two-adopter rule needs >=2 files importing it; found ${JSON.stringify(adopters)}`,
+          ).toHaveLength(2);
+        });
+      }
+    }
+  });
+
+  describe("1c — no raw colour / off-grid px in the primitive's own code", () => {
+    for (const p of PRIMITIVES) {
+      const code = sourceCode(p);
+      const failures: string[] = [];
+      const badHex = code.match(/#[0-9a-fA-F]{3,8}\b/) || [];
+      const badRgba = code.match(/rgba?\(/) || [];
+      const badPx = code.match(/\b\d+px\b/) || [];
+      const label = `${p} code has no raw colour or off-grid pixel literal`;
+      if (badHex.length || badRgba.length || badPx.length) {
+        it.skip(label, () => {});
+      } else {
+        it(label, () => {
+          expect(failures).toEqual([]);
+          expect(badHex, `${p}: no raw hex colour`).toEqual([]);
+          expect(badRgba, `${p}: no rgba() colour`).toEqual([]);
+          expect(badPx, `${p}: no off-grid px value`).toEqual([]);
+        });
+      }
+    }
+  });
+});

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -90,6 +90,19 @@ function sourceCode(p: string): string {
   return source(p).replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
 }
 
+/**
+ * Line numbers (1-based) whose text matches `re` — used to make a rule failure
+ * name the primitive, the rule, AND the offending line, per the epic's
+ * requirement that the message be actionable without opening the file.
+ */
+function offendingLines(content: string, re: RegExp): string[] {
+  const out: string[] = [];
+  for (const [i, line] of content.split("\n").entries()) {
+    if (re.test(line)) out.push(`${i + 1}: ${line.trim()}`);
+  }
+  return out;
+}
+
 // Genuine gaps this cell surfaces (reported as findings — the epic delivered
 // call-site adopters within a single file, and SessionRow carries spec-.srow
 // metrics). Only these are skipped, with justifications below; every OTHER
@@ -140,9 +153,9 @@ describe("M527 primitive rules", () => {
         it(label, () => {
           const adopters = importers(p);
           expect(
-            adopters,
+            adopters.length,
             `${p}: two-adopter rule needs >=2 files importing it; found ${JSON.stringify(adopters)}`,
-          ).toHaveLength(2);
+          ).toBeGreaterThanOrEqual(2);
         });
       }
     }
@@ -160,9 +173,21 @@ describe("M527 primitive rules", () => {
       } else {
         it(label, () => {
           const code = sourceCode(p);
-          expect(code.match(/#[0-9a-fA-F]{3,8}\b/) || [], `${p}: no raw hex colour`).toEqual([]);
-          expect(code.match(/rgba?\(/) || [], `${p}: no rgba() colour`).toEqual([]);
-          expect(code.match(/\b\d+px\b/) || [], `${p}: no off-grid px value`).toEqual([]);
+          const hex = offendingLines(code, /#[0-9a-fA-F]{3,8}\b/);
+          const rgba = offendingLines(code, /rgba?\(/);
+          const px = offendingLines(code, /\b\d+px\b/);
+          expect(
+            hex,
+            `${p} [rule 1c — raw colour] has no raw hex; offending line(s): ${hex.join(" | ") || "none"}`,
+          ).toEqual([]);
+          expect(
+            rgba,
+            `${p} [rule 1c — raw colour] has no rgba(); offending line(s): ${rgba.join(" | ") || "none"}`,
+          ).toEqual([]);
+          expect(
+            px,
+            `${p} [rule 1c — off-grid px] has no \`\\d+px\`; offending line(s): ${px.join(" | ") || "none"}`,
+          ).toEqual([]);
         });
       }
     }

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -132,8 +132,10 @@ describe("M527 primitive rules", () => {
       if (UNDER_ADOPTED.has(p)) {
         // Under-adopted at baseline — an epic finding, NOT fixed in this cell
         // ("If a primitive has fewer than two, report it"). Un-skip when a
-        // second adopting file lands. Reason: ${SKIP_REASON[p]}
-        it.skip(label, () => {});
+        // second adopting file lands.
+        it.skip(label, () => {
+          void SKIP_REASON[p];
+        });
       } else {
         it(label, () => {
           const adopters = importers(p);
@@ -150,9 +152,11 @@ describe("M527 primitive rules", () => {
     for (const p of PRIMITIVES) {
       const label = `${p} code has no raw colour or off-grid pixel literal`;
       if (RAW_PX_EXCEPTION.has(p)) {
-        // SessionRow's .srow metrics are spec-authorized off-grid values (see
-        // SKIP_REASON[SessionRow_rawpx]); un-skip if/when a token captures them.
-        it.skip(label, () => {});
+        // SessionRow's .srow metrics are spec-authorized off-grid values; un-skip
+        // if/when a token captures them.
+        it.skip(label, () => {
+          void SKIP_REASON[p + "_rawpx"];
+        });
       } else {
         it(label, () => {
           const code = sourceCode(p);

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -92,21 +92,20 @@ function sourceCode(p: string): string {
 
 // Genuine gaps this cell surfaces (reported as findings — the epic delivered
 // call-site adopters within a single file, and SessionRow carries spec-.srow
-// metrics). The tests below it.skip them with justifications; the doc's
-// adopter counts match these true numbers.
-const UNDER_ADOPTED: Record<string, string> = {
+// metrics). Only these are skipped, with justifications below; every OTHER
+// primitive asserts its rule ACTIVELY, so a regression (a deleted import, a
+// pasted raw literal) fails loudly instead of silently passing.
+const UNDER_ADOPTED: Set<string> = new Set(["IconButton", "Field", "MenuItem", "SessionRow"]);
+const RAW_PX_EXCEPTION: Set<string> = new Set(["SessionRow"]);
+
+const SKIP_REASON: Record<string, string> = {
   IconButton:
     "1 adopting file (SessionHeader.tsx) today — BET-532 migrated two call sites IN that one file. A second file (NewSessionScreen) is already tracked in BET-538; un-skip when it lands.",
   Field:
     "1 adopting file (Settings.tsx) today — BET-533 migrated four call sites, all in Settings. Reaching 2 needs a Field call site migrated from another file (BET-533 named CustomProviderForm.tsx / ConnectProvider.tsx as future adopters).",
   MenuItem:
     "1 adopting file (SessionHeader.tsx) today — the three variants are all in the one session menu. Reaching 2 needs a second role=menu surface that adopts MenuItem.",
-  SessionRow:
-    "1 adopting file (Sidebar.tsx) today — BET-536 migrated top-level + child rows, both in Sidebar. Reaching 2 needs a row migrated in another screen.",
-};
-
-const RAW_PX_EXCEPTIONS: Record<string, string> = {
-  SessionRow:
+  SessionRow_rawpx:
     "the .srow metrics (7px dot, 3px ring, 13px connector, 26px child indent, 20px age slot) are spec-authorized off-grid values, NOT on the spacing grid by design (BET-536 C6). Incapable of token-expression today; un-skip if/when a token or scale captures them.",
 };
 
@@ -129,16 +128,15 @@ describe("M527 primitive rules", () => {
 
   describe("1b — two-adopter rule (standing decision 2)", () => {
     for (const p of PRIMITIVES) {
-      const adopters = importers(p);
-      const label = `${p} has at least two adopting files (got ${adopters.length})`;
-      if (adopters.length < 2) {
-        // Under-adopted today — an epic finding, NOT fixed in this cell
-        // (explicitly out of scope: "If a primitive has fewer than two, report
-        // it"). Documented in the PR + filed as follow-up; un-skip when a
-        // second adopting file lands.
+      const label = `${p} has at least two adopting files`;
+      if (UNDER_ADOPTED.has(p)) {
+        // Under-adopted at baseline — an epic finding, NOT fixed in this cell
+        // ("If a primitive has fewer than two, report it"). Un-skip when a
+        // second adopting file lands. Reason: ${SKIP_REASON[p]}
         it.skip(label, () => {});
       } else {
         it(label, () => {
+          const adopters = importers(p);
           expect(
             adopters,
             `${p}: two-adopter rule needs >=2 files importing it; found ${JSON.stringify(adopters)}`,
@@ -150,20 +148,17 @@ describe("M527 primitive rules", () => {
 
   describe("1c — no raw colour / off-grid px in the primitive's own code", () => {
     for (const p of PRIMITIVES) {
-      const code = sourceCode(p);
-      const failures: string[] = [];
-      const badHex = code.match(/#[0-9a-fA-F]{3,8}\b/) || [];
-      const badRgba = code.match(/rgba?\(/) || [];
-      const badPx = code.match(/\b\d+px\b/) || [];
       const label = `${p} code has no raw colour or off-grid pixel literal`;
-      if (badHex.length || badRgba.length || badPx.length) {
+      if (RAW_PX_EXCEPTION.has(p)) {
+        // SessionRow's .srow metrics are spec-authorized off-grid values (see
+        // SKIP_REASON[SessionRow_rawpx]); un-skip if/when a token captures them.
         it.skip(label, () => {});
       } else {
         it(label, () => {
-          expect(failures).toEqual([]);
-          expect(badHex, `${p}: no raw hex colour`).toEqual([]);
-          expect(badRgba, `${p}: no rgba() colour`).toEqual([]);
-          expect(badPx, `${p}: no off-grid px value`).toEqual([]);
+          const code = sourceCode(p);
+          expect(code.match(/#[0-9a-fA-F]{3,8}\b/) || [], `${p}: no raw hex colour`).toEqual([]);
+          expect(code.match(/rgba?\(/) || [], `${p}: no rgba() colour`).toEqual([]);
+          expect(code.match(/\b\d+px\b/) || [], `${p}: no off-grid px value`).toEqual([]);
         });
       }
     }


### PR DESCRIPTION
## BET-541 — M527.Enforce: primitive rules as tests + fill the inventory (LAST stage)

Encodes the epic's three mechanical rules as `vitest` tests that fail naming
the offender, and fills the `docs/components.md` inventory now that the
primitives exist. **No product code, no token, no baseline changes.**

**Files changed:** `3` files (`docs/components.md`, `docs/visual-verification.md`, `src/renderer/primitives.test.ts` — new).

**Base: `origin/main` @ `8c313cf`**

## Change 1 — `src/renderer/primitives.test.ts` (new)

Covers all **6** primitives (`Card`, `IconButton`, `Field`, `Pill`, `MenuItem`, `SessionRow`):
18 tests = **13 passing / 5 skipped** at baseline.

- **1a — no `className` escape hatch (decision 3):** for each primitive, extracts its props type literal (inline `}: {...}` for 5, the `FieldProps` named alias for Field) and asserts no `/className\??:/` member. Active for all 6 — the net that catches a primitive added without its own `@ts-expect-error` guard.
- **1b — two-adopter rule (decision 2):** counts importing files (the epic's regex, excluding own source + test) and asserts `>= 2` (`toBeGreaterThanOrEqual(2)` — a floor against dead-weight; a third adopter must not fail). Active for Card (2) and Pill (2).
- **1c — no raw colour / off-grid px:** strips comments (comments legitimately document chrome), asserts no `#hex`, no `rgba(`, no `/\b\d+px\b/` in the rendered code. Failure messages name the primitive, the rule, **and the offending line**. Active for Card, IconButton, Field, Pill, MenuItem.

## Findings — reported, not fixed (this cell is told to report under-adoption)

The enforce test surfaces that the epic's **two-adopter rule was met by call sites, not files**:

| Primitive | Adopting files today | Status |
| --- | --- | --- |
| Card | 2 — `Cards.tsx`, `Settings.tsx` | ✅ rule met (1b active) |
| Pill | 2 — `Cards.tsx`, `SessionHeader.tsx` | ✅ rule met (1b active) |
| IconButton | 1 — `SessionHeader.tsx` | ⚠️ under-adopted → `it.skip` |
| Field | 1 — `Settings.tsx` | ⚠️ under-adopted → `it.skip` |
| MenuItem | 1 — `SessionHeader.tsx` | ⚠️ under-adopted → `it.skip` |
| SessionRow | 1 — `Sidebar.tsx` | ⚠️ under-adopted → `it.skip` |

And **1c flags SessionRow** for spec-authorized off-grid `.srow` metrics (`h-[7px]`, `ring-[3px]`, `left-[-8px]`/`w-[3px]`, `left-[13px]`, `pl-[26px]`, `min-w-[20px]`) — these are spec values accepted in BET-536 (C6), not accidental drift, so the test writes the no-raw rule but skips SessionRow with a justification.

**These are `it.skip` with named tests + justification, un-skipped when the gap closes — they are deliberately NOT carved out permanently.**

- Follow-up filed: **BET-546 (PM)** — bring IconButton/Field/MenuItem/SessionRow to a 2nd adopting file. IconButton's is already BET-538 (NewSessionScreen).
- Follow-up filed: **BET-547 (PM)** — resolve SessionRow's spec off-grid px vs the no-raw rule.

## Change 2 — `docs/components.md`

Replaced the placeholder line with the real inventory table (Primitive / File / Adopters / Variants). Adopter counts **match the test's numbers exactly** (Card 2, IconButton 1, Field 1, Pill 2, MenuItem 1, SessionRow 1); Variants read from props, not the spec.

## Change 3 — `docs/visual-verification.md`

Appended one blockquote to "Definition of done for a UI issue" (no renumbering).

## `it.skip` justification (DoD 3)

All 5 skips are named, commented inline, and linked to BET-546 / BET-547 above.

## Verification results

- PR branch (`multica/BET-541-primitive-rules-tests` @ `f579b64`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **1346 pass / 0 fail** (log sha256 `e8c8194e012f4330c7ad841217bc04e9c463b79f758ef44a3f8be3d37e0b372f`).
  - `primitives.test.ts`: **13 pass / 5 skip**; visual (`npm run visual`, prior cycle) 14/14, no baseline moved.
- Base (`origin/main` @ `8c313cf`): untouched (branch contains no product-code change).
- **Conclusion:** 0 new failures; only a test file + 2 docs changed.

## Failure demonstration (DoD 2 — all three cases, then reverted)

1a (add `className` to Card props) →
```
AssertionError: Card: no className in its props type:
expected [ 'className?:', index: 93, …(2) ] to be null
```
1b (delete Settings' `./Card` import → Card drops to 1) →
```
Card: two-adopter rule needs >=2 files importing it; found ["Cards.tsx"]
(expected >= 2, received 1)
```
1c (paste `#ff0000` into Field chrome) →
```
Field [rule 1c — raw colour] has no raw hex; offending line(s):
64: const INPUT_BASE = "... border-#ff0000 ...";
```
All reverted; baseline back to 13 passed / 5 skipped.

`git status` shows nothing under `tests/visual/screens.visual.ts-snapshots/`.
