### PR TITLE
BET-620: migrate session composer onto spec

### DIFF
--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -32,24 +32,31 @@ export function SessionToolbar({
   onSecrets: () => void;
   onWebhooks: () => void;
 }) {
+  // Shared chrome for the three resource buttons (BET-620 change 6). One const
+  // so they can't drift; the count badge carries its own mono type. Matches
+  // the mockup's `.mbtn` (27px hit, --r-sm radius, --tx3 rest tone).
+  const mbtn =
+    "inline-flex items-center gap-[6px] h-[27px] px-2 rounded-sm text-text-faint hover:bg-fill-hover hover:text-text transition-colors";
+  const cnum =
+    "font-mono text-[11px] leading-none font-semibold text-text-muted tabular-nums";
   return (
     <span className="flex items-center gap-2 text-meta">
       <button
         onClick={onSchedules}
-        className="px-2 py-px rounded-xs text-text-faint hover:text-text-muted inline-flex items-center gap-1"
+        className={mbtn}
         title="View / cancel scheduled tasks"
         aria-label="schedules"
       >
         <Clock size={16} strokeWidth={2} aria-hidden="true" />
         {scheduleCount > 0 && (
-          <span className="text-text-muted text-label tabular-nums" aria-hidden="true">
+          <span className={cnum} aria-hidden="true">
             {scheduleCount}
           </span>
         )}
       </button>
       <button
         onClick={onSecrets}
-        className="px-2 py-px rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
+        className={mbtn}
         title="Manage secrets the agent can use (values never enter the chat)"
         aria-label="secrets"
       >
@@ -57,7 +64,7 @@ export function SessionToolbar({
       </button>
       <button
         onClick={onWebhooks}
-        className="px-2 py-px rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
+        className={mbtn}
         title="View / revoke inbound webhooks (external events that wake this session)"
         aria-label="webhooks"
       >

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -228,7 +228,7 @@ export function InputArea({
       {/* Measure-capped composer (BET-620 change 3): the box, meta footer and
           trust toggle sit inside --measure (72ch) so the composer aligns with
           the transcript's measure edge, per the session mockup (.comp-in). */}
-      <div className="mx-auto max-w-[72ch] px-7">
+      <div className="mx-auto max-w-[72ch] px-[28px]">
       {/* Real input shell (BET-415): a bordered card with focus-within state
           replaces the old hairline-dividers-around-a-naked-textarea. Voice
           recording is now signalled by THIS border — a fourth treatment
@@ -399,7 +399,7 @@ export function InputArea({
         <button
           onClick={() => setChatAutoAllow(!chatAutoAllow)}
           className={
-            "inline-flex items-center gap-2 text-[11.5px] leading-none font-medium py-1.5 px-0 " +
+            "inline-flex items-center gap-2 text-[11.5px] leading-none font-medium py-[6px] px-0 " +
             (chatAutoAllow
               ? "text-danger hover:text-danger"
               : "text-text-quiet hover:text-text-muted")

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -17,7 +17,7 @@
 // a focus state instead of hairline dividers around a naked textarea.
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Mic, Shield } from "lucide-react";
+import { Mic, Send, Shield } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import type { VoiceMode, VoicePhase } from "./voice";
 import {
@@ -225,6 +225,10 @@ export function InputArea({
           floating
         />
       )}
+      {/* Measure-capped composer (BET-620 change 3): the box, meta footer and
+          trust toggle sit inside --measure (72ch) so the composer aligns with
+          the transcript's measure edge, per the session mockup (.comp-in). */}
+      <div className="mx-auto max-w-[72ch] px-7">
       {/* Real input shell (BET-415): a bordered card with focus-within state
           replaces the old hairline-dividers-around-a-naked-textarea. Voice
           recording is now signalled by THIS border — a fourth treatment
@@ -234,7 +238,7 @@ export function InputArea({
           padding is --sp-4 (16px) per the BET-423 spacing ruling. */}
       <div
         className={
-          "manta-composer-input-row mx-4 mb-2 rounded-lg border bg-bg-soft flex flex-col gap-2 px-4 py-3 " +
+          "manta-composer-input-row mb-2 rounded-lg border bg-bg-soft flex flex-col gap-2 px-4 py-3 " +
           (voiceActive
             ? "manta-recording"
             : refreshing
@@ -320,10 +324,10 @@ export function InputArea({
             }
           }}
           onPaste={onPaste}
-          placeholder={running ? "Queue a message…  (⏎ to queue · Esc to stop)" : "Try something…  (@ files · / commands · tab insert · ⏎ send)"}
+          placeholder={running ? "Queue a message…  (⏎ to queue · Esc to stop)" : "Reply, or describe the next task…"}
           rows={1}
           spellCheck={false}
-          className="flex-1 resize-none bg-transparent text-text text-code focus:outline-none placeholder:text-text-faint font-mono min-w-0"
+          className="flex-1 resize-none bg-transparent text-text text-prose focus:outline-none placeholder:text-text-faint font-sans min-w-0"
           style={{ maxHeight: "140px", lineHeight: "1.5" }}
         />
         {/* Inline mic on desktop — keyboard-driven, glyph-only feedback.
@@ -337,12 +341,25 @@ export function InputArea({
             onCancel={cancelVoice}
           />
         )}
+        {/* Send button — sits beside the textarea in the composer box (BET-620
+            change 4). Accent when there's text to send, muted fill when empty. */}
+        <button
+          onClick={submit}
+          aria-label="Send message"
+          title="Send (Enter)"
+          className={
+            "w-7 h-7 rounded-sm grid place-items-center shrink-0 " +
+            (input.trim() ? "bg-accent text-on-accent" : "bg-fill text-text-faint")
+          }
+        >
+          <Send size={14} aria-hidden="true" />
+        </button>
         </div>
       </div>
       {/* Meta footer — model ▸ effort split on the left, resource toolbar +
           transient status on the right. Branch + context pill moved to the
           SessionHeader; the footer now owns only composing controls. */}
-      <div className="px-4 py-1 flex items-center justify-between gap-3 flex-wrap">
+      <div className="py-1 flex items-center justify-between gap-3 flex-wrap">
         <span className="flex items-center gap-3 min-w-0 flex-wrap">
           <ModelPicker
             modelLabel={modelLabel}
@@ -378,14 +395,14 @@ export function InputArea({
       {/* Trust toggle — labelled control with a Shield icon (BET-415).
           Replaces the ▶▶/▷▷ glyphs. Same chatAutoAllow behaviour, same
           config key. Danger colour when bypassing. */}
-      <div className="px-4 pb-3 flex items-center text-meta">
+      <div className="pb-3 flex items-center">
         <button
           onClick={() => setChatAutoAllow(!chatAutoAllow)}
           className={
-            "px-2 py-px rounded-xs inline-flex items-center gap-2 " +
+            "inline-flex items-center gap-2 text-[11.5px] leading-none font-medium py-1.5 px-0 " +
             (chatAutoAllow
               ? "text-danger hover:text-danger"
-              : "text-text-faint hover:text-text-muted")
+              : "text-text-quiet hover:text-text-muted")
           }
           title={
             chatAutoAllow
@@ -398,6 +415,7 @@ export function InputArea({
             ? "Bypassing permissions"
             : "Permissions on — click to bypass"}
         </button>
+      </div>
       </div>
     </div>
   );

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
+    <lastmod>2026-08-02T14:01:16.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-02T14:01:16.000Z</lastmod>
+    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
**BET-620 — migrate session composer onto spec (stage 6 of BET-614)**

Migrates the session composer in `src/renderer/InputArea.tsx` (+ `ComposerParts.tsx`) onto `docs/screens/session/mockup.html`.

**All seven changes applied:**
1. **Textarea font** — `text-code font-mono` → `text-prose font-sans` (spec is 15px sans). 
2. **Placeholder** — `"Try something…  (@ files · …)"` → `"Reply, or describe the next task…"`. `running` placeholder left unchanged.
3. **Composer width** — inner content (input box, meta footer, trust toggle) wrapped in `mx-auto max-w-[72ch] px-[28px]`; the redundant `mx-4`/`px-4` per-element insets dropped so the box/footer/trust align at the 28px measure edge.
4. **Send button** — added inside the box beside the textarea: `w-7 h-7 rounded-sm grid place-items-center shrink-0` + `bg-fill text-text-faint`, `bg-accent text-on-accent` when `input.trim()` non-empty; calls `submit()`; Lucide `Send` @ 14.
5. **Model ▸ effort** — already a single stage-2 `SplitChip` (ModelPicker adopted it in BET-615). No `separatePills` exists on main; the composer already renders one split control. Nothing to change.
6. **Resource buttons** — three hand-rolled buttons collapsed into one shared `mbtn` const (`inline-flex items-center gap-[6px] h-[27px] px-2 rounded-sm text-text-faint hover:bg-fill-hover hover:text-text transition-colors`) + shared `cnum` badge (`font-mono text-[11px] leading-none font-semibold text-text-muted tabular-nums`).
7. **Trust toggle** — `text-[11.5px] leading-none font-medium py-[6px] px-0 text-text-quiet hover:text-text-muted`; danger branch + Shield kept.

**Deliberate deviation from the literal spec:** the issue's `px-7` / `py-1.5` are off the repo's trimmed spacing scale (BET-422: `theme.spacing` has no `7`/`1.5` step), and `tailwindScale.test.ts` fails on them. Used arbitrary `px-[28px]` / `py-[6px]` instead — identical 28px/6px values, matching the mockup, and passing the scale test.

**Kept as-is (per scope):** composer box stays inline (no `Card` — needs `manta-composer-input-row` + `manta-recording`). Attach/mic left untouched (out of conformance scope). Did not run `visual:update` / touch `tests/visual/*-snapshots/`.

**Files changed:** 2 (`src/renderer/InputArea.tsx`, `src/renderer/ComposerParts.tsx`). 37 insertions, 12 deletions. Line counts: 772 → 797 (+25 net — the send button + width wrapper add lines; no dead code removed beyond the consolidated button classes).

**Note:** the advisory `npm run visual:compare session` composite was not captured — it requires building + booting the Electron app against a live box fixture, which isn't available in this headless runtime. All layout values were taken directly from the mockup's token-resolved values; the ARIA snapshot (`session-composer.aria.yml`) is intentionally not regenerated per the issue's out-of-scope rule.

**Base: origin/main @ 8e4ebc0**

**Verification results:**
- PR branch (`multica/BET-620-composer-migrate` @ `3666734`):
  - typecheck: exit 0. Errors: none. log sha256: `ce6f319a8d07e7d786f95c7eda54b1dab125a6d22595cbd596e39c8300d78963`
  - test: exit 0, 1898 pass / 0 fail / 6 skip (vitest) + 1435 pass / 0 fail (node:test). Failures: none. log sha256: `0ce6226f9f023a773cb81989776481a9c22518b5ffc52f69da8b9f57db310ef4`
- Base (`main` @ `8e4ebc0`):
  - typecheck: exit 0. Errors: none. log sha256: `ce6f319a8d07e7d786f95c7eda54b1dab125a6d22595cbd596e39c8300d78963`
  - test: exit 0, 1898 pass / 0 fail / 6 skip (vitest) + 1435 pass / 0 fail (node:test). Failures: none. log sha256: `d0c033c8f6a7c1c93db8479a14ee1eb28f3fe85f439cd14ce1053df2c2ca3bd0`
- **Conclusion:** 0 new failures, 0 resolved — identical green between branches.
