### PR TITLE
BET-572: Fix stale setupLogic path comment in scripts/install-lib.d.mts

### DIFF
--- a/scripts/install-lib.d.mts
+++ b/scripts/install-lib.d.mts
@@ -6,7 +6,7 @@
 // helpers, exercised by the plain-Node scripts/install.test.mjs suite (no
 // type declarations needed there — node:test loads the .mjs directly).
 // This file declares ONLY the exports a checked .ts file actually imports
-// (currently: src/renderer/mobile/pairPayload.test.ts, for the BET-386
+// (currently: src/shared/pairPayload.test.ts, for the BET-386
 // buildPairLink round-trip) — extend it if a future .ts file imports more.
 
 /**


### PR DESCRIPTION
Follow-up from BET-554. BET-554 moved `pairPayload.test.ts` to `src/shared/` and updated the cross-reference comments in `scripts/install-lib.mjs` / `install.test.mjs`, but missed the sibling hand-written type decl.

## Change
- `scripts/install-lib.d.mts:9`: comment now references `src/shared/pairPayload.test.ts` (was stale `src/renderer/mobile/pairPayload.test.ts`).
- Comment-only change; no behaviour or types change.

## Verification
- `npm run typecheck` passes.

Closes BET-572.