### PR TITLE
fix(window): on Windows the sidebar sits flush against the top edge

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -23,7 +23,7 @@ import {
   selectCacheTtlMs,
   windowPinId,
 } from "./chatUtils";
-import { MOD_KEY } from "./platform";
+import { IS_WINDOWS, MOD_KEY } from "./platform";
 import { SessionRow, type SessionStatus } from "./SessionRow";
 
 const COLLAPSE_KEY = "manta:collapsed-projects";
@@ -454,8 +454,19 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
 
   return (
     <aside className="w-64 shrink-0 border-r border-border bg-bg-elev flex flex-col">
-      <div className="titlebar-drag h-12 shrink-0" />
-      <div className="px-3 pb-2 flex items-center justify-between">
+      {/* Top drag strip. On macOS this is dead space the traffic-lights
+          overlay (top-left, over the sidebar) — keep it. On Windows the
+          caption buttons are top-right (over the main area), so the sidebar's
+          top-left corner is free: drop the empty strip and let the Workspace
+          header below sit flush against the top edge instead. The header row
+          becomes the drag region there so the frameless window still moves. */}
+      {IS_WINDOWS ? null : <div className="titlebar-drag h-12 shrink-0" />}
+      <div
+        className={
+          "px-3 pb-2 flex items-center justify-between" +
+          (IS_WINDOWS ? " titlebar-drag" : "")
+        }
+      >
         <div className="flex items-center gap-2 min-w-0">
           <h2 className="text-meta font-semibold uppercase tracking-wider text-text-muted">
             Workspace
@@ -473,7 +484,11 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
             </span>
           )}
         </div>
-        <div className="flex items-center gap-1">
+        <div
+          className={
+            "flex items-center gap-1" + (IS_WINDOWS ? " titlebar-no-drag" : "")
+          }
+        >
           <button
             onClick={() => setPaletteOpen(true)}
             className="text-text-muted hover:text-text text-base leading-none"

--- a/src/renderer/platform.ts
+++ b/src/renderer/platform.ts
@@ -10,6 +10,11 @@ const platform =
 
 export const IS_MAC = /mac/i.test(platform);
 
+/** Windows only. macOS traffic-lights sit top-LEFT (over the sidebar);
+ *  Windows mounts its caption buttons top-RIGHT (over the main area), so the
+ *  top-left corner is free for sidebar content to sit flush against. */
+export const IS_WINDOWS = /win/i.test(platform);
+
 /** Prefix for the primary shortcut modifier: "⌘N" on macOS, "Ctrl+N" else. */
 export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl+";
 


### PR DESCRIPTION
## Problem

On Windows the native caption buttons (minimize/maximize/close) sit top-RIGHT, over the main area — not top-left like macOS traffic lights. The sidebar's top-left corner is therefore free, but the sidebar still reserved a 48px `titlebar-drag` strip at its top, which was nothing but empty gap above the "Workspace" header.

## Fix

- **Windows only:** drop the empty top strip so the sidebar content starts at the very top edge.
- The **Workspace header row becomes the drag region** there (`titlebar-drag`), with the search / new-project buttons opting out (`titlebar-no-drag`) so they stay clickable.

The drag replacement is load-bearing, not decorative: in chat mode the app titlebar is hidden, so the sidebar's top strip was the *only* window-drag surface left — deleting it without a replacement would have made the frameless window unmovable.

macOS keeps the strip (traffic lights overlay the top-left); Linux is untouched (native frame). `IS_WINDOWS` added to `platform.ts` as the single source of the branch.

## Verification

- `npm run typecheck` clean; full suite green (111 renderer files / 2061 tests).
- Needs a Windows smoke on the app: sidebar is flush to the top, the window still drags by the Workspace header, and the search / `+` buttons still click.