### PR TITLE
fix(mobile,server): blank session list that only a force-quit could fix, and block markdown in the transcript

### DIFF
--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -15,6 +15,7 @@ struct MantaAppRoot: View {
     @EnvironmentObject private var store: MantaEventStore
     @EnvironmentObject private var sessionStore: SessionListStore
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.scenePhase) private var scenePhase
     @StateObject private var flow: MantaOnboardingFlow
     @State private var paired: Bool
 
@@ -88,6 +89,19 @@ struct MantaAppRoot: View {
         // is parsed and fed into the S2 onboarding flow. Delivery happens via
         // onOpenURL (warm launch) and MantaPairingRouter (cold start through
         // the app delegate's continue userActivity); both converge here.
+        // Coming back to the app re-syncs. Nothing observed the scene phase
+        // before, so `MantaEventStore.resume()` — written for exactly this and
+        // documented as "App foreground / resume" — had ZERO call sites: iOS
+        // suspends the process, the /events socket dies, its timers stop, and
+        // on return the app sat on whatever it had when it went away. Combined
+        // with a list fetch that only ran once at launch, a session list that
+        // went stale or blank stayed that way until the app was force-quit —
+        // which is precisely the "kill and restart and they're back" symptom.
+        .onChange(of: scenePhase) { phase in
+            guard phase == .active, paired else { return }
+            store.resume()
+            Task { await sessionStore.refresh() }
+        }
         .onOpenURL { url in
             _ = MantaPairingRouter.route(url)
         }

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -137,6 +137,9 @@ final class MantaEventStore: ObservableObject {
     private let controller: any MantaEventStreamControl
     private var lastFrameAt: Date
     private var watchdog: Timer?
+    /// No frame (heartbeats included) for this long means the socket is dead
+    /// even if it claims otherwise. Shared by the watchdog and `resume()`.
+    private let staleFrameMs: Double = 45_000
 
     init(
         stream: (any MantaEventStreamControl)? = nil,
@@ -171,8 +174,31 @@ final class MantaEventStore: ObservableObject {
     }
 
     /// App foreground / resume: force a reconnect + resync of missed state.
+    ///
+    /// `ensure()` alone is not enough here. A socket the OS tore down while the
+    /// process was suspended can still report itself open, so `ensure()`'s
+    /// "already live" short-circuit leaves the stream permanently silent; and a
+    /// backgrounded app's reconnect timers do not fire, so the controller may
+    /// have burnt its whole reconnect window and closed for good. Whenever the
+    /// stream is not demonstrably healthy — not `connected`, or no frame
+    /// (heartbeats included) for longer than the watchdog's staleness bar — we
+    /// reopen unconditionally rather than trust it.
     func resume() {
-        controller.markReconnectAndEnsure()
+        let stale = MantaLivenessPolicy.shouldForceReconnect(
+            state: connectionState,
+            lastFrameAt: lastFrameAt,
+            now: Date(),
+            staleMs: staleFrameMs
+        )
+        if connectionState.name == "connected" && !stale {
+            controller.markReconnectAndEnsure()
+        } else {
+            controller.forceReconnect()
+        }
+        lastFrameAt = Date()
+        // Timers are suspended with the process; re-arm rather than assume the
+        // watchdog survived the trip to the background.
+        startWatchdog()
     }
 
     /// Permanent teardown.
@@ -241,7 +267,7 @@ final class MantaEventStore: ObservableObject {
             state: connectionState,
             lastFrameAt: lastFrameAt,
             now: Date(),
-            staleMs: 45_000
+            staleMs: staleFrameMs
         ) {
             controller.forceReconnect()
         }

--- a/mobile/native/MantaUI/SessionCreateSheet.swift
+++ b/mobile/native/MantaUI/SessionCreateSheet.swift
@@ -22,7 +22,12 @@ struct SessionCreateSheet: View {
     /// Pre-selected project (the one the user was looking at), if any.
     let initialProject: String?
     let onClose: () -> Void
-    let onCreated: (String, Int) -> Void
+    /// `(project, windowIndex, freshProjects)`. The FRESH list matters: every
+    /// create RPC already returns the box's post-create session list, and
+    /// throwing it away left the caller resolving the brand-new window against
+    /// a list that predates it — so the just-created session opened nameless
+    /// and without its opencode session id.
+    let onCreated: (String, Int, [MantaProject]) -> Void
 
     /// Where the new session goes: an existing project, or a brand new one.
     private enum Target: Hashable {
@@ -190,7 +195,7 @@ struct SessionCreateSheet: View {
         }
         await MainActor.run {
             creating = false
-            onCreated(project, window.index)
+            onCreated(project, window.index, projects)
         }
     }
 
@@ -198,6 +203,7 @@ struct SessionCreateSheet: View {
         let projectName = newProjectName.trimmingCharacters(in: .whitespaces)
         let dir = cwd.trimmingCharacters(in: .whitespaces)
         var windowIndex = 0
+        var fresh: [MantaProject] = []
 
         if let worktrees = detectedWorktrees, worktrees.count > 1 {
             // Fan out: the first worktree is the project's initial window, the
@@ -212,6 +218,7 @@ struct SessionCreateSheet: View {
                     cwd: worktree.path, chatMode: true))
             }
             windowIndex = Self.findInitialWindow(projects, projectName: projectName, cwd: worktrees[0].path)?.index ?? 0
+            fresh = projects
         } else {
             let windowName = resolvedSessionName
             let projects = try await api.newSession(NewSessionInput(
@@ -222,11 +229,12 @@ struct SessionCreateSheet: View {
                 throw MantaError.transport("created project was not returned")
             }
             windowIndex = window.index
+            fresh = projects
         }
 
         await MainActor.run {
             creating = false
-            onCreated(projectName, windowIndex)
+            onCreated(projectName, windowIndex, fresh)
         }
     }
 

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -26,6 +26,12 @@ final class SessionListStore: ObservableObject {
     @Published private(set) var projects: [MantaProject] = []
     @Published private(set) var loading = false
     @Published private(set) var loadError: String?
+    /// True once a fetch has come back successfully. Without it an EMPTY list
+    /// is ambiguous — "this box has no sessions" and "we never managed to ask"
+    /// look identical — and the view rendered the inviting "No sessions yet.
+    /// Tap + to create one." for both. That is the reassuring-lie state the
+    /// user hit: sessions existed, the list was blank, and nothing said so.
+    @Published private(set) var loadedOnce = false
     @Published private(set) var pinnedWindows: Set<String> = []
     @Published private(set) var hapticsEnabled = true
     /// pinID -> pending delete being held within its 5 s undo window.
@@ -40,6 +46,11 @@ final class SessionListStore: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var attentionSessions: Set<String> = []
     private var modelLabels: [String: String] = [:]
+    /// A refresh asked for while one was already in flight. The request used to
+    /// be DROPPED (`guard !loading else { return }`) and never rescheduled, so
+    /// the foreground/reconnect refresh that raced the launch fetch simply
+    /// vanished and the list stayed on whatever the first one returned.
+    private var refreshQueued = false
 
     init(api: MantaAPIClient = MantaAPIClient.live(), eventStore: MantaEventStore) {
         self.api = api
@@ -70,24 +81,50 @@ final class SessionListStore: ObservableObject {
         if changed { objectWillChange.send() }
     }
 
-    /// Re-fetch the list (pull-to-refresh / reconnect / after create).
+    /// Re-fetch the list (pull-to-refresh / foreground / reconnect / after
+    /// create). Overlapping calls are COALESCED, not discarded: the second
+    /// caller marks a re-run and the loop fires once more when the in-flight
+    /// fetch lands, so a refresh request can never be silently lost.
     func refresh() async {
-        guard !loading else { return }
+        if loading {
+            refreshQueued = true
+            return
+        }
         loading = true
         defer { loading = false }
+        repeat {
+            refreshQueued = false
+            await fetchOnce()
+        } while refreshQueued
+    }
+
+    private func fetchOnce() async {
         do {
             let list = try await api.projects()
             projects = list
+            loadedOnce = true
             loadError = nil
             await refreshModels()
         } catch {
-            loadError = "Couldn't reach your box"
+            // Keep whatever was already on screen — a failed fetch must never
+            // blank a list we successfully loaded before.
+            loadError = Self.describe(error)
         }
     }
 
-    /// Reconcile deltas from one project list transaction (post-create).
-    private func applyProjects(_ list: [MantaProject]) {
+    private static func describe(_ error: Error) -> String {
+        if let known = error as? MantaError, known == .authRequired {
+            return "Your box rejected this device — pair it again."
+        }
+        return "Couldn't reach your box"
+    }
+
+    /// Adopt the project list a mutating RPC already returned (post-create),
+    /// so the caller resolves the new window against a list that contains it
+    /// instead of the pre-create snapshot.
+    func applyProjects(_ list: [MantaProject]) {
         projects = list
+        loadedOnce = true
         loadError = nil
     }
 

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -60,8 +60,24 @@ struct SessionListView: View {
     var body: some View {
         NavigationStack(path: $path) {
             Group {
-                if store.projects.isEmpty && !store.loading {
+                // Three distinct nothing-on-screen cases, and they used to
+                // collapse into one. `projects.isEmpty && !loading` rendered
+                // the inviting "No sessions yet. Tap + to create one." whether
+                // the box really had no sessions, the fetch had FAILED, or it
+                // had never run — which is exactly how a box full of sessions
+                // came up blank and reassuring. A search that matches nothing
+                // rendered a totally bare screen with no message at all.
+                // Gated on loadError, NOT on `loading`: the first frame renders
+                // before `.task` has flipped `loading`, so a `loading`-based
+                // gate flashes the failure state on every cold launch.
+                if !store.loadedOnce && store.loadError == nil {
+                    loadingState
+                } else if !store.loadedOnce {
+                    unreachableState
+                } else if store.projects.isEmpty {
                     emptyState
+                } else if filteredProjects.isEmpty {
+                    noMatchState
                 } else {
                     list
                 }
@@ -129,7 +145,12 @@ struct SessionListView: View {
                 projects: store.projects,
                 initialProject: project,
                 onClose: { sheetRoute = nil },
-                onCreated: { project, index in
+                onCreated: { project, index, fresh in
+                    // Adopt the post-create list BEFORE resolving the window,
+                    // otherwise the lookup runs against the pre-create snapshot
+                    // and the new session opens as an unnamed, session-id-less
+                    // placeholder.
+                    store.applyProjects(fresh)
                     let window = store.projects.first(where: { $0.tmuxSession == project })?
                         .windows.first(where: { $0.index == index })
                     let name = window?.name ?? "session"
@@ -191,6 +212,10 @@ struct SessionListView: View {
         guard !searchText.isEmpty else { return store.projects }
         let q = searchText.lowercased()
         return store.projects.compactMap { p in
+            // A project-name match keeps the whole group. Matching window names
+            // only meant typing the name of the project you were looking at
+            // emptied the screen.
+            if p.tmuxSession.lowercased().contains(q) { return p }
             let kept = p.windows.filter { $0.name.lowercased().contains(q) }
             guard !kept.isEmpty else { return nil }
             var copy = p
@@ -499,6 +524,50 @@ struct SessionListView: View {
                 .font(.system(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
         }
+        .accessibilityIdentifier("sessions-empty")
+    }
+
+    private var loadingState: some View {
+        ProgressView()
+            .accessibilityIdentifier("sessions-loading")
+    }
+
+    /// Never loaded successfully. Says so, and offers the retry — the one
+    /// thing the user could previously only get by force-quitting the app.
+    private var unreachableState: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "wifi.exclamationmark")
+                .font(.system(size: Metrics.type.display))
+                .foregroundColor(tokens.tx4)
+            Text("Can't load your sessions")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx3)
+            Text(store.loadError ?? "Couldn't reach your box")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx4)
+                .multilineTextAlignment(.center)
+            Button("Try again") {
+                Task { await store.refresh() }
+            }
+            .font(.system(size: Metrics.type.small, weight: .semibold))
+            .foregroundColor(tokens.accentTx)
+            .padding(.top, Metrics.spacing.sp1)
+            .disabled(store.loading)
+        }
+        .padding(.horizontal, Metrics.spacing.sp4)
+        .accessibilityIdentifier("sessions-unreachable")
+    }
+
+    private var noMatchState: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Text("No sessions match")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx3)
+            Text("Nothing named “\(searchText)”.")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(tokens.tx4)
+        }
+        .accessibilityIdentifier("sessions-no-match")
     }
 
     @ViewBuilder

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 // Shared helper: map a generated font-weight metric (500 / 600 from
@@ -59,15 +60,292 @@ struct UserBand: View {
 // SwiftUI can parse natively — emphasis, strong, inline code, links —
 // preserving newlines so paragraph structure survives.
 //
-// BLOCK-level markdown (headings, lists, fenced code, thematic breaks) is
-// still unrendered; that needs a real block parser and its own components,
-// which is a separate piece of work, not something to fake here.
+// BLOCK-level markdown is handled by `MantaMarkdownParser` below, which splits
+// a turn into blocks and hands each block's TEXT back through this renderer for
+// its inline spans.
 enum MantaInlineMarkdown {
     static func render(_ raw: String) -> AttributedString {
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
         return (try? AttributedString(markdown: raw, options: options)) ?? AttributedString(raw)
+    }
+}
+
+// MARK: - Block markdown
+//
+// `AttributedString(markdown:)` with `.inlineOnlyPreservingWhitespace` parses
+// ONLY inline spans, and passes every block construct through as literal text.
+// So a turn that opened with `## How it compares` and laid its answer out as a
+// GFM table rendered as its own source: a heading line with two hashes, then
+// `| Latency | record → upload |` and a `|---|---|---|` rule, verbatim.
+//
+// This is the block layer. It is deliberately a small, total, PURE function —
+// no library, no dependency, and no throwing path: anything it does not
+// recognise stays a paragraph and still gets inline rendering, so an
+// unsupported construct degrades to exactly today's behaviour rather than
+// disappearing.
+enum MantaMarkdownBlock: Equatable {
+    case paragraph(String)
+    case heading(level: Int, text: String)
+    /// One list item. `ordered` drives the marker; `depth` its indent.
+    case listItem(depth: Int, marker: String, text: String)
+    case code(language: String?, text: String)
+    case quote(String)
+    case rule
+    case table(MantaMarkdownTable)
+}
+
+enum MantaTableAlignment: Equatable {
+    case leading, center, trailing
+}
+
+struct MantaMarkdownTable: Equatable {
+    var header: [String]
+    var alignments: [MantaTableAlignment]
+    var rows: [[String]]
+
+    /// Header + body, padded/truncated to the header's column count so the grid
+    /// is always rectangular (a ragged row is legal GFM and must not crash or
+    /// misalign the columns).
+    var normalizedRows: [[String]] {
+        rows.map { row in
+            (0..<header.count).map { i in i < row.count ? row[i] : "" }
+        }
+    }
+
+    func alignment(_ column: Int) -> MantaTableAlignment {
+        column < alignments.count ? alignments[column] : .leading
+    }
+}
+
+enum MantaMarkdownParser {
+
+    /// Split a turn's text into blocks. Total: never throws, never drops input.
+    static func blocks(_ raw: String) -> [MantaMarkdownBlock] {
+        let lines = raw.components(separatedBy: "\n")
+        var out: [MantaMarkdownBlock] = []
+        var paragraph: [String] = []
+        var i = 0
+
+        func flushParagraph() {
+            let text = paragraph.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            paragraph.removeAll()
+            if !text.isEmpty { out.append(.paragraph(text)) }
+        }
+
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Fenced code. Consumes to the closing fence, or to the end of the
+            // input when the fence never closes (the streaming case — a half
+            // written block must still render as code, not as loose prose).
+            if let fence = fenceToken(trimmed) {
+                flushParagraph()
+                let language = String(trimmed.dropFirst(fence.count)).trimmingCharacters(in: .whitespaces)
+                var body: [String] = []
+                i += 1
+                while i < lines.count {
+                    let candidate = lines[i].trimmingCharacters(in: .whitespaces)
+                    if candidate.hasPrefix(fence) { i += 1; break }
+                    body.append(lines[i])
+                    i += 1
+                }
+                out.append(.code(language: language.isEmpty ? nil : language,
+                                 text: body.joined(separator: "\n")))
+                continue
+            }
+
+            if trimmed.isEmpty {
+                flushParagraph()
+                i += 1
+                continue
+            }
+
+            if isThematicBreak(trimmed) {
+                flushParagraph()
+                out.append(.rule)
+                i += 1
+                continue
+            }
+
+            if let heading = parseHeading(trimmed) {
+                flushParagraph()
+                out.append(heading)
+                i += 1
+                continue
+            }
+
+            // GFM table: a header row plus a delimiter row. Checked BEFORE the
+            // paragraph fallback and before list parsing, because both would
+            // otherwise swallow the pipes as ordinary text.
+            if let parsed = parseTable(lines, from: i) {
+                flushParagraph()
+                out.append(.table(parsed.table))
+                i = parsed.next
+                continue
+            }
+
+            if let item = parseListItem(line) {
+                flushParagraph()
+                out.append(item)
+                i += 1
+                continue
+            }
+
+            if trimmed.hasPrefix(">") {
+                flushParagraph()
+                var body: [String] = []
+                while i < lines.count {
+                    let candidate = lines[i].trimmingCharacters(in: .whitespaces)
+                    guard candidate.hasPrefix(">") else { break }
+                    body.append(String(candidate.dropFirst()).trimmingCharacters(in: .whitespaces))
+                    i += 1
+                }
+                out.append(.quote(body.joined(separator: "\n")))
+                continue
+            }
+
+            paragraph.append(line)
+            i += 1
+        }
+
+        flushParagraph()
+        return out
+    }
+
+    // MARK: - Line classifiers (each pure + individually testable)
+
+    /// The ``` / ~~~ opener, or nil.
+    static func fenceToken(_ trimmed: String) -> String? {
+        for token in ["```", "~~~"] where trimmed.hasPrefix(token) {
+            return token
+        }
+        return nil
+    }
+
+    static func isThematicBreak(_ trimmed: String) -> Bool {
+        for ch in ["-", "*", "_"] {
+            let stripped = trimmed.replacingOccurrences(of: " ", with: "")
+            if stripped.count >= 3, stripped.allSatisfy({ String($0) == ch }) { return true }
+        }
+        return false
+    }
+
+    static func parseHeading(_ trimmed: String) -> MantaMarkdownBlock? {
+        guard trimmed.hasPrefix("#") else { return nil }
+        let hashes = trimmed.prefix(while: { $0 == "#" })
+        guard hashes.count <= 6 else { return nil }
+        let rest = trimmed.dropFirst(hashes.count)
+        // `#hashtag` is not a heading — ATX requires a space after the run.
+        guard rest.first == " " || rest.isEmpty else { return nil }
+        let text = rest.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return nil }
+        return .heading(level: hashes.count, text: text)
+    }
+
+    static func parseListItem(_ line: String) -> MantaMarkdownBlock? {
+        let indent = line.prefix(while: { $0 == " " || $0 == "\t" }).count
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let depth = min(indent / 2, 3)
+
+        for bullet in ["- ", "* ", "+ "] where trimmed.hasPrefix(bullet) {
+            let text = String(trimmed.dropFirst(bullet.count)).trimmingCharacters(in: .whitespaces)
+            guard !text.isEmpty else { return nil }
+            return .listItem(depth: depth, marker: "•", text: text)
+        }
+
+        // `12. text` / `12) text`
+        let digits = trimmed.prefix(while: { $0.isNumber })
+        if !digits.isEmpty, digits.count <= 9 {
+            let rest = trimmed.dropFirst(digits.count)
+            if let sep = rest.first, sep == "." || sep == ")" {
+                let text = String(rest.dropFirst()).trimmingCharacters(in: .whitespaces)
+                guard !text.isEmpty else { return nil }
+                return .listItem(depth: depth, marker: "\(digits).", text: text)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Table
+
+    /// Parse a GFM table starting at `start`, returning it plus the index of
+    /// the first line AFTER it. nil when the two-line header+delimiter shape
+    /// isn't there — which is what keeps a lone pipe-bearing prose line prose.
+    static func parseTable(_ lines: [String], from start: Int) -> (table: MantaMarkdownTable, next: Int)? {
+        guard start + 1 < lines.count else { return nil }
+        let headerLine = lines[start].trimmingCharacters(in: .whitespaces)
+        guard headerLine.contains("|") else { return nil }
+        let delimiterLine = lines[start + 1].trimmingCharacters(in: .whitespaces)
+        guard let alignments = parseDelimiterRow(delimiterLine) else { return nil }
+
+        let header = splitRow(headerLine)
+        guard header.count == alignments.count else { return nil }
+
+        var rows: [[String]] = []
+        var cursor = start + 2
+        while cursor < lines.count {
+            let candidate = lines[cursor].trimmingCharacters(in: .whitespaces)
+            guard !candidate.isEmpty, candidate.contains("|") else { break }
+            rows.append(splitRow(candidate))
+            cursor += 1
+        }
+        return (MantaMarkdownTable(header: header, alignments: alignments, rows: rows), cursor)
+    }
+
+    /// `|---|:--:|---:|` -> per-column alignment, or nil when the line is not a
+    /// delimiter row (which is what makes a lone pipe-bearing prose line stay
+    /// prose).
+    static func parseDelimiterRow(_ line: String) -> [MantaTableAlignment]? {
+        guard line.contains("|"), line.contains("-") else { return nil }
+        let cells = splitRow(line)
+        guard !cells.isEmpty else { return nil }
+        var out: [MantaTableAlignment] = []
+        for cell in cells {
+            let c = cell.trimmingCharacters(in: .whitespaces)
+            guard !c.isEmpty else { return nil }
+            let left = c.hasPrefix(":")
+            let right = c.hasSuffix(":")
+            let dashes = c.trimmingCharacters(in: CharacterSet(charactersIn: ":"))
+            guard !dashes.isEmpty, dashes.allSatisfy({ $0 == "-" }) else { return nil }
+            if left && right { out.append(.center) }
+            else if right { out.append(.trailing) }
+            else { out.append(.leading) }
+        }
+        return out
+    }
+
+    /// Split one table row into cells, honouring `\|` escapes and dropping the
+    /// optional leading/trailing pipe. An EMPTY first header cell is legal and
+    /// common (a corner cell), so we must not trim empties away wholesale —
+    /// only the delimiters the row shape contributes.
+    static func splitRow(_ line: String) -> [String] {
+        var body = line
+        if body.hasPrefix("|") { body.removeFirst() }
+        if body.hasSuffix("|") && !body.hasSuffix("\\|") { body.removeLast() }
+
+        var cells: [String] = []
+        var current = ""
+        var escaped = false
+        for ch in body {
+            if escaped {
+                current.append(ch == "|" ? "|" : ch)
+                escaped = false
+                continue
+            }
+            if ch == "\\" { escaped = true; continue }
+            if ch == "|" {
+                cells.append(current.trimmingCharacters(in: .whitespaces))
+                current = ""
+                continue
+            }
+            current.append(ch)
+        }
+        if escaped { current.append("\\") }
+        cells.append(current.trimmingCharacters(in: .whitespaces))
+        return cells
     }
 }
 
@@ -78,25 +356,207 @@ struct AssistantProse: View {
     let text: String
     let tokens: Tokens
 
+    private var blocks: [MantaMarkdownBlock] { MantaMarkdownParser.blocks(text) }
+
     var body: some View {
-        // `fixedSize(horizontal: false, …)` is what keeps a long unbreakable
-        // token (a shell command, a URL, a path) INSIDE the screen. Without it
-        // such a token makes the text demand its full unwrapped width, the
-        // scroll view adopts that width, and every sibling — including the
-        // composer, which shares the same layout — is laid out wider than the
-        // display: text stops appearing to wrap, the send button sits off
-        // screen, and each keystroke re-lays out an oversized view, which is
-        // what made typing crawl.
-        Text(MantaInlineMarkdown.render(text))
+        // Spacing 0 + a per-block bottom gap: a uniform VStack spacing would
+        // set consecutive list items as far apart as two paragraphs, which
+        // stops a list reading as one list.
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { pair in
+                blockView(pair.element)
+                    .padding(.bottom, gapBelow(pair.element))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.bottom, Metrics.spacing.sp3)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("assistant-prose")
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: MantaMarkdownBlock) -> some View {
+        switch block {
+        case .paragraph(let content):
+            proseText(content)
+        case .heading(let level, let content):
+            Text(MantaInlineMarkdown.render(content))
+                .font(.system(size: headingSize(level), weight: .semibold))
+                .kerning(Metrics.type.headingTracking * headingSize(level))
+                .foregroundColor(tokens.tx1)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, Metrics.spacing.sp2)
+        case .listItem(let depth, let marker, let content):
+            HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing.sp2) {
+                Text(marker)
+                    .font(.system(size: Metrics.type.body))
+                    .foregroundColor(tokens.tx4)
+                    .monospacedDigit()
+                proseText(content)
+            }
+            .padding(.leading, CGFloat(depth) * Metrics.spacing.sp4)
+        case .code(let language, let content):
+            MarkdownCodeBlock(language: language, text: content, tokens: tokens)
+        case .quote(let content):
+            proseText(content)
+                .foregroundColor(tokens.tx2)
+                .padding(.leading, Metrics.spacing.sp3)
+                .overlay(alignment: .leading) {
+                    tokens.borderSubtle.frame(width: Metrics.spacing.spPx * 2)
+                }
+        case .rule:
+            tokens.borderSubtle
+                .frame(height: Metrics.spacing.spPx)
+                .padding(.vertical, Metrics.spacing.sp1)
+        case .table(let table):
+            MarkdownTableView(table: table, tokens: tokens)
+        }
+    }
+
+    // `fixedSize(horizontal: false, …)` is what keeps a long unbreakable token
+    // (a shell command, a URL, a path) INSIDE the screen. Without it such a
+    // token makes the text demand its full unwrapped width, the scroll view
+    // adopts that width, and every sibling — including the composer, which
+    // shares the same layout — is laid out wider than the display: text stops
+    // appearing to wrap, the send button sits off screen, and each keystroke
+    // re-lays out an oversized view, which is what made typing crawl.
+    private func proseText(_ content: String) -> some View {
+        Text(MantaInlineMarkdown.render(content))
             .font(.system(size: Metrics.type.body))
             .foregroundColor(tokens.tx1)
             .lineSpacing(pointsFor(multiplier: Metrics.type.proseLineHeight, size: Metrics.type.body))
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Metrics.spacing.sp3)
-            .padding(.bottom, Metrics.spacing.sp3)
-            .accessibilityElement(children: .contain)
-            .accessibilityIdentifier("assistant-prose")
+    }
+
+    private func gapBelow(_ block: MantaMarkdownBlock) -> CGFloat {
+        switch block {
+        case .listItem, .heading, .rule: return Metrics.spacing.sp1
+        case .paragraph, .code, .quote, .table: return Metrics.spacing.sp2
+        }
+    }
+
+    /// `#` is the turn's own top level, so it is only slightly larger than
+    /// body; deeper levels converge on body size. A transcript turn is not a
+    /// document — an `h1` set at display size would shout over the user band.
+    private func headingSize(_ level: Int) -> CGFloat {
+        switch level {
+        case 1: return Metrics.type.body + 4
+        case 2: return Metrics.type.body + 2
+        case 3: return Metrics.type.body + 1
+        default: return Metrics.type.body
+        }
+    }
+}
+
+// MARK: - Fenced code
+//
+// Horizontal scroll rather than wrapping: a wrapped command line is a command
+// line you cannot read, and (per the note in `proseText`) letting an
+// unwrappable token dictate the width blows out the whole transcript layout.
+// A horizontal ScrollView takes the width it is GIVEN, so it bounds itself.
+struct MarkdownCodeBlock: View {
+    let language: String?
+    let text: String
+    let tokens: Tokens
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let language, !language.isEmpty {
+                Text(language)
+                    .font(.system(size: Metrics.type.twoXS, weight: .medium))
+                    .foregroundColor(tokens.tx4)
+                    .padding(.horizontal, Metrics.spacing.sp2)
+                    .padding(.top, Metrics.spacing.sp2)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(text)
+                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                    .foregroundColor(tokens.tx1)
+                    .textSelection(.enabled)
+                    .padding(Metrics.spacing.sp2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        }
+        .accessibilityIdentifier("markdown-code")
+    }
+}
+
+// MARK: - GFM table
+//
+// Rows are HStacks of equal-share (`maxWidth: .infinity`) cells, NOT a `Grid`.
+// A Grid sizes each column to its widest cell's IDEAL width, and a prose cell's
+// ideal width is its UNWRAPPED width — the exact layout blow-out the note in
+// `proseText` describes, where one long cell widens the scroll view and drags
+// the composer off screen with it. Equal shares of the width we are actually
+// given can't overflow, and every cell wraps inside its share.
+//
+// Column rules are deliberately omitted: keeping vertical hairlines aligned
+// needs equal-height cells, which needs a height the transcript can't propose.
+// Row hairlines plus a filled header row carry the structure on a phone.
+struct MarkdownTableView: View {
+    let table: MantaMarkdownTable
+    let tokens: Tokens
+
+    var body: some View {
+        VStack(spacing: 0) {
+            row(table.header, header: true)
+            ForEach(Array(table.normalizedRows.enumerated()), id: \.offset) { pair in
+                Divider().overlay(tokens.borderSubtle)
+                row(pair.element, header: false)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.card)
+        // Clip BEFORE the stroke: the header row's own fill is a plain
+        // rectangle and would otherwise square off the container's top corners.
+        .clipShape(RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("markdown-table")
+    }
+
+    private func row(_ cells: [String], header: Bool) -> some View {
+        HStack(alignment: .top, spacing: Metrics.spacing.sp2) {
+            ForEach(Array(cells.enumerated()), id: \.offset) { pair in
+                Text(MantaInlineMarkdown.render(pair.element))
+                    .font(.system(size: Metrics.type.xs, weight: header ? .semibold : .regular))
+                    .foregroundColor(header ? tokens.tx1 : tokens.tx2)
+                    .multilineTextAlignment(textAlignment(pair.offset))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: frameAlignment(pair.offset))
+            }
+        }
+        .padding(.horizontal, Metrics.spacing.sp2)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(header ? tokens.panel : Color.clear)
+    }
+
+    private func textAlignment(_ column: Int) -> TextAlignment {
+        switch table.alignment(column) {
+        case .leading: return .leading
+        case .center: return .center
+        case .trailing: return .trailing
+        }
+    }
+
+    private func frameAlignment(_ column: Int) -> Alignment {
+        switch table.alignment(column) {
+        case .leading: return .leading
+        case .center: return .center
+        case .trailing: return .trailing
+        }
     }
 }
 

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -293,4 +293,113 @@ final class ChatTranscriptTests: XCTestCase {
         let out = ChatQuestionAnswers.answers(questions: q, selected: [0: [0, 1]], customText: "")
         XCTAssertEqual(out, [["x", "y"]])
     }
+
+    // MARK: - Block markdown
+    //
+    // The transcript used to run assistant text through inline-only markdown
+    // parsing, which passes every BLOCK construct through as literal text: a
+    // GFM table rendered as its own pipes and dashes, and `##` headings as
+    // hashes. These pin the block split.
+
+    func testMarkdownTableIsParsedWithHeaderAndRows() {
+        let raw = """
+        Intro line.
+
+        | | today | on-device |
+        |---|---|---|
+        | Latency | record → upload | live partials |
+        | Offline | broken | works |
+
+        Trailing prose.
+        """
+        let blocks = MantaMarkdownParser.blocks(raw)
+        guard blocks.count == 3 else {
+            return XCTFail("expected paragraph + table + paragraph, got \(blocks)")
+        }
+        XCTAssertEqual(blocks[0], .paragraph("Intro line."))
+        XCTAssertEqual(blocks[2], .paragraph("Trailing prose."))
+        guard case .table(let table) = blocks[1] else {
+            return XCTFail("second block is not a table: \(blocks[1])")
+        }
+        // The leading corner cell is EMPTY and must survive — dropping empties
+        // would shift every column left by one.
+        XCTAssertEqual(table.header, ["", "today", "on-device"])
+        XCTAssertEqual(table.alignments, [.leading, .leading, .leading])
+        XCTAssertEqual(table.rows, [
+            ["Latency", "record → upload", "live partials"],
+            ["Offline", "broken", "works"],
+        ])
+    }
+
+    func testMarkdownTableAlignmentsAndRaggedRows() {
+        let raw = """
+        | a | b | c |
+        |:--|:-:|--:|
+        | 1 |
+        | 1 | 2 | 3 | 4 |
+        """
+        let blocks = MantaMarkdownParser.blocks(raw)
+        guard case .table(let table)? = blocks.first else {
+            return XCTFail("expected a table, got \(blocks)")
+        }
+        XCTAssertEqual(table.alignments, [.leading, .center, .trailing])
+        // Ragged rows are padded/truncated to the header width so the layout
+        // can never index past a short row.
+        XCTAssertEqual(table.normalizedRows, [["1", "", ""], ["1", "2", "3"]])
+    }
+
+    func testPipeBearingProseIsNotATable() {
+        // No delimiter row → this is prose that happens to contain pipes, and
+        // treating it as a table would eat the line.
+        let raw = "run `a | b | c` to pipe it"
+        XCTAssertEqual(MantaMarkdownParser.blocks(raw), [.paragraph(raw)])
+    }
+
+    func testEscapedPipeStaysInsideItsCell() {
+        let cells = MantaMarkdownParser.splitRow("| a \\| b | c |")
+        XCTAssertEqual(cells, ["a | b", "c"])
+    }
+
+    func testHeadingsListsRulesAndCode() {
+        let raw = """
+        ## The catch
+
+        - **Model assets.** One-time download.
+        - Second point.
+        1. Ordered one.
+
+        ---
+
+        ```swift
+        let x = 1
+        ```
+        """
+        let blocks = MantaMarkdownParser.blocks(raw)
+        XCTAssertEqual(blocks, [
+            .heading(level: 2, text: "The catch"),
+            .listItem(depth: 0, marker: "•", text: "**Model assets.** One-time download."),
+            .listItem(depth: 0, marker: "•", text: "Second point."),
+            .listItem(depth: 0, marker: "1.", text: "Ordered one."),
+            .rule,
+            .code(language: "swift", text: "let x = 1"),
+        ])
+    }
+
+    func testUnclosedCodeFenceStillRendersAsCode() {
+        // The streaming case: the closing fence has not arrived yet.
+        let blocks = MantaMarkdownParser.blocks("```\nnpm test\n")
+        XCTAssertEqual(blocks, [.code(language: nil, text: "npm test\n")])
+    }
+
+    func testHashtagIsNotAHeading() {
+        XCTAssertEqual(MantaMarkdownParser.blocks("#nofilter"), [.paragraph("#nofilter")])
+    }
+
+    func testPlainProseIsOneParagraphPerBlankLineGroup() {
+        let raw = "line one\nline two\n\nsecond para"
+        XCTAssertEqual(MantaMarkdownParser.blocks(raw), [
+            .paragraph("line one\nline two"),
+            .paragraph("second para"),
+        ])
+    }
 }

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -253,11 +253,45 @@ export function parseSessions(sessStdout, winStdout, owned = new Set()) {
   }));
 }
 
+// True iff a tmux invocation failed because there is genuinely no tmux server
+// (or no session) to talk to — i.e. the box really does have zero sessions.
+// Anything else is a FAULT and must not be reported as "zero sessions".
+//
+// Pure + exported for tests.
+export function isNoTmuxServerError(err) {
+  const msg = typeof err?.message === "string" ? err.message : "";
+  if (!msg) return false;
+  return (
+    /no server running on/i.test(msg) ||
+    /no sessions?$/im.test(msg) ||
+    /error connecting to .*(no such file or directory|connection refused)/i.test(msg)
+  );
+}
+
+// `tmux list-*` output, or "" when tmux legitimately has nothing to list.
+//
+// This used to be a bare `.catch(() => ({ stdout: "" }))` on both queries, which
+// turned ANY tmux fault — a momentarily restarting server, a mangled locale, an
+// ENOENT because the service has no PATH — into a successful 200 carrying an
+// EMPTY session list. The client cannot tell that apart from a box that really
+// has no sessions, so the phone showed "No sessions yet. Tap + to create one."
+// with no error, and (worse) `reconcileOwnedSessions` pruned the ownership
+// sidecar against that phantom empty list. A fault must surface as a fault.
+async function tmuxListOutput(args) {
+  try {
+    const { stdout } = await run("tmux", args);
+    return stdout;
+  } catch (e) {
+    if (isNoTmuxServerError(e)) return "";
+    throw e;
+  }
+}
+
 export async function listProjects() {
   const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
   const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}`;
-  const sess = await run("tmux", ["list-sessions", "-F", sessFmt]).catch(() => ({ stdout: "" }));
-  const wins = await run("tmux", ["list-windows", "-a", "-F", winFmt]).catch(() => ({ stdout: "" }));
+  const sess = { stdout: await tmuxListOutput(["list-sessions", "-F", sessFmt]) };
+  const wins = { stdout: await tmuxListOutput(["list-windows", "-a", "-F", winFmt]) };
   // BET-348: build the owned set from the cache (hydrated on first call),
   // reconcile it against the LIVE tmux session list — anything in the
   // sidecar that no longer exists gets pruned before we serve the listing,

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -7,6 +7,7 @@ import {
   parseSessions,
   tmuxSpawnEnv,
   isMissingSessionError,
+  isNoTmuxServerError,
   newWindow,
   newSession,
   newWindowGetIndex,
@@ -287,6 +288,96 @@ test("resolveCwdOrThrow: '~/<existing dir>' resolves under os.homedir()", async 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// listProjects must not report a tmux FAULT as "this box has zero sessions".
+//
+// Both tmux queries used to end in `.catch(() => ({ stdout: "" }))`, so any
+// failure — a restarting server, a missing PATH, a mangled locale — came back
+// as a successful, EMPTY listing. A client cannot tell that apart from a box
+// that genuinely has no sessions, so the phone showed the inviting "No
+// sessions yet. Tap + to create one." for a box full of work, and the
+// ownership sidecar was reconciled to nothing against the phantom empty list.
+// ---------------------------------------------------------------------------
+
+test("isNoTmuxServerError separates 'no tmux server' from a real fault", () => {
+  assert.equal(
+    isNoTmuxServerError(new Error("tmux exited 1: no server running on /tmp/tmux-1000/default")),
+    true,
+  );
+  assert.equal(
+    isNoTmuxServerError(new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)")),
+    true,
+  );
+  assert.equal(isNoTmuxServerError(new Error("spawn tmux ENOENT")), false);
+  assert.equal(isNoTmuxServerError(new Error("tmux exited 1: lost server")), false);
+  assert.equal(isNoTmuxServerError(undefined), false);
+  assert.equal(isNoTmuxServerError({}), false);
+});
+
+test("listProjects returns [] when tmux genuinely has no server", async () => {
+  _resetOwnedSessionsCache();
+  _setRun(async () => {
+    throw new Error("tmux exited 1: no server running on /tmp/tmux-1000/default");
+  });
+  try {
+    assert.deepEqual(await listProjects(), []);
+  } finally {
+    _setRun(null);
+    _resetOwnedSessionsCache();
+  }
+});
+
+test("listProjects THROWS on a tmux fault rather than reporting zero sessions", async () => {
+  _resetOwnedSessionsCache();
+  _setRun(async () => {
+    throw new Error("spawn tmux ENOENT");
+  });
+  try {
+    await assert.rejects(() => listProjects(), /ENOENT/);
+  } finally {
+    _setRun(null);
+    _resetOwnedSessionsCache();
+  }
+});
+
+test("listProjects THROWS when only the window query faults", async () => {
+  _resetOwnedSessionsCache();
+  _setRun(async (cmd, args) => {
+    if (args.includes("list-sessions")) return { stdout: "alpha\t1\n", stderr: "" };
+    throw new Error("tmux exited 1: lost server");
+  });
+  try {
+    await assert.rejects(() => listProjects(), /lost server/);
+  } finally {
+    _setRun(null);
+    _resetOwnedSessionsCache();
+  }
+});
+
+// A fault must also leave the ownership sidecar alone — reconciling against an
+// empty live-session list is what would silently drop every owned session.
+test("a tmux fault does not prune the owned-session sidecar", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tmux-fault-"));
+  const path = join(dir, "tmux-sessions.json");
+  try {
+    _resetOwnedSessionsCache();
+    await addOwnedSession("alpha", { path });
+    _setRun(async () => {
+      throw new Error("spawn tmux ENOENT");
+    });
+    try {
+      await assert.rejects(() => listProjects());
+    } finally {
+      _setRun(null);
+    }
+    assert.deepEqual(await loadOwnedSessions(path), ["alpha"]);
+  } finally {
+    _resetOwnedSessionsCache();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 
 test("resolveCwdOrThrow: undefined resolves to '.' (current working dir)", () => {
   const out = resolveCwdOrThrow(undefined);


### PR DESCRIPTION
Two reported bugs, from screenshots of the iOS app.

## 1. Sessions screen came up empty on a box full of sessions

Empty, with **no error**, recoverable only by force-quitting. Two independent faults produce it.

**The box lies about being empty.** `listProjects` ended both tmux queries in `.catch(() => ({ stdout: "" }))`, so any tmux fault — a restarting server, a missing PATH, a mangled locale — came back as a *successful, empty* listing. The client cannot tell that apart from a box that genuinely has no sessions, and `reconcileOwnedSessions` then pruned the ownership sidecar against the phantom empty list. `isNoTmuxServerError` now separates "no tmux server" (legitimately empty) from a fault, which throws.

**The app never asks again.** The list was fetched once, at launch. Nothing observed the scene phase, so `MantaEventStore.resume()` — written for foreground/resume — had **zero call sites**. iOS suspends the process, the `/events` socket dies, its timers stop, and on return the app sits on whatever it had. `resume()` also trusted `ensure()`, whose "already live" short-circuit believes a socket the OS tore down; it now reopens unless the stream is demonstrably healthy.

Supporting fixes in the same area:
- `loadedOnce` separates "never loaded / failed" from "genuinely empty". The failure state says so and offers **Try again** instead of the reassuring `No sessions yet. Tap + to create one.` Gated on `loadError`, not `loading`, so a cold launch doesn't flash it.
- Overlapping refreshes are coalesced rather than dropped and never retried.
- Search matches project names too; a no-match search says so instead of rendering a blank screen.
- Create hands its post-create project list back, so the new session resolves against a list that contains it — it used to open unnamed and without its opencode session id.

## 2. Markdown tables rendered as raw pipes

Assistant text ran through `.inlineOnlyPreservingWhitespace`, which parses only inline spans and passes every block construct through as literal text — a GFM table rendered as its own pipes and dashes, `##` headings as hashes.

`MantaMarkdownParser` is a small, total, pure block splitter (tables, headings, lists, fenced code, quotes, rules). Anything unrecognised stays a paragraph and still gets inline rendering, so nothing can disappear. Tables render as `HStack` rows of equal-share cells, **not** a `Grid`: a Grid sizes each column to its widest cell's *unwrapped* width, which is the layout blow-out that drags the composer off screen.

## Tests
- `src/server/tmux.test.mjs` — fault vs. genuinely-empty separation, and that a fault no longer prunes the owned-session sidecar.
- `MantaUITests/ChatTranscriptTests.swift` — block split: empty corner cells, alignments, ragged rows, escaped pipes, pipe-bearing prose that must *not* become a table, unclosed streaming fences.
- Full suite green locally: 1462 pass, typecheck clean.

## ⚠️ Before merging
**The Swift has not been compiled.** It was written on the Linux box, which has no Swift toolchain, and CI's `typecheck-test` does not build the iOS target — so a green check here says nothing about the Swift. It needs a build on the Mac first.

Scope note: `ChatSessionStore.swift` / `MantaEventStreamTests.swift` were being edited concurrently by another agent (BET-655, duplicate rendering) and are deliberately **not** in this branch. The one file both touched, `MantaEventStore.swift`, carries only the `resume()` / `staleFrameMs` hunks here.