### PR TITLE
BET-566: split HOST/TAILNET_HOST consts in src/server/index.mjs

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -479,7 +479,8 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
 });
 
 const PORT = Number(process.env.MANTA_MOBILE_PORT ?? 8787);
-const HOST = process.env.MANTA_MOBILE_HOST ?? "0.0.0.0";const TAILNET_HOST = process.env.MANTA_TAILNET_HOST ?? "";
+const HOST = process.env.MANTA_MOBILE_HOST ?? "0.0.0.0";
+const TAILNET_HOST = process.env.MANTA_TAILNET_HOST ?? "";
 
 // ---------- static file serving ----------
 


### PR DESCRIPTION
Closes BET-566. Cosmetic nit from BET-551 review (PR #467) — splits the joined `HOST`/`TAILNET_HOST` consts onto separate lines. No behaviour change.

Verification: `npm run typecheck` clean; `npm test` 1373 pass / 0 fail.