### PR TITLE
BET-616: Button primitive + two adopters

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -79,6 +79,7 @@ that vanishes. Adopter counts below are **web** adopters only.
 
 | Primitive | File | Adopters | Variants |
 | --- | --- | --- | --- |
+| Button | `src/renderer/Button.tsx` | 2 — `Settings.tsx`, `FolderPickerModal.tsx` | `tone: default\|primary\|ghost\|danger` (required, no default — the bare base is abstract, C4); `disabled`; `type`; `title`; `children`; `hook`. No `size` prop — one size only (the spec has no `.btn.sm` rule). |
 | Card | `src/renderer/Card.tsx` | 3 — `Cards.tsx`, `Settings.tsx`, `NewSessionScreen.tsx` | `danger` (optional); `header`/`actions` slots |
 | Modal | `src/renderer/Modal.tsx` | 4 — `Sidebar.tsx`, `NewSessionScreen.tsx`, `Settings.tsx`, `FolderPickerModal.tsx` | `size: sm\|md\|lg`; `padded`; `tall`; `onDismiss`; `label` |
 | IconButton | `src/renderer/IconButton.tsx` | 2 — `SessionHeader.tsx`, `NewSessionScreen.tsx` | `size: md\|lg\|xl` (`xl` has a single adopting file, `NewSessionScreen.tsx`, by design — it is a size on an existing primitive, not a new primitive, so the two-adopter rule does not gate it); `ariaHaspopup`/`ariaExpanded`/`hook` |

--- a/src/renderer/Button.test.tsx
+++ b/src/renderer/Button.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+//
+// Component tests for the Button chrome primitive (BET-614, stage 1 of M527).
+//
+// As with the other primitives, the "tokens" are class names that map through
+// tailwind.config.js to the design tokens (rounded-md → --r-md, px-[14px] →
+// 14px, h-8 → 32px, text-accent → --accent). jsdom loads no stylesheet, so the
+// contract is asserted on the exact class strings — a retune of Button's chrome
+// fails here immediately. The two adopters (Settings.tsx + FolderPickerModal.tsx)
+// are migrated below through the real exported component.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { Button } from "./Button";
+
+const CHROME =
+  "inline-flex items-center gap-[6px] h-8 px-[14px] rounded-md border text-[12.5px] font-medium leading-none transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent disabled:opacity-50 disabled:cursor-not-allowed";
+
+const TONE = {
+  default: "border-border bg-bg text-text hover:bg-raised hover:border-border-strong",
+  primary: "border-accent-solid bg-accent-solid text-on-accent hover:brightness-110",
+  ghost: "border-transparent bg-transparent text-text-faint hover:bg-fill-hover hover:text-text",
+  danger: "border-transparent bg-transparent text-danger hover:bg-danger-bg",
+} as const;
+
+function buttonEl(h: Harness): HTMLButtonElement {
+  const el = h.container.querySelector("button") as HTMLButtonElement;
+  expect(el).toBeTruthy();
+  return el;
+}
+
+describe("Button", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders the base chrome plus the required tone classes for each of the four tones", () => {
+    (Object.keys(TONE) as (keyof typeof TONE)[]).forEach((tone) => {
+      h?.unmount();
+      h = mount(<Button tone={tone}>Save</Button>);
+      expect(buttonEl(h).className).toBe(`${CHROME} ${TONE[tone]}`);
+    });
+  });
+
+  it("has no size prop — one size only (the spec has no .btn.sm rule)", () => {
+    // If Button ever grew a `size` prop this directive becomes unused and
+    // typecheck fails.
+    // @ts-expect-error — Button must NOT accept a size prop (BET-614, C4)
+    void <Button tone="default" size="sm">x</Button>;
+    expect(true).toBe(true);
+  });
+
+  it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
+    // If Button ever grew a className prop this directive becomes unused and
+    // typecheck fails — the standing-decision-3 guard lives in the types.
+    // @ts-expect-error — Button must NOT accept className (M527 decision 3)
+    void <Button tone="default" className="bg-red-500">x</Button>;
+    expect(true).toBe(true);
+  });
+
+  it("renders the label as children", () => {
+    h = mount(<Button tone="primary">Select folder</Button>);
+    expect(buttonEl(h).textContent).toBe("Select folder");
+  });
+
+  it("passes onClick through", () => {
+    let clicked = 0;
+    h = mount(<Button tone="default" onClick={() => clicked++}>Go</Button>);
+    buttonEl(h).click();
+    expect(clicked).toBe(1);
+  });
+
+  it("wires the native disabled attribute", () => {
+    h = mount(<Button tone="default" disabled>Go</Button>);
+    expect(buttonEl(h).disabled).toBe(true);
+  });
+
+  it("defaults type to button and passes an explicit type through", () => {
+    h = mount(<Button tone="default">Go</Button>);
+    expect(buttonEl(h).getAttribute("type")).toBe("button");
+    h.rerender(<Button tone="default" type="submit">Go</Button>);
+    expect(buttonEl(h).getAttribute("type")).toBe("submit");
+  });
+
+  it("passes title through as the native tooltip", () => {
+    h = mount(<Button tone="default" title="Save changes">Save</Button>);
+    expect(buttonEl(h).getAttribute("title")).toBe("Save changes");
+  });
+
+  it("prepends a manta-* hook class when provided", () => {
+    h = mount(<Button tone="default" hook="manta-folder-confirm">Save</Button>);
+    expect(buttonEl(h).className).toBe(`manta-folder-confirm ${CHROME} ${TONE.default}`);
+  });
+});

--- a/src/renderer/Button.tsx
+++ b/src/renderer/Button.tsx
@@ -1,0 +1,79 @@
+// M527.Button — the button chrome primitive (BET-614, stage 1).
+//
+// Owns the ONE shared chrome for a labelled action button with NO `className`
+// escape hatch (epic standing decision 3): a caller cannot shear the height,
+// radius, padding, focus ring, tone or disabled state, so the button family can
+// only drift if Button itself is retuned.
+//
+// Chrome contract (BET-529 inventory): h-8 (32px) hit area, `--r-md` radius
+// (`rounded-md`), 14px inline padding (`px-[14px]` — a spec value, and the only
+// off-grid px this primitive carries; 32px resolves via `h-8`), a 6px icon gap
+// (`gap-[6px]`), 12.5px medium label (`text-[12.5px]`), `--accent` focus ring,
+// and the four spec tones. C4 (validated constraints): the bare base is
+// abstract (no background, no colour — invisible text), so `tone` is a REQUIRED
+// prop with no default; the base only becomes a real button once a tone picks
+// the surface. C1: every tone that sets a background or border also sets its
+// foreground (default sets bg+border+text together; primary sets accent bg +
+// `text-on-accent`; ghost/danger stay transparent-bg and set text only).
+//
+// Icons are the caller's job (a lucide icon at `size={14}`); the primitive does
+// not style children — it only reserves the `gap-[6px]` so an inline icon sits
+// beside the label. There is deliberately no size prop: the spec has no
+// `.btn.sm` rule, so there is one size only.
+
+import type { ReactNode } from "react";
+
+const BUTTON_BASE =
+  "inline-flex items-center gap-[6px] h-8 px-[14px] rounded-md border " +
+  "text-[12.5px] font-medium leading-none transition-colors " +
+  "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
+  "disabled:opacity-50 disabled:cursor-not-allowed";
+
+const BUTTON_TONE = {
+  default: "border-border bg-bg text-text hover:bg-raised hover:border-border-strong",
+  primary: "border-accent-solid bg-accent-solid text-on-accent hover:brightness-110",
+  ghost: "border-transparent bg-transparent text-text-faint hover:bg-fill-hover hover:text-text",
+  danger: "border-transparent bg-transparent text-danger hover:bg-danger-bg",
+} as const;
+
+export function Button({
+  tone,
+  onClick,
+  disabled,
+  type = "button",
+  title,
+  children,
+  hook,
+}: {
+  /** The visual tone. REQUIRED — the bare base is abstract (C4), so there is no safe default. */
+  tone: keyof typeof BUTTON_TONE;
+  onClick?: () => void;
+  /** Renders the native `disabled` attribute + the not-allowed cursor, and dims the chrome. */
+  disabled?: boolean;
+  /** Native `type`; defaults to `"button"`. */
+  type?: "button" | "submit" | "reset";
+  /** Native `title` tooltip. */
+  title?: string;
+  /** The button label (optionally with a lucide icon at `size={14}`). */
+  children: ReactNode;
+  /**
+   * A stable `manta-*` identity class for the call site (repo contract for
+   * popup triggers — the visual coverage registry keys on it). This is an
+   * IDENTITY hook, not a chrome class: it has no styling and cannot shear the
+   * chrome, so it is not the `className` escape hatch the epic forbids.
+   */
+  hook?: string;
+}) {
+  const className = `${hook ? `${hook} ` : ""}${BUTTON_BASE} ${BUTTON_TONE[tone]}`;
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      title={title}
+      className={className}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -34,6 +34,7 @@ import {
   worktreeBadge,
 } from "./folderPicker";
 import { Modal } from "./Modal";
+import { Button } from "./Button";
 
 type Props = {
   // The initial path the picker opens at. Usually "~" or the project's cwd.
@@ -435,18 +436,12 @@ export function FolderPickerModal({ initialPath, onSelect, onFanOut, onCancel }:
                 {gitState || "not a git repo"}
               </div>
               <div className="flex gap-2 shrink-0">
-                <button
-                  onClick={onCancel}
-                  className="text-meta px-3 py-2 text-text-muted hover:text-text"
-                >
+                <Button onClick={onCancel} tone="ghost">
                   Cancel
-                </button>
-                <button
-                  onClick={() => void select()}
-                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90"
-                >
+                </Button>
+                <Button onClick={() => void select()} tone="primary">
                   Select folder
-                </button>
+                </Button>
               </div>
             </div>
           </>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -24,6 +24,7 @@ import { applyTheme, type ThemePref } from "./theme";
 import { TtlToggle } from "./TtlToggle";
 import { Card } from "./Card";
 import { Field } from "./Field";
+import { Button } from "./Button";
 import { useSettingsToasts, useApplySetting, ToastStack } from "./settingsApply";
 import { errorDisclosure } from "./settingsError";
 import {
@@ -554,7 +555,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
           <GroupCard title="Danger zone" danger>
             <div className="flex items-start justify-between gap-4">
               <div className="text-body text-text-faint">Restore every setting below to its default. This does not remove your box pairing or projects.</div>
-              <button onClick={() => setConfirmReset(true)} className="shrink-0 px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Reset all settings…</button>
+              <Button onClick={() => setConfirmReset(true)} tone="danger">Reset all settings…</Button>
             </div>
           </GroupCard>
         </>
@@ -593,7 +594,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
             <AddPhonePanel />
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Re-run the guided setup (pairing, providers, first project).</div>
-              <button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} className="text-body px-4 py-2 rounded-xs border border-border text-text-muted hover:text-text shrink-0">Run setup again</button>
+              <Button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} tone="default">Run setup again</Button>
             </div>
           </GroupCard>
 
@@ -623,9 +624,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
           <GroupCard title="Danger zone" danger>
             <div className="flex items-center justify-between">
               <div className="text-body text-text-faint">Forget this box on the desktop. If the box is reachable, its current token is revoked too.</div>
-              <button onClick={() => setConfirmRemove(true)} disabled={removingBox} className="shrink-0 text-body px-4 py-2 rounded-xs border border-danger text-danger hover:bg-danger/10 disabled:opacity-40 disabled:cursor-not-allowed">
+              <Button onClick={() => setConfirmRemove(true)} disabled={removingBox} tone="default">
                 {removingBox ? "Removing…" : "Remove box"}
-              </button>
+              </Button>
             </div>
             {removeResult && !removeResult.ok && <div role="alert" className="text-body text-warn">{removeResult.message}</div>}
           </GroupCard>
@@ -834,9 +835,9 @@ export function Settings({ onClose }: { onClose: () => void }) {
               <span className="flex-1 text-body text-text">
                 An opencode restart is needed to apply recent model or endpoint changes. Restarting interrupts all running sessions.
               </span>
-              <button onClick={() => void performRestart()} disabled={restarting} className="shrink-0 px-3 py-2 text-body rounded-xs bg-warn-bg border border-warn text-warn hover:bg-warn/20 disabled:opacity-40">
+              <Button onClick={() => void performRestart()} disabled={restarting} tone="default">
                 {restarting ? "Restarting…" : "Restart opencode"}
-              </button>
+              </Button>
               <button onClick={() => setRestartNeeded(false)} disabled={restarting} className="shrink-0 px-2 py-2 text-body text-text-muted hover:text-text disabled:opacity-40">Later</button>
             </div>
           )}
@@ -879,7 +880,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
             <div className="text-body text-text-faint">The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts.</div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setConfirmRemove(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
-              <button onClick={removeBox} className="px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Remove</button>
+              <Button onClick={removeBox} tone="danger">Remove</Button>
             </div>
           </div>
         </Modal>
@@ -893,7 +894,7 @@ export function Settings({ onClose }: { onClose: () => void }) {
             <div className="text-body text-text-faint">Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.</div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setConfirmReset(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
-              <button onClick={resetAll} className="px-4 py-2 text-body rounded-xs border border-danger text-danger hover:bg-danger/10">Reset</button>
+              <Button onClick={resetAll} tone="danger">Reset</Button>
             </div>
           </div>
         </Modal>

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -23,7 +23,7 @@ import path from "node:path";
 
 // Every primitive in the M527 inventory. Adding one here is the whole cost of
 // putting it under the epic's rules.
-const PRIMITIVES = ["Card", "IconButton", "Field", "Pill", "MenuItem", "SessionRow", "Checkbox"] as const;
+const PRIMITIVES = ["Card", "IconButton", "Field", "Pill", "MenuItem", "SessionRow", "Checkbox", "Button"] as const;
 
 const RENDERER = fileURLToPath(new URL(".", import.meta.url));
 
@@ -142,6 +142,12 @@ const SINGLE_SURFACE: Set<string> = new Set(["SessionRow", "MenuItem"]);
 // the one spec-authorized component.
 const OFF_GRID_PX_ALLOWLIST: Record<string, number[]> = {
   SessionRow: [3, 7, 8, 13, 20, 26],
+  // Button's verbatim spec chrome (BET-611 stage 1): 14px inline padding
+  // (px-[14px]); 32px resolves via h-8, so it needs no entry. The 6px icon gap
+  // (gap-[6px]) and the 12.5px label (text-[12.5px] → 5px after the decimal)
+  // are the other spec pixel values in the BUTTON_BASE constant — all three
+  // are real values from the redesign spec's button definition, not drift.
+  Button: [5, 6, 14],
 };
 
 const SKIP_REASON: Record<string, string> = {
@@ -198,6 +204,7 @@ describe("M527 primitive rules", () => {
       "bg-black/40": ["Modal.tsx"], // the modal overlay tint
       "shadow-lg": ["Modal.tsx"], // window-level floating surface
       "peer-focus-visible:outline-accent": ["Checkbox.tsx"], // checkbox focus ring (BET-589)
+      "hover:brightness-110": ["Button.tsx"], // primary button hover brighten (BET-614)
     };
 
     it("no non-owner file contains a primitive's owned chrome", () => {


### PR DESCRIPTION
**BET-614.1 — `Button` primitive + two adopters** (stage 1 of the eight-component epic, BET-614).

## What

Adds the reusable `Button` chrome primitive and migrates its first two adopters, so the 66 button usages in the redesign spec can stop being copy-pasted inline Tailwind.

- **`src/renderer/Button.tsx`** — built verbatim from the spec's `BUTTON_BASE` / `BUTTON_TONE` constants. Props: `tone` (**required, no default** — the bare base is abstract, constraint C4), `onClick`, `disabled`, `type` (default `"button"`), `title`, `children`, `hook?`. Nothing else — **no `className`, no size prop** (the spec has no `.btn.sm` rule; one size only). Icons are the caller's job; the primitive reserves a `gap-[6px]` for an inline icon but styles no children.
- Chrome ownership registered in `primitives.test.ts`: `Button` added to `PRIMITIVES`, `hover:brightness-110` → `Button.tsx` in `CHROME_OWNERS`, and the spec px values allowlisted (`Button: [5, 6, 14]` — 14px is the spec inline padding; 32px resolves via `h-8`, so no entry; 6px is the icon gap and 5px is the `12.5px` label's fractional match that the off-grid regex flags).
- **Adopters migrated (both, per the two-adopter rule):**
  - `Settings.tsx` — all six bordered buttons → `Button`. `tone="danger"` for the three destructive confirms (Reset all settings…, modal Remove, modal Reset); `tone="default"` for the three inline settings-row actions (Run setup again, Remove box, Restart opencode) per the dispatch.
  - `FolderPickerModal.tsx` — footer Cancel → `tone="ghost"`, Select folder → `tone="primary"`.
- **`docs/components.md`** — `Button` added to the inventory table with its 2 adopters + variant axes.

**Net deletion** (state before/after in the two migrated files): the adopters' inline chrome shrank from **1638 → 882 characters** and **19 → 15 lines** across Settings.tsx + FolderPickerModal.tsx (−756 chars of duplicated Tailwind), replaced by 8 one-line `<Button>` usages. The 79-line primitive is the reusable half this stage invests in; later stages reuse it at each new adopt site.

## Verification results

**Files changed:** 6. `[docs/components.md, src/renderer/Button.test.tsx, src/renderer/Button.tsx, src/renderer/FolderPickerModal.tsx, src/renderer/Settings.tsx, src/renderer/primitives.test.ts]`

- PR branch (`multica/BET-614-Button-primitive` @ `HEAD`):
  - typecheck: exit 0. Errors: none. log sha256: `ce6f319a…`
  - test: exit 0 — vitest **1850 pass / 0 fail / 2 skip** (94 files); node:test **1435 pass / 0 fail**.
- Base (`main` @ `e99a1bd`):
  - typecheck: exit 0. Errors: none. log sha256: `ce6f319a…`
  - test: exit 0 — vitest **1838 pass / 0 fail / 2 skip** (93 files); node:test **1435 pass / 0 fail**.
- **Conclusion:** 0 failures on either branch. The PR adds **12 new vitest tests** (9 for `Button`, 3 primitive-rule checks for it) — all green. The 2 skips on both branches are the pre-existing owner-approved single-surface exemptions (SessionRow, MenuItem), unchanged.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `e99a1bd`**

## Self-check

- `Button.tsx` exists, spec-verbatim constants, `tone` required with no default → **9/10**
- Both adopters converted (all 6 Settings + FolderPicker footer pair) → **9/10**
- `PRIMITIVES` + `CHROME_OWNERS` + `OFF_GRID_PX_ALLOWLIST` updated → **9/10**
- `docs/components.md` inventory updated → **9/10**
- Net chrome deletion (adopters −756 chars) → **9/10**
- Typecheck + full suite green (0 failures, 12 new tests) → **9/10**
