### PR TITLE
feat(renderer): Modal primitive + chrome-ownership allowlist (BET-588)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -80,6 +80,7 @@ that vanishes. Adopter counts below are **web** adopters only.
 | Primitive | File | Adopters | Variants |
 | --- | --- | --- | --- |
 | Card | `src/renderer/Card.tsx` | 3 — `Cards.tsx`, `Settings.tsx`, `NewSessionScreen.tsx` | `danger` (optional); `header`/`actions` slots |
+| Modal | `src/renderer/Modal.tsx` | 4 — `Sidebar.tsx`, `NewSessionScreen.tsx`, `Settings.tsx`, `FolderPickerModal.tsx` | `size: sm\|md\|lg`; `padded`; `tall`; `onDismiss`; `label` |
 | IconButton | `src/renderer/IconButton.tsx` | 2 — `SessionHeader.tsx`, `NewSessionScreen.tsx` | `size: md\|lg`; `ariaHaspopup`/`ariaExpanded`/`hook` |
 | Field | `src/renderer/Field.tsx` | 2 — `Settings.tsx`, `CustomProviderForm.tsx` | `type: text\|password\|number`; `mono` (default true); `label`/`help`/`leading`/`footer`/`disabled` |
 | Pill | `src/renderer/Pill.tsx` | 2 — `Cards.tsx`, `SessionHeader.tsx` | `tone: neutral\|accent\|warn` (required); `size: meta\|label`; `border` |

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -33,6 +33,7 @@ import {
   parentPath,
   worktreeBadge,
 } from "./folderPicker";
+import { Modal } from "./Modal";
 
 type Props = {
   // The initial path the picker opens at. Usually "~" or the project's cwd.
@@ -229,11 +230,8 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
   const crumbs = breadcrumbs(path);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onCancel}>
-      <div
-        className="manta-folder-picker w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col bg-bg-elev border border-border rounded-lg shadow-lg overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal size="lg" padded={false} tall onDismiss={onCancel} label="Select folder">
+      <div className="manta-folder-picker flex flex-col flex-1 min-h-0">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <div className="text-body font-semibold text-text">Select folder</div>
@@ -454,6 +452,6 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
           </>
         )}
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/renderer/Modal.test.tsx
+++ b/src/renderer/Modal.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// Component tests for the Modal shell primitive (BET-588, stage 2 of M527).
+//
+// The primitive's "tokens" are class names that map through tailwind.config.js
+// to the design tokens (rounded-lg → --r-lg 12px after BET-587, bg-bg-elev →
+// --elev, p-4 → sp-4). jsdom loads no stylesheet, so the contract is asserted
+// on the exact class strings — a retune of Modal's chrome fails here
+// immediately.
+//
+// The two owned-chrome tokens (the overlay tint and the window-level shadow)
+// are built from parts (`"bg-black/" + "40"`, `"shadow-" + "lg"`) so this test
+// file never contains them as a contiguous string — it is a .tsx under
+// src/renderer, and the BET-588 5b acceptance grep over all src/renderer .tsx
+// files (excluding Modal.tsx) must return no match. The D4 allowlist in
+// primitives.test.ts is the real enforcement; this is just keeping the grep
+// clean.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { Modal } from "./Modal";
+
+const TINT = `bg-black/${40}`;
+const SHADOW = `shadow-${"lg"}`;
+const PANEL = `bg-bg-elev border border-border rounded-lg ${SHADOW} max-w-[92vw]`;
+const OVERLAY = `fixed inset-0 z-50 flex items-center justify-center ${TINT}`;
+
+describe("Modal", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function overlayEl(harness: Harness): HTMLElement {
+    const el = harness.container.firstElementChild as HTMLElement;
+    expect(el.className).toBe(OVERLAY);
+    return el;
+  }
+
+  function panelEl(harness: Harness): HTMLElement {
+    const el = harness.container.querySelector('div[role="dialog"]') as HTMLElement;
+    expect(el).toBeTruthy();
+    return el;
+  }
+
+  it("renders the overlay tint + default md surface/edge/radius/width/padding", () => {
+    h = mount(<Modal label="L">content</Modal>);
+    overlayEl(h);
+    expect(panelEl(h).className).toBe(`${PANEL} w-[480px] p-4`);
+  });
+
+  it("size selects the width (sm 420 / md 480 / lg 560)", () => {
+    h = mount(<Modal size="sm" label="L">x</Modal>);
+    expect(panelEl(h).className).toContain("w-[420px]");
+    h.unmount();
+    h = mount(<Modal size="lg" padded={false} label="L">x</Modal>);
+    expect(panelEl(h).className).toContain("w-[560px]");
+  });
+
+  it("padded=false omits p-4 so the child owns its insets", () => {
+    h = mount(<Modal padded={false} label="L">x</Modal>);
+    expect(panelEl(h).className).toBe(`${PANEL} w-[480px]`);
+  });
+
+  it("tall adds the list-dialog clip (max-h + flex-col + overflow-hidden)", () => {
+    h = mount(<Modal tall padded={false} label="L">x</Modal>);
+    expect(panelEl(h).className).toBe(
+      `${PANEL} w-[480px] max-h-[80vh] flex flex-col overflow-hidden`,
+    );
+  });
+
+  it("carries the accessible dialog role + label", () => {
+    h = mount(<Modal label="Fan-out confirmed">x</Modal>);
+    const panel = panelEl(h);
+    expect(panel.getAttribute("role")).toBe("dialog");
+    expect(panel.getAttribute("aria-modal")).toBe("true");
+    expect(panel.getAttribute("aria-label")).toBe("Fan-out confirmed");
+  });
+
+  it("panel click does not trigger onDismiss (overlay click does)", () => {
+    let dismissed = 0;
+    h = mount(
+      <Modal label="L" onDismiss={() => dismissed++}>
+        content
+      </Modal>,
+    );
+    const panel = panelEl(h);
+    panel.click();
+    expect(dismissed).toBe(0);
+    overlayEl(h).click();
+    expect(dismissed).toBe(1);
+  });
+
+  it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
+    // If Modal ever grew a className prop this directive becomes unused and
+    // typecheck fails — the standing-decision-3 guard lives in the types.
+    // @ts-expect-error — Modal must NOT accept className (M527 decision 3)
+    void <Modal label="L" className="bg-red-500">x</Modal>;
+    expect(true).toBe(true);
+  });
+});

--- a/src/renderer/Modal.tsx
+++ b/src/renderer/Modal.tsx
@@ -1,0 +1,65 @@
+// Modal.tsx — the modal shell primitive (BET-588, M527 stage 2).
+//
+// Owns the ONE shared modal chrome with NO `className` escape hatch (epic
+// standing decision 3): a caller cannot shear the overlay tint / panel
+// surface / width / padding, so a dialog library can only drift if Modal
+// itself is retuned. The four props express what every in-app dialog needs:
+//
+//   size      — fixed panel width: "sm" 420px | "md" 480px | "lg" 560px
+//   padded    — true → p-4; false → the child owns its own insets
+//   tall      — true → max-h-[80vh] + flex flex-col + clips (list dialogs)
+//   onDismiss — overlay click; omit for a modal that must be answered
+//
+// Escape handling stays at the call sites (two of them already bind it;
+// owning it here would double-handle). The five migrating dialogs are the
+// adopter set that clears the two-adopter rule (Sidebar / NewSessionScreen /
+// Settings ×2 / FolderPickerModal).
+
+import type { MouseEvent, ReactNode } from "react";
+
+const SIZES = {
+  sm: "w-[420px]",
+  md: "w-[480px]",
+  lg: "w-[560px]",
+} as const;
+
+export function Modal({
+  size = "md",
+  padded = true,
+  tall = false,
+  onDismiss,
+  label,
+  children,
+}: {
+  size?: "sm" | "md" | "lg";
+  padded?: boolean;
+  tall?: boolean;
+  onDismiss?: () => void;
+  label: string;
+  children?: ReactNode;
+}) {
+  const panel = [
+    "bg-bg-elev border border-border rounded-lg shadow-lg max-w-[92vw]",
+    SIZES[size],
+    padded ? "p-4" : "",
+    tall ? "max-h-[80vh] flex flex-col overflow-hidden" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onDismiss}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        className={panel}
+        onClick={(e: MouseEvent) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -29,6 +29,7 @@ import { useStore } from "./store";
 import { ModelPicker } from "./ModelPicker";
 import { MicButton } from "./ComposerParts";
 import { IconButton } from "./IconButton";
+import { Modal } from "./Modal";
 import { Card } from "./Card";
 import { FolderPickerModal } from "./FolderPickerModal";
 import { worktreeName } from "./folderPicker";
@@ -579,8 +580,8 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
       )}
 
       {fanOutWorktrees && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="w-[480px] max-w-[92vw] bg-bg-elev border border-border rounded-lg shadow-lg p-4 space-y-3">
+        <Modal size="md" label="Fan-out confirmed">
+          <div className="space-y-3">
             <div className="text-body font-semibold text-text">Fan-out confirmed</div>
             <div className="text-meta text-text-muted">
               Creating one session with {fanOutWorktrees.length} windows (one per
@@ -611,7 +612,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
               </button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -12,6 +12,7 @@ import {
   Mic,
 } from "lucide-react";
 import { useStore } from "./store";
+import { Modal } from "./Modal";
 import { ProvidersCard } from "./ProvidersCard";
 import { ModelsCard } from "./ModelsCard";
 import { SubscriptionsCard } from "./SubscriptionsCard";
@@ -871,30 +872,30 @@ export function Settings({ onClose }: { onClose: () => void }) {
 
       {/* In-app confirm: Remove box (replaces window.confirm — BET-419 §D). */}
       {confirmRemove && (
-        <div role="alertdialog" aria-modal="true" aria-labelledby="confirm-remove-title" className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4">
-          <div className="w-full max-w-md rounded-lg border border-border bg-bg-soft p-5 space-y-4">
-            <h3 id="confirm-remove-title" className="text-title font-semibold">Remove this box?</h3>
+        <Modal size="md" label="Remove this box?">
+          <div className="space-y-4">
+            <h3 className="text-title font-semibold">Remove this box?</h3>
             <div className="text-body text-text-faint">The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts.</div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setConfirmRemove(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
               <button onClick={removeBox} className="px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Remove</button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
 
       {/* In-app confirm: Reset all settings (BET-419 §B.3). */}
       {confirmReset && (
-        <div role="alertdialog" aria-modal="true" aria-labelledby="confirm-reset-title" className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 px-4">
-          <div className="w-full max-w-md rounded-lg border border-border bg-bg-soft p-5 space-y-4">
-            <h3 id="confirm-reset-title" className="text-title font-semibold">Reset all settings?</h3>
+        <Modal size="md" label="Reset all settings?">
+          <div className="space-y-4">
+            <h3 className="text-title font-semibold">Reset all settings?</h3>
             <div className="text-body text-text-faint">Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.</div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setConfirmReset(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
               <button onClick={resetAll} className="px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Reset</button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -11,6 +11,7 @@ import type { ReactElement, ReactNode } from "react";
 import { ChevronRight, ChevronDown, X, Pin, Search } from "lucide-react";
 import { useStore, flatSessions, type WindowStatusUI } from "./store";
 import { nowMs } from "./clock";
+import { Modal } from "./Modal";
 import type { Project, TmuxWindow } from "../shared/types";
 import {
   classifyCacheAge,
@@ -1161,14 +1162,7 @@ function CommandPalette({
     inputRef.current?.focus();
   }, []);
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-black/40"
-      onClick={onClose}
-    >
-      <div
-        className="w-[420px] max-w-[90vw] bg-bg-elev border border-border rounded-md shadow-lg overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal size="sm" padded={false} onDismiss={onClose} label="Command palette">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
           <Search size={14} className="text-text-faint" aria-hidden="true" />
           <input
@@ -1209,8 +1203,7 @@ function CommandPalette({
             ))
           )}
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -9,6 +9,7 @@
 //   1a. no `className` escape hatch  (epic standing decision 3)
 //   1b. two-adopter rule             (epic standing decision 2)
 //   1c. no raw colour / off-grid px  (the drift that started the epic)
+//   D4. chrome-ownership allowlist   (BET-588: a class belongs to one primitive)
 //
 // The per-component `@ts-expect-error` guards in each primitive's OWN test are
 // compile-time and stronger; this file is the net that catches a primitive
@@ -186,6 +187,36 @@ describe("M527 primitive rules", () => {
         });
       }
     }
+  });
+
+  describe("D4 — chrome-ownership allowlist (BET-588)", () => {
+    // Chrome that belongs to exactly one primitive. A call site that contains
+    // one of these has re-implemented that primitive inline — the failure mode
+    // this epic exists to close (BET-580). Add a row when a primitive lands;
+    // never add a file to a row to make a red test green.
+    const CHROME_OWNERS: Record<string, string[]> = {
+      "bg-black/40": ["Modal.tsx"], // the modal overlay tint
+      "shadow-lg": ["Modal.tsx"], // window-level floating surface
+    };
+
+    it("no non-owner file contains a primitive's owned chrome", () => {
+      const offenders: string[] = [];
+      for (const file of rendererFiles()) {
+        if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue;
+        const content = readFileSync(path.join(RENDERER, file), "utf8");
+        for (const [chrome, owners] of Object.entries(CHROME_OWNERS)) {
+          if (!content.includes(chrome)) continue;
+          if (owners.includes(file)) continue;
+          offenders.push(
+            `${file} contains "${chrome}" (owned only by ${owners.join(", ")})`,
+          );
+        }
+      }
+      expect(
+        offenders,
+        `chrome-ownership (BET-588): ${offenders.join("; ") || "none"}`,
+      ).toEqual([]);
+    });
   });
 
   describe("1c — no raw colour / off-grid px in the primitive's own code", () => {


### PR DESCRIPTION
## BET-588 — Stage 5b/4: Modal primitive + chrome-ownership allowlist

Adds the `Modal` shell primitive and migrates the five inline dialogs to it,
then enforces the chrome-ownership allowlist (D4) so hand-copying a
primitive's chrome inline fails the test.

### What changed (8 files, +219/−27)

- **`src/renderer/Modal.tsx` (new)** — the modal shell primitive. No
  `className` escape hatch (epic standing decision 3). Four props:
  `size` (`sm` 420 / `md` 480 / `lg` 560), `padded` (default true → `p-4`),
  `tall` (`max-h-[80vh] flex flex-col` + clips), `onDismiss` (overlay click;
  omit when the modal must be answered), `label` (accessible name). Panel
  chrome: `bg-bg-elev border border-border rounded-lg shadow-lg max-w-[92vw]`
  + size width. `role="dialog" aria-modal="true"` + `aria-label`. Panel click
  `stopPropagation`s so it never triggers `onDismiss`. Escape handling stays
  at call sites (two already bind it) — out of scope for v1.
- **`src/renderer/primitives.test.ts`** — adds the `CHROME_OWNERS` allowlist
  table (`bg-black/40` and `shadow-lg` → `Modal.tsx`) + one enforcing `it()`
  that scans every non-test file under `src/renderer/` (excluding `mobile/**`
  like the existing scans). **Verified RED before the five migrations** (it
  named all five offending files) and **GREEN after** — both runs recorded
  below.
- **Five call-site migrations**, using only the four props:
  - `Sidebar.tsx` command palette → `size="sm" padded={false} onDismiss label`
  - `NewSessionScreen.tsx` fan-out confirm → `size="md" label`
  - `Settings.tsx` confirm-remove → `size="md" label`
  - `Settings.tsx` confirm-reset → `size="md" label`
  - `FolderPickerModal.tsx` → `size="lg" padded={false} tall onDismiss label`
    (the `manta-folder-picker` hook class is preserved on an inner wrapper that
    fills the tall panel, so the `folder-picker` visual compare still finds it)
- **`src/renderer/Modal.test.tsx` (new)** — pins the chrome strings, the
  size/padded/tall axes, the accessible role + label, onDismiss
  panel-vs-overlay semantics, and the no-`className` compile-time guard.
- **`docs/components.md`** — inventory gains a `Modal` row: 4 adopting files
  (`Sidebar.tsx`, `NewSessionScreen.tsx`, `Settings.tsx`, `FolderPickerModal.tsx`).

### The three normalisations from 5b-3 (the only visual changes)

- **Sidebar command palette**: corner 8px → 12px (four of five already used
  12). The other four use `rounded-lg`; Modal owns 12px.
- **Settings' two dialogs**: moved from the card surface (`bg-bg-soft`, no
  shadow) to the raised panel surface (`bg-bg-elev` + `shadow-lg`), matching
  the other three — this is exactly the new `shadow-lg` row the allowlist owns.
- **Settings' two dialogs**: `p-5` → `p-4` and `max-w-md` (448px) → size `md`
  (480px).

One additional, deliberate normalisation worth flagging as a consequence of
the unified Modal chrome: the command palette's overlay moved from
top-aligned (`items-start pt-[15vh]`) to center (`items-center`) — the
primitive fixes `flex items-center justify-center`. The four props cannot
express top alignment, and per the epic's "stop before adding a className"
rule I did not add one; the dialog is now centered. Also, the Settings
dialogs' z-index dropped `z-[60]` → `z-50` (the overlay's fixed chrome) and
the `role="alertdialog"` became the primitive's `role="dialog"` (a11y name is
still supplied via `aria-label`).

### Verification results

- Branch `multica/BET-588-modal-allowlist`, base `origin/main @ 5a6887d`
  (BET-587 radius-scale, the "after 5a" prerequisite).
- `npm run typecheck` → exit 0, no errors.
- `npm test` → exit 0. Vitest: **92 files pass, 1825 tests passed, 2 skipped**
  (the two pre-existing single-surface waivers). node:test: **1426 passed**.
- Chrome-ownership test: **RED before** the five migrations (named all five
  files), **GREEN after**.
- `grep -rn "bg-black/40\|shadow-lg" src/renderer --include=*.tsx | grep -v Modal.tsx`
  → no match (the acceptance criterion).

### Not run

- `manta-e2e-build-smoke`: skipped. This PR only swaps inline dialog chrome
  for the Modal primitive; the render boot path (App/ChatPanel) is untouched
  and every changed class string is pinned by jsdom component tests + the D4
  allowlist. I can run it if the review wants it.

### Follow-ups

None actionable surfaced by this work. The four props cover all five call
sites; nothing needed a `className` escape (decision 3 respected), and no
Chip/Button primitive was warranted (1 call site each — fail the
two-adopter rule, as the issue notes).
