### PR TITLE
SessionRow spec off-grid px → explicit 1c allow-list (BET-547)

### DIFF
--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -109,7 +109,19 @@ function offendingLines(content: string, re: RegExp): string[] {
 // primitive asserts its rule ACTIVELY, so a regression (a deleted import, a
 // pasted raw literal) fails loudly instead of silently passing.
 const UNDER_ADOPTED: Set<string> = new Set(["IconButton", "Field", "MenuItem", "SessionRow"]);
-const RAW_PX_EXCEPTION: Set<string> = new Set(["SessionRow"]);
+
+// Spec-authorized off-grid px values, per primitive, that rule 1c consults
+// instead of skipping the primitive (BET-547). SessionRow's .srow chrome is
+// owner-accepted spec chrome, NOT off-grid drift — BET-536 C6 ("off-grid spec
+// chrome — spec+pre-existing, not invented"): the 7px status dot, 3px ring,
+// -8px selection marker, 13px child connectors, 26px child indent and 20px age
+// slot are real values from the redesign spec's `.srow` definition. A value
+// listed here is spec chrome; a value NOT listed fails 1c and is reported
+// verbatim, so the rule stays active — it just has a documented allow-list for
+// the one spec-authorized component.
+const OFF_GRID_PX_ALLOWLIST: Record<string, number[]> = {
+  SessionRow: [3, 7, 8, 13, 20, 26],
+};
 
 const SKIP_REASON: Record<string, string> = {
   IconButton:
@@ -118,8 +130,6 @@ const SKIP_REASON: Record<string, string> = {
     "1 adopting file (Settings.tsx) today — BET-533 migrated four call sites, all in Settings. Reaching 2 needs a Field call site migrated from another file (BET-533 named CustomProviderForm.tsx / ConnectProvider.tsx as future adopters).",
   MenuItem:
     "1 adopting file (SessionHeader.tsx) today — the three variants are all in the one session menu. Reaching 2 needs a second role=menu surface that adopts MenuItem.",
-  SessionRow_rawpx:
-    "the .srow metrics (7px dot, 3px ring, 13px connector, 26px child indent, 20px age slot) are spec-authorized off-grid values, NOT on the spacing grid by design (BET-536 C6). Incapable of token-expression today; un-skip if/when a token or scale captures them.",
 };
 
 describe("M527 primitive rules", () => {
@@ -164,32 +174,28 @@ describe("M527 primitive rules", () => {
   describe("1c — no raw colour / off-grid px in the primitive's own code", () => {
     for (const p of PRIMITIVES) {
       const label = `${p} code has no raw colour or off-grid pixel literal`;
-      if (RAW_PX_EXCEPTION.has(p)) {
-        // SessionRow's .srow metrics are spec-authorized off-grid values; un-skip
-        // if/when a token captures them.
-        it.skip(label, () => {
-          void SKIP_REASON[p + "_rawpx"];
+      it(label, () => {
+        const code = sourceCode(p);
+        const hex = offendingLines(code, /#[0-9a-fA-F]{3,8}\b/);
+        const rgba = offendingLines(code, /rgba?\(/);
+        const allowed = OFF_GRID_PX_ALLOWLIST[p] ?? [];
+        const px = offendingLines(code, /\b\d+px\b/).filter((line) => {
+          const values = [...line.matchAll(/\d+px/g)].map((m) => parseInt(m[0], 10));
+          return values.some((v) => !allowed.includes(v));
         });
-      } else {
-        it(label, () => {
-          const code = sourceCode(p);
-          const hex = offendingLines(code, /#[0-9a-fA-F]{3,8}\b/);
-          const rgba = offendingLines(code, /rgba?\(/);
-          const px = offendingLines(code, /\b\d+px\b/);
-          expect(
-            hex,
-            `${p} [rule 1c — raw colour] has no raw hex; offending line(s): ${hex.join(" | ") || "none"}`,
-          ).toEqual([]);
-          expect(
-            rgba,
-            `${p} [rule 1c — raw colour] has no rgba(); offending line(s): ${rgba.join(" | ") || "none"}`,
-          ).toEqual([]);
-          expect(
-            px,
-            `${p} [rule 1c — off-grid px] has no \`\\d+px\`; offending line(s): ${px.join(" | ") || "none"}`,
-          ).toEqual([]);
-        });
-      }
+        expect(
+          hex,
+          `${p} [rule 1c — raw colour] has no raw hex; offending line(s): ${hex.join(" | ") || "none"}`,
+        ).toEqual([]);
+        expect(
+          rgba,
+          `${p} [rule 1c — raw colour] has no rgba(); offending line(s): ${rgba.join(" | ") || "none"}`,
+        ).toEqual([]);
+        expect(
+          px,
+          `${p} [rule 1c — off-grid px] has no px value off the spec allow-list; offending line(s): ${px.join(" | ") || "none"}`,
+        ).toEqual([]);
+      });
     }
   });
 });


### PR DESCRIPTION
## BET-547 — SessionRow spec off-grid px → explicit 1c allow-list

Replaces BET-541's `it.skip` for SessionRow's rule **1c** (no raw colour /
off-grid px) with an explicit, documented allow-list the rule consults.

**Resolution: Option B** (explicit allow-list), per the BET-547 dispatch — the
`.srow` values are owner-accepted spec chrome (BET-536 C6), not drift, so no
tokens are added and no rendered chrome changes.

### What changed (`src/renderer/primitives.test.ts`)
- Added `OFF_GRID_PX_ALLOWLIST` (`SessionRow: [3, 7, 8, 13, 20, 26]`) — the
  spec-authorized `.srow` values: 7px dot, 3px ring/radius, -8px selection
  marker, 13px child connectors, 26px child indent, 20px age slot.
- Rule 1c no longer skips SessionRow; it asserts **every** off-grid px in the
  primitive's own code is on the allow-list. A genuinely *new* off-grid value
  fails the test, named with its offending line (preserving BET-541's review
  enhancement). Non-exception primitives keep an empty allow-list, so their
  behaviour is unchanged (any off-grid px fails).
- Removed the dead `RAW_PX_EXCEPTION` set and `SessionRow_rawpx` skip
  justification; no bare `it.skip` remains for SessionRow's 1c.
- Colour checks now also run for SessionRow (they pass — token classes only).

### Rebase note
Rebased onto current `origin/main` after BET-541 (#459) merged. Preserved
BET-541's review fixes: 1b asserts `>=2` adopters and 1c names the offending
line via `offendingLines`. PR diff vs `main` is now only the single
`primitives.test.ts` allow-list delta.

`SessionRow.tsx` and `tokens.css` are byte-for-byte unchanged → visual
baselines cannot move (no renderable change).

**Base: origin/main @ `9df49d6`** (BET-541 merged).

### Verification
- `npm run typecheck`: exit 0, errors none.
- `npm test` (vitest + node:test):
  - vitest: 92 files, 1852 pass / 4 skip / 0 fail.
  - node:test: 1353 pass / 0 fail.
- `primitives.test.ts`: SessionRow 1c now **active**; probe confirmed a new
  un-allowed px value (111px) fails 1c with the offending line named.
- `npm run visual`: unchanged-by-construction (only the test file changed).
