### PR TITLE
feat(welcome): adopt Card danger primitive for error banner (BET-584)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -79,7 +79,7 @@ that vanishes. Adopter counts below are **web** adopters only.
 
 | Primitive | File | Adopters | Variants |
 | --- | --- | --- | --- |
-| Card | `src/renderer/Card.tsx` | 2 — `Cards.tsx`, `Settings.tsx` | `danger` (optional); `header`/`actions` slots |
+| Card | `src/renderer/Card.tsx` | 3 — `Cards.tsx`, `Settings.tsx`, `NewSessionScreen.tsx` | `danger` (optional); `header`/`actions` slots |
 | IconButton | `src/renderer/IconButton.tsx` | 2 — `SessionHeader.tsx`, `NewSessionScreen.tsx` | `size: md\|lg`; `ariaHaspopup`/`ariaExpanded`/`hook` |
 | Field | `src/renderer/Field.tsx` | 2 — `Settings.tsx`, `CustomProviderForm.tsx` | `type: text\|password\|number`; `mono` (default true); `label`/`help`/`leading`/`footer`/`disabled` |
 | Pill | `src/renderer/Pill.tsx` | 2 — `Cards.tsx`, `SessionHeader.tsx` | `tone: neutral\|accent\|warn` (required); `size: meta\|label`; `border` |

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -29,6 +29,7 @@ import { useStore } from "./store";
 import { ModelPicker } from "./ModelPicker";
 import { MicButton } from "./ComposerParts";
 import { IconButton } from "./IconButton";
+import { Card } from "./Card";
 import { FolderPickerModal } from "./FolderPickerModal";
 import { worktreeName } from "./folderPicker";
 import { useVoiceRecorder, type VoiceResult } from "./voice";
@@ -555,9 +556,9 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
         </div>
 
         {error && (
-          <div className="text-meta text-danger bg-danger-bg border border-danger/30 rounded px-3 py-2 break-words">
-            {error}
-          </div>
+          <Card danger>
+            <span className="text-meta text-danger break-words">{error}</span>
+          </Card>
         )}
       </div>
 


### PR DESCRIPTION
Stage 4 of BET-580 — the welcome screen's error banner swaps its hand-rolled danger chrome for the `Card danger` primitive.

**Changes** (2 files, net-negative +5/−4):
- `src/renderer/NewSessionScreen.tsx`: error banner now renders through `Card danger` (deletes six inline classes incl. the one-off `border-danger/30`); `Card` added to imports.
- `docs/components.md`: `Card` inventory row → `3 — Cards.tsx, Settings.tsx, NewSessionScreen.tsx`.

**Explicitly NOT converted (stage 5):** composer box, send button, fan-out modal, worktree checkbox. No new primitive, no new token, no `className` on any primitive.

**Base: origin/main @ 5e81215**

Verification block posted on BET-584.