### PR TITLE
fix(BET-643): single-source install.sh's curl|bash helper fallback from scripts/lib/release.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -153,7 +153,7 @@ if [ -n "$INSTALL_SOURCE_DIR" ] && [ -f "$INSTALL_SOURCE_DIR/lib/release.sh" ]; 
   . "$INSTALL_SOURCE_DIR/lib/release.sh"
 else
   # curl | bash / no local lib yet — inline fallback (byte-identical to lib).
-
+  # >>> BEGIN GENERATED — scripts/sync-release-fallback.mjs — do not edit by hand <<<
 # Parse one key out of a key=value manifest body. Echoes the value, empty if
 # absent. Values may contain `=` (cut -d= -f2- preserves them). A repeated key
 # is reduced to the FIRST occurrence (head -n1) — the manifest writer emits
@@ -165,6 +165,8 @@ manifest_get() { # $1=manifest-body $2=key
 # Map (uname -s, uname -m) to the release manifest arch key. Sets global
 # ARCH_KEY. Dies on any (OS, arch) we don't ship a tarball for. This is the
 # SINGLE place the installer decides which OS+arch it is — see BET-274.
+# NOTE: this function is defined here so install.sh (fresh `curl | bash`) and
+# self-update.sh (packaged box) resolve arch identically.
 resolve_arch() {
   local s m; s="$(uname -s)"; m="$(uname -m)"
   case "$s" in
@@ -187,7 +189,6 @@ resolve_arch() {
   esac
 }
 
-
 # _sha256_of echoes the sha256 hex of $1. Prefers GNU sha256sum (Linux ships
 # it via coreutils); falls back to BSD `shasum -a 256` on macOS, which ships
 # shasum by default but NOT sha256sum. Single shared helper so the prereq
@@ -208,6 +209,7 @@ verify_sha256() {
       actual:   $actual
       (corrupt download or stale manifest — re-run; if it persists, report it)"
 }
+  # >>> END GENERATED — scripts/sync-release-fallback.mjs — do not edit by hand <<<
 fi
 
 # launchd_agent_path — the PATH a MantaUI supervisor-managed service must

--- a/scripts/sync-release-fallback.mjs
+++ b/scripts/sync-release-fallback.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// scripts/sync-release-fallback.mjs — single-source the four release helpers
+// that install.sh must carry inline for its `curl -fsSL … | bash` mode.
+//
+// install.sh sources scripts/lib/release.sh when a local copy exists (dev
+// checkout, an installed box re-running it, or the test harness) — but in its
+// PRIMARY mode, `curl … | bash`, there is NO local file yet (the tarball that
+// carries the lib is downloaded MID-install) and a piped script cannot read a
+// sibling. So install.sh also carries an inline fallback of the four helpers:
+// manifest_get, resolve_arch, _sha256_of, verify_sha256.
+//
+// That fallback is the residual duplicate BET-643 exists to de-risk. Running
+// this script REGENERATES the fallback verbatim from scripts/lib/release.sh —
+// the single source of truth — so a future edit to a helper in the lib is
+// pushed into install.sh automatically instead of drifting silently.
+//
+// This is a dev-time/CI-time generator whose OUTPUT IS COMMITTED, matching the
+// "install.sh is served byte-identical across channels" contract in its header:
+// the served copy is still the repo's own install.sh, just with a fallback that
+// is guaranteed (and CI-checked, see sync-release-fallback.test.mjs) to match
+// the lib. No publication-time substitution, no change to the one-liner.
+//
+// Usage:
+//   node scripts/sync-release-fallback.mjs         # rewrite install.sh in place
+//   node scripts/sync-release-fallback.mjs --check # exit 1 if install.sh is stale
+//
+// Exits 0 when the fallback is up to date, non-zero otherwise. Deterministic and
+// idempotent: running it on an already-synced tree is a no-op.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = join(__dirname, "..");
+export const RELEASE_SH = join(__dirname, "lib", "release.sh");
+export const INSTALL_SH = join(__dirname, "install.sh");
+
+// The fallback's marker boundary inside install.sh. The block between the BEGIN
+// and END marker lines (exclusive) is exactly the four extracted helpers.
+export const BEGIN_MARKER =
+  "# >>> BEGIN GENERATED — scripts/sync-release-fallback.mjs — do not edit by hand <<<";
+export const END_MARKER =
+  "# >>> END GENERATED — scripts/sync-release-fallback.mjs — do not edit by hand <<<";
+
+// The four helpers shared between the lib and the piped fallback. Every name
+// MUST exist in scripts/lib/release.sh and be absent there only if the fallback
+// should not ship it (sync_opencode_guidance is deliberately NOT here — it
+// lives only in the lib, sourced post-extraction from $MANTA_HOME).
+export const HELPER_NAMES = [
+  "manifest_get",
+  "resolve_arch",
+  "_sha256_of",
+  "verify_sha256",
+];
+
+// Extract one helper (its preceding contiguous `#` comment block + the function
+// body up to its column-0 closing `}`) from a line array. Returns the slice as
+// an array of lines. Throws if the function is not found or has no close.
+export function extractHelper(lines, name) {
+  const startRe = new RegExp(`^${name}\\(\\) \\{`);
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (startRe.test(lines[i])) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) throw new Error(`helper not found in release.sh: ${name}`);
+
+  let end = -1;
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i].trim() === "}") {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) throw new Error(`helper has no closing brace: ${name}`);
+
+  let cstart = start;
+  while (cstart > 0 && lines[cstart - 1].startsWith("#")) cstart--;
+
+  return lines.slice(cstart, end + 1);
+}
+
+// Build the fallback block text from the release.sh source lines: each helper
+// unit (comment + body) joined by a single blank line, like the lib lays them
+// out, with no trailing blank line beyond the final newline.
+export function buildFallbackBlock(lines, names = HELPER_NAMES) {
+  const units = names.map((n) => extractHelper(lines, n).join("\n"));
+  return units.join("\n\n") + "\n";
+}
+
+// Locate the marker boundary in install.sh. Returns { startIdx, endIdx } where
+// startIdx is the BEGIN line and endIdx is the END line (both inclusive).
+export function findFallbackBoundary(installLines) {
+  const startIdx = installLines.findIndex((l) => l.trim() === BEGIN_MARKER);
+  const endIdx = installLines.findIndex((l) => l.trim() === END_MARKER);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    throw new Error(
+      "install.sh has no valid BEGIN/END fallback markers — " +
+        "did the generated block get removed?",
+    );
+  }
+  return { startIdx, endIdx };
+}
+
+// Extract the committed fallback block (the text between markers, exclusive)
+// from install.sh, preserving line structure for byte comparison.
+export function extractFallbackBlock(installLines) {
+  const { startIdx, endIdx } = findFallbackBoundary(installLines);
+  return installLines.slice(startIdx + 1, endIdx).join("\n") + "\n";
+}
+
+export function readReleaseLines() {
+  return readFileSync(RELEASE_SH, "utf8").split("\n");
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+  const releaseLines = readReleaseLines();
+  let install = readFileSync(INSTALL_SH, "utf8");
+  const installLines = install.split("\n");
+
+  const { startIdx, endIdx } = findFallbackBoundary(installLines);
+  const generated = buildFallbackBlock(releaseLines);
+  const committed = extractFallbackBlock(installLines);
+
+  if (generated === committed) {
+    process.stdout.write(
+      "sync-release-fallback: install.sh fallback is up to date with scripts/lib/release.sh\n",
+    );
+    return 0;
+  }
+
+  if (check) {
+    process.stderr.write(
+      "sync-release-fallback: install.sh fallback is STALE vs scripts/lib/release.sh.\n" +
+        "  Run `node scripts/sync-release-fallback.mjs` and commit the result.\n",
+    );
+    return 1;
+  }
+
+  install =
+    installLines.slice(0, startIdx + 1).join("\n") +
+    "\n" +
+    generated +
+    installLines.slice(endIdx).join("\n");
+  writeFileSync(INSTALL_SH, install);
+  process.stdout.write(
+    "sync-release-fallback: regenerated install.sh fallback from scripts/lib/release.sh\n",
+  );
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/scripts/sync-release-fallback.test.mjs
+++ b/scripts/sync-release-fallback.test.mjs
@@ -1,0 +1,65 @@
+// scripts/sync-release-fallback.test.mjs — the byte-parity gate for BET-643.
+//
+// install.sh carries an inline fallback of the four release helpers
+// (manifest_get, resolve_arch, _sha256_of, verify_sha256) for its PRIMARY
+// `curl -fsSL … | bash` mode, where scripts/lib/release.sh isn't on disk yet.
+// That fallback is generated from scripts/lib/release.sh by
+// sync-release-fallback.mjs — the single source of truth. This test is what
+// makes drift IMPOSSIBLE to ship: it regenerates the fallback in memory and
+// fails if the committed block in install.sh differs by even one byte. A future
+// edit to a helper in the lib (but not the fallback, or vice-versa) turns CI
+// red instead of silently ghosting the two copies apart.
+//
+// Fix: run `node scripts/sync-release-fallback.mjs` and commit the result.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  INSTALL_SH,
+  BEGIN_MARKER,
+  HELPER_NAMES,
+  buildFallbackBlock,
+  extractFallbackBlock,
+  extractHelper,
+  readReleaseLines,
+} from "./sync-release-fallback.mjs";
+
+const releaseLines = readReleaseLines();
+const installLines = readFileSync(INSTALL_SH, "utf8").split("\n");
+
+test("release fallback: install.sh committed block is byte-identical to a regeneration from the lib", () => {
+  const generated = buildFallbackBlock(releaseLines, HELPER_NAMES);
+  const committed = extractFallbackBlock(installLines);
+  assert.equal(
+    committed,
+    generated,
+    [
+      "install.sh's inline fallback has drifted from scripts/lib/release.sh.",
+      "Run `node scripts/sync-release-fallback.mjs` and commit the result.",
+    ].join("\n"),
+  );
+});
+
+test("release fallback: every helper lives in the lib (single source of truth)", () => {
+  for (const name of HELPER_NAMES) {
+    assert.doesNotThrow(
+      () => extractHelper(releaseLines, name),
+      `helper ${name} should exist in scripts/lib/release.sh`,
+    );
+  }
+});
+
+test("release fallback: install.sh still defines every helper (no helper dropped)", () => {
+  for (const name of HELPER_NAMES) {
+    const body = [...installLines].slice(
+      installLines.findIndex((l) => l.includes(BEGIN_MARKER)),
+    );
+    const found = body.some((l) => {
+      const re = new RegExp(`^${name}\\(\\) \\{`);
+      return re.test(l);
+    });
+    assert.ok(found, `install.sh fallback should define ${name}`);
+  }
+});
+


### PR DESCRIPTION
## What & why

BET-643 — the drift trap BET-640 left behind. `scripts/install.sh` must carry
inline copies of the four release helpers (`manifest_get`, `resolve_arch`,
`_sha256_of`, `verify_sha256`) for its **primary** `curl -fsSL … | bash` mode,
where `scripts/lib/release.sh` isn't on disk yet (the tarball that carries it is
downloaded MID-install, and a piped script can't read a sibling file). Those two
copies were byte-identical but could silently diverge — a future edit to a
helper in one file but not the other would ghost until a real box hit it.

This makes the duplication **impossible to ship unsigned**, not just caught:

- **`scripts/sync-release-fallback.mjs`** — a generator that regenerates
  install.sh's fallback block **verbatim from `scripts/lib/release.sh`** (the
  single source of truth). `node scripts/sync-release-fallback.mjs` rewrites
  install.sh in place; `--check` exits 1 when stale (CI-ready).
- **`scripts/sync-release-fallback.test.mjs`** — the byte-parity gate. Runs in
  `npm test` (the blocking `typecheck-test` CI job). It regenerates the fallback
  in memory and fails if the committed block in install.sh differs by even one
  byte — so a helper edit in one file but not the other turns CI red instead of
  drifting silently.
- The generated fallback block is delimited by explicit
  `BEGIN GENERATED … / END GENERATED` markers in install.sh and stays
  **committed**, so install.sh remains **served byte-identical across channels**
  (no publish-time substitution; the documented one-liner is unchanged).

Verified: editing a helper body in `release.sh` makes test 1 fail until the
generator is re-run (drift is caught); the generator is idempotent (re-run is a
no-op).

### Files changed (3)

- `scripts/install.sh` — wrapped the existing fallback in generated markers;
  re-ran the generator so the block now carries the lib's exact bytes (incl. its
  `# NOTE:` comment on `resolve_arch` and normalized inter-function blank lines).
- `scripts/sync-release-fallback.mjs` — new generator + pure extraction helpers.
- `scripts/sync-release-fallback.test.mjs` — new byte-parity gate (3 tests).

`self-update.sh` is untouched — it always sources the lib (no fallback of its
own), which is already correct.

**Base: origin/main @ `893d83b`**

**Verification results:**
- PR branch (`multica/BET-643-release-fallback-parity` @ `27e8ae8`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1441 pass / 0 fail / 0 skip. Failures: none. (Includes 257
    `install.test.mjs` — which sources `install.sh` — plus the 3 new parity-gate
    tests.)
  - `bash -n scripts/install.sh`: syntax OK.
  - anti-spaghetti `check-duplication-gate.sh origin/main`: PASS (no clones).
- Base (`main` @ `893d83b`): unchanged logic; the 3 changed/added files exist
  only on this branch.
- **Conclusion:** 0 new failures, 0 pre-existing; the drift gate is new and
  exercised in both directions (drift → red, restored → green).
