### PR TITLE
refactor(shared): extract setupLogic/pairPayload out of src/renderer/mobile (BET-554)

### DIFF
--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -1146,7 +1146,7 @@ export function formatPairingOutput(
 
 /**
  * Build the canonical box-form pair link. Mirrors the renderer-side
- * `buildPairPayload` (src/renderer/mobile/pairPayload.ts) but lives here as
+ * `buildPairPayload` (src/shared/pairPayload.ts) but lives here as
  * a tiny local helper because install-lib.mjs is plain Node — importing the
  * TS helper would cross a transpile boundary for a one-liner. The shape
  * MUST round-trip through `parsePairPayload` to a non-null payload, so the
@@ -1172,7 +1172,7 @@ export function formatPairingOutput(
  * literal — mirrors how `pairPage.mjs`'s `validatePairQrQuery` and the
  * renderer's `buildPairPayload` take the same channel-derived value.
  *
- * Cross-reference: keep in sync with src/renderer/mobile/pairPayload.ts
+ * Cross-reference: keep in sync with src/shared/pairPayload.ts
  * `buildPairPayload` (box-form branch). If the canonical shape changes,
  * BOTH helpers must change in lockstep — the test catches drift.
  */

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -597,7 +597,7 @@ test("buildPairLink produces the canonical box-form pair link (BET-177 §2.4)", 
   // enforce the wire shape on the install-lib helper so a future drift is
   // caught here. (BET-386: the actual cross-module round-trip against the
   // real `parsePairPayload`, for all three channel schemes, lives in
-  // src/renderer/mobile/pairPayload.test.ts — vitest, not plain Node,
+  // src/shared/pairPayload.test.ts — vitest, not plain Node,
   // can load the .ts parser directly.)
   //
   // 1. install-lib's buildPairLink produces the canonical shape:
@@ -616,7 +616,7 @@ test("buildPairLink produces the canonical box-form pair link (BET-177 §2.4)", 
 // `buildPairLink` no longer hardcodes the `manta` literal in its URL
 // template — the scheme comes from the `scheme` option (default "manta",
 // same default as the renderer's `buildPairPayload`). Callers pass
-// `resolveConfig().urlScheme`. See src/renderer/mobile/pairPayload.test.ts
+// `resolveConfig().urlScheme`. See src/shared/pairPayload.test.ts
 // for the round-trip-through-parsePairPayload coverage across all three
 // channel schemes.
 
@@ -3774,7 +3774,7 @@ test("buildPairLink round-trips with a serverUrl through parsePairPayload (BET-3
   // mobile deep-link parser + the desktop QR panel) accepts and
   // round-trips to a `{ boxId, code, serverUrl }` payload. We assert
   // the literal here — the round-trip itself is enforced by the vitest
-  // tests at src/renderer/mobile/pairPayload.test.ts (Node has no TS
+  // tests at src/shared/pairPayload.test.ts (Node has no TS
   // loader in this Node:test run).
   const out = formatPairingOutput({
     pairing_code: "123456",

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -37,7 +37,7 @@ import { boxDirectUrl } from "../shared/transport.mjs";
  * @param input    { serverUrl, boxId?, code } from the renderer. The mobile/web
  *                 client only ever supplies `serverUrl` (already-built by the
  *                 caller's `boxDirectUrl(boxId)` for the box form, see
- *                 src/renderer/mobile/setupLogic.ts); the desktop onboarding
+ *                 src/shared/setupLogic.ts); the desktop onboarding
  *                 paste-pair-link path may supply either `serverUrl` (direct
  *                 form) or `boxId` (box form). Exactly one of the two is
  *                 consumed.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -21,7 +21,7 @@ import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
-import { parsePairPayload } from "./mobile/pairPayload";
+import { parsePairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
 import type { AvailableLauncher } from "../shared/types";
 

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -28,7 +28,7 @@ import {
   canConnectSetup,
   normalizeServerUrl,
   prefillFromPairLink,
-} from "./mobile/setupLogic";
+} from "../shared/setupLogic";
 import { VerifyCodeInput } from "./VerifyCodeInput";
 import { PairingCodeInput } from "./PairingCodeInput";
 import { isValidBoxToken } from "../shared/transport.mjs";
@@ -107,7 +107,7 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
 
 // Manual code-entry form. Extracted from PairStep so the disclosure can
 // mount it as a self-contained block. The pure validation/submit-gate lives
-// in renderer/mobile/setupLogic.ts (canConnectSetup / normalizeServerUrl);
+// in shared/setupLogic.ts (canConnectSetup / normalizeServerUrl);
 // this component is wiring + JSX only — no validation logic is duplicated
 // here (BET-382).
 //

--- a/src/renderer/PairingQR.tsx
+++ b/src/renderer/PairingQR.tsx
@@ -2,7 +2,7 @@
 //
 // The QR encodes the CANONICAL box-form `<scheme>://pair?box=<boxId>&code=<6-digit>`
 // payload produced by the SHARED `buildPairPayload` helper
-// (src/renderer/mobile/pairPayload.ts). BET-237 removed the deprecated
+// (src/shared/pairPayload.ts). BET-237 removed the deprecated
 // serverUrl / id forms — `parsePairPayload` rejects anything other than
 // `box=<boxId>&code=<6-digit>`. The canonical form is the SAME shape `manta
 // pair` prints + the install heredoc + the deep-link handler in
@@ -24,7 +24,7 @@
 // renderer at build time (electron.vite.config.ts renderer `define`).
 
 import { useEffect, useMemo, useState } from "react";
-import { buildPairPayload } from "./mobile/pairPayload";
+import { buildPairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
 
 // Channel-aware scheme for the QR prefix. The baked `__MANTA_CHANNEL__`

--- a/src/renderer/VerifyCodeInput.tsx
+++ b/src/renderer/VerifyCodeInput.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from "react";
-import { normalizeVerifyCode } from "./mobile/pairPayload";
+import { normalizeVerifyCode } from "../shared/pairPayload";
 
 type Props = {
   value: string;

--- a/src/renderer/mobile/SetupScreen.tsx
+++ b/src/renderer/mobile/SetupScreen.tsx
@@ -15,7 +15,7 @@ import {
   buildSetupClaimInput,
   resolveSetupServerUrl,
   normalizeServerUrl,
-} from "./setupLogic";
+} from "../../shared/setupLogic";
 
 type Props = {
   // Called after a successful claim (token already persisted by

--- a/src/renderer/mobile/deepLink.ts
+++ b/src/renderer/mobile/deepLink.ts
@@ -34,11 +34,11 @@
 // Dep injection keeps handlePairUrl unit-testable without DOM / fetch / the
 // Capacitor bridge — see deepLink.test.ts beside this file.
 
-import { parsePairPayload } from "./pairPayload";
+import { parsePairPayload } from "../../shared/pairPayload";
 import {
   buildSetupClaimInput,
   resolveSetupServerUrl,
-} from "./setupLogic";
+} from "../../shared/setupLogic";
 import type { ClaimOutcome } from "../../shared/claim.mjs";
 import { dlog } from "./debugLog";
 

--- a/src/renderer/mobile/pairingLogic.ts
+++ b/src/renderer/mobile/pairingLogic.ts
@@ -30,7 +30,7 @@ export {
   networkFailure,
 } from "../../shared/claim.mjs";
 import { isSubmittableCode, normalizeCode } from "../../shared/claim.mjs";
-import { normalizeVerifyCode } from "./pairPayload";
+import { normalizeVerifyCode } from "../../shared/pairPayload";
 import type { ClaimFailureKind, ClaimOutcome } from "../../shared/claim.mjs";
 
 // Historical alias: the mobile client + tests refer to the classified outcome

--- a/src/renderer/pairClaim.ts
+++ b/src/renderer/pairClaim.ts
@@ -64,7 +64,7 @@ export async function claimBox(input: {
   // hostname (https://<boxId>.boxes.mantaui.com); when an explicit override is
   // supplied (BET-268 tailnet path), it's the user-entered URL after
   // normalization. Main's claimPairing dispatcher accepts either shape; using
-  // the pre-resolved URL mirrors the mobile client (renderer/mobile/
+  // the pre-resolved URL mirrors the mobile client (shared/
   // setupLogic.buildSetupClaimInput) and keeps `boxDirectUrl` as the single
   // source of truth for the default URL.
   const claimInput = buildSetupClaimInput({

--- a/src/renderer/pairClaim.ts
+++ b/src/renderer/pairClaim.ts
@@ -13,7 +13,7 @@
 //
 // The helper is intentionally non-pure (it touches window.api, the store,
 // and the httpApi transport swap), but the parts that ARE pure (claim input
-// shape, persisted server URL) live in renderer/mobile/setupLogic.ts and are
+// shape, persisted server URL) live in shared/setupLogic.ts and are
 // already tested in setupLogic.test.ts — single source of truth reused here.
 //
 // Side effects on success:
@@ -30,7 +30,7 @@ import { useStore } from "./store";
 import {
   buildSetupClaimInput,
   resolveSetupServerUrl,
-} from "./mobile/setupLogic";
+} from "../shared/setupLogic";
 import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { installHttpTransport } from "./transportInstall";
 import { networkFailure, type ClaimOutcome } from "../shared/claim.mjs";

--- a/src/shared/pairPayload.test.ts
+++ b/src/shared/pairPayload.test.ts
@@ -4,7 +4,7 @@ import {
   buildPairPayload,
   type PairPayload,
 } from "./pairPayload";
-import { CHANNELS, CHANNEL_IDS } from "../../shared/channel.mjs";
+import { CHANNELS, CHANNEL_IDS } from "./channel.mjs";
 // BET-386: install-lib.mjs's buildPairLink is the OTHER emitter of this
 // wire shape (install.sh's pairing block, via scripts/manta-pair.mjs) —
 // plain .mjs, no Electron/DOM dependency, importable straight into vitest's
@@ -13,7 +13,7 @@ import { CHANNELS, CHANNEL_IDS } from "../../shared/channel.mjs";
 // parser in one place, rather than re-implementing the wire shape as a
 // literal string in scripts/install.test.mjs (which is plain Node and
 // can't load this .ts parser directly).
-import { buildPairLink } from "../../../scripts/install-lib.mjs";
+import { buildPairLink } from "../../scripts/install-lib.mjs";
 
 const BOX = "0123456789abcdef0123456789abcdef"; // 32 hex
 

--- a/src/shared/pairPayload.ts
+++ b/src/shared/pairPayload.ts
@@ -55,7 +55,7 @@ import { normalizeCode } from "./claim.mjs";
 import {
   isValidBoxToken,
   isPrivateServerUrl,
-} from "../../shared/transport.mjs";
+} from "./transport.mjs";
 import { normalizeServerUrl } from "./setupLogic";
 
 export type PairPayload = {

--- a/src/shared/pairPayload.ts
+++ b/src/shared/pairPayload.ts
@@ -51,7 +51,7 @@
 // and isPrivateServerUrl (../../shared/transport.mjs — single source of
 // truth for the ranges; every other consumer imports it from there).
 
-import { normalizeCode } from "../../shared/claim.mjs";
+import { normalizeCode } from "./claim.mjs";
 import {
   isValidBoxToken,
   isPrivateServerUrl,

--- a/src/shared/setupLogic.test.ts
+++ b/src/shared/setupLogic.test.ts
@@ -7,8 +7,8 @@ import {
   normalizeServerUrl,
   prefillFromPairLink,
 } from "./setupLogic";
-import { boxDirectUrl } from "../../shared/transport.mjs";
-import { CHANNELS, CHANNEL_IDS } from "../../shared/channel.mjs";
+import { boxDirectUrl } from "./transport.mjs";
+import { CHANNELS, CHANNEL_IDS } from "./channel.mjs";
 
 // BET-373 (review cycle 1): every channel's scheme, derived from the table
 // (not hardcoded) so a fourth channel automatically extends this coverage —

--- a/src/shared/setupLogic.ts
+++ b/src/shared/setupLogic.ts
@@ -1,5 +1,5 @@
-import { isSubmittableCode } from "../../shared/claim.mjs";
-import { boxDirectUrl, isValidBoxToken } from "../../shared/transport.mjs";
+import { isSubmittableCode } from "./claim.mjs";
+import { boxDirectUrl, isValidBoxToken } from "./transport.mjs";
 import { parsePairPayload } from "./pairPayload";
 
 export type SetupFields = {


### PR DESCRIPTION
## Summary (BET-554 — S2 prerequisite)

The mobile web client shell is retired (BET-550 §12), but `src/renderer/mobile/`
holds pairing/setup logic that **desktop onboarding** imports. Deleting the dir
wholesale would break desktop onboarding. This PR extracts the two surviving
shared modules — `setupLogic` and `pairPayload` (+ their tests) — from
`src/renderer/mobile/` into `src/shared/`, and updates every consumer.

Move only. No behaviour change (diff is path changes in imports + comments).

## What moved
- `src/renderer/mobile/setupLogic.ts` → `src/shared/setupLogic.ts`
- `src/renderer/mobile/pairPayload.ts` → `src/shared/pairPayload.ts`
- both `.test.ts` files with them.

Shell modules (`deepLink`, `pairingLogic`, `SetupScreen`, `MobileApp`, …) stay
in `src/renderer/mobile/` for S5 to delete; they still compile because their
imports were repointed at `../../shared/…`.

## Consumers updated
- Desktop: `App.tsx`, `PairStep.tsx`, `PairingQR.tsx`, `VerifyCodeInput.tsx`, `pairClaim.ts`
- Mobile shell (repoint, not moved): `deepLink.ts`, `pairingLogic.ts`, `SetupScreen.tsx`
- `src/main/auth.ts` reference comment → `src/shared/setupLogic.ts`
- cross-reference comments in `scripts/install-lib.mjs` / `scripts/install.test.mjs`

## DoD self-check
- [x] setupLogic + pairPayload + tests live outside `src/renderer/mobile/`; every consumer updated (grep clean — no residual `./mobile/setupLogic`/`./mobile/pairPayload` refs)
- [x] nothing else moved; shell modules stay put (imports repointed only)
- [x] `npm run typecheck && npm test` pass (see Verification results)
- [x] Desktop onboarding confirmed: `npm run build` produces the desktop renderer bundle (which contains all onboarding components) cleanly with the relocated imports; playwright electron project verification passed on the built bundles; moved modules' 106 unit tests pass.

**Base: origin/main @ 8e505a6**

## Verification results
- PR branch (`multica/BET-554-extract-shared-modules` @ `11384e0`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0; vitest 94 files / 1866 pass / 2 skip; node:test 1373 pass / 0 fail. Failures: none. log sha256: `f32fae033b3d5a3c38564dc737b5a8d599a8c6c55a8640772bf49eb1923066fb`
- Base (`main` @ `8e505a6`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0; identical pass counts. Failures: none. log sha256: `de8564d1c6447b874c318e9279ba6eb9e64e952435ab1243dd7e39cdc7aafd74`
- **Conclusion:** 0 new failures. Both branches identical (typecheck sha matches; test result counts identical, sha differs only due to timing/working-dir paths in log).