### PR TITLE
feat(ios): running row + ambient refetch sweep (BET-630, D1)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -58,6 +58,13 @@ struct ChatScreen: View {
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
                 bottomCards
+                // BET-630 (D1): the running-state working row. Shown only while a
+                // turn runs; the ambient refetch sweep lives on the composer's
+                // top divider and means a different thing, so the two never
+                // share an indicator. Not shown during a background refetch.
+                if store.running {
+                    RunningIndicator(store: store)
+                }
                 ComposerView(
                     sessionId: store.sessionId,
                     projectName: projectName,

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -45,6 +45,10 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var childStores: [String: ChatSessionStore] = [:]
     @Published private(set) var loading = false
     @Published private(set) var loadFailed = false
+    /// True while a canonical transcript refetch (or the initial load) is in
+    /// flight. Drives the ambient hairline sweep on the composer's top divider
+    /// (BET-630, D1) — distinct from `running`, which drives the working row.
+    @Published private(set) var refreshing = false
 
     let sessionId: String
     let isReadOnly: Bool
@@ -101,10 +105,12 @@ final class ChatSessionStore: ObservableObject {
     func load() {
         guard !loading else { return }
         loading = true
+        refreshing = true
         Task {
             let messages = (try? await api.messages(sessionId: sessionId)) ?? []
             await MainActor.run {
                 loading = false
+                refreshing = false
                 loadFailed = messages.isEmpty
                 transcript = ChatTranscriptMapper.blocks(from: messages)
                 rebuildBlocks()
@@ -193,10 +199,12 @@ final class ChatSessionStore: ObservableObject {
     }
 
     func refetch() async {
+        refreshing = true
         let messages = (try? await api.messages(sessionId: sessionId)) ?? []
         await MainActor.run {
             transcript = ChatTranscriptMapper.blocks(from: messages)
             rebuildBlocks()
+            refreshing = false
             if !isReadOnly { Task { await self.refreshPermissions() } }
         }
     }
@@ -367,6 +375,11 @@ final class ChatSessionStore: ObservableObject {
 
     /// The newest pending question request, if any.
     var newestQuestion: QuestionRequest? { questions.last }
+
+    /// When the current turn started (nil when idle). The running row measures
+    /// live elapsed against its own 1s tick rather than stream-state changes
+    /// (BET-630, D1).
+    var runningStart: Date? { runningSince }
 
     /// §8 header subtitle ("running · 2m · 8%" / "idle").
     var headerSubtitle: String {

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -79,7 +79,7 @@ struct ComposerView: View {
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
         .background(tokens.canvas.ignoresSafeArea())
-        .overlay(alignment: .top) { divider }
+        .overlay(alignment: .top) { topDivider }
         .photosPicker(isPresented: $showPhotoPicker, selection: $photoItems, maxSelectionCount: 5, matching: .images)
         .fileImporter(isPresented: $showDocPicker, allowedContentTypes: [.item]) { result in
             handleDocument(result)
@@ -94,10 +94,19 @@ struct ComposerView: View {
         }
     }
 
-    private var divider: some View {
-        Rectangle()
-            .fill(tokens.borderSubtle)
-            .frame(height: Metrics.spacing.spPx)
+    /// The composer's top hairline. While a background transcript refetch (or the
+    /// initial load) runs — and the turn is NOT running — it becomes an ambient
+    /// accent sweep (BET-630, D1). A running turn shows the working row instead;
+    /// the two states never share an indicator.
+    @ViewBuilder
+    private var topDivider: some View {
+        if store.refreshing && !store.running {
+            RefetchSweep(tokens: tokens)
+        } else {
+            Rectangle()
+                .fill(tokens.borderSubtle)
+                .frame(height: Metrics.spacing.spPx)
+        }
     }
 
     // MARK: - Model pill
@@ -452,5 +461,39 @@ struct ComposerView: View {
 
     private func surfaceHint(_ message: String) {
         hintState(message)
+    }
+}
+
+/// Ambient transcript-refetch sweep on the composer's top hairline (BET-630, D1).
+/// A slow accent gradient travels L→R while the canonical transcript syncs in the
+/// background; border-only (1px) so there is no layout shift. Distinct from the
+/// running row — the two mean different things and never share an indicator.
+/// Mirrors the desktop `.manta-loading-divider` (src/renderer/index.css).
+private struct RefetchSweep: View {
+    let tokens: Tokens
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { context in
+            let period = 1.5
+            let t = (context.date.timeIntervalSinceReferenceDate
+                .truncatingRemainder(dividingBy: period) / period)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Rectangle().fill(tokens.borderSubtle)
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                colors: [.clear, tokens.accent.opacity(0.85), .clear],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: geo.size.width * 0.42)
+                        .offset(x: (CGFloat(t) * 1.45 - 0.42) * geo.size.width)
+                }
+            }
+            .frame(height: Metrics.spacing.spPx)
+            .clipped()
+        }
     }
 }

--- a/mobile/native/MantaUI/RunningIndicator.swift
+++ b/mobile/native/MantaUI/RunningIndicator.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+// ===========================================================================
+// BET-630 — the running-state working row (D1, build-order row 5).
+//
+// Ports the desktop RunningIndicator (src/renderer/MessageRow.tsx): a spinner
+// glyph + verb + live elapsed, shown ABOVE the composer while a turn runs. It
+// is deliberately distinct from the ambient refetch sweep on the composer's
+// top divider (the transcript-syncing indicator) — the two mean different
+// things and never share an indicator. The header subtitle (`running · 2m ·
+// 8%`) stays the at-a-glance status; this row is the wait affordance the user
+// is actually looking at.
+//
+// Mounted by ChatScreen only while `store.running`, so @State (verb + `now`)
+// reinitializes fresh each time a turn starts; the view leaves the hierarchy
+// when the turn ends.
+// ===========================================================================
+
+struct RunningIndicator: View {
+    @ObservedObject var store: ChatSessionStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// The rotation the working row cycles, mirroring the desktop SPINNER_VERBS.
+    private static let verbs = [
+        "Cogitating", "Ruminating", "Pondering", "Reflecting",
+        "Considering", "Deliberating", "Musing", "Contemplating",
+    ]
+
+    /// Picked once per mount so the verb doesn't shuffle between ticks.
+    @State private var verb = RunningIndicator.verbs[Int.random(in: RunningIndicator.verbs.indices)]
+    /// 1s tick reference; read in the body so the elapsed label re-renders.
+    @State private var now = Date()
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    var body: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(tokens.accent)
+            Text("\(verb)…")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx1)
+            Text("(\(SessionTimerFormat.liveElapsed(elapsed)))")
+                .font(.system(size: Metrics.type.small, design: .monospaced))
+                .foregroundColor(tokens.tx4)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("running-indicator")
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
+            now = Date()
+        }
+    }
+
+    private var elapsed: TimeInterval {
+        guard let start = store.runningStart else { return 0 }
+        return now.timeIntervalSince(start)
+    }
+}

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -147,6 +147,19 @@ enum SessionTimerFormat {
         let m = t / 60
         return "\(m) minute" + (m == 1 ? "" : "s")
     }
+
+    /// Live elapsed for the running row ("12s" / "1m 12s" / "1h 5m"). Unlike the
+    /// compact `elapsed` (the header slot), this keeps the seconds so a running
+    /// turn's elapsed visibly ticks even before the first minute (BET-630, D1).
+    static func liveElapsed(_ interval: TimeInterval) -> String {
+        let t = Int(interval)
+        let s = t % 60
+        let m = (t / 60) % 60
+        let h = t / 3600
+        if h > 0 { return "\(h)h \(m)m" }
+        if m > 0 { return "\(m)m \(s)s" }
+        return "\(s)s"
+    }
 }
 
 // MARK: - Pin identity (client-side, persisted in config)

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -65,6 +65,13 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertEqual(SessionTimerFormat.runningDuration(1), "1 second")
     }
 
+    func testLiveElapsedKeepsSeconds() {
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(5), "5s")
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(72), "1m 12s")
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(60), "1m 0s")
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(3725), "1h 2m")
+    }
+
     // MARK: - Pin identity
 
     func testWindowPinID() {


### PR DESCRIPTION
## BET-630 — running row + ambient refetch sweep (build-order row 5, D1)

Parent: BET-624. Doc: `docs/mobile-redesign/CHAT-SCREEN-CONSOLIDATED.md` (build-order row 5).

Ports the desktop pair to the native chat screen. Per D1, the two states are
different things and must not share one indicator:

1. **Working row above the composer** — spinner + verb + **live elapsed**
   (`Cogitating… (1m 12s)`), shown only while a turn runs. This is the wait
   affordance the user is looking at (the header subtitle, 11pt at the top,
   stays the at-a-glance status and is unchanged, per `DECISIONS.md:615-621`).
2. **Ambient hairline sweep on the composer's top divider** — a slow accent
   gradient travelling L→R while the canonical transcript **syncs** in the
   background (refetch or initial load), and the turn is **not** running. This
   mirrors the desktop `.manta-loading-divider` (`src/renderer/index.css:83-87`).

DONE WHEN: a mid-turn capture shows the row with a live elapsed; a refetch shows
the sweep and no row.

### What changed (Swift-only)

- `ChatSessionStore.swift` — new published `refreshing` (armed during `load()`
  and `refetch()`, so it covers both the initial load and background syncs,
  exactly like the desktop's first-open arming in `useSseBus.ts:629-633`);
  exposes `runningStart` for the row's live elapsed.
- `RunningIndicator.swift` (new) — the working row (spinner + verb + live
  elapsed, 1s tick, verb picked once per mount, mirroring desktop `SPINNER_VERBS`).
- `ChatScreen.swift` — mounts the row above the composer, `if store.running`.
- `ComposerView.swift` — its top hairline becomes an ambient `RefetchSweep`
  while `store.refreshing && !store.running`; otherwise the normal `borderSubtle`
  divider. `RefetchSweep` is a `TimelineView`-driven gradient, border-only (1px,
  no layout shift).
- `SessionModels.swift` — `SessionTimerFormat.liveElapsed` ("5s" / "1m 12s" /
  "1h 5m") + unit tests.

### Not in scope

- D2 loading skeleton (row 6), D3 idle context percent (row 8), header subtitle —
  all separate issues/unchanged.

### Self-check

- Working row shows during a run, hidden on idle and during a refetch: gate is
  `store.running` (row) vs `store.refreshing && !store.running` (sweep) — 9/10.
- Live elapsed ticks (1s timer, seconds preserved) — 9/10.
- Sweep shows on a sync with no row (refetch/initial load armed) — 8/10
  (capture timing lives with the macos driver).
- Header subtitle untouched — 9/10.

### Verification

**TypeScript/JS surfaces are untouched by this diff** (only `mobile/native/`
Swift files). `npm run typecheck` / `npm test` are consequently unaffected; CI's
`typecheck-test` runs them on merge. The meaningful verification for this
native-iOS change is the build + the two simulator captures below, which require
the Apple toolchain and are handed to `macos`.

Base: `origin/main @ df58320`.
