### PR TITLE
BET-625: test(ios): live-box pairing driver UI test + document the staging box

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1958,18 +1958,16 @@ agent blocks — so a not-yet-registered model still shows up.
 
 ## iOS release / TestFlight (Codemagic — the WORKING mechanism)
 
-The iOS app (the native SwiftUI client in `mobile/native/`) ships to TestFlight
-via **Codemagic CI**, configured by **`codemagic.yaml`** at the repo root. This
+The iOS app (the Capacitor wrapper in `mobile/ios/`) ships to TestFlight via
+**Codemagic CI**, configured by **`codemagic.yaml`** at the repo root. This
 section is the hard-won record of what works and — just as important — the dead
-ends, so nobody re-walks them. (Restored in BET-601 after BET-559 removed it
-with the retired Capacitor wrapper; the pipeline now builds the native app.)
+ends, so nobody re-walks them.
 
 **TL;DR of the pipeline:** push a git tag `ios-v*` → Codemagic clones the repo,
-runs xcodegen against `mobile/native/project.yml` (source of truth →
-`MantaUI.xcodeproj`), **creates its own distribution cert + App Store profile
-via the App Store Connect API key** from a PERSISTENT private key, archives the
-`MantaUI` scheme, and uploads to TestFlight. No Mac in the loop. The box can
-drive the whole thing (trigger + monitor) over the Codemagic + ASC REST APIs.
+builds the web bundle, syncs Capacitor, pods, **creates its own distribution
+cert + App Store profile via the App Store Connect API key**, archives the
+`App` scheme, and uploads to TestFlight. No Mac in the loop. The box can drive
+the whole thing (trigger + monitor) over the Codemagic + ASC REST APIs.
 
 ### Why Codemagic, NOT Xcode Cloud (do not retry Xcode Cloud)
 
@@ -1993,28 +1991,25 @@ disconnecting/reconnecting the GitHub source. The `action_required` /
 emails were all downstream of this one auth failure (the ITMS-90035 signature
 errors specifically came from Xcode Cloud's throwaway **ad-hoc / development**
 side-exports, which are red herrings — the app-store export signed correctly).
-**Do not reintroduce an Xcode Cloud workflow.** The Capacitor wrapper it left
-stale files in (`mobile/ios/…`) was itself deleted in BET-559; the native app it
-replaced uses Codemagic's `app-store-connect` CLI + `xcode-project`, which
-authenticate and upload reliably — no Xcode Cloud auth path.
-
+**Do not reintroduce an Xcode Cloud workflow.** The stale files it left
+(`mobile/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme` and
+`mobile/ios/App/ci_scripts/ci_post_clone.sh`) are harmless leftovers; the
+shared scheme is still needed by Codemagic, the `ci_scripts/` post-clone is
+Xcode-Cloud-only and unused by Codemagic (safe to delete).
 
 ### App Store Connect facts (constants used everywhere)
 
 - **App name**: MantaUI. **ASC app Apple ID**: `6792363427`.
 - **Bundle id**: `com.antoinedc.mantaui` (was `com.antoinedc.MantaUI` originally —
   renamed before anything shipped; the id is permanent post-release). Set in
-  `mobile/native/project.yml` `PRODUCT_BUNDLE_IDENTIFIER` (xcodegen generates it
-  into the pbxproj's Debug+Release configs).
-- **On-device display name**: MantaUI (`PRODUCT_NAME` /
-  `INFOPLIST_KEY_CFBundleDisplayName` in `mobile/native/project.yml`;
-  `INFOPLIST_FILE: MantaUI/Info.plist`).
-- **Xcode target/scheme**: `MantaUI` (defined in `mobile/native/project.yml`;
-  xcodegen generates the scheme). This is the scheme name Codemagic's
-  `ios-testflight` workflow archives.
-- **Version source**: `MARKETING_VERSION` lives in `mobile/native/project.yml`
-  (both Debug+Release via xcodegen). This is what `ios-release-tag.yml` reads to
-  create the `ios-v<version>` tag, so bump it there to ship.
+  `capacitor.config.json` `appId`, the iOS `PRODUCT_BUNDLE_IDENTIFIER` (both
+  Debug+Release configs), and the Android `applicationId`/`namespace`/
+  `MainActivity` package.
+- **On-device display name**: MantaUI (`CFBundleDisplayName` in
+  `mobile/ios/App/App/Info.plist` + `appName` in `capacitor.config.json`).
+- **Xcode target/scheme**: `App` (Capacitor convention — internal only, NOT
+  user-visible; do NOT rename it, that path throws "already taken by your team"
+  and breaks the scheme/pods/ci_scripts wiring).
 - **Team ID (seedId)**: `FSQ3HS4Z24`.
 
 ### Signing — the crux, and every trap in order
@@ -2023,10 +2018,8 @@ iOS code signing was THE blocker (every archive failure traced to it). The
 final working model, in `codemagic.yaml`'s "Set up code signing" step:
 
 1. `keychain initialize`
-2. **Materialize the PERSISTENT RSA private key** from the `ios_signing` env
-   group's `CERTIFICATE_PRIVATE_KEY` into `/tmp/dist_key` (chmod 600). One stable
-   key ⇒ one stable distribution cert reused across builds. (Per-build throwaway
-   keys were REMOVED after the ios-v1.0.8 outage — see the root-cause lesson.)
+2. **Generate an RSA private key ON the build machine**
+   (`ssh-keygen -t rsa -b 2048 -m PEM -f /tmp/dist_key -q -N ""`).
 3. **Create a distribution cert FROM that key** via the ASC API key
    (`app-store-connect certificates create --type IOS_DISTRIBUTION
    --certificate-key=@file:/tmp/dist_key --save`), falling back to
@@ -2047,11 +2040,8 @@ only usable by whoever holds its **private key**. Every early failure
 requires a provisioning profile`) came from a cert whose private key was NOT on
 the Codemagic build machine. A cert created out-of-band (e.g. via the ASC API
 from the box, with the key on the box) is **worthless to Codemagic**. The build
-machine must HOLD the key and create the cert from it (steps 2→3 above) — this
-is the single most important thing in this section. The key is the PERSISTENT
-`CERTIFICATE_PRIVATE_KEY` (ios_signing group) so the same cert is reused across
-builds; never switch back to a per-build throwaway key (see the ios-v1.0.8 note
-below).
+machine MUST generate the key and create the cert from it. This is step 2→3
+above and is the single most important thing in this section.
 
 **Dead ends that were tried and REMOVED (do not reintroduce):**
 - A declarative `environment: ios_signing:` block → resolves signing at
@@ -2061,13 +2051,11 @@ below).
   Xcode project → the profile Codemagic installs on the machine isn't named
   that, so xcodebuild errors "No profile … matching 'MantaUI App Store'".
   Let `use-profiles` set the specifier instead.
-- `CODE_SIGN_STYLE = Automatic` in the project → **do NOT rely on Automatic
-  signing to resolve profiles.** The native `mobile/native/project.yml` sets
-  `CODE_SIGN_STYLE: Automatic`; leave it that way — the "Set up code signing"
-  step's `xcode-project use-profiles` flips the generated project to Manual with
-  the fetched App Store profile at build time. The failure mode was Automatic
-  WITHOUT `use-profiles` (expecting Xcode to auto-pick a profile), which errors
-  "No profile … matching". Don't hand-edit project.yml to Manual.
+- `CODE_SIGN_STYLE = Automatic` in the project → conflicts with Codemagic's
+  Manual signing. The project's target Release config is now
+  `CODE_SIGN_STYLE = Manual` + `DEVELOPMENT_TEAM = FSQ3HS4Z24` +
+  `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "Apple Distribution"` (no hardcoded
+  profile specifier — `use-profiles` fills it).
 - `--export-options-plist /tmp/export_options.plist` → wrong path;
   `use-profiles` writes it to `$CM_BUILD_DIR/export_options.plist`. Both the
   `use-profiles` and `build-ipa` calls must use the SAME `$CM_BUILD_DIR` path.
@@ -2092,8 +2080,8 @@ Codemagic's API.
 `codemagic.yaml`'s `triggering:` builds on git tag `ios-v*`. The box can:
 - **Trigger by tag**: push `ios-v<version>` (the `ios-release-tag.yml` GitHub
   Actions workflow auto-creates `ios-v<MARKETING_VERSION>` on merge to main —
-  reads `MARKETING_VERSION` from `mobile/native/project.yml`; idempotent, only
-  tags a new version; `workflow_dispatch` force-tags with a build suffix).
+  reads `MARKETING_VERSION` from `project.pbxproj`; idempotent, only tags a new
+  version; `workflow_dispatch` force-tags with a build suffix).
 - **Trigger by Codemagic API** (what was used during bring-up — does NOT need a
   tag, good for iterating):
   ```
@@ -2142,11 +2130,9 @@ Beta App Review of the first build.
 ### Versioning
 
 `MARKETING_VERSION` (CFBundleShortVersionString) lives in
-`mobile/native/project.yml` (xcodegen writes it to both Debug+Release configs of
-the generated pbxproj). Bump it there to ship a new TestFlight version; the
-auto-tag workflow keys off it. `CURRENT_PROJECT_VERSION` (build
+`project.pbxproj` (both Debug+Release). Bump it to ship a new TestFlight
+version; the auto-tag workflow keys off it. `CURRENT_PROJECT_VERSION` (build
 number) — Codemagic/ASC handle uniqueness. First shipped version: `1.0.1`.
-Current native source has `0.1.0` (pre-first-release).
 
 ## Release & CD pipeline — TAG-DRIVEN, one manual step
 
@@ -2181,7 +2167,7 @@ the ONE monorepo; the tag prefix is what routes.
 
 **How to cut a release (all targets):**
 ```
-# iOS — bump MARKETING_VERSION in mobile/native/project.yml first, merge, then:
+# iOS — bump MARKETING_VERSION in project.pbxproj first, merge, then:
 git tag ios-v1.0.8 && git push origin ios-v1.0.8
 # (the ios-release-tag.yml workflow also AUTO-tags ios-v<MARKETING_VERSION> on
 #  merge to main, so iOS often needs no manual tag — just the version bump.)
@@ -2420,6 +2406,35 @@ it impossible rather than unlikely. The mac-desktop build's overlay
 (`electron-builder.staging.yml`, created in BET-370) changes appId +
 productName + URL scheme + update-feed URL + dmg filename so staging can
 install side-by-side with prod on the same Mac.
+
+### Staging TEST BOX — disposable, reset it freely
+
+`dev@135.181.255.249` (Hetzner `ubuntu-2gb-hel1-1`) is a **throwaway staging
+box** used to test the installer, pairing, and the mobile/desktop clients
+end-to-end against a real box that is NOT anyone's working machine. **It carries
+no work worth keeping: wipe it, re-install it, revoke its tokens, restart its
+services, change its config — no coordination needed.** Do NOT do any of that to
+the dev box (`dev@157.90.224.92`) or the prod box.
+
+- Installed the normal user way (`curl mantaui.com/install.sh | bash`), so it
+  is a plain box install at `~/manta` (runtime node at
+  `~/manta/runtime/node/bin/node`), NOT a git clone of this repo. There is no
+  `~/projects/better-ui` on it.
+- Services are `systemd --user`: `manta-server` (127.0.0.1:8787) and
+  `opencode-serve`. Restart with `systemctl --user restart manta-server`.
+- Public ingress is the standard gateway path: `~/.manta/ingress.json` is
+  `{"mode":"public"}` and `~/.manta/auth.json` carries `gateway_host`
+  `<box_id>.boxes.mantaui.com` — i.e. the box is reachable from a phone /
+  simulator over HTTPS with no tunnel. `GET /` returns **401** from outside;
+  that is the auth gate working, not a broken box.
+- Pair a client against it by minting a code ON the box —
+  `ssh dev@135.181.255.249 'curl -s http://127.0.0.1:8787/auth/pair'` — then
+  entering the code plus the `https://<box_id>.boxes.mantaui.com` server URL in
+  the client. `/auth/pair` is loopback-only by design, so the SSH hop is
+  mandatory.
+- Its SSH host key changes whenever it is reimaged. A
+  `REMOTE HOST IDENTIFICATION HAS CHANGED` warning for this IP is expected —
+  `ssh-keygen -R 135.181.255.249` and reconnect.
 
 ### Prod box topology (why deploys are shaped this way)
 

--- a/generated/swift/Theme.swift
+++ b/generated/swift/Theme.swift
@@ -58,7 +58,7 @@ struct Tokens {
         let accentTx: Color = Color(hex: "#1F55D6")
         let accentSolid: Color = Color(hex: "#1F55D6")
         let onAccent: Color = Color(hex: "#FFFFFF")
-        let accentSoft: Color = Color(hex: "#1F55D6")
+        let accentSoft: Color = Color(hex: "#DFE8FF")
         let ok: Color = Color(hex: "#0A7A53")
         let warn: Color = Color(hex: "#8A5A08")
         let danger: Color = Color(hex: "#BE2F3C")

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -18,6 +18,10 @@ final class ChatModelStore: ObservableObject {
     @Published private(set) var models: [OpencodeModel] = []
     @Published private(set) var defaultModel: OpencodeModelID?
     @Published private(set) var override: OpencodeModelID?
+    /// Reasoning-effort variant for the selected model (opencode calls these
+    /// model "variants"). Model-specific, so it is cleared whenever the model
+    /// changes rather than carried onto a model that has no such setting.
+    @Published private(set) var variant: String?
     @Published private(set) var loadFailed = false
 
     let sessionId: String
@@ -27,11 +31,16 @@ final class ChatModelStore: ObservableObject {
         self.sessionId = sessionId
         self.api = api
         self.override = Self.loadOverride(for: sessionId)
+        self.variant = UserDefaults.standard.string(forKey: Self.variantKey(for: sessionId))
     }
 
     /// The UserDefaults key mirroring the desktop's per-session model key.
     static func storageKey(for sessionId: String) -> String {
         "manta:chat:\(sessionId):model"
+    }
+
+    static func variantKey(for sessionId: String) -> String {
+        "manta:chat:\(sessionId):variant"
     }
 
     func load() {
@@ -54,17 +63,36 @@ final class ChatModelStore: ObservableObject {
     /// The selection to send on `opencode:prompt` (nil = let opencode pick).
     var promptModel: SendPromptInput.Model? {
         guard let active else { return nil }
-        return SendPromptInput.Model(providerID: active.providerID, modelID: active.modelID, variant: nil)
+        return SendPromptInput.Model(providerID: active.providerID, modelID: active.modelID, variant: variant)
     }
 
-    /// Set (or clear, with nil) the per-session override, persisting it.
+    /// Set (or clear, with nil) the per-session override, persisting it. A
+    /// model change drops the effort variant: the levels one model offers mean
+    /// nothing on another, and most models offer none at all.
     func setOverride(_ id: OpencodeModelID?) {
+        let modelChanged = id != override
         override = id
         if let id {
             UserDefaults.standard.set(ChatModel.encode(id), forKey: Self.storageKey(for: sessionId))
         } else {
             UserDefaults.standard.removeObject(forKey: Self.storageKey(for: sessionId))
         }
+        if modelChanged { setVariant(nil) }
+    }
+
+    /// Set (or clear) the effort variant for the active model.
+    func setVariant(_ id: String?) {
+        variant = id
+        if let id, !id.isEmpty {
+            UserDefaults.standard.set(id, forKey: Self.variantKey(for: sessionId))
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.variantKey(for: sessionId))
+        }
+    }
+
+    /// The effort variants the ACTIVE model offers (empty when it has none).
+    var activeVariants: [OpencodeModel.Variant] {
+        ChatModel.activeModel(models, override: override, default: defaultModel)?.variants ?? []
     }
 
     static func loadOverride(for sessionId: String) -> OpencodeModelID? {

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -214,8 +214,6 @@ struct ChatSubagentScreen: View {
     let tokens: Tokens
     @Environment(\.dismiss) private var dismiss
 
-    private static let bottomAnchorID = "subagent-transcript-bottom"
-
     var body: some View {
         VStack(spacing: 0) {
             SubagentHeader(
@@ -224,32 +222,17 @@ struct ChatSubagentScreen: View {
                 onBack: { dismiss() },
                 tokens: tokens
             )
-            // `defaultScrollAnchor(.bottom)` alone is not enough here: the
-            // child transcript arrives AFTER the first layout, and a LazyVStack
-            // measures nothing until its rows materialise, so the anchor is
-            // applied against a near-empty content height. The offset then
-            // never corrects — which is the dead space that appeared above the
-            // child's first row. An explicit scroll to a bottom sentinel when
-            // the content changes settles it whatever order things arrive in.
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        TranscriptView(blocks: store.blocks, tokens: tokens)
-                        Color.clear
-                            .frame(height: 1)
-                            .id(Self.bottomAnchorID)
-                    }
-                }
-                .defaultScrollAnchor(.bottom)
-                .onChange(of: store.blocks.count) { _ in
-                    proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
-                }
-                .onAppear {
-                    DispatchQueue.main.async {
-                        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
-                    }
+            // `.bottom` ALONE also aligns SHORT content to the bottom, which
+            // is what put a screenful of dead space above a subagent report
+            // that does not fill the view. Scoping the anchor to `.sizeChanges`
+            // keeps the useful half — the view sticks to the bottom as the
+            // child streams — while content that fits simply starts at the top.
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    TranscriptView(blocks: store.blocks, tokens: tokens)
                 }
             }
+            .defaultScrollAnchor(.bottom, for: .sizeChanges)
         }
         .background(tokens.canvas.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -214,6 +214,8 @@ struct ChatSubagentScreen: View {
     let tokens: Tokens
     @Environment(\.dismiss) private var dismiss
 
+    private static let bottomAnchorID = "subagent-transcript-bottom"
+
     var body: some View {
         VStack(spacing: 0) {
             SubagentHeader(
@@ -222,12 +224,32 @@ struct ChatSubagentScreen: View {
                 onBack: { dismiss() },
                 tokens: tokens
             )
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    TranscriptView(blocks: store.blocks, tokens: tokens)
+            // `defaultScrollAnchor(.bottom)` alone is not enough here: the
+            // child transcript arrives AFTER the first layout, and a LazyVStack
+            // measures nothing until its rows materialise, so the anchor is
+            // applied against a near-empty content height. The offset then
+            // never corrects — which is the dead space that appeared above the
+            // child's first row. An explicit scroll to a bottom sentinel when
+            // the content changes settles it whatever order things arrive in.
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        TranscriptView(blocks: store.blocks, tokens: tokens)
+                        Color.clear
+                            .frame(height: 1)
+                            .id(Self.bottomAnchorID)
+                    }
+                }
+                .defaultScrollAnchor(.bottom)
+                .onChange(of: store.blocks.count) { _ in
+                    proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+                }
+                .onAppear {
+                    DispatchQueue.main.async {
+                        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+                    }
                 }
             }
-            .defaultScrollAnchor(.bottom)
         }
         .background(tokens.canvas.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -124,10 +124,20 @@ struct ChatScreen: View {
 
             Spacer(minLength: 0)
 
-            // Trailing 38×38 glass button (§8) — a placeholder in S4 (the
-            // overflow sheet with fork/settings is a later stage).
-            Color.clear
-                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+            // Trailing 38×38 glass button (§8) — a tappable placeholder in S4.
+            // Inert until BET-626 builds the real overflow sheet; it carries a
+            // stable identifier so the simulator capture driver (BET-625) and
+            // BET-626 can both address it. No action yet — BET-626 wires it.
+            Button(action: {}) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                    .background(.ultraThinMaterial, in: Circle())
+                    .accessibilityLabel("More options")
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("overflow-button")
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -79,7 +79,11 @@ struct ChatScreen: View {
         }
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
-        .overlay(alignment: .top) { header }
+        // The header is an INSET, not an overlay: as an overlay it floated on
+        // top of the transcript with nothing reserving its space, so the first
+        // rows sat underneath it and were clipped at rest, not just while
+        // scrolling.
+        .safeAreaInset(edge: .top) { header }
         .onAppear { store.start() }
         .onDisappear { store.stop() }
         .accessibilityElement(children: .contain)

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -53,6 +53,7 @@ struct ComposerView: View {
     /// Measured height of the input. See MultilineTextView: a scroll-enabled
     /// UITextView has no intrinsic height, so the composer must give it one.
     @State private var inputHeight: CGFloat = Metrics.type.display
+    @State private var showModelPicker = false
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
@@ -86,6 +87,9 @@ struct ComposerView: View {
         .padding(.vertical, Metrics.spacing.sp2)
         .background(tokens.canvas.ignoresSafeArea())
         .overlay(alignment: .top) { divider }
+        .sheet(isPresented: $showModelPicker) {
+            ModelPickerSheet(modelStore: modelStore)
+        }
         .photosPicker(isPresented: $showPhotoPicker, selection: $photoItems, maxSelectionCount: 5, matching: .images)
         .fileImporter(isPresented: $showDocPicker, allowedContentTypes: [.item]) { result in
             handleDocument(result)
@@ -111,27 +115,8 @@ struct ComposerView: View {
     // MARK: - Model pill
 
     private var modelPill: some View {
-        Menu {
-            Button {
-                modelStore.setOverride(nil)
-            } label: {
-                Label(settingIsDefault ? "Default (in use)" : "Default", systemImage: settingIsDefault ? "checkmark" : "circle")
-            }
-            if modelStore.models.isEmpty {
-                Text("No models")
-            } else {
-                ForEach(ChatModel.groups(modelStore.models), id: \.provider) { group in
-                    Section(group.provider) {
-                        ForEach(group.models, id: \.id) { model in
-                            Button {
-                                modelStore.setOverride(OpencodeModelID(providerID: model.providerID, modelID: model.id))
-                            } label: {
-                                Label(model.name, systemImage: isActive(model) ? "checkmark" : "circle")
-                            }
-                        }
-                    }
-                }
-            }
+        Button {
+            showModelPicker = true
         } label: {
             HStack(spacing: Metrics.spacing.sp1) {
                 Image(systemName: "sparkles")
@@ -139,23 +124,22 @@ struct ComposerView: View {
                 Text(ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel))
                     .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                     .lineLimit(1)
+                if let variant = modelStore.variant, !variant.isEmpty {
+                    Text("·")
+                        .font(.system(size: Metrics.type.small))
+                    Text(variant.capitalized)
+                        .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                        .lineLimit(1)
+                }
             }
             .foregroundColor(tokens.accentTx)
             .padding(.horizontal, Metrics.spacing.sp2)
             .padding(.vertical, Metrics.spacing.sp1)
             .background(tokens.accentSoft, in: Capsule())
         }
+        .buttonStyle(.plain)
         .accessibilityLabel("Model picker")
         .accessibilityIdentifier("model-picker")
-    }
-
-    private var settingIsDefault: Bool {
-        modelStore.override == nil
-    }
-
-    private func isActive(_ model: OpencodeModel) -> Bool {
-        guard let active = modelStore.active else { return false }
-        return active.providerID == model.providerID && active.modelID == model.id
     }
 
     // MARK: - Attach

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -50,6 +50,9 @@ struct ComposerView: View {
     @StateObject private var recorder = VoiceRecorder()
     @State private var micMode: VoiceMode = .dictate
     @State private var micRecording = false
+    /// Measured height of the input. See MultilineTextView: a scroll-enabled
+    /// UITextView has no intrinsic height, so the composer must give it one.
+    @State private var inputHeight: CGFloat = Metrics.type.display
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
@@ -64,14 +67,17 @@ struct ComposerView: View {
             HStack(alignment: .bottom, spacing: Metrics.spacing.sp2) {
                 MultilineTextView(
                     text: $text,
+                    height: $inputHeight,
                     controller: controller,
                     placeholder: "Message…",
                     font: UIFont.systemFont(ofSize: Metrics.type.body),
                     textColor: UIColor(tokens.tx1),
                     placeholderColor: UIColor(tokens.tx4),
+                    minHeight: Metrics.type.display,
                     maxHeight: Metrics.type.display * 3
                 )
                 .frame(maxWidth: .infinity)
+                .frame(height: inputHeight)
                 if micAvailable { micButton }
                 sendButton
             }
@@ -90,7 +96,9 @@ struct ComposerView: View {
         .onAppear {
             modelStore.load()
             checkMicAvailability()
-            controller.focus()
+            // Deliberately NOT focusing the input here: raising the keyboard on
+            // entry hides most of the transcript you opened the session to
+            // read. Tapping the input is the way in, as in Messages.
         }
     }
 

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -279,7 +279,7 @@ struct OpencodeModel: Codable, Equatable, Sendable {
 
 /// `{ providerID, modelID }` — the minimal selection sent with a prompt and
 /// returned by `opencode:default-model`.
-struct OpencodeModelID: Codable, Equatable, Sendable {
+struct OpencodeModelID: Codable, Equatable, Hashable, Sendable {
     var providerID: String
     var modelID: String
 

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+// ===========================================================================
+// Model + effort selection.
+//
+// These are TWO independent choices and are presented as such: which model
+// answers, and how much reasoning effort it spends. Effort is model-specific
+// (opencode exposes it as a model's "variants"), so the effort list is derived
+// from the chosen model and is simply absent for a model that offers none —
+// rather than being a fixed set of levels that silently do nothing.
+//
+// Stock components on purpose: a Form with two navigation-link Pickers is the
+// system's own shape for this, complete with checkmarks, grouped sections,
+// search-free scrolling of a long provider list, dynamic type and VoiceOver.
+// The menu it replaces put every provider, model and level in one long popup.
+// ===========================================================================
+
+struct ModelPickerSheet: View {
+    @ObservedObject var modelStore: ChatModelStore
+    @Environment(\.dismiss) private var dismiss
+
+    /// `nil` = follow the box's configured default.
+    private var modelSelection: Binding<OpencodeModelID?> {
+        Binding(
+            get: { modelStore.override },
+            set: { modelStore.setOverride($0) }
+        )
+    }
+
+    private var variantSelection: Binding<String?> {
+        Binding(
+            get: { modelStore.variant },
+            set: { modelStore.setVariant($0) }
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Model", selection: modelSelection) {
+                        Text("Default").tag(OpencodeModelID?.none)
+                        ForEach(ChatModel.groups(modelStore.models), id: \.provider) { group in
+                            Section(group.provider) {
+                                ForEach(group.models, id: \.id) { model in
+                                    Text(model.name)
+                                        .tag(Optional(OpencodeModelID(providerID: model.providerID, modelID: model.id)))
+                                }
+                            }
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+                } footer: {
+                    Text(modelFooter)
+                }
+
+                Section {
+                    if modelStore.activeVariants.isEmpty {
+                        LabeledContent("Effort") {
+                            Text("Not available")
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Picker("Effort", selection: variantSelection) {
+                            Text("Default").tag(String?.none)
+                            ForEach(modelStore.activeVariants, id: \.id) { variant in
+                                Text(variant.id.capitalized).tag(Optional(variant.id))
+                            }
+                        }
+                        .pickerStyle(.navigationLink)
+                    }
+                } footer: {
+                    Text(effortFooter)
+                }
+            }
+            .navigationTitle("Model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .onAppear { modelStore.load() }
+    }
+
+    private var modelFooter: String {
+        modelStore.override == nil
+            ? "Using the model your box is configured to use."
+            : "This choice applies to this session only."
+    }
+
+    private var effortFooter: String {
+        modelStore.activeVariants.isEmpty
+            ? "This model has no effort setting."
+            : "More effort means more reasoning time before it answers."
+    }
+}

--- a/mobile/native/MantaUI/MultilineTextView.swift
+++ b/mobile/native/MantaUI/MultilineTextView.swift
@@ -34,11 +34,19 @@ final class ComposerTextController: ObservableObject {
 
 struct MultilineTextView: UIViewRepresentable {
     @Binding var text: String
+    /// Measured height of the text, clamped to [minHeight, maxHeight]. A
+    /// scroll-enabled UITextView reports NO intrinsic content size, so without
+    /// this the representable is a greedy view: SwiftUI hands it every point of
+    /// free space and the composer grows to the full screen — the field pinned
+    /// to the top with its own send/mic buttons stranded at the bottom. The
+    /// height is measured here and applied by the composer as a real frame.
+    @Binding var height: CGFloat
     @ObservedObject var controller: ComposerTextController
     var placeholder: String
     var font: UIFont
     var textColor: UIColor
     var placeholderColor: UIColor
+    var minHeight: CGFloat
     var maxHeight: CGFloat
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
@@ -55,7 +63,9 @@ struct MultilineTextView: UIViewRepresentable {
         view.delegate = context.coordinator
         view.accessibilityIdentifier = "composer-input"
         controller.textView = view
+        view.setContentHuggingPriority(.required, for: .vertical)
         updatePlaceholder(view)
+        DispatchQueue.main.async { recalculateHeight(view) }
         return view
     }
 
@@ -66,16 +76,22 @@ struct MultilineTextView: UIViewRepresentable {
         }
         if view.font != font { view.font = font }
         if view.textColor != textColor { view.textColor = textColor }
-        // Enforce the bounded max height so the input scrolls instead of
-        // pushing the whole composer off-screen on a long draft.
-        view.isScrollEnabled = neededScrolling(containerHeight: view.bounds.height)
         updatePlaceholder(view)
+        recalculateHeight(view)
     }
 
-    private func neededScrolling(containerHeight: CGFloat) -> Bool {
-        guard let view = controller.textView else { return false }
-        let size = view.sizeThatFits(CGSize(width: view.bounds.width, height: .greatestFiniteMagnitude))
-        return size.height > maxHeight
+    /// Measure, clamp, and publish. Above `maxHeight` the text view scrolls
+    /// instead of growing, so a long draft can never push the composer off
+    /// screen.
+    private func recalculateHeight(_ view: UITextView) {
+        let width = view.bounds.width
+        guard width > 0 else { return }
+        let fitted = view.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude)).height
+        let clamped = min(max(fitted, minHeight), maxHeight)
+        view.isScrollEnabled = fitted > maxHeight
+        if abs(clamped - height) > 0.5 {
+            DispatchQueue.main.async { height = clamped }
+        }
     }
 
     private func updatePlaceholder(_ view: UITextView) {
@@ -105,6 +121,7 @@ struct MultilineTextView: UIViewRepresentable {
 
         func textViewDidChange(_ textView: UITextView) {
             parent.text = textView.text
+            parent.recalculateHeight(textView)
         }
     }
 }

--- a/mobile/native/MantaUI/SessionCreateSheet.swift
+++ b/mobile/native/MantaUI/SessionCreateSheet.swift
@@ -3,308 +3,230 @@ import SwiftUI
 // ===========================================================================
 // S3 — create-session sheet (BET-595 §create).
 //
-// THE OWNER OVERRIDE (§5.5 "you do not create a session" is overridden): the
-// user chooses a NAME and (on new-project) a FOLDER (optionally a worktree
-// fan-out), then the FIRST MESSAGE creates the session — no session is
-// created at "Continue"; it is created the moment the first message is sent,
-// then that message is delivered to it. Ports the retired `MobileCreateSheet`
-// / `MobileFolderPicker` to SwiftUI per §7-ported folderPicker helpers.
+// The `+` on the session list opens THIS. It used to be handed a fixed mode
+// (either "new project" or "new session in whatever project happened to be
+// first"), so there was no way to choose which project a session belonged to.
+// Now the project is a choice inside the sheet — any existing project, or a
+// new one — and the session name is optional.
+//
+// Deliberately built from STOCK SwiftUI (NavigationStack + Form + Picker +
+// toolbar Cancel/Create): this is a system-shaped data-entry screen, and the
+// platform's own components carry the keyboard handling, grouped styling,
+// dynamic type and accessibility for free. The bespoke token-styled fields it
+// replaced did none of that.
 // ===========================================================================
 
-enum SessionCreateMode: Equatable {
-    case newProject
-    case newSession(projectName: String)
-}
-
 struct SessionCreateSheet: View {
-    let mode: SessionCreateMode
+    /// Existing projects, so the picker can offer them.
+    let projects: [MantaProject]
+    /// Pre-selected project (the one the user was looking at), if any.
+    let initialProject: String?
     let onClose: () -> Void
     let onCreated: (String, Int) -> Void
-    @Environment(\.colorScheme) private var colorScheme
 
-    @State private var step: Step = .form
-    @State private var name = ""
+    /// Where the new session goes: an existing project, or a brand new one.
+    private enum Target: Hashable {
+        case existing(String)
+        case newProject
+    }
+
+    @State private var target: Target = .newProject
+    @State private var newProjectName = ""
     @State private var cwd = "~"
+    @State private var sessionName = ""
     @State private var detectedWorktrees: [MantaWorktree]?
     @State private var creating = false
     @State private var error: String?
     @State private var folderPickerOpen = false
-    @State private var firstMessage = ""
 
     private let api = MantaAPIClient.live()
 
-    enum Step { case form, firstMessage }
-
-    private var tokens: Tokens { Tokens.scheme(colorScheme) }
-
-    private var titleText: String {
-        switch mode {
-        case .newProject: return "New project"
-        case .newSession(let project): return "New session in \"\(project)\""
-        }
-    }
-
-    private var isNewProject: Bool {
-        if case .newProject = mode { return true }
-        return false
-    }
-
     var body: some View {
-        ZStack {
-            tokens.canvas.ignoresSafeArea()
-            VStack(spacing: 0) {
-                header
-                switch step {
-                case .form: formStep
-                case .firstMessage: firstMessageStep
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Project", selection: $target) {
+                        ForEach(projects, id: \.tmuxSession) { project in
+                            Text(project.tmuxSession).tag(Target.existing(project.tmuxSession))
+                        }
+                        Text("New project…").tag(Target.newProject)
+                    }
                 }
-            }
-        }
-        .overlay {
-            if folderPickerOpen {
-                FolderPickerView(
-                    initialPath: cwd,
-                    onSelect: { path in
-                        cwd = path
-                        folderPickerOpen = false
-                    },
-                    onFanOut: { base, wts in
-                        cwd = base
-                        detectedWorktrees = wts
-                        folderPickerOpen = false
-                    },
-                    onCancel: { folderPickerOpen = false }
-                )
-                .transition(.move(edge: .bottom))
-            }
-        }
-    }
 
-    private var header: some View {
-        HStack {
-            Text(titleText)
-                .font(.system(size: Metrics.type.body, weight: .semibold))
-                .foregroundColor(tokens.tx1)
-            Spacer()
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: Metrics.type.body, weight: .regular))
-                    .foregroundColor(tokens.tx2)
-            }
-            .accessibilityLabel("Close")
-        }
-        .padding(.horizontal, Metrics.spacing.sp3)
-        .padding(.vertical, Metrics.spacing.sp3)
-    }
-
-    // MARK: - Form step
-
-    private var formStep: some View {
-        VStack(spacing: Metrics.spacing.sp3) {
-            field(label: "Name", placeholder: isNewProject ? "my-project" : "session", text: $name)
-
-            if isNewProject {
-                VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
-                    Text("Default working directory")
-                        .font(.system(size: Metrics.type.twoXS, weight: .semibold))
-                        .foregroundColor(tokens.tx3)
-                    HStack(spacing: Metrics.spacing.sp2) {
-                        TextField("~/code/foo", text: $cwd)
-                            .font(.system(size: Metrics.type.small, design: .monospaced))
-                            .foregroundColor(tokens.tx1)
-                            .padding(.horizontal, Metrics.spacing.sp3)
-                            .padding(.vertical, Metrics.spacing.sp2)
-                            .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                if target == .newProject {
+                    Section("New project") {
+                        TextField("Name", text: $newProjectName)
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
                         Button {
                             folderPickerOpen = true
                         } label: {
-                            Image(systemName: "folder")
-                                .font(.system(size: Metrics.type.body))
-                                .foregroundColor(tokens.tx2)
-                                .padding(Metrics.spacing.sp2)
-                                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                            LabeledContent("Folder") {
+                                Text(cwd)
+                                    .font(.system(.body, design: .monospaced))
+                                    .lineLimit(1)
+                                    .truncationMode(.head)
+                            }
                         }
-                        .accessibilityLabel("Browse folders")
+                        .buttonStyle(.plain)
                     }
-                    worktreeInfo
+                    if let worktrees = detectedWorktrees, worktrees.count > 1 {
+                        Section("Git worktrees") {
+                            Text("\(worktrees.count) worktrees found — one session will be opened for each.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                            ForEach(worktrees, id: \.path) { worktree in
+                                Text(WorktreeInfoLogic.name(worktree))
+                                    .font(.system(.footnote, design: .monospaced))
+                            }
+                        }
+                    }
                 }
-            }
 
-            if let error {
-                Text(error)
-                    .font(.system(size: Metrics.type.small))
-                    .foregroundColor(tokens.danger)
-            }
-
-            VStack(spacing: Metrics.spacing.sp2) {
-                Button {
-                    continueToFirstMessage()
-                } label: {
-                    primaryButton("Continue")
+                Section {
+                    TextField("Session name", text: $sessionName, prompt: Text("Optional"))
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } footer: {
+                    Text("Leave empty and the session is named for you.")
                 }
-                .disabled(!formValid)
-                Button(action: onClose) {
-                    Text("Cancel")
-                        .font(.system(size: Metrics.type.small, weight: .medium))
-                        .foregroundColor(tokens.tx3)
-                        .padding(Metrics.spacing.sp2)
-                }
-            }
-            .padding(.top, Metrics.spacing.sp1)
-        }
-        .padding(.horizontal, Metrics.spacing.sp3)
-    }
 
-    @ViewBuilder
-    private var worktreeInfo: some View {
-        if let wts = detectedWorktrees, wts.count > 1 {
-            VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
-                Text("Detected \(wts.count) git worktrees. Open a session for each?")
-                    .font(.system(size: Metrics.type.small))
-                    .foregroundColor(tokens.tx2)
-                ForEach(wts, id: \.path) { w in
-                    HStack {
-                        Text(WorktreeInfoLogic.name(w))
-                            .font(.system(size: Metrics.type.xs, design: .monospaced))
-                            .foregroundColor(tokens.tx1)
-                        Spacer()
-                        Text(w.path)
-                            .font(.system(size: Metrics.type.xs, design: .monospaced))
-                            .foregroundColor(tokens.tx4)
-                            .lineLimit(1)
+                if let error {
+                    Section {
+                        Text(error).foregroundStyle(.red)
                     }
                 }
             }
-            .padding(Metrics.spacing.sp2)
-            .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-        }
-    }
-
-    private func continueToFirstMessage() {
-        guard formValid else { return }
-        if isNewProject {
-            Task {
-                // Auto-detect worktrees for the fan-out question (best-effort).
-                let trimmed = cwd.trimmingCharacters(in: .whitespaces)
-                if let wts = try? await api.listWorktrees(trimmed), wts.count > 1 {
-                    detectedWorktrees = wts
+            .navigationTitle("New session")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onClose)
                 }
-            }
-        }
-        step = .firstMessage
-    }
-
-    // MARK: - First-message step (creation happens HERE)
-
-    private var firstMessageStep: some View {
-        VStack(spacing: Metrics.spacing.sp3) {
-            Text("Type your first message")
-                .font(.system(size: Metrics.type.small))
-                .foregroundColor(tokens.tx2)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            TextField("Message…", text: $firstMessage, axis: .vertical)
-                .lineLimit(1...6)
-                .font(.system(size: Metrics.type.body))
-                .foregroundColor(tokens.tx1)
-                .padding(Metrics.spacing.sp3)
-                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-                .autocorrectionDisabled()
-
-            if let error {
-                Text(error)
-                    .font(.system(size: Metrics.type.small))
-                    .foregroundColor(tokens.danger)
-            }
-
-            Button {
-                createAndSend()
-            } label: {
-                primaryButton(creating ? "Creating…" : "Create session")
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create", action: create)
+                        .disabled(!formValid || creating)
+                }
             }
             .disabled(creating)
+            .overlay {
+                if creating { ProgressView().controlSize(.large) }
+            }
         }
-        .padding(.horizontal, Metrics.spacing.sp3)
-        .padding(.top, Metrics.spacing.sp2)
+        .onAppear(perform: selectInitialTarget)
+        .sheet(isPresented: $folderPickerOpen) {
+            FolderPickerView(
+                initialPath: cwd,
+                onSelect: { path in
+                    cwd = path
+                    folderPickerOpen = false
+                },
+                onFanOut: { base, worktrees in
+                    cwd = base
+                    detectedWorktrees = worktrees
+                    folderPickerOpen = false
+                },
+                onCancel: { folderPickerOpen = false }
+            )
+        }
     }
 
-    private func createAndSend() {
-        guard !creating else { return }
-        let message = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !message.isEmpty else { return }
+    private func selectInitialTarget() {
+        if let initialProject, projects.contains(where: { $0.tmuxSession == initialProject }) {
+            target = .existing(initialProject)
+        } else if let first = projects.first {
+            target = .existing(first.tmuxSession)
+        } else {
+            target = .newProject
+        }
+    }
+
+    private var formValid: Bool {
+        switch target {
+        case .existing: return true
+        case .newProject: return !newProjectName.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+    }
+
+    // MARK: - Create
+    //
+    // The session is created for real here (tmux window + opencode session);
+    // the caller pushes it, and the user types their first message in the
+    // session itself rather than in this sheet.
+
+    private func create() {
+        guard !creating, formValid else { return }
         creating = true
         error = nil
         Task {
             do {
-                switch mode {
+                switch target {
+                case .existing(let project):
+                    try await createWindow(in: project)
                 case .newProject:
-                    try await createProjectAndSend(message)
-                case .newSession(let project):
-                    try await createWindowAndSend(projectName: project, message: message)
+                    try await createProject()
                 }
             } catch {
-                self.error = "Couldn't create the session"
-                creating = false
+                await MainActor.run {
+                    self.error = "Couldn't create the session"
+                    self.creating = false
+                }
             }
         }
     }
 
-    private func createProjectAndSend(_ message: String) async throws {
-        let projectName = name.trimmingCharacters(in: .whitespaces)
-        let dir = cwd.trimmingCharacters(in: .whitespaces)
-        var targetSessionID: String?
-        var targetProject: String = projectName
-        var targetWindow: Int = 0
-
-        if let wts = detectedWorktrees, wts.count > 1 {
-            let first = wts[0]
-            var projects = try await api.newSession(NewSessionInput(
-                name: projectName, cwd: first.path, windowName: WorktreeInfoLogic.name(first),
-                createDir: false, chatMode: true))
-            for w in wts.dropFirst() {
-                projects = try await api.newWindow(NewWindowInput(
-                    sessionName: projectName, windowName: WorktreeInfoLogic.name(w),
-                    cwd: w.path, chatMode: true))
-            }
-            if let window = Self.findInitialWindow(projects, projectName: projectName, cwd: first.path) {
-                targetSessionID = window.opencodeSessionId
-                targetWindow = window.index
-            }
-        } else {
-            let projects = try await api.newSession(NewSessionInput(
-                name: projectName, cwd: dir, windowName: "default",
-                createDir: true, chatMode: true))
-            if let proj = projects.first(where: { $0.tmuxSession == projectName }),
-               let window = proj.windows.first(where: { $0.name == "default" }) ?? proj.windows.first {
-                targetSessionID = window.opencodeSessionId
-                targetWindow = window.index
-            }
-        }
-
-        guard let sessionID = targetSessionID else {
-            throw MantaError.transport("created session returned no chat id")
-        }
-        try await api.sendPrompt(SendPromptInput(sessionId: sessionID, text: message))
-        await MainActor.run {
-            creating = false
-            onCreated(targetProject, targetWindow)
-        }
+    private var resolvedSessionName: String {
+        let trimmed = sessionName.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? "session" : trimmed
     }
 
-    private func createWindowAndSend(projectName: String, message: String) async throws {
-        let windowName = name.trimmingCharacters(in: .whitespaces).isEmpty ? "session" : name.trimmingCharacters(in: .whitespaces)
+    private func createWindow(in project: String) async throws {
+        let windowName = resolvedSessionName
         let projects = try await api.newWindow(NewWindowInput(
-            sessionName: projectName, windowName: windowName, cwd: nil, chatMode: true))
-        guard let proj = projects.first(where: { $0.tmuxSession == projectName }),
-              let window = proj.windows.first(where: { $0.name == windowName }),
-              let sessionID = window.opencodeSessionId else {
-            throw MantaError.transport("created session returned no chat id")
+            sessionName: project, windowName: windowName, cwd: nil, chatMode: true))
+        guard let proj = projects.first(where: { $0.tmuxSession == project }),
+              let window = proj.windows.first(where: { $0.name == windowName }) ?? proj.windows.last else {
+            throw MantaError.transport("created session was not returned")
         }
-        try await api.sendPrompt(SendPromptInput(sessionId: sessionID, text: message))
         await MainActor.run {
             creating = false
-            onCreated(projectName, window.index)
+            onCreated(project, window.index)
+        }
+    }
+
+    private func createProject() async throws {
+        let projectName = newProjectName.trimmingCharacters(in: .whitespaces)
+        let dir = cwd.trimmingCharacters(in: .whitespaces)
+        var windowIndex = 0
+
+        if let worktrees = detectedWorktrees, worktrees.count > 1 {
+            // Fan out: the first worktree is the project's initial window, the
+            // rest are added alongside it.
+            var projects = try await api.newSession(NewSessionInput(
+                name: projectName, cwd: worktrees[0].path,
+                windowName: WorktreeInfoLogic.name(worktrees[0]),
+                createDir: false, chatMode: true))
+            for worktree in worktrees.dropFirst() {
+                projects = try await api.newWindow(NewWindowInput(
+                    sessionName: projectName, windowName: WorktreeInfoLogic.name(worktree),
+                    cwd: worktree.path, chatMode: true))
+            }
+            windowIndex = Self.findInitialWindow(projects, projectName: projectName, cwd: worktrees[0].path)?.index ?? 0
+        } else {
+            let windowName = resolvedSessionName
+            let projects = try await api.newSession(NewSessionInput(
+                name: projectName, cwd: dir, windowName: windowName,
+                createDir: true, chatMode: true))
+            guard let proj = projects.first(where: { $0.tmuxSession == projectName }),
+                  let window = proj.windows.first(where: { $0.name == windowName }) ?? proj.windows.first else {
+                throw MantaError.transport("created project was not returned")
+            }
+            windowIndex = window.index
+        }
+
+        await MainActor.run {
+            creating = false
+            onCreated(projectName, windowIndex)
         }
     }
 
@@ -313,40 +235,5 @@ struct SessionCreateSheet: View {
         guard let proj = projects.first(where: { $0.tmuxSession == projectName }) else { return nil }
         if let exact = proj.windows.first(where: { $0.paneCurrentPath == cwd }) { return exact }
         return proj.windows.min(by: { $0.index < $1.index })
-    }
-
-    // MARK: - shared pieces
-
-    private var formValid: Bool {
-        !name.trimmingCharacters(in: .whitespaces).isEmpty
-    }
-
-    @ViewBuilder
-    private func field(label: String, placeholder: String, text: Binding<String>) -> some View {
-        VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
-            Text(label)
-                .font(.system(size: Metrics.type.twoXS, weight: .semibold))
-                .foregroundColor(tokens.tx3)
-            TextField(placeholder, text: text)
-                .font(.system(size: Metrics.type.body))
-                .foregroundColor(tokens.tx1)
-                .padding(.horizontal, Metrics.spacing.sp3)
-                .padding(.vertical, Metrics.spacing.sp2)
-                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-        }
-    }
-
-    @ViewBuilder
-    private func primaryButton(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: Metrics.type.small, weight: .semibold))
-            .foregroundColor(text.hasPrefix("Creating") ? tokens.tx4 : tokens.onAccent)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, Metrics.spacing.sp3)
-            .background(
-                text.hasPrefix("Creating") ? AnyShapeStyle(tokens.panel) : AnyShapeStyle(tokens.accentSolid),
-                in: RoundedRectangle(cornerRadius: Metrics.radius.md))
     }
 }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -131,8 +131,14 @@ struct SessionListView: View {
                 ForEach(filteredProjects) { project in
                     Section {
                         groupHeader(project.tmuxSession)
-                        ForEach(project.windows) { window in
-                            row(project: project, window: window)
+                        // Identity MUST be project-scoped. `MantaWindow.id` is
+                        // the tmux window index, which repeats across projects
+                        // (every project has a window 0), and a LazyVStack
+                        // keeps ONE flat identity space across the nested
+                        // ForEachs — so the second project's window 0 collided
+                        // with the first project's and rendered as a blank row.
+                        ForEach(project.windows.map { SessionRowKey(project: project.tmuxSession, window: $0) }) { entry in
+                            row(project: project, window: entry.window)
                         }
                     }
                 }
@@ -471,6 +477,15 @@ struct SessionListView: View {
 }
 
 // MARK: - Row content (§7.1 slots)
+
+/// Project-scoped row identity for the session list. A tmux window index is
+/// only unique WITHIN its project, so it cannot be the identity of a row in a
+/// LazyVStack that renders every project in one flat identity space.
+private struct SessionRowKey: Identifiable {
+    let project: String
+    let window: MantaWindow
+    var id: String { "\(project)#\(window.index)" }
+}
 
 private struct SessionRowContent: View {
     let window: MantaWindow

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -349,39 +349,44 @@ struct SessionListView: View {
 
     // MARK: - Floating capsule (+ search) + create
 
+    // The search + create control FLOATS over the list on Liquid Glass, the
+    // system material for iOS 26 chrome. It used to be a flat
+    // `.ultraThinMaterial` rectangle spanning the full width, which reads as an
+    // opaque grey band with a hard seam — not glass, and visibly not a system
+    // control. Each element carries its own glass so the pill and the button
+    // are separate floating shapes, which is what `GlassEffectContainer` is
+    // for; there is no full-bleed backing plate any more.
     private var capsule: some View {
-        HStack(spacing: Metrics.spacing.sp3) {
-            HStack(spacing: Metrics.spacing.sp2) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: Metrics.type.xs))
-                    .foregroundColor(tokens.tx4)
-                TextField("Search sessions", text: $searchText)
-                    .font(.system(size: Metrics.type.small))
-                    .foregroundColor(tokens.tx1)
-            }
-            .padding(.horizontal, Metrics.spacing.sp3)
-            .padding(.vertical, Metrics.spacing.sp2)
-            .overlay {
-                Capsule().stroke(tokens.borderSubtle, lineWidth: 1)
-            }
+        GlassEffectContainer(spacing: Metrics.spacing.sp3) {
+            HStack(spacing: Metrics.spacing.sp3) {
+                HStack(spacing: Metrics.spacing.sp2) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: Metrics.type.xs))
+                        .foregroundColor(tokens.tx4)
+                    TextField("Search sessions", text: $searchText)
+                        .font(.system(size: Metrics.type.small))
+                        .foregroundColor(tokens.tx1)
+                }
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp3)
+                .glassEffect(.regular.interactive(), in: .capsule)
 
-            Button {
-                SessionHaptics.fire(.selection, enabled: store.hapticsEnabled)
-                presentCreateMenu()
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: Metrics.type.body, weight: .semibold))
-                    .foregroundColor(tokens.accentTx)
-                    .frame(width: 44, height: 44)
-                    .background(tokens.accentSolid, in: Circle())
+                Button {
+                    SessionHaptics.fire(.selection, enabled: store.hapticsEnabled)
+                    presentCreateMenu()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: Metrics.type.body, weight: .semibold))
+                        .foregroundColor(tokens.accentTx)
+                        .frame(width: 44, height: 44)
+                }
+                .glassEffect(.regular.tint(tokens.accentSolid).interactive(), in: .circle)
+                .buttonStyle(.plain)
+                .accessibilityLabel("New")
             }
-            .accessibilityLabel("New")
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.bottom, Metrics.spacing.sp2)
-        .background {
-            Rectangle().fill(.ultraThinMaterial).ignoresSafeArea()
-        }
     }
 
     private func presentCreateMenu() {

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -26,7 +26,10 @@ struct SessionListView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var searchText = ""
-    @State private var createItem: CreateItem?
+    // ONE sheet binding. Three separate `.sheet` modifiers used to sit on the
+    // same view, and SwiftUI honours only one of them — which is why the `+`
+    // button appeared dead: its sheet was never the one that won.
+    @State private var sheetRoute: SheetRoute?
     // ONE path-driven stack. It used to be a bare NavigationStack whose only
     // destination was item-based (`navigationDestination(item:)`) while the
     // subagent row inside the chat screen pushed a VALUE
@@ -38,11 +41,11 @@ struct SessionListView: View {
     // (a session target here, a subagent value pushed from inside the chat
     // screen), and a typed path would silently swallow the second.
     @State private var path = NavigationPath()
-    @State private var renameTarget: MantaWindow?
+
     @State private var renameProject = ""
     @State private var renameValue = ""
     @State private var confirmDeleteProject = ""
-    @State private var confirmDeleteWindow: MantaWindow?
+
     @State private var deleteRunningText = ""
     @State private var showSettings = false
 
@@ -74,7 +77,6 @@ struct SessionListView: View {
             .refreshable { await store.refresh() }
             .safeAreaInset(edge: .bottom) { capsule }
             .overlay(alignment: .top) { errorBanner }
-            .sheet(item: $renameTarget) { _ in renameSheet(targetProject: renameProject) }
             .navigationDestination(for: SessionOpenTarget.self) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
                     ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore)
@@ -88,21 +90,29 @@ struct SessionListView: View {
                 }
             }
         }
-        .sheet(item: $confirmDeleteWindow) { target in confirmDeleteSheet(target: target) }
         .overlay(alignment: .bottom) { undoToast }
-        .sheet(item: $createItem) { item in
-            SessionCreateSheet(
-                mode: item.mode,
-                onClose: { createItem = nil },
-                onCreated: { project, index in
-                    let window = store.projects.first(where: { $0.tmuxSession == project })?
-                        .windows.first(where: { $0.index == index })
-                    let name = window?.name ?? "session"
-                    createItem = nil
-                    path.append(SessionOpenTarget(project: project, windowIndex: index, name: name, sessionId: window?.opencodeSessionId))
-                }
-            )
-            .presentationDetents([.medium, .large])
+        .sheet(item: $sheetRoute) { route in
+            switch route {
+            case .create(let project):
+                SessionCreateSheet(
+                    projects: store.projects,
+                    initialProject: project,
+                    onClose: { sheetRoute = nil },
+                    onCreated: { project, index in
+                        let window = store.projects.first(where: { $0.tmuxSession == project })?
+                            .windows.first(where: { $0.index == index })
+                        let name = window?.name ?? "session"
+                        sheetRoute = nil
+                        path.append(SessionOpenTarget(project: project, windowIndex: index, name: name, sessionId: window?.opencodeSessionId))
+                    }
+                )
+            case .rename(let window, let project):
+                renameSheet(target: window, targetProject: project)
+                    .presentationDetents([.height(320)])
+            case .confirmDelete(let window):
+                confirmDeleteSheet(target: window)
+                    .presentationDetents([.height(320)])
+            }
         }
         .fullScreenCover(isPresented: $showSettings) {
             SettingsScreen()
@@ -200,8 +210,8 @@ struct SessionListView: View {
             let id = SessionPinID.window(project.tmuxSession, index: window.index)
             Button("Rename") {
                 renameProject = project.tmuxSession
-                renameTarget = window
                 renameValue = window.name
+                sheetRoute = .rename(window: window, project: project.tmuxSession)
             }
             Button(store.isPinned(session: project.tmuxSession, index: window.index) ? "Unpin" : "Pin") {
                 store.togglePin(session: project.tmuxSession, index: window.index)
@@ -258,7 +268,7 @@ struct SessionListView: View {
             let durationText = runningDuration(of: window)
             deleteRunningText = durationText
             confirmDeleteProject = project.tmuxSession
-            confirmDeleteWindow = window
+            sheetRoute = .confirmDelete(window: window)
             SessionHaptics.fire(.warning, enabled: store.hapticsEnabled)
         } else {
             store.beginIdleDelete(session: project.tmuxSession, index: window.index)
@@ -287,7 +297,7 @@ struct SessionListView: View {
             Button {
                 let index = target.index
                 let project = confirmDeleteProject
-                confirmDeleteWindow = nil
+                sheetRoute = nil
                 Task {
                     if let sid = target.opencodeSessionId {
                         try? await MantaAPIClient.live().deleteSession(sessionId: sid, sessionName: project, windowIndex: index)
@@ -306,7 +316,7 @@ struct SessionListView: View {
                     .background(tokens.danger, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
             }
             Button {
-                confirmDeleteWindow = nil
+                sheetRoute = nil
             } label: {
                 Text("Cancel")
                     .font(.system(size: Metrics.type.small, weight: .medium))
@@ -315,7 +325,6 @@ struct SessionListView: View {
             }
         }
         .padding(Metrics.spacing.sp4)
-        .presentationDetents([.height(320)])
     }
 
     // MARK: - Undo toast
@@ -405,16 +414,12 @@ struct SessionListView: View {
     }
 
     private func presentCreateMenu() {
-        if store.projects.isEmpty {
-            createItem = CreateItem(mode: .newProject)
-        } else {
-            createItem = CreateItem(mode: .newSession(projectName: store.projects.first?.tmuxSession ?? ""))
-        }
+        sheetRoute = .create(project: store.projects.first?.tmuxSession)
     }
 
     // MARK: - Rename (§7.2 context menu)
 
-    private func renameSheet(targetProject: String) -> some View {
+    private func renameSheet(target: MantaWindow, targetProject: String) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
             Text("Rename session")
                 .font(.system(size: Metrics.type.body, weight: .semibold))
@@ -428,24 +433,23 @@ struct SessionListView: View {
                 .autocorrectionDisabled()
             HStack {
                 Spacer()
-                Button("Cancel") { renameTarget = nil }
+                Button("Cancel") { sheetRoute = nil }
                     .foregroundColor(tokens.tx2)
                 Button("Save") {
                     let value = renameValue.trimmingCharacters(in: .whitespaces)
-                    if !value.isEmpty, let target = renameTarget {
+                    if !value.isEmpty {
                         Task {
                             try? await MantaAPIClient.live().renameWindow(session: targetProject, index: target.index, newName: value)
                             await store.refresh()
                         }
                     }
-                    renameTarget = nil
+                    sheetRoute = nil
                 }
                 .fontWeight(.semibold)
                 .foregroundColor(tokens.accentTx)
             }
         }
         .padding(Metrics.spacing.sp4)
-        .presentationDetents([.height(220)])
     }
 
     // MARK: - Fork
@@ -586,9 +590,20 @@ enum SessionHaptics {
 
 // MARK: - Identifiable helpers
 
-private struct CreateItem: Identifiable {
-    let id = UUID()
-    let mode: SessionCreateMode
+/// Every sheet this screen can present, so exactly one `.sheet` modifier is
+/// attached to the view.
+private enum SheetRoute: Identifiable {
+    case create(project: String?)
+    case rename(window: MantaWindow, project: String)
+    case confirmDelete(window: MantaWindow)
+
+    var id: String {
+        switch self {
+        case .create(let project): return "create:\(project ?? "")"
+        case .rename(let window, let project): return "rename:\(project):\(window.index)"
+        case .confirmDelete(let window): return "delete:\(window.index)"
+        }
+    }
 }
 
 /// A route value, so its identity must be stable and derived from what it

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -377,7 +377,12 @@ struct SessionListView: View {
                 } label: {
                     Image(systemName: "plus")
                         .font(.system(size: Metrics.type.body, weight: .semibold))
-                        .foregroundColor(tokens.accentTx)
+                        // onAccent, NOT accentTx: accentTx is the accent colour
+                        // for text on a NEUTRAL background. Over a solid accent
+                        // fill it is the same colour in light mode, which is why
+                        // this button was a featureless blue disc. Every other
+                        // filled-accent control in the app already uses onAccent.
+                        .foregroundColor(tokens.onAccent)
                         .frame(width: 44, height: 44)
                 }
                 .glassEffect(.regular.tint(tokens.accentSolid).interactive(), in: .circle)

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -27,7 +27,17 @@ struct SessionListView: View {
 
     @State private var searchText = ""
     @State private var createItem: CreateItem?
-    @State private var openTarget: SessionOpenTarget?
+    // ONE path-driven stack. It used to be a bare NavigationStack whose only
+    // destination was item-based (`navigationDestination(item:)`) while the
+    // subagent row inside the chat screen pushed a VALUE
+    // (`NavigationLink(value:)`). Mixing the two in one stack is what made a
+    // subagent tap resolve against the session destination — you landed back on
+    // the parent session and only saw the child after going back. Everything is
+    // a value push now, so each entry resolves against its own destination.
+    // NavigationPath, not a typed array: the stack carries TWO route types
+    // (a session target here, a subagent value pushed from inside the chat
+    // screen), and a typed path would silently swallow the second.
+    @State private var path = NavigationPath()
     @State private var renameTarget: MantaWindow?
     @State private var renameProject = ""
     @State private var renameValue = ""
@@ -39,7 +49,7 @@ struct SessionListView: View {
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             Group {
                 if store.projects.isEmpty && !store.loading {
                     emptyState
@@ -65,7 +75,7 @@ struct SessionListView: View {
             .safeAreaInset(edge: .bottom) { capsule }
             .overlay(alignment: .top) { errorBanner }
             .sheet(item: $renameTarget) { _ in renameSheet(targetProject: renameProject) }
-            .navigationDestination(item: $openTarget) { target in
+            .navigationDestination(for: SessionOpenTarget.self) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
                     ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore)
                 } else if let project = store.projects.first(where: { $0.tmuxSession == target.project }),
@@ -89,7 +99,7 @@ struct SessionListView: View {
                         .windows.first(where: { $0.index == index })
                     let name = window?.name ?? "session"
                     createItem = nil
-                    openTarget = SessionOpenTarget(project: project, windowIndex: index, name: name, sessionId: window?.opencodeSessionId)
+                    path.append(SessionOpenTarget(project: project, windowIndex: index, name: name, sessionId: window?.opencodeSessionId))
                 }
             )
             .presentationDetents([.medium, .large])
@@ -117,9 +127,9 @@ struct SessionListView: View {
         // still fine).
         if let project = store.projects.first(where: { $0.windows.contains { $0.opencodeSessionId == sessionId } }),
            let window = project.windows.first(where: { $0.opencodeSessionId == sessionId }) {
-            openTarget = SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: sessionId)
+            path.append(SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: sessionId))
         } else {
-            openTarget = SessionOpenTarget(project: "", windowIndex: 0, name: "session", sessionId: sessionId)
+            path.append(SessionOpenTarget(project: "", windowIndex: 0, name: "session", sessionId: sessionId))
         }
     }
 
@@ -174,7 +184,7 @@ struct SessionListView: View {
     @ViewBuilder
     private func row(project: MantaProject, window: MantaWindow) -> some View {
         Button {
-            openTarget = SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: window.opencodeSessionId)
+            path.append(SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: window.opencodeSessionId))
         } label: {
             SessionRowContent(
                 window: window,
@@ -581,12 +591,24 @@ private struct CreateItem: Identifiable {
     let mode: SessionCreateMode
 }
 
-private struct SessionOpenTarget: Identifiable, Hashable {
-    let id = UUID()
+/// A route value, so its identity must be stable and derived from what it
+/// addresses — never a fresh UUID, which would make the same session push as a
+/// different destination every time it is constructed.
+private struct SessionOpenTarget: Hashable {
     let project: String
     let windowIndex: Int
     let name: String
     let sessionId: String?
+
+    static func == (lhs: SessionOpenTarget, rhs: SessionOpenTarget) -> Bool {
+        lhs.project == rhs.project && lhs.windowIndex == rhs.windowIndex && lhs.sessionId == rhs.sessionId
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(project)
+        hasher.combine(windowIndex)
+        hasher.combine(sessionId)
+    }
 }
 
 /// The chat screen this row opens is S4's (chat wired to live data). This

--- a/mobile/native/MantaUI/TerminalWebView.swift
+++ b/mobile/native/MantaUI/TerminalWebView.swift
@@ -283,8 +283,11 @@ final class TerminalContainerController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        // Present the software keyboard + accessory.
-        inputField.becomeFirstResponder()
+        // Do NOT raise the keyboard on entry: it covers half the terminal
+        // before the user has read a single line, and the floating bar exists
+        // precisely to offer the keyboard on demand (its ⌨ button calls
+        // becomeFirstResponder), as does a tap on the terminal surface.
+        floatingBar.isHidden = false
         socket?.reconnectNow()
         Task { await fetchDictateAvailability() }
     }
@@ -322,6 +325,13 @@ final class TerminalContainerController: UIViewController {
         floatingBar.onInterrupt = { [weak self] in self?.sendToShell("\u{03}") }
         floatingBar.onPaste = { [weak self] in self?.paste() }
         floatingBar.onShowKeyboard = { [weak self] in self?.inputField.becomeFirstResponder() }
+
+        // Tap the surface to type — the keyboard is no longer raised on entry,
+        // so this is the second way in besides the bar's keyboard button.
+        // `cancelsTouchesInView = false` keeps xterm's own selection working.
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleSurfaceTap))
+        tap.cancelsTouchesInView = false
+        webView.addGestureRecognizer(tap)
         floatingBar.onDictateBegan = { [weak self] in self?.dictateBegan() }
         floatingBar.onDictateEnded = { [weak self] in self?.dictateEnded() }
 
@@ -359,8 +369,15 @@ final class TerminalContainerController: UIViewController {
     // MARK: - Page load + font
 
     private func loadPage() {
-        guard let url = Bundle.main.url(forResource: "terminal", withExtension: "html", subdirectory: "terminal") else {
+        // The folder reference keeps `terminal/` in the bundle; the root
+        // fallback covers a build where the resources were flattened, because
+        // the failure mode is invisible — a black webview with no terminal and
+        // no error on screen.
+        let url = Bundle.main.url(forResource: "terminal", withExtension: "html", subdirectory: "terminal")
+            ?? Bundle.main.url(forResource: "terminal", withExtension: "html")
+        guard let url else {
             state.connectionLabel = "terminal bundle missing"
+            assertionFailure("terminal.html is not in the app bundle — check the Copy Bundle Resources phase")
             return
         }
         webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
@@ -371,6 +388,11 @@ final class TerminalContainerController: UIViewController {
         wv.evaluateJavaScript("window.__manta.setFontSize(\(font)); window.__manta.fit();") { [weak self] _, _ in
             self?.connectSocket()
         }
+    }
+
+    @objc private func handleSurfaceTap() {
+        guard !inputField.isFirstResponder else { return }
+        inputField.becomeFirstResponder()
     }
 
     // MARK: - Pinch to zoom (font size, §9.2)

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -49,6 +49,27 @@ struct UserBand: View {
     }
 }
 
+
+// MARK: - Inline markdown
+//
+// The native transcript has no markdown renderer (the spike explicitly did not
+// build one), so assistant turns showed their source: `**bold**`, backticked
+// code and link syntax appeared verbatim. This covers the INLINE subset that
+// SwiftUI can parse natively — emphasis, strong, inline code, links —
+// preserving newlines so paragraph structure survives.
+//
+// BLOCK-level markdown (headings, lists, fenced code, thematic breaks) is
+// still unrendered; that needs a real block parser and its own components,
+// which is a separate piece of work, not something to fake here.
+enum MantaInlineMarkdown {
+    static func render(_ raw: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: raw, options: options)) ?? AttributedString(raw)
+    }
+}
+
 // MARK: - Assistant prose
 //
 // §8: full width, `tx1`, 15px/`--prose-lh`, margin-bottom `--sp-3`.
@@ -57,7 +78,7 @@ struct AssistantProse: View {
     let tokens: Tokens
 
     var body: some View {
-        Text(text)
+        Text(MantaInlineMarkdown.render(text))
             .font(.system(size: Metrics.type.body))
             .foregroundColor(tokens.tx1)
             .lineSpacing(pointsFor(multiplier: Metrics.type.proseLineHeight, size: Metrics.type.body))

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -173,9 +173,9 @@ enum StepGroupRow: Identifiable {
     case step(ToolStep)
     case subagent(SubagentSession)
 
-    var id: UUID {
+    var id: String {
         switch self {
-        case .step(let step): return step.id
+        case .step(let step): return step.id.uuidString
         case .subagent(let agent): return agent.id
         }
     }
@@ -265,7 +265,14 @@ enum SubagentStatus: Hashable {
 }
 
 struct SubagentSession: Identifiable, Hashable {
-    let id: UUID
+    /// STABLE across rebuilds — the child opencode session id when there is
+    /// one. It used to be a fresh `UUID()` minted in `init`, and the transcript
+    /// is re-derived from scratch on every streamed event, so the value pushed
+    /// onto the NavigationStack stopped matching anything in the current
+    /// transcript within milliseconds. That is what made a tap on a subagent
+    /// row land on the wrong screen and reveal the right one only after going
+    /// back: navigation identity has to outlive a re-render.
+    let id: String
     let taskName: String
     let status: SubagentStatus
     // Live duration (e.g. "1m12s") while running; nil when done.
@@ -277,7 +284,8 @@ struct SubagentSession: Identifiable, Hashable {
     let childSessionId: String?
 
     init(taskName: String, status: SubagentStatus, duration: String?, transcript: [TranscriptBlock], childSessionId: String? = nil) {
-        self.id = UUID()
+        // Fixtures carry no child session, so they fall back to the task name.
+        self.id = childSessionId ?? "task:\(taskName)"
         self.taskName = taskName
         self.status = status
         self.duration = duration

--- a/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
@@ -1,0 +1,153 @@
+import XCTest
+
+// ===========================================================================
+// Chat-surface capture driver for the native chat epic (BET-624, row 0 =
+// BET-625). The manta-sim-drive plugin builds each of these test classes in
+// the Simulator and globs the PNG it drops into the runner's own container,
+// then uploads it to the box. The order of this epic means the surfaces the
+// captures show land AFTER this driver: the overflow sheet (BET-626), the
+// running row (BET-630) and the loading skeleton (BET-631) are accepted by a
+// screenshot produced through these actions.
+//
+// Shared navigation:
+//   - MANTA_OPEN_ROW names a row to open (label-prefix hop, `|`-delimited);
+//     empty falls back to the first row by normalized coordinate. A chat-mode
+//     window and a plain tmux window land on different screens, so the caller
+//     picks which row for which capture.
+//   - Each test writes one uniquely named PNG so the plugin can pick it up.
+// ===========================================================================
+
+private enum MantaChatCapture {
+
+    /// Open the first/named session row so the app lands on the chat screen
+    /// (mirrors MantaOpenSessionUITests.testOpenFirstSession).
+    static func openChat(in app: XCUIApplication) {
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            print("PAIRDRIVE open-row=first-by-coordinate")
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let target = app.descendants(matching: .any).matching(prefix).firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            print("PAIRDRIVE open-row=\(hop) kind=\(target.elementType.rawValue)")
+            sleep(4)
+        }
+        // Give the chat screen a moment to push into the navigation stack.
+        sleep(2)
+    }
+
+    /// The runner tears the app down the moment the test ends, so a host-side
+    /// `simctl io screenshot` always catches Springboard instead. Capture from
+    /// inside the test and drop it in the runner's own container, which the
+    /// driver plugin globs for on the host.
+    static func capture(_ name: String) {
+        let shot = XCUIScreen.main.screenshot()
+        let out = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(name)
+        try? shot.pngRepresentation.write(to: out)
+        print("PAIRDRIVE shot=\(out.path)")
+    }
+}
+
+// Opens the chat overflow sheet — taps the trailing 38×38 header button
+// (`overflow-button`, BET-626's real sheet) — and captures the sheet.
+final class MantaOverflowCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureOverflowSheet() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        MantaChatCapture.openChat(in: app)
+
+        let overflow = app.buttons["overflow-button"]
+        guard overflow.waitForExistence(timeout: 10) else {
+            throw XCTSkip("PAIRDRIVE overflow: no overflow-button (chat not open?)")
+        }
+        overflow.tap()
+        print("PAIRDRIVE overflow=opened")
+
+        // Let the sheet settle at its half-height detent (BET-626).
+        sleep(2)
+        MantaChatCapture.capture("manta-overflow-sheet.png")
+    }
+}
+
+// Sends a prompt and captures while the turn is still running, so the
+// mid-turn state (running row / elapsed time, BET-630) is visible.
+final class MantaMidTurnCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureMidTurn() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        MantaChatCapture.openChat(in: app)
+
+        let input = app.textViews["composer-input"]
+        guard input.waitForExistence(timeout: 10) else {
+            throw XCTSkip("PAIRDRIVE midturn: no composer input")
+        }
+        input.tap()
+        input.typeText("Say the alphabet slowly, one letter per line, pausing after each line.")
+        let send = app.buttons["send-button"]
+        XCTAssertTrue(send.waitForExistence(timeout: 5), "no send button")
+        send.tap()
+        print("PAIRDRIVE midturn=sent")
+
+        // Capture while the turn is still in flight.
+        sleep(5)
+        MantaChatCapture.capture("manta-mid-turn.png")
+    }
+}
+
+// Opens a session and captures as close to the push as possible, so the
+// initial-load skeleton (BET-631) is on screen rather than a settled
+// transcript.
+final class MantaLoadCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureDuringLoad() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let target = app.descendants(matching: .any).matching(prefix).firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            sleep(4)
+        }
+
+        // Minimal delay — don't wait for the transcript to settle, capture the
+        // loading state.
+        usleep(300_000)
+        MantaChatCapture.capture("manta-load.png")
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaPairFixture.swift
+++ b/mobile/native/MantaUIUITests/MantaPairFixture.swift
@@ -15,4 +15,6 @@ import Foundation
 enum MantaPairFixture {
     static let code = ""
     static let server = ""
+    /// Row label the open-session drive should tap; empty taps the first row.
+    static let openRow = ""
 }

--- a/mobile/native/MantaUIUITests/MantaPairFixture.swift
+++ b/mobile/native/MantaUIUITests/MantaPairFixture.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// Build-time carrier for the live-box pairing drive (MantaPairingDriverUITests).
+//
+// A UI test runs inside the Simulator in its own sandbox: it cannot read the
+// host's filesystem, and `xcodebuild`'s `TEST_RUNNER_*` env passthrough does
+// NOT reach the runner on this toolchain (verified empty at run time). The one
+// channel that always works is the compiler — so the driver plugin overwrites
+// the two values here immediately before `xcodebuild test`, and restores the
+// file (git checkout) afterwards.
+//
+// Both values are EMPTY in the repo on purpose: a pairing code is single-use
+// and expires in minutes, so there is nothing to leak, and an ordinary test
+// run skips the drive instead of attempting a claim.
+enum MantaPairFixture {
+    static let code = ""
+    static let server = ""
+}

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -22,11 +22,16 @@ final class MantaPairingDriverUITests: XCTestCase {
 
     func testPairAgainstLiveBox() throws {
         let env = ProcessInfo.processInfo.environment
+        // Marker line: the plugin's job log is head-capped, so the ONE thing
+        // that must always be greppable is whether the credentials arrived.
+        let seen = env.keys.filter { $0.contains("MANTA_PAIR") }.sorted().joined(separator: ",")
+        print("PAIRDRIVE env-keys=[\(seen)]")
         guard let code = env["MANTA_PAIR_CODE"], !code.isEmpty,
               let server = env["MANTA_PAIR_SERVER"], !server.isEmpty
         else {
-            throw XCTSkip("MANTA_PAIR_CODE / MANTA_PAIR_SERVER not set — live pairing drive skipped")
+            throw XCTSkip("PAIRDRIVE SKIP: MANTA_PAIR_CODE / MANTA_PAIR_SERVER missing from the runner env")
         }
+        print("PAIRDRIVE start code-digits=\(code.count) server=\(server)")
 
         let app = XCUIApplication()
         app.launch()
@@ -61,12 +66,14 @@ final class MantaPairingDriverUITests: XCTestCase {
             usleep(300_000)
         }
         if failure.exists {
+            print("PAIRDRIVE FAIL \(failure.label)")
             XCTFail("pairing failed: \(failure.label)")
             return
         }
         XCTAssertTrue(notifications.exists, "neither the notifications primer nor a failure card appeared")
 
         app.buttons["Continue"].firstMatch.tap()
+        print("PAIRDRIVE PAIRED")
 
         print("AX-TREE-BEGIN")
         print(app.debugDescription)

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -123,6 +123,14 @@ final class MantaOpenSessionUITests: XCTestCase {
         print("PAIRDRIVE open-row=\(row.label)")
         row.tap()
         sleep(6)
-        print("PAIRDRIVE opened")
+        // The runner tears the app down the moment the test ends, so a
+        // host-side `simctl io screenshot` always catches Springboard instead.
+        // Capture from inside the test and drop the PNG in the runner's own
+        // container, which the driver plugin globs for on the host.
+        let shot = XCUIScreen.main.screenshot()
+        let out = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("manta-open-session.png")
+        try? shot.pngRepresentation.write(to: out)
+        print("PAIRDRIVE opened shot=\(out.path)")
     }
 }

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -119,8 +119,18 @@ final class MantaOpenSessionUITests: XCTestCase {
         // reliably queryable as buttons; a normalized coordinate tap lands on
         // the first row under the "Sessions" title regardless of element type.
         _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
-        print("PAIRDRIVE rows buttons=\(app.buttons.count) cells=\(app.cells.count) texts=\(app.staticTexts.count)")
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        // MANTA_OPEN_ROW names the row to open; empty falls back to the first
+        // row by coordinate. A named row matters because a chat-mode window
+        // and a plain tmux window land on completely different screens.
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let named = app.staticTexts[wanted]
+        if !wanted.isEmpty, named.waitForExistence(timeout: 5), named.isHittable {
+            print("PAIRDRIVE open-row=\(wanted)")
+            named.tap()
+        } else {
+            print("PAIRDRIVE open-row=first-by-coordinate")
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        }
         sleep(6)
         // The runner tears the app down the moment the test ends, so a
         // host-side `simctl io screenshot` always catches Springboard instead.

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -85,3 +85,24 @@ final class MantaPairingDriverUITests: XCTestCase {
         print("AX-TREE-END")
     }
 }
+
+// Answering the system notification alert is not something `simctl` can do
+// (`simctl privacy` has no notifications service), and the alert re-presents
+// on every launch until it is answered — which obscures every screenshot taken
+// after pairing. Springboard is an ordinary accessibility target, so tapping it
+// from a UI test is the deterministic way to clear it.
+final class MantaSystemAlertUITests: XCTestCase {
+
+    func testAnswerNotificationAlert() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        for label in ["Allow", "Don't Allow", "OK"] {
+            let button = springboard.buttons[label]
+            if button.waitForExistence(timeout: 3) {
+                button.tap()
+                print("PAIRDRIVE alert-answered=\(label)")
+                return
+            }
+        }
+        print("PAIRDRIVE alert-answered=none")
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+// Drives the S2 onboarding joiner end-to-end against a REAL box, so pairing
+// can be exercised from CI or from a plugin run without a human typing into
+// the Simulator. The app registers no URL scheme, so `simctl openurl` cannot
+// deliver a pair payload — the only faithful path is the one a user takes:
+// type the six digits, reveal the advanced server field, submit.
+//
+// Skipped unless BOTH env vars are present, so an ordinary test run (which
+// has no live box and no unexpired code) is unaffected:
+//
+//   MANTA_PAIR_CODE   six digits from `curl 127.0.0.1:8787/auth/pair` ON the box
+//   MANTA_PAIR_SERVER https://<box_id>.boxes.mantaui.com
+//
+// xcodebuild forwards `TEST_RUNNER_MANTA_PAIR_CODE=…` to the runner process
+// with the prefix stripped, which is how a plugin supplies them.
+final class MantaPairingDriverUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testPairAgainstLiveBox() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let code = env["MANTA_PAIR_CODE"], !code.isEmpty,
+              let server = env["MANTA_PAIR_SERVER"], !server.isEmpty
+        else {
+            throw XCTSkip("MANTA_PAIR_CODE / MANTA_PAIR_SERVER not set — live pairing drive skipped")
+        }
+
+        let app = XCUIApplication()
+        app.launch()
+
+        // Entry screen. A previously-paired install would boot straight into
+        // the session list, so a missing OTP field is a real signal (stale
+        // Keychain credentials) rather than a timing flake.
+        let otp = app.textFields["onboarding-otp"]
+        XCTAssertTrue(otp.waitForExistence(timeout: 15),
+                      "onboarding entry screen never appeared — is the app already paired?")
+        otp.tap()
+        otp.typeText(code)
+
+        // The six-digit code alone cannot address a box; the claim target is
+        // the server URL behind the advanced disclosure.
+        let advanced = app.buttons["My box isn't reachable from the internet"]
+        if advanced.waitForExistence(timeout: 3) { advanced.tap() }
+        let serverField = app.textFields["onboarding-server-url"]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 5), "server URL field never appeared")
+        serverField.tap()
+        serverField.typeText(server)
+
+        app.buttons["Continue"].firstMatch.tap()
+
+        // Success lands on the notifications primer; every failure kind lands
+        // on the failure card. Wait on both so a failed claim reports what the
+        // user would actually see instead of timing out anonymously.
+        let notifications = app.staticTexts["Know when it needs you"]
+        let failure = app.staticTexts["onboarding-failure-subtitle"]
+        let deadline = Date().addingTimeInterval(45)
+        while Date() < deadline, !notifications.exists, !failure.exists {
+            usleep(300_000)
+        }
+        if failure.exists {
+            XCTFail("pairing failed: \(failure.label)")
+            return
+        }
+        XCTAssertTrue(notifications.exists, "neither the notifications primer nor a failure card appeared")
+
+        app.buttons["Continue"].firstMatch.tap()
+
+        print("AX-TREE-BEGIN")
+        print(app.debugDescription)
+        print("AX-TREE-END")
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -106,3 +106,23 @@ final class MantaSystemAlertUITests: XCTestCase {
         print("PAIRDRIVE alert-answered=none")
     }
 }
+
+// Opens the first session row so the screenshot after this run shows the
+// terminal/chat screen rather than the list — i.e. it exercises the box
+// connection past the session list (websocket attach for a TUI window).
+final class MantaOpenSessionUITests: XCTestCase {
+
+    func testOpenFirstSession() {
+        let app = XCUIApplication()
+        app.launch()
+        let row = app.buttons.matching(NSPredicate(format: "label CONTAINS ''")).firstMatch
+        guard row.waitForExistence(timeout: 15) else {
+            print("PAIRDRIVE open=no-rows")
+            return
+        }
+        print("PAIRDRIVE open-row=\(row.label)")
+        row.tap()
+        sleep(6)
+        print("PAIRDRIVE opened")
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -21,17 +21,26 @@ final class MantaPairingDriverUITests: XCTestCase {
     }
 
     func testPairAgainstLiveBox() throws {
+        // Credentials reach the runner through a JSON drop at /tmp/manta-pair.json
+        // INSIDE the simulator (the host writes it to the device's own
+        // data/tmp). `xcodebuild`'s TEST_RUNNER_* env passthrough does NOT
+        // reach a UI-test runner here — verified empty — so the file is the
+        // supported channel, with the env kept as a fallback.
         let env = ProcessInfo.processInfo.environment
-        // Marker line: the plugin's job log is head-capped, so the ONE thing
-        // that must always be greppable is whether the credentials arrived.
-        let seen = env.keys.filter { $0.contains("MANTA_PAIR") }.sorted().joined(separator: ",")
-        print("PAIRDRIVE env-keys=[\(seen)]")
-        guard let code = env["MANTA_PAIR_CODE"], !code.isEmpty,
-              let server = env["MANTA_PAIR_SERVER"], !server.isEmpty
-        else {
-            throw XCTSkip("PAIRDRIVE SKIP: MANTA_PAIR_CODE / MANTA_PAIR_SERVER missing from the runner env")
+        var code = env["MANTA_PAIR_CODE"] ?? ""
+        var server = env["MANTA_PAIR_SERVER"] ?? ""
+        if code.isEmpty || server.isEmpty,
+           let data = FileManager.default.contents(atPath: "/tmp/manta-pair.json"),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+            code = json["code"] ?? code
+            server = json["server"] ?? server
         }
-        print("PAIRDRIVE start code-digits=\(code.count) server=\(server)")
+        // The plugin's job log is head-capped, so the ONE thing that must
+        // always be greppable is whether the credentials arrived.
+        print("PAIRDRIVE input code-digits=\(code.count) server=\(server.isEmpty ? "MISSING" : server)")
+        guard !code.isEmpty, !server.isEmpty else {
+            throw XCTSkip("PAIRDRIVE SKIP: no pairing code/server (env and /tmp/manta-pair.json both empty)")
+        }
 
         let app = XCUIApplication()
         app.launch()

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -123,13 +123,22 @@ final class MantaOpenSessionUITests: XCTestCase {
         // row by coordinate. A named row matters because a chat-mode window
         // and a plain tmux window land on completely different screens.
         let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
-        let named = app.staticTexts[wanted]
-        if !wanted.isEmpty, named.waitForExistence(timeout: 5), named.isHittable {
-            print("PAIRDRIVE open-row=\(wanted)")
-            named.tap()
-        } else {
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
             print("PAIRDRIVE open-row=first-by-coordinate")
             app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        }
+        // Each hop is one push (session row, then e.g. a subagent row), so a
+        // drill-in can be driven end to end rather than only the first screen.
+        for hop in hops {
+            let target = app.staticTexts[hop]
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            print("PAIRDRIVE open-row=\(hop)")
+            sleep(3)
         }
         sleep(6)
         // The runner tears the app down the moment the test ends, so a

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -131,14 +131,18 @@ final class MantaOpenSessionUITests: XCTestCase {
         // Each hop is one push (session row, then e.g. a subagent row), so a
         // drill-in can be driven end to end rather than only the first screen.
         for hop in hops {
-            let target = app.staticTexts[hop]
+            // A list row combines its children for accessibility, so it is ONE
+            // element whose label is "<name>, <subtitle>" — an exact staticText
+            // match finds only headers, never a row.
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let target = app.descendants(matching: .any).matching(prefix).firstMatch
             guard target.waitForExistence(timeout: 10) else {
                 print("PAIRDRIVE open-miss=\(hop)")
                 break
             }
             target.tap()
-            print("PAIRDRIVE open-row=\(hop)")
-            sleep(3)
+            print("PAIRDRIVE open-row=\(hop) kind=\(target.elementType.rawValue)")
+            sleep(4)
         }
         sleep(6)
         // The runner tears the app down the moment the test ends, so a

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -115,13 +115,12 @@ final class MantaOpenSessionUITests: XCTestCase {
     func testOpenFirstSession() {
         let app = XCUIApplication()
         app.launch()
-        let row = app.buttons.matching(NSPredicate(format: "label CONTAINS ''")).firstMatch
-        guard row.waitForExistence(timeout: 15) else {
-            print("PAIRDRIVE open=no-rows")
-            return
-        }
-        print("PAIRDRIVE open-row=\(row.label)")
-        row.tap()
+        // The rows combine their children for accessibility, so they are not
+        // reliably queryable as buttons; a normalized coordinate tap lands on
+        // the first row under the "Sessions" title regardless of element type.
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        print("PAIRDRIVE rows buttons=\(app.buttons.count) cells=\(app.cells.count) texts=\(app.staticTexts.count)")
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
         sleep(6)
         // The runner tears the app down the moment the test ends, so a
         // host-side `simctl io screenshot` always catches Springboard instead.

--- a/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaPairingDriverUITests.swift
@@ -21,25 +21,21 @@ final class MantaPairingDriverUITests: XCTestCase {
     }
 
     func testPairAgainstLiveBox() throws {
-        // Credentials reach the runner through a JSON drop at /tmp/manta-pair.json
-        // INSIDE the simulator (the host writes it to the device's own
-        // data/tmp). `xcodebuild`'s TEST_RUNNER_* env passthrough does NOT
-        // reach a UI-test runner here — verified empty — so the file is the
-        // supported channel, with the env kept as a fallback.
+        // Credentials reach the runner through MantaPairFixture, which the driver
+        // plugin overwrites immediately before `xcodebuild test`. A UI test cannot
+        // read the host filesystem, and TEST_RUNNER_* env passthrough does NOT
+        // reach the runner on this toolchain (verified empty), so the compiler is
+        // the channel; env is kept as a fallback.
         let env = ProcessInfo.processInfo.environment
         var code = env["MANTA_PAIR_CODE"] ?? ""
         var server = env["MANTA_PAIR_SERVER"] ?? ""
-        if code.isEmpty || server.isEmpty,
-           let data = FileManager.default.contents(atPath: "/tmp/manta-pair.json"),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
-            code = json["code"] ?? code
-            server = json["server"] ?? server
-        }
+        if code.isEmpty { code = MantaPairFixture.code }
+        if server.isEmpty { server = MantaPairFixture.server }
         // The plugin's job log is head-capped, so the ONE thing that must
         // always be greppable is whether the credentials arrived.
         print("PAIRDRIVE input code-digits=\(code.count) server=\(server.isEmpty ? "MISSING" : server)")
         guard !code.isEmpty, !server.isEmpty else {
-            throw XCTSkip("PAIRDRIVE SKIP: no pairing code/server (env and /tmp/manta-pair.json both empty)")
+            throw XCTSkip("PAIRDRIVE SKIP: no pairing code/server (MantaPairFixture is empty and no env override)")
         }
 
         let app = XCUIApplication()

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -12,7 +12,18 @@ targets:
     platform: iOS
     deploymentTarget: "26.0"
     sources:
+      # NOTE the exclude + folder pair below: the terminal page is loaded with
+      # `Bundle.main.url(forResource:"terminal", withExtension:"html",
+      # subdirectory:"terminal")`, which only resolves if the directory SURVIVES
+      # into the bundle. Listed as ordinary sources, xcodegen emits one file
+      # reference per file and Copy Bundle Resources FLATTENS them to the bundle
+      # root, so that lookup returned nil and the terminal screen rendered a
+      # black void. `type: folder` makes it a folder reference, copied whole.
       - path: MantaUI
+        excludes:
+          - "Resources/terminal"
+      - path: MantaUI/Resources/terminal
+        type: folder
       # The design tokens are GENERATED (scripts/gen-swift-tokens.mjs reads
       # src/renderer/tokens.css). Referenced by path from the app target so the
       # Swift source of truth stays the generated file — never copied or

--- a/src/renderer/tokens.css
+++ b/src/renderer/tokens.css
@@ -271,7 +271,11 @@
   --accent-tx: #1F55D6;
   --accent-solid: #1F55D6;
   --on-accent: #FFFFFF;
-  --accent-soft: #1F55D6;
+  /* A SOFT tint, not the accent itself. It was #1F55D6 — byte-identical to
+     --accent-tx, the colour drawn ON it — so every light-mode pill that pairs
+     them (the composer's model picker, the attach button, transcript glyphs)
+     rendered as a solid blue blob with invisible content. */
+  --accent-soft: #DFE8FF;
   --ok: #0A7A53;
   --warn: #8A5A08;
   --danger: #BE2F3C;
@@ -297,7 +301,7 @@
   --border-rgb: 218 213 204;
   --tx1-rgb: 26 24 21;
   --accent-rgb: 46 107 255;
-  --accent-soft-rgb: 31 85 214;
+  --accent-soft-rgb: 223 232 255;
 
   --shadow-sm: 0 1px 2px rgb(26 24 21 / 0.06);
   --shadow-md: 0 8px 24px rgb(26 24 21 / 0.10);


### PR DESCRIPTION
Opened automatically for `multica/BET-625-sim-chat-captures`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-625.