### PR TITLE
fix(prod): terminate the Unattended-Upgrade::Mail line (recovered from a stale branch)

### DIFF
--- a/scripts/prod/50unattended-upgrades
+++ b/scripts/prod/50unattended-upgrades
@@ -26,7 +26,7 @@ Unattended-Upgrade::AutoFixInterruptedDpkg "true";
 
 // Email the maintainer on errors. Unset by default (no SMTP relay on this box);
 // flip to a real address when a relay is set up.
-Unattended-Upgrade::Mail ""
+Unattended-Upgrade::Mail "";
 
 // Logging — visible via `journalctl -u unattended-upgrades`.
 Unattended-Upgrade::SyslogEnable "true";


### PR DESCRIPTION
`apt.conf` entries are semicolon-terminated. Without it, apt reads the following directive as a continuation of this value, so part of the unattended-upgrade config is silently not applied on the prod box.

Recovered during the branch sweep. The fix existed **only** on `multica/BET-163-prod-box-hardening`, which was never merged; its three other commits target `scripts/prod/backup-relay.sh` and `scripts/prod/manta-backup.cron`, neither of which exists any more (the relay was deleted in BET-204). Merging that branch would have re-introduced dead files, so the one still-valid line is taken on its own and the branch is retired.