### PR TITLE
fix(chat): prose slides in like a card, one markdown block at a time

### DIFF
--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -72,7 +72,7 @@ export const AssistantPart = memo(function AssistantPart({
   showThinking: boolean;
   // True ONLY for the text part currently being written (last part of the last
   // assistant message while the turn runs). Adds `manta-streaming`, which owns
-  // the per-block fade-in and the trailing caret in index.css. A primitive so
+  // the per-block slide-in and the trailing caret in index.css. A primitive so
   // the memo chain is untouched; false everywhere else, so a settled transcript
   // never animates and never shows a caret.
   streaming?: boolean;
@@ -96,11 +96,14 @@ export const AssistantPart = memo(function AssistantPart({
   //      (ToolCall / CollapsibleLines useState). So we always render a stable
   //      wrapper element and only vary its className.
   //
-  // The streaming TEXT part is exempt: its markdown blocks already fade in
-  // individually via `.manta-streaming > *`, and sliding the whole container on
-  // top of that would animate the same content twice. A tool card has no such
-  // fade, so it must slide — which the old `streaming` guard wrongly suppressed
-  // (a tool card is always the last, streaming, part at the instant it appears).
+  // The streaming TEXT part is exempt — it slides PER MARKDOWN BLOCK instead,
+  // via `.manta-streaming > *`, which runs the very same keyframes. Prose
+  // arrives paragraph by paragraph over many seconds, so the block is its unit
+  // of arrival the way the part is a card's; sliding the container on top of
+  // that would move the same content twice, 8px inside another 8px. A tool card
+  // has no such per-block motion, so the card itself must slide — which the old
+  // `streaming` guard wrongly suppressed (a tool card is always the last, and
+  // therefore "streaming", part at the instant it appears).
   //
   // The slide goes on a WRAPPER rather than the part's own root because the
   // roots are shared primitives (ToolCard, OutputWell) that deliberately expose

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -152,18 +152,23 @@ describe("Transcript entry motion", () => {
     expect(partsIn(h)).toBe(1);
   });
 
-  it("does NOT slide the live text part — it owns its own per-block fade", () => {
-    // The streaming TEXT part is the sole exemption: `.manta-streaming` fades
-    // its markdown blocks in individually, so wrapping it in the container
-    // slide too would animate the same content twice. Frozen at mount as
-    // non-sliding, it stays non-sliding even after the turn settles.
+  it("slides the live text part PER BLOCK, not as a container", () => {
+    // Prose is not exempt from the motion — only from the CONTAINER slide. It
+    // carries `.manta-streaming`, whose `> *` rule runs the same keyframes on
+    // each markdown block as it arrives, so prose and cards slide identically.
+    // Wrapping the container too would move the same content twice, 8px inside
+    // another 8px. Both halves are asserted: no container slide, and the class
+    // that supplies the per-block slide IS present — without that second
+    // assertion this test would still pass if prose animated not at all.
     h = open();
     render(h, [...HISTORY, OPTIMISTIC], true);
 
     const streaming = [...HISTORY, OPTIMISTIC, msg("a_new", "assistant", "writing")];
     render(h, streaming, true);
     expect(partsIn(h)).toBe(0);
+    expect(h.container.querySelectorAll(".manta-streaming").length).toBe(1);
 
+    // Frozen at mount: settling the turn must not retro-add a container slide.
     render(h, streaming, false);
     expect(partsIn(h)).toBe(0);
   });

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -160,20 +160,28 @@ html, body, #root {
    Two effects, both scoped to the ONE message currently being written, so
    nothing in the settled transcript animates or carries a caret.
 
-   1. Block fade-in. Each markdown block enters with a short fade + 3px rise
-      instead of appearing instantly. It fires on MOUNT, so an already-rendered
-      paragraph that merely grows does not re-animate, and the canonical
-      refetch (which reconciles rather than remounts) does not re-fire it.
+   1. Block slide-in. Each markdown block enters with the SAME motion a tool
+      card uses (see manta-part-in below) — same distance, duration and easing —
+      so prose and cards arrive identically and a turn assembles itself in one
+      visual language. It fires on MOUNT, so an already-rendered paragraph that
+      merely grows does not re-animate, and the canonical refetch (which
+      reconciles rather than remounts) does not re-fire it.
+
+      It used to be its own weaker `manta-chunk-in` (3px / 0.18s). At that
+      distance the rise is below the threshold where it reads as movement, so
+      prose looked like it merely faded while cards slid — reported as "prose
+      never slides in". The keyframes are now shared rather than duplicated at
+      matching values, so the two cannot drift apart again.
+
+      NOTE the block is the unit here, and the container is deliberately NOT
+      also slid (AssistantPart exempts the live text part): sliding both would
+      move the same content twice, 8px inside another 8px.
    2. Trailing caret. A thin accent block after the last block's last line,
       marking where output is being written. Drawn with ::after on the last
       child so it sits INLINE at the end of the text — a sibling element would
       break onto its own line after a block-level <p>. */
-@keyframes manta-chunk-in {
-  from { opacity: 0; transform: translateY(3px); }
-  to { opacity: 1; transform: none; }
-}
 .manta-streaming > * {
-  animation: manta-chunk-in 0.18s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
+  animation: manta-part-in 0.22s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
 }
 .manta-streaming > *:last-child::after {
   content: "";
@@ -203,7 +211,8 @@ html, body, #root {
    why the earlier whole-row version could never fire: the row was always
    exempt as "currently streaming" when it mounted, and no longer new by the
    time it settled. The live-streaming text part is still exempt here because
-   its markdown blocks fade in individually via .manta-streaming (BET-649).
+   its markdown blocks already run these same keyframes one at a time via
+   .manta-streaming (BET-649) — it slides per block, not as a container.
 
    `entering` (decided in Transcript.tsx by updateEntryMotion) is what keeps
    history still: a transcript the user merely loaded animates nothing. */


### PR DESCRIPTION
Follow-up to #587.

Prose *did* animate — it just used a weaker motion than a card: a 3px rise over 0.18s against the card's 8px over 0.22s. Below that distance the rise reads as a fade rather than as movement, which is why prose looked like it never slid in while cards did.

`.manta-streaming > *` now runs the card's own `manta-part-in` keyframes, at the card's duration and easing, so prose and cards arrive in one visual language. The keyframes are **shared** rather than duplicated at matching values — the previous split is exactly how the two drifted apart in the first place — so `manta-chunk-in` is gone.

**The block stays the unit for prose, and the container stays exempt.** Prose arrives paragraph by paragraph over many seconds, the way a turn arrives card by card, so the markdown block is its unit of arrival. Sliding the container *as well* would move the same content twice — 8px inside another 8px.

The `Transcript` test that pinned "the live text part does not slide as a container" now also asserts the class supplying the per-block slide is present. Without that second half, the test would pass just as happily if prose animated not at all — which is the state this PR is fixing.

No logic change: renderer behaviour is identical, only the CSS the streaming text part points at. `typecheck` clean, full suite green.

As with #587, the actual motion needs eyes in the running app — jsdom has no layout and can only assert which classes are attached.
