### PR TITLE
chore: autopr smoke check (BET-573)

### DIFF
--- a/.autopr-smoke
+++ b/.autopr-smoke
@@ -1,0 +1,1 @@
+# autopr smoke check — delete me


### PR DESCRIPTION
Opened automatically for `agent/smoke/autopr-check`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-573.