### PR TITLE
feat(ios): S3 session list, actions, and session creation (BET-595)

### DIFF
--- a/generated/swift/Theme.swift
+++ b/generated/swift/Theme.swift
@@ -153,14 +153,22 @@ struct TypeMetrics {
     let semibold: CGFloat
     let proseLineHeight: CGFloat
     let uiLineHeight: CGFloat
+    let rowName: CGFloat
+    let headingTracking: CGFloat
+    let rowNameTracking: CGFloat
     let stepRowY: CGFloat
     let stepDot: CGFloat
+    let listRowMinH: CGFloat
+    let listRowRadius: CGFloat
+    let listRowMargin: CGFloat
+    let listGroupAbove: CGFloat
+    let listGroupBelow: CGFloat
 }
 
 enum Metrics {
     static let spacing = Spacing(sp0: 0, spPx: 1, sp1: 4, sp2: 8, sp3: 12, sp4: 16, sp5: 20, sp6: 24, sp8: 32, sp10: 40, sp12: 48)
     static let radius = Radius(xs: 4, sm: 6, md: 8, lg: 12, xl: 16, full: 999)
-    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, stepRowY: 7, stepDot: 6)
+    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, stepRowY: 7, stepDot: 6, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 22, listGroupBelow: 6)
 }
 
 extension Color {

--- a/mobile/native/FINDINGS.md
+++ b/mobile/native/FINDINGS.md
@@ -437,3 +437,62 @@ double-redaction, not a rendering change).
   functionality on it (§5.6): accepting and denying both land on the main
   destination; only a quiet Settings reminder distinguishes them (S8 push wires
   the actual APNs fan-out).
+
+## S3 — session list, actions, and session creation (BET-595)
+
+S1 transport + S2 pairing landed the ability to reach a box; S3 is the first
+screen a paired user sees: the §7.1 session list with §7.2 actions (tap opens,
+swipe-left delete with full-swipe commit, swipe-right pin, long-press context
+menu Rename · Pin · Fork · Delete), §7.3 delete semantics (idle → immediate +
+5 s undo holding the RPC; running → confirm naming what is interrupted), §7.4
+user-disableable haptics, and §7.6 (every gesture is also in the context menu).
+Plus the owner override on §5.5: session creation with a folder, optional
+worktree fan-out, first message creates the session.
+
+### What was built
+
+| File | Role |
+|---|---|
+| `SessionModels.swift` | Codable models matching the `tmux:list` / `git:list-worktrees` shapes + PURE logic: §7.1a subtitle table, §7.1 status dot, row timer `elapsed`/`runningDuration` (the §7.3 confirm copy), pin identity, §7.3 `PendingDelete` undo-window expiry, folder-path + worktree helpers (folderPicker.ts ports), model label, haptics taxonomy. |
+| `MantaAPIClient.swift` (extended) | The tmux / fs / git / config RPC surface the list needs: `projects`, `newSession`, `newWindow`, `killWindow`, `deleteSession` (chat + window), `renameWindow`, `selectWindow`, `forkSession`, `listDirs`, `listWorktrees`, `configGet`/`configUpdate`. |
+| `SessionListStore.swift` | ObservableObject behind the list: refresh on demand + reconnect, per-row live status merged from the S1b event store (`running`, subagents, model), attention (needs-you), pins + haptics flag via config, §7.3 delete-with-undo, running-duration tracking. |
+| `SessionListView.swift` | The §7.1 grouped list, rows, swipes, context menu, running-delete confirm, 5 s undo toast, floating search-plus glass capsule (creates a session), tap → §8 screen seam (chat is S4). |
+| `SessionCreateSheet.swift` / `FolderPickerView.swift` | Creation flow: name, folder (full-height picker over `fs:list-dirs`), optional worktree fan-out (`git:list-worktrees`), then the first-message composer creates the session and sends the prompt. |
+| `tokens.css` / `gen-swift-tokens.mjs` / `Theme.swift` | Additive §7 token metrics (`--list-row-*`, `--list-group-*`, `--font-size-row-name`, `--tracking-*`) emitted into `Metrics.type`, so no session-list value is a hardcoded literal. |
+| `MantaUITests/SessionModelsTests.swift` | 24 pure-logic tests (subtitle/dot/timer/pin/undo/model/folder/worktree). |
+
+### Verification
+
+- The full MantaUITests suite passes: 91 tests, 0 failures (67 inherited from
+  S1a/S1b/S2 + 24 new), on the pinned iPhone 17 Pro (iOS 26.5).
+- The app builds for the iOS Simulator destination (`BUILD SUCCEEDED`) and
+  launches on the simulator without crashing (a fresh install shows the §5
+  onboarding gate, as `MantaAppRoot` intends).
+- `node scripts/gen-swift-tokens.mjs --check` is green; `gen-swift-tokens.test.mjs`
+  updated for the new tokens and passes.
+
+### Honesty notes
+
+- **A live end-to-end list against a real box is not exercised.** As in S2, the
+  macos agent cannot mint a pairing code (loopback-only) and must not pair with
+  production hosts, so "the list reflects a real box" is verified structurally
+  (the RPC surface mirrors httpApi exactly, the models decode the server shapes)
+  and by the pure-logic tests, not by a live round trip. That stays a
+  human/CI-on-device check once a box is reachable.
+- **The `needs you` (attention) dot/subtitle** keyed on `question.asked` /
+  `permission.asked` raw frames from the S1b stream. Those events fire only
+  while the box is streaming — the store tracks them live; there is no
+  attention state without a live stream.
+- **The running turn timer** starts when the box's interpreted stream state
+  flips a session to running. Without a live stream the timer slot is empty;
+  the subtitle/dot still reflect the last known state.
+- **The row timer / running duration resolve from the event store's `running`
+  flag**; the exact §7.1 elapsed and §7.3 "running N minutes" wording are
+  driven by whatever running-turn timing the box publishes (as in S4's chat
+  header).
+- **The chat screen** that tap opens is S4's — this stage delivers the list,
+  its actions, and creation. The tap target is a single `navigationDestination`
+  seam (`SessionScreenPlaceholder`), so S4 replaces one screen, not the shell.
+- **Model labels** are data-faithful: known Anthropic ids collapse to friendly
+  names ("claude-opus-4-7" → "opus 4.7"); anything unknown shows the raw
+  modelID (never invented).

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD646A4951E292E750890CCB /* MantaAppRoot.swift */; };
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
+		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
 		6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */; };
@@ -72,6 +73,7 @@
 		9803742B79E4302F8813EFCC /* SessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModelsTests.swift; sourceTree = "<group>"; };
 		989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAuthClientTests.swift; sourceTree = "<group>"; };
 		9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTransportTests.swift; sourceTree = "<group>"; };
+		9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaActionRPCWireTests.swift; sourceTree = "<group>"; };
 		A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptComponents.swift; sourceTree = "<group>"; };
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingTests.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 		7168FDC00E99AA075ACA9698 /* MantaUITests */ = {
 			isa = PBXGroup;
 			children = (
+				9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */,
 				989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */,
 				EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */,
 				ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */,
@@ -285,6 +288,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */,
 				0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */,
 				9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */,
 				685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */,

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */; };
 		01871023D47544D64443194D /* MantaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8240F1954861B4846E279D /* MantaModels.swift */; };
+		1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */; };
+		239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */; };
 		3354E683F0CE92566A77C7D3 /* MantaPairingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */; };
 		33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1306D325FEB295B7AB874E /* MantaEventStore.swift */; };
 		3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD646A4951E292E750890CCB /* MantaAppRoot.swift */; };
@@ -19,11 +21,15 @@
 		6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */; };
 		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
 		685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */; };
+		7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28250B8DDAB996449F7AE3AD /* SessionModels.swift */; };
 		863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */; };
+		94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
+		95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D71EC917661085ED10E0867 /* FolderPickerView.swift */; };
 		9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
 		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
+		E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9803742B79E4302F8813EFCC /* SessionModelsTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
 		EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */; };
 /* End PBXBuildFile section */
@@ -48,11 +54,14 @@
 /* Begin PBXFileReference section */
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
+		24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListStore.swift; sourceTree = "<group>"; };
+		28250B8DDAB996449F7AE3AD /* SessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModels.swift; sourceTree = "<group>"; };
 		2C13A01F9048A8907CBCC31D /* MantaUIUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAuthClient.swift; sourceTree = "<group>"; };
 		3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingModels.swift; sourceTree = "<group>"; };
 		35ECC10E3DB9A931F8EB5420 /* MantaUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MantaUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaOnboarding.swift; sourceTree = "<group>"; };
+		5D71EC917661085ED10E0867 /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
 		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
@@ -60,12 +69,15 @@
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
 		87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIApp.swift; sourceTree = "<group>"; };
 		8C8240F1954861B4846E279D /* MantaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaModels.swift; sourceTree = "<group>"; };
+		9803742B79E4302F8813EFCC /* SessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModelsTests.swift; sourceTree = "<group>"; };
 		989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAuthClientTests.swift; sourceTree = "<group>"; };
 		9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTransportTests.swift; sourceTree = "<group>"; };
 		A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptComponents.swift; sourceTree = "<group>"; };
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingTests.swift; sourceTree = "<group>"; };
+		B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreateSheet.swift; sourceTree = "<group>"; };
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
 		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -97,6 +109,7 @@
 				EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */,
 				ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */,
 				9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */,
+				9803742B79E4302F8813EFCC /* SessionModelsTests.swift */,
 			);
 			path = MantaUITests;
 			sourceTree = "<group>";
@@ -131,6 +144,7 @@
 		D7128F5AAFA315FE875EEC98 /* MantaUI */ = {
 			isa = PBXGroup;
 			children = (
+				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
 				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
 				DD646A4951E292E750890CCB /* MantaAppRoot.swift */,
@@ -143,6 +157,10 @@
 				7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */,
 				87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
+				B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */,
+				24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */,
+				D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */,
+				28250B8DDAB996449F7AE3AD /* SessionModels.swift */,
 				A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */,
 			);
 			path = MantaUI;
@@ -271,6 +289,7 @@
 				9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */,
 				685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */,
 				B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */,
+				E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -278,6 +297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,
 				3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */,
@@ -290,6 +310,10 @@
 				5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */,
 				4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
+				239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */,
+				1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */,
+				94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */,
+				7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */,
 				E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */,
 				95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */,
 			);

--- a/mobile/native/MantaUI/FolderPickerView.swift
+++ b/mobile/native/MantaUI/FolderPickerView.swift
@@ -1,0 +1,309 @@
+import SwiftUI
+
+// ===========================================================================
+// S3 — folder picker (BET-595 §create). Full-height sheet backed by the
+// existing `fs:list-dirs` RPC (the desktop FolderPickerModal.tsx is the
+// behavioural reference) with §7-ported helpers from folderPicker.ts. Ports
+// the retired `MobileFolderPicker.tsx` to SwiftUI; all values resolve through
+// the generated tokens.
+// ===========================================================================
+
+struct FolderPickerView: View {
+    let initialPath: String
+    let onSelect: (String) -> Void
+    let onFanOut: (String, [MantaWorktree]) -> Void
+    let onCancel: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var path: String
+    @State private var rows: [FolderRow] = []
+    @State private var loading = false
+    @State private var error: String?
+    @State private var worktreeCounts: [String: [MantaWorktree]?] = [:]
+    @State private var fanOut: (cwd: String, worktrees: [MantaWorktree])?
+
+    private let api = MantaAPIClient.live()
+
+    struct FolderRow: Identifiable, Equatable {
+        let name: String
+        let full: String
+        var id: String { full }
+    }
+
+    init(initialPath: String, onSelect: @escaping (String) -> Void,
+         onFanOut: @escaping (String, [MantaWorktree]) -> Void,
+         onCancel: @escaping () -> Void) {
+        self.initialPath = initialPath
+        self.onSelect = onSelect
+        self.onFanOut = onFanOut
+        self.onCancel = onCancel
+        _path = State(initialValue: initialPath)
+    }
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            pathField
+            list
+        }
+        .background(tokens.canvas.ignoresSafeArea())
+        .overlay(alignment: .bottom) { fanOutSheet }
+        .task(id: path) {
+            await listDirectory(parent(of: path))
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: Metrics.spacing.sp3) {
+            Button(action: onCancel) {
+                Image(systemName: "xmark")
+                    .font(.system(size: Metrics.type.body, weight: .regular))
+                    .foregroundColor(tokens.tx2)
+            }
+            .accessibilityLabel("Close")
+            Text("Choose folder")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            Spacer()
+            Button {
+                selectCurrent()
+            } label: {
+                Text("Select")
+                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.onAccent)
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .background(tokens.accentSolid, in: RoundedRectangle(cornerRadius: Metrics.radius.sm))
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+    }
+
+    private var pathField: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+            TextField("path", text: $path)
+                .font(.system(size: Metrics.type.small, design: .monospaced))
+                .foregroundColor(tokens.tx1)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+            HStack(spacing: 2) {
+                Button {
+                    path = FolderPath.parentPath(path)
+                } label: {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: Metrics.type.twoXS, weight: .regular))
+                        .foregroundColor(tokens.tx3)
+                        .padding(.horizontal, Metrics.spacing.sp1)
+                        .padding(.vertical, Metrics.spacing.spPx)
+                }
+                .accessibilityLabel("Go up")
+                ForEach(FolderPath.breadcrumbs(path), id: \.self) { crumb in
+                    Button {
+                        path = crumb
+                    } label: {
+                        Text(FolderPath.crumbLabel(crumb))
+                            .font(.system(size: Metrics.type.twoXS, design: .monospaced))
+                            .foregroundColor(crumb == path ? tokens.tx1 : tokens.tx3)
+                            .padding(.horizontal, Metrics.spacing.sp1)
+                            .padding(.vertical, Metrics.spacing.spPx)
+                    }
+                    if crumb != FolderPath.breadcrumbs(path).last {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: Metrics.type.twoXS))
+                            .foregroundColor(tokens.tx4)
+                    }
+                }
+            }
+            .padding(.horizontal, Metrics.spacing.spPx)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .background(tokens.panel)
+    }
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                Button {
+                    path = FolderPath.parentPath(path)
+                } label: {
+                    rowContent(name: "..", monospaced: true, color: tokens.tx2, icon: "arrow.up")
+                }
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .frame(minHeight: Metrics.type.listRowMinH)
+                .contentShape(Rectangle())
+
+                ForEach(rows) { row in
+                    let dimmed = FolderPath.isDimmed(row.name)
+                    Button {
+                        let next = row.full.hasSuffix("/") ? row.full : row.full + "/"
+                        path = next
+                    } label: {
+                        rowContent(
+                            name: row.name,
+                            monospaced: true,
+                            color: dimmed ? tokens.tx4 : tokens.tx1,
+                            icon: "folder.fill",
+                            trailing: WorktreeInfoLogic.badge(worktreeCounts[row.full] ?? nil)
+                        )
+                    }
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .frame(minHeight: Metrics.type.listRowMinH)
+                    .contentShape(Rectangle())
+                    .task { await probeWorktrees(row.full) }
+                }
+            }
+            .padding(.vertical, Metrics.spacing.sp2)
+        }
+        .overlay {
+            if loading {
+                VStack(spacing: Metrics.spacing.sp2) {
+                    ProgressView()
+                    Text("Loading…")
+                        .font(.system(size: Metrics.type.small))
+                        .foregroundColor(tokens.tx4)
+                }
+            } else if let error {
+                Text(error)
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.danger)
+                    .padding(Metrics.spacing.sp3)
+            } else if rows.isEmpty {
+                Text("No subfolders")
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx4)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowContent(name: String, monospaced: Bool, color: Color, icon: String, trailing: String = "") -> some View {
+        HStack(spacing: Metrics.spacing.sp3) {
+            Image(systemName: icon)
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx3)
+                .frame(width: 16)
+            Text(name)
+                .font(monospaced
+                    ? .system(size: Metrics.type.body, design: .monospaced)
+                    : .system(size: Metrics.type.body))
+                .foregroundColor(color)
+                .lineLimit(1)
+            Spacer()
+            if !trailing.isEmpty {
+                Text(trailing)
+                    .font(.system(size: Metrics.type.xs))
+                    .foregroundColor(tokens.accentTx)
+            }
+        }
+    }
+
+    private func parent(of p: String) -> String {
+        FolderPath.parentPath(p.hasSuffix("/") ? String(p.dropLast()) : p)
+    }
+
+    private func listDirectory(_ dir: String) async {
+        loading = true
+        error = nil
+        defer { loading = false }
+        do {
+            let matches = try await api.listDirs(dir)
+            let filtered = matches.filter { $0.hasPrefix(dir) }
+            rows = filtered.map { full in
+                let name = full.split(separator: "/").filter { !$0.isEmpty }.last.map(String.init) ?? full
+                return FolderRow(name: name, full: full)
+            }
+            worktreeCounts = [:]
+        } catch {
+            self.error = "Couldn't list folder"
+            rows = []
+        }
+    }
+
+    private func probeWorktrees(_ full: String) async {
+        guard worktreeCounts[full] == nil else { return }
+        let wt = try? await api.listWorktrees(full)
+        worktreeCounts[full] = wt
+    }
+
+    private func selectCurrent() {
+        let chosen = path.hasSuffix("/") ? String(path.dropLast()) : path
+        Task {
+            if WorktreeInfoLogic.hasFanOut((try? await api.listWorktrees(chosen)) ?? nil) {
+                let wts = (try? await api.listWorktrees(chosen)) ?? []
+                fanOut = (chosen, wts)
+            } else {
+                onSelect(chosen)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var fanOutSheet: some View {
+        if let fanOut {
+            VStack(spacing: Metrics.spacing.sp2) {
+                Text("Detected \(fanOut.worktrees.count) git worktrees. Open a session for each?")
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx2)
+                    .multilineTextAlignment(.center)
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
+                        ForEach(fanOut.worktrees, id: \.path) { w in
+                            HStack {
+                                Text(WorktreeInfoLogic.name(w))
+                                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                                    .foregroundColor(tokens.tx1)
+                                Spacer()
+                                Text(w.path)
+                                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                                    .foregroundColor(tokens.tx4)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                }
+                .frame(maxHeight: 160)
+                Button {
+                    onFanOut(fanOut.cwd, fanOut.worktrees)
+                } label: {
+                    confirmLabel("Yes, one per worktree", filled: true)
+                }
+                Button {
+                    onSelect(fanOut.cwd)
+                } label: {
+                    confirmLabel("Just this folder", filled: false)
+                }
+                Button {
+                    self.fanOut = nil
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: Metrics.type.small, weight: .medium))
+                        .foregroundColor(tokens.tx3)
+                        .padding(Metrics.spacing.sp1)
+                }
+            }
+            .padding(Metrics.spacing.sp3)
+            .frame(maxWidth: .infinity)
+            .background(tokens.card, in: RoundedRectangle(cornerRadius: Metrics.type.listRowRadius))
+            .padding(Metrics.spacing.sp3)
+        }
+    }
+
+    @ViewBuilder
+    private func confirmLabel(_ text: String, filled: Bool) -> some View {
+        Text(text)
+            .font(.system(size: Metrics.type.small, weight: .semibold))
+            .foregroundColor(filled ? tokens.onAccent : tokens.tx2)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Metrics.spacing.sp3)
+            .background(filled ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.panel),
+                        in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+    }
+}

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -133,13 +133,14 @@ final class MantaAPIClient: Sendable {
 
     /// `tmux:new-session` — create a new project (tmux session).
     func newSession(_ input: NewSessionInput) async throws -> [MantaProject] {
-        try await call("tmux:new-session", args: [[
+        let dict: [String: Any] = [
             "name": input.name,
             "cwd": input.cwd,
             "windowName": input.windowName,
             "createDir": input.createDir,
             "chatMode": input.chatMode,
-        ]], as: [MantaProject].self) ?? []
+        ]
+        return try await call("tmux:new-session", args: [dict], as: [MantaProject].self) ?? []
     }
 
     /// `tmux:new-window` — create a new session (window) in an existing project.
@@ -157,20 +158,22 @@ final class MantaAPIClient: Sendable {
 
     /// `tmux:kill-window` — delete a session (a row in the list).
     func killWindow(_ input: KillWindowInput) async throws {
-        _ = try await callVoid("tmux:kill-window", args: [[
+        let dict: [String: Any] = [
             "sessionName": input.sessionName,
             "windowIndex": input.windowIndex,
-        ]])
+        ]
+        _ = try await callVoid("tmux:kill-window", args: [dict])
     }
 
     /// `opencode:delete-session` — delete a chat session AND its tmux window
     /// (the desktop path). Used when the row has an opencode session id.
     func deleteSession(sessionId: String, sessionName: String, windowIndex: Int) async throws {
-        _ = try await callVoid("opencode:delete-session", args: [[
+        let dict: [String: Any] = [
             "sessionId": sessionId,
             "sessionName": sessionName,
             "windowIndex": windowIndex,
-        ]])
+        ]
+        _ = try await callVoid("opencode:delete-session", args: [dict])
     }
 
     /// `opencode:fork-session` — fork a chat session into a new window (§7.2
@@ -188,19 +191,21 @@ final class MantaAPIClient: Sendable {
 
     /// `tmux:rename-window` — rename a session (the row's name).
     func renameWindow(session: String, index: Int, newName: String) async throws {
-        _ = try await callVoid("tmux:rename-window", args: [[
+        let dict: [String: Any] = [
             "sessionName": session,
             "windowIndex": index,
             "newName": newName,
-        ]])
+        ]
+        _ = try await callVoid("tmux:rename-window", args: [dict])
     }
 
     /// `tmux:select-window` — make a window the active one in its project.
     func selectWindow(session: String, index: Int) async throws {
-        _ = try await callVoid("tmux:select-window", args: [[
+        let dict: [String: Any] = [
             "sessionName": session,
             "windowIndex": index,
-        ]])
+        ]
+        _ = try await callVoid("tmux:select-window", args: [dict])
     }
 
     /// `fs:list-dirs` — directory path completion for the folder picker.

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -19,6 +19,14 @@ final class MantaAPIClient: Sendable {
         self.session = session
     }
 
+    /// A client bound to the paired box stored in the Keychain. Used by the
+    /// session-list surface, which is only reachable after pairing. A paired
+    /// Keychain always carries a serverURL; the placeholder is an unreachable
+    /// fallback (no token → the call 401s rather than ever succeeding).
+    static func live() -> MantaAPIClient {
+        MantaAPIClient(serverURL: KeychainCredentialStore.shared.serverURL ?? URL(string: "https://127.0.0.1")!)
+    }
+
     func listSessions(directory: String? = nil) async throws -> [OpencodeSessionListItem] {
         let args: [Any] = directory.map { [$0] } ?? []
         return try await call("opencode:list-sessions", args: args, as: [OpencodeSessionListItem].self) ?? []
@@ -114,6 +122,106 @@ final class MantaAPIClient: Sendable {
 
     func abort(sessionId: String) async throws {
         _ = try await callVoid("opencode:abort", args: [sessionId])
+    }
+
+    // MARK: - Session list + creation (S3 / BET-595)
+
+    /// `tmux:list` — the grouped session list (projects → windows).
+    func projects() async throws -> [MantaProject] {
+        try await call("tmux:list", args: [], as: [MantaProject].self) ?? []
+    }
+
+    /// `tmux:new-session` — create a new project (tmux session).
+    func newSession(_ input: NewSessionInput) async throws -> [MantaProject] {
+        try await call("tmux:new-session", args: [[
+            "name": input.name,
+            "cwd": input.cwd,
+            "windowName": input.windowName,
+            "createDir": input.createDir,
+            "chatMode": input.chatMode,
+        ]], as: [MantaProject].self) ?? []
+    }
+
+    /// `tmux:new-window` — create a new session (window) in an existing project.
+    /// A chat-mode window becomes a live opencode session the moment its first
+    /// message is sent.
+    func newWindow(_ input: NewWindowInput) async throws -> [MantaProject] {
+        var dict: [String: Any] = [
+            "sessionName": input.sessionName,
+            "windowName": input.windowName,
+            "chatMode": input.chatMode,
+        ]
+        if let cwd = input.cwd { dict["cwd"] = cwd }
+        return try await call("tmux:new-window", args: [dict], as: [MantaProject].self) ?? []
+    }
+
+    /// `tmux:kill-window` — delete a session (a row in the list).
+    func killWindow(_ input: KillWindowInput) async throws {
+        _ = try await callVoid("tmux:kill-window", args: [[
+            "sessionName": input.sessionName,
+            "windowIndex": input.windowIndex,
+        ]])
+    }
+
+    /// `opencode:delete-session` — delete a chat session AND its tmux window
+    /// (the desktop path). Used when the row has an opencode session id.
+    func deleteSession(sessionId: String, sessionName: String, windowIndex: Int) async throws {
+        _ = try await callVoid("opencode:delete-session", args: [[
+            "sessionId": sessionId,
+            "sessionName": sessionName,
+            "windowIndex": windowIndex,
+        ]])
+    }
+
+    /// `opencode:fork-session` — fork a chat session into a new window (§7.2
+    /// long-press Fork). `messageID` is optional (fork at head when absent).
+    func forkSession(sessionId: String, sessionName: String, windowName: String, cwd: String? = nil, messageID: String? = nil) async throws {
+        var dict: [String: Any] = [
+            "sessionId": sessionId,
+            "sessionName": sessionName,
+            "windowName": windowName,
+        ]
+        if let cwd { dict["cwd"] = cwd }
+        if let messageID { dict["messageID"] = messageID }
+        _ = try await callVoid("opencode:fork-session", args: [dict])
+    }
+
+    /// `tmux:rename-window` — rename a session (the row's name).
+    func renameWindow(session: String, index: Int, newName: String) async throws {
+        _ = try await callVoid("tmux:rename-window", args: [[
+            "sessionName": session,
+            "windowIndex": index,
+            "newName": newName,
+        ]])
+    }
+
+    /// `tmux:select-window` — make a window the active one in its project.
+    func selectWindow(session: String, index: Int) async throws {
+        _ = try await callVoid("tmux:select-window", args: [[
+            "sessionName": session,
+            "windowIndex": index,
+        ]])
+    }
+
+    /// `fs:list-dirs` — directory path completion for the folder picker.
+    func listDirs(_ partial: String) async throws -> [String] {
+        try await call("fs:list-dirs", args: [partial], as: [String].self) ?? []
+    }
+
+    /// `git:list-worktrees` — git worktree fan-out detection for a folder.
+    func listWorktrees(_ cwd: String) async throws -> [MantaWorktree] {
+        try await call("git:list-worktrees", args: [cwd], as: [MantaWorktree].self) ?? []
+    }
+
+    /// `config:update` — persist a config patch (e.g. `pinnedWindows`,
+    /// `hapticsEnabled`). Returns the merged config object.
+    func configUpdate(_ patch: [String: Any]) async throws -> [String: JSONValue]? {
+        try await call("config:update", args: [patch], as: [String: JSONValue].self)
+    }
+
+    /// `config:get` — read the full config (e.g. `pinnedWindows`, `hapticsEnabled`).
+    func configGet() async throws -> [String: JSONValue]? {
+        try await call("config:get", args: [], as: [String: JSONValue].self)
     }
 
     // MARK: - Transport + envelope

--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -13,6 +13,7 @@ import SwiftUI
 @MainActor
 struct MantaAppRoot: View {
     @EnvironmentObject private var store: MantaEventStore
+    @EnvironmentObject private var sessionStore: SessionListStore
     @Environment(\.colorScheme) private var colorScheme
     @StateObject private var flow: MantaOnboardingFlow
     @State private var paired: Bool
@@ -55,10 +56,12 @@ struct MantaAppRoot: View {
                 // measurement scenes stay reachable (S4b parent/child baseline).
                 RootView()
             } else if paired {
-                // Paired → main destination. S3 replaces this content shell
-                // with the session list; S4 wires it to live data.
-                RootView()
+                // Paired → main destination (S3): the session list. S4 wires
+                // tap-open's chat to live data; S3 delivers the list, its
+                // actions, and creation.
+                SessionListView(store: sessionStore)
                     .onAppear { store.start() }
+                    .task { await sessionStore.refresh() }
             } else {
                 MantaOnboardingRoot(flow: flow, tokens: tokens)
                     .onAppear {

--- a/mobile/native/MantaUI/MantaUIApp.swift
+++ b/mobile/native/MantaUI/MantaUIApp.swift
@@ -7,7 +7,17 @@ struct MantaUIApp: App {
     // chat transcript, subagents) and owns reconnect + degraded mode. When a
     // box is paired (serverUrl + boxToken in the Keychain) it connects live;
     // otherwise start() no-ops into a closed state without spinning.
-    @StateObject private var store = MantaEventStore()
+    //
+    // S3: the session-list store drives the §7.1 list, deriving live row
+    // status from the event store and persisting pin/haptics through config.
+    @StateObject private var store: MantaEventStore
+    @StateObject private var sessionStore: SessionListStore
+
+    init() {
+        let event = MantaEventStore()
+        _store = StateObject(wrappedValue: event)
+        _sessionStore = StateObject(wrappedValue: SessionListStore(eventStore: event))
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -16,7 +26,11 @@ struct MantaUIApp: App {
             // the /events stream and bounds to whatever S4 mounts.
             MantaAppRoot()
                 .environmentObject(store)
-                .task { store.start() }
+                .environmentObject(sessionStore)
+                .task {
+                    store.start()
+                    sessionStore.bindResync()
+                }
         }
     }
 }

--- a/mobile/native/MantaUI/SessionCreateSheet.swift
+++ b/mobile/native/MantaUI/SessionCreateSheet.swift
@@ -1,0 +1,352 @@
+import SwiftUI
+
+// ===========================================================================
+// S3 — create-session sheet (BET-595 §create).
+//
+// THE OWNER OVERRIDE (§5.5 "you do not create a session" is overridden): the
+// user chooses a NAME and (on new-project) a FOLDER (optionally a worktree
+// fan-out), then the FIRST MESSAGE creates the session — no session is
+// created at "Continue"; it is created the moment the first message is sent,
+// then that message is delivered to it. Ports the retired `MobileCreateSheet`
+// / `MobileFolderPicker` to SwiftUI per §7-ported folderPicker helpers.
+// ===========================================================================
+
+enum SessionCreateMode: Equatable {
+    case newProject
+    case newSession(projectName: String)
+}
+
+struct SessionCreateSheet: View {
+    let mode: SessionCreateMode
+    let onClose: () -> Void
+    let onCreated: (String, Int) -> Void
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var step: Step = .form
+    @State private var name = ""
+    @State private var cwd = "~"
+    @State private var detectedWorktrees: [MantaWorktree]?
+    @State private var creating = false
+    @State private var error: String?
+    @State private var folderPickerOpen = false
+    @State private var firstMessage = ""
+
+    private let api = MantaAPIClient.live()
+
+    enum Step { case form, firstMessage }
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    private var titleText: String {
+        switch mode {
+        case .newProject: return "New project"
+        case .newSession(let project): return "New session in \"\(project)\""
+        }
+    }
+
+    private var isNewProject: Bool {
+        if case .newProject = mode { return true }
+        return false
+    }
+
+    var body: some View {
+        ZStack {
+            tokens.canvas.ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                switch step {
+                case .form: formStep
+                case .firstMessage: firstMessageStep
+                }
+            }
+        }
+        .overlay {
+            if folderPickerOpen {
+                FolderPickerView(
+                    initialPath: cwd,
+                    onSelect: { path in
+                        cwd = path
+                        folderPickerOpen = false
+                    },
+                    onFanOut: { base, wts in
+                        cwd = base
+                        detectedWorktrees = wts
+                        folderPickerOpen = false
+                    },
+                    onCancel: { folderPickerOpen = false }
+                )
+                .transition(.move(edge: .bottom))
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text(titleText)
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: Metrics.type.body, weight: .regular))
+                    .foregroundColor(tokens.tx2)
+            }
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp3)
+    }
+
+    // MARK: - Form step
+
+    private var formStep: some View {
+        VStack(spacing: Metrics.spacing.sp3) {
+            field(label: "Name", placeholder: isNewProject ? "my-project" : "session", text: $name)
+
+            if isNewProject {
+                VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+                    Text("Default working directory")
+                        .font(.system(size: Metrics.type.twoXS, weight: .semibold))
+                        .foregroundColor(tokens.tx3)
+                    HStack(spacing: Metrics.spacing.sp2) {
+                        TextField("~/code/foo", text: $cwd)
+                            .font(.system(size: Metrics.type.small, design: .monospaced))
+                            .foregroundColor(tokens.tx1)
+                            .padding(.horizontal, Metrics.spacing.sp3)
+                            .padding(.vertical, Metrics.spacing.sp2)
+                            .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        Button {
+                            folderPickerOpen = true
+                        } label: {
+                            Image(systemName: "folder")
+                                .font(.system(size: Metrics.type.body))
+                                .foregroundColor(tokens.tx2)
+                                .padding(Metrics.spacing.sp2)
+                                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                        }
+                        .accessibilityLabel("Browse folders")
+                    }
+                    worktreeInfo
+                }
+            }
+
+            if let error {
+                Text(error)
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.danger)
+            }
+
+            VStack(spacing: Metrics.spacing.sp2) {
+                Button {
+                    continueToFirstMessage()
+                } label: {
+                    primaryButton("Continue")
+                }
+                .disabled(!formValid)
+                Button(action: onClose) {
+                    Text("Cancel")
+                        .font(.system(size: Metrics.type.small, weight: .medium))
+                        .foregroundColor(tokens.tx3)
+                        .padding(Metrics.spacing.sp2)
+                }
+            }
+            .padding(.top, Metrics.spacing.sp1)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+    }
+
+    @ViewBuilder
+    private var worktreeInfo: some View {
+        if let wts = detectedWorktrees, wts.count > 1 {
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+                Text("Detected \(wts.count) git worktrees. Open a session for each?")
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx2)
+                ForEach(wts, id: \.path) { w in
+                    HStack {
+                        Text(WorktreeInfoLogic.name(w))
+                            .font(.system(size: Metrics.type.xs, design: .monospaced))
+                            .foregroundColor(tokens.tx1)
+                        Spacer()
+                        Text(w.path)
+                            .font(.system(size: Metrics.type.xs, design: .monospaced))
+                            .foregroundColor(tokens.tx4)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .padding(Metrics.spacing.sp2)
+            .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        }
+    }
+
+    private func continueToFirstMessage() {
+        guard formValid else { return }
+        if isNewProject {
+            Task {
+                // Auto-detect worktrees for the fan-out question (best-effort).
+                let trimmed = cwd.trimmingCharacters(in: .whitespaces)
+                if let wts = try? await api.listWorktrees(trimmed), wts.count > 1 {
+                    detectedWorktrees = wts
+                }
+            }
+        }
+        step = .firstMessage
+    }
+
+    // MARK: - First-message step (creation happens HERE)
+
+    private var firstMessageStep: some View {
+        VStack(spacing: Metrics.spacing.sp3) {
+            Text("Type your first message")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            TextField("Message…", text: $firstMessage, axis: .vertical)
+                .lineLimit(1...6)
+                .font(.system(size: Metrics.type.body))
+                .foregroundColor(tokens.tx1)
+                .padding(Metrics.spacing.sp3)
+                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                .autocorrectionDisabled()
+
+            if let error {
+                Text(error)
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.danger)
+            }
+
+            Button {
+                createAndSend()
+            } label: {
+                primaryButton(creating ? "Creating…" : "Create session")
+            }
+            .disabled(creating)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.top, Metrics.spacing.sp2)
+    }
+
+    private func createAndSend() {
+        guard !creating else { return }
+        let message = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { return }
+        creating = true
+        error = nil
+        Task {
+            do {
+                switch mode {
+                case .newProject:
+                    try await createProjectAndSend(message)
+                case .newSession(let project):
+                    try await createWindowAndSend(projectName: project, message: message)
+                }
+            } catch {
+                self.error = "Couldn't create the session"
+                creating = false
+            }
+        }
+    }
+
+    private func createProjectAndSend(_ message: String) async throws {
+        let projectName = name.trimmingCharacters(in: .whitespaces)
+        let dir = cwd.trimmingCharacters(in: .whitespaces)
+        var targetSessionID: String?
+        var targetProject: String = projectName
+        var targetWindow: Int = 0
+
+        if let wts = detectedWorktrees, wts.count > 1 {
+            let first = wts[0]
+            var projects = try await api.newSession(NewSessionInput(
+                name: projectName, cwd: first.path, windowName: WorktreeInfoLogic.name(first),
+                createDir: false, chatMode: true))
+            for w in wts.dropFirst() {
+                projects = try await api.newWindow(NewWindowInput(
+                    sessionName: projectName, windowName: WorktreeInfoLogic.name(w),
+                    cwd: w.path, chatMode: true))
+            }
+            if let window = Self.findInitialWindow(projects, projectName: projectName, cwd: first.path) {
+                targetSessionID = window.opencodeSessionId
+                targetWindow = window.index
+            }
+        } else {
+            let projects = try await api.newSession(NewSessionInput(
+                name: projectName, cwd: dir, windowName: "default",
+                createDir: true, chatMode: true))
+            if let proj = projects.first(where: { $0.tmuxSession == projectName }),
+               let window = proj.windows.first(where: { $0.name == "default" }) ?? proj.windows.first {
+                targetSessionID = window.opencodeSessionId
+                targetWindow = window.index
+            }
+        }
+
+        guard let sessionID = targetSessionID else {
+            throw MantaError.transport("created session returned no chat id")
+        }
+        try await api.sendPrompt(SendPromptInput(sessionId: sessionID, text: message))
+        await MainActor.run {
+            creating = false
+            onCreated(targetProject, targetWindow)
+        }
+    }
+
+    private func createWindowAndSend(projectName: String, message: String) async throws {
+        let windowName = name.trimmingCharacters(in: .whitespaces).isEmpty ? "session" : name.trimmingCharacters(in: .whitespaces)
+        let projects = try await api.newWindow(NewWindowInput(
+            sessionName: projectName, windowName: windowName, cwd: nil, chatMode: true))
+        guard let proj = projects.first(where: { $0.tmuxSession == projectName }),
+              let window = proj.windows.first(where: { $0.name == windowName }),
+              let sessionID = window.opencodeSessionId else {
+            throw MantaError.transport("created session returned no chat id")
+        }
+        try await api.sendPrompt(SendPromptInput(sessionId: sessionID, text: message))
+        await MainActor.run {
+            creating = false
+            onCreated(projectName, window.index)
+        }
+    }
+
+    /// The initial (first-worktree) window after a fan-out create.
+    private static func findInitialWindow(_ projects: [MantaProject], projectName: String, cwd: String) -> MantaWindow? {
+        guard let proj = projects.first(where: { $0.tmuxSession == projectName }) else { return nil }
+        if let exact = proj.windows.first(where: { $0.paneCurrentPath == cwd }) { return exact }
+        return proj.windows.min(by: { $0.index < $1.index })
+    }
+
+    // MARK: - shared pieces
+
+    private var formValid: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    @ViewBuilder
+    private func field(label: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+            Text(label)
+                .font(.system(size: Metrics.type.twoXS, weight: .semibold))
+                .foregroundColor(tokens.tx3)
+            TextField(placeholder, text: text)
+                .font(.system(size: Metrics.type.body))
+                .foregroundColor(tokens.tx1)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+        }
+    }
+
+    @ViewBuilder
+    private func primaryButton(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: Metrics.type.small, weight: .semibold))
+            .foregroundColor(text.hasPrefix("Creating") ? tokens.tx4 : tokens.onAccent)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Metrics.spacing.sp3)
+            .background(
+                text.hasPrefix("Creating") ? AnyShapeStyle(tokens.panel) : AnyShapeStyle(tokens.accentSolid),
+                in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+    }
+}

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -1,0 +1,274 @@
+import Foundation
+import Combine
+import SwiftUI
+
+// ===========================================================================
+// S3 — session-list store (BET-595).
+//
+// Owns the live data behind the §7.1 list:
+//   - the grouped project/window list from `tmux:list` (refreshed on demand
+//     and on every healthy stream reconnect via `resyncHandler`);
+//   - per-row live status (running / attention / subagents / model) merged
+//     from the S1b event store (`sessionStates` keyed by the window's
+//     `opencodeSessionId`) plus attention tracking on the raw frame surface;
+//   - pinned windows (`pinnedWindows`) and the haptics enable flag, both
+//     persisted through `config:update`;
+//   - §7.3 delete-with-undo: an idle delete is held 5 s, the RPC fires only
+//     when the toast expires; running deletes are gated on the view's confirm.
+//
+// The PURE decisions (subtitle, dot, durations, delete-window expiry) live in
+// `SessionModels.swift`; this store is the I/O + state wiring around them.
+// ===========================================================================
+
+@MainActor
+final class SessionListStore: ObservableObject {
+
+    @Published private(set) var projects: [MantaProject] = []
+    @Published private(set) var loading = false
+    @Published private(set) var loadError: String?
+    @Published private(set) var pinnedWindows: Set<String> = []
+    @Published private(set) var hapticsEnabled = true
+    /// pinID -> pending delete being held within its 5 s undo window.
+    @Published private(set) var pendingDeletes: [String: PendingDelete] = [:]
+    /// opencodeSessionID -> when its turn started running (drives the §7.1
+    /// timer slot while running).
+    @Published private(set) var runningSince: [String: Date] = [:]
+
+    private let api: MantaAPIClient
+    private let eventStore: MantaEventStore
+    private var undoTimers: [String: Timer] = [:]
+    private var cancellables: Set<AnyCancellable> = []
+    private var attentionSessions: Set<String> = []
+    private var modelLabels: [String: String] = [:]
+
+    init(api: MantaAPIClient = MantaAPIClient.live(), eventStore: MantaEventStore) {
+        self.api = api
+        self.eventStore = eventStore
+        self.loadConfig()
+        self.eventStore.rawFrameHandler = { [weak self] frame in
+            self?.trackAttention(frame: frame)
+        }
+        eventStore.$sessionStates
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.trackRunning(now: Date()) }
+            .store(in: &cancellables)
+    }
+
+    private func trackRunning(now: Date) {
+        var changed = false
+        for (sid, state) in eventStore.sessionStates {
+            if state.running == true {
+                if runningSince[sid] == nil {
+                    runningSince[sid] = now
+                    changed = true
+                }
+            } else if runningSince[sid] != nil {
+                runningSince.removeValue(forKey: sid)
+                changed = true
+            }
+        }
+        if changed { objectWillChange.send() }
+    }
+
+    /// Re-fetch the list (pull-to-refresh / reconnect / after create).
+    func refresh() async {
+        guard !loading else { return }
+        loading = true
+        defer { loading = false }
+        do {
+            let list = try await api.projects()
+            projects = list
+            loadError = nil
+            await refreshModels()
+        } catch {
+            loadError = "Couldn't reach your box"
+        }
+    }
+
+    /// Reconcile deltas from one project list transaction (post-create).
+    private func applyProjects(_ list: [MantaProject]) {
+        projects = list
+        loadError = nil
+    }
+
+    private func refreshModels() async {
+        guard let sessions = try? await api.listSessions() else { return }
+        var labels: [String: String] = [:]
+        for s in sessions {
+            if let model = s.model {
+                labels[s.id] = ModelLabel.text(providerID: model.providerID, modelID: model.id)
+            }
+        }
+        modelLabels = labels
+    }
+
+    // MARK: - Row status (reads the S1b store)
+
+    /// The window's live status, merging the box's stream state with the
+    /// attention set. Pure inputs; presentation decided in SessionModels.
+    func rowStatus(for window: MantaWindow) -> SessionRowStatus {
+        let sid = window.opencodeSessionId ?? ""
+        let stream = eventStore.sessionStates[sid]
+        let running = stream?.running == true
+        let subagents = runningSubagents(stream?.subagents ?? [])
+        return SessionRowStatus(
+            running: running,
+            attention: attentionSessions.contains(sid),
+            subagentsRunning: subagents,
+            modelLabel: modelLabels[sid]
+        )
+    }
+
+    /// Number of live child subagents for a session (box-published).
+    private func runningSubagents(_ subagents: [StreamSubagentPayload]) -> Int {
+        let counted = subagents.filter { $0.status == "running" }.count
+        if counted > 0 { return counted }
+        if let last = subagents.last, let count = last.runningCount {
+            return Int(count)
+        }
+        return 0
+    }
+
+    // MARK: - Attention (needs-you dot / subtitle)
+
+    /// Track `question.*` / `permission.*` request/response frames as a per-
+    /// session "needs you" signal for the §7.1 warn dot + §7.1a subtitle.
+    private func trackAttention(frame: MantaStreamFrame) {
+        guard let kind = kind(frame), let sid = frame.sessionId else { return }
+        if kind == "question.asked" || kind == "permission.asked" {
+            attentionSessions.insert(sid)
+        } else if kind == "question.replied" || kind == "question.rejected"
+            || kind == "permission.replied" || kind == "permission.rejected" {
+            attentionSessions.remove(sid)
+        }
+        objectWillChange.send()
+    }
+
+    private func kind(_ frame: MantaStreamFrame) -> String? {
+        guard case .object(let obj) = frame.payload ?? .object([:]) else {
+            return frame.kind
+        }
+        // Raw opencode events carry `kind` at the top frame level; fall back
+        // to the envelope kind.
+        if case .string(let s)? = obj["kind"] { return s }
+        return frame.kind
+    }
+
+    // MARK: - Pin (§7.2 swipe-right)
+
+    func togglePin(session: String, index: Int) {
+        let id = SessionPinID.window(session, index: index)
+        var next = pinnedWindows
+        if next.contains(id) { next.remove(id) } else { next.insert(id) }
+        pinnedWindows = next
+        Task { _ = try? await api.configUpdate(["pinnedWindows": Array(next)] as [String: Any]) }
+    }
+
+    func isPinned(session: String, index: Int) -> Bool {
+        pinnedWindows.contains(SessionPinID.window(session, index: index))
+    }
+
+    // MARK: - Haptics flag (user-disableable, §7.4)
+
+    func setHapticsEnabled(_ enabled: Bool) {
+        hapticsEnabled = enabled
+        Task { _ = try? await api.configUpdate(["hapticsEnabled": enabled]) }
+    }
+
+    // MARK: - Delete (§7.3)
+
+    /// An idle delete: hold it in the 5 s undo window. The RPC is NOT fired;
+    /// it fires from `commitExpiredDeletes` only after the toast expires.
+    func beginIdleDelete(session: String, index: Int) {
+        let id = SessionPinID.window(session, index: index)
+        cancelPendingDelete(id)
+        let pending = PendingDelete(
+            target: .window(session: session, index: index),
+            pinID: id,
+            startedAt: Date()
+        )
+        pendingDeletes[id] = pending
+        let timer = Timer(timeInterval: PendingDelete.undoWindow, repeats: false) { [weak self] _ in
+            Task { @MainActor in self?.commitPendingDelete(id) }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        undoTimers[id] = timer
+    }
+
+    /// Undo an idle delete within its undo window.
+    func undoPendingDelete(_ id: String) {
+        cancelPendingDelete(id)
+    }
+
+    /// Fire the RPC for anything still pending whose window has expired.
+    /// Called by the view when the undo toast is auto-dismissed.
+    func commitExpiredDeletes(now: Date = Date()) {
+        let expired = pendingDeletes.values.filter { $0.expired(now: now) }.map(\.pinID)
+        for id in expired { commitPendingDelete(id) }
+    }
+
+    private func cancelPendingDelete(_ id: String) {
+        pendingDeletes.removeValue(forKey: id)
+        undoTimers[id]?.invalidate()
+        undoTimers[id] = nil
+    }
+
+    private func commitPendingDelete(_ id: String) {
+        guard let pending = pendingDeletes.removeValue(forKey: id) else { return }
+        undoTimers[id]?.invalidate()
+        undoTimers[id] = nil
+        switch pending.target {
+        case .window(let session, let index):
+            let chatID = chatSessionID(session: session, index: index)
+            Task {
+                do {
+                    if let chatID {
+                        try await api.deleteSession(sessionId: chatID, sessionName: session, windowIndex: index)
+                    } else {
+                        try await api.killWindow(KillWindowInput(sessionName: session, windowIndex: index))
+                    }
+                    await refresh()
+                } catch {
+                    // Server rejected the delete — refresh so the row's real
+                    // state is shown rather than a phantom removal.
+                    await refresh()
+                }
+            }
+        }
+    }
+
+    /// The opencode session id for a window, if any (for chat deletes).
+    private func chatSessionID(session: String, index: Int) -> String? {
+        projects
+            .first(where: { $0.tmuxSession == session })?
+            .windows
+            .first(where: { $0.index == index })?
+            .opencodeSessionId
+    }
+
+    // MARK: - Create (§7 creation)
+
+    func loadConfig() {
+        Task {
+            guard let config = try? await api.configGet() else { return }
+            if case .array(let pins)? = config["pinnedWindows"] {
+                var set = Set<String>()
+                for pin in pins {
+                    if case .string(let s) = pin { set.insert(s) }
+                }
+                pinnedWindows = set
+            }
+            if case .bool(let h)? = config["hapticsEnabled"] {
+                hapticsEnabled = h
+            }
+        }
+    }
+
+    // MARK: - Refresh on reconnect
+
+    func bindResync() {
+        eventStore.resyncHandler = { [weak self] in
+            Task { @MainActor in await self?.refresh() }
+        }
+    }
+}

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -1,0 +1,540 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// S3 — session list (BET-595). Implements DECISIONS.md §7.
+//
+//   §7.1   grouped list: project group headers (Title Case, 15px/600 tx2),
+//          rows = windows with [dot][name+subtitle][timer], min-height 62,
+//          radius 20, no dividers, most-recently-active row gets `fill`.
+//   §7.1a  subtitle table (subagents / running · model / needs you / absent).
+//   §7.2   tap opens; swipe-left delete (full-swipe commit); swipe-right pin;
+//          long-press context menu (Rename · Pin · Fork, sep, Delete).
+//   §7.3   idle delete → immediate + 5 s undo (RPC held); running → confirm
+//          naming what is interrupted.
+//   §7.4   haptics, user-disableable.
+//   §7.6   every swipe action is also in the context menu (WCAG 2.5.7).
+//
+// A real box drives the list through `SessionListStore`; the chat screen that
+// tap opens is S4's (this stage delivers the list + actions + creation).
+// ===========================================================================
+
+struct SessionListView: View {
+    @ObservedObject var store: SessionListStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var searchText = ""
+    @State private var createItem: CreateItem?
+    @State private var openTarget: SessionOpenTarget?
+    @State private var renameTarget: MantaWindow?
+    @State private var renameProject = ""
+    @State private var renameValue = ""
+    @State private var confirmDeleteProject = ""
+    @State private var confirmDeleteWindow: MantaWindow?
+    @State private var deleteRunningText = ""
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.projects.isEmpty && !store.loading {
+                    emptyState
+                } else {
+                    list
+                }
+            }
+            .navigationTitle("Sessions")
+            .navigationBarTitleDisplayMode(.large)
+            .refreshable { await store.refresh() }
+            .safeAreaInset(edge: .bottom) { capsule }
+            .overlay(alignment: .top) { errorBanner }
+            .sheet(item: $renameTarget) { _ in renameSheet(targetProject: renameProject) }
+            .navigationDestination(item: $openTarget) { target in
+                SessionScreenPlaceholder(name: target.name)
+            }
+        }
+        .sheet(item: $confirmDeleteWindow) { target in confirmDeleteSheet(target: target) }
+        .overlay(alignment: .bottom) { undoToast }
+        .sheet(item: $createItem) { item in
+            SessionCreateSheet(
+                mode: item.mode,
+                onClose: { createItem = nil },
+                onCreated: { project, index in
+                    let name = store.projects.first(where: { $0.tmuxSession == project })?
+                        .windows.first(where: { $0.index == index })?.name ?? "session"
+                    createItem = nil
+                    openTarget = SessionOpenTarget(project: project, windowIndex: index, name: name)
+                }
+            )
+            .presentationDetents([.medium, .large])
+        }
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(filteredProjects) { project in
+                    Section {
+                        groupHeader(project.tmuxSession)
+                        ForEach(project.windows) { window in
+                            row(project: project, window: window)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, Metrics.spacing.spPx)
+        }
+    }
+
+    private var filteredProjects: [MantaProject] {
+        guard !searchText.isEmpty else { return store.projects }
+        let q = searchText.lowercased()
+        return store.projects.compactMap { p in
+            let kept = p.windows.filter { $0.name.lowercased().contains(q) }
+            guard !kept.isEmpty else { return nil }
+            var copy = p
+            copy.windows = kept
+            return copy
+        }
+    }
+
+    @ViewBuilder
+    private func groupHeader(_ name: String) -> some View {
+        Text(titleCased(name))
+            .font(.system(size: Metrics.type.body, weight: .semibold))
+            .kerning(Metrics.type.headingTracking * Metrics.type.body)
+            .foregroundColor(tokens.tx2)
+            .padding(.top, Metrics.type.listGroupAbove)
+            .padding(.bottom, Metrics.type.listGroupBelow)
+            .padding(.leading, Metrics.spacing.sp3)
+            .textCase(nil)
+    }
+
+    @ViewBuilder
+    private func row(project: MantaProject, window: MantaWindow) -> some View {
+        Button {
+            openTarget = SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name)
+        } label: {
+            SessionRowContent(
+                window: window,
+                status: store.rowStatus(for: window),
+                timer: timerText(window),
+                isActive: window.active,
+                pinned: store.isPinned(session: project.tmuxSession, index: window.index),
+                tokens: tokens
+            )
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            let id = SessionPinID.window(project.tmuxSession, index: window.index)
+            Button("Rename") {
+                renameProject = project.tmuxSession
+                renameTarget = window
+                renameValue = window.name
+            }
+            Button(store.isPinned(session: project.tmuxSession, index: window.index) ? "Unpin" : "Pin") {
+                store.togglePin(session: project.tmuxSession, index: window.index)
+                SessionHaptics.fire(.selection, enabled: store.hapticsEnabled)
+            }
+            Button("Fork") {
+                fork(window: window, project: project)
+                SessionHaptics.fire(.selection, enabled: store.hapticsEnabled)
+            }
+            Divider()
+            Button("Delete", role: .destructive) {
+                requestDelete(window: window, project: project)
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                requestDelete(window: window, project: project)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            Button {
+                store.togglePin(session: project.tmuxSession, index: window.index)
+                SessionHaptics.fire(.selection, enabled: store.hapticsEnabled)
+            } label: {
+                Label(store.isPinned(session: project.tmuxSession, index: window.index) ? "Unpin" : "Pin",
+                      systemImage: store.isPinned(session: project.tmuxSession, index: window.index) ? "pin.slash" : "pin")
+            }
+            .tint(store.isPinned(session: project.tmuxSession, index: window.index) ? tokens.tx4 : tokens.accent)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(window.name), \(subtitle(for: window))")
+        .accessibilityHint("Opens the session. Swipe or long-press for actions.")
+    }
+
+    private func timerText(_ window: MantaWindow) -> String? {
+        let status = store.rowStatus(for: window)
+        guard status.running, let sid = window.opencodeSessionId, let since = store.runningSince[sid] else {
+            return nil
+        }
+        return SessionTimerFormat.elapsed(Date().timeIntervalSince(since))
+    }
+
+    private func subtitle(for window: MantaWindow) -> String {
+        SessionRowSubtitle.text(for: store.rowStatus(for: window)) ?? ""
+    }
+
+    // MARK: - Delete (§7.3)
+
+    private func requestDelete(window: MantaWindow, project: MantaProject) {
+        let status = store.rowStatus(for: window)
+        if status.running {
+            let durationText = runningDuration(of: window)
+            deleteRunningText = durationText
+            confirmDeleteProject = project.tmuxSession
+            confirmDeleteWindow = window
+            SessionHaptics.fire(.warning, enabled: store.hapticsEnabled)
+        } else {
+            store.beginIdleDelete(session: project.tmuxSession, index: window.index)
+        }
+    }
+
+    private func runningDuration(of window: MantaWindow) -> String {
+        guard let sid = window.opencodeSessionId, let since = store.runningSince[sid] else {
+            return SessionTimerFormat.runningDuration(0)
+        }
+        return SessionTimerFormat.runningDuration(Date().timeIntervalSince(since))
+    }
+
+    private func confirmDeleteSheet(target: MantaWindow) -> some View {
+        VStack(spacing: Metrics.spacing.sp3) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: Metrics.type.display))
+                .foregroundColor(tokens.warn)
+            Text("Delete this session?")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            Text("This will stop a turn that's been running \(deleteRunningText).")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx2)
+                .multilineTextAlignment(.center)
+            Button {
+                let index = target.index
+                let project = confirmDeleteProject
+                confirmDeleteWindow = nil
+                Task {
+                    if let sid = target.opencodeSessionId {
+                        try? await MantaAPIClient.live().deleteSession(sessionId: sid, sessionName: project, windowIndex: index)
+                    } else {
+                        try? await MantaAPIClient.live().killWindow(KillWindowInput(sessionName: project, windowIndex: index))
+                    }
+                    await store.refresh()
+                    SessionHaptics.fire(.success, enabled: store.hapticsEnabled)
+                }
+            } label: {
+                Text("Delete Session")
+                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.onAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Metrics.spacing.sp3)
+                    .background(tokens.danger, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+            }
+            Button {
+                confirmDeleteWindow = nil
+            } label: {
+                Text("Cancel")
+                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .foregroundColor(tokens.tx2)
+                    .padding(Metrics.spacing.sp2)
+            }
+        }
+        .padding(Metrics.spacing.sp4)
+        .presentationDetents([.height(320)])
+    }
+
+    // MARK: - Undo toast
+
+    @ViewBuilder
+    private var undoToast: some View {
+        if let pending = newestPending {
+            HStack(spacing: Metrics.spacing.sp3) {
+                Image(systemName: "trash")
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx2)
+                Text("Deleted")
+                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .foregroundColor(tokens.tx1)
+                Spacer()
+                Button("Undo") {
+                    store.undoPendingDelete(pending.pinID)
+                }
+                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(tokens.accentTx)
+                .padding(.horizontal, Metrics.spacing.sp2)
+                .padding(.vertical, Metrics.spacing.sp1)
+                .background(tokens.fillActive, in: Capsule())
+            }
+            .padding(.horizontal, Metrics.spacing.sp4)
+            .padding(.vertical, Metrics.spacing.sp2)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Metrics.type.listRowRadius))
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.bottom, Metrics.spacing.sp3)
+            .task {
+                try? await Task.sleep(nanoseconds: UInt64(PendingDelete.undoWindow * 1_000_000_000))
+                store.commitExpiredDeletes()
+                SessionHaptics.fire(.success, enabled: store.hapticsEnabled)
+            }
+        }
+    }
+
+    private var newestPending: PendingDelete? {
+        store.pendingDeletes.values.max(by: { $0.startedAt < $1.startedAt })
+    }
+
+    // MARK: - Floating capsule (+ search) + create
+
+    private var capsule: some View {
+        HStack(spacing: Metrics.spacing.sp3) {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: Metrics.type.xs))
+                    .foregroundColor(tokens.tx4)
+                TextField("Search sessions", text: $searchText)
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx1)
+            }
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.vertical, Metrics.spacing.sp2)
+            .overlay {
+                Capsule().stroke(tokens.borderSubtle, lineWidth: 1)
+            }
+
+            Button {
+                SessionHaptics.fire(.selection, enabled: store.hapticsEnabled)
+                presentCreateMenu()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(tokens.accentTx)
+                    .frame(width: 44, height: 44)
+                    .background(tokens.accentSolid, in: Circle())
+            }
+            .accessibilityLabel("New")
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.bottom, Metrics.spacing.sp2)
+        .background {
+            Rectangle().fill(.ultraThinMaterial).ignoresSafeArea()
+        }
+    }
+
+    private func presentCreateMenu() {
+        if store.projects.isEmpty {
+            createItem = CreateItem(mode: .newProject)
+        } else {
+            createItem = CreateItem(mode: .newSession(projectName: store.projects.first?.tmuxSession ?? ""))
+        }
+    }
+
+    // MARK: - Rename (§7.2 context menu)
+
+    private func renameSheet(targetProject: String) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            Text("Rename session")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            TextField("Name", text: $renameValue)
+                .font(.system(size: Metrics.type.body))
+                .foregroundColor(tokens.tx1)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                .autocorrectionDisabled()
+            HStack {
+                Spacer()
+                Button("Cancel") { renameTarget = nil }
+                    .foregroundColor(tokens.tx2)
+                Button("Save") {
+                    let value = renameValue.trimmingCharacters(in: .whitespaces)
+                    if !value.isEmpty, let target = renameTarget {
+                        Task {
+                            try? await MantaAPIClient.live().renameWindow(session: targetProject, index: target.index, newName: value)
+                            await store.refresh()
+                        }
+                    }
+                    renameTarget = nil
+                }
+                .fontWeight(.semibold)
+                .foregroundColor(tokens.accentTx)
+            }
+        }
+        .padding(Metrics.spacing.sp4)
+        .presentationDetents([.height(220)])
+    }
+
+    // MARK: - Fork
+
+    private func fork(window: MantaWindow, project: MantaProject) {
+        let sid = window.opencodeSessionId ?? ""
+        let newName = "\(window.name) fork"
+        Task {
+            try? await MantaAPIClient.live().forkSession(sessionId: sid, sessionName: project.tmuxSession, windowName: newName)
+            await store.refresh()
+        }
+    }
+
+    // MARK: - Empty / error
+
+    private var emptyState: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Text("No sessions yet")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx3)
+            Text("Tap + to create one.")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx4)
+        }
+    }
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let error = store.loadError {
+            HStack {
+                Image(systemName: "wifi.exclamationmark")
+                Text(error)
+                    .font(.system(size: Metrics.type.small))
+                Spacer()
+            }
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.vertical, Metrics.spacing.sp2)
+            .background(tokens.warn.opacity(0.15), in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.top, Metrics.spacing.sp2)
+        }
+    }
+
+    private func titleCased(_ s: String) -> String {
+        s.split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst().lowercased() }
+            .joined(separator: " ")
+    }
+}
+
+// MARK: - Row content (§7.1 slots)
+
+private struct SessionRowContent: View {
+    let window: MantaWindow
+    let status: SessionRowStatus
+    let timer: String?
+    let isActive: Bool
+    let pinned: Bool
+    let tokens: Tokens
+
+    var body: some View {
+        HStack(spacing: Metrics.spacing.sp3) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: Metrics.spacing.sp2, height: Metrics.spacing.sp2)
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+                HStack(spacing: Metrics.spacing.sp1) {
+                    Text(window.name)
+                        .font(.system(size: Metrics.type.rowName, weight: .medium))
+                        .kerning(Metrics.type.rowNameTracking * Metrics.type.rowName)
+                        .foregroundColor(tokens.tx1)
+                        .lineLimit(1)
+                    if pinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: Metrics.type.twoXS))
+                            .foregroundColor(tokens.tx3)
+                    }
+                }
+                if let subtitle = SessionRowSubtitle.text(for: status) {
+                    Text(subtitle)
+                        .font(.system(size: Metrics.type.xs, weight: .medium))
+                        .foregroundColor(tokens.tx4)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            if let timer {
+                Text(timer)
+                    .font(.system(size: Metrics.type.twoXS, weight: .medium, design: .monospaced))
+                    .foregroundColor(tokens.tx4)
+                    .monospacedDigit()
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .frame(maxWidth: .infinity, minHeight: Metrics.type.listRowMinH, alignment: .leading)
+        .background(isActive ? AnyShapeStyle(tokens.fill) : AnyShapeStyle(Color.clear),
+                    in: RoundedRectangle(cornerRadius: Metrics.type.listRowRadius))
+        .padding(.bottom, Metrics.type.listRowMargin)
+        .contentShape(Rectangle())
+    }
+
+    private var dotColor: Color {
+        switch SessionDotState.forRow(status) {
+        case .running: return tokens.accent
+        case .needsYou: return tokens.warn
+        case .idle: return tokens.tx4
+        }
+    }
+}
+
+// MARK: - Haptics (§7.4)
+
+@MainActor
+enum SessionHaptics {
+    static func fire(_ kind: SessionHapticKind, enabled: Bool) {
+        guard enabled else { return }
+        switch kind {
+        case .impactLight:
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        case .selection:
+            UISelectionFeedbackGenerator().selectionChanged()
+        case .warning:
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        case .success:
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
+    }
+}
+
+// MARK: - Identifiable helpers
+
+private struct CreateItem: Identifiable {
+    let id = UUID()
+    let mode: SessionCreateMode
+}
+
+private struct SessionOpenTarget: Identifiable, Hashable {
+    let id = UUID()
+    let project: String
+    let windowIndex: Int
+    let name: String
+}
+
+/// The chat screen this row opens is S4's (chat wired to live data). This
+/// placeholder marks the tap target so §7.2 "tap opens" is reachable and the
+/// S4 seam is a single navigation destination, not a second navigation shell.
+private struct SessionScreenPlaceholder: View {
+    let name: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    var body: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "text.bubble")
+                .font(.system(size: Metrics.type.display))
+                .foregroundColor(tokens.tx4)
+            Text(name)
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            Text("Chat arrives in a later stage.")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(tokens.canvas.ignoresSafeArea())
+        .navigationTitle(name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+// ===========================================================================
+// S3 — session-list models + pure logic (BET-595).
+//
+// Implements DECISIONS.md §7. The list is grouped by project (a tmux
+// session); each row is a window (a session). The Codable models match the
+// server `tmux:list` / `git:list-worktrees` shapes exactly. The presentation
+// and behaviour helpers are PURE (no HTTP/view/Keychain) so the list's
+// decisions — subtitle per §7.1a, dot colour §7.1, delete semantics §7.3,
+// haptics §7.4, folder browsing, pin identity — are unit-testable.
+//
+// No colour/spacing/radius/size/weight literal appears in app code; every
+// value resolves through the generated tokens in the views.
+// ===========================================================================
+//
+// The design-token contract the views consume (off the spacing/type grid):
+//   Metrics.type.rowName        — row name 15.5px (§7.1)
+//   Metrics.type.headingTracking / rowNameTracking — unitless em trackings
+//   Metrics.type.twoXS          — timer 11px (§7.1)
+//   Metrics.type.xs             — subtitle 12px (§7.1)
+//   Metrics.type.body           — group header 15px/600 (§7.1)
+//   Metrics.spacing.sp3         — row / group-header padding-left 12 (§7.1)
+//   Metrics.type.listRowMinH    — row min height 62 (§7.1)
+//   Metrics.type.listRowRadius  — row radius 20 (§7.1)
+//   Metrics.type.listRowMargin  — row margin-bottom 2 (§7.1)
+//   Metrics.type.listGroupAbove — group header 22px above (§7.1)
+//   Metrics.type.listGroupBelow — group header 6px below (§7.1)
+// The timer is rendered MONO and tabular (SwiftUI `.monospacedDigit()`).
+
+// MARK: - Server shapes (tmux:list / git:list-worktrees)
+
+struct MantaWindow: Codable, Equatable, Sendable, Identifiable {
+    var index: Int
+    var name: String
+    var active: Bool
+    var paneCurrentPath: String
+    var opencodeSessionId: String?
+    var worktreePath: String?
+
+    var id: Int { index }
+}
+
+struct MantaProject: Codable, Equatable, Sendable, Identifiable {
+    var tmuxSession: String
+    var defaultCwd: String
+    var windows: [MantaWindow]
+    var attached: Bool
+    var mantaOwned: Bool?
+
+    var id: String { tmuxSession }
+}
+
+struct MantaWorktree: Codable, Equatable, Sendable {
+    var path: String
+    var head: String
+    var branch: String?
+    var bare: Bool
+    var detached: Bool
+}
+
+/// Create-input payload for `tmux:new-session` (a new project).
+struct NewSessionInput: Sendable {
+    var name: String
+    var cwd: String
+    var windowName: String
+    var createDir: Bool
+    var chatMode: Bool
+}
+
+/// Create-input payload for `tmux:new-window` (a new session in a project).
+struct NewWindowInput: Sendable {
+    var sessionName: String
+    var windowName: String
+    var cwd: String?
+    var chatMode: Bool
+}
+
+/// Delete-input payload for `tmux:kill-window`.
+struct KillWindowInput: Sendable {
+    var sessionName: String
+    var windowIndex: Int
+}
+
+// MARK: - Row presentation (§7.1 / §7.1a)
+
+/// The live, store-derived status of a row. Values are inputs the store
+/// resolves from the box (event stream + opencode session list); this enum
+/// only decides how they are PRESENTED.
+struct SessionRowStatus: Equatable, Sendable {
+    var running: Bool
+    var attention: Bool
+    var subagentsRunning: Int
+    var modelLabel: String?
+}
+
+enum SessionRowSubtitle {
+    /// §7.1a subtitle table — precedence: subagents, then running, then
+    /// blocked, then (nil) idle. The subagent case REPLACES the line.
+    static func text(for s: SessionRowStatus) -> String? {
+        if s.subagentsRunning > 0 {
+            return "\(s.subagentsRunning) subagent" + (s.subagentsRunning == 1 ? "" : "s")
+        }
+        if s.running {
+            if let model = s.modelLabel, !model.isEmpty {
+                return "running · \(model)"
+            }
+            return "running"
+        }
+        if s.attention {
+            return "needs you"
+        }
+        return nil
+    }
+}
+
+/// §7.1 status dot: running → accent, needs-you → warn, idle → tx4.
+enum SessionDotState: Sendable {
+    case running
+    case needsYou
+    case idle
+
+    static func forRow(_ s: SessionRowStatus) -> SessionDotState {
+        if s.attention { return .needsYou }
+        if s.running { return .running }
+        return .idle
+    }
+}
+
+// MARK: - Timer / duration formatting (§7.1 timer slot, §7.3 confirm copy)
+
+enum SessionTimerFormat {
+    /// Compact elapsed line for the row's timer slot (11px mono, tabular).
+    static func elapsed(_ interval: TimeInterval) -> String {
+        let t = Int(interval)
+        if t < 60 { return "\(t)s" }
+        let m = t / 60
+        if m < 60 { return "\(m)m" }
+        return "\(m / 60)h"
+    }
+
+    /// Friendly running-duration for the §7.3 running-delete confirm
+    /// ("4 minutes", "36 seconds").
+    static func runningDuration(_ interval: TimeInterval) -> String {
+        let t = Int(interval.rounded())
+        if t < 60 { return "\(t) second" + (t == 1 ? "" : "s") }
+        let m = t / 60
+        return "\(m) minute" + (m == 1 ? "" : "s")
+    }
+}
+
+// MARK: - Pin identity (client-side, persisted in config)
+
+enum SessionPinID {
+    /// `<tmuxSession>/<windowIndex>` — matches `windowPinId` on desktop.
+    static func window(_ session: String, index: Int) -> String {
+        "\(session)/\(index)"
+    }
+}
+
+// MARK: - Model label (§7.1 subtitle "running · opus 4.8")
+
+enum ModelLabel {
+    /// A compact, data-faithful model label for the running subtitle. Known
+    /// Anthropic ids collapse to their friendly family ("claude-opus-4-7" →
+    /// "opus 4.7"); anything unknown falls back to the raw modelID (honest —
+    /// never invents a name). Device-side formatting, per §17.
+    static func text(providerID: String?, modelID: String) -> String {
+        if let providerID, providerID.lowercased() == "anthropic" {
+            var id = modelID
+            for prefix in ["anthropic/", "claude-"] where id.hasPrefix(prefix) {
+                id = String(id.dropFirst(prefix.count))
+            }
+            // "opus-4-7" → "opus 4.7": the family word then dotted numbers.
+            let m = id.split(separator: "-")
+            if m.count >= 2, let family = m.first,
+               m.dropFirst().allSatisfy({ Int($0) != nil }) {
+                let numbers = m.dropFirst().joined(separator: ".")
+                return "\(family) \(numbers)"
+            }
+            return id.replacingOccurrences(of: "-", with: " ")
+        }
+        return modelID.replacingOccurrences(of: "-", with: " ")
+    }
+}
+
+// MARK: - Delete semantics (§7.3)
+
+/// A delete that is held pending its 5-second undo window. The RPC is not
+/// fired until the window expires; an undo cancels it.
+struct PendingDelete: Equatable, Sendable {
+    enum Target: Equatable, Sendable {
+        case window(session: String, index: Int)
+    }
+
+    var target: Target
+    var pinID: String
+    /// When the 5s undo window started; `expired(now:)` decides the commit.
+    var startedAt: Date
+
+    /// The §7.3 undo window length.
+    static let undoWindow: TimeInterval = 5
+
+    func expired(now: Date) -> Bool {
+        now.timeIntervalSince(startedAt) >= Self.undoWindow
+    }
+}
+
+// MARK: - Folder browsing helpers (ported from src/renderer/folderPicker.ts)
+
+enum FolderPath {
+    static func isDimmed(_ name: String) -> Bool {
+        if name == "node_modules" { return true }
+        return name.hasPrefix(".")
+    }
+
+    static func crumbLabel(_ path: String) -> String {
+        if path == "~" { return "~" }
+        if path == "/" { return "/" }
+        guard let idx = path.lastIndex(of: "/") else { return path }
+        return String(path[path.index(after: idx)...])
+    }
+
+    static func parentPath(_ path: String) -> String {
+        let raw = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.isEmpty { return "" }
+        if raw == "~" || raw == "/" { return raw }
+        let slash = String(raw)
+        if slash.hasPrefix("~/") {
+            guard let idx = slash.lastIndex(of: "/"), idx != slash.startIndex else { return "~" }
+            if slash.distance(from: slash.startIndex, to: idx) <= 1 { return "~" }
+            return String(slash[..<idx])
+        }
+        if slash.hasPrefix("/") {
+            guard let idx = slash.lastIndex(of: "/") else { return slash }
+            if idx == slash.startIndex { return "/" }
+            return String(slash[..<idx])
+        }
+        return raw
+    }
+
+    /// `~/code/foo` → ["~", "~/code", "~/code/foo"]; absolute likewise.
+    static func breadcrumbs(_ path: String) -> [String] {
+        let raw = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.isEmpty { return [] }
+        if raw == "~" { return ["~"] }
+        if raw.hasPrefix("~/") {
+            let parts = raw.dropFirst(2).split(separator: "/").map(String.init)
+            var out: [String] = ["~"]
+            var acc = "~"
+            for p in parts {
+                acc += "/" + p
+                out.append(acc)
+            }
+            return out
+        }
+        if raw.hasPrefix("/") {
+            let parts = raw.split(separator: "/").map(String.init)
+            var out: [String] = ["/"]
+            var acc = ""
+            for p in parts {
+                acc += "/" + p
+                out.append(acc)
+            }
+            return out
+        }
+        return [raw]
+    }
+}
+
+// MARK: - Worktree helpers (ported from folderPicker.ts)
+
+enum WorktreeInfoLogic {
+    /// `⎇ N worktrees` when N > 1, else "" (a single main checkout is noise).
+    static func badge(_ worktrees: [MantaWorktree]?) -> String {
+        guard let worktrees, worktrees.count > 1 else { return "" }
+        return "⎇ \(worktrees.count) worktrees"
+    }
+
+    static func hasFanOut(_ worktrees: [MantaWorktree]?) -> Bool {
+        guard let worktrees else { return false }
+        return worktrees.count > 1
+    }
+
+    /// `⎇ main` when inside a repo (gitListWorktrees returns the main
+    /// checkout first), else "".
+    static func gitStateLabel(_ worktrees: [MantaWorktree]?) -> String {
+        guard let worktrees, let main = worktrees.first, let branch = main.branch, !branch.isEmpty else {
+            return ""
+        }
+        return "⎇ \(branch)"
+    }
+
+    /// Window name for a worktree: dir basename (matches desktop).
+    static func name(_ w: MantaWorktree) -> String {
+        let parts = w.path.split(separator: "/").filter { !$0.isEmpty }
+        if let last = parts.last { return String(last) }
+        return w.branch ?? "wt"
+    }
+}
+
+// MARK: - Haptics (§7.4) — user-disableable
+
+/// The §7.4 haptic vocabulary, classified as a pure enum so the store can
+/// record/gate it. The view maps each case to a UIKit `UIImpactFeedbackGenerator`
+/// / `UINotificationFeedbackGenerator` firing, respecting the enable flag.
+enum SessionHapticKind: Sendable, Equatable {
+    case impactLight   // swipe passes the commit threshold
+    case selection     // a value crosses a discrete step
+    case warning       // destructive confirm for a running session
+    case success       // a delete finally lands
+}

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// S3 — action-RPC wire-shape guard (BET-595 review).
+//
+// The server dispatches every /rpc channel as `fn(...args)`, so each of these
+// action channels must send its payload as a SINGLE element (`args: [dict]`),
+// NOT `args: [[dict]]`. The latter makes `args[0]` an array and the handler
+// reads `undefined`. This test drives the actual client methods through a
+// captured transport and asserts the wire shape, so a re-wrap cannot regress
+// silently the way the double-wrap did.
+// ===========================================================================
+
+final class MantaActionRPCWireTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        CapturingURLProtocol.cache = []
+        CapturingURLProtocol.result = #"{"result": null}"#
+    }
+
+    private func makeClient() -> MantaAPIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CapturingURLProtocol.self]
+        return MantaAPIClient(
+            serverURL: URL(string: "https://box.example")!,
+            tokenProvider: { "tok" },
+            session: URLSession(configuration: config)
+        )
+    }
+
+    /// Assert the most recent request has `args` = exactly one payload object.
+    private func assertSingleWrapped(_ file: StaticString = #filePath, line: UInt = #line) {
+        guard let request = CapturingURLProtocol.cache.last else {
+            XCTFail("no request captured", file: file, line: line)
+            return
+        }
+        let json = CapturingURLProtocol.bodyJSON(request)
+        let args = json?["args"] as? [Any]
+        XCTAssertEqual(args?.count, 1, "args must contain exactly one payload", file: file, line: line)
+        // The single payload must be an OBJECT (payload), never a nested array.
+        XCTAssertFalse(args?.first is [Any], "args[0] must be the payload object, not an array", file: file, line: line)
+        XCTAssertNotNil(args?.first as? [String: Any], "args[0] must be a JSON object", file: file, line: line)
+    }
+
+    func testNewSessionSingleWraps() async throws {
+        let client = makeClient()
+        try await client.newSession(NewSessionInput(name: "p", cwd: "/d", windowName: "w", createDir: true, chatMode: true))
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:new-session")
+    }
+
+    func testNewWindowSingleWraps() async throws {
+        let client = makeClient()
+        try await client.newWindow(NewWindowInput(sessionName: "p", windowName: "w", cwd: nil, chatMode: true))
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:new-window")
+    }
+
+    func testKillWindowSingleWraps() async throws {
+        let client = makeClient()
+        try await client.killWindow(KillWindowInput(sessionName: "p", windowIndex: 2))
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:kill-window")
+    }
+
+    func testDeleteSessionSingleWraps() async throws {
+        let client = makeClient()
+        try await client.deleteSession(sessionId: "s", sessionName: "p", windowIndex: 2)
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/opencode:delete-session")
+    }
+
+    func testRenameWindowSingleWraps() async throws {
+        let client = makeClient()
+        try await client.renameWindow(session: "p", index: 2, newName: "n")
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:rename-window")
+    }
+
+    func testSelectWindowSingleWraps() async throws {
+        let client = makeClient()
+        try await client.selectWindow(session: "p", index: 2)
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:select-window")
+    }
+
+    func testForkSessionSingleWraps() async throws {
+        let client = makeClient()
+        try await client.forkSession(sessionId: "s", sessionName: "p", windowName: "w")
+        assertSingleWrapped()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/opencode:fork-session")
+    }
+
+    // MARK: - request-shape (payload keys present)
+
+    func testNewSessionCarriesCreateFields() async throws {
+        let client = makeClient()
+        try await client.newSession(NewSessionInput(name: "proj", cwd: "~/x", windowName: "w", createDir: true, chatMode: false))
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertEqual(payload?["name"] as? String, "proj")
+        XCTAssertEqual(payload?["cwd"] as? String, "~/x")
+        XCTAssertEqual(payload?["windowName"] as? String, "w")
+        XCTAssertNotNil(payload?["createDir"])
+        XCTAssertNotNil(payload?["chatMode"])
+    }
+}
+
+// MARK: - Capturing URLProtocol
+
+private final class CapturingURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var cache: [URLRequest] = []
+    nonisolated(unsafe) static var result: String = #"{"result": null}"#
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.cache.append(request)
+        let data = Data(Self.result.utf8)
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    /// The request's JSON body (handles URLSession's httpBody → stream split).
+    static func bodyJSON(_ request: URLRequest) -> [String: Any]? {
+        let body: Data
+        if let httpBody = request.httpBody {
+            body = httpBody
+        } else if let stream = request.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            let bufferSize = 4096
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: bufferSize)
+                if read <= 0 { break }
+                data.append(buffer, count: read)
+            }
+            body = data
+        } else {
+            return nil
+        }
+        return try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+    }
+
+    static func lastPayload() -> [String: Any]? {
+        guard let request = cache.last,
+              let args = bodyJSON(request)?["args"] as? [Any],
+              let first = args.first as? [String: Any] else {
+            return nil
+        }
+        return first
+    }
+}

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import MantaUI
+
+final class SessionModelsTests: XCTestCase {
+
+    // MARK: - §7.1a subtitle table
+
+    func testSubtitleSubagentsReplacesRunningAndModel() {
+        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 3, modelLabel: "opus 4.8")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "3 subagents")
+    }
+
+    func testSubtitleSubagentsSingular() {
+        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 1, modelLabel: nil)
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "1 subagent")
+    }
+
+    func testSubtitleRunningShowsModel() {
+        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "running · opus 4.8")
+    }
+
+    func testSubtitleRunningWithoutModelFallsBackToRunning() {
+        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil)
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "running")
+    }
+
+    func testSubtitleNeedsYouWhenBlocked() {
+        let s = SessionRowStatus(running: false, attention: true, subagentsRunning: 0, modelLabel: nil)
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "needs you")
+    }
+
+    func testSubtitleIdleIsNil() {
+        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: nil)
+        XCTAssertNil(SessionRowSubtitle.text(for: s))
+    }
+
+    // MARK: - §7.1 status dot
+
+    func testDotNeedsYouTakesPrecedenceOverRunning() {
+        let s = SessionRowStatus(running: true, attention: true, subagentsRunning: 0, modelLabel: nil)
+        XCTAssertEqual(SessionDotState.forRow(s), .needsYou)
+    }
+
+    func testDotRunning() {
+        XCTAssertEqual(SessionDotState.forRow(SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil)), .running)
+    }
+
+    func testDotIdle() {
+        XCTAssertEqual(SessionDotState.forRow(SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: nil)), .idle)
+    }
+
+    // MARK: - Timer / duration
+
+    func testElapsedCompact() {
+        XCTAssertEqual(SessionTimerFormat.elapsed(5), "5s")
+        XCTAssertEqual(SessionTimerFormat.elapsed(120), "2m")
+        XCTAssertEqual(SessionTimerFormat.elapsed(3720), "1h")
+    }
+
+    func testRunningDurationWording() {
+        XCTAssertEqual(SessionTimerFormat.runningDuration(36), "36 seconds")
+        XCTAssertEqual(SessionTimerFormat.runningDuration(240), "4 minutes")
+        XCTAssertEqual(SessionTimerFormat.runningDuration(60), "1 minute")
+        XCTAssertEqual(SessionTimerFormat.runningDuration(1), "1 second")
+    }
+
+    // MARK: - Pin identity
+
+    func testWindowPinID() {
+        XCTAssertEqual(SessionPinID.window("ethernal", index: 3), "ethernal/3")
+    }
+
+    // MARK: - §7.3 delete undo window
+
+    func testPendingDeleteExpiry() {
+        let now = Date()
+        let pending = PendingDelete(target: .window(session: "s", index: 0), pinID: "s/0", startedAt: now)
+        XCTAssertFalse(pending.expired(now: now.addingTimeInterval(4)))
+        XCTAssertTrue(pending.expired(now: now.addingTimeInterval(5)))
+    }
+
+    // MARK: - Model label
+
+    func testModelLabelAnthropicCollapses() {
+        XCTAssertEqual(ModelLabel.text(providerID: "anthropic", modelID: "claude-opus-4-7"), "opus 4.7")
+        XCTAssertEqual(ModelLabel.text(providerID: "anthropic", modelID: "claude-sonnet-4-6"), "sonnet 4.6")
+    }
+
+    func testModelLabelUnknownFallsBackHonestly() {
+        XCTAssertEqual(ModelLabel.text(providerID: "deepseek", modelID: "deepseek-chat"), "deepseek chat")
+        XCTAssertEqual(ModelLabel.text(providerID: "anthropic", modelID: "custom-thing"), "custom thing")
+    }
+
+    // MARK: - Folder path helpers (folderPicker.ts port)
+
+    func testBreadcrumbsTilde() {
+        XCTAssertEqual(FolderPath.breadcrumbs("~/code/foo"), ["~", "~/code", "~/code/foo"])
+        XCTAssertEqual(FolderPath.breadcrumbs("~"), ["~"])
+    }
+
+    func testBreadcrumbsAbsolute() {
+        XCTAssertEqual(FolderPath.breadcrumbs("/home/dev/code"), ["/", "/home", "/home/dev", "/home/dev/code"])
+    }
+
+    func testParentPath() {
+        XCTAssertEqual(FolderPath.parentPath("~/code/foo"), "~/code")
+        XCTAssertEqual(FolderPath.parentPath("~/code"), "~")
+        XCTAssertEqual(FolderPath.parentPath("/a/b"), "/a")
+        XCTAssertEqual(FolderPath.parentPath("/"), "/")
+    }
+
+    func testCrumbLabel() {
+        XCTAssertEqual(FolderPath.crumbLabel("~/code/foo"), "foo")
+        XCTAssertEqual(FolderPath.crumbLabel("/"), "/")
+        XCTAssertEqual(FolderPath.crumbLabel("~"), "~")
+    }
+
+    func testIsDimmed() {
+        XCTAssertTrue(FolderPath.isDimmed("node_modules"))
+        XCTAssertTrue(FolderPath.isDimmed(".git"))
+        XCTAssertFalse(FolderPath.isDimmed("src"))
+    }
+
+    // MARK: - Worktree helpers
+
+    private func wt(_ path: String, branch: String? = "main") -> MantaWorktree {
+        MantaWorktree(path: path, head: "abc", branch: branch, bare: false, detached: false)
+    }
+
+    func testWorktreeBadgeOnlyForMultiple() {
+        XCTAssertEqual(WorktreeInfoLogic.badge([wt("/a")]), "")
+        XCTAssertEqual(WorktreeInfoLogic.badge([wt("/a"), wt("/b")]), "⎇ 2 worktrees")
+        XCTAssertEqual(WorktreeInfoLogic.badge(nil), "")
+    }
+
+    func testHasFanOutThreshold() {
+        XCTAssertFalse(WorktreeInfoLogic.hasFanOut([wt("/a")]))
+        XCTAssertTrue(WorktreeInfoLogic.hasFanOut([wt("/a"), wt("/b")]))
+        XCTAssertFalse(WorktreeInfoLogic.hasFanOut(nil))
+    }
+
+    func testWorktreeNameIsBasename() {
+        XCTAssertEqual(WorktreeInfoLogic.name(wt("/home/dev/ethernal")), "ethernal")
+    }
+
+    func testGitStateLabelFromFirstWorktree() {
+        XCTAssertEqual(WorktreeInfoLogic.gitStateLabel([wt("/a", branch: "main")]), "⎇ main")
+        XCTAssertEqual(WorktreeInfoLogic.gitStateLabel([]), "")
+    }
+}

--- a/scripts/gen-swift-tokens.mjs
+++ b/scripts/gen-swift-tokens.mjs
@@ -91,9 +91,20 @@ const TYPE_MAP = {
   display: "font-size-display", confirm: "font-size-confirm", otp: "font-size-otp",
   medium: "weight-medium", semibold: "weight-semibold",
   proseLineHeight: "prose-lh", uiLineHeight: "ui-lh",
+  // §7 session-list row name size + the two unitless em tracking multipliers
+  // (heading and row name) off the type grid (BET-595).
+  rowName: "font-size-row-name",
+  headingTracking: "tracking-list-heading",
+  rowNameTracking: "tracking-row-name",
 };
-// Off-grid layout paddings the mockup fixes (§8 / transcript-mockup.html).
-const LAYOUT_MAP = { stepRowY: "step-row-y", stepDot: "step-dot" };
+// Off-grid layout paddings the mockup fixes (§8 / transcript-mockup.html) plus
+// the §7 session-list row/group metrics (BET-595).
+const LAYOUT_MAP = {
+  stepRowY: "step-row-y", stepDot: "step-dot",
+  listRowMinH: "list-row-min-h", listRowRadius: "list-row-radius",
+  listRowMargin: "list-row-margin",
+  listGroupAbove: "list-group-above", listGroupBelow: "list-group-below",
+};
 
 // CSS allows a leading-dot decimal (".035"); Swift requires a leading zero
 // ("0.035"). Normalize so the emitted Swift literals always compile.

--- a/scripts/gen-swift-tokens.test.mjs
+++ b/scripts/gen-swift-tokens.test.mjs
@@ -30,6 +30,14 @@ const ROOT_VARIABLES = [
   ["weight-medium", "500"], ["weight-semibold", "600"],
   ["prose-lh", "1.55"], ["ui-lh", "1.45"],
   ["step-row-y", "7px"], ["step-dot", "6px"],
+  // §7 session-list metrics (BET-595) — must track gen-swift-tokens.mjs
+  // TYPE_MAP/LAYOUT_MAP so the widened generator's lookups resolve in the
+  // test fixture.
+  ["font-size-row-name", "15.5px"],
+  ["tracking-list-heading", "-0.015"], ["tracking-row-name", "-0.01"],
+  ["list-row-min-h", "62px"], ["list-row-radius", "20px"],
+  ["list-row-margin", "2px"],
+  ["list-group-above", "22px"], ["list-group-below", "6px"],
 ];
 
 function cssFor(prefix) {

--- a/src/renderer/tokens.css
+++ b/src/renderer/tokens.css
@@ -119,6 +119,22 @@
   --step-row-y: 7px;
   --step-dot: 6px;
 
+  /* Session-list anatomy (BET-595 §7). The row min-height, row corner radius,
+     row gap, group-header margins and the row-name size/tracking are off the
+     spacing / type grid, so they get names here instead of being hardcoded in
+     the Swift client. The two tracking values are UNITLESS em multipliers
+     (SwiftUI tracking is measured in points; the list view resolves them
+     against its font size). Additive — unused by the web app, no visual
+     change there. */
+  --list-row-min-h: 62px;
+  --list-row-radius: 20px;
+  --list-row-margin: 2px;
+  --list-group-above: 22px;
+  --list-group-below: 6px;
+  --font-size-row-name: 15.5px;
+  --tracking-list-heading: -0.015;
+  --tracking-row-name: -0.01;
+
   /* S2 onboarding display sizes (BET-594). The pairing flow's headings, the
      two-sided four-char confirm code, and the six-digit OTP resolve their font
      sizes through these so a retune is one edit in the token source and the


### PR DESCRIPTION
Opened automatically for `multica/BET-595-session-list`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-595.