### PR TITLE
fix(renderer): onboarding verify stage 2 must catch instead of test a return value (BET-612)

### DIFF
--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -49,7 +49,6 @@ import {
   hasConnectedProvider,
   pickVerifyLabels,
   verifyStageLabels,
-  type VerifyApi,
   type VerifyProgress,
   type VerifyStageIndex,
 } from "./onboardingVerify";
@@ -173,7 +172,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     let providerLabel = "your provider";
     let modelLabel: string | undefined;
     try {
-      const status = await (window.api as unknown as VerifyApi).opencodeProviderAuth({
+      const status = await window.api.opencodeProviderAuth({
         action: "status",
       });
       const cfg = useStore.getState().configSnapshot();
@@ -190,7 +189,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     setVerifyElapsed(0);
     setVerifyProgress({ stage: 0, status: "running" });
     const outcome = await verifyOnboarding({
-      api: window.api as unknown as VerifyApi,
+      api: window.api,
       providerLabel,
       modelLabel,
       onProgress: (p) => setVerifyProgress(p),
@@ -221,7 +220,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     let connected = false;
     try {
       await refreshAndInstallTransport();
-      connected = await hasConnectedProvider(window.api as unknown as VerifyApi);
+      connected = await hasConnectedProvider(window.api);
     } catch (e) {
       console.warn("[manta] post-pair pre-flight failed; advancing anyway:", e);
     }

--- a/src/renderer/onboardingVerify.test.ts
+++ b/src/renderer/onboardingVerify.test.ts
@@ -16,9 +16,9 @@ function makeApi(over: Partial<VerifyApi> = {}): VerifyApi {
       sessionId: "eph-1",
     })),
     opencodeDeleteSessionRaw: vi.fn(async () => ({ ok: true })),
-    opencodePrompt: vi.fn(async () => ({ ok: true })),
+    opencodePrompt: vi.fn(async () => undefined),
     opencodeMessages: vi.fn(async () => []),
-    opencodeProviderAuth: vi.fn(async () => ({ action: "status", providers: [] })),
+    opencodeProviderAuth: (vi.fn(async () => ({ action: "status", providers: [] })) as unknown) as VerifyApi["opencodeProviderAuth"],
     ...over,
   };
 }
@@ -32,7 +32,7 @@ function messagesSequence() {
   const fn = vi.fn(async (sid: string) => {
     calls.push([sid]);
     return steps[Math.min(calls.length - 1, steps.length - 1)];
-  });
+  }) as unknown as VerifyApi["opencodeMessages"];
   return fn;
 }
 
@@ -95,7 +95,9 @@ describe("verifyOnboarding", () => {
 
   it("fails at stage 1 when the prompt is rejected, and deletes the session", async () => {
     const api = makeApi({
-      opencodePrompt: vi.fn(async () => ({ ok: false, error: "unauthorized" })),
+      opencodePrompt: vi.fn(async () => {
+        throw new Error("unauthorized");
+      }),
     });
     const out = await verifyOnboarding({
       api,
@@ -107,8 +109,25 @@ describe("verifyOnboarding", () => {
     if (!out.ok) {
       expect(out.failedStage).toBe(1);
       expect(out.message).toContain("Codex");
+      expect(out.message).toContain("unauthorized");
     }
     expect(api.opencodeDeleteSessionRaw).toHaveBeenCalledWith("eph-1");
+  });
+
+  it("REGRESSION: a resolved-with-undefined prompt is success, not a stage-1 failure", async () => {
+    const api = makeApi({ opencodeMessages: messagesSequence() });
+    const progress: string[] = [];
+    const out = await verifyOnboarding({
+      api,
+      providerLabel: "Claude",
+      modelLabel: "claude-sonnet-4",
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
+      now: () => 0,
+      onProgress: (p) => progress.push(`${p.stage}:${p.status}`),
+    });
+    expect(out).toEqual({ ok: true });
+    expect(progress).toEqual(["0:running", "1:running", "2:running", "2:done"]);
   });
 
   it("fails at stage 2 on timeout (no reply), and deletes the session", async () => {
@@ -134,7 +153,9 @@ describe("verifyOnboarding", () => {
     // Baseline already has a completed assistant message; the poll returns
     // the SAME message — the verifier must keep waiting (and time out).
     const pre = [{ info: { id: "old", role: "assistant", time: { completed: 1 } } }];
-    const api = makeApi({ opencodeMessages: vi.fn(async () => pre) });
+    const api = makeApi({
+      opencodeMessages: (vi.fn(async () => pre) as unknown) as VerifyApi["opencodeMessages"],
+    });
     let t = 0;
     const out = await verifyOnboarding({
       api,
@@ -151,20 +172,20 @@ describe("verifyOnboarding", () => {
 describe("hasConnectedProvider", () => {
   it("returns true when at least one provider is connected", async () => {
     const api = makeApi({
-      opencodeProviderAuth: vi.fn(async () => ({
+      opencodeProviderAuth: (vi.fn(async () => ({
         action: "status",
         providers: [{ id: "anthropic", connected: false }, { id: "openai", connected: true }],
-      })),
+      })) as unknown) as VerifyApi["opencodeProviderAuth"],
     });
     expect(await hasConnectedProvider(api)).toBe(true);
   });
 
   it("returns false when nothing is connected", async () => {
     const api = makeApi({
-      opencodeProviderAuth: vi.fn(async () => ({
+      opencodeProviderAuth: (vi.fn(async () => ({
         action: "status",
         providers: [{ id: "anthropic", connected: false }],
-      })),
+      })) as unknown) as VerifyApi["opencodeProviderAuth"],
     });
     expect(await hasConnectedProvider(api)).toBe(false);
   });

--- a/src/renderer/onboardingVerify.ts
+++ b/src/renderer/onboardingVerify.ts
@@ -25,28 +25,19 @@
 
 // ---------- Types injected from the renderer ----------
 
-// Minimal shape of window.api the verify path actually consumes. Declared
-// here as a type so the test fixture doesn't need to construct the whole
-// preload surface — see onboardingVerify.test.ts.
-export type VerifyApi = {
-  opencodeCreateEphemeralSession: (input: {
-    directory: string;
-    title?: string;
-  }) => Promise<{ ok: boolean; sessionId?: string; error?: string }>;
-  opencodeDeleteSessionRaw: (sessionId: string) => Promise<{ ok: boolean }>;
-  opencodePrompt: (
-    sessionId: string,
-    text: string,
-    modelOverride?: unknown,
-    attachments?: unknown,
-    mentions?: unknown,
-  ) => Promise<{ ok: boolean; error?: string }>;
-  opencodeMessages: (sessionId: string) => Promise<unknown>;
-  opencodeProviderAuth: (input: {
-    action: string;
-    [k: string]: unknown;
-  }) => Promise<unknown>;
-};
+// The minimal shape of window.api the verify path consumes — a Pick of the
+// canonical Api interface so a wrong assumption about any of these five
+// methods is a typecheck failure, not a silent runtime bug.
+import type { Api } from "../shared/api";
+
+export type VerifyApi = Pick<
+  Api,
+  | "opencodeCreateEphemeralSession"
+  | "opencodeDeleteSessionRaw"
+  | "opencodePrompt"
+  | "opencodeMessages"
+  | "opencodeProviderAuth"
+>;
 
 // A verify stage index (0-based) the caller feeds to ProcessPanel.activeIndex.
 export type VerifyStageIndex = 0 | 1 | 2;
@@ -128,18 +119,20 @@ export async function verifyOnboarding(deps: {
   const sessionId = created.sessionId;
 
   try {
-    // Stage 2 — send the probe prompt (credentials accepted by the provider).
+    // Stage 2 — send the probe prompt. opencodePrompt resolves with nothing
+    // on success and THROWS on failure — there is no return value to test.
     onProgress({ stage: 1, status: "running" });
-    const send = await deps.api.opencodePrompt(sessionId, probeText);
-    if (!send || send.ok === false) {
+    try {
+      await deps.api.opencodePrompt(sessionId, probeText);
+    } catch (e) {
       onProgress({ stage: 1, status: "error" });
+      const detail = e instanceof Error ? e.message : String(e);
       return {
         ok: false,
         failedStage: 1,
-        message:
-          send && typeof send.error === "string" && send.error.length > 0
-            ? `${deps.providerLabel} rejected the request: ${send.error}`
-            : `${deps.providerLabel} isn't ready. Reconnect the provider and try again.`,
+        message: detail
+          ? `${deps.providerLabel} rejected the request: ${detail}`
+          : `${deps.providerLabel} isn't ready. Reconnect the provider and try again.`,
       };
     }
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -582,7 +582,7 @@ export function buildHandlers({
         return { ok: false, error: e?.message ? String(e.message) : String(e) };
       }
     },
-    "opencode:delete-session-raw": async ({ sessionId }) => {
+    "opencode:delete-session-raw": async (sessionId) => {
       try {
         await oc.deleteSessionRaw(sessionId);
         return { ok: true };


### PR DESCRIPTION
## Summary

Fixes the onboarding verify flow always failing at stage 2 ("`<Provider> isn't ready. Reconnect the provider and try again.`").

**Root cause 1 (stage 2):** `onboardingVerify.ts` declared its own local `VerifyApi` type that invented a return shape `opencodePrompt → Promise<{ok, error}>` the real API never had. The real contract (`src/shared/api.ts`) is `Promise<void>` — resolves `undefined` on success, throws on failure. Stage 2 tested the (always-`undefined`) return value, so it always hit the failure branch.

**Root cause 2 (leaked orphan sessions):** `opencode:delete-session-raw` (server) destructured `{sessionId}` out of a bare-string argument, yielding `undefined`, and returned `{ok:true}` in the catch, so the verifier's cleanup silently deleted nothing.

## Changes

1. **`onboardingVerify.ts`** — replaced the hand-written `VerifyApi` type with a `Pick` of the canonical `Api` interface (kept name + export). A wrong assumption about any of the five methods is now a **typecheck failure**. Stage 2 now `try/catch`es `opencodePrompt` — the only failure signal — with both user-facing strings unchanged.
2. **`Onboarding.tsx`** — dropped the three `as unknown as VerifyApi` casts (also removed the now-unused `VerifyApi` type import).
3. **`onboardingVerify.test.ts`** — corrected the lying fixture (`opencodePrompt` resolves `undefined` to match the real `Promise<void>` contract), made the stage-1 reject test throw instead of returning `{ok:false}`, and added the explicit regression test.
4. **`rpc.mjs`** — `opencode:delete-session-raw` now accepts the bare `sessionId` string (matching the canonical contract, the client, and the `Api` interface). Body + best-effort catch untouched.

## RED / GREEN verification

The new regression test **`REGRESSION: a resolved-with-undefined prompt is success, not a stage-1 failure`** was confirmed **RED against the pre-fix `onboardingVerify.ts`** (`expected {ok:false, failedStage:1} to deeply equal {ok:true}` — plus the 4 other contract-driven failures the fixed fixture exposes) and **GREEN after the fix** (12/12 pass in `onboardingVerify.test.ts`).

## Verification results

**Files changed:** `4`.

```
src/renderer/Onboarding.tsx           |  7 +++--
src/renderer/onboardingVerify.test.ts | 39 ++++++++++++++++++++-------
src/renderer/onboardingVerify.ts      | 51 +++++++++++++++--------------------
src/server/rpc.mjs                    |  2 +-
4 files changed, 56 insertions(+), 43 deletions(-)
```

- PR branch (`multica/BET-612-verify-stage2` @ `8b733b2`):
  - typecheck: exit `0`. Errors: none. log sha256: `ce6f319a8d07e7d786f95c7eda54b1dab125a6d22595cbd596e39c8300d78963`
  - test: exit `0`, `1435` pass / `0` fail / `0` skip. log sha256: `34cac2b6da2bff24dfdc1c5b0f9083ce6905885e3dd5916d5ee9461f3955bbd7`

**Base: `origin/main` @ `8ee9794`**

**Net code:** source (non-test) files are net-negative (26 insertions / 34 deletions). The only additions are the sanctioned regression test and the stage-2 `try/catch`.

No follow-ups filed — the fix is contained to the verifier + the one server handler, with no remaining duplicate sites (`VerifyApi` was the only divergent local type; grep shows no other consumers).
