### PR TITLE
fix(chat): todo card header "Plan"→"Todo" + done/total counter

### DIFF
--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -188,7 +188,7 @@ export const ActiveTodos = memo(function ActiveTodos({
   return (
     <div className="rounded-sm border border-border-subtle bg-bg-elev overflow-hidden">
       <div className="flex items-center gap-2 px-3 pt-2 pb-1">
-        <span className="text-micro uppercase text-text-faint">Plan</span>
+        <span className="text-micro uppercase text-text-faint">Todo</span>
         <span
           className="ml-auto text-meta tabular-nums"
           style={{

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -593,7 +593,7 @@ describe("todoStatusOf", () => {
 describe("summarizeTodoProgress", () => {
   const todo = (status: string) => ({ status, content: "x" });
 
-  it("counts settled vs in-flight and labels 'N of M'", () => {
+  it("counts settled vs in-flight and labels the done/total counter", () => {
     const p = summarizeTodoProgress([
       todo("in_progress"),
       todo("completed"),
@@ -603,14 +603,14 @@ describe("summarizeTodoProgress", () => {
     expect(p.total).toBe(4);
     expect(p.settled).toBe(2);
     expect(p.inProgress).toBe(1);
-    expect(p.label).toBe("2 of 4");
+    expect(p.label).toBe("2/4");
     expect(p.allSettled).toBe(false);
   });
 
   it("counts cancelled as settled — the model is done with it", () => {
     const p = summarizeTodoProgress([todo("cancelled"), todo("pending")]);
     expect(p.settled).toBe(1);
-    expect(p.label).toBe("1 of 2");
+    expect(p.label).toBe("1/2");
   });
 
   it("segment widths are percentages of the WHOLE list, not the visible cap", () => {
@@ -626,10 +626,10 @@ describe("summarizeTodoProgress", () => {
     expect(p.settledPct + p.activePct).toBeLessThanOrEqual(100);
   });
 
-  it("labels 'complete' once every item is terminal", () => {
+  it("labels the done/total counter once every item is terminal", () => {
     const p = summarizeTodoProgress([todo("completed"), todo("cancelled")]);
     expect(p.allSettled).toBe(true);
-    expect(p.label).toBe("complete");
+    expect(p.label).toBe("2/2");
     expect(p.settledPct).toBe(100);
   });
 
@@ -638,7 +638,7 @@ describe("summarizeTodoProgress", () => {
     expect(p.settledPct).toBe(0);
     expect(p.activePct).toBe(0);
     expect(p.allSettled).toBe(false);
-    expect(p.label).toBe("0 of 0");
+    expect(p.label).toBe("0/0");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -339,7 +339,7 @@ export type TodoProgress = {
   settledPct: number;
   /** Width of the amber in-flight segment, 0-100. */
   activePct: number;
-  /** Header label: "4 of 5", or "complete" once nothing is left. */
+  /** Header label: the done/total counter, e.g. "3/5", "7/7". */
   label: string;
   allSettled: boolean;
 };
@@ -373,7 +373,7 @@ export function summarizeTodoProgress(
     inProgress,
     settledPct: pct(settled),
     activePct: pct(inProgress),
-    label: allSettled ? "complete" : `${settled} of ${total}`,
+    label: `${settled}/${total}`,
     allSettled,
   };
 }


### PR DESCRIPTION
## What
Adjusts the todos card that sits under the running indicator:

- Header label **"Plan"** → **"Todo"**
- The trailing count now shows the **done/total counter** in every state — `7/7`, `3/5`, `2/2` — instead of `N of M` and the spelled-out `complete` when all items are done.

## Why
Clearer microcopy; the counter reads consistently whether or not the list is finished.

## Changes
- `src/renderer/MessageRow.tsx` — header text `Plan` → `Todo`
- `src/renderer/chatUtils.ts` — `summarizeTodoProgress().label` → `` `${settled}/${total}` `` (all states)
- `src/renderer/chatUtils.test.ts` — updated expectations (`2/4`, `1/2`, `2/2`, `0/0`)

## Verification
`npm run typecheck` ✅ · `npm test` ✅ (1481 pass) · `vitest chatUtils` ✅ (325 pass)