### PR TITLE
fix(chat): the transcript animates new messages, and only new messages

### DIFF
--- a/src/renderer/MessageBubble.test.tsx
+++ b/src/renderer/MessageBubble.test.tsx
@@ -11,10 +11,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { mount, type Harness } from "./testHarness";
-import { MessageBubble } from "./MessageBubble";
-
-const BUBBLE_CHROME =
-  "bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words manta-bubble-in";
+import { BUBBLE_CHROME, MessageBubble } from "./MessageBubble";
 
 describe("MessageBubble", () => {
   let h: Harness | null = null;
@@ -43,5 +40,19 @@ describe("MessageBubble", () => {
     const bubble = wrapper.firstElementChild as HTMLElement;
     expect(bubble.className).toBe(BUBBLE_CHROME);
     expect(bubble.textContent).toBe("Hello");
+  });
+
+  // The send animation must be OPT-IN. It shipped unconditional, so opening
+  // any session popped every bubble in the transcript at once.
+  it("does not animate by default — a loaded transcript stays still", () => {
+    h = mount(<MessageBubble>Hello</MessageBubble>);
+    const bubble = h.container.querySelector(".flex.justify-end > div") as HTMLElement;
+    expect(bubble.className).not.toContain("manta-bubble-in");
+  });
+
+  it("animates the send only when the message arrived live", () => {
+    h = mount(<MessageBubble entering>Hello</MessageBubble>);
+    const bubble = h.container.querySelector(".flex.justify-end > div") as HTMLElement;
+    expect(bubble.className).toContain("manta-bubble-in");
   });
 });

--- a/src/renderer/MessageBubble.tsx
+++ b/src/renderer/MessageBubble.tsx
@@ -27,10 +27,25 @@
 
 import type { ReactNode } from "react";
 
-export function MessageBubble({ children }: { children: ReactNode }) {
+export const BUBBLE_CHROME =
+  "bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text " +
+  "max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words";
+
+export function MessageBubble({
+  children,
+  entering = false,
+}: {
+  children: ReactNode;
+  // The iMessage-style send pop, and the ONE thing that must stay gated: this
+  // class used to be unconditional, so every bubble in a transcript the user
+  // merely opened popped on mount and a session switch replayed every send
+  // they had ever made. Only a message that arrives while they are watching
+  // animates (decided in Transcript, see `updateEntryMotion`).
+  entering?: boolean;
+}) {
   return (
     <div className="flex justify-end">
-      <div className="bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text max-w-[min(88%,var(--measure))] whitespace-pre-wrap break-words manta-bubble-in">
+      <div className={entering ? BUBBLE_CHROME + " manta-bubble-in" : BUBBLE_CHROME}>
         {children}
       </div>
     </div>

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -252,22 +252,20 @@ export const MessageRow = memo(function MessageRow({
   // trailing caret on its final text part (BET-649). Primitive prop, so the
   // MessageRow memo chain is untouched.
   streaming?: boolean;
-  // True when this row mounted live at the tail of the transcript AFTER the
-  // initial load (transcript-motion). Drives the whole-row slide-up entry; a
-  // session switch (all rows remount) is NOT `entering`, so history never
-  // replays its entrance. The user bubble gets its own send animation inside
-  // MessageBubble, and the streaming row animates its blocks instead, so
-  // `entering` only applies the row slide to settled assistant/card rows.
-  // Primitive prop — memo chain untouched.
+  // True when this message ARRIVED while the user was watching, as opposed to
+  // being part of the transcript they loaded (transcript-motion). Decided once
+  // in Transcript by `updateEntryMotion` and sticky for the row's whole life —
+  // an earlier version recomputed it per render, which tore the animation's
+  // class off one frame after it started and made the effect invisible.
+  //
+  // The row itself never animates: the user bubble pops (MessageBubble) and an
+  // assistant row's PARTS slide in individually (AssistantPart), because during
+  // a live turn those parts appear one at a time and sliding the container
+  // would mean animating a box that is already on screen. Primitive prop, so
+  // the MessageRow memo chain is untouched.
   entering?: boolean;
 }) {
   const isUser = msg.info.role === "user";
-
-  // Whole-row entry motion for newly-mounted, settled assistant rows. The
-  // streaming message's blocks animate via .manta-streaming instead; the user
-  // bubble animates via .manta-bubble-in inside MessageBubble. Reduced-motion
-  // kills the animation in CSS.
-  const rowMotion = entering && !isUser && !streaming ? " manta-row-in" : "";
 
   // Subtle wall-clock timestamp for each message/action. Sourced from the
   // message's own time.created — no new prop, so the MessageRow memo chain is
@@ -291,7 +289,7 @@ export const MessageRow = memo(function MessageRow({
   // commands, paths and output), 10px, tabular so the digits don't jitter.
   const ts = formatClockTime(msg.info.time?.created);
   const stampedRow = (children: React.ReactNode) => (
-    <div className={"group relative" + rowMotion}>
+    <div className="group relative">
       {ts && (
         <span
           className={
@@ -361,7 +359,7 @@ export const MessageRow = memo(function MessageRow({
               expandedText={text}
             />
           ) : (
-            <MessageBubble>{text}</MessageBubble>
+            <MessageBubble entering={entering}>{text}</MessageBubble>
           )
         )}
       </div>,
@@ -395,6 +393,9 @@ export const MessageRow = memo(function MessageRow({
           // Only the LAST part of the message being written streams — an
           // earlier part is finished even while the turn continues.
           streaming={streaming && i === visibleParts.length - 1}
+          // Slide this part in only when the whole message is new to the user.
+          // A loaded transcript passes `entering=false`, so history is still.
+          entering={entering}
         />
       ))}
       {/* Turn-level duration footer — only on the FINAL assistant message */}

--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -67,6 +67,7 @@ export const AssistantPart = memo(function AssistantPart({
   part,
   showThinking,
   streaming = false,
+  entering = false,
 }: {
   part: OpencodePart;
   showThinking: boolean;
@@ -76,7 +77,31 @@ export const AssistantPart = memo(function AssistantPart({
   // the memo chain is untouched; false everywhere else, so a settled transcript
   // never animates and never shows a caret.
   streaming?: boolean;
+  // True when the parent message ARRIVED while the user was watching, so this
+  // part should slide up as it appears (transcript-motion). This is where the
+  // "cards slide in" effect actually lives: during a turn the parts of one
+  // assistant message mount one at a time, so the PART is the unit that enters,
+  // not the row. A loaded transcript passes false and stays still.
+  entering?: boolean;
 }) {
+  const body = renderAssistantPart(part, showThinking, streaming);
+  // The streaming text part is exempt: its markdown blocks already fade in
+  // individually via `.manta-streaming > *`, and sliding the whole container on
+  // top of that would animate the same content twice.
+  //
+  // The slide goes on a WRAPPER rather than the part's own root because the
+  // roots are shared primitives (ToolCard, OutputWell) that deliberately expose
+  // no className escape hatch. The wrapper is a plain block inside the row's
+  // existing flex column, so it inherits the gap and changes no layout.
+  if (body == null || !entering || streaming) return body;
+  return <div className="manta-part-in">{body}</div>;
+});
+
+function renderAssistantPart(
+  part: OpencodePart,
+  showThinking: boolean,
+  streaming: boolean,
+): React.ReactElement | null {
   if (part.type === "text") {
     const text = (part.text ?? "").replace(/^\n+|\n+$/g, "");
     if (!text) return null;
@@ -154,7 +179,7 @@ export const AssistantPart = memo(function AssistantPart({
   }
 
   return <ToolCard name={part.type} />;
-});
+}
 
 // ===== Tool call rendering =====
 //

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -59,6 +59,21 @@ function props(messages: OpencodeMessage[], running = false): TranscriptProps {
 const bubblesIn = (h: Harness) => h.container.querySelectorAll(".manta-bubble-in").length;
 const partsIn = (h: Harness) => h.container.querySelectorAll(".manta-part-in").length;
 
+// The transcript a session opens with: already on screen, never animated.
+const HISTORY = [msg("u1", "user", "first"), msg("a1", "assistant", "reply")];
+// What a send appends before the server answers.
+const OPTIMISTIC = msg("optimistic-user-1", "user", "new");
+
+/** Mount an opened session, i.e. everything here counts as history. */
+function open(messages: OpencodeMessage[] = HISTORY): Harness {
+  return mount(<Transcript {...props(messages)} />);
+}
+
+/** Push one more render of `messages` through the mounted transcript. */
+function render(h: Harness, messages: OpencodeMessage[], running = false): void {
+  h.rerender(<Transcript {...props(messages, running)} />);
+}
+
 describe("Transcript entry motion", () => {
   let h: Harness | null = null;
   afterEach(() => {
@@ -68,29 +83,15 @@ describe("Transcript entry motion", () => {
 
   it("opens a loaded transcript completely still", () => {
     // The reported symptom: opening a session replayed every user bubble.
-    h = mount(
-      <Transcript
-        {...props([
-          msg("u1", "user", "first"),
-          msg("a1", "assistant", "reply"),
-          msg("u2", "user", "second"),
-          msg("a2", "assistant", "reply two"),
-        ])}
-      />,
-    );
+    h = open([...HISTORY, msg("u2", "user", "second"), msg("a2", "assistant", "reply two")]);
     expect(bubblesIn(h)).toBe(0);
     expect(partsIn(h)).toBe(0);
   });
 
   it("pops the bubble for a message sent right now", () => {
-    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
+    h = open();
     expect(bubblesIn(h)).toBe(0);
-
-    h.rerender(
-      <Transcript
-        {...props([msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")], true)}
-      />,
-    );
+    render(h, [...HISTORY, OPTIMISTIC], true);
     expect(bubblesIn(h)).toBe(1);
   });
 
@@ -98,23 +99,16 @@ describe("Transcript entry motion", () => {
     // This is the regression that made the feature invisible: the flag lasted
     // exactly one render, and a streaming turn re-renders every few ms, so the
     // class was pulled off roughly one frame after the animation started.
-    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
-    const sent = [msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")];
-    h.rerender(<Transcript {...props(sent, true)} />);
-    for (let i = 0; i < 20; i++) h.rerender(<Transcript {...props(sent, true)} />);
+    h = open();
+    const sent = [...HISTORY, OPTIMISTIC];
+    for (let i = 0; i < 20; i++) render(h, sent, true);
     expect(bubblesIn(h)).toBe(1);
   });
 
   it("does not pop a second time when the canonical message replaces the placeholder", () => {
-    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
-    h.rerender(
-      <Transcript
-        {...props([msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")], true)}
-      />,
-    );
-    h.rerender(
-      <Transcript {...props([msg("u1", "user", "first"), msg("msg_real", "user", "new")], true)} />,
-    );
+    h = open();
+    render(h, [...HISTORY, OPTIMISTIC], true);
+    render(h, [...HISTORY, msg("msg_real", "user", "new")], true);
     expect(bubblesIn(h)).toBe(0);
   });
 
@@ -122,33 +116,22 @@ describe("Transcript entry motion", () => {
     // The whole point of the rewrite. The previous shape exempted the row
     // while it was streaming and considered it old once it was not, so this
     // count was 0 at every step of the sequence.
-    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
-    const sent = [msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")];
-    h.rerender(<Transcript {...props(sent, true)} />);
+    h = open();
+    render(h, [...HISTORY, OPTIMISTIC], true);
 
-    const streaming = [...sent, msg("a1", "assistant", "writing")];
-    h.rerender(<Transcript {...props(streaming, true)} />);
+    const streaming = [...HISTORY, OPTIMISTIC, msg("a_new", "assistant", "writing")];
+    render(h, streaming, true);
     // Mid-stream the text part animates its own blocks (.manta-streaming), so
     // the part wrapper deliberately stays out of it.
     expect(partsIn(h)).toBe(0);
 
-    h.rerender(<Transcript {...props(streaming, false)} />);
+    render(h, streaming, false);
     expect(partsIn(h)).toBe(1);
   });
 
   it("leaves history still even after new messages have arrived", () => {
-    h = mount(
-      <Transcript {...props([msg("u1", "user", "first"), msg("a1", "assistant", "reply")])} />,
-    );
-    h.rerender(
-      <Transcript
-        {...props([
-          msg("u1", "user", "first"),
-          msg("a1", "assistant", "reply"),
-          msg("u2", "user", "second"),
-        ])}
-      />,
-    );
+    h = open();
+    render(h, [...HISTORY, msg("u2", "user", "second")]);
     // Exactly the new one — the two rows already on screen are untouched.
     expect(bubblesIn(h)).toBe(1);
     expect(partsIn(h)).toBe(0);

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+//
+// Entry-motion wiring for the transcript (transcript-motion).
+//
+// These are DOM tests, not logic tests, and that distinction is the whole
+// reason the file exists. The gate's pure logic is covered in
+// chatUtils.test.ts; what shipped broken was the WIRING around it. The first
+// version of this feature was merged with a test that asserted a class-name
+// string on a component and nothing else, and it hid two failures that only a
+// mounted transcript can see:
+//
+//   - The animation class was computed for a row that was, at that instant,
+//     rendering nothing (an assistant message with no parts yet) and was
+//     classified as "no longer new" by the time it had content. The class
+//     therefore never reached a visible element in the real send → stream →
+//     settle sequence, in any of its three steps.
+//   - The user bubble's class was unconditional, so it was present on rows
+//     that had merely been loaded from history.
+//
+// So every assertion below queries the rendered DOM after driving the actual
+// message sequence ChatPanel produces.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createRef } from "react";
+import { mount, type Harness } from "./testHarness";
+import { Transcript, type TranscriptProps } from "./Transcript";
+import type { OpencodeMessage } from "../shared/types";
+
+function msg(id: string, role: "user" | "assistant", text: string): OpencodeMessage {
+  return {
+    info: { id, sessionID: "s1", role, time: { created: 1_700_000_000_000 } },
+    parts: [{ id: `${id}-p0`, messageID: id, type: "text", text }],
+  } as unknown as OpencodeMessage;
+}
+
+function props(messages: OpencodeMessage[], running = false): TranscriptProps {
+  return {
+    messages,
+    scrollRef: createRef<HTMLDivElement>(),
+    questionCardRef: createRef<HTMLDivElement>(),
+    taskContextValue: {
+      childMessages: new Map(),
+      liveChildStatus: new Map(),
+      expandedTasks: new Set(),
+      toggleTask: () => {},
+    } as unknown as TranscriptProps["taskContextValue"],
+    showThinking: false,
+    running,
+    activeTodos: null,
+    questions: [],
+    turnInfo: new Map(),
+    finishByMessageId: new Map(),
+    userCommandInfo: new Map(),
+    onReplyQuestion: () => {},
+    onRejectQuestion: () => {},
+  };
+}
+
+const bubblesIn = (h: Harness) => h.container.querySelectorAll(".manta-bubble-in").length;
+const partsIn = (h: Harness) => h.container.querySelectorAll(".manta-part-in").length;
+
+describe("Transcript entry motion", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("opens a loaded transcript completely still", () => {
+    // The reported symptom: opening a session replayed every user bubble.
+    h = mount(
+      <Transcript
+        {...props([
+          msg("u1", "user", "first"),
+          msg("a1", "assistant", "reply"),
+          msg("u2", "user", "second"),
+          msg("a2", "assistant", "reply two"),
+        ])}
+      />,
+    );
+    expect(bubblesIn(h)).toBe(0);
+    expect(partsIn(h)).toBe(0);
+  });
+
+  it("pops the bubble for a message sent right now", () => {
+    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
+    expect(bubblesIn(h)).toBe(0);
+
+    h.rerender(
+      <Transcript
+        {...props([msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")], true)}
+      />,
+    );
+    expect(bubblesIn(h)).toBe(1);
+  });
+
+  it("keeps the send animation through the re-render storm of a live turn", () => {
+    // This is the regression that made the feature invisible: the flag lasted
+    // exactly one render, and a streaming turn re-renders every few ms, so the
+    // class was pulled off roughly one frame after the animation started.
+    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
+    const sent = [msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")];
+    h.rerender(<Transcript {...props(sent, true)} />);
+    for (let i = 0; i < 20; i++) h.rerender(<Transcript {...props(sent, true)} />);
+    expect(bubblesIn(h)).toBe(1);
+  });
+
+  it("does not pop a second time when the canonical message replaces the placeholder", () => {
+    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
+    h.rerender(
+      <Transcript
+        {...props([msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")], true)}
+      />,
+    );
+    h.rerender(
+      <Transcript {...props([msg("u1", "user", "first"), msg("msg_real", "user", "new")], true)} />,
+    );
+    expect(bubblesIn(h)).toBe(0);
+  });
+
+  it("slides in the assistant's parts once its turn settles", () => {
+    // The whole point of the rewrite. The previous shape exempted the row
+    // while it was streaming and considered it old once it was not, so this
+    // count was 0 at every step of the sequence.
+    h = mount(<Transcript {...props([msg("u1", "user", "first")])} />);
+    const sent = [msg("u1", "user", "first"), msg("optimistic-user-1", "user", "new")];
+    h.rerender(<Transcript {...props(sent, true)} />);
+
+    const streaming = [...sent, msg("a1", "assistant", "writing")];
+    h.rerender(<Transcript {...props(streaming, true)} />);
+    // Mid-stream the text part animates its own blocks (.manta-streaming), so
+    // the part wrapper deliberately stays out of it.
+    expect(partsIn(h)).toBe(0);
+
+    h.rerender(<Transcript {...props(streaming, false)} />);
+    expect(partsIn(h)).toBe(1);
+  });
+
+  it("leaves history still even after new messages have arrived", () => {
+    h = mount(
+      <Transcript {...props([msg("u1", "user", "first"), msg("a1", "assistant", "reply")])} />,
+    );
+    h.rerender(
+      <Transcript
+        {...props([
+          msg("u1", "user", "first"),
+          msg("a1", "assistant", "reply"),
+          msg("u2", "user", "second"),
+        ])}
+      />,
+    );
+    // Exactly the new one — the two rows already on screen are untouched.
+    expect(bubblesIn(h)).toBe(1);
+    expect(partsIn(h)).toBe(0);
+  });
+});

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -27,7 +27,12 @@ import { TaskContext, type TaskContextValue } from "./chatShared";
 import { MeasureColumn } from "./MeasureColumn";
 import { ActiveTodos, MessageRow } from "./MessageRow";
 import { QuestionCard } from "./Cards";
-import { isBackgroundJobCompletionTurn } from "./chatUtils";
+import {
+  createEntryMotionState,
+  isBackgroundJobCompletionTurn,
+  updateEntryMotion,
+  type EntryMotionState,
+} from "./chatUtils";
 
 export type TranscriptProps = {
   messages: OpencodeMessage[];
@@ -62,41 +67,21 @@ export function Transcript({
   onReplyQuestion,
   onRejectQuestion,
 }: TranscriptProps) {
-  // Entry-motion tracking (transcript-motion): rows mount live at the tail of
-  // the transcript (a message just sent, an assistant turn that reconciles in
-  // as a whole) should animate a slide-up entry, but the FULL transcript must
-  // NOT replay its entrance on a session switch or the first load. `seen` is
-  // primed with the ids present on the first render where messages become
-  // non-empty, so exactly the rows appended AFTER that prime get `entering`.
+  // Entry motion (transcript-motion). A message that arrives while the user is
+  // watching animates in; a transcript they merely LOADED does not. The whole
+  // gate lives in `updateEntryMotion` (chatUtils, pure + tested) — see the
+  // comment there for the two invariants (primed / sticky) and the two earlier
+  // bugs that made this feature fire on history and never on new messages.
   //
-  // Kept in a ref (not state) — it must not trigger renders, and updating it
-  // during render is safe/idempotent. Per-window refs reset on remount, which
-  // is exactly the session-switch boundary we want to reset on.
-  const seenIdsRef = useRef<Set<string> | null>(null);
-
-  // Compute `entering` per row for this render and advance the seen set.
-  // Mutating a ref during render is fine here: the set converges to the
-  // current message ids and there is no side effect on other components.
-  const seen = seenIdsRef.current;
-  const enteringFor: Record<string, boolean> = {};
-  if (seen == null && messages.length > 0) {
-    // First NON-EMPTY render — the initial population. Nothing animates (the
-    // empty "Welcome" render must not prime the set, or every historically
-    // loaded row would read as new and replay its entrance).
-    seenIdsRef.current = new Set(messages.map((m) => m.info.id));
-  } else if (seen != null) {
-    for (const m of messages) {
-      // The optimistic placeholder a send appends is ALWAYS animated: on a
-      // brand-new session it is the first non-empty render (so would be
-      // primed as "seen"), and it is the exact moment the iMessage send
-      // effect matters most.
-      if (!seen.has(m.info.id) || m.info.id.startsWith("optimistic-user-")) {
-        enteringFor[m.info.id] = true;
-      }
-    }
-    // Merge newly seen ids in so they don't re-enter on the next render.
-    for (const id of Object.keys(enteringFor)) seen.add(id);
-  }
+  // Held in a ref, not state: it must not schedule a render, and folding the
+  // current message list into it during render is idempotent. The ref resets
+  // when Transcript remounts, which is exactly the session-switch boundary.
+  const motionRef = useRef<EntryMotionState | null>(null);
+  motionRef.current ??= createEntryMotionState();
+  const motion = updateEntryMotion(
+    motionRef.current,
+    messages.map((m) => ({ id: m.info.id, role: m.info.role })),
+  );
 
   return (
     <div
@@ -166,7 +151,7 @@ export function Transcript({
                     // The message being written right now: last in the
                     // transcript, assistant, and the turn still running.
                     streaming={isLastInTranscript && running}
-                    entering={!!enteringFor[m.info.id]}
+                    entering={motion.entering.has(m.info.id)}
                   />
                 );
               })}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
+  createEntryMotionState,
+  updateEntryMotion,
+  isOptimisticUserId,
   formatTokens,
   formatBytes,
   formatDuration,
@@ -2638,5 +2641,97 @@ describe("fast-mode model helpers", () => {
       available: false,
       on: false,
     });
+  });
+});
+
+// ===== Transcript entry motion =====
+//
+// The gate that decides which transcript rows animate their arrival. Every
+// case below is a bug that shipped, not a hypothetical: the feature reached
+// production animating exactly the wrong set (all of history, none of the new
+// messages), so these tests pin both halves of the contract.
+
+describe("updateEntryMotion", () => {
+  const user = (id: string) => ({ id, role: "user" });
+  const asst = (id: string) => ({ id, role: "assistant" });
+
+  it("animates nothing on the first populated render — that is history", () => {
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1"), asst("a1"), user("u2")]);
+    expect([...s.entering]).toEqual([]);
+  });
+
+  it("does not prime on an empty transcript, so a new session's first send still animates", () => {
+    // The "Welcome" state renders with zero messages. If that primed the gate,
+    // the very next message would be classified as pre-existing history and a
+    // brand-new session would never animate anything.
+    const s = createEntryMotionState();
+    updateEntryMotion(s, []);
+    expect(s.seen).toBeNull();
+    updateEntryMotion(s, [user("u1")]);
+    expect([...s.entering]).toEqual([]); // u1 IS the first populated render
+  });
+
+  it("animates a message appended after the initial load", () => {
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1"), asst("a1")]);
+    updateEntryMotion(s, [user("u1"), asst("a1"), user("u2")]);
+    expect([...s.entering]).toEqual(["u2"]);
+  });
+
+  it("KEEPS the flag across later renders — dropping it cancels the animation", () => {
+    // A CSS animation is killed the moment its class is removed, and the
+    // element snaps to its end state. The transcript re-renders every few ms
+    // during a streaming turn, so a flag that lasted one render meant the
+    // animation was destroyed about one frame in and never visibly played.
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1")]);
+    updateEntryMotion(s, [user("u1"), asst("a1")]);
+    expect(s.entering.has("a1")).toBe(true);
+    for (let i = 0; i < 50; i++) updateEntryMotion(s, [user("u1"), asst("a1")]);
+    expect(s.entering.has("a1")).toBe(true);
+  });
+
+  it("animates the optimistic placeholder a send appends", () => {
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1"), asst("a1")]);
+    updateEntryMotion(s, [user("u1"), asst("a1"), user("optimistic-user-7")]);
+    expect(s.entering.has("optimistic-user-7")).toBe(true);
+  });
+
+  it("does NOT replay the pop when the canonical message replaces the placeholder", () => {
+    // The server's real message arrives under a different id, so React tears
+    // the bubble down and mounts a new one. Without the handover that reads as
+    // a second pop a few hundred ms after the first.
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1")]);
+    updateEntryMotion(s, [user("u1"), user("optimistic-user-7")]);
+    updateEntryMotion(s, [user("u1"), user("msg_real")]);
+    expect(s.entering.has("msg_real")).toBe(false);
+  });
+
+  it("still animates the assistant reply that follows a placeholder handover", () => {
+    // The handover must be spent on exactly one user row, never on the
+    // assistant turn that arrives alongside it.
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1")]);
+    updateEntryMotion(s, [user("u1"), user("optimistic-user-7")]);
+    updateEntryMotion(s, [user("u1"), user("msg_real"), asst("a_new")]);
+    expect(s.entering.has("msg_real")).toBe(false);
+    expect(s.entering.has("a_new")).toBe(true);
+  });
+
+  it("forgets ids that leave the transcript, so a cleared session stays bounded", () => {
+    const s = createEntryMotionState();
+    updateEntryMotion(s, [user("u1")]);
+    updateEntryMotion(s, [user("u1"), asst("a1")]);
+    expect(s.entering.has("a1")).toBe(true);
+    updateEntryMotion(s, [user("u1")]);
+    expect(s.entering.has("a1")).toBe(false);
+  });
+
+  it("recognises the renderer's optimistic id prefix", () => {
+    expect(isOptimisticUserId("optimistic-user-1770000000000")).toBe(true);
+    expect(isOptimisticUserId("msg_01ABC")).toBe(false);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1972,3 +1972,116 @@ export function resolveFastToggle(
     title: on ? "Fast mode on — click for the standard model" : "Fast mode off — click for the faster model",
   };
 }
+
+// ===== Transcript entry motion =====
+//
+// Which transcript rows are allowed to ANIMATE their arrival. The rule the
+// user actually wants is narrow: a message that lands while they are watching
+// animates; everything else — the transcript they just loaded, the session
+// they just switched into, history paged in above — appears instantly.
+//
+// This is the third attempt at that gate, and the two failures are worth
+// recording because both looked correct in review:
+//
+//   1. The user bubble carried its animation class UNCONDITIONALLY, so every
+//      bubble in a loaded transcript popped on mount. Session switch replayed
+//      the entire history's sends.
+//   2. The assistant row's flag lived for exactly ONE render. React removes
+//      the class on the next render, which CANCELS a running CSS animation and
+//      snaps the element to its end state. During a live turn the transcript
+//      re-renders every few milliseconds, so the animation was destroyed about
+//      one frame after it started — it never visibly played at all.
+//
+// Hence the two invariants this module exists to enforce:
+//
+//   PRIMED — nothing animates until the transcript has been populated once.
+//   The first non-empty render defines "history"; only ids appearing AFTER it
+//   are new. An empty transcript (the "Welcome" state) must NOT prime, or a
+//   brand-new session's first send would be classified as history.
+//
+//   STICKY — once an id is marked entering it STAYS marked for as long as it
+//   is on screen. A CSS animation is a mount-time, play-once effect (fill mode
+//   `both` holds the end state), so keeping the class costs nothing and is the
+//   only way to survive the re-render storm of a streaming turn.
+//
+// Kept pure + mutation-in-place so the caller can hold it in a ref and update
+// it during render without scheduling another one.
+
+/** A message reduced to what the entry-motion gate needs. */
+export type EntryMotionRow = { id: string; role: string };
+
+export type EntryMotionState = {
+  /** Ids already accounted for. `null` until the first non-empty render. */
+  seen: Set<string> | null;
+  /** Ids cleared to animate. Sticky for as long as the id is present. */
+  entering: Set<string>;
+  /** Whether the previous update saw a live optimistic placeholder. */
+  hadOptimistic: boolean;
+};
+
+export function createEntryMotionState(): EntryMotionState {
+  return { seen: null, entering: new Set(), hadOptimistic: false };
+}
+
+/** The renderer's optimistic placeholder id prefix (see ChatPanel `submit`). */
+const OPTIMISTIC_USER_PREFIX = "optimistic-user-";
+
+export function isOptimisticUserId(id: string): boolean {
+  return id.startsWith(OPTIMISTIC_USER_PREFIX);
+}
+
+/**
+ * Fold the current message list into `state`, deciding which ids animate.
+ * MUTATES `state` and returns it (it lives in a ref; a new object per render
+ * would defeat the point).
+ *
+ * The optimistic-placeholder handover is the subtle case. A send appends a
+ * placeholder immediately, then the server's canonical message REPLACES it
+ * under a different id. React sees a different key, so it tears the bubble
+ * down and builds a new one — which would replay the send animation a second
+ * time, a visible double-pop a few hundred milliseconds apart. When a
+ * placeholder retires, the first new user message in that same update is
+ * therefore treated as its continuation and does NOT animate: the bubble it
+ * replaces already played, and the swap should be invisible.
+ */
+export function updateEntryMotion(
+  state: EntryMotionState,
+  rows: EntryMotionRow[],
+): EntryMotionState {
+  const ids = new Set(rows.map((r) => r.id));
+  const hasOptimistic = rows.some((r) => isOptimisticUserId(r.id));
+
+  if (state.seen == null) {
+    // Nothing to do until the transcript is populated — an empty render is
+    // the "Welcome" state, not a history load.
+    if (rows.length === 0) return state;
+    // First non-empty render IS the history. Prime, animate nothing.
+    state.seen = ids;
+    state.hadOptimistic = hasOptimistic;
+    return state;
+  }
+
+  // A placeholder was live last update and is gone now: the canonical message
+  // for that send has landed, and exactly one new user row inherits its
+  // already-played animation instead of starting a fresh one.
+  let handover = state.hadOptimistic && !hasOptimistic;
+
+  for (const row of rows) {
+    if (state.seen.has(row.id)) continue;
+    state.seen.add(row.id);
+    if (handover && row.role === "user" && !isOptimisticUserId(row.id)) {
+      handover = false;
+      continue;
+    }
+    state.entering.add(row.id);
+  }
+
+  // Drop ids that have left the transcript so the sticky set stays bounded
+  // (a cleared/compacted session replaces the whole list).
+  for (const id of state.entering) {
+    if (!ids.has(id)) state.entering.delete(id);
+  }
+
+  state.hadOptimistic = hasOptimistic;
+  return state;
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -182,25 +182,27 @@ html, body, #root {
 }
 
 /* Transcript entry motion (transcript-motion).
-   New rows that mount live at the bottom of the transcript (a user message
-   just sent, an assistant turn that reconciles in as a whole, a newly
-   surfaced card) enter by sliding up a few pixels with a fade, so appends
-   read as "settling in" rather than teleporting. Transform + opacity only
-   (compositor-friendly), `both` fill so a one-shot play holds its end state
-   and dropping the class later is seamless.
+   A tool card / text block that appears while the user is watching slides up
+   a few pixels with a fade, so a turn assembles itself instead of each piece
+   teleporting into place. Transform + opacity only (compositor-friendly),
+   `both` fill so the one-shot play holds its end state.
 
-   WHOLE-ROW animation: the row is the unit, so a card is never assembled
-   piece by piece. The live-streaming message is exempt — its blocks already
-   animate in via .manta-streaming (BET-649), and re-animating the row would
-   double up. `entering` (set in Transcript.tsx) marks rows appended after the
-   initial transcript load, so a session switch never replays the whole
-   history sliding in. */
-@keyframes manta-row-in {
+   THE PART IS THE UNIT, not the row. During a turn the parts of a single
+   assistant message mount one at a time over many seconds, so animating the
+   row would mean sliding a container that is already on screen — which is
+   why the earlier whole-row version could never fire: the row was always
+   exempt as "currently streaming" when it mounted, and no longer new by the
+   time it settled. The live-streaming text part is still exempt here because
+   its markdown blocks fade in individually via .manta-streaming (BET-649).
+
+   `entering` (decided in Transcript.tsx by updateEntryMotion) is what keeps
+   history still: a transcript the user merely loaded animates nothing. */
+@keyframes manta-part-in {
   from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: none; }
 }
-.manta-row-in {
-  animation: manta-row-in 0.22s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
+.manta-part-in {
+  animation: manta-part-in 0.22s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
 }
 
 /* User bubble send (transcript-motion). iMessage-style send: the bubble
@@ -209,7 +211,11 @@ html, body, #root {
    in, rather than a static stamp. The 72% keyframe gives the spring feel
    without introducing a spring-easing dependency. Origin is the bottom-right
    corner (where a send originates) so the overshoot scales toward the
-   transcript, not the gutter. */
+   transcript, not the gutter.
+
+   Applied ONLY when the message arrived live (see MessageBubble): this class
+   was once unconditional, which made every bubble in an opened transcript pop
+   and replayed the user's whole send history on a session switch. */
 @keyframes manta-bubble-in {
   0%   { opacity: 0; transform: translateY(14px) scale(0.9); }
   72%  { opacity: 1; transform: translateY(-2px) scale(1.02); }
@@ -224,7 +230,7 @@ html, body, #root {
    transcript never slides — rows and bubbles simply appear. State is
    unaffected; only the motion is removed. */
 @media (prefers-reduced-motion: reduce) {
-  .manta-row-in,
+  .manta-part-in,
   .manta-bubble-in { animation: none; }
 }
 


### PR DESCRIPTION
The transcript entry motion shipped inverted: it played on the transcript you
opened and never on the message you just sent.

## What was wrong

**The send pop was ungated.** `manta-bubble-in` was applied to every user
bubble unconditionally, so loading a session replayed every send in its
history at once — the reported symptom.

**The row slide could not fire at all.** The rule was "animate a row that is
new and settled", but an assistant row is always still streaming when it first
appears, so it was exempt; by the time it settled its id was no longer new.
There is no moment where both conditions hold, so `.manta-row-in` never
reached a visible element in the real send → stream → settle sequence.

**The flag lasted one render.** Even on the one path that did reach it,
`entering` was recomputed per render and dropped on the next one. Removing a
class cancels a running CSS animation and snaps the element to its end state,
and a live turn re-renders every few milliseconds — so the animation was
destroyed roughly one frame after it started.

Verified by mounting the real transcript and driving the actual sequence: the
slide class appeared 0 times at every step, while a history bubble already
carried the pop class on first paint.

## What it does now

One decision, made once per message and held for as long as that message is on
screen (`updateEntryMotion`, pure + tested):

- **History is still.** Nothing animates until the transcript has been
  populated once, so opening a session or switching between them is silent.
- **The bubble pops once per send.** The optimistic message is replaced by the
  server's canonical copy under a different id, which remounts the bubble and
  would replay the pop a few hundred ms later; that handover is now invisible.
- **The reply's parts slide in individually.** This is what "cards sliding in"
  actually looks like during a turn — the text blocks and tool cards of one
  reply arrive one at a time, so the part is the unit that enters, not the row
  around it. The streaming text part stays exempt; its blocks already fade in
  via `.manta-streaming` (BET-649).

Both animations remain transform/opacity only and disabled under
`prefers-reduced-motion`.

## Testing

The previous version shipped with a test that asserted a class-name string and
nothing else, which is how a feature that could not fire passed review. Added
`Transcript.test.tsx`, which mounts the transcript and drives the real
send/stream/settle sequence; all six cases were confirmed RED against the old
behaviour before going green.

Full renderer suite passes (2096), typecheck clean.