### PR TITLE
fix(chat): tool-card chevron points right when collapsed, down when open

### DIFF
--- a/src/renderer/ToolCard.tsx
+++ b/src/renderer/ToolCard.tsx
@@ -20,7 +20,7 @@
 // mono header size.
 
 import type { ReactNode } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { StatusDot } from "./StatusDot";
 import { CopyButton } from "./CopyButton";
 
@@ -82,10 +82,10 @@ export function ToolCard({
       title={expanded ? "Collapse" : "Expand"}
       className={ACTION}
     >
-      <ChevronDown
+      <ChevronRight
         size={12}
         aria-hidden="true"
-        className={`transition-transform${expanded ? " rotate-180" : ""}`}
+        className={`transition-transform${expanded ? " rotate-90" : ""}`}
       />
     </button>
   ) : null;


### PR DESCRIPTION
The collapsible tool-call card's disclosure chevron pointed down when collapsed and up when open. Swapped to the standard disclosure convention: **right** when collapsed, **down** when expanded (via `ChevronRight` rotated 90°).

- [x] `npm run typecheck` passes
- [x] `ToolCard.test.tsx` + `toolRendering.test.tsx` pass (26)