### PR TITLE
fix(onboarding): auto-advance past step 1 after SSH pairing (BET-579)

### DIFF
--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -54,6 +54,7 @@ import {
   type VerifyStageIndex,
 } from "./onboardingVerify";
 import { installHttpTransport } from "./transportInstall";
+import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { ArrowRight, CheckIcon } from "./onboardingUi";
 import { ProcessPanel } from "./ProcessPanel";
 import mantaMark from "./assets/manta-mark-128.png";
@@ -142,26 +143,22 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   const [verifyElapsed, setVerifyElapsed] = useState(0);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
-  // Pre-flight for everything that runs AFTER a successful pair: refresh
-  // the store from main's config + seed localStorage / swap window.api to
-  // httpApi. The SSH claim path persists credentials via main's commit()
-  // but does NOT seed localStorage or swap window.api to httpApi. Without
-  // this pre-flight, the window.api.opencode* / .opencodeProviderAuth calls
-  // in verify + hasConnectedProvider fail.
+  // Pre-flight for everything that runs AFTER a successful pair.
+  //
+  // Order is load-bearing: the transport swap MUST happen before
+  // store.refresh(). On the SSH auto-claim path the credentials are persisted
+  // by main and window.api is still the Electron preload bridge, which has no
+  // tmuxList — so refresh() would throw before the swap ever happened, and the
+  // wizard would never leave step 1.
+  //
+  // window.api.configGet() is what makes the freshly-minted boxToken visible
+  // here; it exists on BOTH transports. In http mode it returns the manta
+  // SERVER's config, which carries no pairing secrets, so the seed is null and
+  // the already-installed transport is correctly left alone.
   const refreshAndInstallTransport = useCallback(async () => {
+    const seed = desktopHttpClientSeed(await window.api.configGet());
+    if (seed) installHttpTransport(seed);
     await useStore.getState().refresh();
-    const cfg = useStore.getState().configSnapshot();
-    if (
-      typeof cfg.boxToken === "string" &&
-      cfg.boxToken.length > 0 &&
-      typeof cfg.serverUrl === "string" &&
-      cfg.serverUrl.length > 0
-    ) {
-      installHttpTransport({
-        manta_server: cfg.serverUrl.replace(/\/+$/, ""),
-        manta_token: cfg.boxToken,
-      });
-    }
   }, []);
 
   // The post-pair verify. Runs an ephemeral opencode session through three
@@ -214,9 +211,20 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   // Step 1 → step 2 (provider needed) OR step 1 → runVerify (provider
   // already connected). Detecting the latter before stepping forward keeps
   // the user from blinking through an empty step-2 frame.
+  //
+  // Failures are contained rather than propagated: this is invoked as
+  // `void onPaired()`, so a rejection here is silent and freezes the wizard on
+  // step 1 (BET pairing-stall bug). Pairing has already succeeded at this
+  // point, so we advance regardless — ProvidersStep surfaces its own load
+  // error if the box is still unreachable.
   const onPaired = useCallback(async () => {
-    await refreshAndInstallTransport();
-    const connected = await hasConnectedProvider(window.api as unknown as VerifyApi);
+    let connected = false;
+    try {
+      await refreshAndInstallTransport();
+      connected = await hasConnectedProvider(window.api as unknown as VerifyApi);
+    } catch (e) {
+      console.warn("[manta] post-pair pre-flight failed; advancing anyway:", e);
+    }
     if (connected) {
       await runVerify();
     } else {

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -48,7 +48,6 @@ import type { ClaimOutcome } from "../shared/claim.mjs";
 const ACCENT = "var(--accent)";
 const ACCENT_SOLID = "var(--accent-solid)"; // filled buttons (BET-409 AA)
 const DANGER = "var(--danger)";
-const OK_GREEN = "var(--ok)";
 
 // Keep the last N log lines only — main already caps its own tail at 200
 // (handlers.ts LOG_TAIL_MAX); the renderer needs its own cap too, or a long
@@ -930,12 +929,9 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         </ProcessPanel>
       )}
 
-      {/* Done / error / claim */}
-      {done && done.ok && !claimError && (
-        <section className="text-body" style={{ color: OK_GREEN }}>
-          Install finished successfully. {claimRunning ? "Pairing…" : ""}
-        </section>
-      )}
+      {/* In-flight claim only. There is no success message: a successful
+          claim advances onboarding to step 2, which unmounts this step. */}
+      {claimRunning && <section className="text-body">Pairing…</section>}
       {done && !done.ok && (
         <section
           className="text-body space-y-2"


### PR DESCRIPTION
## BET-579 — Onboarding stalls on step 1 after SSH pairing

Fixes the SSH install + auto-claim desktop onboarding path (the only one that
stalls: the manual 6-digit-code path already advanced correctly).

### Root cause
`onPaired()` ran its first statement — `store.refresh()` — before swapping
`window.api` to `httpApi`. On the SSH path the credentials are persisted in
main only, so `window.api` was still the Electron preload bridge, which has no
`tmuxList`; `refresh()` threw, `onPaired()` rejected silently (invoked as
`void onPaired()`), and the wizard froze on step 1.

### Fix (three edits, two files)
1. `Onboarding.tsx` — `refreshAndInstallTransport` now derives the transport
   seed from the shared `desktopHttpClientSeed(window.api.configGet())` and
   calls `installHttpTransport(seed)` BEFORE `store.refresh()`. Order is
   load-bearing: the swap must happen before refresh so a `tmuxList` exists.
2. `Onboarding.tsx` — `onPaired` contains post-pair pre-flight failures in a
   try/catch and advances anyway (`runVerify()` if a provider is already
   connected, else `setPos(2)`), instead of letting a rejection strand the
   user on step 1.
3. `SshInstallStep.tsx` — removed the now-dead "Install finished successfully."
   success message (step 1 unmounts on advance) and the now-unused `OK_GREEN`.
   Kept the in-flight "Pairing…" indicator.

### Manual verification (Electron GUI not runnable on the box — verified by
reading/reasoning as the issue prescribes):
- `grep tmuxList src/preload/index.ts` → no match (root cause still holds)
- `refreshAndInstallTransport` calls `installHttpTransport(seed)` before
  `useStore.getState().refresh()` ✓
- every path through `onPaired` ends in `runVerify()` or `setPos(2)` — no early
  return, no rethrow ✓
- `grep "Install finished successfully" src/renderer/` → no match
- `grep OK_GREEN src/renderer/SshInstallStep.tsx` → no match

**Files changed:** 2. `src/renderer/Onboarding.tsx`, `src/renderer/SshInstallStep.tsx`
(31 insertions / 27 deletions — net-neutral, no new exported symbol).

**Base: origin/main @ 4905465**

### Verification results
- PR branch (`multica/BET-579-onboarding-step1-stall` @ `55346a7`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1425 pass / 0 fail / 0 skip. Failures: none. log sha256: `3c7e0dda63111cd45b4f62eaa223315b2f29d363367c3d817cd31f400c7f0a39`
- Base (`main` @ `4905465`):
  - typecheck: exit 0. Errors: none. log sha256: `00a5b65767585a439874e95183a8a3e16731ab621895b1c6bb2ebbe3c05b5624`
  - test: exit 0, 1425 pass / 0 fail / 0 skip. Failures: none. log sha256: `3209665f63eba065577cef9f2ae4fe40f1d32c74ef67ba96c141686468d7a90d`
- **Conclusion:** 0 new failures, 0 pre-existing. Identical suites on both branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
