### PR TITLE
BET-564: refresh conformance records + make staleness detectable

### DIFF
--- a/docs/screens/folder-picker/conformance.md
+++ b/docs/screens/folder-picker/conformance.md
@@ -4,7 +4,7 @@ App vs `docs/screens/folder-picker/mockup.html`, from `npm run visual:compare fo
 Advisory: nothing here blocks a merge. Findings are recorded so they survive
 the PR that found them.
 
-Last reviewed: 2026-08-02 (8176518)
+Last reviewed: 2026-08-02 (9a17023)
 
 ## Captured state
 

--- a/docs/screens/session/conformance.md
+++ b/docs/screens/session/conformance.md
@@ -4,7 +4,7 @@ App vs `docs/screens/session/mockup.html`, from `npm run visual:compare session`
 Advisory: nothing here blocks a merge. Findings are recorded so they survive
 the PR that found them.
 
-Last reviewed: 2026-08-01 (3802bc0)
+Last reviewed: 2026-08-02 (9a17023)
 
 ## Open divergences
 

--- a/docs/screens/settings/conformance.md
+++ b/docs/screens/settings/conformance.md
@@ -4,13 +4,11 @@ App vs `docs/screens/settings/mockup.html`, from `npm run visual:compare setting
 Advisory: nothing here blocks a merge. Findings are recorded so they survive
 the PR that found them.
 
-Last reviewed: 2026-08-01 (3802bc0)
+Last reviewed: 2026-08-02 (9a17023)
 
 ## Open divergences
 
-- **Extensions launcher card** — the heading text and card ordering of the
-  launcher card differ between `Settings.tsx` and the mockup's `.ext` panel.
-  `tracked: BET-473`
+_None recorded._
 
 ## Accepted divergences
 

--- a/docs/screens/welcome/conformance.md
+++ b/docs/screens/welcome/conformance.md
@@ -4,7 +4,7 @@ App vs `docs/screens/welcome/mockup.html`, from `npm run visual:compare welcome`
 Advisory: nothing here blocks a merge. Findings are recorded so they survive
 the PR that found them.
 
-Last reviewed: 2026-08-01 (3802bc0)
+Last reviewed: 2026-08-02 (9a17023)
 
 ## Open divergences
 

--- a/docs/visual-verification.md
+++ b/docs/visual-verification.md
@@ -146,6 +146,10 @@ user gestures — a click a person could make — not for reaching into internal
    recorded in `docs/screens/<id>/conformance.md` with the "Last reviewed"
    line updated. A finding that lives only in a PR description is lost the
    moment the PR is merged.
+
+   **If your PR moves a baseline, update that screen's `Last reviewed` sha in
+   the same PR.** A record reviewed before the change it should describe is
+   worse than no record — it reads as current.
 5. **Any baseline this PR creates or re-records is in the PR body as an
    image.** Not a filename, not "regenerated" — the picture. A baseline is
    committed *evidence*, and a reviewer who cannot see it is approving a hash.

--- a/scripts/conformance-freshness.test.mjs
+++ b/scripts/conformance-freshness.test.mjs
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { accessSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { SCREENS } from "./visual/screens.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const SNAPSHOTS = "tests/visual/screens.visual.ts-snapshots";
+
+const git = (args) => execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+const gitStatus = (args) => {
+  try {
+    git(args);
+    return 0;
+  } catch (e) {
+    return e.status ?? 1;
+  }
+};
+
+/**
+ * Freshness of conformance records (BET-564). A conformance record is
+ * judgement — no test can arbitrate what it says. But whether a record has
+ * been LOOKED AT since its screen's baseline moved is mechanical, and that
+ * is what this test asserts: a record whose "Last reviewed" sha predates the
+ * last change to its pixel baseline is stale by construction, because it was
+ * written before the thing it claims to describe.
+ *
+ * Mechanism (git, not file mtimes — mtimes lie after a fresh clone):
+ *   baselineChanged = last commit touching <id>-visual-linux.png
+ *   recordSha       = the sha on the "Last reviewed" line
+ *   FAIL           = baselineChanged is NOT an ancestor of recordSha
+ *
+ * Screens with `mockup: null` are skipped — no design, nothing to conform to,
+ * no record expected. Screens without a committed baseline are skipped too
+ * (nothing to have gone stale).
+ *
+ * A screen's record lives in the directory of the mockup it renders against
+ * (region rows share their parent screen's record), e.g. `session-header`
+ * and `session-composer` both reconcile against
+ * `docs/screens/session/conformance.md`.
+ */
+for (const screen of SCREENS) {
+  if (!screen.mockup) continue;
+
+  const mockupDir = dirname(screen.mockup);
+  const recordPath = join(mockupDir, "conformance.md");
+  const recordScreen = screen.mockup.split("/")[2];
+  const baseline = join(SNAPSHOTS, `${screen.id}-visual-linux.png`);
+  const fullBaseline = join(REPO_ROOT, baseline);
+
+  let baselineSha;
+  try {
+    accessSync(fullBaseline);
+    baselineSha = git(["log", "-1", "--format=%H", "--", baseline]);
+  } catch {
+    // No committed baseline for this screen — nothing can have gone stale.
+    continue;
+  }
+
+  test(`conformance record for "${recordScreen}" is fresh (baseline ${screen.id})`, () => {
+    let record;
+    try {
+      record = readFileSync(join(REPO_ROOT, recordPath), "utf8");
+    } catch {
+      assert.fail(`missing conformance record ${recordPath} for screen "${screen.id}" with a filed mockup. ` +
+        `Fix: write one and set its Last reviewed sha.`);
+    }
+
+    const match = record.match(/^Last reviewed:.*\(([0-9a-fA-F]+)\)/m);
+    assert.ok(
+      match,
+      `"Last reviewed" line missing a (sha) in ${recordPath}. ` +
+        `Fix: run \`npm run visual:compare ${recordScreen}\`, reconcile ` +
+        `\`docs/screens/${recordScreen}/conformance.md\`, and update its Last reviewed sha.`,
+    );
+    const recordSha = match[1];
+
+    // exit 0 = ancestor (baseline moved before the review -> record is fresh),
+    // exit 1 = not an ancestor (baseline moved after the review -> stale),
+    // anything else = a sha we cannot resolve -> treat as stale, it cannot be
+    // proven current.
+    const ancestor = gitStatus(["merge-base", "--is-ancestor", baselineSha, recordSha]) === 0;
+    assert.ok(
+      ancestor,
+      `conformance record for "${recordScreen}" is STALE: baseline ${screen.id} ` +
+        `last changed at ${baselineSha.slice(0, 9)}, but its record was reviewed at ` +
+        `${recordSha} (${recordPath}) — the baseline moved after the review, so the ` +
+        `record does not describe the screen as it exists now. Fix: run ` +
+        `\`npm run visual:compare ${recordScreen}\`, reconcile ` +
+        `\`docs/screens/${recordScreen}/conformance.md\`, and update its Last reviewed sha.`,
+    );
+  });
+}


### PR DESCRIPTION
## BET-564 — refresh conformance records + make staleness detectable

Refreshes every `docs/screens/*/conformance.md` to current `main` and makes a
stale record detectable instead of trusting people to remember.

### Change 1 — records reconciled (`npm run visual:compare` run for all four)

| Screen | Record edit | BET closing any removal |
|---|---|---|
| `welcome` | kept "None recorded" | — |
| `session` | kept (None open; accepted pinned-vs-inline ask, PR #392) | — |
| `settings` | **removed the stale "Extensions launcher card" divergence** | BET-473 |
| `folder-picker` | kept all recorded divergences | — |

- `settings` rename/ordering divergence removed: BET-473 (PR #406) moved the
  launcher card after Skill registries and renamed the heading to "CLI launch
  options" — confirmed live in `Settings.tsx` (`"CLI launch options"` at line
  711, rendered after the `Skill registries` GroupCard at line 693). It was the
  divergence the issue flagged.
- All four bumped `Last reviewed:` → `2026-08-02 (9a17023)` (current `main`).

### Change 2 — staleness test (`scripts/conformance-freshness.test.mjs`, node:test)

For every screen with a non-null mockup, asserts via git ancestry that the
record's `Last reviewed` sha is a descendant-or-equal of the last commit
touching that screen's `<id>-visual-linux.png` baseline. If the baseline moved
after the record was reviewed, the record is stale by construction and the test
fails, naming the screen and both shas, with the one-line fix:
"run `npm run visual:compare <id>`, reconcile `docs/screens/<id>/conformance.md`,
and update its Last reviewed sha."

Region rows (`session-header`, `settings-rail`, …) are checked against their
parent screen's record via the mockup directory. `mockup: null` screens skipped.

**Failure demonstrated (then restored):** reverting `folder-picker`'s `Last
reviewed` to `3802bc0` (older than its baseline `817651803`) →
`conformance record for "folder-picker" is STALE: baseline folder-picker last
changed at 817651803, but its record was reviewed at 3802bc0 …`. Restored to
`9a17023`.

### Change 3 — DoD line

`docs/visual-verification.md` DoD item 4 now adds: **If your PR moves a
baseline, update that screen's `Last reviewed` sha in the same PR.**

### Out of scope (per issue)

No divergence fixed, no baseline moved, no `mockup: null` records added, no CI
step — one test in the existing `npm test` run.

**Base: origin/main @ 9a17023**

**Verification results:**
- typecheck: exit 0. Errors: none.
- test: exit 0, 1371 pass / 0 fail / 0 skip (includes the 9 freshness tests).
- `git status` shows nothing under `tests/visual/screens.visual.ts-snapshots/`.
