### PR TITLE
fix(release): bump the server update manifest to 0.0.19 (main is red)

### DIFF
--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,1 +1,1 @@
-{ "version": "0.0.18", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }
+{ "version": "0.0.19", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }


### PR DESCRIPTION
`main`'s required check has been RED since the 0.0.19 version bump.

`website/updates/server.json` still says `0.0.18` while `package.json` says `0.0.19`. That file is what a running box polls every 6h (`src/server/serverUpdate.mjs`) to learn a new server release exists — left behind, the release publishes and **no box is ever offered it**. `scripts/build-website-assets.test.mjs` asserts the pairing precisely to stop that, and it is the failing test.

Found while reconciling the day's work before cutting a server release: any release cut from the current main would have shipped the invisible-update bug.