### PR TITLE
BET-609: chore(release): 0.0.18 — ship the Claude subscription browser-login flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,1 +1,1 @@
-{ "version": "0.0.17", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }
+{ "version": "0.0.18", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }


### PR DESCRIPTION
Opened automatically for `multica/BET-609-release-0-0-18`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-609.