### PR TITLE
feat(ios): S1b event stream, reconnect, and degraded mode (BET-593)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -8,14 +8,18 @@
 
 /* Begin PBXBuildFile section */
 		01871023D47544D64443194D /* MantaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8240F1954861B4846E279D /* MantaModels.swift */; };
+		33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1306D325FEB295B7AB874E /* MantaEventStore.swift */; };
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
+		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
 		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
+		9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
 		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
+		EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,17 +41,21 @@
 
 /* Begin PBXFileReference section */
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
+		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
 		2C13A01F9048A8907CBCC31D /* MantaUIUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		35ECC10E3DB9A931F8EB5420 /* MantaUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MantaUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
+		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
 		799EED7CC4F10C6684A5662C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
 		87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIApp.swift; sourceTree = "<group>"; };
 		8C8240F1954861B4846E279D /* MantaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaModels.swift; sourceTree = "<group>"; };
 		9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTransportTests.swift; sourceTree = "<group>"; };
 		A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptComponents.swift; sourceTree = "<group>"; };
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -73,6 +81,7 @@
 		7168FDC00E99AA075ACA9698 /* MantaUITests */ = {
 			isa = PBXGroup;
 			children = (
+				EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */,
 				9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */,
 			);
 			path = MantaUITests;
@@ -110,7 +119,10 @@
 			children = (
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
 				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
+				1E1306D325FEB295B7AB874E /* MantaEventStore.swift */,
 				8C8240F1954861B4846E279D /* MantaModels.swift */,
+				772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */,
+				7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */,
 				87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */,
@@ -237,6 +249,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */,
 				B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -247,7 +260,10 @@
 			files = (
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,
+				33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */,
 				01871023D47544D64443194D /* MantaModels.swift in Sources */,
+				EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */,
+				5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */,
 				4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */,

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Combine
+
+// ===========================================================================
+// S1b — observable event store + degraded mode (BET-593).
+//
+// The store is the SwiftUI-bindable layer over the /events stream:
+//
+//   - `connectionState` / `degraded` — the stream lifecycle. `degraded` is the
+//     §17 spec: the box became unreachable, so only *new* interpretation stops
+//     and NOTHING already delivered may be clear or re-derived.
+//   - `sessionStates` — the interpreted per-session state the box publishes on
+//     `kind:"stream"` frames, keyed by sessionId, so S4's views can bind.
+//   - reconnect with backoff + re-fetch-on-reconnect (via `resyncHandler`) and
+//     a heartbeat liveness watchdog (half-open socket detection) mirror
+//     src/renderer/api/httpApi.ts.
+//
+// The device never interprets raw events — every `stream.*` payload here is
+// already interpreted by the box (src/server/streamInterp.mjs).
+// ===========================================================================
+
+// MARK: - Per-session interpreted state
+
+struct MantaSessionStreamState: Equatable, Sendable {
+    var sessionId: String
+    /// partID -> accumulated flushed text (the box already applied flush
+    /// boundaries; the device just concatenates).
+    var textByPart: [String: String] = [:]
+    var reasoningByPart: [String: String] = [:]
+    var running: Bool?
+    var turnComplete: Bool?
+    var context: StreamContextPayload?
+    var cache: StreamCachePayload?
+    var truncation: StreamTruncationPayload?
+    var todos: StreamTodosPayload?
+    var questions: StreamQuestionsPayload?
+    var subagents: [StreamSubagentPayload] = []
+
+    init(sessionId: String) {
+        self.sessionId = sessionId
+    }
+}
+
+// MARK: - Pure routing (box `stream.*` subs -> session state)
+
+enum MantaStreamRouter {
+    /// Apply one frame to a session's state. Pure so the mapping is testable.
+    static func applying(_ frame: MantaStreamFrame, to state: MantaSessionStreamState?) -> MantaSessionStreamState {
+        guard frame.kind == "stream", let sub = frame.sub else {
+            return state ?? MantaSessionStreamState(sessionId: frame.sessionId ?? "")
+        }
+        var s = state ?? MantaSessionStreamState(sessionId: frame.sessionId ?? "")
+        switch sub {
+        case "flush":
+            if let p = try? frame.decodedPayload(StreamFlushPayload.self) {
+                if p.field == "reasoning" {
+                    s.reasoningByPart[p.partID, default: ""] += p.text
+                } else {
+                    s.textByPart[p.partID, default: ""] += p.text
+                }
+            }
+        case "running":
+            if let p = try? frame.decodedPayload(StreamRunningPayload.self) { s.running = p.running }
+        case "turnComplete":
+            if let p = try? frame.decodedPayload(StreamTurnCompletePayload.self) { s.turnComplete = p.complete }
+        case "truncation":
+            s.truncation = try? frame.decodedPayload(StreamTruncationPayload.self)
+        case "context":
+            s.context = try? frame.decodedPayload(StreamContextPayload.self)
+        case "cache":
+            s.cache = try? frame.decodedPayload(StreamCachePayload.self)
+        case "todos":
+            s.todos = try? frame.decodedPayload(StreamTodosPayload.self)
+        case "questions":
+            s.questions = try? frame.decodedPayload(StreamQuestionsPayload.self)
+        case "subagent":
+            if let p = try? frame.decodedPayload(StreamSubagentPayload.self) { s.subagents.append(p) }
+        case "subagent.child", "autoRename":
+            break // registration / rename triggers consumed by later stages
+        default:
+            break
+        }
+        return s
+    }
+}
+
+// MARK: - Liveness policy (pure)
+
+enum MantaLivenessPolicy {
+    /// true when the socket reports connected but no frame (incl. heartbeats)
+    /// has arrived within `staleMs` — a half-open path the OS didn't surface.
+    static func shouldForceReconnect(state: MantaConnectionState, lastFrameAt: Date, now: Date, staleMs: Double) -> Bool {
+        guard state.name == "connected" else { return false }
+        return (now.timeIntervalSince(lastFrameAt) * 1000.0) > staleMs
+    }
+}
+
+// MARK: - Stream control abstraction (injectable so the store is testable)
+
+@MainActor
+protocol MantaEventStreamControl: AnyObject {
+    var onState: ((MantaConnectionState) -> Void)? { get set }
+    var onMessage: ((String) -> Void)? { get set }
+    var onReconnect: (() -> Void)? { get set }
+    var onConfigError: ((Error) -> Void)? { get set }
+    var hasConnectedOnce: Bool { get }
+    var currentState: MantaConnectionState { get }
+    func ensure()
+    func markReconnectAndEnsure()
+    func retryNow()
+    func forceReconnect()
+    func close(reason: String)
+}
+
+extension MantaReconnectController: MantaEventStreamControl {}
+
+// MARK: - The store
+
+@MainActor
+final class MantaEventStore: ObservableObject {
+
+    @Published private(set) var connectionState: MantaConnectionState = .idle
+    @Published private(set) var degraded = false
+    @Published private(set) var sessionStates: [String: MantaSessionStreamState] = [:]
+
+    /// Invoked on every healthy reconnect so the app re-fetches state that may
+    /// have changed while disconnected (rather than assuming the stream
+    /// resumed). S4 wires this to re-fetch sessions / messages / permissions /
+    /// questions.
+    var resyncHandler: (() -> Void)?
+
+    /// Event frame we do NOT understand from the interpreted stream are still
+    /// delivered here (raw `opencode`, `status`, …) for consumers that want
+    /// them. S1b only binds to interpreted stream state.
+    var rawFrameHandler: ((MantaStreamFrame) -> Void)?
+
+    private let controller: any MantaEventStreamControl
+    private var lastFrameAt: Date
+    private var watchdog: Timer?
+
+    init(
+        stream: (any MantaEventStreamControl)? = nil,
+        tokenProvider: @escaping () -> String? = { KeychainCredentialStore.shared.boxToken },
+        serverProvider: @escaping () -> URL? = { KeychainCredentialStore.shared.serverURL }
+    ) {
+        self.lastFrameAt = Date()
+        let controller = stream ?? Self.makeController(tokenProvider: tokenProvider, serverProvider: serverProvider)
+        self.controller = controller
+        controller.onState = { [weak self] state in self?.handleState(state) }
+        controller.onMessage = { [weak self] text in self?.handleFrame(text) }
+        controller.onReconnect = { [weak self] in self?.handleReconnect() }
+        controller.onConfigError = { _ in }
+    }
+
+    static func makeController(
+        tokenProvider: @escaping () -> String?,
+        serverProvider: @escaping () -> URL?
+    ) -> any MantaEventStreamControl {
+        MantaReconnectController(
+            url: { Self.eventsWebSocketURL(from: serverProvider()) },
+            makeSocket: { url in
+                MantaURLSessionWebSocket(authHeader: Self.bearer(token: tokenProvider()))
+            }
+        )
+    }
+
+    /// Connect the stream (idempotent) and arm the liveness watchdog.
+    func start() {
+        controller.ensure()
+        startWatchdog()
+    }
+
+    /// App foreground / resume: force a reconnect + resync of missed state.
+    func resume() {
+        controller.markReconnectAndEnsure()
+    }
+
+    /// Permanent teardown.
+    func stop() {
+        watchdog?.invalidate()
+        watchdog = nil
+        controller.close(reason: "store stopped")
+    }
+
+    func restart() {
+        controller.retryNow()
+    }
+
+    /// Tear down / stop scheduling — leaves delivered data intact.
+    func leaveDegradedWithRetry() {
+        restart()
+    }
+
+    // MARK: - Controller callbacks
+
+    private func handleState(_ state: MantaConnectionState) {
+        connectionState = state
+        degraded = controller.hasConnectedOnce && state.isUnreachable
+    }
+
+    private func handleFrame(_ text: String) {
+        lastFrameAt = Date()
+        guard let frame = try? MantaStreamFrame.parse(text) else { return }
+        if frame.isHeartbeat { return }
+        if frame.kind == "stream" {
+            routeStream(frame)
+        } else {
+            rawFrameHandler?(frame)
+        }
+    }
+
+    private func routeStream(_ frame: MantaStreamFrame) {
+        // Degraded mode (§17): only *new* interpretation stops. Nothing already
+        // delivered is cleared or re-derived; the composer stays usable and the
+        // transcript + scroll are untouched because we simply don't mutate the
+        // already-published state while unreachable.
+        guard !degraded else { return }
+        let sid = frame.sessionId ?? ""
+        let next = MantaStreamRouter.applying(frame, to: sessionStates[sid])
+        sessionStates[sid] = next
+    }
+
+    private func handleReconnect() {
+        // On reconnect, re-fetch rather than assuming the stream resumed.
+        resyncHandler?()
+    }
+
+    // MARK: - Liveness watchdog
+
+    private func startWatchdog() {
+        watchdog?.invalidate()
+        let timer = Timer(timeInterval: 15, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.watchdogTick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        watchdog = timer
+    }
+
+    private func watchdogTick() {
+        if MantaLivenessPolicy.shouldForceReconnect(
+            state: connectionState,
+            lastFrameAt: lastFrameAt,
+            now: Date(),
+            staleMs: 45_000
+        ) {
+            controller.forceReconnect()
+        }
+    }
+
+    // MARK: - URL + auth helpers
+
+    static func eventsWebSocketURL(from server: URL?) -> URL? {
+        guard let server else { return nil }
+        var comps = URLComponents(url: server, resolvingAgainstBaseURL: false)
+        comps?.scheme = server.scheme == "https" ? "wss" : "ws"
+        comps?.path = "/events"
+        comps?.query = nil
+        return comps?.url
+    }
+
+    static func bearer(token: String?) -> String? {
+        guard let token, !token.isEmpty else { return nil }
+        return "Bearer \(token)"
+    }
+}

--- a/mobile/native/MantaUI/MantaReconnectController.swift
+++ b/mobile/native/MantaUI/MantaReconnectController.swift
@@ -1,0 +1,337 @@
+import Foundation
+
+// ===========================================================================
+// S1b — reconnecting /events WebSocket (BET-593).
+//
+// Faithful port of the desktop reconnect controller
+// (src/renderer/net/wsTransport.ts) driving the same {kind,payload} event
+// envelope over a WebSocket. It owns:
+//   - the /events socket (Bearer header auth — the box accepts the header on
+//     WS, "a header always wins"),
+//   - exponential-backoff reconnect that never permanently abandons the socket
+//     inside a bounded total window (default 10 min),
+//   - a re-fetch-on-reconnect signal (`onReconnect`), fired on every successful
+//     open that FOLLOWED a drop — the client re-fetches rather than assuming
+//     the stream resumed,
+//   - an unconditional `forceReconnect` used by the liveness watchdog.
+//
+// It is transport-injectable (socket + scheduler) so the whole reconnect /
+// degraded behaviour is unit-testable without real sockets or real sleeps.
+// ===========================================================================
+
+/// Cancel handle for a scheduled fire (real `Timer` or a fake in tests).
+@MainActor
+protocol MantaCancelable: AnyObject {
+    func cancel()
+}
+
+/// Abstract time-scheduler so reconnect delays are testable.
+@MainActor
+protocol MantaScheduler {
+    func schedule(after delayMs: Double, _ block: @escaping @MainActor () -> Void) -> any MantaCancelable
+}
+
+/// Minimal WebSocket surface the controller drives. Deliberately a plain
+/// (non-actor) protocol: the real implementation is a nonisolated class that
+/// hops every callback to the main actor before invoking the closures, so it
+/// does not need to formally cross an actor boundary to adopt
+/// URLSessionWebSocketDelegate.
+protocol MantaWebSocketSession: AnyObject {
+    var onOpen: (@MainActor () -> Void)? { get set }
+    var onMessage: (@MainActor (String) -> Void)? { get set }
+    var onDrop: (@MainActor () -> Void)? { get set }
+    var isOpen: Bool { get }
+    func connect(to url: URL)
+    func close()
+}
+
+/// Real scheduler backed by `Timer` on the main run loop.
+@MainActor
+final class MantaTimerScheduler: MantaScheduler {
+    func schedule(after delayMs: Double, _ block: @escaping @MainActor () -> Void) -> any MantaCancelable {
+        TimerScheduled(delayMs: delayMs, block: block)
+    }
+}
+
+@MainActor
+private final class TimerScheduled: MantaCancelable {
+    private var timer: Timer?
+    init(delayMs: Double, block: @escaping @MainActor () -> Void) {
+        let t = Timer(timeInterval: max(0, delayMs / 1000.0), repeats: false) { _ in
+            Task { @MainActor in block() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        self.timer = t
+    }
+    func cancel() { timer?.invalidate(); timer = nil }
+}
+
+/// Real /events socket using URLSessionWebSocketTask. Authentication is the
+/// `Authorization: Bearer <boxToken>` header on the upgrade request.
+final class MantaURLSessionWebSocket: NSObject, MantaWebSocketSession, URLSessionWebSocketDelegate {
+    var onOpen: (@MainActor () -> Void)?
+    var onMessage: (@MainActor (String) -> Void)?
+    var onDrop: (@MainActor () -> Void)?
+
+    private var task: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private let authHeader: String?
+
+    init(authHeader: String?) {
+        self.authHeader = authHeader
+        super.init()
+    }
+
+    var isOpen: Bool { task?.state == .running }
+
+    func connect(to url: URL) {
+        var request = URLRequest(url: url)
+        if let authHeader, !authHeader.isEmpty {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 60
+        let session = URLSession(configuration: config, delegate: self, delegateQueue: .main)
+        let task = session.webSocketTask(with: request)
+        self.urlSession = session
+        self.task = task
+        task.resume()
+        receive()
+    }
+
+    func close() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        Task { @MainActor [weak self] in self?.onOpen?() }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        Task { @MainActor [weak self] in self?.onDrop?() }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if error != nil {
+            Task { @MainActor [weak self] in self?.onDrop?() }
+        }
+    }
+
+    private func receive() {
+        guard let task else { return }
+        task.receive { [weak self] result in
+            switch result {
+            case .success(let message):
+                switch message {
+                case .string(let text):
+                    Task { @MainActor [weak self] in
+                        self?.onMessage?(text)
+                        self?.receive()
+                    }
+                case .data:
+                    Task { @MainActor [weak self] in self?.receive() }
+                @unknown default:
+                    break
+                }
+            case .failure:
+                Task { @MainActor [weak self] in self?.onDrop?() }
+            }
+        }
+    }
+}
+
+// ===========================================================================
+/// Reconnecting controller (port of WsReconnectController).
+@MainActor
+final class MantaReconnectController {
+
+    /// A healthy open that follows a drop fires this (re-fetch on reconnect).
+    var onReconnect: (() -> Void)?
+    /// Emitted on every state transition (drives the store's degraded flag).
+    var onState: ((MantaConnectionState) -> Void)?
+    /// Delivers one parsed frame string to the consumer.
+    var onMessage: ((String) -> Void)?
+    /// Called once when `url()` yields nothing usable (no server configured).
+    var onConfigError: ((Error) -> Void)?
+
+    private let url: () -> URL?
+    private let makeSocket: (URL) -> any MantaWebSocketSession
+    private let backoff: ExponentialBackoff
+    private let maxTotalWindowMs: Double
+    private let scheduler: any MantaScheduler
+
+    private var socket: (any MantaWebSocketSession)?
+    private var reconnectCancelable: (any MantaCancelable)?
+    private var deadlineCancelable: (any MantaCancelable)?
+    private var attempt = 0
+    private var hadDrop = false
+
+    init(
+        url: @escaping @MainActor () -> URL?,
+        makeSocket: @escaping @MainActor (URL) -> any MantaWebSocketSession,
+        backoff: ExponentialBackoff = ExponentialBackoff(),
+        maxTotalWindowMs: Double = 10 * 60_000,
+        scheduler: any MantaScheduler = MantaTimerScheduler()
+    ) {
+        self.url = url
+        self.makeSocket = makeSocket
+        self.backoff = backoff
+        self.maxTotalWindowMs = maxTotalWindowMs
+        self.scheduler = scheduler
+    }
+
+    var currentState: MantaConnectionState { _state }
+    private var _state: MantaConnectionState = .idle
+
+    /// True once the stream has had at least one healthy connect. The store
+    /// uses this to distinguish "fresh connecting" (not degraded) from "was up
+    /// and dropped" (degraded).
+    var hasConnectedOnce = false
+
+    /// Ensure a live socket. Idempotent when already live.
+    func ensure() {
+        if let socket, socket.isOpen {
+            return
+        }
+        open()
+    }
+
+    /// Unconditional restart (liveness watchdog / app foreground resume):
+    /// mark the next open as a reconnect (so onReconnect fires) and reopen now.
+    func forceReconnect() {
+        hadDrop = true
+        attempt = 0
+        open()
+    }
+
+    func markReconnectAndEnsure() {
+        hadDrop = true
+        ensure()
+    }
+
+    func retryNow() {
+        attempt = 0
+        reconnectCancelable?.cancel()
+        reconnectCancelable = nil
+        deadlineCancelable?.cancel()
+        deadlineCancelable = nil
+        hadDrop = true
+        open()
+        if maxTotalWindowMs > 0, deadlineCancelable == nil,
+           !(_state.name == "connected" || _state.name == "closed") {
+            armDeadline()
+        }
+    }
+
+    func close(reason: String) {
+        reconnectCancelable?.cancel()
+        reconnectCancelable = nil
+        deadlineCancelable?.cancel()
+        deadlineCancelable = nil
+        socket?.close()
+        socket = nil
+        transition(.closed(reason: reason))
+    }
+
+    // MARK: - Socket callbacks
+
+    private func socketDidOpen(_ sock: any MantaWebSocketSession) {
+        guard sock === self.socket else { return }
+        attempt = 0
+        hasConnectedOnce = true
+        deadlineCancelable?.cancel()
+        deadlineCancelable = nil
+        transition(.connected)
+        if hadDrop {
+            hadDrop = false
+            onReconnect?()
+        }
+    }
+
+    private func socketDidReceive(_ sock: any MantaWebSocketSession, text: String) {
+        guard sock === self.socket else { return }
+        onMessage?(text)
+    }
+
+    private func socketDidDrop(_ sock: any MantaWebSocketSession) {
+        guard sock === self.socket else { return }
+        drop()
+    }
+
+    // MARK: - Internal
+
+    private func open() {
+        reconnectCancelable?.cancel()
+        reconnectCancelable = nil
+        socket?.close()
+        socket = nil
+
+        guard let url = url() else {
+            onConfigError?(MantaError.transport("no server configured"))
+            transition(.closed(reason: "no server configured"))
+            return
+        }
+        transition(.connecting(attempt: attempt))
+        let sock = makeSocket(url)
+        sock.onOpen = { [weak self, weak sock] in
+            guard let self, let sock else { return }
+            self.socketDidOpen(sock)
+        }
+        sock.onMessage = { [weak self, weak sock] text in
+            guard let self, let sock else { return }
+            self.socketDidReceive(sock, text: text)
+        }
+        sock.onDrop = { [weak self, weak sock] in
+            guard let self, let sock else { return }
+            self.socketDidDrop(sock)
+        }
+        self.socket = sock
+        sock.connect(to: url)
+    }
+
+    private func drop() {
+        guard self.socket != nil, reconnectCancelable == nil else { return }
+        // A drop means the next successful open is a *reconnect* (→ onReconnect
+        // → re-fetch), matching the reference controller.
+        hadDrop = true
+        let delay = backoff.delayMs(forAttempt: attempt)
+        attempt += 1
+        transition(.reconnecting(attempt: attempt, backoffMs: delay))
+        reconnectCancelable = scheduler.schedule(after: delay) { [weak self] in
+            guard let self else { return }
+            self.reconnectCancelable = nil
+            self.open()
+        }
+        if maxTotalWindowMs > 0 {
+            armDeadline()
+        }
+    }
+
+    private func armDeadline() {
+        guard deadlineCancelable == nil, maxTotalWindowMs > 0 else { return }
+        deadlineCancelable = scheduler.schedule(after: maxTotalWindowMs) { [weak self] in
+            guard let self else { return }
+            self.deadlineCancelable = nil
+            if self._state.name != "connected" {
+                self.close(reason: "reconnect window exceeded")
+            }
+        }
+    }
+
+    private func transition(_ next: MantaConnectionState) {
+        _state = next
+        onState?(next)
+    }
+}

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+// ===========================================================================
+// S1b — event stream transport models (BET-593).
+//
+// Port of the box /events contract from src/renderer/api/httpApi.ts. The
+// /events endpoint is a WebSocket that delivers one JSON text frame per event
+// in the SAME {kind, payload, sub, sessionId} envelope as the SSE route
+// (src/server/events.mjs). The box interprets the raw opencode stream
+// box-side (src/server/streamInterp.mjs) and republishes the derived events as
+// `kind:"stream"` frames with a `sub` routing field. This file owns the pure,
+// sendable, unit-testable half of that: the exponential backoff, the
+// connection-state machine (ports of src/shared/net/backoff.ts + state.ts),
+// the frame envelope + parse, and the typed interpreted-stream payloads.
+//
+// The DEVICE DOES NOT interpret raw events (see §17). Every payload below is
+// already interpreted by the box; the device only demuxes and stores it.
+// ===========================================================================
+
+// MARK: - Exponential backoff (port of src/shared/net/backoff.ts)
+
+/// Deterministic exponential backoff. `delayMs(forAttempt:)` returns a
+/// full-jitter delay in `[0, base * factor^attempt]` capped at `max`.
+struct ExponentialBackoff: Equatable, Sendable {
+    var baseMs: Double
+    var maxMs: Double
+    var factor: Double
+    var jitter: Bool
+
+    /// Matches the reference default: 1s → 15s, binary growth, full jitter.
+    init(base: Double = 1000, max: Double = 15000, factor: Double = 2, jitter: Bool = true) {
+        self.baseMs = base
+        self.maxMs = max
+        self.factor = factor
+        self.jitter = jitter
+    }
+
+    /// The capped, un-jittered delay for `attempt` (0-indexed): base*factor^n.
+    func cappedDelayMs(forAttempt attempt: Int) -> Double {
+        let computed = baseMs * pow(factor, Double(Swift.max(0, attempt)))
+        return Swift.min(computed, maxMs)
+    }
+
+    /// The scheduled delay for `attempt`. With jitter, a uniform random in
+    /// `[0, capped]`; without, exactly `capped`. `rng` is injectable so tests
+    /// can pin the value.
+    func delayMs(forAttempt attempt: Int, rng: () -> Double = { Double.random(in: 0.0..<1.0) }) -> Double {
+        let capped = cappedDelayMs(forAttempt: attempt)
+        guard jitter else { return capped }
+        return rng() * capped
+    }
+}
+
+// MARK: - Connection state machine (port of src/shared/net/state.ts)
+
+enum MantaConnectionState: Equatable, Sendable {
+    case idle
+    case connecting(attempt: Int)
+    case connected
+    case stalled
+    case reconnecting(attempt: Int, backoffMs: Double)
+    case closed(reason: String)
+
+    var name: String {
+        switch self {
+        case .idle: return "idle"
+        case .connecting: return "connecting"
+        case .connected: return "connected"
+        case .stalled: return "stalled"
+        case .reconnecting: return "reconnecting"
+        case .closed: return "closed"
+        }
+    }
+
+    /// True while the stream is NOT carrying events. Used to drive degraded
+    /// mode once the box was reachable and then dropped.
+    var isUnreachable: Bool {
+        switch self {
+        case .idle, .connecting: return false
+        case .connected: return false
+        case .stalled, .reconnecting, .closed: return true
+        }
+    }
+}
+
+/// Legal single-step transitions, mirroring the reference table.
+enum MantaConnectionRule {
+    static func canTransition(from: MantaConnectionState, to: MantaConnectionState) -> Bool {
+        let table: [String: Set<String>] = [
+            "idle": ["connecting"],
+            "connecting": ["connected", "reconnecting", "closed"],
+            "connected": ["stalled", "closed"],
+            "stalled": ["reconnecting", "connected", "closed"],
+            "reconnecting": ["connected", "reconnecting", "closed"],
+            "closed": ["idle"],
+        ]
+        guard let allowed = table[from.name] else { return false }
+        return allowed.contains(to.name)
+    }
+}
+
+// MARK: - Frame envelope + parse
+
+/// A parsed /events frame. `payload` is kept as `JSONValue` so both the raw
+/// opencode events and the typed interpreted stream payloads stay reachable.
+/// The box publishes `{ kind, payload, sub, sessionId }` per frame.
+struct MantaStreamFrame: Equatable, Sendable {
+    var kind: String
+    var sub: String?
+    var sessionId: String?
+    var payload: JSONValue?
+
+    var isHeartbeat: Bool { kind == "heartbeat" }
+
+    /// Decode `payload` into a concrete Decodable type.
+    func decodedPayload<T: Decodable>(_ type: T.Type) throws -> T? {
+        guard let payload else { return nil }
+        let data = try JSONEncoder().encode(payload)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    static func parse(_ text: String) throws -> MantaStreamFrame {
+        let data = Data(text.utf8)
+        let json = try JSONDecoder().decode(JSONValue.self, from: data)
+        guard case .object(let obj) = json else {
+            throw MantaError.transport("event frame not an object")
+        }
+        func string(_ key: String) -> String? {
+            if case .string(let s)? = obj[key] { return s }
+            return nil
+        }
+        guard let kind = string("kind") else {
+            throw MantaError.transport("event frame missing kind")
+        }
+        return MantaStreamFrame(
+            kind: kind,
+            sub: string("sub"),
+            sessionId: string("sessionId"),
+            payload: obj["payload"]
+        )
+    }
+}
+
+// MARK: - Interpreted stream payloads (produced by src/server/streamInterp.mjs)
+
+/// `sub: "flush"` — a text/reasoning delta flushed at a markdown-safe
+/// boundary. `field` is `"text"` or `"reasoning"`. This is the raw material
+/// S4 accumulates into the transcript (the box already applied flush
+/// boundaries; the device just concatenates `text` onto the part).
+struct StreamFlushPayload: Codable, Equatable, Sendable {
+    var messageID: String
+    var partID: String
+    var field: String
+    var text: String
+}
+
+/// `sub: "running"` — derived from `session.status` (busy/tworking/retry).
+struct StreamRunningPayload: Codable, Equatable, Sendable {
+    var running: Bool
+}
+
+/// `sub: "turnComplete"` — emitted by `message.updated`/`session.idle`.
+struct StreamTurnCompletePayload: Codable, Equatable, Sendable {
+    var complete: Bool
+    var running: Bool
+}
+
+/// `sub: "truncation"` — classifyFinish result, box-classified.
+struct StreamTruncationPayload: Codable, Equatable, Sendable {
+    var kind: String
+    var label: String
+    var messageID: String?
+}
+
+/// `sub: "context"` — computeContextBreakdown output (all box-computed).
+struct StreamContextSegment: Codable, Equatable, Sendable {
+    var kind: String
+    var pct: Double
+}
+
+struct StreamContextPayload: Codable, Equatable, Sendable {
+    var freshInput: Double
+    var cacheRead: Double
+    var cacheWrite: Double
+    var totalInput: Double
+    var pct: Double
+    var segments: [StreamContextSegment]
+}
+
+/// `sub: "cache"` — computeStaleCache output.
+struct StreamCachePayload: Codable, Equatable, Sendable {
+    var isStale: Bool
+    var idleMs: Double
+    var staleTokens: Double
+    var ttlMs: Double
+}
+
+/// `sub: "todos"` — selectActiveTodos + selectVisibleTodos output.
+struct StreamTodoItem: Codable, Equatable, Sendable {
+    var id: String?
+    var content: String?
+    var status: String?
+
+    enum CodingKeys: String, CodingKey { case id, content, status }
+
+    init(id: String? = nil, content: String? = nil, status: String? = nil) {
+        self.id = id
+        self.content = content
+        self.status = status
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id)
+        content = try c.decodeIfPresent(String.self, forKey: .content)
+        status = try c.decodeIfPresent(String.self, forKey: .status)
+    }
+}
+
+struct StreamVisibleTodos: Codable, Equatable, Sendable {
+    var visible: [StreamTodoItem]
+    var hiddenPending: Double
+    var hiddenDone: Double
+}
+
+struct StreamTodosPayload: Codable, Equatable, Sendable {
+    var active: [StreamTodoItem]?
+    var visible: StreamVisibleTodos?
+    var allTerminal: Bool
+    var anyTerminal: Bool
+}
+
+/// `sub: "questions"` — applyQuestionEvent output (QuestionLike rows).
+struct StreamQuestionsPayload: Codable, Equatable, Sendable {
+    var questions: [QuestionRequest]
+}
+
+/// `sub: "subagent"` — extractSubagentInfo + runningCount.
+struct StreamSubagentPayload: Codable, Equatable, Sendable {
+    var childSessionId: String
+    var agent: String?
+    var description: String?
+    var prompt: String?
+    var status: String?
+    var title: String?
+    var output: String?
+    var truncated: Bool?
+    var durationMs: Double?
+    var runningCount: Double?
+    var model: StreamSubagentModel?
+
+    struct StreamSubagentModel: Codable, Equatable, Sendable {
+        var providerID: String?
+        var modelID: String?
+    }
+}
+
+/// `sub: "subagent.child"` — a child session registered via session.created.
+struct StreamSubagentChildPayload: Codable, Equatable, Sendable {
+    var childSessionId: String
+}
+
+/// `sub: "autoRename"` — a title-summarization trigger.
+struct StreamAutoRenamePayload: Codable, Equatable, Sendable {
+    var turns: Double
+    var promptInput: String
+    var instruction: String
+}

--- a/mobile/native/MantaUI/MantaUIApp.swift
+++ b/mobile/native/MantaUI/MantaUIApp.swift
@@ -2,9 +2,18 @@ import SwiftUI
 
 @main
 struct MantaUIApp: App {
+    // S1b: the observable event store is the app-wide owner of the /events
+    // stream. It binds to whatever SwiftUI views S4 mounts (session lists,
+    // chat transcript, subagents) and owns reconnect + degraded mode. When a
+    // box is paired (serverUrl + boxToken in the Keychain) it connects live;
+    // otherwise start() no-ops into a closed state without spinning.
+    @StateObject private var store = MantaEventStore()
+
     var body: some Scene {
         WindowGroup {
             RootView()
+                .environmentObject(store)
+                .task { store.start() }
         }
     }
 }

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -1,0 +1,471 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// S1b — event stream tests (BET-593)
+//
+// Covers the pure + transport-injectable halves: frame parsing, typed
+// interpreted-payload decoding, the router (box `stream.*` subs -> session
+// state), the backoff/connection-state/liveness policies, the reconnect
+// controller (drop -> backup -> reconnect -> re-fetch), and the store's
+// degraded mode (only NEW interpretation stops; already-delivered data is
+// never cleared or re-derived).
+// ===========================================================================
+
+// MARK: - Fakes
+
+private final class FakeSocket: MantaWebSocketSession {
+    var onOpen: (@MainActor () -> Void)?
+    var onMessage: (@MainActor (String) -> Void)?
+    var onDrop: (@MainActor () -> Void)?
+    var isOpen = false
+    var connectCount = 0
+    var openedURL: URL?
+    var closeCount = 0
+
+    func connect(to url: URL) {
+        connectCount += 1
+        openedURL = url
+        isOpen = true
+    }
+    func close() { isOpen = false; closeCount += 1 }
+    @MainActor func simulateOpen() { onOpen?() }
+    @MainActor func simulateMessage(_ text: String) { onMessage?(text) }
+    @MainActor func simulateDrop() { isOpen = false; onDrop?() }
+}
+
+@MainActor
+private final class FakeScheduler: MantaScheduler {
+    struct Item {
+        let delayMs: Double
+        let token: UUID
+        let block: @MainActor () -> Void
+    }
+    private var items: [Item] = []
+    private var cancelled: Set<UUID> = []
+
+    func schedule(after delayMs: Double, _ block: @escaping @MainActor () -> Void) -> any MantaCancelable {
+        let item = Item(delayMs: delayMs, token: UUID(), block: block)
+        items.append(item)
+        return FakeCancelable(token: item.token) { [weak self] token in self?.cancelled.insert(token) }
+    }
+
+    var count: Int { items.count }
+    func delay(at index: Int) -> Double? { items.indices.contains(index) ? items[index].delayMs : nil }
+    func fire(at index: Int) {
+        guard items.indices.contains(index), !cancelled.contains(items[index].token) else { return }
+        items[index].block()
+    }
+}
+
+@MainActor
+private final class FakeCancelable: MantaCancelable {
+    private let token: UUID
+    private let onCancel: (UUID) -> Void
+    init(token: UUID, onCancel: @escaping (UUID) -> Void) {
+        self.token = token
+        self.onCancel = onCancel
+    }
+    func cancel() { onCancel(token) }
+}
+
+@MainActor
+private final class FakeStreamControl: MantaEventStreamControl {
+    var onState: ((MantaConnectionState) -> Void)?
+    var onMessage: ((String) -> Void)?
+    var onReconnect: (() -> Void)?
+    var onConfigError: ((Error) -> Void)?
+    var hasConnectedOnce = false
+    var currentState: MantaConnectionState = .idle
+    var makeSocket: ((URL) -> any MantaWebSocketSession)?
+
+    func ensure() {}
+    func markReconnectAndEnsure() {}
+    func retryNow() {}
+    func forceReconnect() {}
+    func close(reason: String) {}
+
+    func drive(_ state: MantaConnectionState) { onState?(state) }
+    func inject(_ text: String) { onMessage?(text) }
+    func injectReconnect() { onReconnect?() }
+}
+
+// MARK: - Frame parsing + payload decoding
+
+@MainActor
+final class MantaEventStreamModelTests: XCTestCase {
+    private func frame(_ text: String) throws -> MantaStreamFrame {
+        try MantaStreamFrame.parse(text)
+    }
+
+    func testParsesStreamFlushEnvelope() throws {
+        let f = try frame(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello"}}"#)
+        XCTAssertEqual(f.kind, "stream")
+        XCTAssertEqual(f.sub, "flush")
+        XCTAssertEqual(f.sessionId, "ses_1")
+        XCTAssertFalse(f.isHeartbeat)
+        let p = try XCTUnwrap(f.decodedPayload(StreamFlushPayload.self))
+        XCTAssertEqual(p.messageID, "msg_2")
+        XCTAssertEqual(p.partID, "part_3")
+        XCTAssertEqual(p.field, "text")
+        XCTAssertEqual(p.text, "Hello")
+    }
+
+    func testParsesHeartbeatFrame() throws {
+        let f = try frame(#"{"kind":"heartbeat","ts":1750000000000}"#)
+        XCTAssertTrue(f.isHeartbeat)
+        XCTAssertNil(f.payload)
+    }
+
+    func testParsesRunningPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamRunningPayload.self))
+        XCTAssertTrue(p.running)
+    }
+
+    func testParsesTurnCompletePayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamTurnCompletePayload.self))
+        XCTAssertTrue(p.complete)
+        XCTAssertFalse(p.running)
+    }
+
+    func testParsesContextPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"context","sessionId":"ses_1","payload":{"freshInput":10,"cacheRead":5,"cacheWrite":2,"totalInput":17,"pct":8,"segments":[{"kind":"fresh","pct":5},{"kind":"cacheWrite","pct":1},{"kind":"cacheRead","pct":2}]}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamContextPayload.self))
+        XCTAssertEqual(p.freshInput, 10)
+        XCTAssertEqual(p.cacheRead, 5)
+        XCTAssertEqual(p.pct, 8)
+        XCTAssertEqual(p.segments.count, 3)
+    }
+
+    func testParsesTruncationPayloadWithMessageID() throws {
+        let f = try frame(#"{"kind":"stream","sub":"truncation","sessionId":"ses_1","payload":{"kind":"output-cap","label":"truncated (output limit)","messageID":"msg_2"}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamTruncationPayload.self))
+        XCTAssertEqual(p.kind, "output-cap")
+        XCTAssertEqual(p.messageID, "msg_2")
+    }
+
+    func testParsesTodosPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"todos","sessionId":"ses_1","payload":{"active":[{"status":"in_progress","content":"run tests"}],"visible":{"visible":[{"status":"in_progress","content":"run tests"}],"hiddenPending":0,"hiddenDone":0},"allTerminal":false,"anyTerminal":false}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamTodosPayload.self))
+        XCTAssertEqual(p.active?.first?.content, "run tests")
+        XCTAssertEqual(p.visible?.visible.count, 1)
+        XCTAssertFalse(p.allTerminal)
+    }
+
+    func testParsesSubagentPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"subagent","sessionId":"ses_1","payload":{"childSessionId":"ses_child","agent":"general","status":"running","runningCount":1,"model":{"providerID":"anthropic","modelID":"claude-sonnet-4-6"}}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamSubagentPayload.self))
+        XCTAssertEqual(p.childSessionId, "ses_child")
+        XCTAssertEqual(p.runningCount, 1)
+        XCTAssertEqual(p.model?.providerID, "anthropic")
+    }
+
+    func testParsesQuestionsPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"questions","sessionId":"ses_1","payload":{"questions":[{"id":"q_1","sessionID":"ses_1","requestId":"que_5","questions":[{"question":"Pick","header":"Pick a DB","options":[{"label":"Postgres","description":""}]}],"tool":{"messageID":"msg_3","callID":"toolu_9"}}]}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamQuestionsPayload.self))
+        XCTAssertEqual(p.questions.count, 1)
+        XCTAssertEqual(p.questions[0].id, "q_1")
+        XCTAssertEqual(p.questions[0].requestId, "que_5")
+        XCTAssertEqual(p.questions[0].questions[0].header, "Pick a DB")
+        XCTAssertEqual(p.questions[0].tool?.callID, "toolu_9")
+    }
+
+    func testFrameMissingKindThrows() {
+        XCTAssertThrowsError(try MantaStreamFrame.parse(#"{"payload":{}}"#))
+    }
+
+    func testFrameNotObjectThrows() {
+        XCTAssertThrowsError(try MantaStreamFrame.parse(#"[1,2,3]"#))
+    }
+
+    func testBackoffCappedSchedule() {
+        let b = ExponentialBackoff(jitter: false)
+        XCTAssertEqual(b.cappedDelayMs(forAttempt: 0), 1000)
+        XCTAssertEqual(b.cappedDelayMs(forAttempt: 1), 2000)
+        XCTAssertEqual(b.cappedDelayMs(forAttempt: 4), 15000) // capped at max
+        XCTAssertEqual(b.delayMs(forAttempt: 4, rng: { 1.0 }), 15000) // capped at max
+    }
+
+    func testBackoffJitterWithinBounds() {
+        let b = ExponentialBackoff(jitter: true)
+        for attempt in 0..<5 {
+            for _ in 0..<50 {
+                let d = b.delayMs(forAttempt: attempt, rng: { 0.5 })
+                XCTAssertGreaterThanOrEqual(d, 0)
+                XCTAssertLessThanOrEqual(d, b.cappedDelayMs(forAttempt: attempt))
+            }
+        }
+    }
+
+    func testConnectionStateTransitions() {
+        XCTAssertTrue(MantaConnectionRule.canTransition(from: .idle, to: .connecting(attempt: 0)))
+        XCTAssertTrue(MantaConnectionRule.canTransition(from: .connecting(attempt: 0), to: .connected))
+        XCTAssertTrue(MantaConnectionRule.canTransition(from: .connected, to: .stalled))
+        XCTAssertTrue(MantaConnectionRule.canTransition(from: .stalled, to: .reconnecting(attempt: 1, backoffMs: 1000)))
+        XCTAssertTrue(MantaConnectionRule.canTransition(from: .reconnecting(attempt: 1, backoffMs: 1000), to: .connected))
+        XCTAssertTrue(MantaConnectionRule.canTransition(from: .closed(reason: "x"), to: .idle))
+        XCTAssertFalse(MantaConnectionRule.canTransition(from: .connected, to: .connecting(attempt: 0)))
+        XCTAssertFalse(MantaConnectionRule.canTransition(from: .idle, to: .closed(reason: "x")))
+    }
+
+    func testConnectionStateUnreachableFlags() {
+        XCTAssertFalse(MantaConnectionState.connected.isUnreachable)
+        XCTAssertFalse(MantaConnectionState.connecting(attempt: 0).isUnreachable)
+        XCTAssertTrue(MantaConnectionState.reconnecting(attempt: 1, backoffMs: 1000).isUnreachable)
+        XCTAssertTrue(MantaConnectionState.closed(reason: "x").isUnreachable)
+    }
+
+    func testLivenessPolicy() {
+        let last = Date()
+        let future = last.addingTimeInterval(50) // 50s later
+        XCTAssertTrue(MantaLivenessPolicy.shouldForceReconnect(
+            state: .connected, lastFrameAt: last, now: future, staleMs: 45_000))
+        XCTAssertFalse(MantaLivenessPolicy.shouldForceReconnect(
+            state: .connected, lastFrameAt: last, now: future.addingTimeInterval(-10), staleMs: 45_000))
+        XCTAssertFalse(MantaLivenessPolicy.shouldForceReconnect(
+            state: .reconnecting(attempt: 1, backoffMs: 1000), lastFrameAt: last, now: future, staleMs: 45_000))
+    }
+}
+
+// MARK: - Router
+
+@MainActor
+final class MantaEventStreamRouterTests: XCTestCase {
+    func testAccumulatesFlushDeltasAcrossParts() throws {
+        let f1 = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello "}}"#)
+        let f2 = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"world"}}"#)
+        let f3 = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"other","field":"text","text":"x"}}"#)
+
+        var state = MantaStreamRouter.applying(f1, to: nil)
+        state = MantaStreamRouter.applying(f2, to: state)
+        state = MantaStreamRouter.applying(f3, to: state)
+
+        XCTAssertEqual(state.textByPart["part_3"], "Hello world")
+        XCTAssertEqual(state.textByPart["other"], "x")
+    }
+
+    func testSetsRunningAndTurnComplete() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        let running = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#)
+        let complete = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+        state = MantaStreamRouter.applying(running, to: state)
+        XCTAssertEqual(state.running, true)
+        state = MantaStreamRouter.applying(complete, to: state)
+        XCTAssertEqual(state.turnComplete, true)
+        XCTAssertEqual(state.running, true) // running is only set by `running` sub
+    }
+
+    func testNonStreamFrameLeavesStateUntouched() throws {
+        let original = MantaSessionStreamState(sessionId: "ses_1")
+        let status = try MantaStreamFrame.parse(#"{"kind":"status","payload":[]}"#)
+        let resulting = MantaStreamRouter.applying(status, to: original)
+        XCTAssertEqual(resulting, original)
+    }
+}
+
+// MARK: - Reconnect controller
+
+@MainActor
+final class MantaReconnectControllerTests: XCTestCase {
+    private func makeController(socket: FakeSocket, scheduler: FakeScheduler) -> MantaReconnectController {
+        MantaReconnectController(
+            url: { URL(string: "wss://0123.boxes.mantaui.com/events") },
+            makeSocket: { _ in socket },
+            backoff: ExponentialBackoff(jitter: false),
+            maxTotalWindowMs: 10 * 60_000,
+            scheduler: scheduler
+        )
+    }
+
+    func testInitialOpenIsNotARecoverableReconnect() async {
+        let socket = FakeSocket()
+        let scheduler = FakeScheduler()
+        let controller = makeController(socket: socket, scheduler: scheduler)
+        var reconnectCount = 0
+        controller.onReconnect = { reconnectCount += 1 }
+
+        await MainActor.run {
+            controller.ensure()
+            XCTAssertEqual(controller.currentState, .connecting(attempt: 0))
+            socket.simulateOpen()
+            XCTAssertEqual(controller.currentState, .connected)
+            XCTAssertEqual(reconnectCount, 0) // initial open is not a reconnect
+            XCTAssertEqual(socket.openedURL?.absoluteString, "wss://0123.boxes.mantaui.com/events")
+        }
+    }
+
+    func testDropBacksOffAndReconnectRefetches() async {
+        let socket = FakeSocket()
+        let scheduler = FakeScheduler()
+        let controller = makeController(socket: socket, scheduler: scheduler)
+        var reconnectCount = 0
+        controller.onReconnect = { reconnectCount += 1 }
+
+        await MainActor.run {
+            controller.ensure()
+            socket.simulateOpen()
+            XCTAssertEqual(socket.connectCount, 1)
+
+            socket.simulateDrop()
+            guard case .reconnecting(let attempt, let backoffMs) = controller.currentState else {
+                return XCTFail("expected reconnecting, got \(controller.currentState)")
+            }
+            XCTAssertEqual(attempt, 1)
+            XCTAssertEqual(backoffMs, 1000) // attempt 0, base 1000ms, no jitter
+            XCTAssertGreaterThanOrEqual(scheduler.count, 2)
+            XCTAssertEqual(scheduler.delay(at: 0), 1000) // reconnect scheduled first
+            XCTAssertEqual(scheduler.delay(at: 1), 10 * 60_000) // deadline second
+
+            // Fire the scheduled reconnect -> fresh open
+            scheduler.fire(at: 0)
+            XCTAssertEqual(socket.connectCount, 2)
+
+            socket.simulateOpen()
+            XCTAssertEqual(controller.currentState, .connected)
+            XCTAssertEqual(reconnectCount, 1) // drop then open => re-fetch
+        }
+    }
+
+    func testReconnectResetsBackoffAfterHealthyOpen() async {
+        let socket = FakeSocket()
+        let scheduler = FakeScheduler()
+        let controller = makeController(socket: socket, scheduler: scheduler)
+
+        await MainActor.run {
+            controller.ensure()
+            socket.simulateOpen()
+            socket.simulateDrop()
+            XCTAssertEqual(scheduler.delay(at: 0), 1000) // first reconnect
+            scheduler.fire(at: 0)
+            socket.simulateOpen() // healthy reconnect: onReconnect fires
+            socket.simulateDrop() // fresh drop after healthy open
+            // Backoff restarts at base after a healthy open (attempt reset).
+            guard case .reconnecting(let attempt, let backoffMs) = controller.currentState else {
+                return XCTFail("expected reconnecting, got \(controller.currentState)")
+            }
+            XCTAssertEqual(attempt, 1)
+            XCTAssertEqual(backoffMs, 1000)
+        }
+    }
+
+    func testTotalWindowExceededCloses() async {
+        let socket = FakeSocket()
+        let scheduler = FakeScheduler()
+        let controller = makeController(socket: socket, scheduler: scheduler)
+
+        await MainActor.run {
+            controller.ensure()
+            socket.simulateOpen()
+            socket.simulateDrop()
+            // entry 1 is the deadline (maxTotalWindowMs): reconnect is entry 0.
+            XCTAssertEqual(scheduler.delay(at: 1), 10 * 60_000)
+            scheduler.fire(at: 1)
+            XCTAssertEqual(controller.currentState, .closed(reason: "reconnect window exceeded"))
+        }
+    }
+
+    func testForceReconnectMarksNextOpenAsReconnect() async {
+        let socket = FakeSocket()
+        let scheduler = FakeScheduler()
+        let controller = makeController(socket: socket, scheduler: scheduler)
+        var reconnectCount = 0
+        controller.onReconnect = { reconnectCount += 1 }
+
+        await MainActor.run {
+            controller.ensure()
+            socket.simulateOpen()
+            XCTAssertEqual(reconnectCount, 0)
+            controller.forceReconnect()
+            XCTAssertEqual(socket.connectCount, 2)
+            socket.simulateOpen()
+            XCTAssertEqual(reconnectCount, 1)
+        }
+    }
+}
+
+// MARK: - Store + degraded mode
+
+@MainActor
+final class MantaEventStoreTests: XCTestCase {
+    private func makeStore(_ fake: FakeStreamControl) -> MantaEventStore {
+        MantaEventStore(
+            stream: fake,
+            tokenProvider: { "feedfacefeedfacefeedfacefeedface" },
+            serverProvider: { URL(string: "https://0123.boxes.mantaui.com") }
+        )
+    }
+
+    func testRoutesFramesIntoSessionState() throws {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = true
+        fake.drive(.connected)
+        let store = makeStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello"}}"#)
+        fake.inject(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#)
+
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+        XCTAssertEqual(store.sessionStates["ses_1"]?.running, true)
+    }
+
+    func testHeartbeatDoesNotMutateSessionState() throws {
+        let fake = FakeStreamControl()
+        fake.drive(.connected)
+        let store = makeStore(fake)
+        fake.inject(#"{"kind":"heartbeat","ts":1e12}"#)
+        XCTAssertTrue(store.sessionStates.isEmpty)
+    }
+
+    func testDegradedStopsNewInterpretationButKeepsDeliveredData() throws {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = true
+        fake.drive(.connected)
+        let store = makeStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello"}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+        XCTAssertFalse(store.degraded)
+
+        // Box becomes unreachable -> degraded, but delivered data is intact.
+        fake.drive(.reconnecting(attempt: 1, backoffMs: 1000))
+        XCTAssertTrue(store.degraded)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+
+        // New interpretation while degraded is NOT applied.
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_4","field":"text","text":"NEW"}}"#)
+        XCTAssertNil(store.sessionStates["ses_1"]?.textByPart["part_4"])
+
+        // Restore -> re-fetch fires + new interpretation applies again.
+        var resyncCount = 0
+        store.resyncHandler = { resyncCount += 1 }
+        fake.injectReconnect()
+        XCTAssertEqual(resyncCount, 1)
+        fake.drive(.connected)
+        XCTAssertFalse(store.degraded)
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_4","field":"text","text":"AFTER"}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_4"], "AFTER")
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+    }
+
+    func testFreshConnectingIsNotDegraded() {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = false
+        let store = makeStore(fake)
+        fake.drive(.connecting(attempt: 0))
+        XCTAssertFalse(store.degraded)
+    }
+
+    func testBuildsWebSocketURLFromServerURL() throws {
+        let server = URL(string: "https://0123.boxes.mantaui.com")
+        let ws = try XCTUnwrap(MantaEventStore.eventsWebSocketURL(from: server))
+        XCTAssertEqual(ws.absoluteString, "wss://0123.boxes.mantaui.com/events")
+    }
+
+    func testBearerHeader() {
+        XCTAssertEqual(MantaEventStore.bearer(token: "abc"), "Bearer abc")
+        XCTAssertNil(MantaEventStore.bearer(token: ""))
+        XCTAssertNil(MantaEventStore.bearer(token: nil))
+    }
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-593-event-stream`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-593.