### PR TITLE
feat(chat): transcript entry + iMessage-style send animation

### DIFF
--- a/src/renderer/MessageBubble.test.tsx
+++ b/src/renderer/MessageBubble.test.tsx
@@ -14,7 +14,7 @@ import { mount, type Harness } from "./testHarness";
 import { MessageBubble } from "./MessageBubble";
 
 const BUBBLE_CHROME =
-  "bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words";
+  "bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words manta-bubble-in";
 
 describe("MessageBubble", () => {
   let h: Harness | null = null;

--- a/src/renderer/MessageBubble.tsx
+++ b/src/renderer/MessageBubble.tsx
@@ -30,7 +30,7 @@ import type { ReactNode } from "react";
 export function MessageBubble({ children }: { children: ReactNode }) {
   return (
     <div className="flex justify-end">
-      <div className="bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words">
+      <div className="bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words manta-bubble-in">
         {children}
       </div>
     </div>

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -225,6 +225,7 @@ export const MessageRow = memo(function MessageRow({
   truncation,
   commandInfo,
   streaming = false,
+  entering = false,
 }: {
   msg: OpencodeMessage;
   showThinking: boolean;
@@ -251,8 +252,22 @@ export const MessageRow = memo(function MessageRow({
   // trailing caret on its final text part (BET-649). Primitive prop, so the
   // MessageRow memo chain is untouched.
   streaming?: boolean;
+  // True when this row mounted live at the tail of the transcript AFTER the
+  // initial load (transcript-motion). Drives the whole-row slide-up entry; a
+  // session switch (all rows remount) is NOT `entering`, so history never
+  // replays its entrance. The user bubble gets its own send animation inside
+  // MessageBubble, and the streaming row animates its blocks instead, so
+  // `entering` only applies the row slide to settled assistant/card rows.
+  // Primitive prop — memo chain untouched.
+  entering?: boolean;
 }) {
   const isUser = msg.info.role === "user";
+
+  // Whole-row entry motion for newly-mounted, settled assistant rows. The
+  // streaming message's blocks animate via .manta-streaming instead; the user
+  // bubble animates via .manta-bubble-in inside MessageBubble. Reduced-motion
+  // kills the animation in CSS.
+  const rowMotion = entering && !isUser && !streaming ? " manta-row-in" : "";
 
   // Subtle wall-clock timestamp for each message/action. Sourced from the
   // message's own time.created — no new prop, so the MessageRow memo chain is
@@ -276,7 +291,7 @@ export const MessageRow = memo(function MessageRow({
   // commands, paths and output), 10px, tabular so the digits don't jitter.
   const ts = formatClockTime(msg.info.time?.created);
   const stampedRow = (children: React.ReactNode) => (
-    <div className="group relative">
+    <div className={"group relative" + rowMotion}>
       {ts && (
         <span
           className={

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -22,6 +22,7 @@
 // stability, so passing it through as a prop keeps that identity intact.
 
 import type { OpencodeMessage, QuestionRequest } from "../shared/types";
+import { useRef } from "react";
 import { TaskContext, type TaskContextValue } from "./chatShared";
 import { MeasureColumn } from "./MeasureColumn";
 import { ActiveTodos, MessageRow } from "./MessageRow";
@@ -61,6 +62,42 @@ export function Transcript({
   onReplyQuestion,
   onRejectQuestion,
 }: TranscriptProps) {
+  // Entry-motion tracking (transcript-motion): rows mount live at the tail of
+  // the transcript (a message just sent, an assistant turn that reconciles in
+  // as a whole) should animate a slide-up entry, but the FULL transcript must
+  // NOT replay its entrance on a session switch or the first load. `seen` is
+  // primed with the ids present on the first render where messages become
+  // non-empty, so exactly the rows appended AFTER that prime get `entering`.
+  //
+  // Kept in a ref (not state) — it must not trigger renders, and updating it
+  // during render is safe/idempotent. Per-window refs reset on remount, which
+  // is exactly the session-switch boundary we want to reset on.
+  const seenIdsRef = useRef<Set<string> | null>(null);
+
+  // Compute `entering` per row for this render and advance the seen set.
+  // Mutating a ref during render is fine here: the set converges to the
+  // current message ids and there is no side effect on other components.
+  const seen = seenIdsRef.current;
+  const enteringFor: Record<string, boolean> = {};
+  if (seen == null && messages.length > 0) {
+    // First NON-EMPTY render — the initial population. Nothing animates (the
+    // empty "Welcome" render must not prime the set, or every historically
+    // loaded row would read as new and replay its entrance).
+    seenIdsRef.current = new Set(messages.map((m) => m.info.id));
+  } else if (seen != null) {
+    for (const m of messages) {
+      // The optimistic placeholder a send appends is ALWAYS animated: on a
+      // brand-new session it is the first non-empty render (so would be
+      // primed as "seen"), and it is the exact moment the iMessage send
+      // effect matters most.
+      if (!seen.has(m.info.id) || m.info.id.startsWith("optimistic-user-")) {
+        enteringFor[m.info.id] = true;
+      }
+    }
+    // Merge newly seen ids in so they don't re-enter on the next render.
+    for (const id of Object.keys(enteringFor)) seen.add(id);
+  }
+
   return (
     <div
       ref={scrollRef}
@@ -129,6 +166,7 @@ export function Transcript({
                     // The message being written right now: last in the
                     // transcript, assistant, and the turn still running.
                     streaming={isLastInTranscript && running}
+                    entering={!!enteringFor[m.info.id]}
                   />
                 );
               })}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -181,6 +181,53 @@ html, body, #root {
   .manta-streaming > *:last-child::after { animation: none; }
 }
 
+/* Transcript entry motion (transcript-motion).
+   New rows that mount live at the bottom of the transcript (a user message
+   just sent, an assistant turn that reconciles in as a whole, a newly
+   surfaced card) enter by sliding up a few pixels with a fade, so appends
+   read as "settling in" rather than teleporting. Transform + opacity only
+   (compositor-friendly), `both` fill so a one-shot play holds its end state
+   and dropping the class later is seamless.
+
+   WHOLE-ROW animation: the row is the unit, so a card is never assembled
+   piece by piece. The live-streaming message is exempt — its blocks already
+   animate in via .manta-streaming (BET-649), and re-animating the row would
+   double up. `entering` (set in Transcript.tsx) marks rows appended after the
+   initial transcript load, so a session switch never replays the whole
+   history sliding in. */
+@keyframes manta-row-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+.manta-row-in {
+  animation: manta-row-in 0.22s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
+}
+
+/* User bubble send (transcript-motion). iMessage-style send: the bubble
+   springs in from just below where the composer sits — a short rise with a
+   slight scale overshoot so it reads as a single "pop" that the text lands
+   in, rather than a static stamp. The 72% keyframe gives the spring feel
+   without introducing a spring-easing dependency. Origin is the bottom-right
+   corner (where a send originates) so the overshoot scales toward the
+   transcript, not the gutter. */
+@keyframes manta-bubble-in {
+  0%   { opacity: 0; transform: translateY(14px) scale(0.9); }
+  72%  { opacity: 1; transform: translateY(-2px) scale(1.02); }
+  100% { opacity: 1; transform: none; }
+}
+.manta-bubble-in {
+  animation: manta-bubble-in 0.3s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: bottom right;
+}
+
+/* Vestibular safety (MDN prefers-reduced-motion): with reduce set, the
+   transcript never slides — rows and bubbles simply appear. State is
+   unaffected; only the motion is removed. */
+@media (prefers-reduced-motion: reduce) {
+  .manta-row-in,
+  .manta-bubble-in { animation: none; }
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
## What
Three transcript-motion improvements, all CSS `transform`+`opacity` only (compositor-friendly) and gated behind `prefers-reduced-motion` for vestibular safety (per MDN).

1. **Slide-up entry for new transcript rows** — `.manta-row-in` (translateY(8px) + fade, 220ms). Newly-mounted settled assistant/card rows slide in instead of teleporting.
   - Gated in `Transcript.tsx` via a seen-ids ref primed on the first non-empty render, so a session switch never replays the whole history sliding in.
   - The live-streaming message is exempt — its blocks already fade in via the existing BET-649 `.manta-streaming` animation.
2. **`entering` is whole-row** — a card is never assembled piece-by-piece when it mounts (the "full components, no partial reveal" ask).
3. **iMessage-style send bubble** — `.manta-bubble-in`: the user bubble springs in from below the composer with a scale overshoot (`transform-origin: bottom right`). The optimistic placeholder always animates on send.

## Rationale / research
- Animate only `transform` + `opacity` (web.dev — compositor, no layout thrash).
- `prefers-reduced-motion` disables all entry motion (MDN).
- Animate on **mount only**, never on content growth during streaming — re-entering per delta is janky.

## Verification
- `npm run typecheck` clean.
- `vitest run` — 111 files / 2073 tests pass (updated `MessageBubble.test.tsx` for the new class).