### PR TITLE
feat(chat): mic + attach beside the model chip, and a fast-mode toggle

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2249,6 +2249,7 @@ export function ChatPanel({
       <Composer
         attachments={attachments}
         onRemoveAttachment={removeAttachment}
+        onAttachFiles={(files) => void addDroppedFiles(files)}
         typeahead={typeahead}
         typeaheadRows={typeaheadRows}
         onTypeaheadSelect={applyTypeahead}

--- a/src/renderer/Chip.tsx
+++ b/src/renderer/Chip.tsx
@@ -82,6 +82,13 @@ export function SplitChip({
   leftExpanded,
   rightExpanded,
   popup = false,
+  extra,
+  onExtraClick,
+  extraTitle,
+  extraLabel,
+  extraHook,
+  extraPressed,
+  extraDisabled = false,
 }: {
   /** Left-segment content (e.g. model name + an icon). */
   left: ReactNode;
@@ -124,12 +131,48 @@ export function SplitChip({
    * a non-popup adopter (e.g. a checkbox row) omits it.
    */
   popup?: boolean;
+  /**
+   * OPTIONAL third segment, for a boolean TOGGLE that belongs to the same
+   * control (e.g. the composer's ⚡ fast-mode switch, which modifies the model
+   * the other two segments describe). It is deliberately NOT a popup — it gets
+   * `aria-pressed`, never `aria-haspopup`, so the popup coverage registry does
+   * not count it as a surface that must be closed. Omit it and the chip is the
+   * plain two-segment split.
+   */
+  extra?: ReactNode;
+  onExtraClick?: () => void;
+  /** Native `title` on the extra segment — state-dependent explanatory copy. */
+  extraTitle?: string;
+  /**
+   * STABLE accessible name for the extra segment. Required in practice for an
+   * icon-only toggle: without it the name falls back to `title`, which changes
+   * with state, so the control renames itself as the user toggles it (and every
+   * aria snapshot containing it churns). The label names the control; `title`
+   * explains the state; `aria-pressed` carries the state itself.
+   */
+  extraLabel?: string;
+  /** A stable `manta-*` identity class for the extra segment button. */
+  extraHook?: string;
+  /** `aria-pressed` for the extra segment — its on/off state. */
+  extraPressed?: boolean;
+  /** Render the extra segment non-interactive (dimmed, `disabled`). */
+  extraDisabled?: boolean;
 }) {
   const listbox = popup ? { "aria-haspopup": "listbox" as const } : {};
   const leftAria = leftExpanded !== undefined ? { "aria-expanded": leftExpanded } : {};
   const rightAria = rightExpanded !== undefined ? { "aria-expanded": rightExpanded } : {};
   const leftClass = `${leftHook ? `${leftHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full hover:bg-fill-hover hover:text-text`;
   const rightClass = `${rightHook ? `${rightHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border hover:bg-fill-hover${rightAccent ? " text-accent-tx font-semibold" : ""}`;
+  // The toggle segment shares the divider + padding of the right segment, so
+  // the three read as one control. Its tone is the only difference: on =
+  // accent (matching CHIP_ON's text), disabled = --tx4 with no hover.
+  const extraClass =
+    `${extraHook ? `${extraHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border ` +
+    (extraDisabled
+      ? "text-text-quiet cursor-not-allowed"
+      : extraPressed
+        ? "text-accent-tx hover:bg-fill-hover"
+        : "text-text-faint hover:bg-fill-hover hover:text-text");
   return (
     <div className={`${hook ? `${hook} ` : ""}${CHIP_SHELL} p-0 overflow-hidden ${CHIP_REST}`}>
       <button type="button" onClick={onLeftClick} title={leftTitle} className={leftClass} {...listbox} {...leftAria}>
@@ -138,6 +181,19 @@ export function SplitChip({
       <button type="button" onClick={onRightClick} title={rightTitle} className={rightClass} {...listbox} {...rightAria}>
         {right}
       </button>
+      {extra !== undefined && (
+        <button
+          type="button"
+          onClick={onExtraClick}
+          title={extraTitle}
+          aria-label={extraLabel}
+          disabled={extraDisabled}
+          aria-pressed={extraPressed}
+          className={extraClass}
+        >
+          {extra}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -6,7 +6,7 @@
 // and the press-and-hold mic button. InputArea.tsx composes them.
 
 import { useRef } from "react";
-import { Clock, Key, Webhook, X, Mic, Loader2 } from "lucide-react";
+import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip } from "lucide-react";
 import type { VoiceMode, VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import { ALT_KEY } from "./platform";
@@ -71,6 +71,45 @@ export function SessionToolbar({
         <Webhook size={16} strokeWidth={2} aria-hidden="true" />
       </button>
     </span>
+  );
+}
+
+// AttachButton — the composer's explicit "attach a file" affordance.
+//
+// Attaching used to be discoverable only by DRAGGING a file onto the panel or
+// PASTING an image; mobile got a picker in its ⋯ sheet but the desktop
+// composer had no visible entry point at all. This is that entry point: a
+// glyph button next to the model chip that opens the OS file picker and hands
+// the chosen File[] to the SAME `addDroppedFiles` path drag-drop uses (chips,
+// mime split, upload). No new upload code — only a new way to reach it.
+//
+// The <input type="file"> is hidden and reset to "" after each pick so that
+// choosing the same file twice in a row still fires `change`.
+export function AttachButton({ onFiles }: { onFiles: (files: File[]) => void }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        title="Attach files"
+        aria-label="Attach files"
+        className="shrink-0 leading-none bg-transparent text-text-faint hover:text-text-muted transition-colors"
+      >
+        <Paperclip size={16} aria-hidden="true" />
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        hidden
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          e.target.value = "";
+          if (files.length > 0) onFiles(files);
+        }}
+      />
+    </>
   );
 }
 

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -30,10 +30,10 @@ import {
   type Attachment,
   resolveActiveModel,
 } from "./chatShared";
-import { shortModelName } from "./chatUtils";
+import { baseModelId, isFastModelId, shortModelName } from "./chatUtils";
 import { ModelPicker } from "./ModelPicker";
 import { MeasureColumn } from "./MeasureColumn";
-import { AttachmentStrip, MicButton, SessionToolbar } from "./ComposerParts";
+import { AttachButton, AttachmentStrip, MicButton, SessionToolbar } from "./ComposerParts";
 // Re-exported so existing `import { TypeaheadPopup } from "./InputArea"` call
 // sites (Composer) keep working after the leaf component moved to ./ComposerParts.
 export { TypeaheadPopup } from "./ComposerParts";
@@ -106,6 +106,7 @@ export function InputArea({
   refreshing,
   attachments,
   onRemoveAttachment,
+  onAttachFiles,
   modelLabel,
   chatAutoAllow,
   setChatAutoAllow,
@@ -152,6 +153,10 @@ export function InputArea({
   // context chips (folder / branch) which sit ABOVE the box in the header.
   attachments: Attachment[];
   onRemoveAttachment: (id: string) => void;
+  // Files chosen through the composer's 📎 button. Same sink as drag-drop
+  // (ChatPanel's addDroppedFiles) — the button is a second door, not a second
+  // upload path.
+  onAttachFiles: (files: File[]) => void;
   modelLabel: string | null;
   chatAutoAllow: boolean;
   setChatAutoAllow: (v: boolean) => Promise<void>;
@@ -202,10 +207,22 @@ export function InputArea({
   // (e.g. "Claude Opus 4.7" → "Opus 4.7"), which sits as its own pill with
   // the effort pill showing the accent. Passed via ModelPicker's existing
   // `labelOverride` (a call-site change — ModelPicker gains no new props).
+  // When the active model is a `-fast` twin, the chip shows the BASE model's
+  // name and lets the lit ⚡ segment carry the mode — "Opus 4.7 Rationale ⚡"
+  // rather than "Opus 4.7 Rationale Fast ⚡", which says it twice. Falls back
+  // to the model's own name whenever the base twin isn't in the list.
   const shortLabel = useMemo(
     () => {
       const activeModel = resolveActiveModel(models, modelOverride, defaultModel);
-      return activeModel ? shortModelName(activeModel.name) : null;
+      if (!activeModel) return null;
+      const base = isFastModelId(activeModel.id)
+        ? models?.find(
+            (m) =>
+              m.providerID === activeModel.providerID &&
+              m.id === baseModelId(activeModel.id),
+          )
+        : null;
+      return shortModelName(base?.name ?? activeModel.name);
     },
     [models, modelOverride, defaultModel],
   );
@@ -332,17 +349,9 @@ export function InputArea({
           className="flex-1 resize-none bg-transparent text-text text-prose focus:outline-none placeholder:text-text-faint font-sans min-w-0"
           style={{ maxHeight: "140px", lineHeight: "1.5" }}
         />
-        {/* Inline mic on desktop — keyboard-driven, glyph-only feedback.
-            The mobile PTT FAB is rendered above the composer wrapper. */}
-        {voiceEnabled && !isMobileShell && (
-          <MicButton
-            phase={voicePhase}
-            mode={voiceMode}
-            onStart={startVoice}
-            onStop={stopVoice}
-            onCancel={cancelVoice}
-          />
-        )}
+        {/* The desktop mic + attach buttons moved DOWN into the meta row
+            beside the model picker; the box now holds only the message and
+            Send. The mobile PTT FAB is still rendered above the composer. */}
         {/* Send button — sits beside the textarea in the composer box (BET-620
             change 4). Accent when there's text to send, muted fill when empty. */}
         <button
@@ -373,6 +382,26 @@ export function InputArea({
             onSelect={onSelectModel}
             labelOverride={shortLabel}
           />
+          {/* Input-mode affordances (🎤 / 📎) sit HERE, beside the model
+              group, rather than inside the input box. They choose HOW you
+              compose — the same category as which model you compose for —
+              whereas the box holds the message itself and its send action.
+              The mic moved out of the box for this reason; the mobile PTT FAB
+              is unaffected (it is positioned by mobile.css, not this row). */}
+          {!isMobileShell && (
+            <span className="flex items-center gap-3">
+              {voiceEnabled && (
+                <MicButton
+                  phase={voicePhase}
+                  mode={voiceMode}
+                  onStart={startVoice}
+                  onStop={stopVoice}
+                  onCancel={cancelVoice}
+                />
+              )}
+              <AttachButton onFiles={onAttachFiles} />
+            </span>
+          )}
         </span>
         <span className="shrink-0 flex items-center gap-3 flex-wrap">
           <SessionToolbar

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -13,10 +13,10 @@
 // raw id is sent back via onSelect.
 
 import { useMemo, useRef, useState } from "react";
-import { ChevronDown, Sparkles } from "lucide-react";
+import { ChevronDown, Sparkles, Zap } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import { type ModelSelection, resolveActiveModel } from "./chatShared";
-import { titleCase } from "./chatUtils";
+import { hideFastSiblingGroups, resolveFastToggle, titleCase } from "./chatUtils";
 import { useClickAway } from "./hooks/useClickAway";
 import { SplitChip } from "./Chip";
 import { EffortMenu } from "./EffortMenu";
@@ -66,20 +66,39 @@ export function ModelPicker({
     setVariantOpen(false);
   });
 
-  // Group models by providerID so the list reads e.g. "anthropic" → 3 models.
-  const groups = useMemo(() => {
+  // The models a user may actually switch TO: enabled, not deprecated, not
+  // deactivated in Settings. Both the dropdown and the ⚡ toggle read from this
+  // one set, so a model hidden in Settings can't be reached by either route.
+  // (`activeModel` below deliberately resolves against the FULL list — an
+  // already-selected model must keep displaying its own name even if it was
+  // later deactivated.)
+  const selectableModels = useMemo(() => {
     if (!models) return null;
     const deactivatedMain = new Set(deactivatedMainModels ?? []);
+    return models.filter(
+      (m) =>
+        m.enabled !== false &&
+        m.status !== "deprecated" &&
+        !deactivatedMain.has(`${m.providerID}/${m.id}`),
+    );
+  }, [models, deactivatedMainModels]);
+
+  // Group models by providerID so the list reads e.g. "anthropic" → 3 models.
+  const groups = useMemo(() => {
+    if (!selectableModels) return null;
     const map = new Map<string, OpencodeModel[]>();
-    for (const m of models) {
-      if (m.enabled === false || m.status === "deprecated") continue;
-      if (deactivatedMain.has(`${m.providerID}/${m.id}`)) continue;
+    for (const m of selectableModels) {
       const arr = map.get(m.providerID) ?? [];
       arr.push(m);
       map.set(m.providerID, arr);
     }
-    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
-  }, [models, deactivatedMainModels]);
+    const sorted = [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+    // "Fast" flavours (`<id>-fast`) are a MODE of their base model, not a
+    // separate choice — they're reached through the ⚡ segment below, so they
+    // don't get a row here. `hideFastSiblingGroups` keeps an orphan whose base
+    // is missing/deactivated, which would otherwise become unreachable.
+    return hideFastSiblingGroups(sorted);
+  }, [selectableModels]);
 
   // Resolve the active model object (for the friendly name + variant list).
   // Shared resolution path with ChatPanel (BET-415 duplication gate).
@@ -116,6 +135,15 @@ export function ModelPicker({
       ? defaultLabel
       : activeModel?.name ?? modelLabel ?? "opencode");
 
+  // ⚡ fast-mode toggle — the third segment. Flipping it swaps the active model
+  // for its `-fast` twin (or back), carrying the selected effort across. It is
+  // disabled when there is no twin, or when the twin doesn't offer the current
+  // effort, so the toggle can never silently change the user's effort choice.
+  const fast = useMemo(
+    () => resolveFastToggle(selectableModels, activeModel, activeVariantId),
+    [selectableModels, activeModel, activeVariantId],
+  );
+
   return (
     <div ref={rootRef} className="overflow-visible min-w-0 relative">
       <SplitChip
@@ -146,6 +174,18 @@ export function ModelPicker({
           setModelOpen(false);
           setVariantOpen((v) => !v);
         }}
+        extra={<Zap size={13} aria-hidden="true" fill={fast.on ? "currentColor" : "none"} />}
+        onExtraClick={() => {
+          if (!fast.available || !fast.target) return;
+          setModelOpen(false);
+          setVariantOpen(false);
+          onSelect(fast.target);
+        }}
+        extraTitle={fast.title}
+        extraLabel="Fast mode"
+        extraHook="manta-fast-toggle-btn"
+        extraPressed={fast.on}
+        extraDisabled={!fast.available}
         rightAccent
         popup
         leftHook="manta-model-picker-btn"

--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -683,6 +683,22 @@ export const demoModels: OpencodeModel[] = [
     capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
     variants: [{ id: "balanced" }, { id: "maximum" }],
   },
+  // The `-fast` twin of the model above, so the composer's ⚡ fast-mode toggle
+  // has something to switch to once that model is selected. It is deliberately
+  // NOT listed in the model dropdown (ModelPicker hides a `-fast` id whose base
+  // is present) — reaching it IS the toggle. It carries only "balanced", which
+  // also exercises the disabled-at-this-effort branch: pick "maximum" on the
+  // base model and the toggle greys out.
+  {
+    id: "claude-opus-4-7-thinking-fast",
+    providerID: "anthropic",
+    name: "Claude Opus 4.7 Rationale Fast",
+    status: "active",
+    enabled: true,
+    limit: { context: 1_000_000, output: 32_000 },
+    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+    variants: [{ id: "balanced" }],
+  },
 ];
 
 // AI-CLI TUI launchers the box reports (src/server/launcherRegistry.mjs,

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -63,6 +63,11 @@ import {
   globCovers,
   isApprovalCoveredByAlways,
   shortModelName,
+  isFastModelId,
+  baseModelId,
+  fastModelId,
+  hideFastSiblingGroups,
+  resolveFastToggle,
   filterModelGroups,
   moveMenuHighlight,
 } from "./chatUtils";
@@ -2416,5 +2421,138 @@ describe("shortModelName", () => {
     expect(shortModelName(null)).toBeNull();
     expect(shortModelName(undefined)).toBeNull();
     expect(shortModelName("   ")).toBeNull();
+  });
+});
+
+// ===== Fast-mode sibling models (composer ⚡ toggle) =====
+
+describe("fast-mode model helpers", () => {
+  const M = (
+    providerID: string,
+    id: string,
+    variants?: string[],
+    extra: Partial<OpencodeModel> = {},
+  ): OpencodeModel =>
+    ({
+      id,
+      providerID,
+      name: id,
+      ...(variants ? { variants: variants.map((v) => ({ id: v })) } : {}),
+      ...extra,
+    }) as OpencodeModel;
+
+  it("isFastModelId / baseModelId / fastModelId round-trip", () => {
+    expect(isFastModelId("gpt-5.6-fast")).toBe(true);
+    expect(isFastModelId("gpt-5.6")).toBe(false);
+    // A bare "-fast" is not a fast flavour of anything.
+    expect(isFastModelId("-fast")).toBe(false);
+    expect(baseModelId("gpt-5.6-fast")).toBe("gpt-5.6");
+    expect(baseModelId("gpt-5.6")).toBe("gpt-5.6");
+    expect(fastModelId("gpt-5.6")).toBe("gpt-5.6-fast");
+    expect(fastModelId("gpt-5.6-fast")).toBe("gpt-5.6-fast");
+  });
+
+  it("hideFastSiblingGroups drops a -fast model when its base is present", () => {
+    const groups: Array<[string, OpencodeModel[]]> = [
+      ["openai", [M("openai", "gpt-5.6"), M("openai", "gpt-5.6-fast"), M("openai", "gpt-5.4-mini")]],
+    ];
+    expect(hideFastSiblingGroups(groups)[0][1].map((m) => m.id)).toEqual([
+      "gpt-5.6",
+      "gpt-5.4-mini",
+    ]);
+  });
+
+  it("hideFastSiblingGroups KEEPS an orphan -fast model (nothing else reaches it)", () => {
+    const groups: Array<[string, OpencodeModel[]]> = [
+      ["x", [M("x", "solo-fast")]],
+    ];
+    expect(hideFastSiblingGroups(groups)[0][1].map((m) => m.id)).toEqual(["solo-fast"]);
+  });
+
+  it("hideFastSiblingGroups drops a group left empty", () => {
+    const groups: Array<[string, OpencodeModel[]]> = [
+      ["a", [M("a", "m"), M("a", "m-fast")]],
+      ["b", [M("b", "only-fast"), M("b", "only")]],
+    ];
+    const out = hideFastSiblingGroups(groups);
+    expect(out.map(([p]) => p)).toEqual(["a", "b"]);
+    expect(out[1][1].map((m) => m.id)).toEqual(["only"]);
+  });
+
+  it("resolveFastToggle: base model with a fast twin is available and off", () => {
+    const models = [M("openai", "gpt-5.6", ["low", "high"]), M("openai", "gpt-5.6-fast", ["low", "high"])];
+    const r = resolveFastToggle(models, models[0], "high");
+    expect(r).toMatchObject({
+      available: true,
+      on: false,
+      target: { providerID: "openai", modelID: "gpt-5.6-fast", variant: "high" },
+    });
+  });
+
+  it("resolveFastToggle: fast model reports on and targets the base", () => {
+    const models = [M("openai", "gpt-5.6", ["low"]), M("openai", "gpt-5.6-fast", ["low"])];
+    const r = resolveFastToggle(models, models[1], "low");
+    expect(r).toMatchObject({
+      available: true,
+      on: true,
+      target: { providerID: "openai", modelID: "gpt-5.6", variant: "low" },
+    });
+  });
+
+  it("resolveFastToggle: no variant selected → target carries no variant", () => {
+    const models = [M("openai", "a"), M("openai", "a-fast")];
+    expect(resolveFastToggle(models, models[0], undefined).target).toEqual({
+      providerID: "openai",
+      modelID: "a-fast",
+    });
+  });
+
+  it("resolveFastToggle: disabled when the twin lacks the selected effort", () => {
+    const models = [
+      M("openai", "a", ["low", "max"]),
+      M("openai", "a-fast", ["low"]),
+    ];
+    const r = resolveFastToggle(models, models[0], "max");
+    expect(r.available).toBe(false);
+    expect(r.target).toBeNull();
+    expect(r.title).toContain("max");
+  });
+
+  it("resolveFastToggle: disabled when no twin exists at all", () => {
+    const models = [M("openai", "solo", ["low"])];
+    expect(resolveFastToggle(models, models[0], "low")).toMatchObject({
+      available: false,
+      on: false,
+      target: null,
+    });
+  });
+
+  it("resolveFastToggle: a twin in a DIFFERENT provider does not count", () => {
+    const models = [M("openai", "a"), M("azure", "a-fast")];
+    expect(resolveFastToggle(models, models[0], undefined).available).toBe(false);
+  });
+
+  it("resolveFastToggle: a deactivated/deprecated twin does not count", () => {
+    const models = [
+      M("openai", "a"),
+      M("openai", "a-fast", undefined, { enabled: false }),
+    ];
+    expect(resolveFastToggle(models, models[0], undefined).available).toBe(false);
+  });
+
+  it("resolveFastToggle: fast model with no base still reports on, but not clickable", () => {
+    const models = [M("openai", "orphan-fast")];
+    expect(resolveFastToggle(models, models[0], undefined)).toMatchObject({
+      available: false,
+      on: true,
+      target: null,
+    });
+  });
+
+  it("resolveFastToggle: null model is off + unavailable", () => {
+    expect(resolveFastToggle([], null, undefined)).toMatchObject({
+      available: false,
+      on: false,
+    });
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1804,3 +1804,124 @@ export function shortModelName(name: string | null | undefined): string | null {
   }
   return trimmed;
 }
+
+// ===== Fast-mode sibling models (composer ⚡ toggle) =====
+//
+// Several providers ship a "fast" flavour of a model as a SEPARATE model id
+// with a `-fast` suffix rather than as a variant: `gpt-5.6` / `gpt-5.6-fast`,
+// `gpt-5.4-mini` / `gpt-5.4-mini-fast`, `databricks-claude-opus-4-7` /
+// `…-4-7-fast`. Listing both in the model dropdown doubles its length and
+// makes an orthogonal speed/quality choice look like two unrelated models.
+//
+// So the composer treats fast as a MODE of the base model: the `-fast` id is
+// hidden from the dropdown (as long as its base twin is also visible, else it
+// would be unreachable) and reached instead through a lightning toggle in the
+// model chip. These helpers are the whole rule — the id arithmetic and the
+// availability predicate — kept pure so the toggle's disabled/on states are
+// testable without a live provider list.
+
+const FAST_SUFFIX = "-fast";
+
+/** True when `modelID` is the fast flavour of some base model. */
+export function isFastModelId(modelID: string): boolean {
+  return modelID.length > FAST_SUFFIX.length && modelID.endsWith(FAST_SUFFIX);
+}
+
+/** `"gpt-5.6-fast"` → `"gpt-5.6"`; a non-fast id is returned unchanged. */
+export function baseModelId(modelID: string): string {
+  return isFastModelId(modelID) ? modelID.slice(0, -FAST_SUFFIX.length) : modelID;
+}
+
+/** `"gpt-5.6"` → `"gpt-5.6-fast"`; a fast id is returned unchanged. */
+export function fastModelId(modelID: string): string {
+  return isFastModelId(modelID) ? modelID : `${modelID}${FAST_SUFFIX}`;
+}
+
+/**
+ * Drop `-fast` models from the grouped dropdown list, but ONLY where the base
+ * twin survives in the same provider group — a `-fast` model whose base is
+ * absent (or deactivated) has no toggle to reach it by, so hiding it would
+ * make it unselectable. Groups left empty are dropped so the menu never
+ * renders a provider heading with nothing under it.
+ */
+export function hideFastSiblingGroups(
+  groups: Array<[string, OpencodeModel[]]>,
+): Array<[string, OpencodeModel[]]> {
+  const out: Array<[string, OpencodeModel[]]> = [];
+  for (const [providerID, models] of groups) {
+    const ids = new Set(models.map((m) => m.id));
+    const kept = models.filter((m) => !(isFastModelId(m.id) && ids.has(baseModelId(m.id))));
+    if (kept.length > 0) out.push([providerID, kept]);
+  }
+  return out;
+}
+
+export type FastToggleState = {
+  /** The toggle can be clicked (a counterpart exists that keeps the effort). */
+  available: boolean;
+  /** The active model IS the fast flavour. */
+  on: boolean;
+  /** The selection a click produces; null when unavailable. */
+  target: { providerID: string; modelID: string; variant?: string } | null;
+  /** Tooltip copy explaining the current state. */
+  title: string;
+};
+
+/**
+ * Resolve the ⚡ toggle for the active model.
+ *
+ * Available only when the counterpart model exists AND still offers the
+ * currently-selected effort/variant — flipping to fast must never silently
+ * drop the user's effort choice, so a fast twin that lacks it reads as "no
+ * fast mode for this effort" and the toggle goes disabled (the user's ask).
+ * With no variant selected, only the counterpart's existence matters.
+ */
+export function resolveFastToggle(
+  models: OpencodeModel[] | null,
+  active: OpencodeModel | null,
+  variantId: string | undefined,
+): FastToggleState {
+  const off = (title: string): FastToggleState => ({ available: false, on: false, target: null, title });
+  if (!active || !models) return off("No fast mode for this model");
+
+  const on = isFastModelId(active.id);
+  const counterpartId = on ? baseModelId(active.id) : fastModelId(active.id);
+  const counterpart =
+    models.find(
+      (m) =>
+        m.providerID === active.providerID &&
+        m.id === counterpartId &&
+        m.enabled !== false &&
+        m.status !== "deprecated",
+    ) ?? null;
+
+  if (!counterpart) {
+    // Already on a fast model whose base vanished: report the truth (on) but
+    // give the user nothing to click, rather than lying that fast is off.
+    return on
+      ? { available: false, on: true, target: null, title: "Fast mode on (no standard model available)" }
+      : off("No fast mode for this model");
+  }
+
+  const keepsVariant =
+    variantId === undefined || (counterpart.variants ?? []).some((v) => v.id === variantId);
+  if (!keepsVariant) {
+    return {
+      available: false,
+      on,
+      target: null,
+      title: `No fast mode at ${variantId} effort`,
+    };
+  }
+
+  return {
+    available: true,
+    on,
+    target: {
+      providerID: counterpart.providerID,
+      modelID: counterpart.id,
+      ...(variantId === undefined ? {} : { variant: variantId }),
+    },
+    title: on ? "Fast mode on — click for the standard model" : "Fast mode off — click for the faster model",
+  };
+}


### PR DESCRIPTION
Three changes to the desktop composer's meta row (the strip under the input box).

### Mic moves out of the input box
It sat next to Send, inside the box — a control that chooses *how* you compose, mixed in with the message itself. It now sits beside the model group, which is the same category of choice. The mobile push-to-talk button is untouched.

### Attach button, next to it
Attaching a file was reachable on desktop **only** by dragging onto the panel or pasting an image — there was no visible affordance (mobile has one in its `⋯` sheet). The button opens the OS picker and hands the files to the *same* `addDroppedFiles` path drag-drop already uses, so there's no second upload path, no new chip logic.

### Fast-mode toggle, as a third segment of the model chip

Providers ship "fast" as a **separate model id with a `-fast` suffix** — `gpt-5.6` / `gpt-5.6-fast`, `Claude Opus 4.7` / `Claude Opus 4.7 Fast`, and ~15 more pairs on this box — not as a variant. So the dropdown listed both halves of every pair, and an orthogonal speed/quality choice read as two unrelated models.

Fast is now a **mode of the base model**: the `-fast` id is hidden from the dropdown and reached through the toggle.

- The toggle **carries the selected effort across**, and is **disabled when the twin doesn't offer that effort** — flipping to fast must never silently downgrade an effort the user picked. Tooltip says which (`No fast mode at max effort`).
- Disabled and off when there's no twin at all.
- A `-fast` model whose base is missing or deactivated in Settings **stays listed** — hiding it would make it unreachable.
- While fast is on the chip shows the **base** model's name and lets the lit bolt carry the mode, rather than saying "Fast" twice.

## Verification

Every branch driven through a real browser against the demo fixture:

| state | bolt | model | effort |
|---|---|---|---|
| model with no twin | disabled, off | Opus 4.7 | High |
| model with a twin | enabled, off | Opus 4.7 Rationale | Default |
| after click | enabled, **on** | Opus 4.7 Rationale | Default |
| after 2nd click | enabled, off | Opus 4.7 Rationale | Default |
| effort the twin lacks | **disabled**, off | Opus 4.7 Rationale | Maximum |
| effort the twin has | enabled, off | Opus 4.7 Rationale | Balanced |
| after click | enabled, **on** | Opus 4.7 Rationale | Balanced |

Dropdown contents with the twin present: `["Server default", "Claude Opus 4.7", "Claude Sonnet 4.6", "Claude Opus 4.7 Rationale"]` — the `-fast` twin is correctly absent.

`npm run typecheck` and `npm test` green (2054 vitest + 1462 node:test). 13 new unit tests cover the fast-mode logic.

## Notes for review

- The id arithmetic and availability predicate are **pure functions** in `chatUtils` (`isFastModelId` / `baseModelId` / `fastModelId` / `hideFastSiblingGroups` / `resolveFastToggle`), so the disabled/on states are testable without a live provider list.
- `SplitChip` gains an **optional** third segment. It's deliberately not a popup: `aria-pressed` + a stable `aria-label`, never `aria-haspopup` — so the popup coverage registry doesn't count it as a surface that must be closed, and its accessible name doesn't change as the user toggles it.
- `demoFixture` gains one `-fast` twin so the toggle has something to switch to in the demo and visual harness.
- **No visual baselines change.** Playwright aria snapshots are subset matches, so the two added buttons invalidate none of them. Separately, eight session screens are *already* failing on `main` for unrelated reasons (verified against a pristine `origin/main` checkout) — deliberately not repaired here, so this diff stays readable.