### PR TITLE
feat(ios): S8 push notifications + universal/deep links (BET-600)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3354E683F0CE92566A77C7D3 /* MantaPairingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */; };
 		33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1306D325FEB295B7AB874E /* MantaEventStore.swift */; };
 		3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD646A4951E292E750890CCB /* MantaAppRoot.swift */; };
+		3F3FF5F6BE28352901513A14 /* MantaAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25870866D56CCE59805BCC0E /* MantaAppDelegate.swift */; };
 		41936A0681D76828B8DD2DAD /* terminal.html in Resources */ = {isa = PBXBuildFile; fileRef = E15031A040AEE7D0E9F4968B /* terminal.html */; };
 		431A66604F73FFBD59781D92 /* TerminalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942605E2D67D55C6DCCE83AC /* TerminalScreen.swift */; };
 		4B93850BBF7EE94C3924479E /* xterm.css in Resources */ = {isa = PBXBuildFile; fileRef = 332D81D260E235364BFAD503 /* xterm.css */; };
@@ -61,6 +62,8 @@
 		E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436675A65BF149932C1EADE0 /* ChatScreen.swift */; };
 		E2D12EA2304A2505C26C0698 /* xterm-addon-fit.js in Resources */ = {isa = PBXBuildFile; fileRef = 905097B1C8A76B785330CFB6 /* xterm-addon-fit.js */; };
 		EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */; };
+		ED03A3C1AAFA1094A92A9ECA /* MantaDeepLinkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A1F140660F9AC7AF07E00 /* MantaDeepLinkUITests.swift */; };
+		F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A94FE1BE824F438342AD /* MantaDeepLink.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,7 +89,9 @@
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
 		229392FD3405558D301D0809 /* ChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModel.swift; sourceTree = "<group>"; };
 		24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListStore.swift; sourceTree = "<group>"; };
+		25870866D56CCE59805BCC0E /* MantaAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppDelegate.swift; sourceTree = "<group>"; };
 		28250B8DDAB996449F7AE3AD /* SessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModels.swift; sourceTree = "<group>"; };
+		2B7A1F140660F9AC7AF07E00 /* MantaDeepLinkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaDeepLinkUITests.swift; sourceTree = "<group>"; };
 		2C13A01F9048A8907CBCC31D /* MantaUIUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C3C09F5D2FEAE01B1C9CF1E /* TerminalModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalModels.swift; sourceTree = "<group>"; };
 		2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAuthClient.swift; sourceTree = "<group>"; };
@@ -101,6 +106,7 @@
 		4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecorder.swift; sourceTree = "<group>"; };
 		4F7631E09B6FF7B150392A83 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
 		57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsTests.swift; sourceTree = "<group>"; };
+		5C02DA420B52094269A88E80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5D71EC917661085ED10E0867 /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
 		6BDC7F6FA94631DA4C55A948 /* TerminalWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWebView.swift; sourceTree = "<group>"; };
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
@@ -111,6 +117,7 @@
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
 		81FE763828641B50BF496F4D /* TerminalSessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionState.swift; sourceTree = "<group>"; };
 		87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIApp.swift; sourceTree = "<group>"; };
+		8879A94FE1BE824F438342AD /* MantaDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaDeepLink.swift; sourceTree = "<group>"; };
 		8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelStore.swift; sourceTree = "<group>"; };
 		8C8240F1954861B4846E279D /* MantaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaModels.swift; sourceTree = "<group>"; };
 		905097B1C8A76B785330CFB6 /* xterm-addon-fit.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "xterm-addon-fit.js"; sourceTree = "<group>"; };
@@ -134,6 +141,7 @@
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalModelsTests.swift; sourceTree = "<group>"; };
+		DC240598BDE45C3D43B46191 /* MantaUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MantaUI.entitlements; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
 		E15031A040AEE7D0E9F4968B /* terminal.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = terminal.html; sourceTree = "<group>"; };
 		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
@@ -236,10 +244,13 @@
 				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
 				C42691C89906181C99929354 /* ComposerView.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
+				5C02DA420B52094269A88E80 /* Info.plist */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
 				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
+				25870866D56CCE59805BCC0E /* MantaAppDelegate.swift */,
 				DD646A4951E292E750890CCB /* MantaAppRoot.swift */,
 				2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */,
+				8879A94FE1BE824F438342AD /* MantaDeepLink.swift */,
 				1E1306D325FEB295B7AB874E /* MantaEventStore.swift */,
 				8C8240F1954861B4846E279D /* MantaModels.swift */,
 				4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */,
@@ -248,6 +259,7 @@
 				39978655A14BFA5D39336286 /* MantaSettingsModels.swift */,
 				ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */,
 				7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */,
+				DC240598BDE45C3D43B46191 /* MantaUI.entitlements */,
 				87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */,
 				C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
@@ -272,6 +284,7 @@
 		DF70760D7D88A6A31A5243DA /* MantaUIUITests */ = {
 			isa = PBXGroup;
 			children = (
+				2B7A1F140660F9AC7AF07E00 /* MantaDeepLinkUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 			);
 			path = MantaUIUITests;
@@ -396,6 +409,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED03A3C1AAFA1094A92A9ECA /* MantaDeepLinkUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -431,8 +445,10 @@
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,
+				3F3FF5F6BE28352901513A14 /* MantaAppDelegate.swift in Sources */,
 				3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */,
 				863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */,
+				F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */,
 				33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */,
 				01871023D47544D64443194D /* MantaModels.swift in Sources */,
 				6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */,
@@ -520,10 +536,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = MantaUI/MantaUI.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MantaUI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MantaUI;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "MantaUI uses the microphone for push-to-talk dictation and voice commands in chat.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -623,10 +641,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = MantaUI/MantaUI.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MantaUI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MantaUI;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "MantaUI uses the microphone for push-to-talk dictation and voice commands in chat.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/mobile/native/MantaUI/Info.plist
+++ b/mobile/native/MantaUI/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.antoinedc.mantaui</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>manta</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -303,6 +303,25 @@ final class MantaAPIClient: Sendable {
         try await call("config:get", args: [], as: [String: JSONValue].self)
     }
 
+    /// `POST /push/register-apns` — hand the APNs device token to the box
+    /// (server mirror of the /rpc/push:register-apns channel; both call
+    /// push.addApnsToken, see src/server/index.mjs). Fire-and-forget from the
+    /// push service; a failure here just means the box doesn't push to the
+    /// device (the token is re-sent on the next registration).
+    func registerApnsToken(_ token: String) async throws {
+        var request = URLRequest(url: serverURL.appendingPathComponent("push/register-apns"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let tokenValue = tokenProvider(), !tokenValue.isEmpty {
+            request.setValue("Bearer \(tokenValue)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["token": token])
+        let (_, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+    }
+
     // MARK: - Transport + envelope
 
     static func makeRequest(serverURL: URL, channel: String, args: [Any], token: String?) throws -> URLRequest {

--- a/mobile/native/MantaUI/MantaAppDelegate.swift
+++ b/mobile/native/MantaUI/MantaAppDelegate.swift
@@ -1,0 +1,153 @@
+import UIKit
+import UserNotifications
+
+// ===========================================================================
+// S8 — APNs push (BET-600).
+//
+// The app delegate + the push service own remote-notification registration and
+// routing. It is deliberately a thin extension over what the box already
+// exposes (`POST /push/register-apns { token }`, src/server/index.mjs + the
+// /rpc/push:register-apns channel):
+//
+//   • Registration is opt-in at the S2 onboarding priming screen (§5.6) and is
+//     never a gate — denial still lands in the session list. `applyRegistrationState`
+//     re-registers on launch so a rotated device token is re-handed to the box.
+//   • The device token is handed to the box over the existing endpoint; there
+//     is no client-side suppression (the box's router owns that, deliberately —
+//     iOS revokes a subscription whose delivered push shows nothing).
+//   • Foreground presentation is banner+list+sound (the box's router decides
+//     *whether* a push fires; we only present it).
+//   • A tap routes to the session that fired it via MantaPushRouter, so the
+//     user lands on the session, not the list.
+// ===========================================================================
+
+@MainActor
+final class MantaAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        MantaPushService.applyRegistrationState()
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        MantaPushService.deviceTokenDidArrive(deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        MantaPushService.registrationFailed(error)
+    }
+
+    // Universal link (apple-app-site-association / Associated Domains). Feeds
+    // the pairing payload to the onboarding flow. Handles the cold-start case
+    // (launched by the OS from a link) — warm launches also arrive here AND via
+    // SwiftUI's onOpenURL; both stage into MantaPairingRouter, which is
+    // idempotent for identical payloads.
+    func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else {
+            return false
+        }
+        return MantaPairingRouter.route(url)
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    // Foreground presentation: the box's router decides whether to push; we
+    // just decide how to show the ones that arrive.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .list, .sound])
+    }
+
+    // Tap → deep-link to the session that fired the notification. The APNs
+    // envelope carries the opencode sessionId at the top level of the payload
+    // (server push.mjs → gateway apns.mjs `buildApnsPayload`).
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        if let sessionID = userInfo["sessionId"] as? String, !sessionID.isEmpty {
+            Task { @MainActor in
+                MantaPushRouter.shared.open(sessionID: sessionID)
+            }
+        }
+        completionHandler()
+    }
+}
+
+// MARK: - Registration service
+
+/// The registration half of APNs on the native client. Pure call-through to
+/// the paired box's `/push/register-apns`; never blocks the UI.
+@MainActor
+enum MantaPushService {
+
+    /// Re-assert APNs registration if the user has already authorized. Called
+    /// on launch (token / auth rotation) and can be re-invoked after pairing.
+    static func applyRegistrationState() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let status = settings.authorizationStatus
+            Task { @MainActor in
+                switch status {
+                case .authorized, .provisional, .ephemeral:
+                    UIApplication.shared.registerForRemoteNotifications()
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    /// Explicitly request APNs registration — the S8 side of the S2 priming
+    /// screen's "Continue" (§5.6): credentials now exist, so we can hand the
+    /// token to the box.
+    static func registerAfterPairing() {
+        Task { @MainActor in
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    }
+
+    static func deviceTokenDidArrive(_ token: Data) {
+        let hex = token.map { String(format: "%02x", $0) }.joined()
+        guard !hex.isEmpty else { return }
+        register(hex)
+    }
+
+    static func registrationFailed(_ error: Error) {
+        // Non-fatal: remote notifications are an enhancement, never a gate. A
+        // box that never gets a token simply receives no push until the next
+        // successful registration (e.g. a foreground launch).
+        NSLog("[push] APNs registration failed: %@", String(describing: error))
+    }
+
+    private static func register(_ token: String) {
+        // No box to register with until pairing saves credentials.
+        let client = MantaAPIClient.live()
+        guard KeychainCredentialStore.shared.serverURL != nil,
+              KeychainCredentialStore.shared.boxToken != nil else {
+            return
+        }
+        Task {
+            try? await client.registerApnsToken(token)
+        }
+    }
+}

--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -49,6 +49,7 @@ struct MantaAppRoot: View {
                         flow.onPaired = {
                             paired = true
                             store.start()
+                            MantaPushService.registerAfterPairing()
                         }
                     }
             } else if let scene, !scene.isEmpty {
@@ -68,8 +69,22 @@ struct MantaAppRoot: View {
                         flow.onPaired = {
                             paired = true
                             store.start()
+                            MantaPushService.registerAfterPairing()
                         }
                     }
+            }
+        }
+        // S8 (BET-600): a pairing link — either the manta:// custom scheme or
+        // the associated-domain universal link (https://app.mantaui.com/m/…)—
+        // is parsed and fed into the S2 onboarding flow. Delivery happens via
+        // onOpenURL (warm launch) and MantaPairingRouter (cold start through
+        // the app delegate's continue userActivity); both converge here.
+        .onOpenURL { url in
+            _ = MantaPairingRouter.route(url)
+        }
+        .onReceive(MantaPairingRouter.shared.$pendingPayload) { payload in
+            if let payload {
+                flow.receive(payload: payload)
             }
         }
     }

--- a/mobile/native/MantaUI/MantaDeepLink.swift
+++ b/mobile/native/MantaUI/MantaDeepLink.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SwiftUI
+
+// ===========================================================================
+// S8 — app-wide routing for push deep-links and pairing universal links
+// (BET-600).
+//
+// Two published holders, consumed by the SwiftUI tree:
+//   • MantaPushRouter     — a notification tap opening a session
+//   • MantaPairingRouter  — a pairing link (universal https:// or manta://)
+//                           feeding S2's onboarding flow
+//
+// The app delegate is the delivery point for both when the app is cold-started
+// by the OS; `MantaDeepLink.route` is the single parser used by the delegate's
+// `continue userActivity` and by SwiftUI's `onOpenURL`. Both converge on the
+// same /auth/claim contract via MantaPairing.parsePairPayload, so the custom
+// scheme (`manta://pair?...`) and the universal-link form
+// (`https://app.mantaui.com/m?...`) can never disagree.
+// ===========================================================================
+
+@MainActor
+final class MantaPushRouter: ObservableObject {
+    static let shared = MantaPushRouter()
+
+    /// The opencode sessionId a tapped notification was about. Set by the
+    /// notification delegate, consumed by SessionListView (which clears it
+    /// once it has pushed the matching ChatScreen onto its NavigationStack).
+    @Published var pendingSessionID: String?
+
+    private init() {}
+
+    func open(sessionID: String) {
+        pendingSessionID = sessionID
+    }
+}
+
+@MainActor
+final class MantaPairingRouter: ObservableObject {
+    static let shared = MantaPairingRouter()
+
+    /// A parsed pairing payload awaiting hand-off to the onboarding flow.
+    @Published var pendingPayload: MantaPairing.PairPayload?
+
+    private init() {}
+
+    /// Parse a deep link and stage it for the onboarding flow. Returns true iff
+    /// the URL is a Manta pairing link that should be handled by the app.
+    @discardableResult
+    static func route(_ url: URL) -> Bool {
+        guard let payload = MantaPairing.parsePairPayload(url.absoluteString) else {
+            return false
+        }
+        shared.pendingPayload = payload
+        return true
+    }
+}

--- a/mobile/native/MantaUI/MantaUI.entitlements
+++ b/mobile/native/MantaUI/MantaUI.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.mantaui.com</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/native/MantaUI/MantaUIApp.swift
+++ b/mobile/native/MantaUI/MantaUIApp.swift
@@ -10,6 +10,12 @@ struct MantaUIApp: App {
     //
     // S3: the session-list store drives the §7.1 list, deriving live row
     // status from the event store and persisting pin/haptics through config.
+    //
+    // S8 (BET-600): the app delegate owns APNs registration + notification
+    // routing; MantaPushRouter carries a notification tap's sessionId to the
+    // session list so a push opens the session that fired it, not the list.
+    @UIApplicationDelegateAdaptor(MantaAppDelegate.self) private var appDelegate
+
     @StateObject private var store: MantaEventStore
     @StateObject private var sessionStore: SessionListStore
 
@@ -27,6 +33,7 @@ struct MantaUIApp: App {
             MantaAppRoot()
                 .environmentObject(store)
                 .environmentObject(sessionStore)
+                .environmentObject(MantaPushRouter.shared)
                 .task {
                     store.start()
                     sessionStore.bindResync()

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -22,6 +22,7 @@ import UIKit
 struct SessionListView: View {
     @ObservedObject var store: SessionListStore
     @EnvironmentObject private var eventStore: MantaEventStore
+    @EnvironmentObject private var pushRouter: MantaPushRouter
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var searchText = ""
@@ -95,6 +96,30 @@ struct SessionListView: View {
         }
         .fullScreenCover(isPresented: $showSettings) {
             SettingsScreen()
+        }
+        // S8 (BET-600): a tapped notification opens the session that fired it,
+        // not the list. The push router carries the opencode sessionId; we turn
+        // it into the same openTarget the list rows use. onChange covers a
+        // warm launch (view already mounted), onAppear the cold-start case
+        // (the tap routed before the list appeared).
+        .onAppear { consumePushLink() }
+        .onChange(of: pushRouter.pendingSessionID) { _ in consumePushLink() }
+    }
+
+    // MARK: - Push deep-link (§S8)
+
+    private func consumePushLink() {
+        guard let sessionId = pushRouter.pendingSessionID, !sessionId.isEmpty else { return }
+        pushRouter.pendingSessionID = nil
+        // Resolve the row that fired the notification so the opened screen
+        // carries the right title/project; fall back to a bare session open
+        // (ChatScreen works off sessionId alone, so a not-yet-loaded list is
+        // still fine).
+        if let project = store.projects.first(where: { $0.windows.contains { $0.opencodeSessionId == sessionId } }),
+           let window = project.windows.first(where: { $0.opencodeSessionId == sessionId }) {
+            openTarget = SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: sessionId)
+        } else {
+            openTarget = SessionOpenTarget(project: "", windowIndex: 0, name: "session", sessionId: sessionId)
         }
     }
 

--- a/mobile/native/MantaUITests/MantaPairingTests.swift
+++ b/mobile/native/MantaUITests/MantaPairingTests.swift
@@ -186,4 +186,34 @@ final class MantaPairingTests: XCTestCase {
         let derived = MantaPairing.PairPayload(boxId: box, code: "123456", verify: nil, serverUrl: nil)
         XCTAssertEqual(MantaPairing.claimBaseURL(derived)?.absoluteString, "https://\(box).boxes.mantaui.com")
     }
+
+    // MARK: - S8 pairing-link routing (BET-600)
+
+    /// A pairing universal link (https associated-domain form) routed through
+    /// the S8 entry point stages a payload for the onboarding flow.
+    @MainActor
+    func testUniversalLinkRoutesPairingPayload() {
+        MantaPairingRouter.shared.pendingPayload = nil
+        let url = URL(string: "https://app.mantaui.com/m?box=\(box)&code=123456")!
+        XCTAssertTrue(MantaPairingRouter.route(url))
+        XCTAssertEqual(MantaPairingRouter.shared.pendingPayload?.boxId, box)
+        XCTAssertEqual(MantaPairingRouter.shared.pendingPayload?.code, "123456")
+    }
+
+    /// The custom scheme form routes identically (same parse contract).
+    @MainActor
+    func testCustomSchemeRoutesPairingPayload() {
+        MantaPairingRouter.shared.pendingPayload = nil
+        let url = URL(string: "manta://pair?box=\(box)&code=654321")!
+        XCTAssertTrue(MantaPairingRouter.route(url))
+        XCTAssertEqual(MantaPairingRouter.shared.pendingPayload?.code, "654321")
+    }
+
+    /// A non-pairing URL is not swallowed by the app.
+    @MainActor
+    func testNonPairingUrlNotRouted() {
+        MantaPairingRouter.shared.pendingPayload = nil
+        XCTAssertFalse(MantaPairingRouter.route(URL(string: "https://app.mantaui.com/other")!))
+        XCTAssertNil(MantaPairingRouter.shared.pendingPayload)
+    }
 }

--- a/mobile/native/MantaUIUITests/MantaDeepLinkUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaDeepLinkUITests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+// S8 (BET-600): a pairing link opens the app. This exercises the app-side of
+// the custom-scheme / universal-link entry: the system hands the app the URL
+// and onOpenURL routes it into the S2 onboarding flow's confirm phase (§6.2).
+// Deterministic gate: only runs on a fresh-install (unpaired) launch — a device
+// that is already paired skips, since a pairing link is consumed by onboarding.
+final class MantaDeepLinkUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testPairingLinkRoutesToConfirmScreen() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Fresh-install onboarding entry gate; skip when already paired.
+        let entry = app.scrollViews["onboarding-root"]
+        guard entry.waitForExistence(timeout: 4) else {
+            throw XCTSkip("device already paired — onboarding confirm is not reachable")
+        }
+
+        let url = URL(string: "manta://pair?box=0123abcd0123abcd0123abcd0123abcd&code=123456&verify=K7Q2")!
+        XCUIDevice.shared.system.open(url)
+
+        let heading = app.staticTexts["Link this phone?"]
+        XCTAssertTrue(heading.waitForExistence(timeout: 8),
+                      "pairing link did not open the confirm screen")
+    }
+}

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -27,6 +27,12 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.antoinedc.mantaui
         PRODUCT_NAME: MantaUI
         GENERATE_INFOPLIST_FILE: YES
+        # S8 (BET-600): base Info.plist merged over the generated one — carries
+        # the `manta://` custom URL scheme so a pairing link opens the app.
+        INFOPLIST_FILE: MantaUI/Info.plist
+        # S8 (BET-600): push capability (aps-environment) + Associated Domains
+        # for the pairing universal link (applinks:app.mantaui.com).
+        CODE_SIGN_ENTITLEMENTS: MantaUI/MantaUI.entitlements
         INFOPLIST_KEY_CFBundleDisplayName: MantaUI
         INFOPLIST_KEY_NSMicrophoneUsageDescription: MantaUI uses the microphone for push-to-talk dictation and voice commands in chat.
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES

--- a/website/.well-known/apple-app-site-association
+++ b/website/.well-known/apple-app-site-association
@@ -1,0 +1,17 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "FSQ3HS4Z24.com.antoinedc.mantaui"
+        ],
+        "components": [
+          {
+            "/": "/m/*",
+            "comment": "Pairing universal link — https://app.mantaui.com/m?... (S8 / BET-600)"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Opened automatically for `agent/macos/629808f3`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-600.