### PR TITLE
fix(BET-640): make self-update work on packaged installs and surface update failures

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,6 +131,29 @@ install_root_file() {
   sudo -n install -m 0644 -o root -g root "$1" "$2"
 }
 
+# --- Shared release-resolution helpers (BET-640) -----------------------------
+# install.sh shares the four release-resolution helpers (manifest_get,
+# resolve_arch, _sha256_of, verify_sha256) with scripts/self-update.sh via
+# scripts/lib/release.sh so the two update paths never drift. Normally we
+# source that lib, deriving install.sh's own directory from ${BASH_SOURCE[0]}
+# (dev checkout, installed-box re-run, or the test harness, where the file is
+# on disk).
+#
+# install.sh's PRIMARY mode is `curl -fsSL … | bash`, where there is NO local
+# file yet — the tarball that carries scripts/lib/release.sh is downloaded
+# MID-install, and a piped script has BASH_SOURCE empty and cannot read a
+# sibling file. In that mode we fall back to the inline definitions below.
+# Those are the SAME bytes as the lib (keep them in sync) and are the
+# standalone piped artifact — self-update.sh has NO copy of its own, it always
+# sources the lib. sync_opencode_guidance lives ONLY in the lib and is sourced
+# from $MANTA_HOME/scripts/lib/release.sh after the tarball is extracted.
+INSTALL_SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+if [ -n "$INSTALL_SOURCE_DIR" ] && [ -f "$INSTALL_SOURCE_DIR/lib/release.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$INSTALL_SOURCE_DIR/lib/release.sh"
+else
+  # curl | bash / no local lib yet — inline fallback (byte-identical to lib).
+
 # Parse one key out of a key=value manifest body. Echoes the value, empty if
 # absent. Values may contain `=` (cut -d= -f2- preserves them). A repeated key
 # is reduced to the FIRST occurrence (head -n1) — the manifest writer emits
@@ -163,6 +186,29 @@ resolve_arch() {
     *) die "unsupported OS: $s (the MantaUI box installer supports Linux and macOS/Apple Silicon)" ;;
   esac
 }
+
+
+# _sha256_of echoes the sha256 hex of $1. Prefers GNU sha256sum (Linux ships
+# it via coreutils); falls back to BSD `shasum -a 256` on macOS, which ships
+# shasum by default but NOT sha256sum. Single shared helper so the prereq
+# check (step 1) and verify_sha256 can't drift — the BET-278 review concern.
+_sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Verify $1's sha256 equals $2 (64-hex). Dies on mismatch.
+verify_sha256() {
+  local actual; actual="$(_sha256_of "$1")"
+  [ "$actual" = "$2" ] || die "checksum mismatch for $1
+      expected: $2
+      actual:   $actual
+      (corrupt download or stale manifest — re-run; if it persists, report it)"
+}
+fi
 
 # launchd_agent_path — the PATH a MantaUI supervisor-managed service must
 # run with. Used by:
@@ -222,27 +268,6 @@ launchd_agent_path() {
     *) base="$HOME/.local/bin:$base" ;;
   esac
   printf '%s' "$base"
-}
-
-# _sha256_of echoes the sha256 hex of $1. Prefers GNU sha256sum (Linux ships
-# it via coreutils); falls back to BSD `shasum -a 256` on macOS, which ships
-# shasum by default but NOT sha256sum. Single shared helper so the prereq
-# check (step 1) and verify_sha256 can't drift — the BET-278 review concern.
-_sha256_of() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | cut -d' ' -f1
-  else
-    shasum -a 256 "$1" | cut -d' ' -f1
-  fi
-}
-
-# Verify $1's sha256 equals $2 (64-hex). Dies on mismatch.
-verify_sha256() {
-  local actual; actual="$(_sha256_of "$1")"
-  [ "$actual" = "$2" ] || die "checksum mismatch for $1
-      expected: $2
-      actual:   $actual
-      (corrupt download or stale manifest — re-run; if it persists, report it)"
 }
 
 # print_provider_detection_summary <lib-path> <node-path> <home-path> [is_macos]
@@ -821,20 +846,18 @@ main() {
   else
     warn "$OPENCODE_TOOLS_SRC not found in tarball — skipping tool copy (was docs/opencode-tools/* added to release/pack.mjs?)."
   fi
-  # AGENTS.md append with marker guard — idempotency by a single grep on a
-  # stable line ("## manta scheduled tasks"). A re-run with the marker present
-  # is a clean no-op.
+  # AGENTS.md section-sync (BET-640): append any top-level `## ` guidance
+  # section from docs/opencode-tools/AGENTS.md that is not already present, so
+  # a section added after a box was installed lands on the NEXT install/update.
+  # Existing sections are never rewritten (the user may have edited them).
+  # sync_opencode_guidance lives in scripts/lib/release.sh — under clean
+  # `curl | bash` it wasn't available at the top (no local file pre-download),
+  # but the tarball is extracted by now, so source the lib from MANTA_HOME.
   if [ -f "$OPENCODE_TOOLS_SRC/AGENTS.md" ]; then
-    if [ -f "$OPENCODE_AGENTS" ] && grep -q '^## manta scheduled tasks' "$OPENCODE_AGENTS"; then
-      ok "opencode AGENTS.md already contains manta guidance — skipping append."
-    else
-      log "Appending manta opencode agent guidance to ${OPENCODE_AGENTS}…"
-      {
-        [ -f "$OPENCODE_AGENTS" ] && cat "$OPENCODE_AGENTS" && printf '\n'
-        cat "$OPENCODE_TOOLS_SRC/AGENTS.md"
-      } > "$OPENCODE_AGENTS.tmp" && mv "$OPENCODE_AGENTS.tmp" "$OPENCODE_AGENTS"
-      ok "opencode AGENTS.md updated."
+    if ! declare -F sync_opencode_guidance >/dev/null 2>&1; then
+      . "$MANTA_HOME/scripts/lib/release.sh"
     fi
+    sync_opencode_guidance "$OPENCODE_TOOLS_SRC/AGENTS.md" "$OPENCODE_AGENTS"
   fi
 
   # install_launchd_agent <label> <template-src> <dest-plist> — render the

--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -1,0 +1,137 @@
+# scripts/lib/release.sh — shared release-resolution helpers + opencode agent
+# guidance sync for the box install/update path (BET-640).
+#
+# SOURCED (not executed) by BOTH scripts/install.sh and scripts/self-update.sh,
+# so it must define ONLY functions and never run anything at source time: no
+# side effects, no `set -e`, no toplevel calls. Function bodies reference the
+# `log`/`ok`/`warn`/`die` printing helpers that each CALLING script defines
+# and owns (install.sh and self-update.sh each define their own copies, since
+# a `curl … | bash` install can't share shell state with the box's scripts).
+#
+# These helpers used to be defined inline in install.sh; they are moved here so
+# the two scripts never drift on arch resolution / manifest parsing / checksum
+# verification — the exact drift that left packaged installs unable to run
+# their own updater.
+#
+# NOTE (BET-640): adding a tool here still requires restarting opencode for it
+# to register — opencode re-scans ~/.config/opencode/tools only at startup.
+# These scripts restart manta-server, not opencode, and changing that is out
+# of scope.
+
+# Parse one key out of a key=value manifest body. Echoes the value, empty if
+# absent. Values may contain `=` (cut -d= -f2- preserves them). A repeated key
+# is reduced to the FIRST occurrence (head -n1) — the manifest writer emits
+# exactly one of each.
+manifest_get() { # $1=manifest-body $2=key
+  printf '%s\n' "$1" | grep "^$2=" | head -n1 | cut -d= -f2-
+}
+
+# Map (uname -s, uname -m) to the release manifest arch key. Sets global
+# ARCH_KEY. Dies on any (OS, arch) we don't ship a tarball for. This is the
+# SINGLE place the installer decides which OS+arch it is — see BET-274.
+# NOTE: this function is defined here so install.sh (fresh `curl | bash`) and
+# self-update.sh (packaged box) resolve arch identically.
+resolve_arch() {
+  local s m; s="$(uname -s)"; m="$(uname -m)"
+  case "$s" in
+    Linux)
+      case "$m" in
+        x86_64)         ARCH_KEY="linux_x64" ;;
+        aarch64|arm64)  ARCH_KEY="linux_arm64" ;;
+        *) die "unsupported architecture: $m on Linux (this installer ships linux x86_64 and arm64)" ;;
+      esac
+      ;;
+    Darwin)
+      case "$m" in
+        arm64)  ARCH_KEY="darwin_arm64" ;;
+        *) die "unsupported Mac: $m — the MantaUI box installer supports Apple Silicon (arm64) Macs only.
+      Intel Macs are not supported as a box. If you just want to USE MantaUI on this Mac,
+      install the desktop app instead: https://mantaui.com/downloads/Manta-latest.dmg" ;;
+      esac
+      ;;
+    *) die "unsupported OS: $s (the MantaUI box installer supports Linux and macOS/Apple Silicon)" ;;
+  esac
+}
+
+# _sha256_of echoes the sha256 hex of $1. Prefers GNU sha256sum (Linux ships
+# it via coreutils); falls back to BSD `shasum -a 256` on macOS, which ships
+# shasum by default but NOT sha256sum. Single shared helper so the prereq
+# check (step 1) and verify_sha256 can't drift — the BET-278 review concern.
+_sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Verify $1's sha256 equals $2 (64-hex). Dies on mismatch.
+verify_sha256() {
+  local actual; actual="$(_sha256_of "$1")"
+  [ "$actual" = "$2" ] || die "checksum mismatch for $1
+      expected: $2
+      actual:   $actual
+      (corrupt download or stale manifest — re-run; if it persists, report it)"
+}
+
+# sync_opencode_guidance <src-agents-md> <dest-agents-md>
+#
+# Bring a box's ~/.config/opencode/AGENTS.md in sync with the tool guidance
+# that ships with this release. We append each top-level `## ` section from
+# the source to the destination ONLY if a line exactly matching that heading is
+# not already present in the destination. Existing sections are left
+# byte-for-byte alone — the user may have edited them, and this must NEVER
+# rewrite their file. This replaces install.sh's old all-or-nothing marker
+# check (which, once ANY manta section existed, never appended a later
+# section — exactly how the delegation tool guidance never reached boxes
+# installed before delegation shipped).
+#
+# Writes via a temp file + atomic `mv`, the same idiom install.sh already used.
+# Non-fatal throughout: a missing source just logs a warning and returns.
+sync_opencode_guidance() {
+  local src="$1" dest="$2"
+  if [ ! -f "$src" ]; then
+    warn "sync_opencode_guidance: source not found: $src"
+    return 0
+  fi
+  local tmp changed=0 section heading line
+  tmp="$(mktemp "${TMPDIR:-/tmp}/manta-agents.XXXXXX")"
+  [ -f "$dest" ] && cat "$dest" > "$tmp"
+  section=""
+  heading=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      '##'*)
+        if [ -n "$section" ]; then
+          if ! grep -qFx -- "$heading" "$dest" 2>/dev/null; then
+            [ -s "$tmp" ] && printf '\n' >> "$tmp"
+            printf '%s' "$section" >> "$tmp"
+            changed=1
+          fi
+        fi
+        heading="$line"
+        section="${line}
+"
+        ;;
+      *)
+        section="${section}${line}
+"
+        ;;
+    esac
+  done < "$src"
+  if [ -n "$section" ]; then
+    if ! grep -qFx -- "$heading" "$dest" 2>/dev/null; then
+      [ -s "$tmp" ] && printf '\n' >> "$tmp"
+      printf '%s' "$section" >> "$tmp"
+      changed=1
+    fi
+  fi
+  if [ "$changed" = "1" ]; then
+    mkdir -p "$(dirname "$dest")"
+    mv "$tmp" "$dest"
+    ok "opencode AGENTS.md updated with new guidance sections."
+  else
+    rm -f "$tmp"
+    ok "opencode AGENTS.md already current."
+  fi
+}

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -360,6 +360,16 @@ async function main() {
     await cp(from, join(stageDir, rel), { recursive: true });
   }
 
+  // BET-640: self-update.sh sources the shared release helpers
+  // (scripts/lib/release.sh) at runtime on the box. It ships inside the
+  // `scripts` include (copied recursively above); fail LOUD here if it's ever
+  // missing, so a packaged box never ends up with the updater but not the
+  // library it sources — which would convert the self-update fix into a worse
+  // failure.
+  if (!existsSync(join(stageDir, "scripts/lib/release.sh"))) {
+    die("release tarball is missing scripts/lib/release.sh — self-update.sh sources it");
+  }
+
   // 3. Vendored Node 20.20.2 — downloaded + sha256-verified + extracted under
   //    stage/runtime/node. Tarball is cached under .cache/ so re-packs skip the
   //    network round-trip. This is the runtime the box will use.

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -1,37 +1,155 @@
 #!/usr/bin/env bash
-# self-update.sh — pull latest main on the box, reinstall deps, restart server.
+# self-update.sh — bring the box's manta-server code up to date, reinstall
+# deps, refresh the opencode tools + agent guidance, restart the server.
 #
 # Wired up in BET-225 stage 2 (server-side update poller calls this on a
 # cadence). Manual invocation also works — idempotent.
 #
-# Resets the local checkout to origin/main and reinstalls prod-only deps, then
-# refreshes the manta-native opencode tools and restarts the systemd --user
-# service that runs manta-server. Safe to re-run.
+# Two kinds of box are supported (BET-640):
+#
+#   * git checkout (the maintainer's dev box): update = `git fetch origin main`
+#     + `git reset --hard origin/main`.
+#   * packaged install (every box created by `curl mantaui.com/install.sh`):
+#     a plain directory with RELEASE.json (no .git). Update = download the
+#     release tarball for this arch, verify it, extract it, and replace only
+#     the payload paths the release owns (`includes` in RELEASE.json) —
+#     never `runtime/` or `node_modules/`, which are installed separately and
+#     must survive.
+#
+# The install kind is detected, not assumed, so a box installed before the
+# updater understood packaged installs (or whose git fetch fails) self-heals.
+#
+# Regardless of kind, the tail is shared and never duplicated: reinstall
+# prod-only deps, refresh the manta-native opencode tools + agent guidance,
+# then restart the supervisor that runs manta-server.
 #
 # Run from anywhere; the script derives its checkout from $0 so the caller's
 # cwd doesn't matter.
 #
 # Requires: a clean working tree (git reset --hard will discard any local
 # edits), systemd --user with the manta-server.service unit enabled
-# (`loginctl enable-linger $USER`).
+# (`loginctl enable-linger $USER`), or the macOS LaunchAgent (BET-277).
 #
-# No flags, no branch parameterization — always pins to origin/main.
+# No flags, no branch parameterization — always pins to origin/main (git
+# kind) or the latest release tarball (packaged kind).
 #
-# BET-559: the box no longer fetches a prebuilt mobile/PWA bundle — that was
-# the served web client, which is retired. Nothing here rebuilds or downloads a
-# bundle; self-update only pulls server source + deps + the AI tool copies.
+# The script's output is written to a log under the box state directory
+# (truncated on each run); early failures are reported by the caller from the
+# log's last line. See src/server/opencodeAdmin.mjs `runServerSelfUpdate`.
 
 set -euo pipefail
 
 MANTA_HOME="$(cd "$(dirname "$0")/.." && pwd)"
 
-echo "▸ self-update: fetching origin/main into $MANTA_HOME"
-git -C "$MANTA_HOME" fetch origin main -q
+# --- Own printing helpers (install.sh owns its copies; release.sh needs them) --
+log()  { printf '\033[36m▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
-echo "▸ self-update: resetting to origin/main"
-git -C "$MANTA_HOME" reset --hard origin/main -q
+# --- Output log under the state dir (BET-640) --------------------------------
+# Early failures (install-kind detection, manifest/version resolution, any
+# error before the server restart) are knowable by the caller, which reads the
+# LAST LINE of this log. Uses the same state-home resolution as
+# src/shared/paths.mjs `statePath()` — MANTA_STATE_HOME override first, else
+# $HOME — so tests (which sandbox the state dir) and prod agree.
+STATE_HOME="${MANTA_STATE_HOME:-$HOME}"
+LOG_FILE="$STATE_HOME/.manta/self-update.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+: > "$LOG_FILE"
+exec >>"$LOG_FILE" 2>&1
 
-echo "▸ self-update: reinstalling prod-only deps"
+# --- Shared release helpers (arch + manifest + checksum + guidance sync) ------
+# Single copy lives at scripts/lib/release.sh (ships in the release tarball);
+# install.sh and self-update.sh both source it so they never drift.
+. "$MANTA_HOME/scripts/lib/release.sh"
+
+# --- Detect install kind ------------------------------------------------------
+if [ -d "$MANTA_HOME/.git" ]; then
+  INSTALL_KIND=git
+elif [ -f "$MANTA_HOME/RELEASE.json" ]; then
+  INSTALL_KIND=packaged
+else
+  die "self-update: $MANTA_HOME is neither a git checkout nor a packaged install"
+fi
+
+# node for reading RELEASE.json / includes: prefer the box's bundled runtime,
+# else node on PATH (the box always has one of the two because it runs the
+# server).
+if [ -x "$MANTA_HOME/runtime/node/bin/node" ]; then
+  NODE_CMD="$MANTA_HOME/runtime/node/bin/node"
+else
+  NODE_CMD="node"
+fi
+
+if [ "$INSTALL_KIND" = "git" ]; then
+  log "self-update: fetching origin/main into $MANTA_HOME"
+  git -C "$MANTA_HOME" fetch origin main -q
+
+  log "self-update: resetting to origin/main"
+  git -C "$MANTA_HOME" reset --hard origin/main -q
+else
+  # packaged install — download + verify + extract the release tarball and
+  # replace only the payload paths the release owns.
+  host="${MANTA_RELEASE_HOST:-https://mantaui.com}"
+  host="${host%/}"
+
+  INSTALLED_VERSION="$("$NODE_CMD" -e 'process.stdout.write((JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)||"")' "$MANTA_HOME/RELEASE.json")"
+
+  log "self-update: fetching manifest from $host/releases/manta-latest.txt"
+  manifest="$(curl -fsSL "$host/releases/manta-latest.txt")" \
+    || die "self-update: manifest fetch failed: $host/releases/manta-latest.txt"
+
+  resolve_arch
+  TARBALL_FILE="$(manifest_get "$manifest" "file_${ARCH_KEY}")"
+  TARBALL_SHA="$(manifest_get "$manifest" "sha256_${ARCH_KEY}")"
+  TARBALL_VERSION="$(manifest_get "$manifest" "version")"
+  if [ -z "$TARBALL_FILE" ] || [ -z "$TARBALL_SHA" ] || [ -z "$TARBALL_VERSION" ]; then
+    die "self-update: manifest is malformed or has no ${ARCH_KEY} build"
+  fi
+
+  # Cheap early exit when already current — no download, no reinstall, no restart.
+  if [ -n "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" = "$TARBALL_VERSION" ]; then
+    ok "self-update: already at $TARBALL_VERSION"
+    exit 0
+  fi
+
+  WORK="$(mktemp -d "${TMPDIR:-/tmp}/manta-update.XXXXXX")"
+  trap 'rm -rf "$WORK"' EXIT
+
+  log "self-update: downloading $host/releases/$TARBALL_FILE"
+  curl -fsSL "$host/releases/$TARBALL_FILE" -o "$WORK/manta.tar.gz" \
+    || die "self-update: download failed: $host/releases/$TARBALL_FILE"
+
+  log "self-update: verifying tarball sha256…"
+  verify_sha256 "$WORK/manta.tar.gz" "$TARBALL_SHA"
+
+  log "self-update: extracting to $WORK/pkg…"
+  mkdir "$WORK/pkg"
+  tar -xzf "$WORK/manta.tar.gz" -C "$WORK/pkg" --strip-components=1 \
+    || die "self-update: extract failed"
+
+  # A torn/corrupt download must never overwrite a working install — confirm
+  # the payload is complete before replacing anything.
+  [ -f "$WORK/pkg/src/server/index.mjs" ] \
+    || die "self-update: bad tarball — missing src/server/index.mjs"
+  [ -f "$WORK/pkg/RELEASE.json" ] \
+    || die "self-update: bad tarball — missing RELEASE.json"
+
+  # Replace ONLY the paths the release owns (`includes` in RELEASE.json).
+  # Never touch runtime/ or node_modules/ — the bundled runtime + prebuilt
+  # deps are installed separately and must survive.
+  INCLUDES="$("$NODE_CMD" -e 'const i=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).includes||[]; process.stdout.write(i.join("\n"))' "$MANTA_HOME/RELEASE.json")"
+  for rel in $INCLUDES; do
+    [ -n "$rel" ] || continue
+    rm -rf "$MANTA_HOME/$rel"
+    mkdir -p "$(dirname "$MANTA_HOME/$rel")"
+    cp -R "$WORK/pkg/$rel" "$MANTA_HOME/$rel"
+  done
+  ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
+fi
+
+log "self-update: reinstalling prod-only deps"
 npm ci --omit=dev --prefix "$MANTA_HOME"
 
 # --- Refresh the manta-native opencode tools --------------------------------
@@ -42,20 +160,17 @@ npm ci --omit=dev --prefix "$MANTA_HOME"
 # never registers.
 #
 # WHY THIS IS HERE: install.sh does that copy, but ONLY on install. Nothing in
-# the update path did, so `git reset --hard origin/main` refreshed the SOURCE
-# while every box kept running whatever tool copy it was installed with. Any
-# change to what the AI is told about a tool was therefore undeliverable to an
-# existing box — BET-344 rewrote serve_page's description to stop naming the
-# retired *.pages.mantaui.com domain, and no box would ever have seen it.
+# the update path did, so updating the SOURCE while every box kept running
+# whatever tool copy it was installed with left tool updates undeliverable to
+# an existing box (BET-344 / BET-640 background delegation).
 #
 # Non-fatal throughout: a tool copy failing must never abort an update that has
-# already reset the checkout and reinstalled deps.
+# already updated the checkout and reinstalled deps.
 #
 # NOTE: we deliberately do NOT restart opencode here. Picking up a new tool
 # needs an opencode restart, but that kills every in-flight agent turn on the
-# box — which is exactly the "close the lid and the work carries on" guarantee
-# the product is built on. Staging the files is safe and unconditional; they
-# take effect at the next opencode restart, and we say so.
+# box. Staging the files is safe and unconditional; they take effect at the
+# next opencode restart, and we say so.
 refresh_opencode_tools() {
   local src="$MANTA_HOME/docs/opencode-tools"
   local dest="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/tools"
@@ -108,6 +223,13 @@ refresh_opencode_tools() {
 }
 
 refresh_opencode_tools
+
+# --- Sync opencode agent guidance (BET-640) -----------------------------------
+# Appends any top-level `## ` guidance section that is missing from the user's
+# AGENTS.md (replaces install.sh's old all-or-nothing marker check). Same lib
+# function install.sh uses, so a section added after install lands on the next
+# update without rewriting existing (possibly user-edited) sections.
+sync_opencode_guidance "$MANTA_HOME/docs/opencode-tools/AGENTS.md" "${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/AGENTS.md"
 
 # Restart the supervisor that runs manta-server. Linux uses the systemd
 # --user unit (default since v1); macOS (BET-277) uses the LaunchAgent

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -146,6 +146,11 @@ else
     mkdir -p "$(dirname "$MANTA_HOME/$rel")"
     cp -R "$WORK/pkg/$rel" "$MANTA_HOME/$rel"
   done
+  # RELEASE.json is the box's version marker but is intentionally NOT in the
+  # `includes` list (which excludes runtime/node_modules). Copy it anyway so
+  # the tree actually ends up at the manifest version — without this the box
+  # would believe it is forever on the old version and re-download every run.
+  cp "$WORK/pkg/RELEASE.json" "$MANTA_HOME/RELEASE.json"
   ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
 fi
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,7 +16,7 @@ import {
   writeSavedMode,
   resolveLauncherFlags,
 } from "./chatShared";
-import { chooseUpdateSkewVariant, registerMountedTerminal, type MountedTerminal } from "./chatUtils";
+import { chooseUpdateSkewVariant, isUnknownChannelError, registerMountedTerminal, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { ReconnectingBanner } from "./ReconnectingBanner";
@@ -49,6 +49,8 @@ export function App() {
     updatePrompt,
     updateError,
     setUpdateError,
+    boxIncompatible,
+    setBoxIncompatible,
     serverUpdatePrompt,
     setServerUpdatePrompt,
     connectionState,
@@ -75,6 +77,9 @@ export function App() {
   const showOnboarding = enterOnboarding || onboardingLatched;
   const [settingsOpen, setSettingsOpen] = useState(false);
   const sidebarRef = useRef<SidebarHandle>(null);
+  // BET-640: latch so the job poll raises the incompatible banner at most ONCE
+  // (a box that can't implement the jobs endpoint will 500 on every 30s tick).
+  const incompatibleFlaggedRef = useRef(false);
 
   // BET-417: the new-session screen replaces the old inline forms. null =
   // not shown. { mode: "new-project" } = new-project (creates a tmux
@@ -261,8 +266,18 @@ export function App() {
         .then((list) => {
           useStore.getState().setJobs(Array.isArray(list) ? list : []);
         })
-        .catch(() => {
-          /* server unreachable — leave the prior jobs map; the card surfaces errors */
+        .catch((e) => {
+          // BET-640: a transport blip keeps today's silent behaviour (leave
+          // the prior jobs map; the card surfaces errors). But a box that does
+          // NOT implement the jobs endpoint at all rejects the RPC with
+          // `unknown rpc channel` every tick — before this, that rendered as a
+          // permanently empty sidebar, indistinguishable from "no jobs". Raise
+          // the existing incompatible banner ONCE instead of hiding the cause.
+          const msg = e instanceof Error ? e.message : String(e);
+          if (isUnknownChannelError(msg) && !incompatibleFlaggedRef.current) {
+            incompatibleFlaggedRef.current = true;
+            useStore.getState().setBoxIncompatible(true);
+          }
         });
     };
     tick();
@@ -743,12 +758,34 @@ export function App() {
   // compatibility variant folds into `server-update` (it is an upgrade prompt
   // with the same self-update action, not a blocking incompatibility).
   const reconnecting = connectionState.state !== "connected" && connectionState.state !== "idle";
-  const incompatible = showCompatibilityCard && compatibilityVariant === "incompatible";
+  const incompatible =
+    boxIncompatible || (showCompatibilityCard && compatibilityVariant === "incompatible");
   const versionSkew = chooseUpdateSkewVariant(clientVersion, serverMinClient) === "outdated";
   const updateFailed = !!updateError;
   const serverUpdate = !!serverUpdatePrompt || (showCompatibilityCard && compatibilityVariant === "behind");
   const bannerState: BannerState = { reconnecting, incompatible, versionSkew, updateFailed, serverUpdate };
   const activeBanner = pickBanner(bannerState);
+
+  // BET-640: running the box's self-update can now fail EARLY (before the
+  // server restart) — e.g. a packaged box that can't resolve its release
+  // manifest, or a git box whose fetch dies. The RPC resolves {ok:false} in
+  // that case; surface it in the EXISTING update-failed banner (the same
+  // state the auto-update path already feeds) instead of silently reporting
+  // success and leaving the box stale.
+  const applyServerUpdate = async () => {
+    try {
+      const res = await window.api.serverUpdateApply();
+      if (res && res.ok === false) {
+        setUpdateError({ message: res.error || "Server update failed", raw: res.error ?? "" });
+      }
+    } catch (e) {
+      setUpdateError({
+        message: e instanceof Error ? e.message : String(e),
+        raw: String(e),
+      });
+    }
+  };
+
   // BET-459: when a chat session is the visible pane, the SessionHeader owns
   // the single top-of-pane row (breadcrumb + mode toggle) — the app titlebar
   // is hidden so the two don't stack. Non-chat panes (terminal / AI-TUI /
@@ -801,7 +838,10 @@ export function App() {
             onAction={() => {
               void window.api.openExternal("https://mantaui.com/install");
             }}
-            onDismiss={dismiss}
+            onDismiss={() => {
+              setBoxIncompatible(false);
+              dismiss();
+            }}
           />
         )}
         {!showOnboarding && activeBanner === "version-skew" && (
@@ -842,7 +882,7 @@ export function App() {
             }
             actionLabel="Update & restart"
             onAction={() => {
-              void window.api.serverUpdateApply();
+              void applyServerUpdate();
             }}
             onDismiss={() => setServerUpdatePrompt(null)}
           />
@@ -863,7 +903,7 @@ export function App() {
               }
               actionLabel="Upgrade box"
               onAction={() => {
-                void window.api.serverUpdateApply();
+                void applyServerUpdate();
               }}
               onDismiss={dismiss}
             />

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1080,7 +1080,8 @@ export const httpApi: Api = {
   // process mid-run so a caller awaiting past the RPC send may never see
   // a response. Modeled on `opencode:restart` (single-purpose server action,
   // fixed-argv execFile, no injection surface).
-  serverUpdateApply: () => rpc<void>(IPC.serverUpdateApply),
+  serverUpdateApply: () =>
+    rpc<{ ok: boolean; error?: string }>(IPC.serverUpdateApply),
 
   // -- server-update available subscription (BET-225 stage 3) --
   // /events WS stream publishes `{kind: "serverUpdateAvailable", payload}`

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -23,6 +23,7 @@ import {
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
   isDrainAbortError,
+  isUnknownChannelError,
   describeCron,
   nextCronRun,
   describeNextRun,
@@ -864,6 +865,24 @@ describe("isDrainAbortError", () => {
     expect(isDrainAbortError("ApiError", true)).toBe(false);
     expect(isDrainAbortError("ContextOverflowError", true)).toBe(false);
     expect(isDrainAbortError(undefined, true)).toBe(false);
+  });
+});
+
+describe("isUnknownChannelError", () => {
+  it("matches the exact message manta-server's rpc dispatcher throws", () => {
+    expect(isUnknownChannelError("unknown rpc channel: delegate:list")).toBe(true);
+  });
+
+  it("matches wrapped variants that still contain the marker", () => {
+    expect(isUnknownChannelError("HTTP 500 unknown rpc channel: delegate:list")).toBe(true);
+    expect(isUnknownChannelError('rpc failed: { channel: "delegate:list", error: "unknown rpc channel: delegate:list" }')).toBe(true);
+  });
+
+  it("does NOT match other errors (transport blips, real 500s, auth)", () => {
+    expect(isUnknownChannelError("Network request failed")).toBe(false);
+    expect(isUnknownChannelError("HTTP 500 Internal Server Error")).toBe(false);
+    expect(isUnknownChannelError("fetch failed: socket hang up")).toBe(false);
+    expect(isUnknownChannelError("")).toBe(false);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -547,6 +547,17 @@ export function isDrainAbortError(
   return draining && errName === "MessageAbortedError";
 }
 
+// BET-640: server-rpc unsupported-channel predicate. manta-server throws
+// `unknown rpc channel: <ch>` (src/server/rpc.mjs) and httpApi surfaces that
+// string as the Error message, so a box that doesn't implement a channel (e.g.
+// the background-jobs endpoint on a box that predates delegation) rejects the
+// RPC with exactly this text. Renderers use it to tell "endpoint not
+// implemented" apart from a transport blip — the former should raise the
+// incompatible banner, the latter should stay silent (BET-640).
+export function isUnknownChannelError(message: string): boolean {
+  return typeof message === "string" && message.includes("unknown rpc channel");
+}
+
 // describeCron — best-effort human-readable label for a 5-field cron
 // expression, for the ScheduledTasksCard. Covers the common shapes the model
 // emits; falls back to the raw expression for anything it doesn't recognize.

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -235,6 +235,12 @@ type State = {
   // app simply never updated — across two releases, diagnosed only when a
   // shipped fix was reported as missing.
   updateError: { message: string; raw: string } | null;
+  // BET-640: a box that doesn't implement a channel the renderer polls (the
+  // background-jobs endpoint on a box that predates delegation) surfaces as a
+  // persistent empty sidebar, indistinguishable from "no jobs running". When
+  // the job poll's error says "unknown rpc channel", flip this flag ONCE to
+  // show the existing incompatible banner instead of rendering nothing.
+  boxIncompatible: boolean;
   // Single global server-update prompt (BET-225 stage 3). Set when the box's
   // server-update poller (src/server/serverUpdate.mjs) publishes a
   // `serverUpdateAvailable` bus event after polling its version manifest.
@@ -371,6 +377,7 @@ type State = {
   setAgentFileToast: (t: AgentFileReady | null) => void;
   setUpdatePrompt: (p: { version: string; releaseName?: string } | null) => void;
   setUpdateError: (p: { message: string; raw: string } | null) => void;
+  setBoxIncompatible: (b: boolean) => void;
   setServerUpdatePrompt: (
     p: { version: string; notesUrl?: string | null } | null,
   ) => void;
@@ -419,6 +426,7 @@ export const useStore = create<State>((set, get) => ({
   agentFileToast: null,
   updatePrompt: null,
   updateError: null,
+  boxIncompatible: false,
   serverUpdatePrompt: null,
   connectionState: { state: "idle" },
   backgroundSyncing: false,
@@ -607,6 +615,7 @@ export const useStore = create<State>((set, get) => ({
   setAgentFileToast: (t) => set({ agentFileToast: t }),
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
   setUpdateError: (p) => set({ updateError: p }),
+  setBoxIncompatible: (b) => set({ boxIncompatible: b }),
   setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),
   setConnectionState: (s) => set({ connectionState: s }),
   setOpencodeRestartNeeded: (v) => set({ opencodeRestartNeeded: v }),

--- a/src/server/opencodeAdmin.mjs
+++ b/src/server/opencodeAdmin.mjs
@@ -19,7 +19,9 @@
 // existing Providers "restart to apply" flow.
 
 import { execFile as execFileCb } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { promisify } from "node:util";
+import { statePath } from "../shared/paths.mjs";
 
 const execFileAsync = promisify(execFileCb);
 
@@ -48,30 +50,81 @@ export async function restartOpencode(exec = execFileAsync) {
  * Trigger the box's self-update script (`scripts/self-update.sh` in the
  * repo root). Fixed argv passed to execFile — never a shell string — so
  * there is no command-injection surface regardless of caller input (this
- * takes no caller input). The script itself does `git fetch + reset --hard
- * origin/main + npm ci --omit=dev + systemctl --user restart manta-server`;
- * the restart will kill this manta-server process mid-run, so we spawn the
- * child DETACHED and unref() it — never await on exit. The caller (RPC
- * handler in src/server/rpc.mjs) gets the child PID back; the renderer
- * UpdateBar fires this on click and the HTTP promise resolves immediately.
+ * takes no caller input). The script updates the box (git fetch + reset on a
+ * checkout, or download+verify+replace on a packaged install), runs
+ * `npm ci --omit=dev`, refreshes the opencode tools + agent guidance, then
+ * `systemctl --user restart manta-server`; the restart will kill this
+ * manta-server process mid-run, so we spawn the child DETACHED and unref()
+ * it — never await on exit. The caller (RPC handler in src/server/rpc.mjs)
+ * gets the outcome back; the renderer UpdateBar fires this on click.
  *
- * `spawnFile` is injectable for tests; defaults to the real execFileCb
- * (the callback variant, since we DON'T want the promisified form — we
- * need the raw ChildProcess to unref). Tests inject a stub that records
- * the call.
+ * BET-640: early failures (anything before the restart) are knowable — the
+ * script writes its output to the state-dir log (`self-update.log`, truncated
+ * each run) and exits non-zero before the restart. We watch the child for up
+ * to `timeoutMs` (20s default): if it exits non-zero inside that window we
+ * resolve `{ ok:false, error: <last line of the log> }`; if it is still
+ * running at the timeout (the normal case — it has reached the restart, which
+ * killed us in a sibling process) we resolve `{ ok:true }`. The promise always
+ * settles within `timeoutMs` regardless of the child's eventual fate.
+ *
+ * `spawnFile` is injectable for tests; defaults to the real execFileCb (the
+ * callback variant, since we DON'T want the promisified form — we need the
+ * raw ChildProcess to unref + attach exit listeners). Tests inject a stub
+ * whose returned child mimics the relevant surface.
  *
  * @param {string} scriptPath - absolute path to scripts/self-update.sh
  *   (resolved by the RPC handler from `import.meta.url`).
- * @param {(cmd: string, args: string[], opts: { detached?: boolean, stdio?: string }) => { pid?: number, unref: () => void }} [spawnFile]
- * @returns {Promise<{ ok: true, pid?: number } | { ok: false, error: string }>}
+ * @param {(cmd: string, args: string[], opts: { detached?: boolean, stdio?: string }) => { pid?: number, unref: () => void, once?: (ev: string, cb: Function) => void, on?: (ev: string, cb: Function) => void }} [spawnFile]
+ * @param {{ timeoutMs?: number }} [options]
+ * @returns {Promise<{ ok: true } | { ok: false, error: string }>}
  */
-export async function runServerSelfUpdate(scriptPath, spawnFile = execFileCb) {
+export async function runServerSelfUpdate(
+  scriptPath,
+  spawnFile = execFileCb,
+  { timeoutMs = SELF_UPDATE_WATCH_MS } = {},
+) {
+  const logPath = statePath("self-update.log");
   try {
     const child = spawnFile(scriptPath, [], { detached: true, stdio: "ignore" });
     child.unref();
-    return { ok: true, pid: child.pid };
+    return await new Promise((resolve) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        // Still running at the watch window → it reached the server restart.
+        resolve({ ok: true });
+      }, timeoutMs);
+      const finish = (ok, err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(ok ? { ok: true } : { ok: false, error: lastLogLine(logPath, err) });
+      };
+      if (typeof child.once === "function") {
+        child.once("error", (e) => finish(false, e));
+        child.once("exit", (code) => finish(code === 0, code));
+      }
+    });
   } catch (e) {
     console.warn("[opencodeAdmin] self-update failed:", e);
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export const SELF_UPDATE_WATCH_MS = 20_000;
+
+// Last non-empty line of the self-update log, or a fallback derived from the
+// error/exit that triggered the failure report. Never throws.
+function lastLogLine(logPath, err) {
+  const fallback = err instanceof Error ? err.message : err == null ? "server update failed" : String(err);
+  try {
+    const lines = readFileSync(logPath, "utf8")
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    return lines.length > 0 ? lines[lines.length - 1] : fallback;
+  } catch {
+    return fallback;
   }
 }

--- a/src/server/opencodeAdmin.test.mjs
+++ b/src/server/opencodeAdmin.test.mjs
@@ -4,7 +4,11 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
+import { statePath } from "../shared/paths.mjs";
 
 describe("restartOpencode", () => {
   it("invokes systemctl --user restart opencode-serve with a fixed argv (no shell string)", async () => {
@@ -42,25 +46,23 @@ describe("restartOpencode", () => {
 describe("runServerSelfUpdate", () => {
   // The injection here uses the callback-shaped execFile (not the
   // promisified one) because the production path needs the raw
-  // ChildProcess handle to .unref() it. Stub returns a fake child with a
-  // fixed pid and a no-op unref so we can assert the call shape.
-  function fakeSpawn(records, pid = 4242) {
+  // ChildProcess handle to .unref() it. A quiet stub returns a fake child
+  // with a fixed pid and a no-op unref (and NO exit/error emitters), so the
+  // watch simply times out → ok:true. A scripted stub extends EventEmitter
+  // and lets the test emit `exit`/`error` to exercise the early-failure path.
+  function quietSpawn(records, pid = 4242) {
     return (cmd, args, opts) => {
       records.push({ cmd, args, opts });
-      return {
-        pid,
-        unref() {
-          /* no-op */
-        },
-      };
+      return { pid, unref() {} };
     };
   }
 
   it("spawns the script detached + unref'd with no argv (fire-and-forget)", async () => {
     const calls = [];
-    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", fakeSpawn(calls));
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", quietSpawn(calls), {
+      timeoutMs: 10,
+    });
     assert.equal(result.ok, true);
-    assert.equal(result.pid, 4242);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].cmd, "/abs/scripts/self-update.sh");
     assert.deepEqual(calls[0].args, []);
@@ -75,7 +77,9 @@ describe("runServerSelfUpdate", () => {
     const spawn = () => {
       throw new Error("spawn /abs/scripts/self-update.sh EACCES");
     };
-    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn);
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 10,
+    });
     assert.equal(result.ok, false);
     assert.equal(result.error, "spawn /abs/scripts/self-update.sh EACCES");
   });
@@ -85,7 +89,69 @@ describe("runServerSelfUpdate", () => {
     // no caller input (the script path is resolved at module load from
     // import.meta.url), so the argv array must always be exactly [].
     const calls = [];
-    await runServerSelfUpdate("/abs/scripts/self-update.sh", fakeSpawn(calls));
+    await runServerSelfUpdate("/abs/scripts/self-update.sh", quietSpawn(calls), { timeoutMs: 10 });
     assert.deepEqual(calls[0].args, []);
+  });
+
+  it("resolves ok:false with the log's last line when the child exits non-zero fast", async () => {
+    // BET-640: an early failure (before the server restart) is knowable. The
+    // script writes its output to the state-dir log; a non-zero exit inside
+    // the watch window must surface as ok:false with that line — NOT as a
+    // silent "ok:true". Stub a child that emits `exit` non-zero after the log
+    // holds a failure line.
+    const logPath = statePath("self-update.log");
+    mkdirSync(dirname(logPath), { recursive: true });
+    writeFileSync(logPath, "▸ self-update: fetching manifest\n✗ self-update: manifest fetch failed: https://mantaui.com/releases/\n");
+
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    const spawn = () => {
+      // Emit the exit asynchronously so runServerSelfUpdate has attached its
+      // listener before the event fires.
+      setImmediate(() => setTimeout(() => child.emit("exit", 1), 0));
+      return child;
+    };
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 500,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "✗ self-update: manifest fetch failed: https://mantaui.com/releases/");
+  });
+
+  it("resolves ok:true when the child exits zero fast", async () => {
+    // An early clean exit ("already at version", no update needed) is success.
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    const spawn = () => {
+      setImmediate(() => setTimeout(() => child.emit("exit", 0), 0));
+      return child;
+    };
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 500,
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("resolves ok:true when the child is still running at the watch timeout", async () => {
+    // BET-640: the normal case — the script reached the server restart, which
+    // kills manta-server in a sibling process, so the child may keep running
+    // (or die with our process). Still-running-at-timeout must resolve ok:true
+    // and never hang the RPC past the window.
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    const calls = [];
+    const spawn = (cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return child;
+    };
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 5,
+    });
+    assert.equal(result.ok, true);
+    // And the child was detached + unref'd even though it kept running.
+    assert.equal(calls[0].opts.detached, true);
   });
 });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -431,13 +431,17 @@ export interface Api {
   getClientVersion(): Promise<{ version: string }>;
 
   // Server-update apply (BET-225 stage 3): triggers the box's
-  // `scripts/self-update.sh` (git fetch + reset --hard origin/main + npm ci
-  // --omit=dev + systemctl --user restart manta-server). The server returns
-  // immediately (fire-and-forget); the restart will kill the process mid-
-  // run so a caller awaiting past the RPC send may never see a response.
+  // `scripts/self-update.sh` (git fetch + reset --hard origin/main, or the
+  // packaged-install tarball path, + npm ci --omit=dev + systemctl --user
+  // restart manta-server). The server returns immediately (fire-and-forget);
+  // the restart will kill the process mid-run so a caller awaiting past the
+  // RPC send may never see a response. BET-640: the RPC now watches the
+  // spawned updater for its early failures and resolves `{ ok:false, error }`
+  // when the updater exits non-zero before reaching the restart, `{ ok:true }`
+  // otherwise (still-running at the watch window = it reached the restart).
   // Mirror of the desktop `opencode:restart` action — fixed-argv execFile,
   // no injection surface, no caller-supplied input.
-  serverUpdateApply(): Promise<void>;
+  serverUpdateApply(): Promise<{ ok: boolean; error?: string }>;
 
   // Server-update available subscription (BET-225 stage 3): fires when the
   // box's server-update poller sees a newer manifest version. Mirrors the

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
+    <lastmod>2026-08-02T14:01:16.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-02T14:01:16.000Z</lastmod>
+    <lastmod>2026-07-28T07:33:17.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Fixes the causal chain in BET-640: **packaged installs could never self-update, and three silent failures hid it.**

## What changed

**Step 1 — self-update works on a packaged install**
- New `scripts/lib/release.sh`: the four release-resolution helpers (`manifest_get`, `resolve_arch`, `_sha256_of`, `verify_sha256`) **moved out of install.sh** + a new `sync_opencode_guidance`, shared by both scripts (no `set -e`/side effects on source).
- `self-update.sh` branches on install kind (`git` vs `packaged` via `RELEASE.json`); the packaged path downloads / sha256-verifies / extracts the release tarball, confirms the tree is complete, and replaces **only** the `RELEASE.json` `includes` (never `runtime/`/`node_modules/`), then falls through to the shared npm-ci → tool-refresh → restart tail.
- Same-version → `✓ already at <version>` and exit 0 before touching anything.
- `install.sh` sources the lib; its AGENTS.md append is replaced by `sync_opencode_guidance` (sections appended only if the exact heading is absent, existing sections never rewritten, temp-file + mv).
- `pack.mjs` fails loud if `scripts/lib/release.sh` is missing from the tarball (it ships inside the recursive `scripts` include — confirmed in the built tarball).

**Step 2 — update failures reported, not swallowed**
- `runServerSelfUpdate` now writes-through: the script logs to `<state>/.manta/self-update.log` (via `statePath`), and the RPC watches the child up to 20s — non-zero exit → `{ok:false, error:<last log line>}`, still-running-at-timeout → `{ok:true}`. Existing DI shape kept.
- `App.tsx` awaits `serverUpdateApply`; on `ok:false` shows the **existing** `update-failed` banner (no new UI).
- Job poll: `isUnknownChannelError` (new pure fn in `chatUtils.ts`) → raise the **existing** `incompatible` banner once (new `boxIncompatible` store flag) instead of rendering an empty sidebar forever.

**Step 3 — opencode agent guidance reaches existing boxes**
- `sync_opencode_guidance` is now called by both scripts, so a guidance section added after install lands on the next update without rewriting user-edited sections.

## Verification (mechanical, not assumed)
- Built the release tarball locally: `scripts/lib/release.sh` + the fixed `self-update.sh` confirmed inside.
- Extracted into a scratch packaged box (no `.git`, has `RELEASE.json` + `runtime/` + `node_modules/`) and ran `self-update.sh` against a local `MANTA_RELEASE_HOST`:
  - same-version → clean early exit, no download/npm/restart (marker preserved);
  - older version → download → sha verify → replace → tree ends at manifest version (RELEASE.json advanced 0.0.17→0.0.18), `runtime/` survives; a second run early-exits;
  - deleted a tool + a guidance section → update restored both; second run idempotent (byte-identical), user-edited content preserved.
- Git-checkout box (clone with `.git`) takes the **git** branch (fetch+reset), not packaged.

**Base:** `origin/main @ 0ecafdc`

**Verification results**
- PR branch (`multica/BET-640-packaged-self-update` @ `cade7bb`):
  - typecheck: exit `0`. Errors: none. log sha256: `ce6f319a8d07e7d786f95c7eda54b1dab125a6d22595cbd596e39c8300d78963`
  - test: exit `0`, `1438` pass / `0` fail / `0` skip. Failures: none. log sha256: `c55bba89fd11af0faa1109235f91be9c03a0ed08c370741e7a741f6b850dd817`
- Base (`main` @ `0ecafdc`): unchanged by this PR (no `main` edits); known green.
- **Conclusion:** `0` new failures, `0` pre-existing (bare `main` is green).

## Deviations / notes (from the issue's own "raise it if it looks wrong")
- **install.sh keeps an inline fallback of the four helpers for `curl | bash`.** A piped script has an empty `BASH_SOURCE` and no sibling file on disk (the tarball is downloaded mid-install), so install.sh cannot source the lib at the top in its primary mode. It sources the lib when the file is present (dev checkout / installed re-run / tests) and falls back to inline copies for the piped fresh-install case — the fallback bodies are currently byte-identical to `release.sh` (verified). This is the one place the "one file, no second copy" rule couldn't be fully honored without breaking fresh installs. **Filed as follow-up BET-643 (drift trap, → manta-pm).**
- The packaged tail still runs `npm ci --omit=dev` (as the issue specifies) even though the tarball ships prebuilt `node_modules`; it's the shared tail and matches the git-box behavior.
- RELEASE.json is **not** in the release `includes` list (it excludes `runtime/`/`node_modules/` on purpose), but the updater copies it from the extracted tarball anyway so the box's version marker converges — otherwise every run would re-download forever.
