### PR TITLE
BET-625: simulator driver actions for chat-surface captures

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -124,10 +124,20 @@ struct ChatScreen: View {
 
             Spacer(minLength: 0)
 
-            // Trailing 38×38 glass button (§8) — a placeholder in S4 (the
-            // overflow sheet with fork/settings is a later stage).
-            Color.clear
-                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+            // Trailing 38×38 glass button (§8) — a tappable placeholder in S4.
+            // Inert until BET-626 builds the real overflow sheet; it carries a
+            // stable identifier so the simulator capture driver (BET-625) and
+            // BET-626 can both address it. No action yet — BET-626 wires it.
+            Button(action: {}) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                    .background(.ultraThinMaterial, in: Circle())
+                    .accessibilityLabel("More options")
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("overflow-button")
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)

--- a/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
@@ -71,8 +71,20 @@ final class MantaOverflowCaptureUITests: XCTestCase {
 
         MantaChatCapture.openChat(in: app)
 
-        let overflow = app.buttons["overflow-button"]
+        // Wait for the chat surface to push, then locate the trailing header
+        // overflow button. Query descendants + label fallback for resilience
+        // across SwiftUI element taxonomies.
+        _ = app.descendants(matching: .any)["chat-screen"].waitForExistence(timeout: 10)
+        let byId = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == 'overflow-button'")).firstMatch
+        let overflow = byId.exists ? byId : app.buttons["More options"]
         guard overflow.waitForExistence(timeout: 10) else {
+            // Diagnose: dump the on-screen buttons so a mis-targeted row
+            // (terminal vs chat) is obvious instead of a silent skip.
+            let labels = app.buttons.allElementsBoundByIndex
+                .prefix(40)
+                .map { $0.identifier.isEmpty ? $0.label : $0.identifier }
+            print("PAIRDRIVE overflow-missing buttons=\(labels.joined(separator: "|"))")
             throw XCTSkip("PAIRDRIVE overflow: no overflow-button (chat not open?)")
         }
         overflow.tap()

--- a/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
@@ -1,0 +1,153 @@
+import XCTest
+
+// ===========================================================================
+// Chat-surface capture driver for the native chat epic (BET-624, row 0 =
+// BET-625). The manta-sim-drive plugin builds each of these test classes in
+// the Simulator and globs the PNG it drops into the runner's own container,
+// then uploads it to the box. The order of this epic means the surfaces the
+// captures show land AFTER this driver: the overflow sheet (BET-626), the
+// running row (BET-630) and the loading skeleton (BET-631) are accepted by a
+// screenshot produced through these actions.
+//
+// Shared navigation:
+//   - MANTA_OPEN_ROW names a row to open (label-prefix hop, `|`-delimited);
+//     empty falls back to the first row by normalized coordinate. A chat-mode
+//     window and a plain tmux window land on different screens, so the caller
+//     picks which row for which capture.
+//   - Each test writes one uniquely named PNG so the plugin can pick it up.
+// ===========================================================================
+
+private enum MantaChatCapture {
+
+    /// Open the first/named session row so the app lands on the chat screen
+    /// (mirrors MantaOpenSessionUITests.testOpenFirstSession).
+    static func openChat(in app: XCUIApplication) {
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            print("PAIRDRIVE open-row=first-by-coordinate")
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let target = app.descendants(matching: .any).matching(prefix).firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            print("PAIRDRIVE open-row=\(hop) kind=\(target.elementType.rawValue)")
+            sleep(4)
+        }
+        // Give the chat screen a moment to push into the navigation stack.
+        sleep(2)
+    }
+
+    /// The runner tears the app down the moment the test ends, so a host-side
+    /// `simctl io screenshot` always catches Springboard instead. Capture from
+    /// inside the test and drop it in the runner's own container, which the
+    /// driver plugin globs for on the host.
+    static func capture(_ name: String) {
+        let shot = XCUIScreen.main.screenshot()
+        let out = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(name)
+        try? shot.pngRepresentation.write(to: out)
+        print("PAIRDRIVE shot=\(out.path)")
+    }
+}
+
+// Opens the chat overflow sheet — taps the trailing 38×38 header button
+// (`overflow-button`, BET-626's real sheet) — and captures the sheet.
+final class MantaOverflowCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureOverflowSheet() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        MantaChatCapture.openChat(in: app)
+
+        let overflow = app.buttons["overflow-button"]
+        guard overflow.waitForExistence(timeout: 10) else {
+            throw XCTSkip("PAIRDRIVE overflow: no overflow-button (chat not open?)")
+        }
+        overflow.tap()
+        print("PAIRDRIVE overflow=opened")
+
+        // Let the sheet settle at its half-height detent (BET-626).
+        sleep(2)
+        MantaChatCapture.capture("manta-overflow-sheet.png")
+    }
+}
+
+// Sends a prompt and captures while the turn is still running, so the
+// mid-turn state (running row / elapsed time, BET-630) is visible.
+final class MantaMidTurnCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureMidTurn() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        MantaChatCapture.openChat(in: app)
+
+        let input = app.textViews["composer-input"]
+        guard input.waitForExistence(timeout: 10) else {
+            throw XCTSkip("PAIRDRIVE midturn: no composer input")
+        }
+        input.tap()
+        input.typeText("Say the alphabet slowly, one letter per line, pausing after each line.")
+        let send = app.buttons["send-button"]
+        XCTAssertTrue(send.waitForExistence(timeout: 5), "no send button")
+        send.tap()
+        print("PAIRDRIVE midturn=sent")
+
+        // Capture while the turn is still in flight.
+        sleep(5)
+        MantaChatCapture.capture("manta-mid-turn.png")
+    }
+}
+
+// Opens a session and captures as close to the push as possible, so the
+// initial-load skeleton (BET-631) is on screen rather than a settled
+// transcript.
+final class MantaLoadCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureDuringLoad() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let target = app.descendants(matching: .any).matching(prefix).firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            sleep(4)
+        }
+
+        // Minimal delay — don't wait for the transcript to settle, capture the
+        // loading state.
+        usleep(300_000)
+        MantaChatCapture.capture("manta-load.png")
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaChatCaptureUITests.swift
@@ -21,6 +21,10 @@ private enum MantaChatCapture {
 
     /// Open the first/named session row so the app lands on the chat screen
     /// (mirrors MantaOpenSessionUITests.testOpenFirstSession).
+    ///
+    /// A label-prefix hit is ambiguous: the folder picker's action buttons
+    /// ("New project…", the `plus`) also begin with the row text, so match on
+    /// elements that look like session rows rather than the sheet's buttons.
     static func openChat(in app: XCUIApplication) {
         _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
         let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
@@ -31,16 +35,30 @@ private enum MantaChatCapture {
         }
         for hop in hops {
             let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
-            let target = app.descendants(matching: .any).matching(prefix).firstMatch
+            let candidates = app.descendants(matching: .any).matching(prefix)
+            let target = candidates.allElementsBoundByIndex
+                // A session row is not in the create-project sheet and is not a
+                // bare icon/action control. Skip buttons whose label is exactly
+                // a sheet action ("plus", "gearshape", "Cancel", "Create", …).
+                .first { el in
+                    guard el.elementType != .button else { return false }
+                    return true
+                } ?? candidates.firstMatch
             guard target.waitForExistence(timeout: 10) else {
                 print("PAIRDRIVE open-miss=\(hop)")
                 break
             }
             target.tap()
-            print("PAIRDRIVE open-row=\(hop) kind=\(target.elementType.rawValue)")
+            print("PAIRDRIVE open-row=\(hop) kind=\(target.elementType.rawValue) label=\(target.label)")
             sleep(4)
         }
-        // Give the chat screen a moment to push into the navigation stack.
+        // Wait until the push lands on the chat screen itself (not a subagent
+        // screen or a failure card), then give the header a moment to render.
+        if !app.descendants(matching: .any)["chat-screen"].waitForExistence(timeout: 10) {
+            print("PAIRDRIVE on-chat=false")
+        } else {
+            print("PAIRDRIVE on-chat=true")
+        }
         sleep(2)
     }
 
@@ -148,7 +166,11 @@ final class MantaLoadCaptureUITests: XCTestCase {
         }
         for hop in hops {
             let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
-            let target = app.descendants(matching: .any).matching(prefix).firstMatch
+            let candidates = app.descendants(matching: .any).matching(prefix)
+            let target = candidates.allElementsBoundByIndex
+                // Skip the create-project sheet's action buttons (see openChat).
+                .first { el in el.elementType != .button }
+                ?? candidates.firstMatch
             guard target.waitForExistence(timeout: 10) else {
                 print("PAIRDRIVE open-miss=\(hop)")
                 break


### PR DESCRIPTION
Build-order row 0 for BET-624 (native chat screens). Delivers the simulator driver actions that rows 1–6 use for their screenshot acceptance.

- New `MantaChatCaptureUITests.swift`: `overflow` / `midturn` / `load` capture drivers, each dropping a distinctly-named PNG for the plugin to glob. Shared row-open helper waits for the `chat-screen` surface and dumps on-screen buttons when a row is mis-targeted.
- `ChatScreen.swift`: trailing header placeholder is now a tappable `ellipsis` button carrying `accessibilityIdentifier("overflow-button")` (inert until BET-626), so the driver and BET-626 can both address it.
- `manta-sim-drive` plugin gains `overflow`/`midturn`/`load` actions, default branch → this branch.

Verified on the Mac: driver compiles (rc=0) and `load` produces an in-test PNG end-to-end. Note: the closed PR #526 against `main` was the wrong base — this branch lives on `sim-pair-driver` (where the driver accumulates), so this PR targets that.

Not covered here (external + sibling issues): live-box upload and the surfaces themselves (BET-626/630/631).