### PR TITLE
fix(delegate): stop killing every background job as an orphan

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -254,14 +254,11 @@ const delegateEngine = createDelegateEngine({
   abortSession: (sid) => oc.abortSession(sid),
   // BET-418 §B: detect a running job whose parent opencode session is gone so
   // the sweeper can stop + clean it up (nobody left to report to).
-  sessionExists: async (sid) => {
-    try {
-      const sessions = await oc.listSessions();
-      return Array.isArray(sessions) && sessions.some((s) => s?.id === sid);
-    } catch {
-      return true; // best-effort: assume alive on a transient blip
-    }
-  },
+  // Direct lookup, NOT a listSessions scan: `GET /session` is capped at 100
+  // and the unscoped form is box-wide, so a healthy parent that simply isn't
+  // among the 100 most recent sessions read as "gone" and the sweeper stopped
+  // the job. See opencode.mjs:sessionExists.
+  sessionExists: (sid) => oc.sessionExists(sid),
   oc,
 });
 // eslint-disable-next-line no-unused-vars

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -686,6 +686,39 @@ export async function listSessions(directory) {
 }
 
 /**
+ * Does this opencode session still exist?
+ *
+ * Answered with a DIRECT lookup (`GET /session/{id}`), never by scanning
+ * `listSessions()`. opencode caps `GET /session` at 100 records and the
+ * unscoped form returns the 100 most-recently-updated sessions BOX-WIDE, so on
+ * any box with real history a perfectly healthy session is absent from that
+ * page — a scan reports it as gone. That false "gone" is destructive: the
+ * delegate sweeper reads it as "parent session gone", stops the background job
+ * (BET-418 §B) and stamps it `stopped by user`, so every delegated job died
+ * within a sweep tick and the sidebar never had a job to show.
+ *
+ * Returns:
+ *   true   — 200, the session is alive
+ *   false  — 404, the session is genuinely gone (the ONLY negative)
+ *   true   — anything else (5xx, network error): best-effort "assume alive",
+ *            preserving the existing rule that a transient opencode blip must
+ *            never orphan a healthy job. Only a definitive 404 is destructive.
+ *
+ * @param {string} sessionId
+ * @returns {Promise<boolean>}
+ */
+export async function sessionExists(sessionId) {
+  if (!sessionId) return false;
+  try {
+    const res = await ocFetch(apiUrl(`/session/${encodeURIComponent(sessionId)}`));
+    if (res.status === 404) return false;
+    return true;
+  } catch {
+    return true; // transient failure — never treat as "gone"
+  }
+}
+
+/**
  * Fork a session (copies history up to messageID into a new session).
  * @param {{ sessionId: string, messageID?: string }} opts
  */

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -11,6 +11,7 @@ import {
   forkSession,
   compactSession,
   abortSession,
+  sessionExists,
   listPermissions,
   listQuestions,
   replyPermission,
@@ -1650,4 +1651,113 @@ test("claudeCliStatus prefers ~/.local/bin/claude over /usr/local/bin/claude", (
   // resolveClaudeBinExists walks candidates in order; the home-dir path wins.
   assert.match(status.path, /\.local\/bin\/claude$/);
   assert.equal(status.installed, true);
+});
+
+// ---------------------------------------------------------------------------
+// sessionExists — the delegate sweeper's "is the parent still alive?" probe.
+//
+// THE BUG THIS LOCKS IN: this used to scan `listSessions()`. opencode caps
+// `GET /session` at 100 records and the unscoped form is box-wide, so on a box
+// with real history a healthy parent simply isn't in that page — the scan said
+// "gone", the sweeper stopped the background job as orphaned (BET-418 §B) and
+// stamped it `stopped by user`. Every delegated job died within a sweep tick.
+// ---------------------------------------------------------------------------
+
+test("sessionExists: 200 → alive, via a DIRECT lookup (never a capped list scan)", async () => {
+  const calls = [];
+  await withMockFetch(
+    async (url) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify({ id: "ses_parent" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    async () => {
+      assert.equal(await sessionExists("ses_parent"), true);
+    },
+  );
+  assert.equal(calls.length, 1, "one request, not a list scan");
+  assert.ok(
+    calls[0].endsWith("/session/ses_parent"),
+    `expected a direct /session/{id} lookup, got ${calls[0]}`,
+  );
+  assert.ok(
+    !calls[0].match(/\/session(\?|$)/),
+    `must NOT hit the capped collection endpoint: ${calls[0]}`,
+  );
+});
+
+test("sessionExists: REGRESSION — alive even when absent from the 100-record list page", async () => {
+  // The exact production shape: the collection endpoint returns a full page of
+  // 100 OTHER sessions and does not contain the parent. The old scan-based
+  // implementation returned false here and killed the job.
+  const page = Array.from({ length: 100 }, (_, i) => ({ id: `ses_other_${i}` }));
+  await withMockFetch(
+    async (url) => {
+      const u = String(url);
+      if (u.endsWith("/session")) {
+        return new Response(JSON.stringify(page), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      // The direct lookup still resolves it — that is the whole point.
+      return new Response(JSON.stringify({ id: "ses_parent" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    async () => {
+      assert.equal(await sessionExists("ses_parent"), true);
+    },
+  );
+});
+
+// The remaining cases share one shape — stub a single response, assert the
+// verdict — so they are table-driven rather than five copies of the same body.
+// The asymmetry IS the contract: only a definitive 404 is allowed to be
+// destructive, because that verdict stops a running job and tears down its
+// window and worktree.
+for (const { name, respond, expected } of [
+  {
+    name: "404 → gone (the only negative)",
+    respond: () => new Response(JSON.stringify({ name: "NotFoundError" }), { status: 404 }),
+    expected: false,
+  },
+  {
+    name: "5xx → assume alive (a blip must never orphan a healthy job)",
+    respond: () => new Response("boom", { status: 500 }),
+    expected: true,
+  },
+  {
+    name: "transport throw → assume alive",
+    respond: () => {
+      throw new Error("ECONNREFUSED");
+    },
+    expected: true,
+  },
+]) {
+  test(`sessionExists: ${name}`, async () => {
+    await withMockFetch(
+      async () => respond(),
+      async () => {
+        assert.equal(await sessionExists("ses_probe"), expected);
+      },
+    );
+  });
+}
+
+test("sessionExists: empty id → false without any request", async () => {
+  let called = 0;
+  await withMockFetch(
+    async () => {
+      called++;
+      return new Response(null, { status: 200 });
+    },
+    async () => {
+      assert.equal(await sessionExists(""), false);
+    },
+  );
+  assert.equal(called, 0);
 });


### PR DESCRIPTION
Found while trying to demo the sidebar rail with a real delegated job: **the job was aborted about a minute after starting, and recorded as `stopped by user` — which nobody had done.** It reproduces every time.

## Cause

The sweeper stops a job whose parent opencode session has gone away (BET-418 §B — nobody left to report to). It asked that question by scanning a list:

```js
const sessions = await oc.listSessions();
return sessions.some((s) => s.id === sid);
```

opencode caps `GET /session` at **100 records**, and the unscoped form returns the 100 most-recently-updated sessions **box-wide**. On any box with real history the parent simply isn't in that page, so the scan answers "gone" and the sweeper kills a perfectly healthy job.

Verified live on the dev box:

```
old (list scan)   → false   ← killed the job
new (direct GET)  → true
bogus id          → false
```

The unscoped page there is 46 sessions from `/home/dev`, 26 from `/tmp/opencode`, 12 from an unrelated project — and no room for the parent.

## Why it stayed hidden

The failure is silent and total: the job is aborted, its window and worktree are cleaned up as terminal, and `stopped by user` points the finger at the operator. Background delegation looked like it half-worked when in practice **no job could survive**. It also gets steadily worse as a box accumulates sessions, so it would not have shown up on a fresh box or in early testing.

## Fix

Existence is now a **direct lookup** — `GET /session/{id}` in `opencode.mjs:sessionExists`. Uncapped, O(1), unambiguous.

Only a definitive **404** counts as gone. 5xx and transport errors keep the existing "assume alive" degradation, so a transient opencode blip still can't orphan a healthy job — the destructive answer requires positive evidence.

## Tests

Six, in `src/server/opencode.test.mjs`:
- direct lookup is used, and the capped collection endpoint is **not** hit
- **the regression**: a full 100-record page that doesn't contain the parent — old scan said gone, direct lookup says alive
- 404 → gone (the only negative)
- 5xx → alive
- transport throw → alive
- empty id → false, no request issued

`npm run typecheck` clean; 2073 renderer tests + 1468 server tests pass.

## Relationship to #565

Independent bug, different layer, but they compound: #565 fixes the sidebar never *displaying* a background job, this fixes background jobs never *surviving*. Both are needed before a delegated job is visible and useful. This one can land first — it's server-only.