### PR TITLE
BET-546: two-adopter rule — Field + MenuItem reach a 2nd adopting file

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -70,14 +70,15 @@ The bare `.pill` sets only padding, radius and font — no background, no colour
 Primitives that exist today, their adopting files (matching the two-adopter
 count the enforce test asserts, `src/renderer/primitives.test.ts`), and the
 variant axes their props actually accept (read from the props, not the spec).
-A primitive with fewer than two adopting files is under-adopted — see the
-BET-541 findings.
+A primitive with fewer than two adopting files is either under-adopted (see the
+BET-541 findings) or — in the case of SessionRow — a **single-surface
+exemption** owner-approved in BET-546.
 
 | Primitive | File | Adopters | Variants |
 | --- | --- | --- | --- |
 | Card | `src/renderer/Card.tsx` | 2 — `Cards.tsx`, `Settings.tsx` | `danger` (optional); `header`/`actions` slots |
-| IconButton | `src/renderer/IconButton.tsx` | 1 — `SessionHeader.tsx` | `size: md\|lg`; `ariaHaspopup`/`ariaExpanded`/`hook` |
-| Field | `src/renderer/Field.tsx` | 1 — `Settings.tsx` | `type: text\|password\|number`; `mono` (default true); `label`/`help`/`leading` |
+| IconButton | `src/renderer/IconButton.tsx` | 2 — `SessionHeader.tsx`, `NewSessionScreen.tsx` | `size: md\|lg`; `ariaHaspopup`/`ariaExpanded`/`hook` |
+| Field | `src/renderer/Field.tsx` | 2 — `Settings.tsx`, `CustomProviderForm.tsx` | `type: text\|password\|number`; `mono` (default true); `label`/`help`/`leading`/`footer`/`disabled` |
 | Pill | `src/renderer/Pill.tsx` | 2 — `Cards.tsx`, `SessionHeader.tsx` | `tone: neutral\|accent\|warn` (required); `size: meta\|label`; `border` |
-| MenuItem | `src/renderer/MenuItem.tsx` | 1 — `SessionHeader.tsx` | `variant: normal\|danger\|active` |
-| SessionRow | `src/renderer/SessionRow.tsx` | 1 — `Sidebar.tsx` | `status: run\|att\|idle\|ok\|default` (required); `selected`; `child`; `ageStale` |
+| MenuItem | `src/renderer/MenuItem.tsx` | 2 — `SessionHeader.tsx`, `mobile/SessionScreen.tsx` | `variant: normal\|danger\|active` |
+| SessionRow | `src/renderer/SessionRow.tsx` | 1 — `Sidebar.tsx` — **single-surface exemption** (owner-approved, BET-546) | `status: run\|att\|idle\|ok\|default` (required); `selected`; `child`; `ageStale` |

--- a/src/renderer/CustomProviderForm.tsx
+++ b/src/renderer/CustomProviderForm.tsx
@@ -25,6 +25,7 @@ import {
   slugifyProviderId,
   customProviderDraftError,
 } from "./chatUtils";
+import { Field } from "./Field";
 
 const ACCENT_SOLID = "var(--accent-solid)";
 const DANGER = "var(--danger)";
@@ -332,29 +333,26 @@ function CustomInput(props: {
   onReset?: () => void;
 }) {
   return (
-    <label className="flex flex-col gap-1">
-      {props.label && (
-        <span className="text-label text-text-muted">{props.label}</span>
-      )}
-      <input
-        type={props.type ?? "text"}
-        autoComplete="off"
-        spellCheck={false}
-        placeholder={props.placeholder}
-        value={props.value}
-        disabled={props.disabled}
-        onChange={(e) => props.onChange(e.target.value)}
-        className="w-full rounded bg-bg border border-border px-3 py-2 text-body text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
-      />
-      {props.onReset && (
-        <button
-          type="button"
-          onClick={props.onReset}
-          className="text-micro text-text-faint underline decoration-dotted hover:text-text self-start"
-        >
-          Edit details
-        </button>
-      )}
-    </label>
+    <Field
+      label={props.label}
+      ariaLabel={props.placeholder}
+      placeholder={props.placeholder}
+      value={props.value}
+      type={props.type ?? "text"}
+      mono={false}
+      disabled={props.disabled}
+      onChange={(e) => props.onChange(e.target.value)}
+      footer={
+        props.onReset ? (
+          <button
+            type="button"
+            onClick={props.onReset}
+            className="text-micro text-text-faint underline decoration-dotted hover:text-text self-start"
+          >
+            Edit details
+          </button>
+        ) : undefined
+      }
+    />
   );
 }

--- a/src/renderer/Field.tsx
+++ b/src/renderer/Field.tsx
@@ -57,6 +57,8 @@ type FieldProps = {
   mono?: boolean;
   /** An icon rendered flush to the left of the value; adds the leading inset. */
   leading?: ReactNode;
+  /** Disabled the native input (e.g. while a probe is in flight). */
+  disabled?: boolean;
   /** A ref to the native input (e.g. to focus/select it on mount). */
   inputRef?: Ref<HTMLInputElement>;
 };
@@ -83,6 +85,7 @@ export function Field({
   autoComplete,
   mono = true,
   leading,
+  disabled = false,
   inputRef,
 }: FieldProps) {
   // sp-3 / sp-4 = 12px vertical / 16px horizontal. A leading icon replaces the
@@ -117,6 +120,7 @@ export function Field({
           ref={inputRef}
           autoComplete={autoComplete}
           spellCheck={false}
+          disabled={disabled}
           className={`${INPUT_BASE} ${inset} ${fontCls}`}
         />
       </div>

--- a/src/renderer/mobile/SessionScreen.tsx
+++ b/src/renderer/mobile/SessionScreen.tsx
@@ -3,6 +3,7 @@ import { MoreHorizontal } from "lucide-react";
 import { useStore, resolveSessionOwner } from "../store";
 import { ChatPanel } from "../ChatPanel";
 import { Terminal } from "../Terminal";
+import { MenuItem } from "../MenuItem";
 import { KeyboardBar } from "./KeyboardBar";
 import {
   type SessionMode,
@@ -391,12 +392,12 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
                 </div>
               </div>
             ) : (
-              <>
-                <button onClick={startRename}>Rename</button>
+              <div role="menu">
+                <MenuItem onSelect={startRename}>Rename</MenuItem>
                 {sid && (
                   <>
-                    <button
-                      onClick={() => {
+                    <MenuItem
+                      onSelect={() => {
                         // iOS only opens the picker from a user gesture — the click
                         // on the hidden input must happen synchronously in this
                         // tap handler (BET-260).
@@ -405,11 +406,11 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
                       }}
                     >
                       Attach photo or file…
-                    </button>
-                    <button onClick={forkSession}>Fork session</button>
-                    <button onClick={compactSession}>Compact context</button>
-                    <button
-                      onClick={() => {
+                    </MenuItem>
+                    <MenuItem onSelect={forkSession}>Fork session</MenuItem>
+                    <MenuItem onSelect={compactSession}>Compact context</MenuItem>
+                    <MenuItem
+                      onSelect={() => {
                         // Open the ScheduledTasksCard inside ChatPanel via the
                         // window CustomEvent bridge (the sheet is outside it).
                         window.dispatchEvent(
@@ -423,9 +424,9 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
                       {scheduleCount > 0
                         ? `Scheduled tasks · ${scheduleCount}`
                         : "Scheduled tasks"}
-                    </button>
-                    <button
-                      onClick={() => {
+                    </MenuItem>
+                    <MenuItem
+                      onSelect={() => {
                         // Open the SecretsCard inside ChatPanel via the window
                         // CustomEvent bridge (mirror of manta-open-schedules).
                         window.dispatchEvent(
@@ -437,9 +438,9 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
                       }}
                     >
                       Secrets
-                    </button>
-                    <button
-                      onClick={() => {
+                    </MenuItem>
+                    <MenuItem
+                      onSelect={() => {
                         // Open the WebhooksCard inside ChatPanel via the window
                         // CustomEvent bridge (mirror of manta-open-schedules).
                         window.dispatchEvent(
@@ -451,19 +452,19 @@ export function SessionScreen({ projectName, windowIndex, onBack }: Props) {
                       }}
                     >
                       Webhooks
-                    </button>
-                    <button className="danger" onClick={deleteSession}>
+                    </MenuItem>
+                    <MenuItem variant="danger" onSelect={deleteSession}>
                       Delete session
-                    </button>
+                    </MenuItem>
                   </>
                 )}
                 {!sid && (
-                  <button className="danger" onClick={killWindow}>
+                  <MenuItem variant="danger" onSelect={killWindow}>
                     Kill window
-                  </button>
+                  </MenuItem>
                 )}
-                <button onClick={closeSheet}>Cancel</button>
-              </>
+                <MenuItem onSelect={closeSheet}>Cancel</MenuItem>
+              </div>
             )}
           </div>
         </div>

--- a/src/renderer/mobile/mobile.css
+++ b/src/renderer/mobile/mobile.css
@@ -397,7 +397,8 @@ body,
 .mobile-sheet button:active {
   background: var(--card);
 }
-.mobile-sheet button.danger {
+.mobile-sheet button.danger,
+.mobile-sheet button.text-danger {
   color: var(--danger);
 }
 

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -103,12 +103,20 @@ function offendingLines(content: string, re: RegExp): string[] {
   return out;
 }
 
-// Genuine gaps this cell surfaces (reported as findings — the epic delivered
-// call-site adopters within a single file, and SessionRow carries spec-.srow
-// metrics). Only these are skipped, with justifications below; every OTHER
-// primitive asserts its rule ACTIVELY, so a regression (a deleted import, a
-// pasted raw literal) fails loudly instead of silently passing.
-const UNDER_ADOPTED: Set<string> = new Set(["IconButton", "Field", "MenuItem", "SessionRow"]);
+// Bet-546 landed the second adopting files for IconButton (NewSessionScreen,
+// BET-538), Field (CustomProviderForm) and MenuItem (the mobile SessionScreen ⋯
+// sheet), so all three now assert the two-adopter rule ACTIVELY.
+//
+// SINGLE_SURFACE is a FORMAL, owner-approved exemption from the two-adopter
+// rule (BET-546, option (a) confirmed by the owner 2026-08-01) — not a pending
+// finding. SessionRow is a density-scoped primitive (C2): its metrics resolve
+// only under a [data-density] ancestor, and the sole density-scoped session-row
+// surface in the renderer is the desktop rail (Sidebar.tsx). The only other
+// session list (mobile/SessionListScreen) is chrome-incompatible (56px two-line
+// rows, no [data-density] scope), so adopting the primitive there is a redesign,
+// not a no-visual-change migration. Its 2nd adopter is deferred to the BET-527
+// mobile-consolidation follow-up.
+const SINGLE_SURFACE: Set<string> = new Set(["SessionRow"]);
 
 // Spec-authorized off-grid px values, per primitive, that rule 1c consults
 // instead of skipping the primitive (BET-547). SessionRow's .srow chrome is
@@ -124,12 +132,8 @@ const OFF_GRID_PX_ALLOWLIST: Record<string, number[]> = {
 };
 
 const SKIP_REASON: Record<string, string> = {
-  IconButton:
-    "1 adopting file (SessionHeader.tsx) today — BET-532 migrated two call sites IN that one file. A second file (NewSessionScreen) is already tracked in BET-538; un-skip when it lands.",
-  Field:
-    "1 adopting file (Settings.tsx) today — BET-533 migrated four call sites, all in Settings. Reaching 2 needs a Field call site migrated from another file (BET-533 named CustomProviderForm.tsx / ConnectProvider.tsx as future adopters).",
-  MenuItem:
-    "1 adopting file (SessionHeader.tsx) today — the three variants are all in the one session menu. Reaching 2 needs a second role=menu surface that adopts MenuItem.",
+  SessionRow:
+    "single-density-surface primitive: 1 adopting file (Sidebar.tsx) — the only [data-density]-scoped session-row surface. The second session list (mobile/SessionListScreen) uses incompatible card chrome (56px two-line rows, no [data-density] ancestor), so adopting the primitive there is a redesign, not a no-visual-change migration. Owner-approved formal exemption from the two-adopter rule (BET-546); 2nd adopter deferred to the BET-527 follow-up.",
 };
 
 describe("M527 primitive rules", () => {
@@ -152,10 +156,9 @@ describe("M527 primitive rules", () => {
   describe("1b — two-adopter rule (standing decision 2)", () => {
     for (const p of PRIMITIVES) {
       const label = `${p} has at least two adopting files`;
-      if (UNDER_ADOPTED.has(p)) {
-        // Under-adopted at baseline — an epic finding, NOT fixed in this cell
-        // ("If a primitive has fewer than two, report it"). Un-skip when a
-        // second adopting file lands.
+      if (SINGLE_SURFACE.has(p)) {
+        // Owner-approved formal exemption from the two-adopter rule as a
+        // single-density-surface primitive (BET-546) — see SINGLE_SURFACE.
         it.skip(label, () => {
           void SKIP_REASON[p];
         });


### PR DESCRIPTION
## BET-546 — two-adopter rule: Field + MenuItem reach a 2nd adopting file (IconButton via BET-538)

Rebased onto current `origin/main` (BET-541 enforce test + BET-547 spec allow-list already merged); the redundant stacked test bundle is dropped. **Ready for review.**

### Changes (6 files)
- `src/renderer/Field.tsx` — add a native `disabled?: boolean` prop (pass-through to the input; mirrors the existing `min`/`max`/`autoComplete` native props, not a chrome escape hatch).
- `src/renderer/CustomProviderForm.tsx` — migrate `CustomInput` (name / baseURL / API-key inputs — the epic-named BET-533 future adopter) onto `<Field>`. 2nd adopting file for Field (with `Settings.tsx`).
- `src/renderer/mobile/SessionScreen.tsx` + `mobile/mobile.css` — migrate the mobile `⋯` session-action sheet onto the `MenuItem` primitive (`role="menu"` container; actions become `role="menuitem"`). 2nd `role="menu"` surface (with `SessionHeader`). `.mobile-sheet button` keeps controlling the sheet chrome; `.mobile-sheet button.text-danger` preserves the red Delete/Kill rows (MenuItem has no `className`-based danger marker).
- `src/renderer/primitives.test.ts` — **IconButton / Field / MenuItem now assert the two-adopter rule actively** (each has 2 adopting files). **SessionRow keeps an owner-approved `SINGLE_SURFACE` exemption** (option (a), confirmed by Antoine 2026-08-01): density-scoped primitive (C2), sole compatible surface = the desktop rail; its 2nd adopter is deferred to the BET-527 mobile-consolidation follow-up. IconButton's un-skip is **not** duplicated — the merged BET-541 test still had it in the under-adopted set, so this PR is the only place it is un-skipped (it genuinely has 2 adopters via BET-538's `NewSessionScreen` migration).
- `docs/components.md` — Adopters column reflects the final state (IconButton 2, Field 2, MenuItem 2; SessionRow 1 + single-surface exemption).

### Verification results (head `84603bb`)
- typecheck: exit 0, no errors.
- `npm test`: vitest **1855 passed / 1 skipped** (the skip = SessionRow exemption); node:test 1353 passed / 0 fail. `primitives.test.ts` in isolation: 17 pass / 1 skip.
- `npm run visual`: **14 passed**, no baseline moved (custom-provider form is not a captured screen; mobile sheet is outside the desktop visual suite).

### Notes
- No visual baseline moved; the mobile `⋯` sheet is outside the desktop visual suite, so review should spot-check it post-merge.
- Mobile changes (`SessionScreen.tsx`, `mobile.css`) can't be pixel-verified on-device here.
