### PR TITLE
feat(ios): S5 composer — attachments, model picker, voice (BET-597)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
+		5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
 		650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */; };
@@ -30,9 +31,15 @@
 		94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
 		95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D71EC917661085ED10E0867 /* FolderPickerView.swift */; };
+		96F128D3EBC0D1432F603FDB /* ComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938AB4A14437119280E1B53A /* ComposerTests.swift */; };
+		98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */; };
 		9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
 		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
+		C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */; };
+		CC6A77686B936B4DB6026466 /* ChatModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */; };
+		D776E336456236DC1493565F /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229392FD3405558D301D0809 /* ChatModel.swift */; };
+		D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42691C89906181C99929354 /* ComposerView.swift */; };
 		E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9803742B79E4302F8813EFCC /* SessionModelsTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
 		E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436675A65BF149932C1EADE0 /* ChatScreen.swift */; };
@@ -57,8 +64,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVoice.swift; sourceTree = "<group>"; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
+		229392FD3405558D301D0809 /* ChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModel.swift; sourceTree = "<group>"; };
 		24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListStore.swift; sourceTree = "<group>"; };
 		28250B8DDAB996449F7AE3AD /* SessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModels.swift; sourceTree = "<group>"; };
 		2C13A01F9048A8907CBCC31D /* MantaUIUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -68,6 +77,7 @@
 		436675A65BF149932C1EADE0 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
 		471BF240012879FDED5689C1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
 		4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaOnboarding.swift; sourceTree = "<group>"; };
+		4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecorder.swift; sourceTree = "<group>"; };
 		4F7631E09B6FF7B150392A83 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
 		5D71EC917661085ED10E0867 /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
@@ -76,7 +86,9 @@
 		799EED7CC4F10C6684A5662C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
 		87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIApp.swift; sourceTree = "<group>"; };
+		8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelStore.swift; sourceTree = "<group>"; };
 		8C8240F1954861B4846E279D /* MantaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaModels.swift; sourceTree = "<group>"; };
+		938AB4A14437119280E1B53A /* ComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTests.swift; sourceTree = "<group>"; };
 		9803742B79E4302F8813EFCC /* SessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModelsTests.swift; sourceTree = "<group>"; };
 		989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAuthClientTests.swift; sourceTree = "<group>"; };
 		9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTransportTests.swift; sourceTree = "<group>"; };
@@ -85,7 +97,9 @@
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingTests.swift; sourceTree = "<group>"; };
 		B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreateSheet.swift; sourceTree = "<group>"; };
+		C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineTextView.swift; sourceTree = "<group>"; };
 		C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptTests.swift; sourceTree = "<group>"; };
+		C42691C89906181C99929354 /* ComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerView.swift; sourceTree = "<group>"; };
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
@@ -116,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */,
+				938AB4A14437119280E1B53A /* ComposerTests.swift */,
 				9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */,
 				989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */,
 				EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */,
@@ -156,9 +171,13 @@
 		D7128F5AAFA315FE875EEC98 /* MantaUI */ = {
 			isa = PBXGroup;
 			children = (
+				229392FD3405558D301D0809 /* ChatModel.swift */,
 				4F7631E09B6FF7B150392A83 /* ChatModels.swift */,
+				8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */,
 				436675A65BF149932C1EADE0 /* ChatScreen.swift */,
 				471BF240012879FDED5689C1 /* ChatSessionStore.swift */,
+				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
+				C42691C89906181C99929354 /* ComposerView.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
 				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
@@ -171,12 +190,14 @@
 				772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */,
 				7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */,
 				87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */,
+				C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */,
 				24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */,
 				D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */,
 				28250B8DDAB996449F7AE3AD /* SessionModels.swift */,
 				A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */,
+				4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */,
 			);
 			path = MantaUI;
 			sourceTree = "<group>";
@@ -301,6 +322,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */,
+				96F128D3EBC0D1432F603FDB /* ComposerTests.swift in Sources */,
 				5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */,
 				0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */,
 				9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */,
@@ -314,9 +336,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D776E336456236DC1493565F /* ChatModel.swift in Sources */,
+				CC6A77686B936B4DB6026466 /* ChatModelStore.swift in Sources */,
 				6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */,
 				E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */,
 				8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */,
+				C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */,
+				D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,
@@ -329,6 +355,7 @@
 				EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */,
 				5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */,
 				4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */,
+				5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */,
 				1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */,
@@ -336,6 +363,7 @@
 				7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */,
 				E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */,
 				95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */,
+				98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -402,6 +430,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = MantaUI;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "MantaUI uses the microphone for push-to-talk dictation and voice commands in chat.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -504,6 +533,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = MantaUI;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "MantaUI uses the microphone for push-to-talk dictation and voice commands in chat.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+// ===========================================================================
+// S5 — model picker pure logic (BET-597).
+//
+// The composer's model pill + menu. All decision logic is pure and tests
+// against `OpencodeModel[]` / `OpencodeModelID` values (box-side `opencode:models`
+// + `opencode:default-model`). The per-session override is an opaque
+// `providerID/modelID` string in UserDefaults (not a credential); the raw
+// string form travels between this module and the user-defaults-backed store.
+//
+// Behavioural reference: the desktop `ModelPicker.tsx` — per-session override
+// with the configured default as fallback. No design values invented here.
+// ===========================================================================
+
+enum ChatModel {
+
+    /// Group models by provider, providers ordered alphabetically (matching
+    /// the desktop `groups`). Enabled-only, deprecated excluded.
+    static func groups(_ models: [OpencodeModel]) -> [(provider: String, models: [OpencodeModel])] {
+        var map: [String: [OpencodeModel]] = [:]
+        for m in models where isPickable(m) {
+            map[m.providerID, default: []].append(m)
+        }
+        return map.keys.sorted().compactMap { provider in
+            map[provider].map { (provider, $0) }
+        }
+    }
+
+    /// A model is pickable when it is not explicitly disabled and not
+    /// deprecated. Absent `enabled`/`status` (common) → pickable.
+    static func isPickable(_ m: OpencodeModel) -> Bool {
+        if m.enabled == false { return false }
+        if m.status?.lowercased() == "deprecated" { return false }
+        return true
+    }
+
+    /// The effective selection: override wins, else the configured default.
+    static func effective(_ override: OpencodeModelID?, _ defaultModel: OpencodeModelID?) -> OpencodeModelID? {
+        override ?? defaultModel
+    }
+
+    /// Resolve the active model object (for the pill's friendly name), or nil
+    /// when neither an override nor the default names a known pickable model.
+    static func activeModel(_ models: [OpencodeModel], override: OpencodeModelID?, default defaultModel: OpencodeModelID?) -> OpencodeModel? {
+        guard let selection = effective(override, defaultModel) else { return nil }
+        return models.first { $0.providerID == selection.providerID && $0.id == selection.modelID }
+    }
+
+    /// The pill's short label: the active model's friendly name, else
+    /// "Default" when no effective selection resolves.
+    static func label(_ models: [OpencodeModel], override: OpencodeModelID?, default defaultModel: OpencodeModelID?) -> String {
+        if let active = activeModel(models, override: override, default: defaultModel) {
+            return active.name
+        }
+        if override != nil || defaultModel != nil { return "Default" }
+        return "Default"
+    }
+
+    /// Fuzzy-match a spoken/named model against the pickable list (desktop's
+    /// `fuzzyMatchModel`-style resolution for the voice `model` action).
+    static func findByQuery(_ models: [OpencodeModel], query: String) -> OpencodeModel? {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return nil }
+        for m in models where isPickable(m) {
+            if m.id.lowercased() == q { return m }
+            if m.name.lowercased() == q { return m }
+        }
+        for m in models where isPickable(m) {
+            if m.id.lowercased().contains(q) || m.name.lowercased().contains(q) { return m }
+        }
+        return nil
+    }
+
+    /// Encode a selection as the persisted `providerID/modelID` string.
+    static func encode(_ id: OpencodeModelID) -> String {
+        "\(id.providerID)/\(id.modelID)"
+    }
+
+    /// Decode a persisted override string, or nil when malformed/empty.
+    static func decode(_ raw: String) -> OpencodeModelID? {
+        let parts = raw.split(separator: "/", maxSplits: 1).map(String.init)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+        return OpencodeModelID(providerID: parts[0], modelID: parts[1])
+    }
+}

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Combine
+
+// ===========================================================================
+// S5 — model store for the composer (BET-597).
+//
+// Owns the model list + per-session override. Box-side data comes from the
+// existing `opencode:models` / `opencode:default-model` RPCs; the per-session
+// override is a plain `providerID/modelID` string in UserDefaults (NOT a
+// credential — the raw string encodes provider+model ids only), mirroring the
+// desktop's `manta:chat:<sessionId>:model` localStorage key. Resolution
+// (override ?? default) is pure ChatModel logic, tested separately.
+// ===========================================================================
+
+@MainActor
+final class ChatModelStore: ObservableObject {
+
+    @Published private(set) var models: [OpencodeModel] = []
+    @Published private(set) var defaultModel: OpencodeModelID?
+    @Published private(set) var override: OpencodeModelID?
+    @Published private(set) var loadFailed = false
+
+    let sessionId: String
+    private let api: MantaAPIClient
+
+    init(sessionId: String, api: MantaAPIClient) {
+        self.sessionId = sessionId
+        self.api = api
+        self.override = Self.loadOverride(for: sessionId)
+    }
+
+    /// The UserDefaults key mirroring the desktop's per-session model key.
+    static func storageKey(for sessionId: String) -> String {
+        "manta:chat:\(sessionId):model"
+    }
+
+    func load() {
+        Task {
+            let modelsResult = (try? await api.models()) ?? []
+            let defaultResult = try? await api.defaultModel()
+            await MainActor.run {
+                self.models = modelsResult
+                self.defaultModel = defaultResult
+                self.loadFailed = modelsResult.isEmpty && defaultResult == nil
+            }
+        }
+    }
+
+    /// The effective selection for the next turn: override wins, else default.
+    var active: OpencodeModelID? {
+        ChatModel.effective(override, defaultModel)
+    }
+
+    /// The selection to send on `opencode:prompt` (nil = let opencode pick).
+    var promptModel: SendPromptInput.Model? {
+        guard let active else { return nil }
+        return SendPromptInput.Model(providerID: active.providerID, modelID: active.modelID, variant: nil)
+    }
+
+    /// Set (or clear, with nil) the per-session override, persisting it.
+    func setOverride(_ id: OpencodeModelID?) {
+        override = id
+        if let id {
+            UserDefaults.standard.set(ChatModel.encode(id), forKey: Self.storageKey(for: sessionId))
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.storageKey(for: sessionId))
+        }
+    }
+
+    static func loadOverride(for sessionId: String) -> OpencodeModelID? {
+        guard let raw = UserDefaults.standard.string(forKey: storageKey(for: sessionId)) else { return nil }
+        return ChatModel.decode(raw)
+    }
+}

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -19,19 +19,24 @@ import SwiftUI
 
 struct ChatScreen: View {
     let title: String
+    let projectName: String
     @ObservedObject var eventStore: MantaEventStore
     @StateObject private var store: ChatSessionStore
+    @StateObject private var modelStore: ChatModelStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
 
-    init(sessionId: String, title: String, eventStore: MantaEventStore) {
+    init(sessionId: String, title: String, projectName: String, eventStore: MantaEventStore) {
         self.title = title
+        self.projectName = projectName
         self.eventStore = eventStore
+        let api = MantaAPIClient.live()
         _store = StateObject(wrappedValue: ChatSessionStore(
             sessionId: sessionId,
             eventStore: eventStore,
-            api: MantaAPIClient.live()
+            api: api
         ))
+        _modelStore = StateObject(wrappedValue: ChatModelStore(sessionId: sessionId, api: api))
     }
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
@@ -50,7 +55,18 @@ struct ChatScreen: View {
             }
         }
         .background(tokens.canvas.ignoresSafeArea())
-        .safeAreaInset(edge: .bottom) { bottomCards }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                bottomCards
+                ComposerView(
+                    sessionId: store.sessionId,
+                    projectName: projectName,
+                    api: MantaAPIClient.live(),
+                    store: store,
+                    modelStore: modelStore
+                )
+            }
+        }
         .navigationDestination(for: SubagentSession.self) { agent in
             if let child = store.store(for: agent.childSessionId) {
                 ChatSubagentScreen(

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -237,6 +237,106 @@ final class ChatSessionStore: ObservableObject {
         }
     }
 
+    // MARK: - Composer (S5 / BET-597)
+
+    /// Send a prompt for this session. `text` needs no trimming here (the
+    /// composer trims); attachments + model are optional and flow through the
+    /// unchanged `opencode:prompt` surface.
+    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?) {
+        Task {
+            try? await api.sendPrompt(SendPromptInput(
+                sessionId: sessionId,
+                text: text,
+                model: model,
+                attachments: attachments.isEmpty ? nil : attachments
+            ))
+        }
+    }
+
+    /// Interrupt the running turn (voice `abort`).
+    func abort() {
+        Task { try? await api.abort(sessionId: sessionId) }
+    }
+
+    /// Compact the session to free context (voice `compact`).
+    func compact() {
+        Task { try? await api.compactSession(sessionId: sessionId) }
+    }
+
+    /// Dispatch a store-level voice action. Returns a human hint string when
+    /// the action was NOT handled here (the caller should surface it), or nil
+    /// when it was handled. Actions that insert/modify composer text
+    /// (`submit`/`append`/`unknown`) and the app-level ones (`newSession`,
+    /// `openSettings`, `switchWindow`, `fork`, `clear`, `help`,
+    /// `toggleTrust`) are NOT this store's job — the composer routes those.
+    @discardableResult
+    func dispatchVoice(_ action: VoiceAction) -> String? {
+        switch action {
+        case .allowOnce:
+            replyToLatestPermission(.once)
+            return nil
+        case .allowAlways:
+            replyToLatestPermission(.always)
+            return nil
+        case .reject:
+            if newestPermission != nil {
+                replyToLatestPermission(.reject)
+            } else if newestQuestion != nil {
+                rejectQuestion(newestQuestion!)
+            }
+            return nil
+        case .answer(let choice):
+            return answerLatestQuestion(choice: choice)
+        case .abort:
+            abort()
+            return nil
+        case .compact:
+            compact()
+            return nil
+        default:
+            return ChatVoiceHint.text(for: action)
+        }
+    }
+
+    private func replyToLatestPermission(_ reply: PermissionReply) {
+        guard let permission = newestPermission else { return }
+        replyPermission(permission, reply: reply)
+    }
+
+    /// Answer the newest pending question from a spoken `choice`: a bare
+    /// "yes"/"no" token, a numbered option (1..n), or an option label / free
+    /// text. Returns a hint (non-nil) when no question is pending — the caller
+    /// surfaces it; nil when answered.
+    private func answerLatestQuestion(choice: String) -> String? {
+        guard let question = newestQuestion, let first = question.questions.first else {
+            return "No question waiting"
+        }
+        let trimmed = choice.trimmingCharacters(in: .whitespacesAndNewlines)
+        let optionIndex: Int?
+        if let asNumber = Int(trimmed), asNumber >= 1, asNumber <= first.options.count {
+            optionIndex = asNumber - 1
+        } else if let labelIndex = first.options.firstIndex(where: {
+            $0.label.compare(trimmed, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }) {
+            optionIndex = labelIndex
+        } else {
+            optionIndex = nil
+        }
+        var answers = [[String]]()
+        for (index, q) in question.questions.enumerated() {
+            if let optionIndex, q.options.indices.contains(optionIndex) {
+                answers.append([q.options[optionIndex].label])
+            } else if index == 0 {
+                // Free-form answer applies to the spoken question (the first).
+                answers.append([trimmed])
+            } else {
+                answers.append([])
+            }
+        }
+        replyQuestion(question, answers: answers)
+        return nil
+    }
+
     // MARK: - Subagent drill-in (BET-576)
 
     func ensureChildStore(_ childSessionId: String) -> ChatSessionStore {
@@ -260,6 +360,13 @@ final class ChatSessionStore: ObservableObject {
     }
 
     // MARK: - Header
+
+    /// The newest pending permission, if any (used by the composer's voice
+    /// answer routing + the bottom cards).
+    var newestPermission: PermissionRequest? { permissions.last }
+
+    /// The newest pending question request, if any.
+    var newestQuestion: QuestionRequest? { questions.last }
 
     /// §8 header subtitle ("running · 2m · 8%" / "idle").
     var headerSubtitle: String {

--- a/mobile/native/MantaUI/ChatVoice.swift
+++ b/mobile/native/MantaUI/ChatVoice.swift
@@ -1,0 +1,143 @@
+import Foundation
+import UniformTypeIdentifiers
+
+// ===========================================================================
+// S5 — voice pure logic (BET-597).
+//
+// Two jobs, both device-side PRESENTATION of box-produced results (§17):
+//   1. Interpret the box's `voice:classify-command` reply into a typed
+//      `VoiceAction` the composer/router can dispatch. The classifier runs on
+//      the box; this is only a faithful mapping of its wire reply.
+//   2. Attachment MIME detection (which extension → which `mime` tag to send
+//      to `POST /api/upload` + `opencode:prompt`), so the box can decide
+//      FilePart-vs-path the way the desktop does.
+// All pure; unit-tested in MantaUITests.
+// ===========================================================================
+
+/// The recorder's capture mode: dictate inserts transcribed text at the caret;
+/// command routes it through the box classifier to perform an action.
+enum VoiceMode: Equatable {
+    case dictate
+    case command
+}
+
+/// A typed voice command (the classifier's kinds, mapped to Swift). Undecided
+/// / LLM-degraded input becomes `unknown`.
+enum VoiceAction: Equatable {
+    case submit(text: String)
+    case append(text: String)
+    case clear
+    case compact
+    case fork
+    case abort
+    case help
+    case toggleTrust
+    case allowOnce
+    case allowAlways
+    case reject
+    case answer(choice: String)
+    case model(query: String)
+    case switchWindow(index: Int)
+    case newSession
+    case openSettings
+    case unknown(transcript: String)
+}
+
+/// A human hint for a voice action the composer/store chose not to perform
+/// (app-level or navigation actions out of the chat surface). Honest wording —
+/// never a fabricated success.
+enum ChatVoiceHint {
+    static func text(for action: VoiceAction) -> String {
+        switch action {
+        case .clear: return "“Clear” isn't available in this chat yet"
+        case .compact: return "Compacted to free context"
+        case .fork: return "Forking isn't available in this chat yet"
+        case .help: return "Try “submit…”, “abort”, or “answer…”"
+        case .toggleTrust: return "Trust mode isn't available in this chat"
+        case .newSession: return "New-session isn't available in this chat"
+        case .openSettings: return "Settings isn't available in this chat"
+        case .switchWindow: return "Switch-window isn't available in this chat"
+        default: return "Done"
+        }
+    }
+}
+
+enum ChatVoice {
+
+    /// Map the box's `voice:classify-command` reply onto a typed action.
+    /// Kind is lowercased for the match; the current synonym for "submit on a
+    /// relayed {kind,text}" is also tolerated.
+    static func parse(_ r: VoiceClassifyResult) -> VoiceAction {
+        switch r.kind?.lowercased() {
+        case "submit": return .submit(text: r.text ?? "")
+        case "append": return .append(text: r.text ?? "")
+        case "clear": return .clear
+        case "compact": return .compact
+        case "fork": return .fork
+        case "abort": return .abort
+        case "help": return .help
+        case "toggle-trust", "toggle_trust": return .toggleTrust
+        case "allow-once", "allow_once": return .allowOnce
+        case "allow-always", "allow_always": return .allowAlways
+        case "reject": return .reject
+        case "answer": return .answer(choice: r.choice ?? "")
+        case "model": return .model(query: r.query ?? "")
+        case "switch-window", "switch_window": return .switchWindow(index: r.index ?? 1)
+        case "new-session", "new_session": return .newSession
+        case "open-settings", "open_settings": return .openSettings
+        default:
+            return .unknown(transcript: r.transcript ?? r.text ?? "")
+        }
+    }
+
+    /// The `answer` choice as a bare lowercase word (for "yes"/"no" cores);
+    /// otherwise `nil` so the caller treats it as an option label / free text.
+    static func choiceToken(_ choice: String) -> String? {
+        switch choice.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "yes", "yep", "ok", "okay", "sure": return "yes"
+        case "no", "nope", "nay": return "no"
+        default: return nil
+        }
+    }
+
+    // MARK: - Attachment MIME detection
+
+    /// Resolve a file's MIME type from its extension via the system registry,
+    /// defaulting to `application/octet-stream` for unknowns (a file with no
+    /// declared type is still attachable — the box treats unknown mimes as
+    /// plain-file block attachments).
+    static func mime(forFilename filename: String) -> String {
+        let ext = (filename as NSString).pathExtension
+        guard !ext.isEmpty,
+              let type = UTType(filenameExtension: ext.lowercased()),
+              let mime = type.preferredMIMEType, !mime.isEmpty else {
+            return "application/octet-stream"
+        }
+        return mime
+    }
+
+    /// The short textual label for a mic-attached file (chips row) — the
+    /// basename, truncated to a bounded length for the chip.
+    static func chipLabel(forFilename filename: String) -> String {
+        let name = (filename as NSString).lastPathComponent
+        return name.count <= 28 ? name : String(name.prefix(25)) + "…"
+    }
+
+    /// Best-effort MIME detection for a photo's bytes, so the box can decide
+    /// FilePart-vs-path the way the desktop does (`image/*` → FilePart).
+    /// Sniffs the leading magic bytes (JPEG / PNG); anything else defaults to
+    /// `image/jpeg` (PhotosPicker hands back a re-encoded image the user
+    /// picked; the exact codec is rarely observable without that sniff).
+    static func mime(forImageData data: Data) -> String {
+        let bytes = [UInt8](data.prefix(8))
+        if bytes.count >= 3, bytes[0] == 0xFF, bytes[1] == 0xD8, bytes[2] == 0xFF {
+            return "image/jpeg"
+        }
+        if bytes.count >= 8,
+           bytes[0] == 0x89, bytes[1] == 0x50, bytes[2] == 0x4E, bytes[3] == 0x47,
+           bytes[4] == 0x0D, bytes[5] == 0x0A, bytes[6] == 0x1A, bytes[7] == 0x0A {
+            return "image/png"
+        }
+        return "image/jpeg"
+    }
+}

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -1,0 +1,456 @@
+import SwiftUI
+import PhotosUI
+import UniformTypeIdentifiers
+
+// ===========================================================================
+// S5 — the composer (BET-597).
+//
+// The app's primary control, attached to the bottom of the chat screen. Three
+// extras land here, all ported — none reimplemented:
+//
+//   1. Attachments — native PhotosPicker + UIDocumentPicker, uploaded through
+//      the UNCHANGED `POST /api/upload?session=<project>` endpoint (raw bytes
+//      + `X-Filename`, exactly as the desktop's uploadBuffer does), then sent
+//      as FilePart attachments on `opencode:prompt`.
+//   2. Model picker — per-session override (UserDefaults) with the configured
+//      default as fallback; box data from `opencode:models`/`default-model`.
+//   3. Voice — hold to record + dictate (insert at caret); long-press promotes
+//      to command mode routed through the box classifier. The mic button is
+//      hidden when no Groq key is configured (same as desktop).
+//
+// The device does NOT transcribe or classify — Groq runs on the box (voice:*
+// RPCs). Every colour/spacing/radius/size resolves through the tokens.
+// ===========================================================================
+
+struct ComposerAttachment: Identifiable, Equatable {
+    let id = UUID()
+    let filename: String
+    let mime: String
+    let remotePath: String
+    let isImage: Bool
+}
+
+struct ComposerView: View {
+    let sessionId: String
+    let projectName: String
+    let api: MantaAPIClient
+    @ObservedObject var store: ChatSessionStore
+    @ObservedObject var modelStore: ChatModelStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var text = ""
+    @State private var attachments: [ComposerAttachment] = []
+    @State private var showPhotoPicker = false
+    @State private var showDocPicker = false
+    @State private var photoItems: [PhotosPickerItem] = []
+    @State private var micAvailable = false
+    @State private var hint: String?
+    @State private var showHint = false
+    @StateObject private var controller = ComposerTextController()
+    @StateObject private var recorder = VoiceRecorder()
+    @State private var micMode: VoiceMode = .dictate
+    @State private var micRecording = false
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            if !attachments.isEmpty { chipsRow }
+            HStack(spacing: Metrics.spacing.sp1) {
+                attachButton
+                modelPill
+                Spacer(minLength: 0)
+            }
+            HStack(alignment: .bottom, spacing: Metrics.spacing.sp2) {
+                MultilineTextView(
+                    text: $text,
+                    controller: controller,
+                    placeholder: "Message…",
+                    font: UIFont.systemFont(ofSize: Metrics.type.body),
+                    textColor: UIColor(tokens.tx1),
+                    placeholderColor: UIColor(tokens.tx4),
+                    maxHeight: Metrics.type.display * 3
+                )
+                .frame(maxWidth: .infinity)
+                if micAvailable { micButton }
+                sendButton
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .background(tokens.canvas.ignoresSafeArea())
+        .overlay(alignment: .top) { divider }
+        .photosPicker(isPresented: $showPhotoPicker, selection: $photoItems, maxSelectionCount: 5, matching: .images)
+        .fileImporter(isPresented: $showDocPicker, allowedContentTypes: [.item]) { result in
+            handleDocument(result)
+        }
+        .onChange(of: photoItems) { _ in
+            Task { await processPhotos() }
+        }
+        .onAppear {
+            modelStore.load()
+            checkMicAvailability()
+            controller.focus()
+        }
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(tokens.borderSubtle)
+            .frame(height: Metrics.spacing.spPx)
+    }
+
+    // MARK: - Model pill
+
+    private var modelPill: some View {
+        Menu {
+            Button {
+                modelStore.setOverride(nil)
+            } label: {
+                Label(settingIsDefault ? "Default (in use)" : "Default", systemImage: settingIsDefault ? "checkmark" : "circle")
+            }
+            if modelStore.models.isEmpty {
+                Text("No models")
+            } else {
+                ForEach(ChatModel.groups(modelStore.models), id: \.provider) { group in
+                    Section(group.provider) {
+                        ForEach(group.models, id: \.id) { model in
+                            Button {
+                                modelStore.setOverride(OpencodeModelID(providerID: model.providerID, modelID: model.id))
+                            } label: {
+                                Label(model.name, systemImage: isActive(model) ? "checkmark" : "circle")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: Metrics.spacing.sp1) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: Metrics.type.xs, weight: .medium))
+                Text(ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel))
+                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                    .lineLimit(1)
+            }
+            .foregroundColor(tokens.accentTx)
+            .padding(.horizontal, Metrics.spacing.sp2)
+            .padding(.vertical, Metrics.spacing.sp1)
+            .background(tokens.accentSoft, in: Capsule())
+        }
+        .accessibilityLabel("Model picker")
+        .accessibilityIdentifier("model-picker")
+    }
+
+    private var settingIsDefault: Bool {
+        modelStore.override == nil
+    }
+
+    private func isActive(_ model: OpencodeModel) -> Bool {
+        guard let active = modelStore.active else { return false }
+        return active.providerID == model.providerID && active.modelID == model.id
+    }
+
+    // MARK: - Attach
+
+    private var attachButton: some View {
+        Menu {
+            Button {
+                showPhotoPicker = true
+            } label: {
+                Label("Photo", systemImage: "photo")
+            }
+            Button {
+                showDocPicker = true
+            } label: {
+                Label("File", systemImage: "doc")
+            }
+        } label: {
+            Image(systemName: "paperclip")
+                .font(.system(size: Metrics.type.body, weight: .medium))
+                .foregroundColor(tokens.tx2)
+                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                .background(attachments.isEmpty ? AnyShapeStyle(tokens.inset) : AnyShapeStyle(tokens.accentSoft), in: Circle())
+                .accessibilityLabel("Attach")
+        }
+        .accessibilityIdentifier("attach-button")
+    }
+
+    private func handleDocument(_ result: Result<URL, Error>) {
+        guard case .success(let url) = result else { return }
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        let filename = url.lastPathComponent
+        guard let data = try? Data(contentsOf: url) else {
+            surfaceHint("Couldn't read that file")
+            return
+        }
+        let mime = ChatVoice.mime(forFilename: filename)
+        Task {
+            do {
+                let remote = try await api.upload(project: projectName, filename: filename, data: data)
+                await MainActor.run {
+                    attachments.append(ComposerAttachment(filename: filename, mime: mime, remotePath: remote, isImage: mime.hasPrefix("image/")))
+                }
+            } catch {
+                surfaceHint("Upload failed")
+            }
+        }
+    }
+
+    private func processPhotos() async {
+        for item in photoItems {
+            guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
+            let mime = ChatVoice.mime(forImageData: data)
+            let filename = "photo-\(Int(Date().timeIntervalSince1970)).jpg"
+            do {
+                let remote = try await api.upload(project: projectName, filename: filename, data: data)
+                await MainActor.run {
+                    attachments.append(ComposerAttachment(filename: filename, mime: mime, remotePath: remote, isImage: true))
+                }
+            } catch {
+                surfaceHint("Photo upload failed")
+            }
+        }
+        await MainActor.run { photoItems = [] }
+    }
+
+    private var chipsRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Metrics.spacing.sp1) {
+                ForEach(attachments) { attachment in
+                    HStack(spacing: Metrics.spacing.sp1) {
+                        Image(systemName: attachment.isImage ? "photo" : "doc")
+                            .font(.system(size: Metrics.type.twoXS))
+                            .foregroundColor(tokens.accentTx)
+                        Text(ChatVoice.chipLabel(forFilename: attachment.filename))
+                            .font(.system(size: Metrics.type.twoXS))
+                            .foregroundColor(tokens.accentTx)
+                        Button {
+                            attachments.removeAll { $0.id == attachment.id }
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: Metrics.type.twoXS))
+                                .foregroundColor(tokens.accentTx)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, Metrics.spacing.sp2)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .background(tokens.accentSoft, in: Capsule())
+                }
+            }
+        }
+        .accessibilityIdentifier("attachment-chips")
+    }
+
+    // MARK: - Voice
+
+    private var micButton: some View {
+        Button {
+            // Tap without hold = no-op (recording is gesture-driven); kept as a
+            // hit target with an accessibility action that starts dictation.
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(micIconFill)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                Image(systemName: micIcon)
+                    .font(.system(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(micIconColor)
+            }
+        }
+        .buttonStyle(.plain)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in micPress() }
+                .onEnded { _ in micRelease() }
+        )
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in promoteToCommand() }
+        )
+        .accessibilityLabel("Hold to dictate, long press for command")
+        .accessibilityIdentifier("mic-button")
+        .disabled(!micAvailable)
+    }
+
+    private var micIcon: String {
+        switch recorder.phase {
+        case .recording: return micMode == .command ? "waveform.badge.mic" : "mic.fill"
+        case .processing: return "hourglass"
+        case .error: return "exclamationmark.triangle"
+        default: return "mic"
+        }
+    }
+
+    private var micIconFill: Color {
+        switch recorder.phase {
+        case .recording: return micMode == .command ? tokens.danger.opacity(0.2) : tokens.accentSolid
+        default: return tokens.inset
+        }
+    }
+
+    private var micIconColor: Color {
+        switch recorder.phase {
+        case .recording: return micMode == .command ? tokens.danger : tokens.onAccent
+        case .error: return tokens.danger
+        default: return tokens.tx2
+        }
+    }
+
+    private func micPress() {
+        guard micAvailable, recorder.phase != .recording, recorder.phase != .processing else { return }
+        Task {
+            let granted = await recorder.requestPermission()
+            guard granted else {
+                recorder.fail("Microphone permission needed")
+                hintState("Microphone permission is required")
+                return
+            }
+            micMode = .dictate
+            recorder.start()
+        }
+    }
+
+    private func promoteToCommand() {
+        guard recorder.phase == .recording else { return }
+        micMode = .command
+    }
+
+    private func micRelease() {
+        guard recorder.phase != .processing else { return }
+        guard let data = recorder.stop() else {
+            // Too short — treat as an accidental tap, not an error (§ desktop
+            // too-short guard). Quiet.
+            return
+        }
+        let mode = micMode
+        Task {
+            await transcribe(data: data, mode: mode)
+        }
+    }
+
+    private func transcribe(data: Data, mode: VoiceMode) async {
+        let result = try? await api.voiceTranscribe(data: data, mime: "audio/mp4")
+        let transcript = result?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !transcript.isEmpty else {
+            hintState("No speech detected")
+            return
+        }
+        if mode == .command {
+            await classify(transcript)
+        } else {
+            await MainActor.run { insertAtCaret(transcript) }
+        }
+    }
+
+    /// Insert text at the caret (dictate). Falls back to append if the input
+    /// isn't focused/bound yet.
+    private func insertAtCaret(_ string: String) {
+        if controller.textView != nil {
+            controller.insertAtCaret(string)
+        } else {
+            text += string
+        }
+    }
+
+    private func classify(_ transcript: String) async {
+        guard let classify = try? await api.voiceClassifyCommand(transcript: transcript) else {
+            hintState("Couldn't understand that command")
+            return
+        }
+        let action = ChatVoice.parse(classify)
+        let hint = handleVoiceAction(action)
+        if let hint { hintState(hint) }
+    }
+
+    /// Route a typed voice action. Returns a hint string when the composer was
+    /// responsible for surfacing it (text-inserting / not-handled-here), nil
+    /// when the store handled it.
+    private func handleVoiceAction(_ action: VoiceAction) -> String? {
+        switch action {
+        case .submit(let text):
+            submitVoice(text)
+            return nil
+        case .append(let text):
+            if !text.isEmpty { insertAtCaret(text) }
+            return nil
+        case .model(let query):
+            if let model = ChatModel.findByQuery(modelStore.models, query: query) {
+                modelStore.setOverride(OpencodeModelID(providerID: model.providerID, modelID: model.id))
+                return nil
+            }
+            return "No model found for “\(query)”"
+        case .unknown(let transcript):
+            if !transcript.isEmpty { insertAtCaret(transcript) }
+            return nil
+        default:
+            return store.dispatchVoice(action)
+        }
+    }
+
+    private func submitVoice(_ voiceText: String) {
+        let trimmed = voiceText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        insertAtCaret(trimmed)
+        submit()
+    }
+
+    // MARK: - Send
+
+    private var sendButton: some View {
+        Button(action: submit) {
+            Image(systemName: "arrow.up")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(canSend ? tokens.onAccent : tokens.tx4)
+                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                .background(canSend ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.inset), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSend)
+        .accessibilityLabel("Send")
+        .accessibilityIdentifier("send-button")
+    }
+
+    private var canSend: Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
+    }
+
+    private func submit() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
+        let model = modelStore.promptModel
+        let sendAttachments = attachments.map { attachment in
+            SendPromptInput.Attachment(remotePath: attachment.remotePath, mime: attachment.mime, filename: attachment.filename)
+        }
+        store.send(text: trimmed, attachments: sendAttachments, model: model)
+        text = ""
+        attachments = []
+        controller.focus()
+    }
+
+    // MARK: - Mic availability (Groq key gate)
+
+    private func checkMicAvailability() {
+        Task {
+            let config = try? await api.configGet()
+            let key = config.flatMap { ChatJSON.string($0["groqApiKey"]) }
+            let available = !(key?.isEmpty ?? true)
+            await MainActor.run { micAvailable = available }
+        }
+    }
+
+    // MARK: - Hint
+
+    private func hintState(_ message: String) {
+        hint = message
+        withAnimation { showHint = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+            withAnimation { showHint = false }
+        }
+    }
+
+    private func surfaceHint(_ message: String) {
+        hintState(message)
+    }
+}

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -213,6 +213,80 @@ final class MantaAPIClient: Sendable {
         try await call("fs:list-dirs", args: [partial], as: [String].self) ?? []
     }
 
+    // MARK: - Composer extras (S5 / BET-597)
+
+    /// `opencode:models` — models from CONNECTED providers only (no API keys).
+    func models() async throws -> [OpencodeModel] {
+        try await call("opencode:models", args: [], as: [OpencodeModel].self) ?? []
+    }
+
+    /// `opencode:default-model` — the configured global default, or nil when
+    /// opencode picks its own.
+    func defaultModel() async throws -> OpencodeModelID? {
+        try await call("opencode:default-model", args: [], as: OpencodeModelID.self)
+    }
+
+    /// `opencode:compact-session` — free context for the voice `compact` action.
+    func compactSession(sessionId: String) async throws {
+        _ = try await callVoid("opencode:compact-session", args: [sessionId])
+    }
+
+    /// Upload raw bytes to `POST /api/upload?session=<project>` with the
+    /// `X-Filename` header (unchanged endpoint, already serving the desktop).
+    /// Returns the remote absolute path the box stored.
+    func upload(project: String, filename: String, data: Data) async throws -> String {
+        let query = URLQueryItem(name: "session", value: project)
+        var url = serverURL.appendingPathComponent("api").appendingPathComponent("upload")
+        url.append(queryItems: [query])
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        if let token = tokenProvider(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let encodedName = filename.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? filename
+        request.setValue(encodedName, forHTTPHeaderField: "X-Filename")
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+
+        let (dataOut, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        guard let object = (try JSONSerialization.jsonObject(with: dataOut) as? [String: Any]) else {
+            throw MantaError.transport("invalid upload envelope")
+        }
+        if let error = object["error"] as? String, !error.isEmpty {
+            throw MantaError.server(error)
+        }
+        guard let path = object["path"] as? String, !path.isEmpty else {
+            throw MantaError.transport("upload returned no path")
+        }
+        return path
+    }
+
+    /// `voice:transcribe` — ship recorded audio (base64 over the JSON RPC
+    /// wire, as the desktop shim does) to the box's Groq transcription.
+    /// Returns the transcribed text, or nil when the clip was empty.
+    func voiceTranscribe(data: Data, mime: String) async throws -> String? {
+        let input: [String: Any] = [
+            "buffer": data.base64EncodedString(),
+            "mime": mime,
+        ]
+        try await Task.sleep(nanoseconds: 0)
+        let result: [String: JSONValue]? = try await call("voice:transcribe", args: [input], as: [String: JSONValue].self)
+        return ChatJSON.string(result?["text"])
+    }
+
+    /// `voice:classify-command` — route a transcript through the box's rules +
+    /// (fallback) LLM classifier. Returns the structured action.
+    func voiceClassifyCommand(transcript: String, useLlmFallback: Bool? = nil) async throws -> VoiceClassifyResult? {
+        var input: [String: Any] = ["transcript": transcript]
+        if let useLlmFallback { input["useLlmFallback"] = useLlmFallback }
+        let envelope: VoiceClassifyEnvelope? = try await call("voice:classify-command", args: [input], as: VoiceClassifyEnvelope.self)
+        return envelope?.action
+    }
+
     /// `git:list-worktrees` — git worktree fan-out detection for a folder.
     func listWorktrees(_ cwd: String) async throws -> [MantaWorktree] {
         try await call("git:list-worktrees", args: [cwd], as: [MantaWorktree].self) ?? []
@@ -279,3 +353,10 @@ final class MantaAPIClient: Sendable {
 }
 
 private struct VoidResult: Decodable {}
+
+/// The `voice:classify-command` reply is `{ action, source }` — the action is
+/// the structured `VoiceAction`; `source` ("rules" | "llm" | "none") is
+/// diagnostic only and discarded here (the device never interprets).
+private struct VoiceClassifyEnvelope: Decodable {
+    var action: VoiceClassifyResult?
+}

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -253,3 +253,52 @@ enum PermissionReply: String, Sendable {
     case always
     case reject
 }
+
+// MARK: - S5 composer: model picker + voice (BET-597)
+//
+// Models for the composer extras. `OpencodeModel` mirrors the box's
+// `opencode:models` payload (from `getProviders()` → `listModels()`); the
+// `VoiceClassifyResult` mirrors `voice:classify-command`'s reply. These are
+// wire DTOs only — resolution/selection logic lives in ChatModel / ChatVoice
+// (pure, tested).
+
+/// A model from a connected provider, as served by `opencode:models`.
+struct OpencodeModel: Codable, Equatable, Sendable {
+    struct Variant: Codable, Equatable, Sendable {
+        var id: String
+    }
+
+    var id: String
+    var providerID: String
+    var name: String
+    var family: String?
+    var status: String?
+    var enabled: Bool?
+    var variants: [Variant]?
+}
+
+/// `{ providerID, modelID }` — the minimal selection sent with a prompt and
+/// returned by `opencode:default-model`.
+struct OpencodeModelID: Codable, Equatable, Sendable {
+    var providerID: String
+    var modelID: String
+
+    enum CodingKeys: String, CodingKey {
+        case providerID
+        case modelID
+    }
+}
+
+/// The box-side voice classifier's reply (voice:classify-command). Standard
+/// actions carry `kind` (+ optional payload); the LLM fallback degrades to
+/// `unknown` carrying the verbatim transcript. Never interpreted device-side —
+/// the classifier IS the box.
+struct VoiceClassifyResult: Codable, Equatable, Sendable {
+    var kind: String?
+    var text: String?
+    var index: Int?
+    var query: String?
+    var choice: String?
+    var transcript: String?
+    var actions: [VoiceClassifyResult]?
+}

--- a/mobile/native/MantaUI/MultilineTextView.swift
+++ b/mobile/native/MantaUI/MultilineTextView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// S5 — composer text input (BET-597).
+//
+// A UITextView-backed multiline input that owns the caret, so voice dictation
+// can insert AT the caret (the issue's dictate behaviour) rather than only
+// appending to the end. The controller is the bridge: the representable hands
+// it the live UITextView, and the composer calls `insertAtCaret` / `focus`.
+// Thin — no transcript/logic here.
+// ===========================================================================
+
+@MainActor
+final class ComposerTextController: ObservableObject {
+    weak var textView: UITextView?
+
+    func insertAtCaret(_ string: String) {
+        guard let textView else { return }
+        let selected = textView.selectedRange
+        let location = selected.location
+        guard let current = textView.text else { return }
+        let newText = (current as NSString).replacingCharacters(in: selected, with: string)
+        textView.text = newText
+        let cursor = NSRange(location: location + (string as NSString).length, length: 0)
+        textView.selectedRange = cursor
+        textView.delegate?.textViewDidChange?(textView)
+    }
+
+    func focus() {
+        textView?.becomeFirstResponder()
+    }
+}
+
+struct MultilineTextView: UIViewRepresentable {
+    @Binding var text: String
+    @ObservedObject var controller: ComposerTextController
+    var placeholder: String
+    var font: UIFont
+    var textColor: UIColor
+    var placeholderColor: UIColor
+    var maxHeight: CGFloat
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isScrollEnabled = true
+        view.alwaysBounceVertical = false
+        view.backgroundColor = .clear
+        view.font = font
+        view.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        view.textContainer.lineFragmentPadding = 0
+        view.textColor = textColor
+        view.delegate = context.coordinator
+        view.accessibilityIdentifier = "composer-input"
+        controller.textView = view
+        updatePlaceholder(view)
+        return view
+    }
+
+    func updateUIView(_ view: UITextView, context: Context) {
+        if view.text != text {
+            view.text = text
+            updatePlaceholder(view)
+        }
+        if view.font != font { view.font = font }
+        if view.textColor != textColor { view.textColor = textColor }
+        // Enforce the bounded max height so the input scrolls instead of
+        // pushing the whole composer off-screen on a long draft.
+        view.isScrollEnabled = neededScrolling(containerHeight: view.bounds.height)
+        updatePlaceholder(view)
+    }
+
+    private func neededScrolling(containerHeight: CGFloat) -> Bool {
+        guard let view = controller.textView else { return false }
+        let size = view.sizeThatFits(CGSize(width: view.bounds.width, height: .greatestFiniteMagnitude))
+        return size.height > maxHeight
+    }
+
+    private func updatePlaceholder(_ view: UITextView) {
+        let label: UILabel
+        if let existing = view.viewWithTag(919_001) as? UILabel {
+            label = existing
+        } else {
+            label = UILabel()
+            label.tag = 919_001
+            label.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 2),
+                label.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
+                label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -2),
+            ])
+        }
+        label.text = placeholder
+        label.font = font
+        label.textColor = placeholderColor
+        label.isHidden = !text.isEmpty
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: MultilineTextView
+        init(_ parent: MultilineTextView) { self.parent = parent }
+
+        func textViewDidChange(_ textView: UITextView) {
+            parent.text = textView.text
+        }
+    }
+}

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -53,7 +53,7 @@ struct SessionListView: View {
             .sheet(item: $renameTarget) { _ in renameSheet(targetProject: renameProject) }
             .navigationDestination(item: $openTarget) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
-                    ChatScreen(sessionId: sessionId, title: target.name, eventStore: eventStore)
+                    ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore)
                 } else {
                     SessionScreenPlaceholder(name: target.name)
                 }

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -1,0 +1,133 @@
+import AVFoundation
+import Foundation
+
+// ===========================================================================
+// S5 — iOS voice capture (BET-597).
+//
+// A thin AVFoundation recorder. The recording, transcription AND command
+// classification all live on the box (Groq via `voice:transcribe` /
+// `voice:classify-command`) — the device's only job here is to capture the
+// audio and hand the bytes over, exactly as the desktop does. This file owns
+// the capture + the mic permission gate; it does NOT transcribe or classify.
+//
+// The mime is `audio/mp4`: iOS records AAC-in-.m4a via AVAudioRecorder, the
+// only sane container on Apple platforms (matches the retired web client's
+// `audio/mp4` fallback — the one thing Apple ships).
+// ===========================================================================
+
+@MainActor
+final class VoiceRecorder: ObservableObject {
+
+    enum Phase: Equatable {
+        case idle
+        case requesting       // waiting on mic permission / session start
+        case recording
+        case processing       // stop requested, bytes being handed to the box
+        case error(String)
+    }
+
+    @Published private(set) var phase: Phase = .idle
+
+    /// Min duration of a usable clip (seconds). Shorter presses are ignored
+    /// as accidental taps, mirroring the desktop's too-short guard.
+    static let minDuration: TimeInterval = 0.4
+    static let maxDuration: TimeInterval = 60
+
+    private var recorder: AVAudioRecorder?
+    private var url: URL?
+    private var startDate: Date?
+
+    /// Request mic permission the first time it is pressed. Returns true only
+    /// when granted. Must be called before `start()`.
+    func requestPermission() async -> Bool {
+        switch AVAudioApplication.shared.recordPermission {
+        case .granted:
+            return true
+        case .denied:
+            return false
+        case .undetermined:
+            return await withCheckedContinuation { continuation in
+                AVAudioApplication.requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        @unknown default:
+            return false
+        }
+    }
+
+    /// Begin capturing. Call `requestPermission()` first; start() is a no-op
+    /// when recording is already in flight.
+    func start() {
+        guard phase != .recording else { return }
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-\(UUID().uuidString).m4a")
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 48000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+        ]
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .default)
+            try session.setActive(true)
+
+            let recorder = try AVAudioRecorder(url: fileURL, settings: settings)
+            recorder.isMeteringEnabled = false
+            self.recorder = recorder
+            self.url = fileURL
+            self.startDate = Date()
+            phase = .recording
+            recorder.record(forDuration: Self.maxDuration)
+        } catch {
+            phase = .error("Couldn't start recording")
+        }
+    }
+
+    /// Stop capturing and return the recorded bytes. `nil` when the clip was
+    /// too short (accidental tap) or empty — the caller treats that as "no
+    /// speech", NOT an error.
+    func stop() -> Data? {
+        let elapsed = startDate.map { Date().timeIntervalSince($0) } ?? 0
+        recorder?.stop()
+        deactivateSession()
+        guard elapsed >= Self.minDuration else {
+            discard()
+            return nil
+        }
+        guard let url, let data = try? Data(contentsOf: url), !data.isEmpty else {
+            discard()
+            return nil
+        }
+        discard()
+        phase = .idle
+        return data
+    }
+
+    /// Cancel a capture (e.g. the user drags away before release).
+    func cancel() {
+        recorder?.stop()
+        discard()
+        deactivateSession()
+        phase = .idle
+    }
+
+    /// Surface a transient error phase to the UI (caller supplies the reason).
+    func fail(_ message: String) {
+        phase = .error(message)
+    }
+
+    private func discard() {
+        if let url { try? FileManager.default.removeItem(at: url) }
+        recorder = nil
+        url = nil
+        startDate = nil
+    }
+
+    private func deactivateSession() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// S5 — composer pure logic (BET-597). Covers ChatModel (model resolution for
+// the picker) and ChatVoice (classifier-reply mapping + attachment MIME). No
+// HTTP / view / Keychain / AVAudioRecorder involved.
+// ===========================================================================
+
+final class ComposerTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func model(_ provider: String, _ id: String, name: String? = nil, enabled: Bool? = nil, status: String? = nil) -> OpencodeModel {
+        OpencodeModel(
+            id: id,
+            providerID: provider,
+            name: name ?? id,
+            family: nil,
+            status: status,
+            enabled: enabled,
+            variants: nil
+        )
+    }
+
+    private func selection(_ provider: String, _ id: String) -> OpencodeModelID {
+        OpencodeModelID(providerID: provider, modelID: id)
+    }
+
+    // MARK: - ChatModel.groups
+
+    func testGroupsAlphabeticalAndEnabledOnly() {
+        let models = [
+            model("zebra", "z1"),
+            model("anthropic", "haiku"),
+            model("anthropic", "deprecated", status: "deprecated"),
+            model("groq", "disabled", enabled: false),
+            model("anthropic", "sonnet"),
+        ]
+        let groups = ChatModel.groups(models)
+        XCTAssertEqual(groups.map(\.provider), ["anthropic", "zebra"])
+        XCTAssertEqual(groups[0].models.map(\.id), ["haiku", "sonnet"])
+    }
+
+    // MARK: - ChatModel.effective
+
+    func testEffectiveOverrideWinsOverDefault() {
+        XCTAssertEqual(
+            ChatModel.effective(selection("anthropic", "sonnet"), selection("anthropic", "opus")),
+            selection("anthropic", "sonnet")
+        )
+        XCTAssertEqual(ChatModel.effective(nil, selection("anthropic", "opus")), selection("anthropic", "opus"))
+        XCTAssertNil(ChatModel.effective(nil, nil))
+    }
+
+    // MARK: - ChatModel.activeModel + label
+
+    func testActiveModelResolvesOverrideThenDefaultThenNil() {
+        let models = [model("anthropic", "sonnet"), model("anthropic", "opus")]
+        XCTAssertEqual(
+            ChatModel.activeModel(models, override: selection("anthropic", "sonnet"), default: selection("anthropic", "opus"))?.id,
+            "sonnet"
+        )
+        XCTAssertEqual(
+            ChatModel.activeModel(models, override: nil, default: selection("anthropic", "opus"))?.id,
+            "opus"
+        )
+        XCTAssertEqual(ChatModel.activeModel(models, override: nil, default: selection("other", "x"))?.id, nil)
+        XCTAssertEqual(ChatModel.activeModel(models, override: nil, default: nil), nil)
+    }
+
+    func testLabelUsesFriendlyNameAndDefaults() {
+        let models = [model("anthropic", "sonnet", name: "Claude Sonnet 4.6")]
+        XCTAssertEqual(ChatModel.label(models, override: selection("anthropic", "sonnet"), default: nil), "Claude Sonnet 4.6")
+        XCTAssertEqual(ChatModel.label(models, override: nil, default: nil), "Default")
+    }
+
+    // MARK: - ChatModel.findByQuery
+
+    func testFindByQueryExactThenSubstring() {
+        let models = [model("anthropic", "claude-sonnet-4-6", name: "Claude Sonnet"), model("deepseek", "deepseek-chat")]
+        XCTAssertEqual(ChatModel.findByQuery(models, query: "deepseek-chat")?.id, "deepseek-chat")
+        XCTAssertEqual(ChatModel.findByQuery(models, query: "CLAUDE SONNET")?.id, "claude-sonnet-4-6")
+        XCTAssertEqual(ChatModel.findByQuery(models, query: "sonnet")?.id, "claude-sonnet-4-6")
+        XCTAssertNil(ChatModel.findByQuery(models, query: "   "))
+    }
+
+    // MARK: - ChatModel.encode/decode
+
+    func testOverrideEncodeDecodeRoundTrip() {
+        let id = selection("anthropic", "claude-sonnet-4-6")
+        XCTAssertEqual(ChatModel.decode(ChatModel.encode(id)), id)
+        XCTAssertNil(ChatModel.decode(""))
+        XCTAssertNil(ChatModel.decode("no-slash"))
+    }
+
+    // MARK: - ChatVoice.parse
+
+    private func classify(_ kind: String, text: String? = nil, choice: String? = nil, query: String? = nil, index: Int? = nil, transcript: String? = nil) -> VoiceClassifyResult {
+        VoiceClassifyResult(kind: kind, text: text, index: index, query: query, choice: choice, transcript: transcript, actions: nil)
+    }
+
+    func testParseStandardActions() {
+        XCTAssertEqual(ChatVoice.parse(classify("abort")), .abort)
+        XCTAssertEqual(ChatVoice.parse(classify("compact")), .compact)
+        XCTAssertEqual(ChatVoice.parse(classify("allow-once")), .allowOnce)
+        XCTAssertEqual(ChatVoice.parse(classify("reject")), .reject)
+        XCTAssertEqual(ChatVoice.parse(classify("submit", text: "look at this")), .submit(text: "look at this"))
+        XCTAssertEqual(ChatVoice.parse(classify("append", text: "remember")), .append(text: "remember"))
+        XCTAssertEqual(ChatVoice.parse(classify("answer", choice: "3")), .answer(choice: "3"))
+        XCTAssertEqual(ChatVoice.parse(classify("model", query: "haiku")), .model(query: "haiku"))
+        XCTAssertEqual(ChatVoice.parse(classify("switch-window", index: 2)), .switchWindow(index: 2))
+    }
+
+    func testParseUnknownDegrades() {
+        XCTAssertEqual(ChatVoice.parse(classify("unknown", transcript: "do the thing")), .unknown(transcript: "do the thing"))
+        // A nil/empty kind is treated as unknown.
+        XCTAssertEqual(ChatVoice.parse(classify("", transcript: "hi")), .unknown(transcript: "hi"))
+    }
+
+    // MARK: - ChatVoice.choiceToken
+
+    func testChoiceTokenCores() {
+        XCTAssertEqual(ChatVoice.choiceToken("yes"), "yes")
+        XCTAssertEqual(ChatVoice.choiceToken("NOPE"), "no")
+        XCTAssertEqual(ChatVoice.choiceToken("okay"), "yes")
+        XCTAssertNil(ChatVoice.choiceToken("the third one"))
+    }
+
+    // MARK: - ChatVoice.mime
+
+    func testMimeFromFilenameExtension() {
+        XCTAssertEqual(ChatVoice.mime(forFilename: "report.pdf"), "application/pdf")
+        XCTAssertEqual(ChatVoice.mime(forFilename: "shot.PNG"), "image/png")
+        XCTAssertEqual(ChatVoice.mime(forFilename: "notes"), "application/octet-stream")
+    }
+
+    func testMimeFromImageDataSniff() {
+        let jpeg: [UInt8] = [0xFF, 0xD8, 0xFF, 0xE0]
+        let png: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00]
+        XCTAssertEqual(ChatVoice.mime(forImageData: Data(jpeg)), "image/jpeg")
+        XCTAssertEqual(ChatVoice.mime(forImageData: Data(png)), "image/png")
+        XCTAssertEqual(ChatVoice.mime(forImageData: Data([0x00, 0x01, 0x02])), "image/jpeg")
+    }
+
+    // MARK: - Voice action store routing (permission/question)
+
+    @MainActor
+    func testDispatchVoiceAnswerFallsBackWhenNoQuestion() {
+        // No question pending → a hint (non-nil), and it must not crash.
+        let store = ChatSessionStore(sessionId: "ses", eventStore: MantaEventStore(), api: MantaAPIClient(serverURL: URL(string: "https://box.example")!))
+        let hint = store.dispatchVoice(.answer(choice: "yes"))
+        XCTAssertNotNil(hint)
+    }
+}

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -24,6 +24,7 @@ targets:
         PRODUCT_NAME: MantaUI
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: MantaUI
+        INFOPLIST_KEY_NSMicrophoneUsageDescription: MantaUI uses the microphone for push-to-talk dictation and voice commands in chat.
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES


### PR DESCRIPTION
Opened automatically for `multica/BET-597-composer`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-597.