### PR TITLE
fix(renderer): error boundary + ask-card redesign to spec

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,6 +26,7 @@ import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
 import { parsePairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
+import { ErrorBoundary } from "./ErrorBoundary";
 import type { AvailableLauncher } from "../shared/types";
 
 // BET-373 (channel-aware wire format): the deep-link URL the OS hands this
@@ -37,7 +38,36 @@ import type { AvailableLauncher } from "../shared/types";
 // `manta://` link can never silently pass through a staging build.
 const PAIR_PARSE_SCHEME = channelConfig(__MANTA_CHANNEL__).urlScheme;
 
+// The whole app tree is wrapped once in an ErrorBoundary so an uncaught render
+// throw anywhere degrades to a minimal centered "Something went wrong — Reload"
+// (using existing tokens) instead of React 18 unmounting the root to a white
+// screen. AppInner holds the real component; App is the boundary wrapper.
 export function App() {
+  return (
+    <ErrorBoundary
+      fallback={(err, reset) => (
+        <div className="h-full w-full flex items-center justify-center bg-bg text-text">
+          <div className="bg-danger-bg border border-danger rounded-md px-4 py-3 text-meta text-center">
+            <div className="text-text mb-2 break-words">
+              Something went wrong{err.message ? ` — ${err.message}` : ""}
+            </div>
+            <button
+              type="button"
+              onClick={reset}
+              className="text-accent hover:underline"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      )}
+    >
+      <AppInner />
+    </ErrorBoundary>
+  );
+}
+
+function AppInner() {
   const {
     loaded,
     projects,

--- a/src/renderer/Card.test.tsx
+++ b/src/renderer/Card.test.tsx
@@ -15,6 +15,7 @@
 // PermissionCard / QuestionCard call sites below.
 
 import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
 import { mount, type Harness } from "./testHarness";
 import { Card } from "./Card";
 import { PermissionCard, QuestionCard } from "./Cards";
@@ -64,6 +65,16 @@ describe("Card", () => {
     expect(actions.textContent).toBe("Go");
   });
 
+  it("elevated adds the --shadow-md lift; default stays flat", () => {
+    h = mount(<Card>flat</Card>);
+    expect((h.container.firstElementChild as HTMLElement).className).toBe(CHROME);
+    h.unmount();
+    h = mount(<Card elevated>lifted</Card>);
+    expect((h.container.firstElementChild as HTMLElement).className).toBe(
+      `${CHROME} shadow-md`,
+    );
+  });
+
   it("renders children flush to the top when there is no header", () => {
     h = mount(<Card>alone</Card>);
     const chrome = h.container.firstElementChild as HTMLElement;
@@ -111,18 +122,47 @@ describe("Card migration — ask-card call sites (BET-531 two-adopter rule)", ()
     ],
   };
 
-  it("PermissionCard renders through Card's non-danger chrome (no className injection)", () => {
+  it("PermissionCard renders through Card's non-danger chrome + elevated lift (no className injection)", () => {
     h = mount(<PermissionCard perm={perm} onReply={() => {}} />);
-    expect(chromeEl(h).className).toBe(CHROME);
+    // Ask cards float over the transcript, so they carry the elevated lift.
+    expect(chromeEl(h).className).toBe(`${CHROME} shadow-md`);
     expect(h.text()).toContain("Allow once");
     expect(h.text()).toContain("Reject");
     expect(h.text()).toContain("ls -la");
   });
 
-  it("QuestionCard renders through Card's chrome with the action footer", () => {
+  it("QuestionCard renders through Card's elevated chrome with the action footer", () => {
     h = mount(<QuestionCard request={question} onReply={() => {}} onReject={() => {}} />);
-    expect(chromeEl(h).className).toBe(CHROME);
+    expect(chromeEl(h).className).toBe(`${CHROME} shadow-md`);
     expect(h.text()).toContain("Submit");
     expect(h.text()).toContain("Dismiss");
+  });
+
+  it("clicking a QuestionCard option toggles selection without throwing; Submit renders", () => {
+    h = mount(<QuestionCard request={question} onReply={() => {}} onReject={() => {}} />);
+    // Full-width `.opt` option rows are labels wrapping an sr-only control.
+    const inputs = Array.from(
+      h.container.querySelectorAll("input[type='radio'], input[type='checkbox']"),
+    ) as HTMLInputElement[];
+    expect(inputs.length).toBe(2);
+    // Single-select preselects the recommended option (B). Click option A.
+    act(() => inputs[0].click());
+    expect(inputs[0].checked).toBe(true);
+    // No throw, and the primary Submit action still renders.
+    expect(h.text()).toContain("Submit");
+  });
+
+  it("QuestionCard survives a malformed payload (missing options) without throwing", () => {
+    const bad = {
+      id: "qbad",
+      sessionID: "s1",
+      requestId: "que_bad",
+      // A question with NO options array — the defensive guard must not throw.
+      questions: [{ question: "Broken?", header: "Broken" }],
+    } as unknown as QuestionRequest;
+    h = mount(<QuestionCard request={bad} onReply={() => {}} onReject={() => {}} />);
+    // Still renders the shell + actions rather than blanking.
+    expect(h.text()).toContain("Broken");
+    expect(h.text()).toContain("Submit");
   });
 });

--- a/src/renderer/Card.tsx
+++ b/src/renderer/Card.tsx
@@ -20,19 +20,27 @@ const CARD_DANGER_CHROME = "rounded-lg border border-danger bg-danger-bg px-4 py
 
 export function Card({
   danger = false,
+  elevated = false,
   header,
   children,
   actions,
 }: {
   danger?: boolean;
+  /**
+   * Add the `--shadow-md` floating lift. Opt-in (default false) so the shared
+   * primitive's existing adopters (GroupCard in Settings) stay flat; only the
+   * ask cards, which float over the transcript, pass `elevated`.
+   */
+  elevated?: boolean;
   header?: ReactNode;
   children?: ReactNode;
   actions?: ReactNode;
 }) {
   const hasHeader = header !== undefined;
   const hasBody = children !== undefined;
+  const base = danger ? CARD_DANGER_CHROME : CARD_CHROME;
   return (
-    <div className={danger ? CARD_DANGER_CHROME : CARD_CHROME}>
+    <div className={elevated ? `${base} shadow-md` : base}>
       {hasHeader && <div className="flex items-start gap-3">{header}</div>}
       {hasBody && (hasHeader ? <div className="mt-3">{children}</div> : children)}
       {actions !== undefined && (

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -13,7 +13,7 @@
 // badge, plain-language titles, checkbox question options and a button ladder.
 
 import { useState, type ReactNode } from "react";
-import { Shield, HelpCircle, Check } from "lucide-react";
+import { Shield, HelpCircle, Check, Send } from "lucide-react";
 import type { PermissionRequest, QuestionRequest } from "../shared/types";
 import { buildQuestionAnswers, canSubmitQuestion } from "./chatUtils";
 import { Card } from "./Card";
@@ -48,6 +48,7 @@ function AskCardShell({
   return (
     <div className="text-meta">
       <Card
+        elevated
         header={
           <>
             <span
@@ -58,7 +59,7 @@ function AskCardShell({
             </span>
             <div className="min-w-0 flex-1">
               <div className="text-text font-medium mb-px">{title}</div>
-              {subtitle && <div className="text-text-muted mb-px">{subtitle}</div>}
+              {subtitle && <div className="text-text-faint mb-px">{subtitle}</div>}
             </div>
           </>
         }
@@ -202,30 +203,38 @@ export function PermissionCard({
   const desc = permissionDescription(perm);
 
   // Button ladder (the loudest element on screen is the primary action):
-  //   Allow once — the FILLED accent primary.
+  //   Allow once — the FILLED accent primary, with a Check + ⏎ hint.
   //   Always allow <tool> — outlined secondary.
-  //   Reject — text-coloured, pushed to the far right, gains --danger on hover.
+  //   (spacer)
+  //   Reject — ghost, pushed to the far right, gains --danger on hover.
   const actions = (
     <>
       <button
         onClick={() => onReply("once")}
-        className="px-3 py-1 rounded-md text-on-accent text-meta font-medium"
+        className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium"
         style={{ backgroundColor: "var(--accent-solid)" }}
       >
+        <Check size={13} aria-hidden="true" />
         Allow once
+        <span className="text-on-accent opacity-70" aria-hidden="true">
+          ⏎
+        </span>
       </button>
       {alwaysScope ? (
         <button
           onClick={() => onReply("always")}
           title={`Always allow ${alwaysScope}`}
-          className="px-3 py-1 rounded-md border border-border-strong text-text hover:bg-bg-soft text-meta"
+          className="h-8 px-[14px] inline-flex items-center rounded-md border border-border-strong text-text hover:bg-bg-soft text-meta"
         >
-          Always allow <span className="text-text-faint">{alwaysScope}</span>
+          Always allow&nbsp;
+          <span className="text-text-faint">{alwaysScope}</span>
         </button>
       ) : null}
+      {/* spacer pushes Reject to the far right */}
+      <div className="flex-1" />
       <button
         onClick={() => onReply("reject")}
-        className="ml-auto px-3 py-1 rounded-md text-muted hover:text-danger hover:bg-danger-bg text-meta"
+        className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta"
       >
         Reject
       </button>
@@ -276,13 +285,17 @@ export function QuestionCard({
   onReply: (answers: string[][]) => void;
   onReject: () => void;
 }) {
+  // Defensive: a malformed payload (missing `questions`, or a question with no
+  // `options`) must not throw and blank the app. Normalize to safe arrays.
+  const rawQuestions = Array.isArray(request.questions) ? request.questions : [];
+
   // Pre-parse options once: strip "(Recommended)" and track which are
   // recommended so we can preselect (single-select only) and badge them.
   // The ORIGINAL label is kept as `origLabel` (the wire key opencode
   // matches on); `label` is the display text.
-  const parsedQuestions = request.questions.map((info) => ({
+  const parsedQuestions = rawQuestions.map((info) => ({
     info,
-    options: info.options.map((opt) => {
+    options: (Array.isArray(info.options) ? info.options : []).map((opt) => {
       const { text, recommended } = parseRecommended(opt.label);
       return { ...opt, displayLabel: text, origLabel: opt.label, recommended };
     }),
@@ -300,7 +313,7 @@ export function QuestionCard({
     }),
   );
   const [customValues, setCustomValues] = useState<string[]>(() =>
-    request.questions.map(() => ""),
+    rawQuestions.map(() => ""),
   );
 
   function toggleOption(qIdx: number, origLabel: string, multiple: boolean) {
@@ -324,133 +337,175 @@ export function QuestionCard({
   const answeredCount = selected.filter(
     (s, i) => s.size > 0 || (customValues[i] ?? "").trim().length > 0,
   ).length;
-  const totalQuestions = request.questions.length;
+  const totalQuestions = rawQuestions.length;
   const isMulti = totalQuestions > 1;
+  const singleInfo = totalQuestions === 1 ? parsedQuestions[0]?.info : undefined;
+
+  // One option row — the spec's full-width `.opt` button. Selected/hover →
+  // border-accent + accent-bg; the `.mk` mark is the 15px checkbox square,
+  // filled with the accent-solid + Check icon when selected. Rendered as a
+  // real accessible control: an sr-only radio/checkbox drives the same
+  // toggleOption logic (origLabel stays the selection key).
+  function renderOption(
+    qIdx: number,
+    multiple: boolean,
+    opt: { origLabel: string; displayLabel: string; description: string; recommended: boolean },
+  ) {
+    const isSelected = selected[qIdx].has(opt.origLabel);
+    return (
+      <label
+        key={opt.origLabel}
+        className={
+          "flex items-center w-full text-left rounded-md border px-3 py-[10px] cursor-pointer text-label font-medium transition-colors " +
+          (isSelected
+            ? "border-accent bg-accent-bg"
+            : "border-border bg-bg hover:border-accent hover:bg-accent-bg")
+        }
+        title={opt.description}
+      >
+        <span
+          className={
+            "inline-flex items-center justify-center w-[15px] h-[15px] rounded-xs border shrink-0 mr-2 " +
+            (isSelected
+              ? "border-transparent text-on-accent"
+              : "border-border-strong")
+          }
+          style={isSelected ? { backgroundColor: "var(--accent-solid)" } : undefined}
+        >
+          {isSelected && <Check size={10} strokeWidth={4} aria-hidden="true" />}
+        </span>
+        <span className="text-text min-w-0">{opt.displayLabel}</span>
+        {opt.recommended && (
+          // The "Recommended" standing tag — a GREEN Pill placed INLINE right
+          // after the label. Pill owns the chrome; ml-2 is the placement.
+          <span className="ml-2 shrink-0">
+            <Pill tone="ok" size="label">
+              Recommended
+            </Pill>
+          </span>
+        )}
+        <input
+          type={multiple ? "checkbox" : "radio"}
+          name={`q-${qIdx}`}
+          checked={isSelected}
+          onChange={() => toggleOption(qIdx, opt.origLabel, multiple)}
+          className="sr-only"
+        />
+      </label>
+    );
+  }
+
+  // The `.ask-free` free-text box — a bordered container with a leading Send
+  // icon and a transparent input. Enter submits when the request is answerable.
+  function renderFreeText(qIdx: number) {
+    return (
+      <div className="flex items-center gap-2 border border-border rounded-md bg-bg px-3 py-2">
+        <Send size={14} aria-hidden="true" className="text-text-quiet shrink-0" />
+        <input
+          type="text"
+          placeholder="Or type your own answer…"
+          value={customValues[qIdx]}
+          onChange={(e) => {
+            const v = e.target.value;
+            setCustomValues((prev) => {
+              const next = [...prev];
+              next[qIdx] = v;
+              return next;
+            });
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey && canSubmit) {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          className="flex-1 min-w-0 bg-transparent border-0 outline-none text-meta text-text placeholder:text-text-faint"
+        />
+      </div>
+    );
+  }
 
   return (
     <AskCardShell
       badge={<HelpCircle size={16} aria-hidden="true" />}
       badgeBg="var(--accent-bg)"
       badgeColor="var(--accent-tx)"
-      title="Question"
-      subtitle={
-        isMulti ? (
-          <span>
-            {answeredCount} of {totalQuestions} answered
-          </span>
-        ) : undefined
-      }
+      // Single question → the header IS the question (2-line: header + question
+      // sub). Multiple → keep a generic "Question" card title; each sub-question
+      // renders its own numbered block in the body.
+      title={isMulti ? "Question" : singleInfo?.header ?? "Question"}
+      subtitle={isMulti ? undefined : singleInfo?.question}
       body={
         <>
           <div className="space-y-3">
-            {parsedQuestions.map(({ info, options }, qIdx) => (
-              <div key={qIdx}>
-                {/* Numbered section header when multiple questions */}
-                {isMulti && (
-                  <div className="text-text-faint text-label mb-px">
-                    {qIdx + 1}. {info.header}
-                  </div>
-                )}
-                {!isMulti && (
-                  <div className="text-text-muted mb-px font-medium">{info.header}</div>
-                )}
-                <div className="text-text mb-2 leading-snug">{info.question}</div>
-
-                {/* Checkbox options — multi-select aware */}
-                <div className="mt-px flex flex-col gap-1">
-                  {options.map((opt) => {
-                    const isSelected = selected[qIdx].has(opt.origLabel);
-                    const multiple = info.multiple ?? false;
-                    return (
-                      <label
-                        key={opt.origLabel}
-                        className={
-                          "flex items-start gap-2 rounded-sm px-2 py-1 cursor-pointer border text-meta transition-colors " +
-                          (isSelected
-                            ? "border-accent bg-accent-bg"
-                            : "border-border hover:bg-bg-soft")
-                        }
-                        title={opt.description}
-                      >
-                        <span
-                          className={
-                            "inline-flex items-center justify-center w-4 h-4 rounded-xs border shrink-0 mt-px " +
-                            (isSelected
-                              ? "bg-accent-solid border-transparent text-on-accent"
-                              : "border-border-strong")
-                          }
-                          style={isSelected ? { backgroundColor: "var(--accent-solid)" } : undefined}
-                        >
-                          {isSelected && <Check size={12} aria-hidden="true" />}
+            {parsedQuestions.map(({ info, options }, qIdx) => {
+              const multiple = info.multiple ?? false;
+              return (
+                <div key={qIdx}>
+                  {/* Multi-question: a numbered `.qb` block with a circular */}
+                  {/* badge + question + `em` context, separated by `.qsep`. */}
+                  {isMulti && (
+                    <>
+                      {qIdx > 0 && <div className="h-px bg-border-subtle mb-3" />}
+                      <div className="flex items-start gap-2 mb-2">
+                        <span className="inline-flex items-center justify-center w-[18px] h-[18px] rounded-full bg-fill-active text-text-faint font-mono font-semibold text-micro shrink-0">
+                          {qIdx + 1}
                         </span>
-                        <span className="text-text min-w-0">{opt.displayLabel}</span>
-                        {opt.recommended && (
-                          // The accent "Recommended" standing tag — a Pill.
-                          // `ml-auto shrink-0` is the flex-row placement (a
-                          // site concern, wrapped here); Pill owns the chrome.
-                          <span className="ml-auto shrink-0">
-                            <Pill tone="accent" size="label">
-                              Recommended
-                            </Pill>
-                          </span>
-                        )}
-                        <input
-                          type={multiple ? "checkbox" : "radio"}
-                          name={`q-${qIdx}`}
-                          checked={isSelected}
-                          onChange={() => toggleOption(qIdx, opt.origLabel, multiple)}
-                          className="sr-only"
-                        />
-                      </label>
-                    );
-                  })}
-                </div>
+                        <div className="min-w-0">
+                          <div className="text-text font-semibold text-label leading-snug">
+                            {info.header}
+                          </div>
+                          <div className="text-text-faint text-meta leading-snug mt-px">
+                            {info.question}
+                          </div>
+                        </div>
+                      </div>
+                    </>
+                  )}
 
-                {/* Free-text input — always available */}
-                <input
-                  type="text"
-                  placeholder="Or type your own answer…"
-                  value={customValues[qIdx]}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setCustomValues((prev) => {
-                      const next = [...prev];
-                      next[qIdx] = v;
-                      return next;
-                    });
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey && canSubmit) {
-                      e.preventDefault();
-                      handleSubmit();
-                    }
-                  }}
-                  className="mt-2 w-full rounded-xs border border-border bg-transparent px-2 py-px text-meta text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
-                />
-              </div>
-            ))}
+                  {/* Full-width `.opt` option buttons. */}
+                  <div className="space-y-2">
+                    {options.map((opt) => renderOption(qIdx, multiple, opt))}
+                  </div>
+
+                  {/* `.ask-free` free-text box — always available. */}
+                  <div className="mt-2">{renderFreeText(qIdx)}</div>
+                </div>
+              );
+            })}
           </div>
 
-          <hr className="border-border my-3" />
+          <hr className="border-border-subtle my-3" />
         </>
       }
       actions={
         <>
-          <button
-            onClick={onReject}
-            className="ml-auto px-3 py-1 rounded-md text-muted hover:text-danger hover:bg-danger-bg text-meta"
-            title="Dismiss this question"
-          >
-            Dismiss
-          </button>
-          {/* Submit is the filled accent primary — the loudest element. */}
+          {/* Submit FIRST — the filled accent primary with a trailing ⏎ hint. */}
           <button
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className="px-3 py-1 rounded-md text-on-accent text-meta font-medium disabled:opacity-40"
+            className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium disabled:opacity-40"
             style={{ backgroundColor: "var(--accent-solid)" }}
           >
             Submit
+            <span className="text-on-accent opacity-70" aria-hidden="true">
+              ⏎
+            </span>
+          </button>
+          {/* Multi-question progress — mono `.prog`. */}
+          {isMulti && (
+            <span className="text-text-faint text-meta font-mono ml-2">
+              {answeredCount} of {totalQuestions} answered
+            </span>
+          )}
+          {/* spacer pushes Dismiss to the far right */}
+          <div className="flex-1" />
+          <button
+            onClick={onReject}
+            className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta"
+            title="Dismiss this question"
+          >
+            Dismiss
           </button>
         </>
       }

--- a/src/renderer/ErrorBoundary.test.tsx
+++ b/src/renderer/ErrorBoundary.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+//
+// Component tests for the ErrorBoundary (FIX 1): a child that throws must
+// render the inline fallback (NOT a blank container), and `reset` + a
+// re-render with a non-throwing child must recover.
+//
+// React logs the caught render error to console.error even when a boundary
+// handles it; we silence that expected noise so the suite output stays clean.
+
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { act, useState } from "react";
+import { mount, type Harness } from "./testHarness";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Boom({ blow }: { blow: boolean }): JSX.Element {
+  if (blow) throw new Error("kaboom");
+  return <div>recovered content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  let h: Harness | null = null;
+  // React re-throws a caught render error to the DOM so its dev overlay can see
+  // it; jsdom then reports it as an uncaught "error" event. The boundary IS
+  // handling it, so swallow that expected event to keep the suite output clean.
+  const swallow = (e: Event) => e.preventDefault();
+  beforeEach(() => {
+    window.addEventListener("error", swallow);
+  });
+  afterEach(() => {
+    window.removeEventListener("error", swallow);
+    h?.unmount();
+    h = null;
+    vi.restoreAllMocks();
+  });
+
+  it("renders the inline fallback (not a blank container) when a child throws", () => {
+    // Silence the expected React error log for the caught throw.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    h = mount(
+      <ErrorBoundary>
+        <Boom blow />
+      </ErrorBoundary>,
+    );
+    // The container is NOT blank — the fallback rendered.
+    expect(h.text()).not.toBe("");
+    expect(h.text()).toContain("kaboom");
+    expect(h.text()).toContain("Reload");
+  });
+
+  it("logs the real error via console.error('[error-boundary]', …)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    h = mount(
+      <ErrorBoundary>
+        <Boom blow />
+      </ErrorBoundary>,
+    );
+    expect(
+      spy.mock.calls.some((c) => c[0] === "[error-boundary]"),
+    ).toBe(true);
+  });
+
+  it("recovers when reset is clicked and the child no longer throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // A controllable child: the boundary reset re-renders children, at which
+    // point `blow` has flipped to false via the parent's state.
+    function Host(): JSX.Element {
+      const [blow, setBlow] = useState(true);
+      return (
+        <div>
+          <button type="button" onClick={() => setBlow(false)}>
+            fix
+          </button>
+          <ErrorBoundary>
+            <Boom blow={blow} />
+          </ErrorBoundary>
+        </div>
+      );
+    }
+    h = mount(<Host />);
+    // Fallback is up.
+    expect(h.text()).toContain("Reload");
+
+    // Flip the child to non-throwing FIRST, then reset the boundary so the
+    // re-render mounts the recovered child.
+    const fixBtn = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "fix",
+    ) as HTMLButtonElement;
+    act(() => fixBtn.click());
+    const reloadBtn = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Reload",
+    ) as HTMLButtonElement;
+    act(() => reloadBtn.click());
+
+    expect(h.text()).toContain("recovered content");
+    expect(h.text()).not.toContain("Reload");
+  });
+
+  it("uses a custom fallback when provided", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    h = mount(
+      <ErrorBoundary fallback={(e) => <div>custom: {e.message}</div>}>
+        <Boom blow />
+      </ErrorBoundary>,
+    );
+    expect(h.text()).toBe("custom: kaboom");
+  });
+});

--- a/src/renderer/ErrorBoundary.tsx
+++ b/src/renderer/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+// ===== ErrorBoundary =====
+//
+// React 18 unmounts the ENTIRE root on any uncaught render/commit throw, so a
+// single card that throws whites out the whole window with no visible error
+// (see testHarness.tsx's note about a preload gap blanking the app on first
+// launch). The renderer had NO error boundary anywhere — this is the safety
+// net.
+//
+// On error it logs the real error (`console.error("[error-boundary]", …)`) so
+// the cause surfaces instead of a silent white screen, and renders a SMALL
+// inline fallback (not a full-screen takeover) with a "Reload" button that
+// clears the boundary's error state so a transient failure can recover.
+//
+// Chrome is built from existing design tokens (bg-danger-bg / border-danger /
+// text-meta) — no new colors, no off-grid values.
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  /** Custom fallback. Receives the caught error and a `reset` to clear state. */
+  fallback?: (err: Error, reset: () => void) => ReactNode;
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = { error: Error | null };
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surface the real error — today a render throw is a silent white screen.
+    console.error("[error-boundary]", error, info);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) return this.props.fallback(error, this.reset);
+      return (
+        <div className="bg-danger-bg border border-danger rounded-md px-4 py-3 text-meta">
+          <div className="text-text mb-2 break-words">
+            {error.message || "Something went wrong."}
+          </div>
+          <button
+            type="button"
+            onClick={this.reset}
+            className="text-accent hover:underline"
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/renderer/Pill.test.tsx
+++ b/src/renderer/Pill.test.tsx
@@ -60,6 +60,13 @@ describe("Pill", () => {
     expect(el.className).toContain("text-warn");
   });
 
+  it("ok tone renders the --ok-bg surface with a matching --ok foreground (C1)", () => {
+    h = mount(<Pill tone="ok">Recommended</Pill>);
+    const el = pillEl(h);
+    expect(el.className).toContain("bg-ok-bg");
+    expect(el.className).toContain("text-ok");
+  });
+
   it("neutral tone sets no background and reads as a muted label (inherits its surface)", () => {
     h = mount(<Pill tone="neutral">label</Pill>);
     const el = pillEl(h);
@@ -201,19 +208,19 @@ describe("Pill migration — Recommended option tag (BET-534 two-adopter rule)",
     ],
   };
 
-  it("Recommended tag renders through Pill's accent chrome with the --r-full radius (was rounded-xs)", () => {
+  it("Recommended tag renders through Pill's GREEN ok chrome at the label size (BET redesign)", () => {
     h = mount(<QuestionCard request={question} onReply={() => {}} onReject={() => {}} />);
     const pill = Array.from(h.container.querySelectorAll("span.rounded-full")).find(
       (el) => el.textContent === "Recommended",
     ) as HTMLElement;
     expect(pill).toBeTruthy();
-    // The intended delta is exactly the radius: --r-full replaces --r-sm
-    // (rounded-xs), while the accent surface, --accent foreground and the
-    // label size are preserved.
+    // The redesign moves the Recommended tag from accent (blue) to ok (green)
+    // and places it inline; the capsule radius + label size are preserved.
     expect(pill.className).toContain("rounded-full");
     expect(pill.className).not.toContain("rounded-xs");
-    expect(pill.className).toContain("bg-accent-bg");
-    expect(pill.className).toContain("text-accent");
+    expect(pill.className).toContain("bg-ok-bg");
+    expect(pill.className).toContain("text-ok");
+    expect(pill.className).not.toContain("bg-accent-bg");
     expect(pill.className).toContain("text-label");
     expect(pill.className).toContain("px-2");
   });

--- a/src/renderer/Pill.tsx
+++ b/src/renderer/Pill.tsx
@@ -21,9 +21,10 @@
 //   - `neutral` sets no background (it inherits the surface it sits on) and
 //     therefore may inherit its foreground — a muted `--tx2` is declared as
 //     the resting label colour so a bare neutral pill reads as a label.
-//   - `accent` / `warn` set a surface (`--accent-bg` / `--warn-bg`) that
-//     differs from the page, so C1 makes them declare the matching foreground
-//     token (`text-accent` / `text-warn`) to keep contrast valid.
+//   - `accent` / `warn` / `ok` set a surface (`--accent-bg` / `--warn-bg` /
+//     `--ok-bg`) that differs from the page, so C1 makes them declare the
+//     matching foreground token (`text-accent` / `text-warn` / `text-ok`) to
+//     keep contrast valid.
 //
 // An optional `border` flag adds the `--border` edge. `size` is a separate
 // axis from the tone — "meta" (12px, the ContextPill size) is the default,
@@ -33,7 +34,7 @@
 import type { ReactElement, ReactNode } from "react";
 import { cloneElement } from "react";
 
-type PillTone = "neutral" | "accent" | "warn";
+type PillTone = "neutral" | "accent" | "warn" | "ok";
 type PillSize = "meta" | "label";
 
 const PILL_BASE = "inline-flex items-center gap-2 rounded-full px-2 py-px font-semibold";
@@ -41,6 +42,7 @@ const TONE: Record<PillTone, string> = {
   neutral: "text-text-muted",
   accent: "bg-accent-bg text-accent",
   warn: "bg-warn-bg text-warn",
+  ok: "bg-ok-bg text-ok",
 };
 const SIZE: Record<PillSize, string> = {
   meta: "text-meta",

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -27,6 +27,7 @@ import { TaskContext, type TaskContextValue } from "./chatShared";
 import { MeasureColumn } from "./MeasureColumn";
 import { ActiveTodos, MessageRow } from "./MessageRow";
 import { QuestionCard } from "./Cards";
+import { ErrorBoundary } from "./ErrorBoundary";
 import {
   createEntryMotionState,
   isBackgroundJobCompletionTurn,
@@ -102,6 +103,9 @@ export function Transcript({
       style={{ padding: "var(--sp-6) 0", marginBottom: "var(--sp-2)" }}
     >
       <TaskContext.Provider value={taskContextValue}>
+        {/* Defensive boundary around the whole transcript body: a single */}
+        {/* MessageRow / card that throws must not white out the app. */}
+        <ErrorBoundary>
         <div className="flex flex-col justify-end min-h-full">
           {messages.length === 0 ? (
             // Full width, matching the populated flow below so both states
@@ -176,18 +180,23 @@ export function Transcript({
               {questions.length > 0 && (
                 <div className="space-y-2 pt-1" ref={questionCardRef}>
                   {questions.map((q) => (
-                    <QuestionCard
-                      key={q.id}
-                      request={q}
-                      onReply={(answers) => onReplyQuestion(q, answers)}
-                      onReject={() => onRejectQuestion(q)}
-                    />
+                    // A malformed question payload must not kill the app — each
+                    // card gets its own boundary so a bad card degrades to an
+                    // inline error while its siblings still render.
+                    <ErrorBoundary key={q.id}>
+                      <QuestionCard
+                        request={q}
+                        onReply={(answers) => onReplyQuestion(q, answers)}
+                        onReject={() => onRejectQuestion(q)}
+                      />
+                    </ErrorBoundary>
                   ))}
                 </div>
               )}
             </MeasureColumn>
           )}
         </div>
+        </ErrorBoundary>
       </TaskContext.Provider>
     </div>
   );


### PR DESCRIPTION
## Two fixes

### 1. App blanks to white on a card render error
The renderer had **no error boundary anywhere**, so any uncaught render/commit throw unmounts the whole React root — a single bad card whites out the entire window (documented failure mode in `testHarness.tsx:110-116`).

- New `ErrorBoundary.tsx` (class boundary; logs `[error-boundary]` so the real error surfaces instead of a silent white screen; inline token-based fallback with a Reload button).
- Wraps the transcript body and each pending `QuestionCard` in `Transcript.tsx`, and the app root in `App.tsx`.
- Defensive guards in `QuestionCard` for missing `questions`/`options`.

### 2. Ask-card redesign to the locked spec
`QuestionCard`/`PermissionCard` brought to the "Permission & question cards" spec, snapped to existing `tokens.css` utilities (no new colors, no off-grid values beyond exact-pixel arbitrary utilities the spec fixes):

- Single-question: 2-line header (`header` bold + `question` muted), drops the redundant generic "Question" title line.
- Full-width option buttons with a 15px check mark; selected/hover → accent.
- Recommended pill is now green (`ok` tone added to `Pill`) and inline.
- Free-text restyled into a bordered box with a leading Send icon.
- Multi-question: numbered sections + separators, progress moved to the action row.
- Action row: Submit-first (primary, ⏎ hint) · spacer · Dismiss (ghost) right. Same treatment on `PermissionCard`.
- `Card` gains an opt-in `elevated` (shadow-md); existing adopters unaffected.

## Verification
`npm run typecheck` clean. `npm test` green locally — renderer 2104 passed / 7 skipped, server 1481 passed, 0 failures. Tests updated: `Card.test.tsx`, `Pill.test.tsx`, new `ErrorBoundary.test.tsx` (fallback-not-blank, reset recovery, option-click, malformed payload).

Authored by a background agent; rebased onto `main` (the original branch was cut from an unpushed local feature branch — this PR is the isolated 9-file fix).