### PR TITLE
fix(renderer): checked checkbox shows its checkmark again

### DIFF
--- a/src/renderer/Checkbox.test.tsx
+++ b/src/renderer/Checkbox.test.tsx
@@ -56,6 +56,11 @@ describe("Checkbox", () => {
     expect(box.className).toContain("bg-accent-solid");
     expect(box.className).toContain("text-on-accent");
     expect(h.container.querySelector("svg")).not.toBeNull();
+    // REGRESSION: the canvas fill must be GONE when checked. Both are
+    // backgroundColor utilities of equal specificity, and Tailwind emits
+    // `.bg-bg` after `.bg-accent-solid`, so keeping both left the box on the
+    // canvas fill with an --on-accent glyph on it — an invisible checkmark.
+    expect(box.className).not.toContain("bg-bg");
   });
 
   it("renders the label prop as text after the box and propagates it as the accessible name", () => {

--- a/src/renderer/Checkbox.tsx
+++ b/src/renderer/Checkbox.tsx
@@ -12,6 +12,16 @@
 // that uses `peer` — a class on the input that styles the preceding-sibling
 // box — the checked fill and glyph are driven from the `checked` prop so the
 // glyph stays out of the DOM when unchecked.
+//
+// GOTCHA — the two fills MUST be mutually exclusive. `bg-bg` was originally
+// emitted unconditionally with `bg-accent-solid` appended when checked, on the
+// assumption that the later class in the string wins. It does not: both are
+// backgroundColor utilities of equal specificity, so the winner is whichever
+// Tailwind emits LAST in the compiled sheet — and that is `.bg-bg`. A checked
+// box therefore kept the canvas fill while the glyph was painted in
+// `--on-accent` (near-black on dark, white on light), i.e. an invisible
+// checkmark in both themes. Never put a base fill and a state fill on the same
+// element; pick one in the ternary.
 
 import { Check } from "lucide-react";
 
@@ -52,9 +62,9 @@ export function Checkbox({
       <span
         aria-hidden="true"
         className={
-          "w-4 h-4 rounded-xs border border-border-strong bg-bg inline-grid place-items-center " +
+          "w-4 h-4 rounded-xs border border-border-strong inline-grid place-items-center " +
           "peer-focus-visible:outline-2 peer-focus-visible:outline-offset-1 peer-focus-visible:outline-accent " +
-          (checked ? "bg-accent-solid text-on-accent" : "")
+          (checked ? "bg-accent-solid text-on-accent" : "bg-bg")
         }
       >
         {checked && <Check size={12} />}


### PR DESCRIPTION
## The bug

Toggling any checkbox on left the box looking empty — no checkmark.

## Cause

The box carried the canvas fill (`bg-bg`) unconditionally and *appended* the accent fill (`bg-accent-solid`) when checked, on the assumption that the later class in the string wins. It doesn't. Both are `backgroundColor` utilities of equal specificity, so the winner is whichever Tailwind emits **last in the compiled sheet** — and that is `.bg-bg`:

```
1823:.bg-accent-solid { ... }
1835:.bg-bg { ... }          ← wins
```

(from a real `tailwindcss@3.4` build of this repo's config + content globs)

So a checked box kept the canvas fill while the glyph was painted in `--on-accent` — near-black on dark, white on light. The checkmark was in the DOM the whole time, painted the same colour as what sat behind it, **in both themes**.

## Fix

Pick one fill in the ternary so the base and state fills are mutually exclusive.

```diff
-"… border-border-strong bg-bg inline-grid place-items-center " +
+"… border-border-strong inline-grid place-items-center " +
 "peer-focus-visible:outline-2 …" +
-(checked ? "bg-accent-solid text-on-accent" : "")
+(checked ? "bg-accent-solid text-on-accent" : "bg-bg")
```

## Blast radius

Every `Checkbox` call site: Settings boolean rows, the Plugins gate, launcher CLI flags, Main/Sub model availability columns, provider + custom-provider model lists, and the new-session worktree option.

The question-card option marks are a **separate** hand-rolled implementation that sets its fill via inline `style`, which outranks any utility — never affected. That's likely why the bug read as inconsistent. `ModelsCard`'s default-model radio uses a `checked:` *variant* (variants sort after bare utilities) plus an inline style, so it's also fine.

## Guard

`Checkbox.test.tsx` now asserts the canvas fill is **absent** when checked, so re-merging the two classes fails immediately. Swept the rest of the renderer for the same shape — every other hit is a `hover:`/`checked:` variant or a separate ternary arm, both of which are safe.

## Verification

- `npm run typecheck` clean
- `npm test` green — 2115 renderer + 1481 server