### PR TITLE
fix(delegate): pre-flight ruleset denied every tool it was meant to grant

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -185,10 +185,26 @@ export function buildPermissionRuleset(tools) {
     seen.add(key);
     return true;
   });
-  // The catch-all deny MUST be last — it is what stops an unmatched tool from
-  // resolving to `ask` and hanging the job.
-  deduped.push({ permission: "*", pattern: "**", action: "deny" });
-  return deduped;
+  // The catch-all deny MUST be FIRST, with the specific allows after it.
+  //
+  // opencode resolves a tool call against this list LAST-MATCH-WINS, which is
+  // the opposite of what this originally assumed. Appending the catch-all last
+  // meant `{permission:"*", pattern:"**", action:"deny"}` matched every call
+  // and won over every allow that preceded it — so a delegated job could not
+  // run a SINGLE tool, whatever it had been granted. The job then burned a
+  // worktree, a window and a model session doing nothing but reporting that it
+  // was denied.
+  //
+  // Verified against the running opencode (v1.15.12) rather than reasoned
+  // about, because the API accepts either order silently:
+  //   [bash ** allow, * ** deny] → bash DENIED ("a rule prevents you…")
+  //   [* ** deny, bash ** allow] → bash COMPLETED
+  // opencode also prepends its own `{permission:"*", pattern:"*",
+  // action:"allow"}` default ahead of whatever we send, which is why an
+  // explicit catch-all deny is still required to stop an ungranted tool from
+  // resolving to allow/ask — it just has to sit UNDER the grants, not over
+  // them.
+  return [{ permission: "*", pattern: "**", action: "deny" }, ...deduped];
 }
 
 // Find the tmux session that owns a given opencode sessionID. Mirrors the

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -673,17 +673,27 @@ test("finishJob is idempotent for an already-terminal job", async () => {
 // buildPermissionRuleset (BET-418 §A)
 // ----------------------------------------------------------------------------
 
-test("buildPermissionRuleset appends the mandatory catch-all deny last", () => {
+// REGRESSION (verified against live opencode v1.15.12): opencode resolves this
+// list LAST-MATCH-WINS. The catch-all deny therefore has to sit FIRST, under
+// the grants. When it was appended last it matched every call and beat every
+// allow, so a delegated job could not run a single tool it had been granted:
+//   [bash ** allow, * ** deny] → bash DENIED
+//   [* ** deny, bash ** allow] → bash COMPLETED
+test("buildPermissionRuleset puts the catch-all deny FIRST, under the grants", () => {
   const rs = buildPermissionRuleset([
     { permission: "bash", pattern: "pytest *" },
     { permission: "write", pattern: "**/*.ts" },
   ]);
   assert.deepEqual(rs, [
+    { permission: "*", pattern: "**", action: "deny" },
     { permission: "bash", pattern: "pytest *", action: "allow" },
     { permission: "write", pattern: "**/*.ts", action: "allow" },
-    { permission: "*", pattern: "**", action: "deny" },
   ]);
-  assert.equal(rs[rs.length - 1].action, "deny", "catch-all deny MUST be last");
+  assert.equal(rs[0].action, "deny", "catch-all deny MUST be FIRST (last-match-wins)");
+  assert.ok(
+    rs.slice(1).every((r) => r.action === "allow"),
+    "every grant must come AFTER the catch-all so it can override it",
+  );
 });
 
 test("buildPermissionRuleset with no tools still applies the catch-all deny (job asks nothing, denies everything)", () => {
@@ -697,9 +707,10 @@ test("buildPermissionRuleset de-dups identical rules and defaults action to allo
     { permission: "bash", pattern: "pytest *" },
     { permission: "bash", pattern: "rm *", action: "deny" },
   ]);
-  assert.equal(rs.length, 3, "two allows (de-duped) + one explicit deny + catch-all");
-  assert.equal(rs[0].action, "allow");
-  assert.equal(rs[1].action, "deny");
+  assert.equal(rs.length, 3, "catch-all + one de-duped allow + one explicit deny");
+  assert.equal(rs[0].action, "deny", "catch-all first");
+  assert.equal(rs[1].action, "allow");
+  assert.equal(rs[2].action, "deny");
 });
 
 // BET-418 §A acceptance: a job whose ruleset omits `bash` must FAIL its first
@@ -713,7 +724,7 @@ test("a ruleset omitting bash has no bash-allow rule (command fails, no hang)", 
   ]);
   const bashAllow = rs.find((r) => r.permission === "bash" && r.action === "allow");
   assert.equal(bashAllow, undefined, "no bash-allow rule — bash hits the catch-all deny");
-  assert.equal(rs[rs.length - 1].action, "deny");
+  assert.equal(rs[0].action, "deny", "catch-all deny is the floor, and nothing lifts bash off it");
 });
 
 // ----------------------------------------------------------------------------
@@ -841,12 +852,13 @@ test("startJobWithApproval starts the job on approve and forwards the ruleset", 
   assert.ok(h.engine.approve(req.payload.id, [{ permission: "bash", pattern: "pytest * -x" }]));
   const res = await p;
   assert.equal(res.ok, true);
-  // newWindow received the permission ruleset ending in the catch-all deny.
+  // newWindow received the ruleset: catch-all deny FIRST, then the approved
+  // grant — the order that actually lets the grant take effect (last-match-wins).
   const perm = h.newWindowCalls[0]?.permission;
   assert.ok(Array.isArray(perm));
-  assert.deepEqual(perm[perm.length - 1], { permission: "*", pattern: "**", action: "deny" });
-  assert.equal(perm[0].permission, "bash");
-  assert.equal(perm[0].pattern, "pytest * -x");
+  assert.deepEqual(perm[0], { permission: "*", pattern: "**", action: "deny" });
+  assert.equal(perm[1].permission, "bash");
+  assert.equal(perm[1].pattern, "pytest * -x");
 });
 
 // ----------------------------------------------------------------------------
@@ -881,7 +893,7 @@ test("§A4: a job omitting bash receives the catch-all deny at the session-creat
   assert.ok(Array.isArray(perm), "the permission ruleset was forwarded to session creation");
   const bashAllow = perm.find((r) => r.permission === "bash" && r.action === "allow");
   assert.equal(bashAllow, undefined, "no bash-allow rule — bash hits the catch-all deny");
-  assert.deepEqual(perm[perm.length - 1], { permission: "*", pattern: "**", action: "deny" });
+  assert.deepEqual(perm[0], { permission: "*", pattern: "**", action: "deny" });
 
   // 2. Simulate opencode denying the job's first bash command. opencode
   //    surfaces a tool denial as a session.error (the job's turn aborts); the


### PR DESCRIPTION
Found while dispatching a background job to do real work: **the job could not run a single tool, whatever it had been granted.** It started, was refused by its own permission ruleset on the first call, and finished having done nothing — after creating a worktree, a tmux window and a full model session.

## Cause

`buildPermissionRuleset` appended the catch-all last:

```js
deduped.push({ permission: "*", pattern: "**", action: "deny" });
```

on the assumption that a trailing catch-all acts as a floor. **opencode resolves the list last-match-wins**, so that rule matched every call and beat every `allow` above it. Every grant was inert.

## Verified, not reasoned about

The API accepts either order silently and echoes it back unchanged, so this had to be checked against the running opencode (v1.15.12):

| ruleset sent | result |
|---|---|
| `[bash ** allow, * ** deny]` | bash **DENIED** — *"a rule prevents you from using this specific tool call"* |
| `[* ** deny, bash ** allow]` | bash **COMPLETED** — returned `PERMTEST_OK` |

The denial message also revealed that opencode prepends its own `{permission:"*", pattern:"*", action:"allow"}` default ahead of whatever we send — which is why an explicit catch-all deny is still needed to stop an ungranted tool resolving to allow. It just has to sit **under** the grants rather than over them.

## Fix

Catch-all deny first, grants after.

**BET-418 §A's guarantee is unchanged:** a tool that was never granted still has nothing to lift it off the deny floor, so it fails fast rather than hanging on an `ask`. That was the whole point of the catch-all and it still holds — the existing §A4 test covering it passes unmodified in substance.

## Tests

The old ordering was pinned by a test literally asserting *"catch-all deny MUST be last"* — it encoded the bug. That test and three other order-dependent assertions are inverted, and the primary one now documents the live-verified behaviour so the next person doesn't re-flip it.

`npm run typecheck` clean, 2073 renderer + 1468 server tests pass, `duplication-gate` passes.

## Context

Third in a chain of independent bugs that each made background delegation look like an unfinished feature:
- #570 — jobs were killed after ~60s as false orphans
- #565 — jobs never appeared in the sidebar
- **this** — jobs could never run a tool

All three had to be fixed before a delegated job could do anything useful.