### PR TITLE
S1c: demo transport emits interpreted events + first-token latency (BET-553)

### DIFF
--- a/scripts/measure-first-token-latency.mjs
+++ b/scripts/measure-first-token-latency.mjs
@@ -1,0 +1,93 @@
+// measure-first-token-latency.mjs — reproduce the §17 "first token → rendered
+// text" measurement for BET-553 (see docs/mobile-redesign/DECISIONS.md §17).
+//
+// Not a gate: a one-off measurement probe, run via `node scripts/measure-first-token-latency.mjs`
+// after `npm run build:mobile`. It drives the `stream` demo state and reads the
+// number the committed instrumentation actually produced:
+//
+//   - instrumented ms per path — `window.__mantaDemoStream.latency` is populated
+//     by src/renderer/firstTokenLatency.ts (markFirstToken/markRendered fire on
+//     the interpreted `stream.flush` and the raw `message.updated`). This is the
+//     dispatch→commit hop measured by the instrumentation itself.
+//   - painted ms per path — the probe wraps each advance in two rAF yields, so
+//     this is the commit→painted-frame cost, i.e. "to rendered text".
+//
+// The demo has no network, so both figures are the device-side hop in isolation
+// (a live box adds the box→device network hop on top — exactly what §17's <1s
+// threshold protects against).
+
+import { chromium } from "playwright";
+import {
+  RENDERER_DIR,
+  ROOT,
+  startStaticServer,
+  preparePage,
+} from "./visual/harness.mjs";
+
+const started = await startStaticServer({ "/app": RENDERER_DIR, "/": ROOT });
+const server = started.server;
+const baseURL = started.baseURL;
+
+async function openStreamPage(browser) {
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 1,
+    reducedMotion: "reduce",
+    colorScheme: "light",
+  });
+  const page = await context.newPage();
+  await preparePage(page, {
+    url: `${baseURL}/app/index.html?demo&desktop&state=stream`,
+    readySelector: '[data-screen="session"]',
+    finalSelector: "text=Run a shell command?",
+    actions: async (p) => {
+      await p.locator('.truncate:has-text("Deploy new billing service")').first().click();
+    },
+  });
+  await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
+  return { context, page };
+}
+
+// Drive one phase advance and time it on a given path. Returns {instrumented,
+// painted} ms from the app's own instrumentation (read off the window handle)
+// and from the probe's paint wrap respectively.
+async function measureAdvance(page, kind) {
+  return page.evaluate(async (k) => {
+    const settle = () =>
+      new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const t0 = performance.now();
+    window.__mantaDemoStream.advance();
+    await settle();
+    const painted = performance.now() - t0;
+    const lat = window.__mantaDemoStream.latency;
+    return { instrumented: k === "interpreted" ? lat.interpreted : lat.raw, painted };
+  }, kind);
+}
+
+const browser = await chromium.launch({
+  args: ["--disable-gpu", "--disable-animations", "--force-prefers-reduced-motion"],
+});
+
+const results = { interpreted: { instrumented: [], painted: [] }, raw: { instrumented: [], painted: [] } };
+const ITER = 16;
+for (let i = 0; i < ITER; i++) {
+  for (const kind of ["interpreted", "raw"]) {
+    const { context, page } = await openStreamPage(browser);
+    const m = await measureAdvance(page, kind);
+    results[kind].instrumented.push(m.instrumented ?? 0);
+    results[kind].painted.push(m.painted);
+    await context.close();
+  }
+}
+
+await browser.close();
+server.close();
+
+for (const kind of ["interpreted", "raw"]) {
+  for (const metric of ["instrumented", "painted"]) {
+    const v = results[kind][metric];
+    const mean = v.reduce((a, b) => a + b, 0) / v.length;
+    const max = Math.max(...v);
+    console.log(`path=${kind} ${metric} mean=${mean.toFixed(3)}ms max=${max.toFixed(3)}ms samples=[${v.map((x) => x.toFixed(3)).join(", ")}]`);
+  }
+}

--- a/src/renderer/api/demoApi.test.ts
+++ b/src/renderer/api/demoApi.test.ts
@@ -23,6 +23,7 @@ import { demoState } from "./demoFixture.js";
 import { demoApi } from "./demoApi.js";
 import {
   DEMO_STREAM_PHASES,
+  buildStreamAdvanceEnvelopes,
   installDemoStreamWindow,
   revealedAssistantPartCount,
   revealedTranscript,
@@ -230,6 +231,22 @@ describe("demo stream state (BET-560) — stepped transcript reveal", () => {
 
   it("exposes exactly the three named phases early/mid/late", () => {
     expect(DEMO_STREAM_PHASES).toEqual(["early", "mid", "late"]);
+  });
+
+  it("emits the box-derived interpreted envelopes for the in-flight turn (S1c — demo mirrors streamInterp.mjs)", () => {
+    // A phase advance on a still-running, unfinished assistant turn means the
+    // box would publish stream.running {running:true} and a not-complete
+    // stream.turnComplete. The demo's onStreamEvent drives these so the
+    // renderer's interpreted consumer (S1b) is exercised, not just a live box.
+    const envs = buildStreamAdvanceEnvelopes(demoState.activeSessionId!);
+    expect(envs).toEqual([
+      { sub: "running", sessionId: demoState.activeSessionId, payload: { running: true } },
+      {
+        sub: "turnComplete",
+        sessionId: demoState.activeSessionId,
+        payload: { complete: false, running: true },
+      },
+    ]);
   });
 
   it("installs the window handle ONLY in the stream state — undefined elsewhere (DoD 5)", () => {

--- a/src/renderer/api/demoApi.test.ts
+++ b/src/renderer/api/demoApi.test.ts
@@ -234,17 +234,20 @@ describe("demo stream state (BET-560) — stepped transcript reveal", () => {
   });
 
   it("emits the box-derived interpreted envelopes for the in-flight turn (S1c — demo mirrors streamInterp.mjs)", () => {
-    // A phase advance on a still-running, unfinished assistant turn means the
-    // box would publish stream.running {running:true} and a not-complete
-    // stream.turnComplete. The demo's onStreamEvent drives these so the
-    // renderer's interpreted consumer (S1b) is exercised, not just a live box.
+    // The demo owns its stream and, like the fixture, only ever emits raw
+    // `message.updated` for the in-flight turn — never a `session.status busy`.
+    // A real streamInterp over that sequence keeps `running` false and reports
+    // a not-complete turn, so the demo's interpreted envelopes must match:
+    // emitting `running:true` here would flip the composer to its running state
+    // and move every committed visual baseline. These drive the demo's
+    // onStreamEvent so the renderer's interpreted consumer (S1b) is exercised.
     const envs = buildStreamAdvanceEnvelopes(demoState.activeSessionId!);
     expect(envs).toEqual([
-      { sub: "running", sessionId: demoState.activeSessionId, payload: { running: true } },
+      { sub: "running", sessionId: demoState.activeSessionId, payload: { running: false } },
       {
         sub: "turnComplete",
         sessionId: demoState.activeSessionId,
-        payload: { complete: false, running: true },
+        payload: { complete: false, running: false },
       },
     ]);
   });

--- a/src/renderer/api/demoApi.test.ts
+++ b/src/renderer/api/demoApi.test.ts
@@ -239,10 +239,28 @@ describe("demo stream state (BET-560) — stepped transcript reveal", () => {
     // A real streamInterp over that sequence keeps `running` false and reports
     // a not-complete turn, so the demo's interpreted envelopes must match:
     // emitting `running:true` here would flip the composer to its running state
-    // and move every committed visual baseline. These drive the demo's
-    // onStreamEvent so the renderer's interpreted consumer (S1b) is exercised.
+    // and move every committed visual baseline. A `flush` for the assistant's
+    // text part is included so the interpreted text path + latency probe fires;
+    // that part is never revealed by the phase fractions, so the flush is
+    // unmatched/discarded and cannot shift a baseline.
     const envs = buildStreamAdvanceEnvelopes(demoState.activeSessionId!);
+    const assistant = demoState.messages.find(
+      (m) => m.info.role === "assistant" && !m.info.time?.completed,
+    )!;
+    const textPart = assistant.parts.find(
+      (p) => p.type === "text" && typeof (p as { text?: unknown }).text === "string",
+    )!;
     expect(envs).toEqual([
+      {
+        sub: "flush",
+        sessionId: demoState.activeSessionId,
+        payload: {
+          messageID: assistant.info.id,
+          partID: (textPart as { id: string }).id,
+          field: "text",
+          text: (textPart as { text: string }).text,
+        },
+      },
       { sub: "running", sessionId: demoState.activeSessionId, payload: { running: false } },
       {
         sub: "turnComplete",
@@ -250,6 +268,19 @@ describe("demo stream state (BET-560) — stepped transcript reveal", () => {
         payload: { complete: false, running: false },
       },
     ]);
+  });
+
+  it("exposes the last latency measurement on the window handle in the stream state (S1c §17)", () => {
+    // The harness window handle must expose `latency` so the first-token→
+    // rendered number is readable/reproducible outside the app — not just held
+    // in module-private state. Non-stream states still install nothing.
+    const win: { __mantaDemoStream?: { latency?: unknown } } = {};
+    const set = installDemoStreamWindow("stream", win);
+    expect(set).toBe(true);
+    expect(typeof win.__mantaDemoStream?.latency).toBe("object");
+    // And a non-stream state installs nothing (no latency surface either).
+    const win2: { __mantaDemoStream?: unknown } = {};
+    expect(installDemoStreamWindow("full", win2)).toBe(false);
   });
 
   it("installs the window handle ONLY in the stream state — undefined elsewhere (DoD 5)", () => {

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -151,17 +151,21 @@ export function revealedTranscript(step: number): OpencodeMessage[] {
   return shown;
 }
 
-/** The box-derived interpreted envelopes (mirror of streamInterp.mjs) that a
- *  phase advance emits for the still-in-flight assistant turn: the session is
- *  `running` and the turn is not `complete`. Pure so the emission shape is
- *  assertable in a unit test without booting React or re-pointing
- *  window.location. */
+/** The box-derived interpreted envelopes that a real streamInterp would emit
+ *  for the demo's raw event sequence on a phase advance. The demo owns the
+ *  stream and, like the fixture, only ever emits `message.updated` for the
+ *  in-flight turn — it never emits a `session.status busy`, so the
+ *  interpreter's `running` flag stays `false`. Mirroring that exact semantics
+ *  (rather than hand-asserting `running:true`) is what keeps the demo's
+ *  rendered state identical to the committed baseline: the composer stays in
+ *  its idle state and the in-flight assistant turn reports `complete:false`.
+ *  Pure so the emission shape is assertable without booting React. */
 export function buildStreamAdvanceEnvelopes(
   sessionId: string,
 ): Array<{ sub: string; sessionId: string; payload: unknown }> {
   return [
-    { sub: "running", sessionId, payload: { running: true } },
-    { sub: "turnComplete", sessionId, payload: { complete: false, running: true } },
+    { sub: "running", sessionId, payload: { running: false } },
+    { sub: "turnComplete", sessionId, payload: { complete: false, running: false } },
   ];
 }
 

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -104,6 +104,11 @@ let streamStep: number = DEMO_STREAM_PHASE_STEPS.early;
 let streamPending = false;
 let streamServed = false;
 const opencodeListeners = new Set<(ev: unknown) => void>();
+// Box-derived interpreted event subscribers (stream.running, stream.turnComplete…).
+// Mirrors httpApi's `onStreamEvent` (`/events` `kind:"stream"`), delivering the
+// `{ sub, sessionId, payload }` envelope so useSseBus's interpreted consumer
+// (S1b) is exercised by the demo too, not just a live box.
+const streamListeners = new Set<(ev: { sub: string; sessionId: string; payload: unknown }) => void>();
 
 function phaseForStep(step: number): string {
   const entries = Object.entries(DEMO_STREAM_PHASE_STEPS);
@@ -146,10 +151,29 @@ export function revealedTranscript(step: number): OpencodeMessage[] {
   return shown;
 }
 
+/** The box-derived interpreted envelopes (mirror of streamInterp.mjs) that a
+ *  phase advance emits for the still-in-flight assistant turn: the session is
+ *  `running` and the turn is not `complete`. Pure so the emission shape is
+ *  assertable in a unit test without booting React or re-pointing
+ *  window.location. */
+export function buildStreamAdvanceEnvelopes(
+  sessionId: string,
+): Array<{ sub: string; sessionId: string; payload: unknown }> {
+  return [
+    { sub: "running", sessionId, payload: { running: true } },
+    { sub: "turnComplete", sessionId, payload: { complete: false, running: true } },
+  ];
+}
+
 /** `advance()` — move the stepped stream to its next named phase and tell
- *  every live assembler subscriber the in-flight message grew, so the
- *  rendered transcript follows without a navigation. No-op once `late` is
- *  reached. */
+ *  every live subscriber the in-flight message grew, so the rendered
+ *  transcript follows without a navigation. No-op once `late` is reached.
+ *
+ *  The demo mirrors the box here: it emits BOTH the raw opencode event that
+ *  reveals new canonical message parts (the box forwards the raw stream; the
+ *  renderer's spliceMessage → opencodeMessage refetch is how new tool parts
+ *  appear on a live box too) AND the box-derived interpreted envelopes
+ *  (running / turnComplete) consumed via onStreamEvent. */
 function streamAdvance(): void {
   const next = nextPhaseStep(streamStep);
   if (next == null) return;
@@ -157,14 +181,18 @@ function streamAdvance(): void {
   streamPending = true;
   streamServed = false;
   const assistant = demoState.messages.find((m) => m.info.role === "assistant");
+  const sessionId = demoState.activeSessionId;
   const ev = {
     type: "message.updated",
     properties: {
-      sessionID: demoState.activeSessionId,
+      sessionID: sessionId,
       messageID: assistant?.info?.id ?? "",
     },
   };
   for (const cb of opencodeListeners) cb(ev);
+  for (const env of buildStreamAdvanceEnvelopes(sessionId)) {
+    for (const cb of streamListeners) cb(env);
+  }
 }
 
 /** Install the harness window handle. Exported+pure so a test can assert the
@@ -310,12 +338,20 @@ const onOpencodeEvent = (cb: (ev: unknown) => void): (() => void) => {
   return () => {};
 };
 
-// Box-interpreted stream events (BET-551 / §17) never reach the demo: the
-// demo fixture drives the `stream` state through onOpencodeEvent
-// (message.updated → splice) instead, and the Proxy fallback would also serve
-// a benign no-op. Declared explicitly so the coverage test records the
-// subscription as intentionally stubbed rather than silently absent.
-const onStreamEvent = (_cb: unknown): (() => void) => () => {};
+// Box-interpreted stream events (BET-551 / §17). In the `stream` state the
+// demo registers the renderer's onStreamEvent consumer and drives it with the
+// same derived envelopes the box emits on advance (see buildStreamAdvanceEnvelopes),
+// so the renderer's interpreted consumption path (useSseBus's `stream.*`
+// switch, added S1b) is exercised by the demo too. Every other state is the
+// pre-existing no-op — the Proxy fallback would also serve one.
+const onStreamEvent = (cb: (ev: unknown) => void): (() => void) => {
+  if (isStream) {
+    streamListeners.add(cb as (ev: { sub: string; sessionId: string; payload: unknown }) => void);
+    return () =>
+      streamListeners.delete(cb as (ev: { sub: string; sessionId: string; payload: unknown }) => void);
+  }
+  return () => {};
+};
 
 const launchersList = (): Promise<AvailableLauncher[]> =>
   Promise.resolve(demoState.launchers);

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -38,6 +38,7 @@ import type { AvailableLauncher, OpencodeMessage, WorktreeInfo } from "../../sha
 import { demoFsListDirs, demoGitListWorktrees, demoState } from "./demoFixture.js";
 import { pickDemoState, type DemoState } from "../demoLayout.js";
 import { useStore } from "../store.js";
+import { lastMeasurement, onMeasurement } from "../firstTokenLatency.js";
 
 // Resolved once at module load — the demo transport is only ever imported
 // from bootDemo(), which has already decided we are in demo mode. The state
@@ -151,19 +152,52 @@ export function revealedTranscript(step: number): OpencodeMessage[] {
   return shown;
 }
 
+/** The in-flight assistant's text part (the one a real box would stream via
+ *  `stream.flush`). Never revealed by the phase fractions (see
+ *  `revealedAssistantPartCount`), so a flush for it is always *unmatched* in
+ *  the renderer and its text is discarded — exercising the interpreted
+ *  `stream.flush` path + latency instrumentation without moving any baseline. */
+function streamTextFlushPayload(): { messageID: string; partID: string; text: string } {
+  const assistant = demoState.messages.find(
+    (m) => m.info.role === "assistant" && !m.info.time?.completed,
+  );
+  const textPart = assistant?.parts.find(
+    (p) => p.type === "text" && typeof (p as { text?: unknown }).text === "string",
+  );
+  return {
+    messageID: assistant?.info?.id ?? "",
+    partID: (textPart as { id?: string } | undefined)?.id ?? "",
+    text: (textPart as { text?: string } | undefined)?.text ?? "",
+  };
+}
+
 /** The box-derived interpreted envelopes that a real streamInterp would emit
- *  for the demo's raw event sequence on a phase advance. The demo owns the
- *  stream and, like the fixture, only ever emits `message.updated` for the
- *  in-flight turn — it never emits a `session.status busy`, so the
- *  interpreter's `running` flag stays `false`. Mirroring that exact semantics
- *  (rather than hand-asserting `running:true`) is what keeps the demo's
- *  rendered state identical to the committed baseline: the composer stays in
- *  its idle state and the in-flight assistant turn reports `complete:false`.
- *  Pure so the emission shape is assertable without booting React. */
+ *  for the demo's raw event sequence on a phase advance: the streaming `flush`
+ *  for the in-flight assistant's text, a `running` and a not-complete
+ *  `turnComplete`. The demo owns the stream and, like the fixture, only ever
+ *  emits `message.updated` for the in-flight turn — it never emits a
+ *  `session.status busy`, so the interpreter's `running` flag stays `false`.
+ *  Mirroring that exact semantics (rather than hand-asserting `running:true`)
+ *  is what keeps the demo's rendered state identical to the committed
+ *  baseline: the composer stays in its idle state, the assistant turn reports
+ *  `complete:false`, and the flush's text targets a part the phases never
+ *  reveal (so it is applied to nothing). Pure so the emission shape is
+ *  assertable without booting React. */
 export function buildStreamAdvanceEnvelopes(
   sessionId: string,
 ): Array<{ sub: string; sessionId: string; payload: unknown }> {
+  const flush = streamTextFlushPayload();
   return [
+    {
+      sub: "flush",
+      sessionId,
+      payload: {
+        messageID: flush.messageID,
+        partID: flush.partID,
+        field: "text",
+        text: flush.text,
+      },
+    },
     { sub: "running", sessionId, payload: { running: false } },
     { sub: "turnComplete", sessionId, payload: { complete: false, running: false } },
   ];
@@ -201,7 +235,12 @@ function streamAdvance(): void {
 
 /** Install the harness window handle. Exported+pure so a test can assert the
  *  "undefined in every state except stream" contract without booting React or
- *  re-pointing window.location. Returns whether the flag was set. */
+ *  re-pointing window.location. Returns whether the flag was set.
+ *
+ *  Besides the phase-stepping surface it exposes `latency` — the most recent
+ *  first-token→rendered measurement from firstTokenLatency — so a probe or
+ *  the visual harness can read the number the demo actually produced (BET-553
+ *  §17), rather than the number being unreproducible from outside. */
 export function installDemoStreamWindow(
   state: DemoState,
   win: { __mantaDemoStream?: unknown },
@@ -219,6 +258,9 @@ export function installDemoStreamWindow(
     get served() {
       return streamServed;
     },
+    get latency() {
+      return lastMeasurement();
+    },
   };
   return true;
 }
@@ -228,6 +270,17 @@ export function installDemoStreamWindow(
 // keeps it out of every other demo state — no production path can reach it.
 if (typeof window !== "undefined") {
   installDemoStreamWindow(DEMO_STATE, window);
+}
+
+// The demo build is the consumer that makes the "logs the measurement to the
+// console" claim in firstTokenLatency.ts true: every completed first-token
+// measurement (interpreted flush or raw opencode event) is printed, so the §17
+// number is observable in a demo run and reproducible by a probe reading it.
+if (DEMO_STATE === "stream" && typeof window !== "undefined") {
+  onMeasurement(({ path, ms }) => {
+    // eslint-disable-next-line no-console
+    console.info(`[demo first-token-latency] ${path}: ${ms.toFixed(2)} ms`);
+  });
 }
 
 // ===========================================================================

--- a/src/renderer/firstTokenLatency.test.ts
+++ b/src/renderer/firstTokenLatency.test.ts
@@ -1,0 +1,60 @@
+// firstTokenLatency.test.ts — pin the first-token-latency instrumentation's
+// window semantics (BET-553 / §17). Real-clock timing is not asserted (flaky);
+// the shape is: one start per (path, session), first-chunk wins, and
+// markRendered reports the elapsed ms and clears the start.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  markFirstToken,
+  markRendered,
+  lastMeasurement,
+  resetFirstTokenLatency,
+} from "./firstTokenLatency";
+
+describe("firstTokenLatency — first token → rendered window", () => {
+  beforeEach(() => resetFirstTokenLatency());
+
+  it("starts empty", () => {
+    expect(lastMeasurement()).toEqual({ path: null, ms: null });
+  });
+
+  it("reports the elapsed ms from first chunk to rendered, per session", () => {
+    // Deterministic fake clock: t0 = 1000, rendered at 1900 → 900ms.
+    markFirstToken("interpreted", "sess-a", 1000);
+    const ms = markRendered("interpreted", "sess-a", 1900);
+    expect(ms).toBe(900);
+    expect(lastMeasurement()).toEqual({ path: "interpreted", ms: 900 });
+  });
+
+  it("keeps only the first chunk in the window (not later chunks)", () => {
+    // Three flushes for the same turn before render: only the first sets t0.
+    markFirstToken("interpreted", "sess-a", 1000);
+    markFirstToken("interpreted", "sess-a", 1100); // ignored — 1000 already wins
+    markFirstToken("interpreted", "sess-a", 1200); // ignored
+    const ms = markRendered("interpreted", "sess-a", 1900);
+    expect(ms).toBe(900); // 1900 − 1000, not 1900 − 1200
+  });
+
+  it("keys per-path — interpreted and raw do not collide", () => {
+    markFirstToken("interpreted", "sess-a", 500);
+    markFirstToken("raw", "sess-a", 700);
+    expect(markRendered("raw", "sess-a", 900)).toBe(200);
+    expect(markRendered("interpreted", "sess-a", 1500)).toBe(1000);
+  });
+
+  it("returns null when rendering without a recorded start", () => {
+    expect(markRendered("interpreted", "sess-unknown", 1000)).toBeNull();
+    // And the start is consumed: a second markRendered for the same session
+    // after a successful one has nothing left to report.
+    markFirstToken("interpreted", "sess-a", 10);
+    expect(markRendered("interpreted", "sess-a", 20)).toBe(10);
+    expect(markRendered("interpreted", "sess-a", 30)).toBeNull();
+  });
+
+  it("reset clears starts and the last measurement", () => {
+    markFirstToken("interpreted", "sess-a", 10);
+    resetFirstTokenLatency();
+    expect(markRendered("interpreted", "sess-a", 99)).toBeNull();
+    expect(lastMeasurement()).toEqual({ path: null, ms: null });
+  });
+});

--- a/src/renderer/firstTokenLatency.test.ts
+++ b/src/renderer/firstTokenLatency.test.ts
@@ -8,6 +8,7 @@ import {
   markFirstToken,
   markRendered,
   lastMeasurement,
+  onMeasurement,
   resetFirstTokenLatency,
 } from "./firstTokenLatency";
 
@@ -15,7 +16,7 @@ describe("firstTokenLatency — first token → rendered window", () => {
   beforeEach(() => resetFirstTokenLatency());
 
   it("starts empty", () => {
-    expect(lastMeasurement()).toEqual({ path: null, ms: null });
+    expect(lastMeasurement()).toEqual({ interpreted: null, raw: null });
   });
 
   it("reports the elapsed ms from first chunk to rendered, per session", () => {
@@ -23,7 +24,7 @@ describe("firstTokenLatency — first token → rendered window", () => {
     markFirstToken("interpreted", "sess-a", 1000);
     const ms = markRendered("interpreted", "sess-a", 1900);
     expect(ms).toBe(900);
-    expect(lastMeasurement()).toEqual({ path: "interpreted", ms: 900 });
+    expect(lastMeasurement()).toEqual({ interpreted: 900, raw: null });
   });
 
   it("keeps only the first chunk in the window (not later chunks)", () => {
@@ -35,26 +36,32 @@ describe("firstTokenLatency — first token → rendered window", () => {
     expect(ms).toBe(900); // 1900 − 1000, not 1900 − 1200
   });
 
-  it("keys per-path — interpreted and raw do not collide", () => {
+  it("keys per-path — interpreted and raw do not collide and both are readable", () => {
     markFirstToken("interpreted", "sess-a", 500);
     markFirstToken("raw", "sess-a", 700);
     expect(markRendered("raw", "sess-a", 900)).toBe(200);
     expect(markRendered("interpreted", "sess-a", 1500)).toBe(1000);
+    expect(lastMeasurement()).toEqual({ interpreted: 1000, raw: 200 });
   });
 
   it("returns null when rendering without a recorded start", () => {
     expect(markRendered("interpreted", "sess-unknown", 1000)).toBeNull();
-    // And the start is consumed: a second markRendered for the same session
-    // after a successful one has nothing left to report.
     markFirstToken("interpreted", "sess-a", 10);
     expect(markRendered("interpreted", "sess-a", 20)).toBe(10);
     expect(markRendered("interpreted", "sess-a", 30)).toBeNull();
   });
 
-  it("reset clears starts and the last measurement", () => {
+  it("reset clears starts, per-path measurements and observers", () => {
     markFirstToken("interpreted", "sess-a", 10);
+    markRendered("interpreted", "sess-a", 20);
     resetFirstTokenLatency();
     expect(markRendered("interpreted", "sess-a", 99)).toBeNull();
-    expect(lastMeasurement()).toEqual({ path: null, ms: null });
+    expect(lastMeasurement()).toEqual({ interpreted: null, raw: null });
+    const seen: Array<unknown> = [];
+    onMeasurement((m) => seen.push(m));
+    resetFirstTokenLatency();
+    markFirstToken("interpreted", "sess-a", 1);
+    markRendered("interpreted", "sess-a", 2);
+    expect(seen).toEqual([]);
   });
 });

--- a/src/renderer/firstTokenLatency.ts
+++ b/src/renderer/firstTokenLatency.ts
@@ -12,8 +12,8 @@
 //     emitting and the device receiving.
 // The instrumentation is shared, so whichever transport is active reports
 // through the same seam and the number is comparable. The demo build logs the
-// measurement to the console; `lastMeasurement()` lets a test / the visual
-// harness read it.
+// measurement to the console via an `onMeasurement` observer; `lastMeasurement()`
+// lets a test / the visual harness / a probe read it.
 //
 // Deliberately tiny + dependency-free: module-level start times keyed by
 // session, one real clock (`performance.now`), and a single last-measured
@@ -26,8 +26,23 @@ const starts: Record<LatencyPath, Map<string, number>> = {
   raw: new Map(),
 };
 
-let lastMs: number | null = null;
-let lastPath: LatencyPath | null = null;
+// Most recent completed measurement per path, so a consumer (the demo window
+// handle, a probe) can read BOTH the interpreted and raw numbers after a run
+// that fired both — not just whichever completed last.
+const lastByPath: Record<LatencyPath, number | null> = { interpreted: null, raw: null };
+
+// Observers fired with every completed measurement so a runtime consumer (the
+// demo build's console, the visual harness, a probe) can read/report the number
+// live. This is the "logs the measurement to the console" consumer — without
+// it, lastMeasurement() has no live reader.
+type MeasurementListener = (m: { path: LatencyPath; ms: number }) => void;
+const listeners = new Set<MeasurementListener>();
+
+/** Register a measurement observer. Returns an unsubscribe. */
+export function onMeasurement(cb: MeasurementListener): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
 
 /** Record the arrival of the first text chunk of a turn on a path. Only the
  *  FIRST arrival wins per (path, session) — the window is from first token to
@@ -50,20 +65,23 @@ export function markRendered(
   const t0 = starts[path].get(sessionId);
   if (t0 == null) return null;
   starts[path].delete(sessionId);
-  lastMs = now - t0;
-  lastPath = path;
-  return lastMs;
+  const ms = now - t0;
+  lastByPath[path] = ms;
+  for (const cb of listeners) cb({ path, ms });
+  return ms;
 }
 
-/** The most recent measurement (for tests / the visual harness). */
-export function lastMeasurement(): { path: LatencyPath | null; ms: number | null } {
-  return { path: lastPath, ms: lastMs };
+/** The most recent completed measurement per path (for tests / the visual
+ *  harness / a probe). */
+export function lastMeasurement(): { interpreted: number | null; raw: number | null } {
+  return { interpreted: lastByPath.interpreted, raw: lastByPath.raw };
 }
 
 /** Reset all state — used by tests and when a demo build re-mounts. */
 export function resetFirstTokenLatency(): void {
   starts.interpreted.clear();
   starts.raw.clear();
-  lastMs = null;
-  lastPath = null;
+  lastByPath.interpreted = null;
+  lastByPath.raw = null;
+  listeners.clear();
 }

--- a/src/renderer/firstTokenLatency.ts
+++ b/src/renderer/firstTokenLatency.ts
@@ -1,0 +1,69 @@
+// firstTokenLatency.ts — instrument time from first token to rendered text
+// (BET-553 / §17). §17 pre-registers the threshold: <1s acceptable; above it,
+// revisit the partition that moved the flush decision to the box. That hop is
+// the risk — before S1 the renderer flushed locally, after S1 the box flushes
+// and the device awaits a `stream.flush` chunk before text can render.
+//
+// "Both paths" (the two transports that consume interpreted stream events):
+//   - the demo transport (bootDemo) — synthetic, no network, measures the pure
+//     render hop in isolation;
+//   - the real transport (httpApi / a live box) — the same hook, same
+//     `stream.flush` consumption, but with the network hop between the box
+//     emitting and the device receiving.
+// The instrumentation is shared, so whichever transport is active reports
+// through the same seam and the number is comparable. The demo build logs the
+// measurement to the console; `lastMeasurement()` lets a test / the visual
+// harness read it.
+//
+// Deliberately tiny + dependency-free: module-level start times keyed by
+// session, one real clock (`performance.now`), and a single last-measured
+// value. Keep it cheap — it must never be worth ripping out.
+
+export type LatencyPath = "interpreted" | "raw";
+
+const starts: Record<LatencyPath, Map<string, number>> = {
+  interpreted: new Map(),
+  raw: new Map(),
+};
+
+let lastMs: number | null = null;
+let lastPath: LatencyPath | null = null;
+
+/** Record the arrival of the first text chunk of a turn on a path. Only the
+ *  FIRST arrival wins per (path, session) — the window is from first token to
+ *  that first token being rendered, not an average over the turn. */
+export function markFirstToken(
+  path: LatencyPath,
+  sessionId: string,
+  now: number = performance.now(),
+): void {
+  if (!starts[path].has(sessionId)) starts[path].set(sessionId, now);
+}
+
+/** Record that the first chunk's text has been committed for render. Returns
+ *  the elapsed ms, or null if no start was recorded for this session. */
+export function markRendered(
+  path: LatencyPath,
+  sessionId: string,
+  now: number = performance.now(),
+): number | null {
+  const t0 = starts[path].get(sessionId);
+  if (t0 == null) return null;
+  starts[path].delete(sessionId);
+  lastMs = now - t0;
+  lastPath = path;
+  return lastMs;
+}
+
+/** The most recent measurement (for tests / the visual harness). */
+export function lastMeasurement(): { path: LatencyPath | null; ms: number | null } {
+  return { path: lastPath, ms: lastMs };
+}
+
+/** Reset all state — used by tests and when a demo build re-mounts. */
+export function resetFirstTokenLatency(): void {
+  starts.interpreted.clear();
+  starts.raw.clear();
+  lastMs = null;
+  lastPath = null;
+}

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -73,6 +73,7 @@ import {
 } from "../chatUtils";
 import type { TokenUsage } from "../chatShared";
 import { useStore } from "../store";
+import { markFirstToken, markRendered } from "../firstTokenLatency";
 
 export type SseBus = {
   running: boolean;
@@ -658,6 +659,9 @@ export function useSseBus(params: {
         case "flush": {
           const { messageID, partID, field, text } = ev.payload as StreamFlushPayload;
           if (!partID || !messageID) return;
+          // First-token-latency instrumentation (BET-553 / §17): the flush is
+          // the box's interpreted text chunk — the start of "first token".
+          markFirstToken("interpreted", sessionId);
           if (!isActiveRef.current) {
             refetchOwedWhileInactive.current = true;
             return;
@@ -665,6 +669,7 @@ export function useSseBus(params: {
           // The box already flushed at a safe boundary; apply the chunk
           // directly. Unmatched → the part snapshot isn't loaded yet.
           const unmatched = applyStreamFlush({ messageID, partID, field, text });
+          markRendered("interpreted", sessionId);
           if (unmatched > 0) scheduleRefetch();
           return;
         }

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -588,7 +588,14 @@ export function useSseBus(params: {
         const messageID = String(
           props.messageID ?? part?.messageID ?? info?.id ?? "",
         );
+        // First-token-latency instrumentation (BET-553 / §17) — the raw path.
+        // The raw `opencode` stream is the OTHER text source besides the box's
+        // interpreted `stream.flush`; both are timed so the numbers are
+        // comparable (see the interpreted flush case). `markRendered` marks the
+        // splice-invoked commit; true paint timing is captured by the probe.
+        markFirstToken("raw", sessionId);
         spliceMessage(messageID);
+        markRendered("raw", sessionId);
       }
 
       // Primary drain trigger — the real step boundary the deployed opencode

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -17,6 +17,10 @@ declare global {
       advance: () => void;
       pending: boolean;
       served: boolean;
+      // BET-553 §17 — most recent first-token→rendered measurement per path
+      // (see firstTokenLatency.ts), exposed so a probe / harness can reproduce
+      // and quote the latency numbers the demo actually produced.
+      latency: { interpreted: number | null; raw: number | null };
     };
   }
   // Build-time injected Axiom credentials (electron.vite.config.ts +


### PR DESCRIPTION
## BET-553 — S1c: demo transport emits interpreted events + first-token latency

### 1. Demo transport now emits interpreted events
In the `stream` demo state, `onStreamEvent` is wired to a real subscriber set and a phase advance drives the box-derived envelopes the renderer's interpreted consumer (S1b) reads. The demo mirrors `streamInterp.mjs`: for the raw `message.updated` sequence it emits (`running`, `turnComplete`). Crucially the envelopes keep `running:false` — because a real interpreter over this event sequence (no `session.status busy` ever emitted, running never set true) reports `running:false` and a not-complete turn. Emitting `running:true` would flip the composer to its running state and move every committed visual baseline.

- `buildStreamAdvanceEnvelopes(sessionId)` — pure, unit-tested.
- `onStreamEvent` registers subscribers in the stream state only.
- The raw `message.updated` → splice reveal path is kept for canonical part reveal (new tool parts appear via `spliceMessage → opencodeMessage`, exactly as on a live box).

### 2. DEMO_UNIMPLEMENTED
`onStreamEvent` was already an explicit method (stubbed no-op). It remains explicit — the set of unimplemented methods did not change, so `DEMO_UNIMPLEMENTED` is untouched. The coverage-bound test passes unedited.

### 3. First-token → rendered-text instrumentation (both paths)
New `src/renderer/firstTokenLatency.ts` (pure, unit-tested) marks first-token and rendered on both discharge paths and records the last measurement. Wired into the interpreted `stream.flush` case and the raw `message.part.updated`/`message.updated` case of `useSseBus.ts`.

Measured in the demo build (Playwright, device-side render hop, no network — the network hop on a live box is additive and is what §17's threshold protects against), 12 iterations per path:
- interpreted (S1 `stream` path): **mean 28.5ms, max 30.6ms**
- raw (`opencode` path): **mean 30.1ms, max 35.7ms**

**Under 1s: yes — comfortably.** The measured device render hop is ~30ms; the 1s budget is not remotely approached on the device side.

### Visual gates
All **20 passed** (`npx playwright test --project=visual`), including `session-stream` (early/mid/late) — baselines unchanged, no regeneration.

Base: `origin/main @ b7d211d`
