### PR TITLE
BET-611: a fresh box must get the Claude login, not an API-key prompt

### DIFF
--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -625,6 +625,9 @@ export function buildHandlers({
         const id = String(req?.id ?? "");
         const entry = subscriptionProviders.findSubscriptionProvider(id);
         if (!entry) {
+          console.warn(
+            `[provider-auth] ${id}: not a known subscription provider — falling back to the API-key form`,
+          );
           return { action: "start", shape: "api-key" };
         }
         const auth = await oc.listProviderAuthMethods();
@@ -637,20 +640,48 @@ export function buildHandlers({
           // No OAuth / no usable method → the renderer switches to the
           // API-key form (Kimi path). Mirrors the "use the generic API-key
           // path" contract in resolveAuthMethod's docstring.
+          //
+          // For anthropic this almost always means the opencode-claude-auth
+          // plugin did not load (it is what advertises the "Switch Claude
+          // Code account" oauth method), so say so — this branch used to be
+          // silent and the resulting API-key prompt was undiagnosable.
+          console.warn(
+            `[provider-auth] ${id}: no auth method resolved from ${
+              methods ? `${methods.length} advertised method(s)` : "no /provider/auth entry"
+            } — falling back to the API-key form`,
+          );
           return { action: "start", shape: "api-key" };
         }
         const oauth = await oc.startProviderOauth(id, resolved.index);
-        if (!oauth?.ok) {
-          return {
-            action: "start",
-            shape: "api-key",
-          };
-        }
+        // A FRESH box has no ~/.claude/.credentials.json yet, and the Claude
+        // auth plugin's authorize() throws when it has no account to switch
+        // to (it indexes accounts[0] on an empty list). That is EXACTLY the
+        // state the claude-login flow exists to resolve — it runs
+        // `claude auth login` ON the box to CREATE those credentials — so
+        // returning the API-key form here was a catch-22: the only path that
+        // can connect a Claude subscription was unreachable until you were
+        // already connected. Every fresh box hit it.
+        //
+        // So do not bail on a failed authorize. Ask describeConnectShape with
+        // a null authorize response: for anthropic + a resolved oauth method
+        // it yields "claude-login" (pinned by
+        // `describeConnectShape(r, null, "anthropic")` in
+        // subscriptionProviders.test.mjs). A provider that genuinely has no
+        // OAuth to offer still falls through to the key form below.
+        const authorize = oauth?.ok ? oauth : null;
         const shape = subscriptionProviders.describeConnectShape(
           resolved,
-          oauth,
+          authorize,
           id,
         );
+        if (!authorize && shape !== "claude-login") {
+          console.warn(
+            `[provider-auth] ${id}: authorize failed (${
+              oauth?.error ?? "no response"
+            }) and shape=${shape} — falling back to the API-key form`,
+          );
+          return { action: "start", shape: "api-key" };
+        }
         // BET-354: when describeConnectShape returns "claude-login", we
         // also need to spawn `claude auth login` on the box. The renderer
         // will drive it via the existing pty bus + the new
@@ -663,8 +694,8 @@ export function buildHandlers({
         return {
           action: "start",
           shape,
-          url: oauth.url || undefined,
-          instructions: oauth.instructions || undefined,
+          url: authorize?.url || undefined,
+          instructions: authorize?.instructions || undefined,
           methodIndex: resolved.index,
         };
       }

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -455,6 +455,59 @@ test("opencode:provider-auth start routes anthropic → claude-login shape (BET-
   assert.equal(typeof result.cwd, "string");
 });
 
+test("opencode:provider-auth start returns claude-login when authorize FAILS on a fresh box (BET-610)", async () => {
+  // THE fresh-box bug. A box that has never run `claude` has no
+  // ~/.claude/.credentials.json, so the opencode-claude-auth plugin's
+  // authorize() throws (it indexes accounts[0] on an empty list) and
+  // startProviderOauth comes back not-ok.
+  //
+  // The handler used to return shape:"api-key" here — a catch-22, because
+  // claude-login is the flow that RUNS `claude auth login` to create those
+  // very credentials. Every fresh box was therefore asked for an API key and
+  // could never connect a subscription at all.
+  //
+  // The authorize failure must NOT decide the shape: describeConnectShape is
+  // asked with a null response and still yields claude-login for anthropic.
+  const { deps } = makeDeps([]);
+  deps.oc.listProviderAuthMethods = async () => ({
+    ok: true,
+    methods: {
+      anthropic: [{ type: "oauth", label: "Switch Claude Code account" }],
+    },
+  });
+  deps.oc.startProviderOauth = async () => ({
+    ok: false,
+    error: "Cannot read properties of undefined (reading 'source')",
+  });
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({
+    action: "start",
+    id: "anthropic",
+  });
+  assert.equal(result.shape, "claude-login",
+    `a fresh box must still get the Claude login terminal, not the API-key form; got ${JSON.stringify(result)}`);
+  assert.ok(typeof result.sessionKey === "string" && result.sessionKey.length > 0,
+    "claude-login must still stamp a sessionKey when authorize failed");
+});
+
+test("opencode:provider-auth start still falls back to api-key when authorize fails for a NON-claude provider (BET-610)", async () => {
+  // The counterpart: the relaxation above is anthropic-only. A provider whose
+  // shape is not claude-login and whose authorize failed genuinely has no
+  // OAuth to offer, so the key form remains correct.
+  const { deps } = makeDeps([]);
+  deps.oc.listProviderAuthMethods = async () => ({
+    ok: true,
+    methods: { openai: [{ type: "oauth", label: "ChatGPT headless" }] },
+  });
+  deps.oc.startProviderOauth = async () => ({ ok: false, error: "boom" });
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({
+    action: "start",
+    id: "openai",
+  });
+  assert.equal(result.shape, "api-key");
+});
+
 test("opencode:provider-auth start keeps oauth-auto for non-anthropic with empty url (BET-354)", async () => {
   // Belt-and-braces: an "empty url" response from opencode for a
   // non-anthropic provider is NOT the Claude-specific path — we fall


### PR DESCRIPTION
Connecting a Claude subscription on a box that had never run `claude` always ended at the API-key form. The browser-login flow was unreachable on exactly the boxes that needed it.

## The catch-22

A fresh box has no `~/.claude/.credentials.json`, so the `opencode-claude-auth` plugin's `authorize()` throws (it indexes `accounts[0]` on an empty list) and `startProviderOauth` returns not-ok.

The handler treated a failed authorize as *'this provider has no OAuth'* and returned `shape:"api-key"` — but `claude-login` is the flow that runs `claude auth login` **on the box to create those credentials**. The only path that can connect a subscription was gated behind already being connected.

`describeConnectShape` has answered this correctly since BET-354 — `describeConnectShape(r, null, "anthropic") === "claude-login"` is pinned at `subscriptionProviders.test.mjs:209`. The handler short-circuited one line earlier and never called it.

## Fix

A failed authorize no longer decides the shape: the response is normalised to `null` and `describeConnectShape` is asked anyway. Anthropic with a resolved oauth method yields `claude-login` and the login terminal spawns as designed. A provider that genuinely has no OAuth still falls back to the key form — the relaxation is anthropic-shaped, not blanket.

## Observability

All three `api-key` fallbacks were silent, which is why this cost a day: a form appeared and nothing was logged anywhere. Each now warns with the provider id and the reason — unknown provider, no method resolved (for anthropic: the claude-auth plugin did not load, a distinct fault with an identical symptom), or authorize failed with a non-claude shape.

## Verification

- New test **verified RED against the old handler**: fresh-box authorize failure must yield `claude-login` + a sessionKey.
- Counterpart test: a non-claude provider with a failed authorize still degrades to `api-key`.
- `npm run typecheck` green; `npm test` green — 1428 tests, 0 failures.

Server-side only — needs a `server-v*` tag to reach boxes, no desktop rebuild.