### PR TITLE
feat(update): box-update progress bar, automatic opencode restart, consent gate

### DIFF
--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -65,6 +65,7 @@ exec >>"$LOG_FILE" 2>&1
 . "$MANTA_HOME/scripts/lib/release.sh"
 
 # --- Detect install kind ------------------------------------------------------
+echo "MANTA_PROGRESS 1/6 Checking for updates"
 if [ -d "$MANTA_HOME/.git" ]; then
   INSTALL_KIND=git
 elif [ -f "$MANTA_HOME/RELEASE.json" ]; then
@@ -82,6 +83,7 @@ else
   NODE_CMD="node"
 fi
 
+echo "MANTA_PROGRESS 2/6 Downloading update"
 if [ "$INSTALL_KIND" = "git" ]; then
   log "self-update: fetching origin/main into $MANTA_HOME"
   git -C "$MANTA_HOME" fetch origin main -q
@@ -154,6 +156,7 @@ else
   ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
 fi
 
+echo "MANTA_PROGRESS 3/6 Installing dependencies"
 log "self-update: reinstalling prod-only deps"
 npm ci --omit=dev --prefix "$MANTA_HOME"
 
@@ -219,14 +222,9 @@ refresh_opencode_tools() {
     return 0
   fi
   echo "✓ self-update: opencode tools refreshed ($changed of $copied changed)"
-  echo "  ↳ restart opencode to load them (this will end any running agent turn):"
-  if command -v systemctl >/dev/null 2>&1; then
-    echo "      systemctl --user restart opencode-serve"
-  elif [ "$(uname -s)" = "Darwin" ]; then
-    echo "      launchctl kickstart -k gui/\$(id -u)/com.mantaui.opencode"
-  fi
 }
 
+echo "MANTA_PROGRESS 4/6 Refreshing AI tools"
 refresh_opencode_tools
 
 # --- Sync opencode agent guidance (BET-640) -----------------------------------
@@ -236,6 +234,23 @@ refresh_opencode_tools
 # update without rewriting existing (possibly user-edited) sections.
 sync_opencode_guidance "$MANTA_HOME/docs/opencode-tools/AGENTS.md" "${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/AGENTS.md"
 
+echo "MANTA_PROGRESS 5/6 Restarting opencode"
+# Restart opencode so refreshed tools are actually loaded. opencode only
+# re-scans its tools/ directory at startup, so without this an update
+# leaves the new tools inert on disk. UNCONDITIONAL: the user confirmed a
+# restart before the update started, so the behaviour must be predictable
+# rather than depending on whether any tool file happened to change.
+if command -v systemctl >/dev/null 2>&1; then
+  echo "▸ self-update: restarting opencode-serve"
+  systemctl --user restart opencode-serve || echo "⚠ self-update: opencode restart failed"
+elif [ "$(uname -s)" = "Darwin" ]; then
+  echo "▸ self-update: kickstarting com.mantaui.opencode LaunchAgent"
+  launchctl kickstart -k "gui/$(id -u)/com.mantaui.opencode" || echo "⚠ self-update: opencode restart failed"
+else
+  echo "⚠ self-update: no systemctl/launchctl — restart opencode manually"
+fi
+
+echo "MANTA_PROGRESS 6/6 Restarting box server"
 # Restart the supervisor that runs manta-server. Linux uses the systemd
 # --user unit (default since v1); macOS (BET-277) uses the LaunchAgent
 # installed by install.sh — `launchctl kickstart -k` kills any running

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,6 +20,8 @@ import {
 import { chooseUpdateSkewVariant, isUnknownChannelError, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
 import { parsePairPayload } from "../shared/pairPayload";
@@ -54,6 +56,7 @@ export function App() {
     setBoxIncompatible,
     serverUpdatePrompt,
     setServerUpdatePrompt,
+    serverUpdateProgress,
     connectionState,
     launcherFlags,
   } = useStore();
@@ -442,6 +445,20 @@ export function App() {
     return off;
   }, []);
 
+  // Server-update progress (this ticket): while the box runs
+  // scripts/self-update.sh, manta-server tails its log and republishes each
+  // MANTA_PROGRESS marker as a `serverUpdateProgress` bus event. The renderer
+  // renders a determinate progress bar in the server-update UpdateBar so the
+  // update reads as advancing rather than a frozen button. Mirrors the
+  // onServerUpdateAvailable subscription above.
+  useEffect(() => {
+    if (!window.api.onServerUpdateProgress) return;
+    const off = window.api.onServerUpdateProgress((p) => {
+      useStore.getState().setServerUpdateProgress(p);
+    });
+    return off;
+  }, []);
+
   // Version-skew guard (BET-225 stage 3 Part C). After the renderer is
   // mounted, fetch the client + server version pair ONCE (no second poll,
   // per the stage-3 spec) and let `chooseUpdateSkewVariant` decide
@@ -810,6 +827,12 @@ export function App() {
   // that case; surface it in the EXISTING update-failed banner (the same
   // state the auto-update path already feeds) instead of silently reporting
   // success and leaving the box stale.
+  // Restarting opencode ends every in-flight agent turn, so the box
+  // self-update is gated behind an explicit confirm dialog. The two
+  // server-update UpdateBars open it; "Update & restart" in the dialog is what
+  // actually fires applyServerUpdate().
+  const [confirmServerUpdate, setConfirmServerUpdate] = useState(false);
+
   const applyServerUpdate = async () => {
     try {
       const res = await window.api.serverUpdateApply();
@@ -919,10 +942,9 @@ export function App() {
               </>
             }
             actionLabel="Update & restart"
-            onAction={() => {
-              void applyServerUpdate();
-            }}
+            onAction={() => setConfirmServerUpdate(true)}
             onDismiss={() => setServerUpdatePrompt(null)}
+            progress={serverUpdateProgress ?? undefined}
           />
         )}
         {!showOnboarding &&
@@ -940,10 +962,9 @@ export function App() {
                 </>
               }
               actionLabel="Upgrade box"
-              onAction={() => {
-                void applyServerUpdate();
-              }}
+              onAction={() => setConfirmServerUpdate(true)}
               onDismiss={dismiss}
+              progress={serverUpdateProgress ?? undefined}
             />
           )}
         {!isChatPaneActive && (
@@ -1111,6 +1132,41 @@ export function App() {
       </main>
       {settingsOpen && (
         <Settings onClose={() => setSettingsOpen(false)} initialSection={settingsSection} />
+      )}
+      {/* Box self-update confirm: restarting opencode ends every in-flight
+          agent turn, so the destructive restart needs explicit consent before
+          the update starts. */}
+      {confirmServerUpdate && (
+        <Modal
+          size="md"
+          label="Update the box?"
+          onDismiss={() => setConfirmServerUpdate(false)}
+        >
+          <div className="space-y-4">
+            <h3 className="text-title font-semibold">Update the box?</h3>
+            <div className="text-body text-text-faint">
+              This restarts opencode, which will end every agent turn currently
+              running in any session. Any unsaved work in a running turn is lost.
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmServerUpdate(false)}
+                className="px-4 py-2 text-body text-text-muted hover:text-text"
+              >
+                Cancel
+              </button>
+              <Button
+                tone="primary"
+                onClick={() => {
+                  setConfirmServerUpdate(false);
+                  void applyServerUpdate();
+                }}
+              >
+                Update &amp; restart
+              </Button>
+            </div>
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/renderer/UpdateBar.test.tsx
+++ b/src/renderer/UpdateBar.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+//
+// Component tests for the shared UpdateBar banner. The bar has two shapes:
+//   - default: a message + an action button (+ optional dismiss ×).
+//   - progress: a determinate progress bar in place of BOTH buttons (an
+//     update in flight is not dismissible), driven by {step,total,label}.
+//
+// jsdom loads no stylesheet, so the progress-width contract is asserted on the
+// inline style string and the aria-* attributes.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act } from "react";
+import { mount, type Harness } from "./testHarness";
+import { UpdateBar } from "./UpdateBar";
+
+describe("UpdateBar", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("without progress: renders the action button and clicking it fires onAction", () => {
+    const onAction = vi.fn();
+    h = mount(
+      <UpdateBar text="Server update available" actionLabel="Update & restart" onAction={onAction} />,
+    );
+    const btn = [...h.container.querySelectorAll("button")].find(
+      (b) => b.textContent === "Update & restart",
+    ) as HTMLButtonElement | undefined;
+    expect(btn).toBeTruthy();
+    // No progressbar in the default shape.
+    expect(h.container.querySelector('[role="progressbar"]')).toBeNull();
+    act(() => btn!.click());
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("with progress: renders a progressbar with correct aria values and NO action/dismiss buttons", () => {
+    h = mount(
+      <UpdateBar
+        text="Server update available"
+        actionLabel="Update & restart"
+        onAction={() => {}}
+        onDismiss={() => {}}
+        progress={{ step: 3, total: 6, label: "Installing dependencies" }}
+      />,
+    );
+    const bar = h.container.querySelector('[role="progressbar"]') as HTMLElement | null;
+    expect(bar).toBeTruthy();
+    expect(bar!.getAttribute("aria-valuenow")).toBe("3");
+    expect(bar!.getAttribute("aria-valuemin")).toBe("1");
+    expect(bar!.getAttribute("aria-valuemax")).toBe("6");
+    // The action button and dismiss button are BOTH absent in progress mode.
+    expect(h.container.querySelector("button")).toBeNull();
+    // The label + step/total are shown.
+    expect(h.text()).toContain("Installing dependencies");
+    expect(h.text()).toContain("(3/6)");
+  });
+
+  it("progress width style reflects step/total (3/6 → 50%)", () => {
+    h = mount(
+      <UpdateBar
+        text="x"
+        actionLabel="x"
+        onAction={() => {}}
+        progress={{ step: 3, total: 6, label: "Installing dependencies" }}
+      />,
+    );
+    const bar = h.container.querySelector('[role="progressbar"]') as HTMLElement;
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("50%");
+  });
+});

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -39,6 +39,9 @@ export type UpdateBarProps = {
   onDismiss?: () => void;
   /** When true (default), show the × button. Skew guard passes false. */
   dismissible?: boolean;
+  /** When set, the bar renders a determinate progress bar in place of the
+   *  action button. */
+  progress?: { step: number; total: number; label: string };
 };
 
 /**
@@ -52,6 +55,7 @@ export function UpdateBar({
   onAction,
   onDismiss,
   dismissible = true,
+  progress,
 }: UpdateBarProps) {
   return (
     // `pr-[…]` (not `px-3`) reserves the OS caption-button strip: this bar
@@ -63,24 +67,49 @@ export function UpdateBar({
     // macOS/Linux (neither defines the `titlebar-area-*` env vars), so this is
     // exactly `px-3` everywhere else.
     <div className="shrink-0 bg-accent/10 border-b border-accent/30 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2">
-      <span className="flex-1 truncate">{text}</span>
-      <button
-        onClick={() => {
-          onAction();
-        }}
-        className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
-      >
-        {actionLabel}
-      </button>
-      {dismissible && onDismiss && (
-        <button
-          onClick={() => onDismiss()}
-          className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center"
-          title="Dismiss"
-          aria-label="Dismiss update"
+      <span className="flex-1 truncate">
+        {progress ? (
+          <>
+            {progress.label} ({progress.step}/{progress.total})
+          </>
+        ) : (
+          text
+        )}
+      </span>
+      {progress ? (
+        <div
+          className="shrink-0 w-32 h-1.5 rounded-full bg-accent/20 overflow-hidden"
+          role="progressbar"
+          aria-valuenow={progress.step}
+          aria-valuemin={1}
+          aria-valuemax={progress.total}
         >
-          <X size={14} aria-hidden="true" />
-        </button>
+          <div
+            className="h-full bg-accent transition-all"
+            style={{ width: `${(progress.step / progress.total) * 100}%` }}
+          />
+        </div>
+      ) : (
+        <>
+          <button
+            onClick={() => {
+              onAction();
+            }}
+            className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
+          >
+            {actionLabel}
+          </button>
+          {dismissible && onDismiss && (
+            <button
+              onClick={() => onDismiss()}
+              className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center"
+              title="Dismiss"
+              aria-label="Dismiss update"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -59,6 +59,7 @@ export const DEMO_UNIMPLEMENTED = [
   "onPtyEvent",
   "onScreenshotDetected",
   "onServerUpdateAvailable",
+  "onServerUpdateProgress",
   "openExternal",
   "opencodeAbort",
   "opencodeAgents",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -332,6 +332,7 @@ type Kind =
   | "agentFile"
   | "desktopNotify"
   | "serverUpdateAvailable"
+  | "serverUpdateProgress"
   | "delegate.updated"
   | "stream";
 
@@ -347,6 +348,7 @@ const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   agentFile: new Set(),
   desktopNotify: new Set(),
   serverUpdateAvailable: new Set(),
+  serverUpdateProgress: new Set(),
   "delegate.updated": new Set(),
   stream: new Set(),
 };
@@ -1091,6 +1093,14 @@ export const httpApi: Api = {
   // so the store field stays in sync — actual mobile UI is a later pass.
   onServerUpdateAvailable: (cb) =>
     on<ServerUpdateAvailablePayload>("serverUpdateAvailable", cb),
+
+  // -- server-update progress subscription --
+  // /events WS publishes `{kind: "serverUpdateProgress", payload:{step,total,
+  // label}}` for each MANTA_PROGRESS marker the box's self-update script
+  // emits. The renderer's UpdateBar renders a determinate progress bar from
+  // these while the update is in flight.
+  onServerUpdateProgress: (cb) =>
+    on<{ step: number; total: number; label: string }>("serverUpdateProgress", cb),
 
   // -- plugins (BET-189 / BET-190) --
   // Read the current plugin registry the Mac executor has published. The

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -252,6 +252,12 @@ type State = {
   // for a STRICTLY newer version; the server-side dedup gate mirrors this
   // exactly, see src/server/serverUpdate.mjs).
   serverUpdatePrompt: { version: string; notesUrl?: string | null } | null;
+  // Live progress of an in-flight box self-update. Set from the box's
+  // `serverUpdateProgress` bus events (one per MANTA_PROGRESS marker the
+  // self-update script emits). null when no update is running; drives the
+  // UpdateBar's determinate progress bar. Mirrors the serverUpdatePrompt
+  // shape/lifecycle (a plain state + setter pair).
+  serverUpdateProgress: { step: number; total: number; label: string } | null;
   // Live events-WebSocket connection state (from the shared
   // ConnectionState machine). Surface to the UI so a title-bar pill can
   // show "reconnecting…" when the link is down. Updated by the httpApi
@@ -381,6 +387,9 @@ type State = {
   setServerUpdatePrompt: (
     p: { version: string; notesUrl?: string | null } | null,
   ) => void;
+  setServerUpdateProgress: (
+    p: { step: number; total: number; label: string } | null,
+  ) => void;
   // Deep-link pairing (BET-240): write/clear the pending pair link. Pass
   // null to consume (PairStep clears on use); App.tsx writes the URL when
   // the preload's pair:link-received IPC fires.
@@ -428,6 +437,7 @@ export const useStore = create<State>((set, get) => ({
   updateError: null,
   boxIncompatible: false,
   serverUpdatePrompt: null,
+  serverUpdateProgress: null,
   connectionState: { state: "idle" },
   backgroundSyncing: false,
   videoRenderNow: null,
@@ -617,6 +627,7 @@ export const useStore = create<State>((set, get) => ({
   setUpdateError: (p) => set({ updateError: p }),
   setBoxIncompatible: (b) => set({ boxIncompatible: b }),
   setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),
+  setServerUpdateProgress: (p) => set({ serverUpdateProgress: p }),
   setConnectionState: (s) => set({ connectionState: s }),
   setOpencodeRestartNeeded: (v) => set({ opencodeRestartNeeded: v }),
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -324,8 +324,12 @@ rpcHandlers = buildHandlers({
   // `server:update-apply` IPC channel. The handler in rpc.mjs calls this
   // with SELF_UPDATE_SCRIPT (resolved at module load from `import.meta.url`).
   // The unit test in rpc.test.mjs passes a stub instead so the channel
-  // routing can be exercised without actually spawning a child.
-  runServerSelfUpdate,
+  // routing can be exercised without actually spawning a child. The bound
+  // `publish` lets the updater tail its log and republish progress markers
+  // (`serverUpdateProgress` bus events) so the renderer can render a
+  // determinate progress bar.
+  runServerSelfUpdate: (scriptPath) =>
+    runServerSelfUpdate(scriptPath, undefined, { publish: (e) => bus.publish(e) }),
 });
 
 // Server-update checker: polls https://mantaui.com/updates/server.json every

--- a/src/server/opencodeAdmin.mjs
+++ b/src/server/opencodeAdmin.mjs
@@ -84,6 +84,16 @@ export async function runServerSelfUpdate(
   { timeoutMs = SELF_UPDATE_WATCH_MS, publish } = {},
 ) {
   const logPath = statePath("self-update.log");
+  // NOTE: progress polling below assumes scripts/self-update.sh truncates this
+  // log (`: > "$LOG_FILE"`) as one of its first acts, so anything the poller
+  // reads belongs to the CURRENT run. If a tick ever landed before that
+  // truncation it would latch `highestStep` on the previous run's final step
+  // and publish nothing for this one — the bar would stay empty. The script
+  // truncates within milliseconds of starting and the first tick is 500ms in,
+  // so this is not reachable in practice; it is also benign (no progress bar,
+  // i.e. today's behaviour) and self-corrects on the next update. Do NOT
+  // "fix" it by truncating here — that destroys the log `lastLogLine` reads
+  // to report an early failure.
   try {
     const child = spawnFile(scriptPath, [], { detached: true, stdio: "ignore" });
     child.unref();

--- a/src/server/opencodeAdmin.mjs
+++ b/src/server/opencodeAdmin.mjs
@@ -81,7 +81,7 @@ export async function restartOpencode(exec = execFileAsync) {
 export async function runServerSelfUpdate(
   scriptPath,
   spawnFile = execFileCb,
-  { timeoutMs = SELF_UPDATE_WATCH_MS } = {},
+  { timeoutMs = SELF_UPDATE_WATCH_MS, publish } = {},
 ) {
   const logPath = statePath("self-update.log");
   try {
@@ -89,9 +89,41 @@ export async function runServerSelfUpdate(
     child.unref();
     return await new Promise((resolve) => {
       let settled = false;
+      // BET progress: while the child runs, tail the log for `MANTA_PROGRESS
+      // <step>/<total> <label>` markers and republish each NEW (strictly
+      // increasing) step to the bus so the renderer's UpdateBar can render a
+      // determinate progress bar. Optional — no `publish`, no polling. Every
+      // read is defensive: a missing/unreadable log must never throw.
+      let highestStep = 0;
+      let pollTimer = null;
+      if (typeof publish === "function") {
+        pollTimer = setInterval(() => {
+          try {
+            const text = readFileSync(logPath, "utf8");
+            for (const line of text.split(/\r?\n/)) {
+              const p = parseProgressLine(line);
+              if (p && p.step > highestStep) {
+                highestStep = p.step;
+                publish({
+                  kind: "serverUpdateProgress",
+                  payload: { step: p.step, total: p.total, label: p.label },
+                });
+              }
+            }
+          } catch {
+            // Log not yet written / unreadable — try again next tick.
+          }
+        }, 500);
+        if (typeof pollTimer.unref === "function") pollTimer.unref();
+      }
+      const clearPoll = () => {
+        if (pollTimer) clearInterval(pollTimer);
+        pollTimer = null;
+      };
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
+        clearPoll();
         // Still running at the watch window → it reached the server restart.
         resolve({ ok: true });
       }, timeoutMs);
@@ -99,6 +131,7 @@ export async function runServerSelfUpdate(
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        clearPoll();
         resolve(ok ? { ok: true } : { ok: false, error: lastLogLine(logPath, err) });
       };
       if (typeof child.once === "function") {
@@ -113,6 +146,26 @@ export async function runServerSelfUpdate(
 }
 
 export const SELF_UPDATE_WATCH_MS = 20_000;
+
+/**
+ * Parse a single `MANTA_PROGRESS <step>/<total> <label>` line emitted by
+ * scripts/self-update.sh into `{ step, total, label }`, or `null` when the
+ * line does not match / is malformed (step out of the 1..total range, total
+ * non-positive, non-finite numbers). Pure + tolerant of surrounding
+ * whitespace and null/undefined input.
+ *
+ * @param {unknown} line
+ * @returns {{ step: number, total: number, label: string } | null}
+ */
+export function parseProgressLine(line) {
+  const m = /^MANTA_PROGRESS (\d+)\/(\d+) (.+)$/.exec(String(line ?? "").trim());
+  if (!m) return null;
+  const step = Number(m[1]);
+  const total = Number(m[2]);
+  if (!Number.isFinite(step) || !Number.isFinite(total) || total <= 0) return null;
+  if (step < 1 || step > total) return null;
+  return { step, total, label: m[3].trim() };
+}
 
 // Last non-empty line of the self-update log, or a fallback derived from the
 // error/exit that triggered the failure report. Never throws.

--- a/src/server/opencodeAdmin.test.mjs
+++ b/src/server/opencodeAdmin.test.mjs
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
+import { restartOpencode, runServerSelfUpdate, parseProgressLine } from "./opencodeAdmin.mjs";
 import { statePath } from "../shared/paths.mjs";
 
 describe("restartOpencode", () => {
@@ -153,5 +153,105 @@ describe("runServerSelfUpdate", () => {
     assert.equal(result.ok, true);
     // And the child was detached + unref'd even though it kept running.
     assert.equal(calls[0].opts.detached, true);
+  });
+
+  it("publishes each new progress step in ascending order and never republishes one already sent", async () => {
+    // The self-update script emits `MANTA_PROGRESS <step>/<total> <label>`
+    // markers into its log; runServerSelfUpdate tails the log and republishes
+    // each strictly-increasing step as a `serverUpdateProgress` bus event.
+    const logPath = statePath("self-update.log");
+    mkdirSync(dirname(logPath), { recursive: true });
+    // Seed the log with three markers (and unrelated log noise). The poll runs
+    // every 500ms; with a longer timeout the first tick reads all three.
+    writeFileSync(
+      logPath,
+      [
+        "MANTA_PROGRESS 1/6 Checking for updates",
+        "▸ self-update: fetching origin/main",
+        "MANTA_PROGRESS 2/6 Downloading update",
+        "MANTA_PROGRESS 3/6 Installing dependencies",
+        "",
+      ].join("\n"),
+    );
+
+    const events = [];
+    const publish = (e) => events.push(e);
+
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    const spawn = () => {
+      // Exit cleanly a little after the first poll tick fires so the poller
+      // has a chance to read the seeded markers.
+      setTimeout(() => child.emit("exit", 0), 600);
+      return child;
+    };
+
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 5000,
+      publish,
+    });
+    assert.equal(result.ok, true);
+
+    const progress = events.filter((e) => e.kind === "serverUpdateProgress");
+    assert.equal(progress.length, 3);
+    assert.deepEqual(
+      progress.map((e) => e.payload.step),
+      [1, 2, 3],
+    );
+    assert.deepEqual(progress[0].payload, {
+      step: 1,
+      total: 6,
+      label: "Checking for updates",
+    });
+    assert.deepEqual(progress[2].payload, {
+      step: 3,
+      total: 6,
+      label: "Installing dependencies",
+    });
+  });
+
+  it("does not throw when publish is omitted (no polling)", async () => {
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    const spawn = () => {
+      setImmediate(() => setTimeout(() => child.emit("exit", 0), 0));
+      return child;
+    };
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 500,
+    });
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("parseProgressLine", () => {
+  it("parses a well-formed MANTA_PROGRESS line", () => {
+    assert.deepEqual(parseProgressLine("MANTA_PROGRESS 3/6 Installing dependencies"), {
+      step: 3,
+      total: 6,
+      label: "Installing dependencies",
+    });
+  });
+
+  it("returns null for a non-matching line, empty string, null and undefined", () => {
+    assert.equal(parseProgressLine("▸ self-update: fetching origin/main"), null);
+    assert.equal(parseProgressLine(""), null);
+    assert.equal(parseProgressLine(null), null);
+    assert.equal(parseProgressLine(undefined), null);
+  });
+
+  it("returns null when step > total and when step < 1", () => {
+    assert.equal(parseProgressLine("MANTA_PROGRESS 7/6 Too far"), null);
+    assert.equal(parseProgressLine("MANTA_PROGRESS 0/6 Zero"), null);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    assert.deepEqual(parseProgressLine("   MANTA_PROGRESS 2/6 Downloading update   "), {
+      step: 2,
+      total: 6,
+      label: "Downloading update",
+    });
   });
 });

--- a/src/server/opencodeAdmin.test.mjs
+++ b/src/server/opencodeAdmin.test.mjs
@@ -10,6 +10,20 @@ import { dirname } from "node:path";
 import { restartOpencode, runServerSelfUpdate, parseProgressLine } from "./opencodeAdmin.mjs";
 import { statePath } from "../shared/paths.mjs";
 
+// A fake detached child that exits with `code` once the caller has attached
+// its listeners. Shared because several cases differ ONLY in the exit code and
+// what they assert afterwards — inlining it three times is what the
+// duplication gate (rightly) flagged.
+function exitingChild(code) {
+  const child = new EventEmitter();
+  child.pid = 4242;
+  child.unref = () => {};
+  return () => {
+    setImmediate(() => setTimeout(() => child.emit("exit", code), 0));
+    return child;
+  };
+}
+
 describe("restartOpencode", () => {
   it("invokes systemctl --user restart opencode-serve with a fixed argv (no shell string)", async () => {
     const calls = [];
@@ -121,14 +135,7 @@ describe("runServerSelfUpdate", () => {
 
   it("resolves ok:true when the child exits zero fast", async () => {
     // An early clean exit ("already at version", no update needed) is success.
-    const child = new EventEmitter();
-    child.pid = 4242;
-    child.unref = () => {};
-    const spawn = () => {
-      setImmediate(() => setTimeout(() => child.emit("exit", 0), 0));
-      return child;
-    };
-    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", exitingChild(0), {
       timeoutMs: 500,
     });
     assert.equal(result.ok, true);
@@ -212,14 +219,7 @@ describe("runServerSelfUpdate", () => {
   });
 
   it("does not throw when publish is omitted (no polling)", async () => {
-    const child = new EventEmitter();
-    child.pid = 4242;
-    child.unref = () => {};
-    const spawn = () => {
-      setImmediate(() => setTimeout(() => child.emit("exit", 0), 0));
-      return child;
-    };
-    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", exitingChild(0), {
       timeoutMs: 500,
     });
     assert.equal(result.ok, true);

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -455,6 +455,15 @@ export interface Api {
     cb: (payload: ServerUpdateAvailablePayload) => void,
   ): () => void;
 
+  // Server-update progress subscription. While `scripts/self-update.sh` runs
+  // on the box, the server tails its log and republishes each `MANTA_PROGRESS
+  // <step>/<total> <label>` marker as a `serverUpdateProgress` bus event. The
+  // renderer's UpdateBar renders a determinate progress bar from these so the
+  // user sees the update advancing instead of a frozen button.
+  onServerUpdateProgress(
+    cb: (p: { step: number; total: number; label: string }) => void,
+  ): () => void;
+
   // Plugins (BET-189 / BET-190): read the current plugin registry the Mac
   // executor has published. Backed by GET /api/plugins/registry via the
   // `plugins:registry` RPC channel. Returns the rows verbatim — invalid


### PR DESCRIPTION
Fixes three problems with updating the box. Implemented by a delegated background job against a fixed spec; rebased onto `main`, reviewed and adjusted by me (see *Review changes* below).

## 1. The update left the AI tools inert

`self-update.sh` refreshed the opencode tools on disk and then only **printed advice** to restart opencode. So after every box update the refreshed tools sat there doing nothing until somebody manually restarted the service.

Now the script restarts opencode itself — unconditionally, via the same three-way supervisor branch already used for manta-server (systemctl → launchctl → warn), and non-fatally so a failed restart can't abort the update.

## 2. Clicking "Update & restart" gave no feedback whatsoever

The RPC returns the moment the script is spawned, so the UI had nothing to show. The script now emits six `MANTA_PROGRESS n/6 <label>` markers; the server tails its log, parses them, and republishes each new step on the bus; `UpdateBar` renders a determinate progress bar.

Only strictly-increasing steps are published, the poll interval is `unref()`d and cleared on both settle paths, and every read is defensive — a missing log can never throw. **The existing return contract and detached-spawn/watchdog behaviour are unchanged.**

## 3. A destructive restart happened without consent

Restarting opencode ends **every in-flight agent turn in every session**. That now sits behind an explicit confirm dialog before the update starts:

> **Update the box?**
> This restarts opencode, which will end every agent turn currently running in any session. Any unsaved work in a running turn is lost.

## Review changes I made on top

- **Rebase conflict resolved.** The job branched before #572 (Windows caption-button inset) landed and reverted that padding. Kept both: the progress bar *and* the Windows reservation.
- **Duplication gate.** Two test cases differed only by exit code — extracted `exitingChild(code)`. Gate now passes clean.
- **Documented a real edge case rather than papering over it.** The progress poller trusts that `self-update.sh` truncates its log as one of its first acts. I nearly "hardened" this by truncating before spawn — that breaks `lastLogLine`, which reads the log to report an early failure, so the comment now explicitly warns against it. The race is unreachable in practice (truncation happens within ms; first poll is 500ms in) and benign if it ever hit (no progress bar — today's behaviour).

## Tests

- `parseProgressLine` — well-formed, non-matching, empty, null/undefined, `step > total`, `step < 1`, surrounding whitespace
- progress publishing — three ascending steps, never republished; `publish` omitted → no throw
- `UpdateBar.test.tsx` (new) — default renders the action button and fires `onAction`; with `progress` renders `role="progressbar"` with correct aria and **no** action/dismiss buttons; width reflects step/total

`npm run typecheck` clean · 2079 renderer + 1472 server tests pass · `duplication-gate` PASS · `bash -n scripts/self-update.sh` clean.

`E2E Smoke Test` is red on `main` already (visual baseline drift) — not touched here, and no baselines were regenerated.