### PR TITLE
feat(ios): restore TestFlight pipeline for native app (BET-601)

### DIFF
--- a/.github/workflows/codemagic-ios-trigger.yml
+++ b/.github/workflows/codemagic-ios-trigger.yml
@@ -1,0 +1,89 @@
+# Reliably trigger the Codemagic iOS build on ANY ios-v* tag push.
+#
+# WHY THIS EXISTS
+# ---------------
+# codemagic.yaml has a `triggering: { events: [tag], tag_patterns: [ios-v*] }`
+# block, but that path depends on GitHub delivering a webhook to Codemagic for
+# the tag-push event. That delivery is NOT reliable:
+#   - Tags pushed with a workflow's GITHUB_TOKEN never create a GitHub Actions
+#     run, so this workflow's own `push` trigger cannot fire for them
+#     (verified 2026-07-26: 0 runs across ios-v1.0.11…1.0.14).
+#   - Even human-pushed tags occasionally miss (ios-v1.0.10, 2026-07-20: the
+#     tag existed on the remote but Codemagic created no build).
+# When the webhook silently drops, the build never starts and there is no
+# signal — you only notice by the ABSENCE of a TestFlight build.
+#
+# This workflow removes the webhook from the critical path: on every ios-v*
+# tag push it POSTs to the Codemagic REST API to start the build explicitly,
+# and produces a red/green Action run confirming the request. It covers BOTH
+# manual `git push ios-v*` AND the bot tag pushed by ios-release-tag.yml.
+#
+# TWO ENTRY POINTS, ONE PATH
+# --------------------------
+# 1. `push` (a human running `git push origin ios-v*`).
+# 2. `workflow_call` from ios-release-tag.yml, for the tag that workflow
+#    pushes with GITHUB_TOKEN — GitHub does not create workflow runs for
+#    GITHUB_TOKEN pushes, so entry point 1 can never cover the bot case.
+# The two are mutually exclusive by construction, so a tag is never built
+# twice. Codemagic additionally rejects a second POST for the same
+# tag+commit while a build is queued/running.
+#
+# TOKEN
+# -----
+# Uses the CODEMAGIC_API_KEY repo secret (added 2026-07-20). This makes the
+# trigger independent of where the runner lives (no box-local secret file).
+
+name: Codemagic iOS trigger
+
+on:
+  push:
+    tags:
+      - "ios-v*"
+  # Called directly by ios-release-tag.yml for BOT-pushed tags. Required
+  # because GitHub does not create workflow runs for refs pushed with
+  # GITHUB_TOKEN, so the `push` trigger above can never fire for those —
+  # verified 0/4 runs across ios-v1.0.11…1.0.14 (2026-07-26).
+  workflow_call:
+    inputs:
+      tag:
+        description: "The ios-v* tag to build"
+        required: true
+        type: string
+
+concurrency:
+  # One in-flight trigger per tag; never cancel (we want the POST to complete).
+  group: codemagic-ios-trigger-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Start Codemagic ios-testflight build for this tag
+        env:
+          CODEMAGIC_API_KEY: ${{ secrets.CODEMAGIC_API_KEY }}
+          # `inputs` is empty on a push event, so this resolves to the pushed
+          # tag ref; on a workflow_call it is the tag the caller just created.
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CODEMAGIC_API_KEY:-}" ]; then
+            echo "::error::CODEMAGIC_API_KEY repo secret is not set — cannot trigger Codemagic."
+            exit 1
+          fi
+          echo "Triggering Codemagic ios-testflight build for tag ${TAG}…"
+          # -f makes curl exit non-zero on an HTTP error so this Action fails RED
+          # (a silent 4xx/5xx must not read as success).
+          RESP="$(curl -sf -X POST \
+            -H "x-auth-token: ${CODEMAGIC_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"appId\":\"6a5bfe08d7050a29d2f33802\",\"workflowId\":\"ios-testflight\",\"tag\":\"${TAG}\"}" \
+            https://api.codemagic.io/builds)"
+          echo "Codemagic response: ${RESP}"
+          # Confirm the API returned a buildId; anything else is a failure.
+          echo "${RESP}" | grep -q '"buildId"' || {
+            echo "::error::Codemagic did not return a buildId for ${TAG}: ${RESP}"
+            exit 1
+          }
+          echo "Codemagic build started for ${TAG}."

--- a/.github/workflows/ios-release-tag.yml
+++ b/.github/workflows/ios-release-tag.yml
@@ -1,0 +1,152 @@
+# Auto-tag iOS releases on merge to main → triggers the Codemagic workflow.
+#
+# WHY THIS EXISTS
+# ---------------
+# iOS builds/TestFlight delivery run in Codemagic (see codemagic.yaml), whose
+# start condition is a git TAG matching `ios-v*`. Codemagic clones the tag,
+# xcodegen-generates the native project in mobile/native, signs via the ASC API
+# key, archives the `MantaUI` scheme, and delivers to TestFlight. None of that
+# needs a local Mac — but SOMETHING has to create the tag.
+#
+# This workflow is that something: on every push to main it reads the iOS
+# marketing version (MARKETING_VERSION in mobile/native/project.yml, the source
+# of truth for the xcodegen project) and, if no `ios-v<version>` tag exists yet,
+# creates and pushes it. Pushing the tag is what fires the Codemagic build (see
+# the trigger job below). So the full chain is:
+#
+#   merge PR → main → (this) reads version → pushes ios-v<version> → trigger job
+#   → Codemagic → archive → TestFlight
+#
+# To ship a new TestFlight build: bump MARKETING_VERSION in
+# mobile/native/project.yml, merge to main, and this tags it automatically. If
+# the version is unchanged the tag already exists and this no-ops (safe on every
+# push).
+#
+# MANUAL OVERRIDE
+# ---------------
+# workflow_dispatch lets a human/agent force a tag without a version bump —
+# useful to re-trigger a build. It appends a build suffix so it never collides
+# with an existing ios-v<version> tag (which would be rejected as duplicate).
+#
+# LOOP / SKIP GUARDS
+# ------------------
+# - Skips the mobile-bundle bot's `[skip ci]` commits (they carry no iOS change).
+# - Only pushes a tag that does NOT already exist, so re-runs on an unchanged
+#   version are no-ops — no duplicate-tag push failures.
+
+name: iOS release tag
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why force an iOS build (appended to the build metadata)"
+        required: false
+        default: "manual"
+
+concurrency:
+  group: ios-release-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    outputs:
+      pushed_tag: ${{ steps.tag.outputs.pushed_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so tag existence checks are accurate.
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read iOS marketing version
+        id: ver
+        run: |
+          set -euo pipefail
+          # mobile/native/project.yml is the xcodegen source of truth and the
+          # canonical home of MARKETING_VERSION (the generated pbxproj derives
+          # from it). Grep the first occurrence; strip the YAML `MARKETING_VERSION:`
+          # prefix, optional quotes and any trailing comment/whitespace.
+          PROJECT_YML="mobile/native/project.yml"
+          VERSION="$(grep -m1 'MARKETING_VERSION' "$PROJECT_YML" \
+            | sed -E 's/.*MARKETING_VERSION:[[:space:]]*"?([0-9]+(\.[0-9]+){0,5})"?.*/\1/' \
+            | tr -d '[:space:]')"
+          if [ -z "$VERSION" ] || ! echo "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+            echo "::error::Could not read MARKETING_VERSION from $PROJECT_YML (got '$VERSION')"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "iOS marketing version: $VERSION"
+
+      - name: Create + push ios-v<version> tag if absent
+        id: tag
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REASON: ${{ github.event.inputs.reason }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          BASE_TAG="ios-v${VERSION}"
+
+          # On a manual dispatch, force a build even if the version tag exists,
+          # by appending a unique build suffix. On a normal push, only tag when
+          # the base version tag is new.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            SUFFIX="$(date -u +%Y%m%d%H%M%S)"
+            TAG="${BASE_TAG}-build.${SUFFIX}"
+            MSG="iOS build (manual: ${DISPATCH_REASON:-manual}) — ${TAG}"
+          else
+            TAG="$BASE_TAG"
+            MSG="iOS release ${TAG} (auto-tagged on merge to main)"
+          fi
+
+          # Refresh tags and skip if this exact tag already exists remotely.
+          git fetch --tags --quiet
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists — nothing to do (no version bump)."
+            exit 0
+          fi
+
+          git tag -a "$TAG" -m "$MSG"
+          git push origin "refs/tags/${TAG}"
+          echo "pushed_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Pushed ${TAG}."
+
+  # Start the Codemagic build for the tag we just pushed.
+  #
+  # WHY THIS IS A `uses:` AND NOT AN INLINE curl
+  # --------------------------------------------
+  # codemagic-ios-trigger.yml already owns the "POST to Codemagic" logic for
+  # human-pushed tags. Calling it keeps ONE implementation instead of two
+  # copies that drift.
+  #
+  # WHY IT IS NEEDED AT ALL
+  # -----------------------
+  # The tag above is pushed with GITHUB_TOKEN, and GitHub does not create
+  # workflow runs for refs pushed with GITHUB_TOKEN. So the trigger workflow's
+  # own `on: push: tags:` will NOT fire for it — measured 0 runs across
+  # ios-v1.0.11…1.0.14. Codemagic's own tag webhook usually catches these
+  # (it is not subject to the Actions suppression) but it drops silently
+  # sometimes (ios-v1.0.10 produced no build at all), which is what this
+  # explicit call insures against.
+  #
+  # No double-trigger: a GITHUB_TOKEN push emits no push event, so the two
+  # entry points never both fire for the same tag.
+  trigger:
+    needs: tag
+    if: needs.tag.outputs.pushed_tag != ''
+    uses: ./.github/workflows/codemagic-ios-trigger.yml
+    with:
+      tag: ${{ needs.tag.outputs.pushed_tag }}
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1958,16 +1958,18 @@ agent blocks — so a not-yet-registered model still shows up.
 
 ## iOS release / TestFlight (Codemagic — the WORKING mechanism)
 
-The iOS app (the Capacitor wrapper in `mobile/ios/`) ships to TestFlight via
-**Codemagic CI**, configured by **`codemagic.yaml`** at the repo root. This
+The iOS app (the native SwiftUI client in `mobile/native/`) ships to TestFlight
+via **Codemagic CI**, configured by **`codemagic.yaml`** at the repo root. This
 section is the hard-won record of what works and — just as important — the dead
-ends, so nobody re-walks them.
+ends, so nobody re-walks them. (Restored in BET-601 after BET-559 removed it
+with the retired Capacitor wrapper; the pipeline now builds the native app.)
 
 **TL;DR of the pipeline:** push a git tag `ios-v*` → Codemagic clones the repo,
-builds the web bundle, syncs Capacitor, pods, **creates its own distribution
-cert + App Store profile via the App Store Connect API key**, archives the
-`App` scheme, and uploads to TestFlight. No Mac in the loop. The box can drive
-the whole thing (trigger + monitor) over the Codemagic + ASC REST APIs.
+runs xcodegen against `mobile/native/project.yml` (source of truth →
+`MantaUI.xcodeproj`), **creates its own distribution cert + App Store profile
+via the App Store Connect API key** from a PERSISTENT private key, archives the
+`MantaUI` scheme, and uploads to TestFlight. No Mac in the loop. The box can
+drive the whole thing (trigger + monitor) over the Codemagic + ASC REST APIs.
 
 ### Why Codemagic, NOT Xcode Cloud (do not retry Xcode Cloud)
 
@@ -1991,25 +1993,28 @@ disconnecting/reconnecting the GitHub source. The `action_required` /
 emails were all downstream of this one auth failure (the ITMS-90035 signature
 errors specifically came from Xcode Cloud's throwaway **ad-hoc / development**
 side-exports, which are red herrings — the app-store export signed correctly).
-**Do not reintroduce an Xcode Cloud workflow.** The stale files it left
-(`mobile/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme` and
-`mobile/ios/App/ci_scripts/ci_post_clone.sh`) are harmless leftovers; the
-shared scheme is still needed by Codemagic, the `ci_scripts/` post-clone is
-Xcode-Cloud-only and unused by Codemagic (safe to delete).
+**Do not reintroduce an Xcode Cloud workflow.** The Capacitor wrapper it left
+stale files in (`mobile/ios/…`) was itself deleted in BET-559; the native app it
+replaced uses Codemagic's `app-store-connect` CLI + `xcode-project`, which
+authenticate and upload reliably — no Xcode Cloud auth path.
+
 
 ### App Store Connect facts (constants used everywhere)
 
 - **App name**: MantaUI. **ASC app Apple ID**: `6792363427`.
 - **Bundle id**: `com.antoinedc.mantaui` (was `com.antoinedc.MantaUI` originally —
   renamed before anything shipped; the id is permanent post-release). Set in
-  `capacitor.config.json` `appId`, the iOS `PRODUCT_BUNDLE_IDENTIFIER` (both
-  Debug+Release configs), and the Android `applicationId`/`namespace`/
-  `MainActivity` package.
-- **On-device display name**: MantaUI (`CFBundleDisplayName` in
-  `mobile/ios/App/App/Info.plist` + `appName` in `capacitor.config.json`).
-- **Xcode target/scheme**: `App` (Capacitor convention — internal only, NOT
-  user-visible; do NOT rename it, that path throws "already taken by your team"
-  and breaks the scheme/pods/ci_scripts wiring).
+  `mobile/native/project.yml` `PRODUCT_BUNDLE_IDENTIFIER` (xcodegen generates it
+  into the pbxproj's Debug+Release configs).
+- **On-device display name**: MantaUI (`PRODUCT_NAME` /
+  `INFOPLIST_KEY_CFBundleDisplayName` in `mobile/native/project.yml`;
+  `INFOPLIST_FILE: MantaUI/Info.plist`).
+- **Xcode target/scheme**: `MantaUI` (defined in `mobile/native/project.yml`;
+  xcodegen generates the scheme). This is the scheme name Codemagic's
+  `ios-testflight` workflow archives.
+- **Version source**: `MARKETING_VERSION` lives in `mobile/native/project.yml`
+  (both Debug+Release via xcodegen). This is what `ios-release-tag.yml` reads to
+  create the `ios-v<version>` tag, so bump it there to ship.
 - **Team ID (seedId)**: `FSQ3HS4Z24`.
 
 ### Signing — the crux, and every trap in order
@@ -2018,8 +2023,10 @@ iOS code signing was THE blocker (every archive failure traced to it). The
 final working model, in `codemagic.yaml`'s "Set up code signing" step:
 
 1. `keychain initialize`
-2. **Generate an RSA private key ON the build machine**
-   (`ssh-keygen -t rsa -b 2048 -m PEM -f /tmp/dist_key -q -N ""`).
+2. **Materialize the PERSISTENT RSA private key** from the `ios_signing` env
+   group's `CERTIFICATE_PRIVATE_KEY` into `/tmp/dist_key` (chmod 600). One stable
+   key ⇒ one stable distribution cert reused across builds. (Per-build throwaway
+   keys were REMOVED after the ios-v1.0.8 outage — see the root-cause lesson.)
 3. **Create a distribution cert FROM that key** via the ASC API key
    (`app-store-connect certificates create --type IOS_DISTRIBUTION
    --certificate-key=@file:/tmp/dist_key --save`), falling back to
@@ -2040,8 +2047,11 @@ only usable by whoever holds its **private key**. Every early failure
 requires a provisioning profile`) came from a cert whose private key was NOT on
 the Codemagic build machine. A cert created out-of-band (e.g. via the ASC API
 from the box, with the key on the box) is **worthless to Codemagic**. The build
-machine MUST generate the key and create the cert from it. This is step 2→3
-above and is the single most important thing in this section.
+machine must HOLD the key and create the cert from it (steps 2→3 above) — this
+is the single most important thing in this section. The key is the PERSISTENT
+`CERTIFICATE_PRIVATE_KEY` (ios_signing group) so the same cert is reused across
+builds; never switch back to a per-build throwaway key (see the ios-v1.0.8 note
+below).
 
 **Dead ends that were tried and REMOVED (do not reintroduce):**
 - A declarative `environment: ios_signing:` block → resolves signing at
@@ -2051,11 +2061,13 @@ above and is the single most important thing in this section.
   Xcode project → the profile Codemagic installs on the machine isn't named
   that, so xcodebuild errors "No profile … matching 'MantaUI App Store'".
   Let `use-profiles` set the specifier instead.
-- `CODE_SIGN_STYLE = Automatic` in the project → conflicts with Codemagic's
-  Manual signing. The project's target Release config is now
-  `CODE_SIGN_STYLE = Manual` + `DEVELOPMENT_TEAM = FSQ3HS4Z24` +
-  `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "Apple Distribution"` (no hardcoded
-  profile specifier — `use-profiles` fills it).
+- `CODE_SIGN_STYLE = Automatic` in the project → **do NOT rely on Automatic
+  signing to resolve profiles.** The native `mobile/native/project.yml` sets
+  `CODE_SIGN_STYLE: Automatic`; leave it that way — the "Set up code signing"
+  step's `xcode-project use-profiles` flips the generated project to Manual with
+  the fetched App Store profile at build time. The failure mode was Automatic
+  WITHOUT `use-profiles` (expecting Xcode to auto-pick a profile), which errors
+  "No profile … matching". Don't hand-edit project.yml to Manual.
 - `--export-options-plist /tmp/export_options.plist` → wrong path;
   `use-profiles` writes it to `$CM_BUILD_DIR/export_options.plist`. Both the
   `use-profiles` and `build-ipa` calls must use the SAME `$CM_BUILD_DIR` path.
@@ -2080,8 +2092,8 @@ Codemagic's API.
 `codemagic.yaml`'s `triggering:` builds on git tag `ios-v*`. The box can:
 - **Trigger by tag**: push `ios-v<version>` (the `ios-release-tag.yml` GitHub
   Actions workflow auto-creates `ios-v<MARKETING_VERSION>` on merge to main —
-  reads `MARKETING_VERSION` from `project.pbxproj`; idempotent, only tags a new
-  version; `workflow_dispatch` force-tags with a build suffix).
+  reads `MARKETING_VERSION` from `mobile/native/project.yml`; idempotent, only
+  tags a new version; `workflow_dispatch` force-tags with a build suffix).
 - **Trigger by Codemagic API** (what was used during bring-up — does NOT need a
   tag, good for iterating):
   ```
@@ -2130,9 +2142,11 @@ Beta App Review of the first build.
 ### Versioning
 
 `MARKETING_VERSION` (CFBundleShortVersionString) lives in
-`project.pbxproj` (both Debug+Release). Bump it to ship a new TestFlight
-version; the auto-tag workflow keys off it. `CURRENT_PROJECT_VERSION` (build
+`mobile/native/project.yml` (xcodegen writes it to both Debug+Release configs of
+the generated pbxproj). Bump it there to ship a new TestFlight version; the
+auto-tag workflow keys off it. `CURRENT_PROJECT_VERSION` (build
 number) — Codemagic/ASC handle uniqueness. First shipped version: `1.0.1`.
+Current native source has `0.1.0` (pre-first-release).
 
 ## Release & CD pipeline — TAG-DRIVEN, one manual step
 
@@ -2167,7 +2181,7 @@ the ONE monorepo; the tag prefix is what routes.
 
 **How to cut a release (all targets):**
 ```
-# iOS — bump MARKETING_VERSION in project.pbxproj first, merge, then:
+# iOS — bump MARKETING_VERSION in mobile/native/project.yml first, merge, then:
 git tag ios-v1.0.8 && git push origin ios-v1.0.8
 # (the ios-release-tag.yml workflow also AUTO-tags ios-v<MARKETING_VERSION> on
 #  merge to main, so iOS often needs no manual tag — just the version bump.)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,20 +1,160 @@
-# Codemagic CI/CD — macOS desktop (Electron) distribution only.
+# Codemagic CI/CD — iOS TestFlight + macOS desktop (Electron) distribution.
 #
-# BET-559: the iOS TestFlight workflow (which built the retired Capacitor
-# wrapper in mobile/ios) was removed along with the Capacitor shell. This file
-# now drives only the mac-desktop workflow: electron-builder → signed +
-# notarized DMG → mantaui.com.
+# BET-601 (S9): the iOS TestFlight workflow was restored after BET-559 removed
+# it (with the Capacitor shell). It now builds the NATIVE app in mobile/native
+# (xcodegen → MantaUI.xcodeproj, scheme `MantaUI`) instead of the retired
+# Capacitor wrapper in mobile/ios. The mac-desktop workflow is unchanged.
+#
+# WHY CODEMAGIC (not Xcode Cloud): Xcode Cloud built + signed fine but could
+# NEVER authenticate to upload the binary to App Store Connect ("Session Proxy
+# Provider Code=1" — a known Xcode Cloud auth bug). Codemagic uploads via the
+# App Store Connect API key, which authenticates reliably. Do not reintroduce
+# Xcode Cloud.
 #
 # ONE-TIME SETUP IN THE CODEMAGIC WEB UI (you do this once):
 #   1. Sign up at codemagic.io, connect the GitHub repo antoinedc/MantaUI.
-#   2. For the desktop: create the "Developer ID Application" cert + the
-#      App Store Connect API key and wire the env groups (mac_signing /
-#      mantaui / prod_deploy) as documented in the mac-desktop workflow below.
+#   2. iOS: the ASC API key integration must be named "APS Key" (referenced
+#      below as app_store_connect: APS Key). The persistent iOS distribution
+#      private key lives in the "ios_signing" env group as
+#      CERTIFICATE_PRIVATE_KEY.
+#   3. Desktop: create the "Developer ID Application" cert + wire the env
+#      groups as documented in the mac-desktop workflow below.
 #
-# TRIGGER: a git tag matching mac-v*. Also runnable manually from the
-#   Codemagic UI.
+# TRIGGER: a git tag matching ios-v* (iOS) or mac-v* (desktop); the tag prefix
+#   routes each build so one never fires the other. iOS tags are usually
+#   created automatically by .github/workflows/ios-release-tag.yml on merge to
+#   main (reads MARKETING_VERSION from mobile/native/project.yml).
 
 workflows:
+  # ---------------------------------------------------------------------------
+  # iOS native (mobile/native) → signed .ipa → TestFlight
+  # ---------------------------------------------------------------------------
+  # Restored in BET-601. Builds the SwiftUI app in mobile/native: xcodegen
+  # generates MantaUI.xcodeproj from project.yml (the source of truth), then a
+  # distribution cert + App Store profile are created on the build machine from
+  # the PERSISTENT private key (CERTIFICATE_PRIVATE_KEY in the ios_signing env
+  # group), and the archive is uploaded to TestFlight via the ASC API key.
+  #
+  # PRIVATE-KEY CUSTODY is the crux: a distribution certificate is only usable
+  # by whoever holds its private key, so the key lives on the build machine and
+  # the cert is created FROM it. Do NOT go back to a per-build throwaway key —
+  # each such build minted a new cert whose key died with the VM; after 2
+  # builds the account's cert quota (max 2/type) filled with unusable certs and
+  # signing silently produced zero profiles (the ios-v1.0.8 outage, c899c89).
+  ios-testflight:
+    name: MantaUI iOS → TestFlight
+    instance_type: mac_mini_m2      # 500 free M2 minutes/month
+    max_build_duration: 60
+    integrations:
+      app_store_connect: APS Key  # MUST match the ASC API key integration name in the Codemagic UI exactly (Team > Integrations > Developer Portal)
+    environment:
+      # NOTE: no declarative `ios_signing:` block on purpose. That block makes
+      # Codemagic resolve signing at environment-setup time (before scripts run)
+      # and fails with "No matching profiles found" if the profile doesn't
+      # already exist. Instead the "Set up code signing" script below runs
+      # `app-store-connect fetch-signing-files --create`, which CREATES the
+      # distribution cert + App Store profile via the ASC API key if missing.
+      groups:
+        # ios_signing holds CERTIFICATE_PRIVATE_KEY — the PERSISTENT RSA key
+        # (secure app variable, uploaded via the Codemagic API; durable copy at
+        # ~/.manta/ios-dist-key.pem on the box). One stable key ⇒ one stable
+        # distribution cert reused across builds.
+        - ios_signing
+      vars:
+        BUNDLE_ID: "com.antoinedc.mantaui"
+        APP_STORE_APPLE_ID: 6792363427
+        XCODE_PROJECT: "mobile/native/MantaUI.xcodeproj"
+        XCODE_SCHEME: "MantaUI"
+      node: 22
+      xcode: latest
+    triggering:
+      events:
+        - tag
+      tag_patterns:
+        - pattern: "ios-v*"
+          include: true
+    scripts:
+      - name: Generate Xcode project from project.yml (xcodegen)
+        script: |
+          # mobile/native/project.yml is the source of truth; MantaUI.xcodeproj
+          # is derived from it (xcodegen). Generate it so the pbxproj can never
+          # drift from the spec — this is what keeps MARKETING_VERSION + the
+          # bundle id correct even if only project.yml was bumped. The generated
+          # project is deterministic, so re-generating over the checked-in file
+          # is a no-op when they already match.
+          brew install xcodegen
+          cd mobile/native
+          xcodegen generate
+      - name: Set up code signing (App Store profile via ASC API key)
+        script: |
+          # THE PRIVATE-KEY REQUIREMENT: a distribution certificate is only
+          # usable for signing by whoever holds its PRIVATE KEY. The key comes
+          # from the PERSISTENT secure variable CERTIFICATE_PRIVATE_KEY
+          # (ios_signing group) so every build reuses the SAME key and the SAME
+          # cert. A per-build throwaway key minted a new cert every build until
+          # the 2-cert quota filled with certs whose keys were lost — then
+          # signing silently produced zero profiles (ios-v1.0.8).
+          keychain initialize
+
+          # 1. Materialize the persistent private key.
+          printf '%s\n' "$CERTIFICATE_PRIVATE_KEY" > /tmp/dist_key
+          chmod 600 /tmp/dist_key
+
+          # 2. Create the distribution certificate FROM that key via the ASC API
+          #    key — first run only; afterwards it 409s (cert exists) and the
+          #    fallback `list` finds the existing cert matching our key.
+          #    --save stores the resulting cert next to the key so
+          #    fetch/keychain steps can find both.
+          app-store-connect certificates create \
+            --type IOS_DISTRIBUTION \
+            --certificate-key=@file:/tmp/dist_key \
+            --save || \
+          app-store-connect certificates list \
+            --type IOS_DISTRIBUTION \
+            --certificate-key=@file:/tmp/dist_key \
+            --save
+
+          # 3. Fetch signing files, passing the SAME private key so Codemagic can
+          #    match the cert to its key and build a usable p12 + create the
+          #    App Store provisioning profile for the bundle id.
+          app-store-connect fetch-signing-files "$BUNDLE_ID" \
+            --platform IOS \
+            --type IOS_APP_STORE \
+            --certificate-key=@file:/tmp/dist_key \
+            --create
+
+          # 4. Import the certificate(s) into the keychain.
+          keychain add-certificates
+
+          # 5. Write the profile's specifier into the Xcode project + the export
+          #    options plist that build-ipa consumes. This also converts the
+          #    project's `CODE_SIGN_STYLE = Automatic` (project.yml) to Manual
+          #    with the fetched profile, so the archive resolves a concrete cert.
+          xcode-project use-profiles \
+            --export-options-plist "$CM_BUILD_DIR/export_options.plist"
+      - name: Build + archive .ipa
+        script: |
+          # use-profiles (previous step) set the project to manual signing with
+          # the fetched App Store profile and wrote the export options plist to
+          # $CM_BUILD_DIR/export_options.plist. Feed it so the archive + export
+          # have a concrete profile (fixes "app requires a provisioning
+          # profile"). Force the team so manual signing resolves. No pods, so a
+          # --project rather than the Capacitor era's --workspace.
+          xcode-project build-ipa \
+            --project "$XCODE_PROJECT" \
+            --scheme "$XCODE_SCHEME" \
+            --archive-xcargs "DEVELOPMENT_TEAM=FSQ3HS4Z24" \
+            --export-options-plist "$CM_BUILD_DIR/export_options.plist"
+    artifacts:
+      - build/ios/ipa/*.ipa
+      - /tmp/xcodebuild_logs/*.log
+    publishing:
+      app_store_connect:
+        auth: integration          # use the ASC API key integration
+        submit_to_testflight: true
+        # Internal testers get it automatically once processing completes.
+        # No App Store review needed for internal TestFlight.
+
   # ---------------------------------------------------------------------------
   # macOS desktop (Electron) → signed + notarized DMG → mantaui.com
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## S9 — Restore the iOS release pipeline (BET-601)

Restores the iOS → TestFlight pipeline that BET-559 removed along with the
retired Capacitor wrapper, now pointed at the **native** app in
`mobile/native/`.

### Changes

- **`codemagic.yaml`** — restored the `ios-testflight` workflow (recovered from
  git history, not re-derived), adapted for the native build:
  - `xcodegen generate` produces `MantaUI.xcodeproj` from
    `mobile/native/project.yml` (source of truth) so the pbxproj can never drift
    from the spec — this is what keeps `MARKETING_VERSION` + bundle id correct.
  - Signs via the **persistent** private key (`CERTIFICATE_PRIVATE_KEY` /
    `ios_signing` group) → distribution cert created on the build machine with
    the ASC API key (private-key custody: not a per-build throwaway key).
  - `xcode-project build-ipa --project mobile/native/MantaUI.xcodeproj
    --scheme MantaUI` (no pods/workspace/Capacitor steps).
  - `triggering: tag_patterns: ios-v*` restored; `publishing.app_store_connect`
    submits to TestFlight.
- **`.github/workflows/ios-release-tag.yml`** — restored auto-tag-on-version-bump;
  now reads `MARKETING_VERSION` from `mobile/native/project.yml` (was the
  deleted Capacitor `project.pbxproj`), then calls the trigger workflow.
- **`.github/workflows/codemagic-ios-trigger.yml`** — restored; POSTs to
  Codemagic `ios-testflight` on `ios-v*` tags (covers the GITHUB_TOKEN tag
  whose Actions run GitHub never creates).
- **`AGENTS.md`** — updated the iOS release section to match the native build:
  scheme `MantaUI`, version source `project.yml`, persistent-key signing,
  removed stale Capacitor paths.

### Verification

No application code changed — this is CI config + docs only. `npm run
typecheck && npm test` are unaffected (identical to `main`); there is
nothing new to compile. The restored workflow files parse as valid YAML and
the branch diff lists only the four intended files.

**Files changed:** 4
- `codemagic.yaml`
- `.github/workflows/ios-release-tag.yml`
- `.github/workflows/codemagic-ios-trigger.yml`
- `AGENTS.md`

**Base: origin/main @ `b3a45fc`**

### Note on the "Done when" / end-to-end ASC verification

The issue's acceptance is "a tag produces a build that reaches App Store
Connect with `processingState: VALID`, verified against the ASC API." That is
a real end-to-end Codemagic run that fires **after** this PR merges to `main`
(`ios-release-tag.yml` auto-tags `ios-v<MARKETING_VERSION>` on merge → Codemagic
builds the native app → uploads to TestFlight). It requires a Codemagic build
(no `CODEMAGIC_API_KEY` is available in this session) and, per the workspace
rules, CI is not waited on. The config restoration is the deliverable here;
the ASC-arrival check is the merge-then-tag close-out. Signing follows the
recovered, documented persistent-key model, so it should not hit an
undocumented failure.
