### PR TITLE
fix(windows): top-of-window bars sat under the caption buttons

### DIFF
--- a/src/renderer/ReconnectingBanner.tsx
+++ b/src/renderer/ReconnectingBanner.tsx
@@ -44,7 +44,11 @@ export function ReconnectingBanner({ state, onRetryNow }: ReconnectingBannerProp
     <div
       role="status"
       aria-live="polite"
-      className="shrink-0 bg-accent/10 border-b border-accent/30 px-3 py-2 text-meta text-text flex items-center gap-2"
+      // Same top-of-window caption-button reservation as UpdateBar — this
+      // banner also renders above the titlebar row and also carries a
+      // right-aligned button ("Retry now"), which the Windows caption buttons
+      // covered. 0 on macOS/Linux, so identical to `px-3` there.
+      className="shrink-0 bg-accent/10 border-b border-accent/30 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2"
     >
       <span className="flex-1 truncate">
         {renderCopy(state)}

--- a/src/renderer/TopBanners.test.tsx
+++ b/src/renderer/TopBanners.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// Windows caption-button clearance for the two bars that render at the very
+// TOP of the window, above the titlebar row: UpdateBar and ReconnectingBanner.
+//
+// THE BUG THIS LOCKS IN: on Windows the app uses `titleBarOverlay`, so the OS
+// paints minimize/maximize/close over the top-right of the window. Both bars
+// put their controls on the right ("Update & restart" + ×, "Retry now"), and
+// both used a symmetric `px-3` — so the caption buttons sat directly on top of
+// them and they could not be clicked at all.
+//
+// The titlebar row already reserves that strip (`.titlebar-inset-right`, fed by
+// `--titlebar-inset-right`); these bars must reserve it too. The variable is
+// derived from the `titlebar-area-*` env vars, which only Windows defines, so
+// it evaluates to 0 on macOS/Linux and the padding stays exactly `px-3` there —
+// no platform branch in JS, and nothing to regress per-OS.
+//
+// jsdom loads no stylesheet and does not implement `env()`, so — as with
+// SessionRow — the contract is asserted on the exact class string.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { UpdateBar } from "./UpdateBar";
+import { ReconnectingBanner } from "./ReconnectingBanner";
+
+const INSET = "pr-[calc(var(--sp-3)+var(--titlebar-inset-right))]";
+
+describe("top-of-window bars clear the Windows caption buttons", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("UpdateBar reserves the caption strip instead of padding symmetrically", () => {
+    h = mount(
+      <UpdateBar
+        text="Server update available: 0.0.20"
+        actionLabel="Update & restart"
+        onAction={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el.className).toContain(INSET);
+    expect(el.className).toContain("pl-3");
+    // A symmetric px-3 is what put the buttons under the caption controls.
+    expect(el.className).not.toContain("px-3");
+  });
+
+  it("ReconnectingBanner does the same — its 'Retry now' button was covered too", () => {
+    h = mount(
+      <ReconnectingBanner
+        state={{ state: "reconnecting", attempt: 2, backoffMs: 5_000 }}
+        onRetryNow={() => {}}
+      />,
+    );
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.className).toContain(INSET);
+    expect(el.className).toContain("pl-3");
+    expect(el.className).not.toContain("px-3");
+  });
+
+  it("the reservation is token-driven, so macOS/Linux collapse it to zero", () => {
+    // --titlebar-inset-right is `100vw - titlebar-area-x - titlebar-area-width`
+    // with fallbacks of 0px/100vw, so a platform that defines neither env var
+    // yields 0 and the bar keeps a plain 12px right pad. Asserting the class
+    // references the VARIABLE (not a hardcoded Windows width) is what keeps
+    // that true.
+    h = mount(
+      <UpdateBar text="x" actionLabel="Go" onAction={() => {}} onDismiss={() => {}} />,
+    );
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el.className).toContain("var(--titlebar-inset-right)");
+    expect(el.className).not.toMatch(/pr-\[\d+px\]/);
+  });
+});

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -54,7 +54,15 @@ export function UpdateBar({
   dismissible = true,
 }: UpdateBarProps) {
   return (
-    <div className="shrink-0 bg-accent/10 border-b border-accent/30 px-3 py-2 text-meta text-text flex items-center gap-2">
+    // `pr-[…]` (not `px-3`) reserves the OS caption-button strip: this bar
+    // renders ABOVE the titlebar row, so on Windows (titleBarOverlay) the
+    // minimize/maximize/close buttons are painted over its right edge and sat
+    // on top of the action + dismiss buttons — unclickable. The titlebar row
+    // already reserves this via `.titlebar-inset-right`; a top-of-window bar
+    // needs the same reservation. `--titlebar-inset-right` evaluates to 0 on
+    // macOS/Linux (neither defines the `titlebar-area-*` env vars), so this is
+    // exactly `px-3` everywhere else.
+    <div className="shrink-0 bg-accent/10 border-b border-accent/30 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2">
       <span className="flex-1 truncate">{text}</span>
       <button
         onClick={() => {


### PR DESCRIPTION
On Windows the app uses `titleBarOverlay`, so the OS paints minimize/maximize/close over the top-right of the window.

`UpdateBar` and `ReconnectingBanner` both render **above** the titlebar row, and both put their controls on the right — "Update & restart" + the dismiss ×, and "Retry now" — using a symmetric `px-3`. The caption buttons landed directly on top of them.

**Consequence: on Windows the box-update prompt and the manual reconnect were both unclickable.** Which is a large part of why updating the box "does nothing" there.

The titlebar row already reserves that strip (`.titlebar-inset-right`); a bar sitting at the very top of the window needs the same reservation and never got it.

## Fix

Both bars now use `pl-3` + `pr-[calc(var(--sp-3)+var(--titlebar-inset-right))]`.

`--titlebar-inset-right` is derived from the `titlebar-area-*` env vars, which **only Windows defines** — it collapses to `0` on macOS and Linux, so the result is byte-identical to the previous `px-3` there. No platform branch in JS, nothing to regress per-OS, and `--sp-3` is 12px so the left/right padding still matches everywhere else.

## Tests

Three in `TopBanners.test.tsx`:
- each bar reserves the caption strip
- neither keeps the symmetric `px-3` that caused the overlap
- the value references the **token**, not a hardcoded Windows width — which is what keeps macOS/Linux at zero

`npm run typecheck` clean, 2076 renderer + 1468 server tests pass, `duplication-gate` passes.

Companion to #565 and #570 (sidebar rail / background jobs), but independent of both.