### PR TITLE
feat(ios): overflow sheet shell with session name + branch (BET-626)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -20,15 +20,22 @@ import SwiftUI
 struct ChatScreen: View {
     let title: String
     let projectName: String
+    /// Folder whose git branch the overflow sheet header shows (D4). Nil when
+    /// the project couldn't be resolved — then no `⎇ <branch>` line renders.
+    let gitFolder: String?
     @ObservedObject var eventStore: MantaEventStore
     @StateObject private var store: ChatSessionStore
     @StateObject private var modelStore: ChatModelStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
 
-    init(sessionId: String, title: String, projectName: String, eventStore: MantaEventStore) {
+    @State private var showOverflow = false
+    @State private var branch = ""
+
+    init(sessionId: String, title: String, projectName: String, eventStore: MantaEventStore, gitFolder: String? = nil) {
         self.title = title
         self.projectName = projectName
+        self.gitFolder = gitFolder
         self.eventStore = eventStore
         let api = MantaAPIClient.live()
         _store = StateObject(wrappedValue: ChatSessionStore(
@@ -40,6 +47,16 @@ struct ChatScreen: View {
     }
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    /// Resolve the `⎇ <branch>` label (D4) for the overflow sheet header from
+    /// the session's git folder. Empty when the folder is unknown or not in a
+    /// repo — the sheet then carries only the session name.
+    private func loadBranch() async {
+        guard let gitFolder, !gitFolder.isEmpty else { return }
+        let api = MantaAPIClient.live()
+        let worktrees = try? await api.listWorktrees(gitFolder)
+        branch = WorktreeInfoLogic.gitStateLabel(worktrees)
+    }
 
     var body: some View {
         // ChatScreen is PUSHED within SessionListView's NavigationStack, so it
@@ -80,6 +97,12 @@ struct ChatScreen: View {
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
         .overlay(alignment: .top) { header }
+        .sheet(isPresented: $showOverflow) {
+            OverflowSheet(title: title, branch: branch, tokens: tokens)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .task { await loadBranch() }
         .onAppear { store.start() }
         .onDisappear { store.stop() }
         .accessibilityElement(children: .contain)
@@ -120,10 +143,21 @@ struct ChatScreen: View {
 
             Spacer(minLength: 0)
 
-            // Trailing 38×38 glass button (§8) — a placeholder in S4 (the
-            // overflow sheet with fork/settings is a later stage).
-            Color.clear
-                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+            // Trailing 38×38 glass button (§8) — opens the overflow sheet
+            // (BET-624 row 1). Stable identifier so the simulator capture
+            // driver (BET-625) can tap it.
+            Button {
+                showOverflow = true
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                    .background(.ultraThinMaterial, in: Circle())
+                    .accessibilityLabel("More options")
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("overflow-button")
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
@@ -194,6 +228,54 @@ struct ChatScreen: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
         .onTapGesture { store.load() }
+    }
+}
+
+// MARK: - Overflow sheet (BET-624 row 1 shell)
+
+/// The overflow sheet (§8, DECISIONS.md:667-670) — row 1 of the epic builds
+/// the SHELL only: a real sheet that rests at half height, drags to full,
+/// flicks away, dims the screen behind proportionally, and shows the session
+/// name plus the git branch (D4) in its header. The content rows (attach ·
+/// scheduled tasks · secrets · …) land in build rows 2-4, so the body is an
+/// empty container those issues fill.
+struct OverflowSheet: View {
+    let title: String
+    let branch: String
+    let tokens: Tokens
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(tokens.canvas.ignoresSafeArea())
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("overflow-sheet")
+    }
+
+    /// Session name, then `⎇ <branch>` beneath it (D4) — the branch lives in
+    /// the sheet header, not the two-line chat header.
+    private var header: some View {
+        VStack(spacing: Metrics.spacing.spPx) {
+            Text(title)
+                .font(.system(size: Metrics.type.chatTitle, weight: mantaFontWeight(Metrics.type.semibold)))
+                .kerning(Metrics.type.chatTitleTracking * Metrics.type.chatTitle)
+                .foregroundColor(tokens.tx1)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if !branch.isEmpty {
+                Text(branch)
+                    .font(.system(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.medium)))
+                    .foregroundColor(tokens.tx4)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp3)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -67,7 +67,13 @@ struct SessionListView: View {
             .sheet(item: $renameTarget) { _ in renameSheet(targetProject: renameProject) }
             .navigationDestination(item: $openTarget) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
-                    ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore)
+                    let project = store.projects.first(where: { $0.tmuxSession == target.project })
+                    let window = project?.windows.first(where: { $0.index == target.windowIndex })
+                    // The sheet's branch (D4) resolves against the session's
+                    // git folder — prefer the window's worktree, else the
+                    // project's default cwd.
+                    let gitFolder = window?.worktreePath ?? project?.defaultCwd
+                    ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore, gitFolder: gitFolder)
                 } else if let project = store.projects.first(where: { $0.tmuxSession == target.project }),
                           let window = project.windows.first(where: { $0.index == target.windowIndex }) {
                     // S6 (BET-598): a non-chat window opens the native


### PR DESCRIPTION
Build order row 1 of BET-624. Implements the native overflow sheet shell.

**What changed**
- `mobile/native/MantaUI/ChatScreen.swift`: replaced the trailing `Color.clear` header placeholder with a real 38×38 glass MoreHorizontal button (id `overflow-button`, so the BET-625 sim-drive capture can tap it). Tapping presents `OverflowSheet` as a real sheet — `.presentationDetents([.medium, .large])` (rests half-height, drags to full, flick-to-dismiss) with `.presentationDragIndicator(.visible)` (functional grabber); SwiftUI dims the canvas behind proportionally. The sheet header shows the session name and, under it, `⎇ <branch>` (D4 — branch stays out of the two-line chat header).
- Branch resolved async on appear via `git:list-worktrees` + the existing `WorktreeInfoLogic.gitStateLabel`; renders nothing when no repo/folder, matching the folder picker.
- `mobile/native/MantaUI/SessionListView.swift`: passes the session's git folder (window `worktreePath` ?? project `defaultCwd`) into ChatScreen for branch resolution.
- Content rows (attach · scheduled tasks · secrets · …) are build rows 2–4; this row is the shell only.

**Verification**
- `npm run typecheck`: exit 0 (both tsconfigs).
- `npm test`: 1435 pass / 0 fail / 0 skip.
- This is an iOS Swift change; the acceptance screenshot requires the Apple toolchain and is produced by the sim-drive capture on a Mac (handed off to macos).

Base: origin/main @ `df58320`