### PR TITLE
fix(mobile): show context percent in chat header at idle (BET-633)

### DIFF
--- a/docs/mobile-redesign/DECISIONS.md
+++ b/docs/mobile-redesign/DECISIONS.md
@@ -615,7 +615,9 @@ it carries everything rather than a subset.
 - Native header, transparent, no large title. Custom two-line centred title:
   session name 14.5px/600 tracking −0.01em `tx1` with ellipsis; below it
   11px/500 `tx4` of the form "running · 2m · 8%", with the word "running" in
-  `accentTx` when busy, falling back to "idle".
+  `accentTx` when busy; when idle, `idle · N%` (the context number matters most
+  before sending, so it stays visible), collapsing to bare "idle" only when no
+  context is established yet.
 - Leading and trailing 38×38 circular glass buttons: ChevronLeft, MoreHorizontal.
 - **Session status lives in the header subtitle** — which is exactly where
   BET-406 phase 7 is moving it on desktop. The two clients converge.

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -316,8 +316,10 @@ enum ChatQuestionAnswers {
 }
 
 // MARK: - Header subtitle (§8 "running · 2m · 8%" / idle)/// The §8 chat-header subtitle: while running, `running · <elapsed> · <N>%`;
-/// otherwise `idle`. Token-aware on the surrounding prose only; the string is
-/// assembled here so the view stays a thin token resolver.
+/// while idle, `idle · <N>%` (the context number matters most before sending),
+/// falling back to `idle` when no context is established yet. Token-aware on
+/// the surrounding prose only; the string is assembled here so the view stays a
+/// thin token resolver.
 enum ChatHeaderSubtitle {
     static func text(running: Bool, elapsed: TimeInterval, contextPct: Double?) -> String {
         if running {
@@ -326,6 +328,9 @@ enum ChatHeaderSubtitle {
                 return "running · \(elapsed) · \(Int(pct.rounded()))%"
             }
             return "running · \(elapsed)"
+        }
+        if let pct = contextPct {
+            return "idle · \(Int(pct.rounded()))%"
         }
         return "idle"
     }

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -190,6 +190,10 @@ final class ChatTranscriptTests: XCTestCase {
         XCTAssertEqual(ChatHeaderSubtitle.text(running: true, elapsed: 0, contextPct: nil), "running · 0s")
     }
 
+    func testHeaderSubtitleIdleWithContext() {
+        XCTAssertEqual(ChatHeaderSubtitle.text(running: false, elapsed: 0, contextPct: 12.6), "idle · 13%")
+    }
+
     func testHeaderSubtitleIdle() {
         XCTAssertEqual(ChatHeaderSubtitle.text(running: false, elapsed: 0, contextPct: nil), "idle")
     }


### PR DESCRIPTION
## BET-633 — show the context percent at idle

Locked decision D3, build order row 8. When a session is idle the chat header
subtitle previously dropped the context percent and read just `idle`. The number
matters most **before** sending, i.e. while idle, so the idle string now reads
`idle · N%` and collapses to bare `idle` only when no context is established.

**Files changed:** 3
- `mobile/native/MantaUI/ChatModels.swift` — `ChatHeaderSubtitle.text` now emits `idle · N%` when `contextPct` is present (same `Int(pct.rounded())%` formatting as the running case).
- `mobile/native/MantaUITests/ChatTranscriptTests.swift` — added `testHeaderSubtitleIdleWithContext` (`idle · 13%`), existing `testHeaderSubtitleIdle` (`idle`, no context) unchanged.
- `docs/mobile-redesign/DECISIONS.md` §8 — updated the subtitle spec so the design record matches the locked decision (avoids spec/code drift).

**Verification results:**
- This is a Swift native change. The repo has **no per-PR Swift test gate** — native XCTest runs only on the Mac (local) or Codemagic on `ios-v*` tags, and there is no Swift toolchain on this Linux box, so `xcodebuild`/`swift test` cannot be run here.
- Verification is the added/updated unit test (asserts exactly the DONE-WHEN string `idle · 13%` and the no-context fallback `idle`) plus a pure-function code review. Both the running and idle branches share the identical `Int(pct.rounded())%` formatting, exercised by the pre-existing running-with-context test.
- `npm run typecheck` / `npm test` do not cover Swift source and were not changed by this PR.

**Base:** origin/main @ `df58320`
