### PR TITLE
fix(BET-639): decode top-level String rpc results (vcs-branch crash)

### DIFF
--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -347,7 +347,12 @@ final class MantaAPIClient: Sendable {
         guard let result = object["result"], !(result is NSNull) else {
             return nil
         }
-        let resultData = try JSONSerialization.data(withJSONObject: result)
+        // `.fragmentsAllowed` so a top-level String/Number (e.g. the bare git
+        // branch name `String?` returned by `opencode:vcs-branch`) round-trips
+        // instead of throwing. Without it `JSONSerialization` rejects any
+        // non-object/non-array top level, which SIGABRT'd on any chat opened
+        // in a git checkout.
+        let resultData = try JSONSerialization.data(withJSONObject: result, options: [.fragmentsAllowed])
         return try JSONDecoder().decode(type, from: resultData)
     }
 

--- a/mobile/native/MantaUITests/MantaTransportTests.swift
+++ b/mobile/native/MantaUITests/MantaTransportTests.swift
@@ -142,6 +142,15 @@ final class MantaTransportTests: XCTestCase {
         XCTAssertEqual(question.tool?.callID, "toolu_10")
     }
 
+    func testDecodesTopLevelStringResultForVcsBranch() throws {
+        // `opencode:vcs-branch` returns a bare git branch name as a top-level
+        // String inside the envelope. Regression: decode must round-trip it
+        // instead of throwing (a top-level String is a JSON fragment).
+        let payload = #"{"result": "main"}"#
+        let branch = try MantaAPIClient.decode(json(payload), as: String?.self)
+        XCTAssertEqual(branch, "main")
+    }
+
     func testDecodesVoidResultPayloadsForWriteMethods() throws {
         let payload = #"{"result":null}"#
         let data = try json(payload)


### PR DESCRIPTION
Opened automatically for `multica/BET-639-vcs-branch-string-decode`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-639.