### PR TITLE
feat(renderer): wire shadow scale to tokens, drop inline boxShadow (BET-581)

### DIFF
--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -141,8 +141,7 @@ export function TypeaheadPopup({
 }) {
   return (
     <div
-      className="shrink-0 mx-4 mb-1 max-h-[240px] overflow-y-auto rounded-xl border border-border bg-bg-soft text-meta font-mono"
-      style={{ boxShadow: "var(--shadow-md)" }}
+      className="shrink-0 mx-4 mb-1 max-h-[240px] overflow-y-auto rounded-xl border border-border bg-bg-soft text-meta font-mono shadow-md"
     >
       {rows.length === 0 && (
         <div className="px-2 py-1 text-text-faint italic">{emptyHint}</div>

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -231,7 +231,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onCancel}>
       <div
-        className="manta-folder-picker w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col bg-bg-elev border border-border rounded-xl shadow-xl overflow-hidden"
+        className="manta-folder-picker w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col bg-bg-elev border border-border rounded-xl shadow-lg overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -579,7 +579,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
 
       {fanOutWorktrees && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="w-[480px] max-w-[92vw] bg-bg-elev border border-border rounded-xl shadow-xl p-4 space-y-3">
+          <div className="w-[480px] max-w-[92vw] bg-bg-elev border border-border rounded-xl shadow-lg p-4 space-y-3">
             <div className="text-body font-semibold text-text">Fan-out confirmed</div>
             <div className="text-meta text-text-muted">
               Creating one session with {fanOutWorktrees.length} windows (one per

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1166,7 +1166,7 @@ function CommandPalette({
       onClick={onClose}
     >
       <div
-        className="w-[420px] max-w-[90vw] bg-bg-elev border border-border rounded-lg shadow-xl overflow-hidden"
+        className="w-[420px] max-w-[90vw] bg-bg-elev border border-border rounded-lg shadow-lg overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border">

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -73,8 +73,7 @@ export function Toast({ toast, onDismiss }: ToastProps) {
   return (
     <div
       role="status"
-      className="w-full max-w-[420px] rounded-xl border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2"
-      style={{ boxShadow: "var(--shadow-md)" }}
+      className="w-full max-w-[420px] rounded-xl border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2 shadow-md"
     >
       <span className="flex-1 min-w-0 whitespace-pre-wrap break-words">{toast.message}</span>
       {toast.action && (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,6 +84,16 @@ export default {
     height: dimensionScale,
     minHeight: dimensionScale,
     maxHeight: dimensionScale,
+    // The token scale is the whole scale. Declared at theme level (not
+    // extend) so Tailwind's stock shadows — `shadow`, `shadow-xl`,
+    // `shadow-2xl`, `shadow-inner` — cannot be used by accident; only the
+    // three steps tokens.css defines exist.
+    boxShadow: {
+      none: "none",
+      sm: "var(--shadow-sm)",
+      md: "var(--shadow-md)",
+      lg: "var(--shadow-lg)",
+    },
     extend: {
       colors: {
         bg: {


### PR DESCRIPTION
## BET-580.2 — Stage 2 of 5: wire the shadow scale to the tokens

**Base: origin/main @ 46cf0c6**

### What & why
`tailwind.config.js` declared no `boxShadow`, so Tailwind's default scale was
live and `shadow-md` in markup resolved to the stock value, not the
`--shadow-md` token. Two files worked around this with inline
`style={{ boxShadow: "var(--shadow-md)" }}` — two code paths for one thing.

### Changes
- **tailwind.config.js**: added `boxShadow` at **theme level** (beside
  spacing/width/height, NOT in `extend`) with `none/sm/md/lg` → `var(--shadow-*)`.
  Replaces (not merges) Tailwind's default scale, so `shadow-xl`, `shadow-2xl`,
  `shadow-inner` etc. can no longer be used by accident. Verified: built CSS
  exposes only `.shadow-{md,lg}` (plus `sm`/`none` when used).
- **ComposerParts.tsx**: removed the inline `boxShadow` workaround, added
  `shadow-md` to the existing `className`.
- **Toast.tsx**: removed the inline `boxShadow` workaround, added `shadow-md`
  to the existing `className`.
- **Sidebar.tsx / NewSessionScreen.tsx / FolderPickerModal.tsx**: `shadow-xl`
  → `shadow-lg` (the token's third step: "a surface floating over the whole
  window").

### Out of scope (left as-is, per issue)
- `index.css` `.manta-composer-input-row` raw `box-shadow: var(--shadow-sm)`
  (the `:focus-within` layer can't be a utility class).
- The four remaining `boxShadow` **object-style** usages in `.tsx`
  (`ContextBar.tsx:111`, `Terminal.tsx:450`, `SessionHeader.tsx:227`,
  `Onboarding.tsx:94`) are non-scale shadows — inset segment separators and a
  focus ring — not the elevation token, so they are untouched. The issue's
  `grep "shadow-xl\|boxShadow" → no match` acceptance criterion over-matches
  these; the actual intent (`shadow-xl` gone + both inline `--shadow-md`
  workarounds gone) is fully met. `shadow-xl` now has **0** matches.

### Visual baselines
Ran `npm run visual` (22 tests) — all pass with **0** diffs; ran
`npm run visual:update` — **no PNG baseline changed** (working tree clean).
This matches the documented reason in `shadow.visual.ts`: captured regions
crop to the element box and box-shadow paints outside the border box, so no
capture displays the shadow-scale value.

**Files changed:** `6` files.
```
ComposerParts.tsx  | 3 +-
FolderPickerModal.tsx | 2 +-
NewSessionScreen.tsx | 2 +-
Sidebar.tsx | 2 +-
Toast.tsx | 3 +-
tailwind.config.js | 10 +-
```

**Verification results:**
- PR branch (`multica/BET-581-shadow-scale-tokens` @ `2e29ec7`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1426 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `46cf0c6`): not re-run independently — 0 new failures on the PR
  branch, changes are pure config/className (no logic), and the full suite is
  green on the branch.
- **Conclusion:** 0 new failures.