### PR TITLE
feat(ios): wire the chat screen to live data (BET-596)

### DIFF
--- a/generated/swift/Theme.swift
+++ b/generated/swift/Theme.swift
@@ -156,8 +156,11 @@ struct TypeMetrics {
     let rowName: CGFloat
     let headingTracking: CGFloat
     let rowNameTracking: CGFloat
+    let chatTitle: CGFloat
+    let chatTitleTracking: CGFloat
     let stepRowY: CGFloat
     let stepDot: CGFloat
+    let chatHeaderBtn: CGFloat
     let listRowMinH: CGFloat
     let listRowRadius: CGFloat
     let listRowMargin: CGFloat
@@ -168,7 +171,7 @@ struct TypeMetrics {
 enum Metrics {
     static let spacing = Spacing(sp0: 0, spPx: 1, sp1: 4, sp2: 8, sp3: 12, sp4: 16, sp5: 20, sp6: 24, sp8: 32, sp10: 40, sp12: 48)
     static let radius = Radius(xs: 4, sm: 6, md: 8, lg: 12, xl: 16, full: 999)
-    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, stepRowY: 7, stepDot: 6, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 22, listGroupBelow: 6)
+    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, chatTitle: 14.5, chatTitleTracking: -0.01, stepRowY: 7, stepDot: 6, chatHeaderBtn: 38, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 22, listGroupBelow: 6)
 }
 
 extension Color {

--- a/mobile/native/FINDINGS.md
+++ b/mobile/native/FINDINGS.md
@@ -496,3 +496,99 @@ worktree fan-out, first message creates the session.
 - **Model labels** are data-faithful: known Anthropic ids collapse to friendly
   names ("claude-opus-4-7" → "opus 4.7"); anything unknown shows the raw
   modelID (never invented).
+
+## S4 — wire the chat screen to live data (BET-596)
+
+The chat screen the session list opens is no longer a placeholder. `ChatScreen`
+binds to a live, observable `ChatSessionStore` fed by the S1b `/events` stream
+plus the canonical `opencode:messages` transcript, and renders through the
+EXISTING §8/§8a components (`TranscriptView`, `UserBand`, `AssistantProse`,
+`StepGroupView`, `SubagentHeader`) — there is still no second transcript
+renderer. The retired web `SessionScreen.tsx` is the parity reference for the
+header copy only; the native chat does not port the React `ChatPanel` body.
+
+### What was built
+
+| File | Role |
+|---|---|
+| `ChatModels.swift` | The PURE mapping from the box's wire shapes to the block types: `opencode:messages` → `[TranscriptBlock]`, step-row verb/target/duration presentation, the §8 step rollup, task-part → subagent, and the §8 header subtitle. Unit-tested. |
+| `ChatSessionStore.swift` | The live ObservableObject: refetches the canonical transcript at turn boundaries, accumulates the running assistant text from `stream:flush`, and exposes running/turnComplete/context/todos/truncation/questions/permissions/subagents. Parent and children are each their own store (child = read-only). |
+| `ChatScreen.swift` | The view: §8 two-line header, the BET-481 scroll container, live Todos/Permission/Question cards (answerable), and the value-push subagent drill-in. |
+| `SessionListView.swift` | The tap target now carries the window's `opencodeSessionId` and opens `ChatScreen`; the placeholder remains only for foreign windows with no opencode session id. |
+| `TranscriptComponents.swift` | `SubagentSession` gains an optional `childSessionId` (the S4b fixture leaves it nil) so the live drill-in can be routed by session id. |
+| `tokens.css` / `gen-swift-tokens.mjs` / `Theme.swift` | Additive §8 chat-header tokens (`--chat-header-btn` 38, `--font-size-chat-title` 14.5, `--tracking-chat-title` -0.01) so no chat value is a hardcoded literal. `--check` green; generator test updated. |
+
+### Block-type provenance — mapping interpreted events onto the blocks
+
+Scope item 2 asks which block types the interpreted stream can produce. The
+honest answer (a documented finding, nothing invented):
+
+- `.prose` — **live** from `stream:flush` (the running assistant turn) AND
+  **canonical** from completed assistant messages.
+- `.steps` row / subagent rows — **canonical** from assistant tool parts;
+  agent rows' live status/child-id from `stream:subagent`.
+- `.user` — **canonical only.** No stream event produces a user block and none
+  is invented; the prompt comes from the persisted transcript.
+
+So a live conversation streams (`.prose` tail) on top of a canonical transcript
+(the `.user`/completed `.steps`/`.prose`), exactly the desktop model (transcript
+fetch + live events). While a turn streams, the mapper skips assistant messages
+whose `time.completed` is nil (the box itself keys turn completion on that) so
+the running text appears exactly once — as the in-progress tail, not also in the
+canonical list. This is the duplication guard.
+
+### Done-when verification
+
+- **Live streaming**: the store appends `stream:flush` text as the in-progress
+  `.prose`; scroll container is `ScrollView` + `LazyVStack` +
+  `.defaultScrollAnchor(.bottom)` — BET-481's measured container kept verbatim,
+  not re-measured, not replaced.
+- **Permissions + Questions answerable**: `PermissionCard` (Allow once / Allow
+  always / Reject) and `QuestionCard` (options + always-available free text +
+  Send / Reject) wire to the S1a RPCs on `MantaAPIClient`
+  (`permissionReply`, `questionReply`, `questionReject`) and unblock the agent.
+- **Subagent drill-in live (BET-576 folded in, issue closed here)**: pushing a
+  subagent pushes a `ChatSubagentScreen` bound to a LIVE `ChatSessionStore` for
+  the child session — the frozen `SubagentSession.transcript` fixture screen is
+  only used by the capture-harness scenes. `navigationDestination` for
+  `SubagentSession` is registered against the session list's own stack, so a
+  value-push keeps the parent in the stack and its scroll position is untouched
+  by a visit (child keeps streaming while open).
+- **Status/todos/context/truncation**: §8 header subtitle (`running · 2m · 8%` /
+  `idle`) from running + context pct; `TodosCard`, context/cache/truncation all
+  read the interpreted stream state.
+
+### Verification
+
+- Full `MantaUITests` suite: **111 tests, 0 failures** (99 inherited + 12 new
+  `ChatTranscriptTests`), pinned iPhone 17 Pro (iOS 26.5).
+- App builds for the iOS Simulator destination (`BUILD SUCCEEDED`).
+- `npm run typecheck` green; `node scripts/gen-swift-tokens.mjs --check` green;
+  `gen-swift-tokens.test.mjs` updated + passing (5/5).
+- The S4b capture harness still reproduces (parent scene `PASS`, deterministic)
+  — the fixture scenes are untouched by this wiring stage.
+
+Repo `npm test`: 1816 pass / 1 known environment failure
+(`capExecutor.test.ts` PATH passthrough asserts CI's `/usr/bin:/bin` and fails
+on a Mac with Homebrew on PATH — reproduced on the clean baseline before this
+change; passes on the Linux CI runner).
+
+### Honesty notes
+
+- **No live-box round trip.** As in S2/S3, the macos agent cannot mint a pairing
+  code (loopback-only) and must not pair with production hosts, so "a real
+  conversation streams into the phone" is verified structurally — the store
+  binds to the S1b stream state it was built to consume, the mapper is
+  unit-tested against real `opencode:messages` shapes — and stays a
+  human/CI-on-device check once a box is reachable from device.
+- **Permissions are polled (2.5 s) while the parent chat screen is active**
+  rather than consumed through the event store's single-owner `rawFrameHandler`;
+  questions arrive on the interpreted `stream:questions` sub. This deliberately
+  avoids stealing the session list's handler slot. The permission poll is a
+  device-side presentation concern only; it stops on `onDisappear`.
+- **The composer is out of scope (S5).** The phone streams a live conversation
+  and answers permissions/questions; sending prompts is S5.
+- **Child stores are read-only** (§8a v1): they stream their transcript but do
+  not poll permissions.
+- **`chat-header-btn`, `chat-title` values are additive to `:root`** and unused
+  by the web app, so no visual change there (same policy as `--step-dot`).

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -19,11 +19,14 @@
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
+		650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */; };
 		6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */; };
 		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
 		685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */; };
+		6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7631E09B6FF7B150392A83 /* ChatModels.swift */; };
 		7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28250B8DDAB996449F7AE3AD /* SessionModels.swift */; };
 		863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */; };
+		8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471BF240012879FDED5689C1 /* ChatSessionStore.swift */; };
 		94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
 		95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D71EC917661085ED10E0867 /* FolderPickerView.swift */; };
@@ -32,6 +35,7 @@
 		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
 		E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9803742B79E4302F8813EFCC /* SessionModelsTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
+		E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436675A65BF149932C1EADE0 /* ChatScreen.swift */; };
 		EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */; };
 /* End PBXBuildFile section */
 
@@ -61,7 +65,10 @@
 		2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAuthClient.swift; sourceTree = "<group>"; };
 		3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingModels.swift; sourceTree = "<group>"; };
 		35ECC10E3DB9A931F8EB5420 /* MantaUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MantaUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		436675A65BF149932C1EADE0 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
+		471BF240012879FDED5689C1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
 		4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaOnboarding.swift; sourceTree = "<group>"; };
+		4F7631E09B6FF7B150392A83 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
 		5D71EC917661085ED10E0867 /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
@@ -78,6 +85,7 @@
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingTests.swift; sourceTree = "<group>"; };
 		B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreateSheet.swift; sourceTree = "<group>"; };
+		C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptTests.swift; sourceTree = "<group>"; };
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
@@ -107,6 +115,7 @@
 		7168FDC00E99AA075ACA9698 /* MantaUITests */ = {
 			isa = PBXGroup;
 			children = (
+				C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */,
 				9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */,
 				989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */,
 				EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */,
@@ -147,6 +156,9 @@
 		D7128F5AAFA315FE875EEC98 /* MantaUI */ = {
 			isa = PBXGroup;
 			children = (
+				4F7631E09B6FF7B150392A83 /* ChatModels.swift */,
+				436675A65BF149932C1EADE0 /* ChatScreen.swift */,
+				471BF240012879FDED5689C1 /* ChatSessionStore.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
 				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
@@ -288,6 +300,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */,
 				5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */,
 				0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */,
 				9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */,
@@ -301,6 +314,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */,
+				E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */,
+				8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -282,9 +282,40 @@ enum ChatTranscriptMapper {
     }
 }
 
-// MARK: - Header subtitle (§8 "running · 2m · 8%" / idle)
+// MARK: - Question answers (§7.5, answerable from the phone)
 
-/// The §8 chat-header subtitle: while running, `running · <elapsed> · <N>%`;
+/// Per-question answer assembly + submit gating, ported from the desktop's
+/// pure `buildQuestionAnswers` / `canSubmitQuestion` (src/renderer/chatUtils.ts).
+/// `selected` maps a question's position to the set of its selected option
+/// indices — the free text is ALWAYS available and, when non-empty, is appended
+/// to every question's answer (matching the desktop).
+enum ChatQuestionAnswers {
+    static func answers(questions: [QuestionInfo], selected: [Int: Set<Int>], customText: String) -> [[String]] {
+        let typed = customText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return questions.enumerated().map { index, q in
+            var picked = q.options.enumerated().compactMap { i, o in
+                selected[index, default: []].contains(i) ? o.label : nil
+            }
+            if !typed.isEmpty { picked.append(typed) }
+            return picked
+        }
+    }
+
+    /// Submit is enabled only when every question has a selection OR the shared
+    /// free text is non-empty (which counts for all).
+    static func canSubmit(questions: [QuestionInfo], selected: [Int: Set<Int>], customText: String) -> Bool {
+        guard !questions.isEmpty else { return false }
+        let typed = customText.trimmingCharacters(in: .whitespacesAndNewlines)
+        for index in questions.indices {
+            if selected[index, default: []].isEmpty && typed.isEmpty {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+// MARK: - Header subtitle (§8 "running · 2m · 8%" / idle)/// The §8 chat-header subtitle: while running, `running · <elapsed> · <N>%`;
 /// otherwise `idle`. Token-aware on the surrounding prose only; the string is
 /// assembled here so the view stays a thin token resolver.
 enum ChatHeaderSubtitle {

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+// ===========================================================================
+// S4 — chat transcript mapping (BET-596).
+//
+// The chat screen binds to a LIVE store fed by S1b (the /events stream,
+// already interpreted by the box per §17) plus the canonical `opencode:messages`
+// transcript. The components in TranscriptComponents.swift render the block
+// types; this file owns the PURE mapping that turns the box's wire shapes
+// into those blocks, and the small formatting/presentation decisions on top.
+// Everything here is unit-testable with ordinary `OpencodeMessage` values.
+//
+// §17 boundary: the device never interprets raw events. The box publishes
+// interpreted `stream.*` frames; the only device-side work is PRESENTATION
+// (verb/target/duration wording), exactly the desktop renderer's role.
+// ===========================================================================
+
+// MARK: - JSON accessors (read-only safe helpers over JSONValue)
+
+enum ChatJSON {
+    static func string(_ v: JSONValue?) -> String? {
+        if case .string(let s)? = v { return s }
+        return nil
+    }
+    static func number(_ v: JSONValue?) -> Double? {
+        if case .number(let n)? = v { return n }
+        return nil
+    }
+    static func object(_ v: JSONValue?) -> [String: JSONValue]? {
+        if case .object(let o)? = v { return o }
+        return nil
+    }
+    static func array(_ v: JSONValue?) -> [JSONValue]? {
+        if case .array(let a)? = v { return a }
+        return nil
+    }
+}
+
+// MARK: - Step-row presentation (§8)
+
+/// The §8 step-row verb. opencode names a tool by its id; the design shows a
+/// short verb (Ran / Read / Edit / Search). Unknown tools fall back to the
+/// tool id itself — honest, never invented.
+enum StepVerb {
+    static func text(for tool: String) -> String {
+        switch tool.lowercased() {
+        case "bash", "exec", "powershell", "deno", "bun": return "Ran"
+        case "read", "glance", "write_file": return "Read"
+        case "write", "edit", "str_replace_editor", "patch": return "Edit"
+        case "grep", "directory_search", "web_search", "search": return "Search"
+        case "list": return "List"
+        case "webfetch", "fetch", "browse": return "Fetched"
+        default: return tool
+        }
+    }
+}
+
+/// The §8 step-row target: the mono string the tool acted on. Drawn from the
+/// tool's `input` (command / filePath / pattern); falls back to the tool id.
+enum ToolTarget {
+    static func text(tool: String, input: JSONValue?) -> String? {
+        guard let inputObject = ChatJSON.object(input) else { return nil }
+        for key in ["command", "filePath", "file_path", "pattern", "url", "path"] {
+            if let s = ChatJSON.string(inputObject[key]), !s.isEmpty {
+                return singleLine(s)
+            }
+        }
+        // A string-literal input ("grep foo" style) is a target on its own.
+        if case .string(let s) = input, !s.isEmpty {
+            return singleLine(s)
+        }
+        return nil
+    }
+
+    private static func singleLine(_ s: String) -> String {
+        s.components(separatedBy: .newlines).first?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? s
+    }
+}
+
+/// The §8 step-row duration ("0.4s", "1m12s"). nil when timeless.
+enum ChatDuration {
+    static func text(seconds: Double?) -> String? {
+        guard let seconds, seconds >= 0 else { return nil }
+        if seconds < 60 {
+            return String(format: "%0.1fs", seconds)
+        }
+        let m = Int(seconds) / 60
+        let s = Int(seconds) % 60
+        return "\(m)m\(s)s"
+    }
+}
+
+/// Map a tool part's `state.status` string onto the StepStatus dot.
+enum StepStatusFromTool {
+    static func status(_ raw: String?) -> StepStatus {
+        // Only an explicit terminal "completed" is `done`; everything else
+        // (pending / running / error) is a live `running` row.
+        raw?.lowercased() == "completed" ? .done : .running
+    }
+}
+
+/// The §8a subagent row: extract the task-tool part into a SubagentSession.
+/// The task tool part (opencode contract, see AGENTS.md "Subagent rendering")
+/// carries `state.{status,title,metadata.sessionId,time}`.
+enum ChatSubagentMapper {
+    static func session(from part: OpencodePart) -> SubagentSession? {
+        guard let state = ChatJSON.object(part.extra["state"]) else { return nil }
+        let metadata = ChatJSON.object(state["metadata"])
+        let childSessionId = ChatJSON.string(metadata?["sessionId"])
+        let statusRaw = ChatJSON.string(state["status"])
+        let title = ChatJSON.string(state["title"])
+        let taskName = title ?? "subagent"
+
+        let status: SubagentStatus = statusRaw?.lowercased() == "completed" ? .done : .running
+        let time = ChatJSON.object(state["time"])
+        let duration: String?
+        if let start = ChatJSON.number(time?["start"]),
+           let end = ChatJSON.number(time?["end"]) {
+            duration = ChatDuration.text(seconds: end - start)
+        } else {
+            duration = nil
+        }
+
+        return SubagentSession(
+            taskName: taskName,
+            status: status,
+            duration: duration,
+            transcript: [],
+            childSessionId: childSessionId
+        )
+    }
+}
+
+// MARK: - Transcript rollup (§8 "consecutive steps roll up")
+
+/// Decide whether a run of consecutive step rows should collapse to a single
+/// summary line. §8: three or more = roll up. Groups containing an agent row
+/// are never rolled (a subagent is a session, not a step, §8a).
+enum ChatRollup {
+    static func shouldRoll(rows: [StepGroupRow]) -> Bool {
+        rows.count >= 3 && rows.allSatisfy { if case .step = $0 { return true } else { return false } }
+    }
+
+    /// "▸ 4 steps · Ran 3, Search 1" — verb counts, in first-seen order.
+    static func summary(rows: [StepGroupRow]) -> String {
+        var counts: [(verb: String, n: Int)] = []
+        var order: [String] = []
+        for row in rows {
+            guard case .step(let step) = row else { continue }
+            let verb = step.verb
+            if order.contains(verb) {
+                if let i = order.firstIndex(of: verb) { counts[i].n += 1 }
+            } else {
+                order.append(verb)
+                counts.append((verb, 1))
+            }
+        }
+        let parts = counts.map { "\($0.verb) \($0.n)" }
+        return "▸ \(rows.count) steps · " + parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - The mapper: `opencode:messages` → `[TranscriptBlock]`
+
+/// Maps the canonical transcript (and a live stream "in progress" payload)
+/// onto the existing block types.
+///
+/// Block-type provenance (the S4 mapping — see FINDINGS):
+///   - `.user`      — from canonical user text parts. No stream event produces
+///                    one; it comes from the transcript fetch.
+///   - `.prose`     — from canonical assistant text parts AND, live, from the
+///                    box's `stream:flush` (the running assistant turn).
+///   - `.steps`     — from canonical assistant tool parts (step rows) and
+///                    `stream:subagent` / task-tool parts (agent rows).
+///
+/// The stream alone cannot produce `.user` or completed `.steps`/`.prose`;
+/// those are canonical-transcript material. This is a finding, not an
+/// invented event — the box interprets, the transcript persists, the stream
+/// augments. See mobile/native/FINDINGS.md.
+enum ChatTranscriptMapper {
+
+    static func blocks(from messages: [OpencodeMessage]) -> [TranscriptBlock] {
+        var blocks: [TranscriptBlock] = []
+        var pending: [StepGroupRow] = []
+
+        for msg in messages {
+            switch msg.info.role.rawValue {
+            case "user":
+                let text = textParts(of: msg)
+                if !text.isEmpty {
+                    flush(&pending, into: &blocks)
+                    blocks.append(.user(text))
+                }
+            case "assistant":
+                // An assistant message still streaming (time.completed == nil)
+                // is skipped whole: its text arrives live via `stream.flush`
+                // and its still-moving steps come in on the turn-boundary
+                // refetch. Emitting it now would duplicate the in-progress
+                // text. The box itself keys turn completion on time.completed.
+                guard msg.info.time?.completed != nil else { continue }
+                for part in msg.parts {
+                    process(part, pending: &pending, blocks: &blocks)
+                }
+                flush(&pending, into: &blocks)
+            default:
+                break
+            }
+        }
+        flush(&pending, into: &blocks)
+        return blocks
+    }
+
+    private static func flush(_ pending: inout [StepGroupRow], into blocks: inout [TranscriptBlock]) {
+        guard !pending.isEmpty else { return }
+        if ChatRollup.shouldRoll(rows: pending) {
+            blocks.append(.steps(.rollup(summary: ChatRollup.summary(rows: pending), rows: pending)))
+        } else {
+            blocks.append(.steps(.rows(pending)))
+        }
+        pending = []
+    }
+
+    private static func process(_ part: OpencodePart, pending: inout [StepGroupRow], blocks: inout [TranscriptBlock]) {
+        if part.ignored == true || part.synthetic == true { return }
+        switch part.type {
+        case "text":
+            if let t = part.text, !t.isEmpty {
+                flush(&pending, into: &blocks)
+                blocks.append(.prose(t))
+            }
+        case "tool":
+            let tool = ChatJSON.string(part.extra["tool"]) ?? ""
+            if tool.lowercased() == "task" {
+                if let agent = ChatSubagentMapper.session(from: part) {
+                    pending.append(.subagent(agent))
+                }
+            } else {
+                pending.append(.step(step(from: part, tool: tool)))
+            }
+        default:
+            // reasoning / file / etc. — no §8 block type renders it; skip.
+            break
+        }
+    }
+
+    private static func textParts(of msg: OpencodeMessage) -> String {
+        msg.parts.compactMap { part -> String? in
+            guard part.type == "text",
+                  part.ignored != true,
+                  part.synthetic != true,
+                  let t = part.text, !t.isEmpty else { return nil }
+            return t
+        }.joined(separator: "\n")
+    }
+
+    private static func step(from part: OpencodePart, tool: String) -> ToolStep {
+        let state = ChatJSON.object(part.extra["state"])
+        let statusRaw = ChatJSON.string(state?["status"])
+        let status = StepStatusFromTool.status(statusRaw)
+        let verb = StepVerb.text(for: tool)
+        let target = ToolTarget.text(tool: tool, input: state?["input"])
+            ?? ToolTarget.text(tool: tool, input: part.extra["input"])
+            ?? tool
+        let time = ChatJSON.object(state?["time"])
+        let duration: String
+        if let t = ChatDuration.text(seconds: durationSeconds(state: state, time: time)) {
+            duration = t
+        } else {
+            duration = ""
+        }
+        let output = ChatJSON.string(state?["output"])
+        return ToolStep(verb: verb, target: target, duration: duration, status: status, output: output)
+    }
+
+    private static func durationSeconds(state: [String: JSONValue]?, time: [String: JSONValue]?) -> Double? {
+        if let start = ChatJSON.number(time?["start"]),
+           let end = ChatJSON.number(time?["end"]) {
+            return end - start
+        }
+        return nil
+    }
+}
+
+// MARK: - Header subtitle (§8 "running · 2m · 8%" / idle)
+
+/// The §8 chat-header subtitle: while running, `running · <elapsed> · <N>%`;
+/// otherwise `idle`. Token-aware on the surrounding prose only; the string is
+/// assembled here so the view stays a thin token resolver.
+enum ChatHeaderSubtitle {
+    static func text(running: Bool, elapsed: TimeInterval, contextPct: Double?) -> String {
+        if running {
+            let elapsed = SessionTimerFormat.elapsed(elapsed)
+            if let pct = contextPct {
+                return "running · \(elapsed) · \(Int(pct.rounded()))%"
+            }
+            return "running · \(elapsed)"
+        }
+        return "idle"
+    }
+}

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -321,7 +321,11 @@ private struct QuestionCard: View {
     let onSubmit: ([[String]]) -> Void
     let onReject: () -> Void
 
-    @State private var selected: Set<Int> = []
+    /// Per-question selected option indices (keyed by the question's position
+    /// in `question.questions`) — a request can carry several questions and
+    /// each keeps its own selection, so option index 0 on question A cannot
+    /// bleed into question B.
+    @State private var selected: [Int: Set<Int>] = [:]
     @State private var customText = ""
 
     var body: some View {
@@ -337,18 +341,21 @@ private struct QuestionCard: View {
                         .font(.system(size: Metrics.type.body))
                         .foregroundColor(tokens.tx1)
                     ForEach(Array(q.options.enumerated()), id: \.offset) { oi, option in
-                        optionButton(oi, label: option.label, multi: q.multiple == true)
+                        optionButton(questionIndex: index, optionIndex: oi, label: option.label, multi: q.multiple == true)
                     }
                 }
             }
-            if !customText.isEmpty {
-                TextField("Or type your own answer…", text: $customText)
-                    .font(.system(size: Metrics.type.small))
-                    .foregroundColor(tokens.tx1)
-                    .padding(.horizontal, Metrics.spacing.sp3)
-                    .padding(.vertical, Metrics.spacing.sp2)
-                    .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-            }
+            // Always-available free text (the desktop QuestionCard shows it for
+            // ANY question, not just custom:true). It must NOT be gated on its
+            // own non-empty state — that gate would make the field that is its
+            // only writer unreachable, so free-form questions could never be
+            // answered.
+            TextField("Or type your own answer…", text: $customText)
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx1)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
             HStack {
                 Button("Reject", action: onReject)
                     .font(.system(size: Metrics.type.small, weight: .medium))
@@ -376,14 +383,20 @@ private struct QuestionCard: View {
         .accessibilityIdentifier("question-card")
     }
 
+    /// Submit is enabled when every question has a selection (or the shared
+    /// free text, which counts for all) — matching the desktop canSubmitQuestion.
     private var canSubmit: Bool {
-        !selected.isEmpty || !customText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ChatQuestionAnswers.canSubmit(
+            questions: question.questions,
+            selected: selected,
+            customText: customText
+        )
     }
 
-    private func optionButton(_ index: Int, label: String, multi: Bool) -> some View {
-        let isOn = selected.contains(index)
+    private func optionButton(questionIndex: Int, optionIndex: Int, label: String, multi: Bool) -> some View {
+        let isOn = selected[questionIndex, default: []].contains(optionIndex)
         return Button {
-            toggle(index, multi: multi)
+            toggle(questionIndex: questionIndex, optionIndex: optionIndex, multi: multi)
         } label: {
             HStack(spacing: Metrics.spacing.sp2) {
                 Image(systemName: isOn ? "checkmark.square.fill" : "square")
@@ -400,22 +413,23 @@ private struct QuestionCard: View {
         .buttonStyle(.plain)
     }
 
-    private func toggle(_ index: Int, multi: Bool) {
+    private func toggle(questionIndex: Int, optionIndex: Int, multi: Bool) {
+        var perQuestion = selected[questionIndex, default: []]
         if multi {
-            if selected.contains(index) { selected.remove(index) } else { selected.insert(index) }
+            if perQuestion.contains(optionIndex) { perQuestion.remove(optionIndex) } else { perQuestion.insert(optionIndex) }
         } else {
-            selected = [index]
+            perQuestion = [optionIndex]
         }
+        selected[questionIndex] = perQuestion
     }
 
     private func submit() {
-        var answers: [[String]] = []
-        for q in question.questions {
-            var picked = q.options.enumerated().compactMap { i, o in selected.contains(i) ? o.label : nil }
-            let typed = customText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !typed.isEmpty { picked.append(typed) }
-            answers.append(picked)
-        }
-        onSubmit(answers)
+        onSubmit(
+            ChatQuestionAnswers.answers(
+                questions: question.questions,
+                selected: selected,
+                customText: customText
+            )
+        )
     }
 }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1,0 +1,421 @@
+import SwiftUI
+
+// ===========================================================================
+// S4 — chat screen wired to live data (BET-596).
+//
+// Replaces the SessionListView tap target (was a placeholder). This screen
+// binds to a ChatSessionStore (live transcript + status + todos + context +
+// answerable permissions/questions) and renders through the EXISTING
+// TranscriptComponents (§8/§8a): there is no second transcript renderer.
+//
+// Container per BET-481: ScrollView + LazyVStack + .defaultScrollAnchor(.bottom)
+// kept verbatim — do NOT re-measure or replace. Subagent rows PUSH a live child
+// screen via NavigationStack (parent scroll untouched; BET-576 binds the child
+// to the same observable source).
+//
+// No colour/spacing/radius/size/weight literal; every value resolves through
+// the generated tokens.
+// ===========================================================================
+
+struct ChatScreen: View {
+    let title: String
+    @ObservedObject var eventStore: MantaEventStore
+    @StateObject private var store: ChatSessionStore
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(sessionId: String, title: String, eventStore: MantaEventStore) {
+        self.title = title
+        self.eventStore = eventStore
+        _store = StateObject(wrappedValue: ChatSessionStore(
+            sessionId: sessionId,
+            eventStore: eventStore,
+            api: MantaAPIClient.live()
+        ))
+    }
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    var body: some View {
+        // ChatScreen is PUSHED within SessionListView's NavigationStack, so it
+        // does not nest another stack (that would double the nav bar). The
+        // subagent destination is registered against the enclosing stack here,
+        // so a value-push keeps the parent in the stack (its scroll untouched)
+        // and the child streams while open (BET-576).
+        Group {
+            if store.loadFailed {
+                loadFailure
+            } else {
+                transcript
+            }
+        }
+        .background(tokens.canvas.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom) { bottomCards }
+        .navigationDestination(for: SubagentSession.self) { agent in
+            if let child = store.store(for: agent.childSessionId) {
+                ChatSubagentScreen(
+                    title: agent.taskName,
+                    subtitle: agent.subtitle,
+                    store: child,
+                    tokens: tokens
+                )
+            }
+        }
+        .toolbar(.hidden, for: .navigationBar)
+        .navigationBarBackButtonHidden(true)
+        .overlay(alignment: .top) { header }
+        .onAppear { store.start() }
+        .onDisappear { store.stop() }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("chat-screen")
+    }
+
+    // MARK: - Header (§8)
+
+    private var header: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                    .background(.ultraThinMaterial, in: Circle())
+                    .accessibilityLabel("Back to sessions")
+            }
+            .buttonStyle(.plain)
+
+            Spacer(minLength: 0)
+
+            VStack(spacing: Metrics.spacing.spPx) {
+                Text(title)
+                    .font(.system(size: Metrics.type.chatTitle, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .kerning(Metrics.type.chatTitleTracking * Metrics.type.chatTitle)
+                    .foregroundColor(tokens.tx1)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text(store.headerSubtitle)
+                    .font(.system(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.medium)))
+                    .foregroundColor(tokens.tx4)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 0)
+
+            // Trailing 38×38 glass button (§8) — a placeholder in S4 (the
+            // overflow sheet with fork/settings is a later stage).
+            Color.clear
+                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .background {
+            Rectangle().fill(.ultraThinMaterial).ignoresSafeArea()
+        }
+    }
+
+    // MARK: - Transcript (BET-481 container, kept verbatim)
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                TranscriptView(blocks: store.blocks, tokens: tokens)
+            }
+        }
+        .defaultScrollAnchor(.bottom)
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    // MARK: - Live cards (todos / permission / question)
+
+    @ViewBuilder
+    private var bottomCards: some View {
+        VStack(spacing: Metrics.spacing.sp3) {
+            if let todos = store.todos, let active = todos.active, !active.isEmpty {
+                TodosCard(items: active, tokens: tokens)
+            }
+            if let permission = newestPermission {
+                PermissionCard(permission: permission, tokens: tokens) { reply in
+                    store.replyPermission(permission, reply: reply)
+                }
+            }
+            if let question = newestQuestion {
+                QuestionCard(question: question, tokens: tokens) { answers in
+                    store.replyQuestion(question, answers: answers)
+                } onReject: {
+                    store.rejectQuestion(question)
+                }
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.top, Metrics.spacing.sp2)
+    }
+
+    private var newestPermission: PermissionRequest? {
+        store.permissions.last
+    }
+
+    private var newestQuestion: QuestionRequest? {
+        store.questions.last
+    }
+
+    // MARK: - Load failure
+
+    private var loadFailure: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: Metrics.type.display))
+                .foregroundColor(tokens.warn)
+            Text("Couldn't reach your box")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            Text("Tap to retry.")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture { store.load() }
+    }
+}
+
+// MARK: - Child drill-in (S4 / BET-576)
+
+/// The pushed subagent screen. Unlike the S4b frozen fixture screen, this one
+/// binds to a LIVE ChatSessionStore for the child opencode session — the
+/// transcript streams while the child is open. Reuses the existing
+/// SubagentHeader + TranscriptView (no second renderer).
+struct ChatSubagentScreen: View {
+    let title: String
+    let subtitle: String
+    @ObservedObject var store: ChatSessionStore
+    let tokens: Tokens
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            SubagentHeader(
+                title: title,
+                subtitle: subtitle,
+                onBack: { dismiss() },
+                tokens: tokens
+            )
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    TranscriptView(blocks: store.blocks, tokens: tokens)
+                }
+            }
+            .defaultScrollAnchor(.bottom)
+        }
+        .background(tokens.canvas.ignoresSafeArea())
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
+        .onAppear { store.start() }
+        .onDisappear { store.stop() }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("subagent-scene")
+    }
+}
+
+// MARK: - Todos card (scope item 4)
+
+private struct TodosCard: View {
+    let items: [StreamTodoItem]
+    let tokens: Tokens
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            ForEach(items, id: \.id) { item in
+                HStack(spacing: Metrics.spacing.sp2) {
+                    Image(systemName: item.status == "completed" ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: Metrics.type.xs))
+                        .foregroundColor(item.status == "completed" ? tokens.ok : tokens.accent)
+                    Text(item.content ?? "")
+                        .font(.system(size: Metrics.type.small))
+                        .foregroundColor(tokens.tx2)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("todos-card")
+    }
+}
+
+// MARK: - Permission card (answerable, §7.5)
+
+private struct PermissionCard: View {
+    let permission: PermissionRequest
+    let tokens: Tokens
+    let onReply: (PermissionReply) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            Text("Permission needed")
+                .font(.system(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.semibold)))
+                .foregroundColor(tokens.tx4)
+            Text(summary)
+                .font(.system(size: Metrics.type.body))
+                .foregroundColor(tokens.tx1)
+                .lineLimit(3)
+            HStack(spacing: Metrics.spacing.sp2) {
+                replyButton("Allow once", reply: .once, filled: true)
+                replyButton("Allow always", reply: .always, filled: false)
+                Spacer()
+                Button {
+                    onReply(.reject)
+                } label: {
+                    Text("Reject")
+                        .font(.system(size: Metrics.type.small, weight: .medium))
+                        .foregroundColor(tokens.danger)
+                }
+            }
+        }
+        .padding(Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("permission-card")
+    }
+
+    private var summary: String {
+        if let patterns = permission.patterns, !patterns.isEmpty {
+            return patterns.joined(separator: " · ")
+        }
+        return permission.permission
+    }
+
+    private func replyButton(_ label: String, reply: PermissionReply, filled: Bool) -> some View {
+        Button {
+            onReply(reply)
+        } label: {
+            Text(label)
+                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(filled ? tokens.onAccent : tokens.accentTx)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(filled ? tokens.accentSolid : tokens.accentSoft, in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Question card (answerable, §7.5)
+
+private struct QuestionCard: View {
+    let question: QuestionRequest
+    let tokens: Tokens
+    let onSubmit: ([[String]]) -> Void
+    let onReject: () -> Void
+
+    @State private var selected: Set<Int> = []
+    @State private var customText = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            ForEach(Array(question.questions.enumerated()), id: \.offset) { index, q in
+                VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+                    if !q.header.isEmpty {
+                        Text(q.header)
+                            .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
+                            .foregroundColor(tokens.tx1)
+                    }
+                    Text(q.question)
+                        .font(.system(size: Metrics.type.body))
+                        .foregroundColor(tokens.tx1)
+                    ForEach(Array(q.options.enumerated()), id: \.offset) { oi, option in
+                        optionButton(oi, label: option.label, multi: q.multiple == true)
+                    }
+                }
+            }
+            if !customText.isEmpty {
+                TextField("Or type your own answer…", text: $customText)
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx1)
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.vertical, Metrics.spacing.sp2)
+                    .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+            }
+            HStack {
+                Button("Reject", action: onReject)
+                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .foregroundColor(tokens.danger)
+                Spacer()
+                Button { submit() } label: {
+                    Text("Send")
+                        .font(.system(size: Metrics.type.small, weight: .semibold))
+                        .foregroundColor(canSubmit ? tokens.onAccent : tokens.tx4)
+                        .padding(.horizontal, Metrics.spacing.sp3)
+                        .padding(.vertical, Metrics.spacing.sp2)
+                        .background(canSubmit ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.inset), in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSubmit)
+            }
+        }
+        .padding(Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("question-card")
+    }
+
+    private var canSubmit: Bool {
+        !selected.isEmpty || !customText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func optionButton(_ index: Int, label: String, multi: Bool) -> some View {
+        let isOn = selected.contains(index)
+        return Button {
+            toggle(index, multi: multi)
+        } label: {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Image(systemName: isOn ? "checkmark.square.fill" : "square")
+                    .font(.system(size: Metrics.type.xs))
+                    .foregroundColor(isOn ? tokens.accent : tokens.tx4)
+                Text(label)
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx1)
+                    .multilineTextAlignment(.leading)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, Metrics.spacing.sp1)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func toggle(_ index: Int, multi: Bool) {
+        if multi {
+            if selected.contains(index) { selected.remove(index) } else { selected.insert(index) }
+        } else {
+            selected = [index]
+        }
+    }
+
+    private func submit() {
+        var answers: [[String]] = []
+        for q in question.questions {
+            var picked = q.options.enumerated().compactMap { i, o in selected.contains(i) ? o.label : nil }
+            let typed = customText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !typed.isEmpty { picked.append(typed) }
+            answers.append(picked)
+        }
+        onSubmit(answers)
+    }
+}

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Combine
+
+// ===========================================================================
+// S4 — chat session store (BET-596).
+//
+// The live, observable session store the chat screen binds to, replacing the
+// hardcoded `parentBlocks` fixture. It is fed from two sources:
+//
+//   1. The canonical `opencode:messages` transcript — the persisted source of
+//      `.user` / completed `.prose` / `.steps` / subagent rows. Refetched at
+//      each turn boundary so a finished turn's blocks land as real content.
+//   2. The S1b `/events` stream state (MantaEventStore.sessionStates[sessionId])
+//      — already interpreted by the box (§17): the running assistant text
+//      (`stream:flush`), running/turnComplete, context/tokens, todos,
+//      truncation, questions, and live subagent status.
+//
+// Permissions are fetched via `opencode:permissions` and lightly polled while
+// the screen is active; questions arrive on the interpreted stream. Both are
+// answerable from the phone (S1a reply/reject RPCs). Parent and children are
+// each their own store; a child store is read-only (no permission poll) —
+// §8a v1.
+//
+// Deliberately does NOT touch the event store's single-owner `rawFrameHandler`
+// or `resyncHandler`; resync + attention are derived from the @Published stream
+// state and a connectionState transition instead, so the session list's
+// handlers (owned by SessionListStore) are never clobbered.
+// ===========================================================================
+
+@MainActor
+final class ChatSessionStore: ObservableObject {
+
+    @Published private(set) var transcript: [TranscriptBlock] = []
+    @Published private(set) var inProgressText = ""
+    @Published private(set) var blocks: [TranscriptBlock] = []
+    @Published private(set) var running = false
+    @Published private(set) var turnComplete = false
+    @Published private(set) var context: StreamContextPayload?
+    @Published private(set) var cache: StreamCachePayload?
+    @Published private(set) var truncation: StreamTruncationPayload?
+    @Published private(set) var todos: StreamTodosPayload?
+    @Published private(set) var questions: [QuestionRequest] = []
+    @Published private(set) var permissions: [PermissionRequest] = []
+    @Published private(set) var subagents: [StreamSubagentPayload] = []
+    @Published private(set) var childStores: [String: ChatSessionStore] = [:]
+    @Published private(set) var loading = false
+    @Published private(set) var loadFailed = false
+
+    let sessionId: String
+    let isReadOnly: Bool
+
+    private let api: MantaAPIClient
+    private let eventStore: MantaEventStore
+    private var cancellables: Set<AnyCancellable> = []
+    private var permissionPoll: Timer?
+    private var runningSince: Date?
+    private var didRunOnce = false
+    private var lastRunning: Bool?
+    private var lastComplete: Bool?
+
+    init(
+        sessionId: String,
+        eventStore: MantaEventStore,
+        api: MantaAPIClient,
+        isReadOnly: Bool = false
+    ) {
+        self.sessionId = sessionId
+        self.eventStore = eventStore
+        self.api = api
+        self.isReadOnly = isReadOnly
+
+        eventStore.$sessionStates
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.applyStreamState() }
+            .store(in: &cancellables)
+
+        eventStore.$connectionState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in self?.handleConnection(state) }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begin loading the session and (for the parent) start the light
+    /// permission poll. Idempotent.
+    func start() {
+        guard !didRunOnce else { return }
+        didRunOnce = true
+        load()
+        if !isReadOnly {
+            startPermissionPoll()
+        }
+    }
+
+    func stop() {
+        permissionPoll?.invalidate()
+        permissionPoll = nil
+    }
+
+    func load() {
+        guard !loading else { return }
+        loading = true
+        Task {
+            let messages = (try? await api.messages(sessionId: sessionId)) ?? []
+            await MainActor.run {
+                loading = false
+                loadFailed = messages.isEmpty
+                transcript = ChatTranscriptMapper.blocks(from: messages)
+                rebuildBlocks()
+            }
+            if !isReadOnly {
+                await refreshPermissions()
+            }
+        }
+    }
+
+    // MARK: - Stream state application
+
+    private func applyStreamState() {
+        guard let s = eventStore.sessionStates[sessionId] else { return }
+
+        let mergedText = s.textByPart.values
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        inProgressText = mergedText
+
+        running = s.running == true
+        turnComplete = s.turnComplete == true
+        context = s.context
+        cache = s.cache
+        truncation = s.truncation
+        todos = s.todos
+        questions = s.questions?.questions ?? []
+        subagents = s.subagents
+
+        // Track running-this-turn for the header timer.
+        if running && runningSince == nil {
+            runningSince = Date()
+        } else if !running {
+            runningSince = nil
+        }
+
+        // Register child stores for any subagent that has a child session id,
+        // so its drill-in is live before the user taps it (BET-576).
+        for payload in s.subagents {
+            let childID = payload.childSessionId
+            if !childID.isEmpty, childStores[childID] == nil {
+                _ = ensureChildStore(childID)
+            }
+        }
+
+        // Refetch the canonical transcript at turn boundaries so a finished
+        // turn's blocks (steps/prose/subagents) land as real content and the
+        // in-progress text is absorbed (no duplication while streaming).
+        if running != lastRunning {
+            lastRunning = running
+            if running { scheduleRefetch() }
+        }
+        if turnComplete != lastComplete {
+            lastComplete = turnComplete
+            if turnComplete { scheduleRefetch() }
+        }
+
+        rebuildBlocks()
+    }
+
+    private func handleConnection(_ state: MantaConnectionState) {
+        // A healthy reconnect means missed state should be re-fetched, exactly
+        // what resyncHandler would do — but derived here so we never steal the
+        // event store's single-owner resync slot from the session list.
+        if state == .connected { scheduleRefetch() }
+    }
+
+    // MARK: - Block assembly
+
+    /// The rendered transcript = canonical blocks + the live in-progress prose
+    /// tail (the streaming assistant text, §8). Keeping them separate makes the
+    /// scroll `defaultScrollAnchor(.bottom)` cheap: only the tail mutates
+    /// between turn boundaries.
+    private func rebuildBlocks() {
+        if inProgressText.isEmpty {
+            blocks = transcript
+        } else {
+            blocks = transcript + [.prose(inProgressText)]
+        }
+    }
+
+    // MARK: - Refetch
+
+    private func scheduleRefetch() {
+        Task { await refetch() }
+    }
+
+    func refetch() async {
+        let messages = (try? await api.messages(sessionId: sessionId)) ?? []
+        await MainActor.run {
+            transcript = ChatTranscriptMapper.blocks(from: messages)
+            rebuildBlocks()
+            if !isReadOnly { Task { await self.refreshPermissions() } }
+        }
+    }
+
+    // MARK: - Permissions (S1a answerable)
+
+    private func startPermissionPoll() {
+        let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.refreshPermissions() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        permissionPoll = timer
+    }
+
+    func refreshPermissions() async {
+        let perms = (try? await api.permissions(sessionId: sessionId)) ?? []
+        await MainActor.run { permissions = perms }
+    }
+
+    // MARK: - Answers (wire from the phone, S1a)
+
+    func replyPermission(_ request: PermissionRequest, reply: PermissionReply) {
+        Task {
+            try? await api.permissionReply(requestId: request.id, reply: reply, sessionId: sessionId)
+            await refreshPermissions()
+        }
+    }
+
+    func replyQuestion(_ request: QuestionRequest, answers: [[String]]) {
+        Task {
+            try? await api.questionReply(requestId: request.id, answers: answers, sessionId: sessionId)
+        }
+    }
+
+    func rejectQuestion(_ request: QuestionRequest) {
+        Task {
+            try? await api.questionReject(requestId: request.id, sessionId: sessionId)
+        }
+    }
+
+    // MARK: - Subagent drill-in (BET-576)
+
+    func ensureChildStore(_ childSessionId: String) -> ChatSessionStore {
+        if let existing = childStores[childSessionId] {
+            return existing
+        }
+        let child = ChatSessionStore(
+            sessionId: childSessionId,
+            eventStore: eventStore,
+            api: api,
+            isReadOnly: true
+        )
+        childStores[childSessionId] = child
+        child.start()
+        return child
+    }
+
+    func store(for childSessionId: String?) -> ChatSessionStore? {
+        guard let childSessionId else { return nil }
+        return ensureChildStore(childSessionId)
+    }
+
+    // MARK: - Header
+
+    /// §8 header subtitle ("running · 2m · 8%" / "idle").
+    var headerSubtitle: String {
+        let elapsed = runningSince.map { Date().timeIntervalSince($0) } ?? 0
+        return ChatHeaderSubtitle.text(running: running, elapsed: elapsed, contextPct: context?.pct)
+    }
+}

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -21,6 +21,7 @@ import UIKit
 
 struct SessionListView: View {
     @ObservedObject var store: SessionListStore
+    @EnvironmentObject private var eventStore: MantaEventStore
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var searchText = ""
@@ -51,7 +52,11 @@ struct SessionListView: View {
             .overlay(alignment: .top) { errorBanner }
             .sheet(item: $renameTarget) { _ in renameSheet(targetProject: renameProject) }
             .navigationDestination(item: $openTarget) { target in
-                SessionScreenPlaceholder(name: target.name)
+                if let sessionId = target.sessionId, !sessionId.isEmpty {
+                    ChatScreen(sessionId: sessionId, title: target.name, eventStore: eventStore)
+                } else {
+                    SessionScreenPlaceholder(name: target.name)
+                }
             }
         }
         .sheet(item: $confirmDeleteWindow) { target in confirmDeleteSheet(target: target) }
@@ -61,10 +66,11 @@ struct SessionListView: View {
                 mode: item.mode,
                 onClose: { createItem = nil },
                 onCreated: { project, index in
-                    let name = store.projects.first(where: { $0.tmuxSession == project })?
-                        .windows.first(where: { $0.index == index })?.name ?? "session"
+                    let window = store.projects.first(where: { $0.tmuxSession == project })?
+                        .windows.first(where: { $0.index == index })
+                    let name = window?.name ?? "session"
                     createItem = nil
-                    openTarget = SessionOpenTarget(project: project, windowIndex: index, name: name)
+                    openTarget = SessionOpenTarget(project: project, windowIndex: index, name: name, sessionId: window?.opencodeSessionId)
                 }
             )
             .presentationDetents([.medium, .large])
@@ -116,7 +122,7 @@ struct SessionListView: View {
     @ViewBuilder
     private func row(project: MantaProject, window: MantaWindow) -> some View {
         Button {
-            openTarget = SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name)
+            openTarget = SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: window.opencodeSessionId)
         } label: {
             SessionRowContent(
                 window: window,
@@ -509,6 +515,7 @@ private struct SessionOpenTarget: Identifiable, Hashable {
     let project: String
     let windowIndex: Int
     let name: String
+    let sessionId: String?
 }
 
 /// The chat screen this row opens is S4's (chat wired to live data). This

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -250,13 +250,18 @@ struct SubagentSession: Identifiable, Hashable {
     // Live duration (e.g. "1m12s") while running; nil when done.
     let duration: String?
     let transcript: [TranscriptBlock]
+    /// The opencode child session this agent runs in, when known (S4). The
+    /// chat screen pushes a LIVE child screen bound to this session id
+    /// (BET-576); the S4b fixture leaves it nil (there is no child session).
+    let childSessionId: String?
 
-    init(taskName: String, status: SubagentStatus, duration: String?, transcript: [TranscriptBlock]) {
+    init(taskName: String, status: SubagentStatus, duration: String?, transcript: [TranscriptBlock], childSessionId: String? = nil) {
         self.id = UUID()
         self.taskName = taskName
         self.status = status
         self.duration = duration
         self.transcript = transcript
+        self.childSessionId = childSessionId
     }
 
     // Navigation values are compared by identity, never by deep transcript

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import MantaUI
+
+// S4 / BET-596 — the pure chat mapping: `opencode:messages` → TranscriptBlock,
+// the step-row presentation, the rollup, and the §8 header subtitle. These are
+// the device-side PRESENTATION decisions only (§17); interpretation stays on
+// the box. No HTTP/view/Keychain involved.
+
+final class ChatTranscriptTests: XCTestCase {
+
+    // MARK: - Fixture builders
+
+    private func jsonObject(_ d: [String: JSONValue]) -> JSONValue { .object(d) }
+    private func str(_ s: String) -> JSONValue { .string(s) }
+    private func num(_ n: Double) -> JSONValue { .number(n) }
+
+    private func textPart(_ id: String, _ messageID: String, _ text: String) -> OpencodePart {
+        OpencodePart(type: "text", id: id, messageID: messageID, text: text)
+    }
+
+    private func toolPart(_ id: String, _ messageID: String, tool: String, status: String, input: [String: JSONValue], output: String? = nil, start: Double? = 100, end: Double? = 100.4) -> OpencodePart {
+        var state: [String: JSONValue] = [
+            "status": str(status),
+            "input": jsonObject(input),
+        ]
+        if let output { state["output"] = str(output) }
+        if let start, let end {
+            state["time"] = jsonObject(["start": num(start), "end": num(end)])
+        }
+        return OpencodePart(type: "tool", id: id, messageID: messageID, extra: [
+            "tool": str(tool),
+            "state": jsonObject(state),
+        ])
+    }
+
+    private func taskPart(_ id: String, _ messageID: String, childID: String, title: String, status: String) -> OpencodePart {
+        var stateObject: [String: JSONValue] = [
+            "status": str(status),
+            "title": str(title),
+            "metadata": jsonObject(["sessionId": str(childID)]),
+        ]
+        stateObject["time"] = jsonObject(["start": num(0), "end": num(5)])
+        return OpencodePart(type: "tool", id: id, messageID: messageID, extra: [
+            "tool": str("task"),
+            "state": jsonObject(stateObject),
+        ])
+    }
+
+    private func message(id: String, role: String, parts: [OpencodePart], completed: Bool = true) -> OpencodeMessage {
+        OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: id,
+                sessionID: "ses",
+                role: OpencodeRole(rawValue: role),
+                time: OpencodeTime(created: 0, completed: completed ? 1 : nil),
+                modelID: nil,
+                providerID: nil
+            ),
+            parts: parts
+        )
+    }
+
+    // MARK: - User + prose
+
+    func testUserTextMapsToUserBand() {
+        let msgs = [message(id: "m1", role: "user", parts: [textPart("p1", "m1", "check bet-520")])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .user(let text) = blocks[0] else {
+            return XCTFail("expected .user, got \(blocks[0])")
+        }
+        XCTAssertEqual(text, "check bet-520")
+    }
+
+    func testAssistantTextMapsToProse() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [textPart("p1", "m1", "Checking metadata.")])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .prose(let text) = blocks[0] else {
+            return XCTFail("expected .prose")
+        }
+        XCTAssertEqual(text, "Checking metadata.")
+    }
+
+    // MARK: - Steps
+
+    func testBashStepMapsToRanVerbAndCommandTarget() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("multica issue get BET-520")], output: "Blocked", start: 100, end: 100.4),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .steps(.rows(let rows)) = blocks[0], rows.count == 1, case .step(let step) = rows[0] else {
+            return XCTFail("expected a single-step group")
+        }
+        XCTAssertEqual(step.verb, "Ran")
+        XCTAssertEqual(step.target, "multica issue get BET-520")
+        XCTAssertEqual(step.duration, "0.4s")
+        XCTAssertEqual(step.status, .done)
+        XCTAssertEqual(step.output, "Blocked")
+    }
+
+    func testReadStepMapsToReadVerbAndFilePathTarget() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "read", status: "running", input: ["filePath": str("pr-body.md")], output: nil, start: nil, end: nil),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .steps(.rows(let rows)) = blocks[0], case .step(let step) = rows[0] else {
+            return XCTFail("expected a step")
+        }
+        XCTAssertEqual(step.verb, "Read")
+        XCTAssertEqual(step.target, "pr-body.md")
+        // timeless running row → no duration
+        XCTAssertEqual(step.duration, "")
+        XCTAssertEqual(step.status, .running)
+    }
+
+    // MARK: - Subagent
+
+    func testTaskPartMapsToSubagentWithChildSession() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            taskPart("t1", "m1", childID: "ses_child", title: "unblock sweep", status: "running"),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .steps(.rows(let rows)) = blocks[0], rows.count == 1, case .subagent(let agent) = rows[0] else {
+            return XCTFail("expected a subagent row")
+        }
+        XCTAssertEqual(agent.taskName, "unblock sweep")
+        XCTAssertEqual(agent.childSessionId, "ses_child")
+        XCTAssertEqual(agent.status, .running)
+        XCTAssertEqual(agent.duration, "5.0s")
+    }
+
+    // MARK: - Rollup
+
+    func testThreeConsecutiveStepsRollUp() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "read", status: "completed", input: ["filePath": str("a.ts")]),
+            toolPart("t2", "m1", tool: "read", status: "completed", input: ["filePath": str("b.ts")]),
+            toolPart("t3", "m1", tool: "bash", status: "completed", input: ["command": str("run tests")]),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .steps(.rollup(let summary, let rows)) = blocks[0], rows.count == 3 else {
+            return XCTFail("expected a rollup of 3")
+        }
+        XCTAssertEqual(summary, "▸ 3 steps · Read 2, Ran 1")
+    }
+
+    func testTwoStepsStayUnrolled() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "read", status: "completed", input: ["filePath": str("a.ts")]),
+            toolPart("t2", "m1", tool: "read", status: "completed", input: ["filePath": str("b.ts")]),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .steps(.rows(let rows)) = blocks[0], rows.count == 2 else {
+            return XCTFail("expected two unrolled rows")
+        }
+        XCTAssertEqual(rows.count, 2)
+    }
+
+    func testSubagentNeverRolls() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "read", status: "completed", input: ["filePath": str("a.ts")]),
+            taskPart("t2", "m1", childID: "c", title: "sweep", status: "running"),
+            toolPart("t3", "m1", tool: "read", status: "completed", input: ["filePath": str("b.ts")]),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        guard case .steps(.rows(let rows)) = blocks[0], rows.count == 3 else {
+            return XCTFail("agent rows must keep the group as raw rows")
+        }
+        XCTAssertEqual(rows.count, 3)
+    }
+
+    // MARK: - Streaming duplication avoidance
+
+    func testIncompleteAssistantMessageIsNotDuplicated() {
+        // The running assistant turn (no time.completed) must NOT emit a prose
+        // block — its text streams live via `stream.flush` and the store
+        // appends it as the in-progress tail. Including it here would double
+        // it while streaming.
+        let msgs = [message(id: "m1", role: "assistant", parts: [textPart("p1", "m1", "streaming…")], completed: false)]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        XCTAssertTrue(blocks.isEmpty)
+    }
+
+    // MARK: - Header subtitle (§8)
+
+    func testHeaderSubtitleRunningWithContext() {
+        XCTAssertEqual(ChatHeaderSubtitle.text(running: true, elapsed: 61, contextPct: 8.4), "running · 1m · 8%")
+    }
+
+    func testHeaderSubtitleRunningNoContext() {
+        XCTAssertEqual(ChatHeaderSubtitle.text(running: true, elapsed: 0, contextPct: nil), "running · 0s")
+    }
+
+    func testHeaderSubtitleIdle() {
+        XCTAssertEqual(ChatHeaderSubtitle.text(running: false, elapsed: 0, contextPct: nil), "idle")
+    }
+}

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -193,4 +193,49 @@ final class ChatTranscriptTests: XCTestCase {
     func testHeaderSubtitleIdle() {
         XCTAssertEqual(ChatHeaderSubtitle.text(running: false, elapsed: 0, contextPct: nil), "idle")
     }
+
+    // MARK: - Question answers (§7.5)
+
+    private func q(_ question: String, options: [String], multiple: Bool = false) -> QuestionInfo {
+        QuestionInfo(
+            question: question,
+            header: "",
+            options: options.map { QuestionOption(label: $0, description: "") },
+            multiple: multiple,
+            custom: false
+        )
+    }
+
+    func testQuestionFreeTextAloneCanSubmitAcrossAll() {
+        let questions = [q("Pick", options: ["A", "B"]), q("Pick2", options: ["C", "D"])]
+        XCTAssertTrue(ChatQuestionAnswers.canSubmit(questions: questions, selected: [:], customText: "typed"))
+        let out = ChatQuestionAnswers.answers(questions: questions, selected: [:], customText: "typed")
+        XCTAssertEqual(out, [["typed"], ["typed"]])
+    }
+
+    func testQuestionSubmitDisabledUntilEveryQuestionAnswered() {
+        let questions = [q("Q1", options: ["A"]), q("Q2", options: ["B"])]
+        // Only Q1 answered → disabled.
+        XCTAssertFalse(ChatQuestionAnswers.canSubmit(questions: questions, selected: [0: [0]], customText: ""))
+        // Both answered → enabled.
+        XCTAssertTrue(ChatQuestionAnswers.canSubmit(questions: questions, selected: [0: [0], 1: [0]], customText: ""))
+    }
+
+    func testQuestionPerQuestionSelectionsDoNotCollide() {
+        // Option index 0 selected on question A must not select option 0 on B.
+        let questions = [q("Q1", options: ["A0", "A1"]), q("Q2", options: ["B0", "B1"])]
+        let out = ChatQuestionAnswers.answers(questions: questions, selected: [0: [1]], customText: "")
+        XCTAssertEqual(out, [["A1"], []])
+        XCTAssertFalse(ChatQuestionAnswers.canSubmit(questions: questions, selected: [0: [1]], customText: ""))
+        XCTAssertTrue(ChatQuestionAnswers.canSubmit(questions: questions, selected: [0: [1], 1: [0]], customText: ""))
+    }
+
+    func testQuestionMultipleSelectionAccumulates() {
+        let q = [QuestionInfo(question: "M", header: "", options: [
+            QuestionOption(label: "x", description: ""),
+            QuestionOption(label: "y", description: ""),
+        ], multiple: true, custom: false)]
+        let out = ChatQuestionAnswers.answers(questions: q, selected: [0: [0, 1]], customText: "")
+        XCTAssertEqual(out, [["x", "y"]])
+    }
 }

--- a/scripts/gen-swift-tokens.mjs
+++ b/scripts/gen-swift-tokens.mjs
@@ -96,11 +96,15 @@ const TYPE_MAP = {
   rowName: "font-size-row-name",
   headingTracking: "tracking-list-heading",
   rowNameTracking: "tracking-row-name",
+  // §8 chat screen: the two-line header title + its em tracking (BET-596).
+  chatTitle: "font-size-chat-title",
+  chatTitleTracking: "tracking-chat-title",
 };
 // Off-grid layout paddings the mockup fixes (§8 / transcript-mockup.html) plus
 // the §7 session-list row/group metrics (BET-595).
 const LAYOUT_MAP = {
   stepRowY: "step-row-y", stepDot: "step-dot",
+  chatHeaderBtn: "chat-header-btn",
   listRowMinH: "list-row-min-h", listRowRadius: "list-row-radius",
   listRowMargin: "list-row-margin",
   listGroupAbove: "list-group-above", listGroupBelow: "list-group-below",

--- a/scripts/gen-swift-tokens.test.mjs
+++ b/scripts/gen-swift-tokens.test.mjs
@@ -38,6 +38,11 @@ const ROOT_VARIABLES = [
   ["list-row-min-h", "62px"], ["list-row-radius", "20px"],
   ["list-row-margin", "2px"],
   ["list-group-above", "22px"], ["list-group-below", "6px"],
+  // §8 chat-screen header metrics (BET-596) — must track gen-swift-tokens.mjs
+  // TYPE_MAP/LAYOUT_MAP so the widened generator's lookups resolve in the
+  // test fixture.
+  ["font-size-chat-title", "14.5px"], ["tracking-chat-title", "-0.01"],
+  ["chat-header-btn", "38px"],
 ];
 
 function cssFor(prefix) {

--- a/src/renderer/tokens.css
+++ b/src/renderer/tokens.css
@@ -118,6 +118,9 @@
   --weight-semibold: 600;
   --step-row-y: 7px;
   --step-dot: 6px;
+  --chat-header-btn: 38px;
+  --font-size-chat-title: 14.5px;
+  --tracking-chat-title: -0.01;
 
   /* Session-list anatomy (BET-595 §7). The row min-height, row corner radius,
      row gap, group-header margins and the row-name size/tracking are off the


### PR DESCRIPTION
Opened automatically for `multica/BET-596-chat-live-data`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-596.