### PR TITLE
docs: point the last two live references at the committed archive, not the served page

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -12,7 +12,9 @@ cells closing; it is authoritative for future issues.
 ## Source of truth
 
 - **The redesign spec** (component inventory, chrome, variants):
+  docs/screens/redesign-spec.html  (committed archive — read this)
   https://0d5784a7a43451f4ad70dd3d9ee5cf72.boxes.mantaui.com/pages/manta-redesign
+  (served copy, EXPIRES 2026-08-13 — do not rely on it)
 - **Tokens**: `src/renderer/tokens.css` (multi-consumer — BET-516 generates a Swift
   theme from it, so a token change is no longer a local edit).
 - **Validation surface**: the component companion (`npm run visual:companion`), which

--- a/docs/mobile-redesign/DECISIONS.md
+++ b/docs/mobile-redesign/DECISIONS.md
@@ -1223,7 +1223,7 @@ link.
 | Transcript + subagent spec | `docs/mobile-redesign/transcript-mockup.html` (§8, §8a, §7.1a) |
 | Mobile implementation epic | BET-550 (server migration → Swift client) |
 | Desktop design epic | BET-565 (continuation of BET-527, primitives shipped) |
-| Desktop redesign epic | BET-406, design record at `/pages/manta-redesign` |
+| Desktop redesign epic | BET-406 (shipped) → BET-565. Design record archived at `docs/screens/redesign-spec.html` — the served `/pages/manta-redesign` copy expires. |
 | The stack spike | BET-431 (BET-432 … BET-438) |
 | Current mobile client | `src/renderer/mobile/` |
 | The CSS override layer that dies | `src/renderer/mobile/mobile.css` |


### PR DESCRIPTION
Documentation only. Follow-up to the design-loop track's #466.

That PR archived the desktop design record at `docs/screens/redesign-spec.html` because `scripts/visual/companion.mjs` fetched it from `/pages/manta-redesign` **at runtime** — a committed script with a fuse set for 2026-08-13, invisible until it fired.

A repo-wide grep for served-page references found **two more live pointers to the same expiring page**:

| File | What it is |
|---|---|
| `docs/components.md:15` | the primitives doc's design reference |
| `docs/mobile-redesign/DECISIONS.md:1226` | the appendix's desktop design record |

Both now name the committed archive **first** and label the served copy with its expiry date, so nobody follows the dead one.

## Remaining hits are safe — checked, not assumed

- `DECISIONS.md:8` cites `/pages/manta-mobile-2`, one of only two pages with **no expiry**, and the doc already states the in-repo file is the source of truth.
- `transcript-mockup.html` mentions the served copies **only to say they expire and it does not**.
- `src/server/servePage.test.mjs` uses `/pages/` paths as test fixtures.

## Why this class matters

A served page under `~/.manta/pages/` is swept at TTL and nothing in git holds it. Everything on that box except two pages dies within two weeks. Any committed file — doc, script or issue — whose only reference is a rendered page is self-contained until that date and silently broken after it.

Verified: typecheck clean, 1353 tests passing.