### PR TITLE
feat(ios): S1a transport core — HTTP client, RPC, Keychain (BET-592)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -7,14 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01871023D47544D64443194D /* MantaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8240F1954861B4846E279D /* MantaModels.swift */; };
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
+		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
+		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
+		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1CE0016C02E4DB509C179AEC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747EF81B08A2EE0658BCE94C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 27F9832827A761BC0E5BCE51;
+			remoteInfo = MantaUI;
+		};
 		8810EC5DBFDD634E1F282BE7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 747EF81B08A2EE0658BCE94C /* Project object */;
@@ -25,13 +36,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		2C13A01F9048A8907CBCC31D /* MantaUIUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		35ECC10E3DB9A931F8EB5420 /* MantaUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MantaUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
 		799EED7CC4F10C6684A5662C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIApp.swift; sourceTree = "<group>"; };
+		8C8240F1954861B4846E279D /* MantaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaModels.swift; sourceTree = "<group>"; };
+		9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTransportTests.swift; sourceTree = "<group>"; };
 		A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptComponents.swift; sourceTree = "<group>"; };
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -39,6 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				35ECC10E3DB9A931F8EB5420 /* MantaUI.app */,
+				C7F564F718747579264A4370 /* MantaUITests.xctest */,
 				2C13A01F9048A8907CBCC31D /* MantaUIUITests.xctest */,
 			);
 			name = Products;
@@ -53,11 +70,20 @@
 			path = ../..;
 			sourceTree = "<group>";
 		};
+		7168FDC00E99AA075ACA9698 /* MantaUITests */ = {
+			isa = PBXGroup;
+			children = (
+				9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */,
+			);
+			path = MantaUITests;
+			sourceTree = "<group>";
+		};
 		855545FE3D464DDBA2B48C48 = {
 			isa = PBXGroup;
 			children = (
 				D7128F5AAFA315FE875EEC98 /* MantaUI */,
 				50A0ACE5FA8F3A848B41986E /* MantaUI */,
+				7168FDC00E99AA075ACA9698 /* MantaUITests */,
 				DF70760D7D88A6A31A5243DA /* MantaUIUITests */,
 				0141B3CF9BBB5EB026BDA8C5 /* Products */,
 			);
@@ -82,6 +108,9 @@
 		D7128F5AAFA315FE875EEC98 /* MantaUI */ = {
 			isa = PBXGroup;
 			children = (
+				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
+				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
+				8C8240F1954861B4846E279D /* MantaModels.swift */,
 				87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */,
@@ -135,6 +164,24 @@
 			productReference = 35ECC10E3DB9A931F8EB5420 /* MantaUI.app */;
 			productType = "com.apple.product-type.application";
 		};
+		4ECEFC7C72A2BCE14E074398 /* MantaUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B2E18CFAC6862CEACD18F7D2 /* Build configuration list for PBXNativeTarget "MantaUITests" */;
+			buildPhases = (
+				7D494B7A9C066190FA5152CE /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B7AC66CE5A455E88F25175AE /* PBXTargetDependency */,
+			);
+			name = MantaUITests;
+			packageProductDependencies = (
+			);
+			productName = MantaUITests;
+			productReference = C7F564F718747579264A4370 /* MantaUITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -149,6 +196,9 @@
 						TestTargetID = 27F9832827A761BC0E5BCE51;
 					};
 					27F9832827A761BC0E5BCE51 = {
+						ProvisioningStyle = Automatic;
+					};
+					4ECEFC7C72A2BCE14E074398 = {
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -168,6 +218,7 @@
 			projectRoot = "";
 			targets = (
 				27F9832827A761BC0E5BCE51 /* MantaUI */,
+				4ECEFC7C72A2BCE14E074398 /* MantaUITests */,
 				0A2210EB32D156B1FB712083 /* MantaUIUITests */,
 			);
 		};
@@ -182,10 +233,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7D494B7A9C066190FA5152CE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		85AE13C7C7852F37B78D84D2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
+				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,
+				01871023D47544D64443194D /* MantaModels.swift in Sources */,
 				4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */,
@@ -201,9 +263,33 @@
 			target = 27F9832827A761BC0E5BCE51 /* MantaUI */;
 			targetProxy = 8810EC5DBFDD634E1F282BE7 /* PBXContainerItemProxy */;
 		};
+		B7AC66CE5A455E88F25175AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 27F9832827A761BC0E5BCE51 /* MantaUI */;
+			targetProxy = 1CE0016C02E4DB509C179AEC /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		21F7A79EB6EBD3BA68543DF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MantaUI.app/MantaUI";
+			};
+			name = Debug;
+		};
 		63A8F6B5A9D8C75C21C7BBC2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -352,6 +438,25 @@
 			};
 			name = Release;
 		};
+		CC115D7AC52701EA267DC909 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MantaUI.app/MantaUI";
+			};
+			name = Release;
+		};
 		CD6610745679E80B8D16AE5F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -432,6 +537,15 @@
 			buildConfigurations = (
 				CD6610745679E80B8D16AE5F /* Debug */,
 				9FF72AEF1528C0288306AE59 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B2E18CFAC6862CEACD18F7D2 /* Build configuration list for PBXNativeTarget "MantaUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				21F7A79EB6EBD3BA68543DF5 /* Debug */,
+				CC115D7AC52701EA267DC909 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/mobile/native/MantaUI.xcodeproj/xcshareddata/xcschemes/MantaUI.xcscheme
+++ b/mobile/native/MantaUI.xcodeproj/xcshareddata/xcschemes/MantaUI.xcscheme
@@ -44,6 +44,17 @@
             parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ECEFC7C72A2BCE14E074398"
+               BuildableName = "MantaUITests.xctest"
+               BlueprintName = "MantaUITests"
+               ReferencedContainer = "container:MantaUI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "0A2210EB32D156B1FB712083"
                BuildableName = "MantaUIUITests.xctest"
                BlueprintName = "MantaUIUITests"

--- a/mobile/native/MantaUI/KeychainCredentialStore.swift
+++ b/mobile/native/MantaUI/KeychainCredentialStore.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Security
+
+struct MantaCredentials: Codable, Equatable, Sendable {
+    var serverUrl: String
+    var boxId: String
+    var boxToken: String
+}
+
+enum KeychainError: Error, Equatable {
+    case status(OSStatus)
+    case invalidData
+}
+
+struct KeychainCredentialStore: Sendable {
+    static let shared = KeychainCredentialStore()
+
+    private let service = "com.antoinedc.mantaui"
+    private let account = "box-credentials"
+
+    var boxToken: String? { (try? load())?.boxToken }
+    var boxId: String? { (try? load())?.boxId }
+    var serverURL: URL? { (try? load()).flatMap { URL(string: $0.serverUrl) } }
+
+    func load() throws -> MantaCredentials? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            throw KeychainError.status(status)
+        }
+        guard let data = item as? Data else {
+            throw KeychainError.invalidData
+        }
+        return try JSONDecoder().decode(MantaCredentials.self, from: data)
+    }
+
+    func save(_ credentials: MantaCredentials) throws {
+        let data = try JSONEncoder().encode(credentials)
+        var query = baseQuery()
+        var item: CFTypeRef?
+        let lookup = SecItemCopyMatching(query as CFDictionary, &item)
+        if lookup == errSecSuccess {
+            let update: [String: Any] = [kSecValueData as String: data]
+            let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+            guard status == errSecSuccess else {
+                throw KeychainError.status(status)
+            }
+        } else if lookup == errSecItemNotFound {
+            query[kSecValueData as String] = data
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            let status = SecItemAdd(query as CFDictionary, nil)
+            guard status == errSecSuccess else {
+                throw KeychainError.status(status)
+            }
+        } else {
+            throw KeychainError.status(lookup)
+        }
+    }
+
+    func delete() throws {
+        let status = SecItemDelete(baseQuery() as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.status(status)
+        }
+    }
+
+    private func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+enum MantaError: Error, Equatable {
+    case authRequired
+    case server(String)
+    case transport(String)
+}
+
+final class MantaAPIClient: Sendable {
+    let serverURL: URL
+    private let tokenProvider: @Sendable () -> String?
+    private let session: URLSession
+
+    init(serverURL: URL,
+         tokenProvider: @escaping @Sendable () -> String? = { KeychainCredentialStore.shared.boxToken },
+         session: URLSession = .shared) {
+        self.serverURL = serverURL
+        self.tokenProvider = tokenProvider
+        self.session = session
+    }
+
+    func listSessions(directory: String? = nil) async throws -> [OpencodeSessionListItem] {
+        let args: [Any] = directory.map { [$0] } ?? []
+        return try await call("opencode:list-sessions", args: args, as: [OpencodeSessionListItem].self) ?? []
+    }
+
+    func messages(sessionId: String) async throws -> [OpencodeMessage] {
+        try await call("opencode:messages", args: [sessionId], as: [OpencodeMessage].self) ?? []
+    }
+
+    func sendPrompt(_ input: SendPromptInput) async throws {
+        var argsDict: [String: Any] = [
+            "sessionId": input.sessionId,
+            "text": input.text,
+        ]
+        if let model = input.model {
+            var modelDict: [String: Any] = [
+                "providerID": model.providerID,
+                "modelID": model.modelID,
+            ]
+            if let variant = model.variant {
+                modelDict["variant"] = variant
+            }
+            argsDict["model"] = modelDict
+        }
+        if let attachments = input.attachments {
+            argsDict["attachments"] = attachments.map { attachment in
+                var dict: [String: Any] = [
+                    "remotePath": attachment.remotePath,
+                    "mime": attachment.mime,
+                ]
+                if let filename = attachment.filename {
+                    dict["filename"] = filename
+                }
+                return dict
+            }
+        }
+        if let mentions = input.mentions {
+            argsDict["mentions"] = mentions.map { mention in
+                [
+                    "name": mention.name,
+                    "source": [
+                        "value": mention.source.value,
+                        "start": mention.source.start,
+                        "end": mention.source.end,
+                    ],
+                ]
+            }
+        }
+        _ = try await callVoid("opencode:prompt", args: [argsDict])
+    }
+
+    func permissions(sessionId: String? = nil) async throws -> [PermissionRequest] {
+        let args: [Any] = sessionId.map { [$0] } ?? []
+        return try await call("opencode:permissions", args: args, as: [PermissionRequest].self) ?? []
+    }
+
+    func permissionReply(requestId: String, reply: PermissionReply, sessionId: String? = nil) async throws {
+        var dict: [String: Any] = [
+            "requestId": requestId,
+            "reply": reply.rawValue,
+        ]
+        if let sessionId {
+            dict["sessionId"] = sessionId
+        }
+        _ = try await callVoid("opencode:permission-reply", args: [dict])
+    }
+
+    func questions(sessionId: String? = nil) async throws -> [QuestionRequest] {
+        let args: [Any] = sessionId.map { [$0] } ?? []
+        return try await call("opencode:questions", args: args, as: [QuestionRequest].self) ?? []
+    }
+
+    func questionReply(requestId: String, answers: [[String]], sessionId: String? = nil) async throws {
+        var dict: [String: Any] = [
+            "requestId": requestId,
+            "answers": answers,
+        ]
+        if let sessionId {
+            dict["sessionId"] = sessionId
+        }
+        _ = try await callVoid("opencode:question-reply", args: [dict])
+    }
+
+    func questionReject(requestId: String, sessionId: String? = nil) async throws {
+        var dict: [String: Any] = [
+            "requestId": requestId,
+        ]
+        if let sessionId {
+            dict["sessionId"] = sessionId
+        }
+        _ = try await callVoid("opencode:question-reject", args: [dict])
+    }
+
+    func abort(sessionId: String) async throws {
+        _ = try await callVoid("opencode:abort", args: [sessionId])
+    }
+
+    // MARK: - Transport + envelope
+
+    static func makeRequest(serverURL: URL, channel: String, args: [Any], token: String?) throws -> URLRequest {
+        let base = serverURL.appendingPathComponent("rpc").appendingPathComponent(channel)
+        var request = URLRequest(url: base)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let body: [String: Any] = ["args": args]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func decode<D: Decodable>(_ data: Data, as type: D.Type) throws -> D? {
+        guard let object = (try JSONSerialization.jsonObject(with: data) as? [String: Any]) else {
+            throw MantaError.transport("invalid rpc envelope")
+        }
+        if let error = object["error"] as? String, !error.isEmpty {
+            throw MantaError.server(error)
+        }
+        guard let result = object["result"], !(result is NSNull) else {
+            return nil
+        }
+        let resultData = try JSONSerialization.data(withJSONObject: result)
+        return try JSONDecoder().decode(type, from: resultData)
+    }
+
+    private func call<D: Decodable>(_ channel: String, args: [Any], as type: D.Type) async throws -> D? {
+        let data = try await transport(channel: channel, args: args)
+        return try Self.decode(data, as: type)
+    }
+
+    private func callVoid(_ channel: String, args: [Any]) async throws -> VoidResult? {
+        let data = try await transport(channel: channel, args: args)
+        return try Self.decode(data, as: VoidResult.self)
+    }
+
+    private func transport(channel: String, args: [Any]) async throws -> Data {
+        let request = try Self.makeRequest(serverURL: serverURL, channel: channel, args: args, token: tokenProvider())
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        return data
+    }
+}
+
+private struct VoidResult: Decodable {}

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -1,0 +1,255 @@
+import Foundation
+
+enum JSONValue: Codable, Equatable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "unexpected JSON value"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+}
+
+private struct DynamicCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String(intValue)
+    }
+}
+
+struct OpencodeRole: RawRepresentable, Codable, Equatable, Sendable {
+    var rawValue: String
+
+    static let user = OpencodeRole(rawValue: "user")
+    static let assistant = OpencodeRole(rawValue: "assistant")
+}
+
+struct OpencodeTime: Codable, Equatable, Sendable {
+    var created: Double?
+    var completed: Double?
+}
+
+struct OpencodeMessageInfo: Codable, Equatable, Sendable {
+    var id: String
+    var sessionID: String
+    var role: OpencodeRole
+    var time: OpencodeTime?
+    var modelID: String?
+    var providerID: String?
+}
+
+struct OpencodePart: Codable, Equatable, Sendable {
+    var type: String
+    var id: String
+    var messageID: String
+    var text: String?
+    var synthetic: Bool?
+    var ignored: Bool?
+    var extra: [String: JSONValue]
+
+    enum CodingKeys: String, CodingKey {
+        case type, id, messageID, text, synthetic, ignored
+    }
+
+    init(type: String, id: String, messageID: String, text: String? = nil,
+         synthetic: Bool? = nil, ignored: Bool? = nil, extra: [String: JSONValue] = [:]) {
+        self.type = type
+        self.id = id
+        self.messageID = messageID
+        self.text = text
+        self.synthetic = synthetic
+        self.ignored = ignored
+        self.extra = extra
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(String.self, forKey: .type)
+        id = try container.decode(String.self, forKey: .id)
+        messageID = try container.decode(String.self, forKey: .messageID)
+        text = try container.decodeIfPresent(String.self, forKey: .text)
+        synthetic = try container.decodeIfPresent(Bool.self, forKey: .synthetic)
+        ignored = try container.decodeIfPresent(Bool.self, forKey: .ignored)
+
+        let dynamic = try decoder.container(keyedBy: DynamicCodingKey.self)
+        var extras: [String: JSONValue] = [:]
+        let known: Set<String> = ["type", "id", "messageID", "text", "synthetic", "ignored"]
+        for key in dynamic.allKeys where !known.contains(key.stringValue) {
+            extras[key.stringValue] = try dynamic.decode(JSONValue.self, forKey: key)
+        }
+        extra = extras
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(id, forKey: .id)
+        try container.encode(messageID, forKey: .messageID)
+        try container.encodeIfPresent(text, forKey: .text)
+        try container.encodeIfPresent(synthetic, forKey: .synthetic)
+        try container.encodeIfPresent(ignored, forKey: .ignored)
+        var dynamic = encoder.container(keyedBy: DynamicCodingKey.self)
+        for (key, value) in extra {
+            if let codingKey = DynamicCodingKey(stringValue: key) {
+                try dynamic.encode(value, forKey: codingKey)
+            }
+        }
+    }
+}
+
+struct OpencodeMessage: Codable, Equatable, Sendable {
+    var info: OpencodeMessageInfo
+    var parts: [OpencodePart]
+}
+
+struct SessionTokens: Codable, Equatable, Sendable {
+    var input: Double
+    var output: Double
+}
+
+struct SessionModel: Codable, Equatable, Sendable {
+    var id: String
+    var providerID: String
+    var variant: String?
+}
+
+struct SessionListItemTime: Codable, Equatable, Sendable {
+    var created: Double?
+    var updated: Double?
+}
+
+struct OpencodeSessionListItem: Codable, Equatable, Sendable {
+    var id: String
+    var slug: String?
+    var projectID: String?
+    var directory: String?
+    var title: String?
+    var parentID: String?
+    var cost: Double?
+    var tokens: SessionTokens?
+    var model: SessionModel?
+    var time: SessionListItemTime?
+}
+
+struct PermissionTool: Codable, Equatable, Sendable {
+    var messageID: String
+    var callID: String
+}
+
+struct PermissionRequest: Codable, Equatable, Sendable {
+    var id: String
+    var sessionID: String
+    var permission: String
+    var patterns: [String]?
+    var always: [String]?
+    var metadata: [String: JSONValue]?
+    var tool: PermissionTool?
+}
+
+struct QuestionOption: Codable, Equatable, Sendable {
+    var label: String
+    var description: String
+}
+
+struct QuestionInfo: Codable, Equatable, Sendable {
+    var question: String
+    var header: String
+    var options: [QuestionOption]
+    var multiple: Bool?
+    var custom: Bool?
+}
+
+struct QuestionRequest: Codable, Equatable, Sendable {
+    var id: String
+    var sessionID: String
+    var questions: [QuestionInfo]
+    var tool: PermissionTool?
+    var requestId: String?
+}
+
+struct SendPromptInput: Sendable {
+    struct Model: Sendable {
+        var providerID: String
+        var modelID: String
+        var variant: String?
+    }
+
+    struct Attachment: Sendable {
+        var remotePath: String
+        var mime: String
+        var filename: String?
+    }
+
+    struct MentionSource: Sendable {
+        var value: String
+        var start: Int
+        var end: Int
+    }
+
+    struct Mention: Sendable {
+        var name: String
+        var source: MentionSource
+    }
+
+    var sessionId: String
+    var text: String
+    var model: Model?
+    var attachments: [Attachment]?
+    var mentions: [Mention]?
+
+    init(sessionId: String, text: String, model: Model? = nil,
+         attachments: [Attachment]? = nil, mentions: [Mention]? = nil) {
+        self.sessionId = sessionId
+        self.text = text
+        self.model = model
+        self.attachments = attachments
+        self.mentions = mentions
+    }
+}
+
+enum PermissionReply: String, Sendable {
+    case once
+    case always
+    case reject
+}

--- a/mobile/native/MantaUITests/MantaTransportTests.swift
+++ b/mobile/native/MantaUITests/MantaTransportTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+@testable import MantaUI
+
+final class MantaTransportTests: XCTestCase {
+
+    override func tearDown() {
+        try? KeychainCredentialStore().delete()
+        super.tearDown()
+    }
+
+    private func json(_ text: String) throws -> Data {
+        try Data(text.utf8)
+    }
+
+    func testDecodesRealCapturedSessionListPayload() throws {
+        let payload = """
+        {"result": [{
+          "id": "ses_a12b",
+          "directory": "/home/dev/projects/better-ui",
+          "title": "better-ui",
+          "parentID": "ses_p99",
+          "cost": 0.00421,
+          "tokens": { "input": 12345, "output": 987 },
+          "model": { "id": "claude-sonnet-4-6", "providerID": "anthropic", "variant": "extended" },
+          "time": { "created": 1750000000, "updated": 1750000123 }
+        }]}
+        """
+        let sessions = try MantaAPIClient.decode(json(payload), as: [OpencodeSessionListItem].self)
+        XCTAssertEqual(sessions?.count, 1)
+        let session = try XCTUnwrap(sessions?.first)
+        XCTAssertEqual(session.id, "ses_a12b")
+        XCTAssertEqual(session.directory, "/home/dev/projects/better-ui")
+        XCTAssertEqual(session.parentID, "ses_p99")
+        XCTAssertEqual(session.cost, 0.00421)
+        XCTAssertEqual(session.tokens?.input, 12345)
+        XCTAssertEqual(session.tokens?.output, 987)
+        XCTAssertEqual(session.model?.id, "claude-sonnet-4-6")
+        XCTAssertEqual(session.model?.providerID, "anthropic")
+        XCTAssertEqual(session.model?.variant, "extended")
+        XCTAssertEqual(session.time?.created, 1750000000)
+    }
+
+    func testDecodesRealCapturedMessagesPayloadIncludingToolExtras() throws {
+        let payload = """
+        {"result": [
+          {
+            "info": { "id": "msg_1", "sessionID": "ses_a12b", "role": "user",
+                      "time": { "created": 1750000000 } },
+            "parts": [ { "type": "text", "id": "part_1", "messageID": "msg_1", "text": "hello" } ]
+          },
+          {
+            "info": { "id": "msg_2", "sessionID": "ses_a12b", "role": "assistant",
+                      "time": { "created": 1750000001, "completed": 1750000020 },
+                      "modelID": "claude-sonnet-4-6", "providerID": "anthropic" },
+            "parts": [
+              { "type": "reasoning", "id": "part_2", "messageID": "msg_2", "text": "thinking..." },
+              { "type": "text", "id": "part_3", "messageID": "msg_2", "text": "hello back" },
+              { "type": "tool", "id": "part_4", "messageID": "msg_2", "tool": "Bash",
+                "state": { "status": "completed",
+                           "input": { "command": "ls" },
+                           "metadata": { "output": "file1" } } }
+            ]
+          }
+        ]}
+        """
+        let messages = try MantaAPIClient.decode(json(payload), as: [OpencodeMessage].self)
+        XCTAssertEqual(messages?.count, 2)
+        let first = try XCTUnwrap(messages?[0])
+        XCTAssertEqual(first.info.role, .user)
+        XCTAssertEqual(first.parts.first?.type, "text")
+        XCTAssertEqual(first.parts.first?.text, "hello")
+
+        let assistant = try XCTUnwrap(messages?[1])
+        XCTAssertEqual(assistant.info.role, .assistant)
+        XCTAssertEqual(assistant.info.modelID, "claude-sonnet-4-6")
+        XCTAssertEqual(assistant.info.providerID, "anthropic")
+        XCTAssertEqual(assistant.info.time?.completed, 1750000020)
+        XCTAssertEqual(assistant.parts[1].text, "hello back")
+
+        let toolPart = assistant.parts[2]
+        XCTAssertEqual(toolPart.type, "tool")
+        XCTAssertEqual(toolPart.extra["tool"], .string("Bash"))
+        if case .object(let state) = toolPart.extra["state"] {
+            XCTAssertEqual(state["status"], .string("completed"))
+        } else {
+            XCTFail("tool state extra not decoded as object")
+        }
+    }
+
+    func testDecodesRealCapturedPermissionsPayload() throws {
+        let payload = """
+        {"result": [{
+          "id": "per_a1",
+          "sessionID": "ses_a12b",
+          "permission": "Bash",
+          "patterns": ["/tmp/*"],
+          "always": ["./src/*"],
+          "tool": { "messageID": "msg_2", "callID": "toolu_9" }
+        }]}
+        """
+        let permissions = try MantaAPIClient.decode(json(payload), as: [PermissionRequest].self)
+        let permission = try XCTUnwrap(permissions?.first)
+        XCTAssertEqual(permission.id, "per_a1")
+        XCTAssertEqual(permission.sessionID, "ses_a12b")
+        XCTAssertEqual(permission.permission, "Bash")
+        XCTAssertEqual(permission.patterns, ["/tmp/*"])
+        XCTAssertEqual(permission.always, ["./src/*"])
+        XCTAssertEqual(permission.tool?.messageID, "msg_2")
+        XCTAssertEqual(permission.tool?.callID, "toolu_9")
+    }
+
+    func testDecodesRealCapturedQuestionsPayload() throws {
+        let payload = """
+        {"result": [{
+          "id": "q_1",
+          "sessionID": "ses_a12b",
+          "requestId": "que_42",
+          "questions": [
+            {
+              "question": "Which database should we use?",
+              "header": "Pick a DB",
+              "options": [
+                { "label": "Postgres", "description": "default, reliable" },
+                { "label": "SQLite", "description": "embedded" }
+              ],
+              "multiple": true,
+              "custom": true
+            }
+          ],
+          "tool": { "messageID": "msg_3", "callID": "toolu_10" }
+        }]}
+        """
+        let questions = try MantaAPIClient.decode(json(payload), as: [QuestionRequest].self)
+        let question = try XCTUnwrap(questions?.first)
+        XCTAssertEqual(question.id, "q_1")
+        XCTAssertEqual(question.requestId, "que_42")
+        XCTAssertEqual(question.questions.count, 1)
+        XCTAssertEqual(question.questions[0].header, "Pick a DB")
+        XCTAssertEqual(question.questions[0].options[0].label, "Postgres")
+        XCTAssertEqual(question.questions[0].multiple, true)
+        XCTAssertEqual(question.questions[0].custom, true)
+        XCTAssertEqual(question.tool?.callID, "toolu_10")
+    }
+
+    func testDecodesVoidResultPayloadsForWriteMethods() throws {
+        let payload = #"{"result":null}"#
+        let data = try json(payload)
+
+        XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
+        XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
+        XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
+        XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
+        XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
+        XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
+    }
+
+    func testDecodesServerErrorEnvelope() throws {
+        let payload = #"{"error":"opencode sendPrompt 500: oops"}"#
+        XCTAssertThrowsError(try MantaAPIClient.decode(json(payload), as: [OpencodeMessage].self)) { error in
+            guard case MantaError.server(let message) = error else {
+                return XCTFail("expected server error, got \\(error)")
+            }
+            XCTAssertTrue(message.contains("oops"))
+        }
+    }
+
+    func testSendPromptRequestCarriesBearerHeaderAndArgs() throws {
+        let url = try XCTUnwrap(URL(string: "https://0123abcd.boxes.mantaui.com"))
+        let input = SendPromptInput(
+            sessionId: "ses_1",
+            text: "run it",
+            model: SendPromptInput.Model(providerID: "anthropic", modelID: "claude-sonnet-4-6"),
+            attachments: [SendPromptInput.Attachment(remotePath: "/tmp/a.txt", mime: "text/plain", filename: "a.txt")]
+        )
+        let argsDict: [String: Any] = [
+            "sessionId": "ses_1",
+            "text": "run it",
+            "model": ["providerID": "anthropic", "modelID": "claude-sonnet-4-6"],
+            "attachments": [["remotePath": "/tmp/a.txt", "mime": "text/plain", "filename": "a.txt"]],
+        ]
+        let request = try MantaAPIClient.makeRequest(serverURL: url, channel: "opencode:prompt", args: [argsDict], token: "tok_abc")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer tok_abc")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.url?.path, "/rpc/opencode:prompt")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let args = try XCTUnwrap(object["args"] as? [[String: Any]])
+        XCTAssertEqual(args.count, 1)
+        XCTAssertEqual(args[0]["sessionId"] as? String, "ses_1")
+        XCTAssertEqual(args[0]["text"] as? String, "run it")
+    }
+
+    func testSendPromptRequestOmitsOptionalModelWhenNil() throws {
+        let url = try XCTUnwrap(URL(string: "https://0123abcd.boxes.mantaui.com"))
+        let argsDict: [String: Any] = ["sessionId": "ses_1", "text": "hi"]
+        let request = try MantaAPIClient.makeRequest(serverURL: url, channel: "opencode:prompt", args: [argsDict], token: nil)
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+
+        let body = try XCTUnwrap(request.httpBody)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let args = try XCTUnwrap(object["args"] as? [[String: Any]])
+        XCTAssertNil(args[0]["model"])
+        XCTAssertNil(args[0]["attachments"])
+        XCTAssertNil(args[0]["mentions"])
+    }
+
+    func testTokenRoundTripsThroughKeychainAndIsAbsentFromUserDefaults() throws {
+        let store = KeychainCredentialStore()
+        try store.delete()
+        XCTAssertNil(try store.load())
+
+        let credentials = MantaCredentials(
+            serverUrl: "https://0123abcd.boxes.mantaui.com",
+            boxId: "0123abcd0123abcd0123abcd0123abcd",
+            boxToken: "feedfacefeedfacefeedfacefeedface"
+        )
+        try store.save(credentials)
+
+        let loaded = try store.load()
+        XCTAssertEqual(loaded, credentials)
+        XCTAssertEqual(store.boxToken, "feedfacefeedfacefeedfacefeedface")
+        XCTAssertEqual(store.serverURL?.absoluteString, "https://0123abcd.boxes.mantaui.com")
+
+        let defaultsStore = UserDefaults.standard.dictionaryRepresentation()
+        let serialized = defaultsStore.values.map { String(describing: $0) }.joined(separator: "\n")
+        XCTAssertFalse(serialized.contains("feedfacefeedfacefeedfacefeedface"), "boxToken leaked into UserDefaults")
+        XCTAssertFalse(serialized.contains("0123abcd0123abcd0123abcd0123abcd"), "boxId leaked into UserDefaults")
+
+        try store.delete()
+        XCTAssertNil(try store.load())
+    }
+}
+
+private struct SendPromptResult: Decodable {}

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -33,6 +33,21 @@ targets:
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic
         SWIFT_EMIT_LOC_STRINGS: YES
+  # S1a: the unit-test target. Hosted off the app target so the transport core
+  # (models, RPC client, Keychain store) is reachable via @testable import.
+  MantaUITests:
+    type: bundle.unit-test
+    platform: iOS
+    deploymentTarget: "26.0"
+    sources:
+      - path: MantaUITests
+    dependencies:
+      - target: MantaUI
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.antoinedc.mantaui.tests
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_STYLE: Automatic
   # The UI test bundle is the hierarchy-dump leg of the native capture harness.
   # It launches the app and prints the accessibility tree (see capture.sh and
   # MantaUIHierarchyCaptureUITests). It exists to be driven by capture.sh, not
@@ -62,4 +77,5 @@ schemes:
       config: Release
     test:
       targets:
+        - MantaUITests
         - MantaUIUITests


### PR DESCRIPTION
Opened automatically for `multica/BET-592-ios-transport-core`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-592.