### PR TITLE
fix(ios): answer/reject questions use the opencode requestId + ship the new composer chrome

### DIFF
--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -91,6 +91,34 @@ enum ChatDuration {
     }
 }
 
+/// Wall-clock time for the swipe-to-reveal timestamp gutter (§8).
+///
+/// opencode stamps `time.created` / `time.completed` in epoch MILLISECONDS —
+/// the same values the desktop's `formatClockTime` reads — so the conversion
+/// lives here once rather than at each call site.
+enum ChatClock {
+    /// Locale-aware hour:minute ("20:06" in a 24-hour locale, "8:06 PM" in a
+    /// 12-hour one). The gutter is a fixed-width strip, so the format has to be
+    /// the shortest one that still reads as a time.
+    private static let hourMinute: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .current
+        f.setLocalizedDateFormatFromTemplate("j:mm")
+        return f
+    }()
+
+    static func date(epochMs: Double?) -> Date? {
+        guard let epochMs, epochMs > 0, epochMs.isFinite else { return nil }
+        return Date(timeIntervalSince1970: epochMs / 1000)
+    }
+
+    /// "" for a missing date so a caller can render nothing without a guard.
+    static func time(_ date: Date?) -> String {
+        guard let date else { return "" }
+        return hourMinute.string(from: date)
+    }
+}
+
 /// Map a tool part's `state.status` string onto the StepStatus dot.
 enum StepStatusFromTool {
     static func status(_ raw: String?) -> StepStatus {
@@ -190,7 +218,10 @@ enum ChatTranscriptMapper {
                 let text = textParts(of: msg)
                 if !text.isEmpty {
                     flush(&pending, into: &blocks)
-                    blocks.append(.user(text))
+                    // A prompt is timestamped when it was WRITTEN; a reply when
+                    // it finished. Both are what the reader means by "when did
+                    // this happen".
+                    blocks.append(.user(text, at: ChatClock.date(epochMs: msg.info.time?.created)))
                 }
             case "assistant":
                 // An assistant message still streaming (time.completed == nil)
@@ -199,8 +230,9 @@ enum ChatTranscriptMapper {
                 // refetch. Emitting it now would duplicate the in-progress
                 // text. The box itself keys turn completion on time.completed.
                 guard msg.info.time?.completed != nil else { continue }
+                let at = ChatClock.date(epochMs: msg.info.time?.completed)
                 for part in msg.parts {
-                    process(part, pending: &pending, blocks: &blocks)
+                    process(part, at: at, pending: &pending, blocks: &blocks)
                 }
                 flush(&pending, into: &blocks)
             default:
@@ -221,7 +253,7 @@ enum ChatTranscriptMapper {
         pending = []
     }
 
-    private static func process(_ part: OpencodePart, pending: inout [StepGroupRow], blocks: inout [TranscriptBlock]) {
+    private static func process(_ part: OpencodePart, at: Date?, pending: inout [StepGroupRow], blocks: inout [TranscriptBlock]) {
         if part.ignored == true || part.synthetic == true { return }
         switch part.type {
         case "text":
@@ -232,7 +264,7 @@ enum ChatTranscriptMapper {
             // the next block (BET-632). Same rule as `textParts(of:)`.
             if let t = part.text, !ChatTranscriptMapper.isBlank(t) {
                 flush(&pending, into: &blocks)
-                blocks.append(.prose(t))
+                blocks.append(.prose(t, at: at))
             }
         case "tool":
             let tool = ChatJSON.string(part.extra["tool"]) ?? ""

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -9,8 +9,10 @@ import UIKit
 // answerable permissions/questions) and renders through the EXISTING
 // TranscriptComponents (§8/§8a): there is no second transcript renderer.
 //
-// Container per BET-481: ScrollView + LazyVStack + .defaultScrollAnchor(.bottom)
-// kept verbatim — do NOT re-measure or replace. Subagent rows PUSH a live child
+// Container per BET-481: ScrollView + LazyVStack — do NOT re-measure or replace.
+// The scroll anchor is the one part that moved: it is scoped to `.sizeChanges`
+// and the initial landing is an explicit post-layout scroll (see `transcript`).
+// Subagent rows PUSH a live child
 // screen via NavigationStack (parent scroll untouched; BET-576 binds the child
 // to the same observable source).
 //
@@ -77,6 +79,17 @@ private struct ChatScreenContent: View {
     @State private var overflowDestination: OverflowDestination?
     /// Live scheduled-task count for the overflow sheet's badge (BET-627).
     @State private var scheduleCount = 0
+    /// Whether the one-shot "open at the newest message" scroll has run.
+    @State private var didLandAtBottom = false
+    /// Live height of the bottom chrome (cards + running row + composer), used
+    /// to size the scrim behind it. Measured from an overlay, so it can never
+    /// feed back into the transcript's layout.
+    @State private var bottomChromeHeight: CGFloat = 0
+
+    /// How far the bottom scrim reaches past the safe area. Comfortably clears
+    /// the tallest home indicator; when the keyboard is up it falls behind the
+    /// keyboard, where there is nothing to dim.
+    private static let scrimOverhang: CGFloat = 44
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
     let onCleared: (String) -> Void
@@ -152,13 +165,53 @@ private struct ChatScreenContent: View {
             }
         }
         .background(tokens.canvas.ignoresSafeArea())
-        .safeAreaInset(edge: .bottom) {
+        // The bottom stack is an OVERLAY, not a safeAreaInset.
+        //
+        // As an inset, the composer's height was part of the scroll view's
+        // layout: every line the text gained shrank the viewport, and with the
+        // transcript anchored to its bottom the content shifted by the same
+        // amount. So growing the composer scrolled the conversation — on the
+        // first wrap and on every line break after it.
+        //
+        // As an overlay it takes no layout space, so the viewport never
+        // changes size and the transcript does not move at all while the
+        // composer grows; the composer simply covers more of it. The space the
+        // inset used to reserve is now a fixed spacer at the tail of the scroll
+        // content (see `transcript`), sized for the composer at REST — so the
+        // last message still comes to rest above a compact composer, and a
+        // grown one overlaps content that is dimmed by the scrim below rather
+        // than pushing it.
+        // Scrim FIRST so it draws beneath the composer.
+        //
+        // It was a `.background` on the composer stack, which is why it
+        // vanished: a background is sized to its container, so the gradient was
+        // exactly the composer's own bounds — entirely hidden behind the
+        // composer, with nothing extending ABOVE it where the transcript
+        // actually scrolls past. As its own bottom-aligned overlay it is sized
+        // to the composer PLUS a fade margin, so the ramp lives above the
+        // composer's top edge where it can do something.
+        //
+        // Its bounds respect the safe area, so it rides up with the composer
+        // when the keyboard opens instead of being stranded at the display
+        // edge. Below it is the screen's canvas background, which its darkest
+        // stop meets nearly seamlessly.
+        .overlay(alignment: .bottom) {
+            Scrim(edge: .bottom, tokens: tokens, overhang: Self.scrimOverhang)
+                // Exactly the composer, plus the overhang BELOW it. No margin
+                // above: the fade must not begin before the composer's top
+                // edge, or it reads as a shadow cast onto the transcript
+                // rather than as the composer's own backdrop. Starting at the
+                // edge means the ramp is only ever seen THROUGH the composer's
+                // glass or below it.
+                .frame(height: bottomChromeHeight + Self.scrimOverhang)
+        }
+        .overlay(alignment: .bottom) {
             VStack(spacing: 0) {
                 bottomCards
                 // BET-630 (D1): the running-state working row. Shown only while a
                 // turn runs; the ambient refetch sweep lives on the composer's
-                // top divider and means a different thing, so the two never
-                // share an indicator. Not shown during a background refetch.
+                // border and means a different thing, so the two never share an
+                // indicator. Not shown during a background refetch.
                 if store.running {
                     RunningIndicator(store: store)
                 }
@@ -169,6 +222,15 @@ private struct ChatScreenContent: View {
                     store: store,
                     modelStore: modelStore
                 )
+            }
+            // Feeds the scrim its height. Safe to measure here: this is an
+            // overlay, so nothing it reports can change the transcript's
+            // layout — which is the property that stopped the composer from
+            // scrolling the conversation in the first place.
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { height in
+                bottomChromeHeight = height
             }
         }
         .navigationDestination(for: SubagentSession.self) { agent in
@@ -181,11 +243,26 @@ private struct ChatScreenContent: View {
                 )
             }
         }
-        // The header is an INSET, not an overlay: as an overlay it floated on
-        // top of the transcript with nothing reserving its space, so the first
-        // rows sat underneath it and were clipped at rest, not just while
-        // scrolling.
-        .safeAreaInset(edge: .top) { header }
+        // The header is an OVERLAY so the transcript runs full-bleed and the
+        // conversation scrolls under the floating buttons — that is the whole
+        // point of floating them.
+        //
+        // It was previously an inset for a real reason: as an overlay nothing
+        // reserved its space, so the first rows sat under it and were clipped
+        // AT REST, not just mid-scroll. That failure is why the transcript now
+        // carries its own top inset (see `transcript`) — the space is reserved
+        // by the scroll content instead of by the header, which is what lets
+        // rows pass beneath the glass while still coming to rest below it.
+        // Top scrim UNDER the header buttons (declared first, so it draws
+        // below them). The chat screen hides the navigation bar, so it gets
+        // none of the system's own scroll-edge treatment — which is what the
+        // session list has and why its top edge reads cleanly. Without this
+        // the transcript runs straight under the clock and the battery.
+        .overlay(alignment: .top) {
+            Scrim(edge: .top, tokens: tokens)
+                .frame(height: Self.headerReservedHeight + Metrics.spacing.sp6)
+        }
+        .overlay(alignment: .top) { header }
         .sheet(isPresented: $showOverflow) { overflowSheet }
         .sheet(item: $overflowDestination) { destination in
             destinationCard(destination)
@@ -299,86 +376,184 @@ private struct ChatScreenContent: View {
 
     // MARK: - Header (§8)
 
+    /// Two floating glass circles over the transcript — nothing else.
+    ///
+    /// The title and subtitle were removed: the session name is already the row
+    /// you tapped to get here, so repeating it costs a whole bar of vertical
+    /// space to say something the user just read. Without it there is no
+    /// content to seat, so the bar itself goes too — the buttons float directly
+    /// on the transcript and the conversation scrolls beneath them.
+    ///
+    /// Each button carries its own glass circle, so the material is
+    /// per-control rather than one edge-to-edge sheet.
     private var header: some View {
-        HStack(spacing: Metrics.spacing.sp2) {
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: Metrics.type.body, weight: .semibold))
-                    .foregroundColor(tokens.tx1)
-                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
-                    .background(.ultraThinMaterial, in: Circle())
-                    .accessibilityLabel("Back to sessions")
+        // Liquid Glass, the iOS 26 system material — the same treatment the
+        // session list's search capsule uses, rather than the flat
+        // `.ultraThinMaterial` disc these carried before. A GlassEffectContainer
+        // groups the two so the system can relate them as one piece of chrome
+        // instead of two unrelated blurs.
+        GlassEffectContainer(spacing: Metrics.spacing.sp2) {
+            HStack(spacing: Metrics.spacing.sp2) {
+                // The system's own glass BUTTON style, NOT a plain button with
+                // `.glassEffect` layered over its label. The layered form
+                // renders correctly and then eats the touch — the button looks
+                // right and does nothing, which is exactly what happened to the
+                // ⋯ menu here. SessionListView's `+` carries the same note; it
+                // learned this first.
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: Metrics.type.body, weight: .semibold))
+                        .foregroundColor(tokens.tx1)
+                        .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                }
+                .buttonStyle(.glass)
+                .clipShape(.circle)
+                .accessibilityLabel("Back to sessions")
+
+                Spacer(minLength: 0)
+
+                // Trailing 38×38 glass button (§8) — the overflow sheet, which is
+                // where every session action lives (DECISIONS.md:667-670).
+                Button {
+                    showOverflow = true
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: Metrics.type.body, weight: .semibold))
+                        .foregroundColor(tokens.tx1)
+                        .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                }
+                .buttonStyle(.glass)
+                .clipShape(.circle)
+                .accessibilityLabel("Session actions")
             }
-            .buttonStyle(.plain)
-
-            Spacer(minLength: 0)
-
-            VStack(spacing: Metrics.spacing.spPx) {
-                Text(title)
-                    .font(.system(size: Metrics.type.chatTitle, weight: mantaFontWeight(Metrics.type.semibold)))
-                    .kerning(Metrics.type.chatTitleTracking * Metrics.type.chatTitle)
-                    .foregroundColor(tokens.tx1)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Text(store.headerSubtitle)
-                    .font(.system(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.medium)))
-                    .foregroundColor(tokens.tx4)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-
-            Spacer(minLength: 0)
-
-            // Trailing 38×38 glass button (§8) — the overflow sheet, which is
-            // where every session action lives (DECISIONS.md:667-670).
-            Button {
-                showOverflow = true
-            } label: {
-                Image(systemName: "ellipsis")
-                    .font(.system(size: Metrics.type.body, weight: .semibold))
-                    .foregroundColor(tokens.tx1)
-                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
-                    .background(.ultraThinMaterial, in: Circle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Session actions")
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
-        .background {
-            Rectangle().fill(.ultraThinMaterial).ignoresSafeArea()
+    }
+
+    // MARK: - Transcript (BET-481 container; anchor + landing corrected)
+
+    /// Id of the zero-height row that marks the end of the transcript. Scrolling
+    /// to a real anchor is what makes the landing deterministic (see below).
+    private static let bottomAnchorID = "transcript-bottom"
+
+    /// Space the transcript reserves for the floating header: the 38pt button
+    /// plus the header's own vertical padding on both sides. Derived from the
+    /// same tokens the header lays itself out with, so retuning the button size
+    /// or the padding moves both together instead of leaving a magic number
+    /// here to drift out of sync.
+    private static let headerReservedHeight =
+        Metrics.type.chatHeaderBtn + Metrics.spacing.sp2 * 2
+
+    /// Space the transcript reserves for the floating composer.
+    ///
+    /// FIXED, and deliberately sized for the composer at REST rather than
+    /// tracking its live height. Tracking is what the safeAreaInset used to do,
+    /// and it is precisely why the transcript lurched every time the text
+    /// wrapped. A constant means the viewport never changes, so the
+    /// conversation holds still while the composer grows over it.
+    ///
+    /// Covers the model-chip row, the compact input box and the stack's own
+    /// vertical padding — all from the tokens those are laid out with.
+    private static let composerReservedHeight =
+        Metrics.type.chatHeaderBtn          // compact input row
+        + Metrics.spacing.sp1 * 2           // its vertical padding
+        + Metrics.type.small + Metrics.spacing.sp1 * 2  // model chip row
+        + Metrics.spacing.sp2 * 3           // stack spacing + outer padding
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    // Reserves the floating header's height INSIDE the scroll
+                    // content. The header is an overlay and reserves nothing
+                    // itself, so without this the first row rests underneath
+                    // the glass instead of below it. Putting the space here
+                    // rather than on the header is what lets content pass under
+                    // the buttons while scrolling and still land clear of them —
+                    // a safeAreaInset would push content down permanently and
+                    // leave nothing to scroll under.
+                    Color.clear.frame(height: Self.headerReservedHeight)
+                    if store.hasEarlier {
+                        LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {
+                            store.loadEarlier()
+                        }
+                    }
+                    TranscriptView(blocks: store.blocks, tokens: tokens)
+                    // The end-of-transcript marker. Zero-height and invisible;
+                    // it exists only so `scrollTo` has something stable to aim
+                    // at that is guaranteed to be the last thing in the stack.
+                    Color.clear
+                        .frame(height: 1)
+                        .id(Self.bottomAnchorID)
+                    // Reserve for the floating composer, inside the scroll
+                    // content — the mirror of the header spacer at the top.
+                    // The composer is an overlay and reserves nothing itself,
+                    // so without this the last message would rest underneath
+                    // it. AFTER the anchor, so "scroll to bottom" still lands
+                    // on the last message rather than on empty space.
+                    Color.clear.frame(height: Self.composerReservedHeight)
+                }
+                // Pin the content to the scroll view's own width. A vertical scroll
+                // view otherwise sizes itself to its WIDEST child, so one long line
+                // of tool output widens the whole screen and drags the composer off
+                // with it.
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollClipDisabled(false)
+            // Scoped to `.sizeChanges` — the same correction the subagent screen
+            // already carries, for the same reason plus one more:
+            //
+            //  * `.bottom` in its all-roles form also decides the INITIAL offset,
+            //    and it decides it from the content height known at the first
+            //    layout pass. A LazyVStack has not measured the rows below the
+            //    viewport at that point and prose rows resolve their height a
+            //    pass or two later, so the offset it picks stops corresponding to
+            //    the bottom the moment the real heights land — which is the blank
+            //    transcript that only a manual scroll repairs.
+            //  * It also bottom-ALIGNS content shorter than the viewport, leaving
+            //    a screenful of dead space above a short session.
+            //
+            // Keeping only the size-changes role preserves the half that is
+            // wanted (the view sticks to the bottom as a turn streams) and hands
+            // the initial landing to the explicit scroll below, which runs after
+            // layout and therefore aims at a height that is actually real.
+            .defaultScrollAnchor(.bottom, for: .sizeChanges)
+            .scrollDismissesKeyboard(.interactively)
+            // Dragging the transcript already lowers the keyboard; a TAP on it now
+            // does the same, which is what "put the keyboard away so I can read"
+            // looks like on iOS. A simultaneous gesture, so it neither blocks the
+            // scroll (a tap that moves is not a tap) nor swallows taps on rows that
+            // have their own action — a subagent row still pushes its child.
+            .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
+            .task { await landAtBottom(proxy) }
         }
     }
 
-    // MARK: - Transcript (BET-481 container, kept verbatim)
-
-    private var transcript: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                if store.hasEarlier {
-                    LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {
-                        store.loadEarlier()
-                    }
-                }
-                TranscriptView(blocks: store.blocks, tokens: tokens)
-            }
-            // Pin the content to the scroll view's own width. A vertical scroll
-            // view otherwise sizes itself to its WIDEST child, so one long line
-            // of tool output widens the whole screen and drags the composer off
-            // with it.
-            .frame(maxWidth: .infinity, alignment: .leading)
+    /// Put the freshly-opened session at its newest message.
+    ///
+    /// Runs once per screen, never again: re-running it on every content change
+    /// would yank the viewport back down while the user is reading history.
+    /// Streaming stickiness is the scroll anchor's job, not this one's.
+    ///
+    /// It scrolls more than once on purpose. The lazy stack materialises rows
+    /// over several layout passes, so a single scroll issued on the first pass
+    /// lands short of the end; repeating it across the next couple of passes
+    /// converges on the real bottom. Each pass is a no-op once the view is
+    /// already there. The trailing 550ms pass exists because prose rows can
+    /// resolve their height a full extra layout pass later than the others —
+    /// without it the "blank transcript that only a manual scroll repairs"
+    /// still bites intermittently.
+    private func landAtBottom(_ proxy: ScrollViewProxy) async {
+        guard !didLandAtBottom else { return }
+        didLandAtBottom = true
+        for delayNs in [UInt64(0), 50_000_000, 250_000_000, 550_000_000] {
+            if delayNs > 0 { try? await Task.sleep(nanoseconds: delayNs) }
+            guard !Task.isCancelled else { return }
+            proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
         }
-        .scrollClipDisabled(false)
-        .defaultScrollAnchor(.bottom)
-        .scrollDismissesKeyboard(.interactively)
-        // Dragging the transcript already lowers the keyboard; a TAP on it now
-        // does the same, which is what "put the keyboard away so I can read"
-        // looks like on iOS. A simultaneous gesture, so it neither blocks the
-        // scroll (a tap that moves is not a tap) nor swallows taps on rows that
-        // have their own action — a subagent row still pushes its child.
-        .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
     }
 
     /// Lower the keyboard by asking whoever holds first responder to give it

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -185,10 +185,7 @@ final class ChatSessionStore: ObservableObject {
     private func applyStreamState() {
         guard let s = eventStore.sessionStates[sessionId] else { return }
 
-        let mergedText = s.textByPart.values
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
-        inProgressText = mergedText
+        inProgressText = s.liveText
 
         running = s.running == true
         turnComplete = s.turnComplete == true
@@ -220,8 +217,11 @@ final class ChatSessionStore: ObservableObject {
         }
 
         // Refetch the canonical transcript at turn boundaries so a finished
-        // turn's blocks (steps/prose/subagents) land as real content and the
-        // in-progress text is absorbed (no duplication while streaming).
+        // turn's blocks (steps/prose/subagents) land as real content. The fetch
+        // itself retires the live text it now covers (see `fetchTranscript`) —
+        // absorption is an explicit step, not something the refetch does for
+        // free. Assuming it was free is what rendered every finished answer
+        // twice (BET-655).
         //
         // The FIRST call here is not a transition, it is the initial snapshot:
         // `@Published` replays its current value the moment we subscribe, which
@@ -261,11 +261,17 @@ final class ChatSessionStore: ObservableObject {
     /// tail (the streaming assistant text, §8). Keeping them separate makes the
     /// scroll `defaultScrollAnchor(.bottom)` cheap: only the tail mutates
     /// between turn boundaries.
+    ///
+    /// The two sources must never hold the same prose at once — that is a
+    /// visible duplicate, not a harmless overlap. The tail is emptied by the
+    /// retirement step in `fetchTranscript`; nothing else may append to it.
     private func rebuildBlocks() {
         if inProgressText.isEmpty {
             blocks = transcript
         } else {
-            blocks = transcript + [.prose(inProgressText)]
+            // The live tail has no completion time yet — it gets one when the
+            // turn ends and the canonical refetch replaces this block.
+            blocks = transcript + [.prose(inProgressText, at: nil)]
         }
     }
 
@@ -322,6 +328,19 @@ final class ChatSessionStore: ObservableObject {
                 if !didFail { hasEarlier = loaded.count >= limit }
                 if !didFail || isFirstLoad {
                     transcript = ChatTranscriptMapper.blocks(from: loaded)
+                    // The transcript now carries these messages, so any live
+                    // copy of them is a duplicate — retire it BEFORE rebuilding
+                    // or the finished answer renders twice, once from each
+                    // source (BET-655). Read the pruned text back synchronously:
+                    // the event-store sink lands on a later run-loop turn, too
+                    // late for the rebuild happening right here.
+                    if !didFail {
+                        eventStore.retireCoveredStreamText(
+                            sessionId: sessionId,
+                            covered: Set(loaded.map(\.info.id))
+                        )
+                        inProgressText = eventStore.sessionStates[sessionId]?.liveText ?? ""
+                    }
                     rebuildBlocks()
                 }
             }
@@ -353,14 +372,45 @@ final class ChatSessionStore: ObservableObject {
     }
 
     func replyQuestion(_ request: QuestionRequest, answers: [[String]]) {
+        // opencode's /question/{id}/reply|reject accept ONLY the `que_…`
+        // requestId — NOT the stable card id (a tool callID). Sending the card
+        // id makes the box return HTTP 400 and the question never clears, so
+        // the blocked turn stays blocked and the session looks dead to the
+        // user. A transcript-recovered question has no requestId and is
+        // unanswerable — drop the card locally rather than erroring.
+        guard let requestId = request.requestId else {
+            questions.removeAll { $0.id == request.id }
+            return
+        }
+        // Drop the card optimistically; restore it on failure so a real send
+        // error doesn't silently leave the question gone while the box stays
+        // blocked on it ("can't send messages").
+        questions.removeAll { $0.id == request.id }
         Task {
-            try? await api.questionReply(requestId: request.id, answers: answers, sessionId: sessionId)
+            do {
+                try await api.questionReply(requestId: requestId, answers: answers, sessionId: sessionId)
+            } catch {
+                if !questions.contains(where: { $0.id == request.id }) {
+                    questions.append(request)
+                }
+            }
         }
     }
 
     func rejectQuestion(_ request: QuestionRequest) {
+        guard let requestId = request.requestId else {
+            questions.removeAll { $0.id == request.id }
+            return
+        }
+        questions.removeAll { $0.id == request.id }
         Task {
-            try? await api.questionReject(requestId: request.id, sessionId: sessionId)
+            do {
+                try await api.questionReject(requestId: requestId, sessionId: sessionId)
+            } catch {
+                if !questions.contains(where: { $0.id == request.id }) {
+                    questions.append(request)
+                }
+            }
         }
     }
 
@@ -376,7 +426,7 @@ final class ChatSessionStore: ObservableObject {
         // screen sits completely unchanged after a send, which reads as "the
         // send did nothing".
         if !text.isEmpty {
-            transcript.append(.user(text))
+            transcript.append(.user(text, at: Date()))
             rebuildBlocks()
         }
         running = true

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import PhotosUI
 import UniformTypeIdentifiers
 
@@ -51,6 +52,18 @@ struct ComposerView: View {
     @State private var micMode: VoiceMode = .dictate
     @State private var micRecording = false
     @State private var showModelPicker = false
+    /// Measured height of the text area, used to decide the composer's layout.
+    /// Measured rather than counted because wrapping — not newlines — is what
+    /// makes the box tall: one long pasted sentence is several visual lines.
+    @State private var textHeight: CGFloat = 0
+    /// Whether the box is in its tall (stacked) form. State rather than a
+    /// derived value because the switch is hysteretic — see `updateLayout`.
+    @State private var isTall = false
+    /// The near-full-screen editing sheet, opened by the expand control.
+    @State private var showExpanded = false
+    /// Ties each control's inline slot to its pinned-bottom slot so the two are
+    /// one moving view rather than two that fade.
+    @Namespace private var controlSlots
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
@@ -62,40 +75,16 @@ struct ComposerView: View {
             // runs one presentation and silently drops the others, which is
             // exactly how attaching a file came to do nothing at all.
             pickerAnchor
-            if !attachments.isEmpty { chipsRow }
+            expandAnchor
+            // Model chip sits above the input box on its own row.
             HStack(spacing: Metrics.spacing.sp1) {
-                attachButton
                 modelPill
                 Spacer(minLength: 0)
             }
-            HStack(alignment: .bottom, spacing: Metrics.spacing.sp2) {
-                ZStack(alignment: .topLeading) {
-                    if text.isEmpty {
-                        Text("Message…")
-                            .font(.system(size: Metrics.type.body))
-                            .foregroundColor(tokens.tx4)
-                            .padding(.top, 8)
-                            .padding(.leading, 5)
-                            .allowsHitTesting(false)
-                    }
-                    TextEditor(text: $text)
-                        .font(.system(size: Metrics.type.body))
-                        .foregroundColor(tokens.tx1)
-                        .scrollContentBackground(.hidden)
-                        .frame(minHeight: Metrics.type.display,
-                               maxHeight: Metrics.type.display * 6)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .focused($inputFocused)
-                        .accessibilityIdentifier("composer-input")
-                }
-                if micAvailable { micButton }
-                sendButton
-            }
+            inputBox
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
-        .background(tokens.canvas.ignoresSafeArea())
-        .overlay(alignment: .top) { topDivider }
         // ONE presentation per view. The model sheet, the photo picker and the
         // file importer were all attached HERE, and SwiftUI honours only one of
         // them — which is why attaching a file silently did nothing. The two
@@ -103,6 +92,10 @@ struct ComposerView: View {
         .sheet(isPresented: $showModelPicker) {
             ModelPickerSheet(modelStore: modelStore)
         }
+        // Attachments also drive the layout (chips force the stacked form), so
+        // the box must move on the same curve when one is added or removed as
+        // it does when the text grows — otherwise attaching a file snaps.
+        .animation(.smooth(duration: 0.22), value: attachments.count)
         .onChange(of: photoItems) { _ in
             Task { await processPhotos() }
         }
@@ -115,19 +108,282 @@ struct ComposerView: View {
         }
     }
 
-    /// The composer's top hairline. While a background transcript refetch (or the
-    /// initial load) runs — and the turn is NOT running — it becomes an ambient
-    /// accent sweep (BET-630, D1). A running turn shows the working row instead;
-    /// the two states never share an indicator.
-    @ViewBuilder
-    private var topDivider: some View {
-        if store.refreshing && !store.running {
-            RefetchSweep(tokens: tokens)
-        } else {
-            Rectangle()
-                .fill(tokens.borderSubtle)
-                .frame(height: Metrics.spacing.spPx)
+    // The composer's top hairline — and the ambient `RefetchSweep` that ran
+    // along it during a background refetch (BET-630 D1) — are both gone with
+    // the full-bleed bar: the floating box has no divider to sweep. The refetch
+    // signal moved onto the box's border (see `boxChrome`), so the state is
+    // still shown and still never shares an indicator with the running row.
+
+    // MARK: - Input box (two layouts)
+
+    /// One visual line of the input's font — the unit the layout switch is
+    /// measured in. Taken from the font itself rather than guessed, so it
+    /// tracks a type-scale change.
+    private var lineHeight: CGFloat {
+        UIFont.systemFont(ofSize: Metrics.type.body).lineHeight
+    }
+
+    /// Chips force the stacked form even on a short message: they need a row of
+    /// their own, and there is nowhere to put one inside a single-row capsule.
+    private var isStacked: Bool {
+        isTall || !attachments.isEmpty
+    }
+
+    /// The editor's measured height for a given number of text lines.
+    ///
+    /// The `+ sp2` is the editor's own internal padding and is the whole reason
+    /// this helper exists: the previous thresholds were bare multiples of
+    /// `lineHeight` and ignored it, so every comparison was off by most of a
+    /// line. Two lines measured 2.45 line-heights, which cleared a "2.4"
+    /// threshold — the box went stacked at TWO lines rather than more than two,
+    /// and the return threshold was similarly mis-placed. Expressing the
+    /// thresholds in LINES and converting here keeps them honest.
+    private func editorHeight(forLines lines: CGFloat) -> CGFloat {
+        lineHeight * lines + Metrics.spacing.sp2
+    }
+
+    /// Re-evaluate the layout from a fresh text height, WITH HYSTERESIS: it
+    /// takes more height to grow into the stacked form than it takes to fall
+    /// back out of it.
+    ///
+    /// The two thresholds sit in the GAPS between whole line counts, so each
+    /// one is unambiguous:
+    ///   * grow at 2.5 lines — 2 lines stays compact, 3 goes stacked, which is
+    ///     "pin the controls once it is more than two lines".
+    ///   * shrink at 1.5 lines — back to one line returns to the capsule, while
+    ///     2 lines stays stacked.
+    ///
+    /// The gap between them is a full line, which is what stops the switch
+    /// re-triggering itself: flipping changes the text's available width (the
+    /// controls move out of its row), so the same string re-measures to a
+    /// different height immediately after — a narrower band would let that
+    /// re-measurement cross back and oscillate.
+    ///
+    /// The animation is applied HERE rather than as a `.animation(value:)` on
+    /// the box, so it wraps the state change itself and every dependent piece
+    /// of the layout — corner radius, height, control positions — moves on one
+    /// curve.
+    private func updateLayout(for height: CGFloat) {
+        textHeight = height
+        let next = isTall
+            ? height > editorHeight(forLines: 1.5)   // stay stacked?
+            : height > editorHeight(forLines: 2.5)   // become stacked?
+        guard next != isTall else { return }
+        withAnimation(.smooth(duration: 0.22)) { isTall = next }
+    }
+
+    /// Corner radius, animated between the two forms rather than swapped.
+    ///
+    /// This used to switch `Capsule` ↔ `RoundedRectangle` through an
+    /// `AnyShape`, which is why the change was abrupt: type-erasing a shape
+    /// discards its animatable data, so there was nothing for SwiftUI to
+    /// interpolate and the corners changed in one frame. One RoundedRectangle
+    /// whose radius animates gives the same two appearances — at half its own
+    /// height a rounded rect IS a capsule — and morphs between them.
+    private var cornerRadius: CGFloat {
+        if isStacked { return Metrics.radius.lg }
+        // Half the compact box's height, derived from the same metrics that
+        // lay it out: the taller of the control row and one line of text, plus
+        // the compact vertical padding.
+        let content = max(Metrics.type.chatHeaderBtn, lineHeight + Metrics.spacing.sp2)
+        return (content + Metrics.spacing.sp1 * 2) / 2
+    }
+
+    /// The input box. ONE view tree for both layouts — this is deliberate and
+    /// load-bearing.
+    ///
+    /// It was previously an `if isStacked { … } else { … }`, which reads more
+    /// clearly but is what DISMISSED THE KEYBOARD on every mode switch: the two
+    /// branches are different view identities, so crossing the threshold tore
+    /// down the TextEditor and built a new one, and focus (and with it the
+    /// keyboard) died with the old instance. Keeping `textArea` at a fixed
+    /// position in this builder keeps its identity — and therefore its
+    /// first-responder status — stable across the switch.
+    ///
+    /// What actually changes between the two modes:
+    ///   * the SHAPE — a capsule when it is one row, a rounded rect once it is
+    ///     tall (a capsule's radius is half its height, so a tall one is a blob)
+    ///   * WHERE the controls sit — inline beside the text when compact, pinned
+    ///     along the bottom when stacked
+    private var inputBox: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            // Chips rail — ONLY when something is actually attached. When the
+            // box is merely tall there is no rail; the expand control is an
+            // overlay (below) and so needs no row of its own.
+            if !attachments.isEmpty {
+                chipsRow
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    // Stop short of the expand control so a long chip list
+                    // scrolls under its own clip instead of running into it.
+                    .padding(.trailing, isTall ? Metrics.spacing.sp6 : 0)
+                    .clipped()
+            }
+
+            // Text, with the controls inline beside it while compact.
+            //
+            // The controls carry `matchedGeometryEffect` so they TRAVEL between
+            // the two positions instead of cross-fading. Without it the inline
+            // copy is removed and the bottom copy inserted, and SwiftUI's
+            // default for that is opacity — the buttons blink out of one place
+            // and in at another, which reads as the layout snapping even when
+            // the box itself is animating smoothly. Only one copy of each id
+            // exists at a time (the branches are exclusive), which is what the
+            // effect requires.
+            HStack(alignment: .bottom, spacing: Metrics.spacing.sp2) {
+                if !isStacked {
+                    attachButton.matchedGeometryEffect(id: "composer.attach", in: controlSlots)
+                }
+                textArea
+                if !isStacked {
+                    if micAvailable {
+                        micButton.matchedGeometryEffect(id: "composer.mic", in: controlSlots)
+                    }
+                    sendButton.matchedGeometryEffect(id: "composer.send", in: controlSlots)
+                }
+            }
+
+            // …and pinned along the bottom once stacked.
+            if isStacked {
+                HStack(spacing: Metrics.spacing.sp2) {
+                    attachButton.matchedGeometryEffect(id: "composer.attach", in: controlSlots)
+                    Spacer(minLength: 0)
+                    if micAvailable {
+                        micButton.matchedGeometryEffect(id: "composer.mic", in: controlSlots)
+                    }
+                    sendButton.matchedGeometryEffect(id: "composer.send", in: controlSlots)
+                }
+            }
         }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, isStacked ? Metrics.spacing.sp2 : Metrics.spacing.sp1)
+        .modifier(BoxChrome(cornerRadius: cornerRadius, stroke: borderColor))
+        // The expand control is an OVERLAY, not a row: it must sit in the top
+        // right corner whether or not there are chips to share a line with, and
+        // as an overlay it costs no vertical space when there are none.
+        .overlay(alignment: .topTrailing) {
+            if isTall {
+                expandButton
+                    .padding(.top, Metrics.spacing.sp2)
+                    .padding(.trailing, Metrics.spacing.sp3)
+            }
+        }
+    }
+
+
+
+    /// Accent while a background refetch is in flight, and never while a turn
+    /// runs — the two states must not share an indicator (BET-630 D1).
+    private var borderColor: Color {
+        store.refreshing && !store.running ? tokens.accent : tokens.borderSubtle
+    }
+
+    /// The text field, shared by both layouts. It reports its own height so the
+    /// layout switch has something real to measure.
+    private var textArea: some View {
+        ZStack(alignment: .topLeading) {
+            if text.isEmpty {
+                Text("Message…")
+                    .font(.system(size: Metrics.type.body))
+                    .foregroundColor(tokens.tx4)
+                    .padding(.top, 8)
+                    .padding(.leading, 5)
+                    .allowsHitTesting(false)
+            }
+            TextEditor(text: $text)
+                .font(.system(size: Metrics.type.body))
+                .foregroundColor(tokens.tx1)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: lineHeight + Metrics.spacing.sp2,
+                       maxHeight: lineHeight * 6)
+                .fixedSize(horizontal: false, vertical: true)
+                .focused($inputFocused)
+                .accessibilityIdentifier("composer-input")
+                // `onGeometryChange` rather than a PreferenceKey +
+                // `onPreferenceChange`: under Swift 6 that pair reports the
+                // height through a @Sendable closure, which cannot write to
+                // this view's @State without hopping actors. This modifier is
+                // the iOS 18 replacement built for exactly this and runs on the
+                // main actor already.
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { height in
+                    updateLayout(for: height)
+                }
+        }
+    }
+
+    /// Opens the near-full-screen editing sheet. Only shown in the stacked
+    /// layout, where the message is already long enough for the small box to be
+    /// the constraint.
+    private var expandButton: some View {
+        Button {
+            showExpanded = true
+        } label: {
+            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(tokens.tx3)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Expand composer")
+        .accessibilityIdentifier("composer-expand")
+    }
+
+    /// The expanded sheet hangs off its OWN zero-size anchor. It cannot go on
+    /// the composer root, which already carries the model-picker sheet — when
+    /// two sheet-family presentations sit on one view SwiftUI honours only one
+    /// of them, which is the bug that once made attaching a file do nothing.
+    private var expandAnchor: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .sheet(isPresented: $showExpanded) { expandedComposer }
+    }
+
+    /// Near-full-screen editing surface: the text fills the sheet, a collapse
+    /// control sits top-right and send sits bottom-right. Sending closes the
+    /// sheet, because the message it was opened to write is gone.
+    private var expandedComposer: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            HStack {
+                Spacer(minLength: 0)
+                Button {
+                    showExpanded = false
+                } label: {
+                    Image(systemName: "arrow.down.right.and.arrow.up.left")
+                        .font(.system(size: Metrics.type.body, weight: .semibold))
+                        .foregroundColor(tokens.tx2)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Collapse composer")
+            }
+            if !attachments.isEmpty { chipsRow }
+            TextEditor(text: $text)
+                .font(.system(size: Metrics.type.body))
+                .foregroundColor(tokens.tx1)
+                .scrollContentBackground(.hidden)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityIdentifier("composer-input-expanded")
+            HStack(spacing: Metrics.spacing.sp2) {
+                attachButton
+                Spacer(minLength: 0)
+                if micAvailable { micButton }
+                Button {
+                    submit()
+                    showExpanded = false
+                } label: {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: Metrics.type.body, weight: .semibold))
+                        .foregroundColor(canSend ? tokens.onAccent : tokens.tx4)
+                        .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                        .background(canSend ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.inset), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend)
+                .accessibilityLabel("Send")
+            }
+        }
+        .padding(Metrics.spacing.sp4)
+        .background(tokens.panel.ignoresSafeArea())
+        .presentationDetents([.large])
     }
 
     // MARK: - Model pill
@@ -153,9 +409,17 @@ struct ComposerView: View {
             .foregroundColor(tokens.accentTx)
             .padding(.horizontal, Metrics.spacing.sp2)
             .padding(.vertical, Metrics.spacing.sp1)
-            .background(tokens.accentSoft, in: Capsule())
         }
-        .buttonStyle(.plain)
+        // Glass rather than the flat accent-soft fill, so the chip belongs to
+        // the same floating chrome as the box beneath it; the accent now lives
+        // in the TEXT alone, which is enough to mark it.
+        //
+        // The system glass BUTTON style, not `.glassEffect` on the label of a
+        // plain button — the layered form renders and then swallows the tap.
+        // This chip had the same defect as the ⋯ menu button; it just was not
+        // tapped before the menu was.
+        .buttonStyle(.glass)
+        .clipShape(.capsule)
         .accessibilityLabel("Model picker")
         .accessibilityIdentifier("model-picker")
     }
@@ -175,11 +439,15 @@ struct ComposerView: View {
                 Label("File", systemImage: "doc")
             }
         } label: {
+            // No filled circle behind the glyph: inside the composer box these
+            // are secondary controls, and a dark disc on a glass surface read
+            // as a hole punched in it. Send keeps its fill — it is the one
+            // primary action here. Tint still carries the attached state.
             Image(systemName: "paperclip")
                 .font(.system(size: Metrics.type.body, weight: .medium))
-                .foregroundColor(tokens.tx2)
+                .foregroundColor(attachments.isEmpty ? tokens.tx2 : tokens.accentTx)
                 .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
-                .background(attachments.isEmpty ? AnyShapeStyle(tokens.inset) : AnyShapeStyle(tokens.accentSoft), in: Circle())
+                .contentShape(Rectangle())
                 .accessibilityLabel("Attach")
         }
         .accessibilityIdentifier("attach-button")
@@ -272,13 +540,21 @@ struct ComposerView: View {
             // hit target with an accessibility action that starts dictation.
         } label: {
             ZStack {
-                Circle()
-                    .fill(micIconFill)
-                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                // The disc is drawn only while RECORDING. At rest the glyph
+                // sits bare on the glass, like the attach control — a resting
+                // dark disc read as a hole in the surface. While recording the
+                // fill is the state indicator, so it stays.
+                if recorder.phase == .recording {
+                    Circle()
+                        .fill(micIconFill)
+                        .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                }
                 Image(systemName: micIcon)
                     .font(.system(size: Metrics.type.body, weight: .semibold))
                     .foregroundColor(micIconColor)
             }
+            .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .simultaneousGesture(
@@ -444,6 +720,11 @@ struct ComposerView: View {
         store.send(text: trimmed, attachments: sendAttachments, model: model)
         text = ""
         attachments = []
+        // Return to the compact form explicitly rather than waiting for the
+        // emptied editor to re-measure. The measurement does arrive, but a beat
+        // later — long enough for the box to sit stacked and empty after a
+        // send, which reads as the composer being stuck.
+        withAnimation(.smooth(duration: 0.22)) { isTall = false }
         inputFocused = true
     }
 
@@ -473,36 +754,29 @@ struct ComposerView: View {
     }
 }
 
-/// Ambient transcript-refetch sweep on the composer's top hairline (BET-630, D1).
-/// A slow accent gradient travels L→R while the canonical transcript syncs in the
-/// background; border-only (1px) so there is no layout shift. Distinct from the
-/// running row — the two mean different things and never share an indicator.
-/// Mirrors the desktop `.manta-loading-divider` (src/renderer/index.css).
-private struct RefetchSweep: View {
-    let tokens: Tokens
 
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { context in
-            let period = 1.5
-            let t = (context.date.timeIntervalSinceReferenceDate
-                .truncatingRemainder(dividingBy: period) / period)
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    Rectangle().fill(tokens.borderSubtle)
-                    Rectangle()
-                        .fill(
-                            LinearGradient(
-                                colors: [.clear, tokens.accent.opacity(0.85), .clear],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                        )
-                        .frame(width: geo.size.width * 0.42)
-                        .offset(x: (CGFloat(t) * 1.45 - 0.42) * geo.size.width)
-                }
+/// The input box's shared chrome: glass fill, hairline border, one shape.
+///
+/// It takes a RADIUS, not a shape. Both forms are the same RoundedRectangle —
+/// at half its own height a rounded rect is a capsule — so the two appearances
+/// differ only in this number, and SwiftUI can interpolate it. Passing an
+/// `AnyShape` instead (a Capsule or a RoundedRectangle) type-erases the
+/// animatable data, which is what made the change snap in one frame.
+private struct BoxChrome: ViewModifier {
+    let cornerRadius: CGFloat
+    let stroke: Color
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        return content
+            // Liquid Glass, the iOS 26 system material, rather than the flat
+            // `.ultraThinMaterial` this used to fill with — same treatment as
+            // the session list's search capsule and the chat header buttons.
+            // The shape is passed through so the glass morphs with the box
+            // instead of snapping between the two forms.
+            .glassEffect(.regular, in: shape)
+            .overlay {
+                shape.strokeBorder(stroke, lineWidth: 1)
             }
-            .frame(height: Metrics.spacing.spPx)
-            .clipped()
-        }
     }
 }

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -21,12 +21,28 @@ import Combine
 
 // MARK: - Per-session interpreted state
 
+/// One part's accumulated live text, tagged with the message it belongs to.
+///
+/// The messageID is the load-bearing field: it is what lets a finished chunk be
+/// RETIRED once the canonical transcript carries the same prose. Without it the
+/// live copy has no expiry and the screen renders a finished answer twice —
+/// once from the transcript, once from the still-live tail (BET-655).
+struct StreamTextChunk: Equatable, Sendable {
+    var partID: String
+    var messageID: String
+    var field: String
+    var text: String
+}
+
 struct MantaSessionStreamState: Equatable, Sendable {
     var sessionId: String
-    /// partID -> accumulated flushed text (the box already applied flush
-    /// boundaries; the device just concatenates).
-    var textByPart: [String: String] = [:]
-    var reasoningByPart: [String: String] = [:]
+    /// Accumulated flushed text, one entry per (part, field), in ARRIVAL order
+    /// (the box already applied flush boundaries; the device just concatenates).
+    ///
+    /// Ordered on purpose: this used to be a dictionary, whose `values` have no
+    /// defined order, so an answer streamed as several parts could reassemble
+    /// with its paragraphs shuffled.
+    var chunks: [StreamTextChunk] = []
     var running: Bool?
     var turnComplete: Bool?
     var context: StreamContextPayload?
@@ -38,6 +54,42 @@ struct MantaSessionStreamState: Equatable, Sendable {
 
     init(sessionId: String) {
         self.sessionId = sessionId
+    }
+
+    /// partID -> accumulated text, for callers that only want a lookup.
+    var textByPart: [String: String] {
+        Dictionary(chunks.filter { $0.field != "reasoning" }.map { ($0.partID, $0.text) },
+                   uniquingKeysWith: { _, latest in latest })
+    }
+
+    var reasoningByPart: [String: String] {
+        Dictionary(chunks.filter { $0.field == "reasoning" }.map { ($0.partID, $0.text) },
+                   uniquingKeysWith: { _, latest in latest })
+    }
+
+    /// The live assistant prose for the turn in flight, in arrival order. Empty
+    /// once every chunk has been retired by a canonical transcript that covers
+    /// it — which is what stops a finished answer rendering twice.
+    var liveText: String {
+        chunks
+            .filter { $0.field != "reasoning" && !$0.text.isEmpty }
+            .map(\.text)
+            .joined(separator: "\n")
+    }
+
+    /// Append a flushed chunk, extending the part's text when it is already
+    /// known. Text and reasoning are tracked separately for the same part.
+    mutating func appending(_ payload: StreamFlushPayload) {
+        if let i = chunks.firstIndex(where: { $0.partID == payload.partID && $0.field == payload.field }) {
+            chunks[i].text += payload.text
+        } else {
+            chunks.append(StreamTextChunk(
+                partID: payload.partID,
+                messageID: payload.messageID,
+                field: payload.field,
+                text: payload.text
+            ))
+        }
     }
 }
 
@@ -53,11 +105,7 @@ enum MantaStreamRouter {
         switch sub {
         case "flush":
             if let p = try? frame.decodedPayload(StreamFlushPayload.self) {
-                if p.field == "reasoning" {
-                    s.reasoningByPart[p.partID, default: ""] += p.text
-                } else {
-                    s.textByPart[p.partID, default: ""] += p.text
-                }
+                s.appending(p)
             }
         case "running":
             if let p = try? frame.decodedPayload(StreamRunningPayload.self) { s.running = p.running }
@@ -80,6 +128,21 @@ enum MantaStreamRouter {
         default:
             break
         }
+        return s
+    }
+
+    /// Retire the live chunks whose message the canonical transcript now
+    /// carries. Pure so the retirement rule is testable without a socket.
+    ///
+    /// The chunk for the message STILL STREAMING is kept even when the fetch
+    /// covered it: a mid-turn transcript holds only the prose written before
+    /// that fetch, so retiring the live copy there would split one answer
+    /// across two blocks and drop everything that arrived since. Once the turn
+    /// ends, the next fetch retires it for real.
+    static func retiring(_ state: MantaSessionStreamState, covered: Set<String>) -> MantaSessionStreamState {
+        var s = state
+        let inFlight = s.running == true ? s.chunks.last?.messageID : nil
+        s.chunks.removeAll { covered.contains($0.messageID) && $0.messageID != inFlight }
         return s
     }
 }
@@ -244,6 +307,18 @@ final class MantaEventStore: ObservableObject {
         let sid = frame.sessionId ?? ""
         let next = MantaStreamRouter.applying(frame, to: sessionStates[sid])
         sessionStates[sid] = next
+    }
+
+    /// Retire live stream text the canonical transcript now carries. A session
+    /// store calls this straight after a successful refetch — the one moment
+    /// the live copy turns from "the only copy" into a duplicate.
+    ///
+    /// Publishes only on a real change, so an already-clean state does not wake
+    /// every subscriber (and cannot loop: retirement is idempotent).
+    func retireCoveredStreamText(sessionId: String, covered: Set<String>) {
+        guard let state = sessionStates[sessionId] else { return }
+        let next = MantaStreamRouter.retiring(state, covered: covered)
+        if next != state { sessionStates[sessionId] = next }
     }
 
     private func handleReconnect() {

--- a/mobile/native/MantaUI/RootView.swift
+++ b/mobile/native/MantaUI/RootView.swift
@@ -89,18 +89,18 @@ struct RootView: View {
     // same grouped container, and a step-group roll-up for machinery coverage.
     private var parentBlocks: [TranscriptBlock] {
         [
-            .user("check bet-520 and see if it's blocked correctly"),
-            .prose("Checking its metadata and the blocker chain."),
+            .user("check bet-520 and see if it's blocked correctly", at: nil),
+            .prose("Checking its metadata and the blocker chain.", at: nil),
             .steps(.rows([
                 .step(ToolStep(verb: "Ran", target: "multica issue get BET-520", duration: "0.4s", status: .done, output: nil)),
             ])),
-            .prose("Blocked correctly — waiting_on names both PoC issues. Now fanning out to audit the three sweeps."),
+            .prose("Blocked correctly — waiting_on names both PoC issues. Now fanning out to audit the three sweeps.", at: nil),
             .steps(.rows([
                 .subagent(SubagentSession(taskName: "unblock sweep", status: .done, duration: nil, transcript: [])),
                 .subagent(SubagentSession(taskName: "unstick sweep", status: .done, duration: nil, transcript: [])),
                 .subagent(SubagentSession(taskName: "pr-closed sweep", status: .running, duration: "1m12s", transcript: childBlocks)),
             ])),
-            .prose("Two are back. The third is still reading the close-on-merge workflow."),
+            .prose("Two are back. The third is still reading the close-on-merge workflow.", at: nil),
             .steps(.rollup(
                 summary: "▸ 4 steps · read 3 files, 1 search",
                 rows: [
@@ -117,12 +117,12 @@ struct RootView: View {
     // components as the parent, not a copy (§8a).
     private var childBlocks: [TranscriptBlock] {
         [
-            .prose("Reading the close-on-merge workflow and its CI posture."),
+            .prose("Reading the close-on-merge workflow and its CI posture.", at: nil),
             .steps(.rows([
                 .step(ToolStep(verb: "Read", target: "multica-close-on-merge.yml", duration: "0.3s", status: .done, output: nil)),
                 .step(ToolStep(verb: "Ran", target: "node scripts/multica-unblock.mjs --dry-run", duration: "1.8s", status: .running, output: nil)),
             ])),
-            .prose("The sweep flips a blocked issue to todo the moment its blockers clear."),
+            .prose("The sweep flips a blocked issue to todo the moment its blockers clear.", at: nil),
         ]
     }
 }

--- a/mobile/native/MantaUI/Scrim.swift
+++ b/mobile/native/MantaUI/Scrim.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+// ===========================================================================
+// Edge scrim.
+//
+// The shared fade behind floating chrome — the chat composer, the session
+// list's search capsule, and the chat transcript's top edge where it runs
+// under the status bar. In every case content scrolls past a control that
+// floats over it, and without a fade the two collide.
+//
+// ONE component because these must match: the same gesture on three surfaces,
+// and hand-rolled gradients would drift the first time any of them was retuned.
+//
+// The ramp is deliberately uneven — most of the darkening happens in the third
+// nearest the edge, so content directly behind the control is well suppressed
+// while the far end of the fade stays subtle enough not to read as a band.
+// ===========================================================================
+
+struct Scrim: View {
+    enum Edge {
+        case top
+        case bottom
+    }
+
+    let edge: Edge
+    let tokens: Tokens
+    /// How far the fade reaches PAST its container's edge.
+    ///
+    /// The bottom scrim needs this because its container stops at the safe
+    /// area while the transcript does not: content keeps rendering down
+    /// through the home-indicator strip, so a scrim bounded to the safe area
+    /// left that strip undimmed and the text came back to full brightness
+    /// below the composer.
+    ///
+    /// A fixed overhang rather than `ignoresSafeArea`, which is what this
+    /// replaced: ignoring the safe area pins the gradient to the display edge,
+    /// so with the keyboard up it stretched behind the keyboard and stopped
+    /// sitting under the composer at all. An overhang moves WITH the
+    /// container — when the keyboard is up it simply falls behind the
+    /// keyboard, where there is nothing to dim anyway.
+    var overhang: CGFloat = 0
+
+    var body: some View {
+        LinearGradient(
+            stops: stops,
+            startPoint: edge == .bottom ? .top : .bottom,
+            endPoint: edge == .bottom ? .bottom : .top
+        )
+        .padding(edge == .bottom ? .bottom : .top, -overhang)
+        // The TOP scrim reaches into the status bar, which is the whole point
+        // of it — that strip is where the transcript was running under the
+        // clock and the battery.
+        //
+        // The BOTTOM one deliberately does NOT reach into the bottom safe area.
+        // It used to, and that is what pinned it to the screen edge: with the
+        // keyboard up the composer rides above the keyboard while the gradient
+        // still stretched to the bottom of the display, so it no longer sat
+        // under the composer at all — only the palest end of the ramp was
+        // visible. Bounded to its container, it tracks the composer wherever
+        // the keyboard puts it. The strip below is already painted canvas by
+        // the screen's own background, so nothing is left bare.
+        .ignoresSafeArea(edges: edge == .top ? .top : [])
+        // Purely decorative: it sits over a scroll view, so without this it
+        // would swallow every touch aimed at the content behind it.
+        .allowsHitTesting(false)
+    }
+
+    /// An eased ramp, not a linear one — and a different easing per edge,
+    /// because the two are solving different problems.
+    ///
+    /// A straight fade announces itself either way: the eye finds the point
+    /// where the gradient begins and reads it as a band with an edge. Both
+    /// profiles therefore start almost flat and steepen, putting the visible
+    /// change where content is already mostly hidden.
+    ///
+    /// They differ in how fast they get there. `location` runs from the far
+    /// end of the fade toward the screen edge in both cases.
+    ///
+    ///   * BOTTOM sits behind the composer, which is itself glass and already
+    ///     obscures what is under it. The ramp can stay gentle for most of its
+    ///     length and only go solid at the very end.
+    ///
+    ///   * TOP has to cover the STATUS BAR — the clock, the signal bars, the
+    ///     battery — which occupies roughly the outer 40% of the fade and has
+    ///     no control of its own sitting over it. A gentle ramp leaves the
+    ///     transcript legible right behind the clock, which is the thing being
+    ///     fixed, so this one reaches solid canvas well before the edge and
+    ///     holds it.
+    private var stops: [Gradient.Stop] {
+        switch edge {
+        case .bottom:
+            return [
+                .init(color: tokens.canvas.opacity(0), location: 0.0),
+                .init(color: tokens.canvas.opacity(0.10), location: 0.25),
+                .init(color: tokens.canvas.opacity(0.32), location: 0.45),
+                .init(color: tokens.canvas.opacity(0.62), location: 0.62),
+                .init(color: tokens.canvas.opacity(0.88), location: 0.80),
+                .init(color: tokens.canvas.opacity(0.98), location: 0.92),
+                .init(color: tokens.canvas.opacity(1.0), location: 1.0),
+            ]
+        case .top:
+            return [
+                .init(color: tokens.canvas.opacity(0), location: 0.0),
+                .init(color: tokens.canvas.opacity(0.30), location: 0.25),
+                .init(color: tokens.canvas.opacity(0.70), location: 0.45),
+                .init(color: tokens.canvas.opacity(0.95), location: 0.60),
+                .init(color: tokens.canvas.opacity(1.0), location: 0.72),
+                .init(color: tokens.canvas.opacity(1.0), location: 1.0),
+            ]
+        }
+    }
+}

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -461,6 +461,17 @@ struct SessionListView: View {
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.bottom, Metrics.spacing.sp2)
+        // Rows passing behind the floating capsule fade out rather than
+        // colliding with it. Same component as the chat composer's scrim, so
+        // the two screens read identically — including the overhang, without
+        // which the list comes back to full brightness in the strip below the
+        // capsule.
+        // Sized to the capsule itself — a `.background` is exactly its
+        // container — plus the overhang below, matching the chat composer:
+        // the fade starts at the control's top edge, never above it.
+        .background {
+            Scrim(edge: .bottom, tokens: tokens, overhang: Metrics.spacing.sp12)
+        }
     }
 
     private func presentCreateMenu() {

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -808,6 +808,18 @@ struct TranscriptView: View {
     let blocks: [TranscriptBlock]
     let tokens: Tokens
 
+    /// How far the transcript slides, and therefore how wide the revealed
+    /// timestamp strip is.
+    private static let gutterWidth: CGFloat = 58
+    /// Finger travel needed for a full reveal. Longer than the strip itself, so
+    /// the strip arrives damped instead of slamming open on a flick.
+    private static let gutterTravel: CGFloat = 96
+
+    /// Live drag offset, negative (leftward) and clamped to the strip width.
+    /// `@GestureState` resets itself the instant the finger lifts, which is what
+    /// springs the transcript back with no release handler of our own.
+    @GestureState private var gutterReveal: CGFloat = 0
+
     var body: some View {
         VStack(spacing: 0) {
             // Iterate over the ELEMENTS, never over indices. `ForEach(blocks
@@ -821,17 +833,58 @@ struct TranscriptView: View {
             // first render is still in flight.
             ForEach(Array(blocks.enumerated()), id: \.offset) { pair in
                 blockView(pair.element)
+                    // The timestamp rides WITH its own block rather than living
+                    // in a parallel column, so it stays aligned to the thing it
+                    // describes no matter how tall that thing is. An overlay
+                    // takes no part in layout, and the offset parks it just
+                    // outside the trailing edge, so nothing about the transcript
+                    // at rest changes: it is off screen until the slide brings
+                    // it in, and the scroll view clips it the rest of the time.
+                    .overlay(alignment: .trailing) {
+                        TimestampGutterLabel(
+                            date: pair.element.timestamp,
+                            width: Self.gutterWidth,
+                            tokens: tokens
+                        )
+                        .offset(x: Self.gutterWidth)
+                    }
             }
         }
+        // The whole transcript slides as ONE piece, the way Messages does it —
+        // per-row swiping would read as "act on this message" (reply/delete),
+        // which is a different gesture with a different outcome.
+        .offset(x: gutterReveal)
+        .animation(.interactiveSpring(response: 0.28, dampingFraction: 0.86), value: gutterReveal)
+        .simultaneousGesture(gutterGesture)
+    }
+
+    /// Horizontal-only drag that reveals the timestamps.
+    ///
+    /// Simultaneous with the scroll view's own pan, and deliberately inert
+    /// unless the movement is clearly sideways and leftward: a vertical scroll
+    /// (or a rightward drag, which is the navigation back-swipe) leaves the
+    /// offset at zero, so neither gesture is stolen from the other.
+    private var gutterGesture: some Gesture {
+        DragGesture(minimumDistance: 16)
+            .updating($gutterReveal) { value, state, _ in
+                let dx = value.translation.width
+                let dy = value.translation.height
+                guard dx < 0, -dx > abs(dy) * 1.5 else {
+                    state = 0
+                    return
+                }
+                let progress = min(1, -dx / Self.gutterTravel)
+                state = -Self.gutterWidth * progress
+            }
     }
 
     @ViewBuilder
     private func blockView(_ block: TranscriptBlock) -> some View {
         switch block {
-        case .user(let text):
+        case .user(let text, _):
             UserBand(text: text, tokens: tokens)
                 .padding(.bottom, Metrics.spacing.sp4)
-        case .prose(let text):
+        case .prose(let text, _):
             AssistantProse(text: text, tokens: tokens)
         case .steps(let content):
             // Machinery is inset to the same margin as prose. Only the USER
@@ -845,10 +898,43 @@ struct TranscriptView: View {
     }
 }
 
+/// The wall-clock time shown in the strip a leftward slide opens up.
+///
+/// Fixed width so every timestamp lands on the same vertical line — a gutter
+/// that ragged-edges as the values change reads as a glitch. Blocks with no
+/// time (machinery) render an empty label of the same width rather than
+/// collapsing, which keeps the rows they sit next to from shifting.
+private struct TimestampGutterLabel: View {
+    let date: Date?
+    let width: CGFloat
+    let tokens: Tokens
+
+    var body: some View {
+        Text(ChatClock.time(date))
+            .font(.system(size: Metrics.type.twoXS))
+            .foregroundColor(tokens.tx4)
+            .monospacedDigit()
+            .lineLimit(1)
+            .frame(width: width, alignment: .center)
+            .accessibilityHidden(true)
+    }
+}
+
 enum TranscriptBlock {
-    case user(String)
-    case prose(String)
+    // The date is the block's wall-clock time, shown only in the swipe-to-reveal
+    // gutter. Machinery (`.steps`) carries none: a step row already states how
+    // long it took, and a second time reading next to it is noise, not detail.
+    case user(String, at: Date?)
+    case prose(String, at: Date?)
     case steps(StepGroupContent)
+
+    /// The time shown in the gutter; nil for blocks that have none.
+    var timestamp: Date? {
+        switch self {
+        case .user(_, let at), .prose(_, let at): return at
+        case .steps: return nil
+        }
+    }
 }
 
 // MARK: - "Load earlier messages"

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -65,7 +65,7 @@ final class ChatTranscriptTests: XCTestCase {
     func testUserTextMapsToUserBand() {
         let msgs = [message(id: "m1", role: "user", parts: [textPart("p1", "m1", "check bet-520")])]
         let blocks = ChatTranscriptMapper.blocks(from: msgs)
-        guard case .user(let text) = blocks[0] else {
+        guard case .user(let text, _) = blocks[0] else {
             return XCTFail("expected .user, got \(blocks[0])")
         }
         XCTAssertEqual(text, "check bet-520")
@@ -74,10 +74,78 @@ final class ChatTranscriptTests: XCTestCase {
     func testAssistantTextMapsToProse() {
         let msgs = [message(id: "m1", role: "assistant", parts: [textPart("p1", "m1", "Checking metadata.")])]
         let blocks = ChatTranscriptMapper.blocks(from: msgs)
-        guard case .prose(let text) = blocks[0] else {
+        guard case .prose(let text, _) = blocks[0] else {
             return XCTFail("expected .prose")
         }
         XCTAssertEqual(text, "Checking metadata.")
+    }
+
+    // MARK: - Timestamps (swipe-to-reveal gutter)
+
+    /// opencode stamps `time` in epoch MILLISECONDS. Reading it as seconds puts
+    /// every message in January 1970, which the gutter would render as a
+    /// plausible-looking (and entirely wrong) time — so the unit is pinned here.
+    func testUserBlockCarriesCreatedTimeInMilliseconds() {
+        let createdMs: Double = 1_785_794_760_000  // 2026-08-03T18:06:00Z
+        let msg = OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: "m1",
+                sessionID: "ses",
+                role: OpencodeRole(rawValue: "user"),
+                time: OpencodeTime(created: createdMs, completed: nil),
+                modelID: nil,
+                providerID: nil
+            ),
+            parts: [textPart("p1", "m1", "check bet-520")]
+        )
+        let blocks = ChatTranscriptMapper.blocks(from: [msg])
+        guard case .user(_, let at) = blocks[0] else {
+            return XCTFail("expected .user, got \(blocks[0])")
+        }
+        XCTAssertEqual(at?.timeIntervalSince1970 ?? 0, createdMs / 1000, accuracy: 0.001)
+    }
+
+    /// A reply is timestamped when it FINISHED — that is the moment the reader
+    /// saw it land.
+    func testProseBlockCarriesCompletedTime() {
+        let completedMs: Double = 1_785_794_820_000
+        let msg = OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: "m1",
+                sessionID: "ses",
+                role: OpencodeRole(rawValue: "assistant"),
+                time: OpencodeTime(created: 1_785_794_800_000, completed: completedMs),
+                modelID: nil,
+                providerID: nil
+            ),
+            parts: [textPart("p1", "m1", "Checking metadata.")]
+        )
+        let blocks = ChatTranscriptMapper.blocks(from: [msg])
+        guard case .prose(_, let at) = blocks[0] else {
+            return XCTFail("expected .prose, got \(blocks[0])")
+        }
+        XCTAssertEqual(at?.timeIntervalSince1970 ?? 0, completedMs / 1000, accuracy: 0.001)
+    }
+
+    /// Machinery has no wall-clock reading in the gutter — its rows already
+    /// state how long each step took.
+    func testStepsBlockHasNoTimestamp() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("ls")]),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        XCTAssertNil(blocks[0].timestamp)
+    }
+
+    /// A missing / zero / non-finite stamp must produce no date, so the gutter
+    /// renders an empty slot instead of 1970.
+    func testChatClockRejectsUnusableStamps() {
+        XCTAssertNil(ChatClock.date(epochMs: nil))
+        XCTAssertNil(ChatClock.date(epochMs: 0))
+        XCTAssertNil(ChatClock.date(epochMs: -1))
+        XCTAssertNil(ChatClock.date(epochMs: .infinity))
+        XCTAssertEqual(ChatClock.time(nil), "")
+        XCTAssertFalse(ChatClock.time(Date(timeIntervalSince1970: 1_785_794_760)).isEmpty)
     }
 
     // MARK: - Steps
@@ -200,7 +268,7 @@ final class ChatTranscriptTests: XCTestCase {
             textPart("p2", "m1", "\n"),
         ])]
         let blocks = ChatTranscriptMapper.blocks(from: msgs)
-        guard case .user(let text) = blocks[0] else {
+        guard case .user(let text, _) = blocks[0] else {
             return XCTFail("expected .user, got \(blocks[0])")
         }
         XCTAssertEqual(text, "check bet-520")

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -263,6 +263,79 @@ final class MantaEventStreamRouterTests: XCTestCase {
         let resulting = MantaStreamRouter.applying(status, to: original)
         XCTAssertEqual(resulting, original)
     }
+
+    // MARK: - Retiring covered text (BET-655)
+
+    private func flush(_ messageID: String, _ partID: String, _ text: String, field: String = "text") throws -> MantaStreamFrame {
+        try MantaStreamFrame.parse(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"\#(messageID)","partID":"\#(partID)","field":"\#(field)","text":"\#(text)"}}"#)
+    }
+
+    /// The live tail is joined in ARRIVAL order. A dictionary's values are
+    /// unordered, so the previous shape could shuffle a multi-part answer.
+    func testLiveTextKeepsArrivalOrder() throws {
+        var state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "first"), to: nil)
+        state = MantaStreamRouter.applying(try flush("msg_2", "part_2", "second"), to: state)
+        state = MantaStreamRouter.applying(try flush("msg_2", "part_3", "third"), to: state)
+
+        XCTAssertEqual(state.liveText, "first\nsecond\nthird")
+    }
+
+    func testReasoningIsNotPartOfTheLiveTail() throws {
+        var state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "prose"), to: nil)
+        state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "thinking", field: "reasoning"), to: state)
+
+        XCTAssertEqual(state.liveText, "prose")
+        XCTAssertEqual(state.textByPart["part_1"], "prose")
+        XCTAssertEqual(state.reasoningByPart["part_1"], "thinking")
+    }
+
+    /// THE REGRESSION: a finished turn whose message the canonical transcript
+    /// now carries must leave NO live text behind, or the screen renders the
+    /// same answer twice — once canonical, once live.
+    func testRetiresTextCoveredByTheTranscript() throws {
+        var state = MantaStreamRouter.applying(try flush("msg_2", "part_3", "the answer"), to: nil)
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#),
+            to: state
+        )
+
+        let retired = MantaStreamRouter.retiring(state, covered: ["msg_2"])
+
+        XCTAssertEqual(retired.liveText, "")
+        XCTAssertTrue(retired.chunks.isEmpty)
+    }
+
+    func testKeepsTextTheTranscriptDoesNotCoverYet() throws {
+        let state = MantaStreamRouter.applying(try flush("msg_9", "part_3", "brand new"), to: nil)
+        let retired = MantaStreamRouter.retiring(state, covered: ["msg_2"])
+        XCTAssertEqual(retired.liveText, "brand new")
+    }
+
+    /// A mid-turn transcript holds only the prose written before the fetch, so
+    /// retiring the streaming message there would split one answer in two and
+    /// drop whatever arrived since. It is kept until the turn ends.
+    func testKeepsTheStreamingMessageEvenWhenCovered() throws {
+        var state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#),
+            to: nil
+        )
+        state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "done earlier"), to: state)
+        state = MantaStreamRouter.applying(try flush("msg_7", "part_2", "still writing"), to: state)
+
+        let retired = MantaStreamRouter.retiring(state, covered: ["msg_2", "msg_7"])
+
+        XCTAssertEqual(retired.liveText, "still writing")
+    }
+
+    /// Retirement runs after every fetch, so it must be idempotent — a second
+    /// pass over already-clean state must not change it (or the store would
+    /// republish and wake every subscriber on a no-op).
+    func testRetiringIsIdempotent() throws {
+        let state = MantaStreamRouter.applying(try flush("msg_2", "part_3", "answer"), to: nil)
+        let once = MantaStreamRouter.retiring(state, covered: ["msg_2"])
+        let twice = MantaStreamRouter.retiring(once, covered: ["msg_2"])
+        XCTAssertEqual(once, twice)
+    }
 }
 
 // MARK: - Reconnect controller
@@ -467,5 +540,132 @@ final class MantaEventStoreTests: XCTestCase {
         XCTAssertEqual(MantaEventStore.bearer(token: "abc"), "Bearer abc")
         XCTAssertNil(MantaEventStore.bearer(token: ""))
         XCTAssertNil(MantaEventStore.bearer(token: nil))
+    }
+}
+
+// MARK: - Stream text ↔ canonical transcript seam (BET-655)
+//
+// The screen draws the canonical transcript PLUS the live streamed tail. The
+// two must never hold the same prose at once. Nothing retired the tail, so
+// every finished answer was drawn twice — once canonical, once live — and the
+// tail then accumulated across the whole session. These tests drive the real
+// seam: frames in through the stream, a canonical transcript in over the wire.
+
+private final class StubTranscriptURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var result: String = #"{"result": []}"#
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let data = Data(Self.result.utf8)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class ChatSessionStoreRetirementTests: XCTestCase {
+
+    private func makeEventStore(_ fake: FakeStreamControl) -> MantaEventStore {
+        MantaEventStore(
+            stream: fake,
+            tokenProvider: { "feedfacefeedfacefeedfacefeedface" },
+            serverProvider: { URL(string: "https://0123.boxes.mantaui.com") }
+        )
+    }
+
+    private func makeAPI() -> MantaAPIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubTranscriptURLProtocol.self]
+        return MantaAPIClient(
+            serverURL: URL(string: "https://box.example")!,
+            tokenProvider: { "tok" },
+            session: URLSession(configuration: config)
+        )
+    }
+
+    /// A canonical transcript carrying one assistant message with `text`.
+    private func transcriptResult(messageID: String, text: String) -> String {
+        """
+        {"result":[{"info":{"id":"\(messageID)","sessionID":"ses_1","role":"assistant"},\
+        "parts":[{"type":"text","id":"part_3","messageID":"\(messageID)","text":"\(text)"}]}]}
+        """
+    }
+
+    private func proseCount(_ blocks: [TranscriptBlock], containing needle: String) -> Int {
+        blocks.reduce(into: 0) { total, block in
+            if case .prose(let body, _) = block, body.contains(needle) { total += 1 }
+        }
+    }
+
+    /// THE REGRESSION. Stream an answer, complete the turn, then let the
+    /// canonical refetch land: the answer must appear exactly ONCE.
+    func testFinishedAnswerIsNotRenderedTwice() async throws {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = true
+        fake.drive(.connected)
+        let eventStore = makeEventStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"the answer"}}"#)
+        fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+
+        StubTranscriptURLProtocol.result = transcriptResult(messageID: "msg_2", text: "the answer")
+        let store = ChatSessionStore(sessionId: "ses_1", eventStore: eventStore, api: makeAPI())
+
+        await store.refetch()
+
+        XCTAssertEqual(proseCount(store.blocks, containing: "the answer"), 1)
+        XCTAssertTrue(store.inProgressText.isEmpty)
+    }
+
+    /// While the turn is still streaming the tail is the ONLY copy, so a
+    /// refetch that returns nothing for it must leave it on screen.
+    func testStreamingTailSurvivesARefetchThatDoesNotCoverIt() async throws {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = true
+        fake.drive(.connected)
+        let eventStore = makeEventStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#)
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_9","partID":"part_1","field":"text","text":"still writing"}}"#)
+
+        StubTranscriptURLProtocol.result = transcriptResult(messageID: "msg_2", text: "an older turn")
+        let store = ChatSessionStore(sessionId: "ses_1", eventStore: eventStore, api: makeAPI())
+
+        await store.refetch()
+
+        XCTAssertEqual(store.inProgressText, "still writing")
+        XCTAssertEqual(proseCount(store.blocks, containing: "still writing"), 1)
+    }
+
+    /// A failed refetch proves nothing about what the transcript carries, so it
+    /// must not retire the tail — that would erase the answer from the screen.
+    func testAFailedRefetchDoesNotRetireTheTail() async throws {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = true
+        fake.drive(.connected)
+        let eventStore = makeEventStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"the answer"}}"#)
+        fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+
+        StubTranscriptURLProtocol.result = "not json at all"
+        let store = ChatSessionStore(sessionId: "ses_1", eventStore: eventStore, api: makeAPI())
+
+        await store.refetch()
+
+        // Asserted on the event store, not the published tail: retirement is
+        // synchronous, whereas the store's sink lands on a later run-loop turn.
+        XCTAssertEqual(eventStore.sessionStates["ses_1"]?.liveText, "the answer")
     }
 }


### PR DESCRIPTION
## Summary
Fixes two iOS bugs in `mobile/native` (native SwiftUI client) and ships the new Liquid-Glass composer chrome that they live in.

### Bug: question card doesn't work; after reject/cancel the session dies and can't send messages
- The native store sent `request.id` (the card's stable id = a **tool callID**) to opencode's `/question/{id}/reply|reject`.
- Those endpoints accept **only** the `que_…` `requestId` — a callID is rejected with HTTP 400 (server already documents this: "the ONLY id … reply|reject accepts").
- Result: Submit and Reject both failed, the card never cleared, the blocked turn stayed blocked, and new prompts stalled → the session looked dead. The desktop already uses `q.requestId`; the native port didn't (was un-ported in S1a).
- Fix (`ChatSessionStore.swift`): use `request.requestId`, optimistically drop the card, restore it on send/reject failure, and no-op on the unanswerable transcript-recovered case (no requestId).
- Also hardens the transcript's initial landing with a trailing re-aim pass so a freshly opened LazyVStack lands on the newest message instead of a blank offset needing a manual scroll.

This branch is based on `feat/floating-glass-chat-chrome` (the new composer), which has not reached `main`; per decision, this PR ships both together.

## Test plan
- `npm run gen:swift-tokens -- --check` (CI drift gate)
- Native Swift validated by the iOS build plugin on the Mac (CI does not compile Swift)