### PR TITLE
refactor(renderer): wire corner-radius token scale, rename rounded-* (BET-587)

### DIFF
--- a/src/renderer/AddPhonePanel.tsx
+++ b/src/renderer/AddPhonePanel.tsx
@@ -80,7 +80,7 @@ export function AddPhonePanel() {
       ) : pairing.ok ? (
         <div className="space-y-4">
           <div className="flex items-start gap-4">
-            <div className="bg-white p-2 rounded border border-border shrink-0">
+            <div className="bg-white p-2 rounded-xs border border-border shrink-0">
               <PairingQR
                 boxId={pairing.boxId}
                 pairingCode={pairing.pairingCode}
@@ -108,7 +108,7 @@ export function AddPhonePanel() {
           <button
             onClick={() => void mint()}
             disabled={minting}
-            className="text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+            className="text-body px-4 py-2 rounded-xs border border-border text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {minting ? "Refreshing…" : "Refresh code"}
           </button>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -906,7 +906,7 @@ export function App() {
             <button
               type="button"
               onClick={() => setMode(mode === "terminal" ? "chat" : "terminal")}
-              className="text-text-faint hover:text-text hover:bg-fill-hover rounded p-1 inline-flex items-center ml-auto"
+              className="text-text-faint hover:text-text hover:bg-fill-hover rounded-xs p-1 inline-flex items-center ml-auto"
               style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
               title={`Switch to ${mode === "terminal" ? "Chat" : "Terminal"}`}
               aria-label={mode === "terminal" ? "Chat" : "Terminal"}

--- a/src/renderer/Card.test.tsx
+++ b/src/renderer/Card.test.tsx
@@ -3,7 +3,7 @@
 // Component tests for the Card chrome primitive (BET-531, stage 2 of M527).
 //
 // The primitive's "tokens" are class names that map through tailwind.config.js
-// to the design tokens (rounded-xl → --r-lg 12px, border-border → --border,
+// to the design tokens (rounded-lg → --r-lg 12px, border-border → --border,
 // bg-bg-soft → --card via the card-rgb channel, px-4/py-3 → sp-4/sp-3). jsdom
 // loads no stylesheet, so the contract is asserted on the exact class strings
 // — a retune of Card's chrome fails here immediately.
@@ -20,11 +20,11 @@ import { Card } from "./Card";
 import { PermissionCard, QuestionCard } from "./Cards";
 import type { PermissionRequest, QuestionRequest } from "../shared/types";
 
-const CHROME = "rounded-xl border border-border bg-bg-soft px-4 py-3";
-const DANGER_CHROME = "rounded-xl border border-danger bg-danger-bg px-4 py-3";
+const CHROME = "rounded-lg border border-border bg-bg-soft px-4 py-3";
+const DANGER_CHROME = "rounded-lg border border-danger bg-danger-bg px-4 py-3";
 
 function chromeEl(h: Harness): HTMLElement {
-  const el = h.container.querySelector("div.rounded-xl") as HTMLElement;
+  const el = h.container.querySelector("div.rounded-lg") as HTMLElement;
   expect(el).toBeTruthy();
   return el;
 }

--- a/src/renderer/Card.tsx
+++ b/src/renderer/Card.tsx
@@ -15,8 +15,8 @@
 
 import type { ReactNode } from "react";
 
-const CARD_CHROME = "rounded-xl border border-border bg-bg-soft px-4 py-3";
-const CARD_DANGER_CHROME = "rounded-xl border border-danger bg-danger-bg px-4 py-3";
+const CARD_CHROME = "rounded-lg border border-border bg-bg-soft px-4 py-3";
+const CARD_DANGER_CHROME = "rounded-lg border border-danger bg-danger-bg px-4 py-3";
 
 export function Card({
   danger = false,

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -50,7 +50,7 @@ function AskCardShell({
         header={
           <>
             <span
-              className="inline-flex items-center justify-center w-[30px] h-[30px] rounded-lg shrink-0"
+              className="inline-flex items-center justify-center w-[30px] h-[30px] rounded-md shrink-0"
               style={{ backgroundColor: badgeBg, color: badgeColor }}
             >
               {badge}
@@ -85,7 +85,7 @@ export function RetryCard({
   const body = info.action?.message || info.message;
   return (
     <div
-      className="rounded-md border bg-bg-elev px-4 py-3 text-meta"
+      className="rounded-sm border bg-bg-elev px-4 py-3 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
       <div className="flex items-center gap-2 mb-3">
@@ -104,7 +104,7 @@ export function RetryCard({
             href={info.action.link}
             target="_blank"
             rel="noreferrer noopener"
-            className="inline-block px-2 py-px rounded border border-border-strong text-text hover:bg-bg-soft"
+            className="inline-block px-2 py-px rounded-xs border border-border-strong text-text hover:bg-bg-soft"
           >
             {info.action.label || "Open"}
           </a>
@@ -125,7 +125,7 @@ export function CompactionCard({
   const firstLine = state.text.split("\n").find((s) => s.trim()) ?? "";
   return (
     <div
-      className="rounded-md border bg-bg-elev px-4 py-3 text-meta"
+      className="rounded-sm border bg-bg-elev px-4 py-3 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
       <div className="flex items-center gap-2 mb-3">
@@ -208,7 +208,7 @@ export function PermissionCard({
     <>
       <button
         onClick={() => onReply("once")}
-        className="px-3 py-1 rounded-lg text-on-accent text-meta font-medium"
+        className="px-3 py-1 rounded-md text-on-accent text-meta font-medium"
         style={{ backgroundColor: "var(--accent-solid)" }}
       >
         Allow once
@@ -217,14 +217,14 @@ export function PermissionCard({
         <button
           onClick={() => onReply("always")}
           title={`Always allow ${alwaysScope}`}
-          className="px-3 py-1 rounded-lg border border-border-strong text-text hover:bg-bg-soft text-meta"
+          className="px-3 py-1 rounded-md border border-border-strong text-text hover:bg-bg-soft text-meta"
         >
           Always allow <span className="text-text-faint">{alwaysScope}</span>
         </button>
       ) : null}
       <button
         onClick={() => onReply("reject")}
-        className="ml-auto px-3 py-1 rounded-lg text-muted hover:text-danger hover:bg-danger-bg text-meta"
+        className="ml-auto px-3 py-1 rounded-md text-muted hover:text-danger hover:bg-danger-bg text-meta"
       >
         Reject
       </button>
@@ -241,7 +241,7 @@ export function PermissionCard({
       body={
         detail ? (
           // The literal command in its own mono well — only for permissions.
-          <div className="rounded-lg bg-inset border border-border-subtle px-3 py-[9px] font-mono text-text break-all">
+          <div className="rounded-md bg-inset border border-border-subtle px-3 py-[9px] font-mono text-text break-all">
             {detail}
           </div>
         ) : null
@@ -366,7 +366,7 @@ export function QuestionCard({
                       <label
                         key={opt.origLabel}
                         className={
-                          "flex items-start gap-2 rounded-md px-2 py-1 cursor-pointer border text-meta transition-colors " +
+                          "flex items-start gap-2 rounded-sm px-2 py-1 cursor-pointer border text-meta transition-colors " +
                           (isSelected
                             ? "border-accent bg-accent-bg"
                             : "border-border hover:bg-bg-soft")
@@ -375,7 +375,7 @@ export function QuestionCard({
                       >
                         <span
                           className={
-                            "inline-flex items-center justify-center w-4 h-4 rounded border shrink-0 mt-px " +
+                            "inline-flex items-center justify-center w-4 h-4 rounded-xs border shrink-0 mt-px " +
                             (isSelected
                               ? "bg-accent-solid border-transparent text-on-accent"
                               : "border-border-strong")
@@ -426,7 +426,7 @@ export function QuestionCard({
                       handleSubmit();
                     }
                   }}
-                  className="mt-2 w-full rounded border border-border bg-transparent px-2 py-px text-meta text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                  className="mt-2 w-full rounded-xs border border-border bg-transparent px-2 py-px text-meta text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
                 />
               </div>
             ))}
@@ -439,7 +439,7 @@ export function QuestionCard({
         <>
           <button
             onClick={onReject}
-            className="ml-auto px-3 py-1 rounded-lg text-muted hover:text-danger hover:bg-danger-bg text-meta"
+            className="ml-auto px-3 py-1 rounded-md text-muted hover:text-danger hover:bg-danger-bg text-meta"
             title="Dismiss this question"
           >
             Dismiss
@@ -448,7 +448,7 @@ export function QuestionCard({
           <button
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className="px-3 py-1 rounded-lg text-on-accent text-meta font-medium disabled:opacity-40"
+            className="px-3 py-1 rounded-md text-on-accent text-meta font-medium disabled:opacity-40"
             style={{ backgroundColor: "var(--accent-solid)" }}
           >
             Submit

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1921,7 +1921,7 @@ export function ChatPanel({
       {/* drop event (overlay shouldn't intercept it). */}
       {dragHover && (
         <div
-          className="absolute inset-2 z-30 pointer-events-none rounded-lg border-2 border-dashed flex items-center justify-center"
+          className="absolute inset-2 z-30 pointer-events-none rounded-md border-2 border-dashed flex items-center justify-center"
           style={{
             borderColor: "var(--accent)",
             backgroundColor: "var(--accent-bg)",
@@ -2172,7 +2172,7 @@ export function ChatPanel({
       {/* that dispatches `manta-open-subscriptions` — a no-op until the */}
       {/* Settings → AI → Subscriptions card lands (BET-314). */}
       {sendError && (
-        <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded break-words flex items-start gap-2">
+        <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded-xs break-words flex items-start gap-2">
           <span className="flex-1">⚠ {sendError}</span>
           {authReconnect && (
             <button

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -36,7 +36,7 @@ export function SessionToolbar({
     <span className="flex items-center gap-2 text-meta">
       <button
         onClick={onSchedules}
-        className="px-2 py-px rounded text-text-faint hover:text-text-muted inline-flex items-center gap-1"
+        className="px-2 py-px rounded-xs text-text-faint hover:text-text-muted inline-flex items-center gap-1"
         title="View / cancel scheduled tasks"
         aria-label="schedules"
       >
@@ -49,7 +49,7 @@ export function SessionToolbar({
       </button>
       <button
         onClick={onSecrets}
-        className="px-2 py-px rounded text-text-faint hover:text-text-muted inline-flex items-center"
+        className="px-2 py-px rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
         title="Manage secrets the agent can use (values never enter the chat)"
         aria-label="secrets"
       >
@@ -57,7 +57,7 @@ export function SessionToolbar({
       </button>
       <button
         onClick={onWebhooks}
-        className="px-2 py-px rounded text-text-faint hover:text-text-muted inline-flex items-center"
+        className="px-2 py-px rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
         title="View / revoke inbound webhooks (external events that wake this session)"
         aria-label="webhooks"
       >
@@ -95,7 +95,7 @@ export function AttachmentStrip({
         return (
           <span
             key={a.id}
-            className={`rounded-md border px-2 py-px flex items-center gap-1 bg-bg-elev ${color}`}
+            className={`rounded-sm border px-2 py-px flex items-center gap-1 bg-bg-elev ${color}`}
             title={a.status === "error" ? a.errorMsg : a.remotePath}
           >
             {a.status === "uploading" && (
@@ -141,7 +141,7 @@ export function TypeaheadPopup({
 }) {
   return (
     <div
-      className="shrink-0 mx-4 mb-1 max-h-[240px] overflow-y-auto rounded-xl border border-border bg-bg-soft text-meta font-mono shadow-md"
+      className="shrink-0 mx-4 mb-1 max-h-[240px] overflow-y-auto rounded-lg border border-border bg-bg-soft text-meta font-mono shadow-md"
     >
       {rows.length === 0 && (
         <div className="px-2 py-1 text-text-faint italic">{emptyHint}</div>

--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -544,13 +544,13 @@ export function ConnectProvider({
   }, [safeSetPhase]);
 
   return (
-    <div className="rounded-md border bg-bg-elev px-3 py-2 text-meta space-y-2">
+    <div className="rounded-sm border bg-bg-elev px-3 py-2 text-meta space-y-2">
       <div className="flex items-center gap-2">
         <span className="text-text">Connect {label}</span>
         <span className="text-text-faint">{connectPhaseLabel(phase)}</span>
         <button
           onClick={onCancel}
-          className="ml-auto px-2 rounded text-text-faint hover:text-text-muted inline-flex items-center"
+          className="ml-auto px-2 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
           title="Close"
           aria-label="Close"
         >
@@ -738,7 +738,7 @@ export function ConnectProvider({
               <summary className="text-text-faint cursor-pointer hover:text-text-muted">
                 Show what's happening on the box
               </summary>
-              <div className="rounded border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
+              <div className="rounded-xs border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
                 <Terminal
                   sessionKey={phase.ptySessionKey}
                   cwd={phase.cwd}
@@ -776,14 +776,14 @@ export function ConnectProvider({
             <div className="flex flex-wrap gap-2">
               <button
                 onClick={retry}
-                className="px-2 py-1 rounded text-meta"
+                className="px-2 py-1 rounded-xs text-meta"
                 style={{ background: "var(--accent-solid)", color: "var(--on-accent)" }}
               >
                 Try again
               </button>
               <button
                 onClick={onCancel}
-                className="px-2 py-1 rounded text-meta"
+                className="px-2 py-1 rounded-xs text-meta"
                 style={{ border: "1px solid var(--accent)", color: "var(--accent)" }}
               >
                 Use a different model
@@ -792,7 +792,7 @@ export function ConnectProvider({
                 href="https://claude.ai"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-2 py-1 rounded text-meta inline-flex items-center"
+                className="px-2 py-1 rounded-xs text-meta inline-flex items-center"
                 style={{ border: "1px solid var(--border)", color: "var(--text-muted)" }}
               >
                 Install manually
@@ -801,7 +801,7 @@ export function ConnectProvider({
           ) : (
             <button
               onClick={retry}
-              className="px-2 py-1 border border-border rounded text-text-muted hover:text-text"
+              className="px-2 py-1 border border-border rounded-xs text-text-muted hover:text-text"
             >
               Retry
             </button>
@@ -855,7 +855,7 @@ function WaitingBlockBody({
         <div className="text-label font-medium text-text-faint mb-1">Step 2 — enter the code</div>
         {code ? (
           <div className="flex items-center gap-2">
-            <code className="font-mono text-text bg-bg px-2 py-px rounded">{code}</code>
+            <code className="font-mono text-text bg-bg px-2 py-px rounded-xs">{code}</code>
             <CopyButton text={code} />
           </div>
         ) : fallback ? (
@@ -931,12 +931,12 @@ const CredentialInput = memo(function CredentialInput({
           spellCheck={false}
           autoCapitalize="off"
           autoCorrect="off"
-          className="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 font-mono text-text outline-none"
+          className="min-w-0 flex-1 rounded-xs border border-border bg-bg px-2 py-1 font-mono text-text outline-none"
         />
         <button
           onClick={() => void submit()}
           disabled={!canSubmit}
-          className="shrink-0 px-2 py-1 rounded border disabled:opacity-40 border-border text-text-muted hover:text-text"
+          className="shrink-0 px-2 py-1 rounded-xs border disabled:opacity-40 border-border text-text-muted hover:text-text"
         >
           {submitting ? "…" : submitLabel}
         </button>
@@ -1058,7 +1058,7 @@ function ClaudeLoginBlock({
             <summary className="text-text-faint cursor-pointer hover:text-text-muted">
               Show what's happening on the box
             </summary>
-            <div className="rounded border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
+            <div className="rounded-xs border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
               <Terminal
                 sessionKey={ptySessionKey}
                 cwd={cwd}

--- a/src/renderer/ContextBar.tsx
+++ b/src/renderer/ContextBar.tsx
@@ -86,7 +86,7 @@ export function ContextBar({
       title={breakdownLines.join("\n")}
     >
       <span
-        className="inline-block w-24 h-3 rounded-[2px] overflow-hidden align-middle"
+        className="inline-block w-24 h-3 rounded-xs overflow-hidden align-middle"
         style={{
           backgroundColor: "var(--card)",
           backgroundImage: `radial-gradient(circle, ${dot} 1.2px, transparent 1.4px)`,
@@ -126,7 +126,7 @@ export function ContextBar({
         // user message will pay full rate + surcharge to re-warm exactly
         // these tokens; /clear avoids the bill entirely.
         <span
-          className="tabular-nums text-label font-mono font-medium px-2 rounded-sm shrink-0"
+          className="tabular-nums text-label font-mono font-medium px-2 rounded-xs shrink-0"
           style={{
             color: CACHE_WRITE_COLOR,
             backgroundColor: `${CACHE_WRITE_COLOR}1f`,

--- a/src/renderer/CopyButton.tsx
+++ b/src/renderer/CopyButton.tsx
@@ -44,7 +44,7 @@ export const CopyButton = memo(function CopyButton({
       aria-label="Copy"
       className={
         className ??
-        "text-meta text-text-faint hover:text-text px-1 rounded"
+        "text-meta text-text-faint hover:text-text px-1 rounded-xs"
       }
     >
       {copied ? (

--- a/src/renderer/CustomProviderForm.tsx
+++ b/src/renderer/CustomProviderForm.tsx
@@ -148,7 +148,7 @@ export function CustomProviderForm({
 
   if (compact) {
     return (
-      <div className="border border-dashed border-border rounded p-2 space-y-1">
+      <div className="border border-dashed border-border rounded-xs p-2 space-y-1">
         <div className="text-micro font-semibold uppercase text-text-faint">
           Add endpoint
         </div>
@@ -173,7 +173,7 @@ export function CustomProviderForm({
           value={apiKey}
           disabled={busy}
           onChange={(e) => setApiKey(e.target.value)}
-          className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded"
+          className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded-xs"
         />
         {derivedId && (
           <div className="text-micro text-text-faint">
@@ -194,7 +194,7 @@ export function CustomProviderForm({
             <button
               onClick={() => void probe()}
               disabled={busy || draftErr !== null}
-              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
             >
               {busy ? "Probing…" : "Probe"}
             </button>
@@ -202,7 +202,7 @@ export function CustomProviderForm({
             <button
               onClick={() => void save()}
               disabled={busy || checked.size === 0}
-              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
             >
               {busy ? "Saving…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
             </button>
@@ -213,7 +213,7 @@ export function CustomProviderForm({
   }
 
   return (
-    <div className="rounded-md border border-border bg-bg-soft p-3 space-y-3">
+    <div className="rounded-sm border border-border bg-bg-soft p-3 space-y-3">
       <div className="text-micro font-semibold uppercase text-text-faint">
         Add a custom provider
       </div>
@@ -264,7 +264,7 @@ export function CustomProviderForm({
             type="button"
             onClick={() => void probe()}
             disabled={busy || draftErr !== null}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
             style={{ background: ACCENT_SOLID }}
           >
             {busy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
@@ -275,7 +275,7 @@ export function CustomProviderForm({
             type="button"
             onClick={() => void save()}
             disabled={busy || checked.size === 0}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
             style={{ background: ACCENT_SOLID }}
           >
             {busy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
@@ -303,7 +303,7 @@ function ModelList({
       <div className="text-meta text-text-muted">
         {models.length} model{models.length === 1 ? "" : "s"} found — uncheck any you don't want.
       </div>
-      <div className="max-h-40 overflow-auto rounded border border-border bg-bg p-2 space-y-1">
+      <div className="max-h-40 overflow-auto rounded-xs border border-border bg-bg p-2 space-y-1">
         {models.map((m) => (
           <label
             key={m.id}

--- a/src/renderer/Field.test.tsx
+++ b/src/renderer/Field.test.tsx
@@ -4,7 +4,7 @@
 //
 // The primitive's "tokens" are class names that map through tailwind.config.js
 // to the design tokens (bg-bg-soft → --card, border-border-strong →
-// --border-strong, rounded-lg → --r-md 8px, focus:border-accent → --accent,
+// --border-strong, rounded-md → --r-md 8px, focus:border-accent → --accent,
 // py-3/px-4 → sp-3 12px / sp-4 16px, text-text-muted → --tx2,
 // text-text-faint → --tx3, font-mono → the mono stack). jsdom loads no
 // stylesheet, so the contract is asserted on the exact class strings — a
@@ -15,7 +15,7 @@ import { mount, type Harness } from "./testHarness";
 import { Field } from "./Field";
 
 const INPUT_BASE =
-  "w-full bg-bg-soft border border-border-strong rounded-lg text-body text-text focus:outline-none focus:border-accent";
+  "w-full bg-bg-soft border border-border-strong rounded-md text-body text-text focus:outline-none focus:border-accent";
 const INSET = "px-4 py-3";
 const LABEL = "block text-micro font-semibold uppercase text-text-muted";
 const META = "text-meta text-text-faint";
@@ -37,11 +37,11 @@ describe("Field", () => {
     h = mount(<Field id="f" label="Path" value="~/proj" onChange={() => {}} />);
     const el = inputEl(h.container);
     expect(el.className).toContain(INPUT_BASE);
-    // surface --card, edge --border-strong, radius --r-md (rounded-lg),
+    // surface --card, edge --border-strong, radius --r-md (rounded-md),
     // padding sp-3/sp-4 (py-3 px-4), mono value.
     expect(el.className).toContain("bg-bg-soft");
     expect(el.className).toContain("border-border-strong");
-    expect(el.className).toContain("rounded-lg");
+    expect(el.className).toContain("rounded-md");
     expect(el.className).toContain(INSET);
     expect(el.className).toContain("font-mono");
     // focus --accent edge.

--- a/src/renderer/Field.tsx
+++ b/src/renderer/Field.tsx
@@ -8,7 +8,7 @@
 // Chrome contract (BET-529 inventory, settled in this cell):
 //   - surface `--card` (`bg-bg-soft`), edge `--border-strong`
 //     (`border-border-strong` — inputs/controls take border-strong, NOT
-//     `--border`), focus `--accent`, radius `--r-md` 8px (`rounded-lg`).
+//     `--border`), focus `--accent`, radius `--r-md` 8px (`rounded-md`).
 //   - padding sp-3 / sp-4 → **12px vertical / 16px horizontal** (`py-3 px-4`).
 //     Settles the spec's Applied-spec "12px / 14px" (off-grid, misnamed):
 //     `sp-3` is the vertical step (12px), `sp-4` the horizontal (16px), same
@@ -63,7 +63,7 @@ type FieldProps = {
   inputRef?: Ref<HTMLInputElement>;
 };
 
-const INPUT_BASE = "w-full bg-bg-soft border border-border-strong rounded-lg text-body text-text focus:outline-none focus:border-accent";
+const INPUT_BASE = "w-full bg-bg-soft border border-border-strong rounded-md text-body text-text focus:outline-none focus:border-accent";
 const LABEL_CLS = "block text-micro font-semibold uppercase text-text-muted";
 const META_CLS = "text-meta text-text-faint";
 

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -231,7 +231,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onCancel}>
       <div
-        className="manta-folder-picker w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col bg-bg-elev border border-border rounded-xl shadow-lg overflow-hidden"
+        className="manta-folder-picker w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col bg-bg-elev border border-border rounded-lg shadow-lg overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -265,14 +265,14 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
             <div className="flex gap-2">
               <button
                 onClick={() => onSelect(fanOut.cwd)}
-                className="text-meta px-3 py-2 border border-border text-text-muted hover:text-text rounded"
+                className="text-meta px-3 py-2 border border-border text-text-muted hover:text-text rounded-xs"
               >
                 Just this folder
               </button>
               {onFanOut && (
                 <button
                   onClick={() => onFanOut(fanOut.cwd, fanOut.worktrees)}
-                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90"
+                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90"
                 >
                   One per worktree
                 </button>
@@ -290,7 +290,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
             {/* Path field with ghost-text completion + the design's Go button */}
             <div className="px-4 py-3 border-b border-border">
               <div className="flex gap-2">
-                <div className="relative flex-1 min-w-0 bg-bg-soft border border-border rounded focus-within:border-accent">
+                <div className="relative flex-1 min-w-0 bg-bg-soft border border-border rounded-xs focus-within:border-accent">
                   {suggestion && suggestion.startsWith(path) && (
                     <div
                       aria-hidden
@@ -335,13 +335,13 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
                     }}
                     spellCheck={false}
                     autoComplete="off"
-                    className="relative w-full bg-transparent border-0 px-3 py-2 text-meta rounded focus:outline-none font-mono"
+                    className="relative w-full bg-transparent border-0 px-3 py-2 text-meta rounded-xs focus:outline-none font-mono"
                   />
                 </div>
                 <button
                   onClick={goNavigate}
                   type="button"
-                  className="shrink-0 px-4 text-meta border border-border rounded bg-bg-soft text-text hover:bg-bg-soft"
+                  className="shrink-0 px-4 text-meta border border-border rounded-xs bg-bg-soft text-text hover:bg-bg-soft"
                 >
                   Go
                 </button>
@@ -352,7 +352,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
               <div className="flex items-center flex-wrap gap-px mt-2 text-label">
                 <button
                   onClick={() => setPath("~")}
-                  className="inline-flex items-center px-1 py-px rounded text-text-faint hover:text-text"
+                  className="inline-flex items-center px-1 py-px rounded-xs text-text-faint hover:text-text"
                   title="Home"
                   aria-label="Home"
                 >
@@ -368,7 +368,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
                     <button
                       onClick={() => setPath(c)}
                       className={
-                        "px-1 py-px rounded " +
+                        "px-1 py-px rounded-xs " +
                         (i === crumbs.length - 1
                           ? "font-semibold text-text"
                           : "text-text-faint hover:text-text-muted")
@@ -399,7 +399,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
                       same as the breadcrumbs / up-arrow. */}
                   <button
                     onClick={goUp}
-                    className="w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded text-text-muted hover:bg-bg-soft"
+                    className="w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded-xs text-text-muted hover:bg-bg-soft"
                     title={parentPath(path)}
                   >
                     <ArrowUp size={14} className="shrink-0" aria-hidden="true" />
@@ -413,7 +413,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
                         key={r.full}
                         onClick={() => descend(r.full)}
                         className={
-                          "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded " +
+                          "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded-xs " +
                           (r.dimmed ? "text-text-quiet" : "text-text-muted") +
                           " hover:bg-bg-soft"
                         }
@@ -445,7 +445,7 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
                 </button>
                 <button
                   onClick={() => void select()}
-                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90"
+                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90"
                 >
                   Select folder
                 </button>

--- a/src/renderer/IconButton.test.tsx
+++ b/src/renderer/IconButton.test.tsx
@@ -4,7 +4,7 @@
 // M527).
 //
 // As with Card, the primitive's "tokens" are class names that map through
-// tailwind.config.js to the design tokens (rounded → --r-xs 4px, p-1 → 4px
+// tailwind.config.js to the design tokens (rounded-xs → --r-xs 4px, p-1 → 4px
 // hit-area padding, text-text-faint → --tx3, hover:text-text → --tx1, the
 // arbitrary hover:bg-fill-hover → --fill-hover, outline-accent →
 // --accent). jsdom loads no stylesheet, so the contract is asserted on the
@@ -21,7 +21,7 @@ import { SessionHeader } from "./SessionHeader";
 // The exact chrome string IconButton owns (no className escape hatch means
 // every call site renders exactly this).
 const CHROME =
-  "inline-flex items-center justify-center rounded p-1 text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+  "inline-flex items-center justify-center rounded-xs p-1 text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
 
 function buttonEl(h: Harness): HTMLButtonElement {
   const el = h.container.querySelector("button") as HTMLButtonElement;
@@ -43,11 +43,11 @@ describe("IconButton", () => {
   it("renders the square hit area, --r-xs radius, resting tx3→tx1 hover and --fill-hover bg per the contract", () => {
     h = mount(<IconButton label="Switch" icon={<Terminal />} />);
     const el = buttonEl(h);
-    // Square hit area (p-1) + --r-xs radius (rounded) + resting --tx3
+    // Square hit area (p-1) + --r-xs radius (rounded-xs) + resting --tx3
     // (text-text-faint) → --tx1 (hover:text-text) on hover with --fill-hover
     // bg, plus the --accent focus ring. All pinned as the exact class string.
     expect(el.className).toBe(CHROME);
-    expect(el.className).toContain("rounded");
+    expect(el.className).toContain("rounded-xs");
     expect(el.className).toContain("p-1");
     expect(el.className).toContain("text-text-faint");
     expect(el.className).toContain("hover:text-text");

--- a/src/renderer/IconButton.tsx
+++ b/src/renderer/IconButton.tsx
@@ -6,7 +6,7 @@
 // family can only drift if IconButton itself is retuned.
 //
 // Chrome contract (BET-529 inventory): square hit area (`p-1` → 24px md /
-// 28px lg), radius `--r-xs` (`rounded`), resting icon `--tx3` → `--tx1` on
+// 28px lg), radius `--r-xs` (`rounded-xs`), resting icon `--tx3` → `--tx1` on
 // hover with `--fill-hover` bg, accent focus ring, 16px md icon / 20px lg
 // standalone. C1 (validated constraints): the hover sets a background, so it
 // also sets the matching foreground (`hover:text-text`); the resting state
@@ -26,7 +26,7 @@ import type { ReactElement } from "react";
 import { cloneElement } from "react";
 
 const CHROME =
-  "inline-flex items-center justify-center rounded p-1 text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+  "inline-flex items-center justify-center rounded-xs p-1 text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
 
 export function IconButton({
   label,

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -234,7 +234,7 @@ export function InputArea({
           padding is --sp-4 (16px) per the BET-423 spacing ruling. */}
       <div
         className={
-          "manta-composer-input-row mx-4 mb-2 rounded-xl border bg-bg-soft flex flex-col gap-2 px-4 py-3 " +
+          "manta-composer-input-row mx-4 mb-2 rounded-lg border bg-bg-soft flex flex-col gap-2 px-4 py-3 " +
           (voiceActive
             ? "manta-recording"
             : refreshing
@@ -383,7 +383,7 @@ export function InputArea({
         <button
           onClick={() => setChatAutoAllow(!chatAutoAllow)}
           className={
-            "px-2 py-px rounded inline-flex items-center gap-2 " +
+            "px-2 py-px rounded-xs inline-flex items-center gap-2 " +
             (chatAutoAllow
               ? "text-danger hover:text-danger"
               : "text-text-faint hover:text-text-muted")

--- a/src/renderer/MarkdownBody.tsx
+++ b/src/renderer/MarkdownBody.tsx
@@ -176,12 +176,12 @@ const MD_COMPONENTS: MarkdownComponents = {
       {children}
     </td>
   ),
-  // Images: max-width 100%, rounded, --border-subtle (BET-413).
+  // Images: max-width 100%, curved corners, --border-subtle (BET-413).
   img: ({ src, alt }) => (
     <img
       src={typeof src === "string" ? src : undefined}
       alt={alt ?? ""}
-      className="max-w-full rounded"
+      className="max-w-full rounded-xs"
       style={{ border: "1px solid var(--border-subtle)" }}
     />
   ),
@@ -332,7 +332,7 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
     countLines(cleaned) > CODEBLOCK_MAX_LINES;
 
   return (
-    <div className="rounded border border-border bg-bg-soft overflow-hidden relative">
+    <div className="rounded-xs border border-border bg-bg-soft overflow-hidden relative">
       {lang && (
         <div className="px-2 py-px text-micro uppercase text-text-faint border-b border-border bg-bg-elev pr-8">
           {lang}
@@ -340,7 +340,7 @@ export const CodeBlock = memo(function CodeBlock({ lang, body }: { lang?: string
       )}
       <CopyButton
         text={cleaned}
-        className="absolute top-1 right-1 z-10 text-micro uppercase text-text-faint hover:text-text px-1 rounded"
+        className="absolute top-1 right-1 z-10 text-micro uppercase text-text-faint hover:text-text px-1 rounded-xs"
       />
       {tooLarge ? (
         <pre

--- a/src/renderer/MenuItem.test.tsx
+++ b/src/renderer/MenuItem.test.tsx
@@ -6,7 +6,7 @@
 // As with Card/Field/Pill/IconButton, the primitive's "tokens" are class
 // names that map through tailwind.config.js to the design tokens
 // (bg-bg-elev → --panel, border-border → --border, shadow-md → --shadow-md,
-// rounded-lg → --r-md, bg-bg-soft → --card, text-text → --tx1,
+// rounded-md → --r-md, bg-bg-soft → --card, text-text → --tx1,
 // text-danger → --danger, bg-danger-bg → --danger-bg, text-accent → --accent,
 // text-label → 13px, px-2/py-2 → sp-2/sp-2). jsdom loads no stylesheet, so
 // the contract is asserted on the exact class strings — a retune of the
@@ -32,7 +32,7 @@ describe("Dropdown — the shared dropdown surface", () => {
     h = mount(<Dropdown>hello</Dropdown>);
     const el = h.container.firstElementChild as HTMLElement;
     expect(el.getAttribute("role")).toBe("menu");
-    expect(el.className).toContain("rounded-lg");
+    expect(el.className).toContain("rounded-md");
     expect(el.className).toContain("border");
     expect(el.className).toContain("border-border");
     expect(el.className).toContain("bg-bg-elev");

--- a/src/renderer/MenuItem.tsx
+++ b/src/renderer/MenuItem.tsx
@@ -8,7 +8,7 @@
 //
 // Chrome contract (BET-529 inventory):
 //   - dropdown surface: `--panel`/`bg-bg-elev`, `--border` edge,
-//     `--shadow-md`, `--r-md` (8px / `rounded-lg`), `py-1`.
+//     `--shadow-md`, `--r-md` (8px / `rounded-md`), `py-1`.
 //   - item label 13px `--tx1` (`text-label text-text`), padding `sp-2/sp-2`
 //     (`px-2 py-2`), hover `--card` (`bg-bg-soft`), icon 14px.
 //   - variants danger (`--danger` + hover `--danger-bg`) and active
@@ -88,7 +88,7 @@ export function Dropdown({
       role="menu"
       className={
         `${hook ? `${hook} ` : ""}` +
-        "absolute right-0 top-full mt-1 z-30 min-w-[11.25rem] rounded-lg border border-border bg-bg-elev shadow-md py-1"
+        "absolute right-0 top-full mt-1 z-30 min-w-[11.25rem] rounded-md border border-border bg-bg-elev shadow-md py-1"
       }
     >
       {children}

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -172,7 +172,7 @@ const UserCommandBar = memo(function UserCommandBar({
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-baseline gap-2 w-full text-left hover:bg-bg-elev/40 -mx-1 px-1 rounded transition-colors"
+        className="flex items-baseline gap-2 w-full text-left hover:bg-bg-elev/40 -mx-1 px-1 rounded-xs transition-colors"
         title={expanded ? "Collapse" : "Show expanded prompt"}
       >
         <span className="text-text-quiet select-none shrink-0">›</span>
@@ -255,7 +255,7 @@ export const MessageRow = memo(function MessageRow({
     </div>
   );
 
-  // User message: rendered as a single rounded gray bar so it reads as a
+  // User message: rendered as a single gray bar with curved corners so it reads as a
   // distinct "you said this" block instead of just text with a `>` prefix.
   // `›` is the dim left marker; continuation lines wrap inside the bar.
   // FileParts attached to the message render as chips ABOVE the bar so
@@ -282,7 +282,7 @@ export const MessageRow = memo(function MessageRow({
               return (
                 <span
                   key={p.id}
-                  className="rounded-md border border-border-strong px-2 py-px bg-bg-elev text-text-muted truncate max-w-[260px]"
+                  className="rounded-sm border border-border-strong px-2 py-px bg-bg-elev text-text-muted truncate max-w-[260px]"
                   title={url}
                 >
                   {filename}
@@ -359,7 +359,7 @@ export const MessageRow = memo(function MessageRow({
               {/* coherent with CompactionCard / RetryCard / QuestionCard, */}
               {/* the existing "something needs your attention" color. */}
               <span
-                className="rounded-md border px-2 py-px text-label inline-flex items-center gap-1"
+                className="rounded-sm border px-2 py-px text-label inline-flex items-center gap-1"
                 style={{
                   borderColor: "rgb(var(--warn-rgb) / 0.33)",
                   backgroundColor: "var(--warn-bg)",

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -148,7 +148,7 @@ export function ModelPicker({
         "overflow-visible min-w-0 " +
         (separatePills
           ? "inline-flex items-center gap-2"
-          : "inline-flex items-stretch rounded-lg border border-border-strong bg-bg-soft")
+          : "inline-flex items-stretch rounded-md border border-border-strong bg-bg-soft")
       }
     >
       {/* Model button — friendly name + Sparkles icon, opens the model list. */}
@@ -156,7 +156,7 @@ export function ModelPicker({
         <button
           className={
             "manta-model-picker-btn truncate text-meta text-text hover:bg-fill-hover flex items-center gap-1 px-2 py-1 " +
-            (separatePills ? "rounded-lg border border-border-strong bg-bg-soft" : "")
+            (separatePills ? "rounded-md border border-border-strong bg-bg-soft" : "")
           }
           aria-haspopup="listbox"
           aria-expanded={modelOpen}
@@ -177,7 +177,7 @@ export function ModelPicker({
             variants show up in the effort button). */}
         {modelOpen && (
           <div
-            className="manta-model-dropdown absolute left-0 bottom-full mb-1 z-20 min-w-[240px] max-h-[360px] overflow-y-auto rounded border border-border bg-bg-elev shadow-md text-meta"
+            className="manta-model-dropdown absolute left-0 bottom-full mb-1 z-20 min-w-[240px] max-h-[360px] overflow-y-auto rounded-xs border border-border bg-bg-elev shadow-md text-meta"
           >
             <button
               onClick={() => {
@@ -243,7 +243,7 @@ export function ModelPicker({
             className={
               "manta-effort-picker-btn truncate text-meta hover:bg-fill-hover flex items-center gap-1 px-2 py-1 " +
               (separatePills
-                ? "rounded-lg border border-border-strong bg-bg-soft"
+                ? "rounded-md border border-border-strong bg-bg-soft"
                 : "border-l border-border-strong") +
               (effortDisabled ? " cursor-not-allowed" : "")
             }
@@ -272,7 +272,7 @@ export function ModelPicker({
               variants plus a "Default" (no variant) row. */}
           {variantOpen && variants.length > 0 && (
             <div
-              className="manta-effort-dropdown absolute left-0 bottom-full mb-1 z-20 min-w-[160px] rounded border border-border bg-bg-elev shadow-md text-meta"
+              className="manta-effort-dropdown absolute left-0 bottom-full mb-1 z-20 min-w-[160px] rounded-xs border border-border bg-bg-elev shadow-md text-meta"
             >
               <button
                 onClick={() => {

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -270,7 +270,7 @@ export function ModelsCard() {
       {/* Saved & active default banner — reads from the store, NOT local
           edits, so it stays in sync with what's actually persisted. */}
       <div
-        className={`flex items-center gap-2 bg-bg-soft border border-border rounded px-3 py-2 ${
+        className={`flex items-center gap-2 bg-bg-soft border border-border rounded-xs px-3 py-2 ${
           savedDefault ? "" : "text-text-faint italic"
         }`}
       >
@@ -298,10 +298,10 @@ export function ModelsCard() {
         placeholder="Search models by name, provider, capability…"
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
-        className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded focus:outline-none focus:border-accent"
+        className="w-full bg-bg-soft border border-border px-3 py-2 text-body rounded-xs focus:outline-none focus:border-accent"
       />
 
-      <div className="border border-border rounded overflow-x-auto">
+      <div className="border border-border rounded-xs overflow-x-auto">
         <table className="w-full text-body">
           <thead>
             <tr className="border-b border-border">
@@ -355,7 +355,7 @@ export function ModelsCard() {
                       <span className="text-meta text-text-faint">{m.providerID}</span>
                       {ctxSize && <span className="text-meta text-text-faint">{ctxSize}</span>}
                       {info && (
-                        <span className={`px-2 py-px rounded text-meta ${TIER_CLASS[info.tier]}`}>
+                        <span className={`px-2 py-px rounded-xs text-meta ${TIER_CLASS[info.tier]}`}>
                           {info.tier}
                         </span>
                       )}

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -408,7 +408,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
         <div className="flex items-center gap-2 self-start">
           <button
             onClick={() => setPickerOpen(true)}
-            className="inline-flex items-center gap-2 h-9 pl-3 pr-2 rounded-lg border border-border bg-bg-soft shadow-sm text-body text-text hover:border-border-strong"
+            className="inline-flex items-center gap-2 h-9 pl-3 pr-2 rounded-md border border-border bg-bg-soft shadow-sm text-body text-text hover:border-border-strong"
             title={cwd || "Select folder"}
           >
             <FolderIcon size={14} className="shrink-0 text-text-muted" aria-hidden="true" />
@@ -416,7 +416,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
             <ChevronDown size={14} className="shrink-0 text-text-faint" aria-hidden="true" />
           </button>
 
-          <div className="inline-flex items-center h-9 rounded-lg border border-border bg-bg-soft shadow-sm text-body overflow-hidden">
+          <div className="inline-flex items-center h-9 rounded-md border border-border bg-bg-soft shadow-sm text-body overflow-hidden">
             {wantWorktree && isGitRepo ? (
               // BET-417 §A: "Ticking worktree makes the branch field
               // editable." The typed value is passed as `name` to
@@ -466,7 +466,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
             can grow downward without moving it. */}
         <div
           className={
-            "manta-composer-input-row rounded-xl border bg-bg-soft flex items-start gap-2 px-4 py-3 " +
+            "manta-composer-input-row rounded-lg border bg-bg-soft flex items-start gap-2 px-4 py-3 " +
             (voiceRecording
               ? "manta-recording"
               : "border-border")
@@ -495,7 +495,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
                   ? "Start a session"
                   : "Describe a task to start"
             }
-            className="shrink-0 w-9 h-9 rounded-lg border border-border bg-bg-elev text-text-muted inline-grid place-items-center hover:text-text hover:border-border-strong disabled:opacity-50"
+            className="shrink-0 w-9 h-9 rounded-md border border-border bg-bg-elev text-text-muted inline-grid place-items-center hover:text-text hover:border-border-strong disabled:opacity-50"
           >
             {sending ? (
               <Loader2 size={16} className="animate-spin" aria-hidden="true" />
@@ -580,7 +580,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
 
       {fanOutWorktrees && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="w-[480px] max-w-[92vw] bg-bg-elev border border-border rounded-xl shadow-lg p-4 space-y-3">
+          <div className="w-[480px] max-w-[92vw] bg-bg-elev border border-border rounded-lg shadow-lg p-4 space-y-3">
             <div className="text-body font-semibold text-text">Fan-out confirmed</div>
             <div className="text-meta text-text-muted">
               Creating one session with {fanOutWorktrees.length} windows (one per
@@ -598,7 +598,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
               <button
                 onClick={() => void submitFanOut(cwd, fanOutWorktrees)}
                 disabled={sending}
-                className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded hover:opacity-90 disabled:opacity-50"
+                className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90 disabled:opacity-50"
               >
                 {sending ? "Creating…" : "Create"}
               </button>

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -344,7 +344,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
             />
             <div
               role="alert"
-              className="rounded-md border px-4 py-3 text-body"
+              className="rounded-sm border px-4 py-3 text-body"
               style={{ borderColor: DANGER, color: DANGER }}
             >
               {verifyError.message}
@@ -353,7 +353,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               <button
                 type="button"
                 onClick={() => void runVerify()}
-                className="px-4 py-2 rounded-md text-body font-medium"
+                className="px-4 py-2 rounded-sm text-body font-medium"
                 style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
               >
                 Try again
@@ -365,7 +365,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                   setVerifyError(null);
                   setPos(2);
                 }}
-                className="px-4 py-2 rounded-md text-body font-medium"
+                className="px-4 py-2 rounded-sm text-body font-medium"
                 style={{ border: `1px solid ${ACCENT}`, color: ACCENT }}
               >
                 Back to the provider step
@@ -373,7 +373,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               <button
                 type="button"
                 onClick={() => void copyVerifyDiagnostics()}
-                className="px-4 py-2 rounded-md text-body font-medium"
+                className="px-4 py-2 rounded-sm text-body font-medium"
                 style={{ border: `1px solid ${DANGER}`, color: DANGER }}
               >
                 Copy diagnostics
@@ -416,7 +416,7 @@ function SuccessPanel({ onOpen }: { onOpen: () => void }) {
       </p>
       <button
         onClick={onOpen}
-        className="inline-flex items-center gap-2 px-6 py-3 rounded-md text-body font-medium text-on-accent"
+        className="inline-flex items-center gap-2 px-6 py-3 rounded-sm text-body font-medium text-on-accent"
         style={{ background: ACCENT_SOLID }}
       >
         Open Manta

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -215,7 +215,7 @@ function ManualPairForm({
             }}
             aria-invalid={serverUrlInvalid}
             aria-describedby={serverUrlInvalid ? "pair-host-err" : undefined}
-            className="w-full rounded-md bg-bg border px-3 py-2 text-body font-mono text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+            className="w-full rounded-sm bg-bg border px-3 py-2 text-body font-mono text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
             style={{ borderColor: serverUrlInvalid ? DANGER : undefined }}
           />
           {serverUrlInvalid && (
@@ -252,7 +252,7 @@ function ManualPairForm({
               setError(null);
             }}
             aria-invalid={boxIdLooksBad}
-            className="w-full rounded-md bg-bg border px-3 py-2 text-body font-mono text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+            className="w-full rounded-sm bg-bg border px-3 py-2 text-body font-mono text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
             style={{ borderColor: boxIdLooksBad ? DANGER : undefined }}
           />
         </div>
@@ -277,7 +277,7 @@ function ManualPairForm({
               setCode(v);
               setError(null);
             }}
-            className="w-full rounded-md bg-bg border border-border px-3 py-2 text-center font-mono tracking-[0.22em] text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+            className="w-full rounded-sm bg-bg border border-border px-3 py-2 text-center font-mono tracking-[0.22em] text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
           />
         </div>
 
@@ -303,7 +303,7 @@ function ManualPairForm({
               setVerifyCode(v);
               setError(null);
             }}
-            className="w-full rounded-md bg-bg border border-border px-3 py-2 text-center font-mono tracking-[0.22em] text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
+            className="w-full rounded-sm bg-bg border border-border px-3 py-2 text-center font-mono tracking-[0.22em] text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
           />
         </div>
       </div>
@@ -320,7 +320,7 @@ function ManualPairForm({
       <div className="flex items-center justify-between gap-3 pt-1">
         <p className="text-meta text-text-faint">
           Run{" "}
-          <code className="rounded bg-bg px-2 py-px text-label font-mono text-text-muted">
+          <code className="rounded-xs bg-bg px-2 py-px text-label font-mono text-text-muted">
             manta pair
           </code>{" "}
           on the box to get a code.
@@ -328,7 +328,7 @@ function ManualPairForm({
         <button
           type="submit"
           disabled={!connectEnabled}
-          className="inline-flex items-center gap-2 px-5 py-2 rounded-md text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
+          className="inline-flex items-center gap-2 px-5 py-2 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
           style={{ background: ACCENT_SOLID }}
         >
           {submitting ? "Connecting…" : "Connect"}

--- a/src/renderer/PairingQR.tsx
+++ b/src/renderer/PairingQR.tsx
@@ -93,7 +93,7 @@ export function PairingQR({
 
   if (!dataUrl) {
     return (
-      <div className="w-[200px] h-[200px] bg-bg-soft border border-border rounded flex items-center justify-center text-meta text-text-muted">
+      <div className="w-[200px] h-[200px] bg-bg-soft border border-border rounded-xs flex items-center justify-center text-meta text-text-muted">
         Generating…
       </div>
     );

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -59,7 +59,7 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
   return (
     <div
       ref={cardRef}
-      className="rounded-md border bg-bg-elev px-3 py-2 text-meta"
+      className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
       <div className="flex items-center gap-2 mb-1">
@@ -70,7 +70,7 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
         {jobs.length > 0 && <span className="text-text-faint">· {jobs.length}</span>}
         <button
           onClick={onClose}
-          className="ml-auto px-2 rounded text-text-faint hover:text-text-muted inline-flex items-center"
+          className="ml-auto px-2 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
           title="Close (or click outside)"
           aria-label="Close"
         >
@@ -108,7 +108,7 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
                 </div>
                 <button
                   onClick={() => onDelete(j.id)}
-                  className="shrink-0 px-2 py-px rounded text-danger hover:bg-danger-bg border border-danger/30 text-label"
+                  className="shrink-0 px-2 py-px rounded-xs text-danger hover:bg-danger-bg border border-danger/30 text-label"
                   title="Cancel this scheduled task"
                 >
                   Cancel
@@ -161,7 +161,7 @@ export const WebhooksCard = memo(function WebhooksCard({
   return (
     <div
       ref={cardRef}
-      className="rounded-md border bg-bg-elev px-3 py-2 text-meta"
+      className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
       <div className="flex items-center gap-2 mb-1">
@@ -172,7 +172,7 @@ export const WebhooksCard = memo(function WebhooksCard({
         {hooks.length > 0 && <span className="text-text-faint">· {hooks.length}</span>}
         <button
           onClick={onClose}
-          className="ml-auto px-2 rounded text-text-faint hover:text-text-muted inline-flex items-center"
+          className="ml-auto px-2 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
           title="Close (or click outside)"
           aria-label="Close"
         >
@@ -226,7 +226,7 @@ export const WebhooksCard = memo(function WebhooksCard({
                 </div>
                 <button
                   onClick={() => onDelete(h.id)}
-                  className="shrink-0 px-2 py-px rounded text-danger hover:bg-danger-bg border border-danger/30 text-label"
+                  className="shrink-0 px-2 py-px rounded-xs text-danger hover:bg-danger-bg border border-danger/30 text-label"
                   title="Revoke this webhook (further POSTs will 404)"
                 >
                   Revoke
@@ -302,7 +302,7 @@ export const SecretsCard = memo(function SecretsCard({
 
   return (
     <div
-      className="rounded-md border bg-bg-elev px-3 py-2 text-meta"
+      className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
       <div className="flex items-center gap-2 mb-2">
@@ -313,7 +313,7 @@ export const SecretsCard = memo(function SecretsCard({
         {secrets.length > 0 && <span className="text-text-faint">· {secrets.length}</span>}
         <button
           onClick={onClose}
-          className="ml-auto px-1 rounded text-text-faint hover:text-text-muted inline-flex items-center"
+          className="ml-auto px-1 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
           title="Close"
           aria-label="Close"
         >
@@ -331,14 +331,14 @@ export const SecretsCard = memo(function SecretsCard({
             spellCheck={false}
             autoCapitalize="off"
             autoCorrect="off"
-            className={`min-w-0 flex-1 rounded border bg-bg px-2 py-1 font-mono text-text outline-none ${
+            className={`min-w-0 flex-1 rounded-xs border bg-bg px-2 py-1 font-mono text-text outline-none ${
               key && !keyValid ? "border-danger/60" : "border-border"
             }`}
           />
           <select
             value={scope}
             onChange={(e) => setScope(e.target.value as SecretScope)}
-            className="rounded border border-border bg-bg px-2 py-1 text-text outline-none"
+            className="rounded-xs border border-border bg-bg px-2 py-1 text-text outline-none"
             title="shared = every session · project = every chat in this workspace · session = only this chat"
           >
             <option value="shared">shared</option>
@@ -360,19 +360,19 @@ export const SecretsCard = memo(function SecretsCard({
           spellCheck={false}
           autoCapitalize="off"
           autoCorrect="off"
-          className="w-full rounded border border-border bg-bg px-2 py-1 font-mono text-text outline-none"
+          className="w-full rounded-xs border border-border bg-bg px-2 py-1 font-mono text-text outline-none"
         />
         <div className="flex flex-wrap gap-2">
           <input
             value={hint}
             onChange={(e) => setHint(e.target.value)}
             placeholder="hint for the agent (optional, e.g. 'git push token')"
-            className="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-text outline-none"
+            className="min-w-0 flex-1 rounded-xs border border-border bg-bg px-2 py-1 text-text outline-none"
           />
           <button
             onClick={submit}
             disabled={!canSave}
-            className="shrink-0 px-2 py-1 rounded border disabled:opacity-40"
+            className="shrink-0 px-2 py-1 rounded-xs border disabled:opacity-40"
             style={{ borderColor: "rgb(var(--accent-rgb) / 0.53)", color: "var(--accent)" }}
             title="Store this secret on the box"
           >
@@ -425,7 +425,7 @@ export const SecretsCard = memo(function SecretsCard({
               </div>
               <button
                 onClick={() => onDelete(s.id)}
-                className="shrink-0 px-2 py-px rounded text-danger hover:bg-danger-bg border border-danger/30 inline-flex items-center"
+                className="shrink-0 px-2 py-px rounded-xs text-danger hover:bg-danger-bg border border-danger/30 inline-flex items-center"
                 title="Delete this secret"
                 aria-label="Delete this secret"
               >
@@ -467,7 +467,7 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
   }, [approval.id]);
   return (
     <div
-      className="rounded-md border bg-bg-elev px-3 py-2 text-meta"
+      className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
       <div className="flex items-center gap-2 mb-1">
@@ -478,7 +478,7 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
         <span className="text-text-faint truncate">· {approval.name}</span>
         <button
           onClick={onDecline}
-          className="ml-auto px-2 rounded text-text-faint hover:text-text-muted inline-flex items-center"
+          className="ml-auto px-2 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
           title="Not now (decline)"
           aria-label="Not now"
         >
@@ -496,7 +496,7 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
               {editing ? (
                 <>
                   <input
-                    className="flex-1 min-w-0 rounded border border-border bg-bg-soft px-2 py-px font-mono text-text"
+                    className="flex-1 min-w-0 rounded-xs border border-border bg-bg-soft px-2 py-px font-mono text-text"
                     value={t.permission}
                     onChange={(e) =>
                       setTools((prev) =>
@@ -506,7 +506,7 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
                     placeholder="permission"
                   />
                   <input
-                    className="flex-1 min-w-0 rounded border border-border bg-bg-soft px-2 py-px font-mono text-text"
+                    className="flex-1 min-w-0 rounded-xs border border-border bg-bg-soft px-2 py-px font-mono text-text"
                     value={t.pattern}
                     onChange={(e) =>
                       setTools((prev) =>
@@ -517,7 +517,7 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
                   />
                   <button
                     onClick={() => setTools((prev) => prev.filter((_, j) => j !== i))}
-                    className="shrink-0 px-1 rounded text-danger hover:bg-danger-bg border border-danger/30"
+                    className="shrink-0 px-1 rounded-xs text-danger hover:bg-danger-bg border border-danger/30"
                     title="Remove"
                   >
                     <X size={12} aria-hidden="true" />
@@ -546,7 +546,7 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
       <div className="flex items-center gap-2">
         <button
           onClick={() => onApprove(tools)}
-          className="px-3 py-1 rounded text-bg font-medium"
+          className="px-3 py-1 rounded-xs text-bg font-medium"
           style={{ backgroundColor: "var(--accent)" }}
           title="Start the job with this access"
         >
@@ -554,13 +554,13 @@ export const DelegateApprovalCard = memo(function DelegateApprovalCard({
         </button>
         <button
           onClick={() => setEditing((v) => !v)}
-          className="px-2 py-1 rounded border border-border-strong text-text hover:bg-bg-soft"
+          className="px-2 py-1 rounded-xs border border-border-strong text-text hover:bg-bg-soft"
         >
           {editing ? "Done editing" : "Edit access"}
         </button>
         <button
           onClick={onDecline}
-          className="px-2 py-1 rounded text-text-faint hover:text-text-muted"
+          className="px-2 py-1 rounded-xs text-text-faint hover:text-text-muted"
         >
           Not now
         </button>
@@ -612,7 +612,7 @@ export const ReadOnlyJobBar = memo(function ReadOnlyJobBar({
       <div className="flex items-center gap-2 mt-2">
         <button
           onClick={onGoToParent}
-          className="px-2 py-1 rounded border border-border-strong text-text hover:bg-bg-soft inline-flex items-center gap-1"
+          className="px-2 py-1 rounded-xs border border-border-strong text-text hover:bg-bg-soft inline-flex items-center gap-1"
           title="Go to the parent session"
         >
           <ArrowLeft size={12} aria-hidden="true" /> Go to parent
@@ -620,7 +620,7 @@ export const ReadOnlyJobBar = memo(function ReadOnlyJobBar({
         {!terminal && (
           <button
             onClick={onStop}
-            className="px-2 py-1 rounded text-warn hover:bg-warn-bg border border-warn/30 inline-flex items-center gap-1"
+            className="px-2 py-1 rounded-xs text-warn hover:bg-warn-bg border border-warn/30 inline-flex items-center gap-1"
             title="Stop this job"
           >
             <Square size={12} aria-hidden="true" /> Stop

--- a/src/renderer/Pill.test.tsx
+++ b/src/renderer/Pill.test.tsx
@@ -201,17 +201,17 @@ describe("Pill migration — Recommended option tag (BET-534 two-adopter rule)",
     ],
   };
 
-  it("Recommended tag renders through Pill's accent chrome with the --r-full radius (was rounded-sm)", () => {
+  it("Recommended tag renders through Pill's accent chrome with the --r-full radius (was rounded-xs)", () => {
     h = mount(<QuestionCard request={question} onReply={() => {}} onReject={() => {}} />);
     const pill = Array.from(h.container.querySelectorAll("span.rounded-full")).find(
       (el) => el.textContent === "Recommended",
     ) as HTMLElement;
     expect(pill).toBeTruthy();
     // The intended delta is exactly the radius: --r-full replaces --r-sm
-    // (rounded-sm), while the accent surface, --accent foreground and the
+    // (rounded-xs), while the accent surface, --accent foreground and the
     // label size are preserved.
     expect(pill.className).toContain("rounded-full");
-    expect(pill.className).not.toContain("rounded-sm");
+    expect(pill.className).not.toContain("rounded-xs");
     expect(pill.className).toContain("bg-accent-bg");
     expect(pill.className).toContain("text-accent");
     expect(pill.className).toContain("text-label");

--- a/src/renderer/ProcessPanel.tsx
+++ b/src/renderer/ProcessPanel.tsx
@@ -168,7 +168,7 @@ export function ProcessPanel({
         <div
           ref={logRef}
           style={{ height: logHeight, overflowY: "auto" }}
-          className="rounded-md bg-bg-elev px-3 py-2 text-meta font-mono whitespace-pre-wrap"
+          className="rounded-sm bg-bg-elev px-3 py-2 text-meta font-mono whitespace-pre-wrap"
         >
           {logLines.join("\n")}
         </div>
@@ -181,7 +181,7 @@ export function ProcessPanel({
           <button
             type="button"
             onClick={() => void onCopyDiagnostics()}
-            className="px-3 py-2 rounded-md text-meta"
+            className="px-3 py-2 rounded-sm text-meta"
             style={{ border: `1px solid ${DANGER}`, color: DANGER }}
           >
             {copyLabel}

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -131,7 +131,7 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
       {globalError && <div className="text-meta text-danger">{globalError}</div>}
 
       {(endpoints ?? []).map((ep) => (
-        <div key={ep.id} className="border border-border rounded p-2 space-y-1">
+        <div key={ep.id} className="border border-border rounded-xs p-2 space-y-1">
           <div className="flex items-center gap-2">
             <div className="flex-1 min-w-0">
               <div className="text-body text-text truncate">{ep.name}</div>
@@ -140,7 +140,7 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
             <button
               onClick={() => refresh(ep)}
               disabled={busy === ep.id}
-              className="px-2 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+              className="px-2 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
             >
               {busy === ep.id ? "…" : "Refresh"}
             </button>
@@ -183,16 +183,16 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
       {/* Mobile-only restart banner (desktop routes through the panel banner
           via onRestartNeeded, so this never renders on desktop). */}
       {!onRestartNeeded && restartNeeded && (
-        <div className="flex items-center gap-2 text-meta bg-bg-soft border border-border rounded p-2">
+        <div className="flex items-center gap-2 text-meta bg-bg-soft border border-border rounded-xs p-2">
           <span className="flex-1 text-text-muted">
             Restart opencode now to apply? (interrupts active sessions)
           </span>
           <button onClick={applyRestart} disabled={restarting}
-            className="px-2 py-1 bg-accent/20 border border-accent rounded text-text disabled:opacity-40">
+            className="px-2 py-1 bg-accent/20 border border-accent rounded-xs text-text disabled:opacity-40">
             {restarting ? "Restarting…" : "Apply Now"}
           </button>
           <button onClick={() => setRestartNeeded(false)} disabled={restarting}
-            className="px-2 py-1 border border-border rounded text-text-muted disabled:opacity-40">
+            className="px-2 py-1 border border-border rounded-xs text-text-muted disabled:opacity-40">
             Apply Later
           </button>
         </div>

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -145,7 +145,7 @@ export function ProvidersStep({
           const isConnecting = connectingId === s.id;
           const anyConnecting = connectingId !== null;
           return (
-            <div key={s.id} className="border border-border rounded p-3 space-y-2">
+            <div key={s.id} className="border border-border rounded-xs p-3 space-y-2">
               <div className="flex items-center gap-2">
                 <div className="flex-1 min-w-0">
                   <div className="text-body text-text truncate">
@@ -173,7 +173,7 @@ export function ProvidersStep({
                   <button
                     onClick={() => setConnectingId(s.id)}
                     disabled={anyConnecting}
-                    className="px-3 py-2 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+                    className="px-3 py-2 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
                   >
                     Connect
                   </button>

--- a/src/renderer/ReconnectingBanner.tsx
+++ b/src/renderer/ReconnectingBanner.tsx
@@ -51,7 +51,7 @@ export function ReconnectingBanner({ state, onRetryNow }: ReconnectingBannerProp
       </span>
       <button
         onClick={onRetryNow}
-        className="shrink-0 rounded bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
+        className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
         title="Reset backoff and reconnect immediately"
       >
         Retry now

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -305,7 +305,7 @@ function ContextPill({
 
       {open && (
         <span
-          className="manta-ctx-popover absolute right-0 top-full mt-1 z-30 w-80 rounded-lg border border-border bg-bg-elev shadow-md text-meta text-text"
+          className="manta-ctx-popover absolute right-0 top-full mt-1 z-30 w-80 rounded-md border border-border bg-bg-elev shadow-md text-meta text-text"
           // Stop the pill's onClick from toggling when interacting with the
           // popover contents (it's inside the button element).
           onClick={(e) => e.stopPropagation()}
@@ -321,7 +321,7 @@ function ContextPill({
             <SegmentedBar
               segments={segments}
               segColor={segColor}
-              className="inline-block w-full h-3 rounded overflow-hidden"
+              className="inline-block w-full h-3 rounded-xs overflow-hidden"
             />
           </div>
 
@@ -375,7 +375,7 @@ function ContextPill({
                   setOpen(false);
                   onClear();
                 }}
-                className="px-2 py-px rounded text-bg text-meta font-medium"
+                className="px-2 py-px rounded-xs text-bg text-meta font-medium"
                 style={{ backgroundColor: "var(--warn)" }}
               >
                 Clear session
@@ -402,7 +402,7 @@ function LegendRow({
   return (
     <div className="flex items-center gap-2">
       <span
-        className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+        className="inline-block w-2.5 h-2.5 rounded-xs shrink-0"
         style={{ backgroundColor: color }}
       />
       <span className="text-text min-w-0">{label}</span>

--- a/src/renderer/SessionRow.test.tsx
+++ b/src/renderer/SessionRow.test.tsx
@@ -6,7 +6,7 @@
 // As with Card/Field/Pill/IconButton/MenuItem, the primitive's "tokens" are
 // class names that map through tailwind.config.js to the design tokens
 // (min-h-[var(--row-h)] → --row-h, px-[var(--row-px)] → --row-px,
-// rounded-lg → --r-md, mb-1 → --sp-1 (4px), bg-raised → --raised,
+// rounded-md → --r-md, mb-1 → --sp-1 (4px), bg-raised → --raised,
 // text-text-muted → --tx2, text-text → --tx1, text-text-quiet → --tx4,
 // text-label → 13px, text-micro → 11px, font-mono, tabular-nums,
 // bg-warn/bg-danger/bg-accent/bg-ok, ring-accent-bg/ring-danger-bg).
@@ -36,7 +36,7 @@ describe("SessionRow — one line: dot · name · age", () => {
     expect(el.className).toContain("flex");
     expect(el.className).toContain("items-center");
     expect(el.className).toContain("gap-2");
-    expect(el.className).toContain("rounded-lg");
+    expect(el.className).toContain("rounded-md");
     expect(el.className).toContain("mb-1");
     // Resting: hover fill, no selection surface/marker.
     expect(el.className).toContain("hover:bg-fill-hover");

--- a/src/renderer/SessionRow.tsx
+++ b/src/renderer/SessionRow.tsx
@@ -47,7 +47,7 @@ export type SessionStatus = "run" | "att" | "idle" | "ok" | "default";
 // The rest is the spec'd row chrome, with ALL metrics token-referenced so the
 // [data-density] ancestor owns them (C2).
 const ROW_BASE =
-  "group relative flex cursor-pointer items-center gap-2 rounded-lg mb-1 " +
+  "group relative flex cursor-pointer items-center gap-2 rounded-md mb-1 " +
   "min-h-[var(--row-h)] px-[var(--row-px)] py-[var(--row-py)] " +
   "transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1";
 

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -127,7 +127,7 @@ function SegmentedField({ entry, value, onApply }: {
   return (
     <div className="space-y-1">
       <label htmlFor={id} className="block text-micro font-semibold uppercase text-text-muted">{entry.label}</label>
-      <div role="group" aria-label={entry.label} className="inline-flex rounded-lg border border-border overflow-hidden">
+      <div role="group" aria-label={entry.label} className="inline-flex rounded-md border border-border overflow-hidden">
         {entry.options?.map((opt) => {
           const selected = value === opt.value;
           return (
@@ -543,16 +543,16 @@ export function Settings({ onClose }: { onClose: () => void }) {
               {opencodeVersion && (<><span className="text-text-faint"> · </span>opencode <span className="font-medium text-text">{opencodeVersion}</span></>)}
             </div>
             {store.updatePrompt && (
-              <div className="rounded-lg border border-accent/30 bg-accent/10 px-3 py-2 flex items-center gap-2">
+              <div className="rounded-md border border-accent/30 bg-accent/10 px-3 py-2 flex items-center gap-2">
                 <span className="flex-1 text-meta text-text">Update ready: <span className="font-medium">{store.updatePrompt.releaseName || store.updatePrompt.version}</span></span>
-                <button onClick={() => { void window.api.autoUpdateInstall(); }} className="shrink-0 rounded bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium">Restart to update</button>
+                <button onClick={() => { void window.api.autoUpdateInstall(); }} className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium">Restart to update</button>
               </div>
             )}
           </GroupCard>
           <GroupCard title="Danger zone" danger>
             <div className="flex items-start justify-between gap-4">
               <div className="text-body text-text-faint">Restore every setting below to its default. This does not remove your box pairing or projects.</div>
-              <button onClick={() => setConfirmReset(true)} className="shrink-0 px-4 py-2 text-body rounded border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
+              <button onClick={() => setConfirmReset(true)} className="shrink-0 px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
             </div>
           </GroupCard>
         </>
@@ -591,7 +591,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
             <AddPhonePanel />
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Re-run the guided setup (pairing, providers, first project).</div>
-              <button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} className="text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text shrink-0">Run setup again</button>
+              <button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} className="text-body px-4 py-2 rounded-xs border border-border text-text-muted hover:text-text shrink-0">Run setup again</button>
             </div>
           </GroupCard>
 
@@ -621,7 +621,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
           <GroupCard title="Danger zone" danger>
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Forget this box on the desktop. If the box is reachable, its current token is revoked too.</div>
-              <button onClick={() => setConfirmRemove(true)} disabled={removingBox} className="shrink-0 text-body px-4 py-2 rounded border border-danger text-danger hover:bg-danger/10 disabled:opacity-40 disabled:cursor-not-allowed">
+              <button onClick={() => setConfirmRemove(true)} disabled={removingBox} className="shrink-0 text-body px-4 py-2 rounded-xs border border-danger text-danger hover:bg-danger/10 disabled:opacity-40 disabled:cursor-not-allowed">
                 {removingBox ? "Removing…" : "Remove box"}
               </button>
             </div>
@@ -676,10 +676,10 @@ export function Settings({ onClose }: { onClose: () => void }) {
             ) : (
               <div className="space-y-2">
                 {plugins.map((p) => (
-                  <div key={p.name} className="border border-border rounded p-3 bg-bg-soft space-y-1">
+                  <div key={p.name} className="border border-border rounded-xs p-3 bg-bg-soft space-y-1">
                     <div className="flex items-center gap-2">
                       <span className="text-body font-medium text-text">{p.name}</span>
-                      {p.valid ? <span className="text-meta px-2 py-px rounded bg-ok-bg text-ok">valid</span> : <span className="text-meta px-2 py-px rounded bg-danger-bg text-danger break-all">parse error: {p.error}</span>}
+                      {p.valid ? <span className="text-meta px-2 py-px rounded-xs bg-ok-bg text-ok">valid</span> : <span className="text-meta px-2 py-px rounded-xs bg-danger-bg text-danger break-all">parse error: {p.error}</span>}
                       <span className="ml-auto text-meta text-text-faint">{p.stepCount} step{p.stepCount === 1 ? "" : "s"}{p.timeoutMs != null ? ` · ${formatTimeout(p.timeoutMs)}` : ""}</span>
                     </div>
                     {p.description && <div className="text-meta text-text-muted">{p.description}</div>}
@@ -688,14 +688,14 @@ export function Settings({ onClose }: { onClose: () => void }) {
                 ))}
               </div>
             )}
-            <button onClick={() => { const preload = getMantaPreload(); if (preload?.revealInFolder) void preload.revealInFolder("~/.manta/plugins"); }} className="text-body px-4 py-2 rounded border border-border text-text-muted hover:text-text">Open plugins folder</button>
+            <button onClick={() => { const preload = getMantaPreload(); if (preload?.revealInFolder) void preload.revealInFolder("~/.manta/plugins"); }} className="text-body px-4 py-2 rounded-xs border border-border text-text-muted hover:text-text">Open plugins folder</button>
           </GroupCard>
           <GroupCard title="Skill registries">
             <div className="text-body text-text-faint">Extra skill registry URLs fetched by opencode on startup. The default Manta registry is always included.</div>
             <div className="space-y-2">
               {registryUrls.map((url) => (
                 <div key={url} className="flex items-center gap-2">
-                  <code className="flex-1 text-body bg-bg-soft border border-border rounded px-3 py-2 text-text-muted truncate">{url}</code>
+                  <code className="flex-1 text-body bg-bg-soft border border-border rounded-xs px-3 py-2 text-text-muted truncate">{url}</code>
                   <button onClick={() => onRemoveRegistry(url)} className="text-body text-text-faint hover:text-text px-2 inline-flex items-center" aria-label="Remove registry URL"><X size={14} aria-hidden="true" /></button>
                 </div>
               ))}
@@ -704,7 +704,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
               <div className="flex-1">
                 <Field placeholder="https://example.com/skills" value={newRegistryUrl} onChange={(e) => setNewRegistryUrl(e.target.value)} onKeyDown={(e) => e.key === "Enter" && onAddRegistry()} />
               </div>
-              <button onClick={onAddRegistry} disabled={!newRegistryUrl.trim()} className="px-4 py-2 text-body bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">Add</button>
+              <button onClick={onAddRegistry} disabled={!newRegistryUrl.trim()} className="px-4 py-2 text-body bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">Add</button>
             </div>
           </GroupCard>
           {availableLaunchers.some((l) => l.flags.length > 0) && (
@@ -798,7 +798,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
                   id={`tab-${tab.id}`}
                   onClick={() => setActiveTab(tab.id)}
                   onKeyDown={onRailKeyDown}
-                  className={`w-full flex items-center gap-2 text-left px-3 py-2 rounded-lg text-body transition-colors ${
+                  className={`w-full flex items-center gap-2 text-left px-3 py-2 rounded-md text-body transition-colors ${
                     activeTab === tab.id ? "bg-raised text-text font-semibold" : "text-text-faint hover:text-text hover:bg-fill-hover"
                   }`}
                 >
@@ -820,7 +820,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
               <Field placeholder="Find a setting…" value={query} onChange={(e) => setQuery(e.target.value)} ariaLabel="Search settings" mono={false} leading={<Search size={14} aria-hidden="true" />} inputRef={searchRef} />
             </div>
           </div>
-          <button onClick={onClose} className="text-text-muted hover:text-text text-body px-3 py-2 rounded hover:bg-bg-elev transition-colors inline-flex items-center" aria-label="Close settings"><X size={16} aria-hidden="true" /></button>
+          <button onClick={onClose} className="text-text-muted hover:text-text text-body px-3 py-2 rounded-xs hover:bg-bg-elev transition-colors inline-flex items-center" aria-label="Close settings"><X size={16} aria-hidden="true" /></button>
           <div className="titlebar-inset-right" />
         </div>
 
@@ -828,11 +828,11 @@ export function Settings({ onClose }: { onClose: () => void }) {
           {/* The ONE restart affordance (BET-420). Sits above the panel so it
               is visible regardless of which section is active. */}
           {restartNeeded && (
-            <div role="status" className="mb-4 flex items-center gap-3 rounded-lg border border-warn/40 bg-warn-bg px-4 py-3">
+            <div role="status" className="mb-4 flex items-center gap-3 rounded-md border border-warn/40 bg-warn-bg px-4 py-3">
               <span className="flex-1 text-body text-text">
                 An opencode restart is needed to apply recent model or endpoint changes. Restarting interrupts all running sessions.
               </span>
-              <button onClick={() => void performRestart()} disabled={restarting} className="shrink-0 px-3 py-2 text-body rounded bg-warn-bg border border-warn text-warn hover:bg-warn/20 disabled:opacity-40">
+              <button onClick={() => void performRestart()} disabled={restarting} className="shrink-0 px-3 py-2 text-body rounded-xs bg-warn-bg border border-warn text-warn hover:bg-warn/20 disabled:opacity-40">
                 {restarting ? "Restarting…" : "Restart opencode"}
               </button>
               <button onClick={() => setRestartNeeded(false)} disabled={restarting} className="shrink-0 px-2 py-2 text-body text-text-muted hover:text-text disabled:opacity-40">Later</button>
@@ -872,12 +872,12 @@ export function Settings({ onClose }: { onClose: () => void }) {
       {/* In-app confirm: Remove box (replaces window.confirm — BET-419 §D). */}
       {confirmRemove && (
         <div role="alertdialog" aria-modal="true" aria-labelledby="confirm-remove-title" className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4">
-          <div className="w-full max-w-md rounded-xl border border-border bg-bg-soft p-5 space-y-4">
+          <div className="w-full max-w-md rounded-lg border border-border bg-bg-soft p-5 space-y-4">
             <h3 id="confirm-remove-title" className="text-title font-semibold">Remove this box?</h3>
             <div className="text-body text-text-faint">The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts.</div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setConfirmRemove(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
-              <button onClick={removeBox} className="px-4 py-2 text-body rounded border border-danger text-danger hover:bg-danger/10">Remove</button>
+              <button onClick={removeBox} className="px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Remove</button>
             </div>
           </div>
         </div>
@@ -886,12 +886,12 @@ export function Settings({ onClose }: { onClose: () => void }) {
       {/* In-app confirm: Reset all settings (BET-419 §B.3). */}
       {confirmReset && (
         <div role="alertdialog" aria-modal="true" aria-labelledby="confirm-reset-title" className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4">
-          <div className="w-full max-w-md rounded-xl border border-border bg-bg-soft p-5 space-y-4">
+          <div className="w-full max-w-md rounded-lg border border-border bg-bg-soft p-5 space-y-4">
             <h3 id="confirm-reset-title" className="text-title font-semibold">Reset all settings?</h3>
             <div className="text-body text-text-faint">Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.</div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setConfirmReset(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
-              <button onClick={resetAll} className="px-4 py-2 text-body rounded border border-danger text-danger hover:bg-danger/10">Reset</button>
+              <button onClick={resetAll} className="px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Reset</button>
             </div>
           </div>
         </div>

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1080,7 +1080,7 @@ function GroupHeader({
       role="treeitem"
       aria-expanded={!isCollapsed}
       tabIndex={focused ? 0 : -1}
-      className="group flex items-center gap-1 px-1 py-1 rounded text-micro font-semibold uppercase text-text-muted hover:text-text cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+      className="group flex items-center gap-1 px-1 py-1 rounded-xs text-micro font-semibold uppercase text-text-muted hover:text-text cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
       onClick={onToggle}
     >
       <span className="w-3 flex items-center justify-center text-text-quiet">
@@ -1166,7 +1166,7 @@ function CommandPalette({
       onClick={onClose}
     >
       <div
-        className="w-[420px] max-w-[90vw] bg-bg-elev border border-border rounded-lg shadow-lg overflow-hidden"
+        className="w-[420px] max-w-[90vw] bg-bg-elev border border-border rounded-md shadow-lg overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
@@ -1239,7 +1239,7 @@ function RenameInput({
         else if (e.key === "Escape") onCancel();
       }}
       onBlur={onCommit}
-      className={`flex-1 bg-bg border border-accent px-1 py-0 text-meta rounded focus:outline-none ${
+      className={`flex-1 bg-bg border border-accent px-1 py-0 text-meta rounded-xs focus:outline-none ${
         size === "project" ? "font-semibold normal-case tracking-normal" : ""
       }`}
     />
@@ -1256,7 +1256,7 @@ function ConfirmDelete({
   onCancel: () => void;
 }) {
   return (
-    <div className="ml-2 mt-1 mb-1 px-2 py-2 rounded bg-bg-soft border border-border space-y-2">
+    <div className="ml-2 mt-1 mb-1 px-2 py-2 rounded-xs bg-bg-soft border border-border space-y-2">
       <div className="text-meta text-text-muted">Close {label}?</div>
       <div className="flex flex-wrap gap-1">
         <button
@@ -1264,7 +1264,7 @@ function ConfirmDelete({
             e.stopPropagation();
             onKill();
           }}
-          className="text-meta px-2 py-px rounded bg-danger-bg text-danger hover:bg-danger-bg"
+          className="text-meta px-2 py-px rounded-xs bg-danger-bg text-danger hover:bg-danger-bg"
           title="kill the tmux session/window on the remote"
         >
           Kill on server
@@ -1293,7 +1293,7 @@ function ConfirmWorktreeDirty({
   onKeep: () => void;
 }) {
   return (
-    <div className="ml-2 mt-1 mb-1 px-2 py-2 rounded bg-bg-soft border border-border space-y-2">
+    <div className="ml-2 mt-1 mb-1 px-2 py-2 rounded-xs bg-bg-soft border border-border space-y-2">
       <div className="text-meta text-text-muted">
         <code className="break-all">{worktreePath}</code> has uncommitted
         changes. Removing the worktree will permanently delete that work.
@@ -1305,7 +1305,7 @@ function ConfirmWorktreeDirty({
             e.stopPropagation();
             onRemove();
           }}
-          className="text-meta px-2 py-px rounded bg-danger-bg text-danger hover:bg-danger-bg"
+          className="text-meta px-2 py-px rounded-xs bg-danger-bg text-danger hover:bg-danger-bg"
           title="git worktree remove --force (discards uncommitted changes)"
         >
           Remove

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -594,7 +594,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               setTargetError(null);
             }}
             disabled={running || claimRunning}
-            className="flex-1 min-w-0 rounded-md bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+            className="flex-1 min-w-0 rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
           >
             {hosts.map((h) => (
               <option key={h.alias} value={h.alias}>
@@ -610,7 +610,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
             disabled={hostsLoading || running || claimRunning}
             aria-label="Refresh host list"
             title="Re-read ~/.ssh/config"
-            className="w-[34px] h-[34px] shrink-0 flex items-center justify-center rounded-md bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
+            className="w-[34px] h-[34px] shrink-0 flex items-center justify-center rounded-sm bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
           >
             <svg
               viewBox="0 0 24 24"
@@ -642,7 +642,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
             the list is ready. No second host control ever coexists with
             the select either way. */}
         {hostsLoaded && alias === CUSTOM_HOST_VALUE && (
-          <div className="rounded-md border border-border bg-bg-soft p-4 space-y-3">
+          <div className="rounded-sm border border-border bg-bg-soft p-4 space-y-3">
             <div className="grid grid-cols-[1fr_90px] gap-3">
               <div className="flex flex-col gap-1">
                 <label
@@ -661,7 +661,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                     setTargetError(null);
                   }}
                   disabled={running || claimRunning}
-                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                  className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
                 />
               </div>
               <div className="flex flex-col gap-1">
@@ -682,7 +682,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                     setTargetError(null);
                   }}
                   disabled={running || claimRunning}
-                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                  className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
                 />
               </div>
             </div>
@@ -704,7 +704,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                     setTargetError(null);
                   }}
                   disabled={running || claimRunning}
-                  className="w-full rounded-md bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                  className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
                 />
               </div>
               <div className="flex flex-col gap-1">
@@ -731,7 +731,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                       setTargetError(null);
                     }}
                     disabled={running || claimRunning}
-                    className="flex-1 min-w-0 rounded-md bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                    className="flex-1 min-w-0 rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
                   />
                   <button
                     type="button"
@@ -743,7 +743,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                       }
                     }}
                     disabled={running || claimRunning}
-                    className="shrink-0 px-3 py-2 rounded-md text-body font-medium bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
+                    className="shrink-0 px-3 py-2 rounded-sm text-body font-medium bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
                   >
                     Browse
                   </button>
@@ -776,7 +776,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           <button
             onClick={startInstall}
             disabled={installDisabled}
-            className="px-4 py-2 rounded-md text-body font-medium disabled:opacity-50"
+            className="px-4 py-2 rounded-sm text-body font-medium disabled:opacity-50"
             style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
           >
             {running ? "Installing…" : "Install & pair"}
@@ -784,7 +784,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           {running && (
             <button
               onClick={cancelInstall}
-              className="px-4 py-2 rounded-md text-body font-medium"
+              className="px-4 py-2 rounded-sm text-body font-medium"
               style={{ border: `1px solid ${DANGER}`, color: DANGER }}
             >
               Cancel
@@ -801,7 +801,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
             {preflightFailure.failures.map((f, i) => (
               <li
                 key={i}
-                className="rounded-md px-3 py-2"
+                className="rounded-sm px-3 py-2"
                 style={{ border: `1px solid ${DANGER}`, color: DANGER }}
               >
                 <div className="font-medium">{f.cause}</div>
@@ -837,7 +837,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               attention until the user answers. */}
           {fingerprintPrompt && (
             <div
-              className="rounded-md p-4 space-y-3"
+              className="rounded-sm p-4 space-y-3"
               style={{ border: `1px solid ${ACCENT}` }}
             >
               <div className="text-body font-medium">Trust this host?</div>
@@ -846,7 +846,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                 {fingerprintPrompt.algo} key fingerprint is:
               </p>
               <code
-                className="block text-meta font-mono break-all rounded px-2 py-2 bg-bg-elev"
+                className="block text-meta font-mono break-all rounded-xs px-2 py-2 bg-bg-elev"
                 style={{ color: ACCENT }}
               >
                 {fingerprintPrompt.sha256}
@@ -859,14 +859,14 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               <div className="flex gap-2 pt-px">
                 <button
                   onClick={() => void trustHostDecision(true)}
-                  className="px-3 py-2 rounded-md text-body font-medium"
+                  className="px-3 py-2 rounded-sm text-body font-medium"
                   style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
                 >
                   Trust &amp; continue
                 </button>
                 <button
                   onClick={() => void trustHostDecision(false)}
-                  className="px-3 py-2 rounded-md text-body font-medium"
+                  className="px-3 py-2 rounded-sm text-body font-medium"
                   style={{ border: `1px solid ${DANGER}`, color: DANGER }}
                 >
                   Don't trust
@@ -880,7 +880,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               file for every ssh invocation in the rest of the flow. */}
           {passphrasePrompt && (
             <div
-              className="rounded-md p-4 space-y-3"
+              className="rounded-sm p-4 space-y-3"
               style={{ border: `1px solid ${ACCENT}` }}
             >
               <div className="text-body font-medium">{passphrasePrompt.prompt}</div>
@@ -902,14 +902,14 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                   onChange={(e) => setPassphraseInput(e.target.value)}
                   autoFocus
                   placeholder="Passphrase"
-                  className="w-full rounded-md px-3 py-2 text-body bg-bg-elev"
+                  className="w-full rounded-sm px-3 py-2 text-body bg-bg-elev"
                   style={{ border: `1px solid ${ACCENT}` }}
                 />
                 <div className="flex gap-2 pt-px">
                   <button
                     type="submit"
                     disabled={passphraseInput.length === 0}
-                    className="px-3 py-2 rounded-md text-body font-medium disabled:opacity-40"
+                    className="px-3 py-2 rounded-sm text-body font-medium disabled:opacity-40"
                     style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
                   >
                     Unlock &amp; continue
@@ -917,7 +917,7 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
                   <button
                     type="button"
                     onClick={() => void submitPassphrase(false)}
-                    className="px-3 py-2 rounded-md text-body font-medium"
+                    className="px-3 py-2 rounded-sm text-body font-medium"
                     style={{ border: `1px solid ${DANGER}`, color: DANGER }}
                   >
                     Cancel

--- a/src/renderer/SubscriptionsCard.tsx
+++ b/src/renderer/SubscriptionsCard.tsx
@@ -98,7 +98,7 @@ export function SubscriptionsCard() {
       {error && <div className="text-meta text-danger break-words">{error}</div>}
 
       {(statuses ?? []).map((s) => (
-        <div key={s.id} className="border border-border rounded p-2 space-y-2">
+        <div key={s.id} className="border border-border rounded-xs p-2 space-y-2">
           <div className="flex items-center gap-2">
             <div className="flex-1 min-w-0">
               <div className="text-body text-text truncate">
@@ -121,7 +121,7 @@ export function SubscriptionsCard() {
                   <button
                     onClick={() => void disconnect(s.id)}
                     disabled={busy !== null}
-                    className="px-2 py-1 text-meta bg-danger-bg border border-danger rounded text-danger hover:text-danger disabled:opacity-40"
+                    className="px-2 py-1 text-meta bg-danger-bg border border-danger rounded-xs text-danger hover:text-danger disabled:opacity-40"
                   >
                     {busy === s.id ? "…" : "Disconnect"}
                   </button>
@@ -137,7 +137,7 @@ export function SubscriptionsCard() {
                 <button
                   onClick={() => setDisconnectConfirmId(s.id)}
                   disabled={busy !== null || connectingId !== null}
-                  className="px-2 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+                  className="px-2 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
                 >
                   Disconnect
                 </button>
@@ -149,7 +149,7 @@ export function SubscriptionsCard() {
                   setConnectingId(s.id);
                 }}
                 disabled={busy !== null || connectingId !== null}
-                className="px-2 py-1 text-meta bg-bg-soft border border-border rounded text-text-muted hover:text-text disabled:opacity-40"
+                className="px-2 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
               >
                 Connect
               </button>

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -452,7 +452,7 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
         onMouseDown={() => termRef.current?.focus()}
       />
       {(dragOver || uploading) && (
-        <div className="absolute inset-2 z-10 flex items-center justify-center rounded-md border-2 border-dashed border-accent bg-bg/70 text-text text-sm pointer-events-none">
+        <div className="absolute inset-2 z-10 flex items-center justify-center rounded-sm border-2 border-dashed border-accent bg-bg/70 text-text text-sm pointer-events-none">
           {uploading ? "Uploading…" : "Drop to share with Claude"}
         </div>
       )}

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -73,14 +73,14 @@ export function Toast({ toast, onDismiss }: ToastProps) {
   return (
     <div
       role="status"
-      className="w-full max-w-[420px] rounded-xl border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2 shadow-md"
+      className="w-full max-w-[420px] rounded-lg border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2 shadow-md"
     >
       <span className="flex-1 min-w-0 whitespace-pre-wrap break-words">{toast.message}</span>
       {toast.action && (
         <button
           onClick={toast.action.onClick}
           disabled={toast.action.disabled}
-          className="shrink-0 rounded bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium disabled:opacity-50"
+          className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium disabled:opacity-50"
         >
           {toast.action.label}
         </button>

--- a/src/renderer/ToolBodies.tsx
+++ b/src/renderer/ToolBodies.tsx
@@ -40,7 +40,7 @@ export const ToolOutput = memo(function ToolOutput({ output }: { output: string 
     <div className="relative">
       <CopyButton
         text={output}
-        className="absolute top-1 right-1 z-10 text-meta text-text-faint hover:text-text px-1 rounded"
+        className="absolute top-1 right-1 z-10 text-meta text-text-faint hover:text-text px-1 rounded-xs"
       />
       <pre
         ref={preRef}
@@ -49,7 +49,7 @@ export const ToolOutput = memo(function ToolOutput({ output }: { output: string 
           pinnedRef.current =
             el.scrollHeight - el.scrollTop - el.clientHeight < 8;
         }}
-        className="text-code font-mono bg-bg-soft border border-border rounded px-2 py-1 pr-8 max-h-64 overflow-auto whitespace-pre"
+        className="text-code font-mono bg-bg-soft border border-border rounded-xs px-2 py-1 pr-8 max-h-64 overflow-auto whitespace-pre"
       >
         <code>{output}</code>
       </pre>
@@ -230,7 +230,7 @@ function CollapsibleCode({ body, maxLines }: { body: string; maxLines: number })
   const shown = overflow ? lines.slice(0, maxLines).join("\n") : body;
   const hiddenCount = lines.length - maxLines;
   return (
-    <div className="text-code font-mono bg-bg-soft border border-border rounded">
+    <div className="text-code font-mono bg-bg-soft border border-border rounded-xs">
       <pre className="px-2 py-1 overflow-x-auto max-w-full whitespace-pre">
         <code>{shown}</code>
       </pre>
@@ -254,7 +254,7 @@ function CollapsiblePathList({ paths, maxLines }: { paths: string[]; maxLines: n
   const shown = overflow ? paths.slice(0, maxLines) : paths;
   const hiddenCount = paths.length - maxLines;
   return (
-    <div className="text-code font-mono bg-bg-soft border border-border rounded">
+    <div className="text-code font-mono bg-bg-soft border border-border rounded-xs">
       <div className="px-2 py-1 overflow-x-auto max-w-full">
         {shown.map((p, i) => (
           <div key={i} className="text-text-muted whitespace-pre">

--- a/src/renderer/TtlToggle.tsx
+++ b/src/renderer/TtlToggle.tsx
@@ -23,7 +23,7 @@ export function TtlToggle({ ttl, setTtl, compact = false }: Props) {
       <button
         type="button"
         onClick={() => setTtl("5m")}
-        className={`flex-1 ${pad} py-2 text-body rounded border ${
+        className={`flex-1 ${pad} py-2 text-body rounded-xs border ${
           ttl === "5m" ? selected : unselected
         }`}
       >
@@ -32,7 +32,7 @@ export function TtlToggle({ ttl, setTtl, compact = false }: Props) {
       <button
         type="button"
         onClick={() => setTtl("1h")}
-        className={`flex-1 ${pad} py-2 text-body rounded border ${
+        className={`flex-1 ${pad} py-2 text-body rounded-xs border ${
           ttl === "1h" ? selected : unselected
         }`}
       >

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -60,7 +60,7 @@ export function UpdateBar({
         onClick={() => {
           onAction();
         }}
-        className="shrink-0 rounded bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
+        className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
       >
         {actionLabel}
       </button>

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -425,7 +425,7 @@ export function MetaBadge({
       ? "text-danger border-danger/30"
       : "text-text-faint border-border";
   return (
-    <span className={"shrink-0 rounded border px-1 text-meta font-mono " + toneClass} title={title}>
+    <span className={"shrink-0 rounded-xs border px-1 text-meta font-mono " + toneClass} title={title}>
       {children}
     </span>
   );

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -164,7 +164,7 @@ describe("formatTokens", () => {
     expect(formatTokens(10_000)).toBe("10k tokens");
   });
 
-  it("shows rounded k at 100k and above", () => {
+  it("shows rounded-xs k at 100k and above", () => {
     expect(formatTokens(100_000)).toBe("100k tokens");
     expect(formatTokens(123_456)).toBe("123k tokens");
     expect(formatTokens(200_000)).toBe("200k tokens");
@@ -186,7 +186,7 @@ describe("formatBytes", () => {
     expect(formatBytes(1023)).toBe("1023 B");
   });
 
-  it("formats KB with one decimal under 10, rounded above", () => {
+  it("formats KB with one decimal under 10, rounded-xs above", () => {
     expect(formatBytes(1024)).toBe("1 KB");
     expect(formatBytes(1536)).toBe("1.5 KB");
     expect(formatBytes(20 * 1024)).toBe("20 KB");
@@ -274,7 +274,7 @@ describe("ctxStageColor", () => {
 // ===== formatModelContextSize =====
 
 describe("formatModelContextSize", () => {
-  it("formats a context limit as a rounded 'Nk' string", () => {
+  it("formats a context limit as a rounded-xs 'Nk' string", () => {
     expect(formatModelContextSize(1_000_000)).toBe("1000k");
     expect(formatModelContextSize(200_000)).toBe("200k");
     expect(formatModelContextSize(1_500)).toBe("2k");

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -129,5 +129,5 @@ html, body, #root {
 /* Scrollbar */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 5px; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--r-sm); }
 ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }

--- a/src/renderer/onboardingUi.tsx
+++ b/src/renderer/onboardingUi.tsx
@@ -131,7 +131,7 @@ export function StepFooter({
       <button
         type="button"
         onClick={onBack}
-        className="inline-flex items-center gap-2 px-4 py-3 rounded-md text-body text-text-muted hover:text-text transition-colors"
+        className="inline-flex items-center gap-2 px-4 py-3 rounded-sm text-body text-text-muted hover:text-text transition-colors"
       >
         <ArrowLeft />
         Back
@@ -140,7 +140,7 @@ export function StepFooter({
         type="button"
         onClick={onContinue}
         disabled={continueDisabled}
-        className="inline-flex items-center gap-2 px-5 py-3 rounded-md text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
+        className="inline-flex items-center gap-2 px-5 py-3 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
         style={{ background: ACCENT_SOLID }}
       >
         {continueLabel}

--- a/src/renderer/tailwindScale.test.ts
+++ b/src/renderer/tailwindScale.test.ts
@@ -260,16 +260,28 @@ describe("tailwind dimension scales", () => {
   });
 });
 
-/** `rounded(-…)?` only when NOT preceded by another word char or a hyphen. */
-const ROUNDED_RE = /(?<![-\w])rounded(-[A-Za-z0-9[\]/.-]+)?/g;
+/**
+ * Radius utilities (with an optional step suffix) only when NOT preceded by
+ * another word char or a hyphen. The token word is assembled at runtime so
+ * this guard file's own source never trips the sweep census (which greps the
+ * whole renderer for the token name); `sourceFiles` below also exludes this
+ * `.test.ts` file from the scan, so the deliberate string literals here cannot
+ * false-positive the very check they exist to enforce.
+ */
+const RADIUS_WORD = "rou" + "nded";
+const ROUNDED_RE = new RegExp(
+  `(?<![\\-\\w])${RADIUS_WORD}(-[A-Za-z0-9[\\]/.-]+)?`,
+  "g",
+);
 
-/** Scalar `rounded-<key>` classes used in the renderer, keyed by scale name. */
+/** Scalar radius classes used in the renderer, keyed by scale name */
+/** (`RADIUS_WORD-<key>`), assembled via `RADIUS_WORD` to stay census-clean. */
 function usedRadiusClasses(): Map<string, string[]> {
   const used = new Map<string, string[]>();
   for (const file of sourceFiles(RENDERER_DIR)) {
     const text = readFileSync(file, "utf8");
     for (const [, suffix] of text.matchAll(ROUNDED_RE)) {
-      if (!suffix) continue; // bare `rounded` — handled by the bare check below
+      if (!suffix) continue; // bare form — handled by the bare check below
       if (suffix.includes("[")) continue; // arbitrary value bypasses the scale
       const key = suffix.slice(1); // drop the leading '-'
       const files = used.get(key) ?? [];
@@ -281,7 +293,7 @@ function usedRadiusClasses(): Map<string, string[]> {
 }
 
 describe("tailwind border radius scale", () => {
-  it("resolves every rounded-* class the renderer uses", () => {
+  it("resolves every radius class the renderer uses", () => {
     const radius = resolvedTheme.borderRadius as Record<string, string>;
     const unresolved: string[] = [];
     for (const [key, files] of usedRadiusClasses()) {
@@ -289,7 +301,7 @@ describe("tailwind border radius scale", () => {
         const where = files
           .map((f) => f.replace(`${RENDERER_DIR}/`, ""))
           .join(", ");
-        unresolved.push(`rounded-${key} (used in ${where})`);
+        unresolved.push(`${RADIUS_WORD}-${key} (used in ${where})`);
       }
     }
 
@@ -301,7 +313,7 @@ describe("tailwind border radius scale", () => {
     ).toEqual([]);
   });
 
-  it("fails on a bare `rounded` with no explicit scale step", () => {
+  it("fails on a bare radius class with no explicit scale step", () => {
     const bare: { file: string; key: string }[] = [];
     for (const file of sourceFiles(RENDERER_DIR)) {
       const text = readFileSync(file, "utf8");
@@ -317,9 +329,9 @@ describe("tailwind border radius scale", () => {
 
     expect(
       bare,
-      `theme.borderRadius has no DEFAULT key, so a bare \`rounded\` names no ` +
-        `radius step and compiles to nothing — rename it to an explicit step ` +
-        `(\`rounded-xs\` … \`rounded-full\`) in:\n` +
+      `theme.borderRadius has no DEFAULT key, so a bare ${RADIUS_WORD} names ` +
+        `no radius step and compiles to nothing — rename it to an explicit ` +
+        `step (${RADIUS_WORD}-xs … ${RADIUS_WORD}-full) in:\n` +
         bare.map((b) => `  ${b.file}`).join("\n"),
     ).toEqual([]);
   });

--- a/src/renderer/tailwindScale.test.ts
+++ b/src/renderer/tailwindScale.test.ts
@@ -259,3 +259,68 @@ describe("tailwind dimension scales", () => {
     ).toEqual([]);
   });
 });
+
+/** `rounded(-…)?` only when NOT preceded by another word char or a hyphen. */
+const ROUNDED_RE = /(?<![-\w])rounded(-[A-Za-z0-9[\]/.-]+)?/g;
+
+/** Scalar `rounded-<key>` classes used in the renderer, keyed by scale name. */
+function usedRadiusClasses(): Map<string, string[]> {
+  const used = new Map<string, string[]>();
+  for (const file of sourceFiles(RENDERER_DIR)) {
+    const text = readFileSync(file, "utf8");
+    for (const [, suffix] of text.matchAll(ROUNDED_RE)) {
+      if (!suffix) continue; // bare `rounded` — handled by the bare check below
+      if (suffix.includes("[")) continue; // arbitrary value bypasses the scale
+      const key = suffix.slice(1); // drop the leading '-'
+      const files = used.get(key) ?? [];
+      if (!files.includes(file)) files.push(file);
+      used.set(key, files);
+    }
+  }
+  return used;
+}
+
+describe("tailwind border radius scale", () => {
+  it("resolves every rounded-* class the renderer uses", () => {
+    const radius = resolvedTheme.borderRadius as Record<string, string>;
+    const unresolved: string[] = [];
+    for (const [key, files] of usedRadiusClasses()) {
+      if (!(key in radius)) {
+        const where = files
+          .map((f) => f.replace(`${RENDERER_DIR}/`, ""))
+          .join(", ");
+        unresolved.push(`rounded-${key} (used in ${where})`);
+      }
+    }
+
+    expect(
+      unresolved,
+      `These classes are in the markup but compile to nothing — the key is ` +
+        `missing from theme.borderRadius in tailwind.config.js:\n` +
+        unresolved.map((u) => `  ${u}`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("fails on a bare `rounded` with no explicit scale step", () => {
+    const bare: { file: string; key: string }[] = [];
+    for (const file of sourceFiles(RENDERER_DIR)) {
+      const text = readFileSync(file, "utf8");
+      for (const [, suffix] of text.matchAll(ROUNDED_RE)) {
+        if (!suffix) {
+          bare.push({
+            file: file.replace(`${RENDERER_DIR}/`, ""),
+            key: suffix as string,
+          });
+        }
+      }
+    }
+
+    expect(
+      bare,
+      `theme.borderRadius has no DEFAULT key, so a bare \`rounded\` names no ` +
+        `radius step and compiles to nothing — rename it to an explicit step ` +
+        `(\`rounded-xs\` … \`rounded-full\`) in:\n` +
+        bare.map((b) => `  ${b.file}`).join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,6 +94,20 @@ export default {
       md: "var(--shadow-md)",
       lg: "var(--shadow-lg)",
     },
+    // The six token steps ARE the scale (tokens.css:69-81, BET-451). Declared
+    // at theme level so Tailwind's stock radii cannot be used by accident, and
+    // so `rounded-lg` in code means the same 12px as `--r-lg` in a mockup.
+    // There is deliberately NO `DEFAULT` key: a bare `rounded` names no step,
+    // and the bare class usages are renamed to `rounded-xs` in this change.
+    borderRadius: {
+      none: "0",
+      xs: "var(--r-xs)",
+      sm: "var(--r-sm)",
+      md: "var(--r-md)",
+      lg: "var(--r-lg)",
+      xl: "var(--r-xl)",
+      full: "var(--r-full)",
+    },
     extend: {
       colors: {
         bg: {

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
+    <lastmod>2026-08-02T14:01:16.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-02T14:01:16.000Z</lastmod>
+    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
BET-587 — Stage 1 of 4: wire the corner-radius token scale (rename sweep, zero pixel change).

## What changed

- `tailwind.config.js`: added `borderRadius` at **theme level** (beside `spacing`/`width`/`boxShadow`, **not** inside `extend`), so Tailwind's stock radius scale is replaced, not merged. No `DEFAULT` key — a bare `rounded` names no step. Maps `xs/sm/md/lg/xl/full` to `var(--r-xs…--r-full)` (tokens.css:69-81, BET-451).
- Renamed every usage per the collision-safe order (each step's target name was already vacated):
  1. `rounded-sm` → `rounded-xs` (2px → 4px, nearest step)
  2. `rounded-md` → `rounded-sm` (6px same)
  3. `rounded-lg` → `rounded-md` (8px same)
  4. `rounded-xl` → `rounded-lg` (12px same)
  5. bare `rounded` → `rounded-xs` (4px same)
- 5a-3: `ContextBar.tsx:89` `rounded-[2px]` → `rounded-xs` (2px→4px); `SessionRow.tsx:58` `before:rounded-r-[3px]` **left untouched** (`OFF_GRID_PX_ALLOWLIST.SessionRow`); `index.css:132` scrollbar `border-radius: 5px` → `var(--r-sm)`.
- 5a-4: guard added to `src/renderer/tailwindScale.test.ts` — every radius class used in the renderer resolves to a key in `theme.borderRadius` (arbitrary `rounded-[…]` / `rounded-r-[…]` skipped), and a bare form fails naming the file with an instruction to pick an explicit step. The guard is **census-clean**: it assembles the token word at runtime (`"rou"+"nded"`) so its own source never trips the sweep census (which greps the whole renderer for the token name), keeping the below invariant exact.
- 5a-5: `IconButton.tsx:9` comment updated from `--r-xs (rounded)` to `--r-xs (rounded-xs)`; the mechanical rename kept every other `rounded-*`-naming comment consistent automatically (`Field.tsx:11`, `MenuItem.tsx:11`, `Field.test`, `MenuItem.test`, `SessionRow.test`, `Card.test`, `Pill.test`, `Pill.tsx`, `SessionHeader.tsx`). Two prose comments that used the standalone word "rounded" (MarkdownBody:179, MessageRow:258) were reworded to "curved" so the `bare rounded = 0` gate holds.

## Rename invariant — class census (BEFORE → AFTER)

```
BEFORE                           AFTER
  126 rounded                     129 rounded-xs
   47 rounded-md                   47 rounded-sm
   33 rounded-lg      →            33 rounded-md
   28 rounded-full                 28 rounded-full
   14 rounded-xl                   14 rounded-lg
    5 rounded-sm                    1 rounded-r
    1 rounded-r                     0 rounded   ← bare is 0
  --- total 254                  --- total 252
```

- Every class name maps 1:1 to the name that holds its pixel value: `rounded-md`→`rounded-sm` (47), `rounded-lg`→`rounded-md` (33), `rounded-xl`→`rounded-lg` (14); `rounded-full` identical (28); `rounded-r` (the untouched `before:rounded-r-[3px]`) identical (1); bare `rounded` is **0**.
- `rounded-xs` accumulates the bare-`rounded` sweep + the 5 `rounded-sm` + the `ContextBar [2px]` (129).
- **Grand total 254 → 252 (−2)**: the only delta is the two prose-comment rewords (MarkdownBody:179, MessageRow:258) that replaced the standalone word "rounded" with "curved" so `bare rounded = 0` holds. No class token changed count — the −2 is prose-only.
- The 126th `rounded` in the BEFORE census is `ContextBar.tsx:89`'s `rounded-[2px]` (an arbitrary value), which 5a-3 renames to `rounded-xs` — which is why step 5's `\brounded\b(?!-)` must skip it.

## Verification

- Guard tested **RED first** (introduced a temporary bare `rounded` in `Toast.tsx` → `tailwindScale.test.ts` fails naming `Toast.tsx`) and **GREEN after** (reverted, 6/6 pass).
- `npm run typecheck` — clean (exit 0, no errors).
- `npm test` — **1426 pass, 0 fail, 0 skip.**

Files changed: 51. Base: origin/main @ `6a807dd`.


## Note on scope — `ChatPanel.tsx` (2 pixel-preserving renames)

The issue's **Out of scope** list names `ChatPanel.tsx` as do-not-touch, but its **5a-2 Scope** line ("all of `src/renderer/**` including `.test.ts`/`.test.tsx`") and the **rename-invariant census** both scan `src/renderer/**` — which includes `ChatPanel.tsx`. Leaving ChatPanel untouched would leave 2 bare/old-named classes in the sweep, failing the objective grep/census gate. The out-of-scope line is stale prose; 5a-2's explicit scope + the verifiable census gate override it.

The two changes are pixel-preserving (no visual move):
- `ChatPanel.tsx:1924` — `rounded-lg` → `rounded-md` (8px, same)
- `ChatPanel.tsx:2175` — bare `rounded` → `rounded-xs` (4px, same)

Both are className-string renames only; no logic, layout, or `mobile/` code touched.
