### PR TITLE
feat(channels): route box updates through MANTA_CHANNEL; give Windows the same tracks

### DIFF
--- a/.github/workflows/windows-desktop-build.yml
+++ b/.github/workflows/windows-desktop-build.yml
@@ -63,8 +63,17 @@ name: Windows desktop build
 on:
   push:
     tags:
+      # prod channel
       - "win-v*"
+      # staging channel — side-by-side install, staging URL scheme
+      - "win-staging-v*"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel to build"
+        type: choice
+        options: [prod, staging]
+        default: prod
 
 concurrency:
   group: windows-desktop-build
@@ -97,13 +106,57 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Resolve the channel ONCE, from the tag when there is one and from the
+      # dispatch input otherwise, and export it for every later step. A
+      # `win-staging-v*` tag is a staging release; `win-v*` is prod. This
+      # mirrors the mac workflow's MANTA_CHANNEL contract so the two platforms
+      # describe a release the same way.
+      - name: Resolve channel
+        id: channel
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF='${{ github.ref_name }}'
+          if [[ '${{ github.ref_type }}' == 'tag' ]]; then
+            case "$REF" in
+              win-staging-v*) CHANNEL=staging ;;
+              win-v*)         CHANNEL=prod ;;
+              *) echo "::error::tag '$REF' is neither win-v* nor win-staging-v*"; exit 1 ;;
+            esac
+          else
+            CHANNEL='${{ inputs.channel }}'
+            CHANNEL="${CHANNEL:-prod}"
+          fi
+          case "$CHANNEL" in prod|staging) ;; *) echo "::error::bad channel '$CHANNEL'"; exit 1 ;; esac
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "MANTA_CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
+          echo "Building the $CHANNEL channel"
+
+      # MANTA_CHANNEL is read by electron.vite.config.ts and baked in as
+      # __MANTA_CHANNEL__, which is what decides the app's URL scheme
+      # (manta:// vs manta-staging://) and its userData directory. Without it
+      # a "staging" build would still register the prod scheme and hijack
+      # prod pairing links.
       - name: Build renderer + main bundles
         run: npm run build
 
       - name: Build the installer
         # --publish never: emit latest.yml next to the .exe but upload
         # nothing. Same flag scripts/release/desktop.sh uses for mac/linux.
-        run: npx electron-builder --win --publish never
+        #
+        # Staging overlays electron-builder.staging.yml — a different appId and
+        # productName, so a staging build installs SIDE BY SIDE with prod on
+        # the same machine instead of upgrading over it. That overlay already
+        # existed for mac and its own comments already named Windows; this is
+        # the wiring it was waiting for.
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.channel.outputs.channel }}" = "staging" ]; then
+            npx electron-builder --win --publish never --config electron-builder.staging.yml
+          else
+            npx electron-builder --win --publish never
+          fi
 
       # Fail loudly rather than uploading an empty artifact. electron-builder
       # can exit 0 having produced nothing if a target is misconfigured.
@@ -146,11 +199,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
+          CHANNEL: ${{ steps.channel.outputs.channel }}
         run: |
           set -euo pipefail
+          if [ "$CHANNEL" = "staging" ]; then
+            TITLE="Manta UI for Windows (Staging) — $TAG"
+          else
+            TITLE="Manta UI for Windows — $TAG"
+          fi
           if ! gh release view "$TAG" >/dev/null 2>&1; then
             gh release create "$TAG" \
-              --title "Manta UI for Windows — $TAG" \
+              --title "$TITLE" \
               --prerelease \
               --notes 'Unsigned internal build. Windows SmartScreen will warn on first run: **More info → Run anyway**. Per-user install, no admin rights needed. Auto-update is not wired up for Windows — grab the next release from here.'
           fi

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -93,8 +93,29 @@ if [ "$INSTALL_KIND" = "git" ]; then
 else
   # packaged install — download + verify + extract the release tarball and
   # replace only the payload paths the release owns.
-  host="${MANTA_RELEASE_HOST:-https://mantaui.com}"
+  # Channel-derived release host. This default used to be an unconditional
+  # `https://mantaui.com`, so a box installed with MANTA_CHANNEL=staging
+  # fetched the PROD manifest and updated itself onto PROD builds — the
+  # staging track was published but no box could ever follow it.
+  #
+  # Mirrors `releaseHost` in src/shared/channel.mjs (prod →
+  # https://mantaui.com, staging → https://mantaui.com/staging). Kept as a
+  # small case rather than shelling out to node so this still works when the
+  # bundled runtime is mid-replacement. `dev` maps to the prod host on
+  # purpose: a dev box is a git checkout, which takes the git branch above and
+  # never reaches this code at all.
+  #
+  # MANTA_CHANNEL reaches us from the environment of whoever spawned this
+  # script — manta-server inherits it from its own systemd unit / LaunchAgent,
+  # which install.sh renders with the channel it installed. An unset value
+  # falls back to prod, matching install.sh's own default.
+  case "${MANTA_CHANNEL:-prod}" in
+    staging) channel_release_host="https://mantaui.com/staging" ;;
+    *)       channel_release_host="https://mantaui.com" ;;
+  esac
+  host="${MANTA_RELEASE_HOST:-$channel_release_host}"
   host="${host%/}"
+  log "self-update: channel=${MANTA_CHANNEL:-prod} release host=$host"
 
   INSTALLED_VERSION="$("$NODE_CMD" -e 'process.stdout.write((JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)||"")' "$MANTA_HOME/RELEASE.json")"
 

--- a/src/server/pairPage.mjs
+++ b/src/server/pairPage.mjs
@@ -16,7 +16,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import QRCode from "qrcode";
 import { isPrivateServerUrl } from "../shared/transport.mjs";
-import { channelConfig } from "../shared/channel.mjs";
+import { channelConfig, resolveBoxChannel as sharedResolveBoxChannel } from "../shared/channel.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -40,13 +40,10 @@ export const CODE_RE = /^\d{6}$/;
  * cheap, and tests rely on being able to mutate the env between cases.
  */
 export function resolveBoxChannel() {
-  const raw =
-    typeof process !== "undefined" && process.env
-      ? process.env.MANTA_CHANNEL ?? ""
-      : "";
-  // channelConfig handles the unknown-channel → prod fallback (same rule
-  // as resolveChannel: a bad lookup must still return a usable config).
-  return channelConfig(raw || "prod");
+  // Re-exported from src/shared/channel.mjs, which is now the single home for
+  // it (the self-updater reads it too). Kept as a named export here so the
+  // existing pairPage callers and tests are untouched.
+  return sharedResolveBoxChannel();
 }
 
 /**

--- a/src/server/serverUpdate.mjs
+++ b/src/server/serverUpdate.mjs
@@ -17,12 +17,32 @@
 // fetch failure path are testable without timers, network, or live `push`.
 
 import { isUpdateAvailable } from "../shared/versionCompare.mjs";
+import { resolveBoxChannel } from "../shared/channel.mjs";
 
 const POLL_MS = 6 * 60 * 60 * 1000; // 6h, per the stage-2 spec.
 
-// Hardcoded by design — the update endpoint is part of the deployed website
-// (website/updates/server.json) and is not user-configurable. A box should not
-// be able to override where it learns about a new release.
+// Not user-configurable — the update endpoint is part of the deployed website
+// (website/updates/server.json) and a box must not be able to point itself at
+// an arbitrary source. It IS channel-derived, though.
+//
+// This used to be a hardcoded prod URL, which quietly broke the staging track:
+// a box installed with MANTA_CHANNEL=staging checked the PROD manifest and
+// therefore updated itself onto PROD builds. The staging server track was
+// published and live but nothing could ever follow it — which is why staging
+// sat versions behind with no one noticing.
+//
+// `channelConfig().updateFeed` is the single source for this (prod →
+// /updates, staging → /staging/updates, dev → null). `null` means "this build
+// has no update feed": see startServerUpdatePoller, which skips polling
+// entirely rather than inventing a URL. A local/dev box chasing a public feed
+// is exactly what you don't want.
+export function manifestUrl(channel = resolveBoxChannel()) {
+  const feed = channel?.updateFeed;
+  return feed ? `${feed}/server.json` : null;
+}
+
+/** Back-compat alias for the prod URL — kept because tests and callers import
+ *  it as the default. Prefer `manifestUrl()`, which respects the channel. */
 export const MANIFEST_URL = "https://mantaui.com/updates/server.json";
 
 /**
@@ -58,14 +78,21 @@ export async function defaultFetchManifest(url = MANIFEST_URL) {
  * @param {string} deps.currentVersion
  * @returns {{ tick: () => Promise<{available:boolean, version?:string, notesUrl?:string|null}> }}
  */
-export function createUpdateCheck({ fetchManifest, currentVersion }) {
+export function createUpdateCheck({ fetchManifest, currentVersion, url }) {
   let inFlight = false;
+  // Channel-derived by default (prod → /updates, staging → /staging/updates).
+  // `null` means this build has no feed — see tick().
+  const feedUrl = url === undefined ? manifestUrl() : url;
 
   async function tick() {
     if (inFlight) return { available: false };
+    // A dev build has `updateFeed: null`. Report "no update" rather than
+    // falling back to the prod feed: a local build must never talk a real box
+    // into installing a public release over it.
+    if (!feedUrl) return { available: false };
     inFlight = true;
     try {
-      const manifest = await fetchManifest(MANIFEST_URL);
+      const manifest = await fetchManifest(feedUrl);
       if (!manifest || typeof manifest.version !== "string") {
         return { available: false };
       }

--- a/src/server/serverUpdate.test.mjs
+++ b/src/server/serverUpdate.test.mjs
@@ -322,51 +322,44 @@ test("poller: stop() clears the interval timer", async () => {
 // noticed, because the failure is silent and looks exactly like "no update".
 // ---------------------------------------------------------------------------
 
-test("manifestUrl: prod → the prod feed", () => {
+// Run `fn` with MANTA_CHANNEL set to `value` (or unset when null), always
+// restoring the previous value. Shared because these cases differ only in the
+// channel and the expected URL — repeating the save/restore dance per test is
+// what the duplication gate flagged.
+function withChannel(value, fn) {
   const prev = process.env.MANTA_CHANNEL;
-  process.env.MANTA_CHANNEL = "prod";
+  if (value === null) delete process.env.MANTA_CHANNEL;
+  else process.env.MANTA_CHANNEL = value;
   try {
-    assert.equal(manifestUrl(), "https://mantaui.com/updates/server.json");
+    fn();
   } finally {
     if (prev === undefined) delete process.env.MANTA_CHANNEL;
     else process.env.MANTA_CHANNEL = prev;
   }
-});
+}
 
-test("manifestUrl: REGRESSION — staging → the STAGING feed, not prod", () => {
-  const prev = process.env.MANTA_CHANNEL;
-  process.env.MANTA_CHANNEL = "staging";
-  try {
-    assert.equal(manifestUrl(), "https://mantaui.com/staging/updates/server.json");
-  } finally {
-    if (prev === undefined) delete process.env.MANTA_CHANNEL;
-    else process.env.MANTA_CHANNEL = prev;
-  }
-});
+const PROD_FEED = "https://mantaui.com/updates/server.json";
 
-test("manifestUrl: dev has no feed at all (null, never a prod fallback)", () => {
-  const prev = process.env.MANTA_CHANNEL;
-  process.env.MANTA_CHANNEL = "dev";
-  try {
-    assert.equal(manifestUrl(), null);
-  } finally {
-    if (prev === undefined) delete process.env.MANTA_CHANNEL;
-    else process.env.MANTA_CHANNEL = prev;
-  }
-});
-
-test("manifestUrl: unset / unrecognised channel falls back to prod", () => {
-  const prev = process.env.MANTA_CHANNEL;
-  delete process.env.MANTA_CHANNEL;
-  try {
-    assert.equal(manifestUrl(), "https://mantaui.com/updates/server.json");
-    process.env.MANTA_CHANNEL = "banana";
-    assert.equal(manifestUrl(), "https://mantaui.com/updates/server.json");
-  } finally {
-    if (prev === undefined) delete process.env.MANTA_CHANNEL;
-    else process.env.MANTA_CHANNEL = prev;
-  }
-});
+// prod / staging / dev / unset / garbage, in one table. The staging row is THE
+// regression: it used to resolve to PROD_FEED, so a staging box updated itself
+// onto prod builds.
+for (const { name, channel, expected } of [
+  { name: "prod → the prod feed", channel: "prod", expected: PROD_FEED },
+  {
+    name: "REGRESSION staging → the STAGING feed, not prod",
+    channel: "staging",
+    expected: "https://mantaui.com/staging/updates/server.json",
+  },
+  { name: "dev has no feed at all (null, never a prod fallback)", channel: "dev", expected: null },
+  { name: "unset falls back to prod", channel: null, expected: PROD_FEED },
+  { name: "unrecognised falls back to prod", channel: "banana", expected: PROD_FEED },
+]) {
+  test(`manifestUrl: ${name}`, () => {
+    withChannel(channel, () => {
+      assert.equal(manifestUrl(), expected);
+    });
+  });
+}
 
 test("createUpdateCheck fetches the channel's feed, not a hardcoded one", async () => {
   const seen = [];

--- a/src/server/serverUpdate.test.mjs
+++ b/src/server/serverUpdate.test.mjs
@@ -21,6 +21,7 @@ import {
   createUpdateCheck,
   startServerUpdatePoller,
   MANIFEST_URL,
+  manifestUrl,
 } from "./serverUpdate.mjs";
 
 function fakeBus() {
@@ -309,4 +310,90 @@ test("poller: stop() clears the interval timer", async () => {
       `stop() should clear the interval (before=${handlesBefore} after=${handlesAfter})`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// Channel routing.
+//
+// THE BUG THIS LOCKS IN: the manifest URL was a hardcoded prod constant, so a
+// box installed with MANTA_CHANNEL=staging checked the PROD manifest and
+// updated itself onto PROD builds. The staging track was published and live,
+// but nothing could follow it — staging drifted versions behind and no one
+// noticed, because the failure is silent and looks exactly like "no update".
+// ---------------------------------------------------------------------------
+
+test("manifestUrl: prod → the prod feed", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "prod";
+  try {
+    assert.equal(manifestUrl(), "https://mantaui.com/updates/server.json");
+  } finally {
+    if (prev === undefined) delete process.env.MANTA_CHANNEL;
+    else process.env.MANTA_CHANNEL = prev;
+  }
+});
+
+test("manifestUrl: REGRESSION — staging → the STAGING feed, not prod", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "staging";
+  try {
+    assert.equal(manifestUrl(), "https://mantaui.com/staging/updates/server.json");
+  } finally {
+    if (prev === undefined) delete process.env.MANTA_CHANNEL;
+    else process.env.MANTA_CHANNEL = prev;
+  }
+});
+
+test("manifestUrl: dev has no feed at all (null, never a prod fallback)", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  process.env.MANTA_CHANNEL = "dev";
+  try {
+    assert.equal(manifestUrl(), null);
+  } finally {
+    if (prev === undefined) delete process.env.MANTA_CHANNEL;
+    else process.env.MANTA_CHANNEL = prev;
+  }
+});
+
+test("manifestUrl: unset / unrecognised channel falls back to prod", () => {
+  const prev = process.env.MANTA_CHANNEL;
+  delete process.env.MANTA_CHANNEL;
+  try {
+    assert.equal(manifestUrl(), "https://mantaui.com/updates/server.json");
+    process.env.MANTA_CHANNEL = "banana";
+    assert.equal(manifestUrl(), "https://mantaui.com/updates/server.json");
+  } finally {
+    if (prev === undefined) delete process.env.MANTA_CHANNEL;
+    else process.env.MANTA_CHANNEL = prev;
+  }
+});
+
+test("createUpdateCheck fetches the channel's feed, not a hardcoded one", async () => {
+  const seen = [];
+  const check = createUpdateCheck({
+    currentVersion: "0.0.1",
+    url: "https://mantaui.com/staging/updates/server.json",
+    fetchManifest: async (u) => {
+      seen.push(u);
+      return { version: "9.9.9" };
+    },
+  });
+  const res = await check.tick();
+  assert.deepEqual(seen, ["https://mantaui.com/staging/updates/server.json"]);
+  assert.equal(res.available, true);
+});
+
+test("createUpdateCheck on a feedless (dev) build reports no update and never fetches", async () => {
+  let called = 0;
+  const check = createUpdateCheck({
+    currentVersion: "0.0.1",
+    url: null,
+    fetchManifest: async () => {
+      called++;
+      return { version: "9.9.9" };
+    },
+  });
+  const res = await check.tick();
+  assert.equal(res.available, false);
+  assert.equal(called, 0, "a dev build must not reach for a public feed");
 });

--- a/src/shared/channel.mjs
+++ b/src/shared/channel.mjs
@@ -116,3 +116,27 @@ export function channelConfig(channel) {
   }
   return CHANNELS[PROD_CHANNEL];
 }
+
+/**
+ * The channel THIS box process was installed for, read from
+ * `process.env.MANTA_CHANNEL` (install.sh bakes it into the systemd unit /
+ * LaunchAgent plist).
+ *
+ * Lives here rather than in any one consumer because it is now read by two
+ * unrelated subsystems — the pairing QR (which needs the channel's URL scheme)
+ * and the self-updater (which needs its release host + update feed). It began
+ * in pairPage.mjs, and while it stayed there the updater simply hardcoded
+ * prod, which is what silently stranded the staging track.
+ *
+ * Falls back to `prod` for an unset or unrecognised value: a mis-configured
+ * box must still pair and still update, not throw at request time. Re-reads
+ * the env on every call rather than memoizing — it is cheap, and tests mutate
+ * the env between cases.
+ */
+export function resolveBoxChannel() {
+  const raw =
+    typeof process !== "undefined" && process.env
+      ? process.env.MANTA_CHANNEL ?? ""
+      : "";
+  return channelConfig(raw || "prod");
+}


### PR DESCRIPTION
## The bug this started from

**A staging box updated itself onto prod builds.**

`MANTA_CHANNEL` (`prod|staging|dev`) already existed, was already resolved at install time, and was already baked into the box's service definition. But it drove exactly one thing — the pairing link's URL scheme. Both update paths ignored it:

```
serverUpdate.mjs:  MANIFEST_URL = "https://mantaui.com/updates/server.json"
self-update.sh:    host="${MANTA_RELEASE_HOST:-https://mantaui.com}"
```

So a box installed with `MANTA_CHANNEL=staging` checked the **prod** manifest and installed **prod** tarballs. The staging server track is published and live, but **nothing could follow it**.

That's why staging sits at `0.0.17` while prod is on `0.0.19` and nobody noticed: the failure is silent and looks exactly like "no update available".

## No new channel system

The table in `src/shared/channel.mjs` already carries `releaseHost` and `updateFeed` per channel — including `updateFeed: null` for `dev`. This just makes the update paths read from it.

| channel | update feed | release host |
|---|---|---|
| prod | `/updates` | `mantaui.com` |
| staging | `/staging/updates` | `mantaui.com/staging` |
| dev | **none** | n/a |

**`dev` answers the "what about local builds" question by doing nothing:** a feedless build reports "no update" and never fetches, so a local build can't talk a box into installing a public release over itself.

`resolveBoxChannel()` moves from `pairPage.mjs` to `src/shared/channel.mjs` now that two unrelated subsystems read it (pairing re-exports it, so its callers and tests are untouched). Leaving it in the pairing module is precisely what let the updater get away with hardcoding prod.

`self-update.sh` now logs its resolved channel and host — the old failure was invisible.

## Windows gets the same two tracks

Still published as **GitHub releases** — the unsigned installer stays off the public download page, as agreed.

- `win-v*` → prod, `win-staging-v*` → staging, or `workflow_dispatch` with a `channel` input. One resolve step decides and rejects an unrecognised tag.
- `MANTA_CHANNEL` is exported **before** `npm run build` so electron-vite bakes `__MANTA_CHANNEL__`. Without it a "staging" build would register the prod `manta://` scheme and **hijack prod pairing links**.
- Staging overlays `electron-builder.staging.yml` (different appId + productName) so it installs **side by side** with prod. That overlay already existed for mac and its own comments already named Windows — this is the wiring it was waiting for.

## Tests

`manifestUrl` per channel (prod, staging, `dev` → null, unset/garbage → prod), `createUpdateCheck` honouring the resolved feed, and a dev build never fetching.

`npm run typecheck` clean · 2079 renderer + 991 server tests pass · `duplication-gate` PASS · `bash -n scripts/self-update.sh` clean · workflow YAML validated.

## Not included

**iOS.** TestFlight *is* staging and the App Store *is* prod, so it needs no infrastructure — only the channel baked into the build. Worth doing, but it's a Codemagic + Info.plist change with its own signing surface, so it belongs in its own PR rather than riding along here.