### PR TITLE
fix(chat): one todo checklist card, at the tail of the transcript

### DIFF
--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -2,11 +2,11 @@
 //
 // Extracted from ChatPanel.tsx (M0.5). Renders one transcript row and the
 // small status/todo widgets that sit around the running turn:
-//   - MessageRow: user bar vs. assistant part list, with turn-duration,
-//     truncation, and persistent-todo footers.
+//   - MessageRow: user bar vs. assistant part list, with turn-duration and
+//     truncation footers.
 //   - UserCommandBar: collapsed `/name args` pill for slash-command turns.
-//   - ActiveTodos: the pinned TodoWrite checklist (under the running
-//     indicator while live; under the last assistant message when idle).
+//   - ActiveTodos: the TodoWrite checklist card, mounted once at the tail of
+//     the transcript by Transcript.tsx (running or idle).
 //   - RunningIndicator: the ✻ spinner + elapsed / token line.
 //
 // AssistantPart lives in ./ToolCall; importing it here (and MessageRow back
@@ -23,6 +23,9 @@ import {
   formatTokens,
   formatHiddenTodosSummary,
   selectVisibleTodos,
+  summarizeTodoProgress,
+  todoStatusOf,
+  type TodoStatus,
   type TruncationKind,
 } from "./chatUtils";
 import {
@@ -93,79 +96,149 @@ export function RunningIndicator({ tokens, atBottom }: { tokens: TokenUsage | nu
 
 // ===== Active todos =====
 //
-// Pinned right under the running indicator while a turn is in flight, showing
-// the most recent TodoWrite tool's checklist. As the assistant marks items
-// in_progress/completed and updates the list via subsequent TodoWrite calls,
-// this re-renders automatically (messages refetch on message.part.updated).
+// The TodoWrite checklist, rendered at the TAIL of the transcript inside the
+// scroll container (see Transcript.tsx) — it scrolls with the conversation
+// rather than sitting in a shrink-0 row above the composer. As the assistant
+// marks items in_progress/completed and updates the list via subsequent
+// TodoWrite calls, this re-renders automatically.
 //
-// Visible items show their per-status icon (same as the inline TodoWriteBody);
-// completed items collapse to a count summary so the active focus stays
-// dominant when the list grows.
+// The card replaces the original terminal-transcript treatment (a `⎿` gutter
+// glyph plus `■ ✓ ☐ ⊘` box-drawing characters). Three reasons that had to go:
+// the corner glyph implied a parent tool call that does not exist; the glyphs
+// render at a different size and baseline in every font, and never matched the
+// SwiftUI client's SF Symbols; and nothing in the row communicated PROGRESS —
+// you had to count ticks. The shell (`rounded-sm border bg-bg-elev`) is the
+// same one RetryCard / CompactionCard use, so the checklist now reads as one
+// of the panel's cards instead of as leaked tool output.
+//
+// Status marks are CSS + one inline SVG rather than text glyphs, so they are
+// font-independent and centre exactly: every mark is the SAME 12px circle
+// whose content is centred by `inline-flex items-center justify-center`,
+// which is what keeps the check optically inside the disc at any zoom.
 
-export const ActiveTodos = memo(function ActiveTodos({ todos }: { todos: Array<Record<string, unknown>> }) {
+function TodoMark({ status }: { status: TodoStatus }) {
+  // One 12px disc for all four states; only the fill/border/child changes.
+  // `justify-center` + `items-center` is doing the centring for BOTH the
+  // check and the in-progress pip — no magic offsets to drift.
+  const base =
+    "inline-flex items-center justify-center w-3 h-3 shrink-0 rounded-full border";
+  if (status === "completed") {
+    return (
+      <span
+        className={base}
+        style={{ borderColor: "var(--ok)", backgroundColor: "var(--ok)" }}
+        aria-hidden
+      >
+        <svg viewBox="0 0 10 10" className="w-2 h-2" fill="none">
+          <path
+            d="M2 5.2 4.1 7.2 8 2.9"
+            stroke="var(--canvas)"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <span
+        className={base}
+        style={{
+          borderColor: "var(--warn)",
+          boxShadow: "0 0 0 3px var(--warn-bg)",
+        }}
+        aria-hidden
+      >
+        <span
+          className="w-1 h-1 rounded-full"
+          style={{ backgroundColor: "var(--warn)" }}
+        />
+      </span>
+    );
+  }
+  if (status === "cancelled") {
+    // Dashed + empty: settled, but deliberately not a success mark.
+    return (
+      <span
+        className={`${base} border-dashed border-border-subtle`}
+        aria-hidden
+      />
+    );
+  }
+  return <span className={`${base} border-border-strong`} aria-hidden />;
+}
+
+export const ActiveTodos = memo(function ActiveTodos({
+  todos,
+}: {
+  todos: Array<Record<string, unknown>>;
+}) {
   // Render at most VISIBLE_TODOS_CAP items inline. Order: current
   // (in_progress) → pending → done so the row the model is actively
   // working on is always on screen even when the list grows past the cap.
   // Overflow collapses into a single faint summary row at the bottom:
   // "+ N pending & M done" / "+ N pending" / "+ M done".
-  // Icons: in_progress = filled orange square, pending = empty square,
-  // completed = green ✓ in dim text, cancelled = ⊘ struck through.
   const { visible, hiddenPending, hiddenDone } = selectVisibleTodos(todos);
   const summary = formatHiddenTodosSummary(hiddenPending, hiddenDone);
-  const lastVisibleIdx = visible.length - 1;
+  // Progress counts the WHOLE list, not the visible slice — the bar exists to
+  // report the part the 5-row cap hides.
+  const progress = summarizeTodoProgress(todos);
   return (
-    <div className="pb-2 text-label">
-      {visible.map((t, i) => {
-        const content = String(t.content ?? "");
-        const status = String(t.status ?? "pending");
-        const isInProgress = status === "in_progress";
-        const isCompleted = status === "completed";
-        const isCancelled = status === "cancelled";
-
-        let icon = "☐";
-        let iconColor: string | undefined;
-        let textCls = "text-text-muted";
-        if (isInProgress) {
-          icon = "■";
-          iconColor = "var(--warn)";
-          textCls = "text-text font-semibold";
-        } else if (isCompleted) {
-          icon = "✓";
-          iconColor = "var(--ok)";
-          textCls = "text-text-faint";
-        } else if (isCancelled) {
-          icon = "⊘";
-          textCls = "text-text-faint line-through opacity-60";
-        }
-        // Show the ⎿ corner only on the very first row of the card. The
-        // summary row (when present) replaces the last todo row's leading
-        // slot with a blank so the gutter stays aligned.
-        return (
-          <div key={i} className="flex">
-            <span className="select-none w-5 shrink-0 text-text-faint">
-              {i === 0 ? "⎿" : " "}
-            </span>
-            <span
-              className="select-none w-4 shrink-0"
-              style={{ color: iconColor }}
-            >
-              {icon}
-            </span>
-            <span className={`flex-1 min-w-0 whitespace-pre-wrap break-words ${textCls}`}>
-              {content}
-            </span>
-          </div>
-        );
-      })}
-      {summary && (
-        <div className="flex">
-          <span className="select-none w-5 shrink-0 text-text-faint">
-            {lastVisibleIdx < 0 ? "⎿" : " "}
-          </span>
-          <span className="select-none w-4 shrink-0" />
-            <span className="flex-1 min-w-0 text-text-faint">{summary}</span>
-        </div>
-      )}
+    <div className="rounded-sm border border-border-subtle bg-bg-elev overflow-hidden">
+      <div className="flex items-center gap-2 px-3 pt-2 pb-1">
+        <span className="text-micro uppercase text-text-faint">Plan</span>
+        <span
+          className="ml-auto text-meta tabular-nums"
+          style={{
+            color: progress.allSettled ? "var(--ok)" : "var(--tx4)",
+          }}
+        >
+          {progress.label}
+        </span>
+      </div>
+      {/* Two-segment progress rail. Settled runs green, the in-flight item
+          runs amber; the remainder is the track showing through. 2px so it
+          reads as a rule under the header rather than as a control. */}
+      <div className="flex h-0.5 bg-border-subtle" aria-hidden>
+        <span
+          className="h-full bg-ok"
+          style={{ width: `${progress.settledPct}%` }}
+        />
+        <span
+          className="h-full bg-warn"
+          style={{ width: `${progress.activePct}%` }}
+        />
+      </div>
+      <div className="flex flex-col gap-1 px-3 pt-2 pb-2 text-label">
+        {visible.map((t, i) => {
+          const status = todoStatusOf(t);
+          const textCls =
+            status === "in_progress"
+              ? "text-text font-semibold"
+              : status === "completed"
+                ? "text-text-quiet"
+                : status === "cancelled"
+                  ? "text-text-quiet line-through"
+                  : "text-text-muted";
+          return (
+            <div key={i} className="flex items-start gap-2">
+              {/* mt-px lifts the 12px disc onto the 13px/1.4 text's optical
+                  centre for the first line of a wrapping row. */}
+              <span className="mt-px shrink-0">
+                <TodoMark status={status} />
+              </span>
+              <span
+                className={`flex-1 min-w-0 whitespace-pre-wrap break-words ${textCls}`}
+              >
+                {String(t.content ?? "")}
+              </span>
+            </div>
+          );
+        })}
+        {summary && <div className="text-meta text-text-quiet">{summary}</div>}
+      </div>
     </div>
   );
 });
@@ -214,14 +287,12 @@ const UserCommandBar = memo(function UserCommandBar({
 // message and producing visible input lag past ~50 messages. All props
 // passed in messages.map() are either primitives or stable references
 // (msg from a stable identity; turnInfo / commandInfo / finishBy*
-// Maps are memoized at panel scope; persistentTodos comes from
-// memoized activeTodos). The default shallow-equals check is what we
-// want — no custom comparator needed.
+// Maps are memoized at panel scope). The default shallow-equals check
+// is what we want — no custom comparator needed.
 export const MessageRow = memo(function MessageRow({
   msg,
   showThinking,
   turnDurationMs,
-  persistentTodos,
   truncation,
   commandInfo,
   streaming = false,
@@ -233,10 +304,6 @@ export const MessageRow = memo(function MessageRow({
   // whole turn (all consecutive assistant messages since the last user msg).
   // Intermediate messages get null so they don't show a footer at all.
   turnDurationMs: number | null;
-  // Set ONLY on the LAST assistant message in the entire transcript when not
-  // running — renders the latest TodoWrite list permanently below the footer.
-  // Same data ChatPanel pins under the running indicator while a turn is live.
-  persistentTodos: Array<Record<string, unknown>> | null;
   // Per-message truncation classification from finishByMessageId. Drives
   // the "truncated" badge appended to the turn-duration footer (or as a
   // standalone footer when there's no duration, e.g. mid-turn assistant
@@ -369,9 +436,9 @@ export const MessageRow = memo(function MessageRow({
   // Assistant: render each part on its own. Per the spec (.amsg) the text is
   // plain paragraphs at the reading size with no leading gutter; the bullet
   // column no longer exists (BET-637). todowrite invocations are filtered out —
-  // the latest checklist is already pinned under the running indicator + final
-  // assistant footer (ActiveTodos), so inlining each call too would duplicate
-  // the same list multiple times for any turn that updates todos.
+  // the latest checklist already renders once as the ActiveTodos card at the
+  // tail of the transcript, so inlining each call too would repeat the same
+  // list for every turn that touches todos.
   const visibleParts = msg.parts.filter((p) => {
     if (p.type === "text") return !p.synthetic && !p.ignored && (p.text ?? "").length > 0;
     if (p.type === "step-start" || p.type === "step-finish") return false;
@@ -442,12 +509,6 @@ export const MessageRow = memo(function MessageRow({
             </>
           )}
         </div>
-      )}
-      {/* Persistent todo list — only on the LAST assistant message in the */}
-      {/* transcript, after the turn has ended. While running, the same data */}
-      {/* renders under the RunningIndicator instead (handled by ChatPanel). */}
-      {persistentTodos && persistentTodos.length > 0 && (
-        <ActiveTodos todos={persistentTodos} />
       )}
     </div>,
   );

--- a/src/renderer/TaskCard.tsx
+++ b/src/renderer/TaskCard.tsx
@@ -129,10 +129,9 @@ export function TaskCard({ state }: { state: ToolState }) {
                   msg={m}
                   showThinking={showThinking}
                   // Subagent transcripts have their own footers; don't paint
-                  // turn-duration / persistent-todo / truncation overlays
-                  // designed for the top-level conversation.
+                  // the turn-duration / truncation overlays designed for the
+                  // top-level conversation.
                   turnDurationMs={null}
-                  persistentTodos={null}
                   truncation={null}
                   commandInfo={null}
                 />

--- a/src/renderer/ToolBodies.tsx
+++ b/src/renderer/ToolBodies.tsx
@@ -212,47 +212,6 @@ export function GrepBody({ state, verbose }: { state: ToolState; verbose: boolea
   return <ConnectorOutput body={lines.join("\n")} maxLines={Infinity} />;
 }
 
-// TodoWrite: input.todos is an array of {content, status, ...}. Render as a
-// checklist with status icons. Status values seen: "pending", "in_progress",
-// "completed", "cancelled".
-export function TodoWriteBody({ state }: { state: ToolState }) {
-  const input = state.input ?? {};
-  const todos = (input.todos as Array<Record<string, unknown>> | undefined) ?? [];
-  if (todos.length === 0) return null;
-  return (
-    <div className="text-meta space-y-px">
-      {todos.map((t, i) => {
-        const content = String(t.content ?? "");
-        const status = String(t.status ?? "pending");
-        const icon =
-          status === "completed"
-            ? "☒"
-            : status === "in_progress"
-              ? "◐"
-              : status === "cancelled"
-                ? "⊘"
-                : "☐";
-        const cls =
-          status === "completed"
-            ? "text-text-faint line-through"
-            : status === "in_progress"
-              ? "text-text"
-              : status === "cancelled"
-                ? "text-text-faint line-through opacity-50"
-                : "text-text-muted";
-        return (
-          <div key={i} className={`flex gap-2 ${cls}`}>
-            <span className="select-none shrink-0" style={{ color: status === "in_progress" ? "var(--warn)" : undefined }}>
-              {icon}
-            </span>
-            <span className="flex-1 whitespace-pre-wrap break-words">{content}</span>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 // WebFetch: input has {url, prompt?}. Output is the fetched content / summary.
 export function WebFetchBody({ state }: { state: ToolState }) {
   const input = state.input ?? {};

--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -23,7 +23,6 @@ import {
   GrepBody,
   ReadBody,
   ToolOutput,
-  TodoWriteBody,
   UnifiedDiff,
   WebFetchBody,
 } from "./ToolBodies";
@@ -274,9 +273,18 @@ function ToolBody({
       return <GlobBody state={state} />;
     case "grep":
       return <GrepBody state={state} verbose={verbose} />;
+    // The checklist has exactly ONE renderer: the ActiveTodos card at the tail
+    // of the transcript. `MessageRow`'s part filter already drops todowrite
+    // parts, so this case is normally unreachable — it stays as a belt-and-
+    // braces guard so that if the filter ever changes, a todowrite call falls
+    // through to NOTHING rather than to the default generic-output well, which
+    // would dump the raw todo JSON into the transcript under a second,
+    // divergent treatment. (There used to be a real TodoWriteBody here that
+    // drew the same list with a different glyph set — `◐ ☒ ☐` vs the card's
+    // marks — and struck through completed items when the card did not.)
     case "todowrite":
     case "todo_write":
-      return <TodoWriteBody state={state} />;
+      return null;
     case "webfetch":
     case "web_fetch":
       return <WebFetchBody state={state} />;

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -143,9 +143,6 @@ export function Transcript({
                     msg={m}
                     showThinking={showThinking}
                     turnDurationMs={turnInfo.get(m.info.id)?.turnDurationMs ?? null}
-                    persistentTodos={
-                      isLastInTranscript && !running ? activeTodos : null
-                    }
                     truncation={finishByMessageId.get(m.info.id) ?? null}
                     commandInfo={cmdInfo}
                     // The message being written right now: last in the
@@ -155,15 +152,23 @@ export function Transcript({
                   />
                 );
               })}
-              {/* Live todos while a turn is running — rendered INSIDE the */}
-              {/* scroll container at the tail of the transcript so the list */}
-              {/* scrolls with the rest of the chat instead of sitting in a */}
-              {/* shrink-0 row above the input (which made it feel "sticky" */}
-              {/* and ate vertical space on long checklists). The */}
-              {/* `!running` branch above still attaches activeTodos to the */}
-              {/* last assistant message via persistentTodos — same data, */}
-              {/* same rendering, just owned by MessageRow once idle. */}
-              {running && activeTodos && activeTodos.length > 0 && (
+              {/* The todo checklist — rendered INSIDE the scroll container at */}
+              {/* the tail of the transcript, so it scrolls with the rest of */}
+              {/* the chat instead of sitting in a shrink-0 row above the */}
+              {/* input (which made it feel "sticky" and ate vertical space on */}
+              {/* long checklists). */}
+              {/* */}
+              {/* ONE mount, running or idle. It used to switch owners at the */}
+              {/* end of a turn — live under this branch, then re-parented into */}
+              {/* the last assistant MessageRow via a `persistentTodos` prop */}
+              {/* once idle. Same data drawn by the same component in two */}
+              {/* places, which cost a prop threaded through MessageRow and */}
+              {/* TaskCard, moved the card by a turn-gap the instant a turn */}
+              {/* ended, and dropped it entirely whenever the last row was a */}
+              {/* USER turn (the prop was gated on the last message being an */}
+              {/* assistant). Anchoring it here keeps it at the bottom of the */}
+              {/* transcript in every state. */}
+              {activeTodos && activeTodos.length > 0 && (
                 <ActiveTodos todos={activeTodos} />
               )}
               {/* Pending question cards. Rendered INSIDE the scroll */}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -13,6 +13,8 @@ import {
   dedupeAgainstBuiltins,
   formatModelContextSize,
   formatHiddenTodosSummary,
+  summarizeTodoProgress,
+  todoStatusOf,
   buildQuestionAnswers,
   canSubmitQuestion,
   commandPrefixKey,
@@ -562,6 +564,81 @@ describe("formatHiddenTodosSummary", () => {
   it("formats both with the literal '&' separator from the spec", () => {
     expect(formatHiddenTodosSummary(5, 5)).toBe("+ 5 pending & 5 done");
     expect(formatHiddenTodosSummary(2, 3)).toBe("+ 2 pending & 3 done");
+  });
+});
+
+// ===== todoStatusOf / summarizeTodoProgress =====
+
+describe("todoStatusOf", () => {
+  it("maps the four canonical statuses", () => {
+    expect(todoStatusOf({ status: "in_progress" })).toBe("in_progress");
+    expect(todoStatusOf({ status: "completed" })).toBe("completed");
+    expect(todoStatusOf({ status: "cancelled" })).toBe("cancelled");
+    expect(todoStatusOf({ status: "pending" })).toBe("pending");
+  });
+
+  it("is case-insensitive — the render path used to compare raw strings, so a "
+    + "mixed-case status sorted as current but drew the pending mark", () => {
+    expect(todoStatusOf({ status: "In_Progress" })).toBe("in_progress");
+    expect(todoStatusOf({ status: "COMPLETED" })).toBe("completed");
+  });
+
+  it("treats an unknown or missing status as pending", () => {
+    expect(todoStatusOf({ status: "blocked" })).toBe("pending");
+    expect(todoStatusOf({})).toBe("pending");
+    expect(todoStatusOf({ status: null })).toBe("pending");
+  });
+});
+
+describe("summarizeTodoProgress", () => {
+  const todo = (status: string) => ({ status, content: "x" });
+
+  it("counts settled vs in-flight and labels 'N of M'", () => {
+    const p = summarizeTodoProgress([
+      todo("in_progress"),
+      todo("completed"),
+      todo("completed"),
+      todo("pending"),
+    ]);
+    expect(p.total).toBe(4);
+    expect(p.settled).toBe(2);
+    expect(p.inProgress).toBe(1);
+    expect(p.label).toBe("2 of 4");
+    expect(p.allSettled).toBe(false);
+  });
+
+  it("counts cancelled as settled — the model is done with it", () => {
+    const p = summarizeTodoProgress([todo("cancelled"), todo("pending")]);
+    expect(p.settled).toBe(1);
+    expect(p.label).toBe("1 of 2");
+  });
+
+  it("segment widths are percentages of the WHOLE list, not the visible cap", () => {
+    const p = summarizeTodoProgress([
+      todo("completed"),
+      todo("completed"),
+      todo("in_progress"),
+      todo("pending"),
+    ]);
+    expect(p.settledPct).toBe(50);
+    expect(p.activePct).toBe(25);
+    // The two segments never exceed the track.
+    expect(p.settledPct + p.activePct).toBeLessThanOrEqual(100);
+  });
+
+  it("labels 'complete' once every item is terminal", () => {
+    const p = summarizeTodoProgress([todo("completed"), todo("cancelled")]);
+    expect(p.allSettled).toBe(true);
+    expect(p.label).toBe("complete");
+    expect(p.settledPct).toBe(100);
+  });
+
+  it("does not divide by zero on an empty list", () => {
+    const p = summarizeTodoProgress([]);
+    expect(p.settledPct).toBe(0);
+    expect(p.activePct).toBe(0);
+    expect(p.allSettled).toBe(false);
+    expect(p.label).toBe("0 of 0");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -311,6 +311,74 @@ export function dedupeAgainstBuiltins<T extends TypeaheadCommandRow>(
 }
 
 /**
+ * The four todo states the ActiveTodos card renders, normalized.
+ *
+ * `status` arrives as a free-form string on both paths (the `todo.updated`
+ * SSE payload and the transcript-scraped TodoWrite input), and the selectors
+ * in streamInterpretation.mjs already lowercase before comparing. The RENDER
+ * path used to compare case-sensitively, so a `"In_Progress"` sorted into the
+ * current bucket but drew the pending checkbox. One normalizer now feeds both
+ * the row and the progress summary, so they can't disagree.
+ */
+export type TodoStatus = "in_progress" | "completed" | "cancelled" | "pending";
+
+export function todoStatusOf(t: Record<string, unknown>): TodoStatus {
+  const s = String(t.status ?? "").toLowerCase();
+  if (s === "in_progress") return "in_progress";
+  if (s === "completed") return "completed";
+  if (s === "cancelled") return "cancelled";
+  return "pending";
+}
+
+export type TodoProgress = {
+  total: number;
+  /** completed + cancelled — everything the model is finished with. */
+  settled: number;
+  inProgress: number;
+  /** Width of the green settled segment of the progress bar, 0-100. */
+  settledPct: number;
+  /** Width of the amber in-flight segment, 0-100. */
+  activePct: number;
+  /** Header label: "4 of 5", or "complete" once nothing is left. */
+  label: string;
+  allSettled: boolean;
+};
+
+/**
+ * Count a todo list into the ActiveTodos card's header label and the two
+ * progress-bar segment widths.
+ *
+ * Counts run over the WHOLE list, not the <= 5 rows `selectVisibleTodos`
+ * renders — the bar's job is to say how much of the plan is left, which is
+ * exactly the thing the visible-row cap hides. Cancelled counts as settled
+ * (the model is done with it) but is drawn neutral rather than green by the
+ * row itself, so a cancelled item advances the bar without claiming success.
+ */
+export function summarizeTodoProgress(
+  todos: Array<Record<string, unknown>>,
+): TodoProgress {
+  let settled = 0;
+  let inProgress = 0;
+  for (const t of todos) {
+    const s = todoStatusOf(t);
+    if (s === "completed" || s === "cancelled") settled += 1;
+    else if (s === "in_progress") inProgress += 1;
+  }
+  const total = todos.length;
+  const pct = (n: number) => (total > 0 ? (n / total) * 100 : 0);
+  const allSettled = total > 0 && settled === total;
+  return {
+    total,
+    settled,
+    inProgress,
+    settledPct: pct(settled),
+    activePct: pct(inProgress),
+    label: allSettled ? "complete" : `${settled} of ${total}`,
+    allSettled,
+  };
+}
+
+/**
  * Format the hidden-counts overflow line for the ActiveTodos card.
  * Returns null when nothing is hidden (caller skips the row entirely).
  * Examples: "+ 5 pending & 5 done", "+ 5 pending", "+ 4 done".


### PR DESCRIPTION
## What
Renders the TodoWrite checklist as **one card pinned at the tail of the transcript** in every state, instead of switching renderer + re-parenting it mid-conversation.

**Before** — the list had two owners and jumped around:
- While a turn ran: `Transcript` mounted `ActiveTodos` at the tail.
- When it ended: re-parented into the last assistant row via a `persistentTodos` prop threaded through `MessageRow`/`TaskCard` — so it jumped by a turn-gap on completion, and vanished entirely when the last row was a user turn.
- Independently, `ToolCall` rendered the raw todowrite part via `TodoWriteBody` — a second list with a different glyph set.

**After**: anchor the card at the transcript tail in all states, drop the prop, delete the inline renderer (todowrite now falls through to nothing rather than dumping raw todo JSON into the transcript).

## Adds
- Status marks become CSS + one inline SVG (instead of box-drawing glyphs `◐ ☒ ☐`) so they center identically at any zoom/font.
- Progress summary — "4 of 5" + a two-segment bar — counted over the WHOLE list, not the ≤5 visible rows the cap was hiding. Cancelled counts as settled but draws neutral.
- `todoStatusOf` normalizes case on the render path (matching the selectors).

## Tests
+77 lines in `chatUtils.test.ts`.

## Notes
This is the clean, intended fix. The earlier WIP `c3b0e6f` ("todo checklist card + main dupes") on `feat/floating-glass-chat-chrome` is superseded by this; ignore it.