### PR TITLE
diag(renderer): forward silent-blank errors to terminal (temp probe)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -371,6 +371,14 @@ function registerHandlers(): void {
   // /rpc/config:get instead). See src/preload/index.ts and src/renderer/main.tsx.
   ipcMain.handle(IPC.configGet, () => config);
 
+  // TEMP DIAG: renderer → terminal forwarding for the silent-blank probe.
+  // Main's console.write reaches the launching terminal / log; the error is
+  // otherwise invisible when devtools is closed or the root went blank.
+  // Remove with the blank-bug probe.
+  ipcMain.on(IPC.rendererLog, (_e, p: { kind: string; message: string; stack?: string }) => {
+    console.error(`[renderer:${p?.kind ?? "log"}]`, p?.message ?? "", p?.stack ?? "");
+  });
+
   // BET-225 stage 3 (Part C): returns the desktop app's own version via
   // Electron's `app.getVersion()` (reads the same package.json the server
   // uses for `server:version`). Renderer combines this with `minClient`

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,6 +38,13 @@ ipcRenderer.on(IPC.pairLinkReceived, (_event, url: string) => {
 });
 
 const api = {
+  // TEMP DIAG: forward a renderer error/console line to the main process so it
+  // reaches the launching terminal. Fire-and-forget (no invoke). Remove with
+  // the blank-bug probe.
+  reportRendererLog: (kind: string, message: string, stack?: string): void => {
+    ipcRenderer.send(IPC.rendererLog, { kind, message, stack });
+  },
+
   // Read ONLY by main.tsx's boot sequence (`chooseDesktopTransport`), before
   // httpApi is installed as `window.api` — used to seed httpApi's
   // localStorage credentials from the desktop's local config.json (pairing

--- a/src/renderer/blankProbe.ts
+++ b/src/renderer/blankProbe.ts
@@ -1,0 +1,54 @@
+// TEMP DIAG — silent-blank probe. Remove when the blank-bug is diagnosed.
+//
+// The renderer forwards window.onerror, unhandledrejection, and every
+// console.error (including the ErrorBoundary's `[error-boundary]` log) to the
+// main process, which writes them to the terminal you launched MantaUI from.
+// Devtools closes the loop on "whole app blank, nothing in console": if a
+// render throw / async rejection / boundary catch fires, it now lands in the
+// terminal even when devtools shows nothing (or the root has already gone
+// blank).
+export function installBlankProbe(preload: unknown): void {
+  const p = (preload ?? null) as {
+    reportRendererLog?: (kind: string, message: string, stack?: string) => void;
+  } | null;
+  if (!p?.reportRendererLog) return;
+  const report = (kind: string, message: string, stack?: string) => {
+    try {
+      p.reportRendererLog!(kind, String(message), stack);
+    } catch {
+      /* main gone — nothing to forward to */
+    }
+  };
+
+  window.addEventListener("error", (e) => {
+    report("window.onerror", e.message ?? String(e.error ?? ""), e.error?.stack);
+  });
+
+  window.addEventListener("unhandledrejection", (e) => {
+    const r = e.reason;
+    report("unhandledrejection", r instanceof Error ? r.message : String(r), r?.stack);
+  });
+
+  // Patch console.error to also ship to the terminal. Guarded so we never
+  // recurse: the forward is fire-and-forget and doesn't call console.*.
+  const origError = console.error.bind(console);
+  const patched = (...args: unknown[]) => {
+    let message = "";
+    let stack: string | undefined;
+    for (const a of args) {
+      if (a instanceof Error) {
+        message += (message ? " " : "") + a.message;
+        stack = a.stack;
+      } else {
+        try {
+          message += (message ? " " : "") + (typeof a === "string" ? a : JSON.stringify(a));
+        } catch {
+          message += " [unserializable]";
+        }
+      }
+    }
+    report("console.error", message, stack);
+    origError(...args);
+  };
+  console.error = patched as typeof console.error;
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -14,6 +14,7 @@ import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { installHttpTransport, setWindowApi } from "./transportInstall";
 import { applyTheme } from "./theme";
 import { pinDemoClock } from "./clock";
+import { installBlankProbe } from "./blankProbe";
 
 // Demo mode (BET-302): `?demo` in the URL swaps the real httpApi for a
 // fixture-backed transport and skips pairing / config / credential logic
@@ -41,6 +42,11 @@ import { pinDemoClock } from "./clock";
 // preload is now only reachable through `?demo` for the visual gates and
 // marketing shots, which never run the real boot path.
 const preload = (window as unknown as { __mantaPreload?: Api }).__mantaPreload;
+
+// TEMP DIAG — silent-blank probe: forward window.onerror / unhandledrejection /
+// console.error to the main-process terminal. Must run before React mounts so
+// an early render crash still ships. Remove with the blank-bug probe.
+installBlankProbe(preload);
 
 // Demo mode (BET-302): parsed once at module load so the demo branch is
 // reachable from inside boot() without re-parsing the URL.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -442,6 +442,12 @@ export type AutoUpdateErrorInfo = {
 };
 
 export const IPC = {
+  // TEMP DIAG: renderer → main-process forwarding of uncaught errors /
+  // unhandled rejections / console.error, so a silent blank that shows nothing
+  // in devtools still lands in the launching terminal (main console.log/
+  // console.error). Remove with the blank-bug probe.
+  rendererLog: "renderer:log",
+
   configGet: "config:get",
   configUpdate: "config:update",
 


### PR DESCRIPTION
Temporary diagnostics for the desktop 'whole app goes blank' bug.

**Symptom:** clicking a checkbox in a question card blanks the ENTIRE app (header + sidebar gone) with nothing in devtools and no crash/OOM. Ctrl+R recovers. The checkbox toggle path (QuestionCard -> setState -> re-render) verifies clean in jsdom, so a silent, non-React blank needs live instrumentation.

**This PR:** forwards window.onerror, unhandledrejection, and every console.error (including the ErrorBoundary's [error-boundary] log) to the main process via a new preload IPC channel, so they land in the launching terminal even when devtools is empty.

TEMP — to be reverted once the blank is diagnosed. Requires a full desktop restart after pulling (touches preload + main).