### PR TITLE
VERIFY-000: shrink 14-line self-clone in onboardingVerify.test.ts

### DIFF
--- a/src/renderer/onboardingVerify.test.ts
+++ b/src/renderer/onboardingVerify.test.ts
@@ -50,19 +50,28 @@ describe("verifyStageLabels", () => {
   });
 });
 
+// Run the success path — a reply arrives after the probe — and capture the
+// api, progress trace, and result. Shared by the success test and the
+// resolved-with-undefined REGRESSION test; keeps the invoke-and-assert
+// boilerplate in one place.
+async function runSuccessVerify() {
+  const api = makeApi({ opencodeMessages: messagesSequence() });
+  const progress: string[] = [];
+  const out = await verifyOnboarding({
+    api,
+    providerLabel: "Claude",
+    modelLabel: "claude-sonnet-4",
+    timeoutMs: 5_000,
+    pollIntervalMs: 1,
+    now: () => 0,
+    onProgress: (p) => progress.push(`${p.stage}:${p.status}`),
+  });
+  return { api, progress, out };
+}
+
 describe("verifyOnboarding", () => {
   it("reports stage progress and deletes the ephemeral session on success", async () => {
-    const api = makeApi({ opencodeMessages: messagesSequence() });
-    const progress: string[] = [];
-    const out = await verifyOnboarding({
-      api,
-      providerLabel: "Claude",
-      modelLabel: "claude-sonnet-4",
-      timeoutMs: 5_000,
-      pollIntervalMs: 1,
-      now: () => 0,
-      onProgress: (p) => progress.push(`${p.stage}:${p.status}`),
-    });
+    const { api, progress, out } = await runSuccessVerify();
     expect(out).toEqual({ ok: true });
     expect(progress).toEqual(["0:running", "1:running", "2:running", "2:done"]);
     expect(api.opencodeCreateEphemeralSession).toHaveBeenCalledWith({
@@ -115,17 +124,7 @@ describe("verifyOnboarding", () => {
   });
 
   it("REGRESSION: a resolved-with-undefined prompt is success, not a stage-1 failure", async () => {
-    const api = makeApi({ opencodeMessages: messagesSequence() });
-    const progress: string[] = [];
-    const out = await verifyOnboarding({
-      api,
-      providerLabel: "Claude",
-      modelLabel: "claude-sonnet-4",
-      timeoutMs: 5_000,
-      pollIntervalMs: 1,
-      now: () => 0,
-      onProgress: (p) => progress.push(`${p.stage}:${p.status}`),
-    });
+    const { progress, out } = await runSuccessVerify();
     expect(out).toEqual({ ok: true });
     expect(progress).toEqual(["0:running", "1:running", "2:running", "2:done"]);
   });


### PR DESCRIPTION
## Verify-000: shrink the 14-line self-clone in onboardingVerify.test.ts

Factors the shared `verifyOnboarding` invoke-and-assert boilerplate (the
success-path run with `messagesSequence()` + Claude/claude-sonnet-4, 5s
timeout, 1ms poll, `now () => 0`, and the progress trace) out of the
success test and the resolved-with-undefined REGRESSION test into one local
helper `runSuccessVerify()`. Both tests keep their exact assertions — the
REGRESSION test is unchanged in behavior.

No gate config touched. No production code touched (test-only change).

`bash scripts/check-duplication-gate.sh origin/main` now exits 0 on this
branch (was FAIL with 1 clone / 13 lines); jscpd reports 0 clones.

**Files changed:** 1 file. `src/renderer/onboardingVerify.test.ts`

**Base: origin/main @ `7c09253`**

**Verification results:**
- PR branch (`multica/VERIFY-000-shrink-onboardingverify-clone` @ `8e0ba68`):
  - typecheck: exit 0. Errors: none. log sha256: `ce6f319a8d07e7d786f95c7eda54b1dab125a6d22595cbd596e39c8300d78963`
  - test: exit 0, 1435 pass / 0 fail / 0 skip. Failures: none. log sha256: `4ff5110076f1da341719cb4460d2e015439f51b29dd21348fd6ebb1c4c49b0e3`
- Base (`main` @ `7c09253`):
  - typecheck: exit 0. Errors: none. log sha256: `ce6f319a8d07e7d786f95c7eda54b1dab125a6d22595cbd596e39c8300d78963`
  - test: exit 0, 1435 pass / 0 fail / 0 skip. Failures: none. log sha256: `0f89527468bfbc62d726109792ae4dd8eca7145771d6f45985883b2a0e4e5348`
- **Conclusion:** 0 new failures, 0 pre-existing. Test-only change; the files' hashes are identical between branches because the change is confined to `onboardingVerify.test.ts` (a test file) and adds no behavior to production code.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**duplication-gate:** `bash scripts/check-duplication-gate.sh origin/main` exits 0 on this branch — before was FAIL (1 clone, 13 lines). Gate config untouched.
