### PR TITLE
BET-590: Reconcile welcome mockup with scale + finish the screen

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -81,7 +81,7 @@ that vanishes. Adopter counts below are **web** adopters only.
 | --- | --- | --- | --- |
 | Card | `src/renderer/Card.tsx` | 3 — `Cards.tsx`, `Settings.tsx`, `NewSessionScreen.tsx` | `danger` (optional); `header`/`actions` slots |
 | Modal | `src/renderer/Modal.tsx` | 4 — `Sidebar.tsx`, `NewSessionScreen.tsx`, `Settings.tsx`, `FolderPickerModal.tsx` | `size: sm\|md\|lg`; `padded`; `tall`; `onDismiss`; `label` |
-| IconButton | `src/renderer/IconButton.tsx` | 2 — `SessionHeader.tsx`, `NewSessionScreen.tsx` | `size: md\|lg`; `ariaHaspopup`/`ariaExpanded`/`hook` |
+| IconButton | `src/renderer/IconButton.tsx` | 2 — `SessionHeader.tsx`, `NewSessionScreen.tsx` | `size: md\|lg\|xl` (`xl` has a single adopting file, `NewSessionScreen.tsx`, by design — it is a size on an existing primitive, not a new primitive, so the two-adopter rule does not gate it); `ariaHaspopup`/`ariaExpanded`/`hook` |
 | Checkbox | `src/renderer/Checkbox.tsx` | 5 — `CustomProviderForm.tsx`, `ProvidersCard.tsx`, `ModelsCard.tsx`, `NewSessionScreen.tsx`, `Settings.tsx` | `checked`; `onChange`; `disabled`; `label`; `id`; `ariaLabel` |
 | Field | `src/renderer/Field.tsx` | 2 — `Settings.tsx`, `CustomProviderForm.tsx` | `type: text\|password\|number`; `mono` (default true); `label`/`help`/`leading`/`footer`/`disabled` |
 | Pill | `src/renderer/Pill.tsx` | 2 — `Cards.tsx`, `SessionHeader.tsx` | `tone: neutral\|accent\|warn` (required); `size: meta\|label`; `border` |

--- a/docs/screens/welcome/conformance.md
+++ b/docs/screens/welcome/conformance.md
@@ -4,7 +4,7 @@ App vs `docs/screens/welcome/mockup.html`, from `npm run visual:compare welcome`
 Advisory: nothing here blocks a merge. Findings are recorded so they survive
 the PR that found them.
 
-Last reviewed: 2026-08-02 (<commit>)
+Last reviewed: 2026-08-02 (a073823)
 
 ## Open divergences
 

--- a/docs/screens/welcome/conformance.md
+++ b/docs/screens/welcome/conformance.md
@@ -4,17 +4,21 @@ App vs `docs/screens/welcome/mockup.html`, from `npm run visual:compare welcome`
 Advisory: nothing here blocks a merge. Findings are recorded so they survive
 the PR that found them.
 
-Last reviewed: 2026-08-02 (9d0017a)
+Last reviewed: 2026-08-02 (<commit>)
 
 ## Open divergences
 
-- Heading is 24px (`text-display`); the mockup specifies 30px. No 30px role exists in the type scale.
-- Heading letter-spacing: mockup specifies `-0.02em`; the app applies none. No tracking token exists.
-- Radii: mockup specifies 10px chips / 14px composer / 9px send button; the app uses the Tailwind radius scale (8 / 12 / 8). The mockup's own spec note claims a 4px grid, which 9, 10 and 14 are not on — the mockup is internally inconsistent and needs an owner ruling.
-- Control heights: mockup specifies 34px for the send button, model/effort pills and the two icon buttons. The app renders 36px for the send button and ~24px for the icon buttons (the `IconButton` primitive is `p-1`). 34 is not on the 4px grid; changing `IconButton` is primitive surgery.
-- Worktree checkbox is the native browser control; the mockup specifies a custom 16px box (`border-strong`, 4px radius, canvas fill). The mockup shows the unchecked state only, so the checked treatment is unspecified.
+- None.
 
 ## Accepted divergences
 
-- The segmented control is implemented as one bordered wrapper with `overflow-hidden` and an internal `border-l`, rather than two adjacent chips with a shared border. Visually equivalent at every state the screen renders.
-- The composer box is not built from the `Card` primitive even though the chrome matches, because it requires the `manta-composer-input-row` hook class for its focus-within ring and the `manta-recording` border state, and primitives accept no `className` (docs/components.md decision 3).
+- The segmented branch/worktree control is one bordered wrapper with an internal
+  divider rather than two adjacent chips sharing a border. Visually equivalent
+  in every state the screen renders.
+- The composer box is not built from `Card` despite matching its chrome: it
+  needs the `manta-composer-input-row` hook class for its focus ring and the
+  `manta-recording` border state, and primitives accept no `className`
+  (`docs/components.md` decision 3).
+- The send button is hand-rolled rather than a primitive. It is the only
+  bordered icon button in the app; at one call site it fails the two-adopter
+  rule (`docs/components.md` decision 2). Revisit if a second one appears.

--- a/docs/screens/welcome/mockup.html
+++ b/docs/screens/welcome/mockup.html
@@ -59,8 +59,8 @@
 
   .heading { text-align: center; margin-bottom: var(--sp-6); }
   .heading h1 {
-    margin: 0 0 var(--sp-2); font-size: 30px; line-height: 1.2;
-    font-weight: 700; letter-spacing: -0.02em; color: var(--tx1);
+    margin: 0 0 var(--sp-2); font-size: 24px; line-height: 1.2;
+    font-weight: 700; color: var(--tx1);
   }
   .heading p { margin: 0; font-size: 15px; color: var(--tx2); }
 
@@ -71,7 +71,7 @@
   .chip {
     display: inline-flex; align-items: center; gap: var(--sp-2);
     height: 36px; padding: 0 var(--sp-3);
-    border: 1px solid var(--border); border-radius: 10px;
+    border: 1px solid var(--border); border-radius: var(--r-md);
     background: var(--card); color: var(--tx1);
     font-size: 14px; box-shadow: var(--shadow-sm);
   }
@@ -86,7 +86,7 @@
   }
   .chip-check {
     width: 16px; height: 16px; border: 1px solid var(--border-strong);
-    border-radius: 4px; background: var(--canvas); flex: none;
+    border-radius: var(--r-xs); background: var(--canvas); flex: none;
   }
 
   /* Composer — a single tall input card. The submit affordance sits INSIDE
@@ -94,7 +94,7 @@
      the input, left-aligned. */
   .composer {
     display: flex; align-items: flex-start; gap: var(--sp-2);
-    border: 1px solid var(--border); border-radius: 14px;
+    border: 1px solid var(--border); border-radius: var(--r-lg);
     background: var(--card); box-shadow: var(--shadow-sm);
     padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-4);
     margin-bottom: var(--sp-3);
@@ -104,7 +104,7 @@
     padding: var(--sp-2) 0 var(--sp-6);
   }
   .send {
-    width: 34px; height: 34px; flex: none; border-radius: 9px;
+    width: 36px; height: 36px; flex: none; border-radius: var(--r-md);
     border: 1px solid var(--border); background: var(--panel);
     display: grid; place-items: center; color: var(--tx2);
   }
@@ -112,13 +112,13 @@
   .controls { display: flex; align-items: center; gap: var(--sp-2); }
   .pill {
     display: inline-flex; align-items: center; gap: var(--sp-2);
-    height: 34px; padding: 0 var(--sp-3);
-    border: 1px solid var(--border); border-radius: 10px;
+    height: 36px; padding: 0 var(--sp-3);
+    border: 1px solid var(--border); border-radius: var(--r-md);
     background: var(--card); font-size: 14px; color: var(--tx1);
   }
   .pill.effort { color: var(--accent-tx); font-weight: 600; }
   .icon-btn {
-    width: 34px; height: 34px; border-radius: 10px; border: 1px solid transparent;
+    width: 36px; height: 36px; border-radius: var(--r-md); border: 1px solid transparent;
     display: grid; place-items: center; color: var(--tx2); background: transparent;
   }
 
@@ -128,7 +128,7 @@
   }
   .spec-note code {
     font-family: "JetBrains Mono Variable", ui-monospace, monospace;
-    font-size: 12px; background: var(--panel); padding: 1px 4px; border-radius: 4px;
+    font-size: 12px; background: var(--panel); padding: 1px 4px; border-radius: var(--r-xs);
   }
 </style>
 </head>
@@ -205,7 +205,7 @@
   <strong>one segmented control</strong> (shared border, no gap); folder is a separate
   chip. The effort pill is the only accent-coloured text on the screen — it is
   the one setting users change per task. Every control is
-  <code>34–36px</code> tall on one <code>4px</code> grid. Empty state of the
+  <code>36px</code> tall on one <code>4px</code> grid. Empty state of the
   sidebar is shown for context and is specified elsewhere.
 </p>
 

--- a/src/renderer/IconButton.test.tsx
+++ b/src/renderer/IconButton.test.tsx
@@ -18,10 +18,14 @@ import { mount, type Harness } from "./testHarness";
 import { IconButton } from "./IconButton";
 import { SessionHeader } from "./SessionHeader";
 
-// The exact chrome string IconButton owns (no className escape hatch means
-// every call site renders exactly this).
+// The exact chrome string IconButton owns for the md (default) size. Padding
+// and radius live in SIZE_CHROME and vary by size (md/lg rounded-xs p-1, xl
+// rounded-md p-2); the rest of the chrome is shared — no className escape
+// hatch means every call site renders exactly these classes.
 const CHROME =
-  "inline-flex items-center justify-center rounded-xs p-1 text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+  "inline-flex items-center justify-center text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent rounded-xs p-1";
+const CHROME_XL =
+  "inline-flex items-center justify-center text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent rounded-md p-2";
 
 function buttonEl(h: Harness): HTMLButtonElement {
   const el = h.container.querySelector("button") as HTMLButtonElement;
@@ -76,6 +80,15 @@ describe("IconButton", () => {
     expect(iconSize(h)).toBe("16");
     h.rerender(<IconButton label="A" icon={<Terminal />} size="lg" />);
     expect(iconSize(h)).toBe("20");
+  });
+
+  it("renders the xl size (36px hit area, --r-md radius, 20px icon) for a standalone control row", () => {
+    h = mount(<IconButton label="A" icon={<Terminal />} size="xl" />);
+    const el = buttonEl(h);
+    expect(iconSize(h)).toBe("20");
+    expect(el.className).toBe(CHROME_XL);
+    expect(el.className).toContain("rounded-md");
+    expect(el.className).toContain("p-2");
   });
 
   it("passes menu semantics through for a trigger-style icon button", () => {

--- a/src/renderer/IconButton.tsx
+++ b/src/renderer/IconButton.tsx
@@ -5,12 +5,14 @@
 // area, radius, resting/hover icon colour or hover fill, so the icon-button
 // family can only drift if IconButton itself is retuned.
 //
-// Chrome contract (BET-529 inventory): square hit area (`p-1` → 24px md /
-// 28px lg), radius `--r-xs` (`rounded-xs`), resting icon `--tx3` → `--tx1` on
-// hover with `--fill-hover` bg, accent focus ring, 16px md icon / 20px lg
-// standalone. C1 (validated constraints): the hover sets a background, so it
-// also sets the matching foreground (`hover:text-text`); the resting state
-// sets `--tx3`.
+// Chrome contract (BET-529 inventory): square hit area (md 24px / lg 28px /
+// xl 36px), radius `--r-xs` for md/lg (`rounded-xs`) and `--r-md` for xl
+// (`rounded-md`), resting icon `--tx3` → `--tx1` on hover with `--fill-hover`
+// bg, accent focus ring, 16px md icon / 20px lg + xl standalone. `xl` is for a
+// standalone control row where the button sits beside 36px pills; `md`/`lg`
+// remain the dense-toolbar sizes. C1 (validated constraints): the hover sets a
+// background, so it also sets the matching foreground (`hover:text-text`); the
+// resting state sets `--tx3`.
 //
 // The hover fill uses the `fill-hover` colour utility (`hover:bg-fill-hover`,
 // registered by BET-539 → `--fill-hover`). No arbitrary value needed — the
@@ -25,8 +27,17 @@
 import type { ReactElement } from "react";
 import { cloneElement } from "react";
 
-const CHROME =
-  "inline-flex items-center justify-center rounded-xs p-1 text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+const CHROME_BASE =
+  "inline-flex items-center justify-center text-text-faint hover:text-text hover:bg-fill-hover focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+
+// Padding + radius vary by size; everything else is shared. `xl` widens the
+// hit area to 36px with `--r-md` so it reads correctly beside 36px pills in a
+// standalone control row.
+const SIZE_CHROME: Record<"md" | "lg" | "xl", string> = {
+  md: "rounded-xs p-1",
+  lg: "rounded-xs p-1",
+  xl: "rounded-md p-2",
+};
 
 export function IconButton({
   label,
@@ -46,8 +57,8 @@ export function IconButton({
   onClick?: () => void;
   /** Native `title` tooltip; defaults to `label`. */
   title?: string;
-  /** md = 16px icon (default), lg = 20px standalone. */
-  size?: "md" | "lg";
+  /** md = 16px icon (default), lg = 20px standalone, xl = 20px standalone with a 36px hit area + `--r-md` radius, for a control row beside 36px pills. */
+  size?: "md" | "lg" | "xl";
   /** Menu/popover semantics for a trigger-style icon button. */
   ariaHaspopup?: "menu" | "dialog" | "listbox" | "grid" | "tree" | "true" | "false";
   ariaExpanded?: boolean;
@@ -61,12 +72,12 @@ export function IconButton({
    */
   hook?: string;
 }) {
-  const iconSize = size === "lg" ? 20 : 16;
+  const iconSize = size === "md" ? 16 : 20;
   // Disabled-only classes are appended by the primitive itself (a disabled
   // icon button stays flat: no hover fill/foreground, not-allowed cursor) —
   // never by a caller, so the standing-decision-3 escape hatch still holds.
   const disabledClasses = "disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-faint";
-  const className = `${hook ? `${hook} ` : ""}${CHROME}${disabled ? ` ${disabledClasses}` : ""}`;
+  const className = `${hook ? `${hook} ` : ""}${CHROME_BASE} ${SIZE_CHROME[size]}${disabled ? ` ${disabledClasses}` : ""}`;
   return (
     <button
       type="button"

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -532,6 +532,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
             icon={<Paperclip />}
             label="Attach a file"
             title="Attaching files is not available when starting a session"
+            size="xl"
             disabled
           />
 
@@ -551,6 +552,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
               icon={<Mic />}
               label="Dictate"
               title="Dictation needs a Groq API key in Settings"
+              size="xl"
               disabled
             />
           )}


### PR DESCRIPTION
## Summary
Stage 4/4 of BET-585. Reconciles the welcome screen mockup with the token scale and finishes the screen.

### 5d-1 — Mockup off hardcoded pixels
`docs/screens/welcome/mockup.html` was the only mockup never migrated onto the radius scale. Replaced every hardcoded `border-radius` with the nearest token (exactly what the app already renders):
- `.chip` 10px → `var(--r-md)`, `.composer` 14px → `var(--r-lg)`, `.send` 9px → `var(--r-md)`, `.pill` 10px → `var(--r-md)`, `.icon-btn` 10px → `var(--r-md)`, `.chip-check` 4px → `var(--r-xs)`, `.spec-note code` 4px → `var(--r-xs)`.
- Controls 34px → 36px (on the 4px grid); spec note now says "Every control is `36px` tall on one `4px` grid".
- Heading 30px → 24px, removed `-0.02em` letter-spacing (no tracking token).

### 5d-2 — `IconButton` gains an `xl` size (D3)
Restructured the single `CHROME` constant into a shared base + per-size padding/radius (everything else identical):
- md (default) `p-1` 16px → 24px box `rounded-xs`
- lg `p-1` 20px → 28px box `rounded-xs`
- xl (new) `p-2` 20px → 36px box `rounded-md` — for a standalone control row beside 36px pills

`NewSessionScreen.tsx` attach + dictate buttons now pass `size="xl"`. Updated the header + size-prop doc comments and the `IconButton` row in `docs/components.md` (`size: md|lg|xl`, noting xl's single adopting file by design — a size on an existing primitive, so the two-adopter rule doesn't gate it).

### 5d-3 — Conformance record rewritten
`docs/screens/welcome/conformance.md`: **Open divergences — none.** The five BET-582 open items are closed. Three accepted divergences remain (segmented control as one wrapper, composer not built from `Card`, send button hand-rolled). "Last reviewed" stamped.

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ (1426 pass, 0 fail)
- `npm run visual:compare welcome` ✅ — app + mockup + composite captured; no heading/radius/height divergence (the mockup now mirrors what the app renders).