### PR TITLE
fix(chat): the composer takes focus on click on Windows

### DIFF
--- a/src/renderer/InputArea.test.tsx
+++ b/src/renderer/InputArea.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+//
+// isComposerControlTarget — the predicate behind the composer box's
+// click-to-focus routing.
+//
+// On Windows a click inside the composer box could leave the <textarea>
+// unfocused: the box lit its `:focus-within` ring (so the click resolved to
+// SOME descendant) but no caret appeared and the field could not be typed
+// into, while every other input in the app worked. InputArea now routes
+// non-control clicks in the box to the message field explicitly instead of
+// trusting the browser's own resolution. This predicate is the escape hatch
+// that keeps the real controls clickable — the half that is easy to get
+// wrong, since a too-broad rule would swallow the Send button's click.
+
+import { describe, it, expect } from "vitest";
+import { isComposerControlTarget } from "./InputArea";
+
+/** Build a detached composer-box-shaped tree and hand back its parts. */
+function box() {
+  const root = document.createElement("div");
+  root.className = "manta-composer-input-row";
+  root.innerHTML = `
+    <div class="strip"><button class="chip-remove"><svg class="chip-icon"></svg></button></div>
+    <div class="row">
+      <textarea class="field"></textarea>
+      <button class="send"><svg class="send-icon"></svg></button>
+    </div>
+    <a class="link">docs</a>
+    <div class="fake-button" role="button"><span class="fake-label">x</span></div>
+  `;
+  const q = (sel: string) => root.querySelector(sel) as Element;
+  return {
+    root,
+    field: q("textarea.field"),
+    row: q(".row"),
+    send: q("button.send"),
+    sendIcon: q(".send-icon"),
+    chipRemove: q("button.chip-remove"),
+    chipIcon: q(".chip-icon"),
+    link: q("a.link"),
+    roleButton: q(".fake-button"),
+    roleButtonLabel: q(".fake-label"),
+  };
+}
+
+describe("isComposerControlTarget", () => {
+  it("does NOT claim the text field — a click there must reach the composer's focus routing", () => {
+    expect(isComposerControlTarget(box().field)).toBe(false);
+  });
+
+  it("does NOT claim the box's own padding/chrome — that is what routes focus to the field", () => {
+    const b = box();
+    expect(isComposerControlTarget(b.root)).toBe(false);
+    expect(isComposerControlTarget(b.row)).toBe(false);
+  });
+
+  it("claims the Send button, so its click is not swallowed by the focus routing", () => {
+    expect(isComposerControlTarget(box().send)).toBe(true);
+  });
+
+  it("claims a click on an icon INSIDE a control (the common real-world hit)", () => {
+    // Pointer events land on the <svg>, not the <button> — the predicate must
+    // walk up, or clicking the Send glyph would focus the field instead.
+    const b = box();
+    expect(isComposerControlTarget(b.sendIcon)).toBe(true);
+    expect(isComposerControlTarget(b.chipIcon)).toBe(true);
+  });
+
+  it("claims an attachment chip's remove button", () => {
+    expect(isComposerControlTarget(box().chipRemove)).toBe(true);
+  });
+
+  it("claims links and role=button controls", () => {
+    const b = box();
+    expect(isComposerControlTarget(b.link)).toBe(true);
+    expect(isComposerControlTarget(b.roleButton)).toBe(true);
+    expect(isComposerControlTarget(b.roleButtonLabel)).toBe(true);
+  });
+
+  it("is null/non-Element safe — the handler passes a raw EventTarget", () => {
+    expect(isComposerControlTarget(null)).toBe(false);
+    expect(isComposerControlTarget(new EventTarget())).toBe(false);
+  });
+});

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -96,6 +96,24 @@ export function caretRowInfo(el: HTMLTextAreaElement | null): CaretRow | null {
   return { atFirstRow, atLastRow };
 }
 
+// True when a mousedown inside the composer box landed on a real control that
+// owns its own click — the Send button, the mic, a resource-toolbar button, an
+// attachment chip's remove button. Everything else in the box (the padding,
+// the chrome, the text field itself) should end up focusing the message field.
+//
+// WHY THIS EXISTS: on Windows the box could be clicked without the <textarea>
+// ever taking focus — the box lit its `:focus-within` ring (so the click DID
+// resolve to some descendant) but no caret appeared and the field was
+// unusable, while every other input in the app worked. Rather than depend on
+// the browser resolving a click inside the box to the textarea, InputArea now
+// routes focus explicitly (see the box's onMouseDown). Keep the control
+// escape hatch: without it, clicking Send would steal focus back to the field
+// and swallow the button's own click.
+export function isComposerControlTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return !!target.closest("button, a, [role='button']");
+}
+
 export function InputArea({
   input,
   setInput,
@@ -264,6 +282,19 @@ export function InputArea({
               ? "border-accent"
               : "border-border-strong")
         }
+        // Route every non-control click in the box to the message field. This
+        // is what makes the composer focusable on Windows, where a click could
+        // resolve to a sibling and leave the field caret-less (see
+        // isComposerControlTarget). Clicking the textarea itself keeps the
+        // browser default so native caret PLACEMENT still works — we only add
+        // the focus() the platform failed to do.
+        onMouseDown={(e) => {
+          if (isComposerControlTarget(e.target)) return;
+          const el = inputRef.current;
+          if (!el) return;
+          if (e.target !== el) e.preventDefault();
+          if (document.activeElement !== el) el.focus();
+        }}
       >
         {/* Attachment chips live INSIDE the box, above the text line (BET-416
             §B). They are part of the message being composed, so they share


### PR DESCRIPTION
## Problem

On Windows the chat composer could not be focused. Clicking it did nothing: the box lit its `:focus-within` ring but **no caret appeared** and the field could not be typed into. Every other text input in the app worked normally, so this was not a window-level keyboard-focus problem.

## Diagnosis

The field is not blocked. It is an ordinary `<textarea>` — not `disabled`/`readOnly`, no overlay above it (inactive panels are `display:none`, the drop overlay is `pointer-events-none`), no `-webkit-app-region: drag` reaching it, and no `mousedown` `preventDefault` over it. That last one is the useful tell: a `preventDefault` would have suppressed the focus ring too, and the ring *does* light up.

So the click resolved to *some* descendant of the box — just not the textarea, which is why the ring appeared with no caret. The only other focusable element in that row is the Send button.

## Fix

Stop depending on the browser to resolve a click inside the box to the right descendant, and route it explicitly: a `mousedown` anywhere in the composer box that is not a real control focuses the message field.

- Clicking the **textarea** keeps the browser default, so native caret *placement* still works (clicking mid-text still moves the caret) — we only add the `focus()` the platform failed to do.
- Clicking the box **padding/chrome** routes focus to the field (and suppresses the default so focus cannot resolve elsewhere).
- `isComposerControlTarget` is the escape hatch keeping **Send, the mic, the resource toolbar and attachment chips** clickable. It walks up from the event target, so a click on a control's *icon* (the common real hit — pointer events land on the `<svg>`) still counts as the control. Without it, the routing would steal focus back to the field and swallow the button's own click.

## Tests

`src/renderer/InputArea.test.tsx` (7 cases, jsdom) covers the predicate — including the icon-inside-a-control case and null/non-Element safety, since the handler passes a raw `EventTarget`.

`npm run typecheck` clean; full suite green (111 renderer files / 2061 tests, 1462 server tests).

## Verification

Not reproducible on Linux/macOS, so this needs a Windows check against the build from the `win-v*` tag cut after merge: click the composer → caret appears and typing works; Send, mic and the ⏰/🔑/🪝 toolbar buttons still respond to a single click.