### PR TITLE
fix(visual): read the redesign spec from the repo, not an expiring URL

### DIFF
--- a/docs/screens/redesign-spec.html
+++ b/docs/screens/redesign-spec.html
@@ -1,0 +1,2820 @@
+<!--
+  ARCHIVED DESIGN RECORD — MantaUI 2.0 redesign spec.
+
+  Committed copy of the page that was served at
+  /pages/manta-redesign. Served pages expire (they are swept at their TTL and
+  nothing in git holds them), and this file is read by
+  scripts/visual/companion.mjs, which is committed and has an npm command.
+  A design record behind an expiring URL is self-contained until it is not.
+
+  Refresh it deliberately:
+      node scripts/visual/companion.mjs --source <url>     # verify a new spec renders
+      curl -s <url> -o docs/screens/redesign-spec.html      # then archive it
+
+  NOTE ON TOKENS: this file carries its own :root, a SNAPSHOT of the design's
+  values. The live source of truth is src/renderer/tokens.css. The two were
+  audited identical except the shadow scale — dark 29/29, light 29/32, root
+  18/21 (whitespace + font-stack fallbacks). The shadow divergence is a real
+  open design decision, tracked as C5 in docs/components.md and settled by the
+  shadow-scale cell of the desktop design epic. Do not "reconcile" it here.
+-->
+<!doctype html>
+<html lang="en" data-theme="dark" data-density="comfortable">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MantaUI 2.0 — Redesign Spec (v2)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+/* ============================================================
+   LOCKED PALETTE — warm-neutral light, manta-cool dark,
+   ONE shared accent hue. All 40 contrast checks pass.
+   ============================================================ */
+[data-theme="dark"]{
+  --canvas:#0B1020; --panel:#0F1526; --card:#151C33; --raised:#1C2440; --inset:#070B16;
+  --border-subtle:#222C49; --border:#33406B; --border-strong:#5E6C9B;
+  --tx1:#F2F5FA; --tx2:#BDC7DB; --tx3:#939FB8; --tx4:#6B7690;
+  --accent:#5A88FF; --accent-tx:#7BA0FF; --accent-solid:#5A88FF; --on-accent:#0B1020;
+  --ok:#3DD9A4; --warn:#F0A934; --danger:#FF6B7A; --info:#49D7F5;
+  --ok-bg:#3DD9A41f; --warn-bg:#F0A9341f; --danger-bg:#FF6B7A1f; --accent-bg:#5A88FF1f;
+  --fill:rgba(255,255,255,.04); --fill-hover:rgba(255,255,255,.07); --fill-active:rgba(255,255,255,.10);
+  --shadow-sm:0 1px 2px rgba(0,0,0,.4); --shadow-md:0 8px 24px rgba(0,0,0,.5); --shadow-lg:0 20px 56px rgba(0,0,0,.6);
+  --diff-add:#12351f; --diff-del:#3a1720;
+}
+[data-theme="light"]{
+  --canvas:#FAF9F7; --panel:#F2F0EC; --card:#FFFFFF; --raised:#EAE7E1; --inset:#F5F3EF;
+  --border-subtle:#E8E4DD; --border:#DAD5CC; --border-strong:#857C6E;
+  --tx1:#1A1815; --tx2:#48433C; --tx3:#665F55; --tx4:#8A8275;
+  --accent:#2E6BFF; --accent-tx:#1F55D6; --accent-solid:#1F55D6; --on-accent:#FFFFFF;
+  --ok:#0A7A53; --warn:#8A5A08; --danger:#BE2F3C; --info:#0B6E85;
+  --ok-bg:#0A7A5314; --warn-bg:#8A5A0814; --danger-bg:#BE2F3C14; --accent-bg:#2E6BFF14;
+  --fill:rgba(26,24,21,.035); --fill-hover:rgba(26,24,21,.06); --fill-active:rgba(26,24,21,.09);
+  --shadow-sm:0 1px 2px rgba(26,24,21,.06); --shadow-md:0 8px 24px rgba(26,24,21,.10); --shadow-lg:0 20px 56px rgba(26,24,21,.14);
+  --diff-add:#E4F4E9; --diff-del:#FCEAEC;
+}
+:root{
+  --font-sans:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;
+  --font-mono:'JetBrains Mono','SF Mono',ui-monospace,Menlo,monospace;
+  /* SPACING — 4px base grid. Nothing in the app uses a value outside this. */
+  --sp-1:4px; --sp-2:8px; --sp-3:12px; --sp-4:16px; --sp-5:20px; --sp-6:24px;
+  --sp-8:32px; --sp-10:40px; --sp-12:48px;
+  /* VERTICAL RHYTHM — the two numbers the transcript is built from */
+  --block-gap:var(--sp-3);   /* between ANY two siblings inside one turn */
+  --turn-gap:var(--sp-6);    /* between turns */
+  --r-xs:4px; --r-sm:6px; --r-md:8px; --r-lg:12px; --r-xl:16px; --r-full:999px;
+  --ease:cubic-bezier(.22,1,.36,1);
+  --measure:72ch;
+}
+[data-density="comfortable"]{--row-h:32px;--row-px:10px;--row-py:6px;--prose-lh:1.55;--ui-lh:1.45;}
+[data-density="compact"]{--row-h:26px;--row-px:8px;--row-py:3px;--prose-lh:1.5;--ui-lh:1.35;}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{background:var(--canvas);color:var(--tx1);font:400 15px/var(--ui-lh) var(--font-sans);
+  -webkit-font-smoothing:antialiased;transition:background .25s var(--ease),color .25s var(--ease)}
+code,kbd,pre,.mono{font-family:var(--font-mono)}
+a{color:var(--accent-tx)}
+h1,h2,h3,h4{margin:0;line-height:1.25;letter-spacing:-.015em}
+
+/* ---- icons: one sprite, no emoji ---- */
+.ic{width:16px;height:16px;stroke:currentColor;fill:none;stroke-width:2;
+    stroke-linecap:round;stroke-linejoin:round;flex-shrink:0;display:block}
+.ic.s{width:14px;height:14px}
+.ic.xs{width:12px;height:12px;stroke-width:2.2}
+
+/* ---- page chrome ---- */
+.topbar{position:sticky;top:0;z-index:50;display:flex;align-items:center;gap:var(--sp-4);
+  padding:var(--sp-2) var(--sp-5);background:color-mix(in srgb,var(--canvas) 88%,transparent);
+  backdrop-filter:blur(12px);border-bottom:1px solid var(--border-subtle);flex-wrap:wrap}
+.brand{display:flex;align-items:center;gap:9px;font-weight:700;letter-spacing:-.02em;font-size:15px}
+.brand .dot{width:20px;height:20px;border-radius:6px;background:linear-gradient(135deg,var(--accent),color-mix(in srgb,var(--accent) 45%,var(--info)))}
+.brand small{font-weight:500;color:var(--tx3);font-size:12px;letter-spacing:0}
+.seg{display:inline-flex;background:var(--panel);border:1px solid var(--border);border-radius:var(--r-md);padding:2px;gap:2px}
+.seg button{border:0;background:transparent;color:var(--tx3);font:500 12px/1 var(--font-sans);
+  padding:6px 11px;border-radius:var(--r-sm);cursor:pointer;transition:.15s var(--ease);white-space:nowrap}
+.seg button:hover{color:var(--tx1);background:var(--fill)}
+.seg button[aria-pressed="true"]{background:var(--card);color:var(--tx1);box-shadow:var(--shadow-sm)}
+.ctl-label{font:600 11px/1 var(--font-sans);color:var(--tx4);text-transform:uppercase;letter-spacing:.07em;margin-right:-8px}
+nav.sections{display:flex;gap:2px;flex-wrap:wrap;margin-left:auto}
+nav.sections a{font-size:12.5px;font-weight:500;color:var(--tx3);text-decoration:none;padding:6px 10px;border-radius:var(--r-sm)}
+nav.sections a:hover{background:var(--fill);color:var(--tx1)}
+
+main{max-width:1220px;margin:0 auto;padding:0 var(--sp-5) 120px}
+section{padding:var(--sp-12) 0;border-bottom:1px solid var(--border-subtle)}
+section:last-child{border-bottom:0}
+.eyebrow{font:600 11px/1 var(--font-sans);letter-spacing:.1em;text-transform:uppercase;color:var(--accent-tx);margin-bottom:var(--sp-3)}
+h2.sec{font-size:30px;font-weight:700;margin-bottom:var(--sp-2);letter-spacing:-.025em}
+h3.sub{font-size:17px;font-weight:600;margin:var(--sp-8) 0 var(--sp-3)}
+h4.sub2{font:600 12px/1 var(--font-sans);margin:var(--sp-5) 0 var(--sp-2);color:var(--tx3);text-transform:uppercase;letter-spacing:.07em}
+p.lede{font-size:16.5px;line-height:1.65;color:var(--tx2);max-width:70ch;margin:0 0 var(--sp-4)}
+p{font-size:14.5px;line-height:1.65;color:var(--tx2);max-width:74ch;margin:0 0 var(--sp-3)}
+ul.notes{margin:0 0 var(--sp-4);padding-left:var(--sp-5);max-width:74ch}
+ul.notes li{font-size:14.5px;line-height:1.65;color:var(--tx2);margin-bottom:7px}
+strong{color:var(--tx1);font-weight:600}
+.mono-inline{font-family:var(--font-mono);font-size:.9em;background:var(--fill);padding:1px 5px;border-radius:var(--r-xs);color:var(--tx1)}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:var(--sp-5)}
+.grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--sp-4)}
+@media(max-width:900px){.grid2,.grid3{grid-template-columns:1fr}}
+.card{background:var(--panel);border:1px solid var(--border-subtle);border-radius:var(--r-lg);padding:var(--sp-4)}
+.card h4{font-size:14px;font-weight:600;margin:0 0 var(--sp-2)}
+.card p{font-size:13.5px;margin:0;color:var(--tx3)}
+table.spec{width:100%;border-collapse:collapse;font-size:13px;margin:var(--sp-2) 0 var(--sp-5)}
+table.spec th{text-align:left;font:600 11px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.07em;
+  color:var(--tx4);padding:var(--sp-2) var(--sp-3);border-bottom:1px solid var(--border)}
+table.spec td{padding:9px var(--sp-3);border-bottom:1px solid var(--border-subtle);color:var(--tx2);vertical-align:top;line-height:1.5}
+table.spec td:first-child{color:var(--tx1);font-weight:500}
+table.spec tr:last-child td{border-bottom:0}
+.pill{display:inline-block;padding:2px 8px;border-radius:var(--r-full);font:600 11px/1.5 var(--font-sans)}
+.pill.bad{background:var(--danger-bg);color:var(--danger)}
+.pill.good{background:var(--ok-bg);color:var(--ok)}
+.pill.warn{background:var(--warn-bg);color:var(--warn)}
+.pill.info{background:var(--accent-bg);color:var(--accent-tx)}
+.callout{border-left:3px solid var(--accent);background:var(--accent-bg);padding:var(--sp-3) var(--sp-4);
+  border-radius:0 var(--r-md) var(--r-md) 0;margin:var(--sp-4) 0;max-width:78ch}
+.callout p{margin:0;color:var(--tx2);font-size:14px}
+.callout.danger{border-left-color:var(--danger);background:var(--danger-bg)}
+.callout.warn{border-left-color:var(--warn);background:var(--warn-bg)}
+.callout.ok{border-left-color:var(--ok);background:var(--ok-bg)}
+</style>
+</head>
+<body>
+
+<!-- ============ ICON SPRITE (Lucide geometry, ISC) ============ -->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+<symbol id="i-folder" viewBox="0 0 24 24"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></symbol>
+<symbol id="i-branch" viewBox="0 0 24 24"><path d="M6 3v12"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></symbol>
+<symbol id="i-terminal" viewBox="0 0 24 24"><path d="m4 17 6-6-6-6"/><path d="M12 19h8"/></symbol>
+<symbol id="i-plus" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></symbol>
+<symbol id="i-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></symbol>
+<symbol id="i-settings" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/></symbol>
+<symbol id="i-chev-d" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></symbol>
+<symbol id="i-chev-r" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></symbol>
+<symbol id="i-more" viewBox="0 0 24 24"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></symbol>
+<symbol id="i-mic" viewBox="0 0 24 24"><path d="M12 19v3"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><rect x="9" y="2" width="6" height="13" rx="3"/></symbol>
+<symbol id="i-clip" viewBox="0 0 24 24"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></symbol>
+<symbol id="i-send" viewBox="0 0 24 24"><path d="m9 10-5 5 5 5"/><path d="M20 4v7a4 4 0 0 1-4 4H4"/></symbol>
+<symbol id="i-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></symbol>
+<symbol id="i-key" viewBox="0 0 24 24"><path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"/><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/></symbol>
+<symbol id="i-hook" viewBox="0 0 24 24"><path d="M18 16.98h-5.99c-1.1 0-1.95.94-2.48 1.9A4 4 0 0 1 2 17c.01-.7.2-1.4.57-2"/><path d="m6 17 3.13-5.78c.53-.97.1-2.18-.5-3.1a4 4 0 1 1 6.89-4.06"/><path d="m12 6 3.13 5.73C15.66 12.7 16.9 13 18 13a4 4 0 0 1 0 8"/></symbol>
+<symbol id="i-shield" viewBox="0 0 24 24"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/></symbol>
+<symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+<symbol id="i-x" viewBox="0 0 24 24"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></symbol>
+<symbol id="i-pin" viewBox="0 0 24 24"><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/></symbol>
+<symbol id="i-spark" viewBox="0 0 24 24"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z"/></symbol>
+<symbol id="i-home" viewBox="0 0 24 24"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 22V12h6v10"/></symbol>
+<symbol id="i-help" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></symbol>
+<symbol id="i-bot" viewBox="0 0 24 24"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></symbol>
+<symbol id="i-gauge" viewBox="0 0 24 24"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></symbol>
+</defs></svg>
+
+<header class="topbar">
+  <div class="brand"><span class="dot"></span> MantaUI 2.0 <small>spec v2 · decisions locked</small></div>
+  <span class="ctl-label">Theme</span>
+  <div class="seg" id="segTheme">
+    <button data-v="light" aria-pressed="false">Light</button>
+    <button data-v="dark" aria-pressed="true">Dark</button>
+  </div>
+  <span class="ctl-label">Density</span>
+  <div class="seg" id="segDensity">
+    <button data-v="comfortable" aria-pressed="true">Comfortable</button>
+    <button data-v="compact" aria-pressed="false">Compact</button>
+  </div>
+  <nav class="sections">
+    <a href="#locked">Decisions</a><a href="#color">Colour</a><a href="#type">Type</a>
+    <a href="#space">Spacing</a><a href="#icons">Icons</a><a href="#shell">App shell</a><a href="#asks">Ask cards</a>
+    <a href="#sidebar">Sidebar</a><a href="#where">Where things live</a><a href="#jobs">Jobs</a>
+    <a href="#new">New session</a><a href="#picker">Picker</a><a href="#settings">Settings</a><a href="#onboarding">Onboarding</a><a href="#coverage">Coverage gaps</a><a href="#plan">Plan</a>
+  </nav>
+</header>
+
+<main>
+
+<!-- ==================== DECISIONS ==================== -->
+<section id="locked">
+  <div class="eyebrow">Round 2</div>
+  <h2 class="sec">Decisions locked</h2>
+  <p class="lede">
+    Everything below is now spec, not options. The remaining open items are at the bottom and are all small.
+  </p>
+
+  <table class="spec">
+    <tr><th style="width:6%"></th><th style="width:26%">Decision</th><th>Consequence</th></tr>
+    <tr><td>Q1</td><td><strong>Warm-neutral light + manta-cool dark</strong>, one shared blue accent</td>
+      <td><span class="pill good">compatible — and better than either alone</span> The neutrals are tuned per-theme for eye comfort; the <em>accent hue is constant</em>, so the brand never shifts when you flip themes. See the note below.</td></tr>
+    <tr><td>Q2</td><td><strong>Sans for chrome + prose</strong>, mono for code/paths/IDs/metrics</td><td>Inter + JetBrains Mono, both self-hosted.</td></tr>
+    <tr><td>Q3</td><td><strong>Restyle the existing project level</strong>, keep the word "workspace"</td><td>Zero backend change. Rail label becomes <em>Workspaces</em>.</td></tr>
+    <tr><td>Q4</td><td><strong>Comfortable only</strong> for now</td><td>No density setting ships. Tokens stay density-aware so it's a one-line addition later.</td></tr>
+    <tr><td>Q5</td><td><strong>Terminal stays dark in both themes</strong></td><td>No light xterm theme; the pane keeps its own surface.</td></tr>
+    <tr><td>Q6</td><td><strong>Mobile ships in the same PRs</strong></td><td>Every phase carries its <span class="mono-inline">mobile.css</span> counterpart + a device check.</td></tr>
+    <tr><td>Q7</td><td><strong>User messages are right-aligned bubbles</strong></td><td>As mocked.</td></tr>
+    <tr><td>Q8</td><td colspan="2"><strong>Eight corrections applied</strong> — sidebar stripped back, real icons, redesigned permission card, and a formal spacing spec. Detailed below.</td></tr>
+    <tr><td>R3</td><td colspan="2"><strong>Seven further corrections</strong> — tighter leading, a real contrast fix on filled controls, counts and workspace dots removed, pin icon, ask cards at full measure, and a question-card mockup. Listed at the end of the Plan section.</td></tr>
+  </table>
+
+  <div class="callout ok">
+    <p><strong>Why warm light + cool dark works.</strong> They're separate variable blocks, so it's
+    free to implement — but the reason it's <em>good</em> is that the two themes have different jobs.
+    A light UI is read in bright ambient light where a pure-white canvas causes glare, and a slightly
+    warm off-white (<span class="mono-inline">#FAF9F7</span>) measurably reduces it. A dark UI is read at night where
+    cool navy reads as calm and is the manta identity. The trap is letting the <em>accent</em> drift warm
+    in light and cool in dark — then your brand colour changes when the sun goes down. So:
+    <strong>neutrals change temperature, the accent never does.</strong></p>
+  </div>
+
+  <h3 class="sub">Your eight corrections</h3>
+  <table class="spec">
+    <tr><th style="width:34%">You said</th><th>What changed</th></tr>
+    <tr><td>Sidebar as clean as possible — name + status only, no branch</td><td>Rows are back to a single line. Branch, model and workspace subtitles removed.</td></tr>
+    <tr><td>One status indicator, not two</td><td>The trailing badge (<span class="mono-inline">·2</span> / <span class="mono-inline">!</span>) is gone. One dot on the left carries every state.</td></tr>
+    <tr><td>Keep the timer</td><td>Kept, right-aligned, tabular mono. It's the only trailing element.</td></tr>
+    <tr><td>Folder icon looks weird</td><td>All emoji replaced with a real stroked icon set (Lucide geometry) — see the Icons section.</td></tr>
+    <tr><td>Permission card should look more modern</td><td>Redesigned: icon badge, clear title/command hierarchy, proper button ladder.</td></tr>
+    <tr><td>Spacing between text and a tool card is too small</td><td><strong>You found a real bug.</strong> Today it's three different values. Now one. Full spec in the Spacing section.</td></tr>
+    <tr><td>New session: drop the name and the host chip</td><td>"What's up next?" and two chips — folder and branch/worktree.</td></tr>
+    <tr><td>Where do schedules / secrets / webhooks / context / stale-cache live?</td><td>Answered in its own section — they move out of the composer into the session header.</td></tr>
+  </table>
+</section>
+
+<!-- ==================== COLOUR ==================== -->
+<section id="color">
+  <div class="eyebrow">Foundations · 01</div>
+  <h2 class="sec">Colour</h2>
+  <p class="lede">
+    Two themes, one accent hue. Flip the header toggle — this whole document, including every mockup,
+    is driven by these variables. All <strong>40 contrast checks pass</strong> in both themes.
+  </p>
+
+  <style>
+  .swatches{display:grid;grid-template-columns:repeat(auto-fill,minmax(152px,1fr));gap:var(--sp-2);margin:var(--sp-3) 0}
+  .sw{border:1px solid var(--border-subtle);border-radius:var(--r-md);overflow:hidden;background:var(--panel)}
+  .sw .chip{height:52px;display:flex;align-items:flex-end;justify-content:flex-end;padding:6px}
+  .sw .meta{padding:var(--sp-2) 9px;font-size:11px;line-height:1.45}
+  .sw .meta b{display:block;font-size:12px;color:var(--tx1);font-weight:600}
+  .sw .meta code{font-family:var(--font-mono);font-size:10.5px;color:var(--tx3)}
+  .ratio{font:600 10px/1 var(--font-mono);padding:3px 5px;border-radius:var(--r-xs);background:rgba(0,0,0,.4);color:#fff}
+  [data-theme="light"] .ratio{background:rgba(255,255,255,.8);color:#111}
+  </style>
+
+  <h4 class="sub2">Surfaces</h4>
+  <div class="swatches">
+    <div class="sw"><div class="chip" style="background:var(--inset)"></div><div class="meta"><b>inset</b><code>--inset</code><br>code wells</div></div>
+    <div class="sw"><div class="chip" style="background:var(--canvas)"></div><div class="meta"><b>canvas</b><code>--canvas</code><br>app background</div></div>
+    <div class="sw"><div class="chip" style="background:var(--panel)"></div><div class="meta"><b>panel</b><code>--panel</code><br>sidebar</div></div>
+    <div class="sw"><div class="chip" style="background:var(--card)"></div><div class="meta"><b>card</b><code>--card</code><br>cards, popovers</div></div>
+    <div class="sw"><div class="chip" style="background:var(--raised)"></div><div class="meta"><b>raised</b><code>--raised</code><br>active row</div></div>
+  </div>
+
+  <h4 class="sub2">Text &amp; borders — every value clears its floor</h4>
+  <div class="swatches">
+    <div class="sw"><div class="chip" style="background:var(--tx1)"><span class="ratio">17.3 / 16.8</span></div><div class="meta"><b>tx1</b><code>--tx1</code><br>body, headings</div></div>
+    <div class="sw"><div class="chip" style="background:var(--tx2)"><span class="ratio">11.1 / 9.3</span></div><div class="meta"><b>tx2</b><code>--tx2</code><br>supporting copy</div></div>
+    <div class="sw"><div class="chip" style="background:var(--tx3)"><span class="ratio">7.1 / 6.0</span></div><div class="meta"><b>tx3</b><code>--tx3</code><br>meta, hints, paths</div></div>
+    <div class="sw"><div class="chip" style="background:var(--tx4)"><span class="ratio">4.2 / 3.6</span></div><div class="meta"><b>tx4</b><code>--tx4</code><br>decorative only</div></div>
+    <div class="sw"><div class="chip" style="background:var(--border-subtle)"></div><div class="meta"><b>border-subtle</b><code>--border-subtle</code><br>dividers</div></div>
+    <div class="sw"><div class="chip" style="background:var(--border)"></div><div class="meta"><b>border</b><code>--border</code><br>cards, panels</div></div>
+    <div class="sw"><div class="chip" style="background:var(--border-strong)"><span class="ratio">3.7 / 3.9</span></div><div class="meta"><b>border-strong</b><code>--border-strong</code><br>inputs, controls</div></div>
+  </div>
+
+  <h4 class="sub2">Accent &amp; semantics</h4>
+  <div class="swatches">
+    <div class="sw"><div class="chip" style="background:var(--accent)"></div><div class="meta"><b>accent</b><code>--accent</code><br>filled actions</div></div>
+    <div class="sw"><div class="chip" style="background:var(--accent-tx)"><span class="ratio">7.5 / 6.0</span></div><div class="meta"><b>accent-tx</b><code>--accent-tx</code><br>accent <em>as text</em></div></div>
+    <div class="sw"><div class="chip" style="background:var(--ok)"><span class="ratio">10.5 / 5.1</span></div><div class="meta"><b>ok</b><code>--ok</code><br>success, additions</div></div>
+    <div class="sw"><div class="chip" style="background:var(--warn)"><span class="ratio">9.4 / 5.6</span></div><div class="meta"><b>warn</b><code>--warn</code><br>attention, cache</div></div>
+    <div class="sw"><div class="chip" style="background:var(--danger)"><span class="ratio">6.9 / 5.5</span></div><div class="meta"><b>danger</b><code>--danger</code><br>errors, blocking</div></div>
+    <div class="sw"><div class="chip" style="background:var(--info)"><span class="ratio">11.1 / 5.6</span></div><div class="meta"><b>info</b><code>--info</code><br>cache reads</div></div>
+  </div>
+  <p style="font-size:13px;color:var(--tx3)">Ratios shown <span class="mono-inline">dark / light</span>, measured against each theme's canvas. Floors: 4.5:1 for text, 3:1 for UI boundaries. <span class="mono-inline">--tx4</span> is the one tier below and is reserved for text that is always duplicated elsewhere.</p>
+</section>
+
+<!-- ==================== TYPE ==================== -->
+<section id="type">
+  <div class="eyebrow">Foundations · 02</div>
+  <h2 class="sec">Typography</h2>
+  <p class="lede">
+    <strong>Inter</strong> for anything read as language, <strong>JetBrains Mono</strong> for anything
+    where character identity or column alignment matters — code, paths, IDs, diffs, token counts, timers.
+    Seven roles, each with leading baked in. Today there are twelve ad-hoc sizes and no line-height at all.
+  </p>
+
+  <style>
+  .typerow{display:grid;grid-template-columns:120px 1fr;gap:var(--sp-5);padding:var(--sp-3) 0;border-bottom:1px solid var(--border-subtle);align-items:baseline}
+  .typerow:last-child{border-bottom:0}
+  .typerow .k{font:600 11px/1.5 var(--font-mono);color:var(--tx3)}
+  .typerow .k span{display:block;color:var(--tx4);font-weight:400;margin-top:3px}
+  </style>
+  <div class="typerow"><div class="k">display<span>24 / 1.25 / 700</span></div><div style="font:700 24px/1.25 var(--font-sans);letter-spacing:-.02em">Deploy new billing service</div></div>
+  <div class="typerow"><div class="k">title<span>17 / 1.3 / 600</span></div><div style="font:600 17px/1.3 var(--font-sans)">Permission needed</div></div>
+  <div class="typerow"><div class="k">prose<span>15 / 1.55 / 400</span></div><div style="font:400 15px/1.55 var(--font-sans);color:var(--tx1)">The transcript. This is what you spend 95% of your time reading, so it gets the largest comfortable size and the most generous leading.</div></div>
+  <div class="typerow"><div class="k">body<span>14 / 1.5 / 400</span></div><div style="font:400 14px/1.5 var(--font-sans);color:var(--tx2)">Secondary copy, card bodies, settings descriptions.</div></div>
+  <div class="typerow"><div class="k">label<span>13 / 1.4 / 500</span></div><div style="font:500 13px/1.4 var(--font-sans);color:var(--tx1)">Session rows, buttons, menu items</div></div>
+  <div class="typerow"><div class="k">meta<span>12 / 1.4 / 500</span></div><div style="font:500 12px/1.4 var(--font-sans);color:var(--tx3)">Timers · counts · status</div></div>
+  <div class="typerow"><div class="k">micro<span>11 / 1.3 / 600 caps</span></div><div style="font:600 11px/1.3 var(--font-sans);letter-spacing:.08em;text-transform:uppercase;color:var(--tx3)">Section headers</div></div>
+  <div class="typerow"><div class="k">code<span>13 / 1.55 / 400 mono</span></div><div style="font:400 13px/1.55 var(--font-mono);color:var(--tx1)">git worktree list --porcelain</div></div>
+
+  <p style="margin-top:var(--sp-4)">
+    <strong>Measure is capped at 72ch.</strong> Bringhurst's 45–75 characters is the long-standing optimum;
+    today the transcript runs ~150 at 2000px. <strong>Leading:</strong> Butterick puts print body at 120–145%,
+    but screens want more and WCAG 1.4.12 requires content to survive 1.5 — so 1.5 is a floor. Prose gets <strong>1.55</strong> — comfortably clear of the floor without
+    feeling airy in a dense tool — UI chrome 1.45, code 1.55.
+  </p>
+  <div class="callout danger">
+    <p><strong>Both fonts must be bundled.</strong> The renderer's CSP has no font origin and
+    <span class="mono-inline">JetBrains Mono</span> is declared today but never shipped — so every OS silently
+    substitutes. Fix: <span class="mono-inline">@fontsource-variable/inter</span> +
+    <span class="mono-inline">@fontsource-variable/jetbrains-mono</span>, bundled by Vite, same-origin, no CSP change.</p>
+  </div>
+</section>
+
+<!-- ==================== SPACING ==================== -->
+<section id="space">
+  <div class="eyebrow">Foundations · 03</div>
+  <h2 class="sec">Spacing &amp; rhythm</h2>
+  <p class="lede">
+    You called this out and you were right — it's a real bug, not a taste difference, and it's exactly
+    the thing that separates "nice" from "flawless". Here is the full spec.
+  </p>
+
+  <h3 class="sub">The bug you spotted</h3>
+  <p>
+    Inside one assistant turn, three different components each pick their own vertical gap, none of them
+    aware of the others:
+  </p>
+  <table class="spec">
+    <tr><th style="width:32%">Between</th><th style="width:16%">Today</th><th style="width:14%">Set by</th><th>Should be</th></tr>
+    <tr><td>Paragraph → paragraph</td><td><span class="pill bad">4px</span></td><td><span class="mono-inline">mb-1</span> in MarkdownBody</td><td rowspan="3" style="vertical-align:middle;color:var(--tx1);font-weight:600">12px — one value, no exceptions</td></tr>
+    <tr><td>Paragraph → tool card</td><td><span class="pill bad">8px</span></td><td><span class="mono-inline">my-2</span> on the tool</td></tr>
+    <tr><td>Tool card → tool card</td><td><span class="pill bad">8px</span></td><td><span class="mono-inline">my-2</span> on the tool</td></tr>
+    <tr><td>Turn → turn</td><td>12px</td><td><span class="mono-inline">space-y-3</span> on the list</td><td>24px</td></tr>
+  </table>
+  <p>
+    So the gap <em>between turns</em> (12px) is larger than the gap between a paragraph and the tool card
+    it introduces (8px), which is larger than the gap between two paragraphs (4px). The hierarchy is
+    inverted — the transcript reads as one undifferentiated column, and the tool card looks glued to the
+    sentence above it. That's precisely what you saw.
+  </p>
+
+  <h3 class="sub">The rule</h3>
+  <div class="callout">
+    <p><strong>Siblings at the same level get the same gap, regardless of what type they are.</strong>
+    A paragraph, a tool card, a diff and a todo list are all just <em>blocks inside a turn</em> — they get
+    <span class="mono-inline">--block-gap</span>. Turns get <span class="mono-inline">--turn-gap</span>, which is double.
+    Two numbers govern the entire transcript.</p>
+  </div>
+
+  <style>
+  .rhythm{display:grid;grid-template-columns:1fr 1fr;gap:var(--sp-5);margin:var(--sp-4) 0}
+  @media(max-width:800px){.rhythm{grid-template-columns:1fr}}
+  .rbox{border:1px solid var(--border);border-radius:var(--r-lg);padding:var(--sp-4);background:var(--panel)}
+  .rbox .lbl{font:600 10px/1 var(--font-sans);letter-spacing:.09em;text-transform:uppercase;color:var(--tx3);margin-bottom:var(--sp-3);display:flex;justify-content:space-between}
+  .fk-p{font:400 14px/1.6 var(--font-sans);color:var(--tx2)}
+  .fk-c{border:1px solid var(--border-subtle);border-radius:var(--r-md);background:var(--card);padding:8px 11px;font:500 12px/1 var(--font-mono);color:var(--tx2);display:flex;gap:8px;align-items:center}
+  .fk-c b{color:var(--tx1);font-weight:600}
+  .bad-stack>*+*{margin-top:4px}
+  .bad-stack .fk-c+.fk-c{margin-top:8px}
+  .good-stack>*+*{margin-top:var(--block-gap)}
+  </style>
+  <div class="rhythm">
+    <div class="rbox">
+      <div class="lbl"><span>Today</span><span class="pill bad">4 / 8 / 8 px</span></div>
+      <div class="bad-stack">
+        <div class="fk-p">I'll add a streaming CSV export next to the existing list endpoint.</div>
+        <div class="fk-p">Reading the current handler first so the filter logic can be shared.</div>
+        <div class="fk-c"><span style="width:6px;height:6px;border-radius:50%;background:var(--ok)"></span><b>Read</b> app/routes/orders.py</div>
+        <div class="fk-c"><span style="width:6px;height:6px;border-radius:50%;background:var(--ok)"></span><b>Edit</b> app/routes/orders.py</div>
+        <div class="fk-p">The filter block is now shared.</div>
+      </div>
+    </div>
+    <div class="rbox">
+      <div class="lbl"><span>Proposed</span><span class="pill good">12px throughout</span></div>
+      <div class="good-stack">
+        <div class="fk-p">I'll add a streaming CSV export next to the existing list endpoint.</div>
+        <div class="fk-p">Reading the current handler first so the filter logic can be shared.</div>
+        <div class="fk-c"><span style="width:6px;height:6px;border-radius:50%;background:var(--ok)"></span><b>Read</b> app/routes/orders.py</div>
+        <div class="fk-c"><span style="width:6px;height:6px;border-radius:50%;background:var(--ok)"></span><b>Edit</b> app/routes/orders.py</div>
+        <div class="fk-p">The filter block is now shared.</div>
+      </div>
+    </div>
+  </div>
+
+  <h3 class="sub">The scale</h3>
+  <p>4px base grid. <strong>No value outside this scale appears anywhere in the app</strong> — that constraint is what makes spacing consistent by construction rather than by vigilance.</p>
+  <style>
+  .spscale{display:flex;gap:var(--sp-3);flex-wrap:wrap;margin:var(--sp-3) 0 var(--sp-5)}
+  .spu{text-align:center}
+  .spu i{display:block;height:26px;background:var(--accent);opacity:.75;border-radius:2px;margin-bottom:6px}
+  .spu span{font:500 10.5px/1.4 var(--font-mono);color:var(--tx3);display:block}
+  .spu b{font:600 11px/1.4 var(--font-sans);color:var(--tx1);display:block}
+  </style>
+  <div class="spscale">
+    <div class="spu"><i style="width:4px"></i><b>1</b><span>4px</span></div>
+    <div class="spu"><i style="width:8px"></i><b>2</b><span>8px</span></div>
+    <div class="spu"><i style="width:12px"></i><b>3</b><span>12px</span></div>
+    <div class="spu"><i style="width:16px"></i><b>4</b><span>16px</span></div>
+    <div class="spu"><i style="width:20px"></i><b>5</b><span>20px</span></div>
+    <div class="spu"><i style="width:24px"></i><b>6</b><span>24px</span></div>
+    <div class="spu"><i style="width:32px"></i><b>8</b><span>32px</span></div>
+    <div class="spu"><i style="width:40px"></i><b>10</b><span>40px</span></div>
+    <div class="spu"><i style="width:48px"></i><b>12</b><span>48px</span></div>
+  </div>
+
+  <h3 class="sub">Applied spec — every surface</h3>
+  <table class="spec">
+    <tr><th style="width:24%">Surface</th><th style="width:26%">Property</th><th style="width:14%">Token</th><th>Value</th></tr>
+    <tr><td rowspan="4">Transcript</td><td>Between blocks in a turn</td><td><span class="mono-inline">--block-gap</span></td><td><strong>12px</strong> — paragraphs, tool cards, diffs, todos, all of it</td></tr>
+    <tr><td>Between turns</td><td><span class="mono-inline">--turn-gap</span></td><td><strong>24px</strong></td></tr>
+    <tr><td>Column padding</td><td>sp-6 / sp-7</td><td>24px top, 28px sides</td></tr>
+    <tr><td>Measure</td><td><span class="mono-inline">--measure</span></td><td>72ch, centred</td></tr>
+    <tr><td rowspan="3">Cards<br><span style="font-weight:400;color:var(--tx3)">tool, permission, question</span></td><td>Padding</td><td>sp-3 / sp-4</td><td>12px vertical, 16px horizontal</td></tr>
+    <tr><td>Header → body</td><td>sp-3</td><td>12px</td></tr>
+    <tr><td>Body → button row</td><td>sp-4</td><td>16px</td></tr>
+    <tr><td rowspan="4">Sidebar</td><td>Rail padding</td><td>sp-2</td><td>8px</td></tr>
+    <tr><td>Row padding</td><td>sp-2 / sp-3</td><td>6px vertical, 10px horizontal · 32px min height</td></tr>
+    <tr><td>Row → row</td><td>sp-1</td><td>4px — enough to separate, tight enough to read as a list</td></tr>
+    <tr><td>Group → group</td><td>sp-4</td><td>16px</td></tr>
+    <tr><td rowspan="4">Composer</td><td>Chip row → input</td><td>sp-2</td><td>8px</td></tr>
+    <tr><td>Input → meta row</td><td>sp-2</td><td>8px</td></tr>
+    <tr><td>Input padding</td><td>sp-3 / sp-4</td><td>12px / 14px</td></tr>
+    <tr><td>Composer → window edge</td><td>sp-3</td><td>12px</td></tr>
+    <tr><td rowspan="2">Header</td><td>Height / padding</td><td>—</td><td>46px tall, 14px horizontal</td></tr>
+    <tr><td>Item gap</td><td>sp-2</td><td>8px, 16px between groups</td></tr>
+    <tr><td rowspan="2">Controls</td><td>Heights</td><td>—</td><td>26px small · 32px default · 40px large</td></tr>
+    <tr><td>Icon → label</td><td>sp-2</td><td>8px (6px inside chips)</td></tr>
+  </table>
+
+  <div class="callout warn">
+    <p><strong>How this gets enforced, not just documented.</strong> Three things, because a spacing spec
+    that lives only in a doc decays within a month:
+    (1) the Tailwind spacing scale is <em>trimmed</em> to these nine steps so an off-grid value can't be
+    written; (2) the transcript's gaps come from one flex <span class="mono-inline">gap</span> on the turn container
+    rather than per-child margins, so a new block type inherits the right spacing automatically and cannot
+    opt out; (3) <span class="mono-inline">MarkdownBody</span> stops setting its own paragraph margins entirely.</p>
+  </div>
+</section>
+
+<!-- ==================== ICONS ==================== -->
+<section id="icons">
+  <div class="eyebrow">Foundations · 04</div>
+  <h2 class="sec">Icons</h2>
+  <p class="lede">
+    You were right that the folder looked wrong — it was the emoji <span class="mono-inline">🗀</span>, which renders as
+    a different glyph on every platform and can't take a colour. The whole UI currently uses emoji as icons
+    (<span class="mono-inline">⏰ 🔑 🪝 ⚙ 🎙</span>). Replaced with one stroked set at a fixed weight.
+  </p>
+
+  <style>
+  .icgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(104px,1fr));gap:var(--sp-2);margin:var(--sp-4) 0}
+  .icard{border:1px solid var(--border-subtle);border-radius:var(--r-md);padding:var(--sp-3) var(--sp-2);
+    display:flex;flex-direction:column;align-items:center;gap:var(--sp-2);background:var(--panel);color:var(--tx2)}
+  .icard .ic{width:20px;height:20px}
+  .icard span{font:500 10.5px/1 var(--font-mono);color:var(--tx3)}
+  </style>
+  <div class="icgrid">
+    <div class="icard"><svg class="ic"><use href="#i-folder"/></svg><span>folder</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-branch"/></svg><span>branch</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-terminal"/></svg><span>terminal</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-spark"/></svg><span>model</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-gauge"/></svg><span>context</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-clock"/></svg><span>schedules</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-key"/></svg><span>secrets</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-hook"/></svg><span>webhooks</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-shield"/></svg><span>permission</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-help"/></svg><span>question</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-pin"/></svg><span>pin</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-search"/></svg><span>search</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-clip"/></svg><span>attach</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-mic"/></svg><span>voice</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-send"/></svg><span>send</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-settings"/></svg><span>settings</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-more"/></svg><span>more</span></div>
+    <div class="icard"><svg class="ic"><use href="#i-plus"/></svg><span>new</span></div>
+  </div>
+  <ul class="notes">
+    <li><strong>16px at 2px stroke</strong> is the default; 14px for inline-with-text, 20px for standalone buttons. One weight everywhere.</li>
+    <li><strong>They take <span class="mono-inline">currentColor</span></strong>, so an icon inherits its state — muted in a resting row, accent when active, danger in a destructive button. Emoji cannot do this, which is why the current toolbar can't be themed.</li>
+    <li><strong>Tree-shaken imports</strong> via <span class="mono-inline">lucide-react</span> — only the ~25 icons actually used get bundled, roughly 6KB.</li>
+    <li><strong>Emoji stay where they're content</strong>, not chrome — a user's message, a commit body. This is only about UI affordances.</li>
+  </ul>
+</section>
+
+<!-- ==================== APP SHELL ==================== -->
+<section id="shell">
+  <div class="eyebrow">The product · 01</div>
+  <h2 class="sec">App shell</h2>
+  <p class="lede">
+    Live mockup with every round-2 correction applied: stripped-back sidebar, real icons, the corrected
+    12px block rhythm, the redesigned permission card, and session tools moved out of the composer.
+  </p>
+
+<style>
+/* ================= MOCK APP ================= */
+.app{border:1px solid var(--border);border-radius:var(--r-xl);overflow:hidden;box-shadow:var(--shadow-lg);
+  background:var(--canvas);display:grid;grid-template-columns:252px 1fr;height:730px;margin:var(--sp-5) 0 var(--sp-2)}
+@media(max-width:900px){.app{grid-template-columns:1fr;height:auto}.app .rail{display:none}}
+
+/* ---- rail ---- */
+.rail{background:var(--panel);border-right:1px solid var(--border-subtle);display:flex;flex-direction:column;min-width:0}
+.rail-top{height:46px;display:flex;align-items:center;gap:var(--sp-2);padding:0 var(--sp-3);border-bottom:1px solid var(--border-subtle);flex-shrink:0}
+.rail-top .logo{width:18px;height:18px;border-radius:5px;background:linear-gradient(135deg,var(--accent),color-mix(in srgb,var(--accent) 40%,var(--info)))}
+.rail-top .nm{font:600 13px/1 var(--font-sans)}
+.iconbtn{width:28px;height:28px;border-radius:var(--r-sm);border:0;background:transparent;color:var(--tx3);
+  cursor:pointer;display:grid;place-items:center;transition:.15s var(--ease)}
+.iconbtn:hover{background:var(--fill-hover);color:var(--tx1)}
+.iconbtn.r{margin-left:auto}
+.rail-search{padding:var(--sp-2) var(--sp-2) var(--sp-1)}
+.rail-search div{display:flex;align-items:center;gap:var(--sp-2);height:30px;padding:0 9px;border-radius:var(--r-md);
+  background:var(--fill);color:var(--tx3);font:400 12.5px/1 var(--font-sans)}
+.rail-search kbd{margin-left:auto;font:500 10px/1 var(--font-sans);color:var(--tx3);background:var(--card);
+  border:1px solid var(--border);border-radius:var(--r-xs);padding:3px 5px}
+.rail-scroll{flex:1;overflow-y:auto;padding:var(--sp-1) var(--sp-2) var(--sp-3);min-height:0}
+.grp{margin-top:var(--sp-4)}
+.grp:first-child{margin-top:var(--sp-2)}
+.grp-h{display:flex;align-items:center;gap:6px;padding:5px 6px;font:600 11px/1 var(--font-sans);
+  letter-spacing:.08em;text-transform:uppercase;color:var(--tx3);cursor:pointer;border-radius:var(--r-sm)}
+.grp-h:hover{background:var(--fill)}
+.grp-h .ic{width:12px;height:12px;color:var(--tx4);stroke-width:2.5}
+.grp-h .cnt{margin-left:auto;font:500 10px/1 var(--font-mono);color:var(--tx4);letter-spacing:0}
+
+/* ---- SESSION ROW: one line. dot · name · timer. nothing else. ---- */
+.srow{display:flex;align-items:center;gap:var(--sp-2);min-height:var(--row-h);
+  padding:var(--row-py) var(--row-px);border-radius:var(--r-md);cursor:pointer;
+  transition:background .12s var(--ease);position:relative;margin-bottom:var(--sp-1)}
+.srow:last-child{margin-bottom:0}
+.srow:hover{background:var(--fill-hover)}
+.srow.on{background:var(--raised)}
+.srow.on::before{content:"";position:absolute;left:-8px;top:50%;transform:translateY(-50%);
+  width:3px;height:16px;border-radius:0 3px 3px 0;background:var(--accent)}
+.srow .st{width:7px;height:7px;border-radius:50%;flex-shrink:0;background:var(--tx4)}
+.srow .st.run{background:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);animation:pulse 1.6s ease-in-out infinite}
+.srow .st.att{background:var(--danger);box-shadow:0 0 0 3px var(--danger-bg);animation:pulse 1.2s ease-in-out infinite}
+.srow .st.idle{background:var(--warn)}
+.srow .st.ok{background:var(--ok)}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}
+.srow .t{font:500 13px/1.4 var(--font-sans);color:var(--tx2);white-space:nowrap;overflow:hidden;
+  text-overflow:ellipsis;flex:1;min-width:0}
+.srow.on .t{color:var(--tx1);font-weight:600}
+/* Timer: fixed slot so digits never jitter the row. */
+.srow .age{font:500 11px/1 var(--font-mono);color:var(--tx4);flex-shrink:0;
+  font-variant-numeric:tabular-nums;min-width:20px;text-align:right}
+.srow .age.stale{visibility:hidden}
+.srow:hover .age.stale{visibility:visible}
+/* Pin: slot is ALWAYS reserved (18px) so revealing it shifts nothing.
+   Hidden at rest in BOTH sections — membership of "Pinned" is the state signal,
+   the glyph is only the affordance. Filled = pinned, outline = not. */
+.srow .pin{width:18px;height:18px;flex-shrink:0;display:grid;place-items:center;
+  opacity:0;color:var(--tx4);transition:opacity .12s var(--ease),color .12s var(--ease);cursor:pointer}
+.srow:hover .pin,.srow.demo-hover .pin{opacity:1}
+.srow .pin:hover{color:var(--accent-tx)}
+.srow.pinned .pin .ic{fill:currentColor;stroke-width:1.25}
+.srow.pinned:hover .pin,.srow.pinned.demo-hover .pin{color:var(--accent-tx)}
+.rail-foot{border-top:1px solid var(--border-subtle);padding:var(--sp-2) var(--sp-3);display:flex;align-items:center;gap:var(--sp-2);flex-shrink:0}
+.avatar{width:26px;height:26px;border-radius:50%;background:linear-gradient(135deg,var(--accent),var(--info));
+  display:grid;place-items:center;font:600 10px/1 var(--font-sans);color:#fff}
+.rail-foot .who{font:500 12.5px/1.3 var(--font-sans);color:var(--tx2)}
+.rail-foot .plan{font:500 10.5px/1.3 var(--font-mono);color:var(--tx4)}
+
+/* ---- main ---- */
+.mainpane{display:flex;flex-direction:column;min-width:0;background:var(--canvas)}
+.topb{height:46px;display:flex;align-items:center;gap:var(--sp-2);padding:0 var(--sp-3);flex-shrink:0;
+  border-bottom:1px solid var(--border-subtle)}
+.crumb{display:flex;align-items:center;gap:7px;font:500 13px/1 var(--font-sans);color:var(--tx1);min-width:0}
+.crumb .mut{color:var(--tx3)}
+.crumb .slash{color:var(--tx4)}
+.tag{display:inline-flex;align-items:center;gap:5px;height:23px;padding:0 8px;border-radius:var(--r-full);
+  border:1px solid var(--border);background:var(--fill);font:500 11.5px/1 var(--font-mono);color:var(--tx3)}
+.tag .ic{width:12px;height:12px}
+.topb .sp{margin-left:auto;display:flex;align-items:center;gap:var(--sp-2)}
+/* context lives HERE now, not in the composer */
+.ctxpill{display:inline-flex;align-items:center;gap:7px;height:26px;padding:0 9px;border-radius:var(--r-full);
+  border:1px solid var(--border);background:var(--fill);cursor:pointer}
+.ctxpill:hover{border-color:var(--border-strong)}
+.ctxpill .track{width:44px;height:5px;border-radius:3px;background:var(--fill-active);overflow:hidden;display:flex}
+.ctxpill .track i{display:block;height:100%}
+.ctxpill .pct{font:600 11.5px/1 var(--font-mono);color:var(--ok);font-variant-numeric:tabular-nums}
+.badge{position:absolute;top:2px;right:2px;min-width:14px;height:14px;padding:0 3px;border-radius:7px;
+  background:var(--accent);color:var(--on-accent);font:600 9px/14px var(--font-sans);text-align:center}
+
+/* ---- transcript: ONE gap value ---- */
+.scroll{flex:1;overflow-y:auto;padding:var(--sp-6) 0;min-height:0}
+.wrap{max-width:var(--measure);margin:0 auto;padding:0 28px;display:flex;flex-direction:column;gap:var(--turn-gap)}
+.turn{display:flex;flex-direction:column;gap:var(--block-gap)}   /* ← the whole fix, one line */
+.uwrap{display:flex;justify-content:flex-end}
+.umsg{background:var(--fill);border:1px solid var(--border-subtle);border-radius:var(--r-lg);
+  padding:11px var(--sp-4);font:400 15px/1.55 var(--font-sans);color:var(--tx1);max-width:88%}
+.amsg{font:400 15px/var(--prose-lh) var(--font-sans);color:var(--tx1);display:flex;flex-direction:column;gap:var(--block-gap)}
+.amsg p{font:inherit;color:inherit;margin:0;max-width:none}
+.amsg .ic-t{font-family:var(--font-mono);font-size:.86em;background:var(--fill);
+  border:1px solid var(--border-subtle);padding:1px 5px;border-radius:var(--r-xs)}
+
+.tool{border:1px solid var(--border-subtle);border-radius:var(--r-md);background:var(--panel);overflow:hidden}
+.tool-h{display:flex;align-items:center;gap:var(--sp-2);padding:9px var(--sp-3);font:500 12.5px/1 var(--font-mono);color:var(--tx2);cursor:pointer}
+.tool-h .g{width:6px;height:6px;border-radius:50%;background:var(--ok);flex-shrink:0}
+.tool-h .g.run{background:var(--accent);animation:pulse 1.4s ease-in-out infinite}
+.tool-h .nmx{color:var(--tx1);font-weight:600}
+.tool-h .arg{color:var(--tx3);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.tool-h .r{margin-left:auto;font-size:11px;color:var(--tx4);display:flex;gap:var(--sp-2);align-items:center}
+.tool-b{border-top:1px solid var(--border-subtle);background:var(--inset);padding:var(--sp-2) var(--sp-3);
+  font:400 12.5px/1.55 var(--font-mono);color:var(--tx2);white-space:pre;overflow-x:auto}
+.dl{display:block;padding:0 6px;margin:0 -6px;border-radius:2px}
+.dl.add{background:var(--diff-add)}
+.dl.del{background:var(--diff-del)}
+.dl .ln{color:var(--tx4);display:inline-block;width:30px;user-select:none}
+
+/* ---- REDESIGNED ask card ---- */
+.ask{border:1px solid var(--border);border-radius:var(--r-lg);background:var(--card);
+  box-shadow:var(--shadow-md);overflow:hidden}
+.ask-top{display:flex;gap:var(--sp-3);padding:var(--sp-4) var(--sp-4) var(--sp-3)}
+.ask-badge{width:30px;height:30px;border-radius:var(--r-md);display:grid;place-items:center;flex-shrink:0;
+  background:var(--warn-bg);color:var(--warn)}
+.ask-badge .ic{width:16px;height:16px}
+.ask.q .ask-badge{background:var(--accent-bg);color:var(--accent-tx)}
+.ask-txt{min-width:0;flex:1}
+.ask-txt h5{font:600 14px/1.35 var(--font-sans);color:var(--tx1);margin:0 0 2px}
+.ask-txt .sub{font:400 12.5px/1.45 var(--font-sans);color:var(--tx3)}
+.ask-cmd{margin:0 var(--sp-4);padding:9px var(--sp-3);border-radius:var(--r-md);background:var(--inset);
+  border:1px solid var(--border-subtle);font:400 12.5px/1.5 var(--font-mono);color:var(--tx1);overflow-x:auto}
+.ask-acts{display:flex;gap:var(--sp-2);padding:var(--sp-4);flex-wrap:wrap;align-items:center}
+.opt{display:block;width:calc(100% - 32px);margin:0 var(--sp-4) var(--sp-2);padding:10px var(--sp-3);
+  text-align:left;border:1px solid var(--border);border-radius:var(--r-md);background:var(--canvas);
+  font:500 13px/1.4 var(--font-sans);color:var(--tx1);cursor:pointer;transition:.15s var(--ease)}
+.opt:hover{border-color:var(--accent);background:var(--accent-bg)}
+
+.btn{height:32px;padding:0 14px;border-radius:var(--r-md);border:1px solid var(--border);background:var(--canvas);
+  color:var(--tx1);font:500 12.5px/1 var(--font-sans);cursor:pointer;display:inline-flex;align-items:center;
+  gap:6px;transition:.15s var(--ease)}
+.btn:hover{background:var(--raised);border-color:var(--border-strong)}
+.btn.pri{background:var(--accent-solid);border-color:var(--accent-solid);color:var(--on-accent)}
+.btn.pri:hover{filter:brightness(1.08)}
+.btn.ghost{background:transparent;border-color:transparent;color:var(--tx3)}
+.btn.ghost:hover{background:var(--fill-hover);color:var(--tx1)}
+.btn.danger{color:var(--danger);border-color:transparent;background:transparent}
+.btn.danger:hover{background:var(--danger-bg)}
+.btn .ic{width:14px;height:14px}
+.btn.pri .ic{stroke-width:2.8}
+.kbd{font:500 10px/1 var(--font-sans);color:var(--tx4);border:1px solid var(--border);border-radius:3px;padding:2px 4px;margin-left:2px}
+/* On any filled surface the canvas tokens are wrong — derive from currentColor. */
+.btn.pri .kbd{color:currentColor;background:color-mix(in srgb,currentColor 18%,transparent);border-color:transparent;opacity:.92}
+
+/* ---- composer: composing only ---- */
+.composer{flex-shrink:0;padding:0 0 var(--sp-3)}
+.comp-in{max-width:var(--measure);margin:0 auto;padding:0 28px}
+.chiprow{display:flex;align-items:center;gap:7px;margin-bottom:var(--sp-2);flex-wrap:wrap}
+.chip{display:inline-flex;align-items:center;gap:6px;height:29px;padding:0 11px;border-radius:var(--r-md);
+  border:1px solid var(--border);background:var(--card);font:500 12px/1 var(--font-sans);color:var(--tx2);
+  cursor:pointer;transition:.15s var(--ease);white-space:nowrap}
+.chip:hover{border-color:var(--border-strong);color:var(--tx1)}
+.chip .ic{width:13px;height:13px;color:var(--tx3)}
+.chip.split{padding:0;overflow:hidden}
+.chip.split>span{display:inline-flex;align-items:center;gap:6px;height:100%;padding:0 11px}
+.chip.split>span+span{border-left:1px solid var(--border)}
+.chip.on{border-color:var(--accent);background:var(--accent-bg);color:var(--accent-tx)}
+.chip.on .ic{color:var(--accent-tx)}
+.cbx{width:13px;height:13px;border:1.5px solid var(--border-strong);border-radius:3px;display:inline-grid;place-items:center}
+.cbx.on{background:var(--accent-solid);border-color:var(--accent-solid);color:var(--on-accent)}
+.cbx .ic{width:10px;height:10px;stroke-width:4;color:currentColor}
+.cbox{border:1px solid var(--border-strong);border-radius:var(--r-lg);background:var(--card);
+  padding:var(--sp-3) 14px;display:flex;align-items:flex-start;gap:var(--sp-3);transition:.15s var(--ease);box-shadow:var(--shadow-sm)}
+.cbox:focus-within{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg)}
+.cbox .ta{flex:1;font:400 15px/1.55 var(--font-sans);color:var(--tx1);min-height:22px}
+.cbox .ta.ph{color:var(--tx3)}
+.cbox .send{width:28px;height:28px;border-radius:var(--r-sm);border:0;background:var(--fill);color:var(--tx3);
+  display:grid;place-items:center;cursor:pointer;flex-shrink:0}
+.cbox .send.hot{background:var(--accent);color:var(--on-accent)}
+.metarow{display:flex;align-items:center;gap:var(--sp-2);margin-top:var(--sp-2);flex-wrap:wrap}
+.mbtn{display:inline-flex;align-items:center;gap:6px;height:27px;padding:0 8px;border-radius:var(--r-sm);
+  border:0;background:transparent;color:var(--tx3);font:500 12px/1 var(--font-sans);cursor:pointer;transition:.15s var(--ease)}
+.mbtn:hover{background:var(--fill-hover);color:var(--tx1)}
+.mbtn .cnum{font:600 11px/1 var(--font-mono);color:var(--tx2);font-variant-numeric:tabular-nums}
+.msplit{display:inline-flex;align-items:center;border:1px solid var(--border);border-radius:var(--r-md);
+  overflow:hidden;height:28px;background:var(--card)}
+.msplit button{border:0;background:transparent;height:100%;padding:0 10px;font:500 12px/1 var(--font-sans);
+  color:var(--tx2);cursor:pointer;display:inline-flex;align-items:center;gap:5px;transition:.15s var(--ease)}
+.msplit button:hover{background:var(--fill-hover);color:var(--tx1)}
+.msplit button+button{border-left:1px solid var(--border)}
+.msplit .lvl{color:var(--accent-tx);font-weight:600}
+.msplit .ic{width:13px;height:13px}
+.spacer{margin-left:auto}
+.trust{display:inline-flex;align-items:center;gap:6px;font:500 11.5px/1 var(--font-sans);color:var(--tx4);
+  border:0;background:transparent;cursor:pointer;padding:6px 0}
+.trust:hover{color:var(--tx2)}
+.trust .ic{width:13px;height:13px}
+</style>
+
+<div class="app">
+  <!-- ============ RAIL ============ -->
+  <aside class="rail">
+    <div class="rail-top">
+      <span class="logo"></span><span class="nm">Manta</span>
+      <button class="iconbtn r" title="New session"><svg class="ic"><use href="#i-plus"/></svg></button>
+    </div>
+    <div class="rail-search"><div><svg class="ic s"><use href="#i-search"/></svg><span>Search</span><kbd>⌘K</kbd></div></div>
+
+    <div class="rail-scroll">
+      <div class="grp">
+        <div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> Pinned</div>
+        <div class="srow pinned on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">2m</span></div>
+        <div class="srow pinned"><span class="st att"></span><span class="t">Investigate 500s in /api</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">8m</span></div>
+      </div>
+
+      <div class="grp">
+        <div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg>ethernal</div>
+        <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">4m</span></div>
+        <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">2h</span></div>
+        <div class="srow"><span class="st idle"></span><span class="t">Bump deps</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age stale">1d</span></div>
+      </div>
+
+      <div class="grp">
+        <div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg>marketing</div>
+        <div class="srow"><span class="st"></span><span class="t">Landing page copy</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">3h</span></div>
+        <div class="srow"><span class="st"></span><span class="t">Build pipeline</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">5h</span></div>
+      </div>
+
+      <div class="grp">
+        <div class="grp-h"><svg class="ic"><use href="#i-chev-r"/></svg>infra</div>
+      </div>
+    </div>
+
+    <div class="rail-foot">
+      <span class="avatar">AC</span>
+      <span><span class="who">Antoine</span><br><span class="plan">Max · connected</span></span>
+      <button class="iconbtn r" title="Settings"><svg class="ic"><use href="#i-settings"/></svg></button>
+    </div>
+  </aside>
+
+  <!-- ============ MAIN ============ -->
+  <div class="mainpane">
+    <div class="topb">
+      <span class="crumb"><span class="mut">infra</span> <span class="slash">/</span> Deploy new billing service</span>
+      <span class="tag"><svg class="ic"><use href="#i-branch"/></svg> feat/orders-csv</span>
+      <span class="sp">
+        <span class="ctxpill" title="Context 54% — 108k of 200k">
+          <span class="track"><i style="width:34%;background:var(--ok)"></i><i style="width:12%;background:var(--warn)"></i><i style="width:8%;background:var(--info)"></i></span>
+          <span class="pct">54%</span>
+        </span>
+        <button class="iconbtn" title="Terminal"><svg class="ic"><use href="#i-terminal"/></svg></button>
+        <button class="iconbtn" title="Session menu"><svg class="ic"><use href="#i-more"/></svg></button>
+      </span>
+    </div>
+
+    <div class="scroll">
+      <div class="wrap">
+        <div class="uwrap"><div class="umsg">
+          It should accept the same filters as the existing <span class="ic-t">GET /orders</span>
+          and stream the result as CSV. Header row first, then one row per order.
+        </div></div>
+
+        <div class="turn">
+          <div class="amsg">
+            <p>I'll add a streaming CSV export next to the existing list endpoint.</p>
+            <p>Reading the current handler first so the filter logic can be shared rather than duplicated.</p>
+          </div>
+
+          <div class="tool">
+            <div class="tool-h"><span class="g"></span><span class="nmx">Read</span><span class="arg">app/routes/orders.py</span>
+              <span class="r"><span>23 lines</span><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div>
+          </div>
+
+          <div class="tool">
+            <div class="tool-h"><span class="g"></span><span class="nmx">Edit</span><span class="arg">app/routes/orders.py</span>
+              <span class="r"><span style="color:var(--ok)">+38</span><span style="color:var(--danger)">−4</span><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div>
+            <div class="tool-b"><span class="dl"><span class="ln">10</span>@router.get("")</span><span class="dl del"><span class="ln">11</span>−async def list_orders(</span><span class="dl add"><span class="ln">11</span>+async def list_orders(</span><span class="dl"><span class="ln">12</span>    status: str | None = Query(default=None),</span><span class="dl add"><span class="ln">17</span>+) -&gt; list[dict]:</span></div>
+          </div>
+
+          <div class="amsg">
+            <p>The filter block is now shared. The new <span class="ic-t">/export.csv</span> route streams through <span class="ic-t">app/utils/stream.py</span>, so a 100k-row export never lands in memory.</p>
+            <p>Running the migration next — that needs your approval.</p>
+          </div>
+
+          <div class="ask">
+            <div class="ask-top">
+              <span class="ask-badge"><svg class="ic"><use href="#i-shield"/></svg></span>
+              <span class="ask-txt">
+                <h5>Run a shell command?</h5>
+                <span class="sub">Applies the pending Alembic migration to the dev database.</span>
+              </span>
+            </div>
+            <div class="ask-cmd">alembic upgrade head</div>
+            <div class="ask-acts">
+              <button class="btn pri"><svg class="ic"><use href="#i-check"/></svg> Allow once <span class="kbd">⏎</span></button>
+              <button class="btn">Always allow <span style="color:var(--tx3)">alembic</span></button>
+              <span class="spacer"></span>
+              <button class="btn danger"><svg class="ic"><use href="#i-x"/></svg> Reject</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-in">
+        <div class="cbox">
+          <span class="ta ph">Reply, or describe the next task…</span>
+          <button class="send hot"><svg class="ic s"><use href="#i-send"/></svg></button>
+        </div>
+        <div class="metarow">
+          <div class="msplit">
+            <button><svg class="ic"><use href="#i-spark"/></svg> Opus 4.8 <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-d"/></svg></button>
+            <button><span class="lvl">High</span> <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-d"/></svg></button>
+          </div>
+          <button class="mbtn" title="Attach"><svg class="ic s"><use href="#i-clip"/></svg></button>
+          <button class="mbtn" title="Voice"><svg class="ic s"><use href="#i-mic"/></svg></button>
+          <span class="spacer"></span>
+          <button class="mbtn" title="Scheduled tasks"><svg class="ic s"><use href="#i-clock"/></svg> <span class="cnum">2</span></button>
+          <button class="mbtn" title="Secrets"><svg class="ic s"><use href="#i-key"/></svg></button>
+          <button class="mbtn" title="Webhooks"><svg class="ic s"><use href="#i-hook"/></svg></button>
+        </div>
+        <button class="trust"><svg class="ic"><use href="#i-shield"/></svg> Permissions on — click to bypass</button>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+
+<!-- ==================== ASK CARDS ==================== -->
+<section id="asks">
+  <div class="eyebrow">The product · 02</div>
+  <h2 class="sec">Permission &amp; question cards</h2>
+  <p class="lede">
+    Both shown at <strong>the full transcript measure</strong> — same 72ch column as the prose, edge-aligned
+    with the assistant's text. They're part of the conversation, not a floating overlay, so they should
+    never be narrower or wider than the body around them.
+  </p>
+
+  <style>
+  .askdemo{max-width:var(--measure);margin:var(--sp-5) auto;display:flex;flex-direction:column;gap:var(--block-gap)}
+  .askdemo .amsg{font:400 15px/var(--prose-lh) var(--font-sans);color:var(--tx1)}
+  .ask-free{margin:0 var(--sp-4) var(--sp-2);display:flex;align-items:center;gap:var(--sp-2);
+    padding:9px var(--sp-3);border:1px solid var(--border);border-radius:var(--r-md);background:var(--canvas)}
+  .ask-free span{font:400 13px/1.4 var(--font-sans);color:var(--tx3)}
+  .opt.sel{border-color:var(--accent);background:var(--accent-bg)}
+  .opt .mk{width:15px;height:15px;border:1.5px solid var(--border-strong);border-radius:4px;
+    display:inline-grid;place-items:center;margin-right:var(--sp-2);vertical-align:-3px}
+  .opt.sel .mk{background:var(--accent-solid);border-color:var(--accent-solid);color:var(--on-accent)}
+  .opt .mk .ic{width:10px;height:10px;stroke-width:4}
+  </style>
+
+  <div class="askdemo">
+    <div class="amsg"><p>Running the migration next — that needs your approval.</p></div>
+
+    <div class="ask">
+      <div class="ask-top">
+        <span class="ask-badge"><svg class="ic"><use href="#i-shield"/></svg></span>
+        <span class="ask-txt">
+          <h5>Run a shell command?</h5>
+          <span class="sub">Applies the pending Alembic migration to the dev database.</span>
+        </span>
+      </div>
+      <div class="ask-cmd">alembic upgrade head</div>
+      <div class="ask-acts">
+        <button class="btn pri"><svg class="ic"><use href="#i-check"/></svg> Allow once <span class="kbd">⏎</span></button>
+        <button class="btn">Always allow <span style="color:var(--tx3)">alembic</span></button>
+        <span class="spacer"></span>
+        <button class="btn danger"><svg class="ic"><use href="#i-x"/></svg> Reject</button>
+      </div>
+    </div>
+
+    <div class="ask q">
+      <div class="ask-top">
+        <span class="ask-badge"><svg class="ic"><use href="#i-help"/></svg></span>
+        <span class="ask-txt">
+          <h5>How should the export handle deleted orders?</h5>
+          <span class="sub">Soft-deleted rows are still in the table. Pick one or more — I'll apply them to both the JSON and CSV paths.</span>
+        </span>
+      </div>
+      <button class="opt sel"><span class="mk"><svg class="ic"><use href="#i-check"/></svg></span>Exclude them entirely</button>
+      <button class="opt"><span class="mk"></span>Include with a <span class="mono-inline">deleted_at</span> column</button>
+      <button class="opt"><span class="mk"></span>Include only when <span class="mono-inline">?include_deleted=true</span></button>
+      <div class="ask-free"><svg class="ic s" style="color:var(--tx4)"><use href="#i-send"/></svg><span>Or type your own answer…</span></div>
+      <div class="ask-acts">
+        <button class="btn pri">Submit <span class="kbd">⏎</span></button>
+        <span class="spacer"></span>
+        <button class="btn ghost">Dismiss</button>
+      </div>
+    </div>
+
+    <div class="amsg"><p>Understood — excluding soft-deleted rows from both paths.</p></div>
+  </div>
+
+  <h3 class="sub">Several questions in one card</h3>
+  <p>
+    opencode's question tool can ask more than one thing at a time — the reply payload is
+    <span class="mono-inline">answers: string[][]</span>, one array per question. Today they'd stack as separate
+    unlabelled blocks. Numbered sections, one Submit, and a progress count make it obvious how much is
+    left to answer.
+  </p>
+
+  <style>
+  .qb{padding:0 var(--sp-4);margin-bottom:var(--sp-3)}
+  .qb .opt{width:100%;margin:0 0 var(--sp-2)}
+  .qb-h{display:flex;align-items:flex-start;gap:var(--sp-2);margin-bottom:var(--sp-2)}
+  .qb-h .num{width:18px;height:18px;border-radius:var(--r-full);background:var(--fill-active);
+    color:var(--tx3);font:600 10.5px/18px var(--font-mono);text-align:center;flex-shrink:0;margin-top:1px}
+  .qb-h .qt{font:600 13.5px/1.45 var(--font-sans);color:var(--tx1)}
+  .qb-h .qt em{display:block;font:400 12.5px/1.45 var(--font-sans);color:var(--tx3);font-style:normal;margin-top:2px}
+  .qb .ask-free{margin:0}
+  .qsep{height:1px;background:var(--border-subtle);margin:0 var(--sp-4) var(--sp-3)}
+  .recpill{margin-left:var(--sp-2);font:600 9.5px/1 var(--font-sans);letter-spacing:.04em;text-transform:uppercase;
+    padding:3px 6px;border-radius:var(--r-full);background:var(--ok-bg);color:var(--ok);vertical-align:1px}
+  .prog{font:500 11.5px/1 var(--font-mono);color:var(--tx3)}
+  </style>
+
+  <div class="askdemo">
+    <div class="ask q">
+      <div class="ask-top">
+        <span class="ask-badge"><svg class="ic"><use href="#i-help"/></svg></span>
+        <span class="ask-txt">
+          <h5>Two things before I write the export</h5>
+          <span class="sub">Both apply to the JSON and CSV paths.</span>
+        </span>
+      </div>
+
+      <div class="qb">
+        <div class="qb-h"><span class="num">1</span><span class="qt">How should deleted orders be handled?
+          <em>Soft-deleted rows are still in the table.</em></span></div>
+        <button class="opt sel"><span class="mk"><svg class="ic"><use href="#i-check"/></svg></span>Exclude them entirely<span class="recpill">Recommended</span></button>
+        <button class="opt"><span class="mk"></span>Include with a <span class="mono-inline">deleted_at</span> column</button>
+        <button class="opt"><span class="mk"></span>Include only when <span class="mono-inline">?include_deleted=true</span></button>
+        <div class="ask-free"><svg class="ic s" style="color:var(--tx4)"><use href="#i-send"/></svg><span>Or type your own answer…</span></div>
+      </div>
+
+      <div class="qsep"></div>
+
+      <div class="qb">
+        <div class="qb-h"><span class="num">2</span><span class="qt">Which timestamp format in the CSV?
+          <em>Pick one or more — I'll emit a column for each.</em></span></div>
+        <button class="opt"><span class="mk"></span>ISO 8601 UTC<span class="recpill">Recommended</span></button>
+        <button class="opt"><span class="mk"></span>Unix epoch seconds</button>
+        <button class="opt"><span class="mk"></span>Local time, no offset</button>
+        <div class="ask-free"><svg class="ic s" style="color:var(--tx4)"><use href="#i-send"/></svg><span>Or type your own answer…</span></div>
+      </div>
+
+      <div class="ask-acts">
+        <button class="btn pri">Submit <span class="kbd">⏎</span></button>
+        <span class="prog">1 of 2 answered</span>
+        <span class="spacer"></span>
+        <button class="btn ghost">Dismiss</button>
+      </div>
+    </div>
+  </div>
+
+  <h4 class="sub2">Recommended answers are preselected</h4>
+  <p>
+    Question 1 above arrives preselected because its first option is marked recommended; question 2's
+    recommendation is shown but <em>not</em> preselected, because it's a multi-select and pre-ticking one
+    box in a "pick one or more" list would quietly bias the answer. So the rule is:
+    <strong>preselect on single-select, label-only on multi-select.</strong>
+  </p>
+  <div class="callout warn">
+    <p><strong>Honest caveat on how "recommended" is detected.</strong> There is no schema field for it —
+    the convention is that the model appends <span class="mono-inline">(Recommended)</span> to the option label
+    and puts it first. So this is a string match, and it will miss a model that phrases it differently.
+    The upside is that it costs nothing and degrades safely: no match simply means nothing is preselected.
+    We strip the marker out of the label and render it as the pill, so the user never sees the raw text —
+    which is already an improvement, because today it renders literally as
+    "<span class="mono-inline">Exclude them entirely (Recommended)</span>".</p>
+  </div>
+
+  <ul class="notes">
+    <li><strong>Same width as the prose.</strong> The card is a block inside the turn, so it inherits the 72ch measure and the 12px block gap — you can see it sitting in the same rhythm as the paragraphs above and below.</li>
+    <li><strong>Icon badge instead of a coloured border.</strong> Today the whole card is outlined in Claude orange, which shouts. A 30px badge — amber shield for permission, blue question mark for a question — carries the same signal at a fraction of the visual weight.</li>
+    <li><strong>Title in plain language, command in a code well.</strong> Today the tool name and the raw command run together in one mono line. Separating "what is being asked" from "the literal command" is what makes it skimmable.</li>
+    <li><strong>Button ladder, not a row of equals.</strong> Primary action filled, secondary outlined, reject pushed to the far right and only tinted on hover — so the destructive option is reachable but never the thing your eye lands on first.</li>
+    <li><strong>Multi-select is explicit.</strong> Checkboxes rather than toggle-styled buttons, because opencode's question tool supports selecting several options and today there's no affordance saying so. The free-text field is always shown (it already is in the real component) and its text is appended after any picked options.</li>
+    <li><strong>Contrast fix you spotted:</strong> filled controls now use a dedicated <span class="mono-inline">--accent-solid</span> token — the same blue in dark, a darker blue in light — taking white-on-blue from 4.50:1 to <strong>6.00:1</strong>, with a heavier check stroke. The old value was technically passing but visually weak for a thin 10px glyph.</li>
+  </ul>
+</section>
+
+<!-- ==================== SIDEBAR ==================== -->
+<section id="sidebar">
+  <div class="eyebrow">The product · 03</div>
+  <h2 class="sec">Sidebar</h2>
+  <p class="lede">
+    Stripped to what you asked for: <strong>one line, one status dot, the name, and the timer.</strong>
+    No branch, no model, no second badge. The dot carries every state; the timer is the only trailing element,
+    and it swaps for the pin control on hover so the row never grows two things at once.
+  </p>
+
+  <div class="grid2">
+    <div>
+      <h4 class="sub2">Every state, one row shape</h4>
+      <div style="background:var(--panel);border:1px solid var(--border-subtle);border-radius:var(--r-lg);padding:var(--sp-2)">
+        <div class="grp-h" style="margin-bottom:var(--sp-1)"><svg class="ic"><use href="#i-chev-d"/></svg> Pinned</div>
+        <div class="srow pinned on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">2m</span></div>
+        <div class="srow pinned"><span class="st att"></span><span class="t">Investigate 500s in /api</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">8m</span></div>
+        <div class="grp-h" style="margin:var(--sp-4) 0 var(--sp-1)"><svg class="ic"><use href="#i-chev-d"/></svg>ethernal</div>
+        <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">4m</span></div>
+        <div class="srow"><span class="st idle"></span><span class="t">Bump deps</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age stale">1d</span></div>
+        <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">2h</span></div>
+        <div class="srow"><span class="st"></span><span class="t">Remote control session</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age stale">3d</span></div>
+      </div>
+      <p style="margin-top:var(--sp-3);font-size:13.5px">
+        Running · blocked on you · finished while away · clean · idle. Each is a colour + motion state on the
+        <em>same</em> 7px dot — no shape changes, no extra glyphs, no trailing badge.
+      </p>
+
+      <h4 class="sub2">Rest vs hover — nothing moves</h4>
+      <div style="background:var(--panel);border:1px solid var(--border-subtle);border-radius:var(--r-lg);padding:var(--sp-2)">
+        <div class="srow"><span class="st ok"></span><span class="t">At rest — unpinned</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">4m</span></div>
+        <div class="srow demo-hover"><span class="st ok"></span><span class="t">Hover — outline pin, click to pin</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">4m</span></div>
+        <div class="srow pinned"><span class="st"></span><span class="t">At rest — pinned</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">2h</span></div>
+        <div class="srow pinned demo-hover"><span class="st"></span><span class="t">Hover — filled pin, click to unpin</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age">2h</span></div>
+        <div class="srow"><span class="st"></span><span class="t">Past the TTL — timer hidden</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age stale">9d</span></div>
+        <div class="srow demo-hover"><span class="st"></span><span class="t">Past the TTL — hover reveals it</span><span class="pin"><svg class="ic s"><use href="#i-pin"/></svg></span><span class="age stale">9d</span></div>
+      </div>
+    </div>
+    <div>
+      <h4 class="sub2">Status vocabulary</h4>
+      <table class="spec">
+        <tr><th style="width:22%">Dot</th><th style="width:26%">Means</th><th>Timer shows</th></tr>
+        <tr><td><span style="display:inline-flex;align-items:center;gap:7px"><span style="width:7px;height:7px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 3px var(--accent-bg)"></span> pulsing accent</span></td><td>Running</td><td>Elapsed since the turn started</td></tr>
+        <tr><td><span style="display:inline-flex;align-items:center;gap:7px"><span style="width:7px;height:7px;border-radius:50%;background:var(--danger);box-shadow:0 0 0 3px var(--danger-bg)"></span> pulsing red</span></td><td>Blocked — permission or question</td><td>How long it's been waiting</td></tr>
+        <tr><td><span style="display:inline-flex;align-items:center;gap:7px"><span style="width:7px;height:7px;border-radius:50%;background:var(--warn)"></span> amber</span></td><td>Finished while you were elsewhere</td><td>Since it finished</td></tr>
+        <tr><td><span style="display:inline-flex;align-items:center;gap:7px"><span style="width:7px;height:7px;border-radius:50%;background:var(--ok)"></span> green</span></td><td>Idle, clean worktree</td><td>Since last activity</td></tr>
+        <tr><td><span style="display:inline-flex;align-items:center;gap:7px"><span style="width:7px;height:7px;border-radius:50%;background:var(--tx4)"></span> grey</span></td><td>Idle</td><td>Since last activity</td></tr>
+      </table>
+      <p style="font-size:13.5px"><strong>Timer rule (unchanged from today):</strong> visible while under the
+      staleness TTL, hidden once past it and revealed on hover — so a rail full of week-old sessions stays
+      quiet. It renders in neutral <span class="mono-inline">--tx4</span> rather than today's green/amber/red,
+      because the dot is now the only thing carrying status. On hover the pin control appears beside it.</p>
+      <h4 class="sub2">What stays out of the rail</h4>
+      <ul class="notes" style="font-size:13.5px">
+        <li>Branch, model, cwd — all available in the session header once you're in the session.</li>
+        <li>The subagent count (<span class="mono-inline">·2</span>) — folded into the running dot rather than a second badge.</li>
+        <li>Terminal vs chat mode — the running indicator behaves identically either way; the distinction is visible in the header.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h3 class="sub">The pin, worked out against your four constraints</h3>
+  <p>
+    The row is four slots: <span class="mono-inline">[dot] [name] [pin] [timer]</span>. The pin slot is
+    <strong>always 18px wide whether or not anything is in it</strong> — that single decision satisfies most
+    of what you asked for, because nothing can shift when the glyph appears.
+  </p>
+  <table class="spec">
+    <tr><th style="width:30%">Constraint</th><th>How it's met</th></tr>
+    <tr><td>Don't always show the pin</td><td>Hidden at rest in <em>both</em> sections. It's an action affordance, not a state indicator — and the state is already unambiguous, because the session is sitting in the group called Pinned.</td></tr>
+    <tr><td>Filled on hover, subtle</td><td>On hover: <strong>outline</strong> pin if unpinned, <strong>filled</strong> if pinned. Both in <span class="mono-inline">--tx4</span>, brightening to accent only when you hover the pin itself — so it's a quiet target, not a second focal point competing with the dot.</td></tr>
+    <tr><td>Pinned rows lost the timer</td><td>Restored. Pinned and unpinned rows are now the same component with the same rules.</td></tr>
+    <tr><td>Pin must not move the timer</td><td>The slot is reserved permanently, so the timer sits at a fixed offset from the right edge and never moves. The timer itself has a <span class="mono-inline">min-width</span> and tabular figures, so <span class="mono-inline">4m</span> → <span class="mono-inline">12m</span> doesn't nudge it either.</td></tr>
+    <tr><td>Both sections consistent</td><td>Identical markup and identical CSS. "Pinned" is a grouping, not a row variant — the only difference is which glyph the pin slot shows on hover.</td></tr>
+  </table>
+  <p>
+    One consequence worth naming: past the staleness TTL the timer is hidden with
+    <span class="mono-inline">visibility</span>, not <span class="mono-inline">display</span> — it still occupies its
+    slot. Otherwise revealing it on hover would pull the pin leftwards, which is the exact jitter you
+    asked to avoid.
+  </p>
+
+  <div class="callout">
+    <p><strong>Workspace groups.</strong> Same tmux-session level as today, restyled: name, chevron,
+    collapse state. No colour dot, no count. Word kept as "workspace". Pins live in a section above,
+    independent of grouping, stored as window ids in <span class="mono-inline">AppConfig</span> — no server change.</p>
+  </div>
+</section>
+
+<!-- ==================== WHERE THINGS LIVE ==================== -->
+<section id="where">
+  <div class="eyebrow">The product · 04</div>
+  <h2 class="sec">Where schedules, secrets, webhooks, context and stale-cache live</h2>
+  <p class="lede">
+    Good question, and the honest answer is that today they're all crammed into the composer footer
+    because that's where there was room — not because they belong together. There's a cleaner split.
+  </p>
+
+  <div class="callout">
+    <p><strong>The principle: the header owns session <em>state</em>, the composer owns <em>composing</em>.</strong>
+    If it describes the session you're in, it goes up top. If it changes what happens when you press
+    Enter, it stays by the input.</p>
+  </div>
+
+  <table class="spec">
+    <tr><th style="width:22%">Thing</th><th style="width:22%">Today</th><th style="width:22%">Proposed</th><th>Why</th></tr>
+    <tr><td>Context % + segments</td><td>Composer meta row</td><td><strong>Header, right</strong></td><td>It's a property of the session, not of the message you're writing. Always visible, and it stops competing for width with the model picker.</td></tr>
+    <tr><td>Stale prompt cache<br>("/clear to save 47k")</td><td>Composer footer pill</td><td><strong>Inside the context popover</strong>, plus an amber tint on the pill when actionable</td><td>It's a detail of context state. Today it's a separate pill that only sometimes appears, which makes the footer jump.</td></tr>
+    <tr><td>Branch</td><td>Composer meta row</td><td><strong>Header tag</strong></td><td>Session state. Also stops the branch chip wrapping to its own line on mobile.</td></tr>
+    <tr><td>Schedules · Secrets · Webhooks</td><td>Three buttons in the composer</td><td><strong>Stay in the composer</strong> — icon-only, right end of the meta row, schedules keeps its count</td><td>Your call, and the right one: they're one click today and burying them behind a menu would be a regression. Icon-only keeps them from crowding the model control, and the count stays because a pending schedule is time-sensitive in a way secrets and webhooks aren't.</td></tr>
+    <tr><td>Fork · Compact · Clear · Delete</td><td>Session toolbar</td><td><strong>Session menu (⋯)</strong></td><td>Destructive and near-destructive actions belong behind one deliberate click, not next to the send button.</td></tr>
+    <tr><td>Model ▸ effort</td><td>Composer meta row</td><td><strong>Stays</strong></td><td>Directly governs the next send.</td></tr>
+    <tr><td>Attach · voice · send</td><td>Composer</td><td><strong>Stays</strong></td><td>Composing.</td></tr>
+    <tr><td>Bypass-permissions toggle</td><td>Composer footer line</td><td><strong>Stays</strong>, right end of the meta row</td><td>Governs what happens on send. Now a labelled control with a shield icon rather than a <span class="mono-inline">▷▷</span> glyph.</td></tr>
+  </table>
+
+  <h3 class="sub">The two popovers</h3>
+  <div class="grid2">
+    <div>
+      <h4 class="sub2">Context — click the pill</h4>
+      <div style="border:1px solid var(--border);border-radius:var(--r-lg);background:var(--card);box-shadow:var(--shadow-md);padding:var(--sp-4);max-width:340px">
+        <div style="display:flex;align-items:baseline;gap:var(--sp-2);margin-bottom:var(--sp-3)">
+          <span style="font:600 15px/1 var(--font-sans)">54%</span>
+          <span style="font:500 12px/1 var(--font-mono);color:var(--tx3)">108k / 200k tokens</span>
+        </div>
+        <div style="height:7px;border-radius:4px;background:var(--fill-active);overflow:hidden;display:flex;margin-bottom:var(--sp-3)">
+          <i style="width:34%;background:var(--ok)"></i><i style="width:12%;background:var(--warn)"></i><i style="width:8%;background:var(--info)"></i>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:6px;font:500 12px/1 var(--font-sans);margin-bottom:var(--sp-4)">
+          <span style="display:flex;gap:8px;align-items:center"><i style="width:9px;height:9px;border-radius:2px;background:var(--ok)"></i><span style="color:var(--tx2)">Fresh input</span><span style="margin-left:auto;font-family:var(--font-mono);color:var(--tx3)">68k</span></span>
+          <span style="display:flex;gap:8px;align-items:center"><i style="width:9px;height:9px;border-radius:2px;background:var(--warn)"></i><span style="color:var(--tx2)">Cache write</span><span style="margin-left:auto;font-family:var(--font-mono);color:var(--tx3)">24k</span></span>
+          <span style="display:flex;gap:8px;align-items:center"><i style="width:9px;height:9px;border-radius:2px;background:var(--info)"></i><span style="color:var(--tx2)">Cache read</span><span style="margin-left:auto;font-family:var(--font-mono);color:var(--tx3)">16k</span></span>
+        </div>
+        <div style="border-top:1px solid var(--border-subtle);padding-top:var(--sp-3);display:flex;gap:var(--sp-2);align-items:center">
+          <span style="display:grid;place-items:center;width:26px;height:26px;border-radius:var(--r-sm);background:var(--warn-bg);color:var(--warn)"><svg class="ic s"><use href="#i-clock"/></svg></span>
+          <span style="font:400 12px/1.4 var(--font-sans);color:var(--tx2);flex:1">Cache went stale — clearing saves <strong>47k</strong> tokens on your next message.</span>
+        </div>
+        <button class="btn" style="width:100%;margin-top:var(--sp-3);justify-content:center">Clear session</button>
+      </div>
+    </div>
+    <div>
+      <h4 class="sub2">Session menu — the ⋯ button</h4>
+      <div style="border:1px solid var(--border);border-radius:var(--r-lg);background:var(--card);box-shadow:var(--shadow-md);padding:var(--sp-1);max-width:270px">
+        <style>
+        .mi{display:flex;align-items:center;gap:var(--sp-3);padding:8px 10px;border-radius:var(--r-sm);
+          font:500 13px/1 var(--font-sans);color:var(--tx2);cursor:pointer}
+        .mi:hover{background:var(--fill-hover);color:var(--tx1)}
+        .mi .ic{color:var(--tx3);width:15px;height:15px}
+        .mi .n{margin-left:auto;font:600 10px/1 var(--font-sans);background:var(--accent);color:var(--on-accent);
+          padding:2px 6px;border-radius:var(--r-full)}
+        .mi .k{margin-left:auto;font:500 10.5px/1 var(--font-mono);color:var(--tx4)}
+        .msep{height:1px;background:var(--border-subtle);margin:var(--sp-1) 0}
+        </style>
+        <div class="mi"><svg class="ic"><use href="#i-branch"/></svg> Fork session</div>
+        <div class="mi"><svg class="ic"><use href="#i-gauge"/></svg> Compact <span class="k">/compact</span></div>
+        <div class="mi"><svg class="ic"><use href="#i-plus"/></svg> Clear <span class="k">/clear</span></div>
+        <div class="msep"></div>
+        <div class="mi" style="color:var(--danger)"><svg class="ic"><use href="#i-x"/></svg> Delete session</div>
+      </div>
+      <p style="margin-top:var(--sp-3);font-size:13.5px">
+        No badge. The menu holds only session <em>actions</em> — the three resources stay one click away in
+        the composer. Mobile already has this <span class="mono-inline">⋯</span> sheet, so the two clients
+        converge rather than maintaining separate layouts.
+      </p>
+    </div>
+  </div>
+</section>
+
+
+
+
+
+<!-- ==================== BACKGROUND JOBS ==================== -->
+<section id="jobs">
+  <div class="eyebrow">The product · 05</div>
+  <h2 class="sec">Background delegation</h2>
+  <p class="lede">
+    BET-374 landed on <span class="mono-inline">origin/main</span> while this spec was being written — all six
+    sub-issues merged. Your framing settles almost every open question, and forces two simplifications beyond
+    the ones you named. The mockup is clickable.
+  </p>
+
+  <h3 class="sub">The governing principle</h3>
+  <div class="callout ok">
+    <p><strong>A background job is disposable, non-critical and read-only. It reports to the main agent, not
+    to you — and it asks once, before it exists, then never again.</strong> You get a pulsing dot and a name
+    while it runs; that's the entire contract. When it's gone it's gone. Everything below follows from this,
+    including two things it rules out that are currently shipped.</p>
+  </div>
+
+  <h3 class="sub">What that decides</h3>
+  <table class="spec">
+    <tr><th style="width:26%">Question</th><th>Answer</th></tr>
+    <tr><td>Completion card?</td><td><strong>No.</strong> The report is addressed to the model. Today it's delivered with <span class="mono-inline">sendPrompt</span>, making it a <em>fake user turn</em> — which under this redesign would have become a right-aligned bubble reading as if you'd typed it. Suppressed.</td></tr>
+    <tr><td>Subtitle in the rail?</td><td><strong>No.</strong> Nesting carries the relationship, the dot carries the state. Rows are identical at both levels: dot, name, timer.</td></tr>
+    <tr><td>Terminal jobs in the rail?</td><td><strong>No.</strong> Cleared the moment status goes terminal — a status change the server already publishes, so no heuristics. Held only while you're actually looking at one, then cleared on leave.</td></tr>
+    <tr><td>Count on the composer?</td><td><strong>No.</strong> Plain icon.</td></tr>
+    <tr><td>Parent session gone?</td><td><strong>Stop the job immediately.</strong> There's nobody left to report to, so continuing burns tokens for nothing.</td></tr>
+    <tr><td>Job asks you for permission?</td><td><strong>Once, before it launches</strong> — never while running. opencode lets a session be created with its permissions already decided, so this is directly implementable. See below.</td></tr>
+  </table>
+
+<style>
+.srow.child{padding-left:26px;position:relative}
+.srow.child::after{content:"";position:absolute;left:13px;top:0;bottom:50%;width:1px;background:var(--border)}
+.srow.child::before{content:"";position:absolute;left:13px;top:50%;width:7px;height:1px;background:var(--border);transform:none;border-radius:0}
+.srow.child.on::before,.srow.child.on::after{background:var(--accent)}
+.jobwin{border:1px solid var(--border);border-radius:var(--r-xl);overflow:hidden;box-shadow:var(--shadow-lg);
+  background:var(--canvas);display:grid;grid-template-columns:246px 1fr;height:500px;margin:var(--sp-4) 0}
+@media(max-width:900px){.jobwin{grid-template-columns:1fr;height:auto}.jobwin .jrail{display:none!important}}
+.robar{display:flex;align-items:center;gap:var(--sp-3);padding:var(--sp-3) var(--sp-4);
+  border-top:1px solid var(--border-subtle);background:var(--panel);flex-shrink:0}
+.robar .tx{font:400 12.5px/1.5 var(--font-sans);color:var(--tx3);flex:1;min-width:0}
+.robar .tx b{color:var(--tx2);font-weight:600}
+.jstate{display:flex;flex-wrap:wrap;gap:6px;margin:var(--sp-4) 0 0;justify-content:center}
+.jstate button{border:1px solid var(--border);background:var(--panel);color:var(--tx3);border-radius:var(--r-full);
+  padding:6px 12px;font:500 11.5px/1 var(--font-sans);cursor:pointer}
+.jstate button:hover{border-color:var(--border-strong);color:var(--tx1)}
+.jstate button.on{background:var(--accent-solid);border-color:var(--accent-solid);color:var(--on-accent);font-weight:600}
+.jbody{display:none}.jbody.on{display:flex;flex-direction:column;min-width:0;background:var(--canvas)}
+.jrail{display:none}.jrail.on{display:flex;flex-direction:column;min-width:0;background:var(--panel);border-right:1px solid var(--border-subtle)}
+.railnote{margin:var(--sp-4) var(--sp-2) 0;font:400 11.5px/1.6 var(--font-sans);color:var(--tx4)}
+</style>
+
+  <h3 class="sub">Every state</h3>
+  <div class="jstate" data-group="job">
+    <button class="on" data-tab="jrun">Running</button>
+    <button data-tab="jdone">Finished → cleared</button>
+    <button data-tab="jfail">Failed → cleared</button>
+    <button data-tab="jview">Watching one</button>
+    <button data-tab="jviewdone">It finishes while you watch</button>
+    <button data-tab="japprove">Approve before launch</button>
+  </div>
+
+<div class="jobwin">
+  <!-- RAILS -->
+  <div class="jrail on" data-panel="jrun">
+    <div class="rail-top"><span class="logo"></span><span class="nm">Manta</span></div>
+    <div class="rail-scroll"><div class="grp"><div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> ethernal</div>
+      <div class="srow on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">2m</span></div>
+      <div class="srow child"><span class="st run"></span><span class="t">fix-flaky-auth-tests</span><span class="age">1m</span></div>
+      <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="age">2h</span></div>
+    </div>
+    <p class="railnote">Pulsing dot and a name. That's the whole contract.</p></div>
+  </div>
+  <div class="jrail" data-panel="jdone">
+    <div class="rail-top"><span class="logo"></span><span class="nm">Manta</span></div>
+    <div class="rail-scroll"><div class="grp"><div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> ethernal</div>
+      <div class="srow on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">1m</span></div>
+      <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="age">2h</span></div>
+    </div>
+    <p class="railnote">Gone. It finished, so there's nothing left to act on.</p></div>
+  </div>
+  <div class="jrail" data-panel="jfail">
+    <div class="rail-top"><span class="logo"></span><span class="nm">Manta</span></div>
+    <div class="rail-scroll"><div class="grp"><div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> ethernal</div>
+      <div class="srow on"><span class="st"></span><span class="t">Deploy new billing service</span><span class="age">6m</span></div>
+      <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="age">2h</span></div>
+    </div>
+    <p class="railnote">Same for a failure. The branch survives in git; the agent decides what to do next.</p></div>
+  </div>
+  <div class="jrail" data-panel="jview">
+    <div class="rail-top"><span class="logo"></span><span class="nm">Manta</span></div>
+    <div class="rail-scroll"><div class="grp"><div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> ethernal</div>
+      <div class="srow"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">2m</span></div>
+      <div class="srow child on"><span class="st run"></span><span class="t">fix-flaky-auth-tests</span><span class="age">1m</span></div>
+      <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="age">2h</span></div>
+    </div></div>
+  </div>
+  <div class="jrail" data-panel="jviewdone">
+    <div class="rail-top"><span class="logo"></span><span class="nm">Manta</span></div>
+    <div class="rail-scroll"><div class="grp"><div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> ethernal</div>
+      <div class="srow"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">1m</span></div>
+      <div class="srow child on"><span class="st ok"></span><span class="t">fix-flaky-auth-tests</span><span class="age">6m</span></div>
+      <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="age">2h</span></div>
+    </div>
+    <p class="railnote">Held only because you're looking at it. Clears the moment you navigate away.</p></div>
+  </div>
+  <div class="jrail" data-panel="japprove">
+    <div class="rail-top"><span class="logo"></span><span class="nm">Manta</span></div>
+    <div class="rail-scroll"><div class="grp"><div class="grp-h"><svg class="ic"><use href="#i-chev-d"/></svg> ethernal</div>
+      <div class="srow on"><span class="st run"></span><span class="t">Deploy new billing service</span><span class="age">3m</span></div>
+      <div class="srow"><span class="st ok"></span><span class="t">Add CSV export</span><span class="age">4m</span></div>
+      <div class="srow"><span class="st"></span><span class="t">Refactor auth middleware</span><span class="age">2h</span></div>
+    </div>
+    <p class="railnote">No row yet — the job doesn't exist until you approve it. Nothing has been created on disk.</p></div>
+  </div>
+
+  <!-- BODIES -->
+  <div class="jbody on" data-panel="jrun">
+    <div class="topb"><span class="crumb"><span class="mut">ethernal</span> <span class="slash">/</span> Deploy new billing service</span>
+      <span class="tag"><svg class="ic"><use href="#i-branch"/></svg> main</span>
+      <span class="sp"><span class="ctxpill"><span class="track"><i style="width:31%;background:var(--ok)"></i></span><span class="pct">31%</span></span>
+      <button class="iconbtn"><svg class="ic"><use href="#i-more"/></svg></button></span></div>
+    <div class="scroll"><div class="wrap"><div class="turn">
+      <div class="amsg"><p>The auth tests are flaky for an unrelated reason, so I've delegated that to a background job and I'll carry on with the export here.</p>
+        <p>Reading the current handler now.</p></div>
+      <div class="tool"><div class="tool-h"><span class="g"></span><span class="nmx">Read</span><span class="arg">app/routes/orders.py</span><span class="r"><span>23 lines</span><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div></div>
+    </div></div></div>
+    <div class="composer"><div class="comp-in">
+      <div class="cbox"><span class="ta ph">Reply, or describe the next task…</span><button class="send hot"><svg class="ic s"><use href="#i-send"/></svg></button></div>
+      <div class="metarow"><div class="msplit"><button><svg class="ic"><use href="#i-spark"/></svg> Opus 4.8</button><button><span class="lvl">High</span></button></div>
+        <button class="mbtn"><svg class="ic s"><use href="#i-clip"/></svg></button>
+        <button class="mbtn"><svg class="ic s"><use href="#i-mic"/></svg></button>
+        <span class="spacer"></span>
+        <button class="mbtn"><svg class="ic s"><use href="#i-clock"/></svg> <span class="cnum">2</span></button>
+        <button class="mbtn"><svg class="ic s"><use href="#i-key"/></svg></button>
+        <button class="mbtn"><svg class="ic s"><use href="#i-hook"/></svg></button></div>
+    </div></div>
+  </div>
+
+  <div class="jbody" data-panel="jdone">
+    <div class="topb"><span class="crumb"><span class="mut">ethernal</span> <span class="slash">/</span> Deploy new billing service</span>
+      <span class="sp"><button class="iconbtn"><svg class="ic"><use href="#i-more"/></svg></button></span></div>
+    <div class="scroll"><div class="wrap"><div class="turn"><div class="amsg">
+      <p>The background job finished — three auth tests were failing because a fixture reused a session across parametrised cases. It scoped the fixture per-case and dropped the sleep-based wait in <span class="ic-t">test_login_retry</span>. That's on <span class="ic-t">job/fix-flaky-auth-tests</span>, 4 files changed.</p>
+      <p>Back to the export — the streaming route is ready for review.</p></div></div></div></div>
+    <div class="composer"><div class="comp-in">
+      <div class="cbox"><span class="ta ph">Reply, or describe the next task…</span><button class="send hot"><svg class="ic s"><use href="#i-send"/></svg></button></div>
+    </div></div>
+  </div>
+
+  <div class="jbody" data-panel="jfail">
+    <div class="topb"><span class="crumb"><span class="mut">ethernal</span> <span class="slash">/</span> Deploy new billing service</span>
+      <span class="sp"><button class="iconbtn"><svg class="ic"><use href="#i-more"/></svg></button></span></div>
+    <div class="scroll"><div class="wrap"><div class="turn"><div class="amsg">
+      <p>The schema-migration job timed out after 30 minutes — it was waiting on a lock the whole time. I've left the branch in place.</p>
+      <p>Want me to retry it with a shorter statement timeout, or look at the lock first?</p></div></div></div></div>
+    <div class="composer"><div class="comp-in">
+      <div class="cbox"><span class="ta ph">Reply, or describe the next task…</span><button class="send hot"><svg class="ic s"><use href="#i-send"/></svg></button></div>
+    </div></div>
+  </div>
+
+  <div class="jbody" data-panel="jview">
+    <div class="topb"><span class="crumb"><span class="mut">ethernal</span> <span class="slash">/</span> fix-flaky-auth-tests</span>
+      <span class="tag"><svg class="ic"><use href="#i-branch"/></svg> job/fix-flaky-auth-tests</span>
+      <span class="sp"><span class="tag" style="border-color:color-mix(in srgb,var(--accent) 40%,transparent);color:var(--accent-tx);background:var(--accent-bg)"><span class="d" style="background:currentColor"></span> running</span></span></div>
+    <div class="scroll"><div class="wrap"><div class="turn">
+      <div class="amsg"><p>Reproducing the failure first — running the auth suite with <span class="ic-t">--lf</span> to get just the last failures.</p></div>
+      <div class="tool"><div class="tool-h"><span class="g"></span><span class="nmx">Bash</span><span class="arg">pytest tests/auth -x --lf</span><span class="r"><span>2 failed</span><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div></div>
+      <div class="amsg"><p>Both failures share a fixture. Checking whether it's session-scoped.</p></div>
+      <div class="tool"><div class="tool-h"><span class="g run"></span><span class="nmx">Grep</span><span class="arg">@pytest.fixture — tests/auth/conftest.py</span><span class="r"><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div></div>
+    </div></div></div>
+    <div class="robar">
+      <svg class="ic" style="color:var(--tx4)"><use href="#i-bot"/></svg>
+      <span class="tx"><b>Read-only — this is a background job.</b> It reports to <em>Deploy new billing service</em>; reply there.</span>
+      <button class="btn sm">Go to parent</button>
+      <button class="btn sm danger" style="border:1px solid color-mix(in srgb,var(--danger) 35%,transparent)">Stop</button>
+    </div>
+  </div>
+
+  <div class="jbody" data-panel="jviewdone">
+    <div class="topb"><span class="crumb"><span class="mut">ethernal</span> <span class="slash">/</span> fix-flaky-auth-tests</span>
+      <span class="tag"><svg class="ic"><use href="#i-branch"/></svg> job/fix-flaky-auth-tests</span>
+      <span class="sp"><span class="tag" style="border-color:color-mix(in srgb,var(--ok) 40%,transparent);color:var(--ok);background:var(--ok-bg)"><span class="d" style="background:currentColor"></span> done</span></span></div>
+    <div class="scroll"><div class="wrap"><div class="turn">
+      <div class="tool"><div class="tool-h"><span class="g"></span><span class="nmx">Edit</span><span class="arg">tests/auth/conftest.py</span><span class="r"><span style="color:var(--ok)">+12</span><span style="color:var(--danger)">−5</span><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div></div>
+      <div class="tool"><div class="tool-h"><span class="g"></span><span class="nmx">Bash</span><span class="arg">git commit -am "fix: scope auth fixture per-case"</span><span class="r"><svg class="ic xs"><use href="#i-chev-d"/></svg></span></div></div>
+      <div class="amsg"><p>Three tests were failing because the fixture reused a session across parametrised cases. Scoped it per-case and removed the sleep-based wait in <span class="ic-t">test_login_retry</span>.</p></div>
+    </div></div></div>
+    <div class="robar">
+      <svg class="ic" style="color:var(--ok)"><use href="#i-check"/></svg>
+      <span class="tx"><b>Finished.</b> Committed to <span class="mono-inline">job/fix-flaky-auth-tests</span> · 4 files changed. This view closes when you leave it.</span>
+      <button class="btn sm">Go to parent</button>
+    </div>
+  </div>
+
+  <div class="jbody" data-panel="japprove">
+    <div class="topb"><span class="crumb"><span class="mut">ethernal</span> <span class="slash">/</span> Deploy new billing service</span>
+      <span class="sp"><button class="iconbtn"><svg class="ic"><use href="#i-more"/></svg></button></span></div>
+    <div class="scroll"><div class="wrap"><div class="turn">
+      <div class="amsg"><p>The auth tests are flaky for an unrelated reason — I'll push that to a background job so we can keep going on the export.</p></div>
+      <div class="ask">
+        <div class="ask-top">
+          <span class="ask-badge" style="background:var(--accent-bg);color:var(--accent-tx)"><svg class="ic"><use href="#i-bot"/></svg></span>
+          <span class="ask-txt">
+            <h5>Start a background job?</h5>
+            <span class="sub"><span class="mono-inline">fix-flaky-auth-tests</span> — "Find and fix the flaky tests in tests/auth, commit to your branch."</span>
+          </span>
+        </div>
+        <div style="margin:0 var(--sp-4) var(--sp-3);padding:var(--sp-3);border:1px solid var(--border-subtle);
+                    border-radius:var(--r-md);background:var(--inset)">
+          <div style="font:600 10.5px/1 var(--font-sans);letter-spacing:.07em;text-transform:uppercase;color:var(--tx3);margin-bottom:var(--sp-2)">It will be allowed to</div>
+          <div style="display:flex;flex-direction:column;gap:6px;font:400 12.5px/1.4 var(--font-sans)">
+            <span style="display:flex;gap:var(--sp-2);align-items:center"><svg class="ic s" style="color:var(--ok);stroke-width:3"><use href="#i-check"/></svg><span style="color:var(--tx1);width:110px">Run commands</span><span class="mono-inline">pytest *</span></span>
+            <span style="display:flex;gap:var(--sp-2);align-items:center"><svg class="ic s" style="color:var(--ok);stroke-width:3"><use href="#i-check"/></svg><span style="color:var(--tx1);width:110px">Edit files</span><span class="mono-inline">tests/**</span></span>
+            <span style="display:flex;gap:var(--sp-2);align-items:center"><svg class="ic s" style="color:var(--ok);stroke-width:3"><use href="#i-check"/></svg><span style="color:var(--tx1);width:110px">Read files</span><span class="mono-inline">**</span></span>
+          </div>
+          <div style="margin-top:var(--sp-3);padding-top:var(--sp-2);border-top:1px solid var(--border-subtle);
+                      font:400 11.5px/1.5 var(--font-sans);color:var(--tx3)">Everything else is denied. Once it starts it cannot ask you for anything.</div>
+        </div>
+        <div class="ask-acts">
+          <button class="btn pri"><svg class="ic"><use href="#i-check"/></svg> Start job</button>
+          <button class="btn">Edit access</button>
+          <span class="spacer"></span>
+          <button class="btn danger"><svg class="ic"><use href="#i-x"/></svg> Not now</button>
+        </div>
+      </div>
+    </div></div></div>
+    <div class="composer"><div class="comp-in">
+      <div class="cbox"><span class="ta ph">Reply, or describe the next task…</span><button class="send hot"><svg class="ic s"><use href="#i-send"/></svg></button></div>
+    </div></div>
+  </div>
+</div>
+
+  <h3 class="sub">Consequence 1 — approve up front, the Claude Code way</h3>
+  <p>
+    You pointed at Claude Code's answer — <em>"Background agents now prompt for tool permissions before launching…
+    rather than the agent encountering permission blocks while running in the background."</em>
+    <strong>I researched whether we can do that, and we can — opencode already has the whole mechanism.</strong>
+    This is better than any of the three options I was weighing, and it retracts what I said last round about
+    delegation being a trust-mode feature. It isn't.
+  </p>
+  <table class="spec">
+    <tr><th style="width:34%">What opencode exposes</th><th>What it gives us</th></tr>
+    <tr><td><span class="mono-inline">POST /session</span> accepts <span class="mono-inline">permission: PermissionRuleset</span></td>
+      <td>A job's session can be <strong>created with its permissions already decided</strong>. No runtime prompting needed at all.</td></tr>
+    <tr><td><span class="mono-inline">PermissionRule = {permission, pattern, action}</span> with <span class="mono-inline">action: allow | deny | ask</span></td>
+      <td>Per-tool, per-pattern grants — <span class="mono-inline">bash</span> limited to <span class="mono-inline">pytest *</span>, <span class="mono-inline">edit</span> limited to <span class="mono-inline">tests/**</span>, and so on.</td></tr>
+    <tr><td><span class="mono-inline">PermissionRequest</span> carries <span class="mono-inline">patterns[]</span> and <span class="mono-inline">always[]</span></td>
+      <td>When you grant "always" in the parent, we learn the exact patterns — so a job can <strong>inherit what you've already approved</strong> and only ask about the delta.</td></tr>
+  </table>
+  <p>
+    So the flow becomes: the model calls <span class="mono-inline">delegate</span>, and <strong>before anything is
+    created</strong> the parent panel shows one approval card listing the access the job needs. Approve, and the
+    session is created with exactly that ruleset — the job never asks again because it has nothing left to ask.
+    That's the <em>Approve before launch</em> state above.
+  </p>
+  <p>This is strictly better than what I proposed last round on every axis:</p>
+  <table class="spec">
+    <tr><th style="width:26%">Option</th><th>Verdict</th></tr>
+    <tr><td>Auto-allow for jobs</td><td>Unattended shell execution with no oversight, silently overriding a setting the user left off. <span class="pill bad">rejected</span></td></tr>
+    <tr><td>Auto-deny for jobs</td><td>Nearly every job dies on its first command, after burning a worktree and a session. <span class="pill bad">rejected</span></td></tr>
+    <tr><td>Refuse to start when trust is off</td><td>My previous recommendation. Safe, but it makes delegation unusable for everyone who keeps prompts on. <span class="pill bad">superseded</span></td></tr>
+    <tr><td><strong>Approve the ruleset before launch</strong></td><td>No deadlock, no override, nothing wasted, and delegation works with prompts on. <span class="pill good">recommended</span></td></tr>
+  </table>
+  <p>
+    It also sharpens the principle rather than breaking it. "Never interrupts you" becomes
+    <strong>"asks once, before it exists — then never again"</strong>, which is a promise you can actually
+    reason about: one card, at a moment you're already engaged, and silence afterwards.
+  </p>
+  <ul class="notes">
+    <li><strong>Skipped entirely when trust mode is on</strong> — there's nothing to approve, so no card.</li>
+    <li><strong>Skipped when the parent's existing grants already cover the request</strong>, using the <span class="mono-inline">always[]</span> patterns. The common case — you already approved <span class="mono-inline">pytest *</span> ten minutes ago — costs nothing.</li>
+    <li><strong>The model declares what it needs</strong> via a new argument on the <span class="mono-inline">delegate</span> tool <span class="pill good">confirmed</span>. That's the one piece of new surface, and it's what makes the card honest: it shows what was actually requested, not a guess.</li>
+    <li><strong>The delegate call blocks until you answer</strong>, bounded (a couple of minutes, then treated as declined). Briefly blocking the parent turn is acceptable here — it's one prompt instead of N, at the only point where the cost is zero.</li>
+  </ul>
+  <div class="callout ok">
+    <p><strong>Verified against the running opencode (v1.15.12), not just the schema.</strong> Creating a session
+    with a ruleset is accepted, persisted, and echoed back on the session object — including the catch-all
+    wildcard form:</p>
+    <pre style="margin:var(--sp-3) 0 0;padding:var(--sp-3);border-radius:var(--r-md);background:var(--inset);
+                border:1px solid var(--border-subtle);font:400 11.5px/1.6 var(--font-mono);color:var(--tx2);overflow-x:auto">POST /session?directory=…
+{ "permission": [
+    { "permission": "bash", "pattern": "echo *", "action": "allow" },
+    { "permission": "*",    "pattern": "**",     "action": "deny"  } ] }
+
+→ 200 { "id": "ses_…", "permission": [ … ] }</pre>
+  </div>
+  <div class="callout warn">
+    <p><strong>Still worth pinning at implementation time: the catch-all must actually be honoured at match
+    time.</strong> The API accepts it, but if an unmatched tool resolved to <span class="mono-inline">ask</span>
+    anyway we would be straight back to a job hanging until the 30-minute timeout with no UI — the exact bug
+    BET-380 exists to fix. One integration test: a job whose ruleset omits <span class="mono-inline">bash</span>
+    must <em>fail</em> its first command, not stall.</p>
+  </div>
+
+  <h3 class="sub">Consequence 2 — the jobs card no longer earns its place</h3>
+  <p>
+    BET-381 shipped a management card listing every job with Stop and Delete. Under this principle almost
+    everything it offers is now either invisible or unwanted: terminal jobs are cleared, statuses aren't
+    reported, counts are gone, and the tree already shows every running job with a Stop button in its own view.
+    What's left is a second list of the same five rows.
+  </p>
+  <div class="callout warn">
+    <p><strong>Confirmed: the card and the fourth composer icon are deleted.</strong> That also disposes of three
+    gaps raised earlier — the two-different-counts inconsistency, the box-wide-vs-per-session split, and the
+    missing confirmations — because the surface they lived on is gone. Net change for BET-381 is a revert of its
+    renderer half.</p>
+  </div>
+
+  <h3 class="sub">Disposable, taken literally</h3>
+  <p>
+    If jobs are disposable, the artefact is <strong>the branch</strong> — and a branch lives in git whether or not
+    a worktree exists. So on terminal status the window and worktree are redundant and should be removed with
+    the record, not left behind. That closes the orphan leak I flagged last round rather than hiding it:
+  </p>
+  <ul class="notes">
+    <li><strong>Clean worktree → remove it and the window immediately.</strong> The commit is on the branch; nothing is lost.</li>
+    <li><strong>Dirty worktree → keep both</strong>, using the refusal logic that already exists. Uncommitted work is the one thing that isn't disposable.</li>
+    <li><strong>Parent gone → stop the job, then the same cleanup.</strong> Your point, and it's right: nobody is left to report to, so continuing just burns tokens.</li>
+  </ul>
+  <p>
+    Without this, the retention sweep prunes the job <em>record</em> after 7 days but never the window or
+    worktree — so a stale window stops being recognisable as a job and <strong>silently reappears as an ordinary
+    top-level session</strong> weeks later, with a slug for a name.
+  </p>
+
+  <h3 class="sub">Remaining gaps</h3>
+  <p>Three, and only the first is real work.</p>
+  <table class="spec">
+    <tr><th style="width:26%">Gap</th><th>Detail</th></tr>
+    <tr><td><strong>Nesting runs on a 10s poll</strong> <span class="pill bad">the real one</span></td>
+      <td>The rail joins tmux's window list against the jobs slice to decide visibility and nesting, and that slice refreshes every 10s. A new job therefore appears as a <em>top-level session</em> for up to ten seconds before jumping under its parent, and a finished one lingers just as long. The server already publishes <span class="mono-inline">delegate.updated</span> and <strong>nothing subscribes to it</strong>. Wiring that up removes both lags and is the highest-value fix here.</td></tr>
+    <tr><td>The abort bug</td>
+      <td><span class="mono-inline">rejectAllPendingQuestions</span> rejects <em>every</em> pending request on abort, including other sessions'. Mostly moot once jobs never ask — but it's wrong independently, since it also affects a second chat session. Abort should scope to the panel's own session.</td></tr>
+    <tr><td>Catch-all deny needs a test, not a decision</td>
+      <td>The API is confirmed working; what's unverified is whether an unmatched tool <em>resolves</em> to deny rather than ask at match time. One integration test settles it.</td></tr>
+  </table>
+  <p style="font-size:13.5px;color:var(--tx3)"><strong>Mobile is out of scope here</strong> — background jobs will be
+  covered in the separate mobile redesign.</p>
+  <p style="font-size:13.5px;color:var(--tx3)">
+    Closed by your decisions: job-status rendering, stale activity strings, orphan windows, destructive-action
+    confirmations, the two counts, the rail-vs-card scope split, and the "don't yank the view" case.
+    Still open from the wider audit and unrelated to delegation: the missing skeleton on inline subagent expand.
+  </p>
+
+  <div class="callout ok">
+    <p><strong>What this doesn't change.</strong> The inline <span class="mono-inline">task</span>-tool subagent
+    rendering is untouched — collapsed card, expand for the child transcript, live status badge. Two delegation
+    modes coexist deliberately, and nothing here re-opens that.</p>
+  </div>
+</section>
+
+<!-- ==================== NEW SESSION ==================== -->
+<section id="new">
+  <div class="eyebrow">The product · 06</div>
+  <h2 class="sec">New session</h2>
+  <p class="lede">
+    Name removed, host chip removed, real icons. Two chips: <strong>folder</strong> and
+    <strong>branch / worktree</strong> — the only two things you actually decide before typing.
+  </p>
+
+  <div style="max-width:720px;margin:var(--sp-5) auto;padding:var(--sp-10) var(--sp-6);background:var(--panel);
+              border:1px solid var(--border-subtle);border-radius:var(--r-xl)">
+    <div style="text-align:center;margin-bottom:var(--sp-6)">
+      <div style="font:700 21px/1.3 var(--font-sans);letter-spacing:-.02em">What's up next?</div>
+      <div style="font:400 14px/1.5 var(--font-sans);color:var(--tx3);margin-top:5px">Start a session on any folder your box can see.</div>
+    </div>
+    <div class="chiprow">
+      <button class="chip"><svg class="ic"><use href="#i-folder"/></svg> leasebot <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-d"/></svg></button>
+      <button class="chip split">
+        <span><svg class="ic"><use href="#i-branch"/></svg> <span style="color:var(--tx3)">main</span></span>
+        <span><span class="cbx"></span> worktree</span>
+      </button>
+    </div>
+    <div class="cbox">
+      <span class="ta ph">Describe a task or ask a question</span>
+      <button class="send"><svg class="ic s"><use href="#i-send"/></svg></button>
+    </div>
+    <div class="metarow">
+      <div class="msplit">
+        <button><svg class="ic"><use href="#i-spark"/></svg> Auto <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-d"/></svg></button>
+        <button><span class="lvl">High</span> <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-d"/></svg></button>
+      </div>
+      <button class="mbtn"><svg class="ic s"><use href="#i-clip"/></svg></button>
+      <button class="mbtn"><svg class="ic s"><use href="#i-mic"/></svg></button>
+    </div>
+  </div>
+
+  <p style="max-width:720px;margin:0 auto var(--sp-4);text-align:center;font-size:13.5px;color:var(--tx3)">
+    Ticking <strong>worktree</strong> makes the branch field editable and creates the session in a fresh
+    <span class="mono-inline">git worktree</span> rather than the checkout you're pointing at:
+  </p>
+  <div style="max-width:720px;margin:0 auto var(--sp-8)">
+    <div class="chiprow" style="justify-content:center">
+      <button class="chip"><svg class="ic"><use href="#i-folder"/></svg> leasebot <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-d"/></svg></button>
+      <button class="chip split on">
+        <span><svg class="ic"><use href="#i-branch"/></svg> feat/lease-export</span>
+        <span><span class="cbx on"><svg class="ic"><use href="#i-check"/></svg></span> worktree</span>
+      </button>
+    </div>
+  </div>
+</section>
+
+<!-- ==================== PICKER ==================== -->
+<section id="picker">
+  <div class="eyebrow">The product · 07</div>
+  <h2 class="sec">Folder picker</h2>
+  <p class="lede">
+    Replaces the ghost-text cwd input. The typed path still works with the existing completion logic —
+    the list is the discovery path, which is what today's version is missing entirely (and which mobile
+    has never had at all).
+  </p>
+
+  <div style="position:relative;border:1px solid var(--border);border-radius:var(--r-xl);overflow:hidden;
+              background:var(--panel);height:520px;margin:var(--sp-5) 0;display:grid;place-items:center;padding:var(--sp-5)">
+    <div style="width:min(540px,100%);background:var(--card);border:1px solid var(--border);
+                border-radius:var(--r-xl);box-shadow:var(--shadow-lg);overflow:hidden">
+      <div style="display:flex;align-items:center;padding:var(--sp-4) var(--sp-5) var(--sp-3)">
+        <span style="font:600 17px/1.3 var(--font-sans)">Select folder</span>
+        <button class="iconbtn r"><svg class="ic"><use href="#i-x"/></svg></button>
+      </div>
+      <div style="padding:0 var(--sp-5) var(--sp-3);display:flex;gap:var(--sp-2)">
+        <div style="flex:1;display:flex;align-items:center;height:34px;padding:0 11px;border:1px solid var(--accent);
+                    box-shadow:0 0 0 3px var(--accent-bg);border-radius:var(--r-md);background:var(--canvas);
+                    font:400 13px/1 var(--font-mono);color:var(--tx1)">/home/dev/projects/leasebot</div>
+        <button class="btn">Go</button>
+      </div>
+      <div style="padding:0 var(--sp-5) var(--sp-3);display:flex;align-items:center;gap:6px;
+                  font:500 12.5px/1 var(--font-sans);color:var(--tx3);flex-wrap:wrap">
+        <svg class="ic s"><use href="#i-home"/></svg>
+        <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-r"/></svg><span>home</span>
+        <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-r"/></svg><span>dev</span>
+        <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-r"/></svg><span>projects</span>
+        <svg class="ic xs" style="color:var(--tx4)"><use href="#i-chev-r"/></svg><span style="color:var(--tx1);font-weight:600">leasebot</span>
+      </div>
+      <div style="margin:0 var(--sp-5);border:1px solid var(--border-subtle);border-radius:var(--r-md);
+                  background:var(--canvas);max-height:222px;overflow-y:auto">
+        <style>
+        .fr{display:flex;align-items:center;gap:var(--sp-3);padding:9px var(--sp-3);
+            font:500 13px/1 var(--font-sans);color:var(--tx1);cursor:pointer}
+        .fr:hover{background:var(--fill-hover)}
+        .fr .ic{color:var(--tx3)}
+        .fr.dim{color:var(--tx4)}.fr.dim .ic{color:var(--tx4)}
+        .fr.sel{background:var(--accent-bg)}
+        .fr.sel .ic{color:var(--accent-tx)}
+        </style>
+        <div class="fr dim"><svg class="ic"><use href="#i-folder"/></svg><span>..</span></div>
+        <div class="fr sel"><svg class="ic"><use href="#i-folder"/></svg><span>backups</span></div>
+        <div class="fr"><svg class="ic"><use href="#i-folder"/></svg><span>docker</span></div>
+        <div class="fr"><svg class="ic"><use href="#i-folder"/></svg><span>docs</span></div>
+        <div class="fr"><svg class="ic"><use href="#i-folder"/></svg><span>drizzle</span>
+          <span class="tag" style="margin-left:auto;height:20px"><svg class="ic"><use href="#i-branch"/></svg> 3 worktrees</span></div>
+        <div class="fr dim"><svg class="ic"><use href="#i-folder"/></svg><span>node_modules</span></div>
+        <div class="fr"><svg class="ic"><use href="#i-folder"/></svg><span>public</span></div>
+        <div class="fr"><svg class="ic"><use href="#i-folder"/></svg><span>scripts</span></div>
+      </div>
+      <div style="display:flex;align-items:center;gap:var(--sp-2);padding:var(--sp-4) var(--sp-5)">
+        <span class="tag"><svg class="ic"><use href="#i-branch"/></svg> main</span>
+        <span class="spacer"></span>
+        <button class="btn ghost">Cancel</button>
+        <button class="btn pri">Select folder</button>
+      </div>
+    </div>
+  </div>
+
+  <ul class="notes">
+    <li><strong>Both input modes.</strong> Typing keeps the current completion behaviour; the list is for when you don't already know the path. Keyboard users lose nothing.</li>
+    <li><strong>Breadcrumbs are clickable</strong> — up three levels is one click, not three <span class="mono-inline">..</span> entries.</li>
+    <li><strong>Worktree detection moves here.</strong> Today it's an interstitial that appears <em>after</em> you hit Create ("Detected 3 git worktrees. Open a session for each?"). Showing the badge while browsing means the decision happens when you're choosing, not as a surprise.</li>
+    <li><strong>Noise is dimmed, not hidden</strong> — <span class="mono-inline">node_modules</span> and dotfolders render at <span class="mono-inline">--tx4</span> so nothing becomes unreachable.</li>
+    <li><strong>Mobile gets it as a full-height sheet</strong>, which is a straight win: <span class="mono-inline">MobileCreateSheet</span> currently has a plain text field and no completion at all.</li>
+  </ul>
+</section>
+
+
+
+
+<!-- ==================== SETTINGS ==================== -->
+<section id="settings">
+  <div class="eyebrow">The product · 08</div>
+  <h2 class="sec">Settings</h2>
+  <p class="lede">
+    Three of the findings are defects rather than taste, including one that <strong>silently destroys what
+    you type</strong>. The mockup below is clickable — walk the eight sections from the left rail.
+  </p>
+
+  <h3 class="sub">What's actually wrong</h3>
+  <table class="spec">
+    <tr><th style="width:30%">Problem</th><th style="width:10%">Severity</th><th>Detail</th></tr>
+    <tr><td>Instant-apply stomps your typing</td><td><span class="pill bad">bug</span></td>
+      <td>A resync effect rewrites every local field whenever the store changes. The Models card saves instantly → store updates → <strong>your unsaved text in another tab is overwritten</strong>. Editing across tabs is unsafe today.</td></tr>
+    <tr><td>Three save models at once</td><td><span class="pill bad">high</span></td>
+      <td>An explicit Save batching 11 keys; instant-apply inside the Models / Providers / Subscriptions cards; and <span class="mono-inline">pluginsEnabled</span> through a different channel entirely. Nobody can tell which changes are live.</td></tr>
+    <tr><td>Three ways to discard silently</td><td><span class="pill bad">high</span></td>
+      <td><strong>Close</strong>, <strong>✕</strong> and <strong>Cancel</strong> all throw away unsaved edits with no dirty state and no warning. And <strong>Save closes the panel</strong>, so you can't save and keep going.</td></tr>
+    <tr><td>Desktop and mobile are hand-copied</td><td><span class="pill bad">high</span></td>
+      <td>No shared schema. Divergent <em>copy</em> for identical settings (cache TTL: 5 sentences desktop, 1 mobile) and divergent <em>coverage</em> — desktop lacks Server URL, mobile lacks agent-file delivery, worktrees, plugins.</td></tr>
+    <tr><td>You can't see what you're connected to</td><td><span class="pill warn">med</span></td>
+      <td>The Connection tab is three actions and no information — no server URL, box ID or server version. Mobile shows the version; desktop doesn't.</td></tr>
+    <tr><td>Three "Restart opencode" affordances</td><td><span class="pill warn">med</span></td>
+      <td>Three components, three confirm styles, three copies, same tab.</td></tr>
+    <tr><td>Two custom-endpoint forms</td><td><span class="pill warn">med</span></td>
+      <td>Settings and onboarding each have one, with <strong>different validation</strong> — onboarding checks the URL scheme, Settings doesn't.</td></tr>
+    <tr><td>Settings with no UI at all</td><td><span class="pill warn">med</span></td>
+      <td><span class="mono-inline">opencodePort</span> and <span class="mono-inline">uploadCleanupHours</span> exist in config and are unreachable from any screen.</td></tr>
+    <tr><td>No search, no defaults, no reset</td><td><span class="pill warn">med</span></td>
+      <td>~20 settings, no way to find one by name, no indication of what's non-default, no reset at any scope.</td></tr>
+    <tr><td>Not a dialog</td><td><span class="pill bad">high</span></td>
+      <td>No <span class="mono-inline">role="dialog"</span>, no focus trap, no <kbd>Esc</kbd>, no focus restore; tab order leaks behind it. No <span class="mono-inline">tablist</span> semantics, so arrow keys don't work. Every text input is unlabelled — the <span class="mono-inline">&lt;label&gt;</span> neither wraps its input nor carries <span class="mono-inline">htmlFor</span>.</td></tr>
+    <tr><td>Raw errors and native alerts</td><td><span class="pill warn">med</span></td>
+      <td>~20 sites render upstream <span class="mono-inline">e.message</span>; two call <span class="mono-inline">alert()</span> — including the entire mobile save-failure path.</td></tr>
+  </table>
+
+  <div class="callout warn">
+    <p><strong>Tool permissions removed as you asked — but flagging that it isn't per-session today.</strong>
+    The composer toggle writes <span class="mono-inline">chatAutoAllow</span>, a single <em>global</em> config key that
+    the server reads per permission request. Flipping it in one session flips it in <em>every</em> session, on
+    desktop and phone, including ones already running. Making it genuinely per-session means moving from a
+    global flag to session-scoped state the server consults per request — small backend change, but a real one.</p>
+  </div>
+
+  <h3 class="sub">Two decisions fix most of the rest</h3>
+  <div class="grid2">
+    <div class="card"><h4>1 · One save model: instant apply + Undo</h4>
+      <p style="margin-bottom:var(--sp-2)">Every change applies immediately and raises a toast with <strong>Undo</strong>. That deletes dirty state, the three-exits problem, the stomping bug and save-closes-the-panel in one move — and matches the cards that already behave this way.</p>
+      <p>Credentials are the exception: an API key commits on blur, not per keystroke.</p></div>
+    <div class="card"><h4>2 · One schema, both platforms</h4>
+      <p style="margin-bottom:var(--sp-2)">Declare every setting once in <span class="mono-inline">src/shared/settingsSchema.ts</span> — id, label, help, control, config key, platform, section — and have both clients render it.</p>
+      <p>Copy drift becomes impossible, and search, "modified" dots, reset-to-default and <span class="mono-inline">htmlFor</span> wiring all fall out for free.</p></div>
+  </div>
+
+  <h3 class="sub">Restructure — eight sections</h3>
+  <p>
+    Six flat tabs today, with the AI tab stacking three mental models and settings landing wherever there was
+    room. Regrouped by <strong>the object being configured</strong>. <strong>General sits above the clusters</strong>,
+    since it's about this app rather than the box or the agent.
+  </p>
+  <table class="spec">
+    <tr><th style="width:12%">Cluster</th><th style="width:16%">Section</th><th>Holds · changes from today</th></tr>
+    <tr><td><em>ungrouped</em></td><td>General</td><td><span class="pill info">gains</span> the theme control. Plus About with a <em>real</em> version — today it's a hardcoded <span class="mono-inline">v0.0.1</span> literal.</td></tr>
+    <tr><td rowspan="3"><strong>Setup</strong><br><span style="font-weight:400;color:var(--tx3)">the machine and its credentials</span></td>
+      <td>Box</td><td>Status, pair a phone, re-run setup, remove box. The editable connection block is gone — the status card already shows the URL, and changing it just means re-pairing. <span class="mono-inline">opencodePort</span> moves to a collapsed Advanced row.</td></tr>
+    <tr><td>Accounts</td><td><span class="pill info">merged</span> Subscriptions and custom endpoints into one list — both are "a way to reach a model". <strong>One</strong> add-endpoint form with <strong>one</strong> validator, shared with onboarding.</td></tr>
+    <tr><td>Models</td><td><span class="pill info">split out</span> from the AI tab. Default / Main / Sub table plus prompt-cache TTL, which is a property of a model request.</td></tr>
+    <tr><td rowspan="4"><strong>Agent</strong><br><span style="font-weight:400;color:var(--tx3)">what it does and what it can use</span></td>
+      <td>Sessions</td><td><span class="pill info">new grouping</span> Auto-rename and worktree behaviour, currently split between the Files tab and General.</td></tr>
+    <tr><td>Files</td><td>Auto-save agent-sent files, downloads directory, upload cleanup.</td></tr>
+    <tr><td>Extensions</td><td><span class="pill info">merged</span> Plugins, skill registries and AI-CLI launch flags — all "extend what the agent can reach", currently in three tabs.</td></tr>
+    <tr><td>Voice</td><td>Unchanged, minus the desktop/mobile copy divergence.</td></tr>
+  </table>
+  <p style="font-size:13.5px;color:var(--tx3)">
+    Deliberately <strong>absent</strong>: tool permissions (stays in the composer), notifications (nothing about
+    the routing is configurable today — it's server-side logic, so there'd be nothing to put in it), analytics,
+    and a terminal-theme control (the terminal is always dark and the tools inside paint their own colours,
+    so there's nothing to offer).
+  </p>
+
+  <h3 class="sub">Click through it</h3>
+  <p style="font-size:13.5px">
+    Every row is tagged so nothing here is ambiguous: untagged rows <strong>exist today</strong>,
+    <span class="pill warn">config only</span> means the key exists but has no screen, and
+    <span class="pill info">new</span> means it doesn't exist yet.
+  </p>
+
+<style>
+.setwin{border:1px solid var(--border);border-radius:var(--r-xl);overflow:hidden;box-shadow:var(--shadow-lg);
+  background:var(--canvas);display:grid;grid-template-columns:212px 1fr;height:640px;margin:var(--sp-4) 0;position:relative}
+@media(max-width:820px){.setwin{grid-template-columns:1fr;height:auto}.setwin .snav{display:none}}
+.snav{background:var(--panel);border-right:1px solid var(--border-subtle);display:flex;flex-direction:column;
+  padding:var(--sp-3) var(--sp-2);overflow-y:auto}
+.snav h3{font:600 15px/1 var(--font-sans);padding:0 var(--sp-2) var(--sp-3)}
+.snav .sfind{display:flex;align-items:center;gap:7px;height:30px;padding:0 9px;border-radius:var(--r-md);
+  background:var(--fill);color:var(--tx3);font:400 12.5px/1 var(--font-sans);margin-bottom:var(--sp-3)}
+.snav .cl{font:600 10px/1 var(--font-sans);letter-spacing:.09em;text-transform:uppercase;color:var(--tx4);
+  padding:0 9px;margin:var(--sp-4) 0 var(--sp-2)}
+.snav-i{display:flex;align-items:center;gap:var(--sp-2);padding:7px 9px;border-radius:var(--r-md);
+  font:500 13px/1 var(--font-sans);color:var(--tx3);cursor:pointer;margin-bottom:1px;border:0;background:transparent;width:100%;text-align:left}
+.snav-i:hover{background:var(--fill-hover);color:var(--tx1)}
+.snav-i.on{background:var(--raised);color:var(--tx1);font-weight:600}
+.snav-i .ic{width:15px;height:15px}
+.snav-i .mod{margin-left:auto;width:6px;height:6px;border-radius:50%;background:var(--accent)}
+.setmain{display:flex;flex-direction:column;min-width:0}
+.sethead{height:46px;display:flex;align-items:center;padding:0 var(--sp-5);border-bottom:1px solid var(--border-subtle);gap:var(--sp-2);flex-shrink:0}
+.sethead h4{font:600 15px/1 var(--font-sans)}
+.setbody{flex:1;overflow-y:auto;padding:var(--sp-5);min-height:0}
+.setgrp{max-width:660px}
+.setgrp+.setgrp{margin-top:var(--sp-8)}
+.setgrp>h5{font:600 11px/1 var(--font-sans);letter-spacing:.08em;text-transform:uppercase;color:var(--tx3);margin:0 0 var(--sp-2)}
+.setrow{display:flex;align-items:flex-start;gap:var(--sp-5);padding:var(--sp-3) 0;border-bottom:1px solid var(--border-subtle)}
+.setrow:last-child{border-bottom:0}
+.setrow .lab{flex:1;min-width:0}
+.setrow .lab b{display:block;font:500 14px/1.4 var(--font-sans);color:var(--tx1)}
+.setrow .lab span.h{display:block;font:400 12.5px/1.5 var(--font-sans);color:var(--tx3);margin-top:3px}
+.setrow .ctl{flex-shrink:0;display:flex;align-items:center;gap:var(--sp-2);padding-top:2px}
+.sw{width:36px;height:20px;border-radius:var(--r-full);background:var(--fill-active);border:1px solid var(--border);
+  position:relative;cursor:pointer;transition:.15s var(--ease);flex-shrink:0}
+.sw i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;background:var(--tx3);transition:.15s var(--ease)}
+.sw.on{background:var(--accent-solid);border-color:var(--accent-solid)}
+.sw.on i{left:18px;background:var(--on-accent)}
+.inp{height:32px;padding:0 10px;border:1px solid var(--border-strong);border-radius:var(--r-md);background:var(--canvas);
+  color:var(--tx1);font:400 12.5px/1 var(--font-mono);min-width:200px}
+.inp.sans{font-family:var(--font-sans);font-size:13px}
+.savedtick{font:500 11px/1 var(--font-sans);color:var(--ok);display:inline-flex;align-items:center;gap:4px}
+.savedtick .ic{width:12px;height:12px;stroke-width:3}
+.statcard{display:flex;align-items:center;gap:var(--sp-3);padding:var(--sp-3) var(--sp-4);border:1px solid var(--border);
+  border-radius:var(--r-lg);background:var(--panel);max-width:660px;margin-bottom:var(--sp-5)}
+.statcard .bl{width:34px;height:34px;border-radius:var(--r-md);display:grid;place-items:center;background:var(--ok-bg);color:var(--ok);flex-shrink:0}
+.statcard .kv{font:500 12px/1.7 var(--font-mono);color:var(--tx3);min-width:0}
+.statcard .kv b{color:var(--tx1);font-weight:600}
+.undo{position:absolute;left:50%;bottom:var(--sp-5);transform:translateX(-50%);display:flex;align-items:center;
+  gap:var(--sp-3);padding:9px var(--sp-3) 9px var(--sp-4);border-radius:var(--r-full);background:var(--card);
+  border:1px solid var(--border);box-shadow:var(--shadow-md);font:500 12.5px/1 var(--font-sans);color:var(--tx2);white-space:nowrap;z-index:5}
+.undo button{border:0;background:transparent;color:var(--accent-tx);font:600 12.5px/1 var(--font-sans);cursor:pointer;padding:0 4px}
+.restartbar{display:flex;align-items:center;gap:var(--sp-3);padding:9px var(--sp-4);background:var(--warn-bg);
+  border-bottom:1px solid color-mix(in srgb,var(--warn) 30%,transparent);font:500 12.5px/1.4 var(--font-sans);color:var(--tx2);flex-shrink:0}
+.restartbar .ic{color:var(--warn);flex-shrink:0}
+.lrow{display:flex;align-items:center;gap:var(--sp-3);padding:var(--sp-3) 0;border-bottom:1px solid var(--border-subtle)}
+.lrow:last-of-type{border-bottom:0}
+.lrow .av{width:28px;height:28px;border-radius:var(--r-sm);display:grid;place-items:center;background:var(--fill-active);
+  color:var(--tx2);font:600 11px/1 var(--font-sans);flex-shrink:0}
+.lrow .nm{font:500 13.5px/1.3 var(--font-sans);color:var(--tx1)}
+.lrow .nm em{display:block;font:400 12px/1.4 var(--font-sans);color:var(--tx3);font-style:normal;margin-top:2px}
+.dot-ok{width:7px;height:7px;border-radius:50%;background:var(--ok);flex-shrink:0}
+.dot-off{width:7px;height:7px;border-radius:50%;background:var(--tx4);flex-shrink:0}
+.mtable{width:100%;border-collapse:collapse;font-size:12.5px}
+.mtable th{text-align:left;font:600 10px/1 var(--font-sans);letter-spacing:.07em;text-transform:uppercase;
+  color:var(--tx4);padding:var(--sp-2);border-bottom:1px solid var(--border)}
+.mtable td{padding:9px var(--sp-2);border-bottom:1px solid var(--border-subtle);color:var(--tx2)}
+.mtable td:first-child{color:var(--tx1);font-weight:500}
+.mtable .ctx{font:500 10.5px/1 var(--font-mono);color:var(--tx4)}
+.radio{width:15px;height:15px;border-radius:50%;border:1.5px solid var(--border-strong);display:inline-grid;place-items:center}
+.radio.on{border-color:var(--accent-solid)}
+.radio.on::after{content:"";width:7px;height:7px;border-radius:50%;background:var(--accent-solid)}
+.segsm{display:inline-flex;border:1px solid var(--border);border-radius:var(--r-md);overflow:hidden;background:var(--card)}
+.segsm span{padding:6px 12px;font:500 12px/1 var(--font-sans);color:var(--tx3);cursor:pointer}
+.segsm span+span{border-left:1px solid var(--border)}
+.segsm span.on{background:var(--raised);color:var(--tx1);font-weight:600}
+.tagrow{display:flex;align-items:center;gap:var(--sp-2);padding:7px 10px;border:1px solid var(--border-subtle);
+  border-radius:var(--r-md);background:var(--panel);margin-bottom:var(--sp-2);font:400 12px/1 var(--font-mono);color:var(--tx2)}
+.danger-z{border:1px solid color-mix(in srgb,var(--danger) 35%,transparent);border-radius:var(--r-lg);
+  padding:var(--sp-3) var(--sp-4);background:var(--danger-bg);max-width:660px}
+.setpanel{display:none}.setpanel.on{display:block}
+.advrow{display:flex;align-items:center;gap:var(--sp-2);font:500 12.5px/1 var(--font-sans);color:var(--tx3);cursor:pointer;padding:var(--sp-3) 0}
+</style>
+
+<div class="setwin" data-group="set">
+  <nav class="snav">
+    <h3>Settings</h3>
+    <div class="sfind"><svg class="ic s"><use href="#i-search"/></svg><span>Find a setting</span><kbd style="margin-left:auto;font:500 10px/1 var(--font-sans);color:var(--tx4)">⌘F</kbd></div>
+    <button class="snav-i on" data-tab="general"><svg class="ic"><use href="#i-settings"/></svg> General</button>
+    <div class="cl">Setup</div>
+    <button class="snav-i" data-tab="box"><svg class="ic"><use href="#i-terminal"/></svg> Box</button>
+    <button class="snav-i" data-tab="accounts"><svg class="ic"><use href="#i-key"/></svg> Accounts</button>
+    <button class="snav-i" data-tab="models"><svg class="ic"><use href="#i-spark"/></svg> Models <span class="mod" title="contains non-default values"></span></button>
+    <div class="cl">Agent</div>
+    <button class="snav-i" data-tab="sessions"><svg class="ic"><use href="#i-branch"/></svg> Sessions</button>
+    <button class="snav-i" data-tab="files"><svg class="ic"><use href="#i-folder"/></svg> Files</button>
+    <button class="snav-i" data-tab="ext"><svg class="ic"><use href="#i-hook"/></svg> Extensions</button>
+    <button class="snav-i" data-tab="voice"><svg class="ic"><use href="#i-mic"/></svg> Voice</button>
+  </nav>
+
+  <div class="setmain">
+    <div class="sethead"><h4 data-title>General</h4><span class="spacer"></span>
+      <button class="iconbtn" title="Close (Esc)"><svg class="ic"><use href="#i-x"/></svg></button></div>
+
+    <div class="setbody">
+      <!-- GENERAL -->
+      <div class="setpanel on" data-panel="general">
+        <div class="setgrp">
+          <h5>Appearance</h5>
+          <div class="setrow"><span class="lab"><b>Theme <span class="pill info">new</span></b>
+            <span class="h">Follows your operating system unless you choose one. Warm neutral in light, manta navy in dark. The terminal pane stays dark in both — the tools running inside it paint their own colours.</span></span>
+            <span class="ctl"><span class="segsm"><span class="on">System</span><span>Light</span><span>Dark</span></span></span></div>
+        </div>
+        <div class="setgrp">
+          <h5>About</h5>
+          <div class="setrow"><span class="lab"><b>Manta</b>
+            <span class="h">Desktop 1.4.0 · server v1.8.2 · opencode 0.14.3<br>Today this reads "Manta UI v0.0.1" — a hardcoded literal, not the real version.</span></span></div>
+        </div>
+        <div class="setgrp">
+          <h5>Danger zone</h5>
+          <div class="danger-z"><div style="display:flex;align-items:center;gap:var(--sp-4)">
+            <span style="flex:1"><b style="display:block;font:500 14px/1.4 var(--font-sans);color:var(--tx1)">Reset all settings <span class="pill info">new</span></b>
+              <span style="display:block;font:400 12.5px/1.5 var(--font-sans);color:var(--tx3);margin-top:3px">Restores every setting to its default. Does not touch your box, sessions, accounts or files.</span></span>
+            <button class="btn danger" style="border:1px solid color-mix(in srgb,var(--danger) 40%,transparent)">Reset</button>
+          </div></div>
+        </div>
+      </div>
+
+      <!-- BOX -->
+      <div class="setpanel" data-panel="box">
+        <div class="statcard">
+          <span class="bl"><svg class="ic"><use href="#i-check"/></svg></span>
+          <span class="kv"><b>Connected</b><br>https://0d5784a7.boxes.mantaui.com<br>box <b>0d5784a7a43451f4ad70dd3d9ee5cf72</b> · server v1.8.2</span>
+        </div>
+        <div class="setgrp">
+          <h5>Devices</h5>
+          <div class="setrow"><span class="lab"><b>Pair a phone</b><span class="h">Show a QR code to scan with the Manta mobile app. The code expires in 5 minutes.</span></span>
+            <span class="ctl"><button class="btn">Generate pairing code</button></span></div>
+          <div class="setrow"><span class="lab"><b>Re-run setup</b><span class="h">Walk through pairing and providers again.</span></span>
+            <span class="ctl"><button class="btn">Run setup</button></span></div>
+        </div>
+        <div class="setgrp">
+          <div class="advrow"><svg class="ic s"><use href="#i-chev-r"/></svg> Advanced</div>
+          <div class="setrow" style="border-top:1px solid var(--border-subtle)"><span class="lab"><b>opencode port <span class="pill warn">config only</span></b>
+            <span class="h">The port opencode listens on, on the box. Leave at 4096 unless you changed it there.</span></span>
+            <span class="ctl"><input class="inp" value="4096" style="min-width:76px"></span></div>
+        </div>
+        <div class="setgrp">
+          <h5>Danger zone</h5>
+          <div class="danger-z"><div style="display:flex;align-items:center;gap:var(--sp-4)">
+            <span style="flex:1"><b style="display:block;font:500 14px/1.4 var(--font-sans);color:var(--tx1)">Remove this box</b>
+              <span style="display:block;font:400 12.5px/1.5 var(--font-sans);color:var(--tx3);margin-top:3px">Forgets the box on this device and revokes its token if the box is reachable. Sessions on the box keep running.</span></span>
+            <button class="btn danger" style="border:1px solid color-mix(in srgb,var(--danger) 40%,transparent)">Remove box</button>
+          </div></div>
+        </div>
+      </div>
+
+      <!-- ACCOUNTS -->
+      <div class="setpanel" data-panel="accounts">
+        <div class="setgrp">
+          <h5>Subscriptions</h5>
+          <div class="lrow"><span class="av">C</span><span class="nm">Claude<em>Claude Pro / Max</em></span><span class="spacer"></span><span class="dot-ok"></span><span style="font:500 12px/1 var(--font-sans);color:var(--ok)">Connected</span><button class="btn sm">Disconnect</button></div>
+          <div class="lrow"><span class="av">O</span><span class="nm">Codex<em>ChatGPT Plus / Pro</em></span><span class="spacer"></span><span class="dot-off"></span><span style="font:500 12px/1 var(--font-sans);color:var(--tx4)">Not connected</span><button class="btn sm">Connect</button></div>
+          <div class="lrow"><span class="av">K</span><span class="nm">Kimi<em>Kimi For Coding</em></span><span class="spacer"></span><span class="dot-off"></span><span style="font:500 12px/1 var(--font-sans);color:var(--tx4)">Not connected</span><button class="btn sm">Connect</button></div>
+        </div>
+        <div class="setgrp">
+          <h5>Custom endpoints</h5>
+          <p style="font-size:12.5px;color:var(--tx3);margin-bottom:var(--sp-3)">Any OpenAI-compatible API. <span class="pill info">new</span> One form and one validator, shared with onboarding — today there are two, and only onboarding checks the URL scheme.</p>
+          <div class="lrow"><span class="av">V</span><span class="nm">VoskaAI<em>https://api.voska.ai/v1 · 6 models</em></span><span class="spacer"></span><button class="btn sm">Refresh</button><button class="iconbtn"><svg class="ic s"><use href="#i-x"/></svg></button></div>
+          <button class="btn" style="margin-top:var(--sp-3)"><svg class="ic"><use href="#i-plus"/></svg> Add endpoint</button>
+        </div>
+      </div>
+
+      <!-- MODELS -->
+      <div class="setpanel" data-panel="models">
+        <div class="setgrp">
+          <div class="sfind" style="margin:0 0 var(--sp-3);background:var(--fill)"><svg class="ic s"><use href="#i-search"/></svg><span>Search models</span></div>
+          <table class="mtable">
+            <tr><th style="width:46%">Model</th><th>Default</th><th>Main</th><th>Sub</th></tr>
+            <tr><td>Claude Opus 4.8 <span class="ctx">1000k</span></td><td><span class="radio on"></span></td><td><span class="sw on" style="width:32px;height:18px"><i style="left:16px;width:12px;height:12px"></i></span></td><td><span class="sw on" style="width:32px;height:18px"><i style="left:16px;width:12px;height:12px"></i></span></td></tr>
+            <tr><td>Claude Sonnet 4.6 <span class="ctx">200k</span></td><td><span class="radio"></span></td><td><span class="sw on" style="width:32px;height:18px"><i style="left:16px;width:12px;height:12px"></i></span></td><td><span class="sw on" style="width:32px;height:18px"><i style="left:16px;width:12px;height:12px"></i></span></td></tr>
+            <tr><td>Claude Haiku 4.5 <span class="ctx">200k</span></td><td><span class="radio"></span></td><td><span class="sw" style="width:32px;height:18px"><i style="width:12px;height:12px"></i></span></td><td><span class="sw on" style="width:32px;height:18px"><i style="left:16px;width:12px;height:12px"></i></span></td></tr>
+            <tr><td>GPT-5.2 <span class="ctx">400k</span></td><td><span class="radio"></span></td><td><span class="sw on" style="width:32px;height:18px"><i style="left:16px;width:12px;height:12px"></i></span></td><td><span class="sw" style="width:32px;height:18px"><i style="width:12px;height:12px"></i></span></td></tr>
+          </table>
+          <p style="font-size:12px;color:var(--tx3);margin-top:var(--sp-3)"><strong>Main</strong> = offered in the composer picker. <strong>Sub</strong> = registered as a named subagent the AI can dispatch to.</p>
+        </div>
+        <div class="setgrp">
+          <h5>Requests</h5>
+          <div class="setrow"><span class="lab"><b>Prompt cache lifetime</b><span class="h">Must match what opencode sends. Past this, the next message re-bills the cached prefix — Manta uses it to predict when clearing would save tokens.</span></span>
+            <span class="ctl"><span class="segsm"><span>5 minutes</span><span class="on">1 hour</span></span></span></div>
+        </div>
+      </div>
+
+      <!-- SESSIONS -->
+      <div class="setpanel" data-panel="sessions">
+        <div class="setgrp">
+          <h5>Naming</h5>
+          <div class="setrow"><span class="lab"><b>Name sessions from the conversation</b><span class="h">Replaces the default name once the first exchange makes the topic clear.</span></span><span class="ctl"><span class="sw on"><i></i></span></span></div>
+        </div>
+        <div class="setgrp">
+          <h5>Git worktrees</h5>
+          <div class="setrow"><span class="lab"><b>Create a worktree for new sessions</b><span class="h">Each session gets its own branch and working directory, so parallel sessions can't collide. Overridable per session.</span></span><span class="ctl"><span class="sw on"><i></i></span></span></div>
+          <div class="setrow"><span class="lab"><b>Remove the worktree when a session closes</b><span class="h">Skipped automatically if the worktree has uncommitted changes.</span></span><span class="ctl"><span class="sw"><i></i></span></span></div>
+        </div>
+      </div>
+
+      <!-- FILES -->
+      <div class="setpanel" data-panel="files">
+        <div class="setgrp">
+          <h5>Files the agent sends you</h5>
+          <div class="setrow"><span class="lab"><b>Save automatically</b><span class="h">Write to your downloads folder without asking. Off means each file raises a Save prompt.</span></span><span class="ctl"><span class="savedtick"><svg class="ic"><use href="#i-check"/></svg> Saved</span><span class="sw"><i></i></span></span></div>
+          <div class="setrow"><span class="lab"><b>Downloads folder</b><span class="h">Absolute path. Empty uses your system downloads folder.</span></span>
+            <span class="ctl"><input class="inp" value="~/Downloads" style="min-width:170px"><button class="btn sm">Browse</button></span></div>
+        </div>
+        <div class="setgrp">
+          <h5>Files you send the agent</h5>
+          <div class="setrow"><span class="lab"><b>Clean up uploads after <span class="pill warn">config only</span></b><span class="h">Dropped files live in <span class="mono-inline">~/.manta-uploads</span> on the box until swept.</span></span>
+            <span class="ctl"><span class="segsm"><span class="on">1 hour</span><span>6 hours</span><span>1 day</span><span>Never</span></span></span></div>
+        </div>
+      </div>
+
+      <!-- EXTENSIONS -->
+      <div class="setpanel" data-panel="ext">
+        <div class="setgrp">
+          <h5>Plugins</h5>
+          <div class="setrow"><span class="lab"><b>Run plugins on this machine</b><span class="h">Any YAML file in <span class="mono-inline">~/.manta/plugins</span> may run shell commands here. There's no per-plugin prompt — treat the folder like <span class="mono-inline">authorized_keys</span>.</span></span><span class="ctl"><span class="sw"><i></i></span></span></div>
+          <div class="tagrow" style="margin-top:var(--sp-3);opacity:.55"><svg class="ic s"><use href="#i-hook"/></svg> ios-leasebot <span class="spacer"></span><span style="color:var(--tx4)">4 steps · 25 min</span><span class="pill good">valid</span></div>
+          <div class="tagrow" style="opacity:.55"><svg class="ic s"><use href="#i-hook"/></svg> db-reset <span class="spacer"></span><span class="pill bad">parse error</span></div>
+          <button class="btn sm" style="margin-top:var(--sp-1)">Open plugins folder</button>
+        </div>
+        <div class="setgrp">
+          <h5>Skill registries</h5>
+          <div class="tagrow">https://antoinedc.github.io/manta-skills <span class="spacer"></span><span class="pill info">default</span></div>
+          <div class="tagrow">https://skills.internal.acme.dev <span class="spacer"></span><button class="iconbtn" style="width:20px;height:20px"><svg class="ic xs"><use href="#i-x"/></svg></button></div>
+          <button class="btn sm"><svg class="ic s"><use href="#i-plus"/></svg> Add registry</button>
+        </div>
+        <div class="setgrp">
+          <h5>CLI launch options</h5>
+          <div class="setrow"><span class="lab"><b>Claude Code — skip all permission prompts</b><span class="h">Applies only to terminal-mode windows running the Claude CLI, not to chat sessions.</span></span><span class="ctl"><span class="sw"><i></i></span></span></div>
+        </div>
+      </div>
+
+      <!-- VOICE -->
+      <div class="setpanel" data-panel="voice">
+        <div class="setgrp">
+          <h5>Speech to text (Groq)</h5>
+          <p style="font-size:12.5px;color:var(--tx3);margin-bottom:var(--sp-3)">Hold the mic to dictate; hold with ⌥ to speak a command. Leave the key blank to hide the mic entirely.</p>
+          <div class="setrow"><span class="lab"><b>API key</b><span class="h">Stored on this device. Only ever sent to Groq.</span></span>
+            <span class="ctl"><input class="inp" type="password" value="gsk_xxxxxxxxxxxxxxxx"></span></div>
+          <div class="setrow"><span class="lab"><b>Transcription model</b></span><span class="ctl"><input class="inp" value="whisper-large-v3-turbo"></span></div>
+          <div class="setrow"><span class="lab"><b>Command model</b><span class="h">Only used when a spoken command doesn't match a built-in rule.</span></span><span class="ctl"><input class="inp" value="llama-3.1-8b-instant"></span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="undo">Theme set to System <button>Undo</button></div>
+  </div>
+</div>
+</section>
+
+<!-- ==================== ONBOARDING ==================== -->
+<section id="onboarding">
+  <div class="eyebrow">The product · 09</div>
+  <h2 class="sec">Onboarding</h2>
+  <p class="lede">
+    Better shape than Settings — the flow is tight, the classified error copy is good, and the SSH installer's
+    progress UI is <strong>the best-designed thing in the product</strong>. Every phase is clickable below,
+    including all four provider sign-in shapes.
+  </p>
+
+  <div class="callout warn">
+    <p><strong>One correction before the mockups: Codex is not an API key.</strong> You grouped
+    "codex/kimi are easier (api key)", but the registry
+    (<span class="mono-inline">src/server/subscriptionProviders.mjs</span>) puts Codex on
+    <strong>device-code OAuth</strong> — and with a deliberate constraint: it prefers the
+    <em>headless</em> variant because the browser variant redirects to <span class="mono-inline">localhost:1455</span>
+    <strong>on the box</strong>, which is unreachable from your laptop or phone. So there are
+    <strong>four</strong> distinct shapes, not three: Claude CLI, Codex device code, Kimi API key, and custom
+    endpoint. Only Kimi is a plain key.</p>
+  </div>
+
+  <h3 class="sub">Problems</h3>
+  <table class="spec">
+    <tr><th style="width:28%">Problem</th><th style="width:10%">Severity</th><th>Detail</th></tr>
+    <tr><td>Verification failure is a dead end</td><td><span class="pill bad">high</span></td>
+      <td>The last step waits 15s for a probe reply. On failure it renders a static red block — <strong>no Retry, no diagnostics, no way forward</strong>. The user is stuck on step 2 with a Continue button they must guess to press again. Worst moment in the flow, because everything <em>else</em> just succeeded.</td></tr>
+    <tr><td>Five-minute waits with no feedback</td><td><span class="pill bad">high</span></td>
+      <td>Both OAuth flows poll for up to 5 minutes behind "Waiting for sign-in" — no elapsed, no countdown, no cancel. Lose the browser tab and you wait five minutes to find out.</td></tr>
+    <tr><td>Mobile can finish setup broken</td><td><span class="pill bad">high</span></td>
+      <td>Mobile pairing <strong>never asks about providers and never verifies</strong>. A mobile-first user pairs, lands on the session list, and nothing works — with no explanation, because the step that would have said so is desktop-only. Given a model is now mandatory, this is the gap that matters most.</td></tr>
+    <tr><td>One spinner hides three operations</td><td><span class="pill warn">med</span></td>
+      <td>"Verifying your box…" spans create-project, send-prompt and poll-for-reply. On failure you can't tell which — and the installer three steps earlier had a six-stage breakdown.</td></tr>
+    <tr><td>Copy defects</td><td><span class="pill good">low</span></td>
+      <td>Pairing-failure text points at a form "below" that's hidden behind an unopened disclosure. Mobile says tap <em>"Generate Pairing Code"</em>; the button reads <em>"Generate pairing code"</em>. First-run uses <strong>two different brand marks</strong> — a PNG on desktop, an inline SVG on mobile.</td></tr>
+    <tr><td>No focus management</td><td><span class="pill warn">med</span></td>
+      <td>Advancing never moves focus. (Errors <em>do</em> refocus correctly — the pattern exists, it just isn't applied on advance.)</td></tr>
+  </table>
+
+  <h3 class="sub">Three decisions</h3>
+  <div class="grid3">
+    <div class="card"><h4>Connecting a model is mandatory</h4><p>No skip, no deferral. There's no product without one — and the dead <span class="mono-inline">skipOnboarding</span> code stays dead. Pairing and provider are both hard gates.</p></div>
+    <div class="card"><h4>The probe leaves nothing behind</h4><p>An ephemeral session deleted the moment the reply lands. No <span class="mono-inline">~/projects/welcome</span>, no billed junk turn sitting in the sidebar, no project the user didn't choose.</p></div>
+    <div class="card"><h4>One progress component everywhere</h4><p>Extract the installer's stage list, counter, elapsed time and Copy-diagnostics as <span class="mono-inline">&lt;ProcessPanel&gt;</span>; reuse it for sign-in, verification and restarts.</p></div>
+  </div>
+
+<style>
+.obwin{border:1px solid var(--border);border-radius:var(--r-xl);overflow:hidden;box-shadow:var(--shadow-lg);
+  background:var(--canvas);min-height:600px;display:flex;flex-direction:column;margin:var(--sp-3) 0 var(--sp-2)}
+.obstage{flex:1;display:grid;place-items:center;padding:var(--sp-8) var(--sp-5)}
+.obcard{width:min(560px,100%)}
+.oblogo{width:44px;height:44px;border-radius:12px;margin:0 auto var(--sp-5);
+  background:linear-gradient(135deg,var(--accent),color-mix(in srgb,var(--accent) 40%,var(--info)))}
+.obrail{display:flex;align-items:center;justify-content:center;gap:var(--sp-3);margin-bottom:var(--sp-6)}
+.obrail .s{display:flex;align-items:center;gap:7px;font:500 12px/1 var(--font-sans);color:var(--tx4)}
+.obrail .s .n{width:19px;height:19px;border-radius:50%;border:1.5px solid var(--border-strong);
+  display:grid;place-items:center;font:600 10.5px/1 var(--font-mono)}
+.obrail .s.on{color:var(--tx1);font-weight:600}
+.obrail .s.on .n{background:var(--accent-solid);border-color:var(--accent-solid);color:var(--on-accent)}
+.obrail .s.ok .n{background:var(--ok);border-color:var(--ok);color:#fff}
+.obrail .s.ok{color:var(--tx3)}
+.obrail .ln{width:26px;height:1px;background:var(--border)}
+.obh{text-align:center;margin-bottom:var(--sp-5)}
+.obh h3{font:700 21px/1.3 var(--font-sans);letter-spacing:-.02em;margin-bottom:6px}
+.obh p{font:400 14px/1.55 var(--font-sans);color:var(--tx3);margin:0 auto;max-width:46ch}
+.obbox{border:1px solid var(--border);border-radius:var(--r-lg);background:var(--card);padding:var(--sp-4);box-shadow:var(--shadow-sm)}
+.fld{margin-bottom:var(--sp-3)}
+.fld label{display:block;font:500 11px/1 var(--font-sans);letter-spacing:.05em;text-transform:uppercase;color:var(--tx3);margin-bottom:6px}
+.fld .inp{width:100%;min-width:0}
+.obfoot{display:flex;align-items:center;gap:var(--sp-2);margin-top:var(--sp-4)}
+.lnk{border:0;background:transparent;color:var(--tx3);font:500 12.5px/1 var(--font-sans);
+  text-decoration:underline;text-underline-offset:3px;cursor:pointer;padding:6px 0}
+.lnk:hover{color:var(--tx1)}
+.proc-h{display:flex;align-items:baseline;gap:var(--sp-2);margin-bottom:var(--sp-3)}
+.proc-h b{font:600 14px/1 var(--font-sans)}
+.proc-h .c{margin-left:auto;font:500 11.5px/1 var(--font-mono);color:var(--tx3);font-variant-numeric:tabular-nums}
+.bar{height:4px;border-radius:2px;background:var(--fill-active);overflow:hidden;margin-bottom:var(--sp-3)}
+.bar i{display:block;height:100%;background:var(--accent-solid);border-radius:2px}
+.stg{display:flex;align-items:center;gap:var(--sp-3);padding:5px 0;font:500 12.5px/1.3 var(--font-sans);color:var(--tx4)}
+.stg .m{width:15px;height:15px;border-radius:50%;display:grid;place-items:center;flex-shrink:0;border:1.5px solid var(--border-strong)}
+.stg.done{color:var(--tx2)}
+.stg.done .m{background:var(--ok);border-color:var(--ok);color:#fff}
+.stg .m .ic{width:9px;height:9px;stroke-width:4}
+.stg.now{color:var(--tx1);font-weight:600}
+.stg.now .m{border-color:var(--accent);border-right-color:transparent;animation:spin .8s linear infinite}
+.stg.err{color:var(--tx1)}
+.stg.err .m{background:var(--danger);border-color:var(--danger);color:#fff}
+.stg .t{margin-left:auto;font:500 11px/1 var(--font-mono);color:var(--tx4);font-variant-numeric:tabular-nums}
+@keyframes spin{to{transform:rotate(360deg)}}
+.log{margin-top:var(--sp-3);border:1px solid var(--border-subtle);border-radius:var(--r-md);background:var(--inset);
+  padding:var(--sp-2) var(--sp-3);font:400 11px/1.65 var(--font-mono);color:var(--tx3);max-height:92px;overflow:hidden}
+.causecard{border:1px solid color-mix(in srgb,var(--danger) 35%,transparent);background:var(--danger-bg);
+  border-radius:var(--r-md);padding:var(--sp-3);margin-bottom:var(--sp-2)}
+.causecard b{display:block;font:600 12.5px/1.4 var(--font-sans);color:var(--tx1);margin-bottom:3px}
+.causecard span{font:400 12.5px/1.5 var(--font-sans);color:var(--tx2)}
+.obpick{display:flex;flex-wrap:wrap;gap:6px;margin:var(--sp-4) 0 0;justify-content:center}
+.obpick button{border:1px solid var(--border);background:var(--panel);color:var(--tx3);border-radius:var(--r-full);
+  padding:6px 12px;font:500 11.5px/1 var(--font-sans);cursor:pointer}
+.obpick button:hover{border-color:var(--border-strong);color:var(--tx1)}
+.obpick button.on{background:var(--accent-solid);border-color:var(--accent-solid);color:var(--on-accent);font-weight:600}
+.obpanel{display:none}.obpanel.on{display:block}
+.otp{display:flex;gap:7px;justify-content:center;margin:var(--sp-3) 0}
+.otp span{width:36px;height:44px;border:1px solid var(--border-strong);border-radius:var(--r-md);background:var(--canvas);
+  display:grid;place-items:center;font:600 19px/1 var(--font-mono);color:var(--tx1)}
+.otp span.empty{color:var(--tx4)}
+.otp span.cur{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg)}
+.term{border:1px solid var(--border-subtle);border-radius:var(--r-md);background:#070B16;padding:var(--sp-2) var(--sp-3);
+  font:400 11px/1.7 var(--font-mono);color:#BDC7DB;height:104px;overflow:hidden}
+.term .g{color:#3DD9A4}.term .y{color:#F0A934}.term .d{color:#6B7690}
+</style>
+
+  <div class="obpick" data-group="ob">
+    <button class="on" data-tab="pick">1 · Pick a box</button>
+    <button data-tab="trust">Trust host</button>
+    <button data-tab="unlock">Unlock key</button>
+    <button data-tab="install">Installing</button>
+    <button data-tab="preflight">✕ Preflight failed</button>
+    <button data-tab="manual">Pair manually</button>
+    <button data-tab="prov">2 · Providers</button>
+    <button data-tab="clicheck">→ Claude: preparing</button>
+    <button data-tab="clifail">✕ CLI install failed</button>
+    <button data-tab="claude">→ Claude</button>
+    <button data-tab="codex">→ Codex</button>
+    <button data-tab="kimi">→ Kimi</button>
+    <button data-tab="custom">→ Custom</button>
+    <button data-tab="check">3 · Checking</button>
+    <button data-tab="checkfail">✕ Check failed</button>
+    <button data-tab="done">Done</button>
+  </div>
+
+<div class="obwin"><div class="obstage"><div class="obcard">
+  <div class="oblogo"></div>
+
+  <!-- PICK -->
+  <div class="obpanel on" data-panel="pick">
+    <div class="obrail"><span class="s on"><span class="n">1</span> Box</span><span class="ln"></span><span class="s"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Connect your box</h3><p>Pick the machine you want to run Manta on. It installs itself over SSH and pairs with this app — no terminal needed.</p></div>
+    <div class="obbox">
+      <div class="fld"><label for="ob-h">Host</label>
+        <select class="inp sans" id="ob-h" style="width:100%;height:34px"><option>dev — dev@157.90.224.92</option><option>prod — root@91.107.196.2</option><option>Custom host…</option></select></div>
+      <div style="font:400 12px/1.5 var(--font-sans);color:var(--tx3);margin-bottom:var(--sp-3)">2 hosts from <span class="mono-inline">~/.ssh/config</span> · just now</div>
+      <button class="btn pri" style="width:100%;justify-content:center;height:36px">Install &amp; pair</button>
+      <div class="obfoot"><button class="lnk">Pair to a box that's already set up</button></div>
+    </div>
+  </div>
+
+  <!-- TRUST -->
+  <div class="obpanel" data-panel="trust">
+    <div class="obrail"><span class="s on"><span class="n">1</span> Box</span><span class="ln"></span><span class="s"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Trust this host?</h3><p>First time connecting to <span class="mono-inline">157.90.224.92</span>. Check the fingerprint matches what the machine reports.</p></div>
+    <div class="obbox">
+      <div style="padding:var(--sp-3);border-radius:var(--r-md);background:var(--inset);border:1px solid var(--border-subtle);
+                  font:400 12px/1.6 var(--font-mono);color:var(--tx1);word-break:break-all;margin-bottom:var(--sp-4)">
+        SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8</div>
+      <div style="display:flex;gap:var(--sp-2)"><button class="btn pri">Trust &amp; continue</button><button class="btn">Don't trust</button></div>
+    </div>
+  </div>
+
+  <!-- UNLOCK -->
+  <div class="obpanel" data-panel="unlock">
+    <div class="obrail"><span class="s on"><span class="n">1</span> Box</span><span class="ln"></span><span class="s"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Unlock your SSH key</h3><p><span class="mono-inline">~/.ssh/id_ed25519</span> has a passphrase and isn't loaded in your agent.</p></div>
+    <div class="obbox">
+      <div class="fld"><label for="ob-p">Passphrase</label><input class="inp" id="ob-p" type="password" value="••••••••••••" style="width:100%"></div>
+      <div style="font:400 12px/1.5 var(--font-sans);color:var(--tx3);margin-bottom:var(--sp-3)">Used in memory for this install only — never written to disk.</div>
+      <div style="display:flex;gap:var(--sp-2)"><button class="btn pri">Unlock &amp; continue</button><button class="btn ghost">Cancel</button></div>
+    </div>
+  </div>
+
+  <!-- INSTALL -->
+  <div class="obpanel" data-panel="install">
+    <div class="obrail"><span class="s on"><span class="n">1</span> Box</span><span class="ln"></span><span class="s"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Setting up your box</h3><p>Installing on <span class="mono-inline">dev@157.90.224.92</span>. You can leave this running.</p></div>
+    <div class="obbox">
+      <div class="proc-h"><b>Installing</b><span class="c">4 of 6 · 1:12</span></div>
+      <div class="bar"><i style="width:58%"></i></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Checking the box <span class="t">0:06</span></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Downloading the release <span class="t">0:31</span></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Installing files <span class="t">0:22</span></div>
+      <div class="stg now"><span class="m"></span> Starting the service <span class="t">0:13</span></div>
+      <div class="stg"><span class="m"></span> Pairing with this app</div>
+      <div class="stg"><span class="m"></span> Done</div>
+      <div class="log">systemd: manta-server.service starting<br>listening on 127.0.0.1:8787<br>registering with gateway.mantaui.com<br>waiting for health check…</div>
+      <div class="obfoot"><button class="lnk">Hide log</button><span class="spacer"></span><button class="btn ghost">Cancel</button></div>
+    </div>
+  </div>
+
+  <!-- PREFLIGHT FAIL -->
+  <div class="obpanel" data-panel="preflight">
+    <div class="obrail"><span class="s on"><span class="n">1</span> Box</span><span class="ln"></span><span class="s"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Couldn't set up that box</h3><p>The checks run before anything is written — <strong>nothing was installed or changed</strong>.</p></div>
+    <div class="obbox">
+      <div class="causecard"><b>SSH refused the connection</b><span>The host answered but rejected the key. Add your public key to <span class="mono-inline">~/.ssh/authorized_keys</span> on the box, or pick a different identity file.</span></div>
+      <div class="causecard"><b>The box's clock is 47 minutes behind</b><span>Certificate issuance and OAuth will fail. Enable NTP on the box, then try again.</span></div>
+      <div class="obfoot"><button class="btn pri">Try again</button><button class="btn">Pick another host</button><span class="spacer"></span><button class="btn ghost">Copy diagnostics</button></div>
+    </div>
+  </div>
+
+  <!-- MANUAL -->
+  <div class="obpanel" data-panel="manual">
+    <div class="obrail"><span class="s on"><span class="n">1</span> Box</span><span class="ln"></span><span class="s"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Pair with an existing box</h3><p>Run <span class="mono-inline">manta pair</span> on the box to get a six-digit code.</p></div>
+    <div class="obbox">
+      <div class="fld"><label for="ob-u">Server URL</label><input class="inp" id="ob-u" value="https://0d5784a7.boxes.mantaui.com" style="width:100%"></div>
+      <div class="fld"><label for="ob-b">Box ID</label><input class="inp" id="ob-b" value="0d5784a7a43451f4ad70dd3d9ee5cf72" style="width:100%"></div>
+      <div class="fld" style="margin-bottom:var(--sp-2)"><label>Pairing code</label>
+        <div class="otp"><span>4</span><span>8</span><span>2</span><span class="cur">1</span><span class="empty">–</span><span class="empty">–</span></div></div>
+      <button class="btn pri" style="width:100%;justify-content:center;height:36px">Connect</button>
+      <div class="obfoot"><button class="lnk">Install on a new machine instead</button></div>
+    </div>
+  </div>
+
+  <!-- PROVIDERS -->
+  <div class="obpanel" data-panel="prov">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Connect a model</h3><p>Sign in with a subscription you already pay for, or bring your own key. Manta can't do anything without one.</p></div>
+    <div class="obbox">
+      <div class="lrow"><span class="av">C</span><span class="nm">Claude<em>Claude Pro / Max</em></span><span class="spacer"></span><button class="btn sm pri">Connect</button></div>
+      <div class="lrow"><span class="av">O</span><span class="nm">Codex<em>ChatGPT Plus / Pro</em></span><span class="spacer"></span><button class="btn sm">Connect</button></div>
+      <div class="lrow"><span class="av">K</span><span class="nm">Kimi<em>Kimi For Coding</em></span><span class="spacer"></span><button class="btn sm">Connect</button></div>
+      <div class="obfoot"><button class="lnk">Use your own API endpoint</button><span class="spacer"></span>
+        <button class="btn pri" style="opacity:.45">Continue</button></div>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      Continue stays disabled until one is connected. No skip — there's no product without a model.</p>
+  </div>
+
+  <!-- CLAUDE CLI CHECK -->
+  <div class="obpanel" data-panel="clicheck">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Setting up Claude</h3><p>One-time setup on your box. This takes a few seconds.</p></div>
+    <div class="obbox">
+      <div class="proc-h"><b>Preparing</b><span class="c">2 of 2 · 0:11</span></div>
+      <div class="bar"><i style="width:94%"></i></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Installed the Claude CLI <span class="t">0:09</span></div>
+      <div class="stg now"><span class="m"></span> Starting sign-in <span class="t">0:02</span></div>
+      <div class="obfoot"><span class="spacer"></span><button class="btn ghost">Cancel</button></div>
+    </div>
+    <p style="font:400 12.5px/1.6 var(--font-sans);color:var(--tx3);margin-top:var(--sp-4);max-width:62ch;margin-left:auto;margin-right:auto">
+      <strong>No decision, no button.</strong> Clicking Connect on Claude runs this automatically and flows
+      straight into the sign-in screen. If the CLI is already there the whole panel is skipped and you land on
+      sign-in directly — so this only ever appears once per box. Codex, Kimi and custom endpoints never see it
+      at all.</p>
+  </div>
+
+  <!-- CLI INSTALL FAILED -->
+  <div class="obpanel" data-panel="clifail">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Couldn't set up Claude</h3><p>Your box is installed and paired — this is only the Claude sign-in helper.</p></div>
+    <div class="obbox">
+      <div class="proc-h"><b>Preparing</b><span class="c">failed at 1 of 2 · 0:14</span></div>
+      <div class="bar"><i style="width:32%;background:var(--danger)"></i></div>
+      <div class="stg err"><span class="m"><svg class="ic"><use href="#i-x"/></svg></span> Installing the Claude CLI <span class="t">download failed</span></div>
+      <div class="stg"><span class="m"></span> Starting sign-in</div>
+      <div style="margin-top:var(--sp-3);padding:var(--sp-2) var(--sp-3);border-left:2px solid var(--border);
+                  font:400 11.5px/1.6 var(--font-mono);color:var(--tx3)">curl: (28) Connection timed out after 10001 ms<br>https://claude.ai/install.sh</div>
+      <div class="obfoot"><button class="btn pri">Try again</button><button class="btn">Use a different model</button>
+        <span class="spacer"></span><button class="btn ghost">Install manually</button></div>
+    </div>
+    <p style="font:400 12.5px/1.6 var(--font-sans);color:var(--tx3);margin-top:var(--sp-4);max-width:62ch;margin-left:auto;margin-right:auto">
+      <strong>The only screen in this flow that stops for input</strong> — and <strong>Use a different model</strong> is
+      the one that matters. Codex, Kimi and custom endpoints need no binary, so a network blip shouldn't strand
+      someone who'd have been perfectly happy on Codex.</p>
+  </div>
+
+  <!-- CLAUDE -->
+  <div class="obpanel" data-panel="claude">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Sign in to Claude</h3><p>Manta is running <span class="mono-inline">claude auth login</span> on your box. Open the link, approve, then paste the code back here.</p></div>
+    <div class="obbox">
+      <div class="fld"><label>Step 1 — open this on any device</label>
+        <div style="display:flex;gap:var(--sp-2)"><input class="inp" value="https://claude.ai/oauth/authorize?code=…" style="flex:1"><button class="btn sm">Open</button></div></div>
+      <div class="fld"><label for="ob-cc">Step 2 — paste the code from that page</label><input class="inp" id="ob-cc" placeholder="paste here" style="width:100%"></div>
+      <details style="margin-bottom:var(--sp-3)"><summary style="font:500 12px/1 var(--font-sans);color:var(--tx3);cursor:pointer">Show what's happening on the box</summary>
+        <div class="term" style="margin-top:var(--sp-2)"><span class="d">$ claude auth login</span><br>Opening browser for authentication…<br><span class="y">Browser could not be opened.</span><br>Visit the URL above to continue.<br><span class="d">waiting for authorization…</span></div></details>
+      <div class="obfoot"><button class="btn pri">Continue</button><span class="spacer"></span><button class="btn ghost">Cancel</button></div>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      Built in <span class="mono-inline">BET-352 → 354</span>, with credential backup/restore (<span class="mono-inline">BET-367</span>)
+      and pre-expiry refresh (<span class="mono-inline">BET-281</span>). The change here is presentational:
+      today the live terminal is always visible at 160px, which reads as "something is going wrong". It becomes
+      a collapsed diagnostic, and the URL and code get promoted to labelled steps.</p>
+  </div>
+
+  <!-- CODEX -->
+  <div class="obpanel" data-panel="codex">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Sign in to ChatGPT</h3><p>Open the link on any device, then enter the code there.</p></div>
+    <div class="obbox">
+      <div class="fld"><label>Step 1 — open this link</label>
+        <div style="display:flex;gap:var(--sp-2);align-items:center">
+          <span class="inp" style="flex:1;display:flex;align-items:center;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">auth.openai.com/device?user_code=HJKL-8823</span>
+          <button class="btn sm">Copy</button><button class="btn sm">Open</button></div></div>
+      <div class="fld"><label>Step 2 — enter this code on that page</label>
+        <div style="display:flex;gap:var(--sp-2);align-items:center">
+          <span style="font:600 20px/1 var(--font-mono);letter-spacing:.14em;color:var(--tx1);padding:7px 12px;
+                       background:var(--inset);border:1px solid var(--border-subtle);border-radius:var(--r-md)">HJKL-8823</span>
+          <button class="btn sm">Copy</button></div></div>
+      <details style="margin-bottom:var(--sp-3)"><summary style="font:500 12px/1 var(--font-sans);color:var(--tx4);cursor:pointer">Message from ChatGPT</summary>
+        <div style="margin-top:var(--sp-2);padding:var(--sp-2) var(--sp-3);border-left:2px solid var(--border);
+                    font:400 12px/1.6 var(--font-sans);color:var(--tx3)">Enter code: HJKL-8823 at https://auth.openai.com/device</div></details>
+      <div class="proc-h"><b>Waiting for you to finish</b><span class="c">1:42 · times out in 3:18</span></div>
+      <div class="bar"><i style="width:34%"></i></div>
+      <div style="font:400 12px/1.5 var(--font-sans);color:var(--tx3);margin-top:var(--sp-2)">
+        Nothing happening? The sign-in tab may have been closed — reopen it with the link above.</div>
+      <div class="obfoot"><span class="spacer"></span><button class="btn ghost">Cancel</button></div>
+    </div>
+    <p style="font:400 12.5px/1.6 var(--font-sans);color:var(--tx3);margin-top:var(--sp-3);max-width:60ch;margin-left:auto;margin-right:auto">
+      <strong>You were right to ask — my first version showed no link, which was simply wrong.</strong>
+      The <span class="mono-inline">waiting</span> shape carries <em>both</em> a <span class="mono-inline">url</span> and an
+      <span class="mono-inline">instructions</span> string, and today the URL <em>is</em> rendered — as a truncated
+      dotted-underline link with a copy button. Checking it turned up two fragilities worth fixing:</p>
+    <ul class="notes" style="max-width:66ch;margin:var(--sp-3) auto 0">
+      <li><strong>The code is regex-scraped out of prose.</strong> There's no <span class="mono-inline">user_code</span> field —
+        <span class="mono-inline">parseDeviceCode</span> runs <span class="mono-inline">/\bcode[:\s]+([A-Z0-9]+-[A-Z0-9]+)/i</span>
+        over the instructions text. If OpenAI reformats that sentence, or ships a three-segment code, <strong>the code chip
+        silently disappears</strong> and the user is left with raw upstream prose. So Step 2 needs a defined fallback:
+        when nothing parses, point at the message block instead of rendering an empty slot.</li>
+      <li><strong>The headline is upstream text, verbatim.</strong> Today <span class="mono-inline">instructions</span> is the
+        primary line of the card, so the most prominent copy on that screen isn't ours — and when the scrape
+        <em>succeeds</em> the code appears twice, once in the prose and once as a chip. Here it's demoted to a collapsed
+        "Message from ChatGPT" and we own the framing.</li>
+    </ul>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      Also worth restating: device code, not an API key — and the <em>headless</em> variant specifically, because the
+      browser variant redirects to <span class="mono-inline">localhost:1455</span> on the box.</p>
+  </div>
+
+  <!-- KIMI -->
+  <div class="obpanel" data-panel="kimi">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Connect Kimi</h3><p>Paste a key from the Kimi console. It's stored on your box, never here.</p></div>
+    <div class="obbox">
+      <div class="fld"><label for="ob-k">API key</label><input class="inp" id="ob-k" type="password" placeholder="sk-…" style="width:100%"></div>
+      <button class="lnk">Get a key at kimi.com/code/console</button>
+      <div class="obfoot"><button class="btn pri">Connect</button><span class="spacer"></span><button class="btn ghost">Cancel</button></div>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      The only true API-key provider of the three. opencode reports no auth methods for it, so it takes the
+      generic key path.</p>
+  </div>
+
+  <!-- CUSTOM -->
+  <div class="obpanel" data-panel="custom">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s on"><span class="n">2</span> Model</span></div>
+    <div class="obh"><h3>Use your own endpoint</h3><p>Any OpenAI-compatible API. We'll call it and show you what it reports before saving.</p></div>
+    <div class="obbox">
+      <div class="fld"><label for="ob-n">Name</label><input class="inp sans" id="ob-n" value="VoskaAI" style="width:100%"></div>
+      <div class="fld"><label for="ob-bu">Base URL</label><input class="inp" id="ob-bu" value="https://api.voska.ai/v1" style="width:100%"></div>
+      <div class="fld"><label for="ob-ak">API key <span style="text-transform:none;letter-spacing:0;color:var(--tx4)">— optional</span></label><input class="inp" id="ob-ak" type="password" value="••••••••••" style="width:100%"></div>
+      <div style="border:1px solid color-mix(in srgb,var(--ok) 35%,transparent);background:var(--ok-bg);
+                  border-radius:var(--r-md);padding:var(--sp-3);margin-bottom:var(--sp-3)">
+        <div style="display:flex;align-items:center;gap:var(--sp-2);font:600 12.5px/1 var(--font-sans);color:var(--ok);margin-bottom:6px">
+          <svg class="ic s" style="stroke-width:3"><use href="#i-check"/></svg> Endpoint answered · 6 models</div>
+        <div style="font:400 11.5px/1.6 var(--font-mono);color:var(--tx2)">voska-large-2 · voska-large-2-mini · voska-code-7b · +3 more</div>
+      </div>
+      <div class="obfoot"><button class="btn pri">Save &amp; continue</button><button class="btn">Test again</button><span class="spacer"></span><button class="btn ghost">Cancel</button></div>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      Probe before save — a typo'd URL or dead key is caught here rather than surfacing as a broken model list
+      later. The provider <span class="mono-inline">id</span> is derived from the name instead of being a fourth field.</p>
+  </div>
+
+  <!-- CHECK -->
+  <div class="obpanel" data-panel="check">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Model</span></div>
+    <div class="obh"><h3>Checking everything works</h3><p>A quick end-to-end test before you start.</p></div>
+    <div class="obbox">
+      <div class="proc-h"><b>Testing</b><span class="c">3 of 3 · 0:04</span></div>
+      <div class="bar"><i style="width:88%"></i></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Reached opencode on your box <span class="t">0:01</span></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Claude credentials accepted <span class="t">0:01</span></div>
+      <div class="stg now"><span class="m"></span> Getting a reply from Opus 4.8 <span class="t">0:02</span></div>
+      <div style="margin-top:var(--sp-3);font:400 12px/1.5 var(--font-sans);color:var(--tx3)">
+        Runs in a temporary session deleted the moment the reply lands. <strong>No project is created and nothing is left on your box.</strong></div>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      Today: one spinner reading "Verifying your box…", which creates <span class="mono-inline">~/projects/welcome</span>,
+      bills a real turn to say "hi", and leaves both behind.</p>
+  </div>
+
+  <!-- CHECK FAIL -->
+  <div class="obpanel" data-panel="checkfail">
+    <div class="obrail"><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Box</span><span class="ln"></span><span class="s ok"><span class="n"><svg class="ic" style="width:10px;height:10px;stroke-width:4"><use href="#i-check"/></svg></span> Model</span></div>
+    <div class="obh"><h3>Your box is ready, but the model didn't reply</h3><p>Pairing and installation succeeded — this is almost always a provider that isn't fully connected yet.</p></div>
+    <div class="obbox">
+      <div class="proc-h"><b>Testing</b><span class="c">failed at 3 of 3 · 0:15</span></div>
+      <div class="bar"><i style="width:66%;background:var(--danger)"></i></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Reached opencode on your box <span class="t">0:01</span></div>
+      <div class="stg done"><span class="m"><svg class="ic"><use href="#i-check"/></svg></span> Claude credentials accepted <span class="t">0:01</span></div>
+      <div class="stg err"><span class="m"><svg class="ic"><use href="#i-x"/></svg></span> Getting a reply from Opus 4.8 <span class="t">timed out</span></div>
+      <div class="obfoot"><button class="btn pri">Try again</button><button class="btn">Back to the model step</button>
+        <span class="spacer"></span><button class="btn ghost">Copy diagnostics</button></div>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-3)">
+      Today this is a static red block with no buttons at all. There's no "continue anyway" — a model is
+      mandatory, so the only way out is to fix it or go back.</p>
+  </div>
+
+  <!-- DONE -->
+  <div class="obpanel" data-panel="done">
+    <div class="obh" style="margin-top:var(--sp-8)">
+      <div style="width:52px;height:52px;border-radius:50%;background:var(--ok-bg);color:var(--ok);
+                  display:grid;place-items:center;margin:0 auto var(--sp-4)">
+        <svg class="ic" style="width:26px;height:26px;stroke-width:2.5"><use href="#i-check"/></svg></div>
+      <h3>You're all set</h3>
+      <p>Your box is paired and Claude is connected.</p>
+      <button class="btn pri" style="margin-top:var(--sp-5);height:36px;padding:0 24px">Open Manta</button>
+    </div>
+    <p style="font:400 12px/1.5 var(--font-sans);color:var(--tx4);text-align:center;margin-top:var(--sp-5)">
+      One button, no card. The new-session composer already handles picking a folder, so there's nothing
+      left to ask here — and no auto-created <span class="mono-inline">welcome</span> project to explain.</p>
+  </div>
+
+</div></div></div>
+
+  <h3 class="sub">Do the provider CLIs need installing? Claude only.</h3>
+  <p>
+    Good instinct, but a pre-step for each would be wrong — and the codebase says so explicitly.
+    <span class="mono-inline">src/server/claudeAuth.mjs</span> carries this comment:
+  </p>
+  <div class="callout danger">
+    <p style="font-family:var(--font-mono);font-size:12.5px;line-height:1.7">
+      "INTENTIONALLY CLAUDE-ONLY — DO NOT GENERALIZE. Codex (<span class="mono-inline">openai</span>) and Kimi
+      (<span class="mono-inline">kimi-for-coding</span>) tokens are minted and refreshed by opencode itself… Only
+      Claude's tokens come from an external CLI. <strong>Every revert on this file has been exactly that
+      generalization</strong>, so this comment is here to break the cycle."</p>
+  </div>
+  <table class="spec">
+    <tr><th style="width:16%">Provider</th><th style="width:18%">Needs a CLI?</th><th>Why</th></tr>
+    <tr><td>Claude</td><td><span class="pill bad">yes</span></td>
+      <td>The server spawns <span class="mono-inline">claude auth login</span> on the box. Tokens are written by the CLI into <span class="mono-inline">~/.claude/.credentials.json</span> and refreshed by re-invoking it.</td></tr>
+    <tr><td>Codex</td><td><span class="pill good">no</span></td>
+      <td>Device-code OAuth handled entirely inside opencode over HTTP. Nothing is spawned.</td></tr>
+    <tr><td>Kimi</td><td><span class="pill good">no</span></td>
+      <td>A key written straight into opencode's auth store.</td></tr>
+    <tr><td>Custom</td><td><span class="pill good">no</span></td>
+      <td>Just an HTTP endpoint.</td></tr>
+  </table>
+
+  <h4 class="sub2">The real gap this uncovers</h4>
+  <ul class="notes">
+    <li><strong><span class="mono-inline">install.sh</span> already installs the Claude CLI</strong> (official installer, idempotent on a PATH probe) — so the SSH-install path is covered today. No pre-step needed there.</li>
+    <li><strong>But "pair to an existing box" skips <span class="mono-inline">install.sh</span> entirely.</strong> That box may never have had the CLI. Today the Claude card spawns a pty that dies instantly, because <span class="mono-inline">resolveClaudeBin()</span> probes two paths and then <strong>falls back to the bare string <span class="mono-inline">"claude"</span></strong> — which ENOENTs. The spawn's error handler is <span class="mono-inline">() =&gt; resolve()</span>, so the failure is <em>swallowed</em>. <strong>This is the case worth building the check for.</strong></li>
+    <li><strong>Two more ways to land there:</strong> the installer's claude download is non-fatal (it warns and continues, so an install can "succeed" without it), and the documented launchd/systemd PATH trap means the CLI can be installed but invisible to the service — a different failure needing a different fix, which is why the check reports <em>where</em> it looked.</li>
+  </ul>
+
+  <div class="callout warn">
+    <p><strong>Worth separating two things the question conflates.</strong>
+    <span class="mono-inline">launcherRegistry.mjs</span> <em>does</em> list <span class="mono-inline">claude</span>,
+    <span class="mono-inline">codex</span> and <span class="mono-inline">kimi</span> with <span class="mono-inline">bin</span> fields,
+    and <span class="mono-inline">install.sh</span> probes all three — but those are <strong>terminal-mode TUI
+    launchers</strong>, not auth. You only need those binaries if you want to run the CLI as an interactive
+    window; chat mode needs none of them. So availability for all three belongs in
+    <strong>Settings → Extensions → CLI launch options</strong> as a status display, <em>not</em> as an onboarding
+    gate. Onboarding gets exactly one CLI check, for Claude.</p>
+  </div>
+
+  <h3 class="sub">Lazy-installing the Claude CLI</h3>
+  <div class="callout ok">
+    <p><strong>You're right and my earlier objection was wrong.</strong> I argued a deferred install would land
+    the binary somewhere the service can't see. It doesn't — I checked
+    <span class="mono-inline">launchd_agent_path()</span> and <span class="mono-inline">$HOME/.local/bin</span> is appended
+    to the service PATH <strong>unconditionally</strong>, with no reference to whether claude exists. So the
+    directory is on the PATH of both supervisors whether or not anything is in it, and the official installer
+    puts the binary in exactly that directory. A later install is visible to the service. No screen before the
+    box, no flag, no compromise.</p>
+  </div>
+  <p>Three things make the lazy install clean rather than merely possible:</p>
+  <ul class="notes">
+    <li><strong>The PATH entry is unconditional</strong> — <span class="mono-inline">launchd_agent_path()</span> composes a static list and prepends <span class="mono-inline">$HOME/.local/bin</span> if absent. Both LaunchAgent plists and both systemd units render from it. Nothing to change.</li>
+    <li><strong>No restart is needed.</strong> <span class="mono-inline">resolveClaudeBin()</span> probes with <span class="mono-inline">existsSync</span> on <em>every</em> invocation, so the next spawn picks the binary up. It isn't cached at boot.</li>
+    <li><strong>The macOS install smoke test asserts nothing about claude</strong> — so removing the step doesn't touch CI.</li>
+  </ul>
+  <p>
+    And the timing cost is smaller than I framed it: a Claude user pays the same download either way, just
+    later and <em>visibly</em>, as a named step rather than a silent stall inside a six-stage installer. Everyone
+    else never pays it at all.
+  </p>
+
+  <h4 class="sub2">What has to change in install.sh</h4>
+  <table class="spec">
+    <tr><th style="width:26%">Change</th><th>Detail</th></tr>
+    <tr><td><strong>Delete step A2</strong></td><td>The claude-CLI install block. No flag, no opt-in — the app owns this now. Its own comment already anticipates the box being usable without it ("a box without Claude must still finish installing, still pair, and still be usable with Codex").</td></tr>
+    <tr><td><strong>Leave the PATH alone</strong></td><td><span class="mono-inline">launchd_agent_path()</span> is unchanged. The <span class="mono-inline">~/.local/bin</span> entry is what makes the lazy install work — deleting it "because claude is gone" would break the whole design. Worth a comment saying so.</td></tr>
+    <tr><td><strong>Fix the tail messaging</strong></td><td>Two places currently print <em>"Fallback (if the app is unavailable): connect providers from inside opencode (Claude: <span class="mono-inline">claude auth login</span>…)"</em> — advice that assumes a binary that's no longer there. And the per-provider detection summary reports <span class="mono-inline">cli_claude</span> as a <em>gap</em>; it should read as "not needed yet".</td></tr>
+    <tr><td><strong>Nothing else</strong></td><td>No smoke-test change, no plist/unit change, no <span class="mono-inline">resolveClaudeBin</span> change.</td></tr>
+  </table>
+
+  <h4 class="sub2">It runs automatically — the only stop is failure</h4>
+  <p>
+    Clicking Connect on Claude installs the CLI and moves straight into sign-in, with no confirmation step.
+    There's nothing to decide: the user has already chosen Claude, and the CLI isn't a separate product they
+    might have an opinion about — it's an implementation detail of signing in. Asking permission would just be
+    a modal in front of a foregone conclusion.
+  </p>
+  <p>
+    It's also idempotent and PATH-probed, so it's a no-op on every subsequent connect — the panel appears at
+    most once per box, and never at all if the CLI is already present (in which case the flow goes directly to
+    sign-in).
+  </p>
+  <p>
+    <strong>Failure is the one case that stops.</strong> It has to, because the install now happens while the
+    user is mid-decision. The failure panel offers <strong>Try again</strong>,
+    <strong>Use a different model</strong> — the important one, since Codex, Kimi and custom endpoints need no
+    binary and are one click away — and <strong>Install manually</strong> with the command. It also states plainly
+    that the box itself is fine, so a failure here doesn't read as "my install is broken".
+  </p>
+
+  <h4 class="sub2">On moving install after the model step</h4>
+  <p>
+    Not possible, and this is worth stating once so it doesn't come back: every provider flow executes
+    <em>on the box</em>. <span class="mono-inline">claude auth login</span> is spawned there, the Codex device flow is
+    opencode's, the Kimi key is written into opencode's auth store, and a custom endpoint is probed from the
+    box. The box must exist and be paired before any provider work can start — it's a data dependency, not an
+    ordering preference. The flow stays: <strong>box → model → check → open</strong>.
+  </p>
+
+  <h3 class="sub">Other changes</h3>
+  <ul class="notes">
+    <li><strong>Mobile gets the model step.</strong> Now that a model is mandatory this is no longer a nice-to-have — mobile can currently finish setup with no provider at all. Kimi and the custom endpoint work fine on a phone; Codex device-code works; only the Claude CLI flow is desktop-bound, and that card should say so rather than dead-end.</li>
+    <li><strong>Focus moves to the new step's heading</strong> on advance. The refocus-on-error pattern is already implemented correctly in these same files; it just isn't applied here.</li>
+    <li><strong>One brand mark</strong> across desktop and mobile first-run, and both copy mismatches fixed.</li>
+    <li><strong>The preflight card shape becomes the house style.</strong> Those <span class="mono-inline">{cause, action}</span> pairs — plus "nothing was installed or changed" — are the best failure UI in the product, and should be how every failure in the flow looks.</li>
+  </ul>
+</section>
+
+
+<!-- ==================== COVERAGE ==================== -->
+<section id="coverage">
+  <div class="eyebrow">Honest accounting</div>
+  <h2 class="sec">What this spec still doesn't cover</h2>
+  <p class="lede">
+    A deliberate pass over every renderer surface, checking it against what's actually specced. Nine sections
+    cover the transcript, sidebar, composer, cards, settings, onboarding and delegation — but a redesign is
+    judged on the parts nobody demoed. <strong>One of these is a concrete collision that will break on contact;
+    the rest are surfaces the spec is currently silent about.</strong>
+  </p>
+
+  <h3 class="sub">1 · The collision — voice has nowhere to live</h3>
+  <div class="callout danger">
+    <p>The composer signals <strong>voice recording by turning its top hairline into a pulsing red divider</strong>
+    (<span class="mono-inline">border-t border-red-500 animate-pulse</span> plus a glow). The redesigned composer
+    <strong>has no dividers</strong> — it's a bordered, rounded box. So the single clearest state in the current
+    composer has no home in the new one, and would silently disappear.</p>
+    <p style="margin-top:var(--sp-2)">Fix is easy — the box's own border becomes the recording indicator, which is
+    arguably better since it's the element you're looking at. But it has to be specced, or it gets dropped.</p>
+  </div>
+
+  <h3 class="sub">2 · Composer satellites — three surfaces anchored to a component we're rebuilding</h3>
+  <p>
+    <span class="mono-inline">Composer.tsx</span> renders three things around the input, none of which appear in any
+    mockup. All three position themselves relative to the composer's geometry, and that geometry is changing.
+  </p>
+  <table class="spec">
+    <tr><th style="width:26%">Surface</th><th>Why it needs speccing</th></tr>
+    <tr><td><strong>AttachmentStrip</strong></td><td>Uploaded-file chips sit <em>above</em> the textarea. The new composer already has a chip row above it for folder/branch on the new-session screen — two different chip rows in the same slot need a resolved relationship.</td></tr>
+    <tr><td><strong>TypeaheadPopup</strong></td><td>The <span class="mono-inline">@</span>-file / <span class="mono-inline">/</span>-command list. It's a popover anchored to the input; with a bordered box and a focus ring, its attachment point and elevation both change.</td></tr>
+    <tr><td><strong>MicButton</strong></td><td>Press-and-hold with three states (idle / dictate / command). The mockups show a static mic icon and nothing else.</td></tr>
+    <tr><td><strong>Drag-drop overlay</strong></td><td>Full-panel drop target with a Claude-orange border — one of the ~40 hardcoded hex constants, so it's touched by phase 0 anyway.</td></tr>
+    <tr><td><strong>RunningIndicator + queued messages</strong></td><td>The live "working…" row with elapsed time, and the list of prompts you've queued behind it. Both sit between the transcript and the composer, exactly where the redesign changed the spacing rhythm.</td></tr>
+  </table>
+
+  <h3 class="sub">3 · Banner pileup</h3>
+  <div class="callout warn">
+    <p><strong><span class="mono-inline">App.tsx</span> stacks up to six full-width bars above the session</strong> —
+    five <span class="mono-inline">UpdateBar</span> variants (app update, update error, server update, version skew,
+    compatibility) plus the reconnect banner. They can co-occur. The spec never mentions them, and the new
+    spacing scale will make a pile of six read as broken chrome rather than dense chrome.</p>
+    <p style="margin-top:var(--sp-2)">Needs a rule: at most one bar visible, by severity, with the rest collapsed
+    into it — or moved into the session header as a status affordance.</p>
+  </div>
+
+  <h3 class="sub">4 · Four toast systems, and the spec adds a fifth</h3>
+  <p>
+    Screenshot-detected, agent-sent-file, <span class="mono-inline">systemNotice</span>, and the desktop
+    <span class="mono-inline">Notification</span> bridge are four separate implementations with different shapes and
+    placements. The settings redesign introduces <strong>Undo</strong>, which is a fifth. That's the moment to
+    define one toast primitive — position, stacking, timeout, action slot, and how it behaves on mobile — rather
+    than adding to the pile.
+  </p>
+
+  <h3 class="sub">5 · Empty and first-run states</h3>
+  <table class="spec">
+    <tr><th style="width:30%">State</th><th>Today</th></tr>
+    <tr><td>Box paired, zero projects</td><td>Not designed. The new-session composer is the natural answer but the spec only shows it as a per-session screen, not as the app's zero state.</td></tr>
+    <tr><td>Workspace with zero sessions</td><td>A bare <span class="mono-inline">+ new session</span> text button.</td></tr>
+    <tr><td>Unpaired desktop</td><td>The string <em>"Open Settings to connect to your box."</em> — which the audit found is <strong>unreachable</strong>, because an unpaired config always routes to onboarding. Dead copy.</td></tr>
+    <tr><td>Search with no results</td><td>⌘K is referenced twice in the spec and never designed.</td></tr>
+  </table>
+
+  <h3 class="sub">6 · Markdown and code, past measure and leading</h3>
+  <p>
+    The type section fixes size, leading and measure — but <span class="mono-inline">MD_COMPONENTS</span> currently
+    <strong>downgrades every heading to a <span class="mono-inline">&lt;div&gt;</span></strong> at near-body size,
+    because with one mono face at one weight, real headings were pointless. With a proper type scale that decision
+    should be revisited, and it's the difference between a transcript that skims well and one that doesn't. Also
+    unspecced: tables, blockquotes, nested lists, images, and the Prism theme pair that light mode requires.
+  </p>
+
+  <h3 class="sub">7 · Terminal-mode chrome</h3>
+  <p>
+    "The terminal stays dark" settles the pane. It doesn't settle the <em>chrome around it</em> — the session
+    header, the mode switcher (currently a raw <span class="mono-inline">&lt;select&gt;</span> with a hardcoded
+    <span class="mono-inline">colorScheme: dark</span>), or how a dark pane sits inside a light app without looking
+    like a rendering bug. Terminal mode is half the product's history and gets one sentence.
+  </p>
+
+  <h3 class="sub">8 · The mobile contract</h3>
+  <div class="callout warn">
+    <p>Mobile is a separate spec — agreed. But mobile reshapes <em>shared desktop components</em> through
+    <span class="mono-inline">manta-*</span> hook classes and two positional <span class="mono-inline">[class*=…]</span>
+    selectors, and this redesign restructures precisely those elements. <strong>If the desktop work lands first
+    without a stated contract, mobile breaks silently</strong> — and the mobile spec will be written against a
+    moving target.</p>
+    <p style="margin-top:var(--sp-2)">What this spec owes the mobile one: the final list of hook classes the shared
+    components will expose, and a commitment that the two positional selectors are replaced by named hooks. That's
+    a paragraph, and it unblocks the other document.</p>
+  </div>
+
+  <h3 class="sub">9 · How we'll know it's right</h3>
+  <p>
+    The plan has one verification mechanism — a CI contrast check — and it's the strongest thing in it. Everything
+    else is judged by eye, across ten phases, on two clients and two themes. Worth adding:
+  </p>
+  <ul class="notes">
+    <li><strong>Golden screenshots per theme.</strong> The harness already exists (<span class="mono-inline">ChatPanel.harness.test.tsx</span>, the demo fixture, the website shots). Doubling them to light + dark makes a theme regression visible instead of reported.</li>
+    <li><strong>Keyboard-path acceptance.</strong> The a11y fixes are specced for Settings only. The new tree sidebar, the ask cards and the folder picker are all new keyboard surfaces with no stated expectation.</li>
+    <li><strong>A motion vocabulary.</strong> Phase 7 says "elevation and motion" and stops there. The tokens exist in the brand file; the spec never picks durations or easings, and there's exactly one <span class="mono-inline">prefers-reduced-motion</span> rule in the codebase today.</li>
+  </ul>
+
+  <h3 class="sub">Who decides what</h3>
+  <p>
+    Seven of the nine I can settle by applying decisions this spec has already made — they need writing down,
+    not deciding. Three are genuine calls that need you, and they're at the bottom.
+  </p>
+  <table class="spec">
+    <tr><th style="width:24%">Gap</th><th style="width:12%">Owner</th><th>Resolution</th></tr>
+    <tr><td>Voice indicator</td><td><span class="pill good">me</span></td>
+      <td><strong>The composer's own border becomes the recording state</strong> — it already has a resting, focus and error treatment, so recording is a fourth. Better than the old divider because it's the element you're already looking at. Pulse the border only, never the fill; honour <span class="mono-inline">prefers-reduced-motion</span> by holding it solid.</td></tr>
+    <tr><td>Attachment chips vs context chips</td><td><span class="pill good">me</span></td>
+      <td>The one real question here, and an existing principle answers it: <em>the header owns session state, the composer owns composing.</em> So <strong>context chips (folder, branch) stay above the box; attachment chips go inside it</strong>, above the text line — they're part of the message you're writing, not of the session.</td></tr>
+    <tr><td>Typeahead, mic states, drop overlay, running indicator</td><td><span class="pill good">me</span></td>
+      <td>Mechanical once the box is the anchor: popover attaches to the box's top edge and inherits card elevation; mic gets the three states it already has; the drop overlay loses its hardcoded orange to a token; the running row inherits the 12px block gap.</td></tr>
+    <tr><td>Toast primitive</td><td><span class="pill good">me</span></td>
+      <td>One component: bottom-centre, max three stacked, 6s default with an optional action slot, never auto-dismissing when it carries an Undo. Replaces four ad-hoc implementations and absorbs the fifth.</td></tr>
+    <tr><td>Empty states</td><td><span class="pill good">me</span></td>
+      <td><strong>The new-session composer <em>is</em> the app's zero state</strong> — it's already designed, it just wasn't cast in that role. Zero-session workspace gets the same treatment inline. The unreachable "Open Settings to connect to your box" string is deleted rather than restyled.</td></tr>
+    <tr><td>Mobile hook contract</td><td><span class="pill good">me</span></td>
+      <td>A list, not a decision: the hook classes the shared components will expose after the restructure, plus replacing the two positional <span class="mono-inline">[class*=…]</span> selectors with named hooks. Written before phase 7 lands so the mobile spec has a fixed target.</td></tr>
+    <tr><td>Verification &amp; motion</td><td><span class="pill good">me</span></td>
+      <td>Double the existing screenshot harness to light + dark; keyboard-path acceptance for the tree, ask cards and picker; motion durations and easings taken from the brand tokens rather than invented.</td></tr>
+    <tr><td>Prism theme pair</td><td><span class="pill good">me</span></td>
+      <td>Two themes derived from the palette so code blocks match the app in both modes. No product content.</td></tr>
+    <tr><td>Terminal in light mode</td><td><span class="pill good">settled</span></td><td>Dark pane inset in a light window; no theme switch on mode change.</td></tr>
+    <tr><td>Markdown heading prominence</td><td><span class="pill good">settled</span></td><td>Balanced — 17 / 15 / 14px semibold, 22 / 18 / 14px above.</td></tr>
+    <tr><td>Update-prompt policy</td><td><span class="pill good">settled</span></td><td>Quiet dot on Settings; bar reserved for blocking states.</td></tr>
+  </table>
+
+  <h3 class="sub">The three, now settled</h3>
+  <div class="callout warn">
+    <p><strong>1 · Terminal mode in a light app — settled.</strong> <span class="pill good">decided</span>
+    The dark pane sits <strong>inset in a light window</strong>: sidebar, header and composer all follow the theme,
+    with a soft inner border and a slightly inset shadow on the pane so it reads as a deliberate surface rather
+    than a rendering fault. The app never switches theme just because you switched modes.</p>
+  </div>
+  <div class="callout warn">
+    <p><strong>2 · Heading prominence — settled: Balanced.</strong> <span class="pill good">decided</span>
+    h1 <span class="mono-inline">17px/600</span>, h2 <span class="mono-inline">15px/600</span>, h3
+    <span class="mono-inline">14px/600</span>, with 22 / 18 / 14px of space above. Most of the effect comes from the
+    gap, not the size, so headings read as landmarks without the transcript turning into a document.
+    <a href="./headings">Comparison page →</a></p>
+  </div>
+  <div class="callout" style="display:none">
+    <p>Today every markdown heading is downgraded to a
+    <span class="mono-inline">&lt;div&gt;</span> at near-body size — rational when everything was one mono face at one
+    weight. With a real type scale we can make them real. <em>Quiet</em> keeps the transcript flat and calm, which
+    matches every other trim you've asked for. <em>Loud</em> (17px / 15px semibold) makes a long structured answer
+    genuinely skimmable, which is the single biggest readability lever left after measure and leading. I lean
+    loud, but you've consistently chosen calmer, so I won't assume.</p>
+  </div>
+  <div class="callout warn">
+    <p><strong>3 · Update-prompt policy — settled.</strong> <span class="pill good">decided</span>
+    "Update available" is <strong>demoted to a quiet dot on the Settings entry</strong>; the full-width bar is
+    reserved for states that actually block you — version skew, incompatibility, and a failed update. Accepted
+    cost: someone can sit on an old build for a while. Revisit if that starts causing support noise.</p>
+  </div>
+
+  <div class="callout">
+    <p><strong>All three settled.</strong> Terminal inset-dark, headings Balanced, update prompts demoted to a
+    dot. Every open design question in this document is now closed.</p>
+  </div>
+</section>
+
+<!-- ==================== PLAN ==================== -->
+<section id="plan">
+  <div class="eyebrow">Delivery</div>
+  <h2 class="sec">The plan</h2>
+  <p class="lede">
+    Nine phases. Each is independently shippable and revertable, mobile ships with its desktop phase
+    (your Q6), and the widest mechanical change goes first with <strong>zero visual diff</strong> — so it can
+    be reviewed without anyone arguing about aesthetics.
+  </p>
+
+  <table class="spec">
+    <tr><th style="width:5%">#</th><th style="width:20%">Phase</th><th style="width:12%">Visible?</th><th style="width:8%">Size</th><th>What lands</th></tr>
+    <tr><td>0</td><td><strong>Token substrate</strong></td><td><span class="pill good">no change</span></td><td>L</td>
+      <td>Tailwind colours → CSS variables + <span class="mono-inline">data-theme</span>, values byte-identical to today. Replace the ~40 hex constants in TS and the ~110 stock-Tailwind semantic classes with tokens. Trim the spacing scale to the nine steps. Verified by screenshot diff.</td></tr>
+    <tr><td>1</td><td><strong>Light mode</strong></td><td><span class="pill info">opt-in</span></td><td>M</td>
+      <td>The warm-neutral light block + Settings control (System / Light / Dark) + <span class="mono-inline">prefers-color-scheme</span>. Prism theme pair. Sweep the ~50 hardcoded hex in <span class="mono-inline">mobile.css</span>. Terminal stays dark (Q5).</td></tr>
+    <tr><td>2</td><td><strong>Contrast pass</strong></td><td><span class="pill warn">subtle</span></td><td>S</td>
+      <td>Retune text + border ramps to the verified values. <strong>CI check</strong> that fails on any token pair below its floor, so it can't regress.</td></tr>
+    <tr><td>3</td><td><strong>Spacing &amp; rhythm</strong></td><td><span class="pill warn">subtle</span></td><td>S</td>
+      <td>The transcript gap fix: one flex <span class="mono-inline">gap</span> on the turn container, <span class="mono-inline">MarkdownBody</span> stops setting paragraph margins, tool cards drop <span class="mono-inline">my-2</span>. Apply the surface spec everywhere. <em>Small diff, disproportionate payoff.</em></td></tr>
+    <tr><td>4</td><td><strong>Icons</strong></td><td><span class="pill warn">subtle</span></td><td>S</td>
+      <td>Emoji → <span class="mono-inline">lucide-react</span> at one weight, inheriting <span class="mono-inline">currentColor</span>.</td></tr>
+    <tr><td>5</td><td><strong>Typography</strong></td><td><span class="pill bad">large</span></td><td>M</td>
+      <td>Bundle Inter + JetBrains Mono, 7-role scale with leading, sans for chrome and prose, capped measure. <em>The phase that changes how it feels.</em></td></tr>
+    <tr><td>6</td><td><strong>Sidebar</strong></td><td><span class="pill bad">large</span></td><td>M</td>
+      <td>Pinned section, workspace groups, single-line rows with one dot + timer, ⌘K search.</td></tr>
+    <tr><td>7</td><td><strong>Header &amp; composer</strong></td><td><span class="pill bad">large</span></td><td>M</td>
+      <td>Context pill + session menu move to the header; composer becomes a bordered input with model ▸ effort split. Redesigned permission/question cards. <strong>Touches every mobile hook class</strong> — see risks.</td></tr>
+    <tr><td>8</td><td><strong>New session &amp; folder picker</strong></td><td><span class="pill bad">large</span></td><td>M</td>
+      <td>Composer-as-setup-form, folder picker with breadcrumbs and worktree badges, shared with mobile as a sheet.</td></tr>
+    <tr><td>9</td><td><strong>Settings</strong></td><td><span class="pill bad">large</span></td><td>L</td>
+      <td>Shared <span class="mono-inline">settingsSchema</span> driving both platforms, instant-apply + Undo, new tab structure with a Permissions tab, search, modified indicators, one restart affordance, and the dialog/a11y fixes. <strong>Fixes the stomping data-loss bug.</strong></td></tr>
+    <tr><td>10</td><td><strong>Composer satellites &amp; system messaging</strong></td><td><span class="pill warn">subtle</span></td><td>M</td>
+      <td>Attachment chips, typeahead popover, mic states incl. the recording indicator the new composer has nowhere to put, drop overlay, running indicator + queued messages. Plus one toast primitive, the banner-collapse rule, and empty states. <strong>Must ship with phase 7</strong> — these anchor to composer geometry.</td></tr>
+    <tr><td>11</td><td><strong>Background jobs</strong></td><td><span class="pill warn">subtle</span></td><td>S</td>
+      <td>Nested job rows cleared on terminal status, suppressed completion turn, read-only job view, <span class="mono-inline">delegate</span> refusing to start when trust is off, deleting the jobs card, window+worktree cleanup on terminal, and wiring the unconsumed <span class="mono-inline">delegate.updated</span> event. Net code <em>removal</em>; rides on phases 6–7.</td></tr>
+    <tr><td>12</td><td><strong>Onboarding</strong></td><td><span class="pill warn">med</span></td><td>M</td>
+      <td>Extract <span class="mono-inline">ProcessPanel</span> from the installer and reuse it for verification, sign-in and restarts. Actionable verification failure, deferrable provider step, mobile provider check, focus management, copy fixes.</td></tr>
+  </table>
+
+  <div class="callout ok">
+    <p><strong>Phases 0–4 are one arc and I'd ship them together.</strong> That's light mode, a WCAG-clean
+    palette, the spacing fix and real icons — <em>with no layout or typography change at all</em>. Every
+    complaint you raised about contrast and spacing is resolved, the theming substrate exists permanently,
+    and the whole arc is mechanically reviewable. Phase 5 (typography) is then a single deliberate
+    "does this feel right" call, and 6–8 are product work on a proven foundation.</p>
+  </div>
+
+  <h3 class="sub">Risks</h3>
+  <table class="spec">
+    <tr><th style="width:26%">Risk</th><th style="width:10%">Severity</th><th>Mitigation</th></tr>
+    <tr><td>Mobile hook classes are load-bearing contracts</td><td><span class="pill bad">high</span></td>
+      <td><span class="mono-inline">mobile.css</span> reshapes reused desktop components through <span class="mono-inline">manta-composer</span>, <span class="mono-inline">manta-ctx-track</span>, <span class="mono-inline">manta-session-toolbar</span>, <span class="mono-inline">manta-composer-branch</span> and two positional <span class="mono-inline">[class*=…]</span> selectors. Phase 7 restructures exactly those elements — and in fact <em>deletes the need for three of them</em>, since the context bar and session toolbar move to the header where mobile already has a <span class="mono-inline">⋯</span> sheet. Rewrite <span class="mono-inline">mobile.css</span> in the same PR; verify on device before merge.</td></tr>
+    <tr><td>Sans-serif is a felt identity change</td><td><span class="pill warn">med</span></td>
+      <td>Isolated in phase 5 so it can be judged — and reverted — alone.</td></tr>
+    <tr><td>Spacing fix reveals other misalignments</td><td><span class="pill warn">med</span></td>
+      <td>Once one gap is correct, neighbouring wrong ones become obvious. Expect a follow-up polish pass; that's the spec doing its job.</td></tr>
+    <tr><td>Two bundled fonts</td><td><span class="pill good">low</span></td>
+      <td>~240KB woff2, same-origin, cached. Strictly better than today's silent per-OS substitution.</td></tr>
+    <tr><td>Screenshot tests need golden updates</td><td><span class="pill good">low</span></td>
+      <td><span class="mono-inline">ChatPanel.harness.test.tsx</span> + the demo harness. Mechanical.</td></tr>
+    <tr><td>Scope creep into behaviour</td><td><span class="pill warn">med</span></td>
+      <td>Phases 6–8 tempt feature work (⌘K ranking, drag-reorder, multi-box groups). Anything not on this page is a separate ticket.</td></tr>
+  </table>
+
+  <h3 class="sub">Round-3 answers, now spec</h3>
+  <table class="spec">
+    <tr><th style="width:24%">Item</th><th>Resolved</th></tr>
+    <tr><td>Default theme</td><td><strong>Follow the system.</strong> <span class="mono-inline">prefers-color-scheme</span> drives it until the user picks explicitly; the Settings control is System / Light / Dark with System selected.</td></tr>
+    <tr><td>Pin limit</td><td><strong>Unlimited.</strong> The Pinned group scrolls with the rest of the rail and collapses like any other group.</td></tr>
+    <tr><td>Timer</td><td><strong>Unchanged from today</strong> — time since last activity, visible under the staleness TTL, hover-only past it. Rendered neutral rather than colour-coded, since the dot is now the sole status carrier.</td></tr>
+    <tr><td>Composer resources</td><td><strong>No badge; the three icons stay under the composer</strong> with the schedule count, exactly as today. Only fork / compact / clear / delete move into the <span class="mono-inline">⋯</span> menu.</td></tr>
+    <tr><td>Effort levels</td><td><strong>Whatever the provider returns</strong> — the menu renders <span class="mono-inline">model.variants</span> verbatim, title-cased. No fixed vocabulary, no mapping table. <em>Consequence worth flagging:</em> a model with no variants gets no effort control at all, so the split collapses to a single model button. That's correct behaviour, but it means the composer's width changes when you switch models — worth watching once it's real.</td></tr>
+  </table>
+
+  <h3 class="sub">Round-3 corrections applied</h3>
+  <table class="spec">
+    <tr><th style="width:34%">You said</th><th>What changed</th></tr>
+    <tr><td>Line spacing looks too much</td><td>Transcript leading <strong>1.65 → 1.55</strong>. Still clear of the WCAG 1.4.12 floor of 1.5, noticeably tighter in a dense tool. Block gaps unchanged at 12px.</td></tr>
+    <tr><td>Checkmark contrast on the blue is bad</td><td><strong>Real defect.</strong> White on <span class="mono-inline">#2E6BFF</span> was 4.50:1 — passing by 0.00 and far too weak for a thin 10px glyph. New <span class="mono-inline">--accent-solid</span> token for filled controls (darker blue in light) takes it to <strong>6.00:1</strong>, plus a heavier check stroke.</td></tr>
+    <tr><td>Drop the pinned / workspace counts</td><td>Removed.</td></tr>
+    <tr><td>What's the colour next to the workspace name?</td><td>It was a per-workspace identity dot. Removed — it was decoration carrying no information you didn't already have from the name.</td></tr>
+    <tr><td>Star → pin icon</td><td>Swapped. Filled when pinned, outline on hover.</td></tr>
+    <tr><td>Ask cards should match the transcript width</td><td>They now sit in the turn's flex column, so they inherit the 72ch measure and the 12px block gap automatically — see the Ask cards section.</td></tr>
+    <tr><td>Add a question card</td><td>Added, with multi-select checkboxes and the always-present free-text field.</td></tr>
+    <tr><td>Return-arrow chip on "Allow once" has bad contrast and an odd border</td><td><strong>Real defect, and a systemic one.</strong> The <span class="mono-inline">⏎</span> chip took its colour and border from canvas-relative tokens while sitting on an accent fill — where those tokens are meaningless. Border removed, colour and background now derived from <span class="mono-inline">currentColor</span>. New system rule: <em>anything placed on a filled surface derives from</em> <span class="mono-inline">currentColor</span><em>, never from canvas tokens.</em></td></tr>
+    <tr><td>Show several questions in one card</td><td>Added — numbered sections, one Submit, "N of M answered" progress.</td></tr>
+    <tr><td>Preselect the recommended answer</td><td>Added for single-select; labelled but not preselected for multi-select, so it can't bias a "pick one or more" list. Detection caveat noted in the Ask cards section.</td></tr>
+    <tr><td>Pin: hover-only, subtler, left of the timer, consistent across sections</td><td>Reworked as a permanently reserved 18px slot — see the constraint-by-constraint table in the Sidebar section. Timers restored on pinned rows.</td></tr>
+  </table>
+
+  <div class="callout ok">
+    <p><strong>Nothing is blocking any more.</strong> Say go and I'll start phase 0 — the token substrate is
+    mechanical, produces no visual diff, and is independent of everything else.</p>
+  </div>
+</section>
+
+</main>
+
+<script>
+(function(){
+  const root=document.documentElement;
+  function wire(id,attr){
+    const seg=document.getElementById(id); if(!seg) return;
+    seg.addEventListener('click',e=>{
+      const b=e.target.closest('button'); if(!b) return;
+      root.setAttribute(attr,b.dataset.v);
+      [...seg.querySelectorAll('button')].forEach(x=>x.setAttribute('aria-pressed',String(x===b)));
+      try{localStorage.setItem('manta-v2-'+attr,b.dataset.v);}catch(_){}
+    });
+    try{
+      const s=localStorage.getItem('manta-v2-'+attr);
+      if(s){root.setAttribute(attr,s);
+        [...seg.querySelectorAll('button')].forEach(x=>x.setAttribute('aria-pressed',String(x.dataset.v===s)));}
+    }catch(_){}
+  }
+  // generic panel groups: [data-group] + [data-tab] buttons + [data-panel] panes
+  document.querySelectorAll('[data-group]').forEach(g=>{
+    g.addEventListener('click',e=>{
+      const b=e.target.closest('[data-tab]'); if(!b||!g.contains(b)) return;
+      const key=b.dataset.tab;
+      g.querySelectorAll('[data-tab]').forEach(x=>x.classList.toggle('on',x===b));
+      const scope=g.closest('.setwin')||g.parentElement;
+      const root=g.classList.contains('obpick')?g.parentElement:scope;
+      root.querySelectorAll('[data-panel]').forEach(p=>p.classList.toggle('on',p.dataset.panel===key));
+      const t=root.querySelector('[data-title]');
+      if(t) t.textContent=b.textContent.trim();
+      const body=root.querySelector('.setbody'); if(body) body.scrollTop=0;
+    });
+  });
+  wire('segTheme','data-theme');
+  wire('segDensity','data-density');
+  document.querySelectorAll('nav.sections a').forEach(a=>{
+    a.addEventListener('click',e=>{
+      const t=document.querySelector(a.getAttribute('href')); if(!t) return;
+      e.preventDefault(); window.scrollTo({top:t.offsetTop-70,behavior:'smooth'});
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/scripts/visual/companion.mjs
+++ b/scripts/visual/companion.mjs
@@ -1,33 +1,54 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import { COMPONENTS } from "./components.mjs";
+import { ROOT } from "./harness.mjs";
 
-// The redesign spec is the source of truth for the companion. Every candidate
+// The redesign spec is the source of truth for the companion: every candidate
 // primitive is rendered from the spec's own CSS, in both themes.
-const SPEC_URL =
-  "https://0d5784a7a43451f4ad70dd3d9ee5cf72.boxes.mantaui.com/pages/manta-redesign";
+//
+// IT IS READ FROM THE REPO, NOT FROM A URL. The spec used to be fetched from a
+// served page under /pages/, which expires — pages are swept at their TTL and
+// nothing in git holds them. That made this committed script, and the npm
+// command that runs it, carry a dead-by-a-certain-date dependency: after the
+// TTL `npm run visual:companion` would fail loudly (as designed) and the
+// owner's validation surface would simply be gone. An archived copy costs
+// 230 KB once and removes the fuse.
+//
+// `--source <url|path>` overrides it, which is how you refresh the archive
+// from a freshly served spec.
+const SPEC_PATH = join(ROOT, "docs/screens/redesign-spec.html");
 
-const v = process.argv.indexOf("--source");
-const sourceUrl =
-  v !== -1
-    ? process.argv[v + 1]
+const flagIdx = process.argv.indexOf("--source");
+const source =
+  flagIdx !== -1
+    ? process.argv[flagIdx + 1]
     : process.argv.find((a) => a.startsWith("--source="))?.slice("--source=".length) ??
-      SPEC_URL;
+      SPEC_PATH;
 
-// Fetch the spec. A non-200 or a network failure fails loudly with the URL and
-// exits 1 — a silently stale companion is worse than none. We deliberately do
-// NOT fall back to a cached copy.
-let res;
-try {
-  res = await fetch(sourceUrl);
-} catch (err) {
-  console.error(`companion: failed to fetch spec ${sourceUrl}: ${err.message}`);
-  process.exit(1);
+// One resolver for both shapes. A missing file or a non-200 fails loudly and
+// exits 1 — a silently stale companion is worse than none, and we deliberately
+// do NOT fall back to anything.
+let src;
+if (/^https?:\/\//.test(source)) {
+  let res;
+  try {
+    res = await fetch(source);
+  } catch (err) {
+    console.error(`companion: failed to fetch spec ${source}: ${err.message}`);
+    process.exit(1);
+  }
+  if (!res.ok) {
+    console.error(`companion: failed to fetch spec ${source} — HTTP ${res.status}`);
+    process.exit(1);
+  }
+  src = await res.text();
+} else {
+  if (!existsSync(source)) {
+    console.error(`companion: spec not found at ${source}`);
+    process.exit(1);
+  }
+  src = readFileSync(source, "utf8");
 }
-if (!res.ok) {
-  console.error(`companion: failed to fetch spec ${sourceUrl} — HTTP ${res.status}`);
-  process.exit(1);
-}
-const src = await res.text();
 
 const css = [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n");
 const sprite = src.match(/<svg[^>]*(?:style="display:none"|hidden|aria-hidden="true")[^>]*>[\s\S]*?<\/svg>/)?.[0] ?? "";


### PR DESCRIPTION
`scripts/visual/companion.mjs` is committed and has an npm command — and it fetched the design spec from a served `/pages/` URL that **expires 2026-08-13**. Served pages are swept at their TTL and nothing in git holds them, so the owner's validation surface carried a twelve-day fuse: after that date `npm run visual:companion` would fail loudly (exactly as BET-540 specified) and the companion would simply be gone.

Archive the spec at `docs/screens/redesign-spec.html` — 230 KB, once — and read it from there. `--source` still accepts a URL **or** a path through one resolver, which is how the archive gets refreshed.

Verified: default run renders all twelve components; `--source /nope/missing.html` and `--source https://example.invalid/x` both fail loudly and exit 1 (no silent fallback); typecheck clean.

The archive's header records that its `:root` is a snapshot, that `tokens.css` is live, and that the only audited difference is the shadow scale (C5) — so nobody reconciles it by hand.

No product code, no baselines move.