### PR TITLE
style-diff: disambiguate spacing/radius token collisions by property family (BET-530)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pair": "node scripts/manta-pair.mjs",
     "pack": "node scripts/release/pack.mjs",
     "pack:desktop": "electron-vite build && electron-builder --config electron-builder.yml",
-    "test": "vitest run && node --import ./scripts/testSandbox.mjs --test src/server/*.test.mjs src/gateway/*.test.mjs scripts/*.test.mjs scripts/release/*.test.mjs",
+    "test": "vitest run && node --import ./scripts/testSandbox.mjs --test src/server/*.test.mjs src/gateway/*.test.mjs scripts/*.test.mjs scripts/release/*.test.mjs scripts/visual/*.test.mjs",
     "test:server": "node --import ./scripts/testSandbox.mjs --test src/server/*.test.mjs src/gateway/*.test.mjs",
     "test:watch": "vitest",
     "build:mobile": "vite build --config electron.vite.config.mobile.ts",

--- a/scripts/visual/style-diff.mjs
+++ b/scripts/visual/style-diff.mjs
@@ -136,6 +136,21 @@ const FAMILY_PREFIX = {
 };
 
 /**
+ * Properties whose value type maps to NO token family at all — a font size
+ * is not a spacing, radius, or border token. A resolved token matching one
+ * of these is a category error, so per the BET-530 constraint they render as
+ * NO match (never a bucket, never a fall-through to another family).
+ * `z-index` is in the issue but isn't one of the tracked PROPERTIES.
+ */
+const NO_FAMILY_PROPERTIES = new Set([
+  "font-size",
+  "font-weight",
+  "line-height",
+  "letter-spacing",
+  "opacity",
+]);
+
+/**
  * The browser-default sentinel per property. A property is SKIPPED when BOTH
  * sides sit at the default (otherwise the report is thousands of lines of
  * transparent/0px/normal noise). `null` = never default-skippable (inherited
@@ -380,18 +395,16 @@ function fmtValue(value, map) {
 
 /**
  * Filter a resolved token name-set down to the ones legitimately matching
- * `prop`'s value type. A property with an explicit family (FAMILY_PREFIX)
- * keeps only that family's tokens; every other property drops any
- * `--sp-*`/`--r-*` token (a cross-family category error). An empty result
- * means "no match" for this property.
+ * `prop`'s value type (BET-530). A property with an explicit family
+ * (FAMILY_PREFIX) keeps only that family's tokens; a property whose type
+ * matches no token family (NO_FAMILY_PROPERTIES) keeps nothing (no match);
+ * every other property is left unchanged. An empty result means "no match".
  */
 export function matchFamilyTokens(prop, toks) {
+  if (NO_FAMILY_PROPERTIES.has(prop)) return [];
   const prefix = FAMILY_PREFIX[prop];
-  return toks.filter((t) =>
-    prefix
-      ? t.startsWith(`--${prefix}`)
-      : !t.startsWith("--sp-") && !t.startsWith("--r-"),
-  );
+  if (!prefix) return toks;
+  return toks.filter((t) => t.startsWith(`--${prefix}`));
 }
 
 export function renderSectionA(appRecords, mockRecords, map) {

--- a/scripts/visual/style-diff.mjs
+++ b/scripts/visual/style-diff.mjs
@@ -111,6 +111,31 @@ const GROUP_OF = {
 };
 
 /**
+ * Which token family is the AUTHORITATIVE match for each property's value
+ * type, used to disambiguate spacing/radius collisions (BET-530).
+ *
+ * `border-radius` takes radius tokens (`--r-*`); `padding-*`/`gap` take
+ * spacing tokens (`--sp-*`). Every OTHER property takes neither — a
+ * `--sp-*`/`--r-*` token matching it is a category error, not a close call
+ * (a 12px font-size is not a `--sp-3|--r-lg` collision). This is ground
+ * truth from the CSS property, not a token-name heuristic.
+ *
+ * A property whose type matches no token family (e.g. font-size, font-weight,
+ * opacity, z-index, line-height) therefore renders as NO match, never as a
+ * bucket and never by falling back to the both-families behaviour.
+ */
+const FAMILY_PREFIX = {
+  "border-radius": "r-",
+  "padding-top": "sp-",
+  "padding-right": "sp-",
+  "padding-bottom": "sp-",
+  "padding-left": "sp-",
+  gap: "sp-",
+  "row-gap": "sp-",
+  "column-gap": "sp-",
+};
+
+/**
  * The browser-default sentinel per property. A property is SKIPPED when BOTH
  * sides sit at the default (otherwise the report is thousands of lines of
  * transparent/0px/normal noise). `null` = never default-skippable (inherited
@@ -353,7 +378,23 @@ function fmtValue(value, map) {
     : `[no token] (${value})`;
 }
 
-function renderSectionA(appRecords, mockRecords, map) {
+/**
+ * Filter a resolved token name-set down to the ones legitimately matching
+ * `prop`'s value type. A property with an explicit family (FAMILY_PREFIX)
+ * keeps only that family's tokens; every other property drops any
+ * `--sp-*`/`--r-*` token (a cross-family category error). An empty result
+ * means "no match" for this property.
+ */
+export function matchFamilyTokens(prop, toks) {
+  const prefix = FAMILY_PREFIX[prop];
+  return toks.filter((t) =>
+    prefix
+      ? t.startsWith(`--${prefix}`)
+      : !t.startsWith("--sp-") && !t.startsWith("--r-"),
+  );
+}
+
+export function renderSectionA(appRecords, mockRecords, map) {
   const counts = new Map(); // group -> side -> token -> count
   const bump = (group, side, token) => {
     if (!counts.has(group)) counts.set(group, new Map());
@@ -372,10 +413,18 @@ function renderSectionA(appRecords, mockRecords, map) {
         if (isPhantomBorderColor(prop, rec.props)) continue;
         const toks = resolveToken(value, map);
         if (!toks) continue;
-        // A value that maps to several colliding tokens is ONE observation —
-        // count the candidate set as a single bucket (`--sp-3|--r-lg`), not
-        // each token separately (which would multiply one element into N).
-        const bucket = toks.length > 1 ? toks.join("|") : toks[0];
+        // Disambiguate spacing/radius collisions by property family (BET-530).
+        // A token family that doesn't match the property's type is a category
+        // error, not a candidate: drop it. If nothing legitimate remains, the
+        // value is "no match" for this property — don't count it and don't
+        // fall back to an honest-but-wrong cross-family bucket.
+        const famToks = matchFamilyTokens(prop, toks);
+        if (famToks.length === 0) continue;
+        // A value that maps to several colliding tokens WITHIN its family is
+        // ONE observation — count the candidate set as a single bucket
+        // (`--sp-a|--sp-b`), not each token separately (which would multiply
+        // one element into N).
+        const bucket = famToks.length > 1 ? famToks.join("|") : famToks[0];
         bump(GROUP_OF[prop], side, bucket);
       }
     }

--- a/scripts/visual/style-diff.test.mjs
+++ b/scripts/visual/style-diff.test.mjs
@@ -11,6 +11,7 @@ const MAP_CSS = `
   --r-lg: 12px;
   --r-xl: 16px;
   --r-sm: 8px;
+  --border-row-px: 8px;
   --color-ink: #111111;
 }
 `;
@@ -46,6 +47,11 @@ test("gap value colliding with spacing+radius keeps only the spacing token", () 
 
 test("a value whose family matches no token renders as NO match, not a filtered-empty bucket", () => {
   const out = render({ "font-size": "12px" });
+  assert.equal(out, "No token-mapped styling on either side.");
+});
+
+test("a no-family property is NO match even when a non-spacing non-radius token shares its value", () => {
+  const out = render({ "font-size": "8px" });
   assert.equal(out, "No token-mapped styling on either side.");
 });
 

--- a/scripts/visual/style-diff.test.mjs
+++ b/scripts/visual/style-diff.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildTokenMap, renderSectionA } from "./style-diff.mjs";
+
+const MAP_CSS = `
+:root {
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-a: 8px;
+  --sp-b: 8px;
+  --r-lg: 12px;
+  --r-xl: 16px;
+  --r-sm: 8px;
+  --color-ink: #111111;
+}
+`;
+
+const map = buildTokenMap(MAP_CSS);
+
+function rec(props) {
+  return { role: "x", ordinal: 1, props };
+}
+
+/** Render Section A for one app record (no mockup) and return the text. */
+function render(props) {
+  return renderSectionA([rec(props)], [], map);
+}
+
+test("border-radius value colliding with spacing+radius keeps only the radius token", () => {
+  const out = render({ "border-radius": "12px" });
+  assert.match(out, /--r-lg ×1/);
+  assert.doesNotMatch(out, /--sp-3/);
+});
+
+test("padding value colliding with spacing+radius keeps only the spacing token", () => {
+  const out = render({ "padding-top": "12px" });
+  assert.match(out, /padding-\*[\s\S]*--sp-3 ×1/);
+  assert.doesNotMatch(out, /--r-lg/);
+});
+
+test("gap value colliding with spacing+radius keeps only the spacing token", () => {
+  const out = render({ gap: "16px" });
+  assert.match(out, /gap[\s\S]*--sp-4 ×1/);
+  assert.doesNotMatch(out, /--r-xl/);
+});
+
+test("a value whose family matches no token renders as NO match, not a filtered-empty bucket", () => {
+  const out = render({ "font-size": "12px" });
+  assert.equal(out, "No token-mapped styling on either side.");
+});
+
+test("two colliding tokens WITHIN the spacing family still bucket honestly", () => {
+  const out = render({ "padding-top": "8px" });
+  assert.match(out, /--sp-a\|--sp-b ×1/);
+});
+
+test("an unambiguous token (colour) is untouched by family filtering", () => {
+  const out = render({ color: "#111111" });
+  assert.match(out, /--color-ink ×1/);
+});


### PR DESCRIPTION
## BET-530 — disambiguate spacing/radius token collisions by property family in style-diff Section A

`renderSectionA` in `scripts/visual/style-diff.mjs` previously bucketed a value that resolved to several tokens as a single honest `--sp-3|--r-lg` bucket (BET-525 behaviour). This change disambiguates by **CSS property** — ground truth, not a token-name heuristic:

- `border-radius` → keeps only radius tokens (`--r-*`)
- `padding-*` / `gap` / `row-gap` / `column-gap` → keeps only spacing tokens (`--sp-*`)
- properties whose value type matches **no** token family (`font-size`, `font-weight`, `line-height`, `letter-spacing`, `opacity`; `z-index` is named in the issue but isn't a tracked property) → **no match** — the value is dropped entirely, never a bucket and never a fall-through to another family.

So `border-radius: 12px` → `--r-lg` (not `--sp-3|--r-lg`), `padding-top: 12px` → `--sp-3`, and the reported bug where a `12px` **font-size** collided with `--sp-3|--r-lg` now correctly renders as *no token match at all* (the report no longer asserts a relationship that doesn't exist).

New pure helper `matchFamilyTokens(prop, toks)` + `renderSectionA` is now exported, with a `node:test` suite (`scripts/visual/style-diff.test.mjs`, wired into `npm test` via the `scripts/visual/*.test.mjs` glob) pinning the disambiguation and the within-family honest-bucket behaviour.

**Files changed:** 3 — `scripts/visual/style-diff.mjs`, `scripts/visual/style-diff.test.mjs` (new), `package.json` (add the visual test glob).

**Base:** `origin/main` @ `8c313cf`

**Verification results:**
- typecheck: exit 0, no errors.
- test: exit 0, 1353 pass / 0 fail / 0 skip (7 new in `scripts/visual/style-diff.test.mjs`).

No product code, no baselines — confined to the reporting script as scoped.
