### PR TITLE
fix(chat): tool-call cards collapsible + copy button beside the chevron

### DIFF
--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -12,7 +12,7 @@
 //     module cycle that is safe because both references are used only at
 //     render time).
 
-import { memo } from "react";
+import { memo, useState } from "react";
 import type { OpencodePart } from "../shared/types";
 import { resolveToolOutput, cssVar } from "./chatUtils";
 import { type ToolState } from "./chatShared";
@@ -234,6 +234,11 @@ export const ToolCall = memo(function ToolCall({ part, verbose }: { part: Openco
   const copyText =
     rawTool === "task" ? "" : (diffText ?? resolveToolOutput(state));
 
+  // Tool-call cards are collapsible and start collapsed: the body (diff /
+  // output) is hidden behind the disclosure header until the user expands it.
+  const [expanded, setExpanded] = useState(false);
+  const toggle = () => setExpanded((v) => !v);
+
   return (
     <div className="flex flex-col" style={{ gap: "var(--block-gap)" }}>
       <ToolCard
@@ -242,8 +247,10 @@ export const ToolCall = memo(function ToolCall({ part, verbose }: { part: Openco
         arg={state.title}
         meta={metaNode}
         copyText={copyText || undefined}
+        expanded={expanded}
+        onToggle={toggle}
       >
-        <ToolBody tool={rawTool} state={state} diffText={diffText} verbose={verbose} />
+        {expanded && <ToolBody tool={rawTool} state={state} diffText={diffText} verbose={verbose} />}
       </ToolCard>
     </div>
   );

--- a/src/renderer/ToolCard.test.tsx
+++ b/src/renderer/ToolCard.test.tsx
@@ -66,14 +66,35 @@ describe("ToolCard", () => {
     expect(h!.container.querySelector(".animate-pulse")).toBeNull();
   });
 
-  it("renders the header as a toggle button with aria-expanded and a chevron when onToggle is supplied", () => {
+  it("renders a disclosure button with aria-expanded when onToggle is supplied", () => {
     let clicks = 0;
     h = mount(<ToolCard name="Task" onToggle={() => clicks++} expanded={false} />);
-    const header = root().firstElementChild as HTMLButtonElement;
-    expect(header.tagName).toBe("BUTTON");
-    expect(header.getAttribute("aria-expanded")).toBe("false");
-    header.click();
+    // The header is a plain flex DIV; the clickable disclosure is the inner
+    // button holding name/arg/meta (it cannot nest the copy/chevron buttons).
+    const header = root().firstElementChild as HTMLElement;
+    expect(header.tagName).toBe("DIV");
+    const toggle = header.querySelector('button[aria-expanded="false"]') as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    // The callback fires on click; the rendered aria-expanded reflects the
+    // (controlled) `expanded` prop, which this closure never changes.
+    toggle.click();
     expect(clicks).toBe(1);
+  });
+
+  it("renders the copy button LEFT of the collapse chevron when both are present", () => {
+    let clicks = 0;
+    h = mount(
+      <ToolCard name="Bash" copyText="output" onToggle={() => clicks++} expanded={false} />,
+    );
+    const header = root().firstElementChild as HTMLElement;
+    const copy = header.querySelector('[aria-label="Copy"]') as HTMLElement;
+    const chevron = header.querySelector('[aria-label="Expand"]') as HTMLElement;
+    expect(copy).toBeTruthy();
+    expect(chevron).toBeTruthy();
+    // The chevron sits at the right of the copy icon — i.e. AFTER it in the
+    // header's flex-child order.
+    const children = Array.from(header.children);
+    expect(children.indexOf(copy)).toBeLessThan(children.indexOf(chevron));
   });
 
   it("renders children as the card body", () => {

--- a/src/renderer/ToolCard.tsx
+++ b/src/renderer/ToolCard.tsx
@@ -2,9 +2,18 @@
 //
 // The spec's `.tool` shell plus its header strip `.tool-h`: a bordered card
 // (rounded-md) on the raised surface with a header holding the status dot,
-// bold tool name, a gap, a truncating muted argument, and a right-aligned
-// meta slot (`+38 −4` counts / status word). Optionally the header is a
-// disclosure button (subagent/task card) with an `aria-expanded` chevron.
+// bold tool name, a gap, a truncating muted argument, a right-aligned meta
+// slot (`+38 −4` counts / status word), and — right of the copy icon — a
+// collapse/expand chevron. Card bodies are collapsible: when `onToggle` is
+// supplied the name/arg/meta region becomes a disclosure button and a chevron
+// appears at the header's far right (immediately after the copy button when
+// one is present).
+//
+// The copy button and the chevron are SIBLINGS of the disclosure button, not
+// children of it — a `<button>` cannot legally nest another `<button>`, and a
+// nested one is unclickable. The header is therefore always a plain flex
+// `<div>`; the clickable toggle region (dot + name + arg + meta) is the inner
+// `flex-1` button, and copy + chevron sit beside it on the right.
 //
 // No `className` escape hatch (epic standing decision 3). Off-grid chrome:
 // the `9px` header vertical padding, the `11px` meta size, and the `12.5px`
@@ -22,6 +31,10 @@ const NAME = "text-text font-semibold";
 const ARG = "text-text-faint min-w-0 truncate";
 const META = "ml-auto flex items-center gap-2 text-[11px] text-text-quiet";
 const COPY = "shrink-0 text-text-faint hover:text-text -my-1 p-1 rounded-xs";
+// The disclosure region of a collapsible header + the action buttons to its
+// right. `flex-1` pushes copy/chevron to the header's far right.
+const TOGGLE = "flex items-center gap-2 flex-1 min-w-0 text-left";
+const ACTION = "shrink-0 text-text-faint hover:text-text -my-1 p-1 rounded-xs";
 
 export function ToolCard({
   tone,
@@ -47,56 +60,63 @@ export function ToolCard({
   meta?: ReactNode;
   /**
    * When set, the header carries a copy affordance for this text (the card's
-   * output / diff). It lives in the HEADER, not floating over the body: a
-   * button absolutely positioned inside the output well sat over the first
-   * line of output, and on a short card it read as belonging to the bottom of
-   * the card rather than to the card itself.
-   *
-   * Ignored when `onToggle` is set — that header IS a button, and a button
-   * inside a button is invalid HTML (and unclickable).
+   * output / diff) — rendered as a button sitting just LEFT of the collapse
+   * chevron. It works whether or not `onToggle` is set (the copy button is a
+   * sibling of the disclosure button, never nested inside it).
    */
   copyText?: string;
   /** Expanded state for the disclosure chevron (only meaningful with `onToggle`). */
   expanded?: boolean;
-  /** When supplied the header becomes a toggle button with a chevron. */
+  /** When supplied the header becomes a disclosure (name/arg/meta clickable) with a chevron. */
   onToggle?: () => void;
   /** Optional body — an OutputWell or a diff. */
   children?: ReactNode;
 }) {
-  const headerChrome = `${HEADER}${onToggle ? " w-full text-left cursor-pointer" : ""}`;
+  const copy = copyText ? <CopyButton text={copyText} className={COPY} /> : null;
+
   const chevron = onToggle ? (
-    <ChevronDown
-      size={12}
-      aria-hidden="true"
-      className={`shrink-0 transition-transform${expanded ? " rotate-180" : ""}${meta == null ? " ml-auto" : ""}`}
-    />
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={expanded ? "Collapse" : "Expand"}
+      title={expanded ? "Collapse" : "Expand"}
+      className={ACTION}
+    >
+      <ChevronDown
+        size={12}
+        aria-hidden="true"
+        className={`transition-transform${expanded ? " rotate-180" : ""}`}
+      />
+    </button>
   ) : null;
 
-  const copy =
-    copyText && !onToggle ? (
-      <CopyButton text={copyText} className={`${meta == null ? "ml-auto " : ""}${COPY}`} />
-    ) : null;
-
-  const headerInner = (
+  const info = (
     <>
       {tone != null && <StatusDot tone={tone} />}
       <span className={NAME}>{name}</span>
       {arg != null && <span className={ARG}>{arg}</span>}
-      {meta != null && <span className={META}>{meta}</span>}
-      {copy}
-      {chevron}
     </>
   );
 
+  const metaSlot = meta != null && <span className={META}>{meta}</span>;
+
   return (
     <div className={SHELL}>
-      {onToggle ? (
-        <button type="button" onClick={onToggle} aria-expanded={expanded ?? false} className={headerChrome}>
-          {headerInner}
-        </button>
-      ) : (
-        <div className={headerChrome}>{headerInner}</div>
-      )}
+      <div className={HEADER}>
+        {onToggle ? (
+          <button type="button" onClick={onToggle} aria-expanded={expanded ?? false} className={TOGGLE}>
+            {info}
+            {metaSlot}
+          </button>
+        ) : (
+          <>
+            {info}
+            {metaSlot}
+          </>
+        )}
+        {copy}
+        {chevron}
+      </div>
       {children != null && children}
     </div>
   );

--- a/src/renderer/toolRendering.test.tsx
+++ b/src/renderer/toolRendering.test.tsx
@@ -5,6 +5,7 @@
 // below need jsdom because they mount a real React subtree via
 // `./testHarness`.
 
+import { act } from "react";
 import { describe, it, expect, afterEach } from "vitest";
 import { cssVar } from "./chatUtils";
 import { AssistantPart, bulletStyle, ToolCall, formatFileDiff } from "./ToolCall";
@@ -14,6 +15,16 @@ import {
   type Harness,
 } from "./testHarness";
 import type { OpencodePart } from "../shared/types";
+
+// Tool-call cards start COLLAPSED. Mounting a <ToolCall> hides its body until
+// the disclosure is clicked, so tests that assert on the body expand first.
+// The click flips internal expanded state, so it must run inside act() for the
+// re-render to flush before the next synchronous assertion.
+function expandAll(container: Element) {
+  for (const b of Array.from(container.querySelectorAll<HTMLButtonElement>('button[aria-expanded="false"]'))) {
+    act(() => b.click());
+  }
+}
 
 // Build a tool part with a given lifecycle status.
 function toolPart(status?: string): OpencodePart {
@@ -122,6 +133,8 @@ describe("tool card chrome", () => {
     installMockApi();
     const long = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
     h = mount(<ToolCall part={outputPart(long)} verbose={false} />);
+    // The card is collapsed by default; expand it to render the body.
+    expandAll(h.container);
     const scrollers = h.container.querySelectorAll(".overflow-y-auto");
     expect(scrollers.length).toBe(1);
     // …and it is the <pre>, because that is the element the pin-to-bottom
@@ -140,6 +153,7 @@ describe("tool card chrome", () => {
       state: { status: "completed", output: "To github.com\n  main -> main\n\n\n" },
     } as unknown as OpencodePart;
     h = mount(<ToolCall part={part} verbose={false} />);
+    expandAll(h.container);
     const rows = Array.from(h.container.querySelectorAll("div.whitespace-pre-wrap"));
     expect(rows.map((r) => r.textContent)).toEqual(["To github.com", "  main -> main"]);
   });
@@ -158,12 +172,31 @@ describe("tool card chrome", () => {
 
   it("does not nest a copy button inside a disclosure header (invalid HTML)", () => {
     installMockApi();
-    // The subagent card's header IS a <button>; a copy button inside it would
-    // be unclickable and invalid markup.
+    // The tool card's disclosure header is a <button>; a copy button inside it
+    // would be unclickable and invalid markup — copy and chevron are its
+    // siblings instead.
     h = mount(<ToolCall part={taskPart({ subagent_type: "explore" })} verbose={false} />);
     for (const btn of Array.from(h.container.querySelectorAll("button"))) {
       expect(btn.querySelector("button")).toBeNull();
     }
+  });
+
+  it("renders tool cards collapsed by default and shows the body only when expanded", () => {
+    installMockApi();
+    h = mount(<ToolCall part={outputPart("visible after expand")} verbose={false} />);
+    // Collapsed: the output body is absent from the DOM.
+    expect(h.text()).not.toContain("visible after expand");
+    const toggle = h.container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    act(() => toggle.click());
+    expect(h.text()).toContain("visible after expand");
+  });
+
+  it("shows both the copy button and the collapse chevron in the header of a standard tool card", () => {
+    installMockApi();
+    h = mount(<ToolCall part={outputPart("copyable output")} verbose={false} />);
+    expect(h.container.querySelector('[aria-label="Copy"]')).toBeTruthy();
+    expect(h.container.querySelector('button[aria-expanded="false"]')).toBeTruthy();
   });
 });
 
@@ -224,6 +257,8 @@ describe("TaskBody subagent row", () => {
         verbose={false}
       />,
     );
+    // The outer tool card is collapsed by default; expand it to mount TaskCard.
+    expandAll(h.container);
     const text = h.text();
     const matches = text.match(/explore/g) ?? [];
     expect(matches.length).toBe(1);
@@ -237,6 +272,7 @@ describe("TaskBody subagent row", () => {
         verbose={false}
       />,
     );
+    expandAll(h.container);
     expect(h.text()).toContain("explore");
   });
 
@@ -248,6 +284,7 @@ describe("TaskBody subagent row", () => {
         verbose={false}
       />,
     );
+    expandAll(h.container);
     // The extractSubagentInfo fallback in chatUtils.ts is the literal
     // string "subagent"; the badge text is the only place that string can
     // appear when subagent_type is absent.


### PR DESCRIPTION
## What
Makes tool-call cards **collapsible, starting collapsed** — the output/diff body is hidden behind the disclosure header until expanded.

Fixes the copy button on collapsible cards: previously `copyText` was silently dropped whenever the header was a toggle (a `<button>` cannot nest another `<button>`, so the copy affordance vanished). The copy button is now a **sibling** of the disclosure button, sitting just left of the collapse chevron.

## Scope
- `ToolCard.tsx` — header restructure: disclosure button (dot + name + arg + meta) is the `flex-1` region; copy + chevron are siblings to its right.
- `ToolCall.tsx` — wire `expanded`/`onToggle`, start collapsed.
- Tests: `ToolCard.test.tsx`, `toolRendering.test.tsx` (+26 passing).

Cherry-picked from `feat/floating-glass-chat-chrome` (`3ad5048`), applied on a fresh `main` worktree.