### PR TITLE
fix(sidebar): delegated jobs never reached the rail, and the age never ticked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -891,6 +891,22 @@ result is delivered back as a separate later message when the job finishes.
 Same "MantaUI tools" pattern as schedule/serve-page/peers/notify/secrets
 (`docs/manta-tools-scheduler.md`). Key facts:
 
+**TERMINOLOGY — "subagent" means two different things, and conflating them
+sends you to the wrong half of the codebase.** Both are colloquially "a
+subagent"; only the second one is this section.
+
+| Term | Started by | Surface | Owns |
+|---|---|---|---|
+| **inline subagent** | the `task` tool | the TRANSCRIPT — collapsed card, expand for the child's turns (see "Subagent rendering") | nothing: no tmux window, no worktree, no branch, and **no sidebar row, ever** |
+| **background job**, a.k.a. **delegated subagent** | the `delegate` tool | the SIDEBAR RAIL — nested under the session that started it | its own opencode session, tmux window, git worktree + branch |
+
+The two coexist deliberately (the model picks per task) and nothing about one
+implies the other. So "delegated subagents don't show in the rail" is a bug
+report about THIS section, while "subagents don't show in the rail" is very
+likely someone looking for inline `task` children, which are working as
+designed. When writing user-facing copy prefer **"background job"** for the
+delegated kind — the rail row, branch and worktree all belong to it.
+
 - **Global opencode tool**, `docs/opencode-tools/delegate.ts`, **COPIED** (not
   symlinked — same `@opencode-ai/plugin` gotcha) to
   `~/.config/opencode/tools/delegate.ts`. Three exports → `delegate`,

--- a/docs/screens/redesign-spec.html
+++ b/docs/screens/redesign-spec.html
@@ -1168,6 +1168,36 @@ table.spec tr:last-child td{border-bottom:0}
     the ones you named. The mockup is clickable.
   </p>
 
+  <h3 class="sub">Two different things are both called "a subagent"</h3>
+  <div class="callout">
+    <p>
+      In conversation both of these get called "a subagent", and confusing them is why this section reads as
+      if it is missing a feature. <strong>Everything below is about the second one only.</strong>
+    </p>
+    <table class="spec" style="margin-top:var(--sp-3)">
+      <tr><th style="width:22%">Name used here</th><th style="width:20%">Started by</th><th>Where you see it</th></tr>
+      <tr>
+        <td><strong>Inline subagent</strong></td>
+        <td>the <span class="mono-inline">task</span> tool</td>
+        <td><strong>In the transcript</strong> — a collapsed card you expand to read the child's turns. No
+        window, no branch, and <em>no row in the sidebar, ever</em>. Untouched by this redesign.</td>
+      </tr>
+      <tr>
+        <td><strong>Background job</strong><br><span style="color:var(--tx4)">a.k.a. "delegated subagent"</span></td>
+        <td>the <span class="mono-inline">delegate</span> tool</td>
+        <td><strong>In the rail</strong> — its own session, window, worktree and branch, nested under the
+        session that started it. This section.</td>
+      </tr>
+    </table>
+    <p style="margin-top:var(--sp-3)">
+      The two coexist deliberately and the model chooses per task. The rule of thumb: <em>if you delegated it
+      and expect a row in the sidebar, it is a background job; if you expect to read it inline, it is an
+      inline subagent and no sidebar row will ever appear for it.</em> This document says "job" throughout
+      because the rail row, the branch and the worktree all belong to that one — "delegated subagent" means
+      exactly the same thing.
+    </p>
+  </div>
+
   <h3 class="sub">The governing principle</h3>
   <div class="callout ok">
     <p><strong>A background job is disposable, non-critical and read-only. It reports to the main agent, not

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,7 +17,7 @@ import {
   writeSavedMode,
   resolveLauncherFlags,
 } from "./chatShared";
-import { chooseUpdateSkewVariant, isUnknownChannelError, registerMountedTerminal, type MountedTerminal } from "./chatUtils";
+import { chooseUpdateSkewVariant, isUnknownChannelError, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { ReconnectingBanner } from "./ReconnectingBanner";
@@ -269,7 +269,22 @@ export function App() {
       window.api
         .delegateList()
         .then((list) => {
-          useStore.getState().setJobs(Array.isArray(list) ? list : []);
+          const store = useStore.getState();
+          store.setJobs(Array.isArray(list) ? list : []);
+          // A job's tmux window is created ON THE BOX, so nothing here has
+          // re-listed windows since bootstrap and the tree is missing it.
+          // computeJobNesting drops a job whose window it can't find, so
+          // without this the job is invisible in the sidebar even though the
+          // slice above holds it. Re-list only when the tree actually
+          // disagrees (window created for a running job, or still present for
+          // a finished one) — not on every event, which would mean a tmux call
+          // per job per activity tick.
+          const after = useStore.getState();
+          if (shouldResyncWindowsForJobs(after.projects, after.jobs)) {
+            void after.refresh().catch(() => {
+              /* transport blip — the next tick re-evaluates the invariant */
+            });
+          }
         })
         .catch((e) => {
           // BET-640: a transport blip keeps today's silent behaviour (leave

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
 import type { ReactElement, ReactNode } from "react";
 import { ChevronRight, ChevronDown, X, Pin, Search } from "lucide-react";
 import { useStore, flatSessions, type WindowStatusUI } from "./store";
-import { nowMs } from "./clock";
+import { nowMs, useAgeTick } from "./clock";
 import { Modal } from "./Modal";
 import type { Project, TmuxWindow } from "../shared/types";
 import {
@@ -784,6 +784,11 @@ function dotFor(status: WindowStatusUI | undefined): { variant: SessionStatus; t
 // produces the content.
 function useAge(status: WindowStatusUI | undefined): { text: string | undefined; stale: boolean } {
   const cacheTtl = useStore((s) => s.cacheTtl);
+  // Subscribe to the shared ticker so the label advances on its own (1m → 2m)
+  // instead of only when an unrelated event happens to re-render the sidebar.
+  // Called BEFORE the early return below — hook order must not depend on
+  // whether this row currently has an age to show.
+  useAgeTick();
   const last = status?.lastMessageAt;
   const showAge = last != null && !status?.running && !status?.attention;
   if (!showAge) return { text: undefined, stale: false };

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -59,6 +59,7 @@ import {
   resolvePin,
   fuzzySessionScore,
   computeJobNesting,
+  shouldResyncWindowsForJobs,
   isNestedJobChild,
   globCovers,
   isApprovalCoveredByAlways,
@@ -2184,6 +2185,89 @@ describe("fuzzySessionScore", () => {
 
   it("is case-insensitive", () => {
     expect(fuzzySessionScore("AUTH", "auth-service", "BETTER-UI")).toBeGreaterThan(0);
+  });
+});
+
+describe("shouldResyncWindowsForJobs", () => {
+  // THE REGRESSION THIS LOCKS IN: a delegated job creates its tmux window on
+  // the box, so the renderer's window tree — only re-listed at bootstrap and
+  // after the app's own actions — never contains it. computeJobNesting then
+  // drops the job (`if (!childWin) continue`) and it renders NOWHERE, while
+  // the jobs slice happily holds it. The sidebar looked like it ignored
+  // background jobs entirely.
+  it("running job whose window is NOT in the tree → resync (the invisible-job bug)", () => {
+    const projects = [mkProject("p", [{ index: 1, name: "parent", opencodeSessionId: "parent" }])];
+    const jobs = { child1: { status: "running", childSessionID: "child1" } };
+    expect(shouldResyncWindowsForJobs(projects, jobs)).toBe(true);
+  });
+
+  it("documents WHY it matters: nesting renders a window-less job NOWHERE", () => {
+    // Not nested, not orphaned, not top-level — computeJobNesting's
+    // `if (!childWin) continue` drops it silently. This is the state the
+    // sidebar was permanently in for every delegated job.
+    const projects = [mkProject("p", [{ index: 1, name: "parent", opencodeSessionId: "parent" }])];
+    const nesting = computeJobNesting(
+      projects[0],
+      { child1: { status: "running", parentSessionID: "parent", childSessionID: "child1" } },
+      undefined,
+    );
+    expect(nesting.hidden.size).toBe(0);
+    expect(nesting.children.size).toBe(0);
+    expect(nesting.orphans).toEqual([]);
+    // …which is exactly the condition the predicate flags for a re-list.
+    expect(
+      shouldResyncWindowsForJobs(projects, {
+        child1: { status: "running", childSessionID: "child1" },
+      }),
+    ).toBe(true);
+  });
+
+  it("running job whose window IS in the tree → no resync", () => {
+    const projects = [
+      mkProject("p", [
+        { index: 1, name: "parent", opencodeSessionId: "parent" },
+        { index: 2, name: "job", opencodeSessionId: "child1" },
+      ]),
+    ];
+    const jobs = { child1: { status: "running", childSessionID: "child1" } };
+    expect(shouldResyncWindowsForJobs(projects, jobs)).toBe(false);
+  });
+
+  it("finished job whose window is STILL in the tree → resync (stale window would linger)", () => {
+    const projects = [
+      mkProject("p", [
+        { index: 1, name: "parent", opencodeSessionId: "parent" },
+        { index: 2, name: "job", opencodeSessionId: "child1" },
+      ]),
+    ];
+    const jobs = { child1: { status: "done", childSessionID: "child1" } };
+    expect(shouldResyncWindowsForJobs(projects, jobs)).toBe(true);
+  });
+
+  it("finished job already cleaned up → no resync (steady state, no tmux call)", () => {
+    const projects = [mkProject("p", [{ index: 1, name: "parent", opencodeSessionId: "parent" }])];
+    const jobs = { child1: { status: "done", childSessionID: "child1" } };
+    expect(shouldResyncWindowsForJobs(projects, jobs)).toBe(false);
+  });
+
+  it("no jobs → no resync", () => {
+    const projects = [mkProject("p", [{ index: 1, name: "parent", opencodeSessionId: "parent" }])];
+    expect(shouldResyncWindowsForJobs(projects, {})).toBe(false);
+  });
+
+  it("job with no childSessionID is ignored (mid-start record)", () => {
+    const projects = [mkProject("p", [{ index: 1, name: "parent", opencodeSessionId: "parent" }])];
+    const jobs = { x: { status: "running", childSessionID: null } };
+    expect(shouldResyncWindowsForJobs(projects, jobs)).toBe(false);
+  });
+
+  it("finds a job window in ANY project, not just the parent's", () => {
+    const projects = [
+      mkProject("a", [{ index: 1, name: "parent", opencodeSessionId: "parent" }]),
+      mkProject("b", [{ index: 1, name: "job", opencodeSessionId: "child1" }]),
+    ];
+    const jobs = { child1: { status: "running", childSessionID: "child1" } };
+    expect(shouldResyncWindowsForJobs(projects, jobs)).toBe(false);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1701,6 +1701,53 @@ export function computeJobNesting(
   return { hidden, children, orphans };
 }
 
+// Does the window tree disagree with the jobs slice, so the tree needs a
+// re-list?
+//
+// `computeJobNesting` can only render a job it can find a WINDOW for
+// (`byOpencodeId.get(job.childSessionID)`), and drops the job outright when it
+// can't. The two inputs refresh on completely different schedules: the jobs
+// slice re-fetches on every `delegate.updated` bus event, while the window tree
+// is only re-listed by `refresh()` — which the app runs at bootstrap and then
+// only after an action it performed itself. A background job creates its tmux
+// window on the BOX, after boot and without the app doing anything, so its
+// window is absent from the tree and the job renders NOWHERE: not nested, not
+// orphaned, not top-level. That is the "delegated jobs never appear in the
+// sidebar" bug, and it self-heals only if the user happens to do something
+// that re-lists windows.
+//
+// Rather than re-listing tmux on a timer (polling the box for a change that is
+// already announced) or on every `delegate.updated` (activity updates fire
+// every ~10s per job, so that is a tmux call per job per tick), this states the
+// invariant the renderer actually depends on and lets the caller re-list only
+// when it is violated:
+//
+//   - a RUNNING job whose child window is missing  → the tree is behind a
+//     window that was created (job would be invisible)
+//   - a window whose session belongs to a TERMINAL job → the tree is behind a
+//     window that was removed (a finished job's window would otherwise linger
+//     and, once its record is swept, reappear as an ordinary session)
+//
+// Pure so it can be tested without a tree, a socket, or a live job.
+export function shouldResyncWindowsForJobs(
+  projects: Project[],
+  jobs: Record<string, { status: string; childSessionID: string | null }>,
+): boolean {
+  const known = new Set<string>();
+  for (const p of projects) {
+    for (const w of p.windows) {
+      if (w.opencodeSessionId) known.add(w.opencodeSessionId);
+    }
+  }
+  for (const job of Object.values(jobs)) {
+    if (!job.childSessionID) continue;
+    const present = known.has(job.childSessionID);
+    if (job.status === "running" && !present) return true;
+    if (job.status !== "running" && present) return true;
+  }
+  return false;
+}
+
 // Convenience: is a given window a job child that should be nested (i.e.
 // hidden from the top-level list)? Combines isJobRow with the running/viewed
 // gate so the Sidebar's top-level filter stays a single expression.

--- a/src/renderer/clock.test.ts
+++ b/src/renderer/clock.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { nowMs, pinDemoClock } from "./clock";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { AGE_TICK_MS, nowMs, pinDemoClock, useAgeTick } from "./clock";
 import { useStore } from "./store";
 import { DEMO_T0 } from "./api/demoFixture";
 
@@ -31,5 +35,100 @@ describe("renderer clock seam", () => {
     pinDemoClock(DEMO_T0);
     const fixtureEvent = DEMO_T0 - 14 * 60_000;
     expect(nowMs() - fixtureEvent).toBe(14 * 60_000);
+  });
+});
+
+// Minimal hook harness — the repo has no @testing-library; it mounts with
+// react-dom/client + act (see hooks/useSseBus.test.tsx).
+function mountHook<T>(hook: () => T): {
+  renders: () => number;
+  latest: () => T | undefined;
+  unmount: () => void;
+} {
+  let count = 0;
+  let latest: T | undefined;
+  const Probe = () => {
+    count++;
+    latest = hook();
+    return null;
+  };
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  act(() => {
+    root.render(createElement(Probe));
+  });
+  return {
+    renders: () => count,
+    latest: () => latest,
+    unmount: () => {
+      act(() => root.unmount());
+      host.remove();
+    },
+  };
+}
+
+describe("age ticker", () => {
+  // THE REGRESSION THIS LOCKS IN: an elapsed-time label reads the clock during
+  // render, so without a ticker it only advances when something ELSE
+  // re-renders the sidebar. It appeared to work only because the activity
+  // poller pushed a fresh status object every 2s — incidental coupling that
+  // leaves "1m" frozen at "1m" the moment that stream stops, while the status
+  // dot (driven by opencode's own session events) keeps updating.
+  it("re-renders subscribers on its own, with no other state change", () => {
+    vi.useFakeTimers();
+    try {
+      const h = mountHook(() => useAgeTick());
+      const initial = h.renders();
+      act(() => {
+        vi.advanceTimersByTime(AGE_TICK_MS * 3);
+      });
+      expect(h.renders()).toBeGreaterThan(initial);
+      h.unmount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops ticking once the last subscriber unmounts", () => {
+    vi.useFakeTimers();
+    try {
+      const h = mountHook(() => useAgeTick());
+      act(() => {
+        vi.advanceTimersByTime(AGE_TICK_MS);
+      });
+      const atUnmount = h.latest();
+      h.unmount();
+      act(() => {
+        vi.advanceTimersByTime(AGE_TICK_MS * 5);
+      });
+      // Version frozen → the shared interval was torn down, not left running.
+      const fresh = mountHook(() => useAgeTick());
+      expect(fresh.latest()).toBe(atUnmount);
+      fresh.unmount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("all rows share ONE interval — N rows cost N re-renders on one tick, not N timers", () => {
+    vi.useFakeTimers();
+    try {
+      const a = mountHook(() => useAgeTick());
+      const b = mountHook(() => useAgeTick());
+      act(() => {
+        vi.advanceTimersByTime(AGE_TICK_MS);
+      });
+      // Same version → both advanced off the same tick, in step.
+      expect(a.latest()).toBe(b.latest());
+      a.unmount();
+      b.unmount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("is bounded well under a minute so a whole-minute label can't lag visibly", () => {
+    expect(AGE_TICK_MS).toBeLessThan(60_000);
   });
 });

--- a/src/renderer/clock.ts
+++ b/src/renderer/clock.ts
@@ -19,11 +19,84 @@
 // now a no-op for elapsed-time purposes (the deterministic clock drives
 // the label) but is kept so the tick-and-re-render cycle continues to
 // run — stripping it would change unrelated behavior.
+import { useSyncExternalStore } from "react";
 import { useStore } from "./store";
 
 export function nowMs(): number {
   const videoNow = useStore.getState().videoRenderNow;
   return videoNow ?? Date.now();
+}
+
+// ---------------------------------------------------------------------------
+// Age ticker.
+// ---------------------------------------------------------------------------
+//
+// An elapsed-time label reads the clock DURING RENDER (`nowMs()`), so it is
+// only as fresh as its last render. Nothing about a session changes when a
+// minute passes, so without a ticker the sidebar's age column never advances
+// on its own — "1m" stays "1m" until some unrelated event happens to re-render
+// the sidebar.
+//
+// It LOOKED like it worked because the activity poller pushes a status batch
+// every 2s and `applyStatusBatch` always returns a fresh `status` object, so
+// every subscriber re-rendered on that cadence. That was incidental coupling,
+// not a design: the ages were being driven by an unrelated event stream, and
+// they freeze the moment it stops (a half-open events socket, a paused poller,
+// a transport that never delivers the `status` kind) — while the status dot
+// keeps working, because the dot for a chat window is driven by opencode's own
+// session events instead. That asymmetry is exactly the reported symptom, and
+// it is why the fix belongs here rather than in the transport: an age label
+// must own its clock.
+//
+// ONE shared interval for every subscriber (not one per row) so N rows cost N
+// re-renders on the same tick rather than N staggered timers, and it is torn
+// down when the last subscriber unmounts. The tick only forces a re-render —
+// the value still comes from `nowMs()`, so demo mode stays deterministic: with
+// `videoRenderNow` pinned, ticking re-renders are byte-identical and the
+// visual baselines are unaffected.
+//
+// 10s: `formatAge` is whole-minute granular, so this bounds the lag at a
+// minute boundary to 10s while costing one shallow re-render per 10s.
+export const AGE_TICK_MS = 10_000;
+
+const tickListeners = new Set<() => void>();
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+let tickVersion = 0;
+
+function subscribeTick(onChange: () => void): () => void {
+  tickListeners.add(onChange);
+  if (tickTimer == null) {
+    tickTimer = setInterval(() => {
+      tickVersion++;
+      for (const fn of tickListeners) {
+        try {
+          fn();
+        } catch {
+          /* a listener throwing must not kill the shared ticker */
+        }
+      }
+    }, AGE_TICK_MS);
+    // Never hold a test runner (or the process) open for the ticker alone.
+    (tickTimer as { unref?: () => void }).unref?.();
+  }
+  return () => {
+    tickListeners.delete(onChange);
+    if (tickListeners.size === 0 && tickTimer != null) {
+      clearInterval(tickTimer);
+      tickTimer = null;
+    }
+  };
+}
+
+const readTickVersion = (): number => tickVersion;
+
+/**
+ * Subscribe the calling component to the shared age ticker so any label
+ * derived from `nowMs()` advances on its own. Returns the tick version purely
+ * so the subscription is observable in tests; callers normally ignore it.
+ */
+export function useAgeTick(): number {
+  return useSyncExternalStore(subscribeTick, readTickVersion, readTickVersion);
 }
 
 /**


### PR DESCRIPTION
Two independent defects found while investigating "the whole sidebar is broken". Both made it look inert; neither was in the box, the transport, or the delegation engine — all three were verified healthy end to end.

## 1. A delegated background job renders nowhere

The rail needs two things to agree: the **jobs list** and the **window list**.

- The jobs list updates live (refetched on every `delegate.updated`).
- The window list is fetched **once at bootstrap**, and thereafter only after an action the app performed itself.

A delegated job creates its tmux window **on the box**, after boot, without the app doing anything. So the window is missing from the tree — and `computeJobNesting` **silently drops** any job it can't find a window for (`if (!childWin) continue`): not nested, not orphaned, not top-level. The job exists, the box reports it correctly, the jobs slice holds it, and it renders **nowhere at all**.

It self-healed only if the user happened to do something that re-listed windows, which is why this read as "background jobs were never wired to the sidebar" rather than as a bug.

**Fix:** `shouldResyncWindowsForJobs` states the invariant the renderer actually depends on, and the app re-lists windows only when it's violated — a running job with no window, or a finished job whose window is still there. Deliberately *not* a poll and *not* a re-list per event: activity updates fire roughly every 10s per job, so that would be a tmux call per job per tick.

## 2. The age column never counted up

An elapsed-time label reads the clock **during render**, so it's only as fresh as its last render — and nothing about a session changes when a minute passes.

It appeared to work only because the activity poller pushes a fresh `status` object every 2s, re-rendering every subscriber. That's incidental coupling, not a design: whenever that stream isn't delivering, `1m` stays `1m` forever — while the status dot keeps updating, because the dot is driven by opencode's own session events instead. That asymmetry is exactly the reported symptom.

**Fix:** the label gets a clock — one shared 10s ticker for all rows (not one timer per row), torn down when the last subscriber unmounts. The value still comes from `nowMs()`, so demo mode stays pinned and the visual baselines are unaffected.

## 3. Terminology

Both the design spec (`docs/screens/redesign-spec.html` §05) and `AGENTS.md` now open the delegation section by disambiguating the two things called "a subagent":

| | Started by | Where you see it |
|---|---|---|
| **inline subagent** | `task` tool | the transcript — collapsed card; **no sidebar row, ever**, by design |
| **background job** (a.k.a. delegated subagent) | `delegate` tool | the rail — owns a session, window, worktree, branch |

Conflating these is what made a real bug look like an absent feature.

## Verification

- `npm run typecheck` clean
- `npm test` — 111 renderer files / 2072 tests, 1462 server tests, all passing
- 8 new tests for the resync invariant, **including one that pins the silent-drop behaviour that caused the bug**, and 3 for the ticker
- Delegation itself confirmed working end to end against a live box (job created, nested correctly server-side, and failed fast on a denied command rather than stalling — the pre-flight permission model behaving as designed)

## Deliberately NOT in this PR

Three further findings, left for separate tickets:
- Terminal (non-chat) windows can never show an age — nothing stamps their last activity and the poller wipes the field every 2s. Needs a box-side change.
- The desktop app ships **zero** telemetry (none in 7 days despite being wired for it) — which is why both bugs above stayed invisible.
- An age older than the cache TTL is hidden until you hover its row. Deliberate, but it reads as broken.