### PR TITLE
BET-625: simulator chat-surface capture drivers (mid-turn + load)

### DIFF
--- a/mobile/native/MantaUIUITests/MantaChatSurfaceCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaChatSurfaceCaptureUITests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+// ===========================================================================
+// Chat-surface capture drivers for the native chat epic (BET-624, row 0 =
+// BET-625). The manta-sim-drive plugin builds each of these test classes in
+// the Simulator and globs the PNG it drops into the runner's own container,
+// then uploads it to the box. The order of this epic means the surfaces the
+// captures show land AFTER this driver: the running row (BET-630) and the
+// loading skeleton (BET-631) are accepted by a screenshot produced through
+// these actions.
+//
+// The chat overflow sheet is captured by MantaOverflowCaptureUITests (BET-627)
+// on main — it taps the `Session actions` header button and captures the
+// sheet, so that surface is NOT duplicated here. These two drivers cover the
+// two captures this row is responsible for that are not otherwise covered:
+//   - mid-turn: the running state / working row (BET-630)
+//   - load: the initial-load skeleton (BET-631)
+//
+// Shared navigation:
+//   - MANTA_OPEN_ROW names a row to open (label-prefix hop, `|`-delimited);
+//     empty falls back to the first row by normalized coordinate. A chat-mode
+//     window and a plain tmux window land on different screens, so the caller
+//     picks which row for which capture.
+//   - Each test writes one uniquely named PNG so the plugin can pick it up.
+// ===========================================================================
+
+private enum MantaChatSurfaceCapture {
+
+    /// Open the first/named session row so the app lands on the chat screen
+    /// (mirrors MantaOpenSessionUITests.testOpenFirstSession).
+    ///
+    /// The runner tears the app down the moment the test ends, so a host-side
+    /// `simctl io screenshot` always catches Springboard instead. Capture from
+    /// inside the test and drop it in the runner's own container, which the
+    /// driver plugin globs for on the host.
+    static func capture(_ name: String, after delay: TimeInterval = 0) {
+        if delay > 0 { usleep(useconds_t(delay * 1_000_000)) }
+        let shot = XCUIScreen.main.screenshot()
+        let out = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(name)
+        try? shot.pngRepresentation.write(to: out)
+        print("PAIRDRIVE shot=\(out.path)")
+    }
+
+    /// Open the first session row so `Sessions` → chat finishes pushing.
+    static func openChatRow(in app: XCUIApplication) {
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            print("PAIRDRIVE open-row=first-by-coordinate")
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+            sleep(4)
+            return
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let users = app.descendants(matching: .any).matching(prefix)
+            let target = users.allElementsBoundByIndex
+                // A session row is not in the create-project sheet and is not a
+                // bare icon/action control. Skip buttons whose label is exactly
+                // a sheet action ("plus", "gearshape", "Cancel", "Create", …).
+                .first { $0.elementType != .button }
+                ?? users.firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            print("PAIRDRIVE open-row=\(hop) kind=\(target.elementType.rawValue)")
+            sleep(4)
+        }
+    }
+}
+
+// Sends a prompt and captures while the turn is still running, so the
+// mid-turn state (running row / elapsed time, BET-630) is visible.
+final class MantaMidTurnCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureMidTurn() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        MantaChatSurfaceCapture.openChatRow(in: app)
+
+        let input = app.textViews["composer-input"]
+        guard input.waitForExistence(timeout: 10) else {
+            throw XCTSkip("PAIRDRIVE midturn: no composer input")
+        }
+        input.tap()
+        input.typeText("Say the alphabet slowly, one letter per line, pausing after each line.")
+        let send = app.buttons["send-button"]
+        XCTAssertTrue(send.waitForExistence(timeout: 5), "no send button")
+        send.tap()
+        print("PAIRDRIVE midturn=sent")
+
+        // Capture while the turn is still in flight.
+        MantaChatSurfaceCapture.capture("manta-mid-turn.png", after: 5)
+    }
+}
+
+// Opens a session and captures as close to the push as possible, so the
+// initial-load skeleton (BET-631) is on screen rather than a settled
+// transcript.
+final class MantaLoadCaptureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureDuringLoad() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? MantaPairFixture.openRow
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+            sleep(2)
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let users = app.descendants(matching: .any).matching(prefix)
+            let target = users.allElementsBoundByIndex
+                .first { $0.elementType != .button }
+                ?? users.firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("PAIRDRIVE open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            sleep(2)
+        }
+
+        // Minimal delay — don't wait for the transcript to settle, capture the
+        // loading state.
+        MantaChatSurfaceCapture.capture("manta-load.png", after: 0.3)
+    }
+}


### PR DESCRIPTION
Adds one file: `mobile/native/MantaUIUITests/MantaChatSurfaceCaptureUITests.swift`. No conflicts with main.

Landing it as part of the branch sweep because it is **live infrastructure that is currently stranded**: the `manta-sim-drive` plugin defaults its `branch` input to `multica/BET-625-sim-chat-captures`, with the note "until they are merged". Every simulator capture run therefore builds off an unmerged branch instead of main. BET-625 is `in_review`.

Two earlier PRs for this branch (#526, #528) were closed without merging, which is how it ended up stranded.