### PR TITLE
S1b: migrate the renderer to consume box-interpreted stream events (BET-552)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -16,6 +16,7 @@ import {
   resetStore,
   mount,
   emitAndFlush,
+  emitStreamAndFlush,
   type MockApi,
   type MockEventBus,
   type Harness,
@@ -526,16 +527,22 @@ describe("ChatPanel abort rejects orphaned questions", () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    await emitAndFlush(bus, h, {
-      type: "question.asked",
-      properties: {
-        sessionID: "ses_test",
-        id: "que_1",
+    await emitStreamAndFlush(bus, h, {
+      sub: "questions",
+      sessionId: "ses_test",
+      payload: {
         questions: [
           {
-            header: "Approach",
-            question: "Which approach?",
-            options: [{ label: "a" }, { label: "b" }],
+            id: "que_1",
+            sessionID: "ses_test",
+            requestId: "que_1",
+            questions: [
+              {
+                header: "Approach",
+                question: "Which approach?",
+                options: [{ label: "a" }, { label: "b" }],
+              },
+            ],
           },
         ],
       },
@@ -544,9 +551,10 @@ describe("ChatPanel abort rejects orphaned questions", () => {
     expect(h.text()).toContain("Which approach?");
 
     // Turn is running.
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
 
     const textarea = h.container.querySelector("textarea") as HTMLTextAreaElement;
@@ -570,9 +578,10 @@ describe("ChatPanel abort rejects orphaned questions", () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
 
     const textarea = h.container.querySelector("textarea") as HTMLTextAreaElement;

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -264,14 +264,10 @@ export function ChatPanel({
     prevScrollHeight,
     questionCardRef,
     wantQuestionScroll,
-    flushPendingDeltas,
-    scheduleFlush,
+    applyStreamFlush,
     scheduleRefetch,
     spliceMessage,
     toggleTaskExpand,
-    pendingDeltas,
-    oldestPendingAt,
-    FLUSH_MAX_AGE_MS,
   } = useTranscriptState({ sessionId, isActive });
 
   // ===== SSE bus state (extracted to useSseBus) =====
@@ -335,11 +331,7 @@ export function ChatPanel({
     childRefetchTimers,
     isActiveRef,
     refetchOwedWhileInactive,
-    pendingDeltas,
-    flushPendingDeltas,
-    scheduleFlush,
-    oldestPendingAt,
-    FLUSH_MAX_AGE_MS,
+    applyStreamFlush,
     // Active-model providerID for the auth-error banner (BET-316).
     // Per-session override (localStorage) wins over the persisted default;
     // null if neither is set — the banner then falls through to the

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -310,6 +310,13 @@ const onOpencodeEvent = (cb: (ev: unknown) => void): (() => void) => {
   return () => {};
 };
 
+// Box-interpreted stream events (BET-551 / §17) never reach the demo: the
+// demo fixture drives the `stream` state through onOpencodeEvent
+// (message.updated → splice) instead, and the Proxy fallback would also serve
+// a benign no-op. Declared explicitly so the coverage test records the
+// subscription as intentionally stubbed rather than silently absent.
+const onStreamEvent = (_cb: unknown): (() => void) => () => {};
+
 const launchersList = (): Promise<AvailableLauncher[]> =>
   Promise.resolve(demoState.launchers);
 
@@ -415,6 +422,7 @@ export const explicitMethods = {
   opencodeOpenStream,
   opencodeCloseStream,
   onOpencodeEvent,
+  onStreamEvent,
   launchersList,
   fsListDirs,
   gitListWorktrees,

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -11,6 +11,7 @@ import {
   type PluginRegistryRow,
   type PtyEvent,
   type ServerUpdateAvailablePayload,
+  type StreamEnvelope,
   type WindowStatus,
 } from "../../shared/types.js";
 import type { Api } from "../../shared/api.js";
@@ -326,8 +327,13 @@ type Kind =
   | "agentFile"
   | "desktopNotify"
   | "serverUpdateAvailable"
-  | "delegate.updated";
+  | "delegate.updated"
+  | "stream";
 
+// Stream-kind listeners receive the DERIVED envelope `{sub, sessionId, payload}`
+// (see dispatchFrame), not just `payload` — the bus event carries the extra
+// routing fields every other kind discards. `on<T>` type-erases the payload,
+// so the consumers simply choose their own shape here.
 const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   opencode: new Set(),
   pty: new Set(),
@@ -337,6 +343,7 @@ const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   desktopNotify: new Set(),
   serverUpdateAvailable: new Set(),
   "delegate.updated": new Set(),
+  stream: new Set(),
 };
 
 // The live event stream is a WebSocket (not SSE/EventSource): iOS standalone
@@ -431,13 +438,23 @@ const WATCHDOG_INTERVAL_MS = 15_000;
 function dispatchFrame(data: unknown) {
   lastFrameAt = Date.now();
   try {
-    const { kind, payload } = JSON.parse(data as string) as {
+    const { kind, payload, sub, sessionId } = JSON.parse(data as string) as {
       kind: Kind | "heartbeat";
       payload: unknown;
+      sub?: string;
+      sessionId?: string;
     };
     if (kind === "heartbeat") return; // liveness ping only — no listener, no demux
     const set = listeners[kind as Kind];
-    if (set) for (const fn of set) fn(payload);
+    if (!set) return;
+    // The `stream` kind wraps a derived sub-event: the box publishes
+    // `{ kind:"stream", sub, sessionId, payload }`. Every other kind is the
+    // flat `{ kind, payload }` envelope and dispatches `payload` alone. This
+    // keeps the stream consumer's `sub`/`sessionId` routing (useSseBus.scoped
+    // to the viewed session) intact without changing the other kinds' shape.
+    for (const fn of set) {
+      fn(kind === "stream" ? { sub, sessionId, payload } : payload);
+    }
   } catch {
     // non-JSON / control frame — ignore
   }
@@ -844,6 +861,11 @@ export const httpApi: Api = {
   opencodeCloseStream: (sessionId) =>
     rpcOptional(IPC.opencodeCloseStream, undefined, sessionId),
   onOpencodeEvent: (cb) => on<OpencodeEvent>("opencode", cb),
+  // Box-side interpreted stream events (BET-551 / §17). The dispatchFrame
+  // stream branch hands each listener a `{sub, sessionId, payload}` envelope
+  // (see the comment there); useSseBus scopes by `sessionId` and demuxes the
+  // derivative by `sub`.
+  onStreamEvent: (cb) => on<StreamEnvelope>("stream", cb),
 
   /**
    * The preload packs opencodePrompt args into a single object before invoking:

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -14,6 +14,7 @@ import {
   resetStore,
   mount,
   emitAndFlush,
+  emitStreamAndFlush,
   type MockApi,
   type MockEventBus,
   type Harness,
@@ -48,20 +49,22 @@ describe("useSseBus via ChatPanel", () => {
     expect(bus.listenerCount()).toBeGreaterThan(0);
   });
 
-  it("transitions running state on session.status events", async () => {
+  it("transitions running state on stream.running events", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // Simulate session going busy
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    // Simulate session going busy (BET-551 / §17 — running is box-derived)
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
 
     // Simulate session going idle
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "idle" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: false },
     });
 
     // Component should still be mounted without errors.
@@ -155,29 +158,28 @@ describe("useSseBus via ChatPanel", () => {
     expect(text).not.toContain("Reconnect");
   });
 
-  it("routes child-session events to scheduleChildRefetch when expanded", async () => {
+  it("routes child-session stream events to scheduleChildRefetch when expanded", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // Emit a child session.created event to register the child
-    await emitAndFlush(bus, h, {
-      type: "session.created",
-      properties: {
-        sessionID: "ses_test",
-        info: { id: "child_123", parentID: "ses_test" },
-      },
+    // Emit a child registration (BET-551 — the box publishes subagent.child)
+    await emitStreamAndFlush(bus, h, {
+      sub: "subagent.child",
+      sessionId: "ses_test",
+      payload: { childSessionId: "child_123" },
     });
 
-    // Now emit a message.part.delta for the child session
-    // This should trigger scheduleChildRefetch if the child is expanded
-    await emitAndFlush(bus, h, {
-      type: "message.part.delta",
-      properties: {
-        sessionID: "child_123",
-        partID: "part_1",
+    // Now emit a stream.flush for the child session. This routes to
+    // scheduleChildRefetch if the child is expanded; either way the panel
+    // stays mounted.
+    await emitStreamAndFlush(bus, h, {
+      sub: "flush",
+      sessionId: "child_123",
+      payload: {
         messageID: "msg_1",
+        partID: "part_1",
         field: "text",
-        delta: "Hello from child",
+        text: "Hello from child",
       },
     });
 
@@ -253,17 +255,19 @@ describe("useSseBus via ChatPanel", () => {
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 
-  it("handles todo.updated events", async () => {
+  it("handles stream.todos events", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    await emitAndFlush(bus, h, {
-      type: "todo.updated",
-      properties: {
-        sessionID: "ses_test",
-        todos: [
-          { content: "Task 1", status: "in_progress", priority: "high" },
-        ],
+    const todos = [{ content: "Task 1", status: "in_progress", priority: "high" }];
+    await emitStreamAndFlush(bus, h, {
+      sub: "todos",
+      sessionId: "ses_test",
+      payload: {
+        active: todos,
+        visible: { visible: todos, hiddenPending: 0, hiddenDone: 0 },
+        allTerminal: false,
+        anyTerminal: false,
       },
     });
 
@@ -320,23 +324,23 @@ describe("useSseBus via ChatPanel", () => {
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 
-  it("handles question events", async () => {
+  it("handles stream.questions events", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    await emitAndFlush(bus, h, {
-      type: "question.asked",
-      properties: { sessionID: "ses_test" },
+    await emitStreamAndFlush(bus, h, {
+      sub: "questions",
+      sessionId: "ses_test",
+      payload: { questions: [] },
     });
-
-    await emitAndFlush(bus, h, {
-      type: "question.replied",
-      properties: { sessionID: "ses_test" },
-    });
-
-    await emitAndFlush(bus, h, {
-      type: "question.rejected",
-      properties: { sessionID: "ses_test" },
+    await emitStreamAndFlush(bus, h, {
+      sub: "questions",
+      sessionId: "ses_test",
+      payload: {
+        questions: [
+          { id: "que_1", sessionID: "ses_test", questions: [["pick one"]], requestId: "que_1" },
+        ],
+      },
     });
 
     // Component should still be mounted.
@@ -380,13 +384,14 @@ describe("useSseBus via ChatPanel", () => {
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 
-  it("handles session.idle", async () => {
+  it("handles stream.turnComplete (idle)", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    await emitAndFlush(bus, h, {
-      type: "session.idle",
-      properties: { sessionID: "ses_test" },
+    await emitStreamAndFlush(bus, h, {
+      sub: "turnComplete",
+      sessionId: "ses_test",
+      payload: { complete: true, running: false },
     });
 
     // Component should still be mounted.
@@ -501,9 +506,10 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
     h = await mountDrainHarness();
 
     // Turn is already running.
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
 
     // User submits a second message mid-turn — it queues instead of sending.
@@ -529,9 +535,10 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
   it("does not abort on a running (non-boundary) tool part", async () => {
     h = await mountDrainHarness();
 
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
     await queueASecondMessage(h.container);
     await h.flush();
@@ -560,9 +567,10 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
       },
     });
 
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
     await queueASecondMessage(h.container);
     await h.flush();
@@ -592,9 +600,10 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
     h = await mountDrainHarness();
 
     // Turn running; queue a second message mid-turn.
-    await emitAndFlush(bus, h, {
-      type: "session.status",
-      properties: { sessionID: "ses_test", status: { type: "busy" } },
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
     });
     await queueASecondMessage(h.container);
     await h.flush();
@@ -609,10 +618,12 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
       },
     });
     // The abort flips the session idle → the drain effect submits the queued
-    // prompt. Emit the idle the abort would produce.
-    await emitAndFlush(bus, h, {
-      type: "session.idle",
-      properties: { sessionID: "ses_test" },
+    // prompt. Emit the turn-complete the abort would produce (BET-551 / §17
+    // — the box reports completion via stream.turnComplete).
+    await emitStreamAndFlush(bus, h, {
+      sub: "turnComplete",
+      sessionId: "ses_test",
+      payload: { complete: true, running: false },
     });
     await h.flush();
 
@@ -643,20 +654,20 @@ describe("useSseBus question.asked refetch gating (BET-418)", () => {
     h = null;
   });
 
-  it("does NOT refetch questions for the viewed session's own question.asked", async () => {
+  it("does NOT refetch questions for the viewed session's own stream.questions", async () => {
     ({ api, bus } = installMockApi());
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
     const before = (api.calls.opencodeQuestions ?? []).length;
 
-    await emitAndFlush(bus, h, {
-      type: "question.asked",
-      properties: {
-        sessionID: "ses_test",
-        id: "que_1",
-        tool: { messageID: "msg_1", callID: "toolu_1" },
-        questions: [["pick one"]],
+    await emitStreamAndFlush(bus, h, {
+      sub: "questions",
+      sessionId: "ses_test",
+      payload: {
+        questions: [
+          { id: "que_1", sessionID: "ses_test", questions: [["pick one"]], requestId: "que_1" },
+        ],
       },
     });
 
@@ -664,20 +675,20 @@ describe("useSseBus question.asked refetch gating (BET-418)", () => {
     expect(after).toBe(before);
   });
 
-  it("drops + does NOT refetch for a foreign (background-job child) session's question.asked", async () => {
+  it("drops + does NOT refetch for a foreign (background-job child) session's stream.questions", async () => {
     ({ api, bus } = installMockApi());
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
     const before = (api.calls.opencodeQuestions ?? []).length;
 
-    await emitAndFlush(bus, h, {
-      type: "question.asked",
-      properties: {
-        sessionID: "ses_child",
-        id: "que_child_live",
-        tool: { messageID: "msg_c", callID: "toolu_c" },
-        questions: [["pick one"]],
+    await emitStreamAndFlush(bus, h, {
+      sub: "questions",
+      sessionId: "ses_child",
+      payload: {
+        questions: [
+          { id: "que_child_live", sessionID: "ses_child", questions: [["pick one"]], requestId: "que_child_live" },
+        ],
       },
     });
 

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -54,18 +54,22 @@ import type {
   OpencodeMessage,
   PermissionRequest,
   QuestionRequest,
+  StreamEnvelope,
+  StreamFlushPayload,
+  StreamRunningPayload,
+  StreamTodosPayload,
+  StreamTruncationPayload,
+  StreamQuestionsPayload,
+  StreamSubagentChildPayload,
 } from "../../shared/types";
 import {
   shouldDropEventForSessionFilter,
-  registerChildSessionFromCreated,
   isDrainAbortError,
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
   collectChildSessionIds,
-  applyQuestionEvent,
   hydrateQuestion,
   authErrorAdvice,
-  type PendingDelta,
 } from "../chatUtils";
 import type { TokenUsage } from "../chatShared";
 import { useStore } from "../store";
@@ -143,11 +147,12 @@ export function useSseBus(params: {
   childRefetchTimers: React.MutableRefObject<Map<string, ReturnType<typeof setTimeout>>>;
   isActiveRef: React.MutableRefObject<boolean>;
   refetchOwedWhileInactive: React.MutableRefObject<boolean>;
-  pendingDeltas: React.MutableRefObject<Map<string, PendingDelta>>;
-  flushPendingDeltas: (force: boolean) => number;
-  scheduleFlush: () => void;
-  oldestPendingAt: React.MutableRefObject<number | null>;
-  FLUSH_MAX_AGE_MS: number;
+  applyStreamFlush: (d: {
+    partID: string;
+    messageID: string;
+    field: string;
+    text: string;
+  }) => number;
   // The session's active model's providerID (e.g. "anthropic", "openai",
   // "kimi-for-coding"). Drives the auth-error banner copy (BET-316) — when
   // a session.error is recognisably a credential failure on one of the
@@ -171,10 +176,7 @@ export function useSseBus(params: {
     expandedTasksRef,
     isActiveRef,
     refetchOwedWhileInactive,
-    pendingDeltas,
-    flushPendingDeltas,
-    scheduleFlush,
-    oldestPendingAt,
+    applyStreamFlush,
     providerID,
     submit,
     submitRef,
@@ -357,12 +359,6 @@ export function useSseBus(params: {
       const props = ev.properties ?? {};
       const evSessionID = typeof props.sessionID === "string" ? props.sessionID : "";
 
-      registerChildSessionFromCreated(
-        ev as { type: string; properties?: { info?: { id?: string; parentID?: string } } },
-        sessionId,
-        childSessionIds.current,
-      );
-
       if (shouldDropEventForSessionFilter(
         ev as { type: string; properties?: { sessionID?: string } },
         sessionId,
@@ -422,34 +418,10 @@ export function useSseBus(params: {
         return;
       }
 
-      if (ev.type === "message.part.delta") {
-        const partID = String(props.partID ?? "");
-        const messageID = String(props.messageID ?? "");
-        const field = String(props.field ?? "text");
-        const delta = String(props.delta ?? "");
-        if (!partID || !delta) return;
+      // NOTE: the viewed session's delta flush, running, todos, truncation and
+      // question interpretation all moved to the box (BET-551 / §17) and are
+      // consumed via the onStreamEvent subscription below — no longer here.
 
-        if (!isActiveRef.current) {
-          refetchOwedWhileInactive.current = true;
-          return;
-        }
-
-        const existing = pendingDeltas.current.get(partID);
-        if (existing && existing.field === field) {
-          existing.text += delta;
-        } else {
-          pendingDeltas.current.set(partID, { messageID, field, text: delta });
-        }
-        if (oldestPendingAt.current == null) {
-          oldestPendingAt.current = Date.now();
-        }
-        scheduleFlush();
-        return;
-      }
-
-      if (ev.type === "session.idle") {
-        setRunning(false);
-      }
       if (ev.type === "session.status") {
         const status = props.status as
           | {
@@ -468,8 +440,6 @@ export function useSseBus(params: {
             }
           | undefined;
         const type = status?.type;
-        if (type === "busy" || type === "retry") setRunning(true);
-        else if (type === "idle") setRunning(false);
         if (type === "retry") {
           setRetryInfo({
             attempt: status?.attempt ?? 0,
@@ -535,7 +505,6 @@ export function useSseBus(params: {
       }
 
       if (ev.type === "session.next.step.ended") {
-        flushPendingDeltas(true);
         maybeDrainQueuedPrompt();
         // Update stepTokens
         const usage = props.usage as { input?: number; output?: number; reasoning?: number; cache?: { read?: number; write?: number } } | undefined;
@@ -552,16 +521,8 @@ export function useSseBus(params: {
             cost,
           });
         }
-        // Update finishByMessageId
-        const finish = props.finish as string | undefined;
-        if (finish) {
-          const messageID = String(props.messageID ?? "");
-          setFinishByMessageId((prev) => {
-            const next = new Map(prev);
-            next.set(messageID, finish as import("../chatUtils").TruncationKind);
-            return next;
-          });
-        }
+        // Truncation classification moved to the box → stream.truncation
+        // (consumed below); finishByMessageId is stamped there, not here.
       }
 
       if (ev.type.startsWith("session.next.compaction.")) {
@@ -590,13 +551,7 @@ export function useSseBus(params: {
         setBranch((prev) => b ?? prev);
       }
 
-      if (ev.type === "todo.updated") {
-        const todos = props.todos as Array<{ content: string; status: string; priority: string }> | undefined;
-        if (todos) {
-          setLiveTodos(todos);
-          setTodosDismissed(false);
-        }
-      }
+      // Todo interpretation moved to the box → stream.todos (consumed below).
 
       if (ev.type === "command.executed") {
         const messageID = String(props.messageID ?? "");
@@ -629,7 +584,6 @@ export function useSseBus(params: {
           props.messageID ?? part?.messageID ?? info?.id ?? "",
         );
         spliceMessage(messageID);
-        flushPendingDeltas(false);
       }
 
       // Primary drain trigger — the real step boundary the deployed opencode
@@ -656,20 +610,9 @@ export function useSseBus(params: {
         void refreshPermissions();
       }
 
-      if (ev.type === "question.asked" || ev.type === "question.replied" || ev.type === "question.rejected") {
-        // Payload-driven live update (restored from BET-64 refactor regression).
-        // Applying the event payload directly (a) hydrates `requestId` from the
-        // asked payload so submit can send the reply, and (b) upserts by callID
-        // so re-asks don't stack. Only the viewed session's own questions are
-        // accepted now (BET-418 §A) — background-job children no longer route
-        // here, so there is no related-id set to consult.
-        setQuestions((prev) =>
-          applyQuestionEvent(prev, ev.type, props, sessionId) as QuestionRequest[],
-        );
-        if (ev.type === "question.replied" || ev.type === "question.rejected") {
-          scheduleRefetch();
-        }
-      }
+      // Question interpretation moved to the box → stream.questions (consumed
+      // below). BET-418 semantics follow: a viewed session's own ask applies
+      // live from the payload (no refetch), a foreign/child ask never applies.
     });
 
     // Initial fetch. Arm `refreshing` here (not just in scheduleRefetch) so the
@@ -688,8 +631,85 @@ export function useSseBus(params: {
       scheduleRefetch();
     }).catch(() => { /* non-fatal */ }).finally(() => setRefreshing(false));
 
+    // Box-side interpreted stream events (BET-551 / §17). The box derives
+    // running, delta-flush, todos, truncation, questions and subagent/child
+    // state from the raw opencode stream and publishes them as `stream.*` —
+    // the renderer consumes those here instead of re-interpreting.
+    const offStream = window.api.onStreamEvent((ev: StreamEnvelope) => {
+      // A stream event scoped to a subagent child session (not this panel's
+      // own session) still needs the child's live-transcript routing — the
+      // same scheduleChildRefetch the raw-event child block above does.
+      if (ev.sessionId !== sessionId) {
+        if (
+          ev.sessionId &&
+          childSessionIds.current.has(ev.sessionId) &&
+          expandedTasksRef.current.has(ev.sessionId)
+        ) {
+          scheduleChildRefetch(ev.sessionId);
+        }
+        return;
+      }
+
+      switch (ev.sub) {
+        case "flush": {
+          const { messageID, partID, field, text } = ev.payload as StreamFlushPayload;
+          if (!partID || !messageID) return;
+          if (!isActiveRef.current) {
+            refetchOwedWhileInactive.current = true;
+            return;
+          }
+          // The box already flushed at a safe boundary; apply the chunk
+          // directly. Unmatched → the part snapshot isn't loaded yet.
+          const unmatched = applyStreamFlush({ messageID, partID, field, text });
+          if (unmatched > 0) scheduleRefetch();
+          return;
+        }
+        case "running":
+        case "turnComplete": {
+          setRunning((ev.payload as StreamRunningPayload).running);
+          return;
+        }
+        case "todos": {
+          const { active } = ev.payload as StreamTodosPayload;
+          if (active) {
+            setLiveTodos(active as Array<{ content: string; status: string; priority: string }>);
+            setTodosDismissed(false);
+          }
+          return;
+        }
+        case "truncation": {
+          const p = ev.payload as StreamTruncationPayload;
+          if (p.messageID && p.kind) {
+            setFinishByMessageId((prev) => {
+              const next = new Map(prev);
+              next.set(p.messageID as string, p.kind as import("../chatUtils").TruncationKind);
+              return next;
+            });
+          }
+          return;
+        }
+        case "questions": {
+          const { questions } = ev.payload as StreamQuestionsPayload;
+          if (Array.isArray(questions)) {
+            setQuestions(questions as QuestionRequest[]);
+          }
+          return;
+        }
+        case "subagent.child": {
+          const { childSessionId } = ev.payload as StreamSubagentChildPayload;
+          if (childSessionId) childSessionIds.current.add(childSessionId);
+          return;
+        }
+        default:
+          // context / cache / subagent / autoRename — consumed by other
+          // surfaces, not this panel's live transcript state.
+          return;
+      }
+    });
+
     return () => {
       off();
+      offStream();
       if (compactionClearTimer.current) clearTimeout(compactionClearTimer.current);
     };
   }, [sessionId]);

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -441,6 +441,9 @@ export function useSseBus(params: {
           | undefined;
         const type = status?.type;
         if (type === "retry") {
+          // The box emits stream.running only for busy/working, so a retry
+          // still sets running here directly (unchanged from pre-S1b).
+          setRunning(true);
           setRetryInfo({
             attempt: status?.attempt ?? 0,
             message: status?.message ?? "",

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -441,9 +441,10 @@ export function useSseBus(params: {
           | undefined;
         const type = status?.type;
         if (type === "retry") {
-          // The box emits stream.running only for busy/working, so a retry
-          // still sets running here directly (unchanged from pre-S1b).
-          setRunning(true);
+          // Running on a retry comes from the box's stream.running (the box
+          // treats retry as running — see streamInterp session.status). This
+          // raw handler only surfaces the retry banner/message; it must not
+          // set running itself, or it would race the box value.
           setRetryInfo({
             attempt: status?.attempt ?? 0,
             message: status?.message ?? "",

--- a/src/renderer/hooks/useTranscriptState.test.tsx
+++ b/src/renderer/hooks/useTranscriptState.test.tsx
@@ -14,6 +14,7 @@ import {
   resetStore,
   mount,
   emitAndFlush,
+  emitStreamAndFlush,
 } from "../testHarness";
 
 const PROPS = {
@@ -45,19 +46,19 @@ describe("useTranscriptState via ChatPanel", () => {
     expect(h.container.querySelector('[class*="transcript"]') || h.container.firstChild).not.toBeNull();
   });
 
-  it("handles message.part.delta events for active panel", async () => {
+  it("handles stream.flush events for active panel", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // Emit a delta event for the active panel
-    await emitAndFlush(bus, h, {
-      type: "message.part.delta",
-      properties: {
-        sessionID: "ses_test",
-        partID: "part_1",
+    // Emit a box-flushed delta for the active panel (BET-551 / §17)
+    await emitStreamAndFlush(bus, h, {
+      sub: "flush",
+      sessionId: "ses_test",
+      payload: {
         messageID: "msg_1",
+        partID: "part_1",
         field: "text",
-        delta: "Hello",
+        text: "Hello",
       },
     });
 
@@ -65,7 +66,7 @@ describe("useTranscriptState via ChatPanel", () => {
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 
-  it("handles message.part.delta for inactive panel by setting refetchOwed", async () => {
+  it("handles stream.flush for inactive panel by setting refetchOwed", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
@@ -75,19 +76,19 @@ describe("useTranscriptState via ChatPanel", () => {
     });
     await h!.flush();
 
-    // Emit a delta event for the inactive panel
-    await emitAndFlush(bus, h, {
-      type: "message.part.delta",
-      properties: {
-        sessionID: "ses_test",
-        partID: "part_2",
+    // Emit a box-flushed delta for the inactive panel
+    await emitStreamAndFlush(bus, h, {
+      sub: "flush",
+      sessionId: "ses_test",
+      payload: {
         messageID: "msg_2",
+        partID: "part_2",
         field: "text",
-        delta: "World",
+        text: "World",
       },
     });
 
-    // Component should still be mounted (delta was suppressed, refetch owed).
+    // Component should still be mounted (flush was suppressed, refetch owed).
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 

--- a/src/renderer/hooks/useTranscriptState.ts
+++ b/src/renderer/hooks/useTranscriptState.ts
@@ -20,13 +20,11 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { OpencodeMessage } from "../../shared/types";
 import {
-  findFlushBoundary,
   mergeBufferedDeltas,
   collectChildSessionIds,
   wasAtBottomBeforeCommit,
   classifyScrollForPin,
   reconcileOptimisticUser,
-  type PendingDelta,
 } from "../chatUtils";
 
 export type TranscriptState = {
@@ -49,17 +47,20 @@ export type TranscriptState = {
   prevScrollHeight: React.MutableRefObject<number>;
   questionCardRef: React.RefObject<HTMLDivElement>;
   wantQuestionScroll: React.MutableRefObject<boolean>;
-  flushPendingDeltas: (force: boolean) => number;
-  scheduleFlush: () => void;
+  // Apply one box-flushed delta (stream.flush) into the transcript
+  // (BET-551 / §17 — the box detects flush boundaries now). Returns the
+  // number of parts that didn't yet match a message, so useSseBus can refetch
+  // when a delta arrived ahead of its part snapshot.
+  applyStreamFlush: (d: {
+    partID: string;
+    messageID: string;
+    field: string;
+    text: string;
+  }) => number;
   scheduleRefetch: () => void;
   spliceMessage: (messageId: string) => void;
   fetchChildTranscript: (childId: string) => void;
   toggleTaskExpand: (childId: string) => void;
-  // Exposed for useSseBus — the delta buffer internals.
-  pendingDeltas: React.MutableRefObject<Map<string, PendingDelta>>;
-  flushTimer: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
-  FLUSH_MAX_AGE_MS: number;
-  oldestPendingAt: React.MutableRefObject<number | null>;
 };
 
 export function useTranscriptState(params: {
@@ -86,10 +87,6 @@ export function useTranscriptState(params: {
   // so live output updates at a steady ~4Hz cap.
   const spliceFirstScheduledAt = useRef<Map<string, number>>(new Map());
   const SPLICE_MAX_WAIT_MS = 250;
-  const pendingDeltas = useRef<Map<string, PendingDelta>>(new Map());
-  const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const FLUSH_MAX_AGE_MS = 250;
-  const oldestPendingAt = useRef<number | null>(null);
   const childSessionIds = useRef<Set<string>>(new Set());
   const [childMessages, setChildMessages] = useState<
     Map<string, OpencodeMessage[]>
@@ -116,38 +113,26 @@ export function useTranscriptState(params: {
     el.scrollTop = el.scrollHeight;
   }, []);
 
-  // Buffered text-delta flush
-  const flushPendingDeltas = useCallback((force: boolean): number => {
-    const buf = pendingDeltas.current;
-    if (buf.size === 0) return 0;
-    const toApply = new Map<string, PendingDelta>();
-    for (const [partID, d] of buf) {
-      if (force) {
-        toApply.set(partID, d);
-        continue;
-      }
-      const idx = findFlushBoundary(d.text);
-      if (idx <= 0) continue;
-      toApply.set(partID, { ...d, text: d.text.slice(0, idx) });
-      const remainder = d.text.slice(idx);
-      if (remainder.length > 0) {
-        buf.set(partID, { ...d, text: remainder });
-      } else {
-        buf.delete(partID);
-      }
-    }
-    if (force) buf.clear();
-    if (toApply.size === 0) return 0;
+  // Apply one box-flushed delta (stream.flush) into the transcript
+  // (BET-551 / §17). The box detects flush boundaries and emits the flushed
+  // chunk ready-to-merge, so there is no renderer-side buffering or boundary
+  // detection here — this just appends the chunk to the named part field and
+  // reports how many parts didn't match a known message (caller refetches).
+  const applyStreamFlush = useCallback((d: {
+    partID: string;
+    messageID: string;
+    field: string;
+    text: string;
+  }): number => {
     let unmatchedCount = 0;
     setMessages((prev) => {
       const { messages: next, unmatched } = mergeBufferedDeltas(
         prev,
-        toApply,
+        new Map([[d.partID, { messageID: d.messageID, field: d.field, text: d.text }]]),
       );
       unmatchedCount = unmatched.length;
       return next ?? prev;
     });
-    if (buf.size === 0) oldestPendingAt.current = null;
     return unmatchedCount;
   }, []);
 
@@ -172,26 +157,6 @@ export function useTranscriptState(params: {
         .finally(() => setRefreshing(false));
     }, 300);
   }, [sessionId, setRefreshing]);
-
-  const scheduleFlush = useCallback(() => {
-    if (flushTimer.current) return;
-    const now = Date.now();
-    const age =
-      oldestPendingAt.current != null ? now - oldestPendingAt.current : 0;
-    const delay = Math.max(0, Math.min(16, FLUSH_MAX_AGE_MS - age));
-    flushTimer.current = setTimeout(() => {
-      flushTimer.current = null;
-      const now2 = Date.now();
-      const aged =
-        oldestPendingAt.current != null &&
-        now2 - oldestPendingAt.current >= FLUSH_MAX_AGE_MS;
-      const unmatched = flushPendingDeltas(aged);
-      if (unmatched > 0) scheduleRefetch();
-      if (pendingDeltas.current.size > 0) {
-        scheduleFlush();
-      }
-    }, delay);
-  }, [flushPendingDeltas, scheduleRefetch]);
 
   const spliceMessage = useCallback((messageId: string) => {
     if (!messageId) {
@@ -321,7 +286,6 @@ export function useTranscriptState(params: {
   useEffect(() => {
     return () => {
       if (refetchTimerRef.current) clearTimeout(refetchTimerRef.current);
-      if (flushTimer.current) clearTimeout(flushTimer.current);
       for (const t of spliceTimers.current.values()) clearTimeout(t);
       spliceTimers.current.clear();
     };
@@ -383,15 +347,10 @@ export function useTranscriptState(params: {
     prevScrollHeight,
     questionCardRef,
     wantQuestionScroll,
-    flushPendingDeltas,
-    scheduleFlush,
+    applyStreamFlush,
     scheduleRefetch,
     spliceMessage,
     fetchChildTranscript,
     toggleTaskExpand,
-    pendingDeltas,
-    flushTimer,
-    FLUSH_MAX_AGE_MS,
-    oldestPendingAt,
   };
 }

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -25,7 +25,7 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import type { OpencodeEvent } from "../shared/types";
+import type { OpencodeEvent, StreamEnvelope } from "../shared/types";
 import { useStore } from "./store";
 
 // React 18's `act` warns unless this global is set. jsdom test env only.
@@ -35,11 +35,18 @@ import { useStore } from "./store";
 // A subscriber registered via the mocked `window.api.onOpencodeEvent`.
 type EventListener = (ev: OpencodeEvent) => void;
 
+// A subscriber registered via the mocked `window.api.onStreamEvent`.
+type StreamListener = (ev: StreamEnvelope) => void;
+
 // The controllable SSE bus the harness hands back so a test can push events
-// exactly as the main process would broadcast them.
+// exactly as the main process would broadcast them. `emit` drives the raw
+// opencode listener; `emitStream` drives the box-interpreted stream listener
+// (BET-551 / §17) with a `StreamEnvelope`.
 export type MockEventBus = {
   emit: (ev: OpencodeEvent) => void;
+  emitStream: (ev: StreamEnvelope) => void;
   listenerCount: () => number;
+  streamListenerCount: () => number;
 };
 
 // A recording of the window.api calls a test may want to assert on. The mock
@@ -58,6 +65,10 @@ function defaultApiImpl(): Record<string, unknown> {
     onOpencodeEvent: (fn: EventListener) => {
       busListeners.add(fn);
       return () => busListeners.delete(fn);
+    },
+    onStreamEvent: (fn: StreamListener) => {
+      streamListeners.add(fn);
+      return () => streamListeners.delete(fn);
     },
     opencodeOpenStream: () => Promise.resolve(),
     opencodeCloseStream: () => Promise.resolve(),
@@ -89,6 +100,7 @@ function defaultApiImpl(): Record<string, unknown> {
 // Shared listener set — a single bus per harness instance is enough for our
 // tests (they mount one ChatPanel). Recreated by installMockApi.
 let busListeners = new Set<EventListener>();
+let streamListeners = new Set<StreamListener>();
 
 // Install a mock `window.api` onto the jsdom window and return the bus +
 // recorder. `overrides` lets a test supply a specific resolved value or a
@@ -106,6 +118,7 @@ export function installMockApi(
   { absent = [] as string[] }: { absent?: string[] } = {},
 ): { api: MockApi; bus: MockEventBus } {
   busListeners = new Set<EventListener>();
+  streamListeners = new Set<StreamListener>();
   const calls: Record<string, unknown[][]> = {};
 
   const bus: MockEventBus = {
@@ -114,7 +127,11 @@ export function installMockApi(
       // we're iterating.
       for (const fn of Array.from(busListeners)) fn(ev);
     },
+    emitStream: (ev) => {
+      for (const fn of Array.from(streamListeners)) fn(ev);
+    },
     listenerCount: () => busListeners.size,
+    streamListenerCount: () => streamListeners.size,
   };
 
   const impl = { ...defaultApiImpl(), ...overrides };
@@ -216,5 +233,16 @@ export async function emitAndFlush(
   ev: OpencodeEvent,
 ): Promise<void> {
   act(() => bus.emit(ev));
+  await h.flush();
+}
+
+// Convenience: emit a box-interpreted stream event through the stream bus and
+// flush (BET-551 / §17).
+export async function emitStreamAndFlush(
+  bus: MockEventBus,
+  h: Harness,
+  ev: StreamEnvelope,
+): Promise<void> {
+  act(() => bus.emitStream(ev));
   await h.flush();
 }

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -175,7 +175,18 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
         const props = evt.properties ?? {};
         const finish = typeof props.finish === "string" ? props.finish : null;
         const kind = classifyFinish(finish, { lastPartIsToolUse: props.lastPartIsToolUse });
-        if (kind) emit(sid, "truncation", { kind, label: describeTruncation(kind).label });
+        if (kind) {
+          // The renderer renders truncation per-message (finishByMessageId),
+          // so carry the step's messageID when the raw event provides one
+          // (S1b consumes this to stamp the badge on the right message).
+          const messageID =
+            typeof props.messageID === "string" ? props.messageID : undefined;
+          emit(sid, "truncation", {
+            kind,
+            label: describeTruncation(kind).label,
+            messageID,
+          });
+        }
         const tokens = props.tokens ?? props.usage;
         if (tokens) {
           const limit = resolveContextLimit(props.model) ?? ASSUMED_CONTEXT_TOKENS;

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -161,7 +161,10 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
       }
       case "session.status": {
         const type = evt.properties?.type;
-        st.running = type === "busy" || type === "working";
+        // retry is a live turn for the renderer's running indicator (matches
+        // pre-S1b renderer semantics) — the box is the single source of truth,
+        // so it must report the same value the renderer's raw handler does.
+        st.running = type === "busy" || type === "working" || type === "retry";
         emit(sid, "running", { running: st.running });
         return;
       }

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -53,6 +53,25 @@ test("session.next.step.ended emits truncation classification", () => {
   const tr = events.find((e) => e.sub === "truncation");
   assert.ok(tr);
   assert.equal(tr.payload.kind, "tool-cutoff");
+  // No messageID on the raw step → none forwarded (S1b consumes it when
+  // present to stamp the per-message truncation badge).
+  assert.equal(tr.payload.messageID, undefined);
+});
+
+test("session.next.step.ended passes messageID through on stream.truncation", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.next.step.ended",
+    properties: {
+      sessionID: SID,
+      messageID: "msg_trunc",
+      finish: "length",
+      tokens: { input: 100 },
+    },
+  });
+  const tr = events.find((e) => e.sub === "truncation");
+  assert.ok(tr);
+  assert.equal(tr.payload.messageID, "msg_trunc");
 });
 
 test("session.next.step.ended emits context breakdown and cache staleness", () => {

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -183,6 +183,17 @@ test("session.idle emits turnComplete true", () => {
   assert.equal(ev.payload.complete, true);
 });
 
+test("session.status retry reports running true (parity with pre-S1b renderer)", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.status",
+    properties: { sessionID: SID, type: "retry" },
+  });
+  const ev = events.find((e) => e.sub === "running");
+  assert.ok(ev);
+  assert.equal(ev.payload.running, true);
+});
+
 test("interpret ignores events with no session id", () => {
   const { interp, events } = make();
   interp.interpret({ type: "message.part.delta", properties: { part: { id: "x" } } });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -11,6 +11,7 @@ import type {
   OpencodeCommand,
   OpencodeEvent,
   OpencodeMessage,
+  StreamEnvelope,
   OpencodeModel,
   OpencodeProviderAuthRequest,
   OpencodeProviderAuthResult,
@@ -196,6 +197,10 @@ export interface Api {
   opencodeOpenStream(sessionId: string): Promise<void>;
   opencodeCloseStream(sessionId: string): Promise<void>;
   onOpencodeEvent(cb: (ev: OpencodeEvent) => void): () => void;
+  // Box-side interpreted stream events (BET-551 / §17). The box publishes
+  // derived `stream.*` events on the same /events bus; this subscription
+  // receives each `StreamEnvelope` for the transport-routed `stream` kind.
+  onStreamEvent(cb: (ev: StreamEnvelope) => void): () => void;
   opencodePrompt(
     sessionId: string,
     text: string,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1176,6 +1176,62 @@ export type OpencodeEvent = {
   properties: Record<string, unknown>;
 };
 
+// ── Box-side interpreted stream events (BET-551 / §17) ──
+//
+// The box is now the single interpreter of the opencode session stream
+// (src/server/streamInterp.mjs). It publishes derived events on the existing
+// /events bus with `{ kind: "stream", sub, sessionId, payload }`, where `sub`
+// names the derivative and `payload` carries its typed value. The renderer
+// consumes these via `onStreamEvent` instead of re-deriving them from raw
+// `opencode` events (S1b). These types mirror the emissions in streamInterp.mjs.
+
+export type StreamFlushPayload = {
+  messageID: string;
+  partID: string;
+  field: "text" | "reasoning";
+  text: string;
+};
+
+export type StreamRunningPayload = { running: boolean };
+
+export type StreamTurnCompletePayload = { complete: boolean; running: boolean };
+
+export type StreamTodosPayload = {
+  active: Array<Record<string, unknown>> | null;
+  visible: { visible: Array<Record<string, unknown>>; hiddenPending: number; hiddenDone: number } | null;
+  allTerminal: boolean;
+  anyTerminal: boolean;
+};
+
+export type StreamTruncationPayload = {
+  kind: string;
+  label: string;
+  messageID?: string;
+};
+
+export type StreamQuestionsPayload = { questions: unknown[] };
+
+export type StreamSubagentChildPayload = { childSessionId: string };
+
+export type StreamSubagentPayload = Record<string, unknown>;
+
+export type StreamEnvelope = {
+  sub:
+    | "flush"
+    | "running"
+    | "turnComplete"
+    | "todos"
+    | "truncation"
+    | "questions"
+    | "subagent.child"
+    | "subagent"
+    | "context"
+    | "cache"
+    | "autoRename";
+  sessionId: string;
+  payload: unknown;
+};
+
 // Slash command exposed by opencode (`/init`, user-defined templates, etc.).
 // `template` is the raw prompt body opencode injects as the user message when
 // the command runs (with `$ARGUMENTS` / `$1` etc. substituted at run time).


### PR DESCRIPTION
## S1b — migrate the renderer to consume box-interpreted stream events (BET-552)

Stage 1 second half. The box (S1a, BET-551) is the single interpreter of the
opencode stream and publishes `stream.*` events on the existing `/events` bus.
This PR makes the renderer stop re-interpreting and start consuming them.

### What changed

- **Transport** — `httpApi` now routes the `stream` bus kind
  (`{sub, sessionId, payload}` envelope) and exposes `onStreamEvent` on the `Api`
  surface (`shared/api.ts`); `shared/types.ts` adds `StreamEnvelope` + typed
  payloads; `demoApi` explicitly stubs `onStreamEvent` (the demo drives its
  `stream` state via `onOpencodeEvent` `message.updated` → kept splice).
- **Server** — `streamInterp` forwards `messageID` on `stream.truncation` so the
  per-message truncation badge survives (the box previously emitted only
  `{kind, label}`).
- **Renderer interpretation deleted (not left dormant):**
  - `useTranscriptState` — dropped the renderer flush-boundary buffering
    (`findFlushBoundary`/`pendingDeltas`/`scheduleFlush`/`FLUSH_MAX_AGE_MS`);
    added a thin `applyStreamFlush` that merges a box-flushed chunk.
  - `useSseBus` — now consumes `stream.running` / `turnComplete` / `todos` /
    `truncation` / `questions` / `flush` / `subagent.child`; deleted the relocated
    delta-buffer, run-state, todo, truncation and question interpretation.
  - The **device-side §17 set is untouched**: scroll pinning, composer, typeahead,
    input history, question form state, optimistic echo, formatting.
- **Tests** — re-pointed `useSseBus.test.tsx`, `useTranscriptState.test.tsx`,
  `ChatPanel.harness.test.tsx` to `stream.*`; `testHarness` gained a mock stream
  bus; `streamInterp.test.mjs` covers the `messageID` passthrough.

### Baseline invariance (how I confirmed it)

The demo transport emits **no** raw `message.part.delta` / `session.status` /
`todo.updated` / `question.asked` — its `stream` state advances via
`onOpencodeEvent` `message.updated` → `spliceMessage`, which is retained
unchanged. `onStreamEvent` is a no-op in demo. So the deleted interpretation
handlers never fire in any demo state, and the rendered transcripts / visual
baselines are unaffected. The primary gate (the relocated pure tests from S1a)
remains green on the server. (I could not run the Playwright visual capture
locally this run.)

### Scope note vs. the four-file ownership

The issue scoped this to `useSseBus.ts`, `useTranscriptState.ts`, `chatUtils.ts`,
`ChatPanel.tsx`. The four-file assumption did not account for the transport gap
(uncovered last run): the renderer's `/events` consumer had no `stream` kind, so
there was *no code path* by which it could receive the interpreted events at all.
The prior run's scope comment (575cdef7) flagged this; this PR lands the
necessary, behavior-preserving plumbing (transport routing + `Api` surface +
server `messageID` + test re-points) on top of the four files. `chatUtils.ts`
(unchanged) and `ChatPanel.tsx` (−8) are the two owned files whose diff is
trivial — the substantive renderer change is in the two hooks.

### Net line count (from `git diff --stat`)

- **4 owned renderer files: −29** (`useSseBus` +20, `useTranscriptState` −41,
  `chatUtils` 0, `ChatPanel` −8) — the renderer interpretation code comes out
  smaller, as intended.
- **Whole PR: +141** (414 insertions / 273 deletions) — the excess is entirely
  the additive transport surface (`httpApi` +28, `shared/types` +56,
  `shared/api`, `demoApi`, `server/streamInterp` field) plus the structurally
  larger `stream.*` test payloads. The strict whole-PR net-negative DoD is not
  met because the forced transport plumbing that the four-file scope omitted
  is additive; the renderer *interpretation* itself shrank. Flagging this
  explicitly rather than papering over it.

### Verification results
- typecheck (`npm run typecheck`): exit 0. Errors: none.
- Test (`npm test`): vitest 1858 pass / 2 skip / 0 fail (93 files);
  node:test 1363 pass / 0 fail. Failures: none.
- Base: `origin/main @ b12f0a3`.

**Follow-up:** none — S1c (BET-553) owns the demo-transport stream and latency
instrumentation separately; not touched here.
