### PR TITLE
fix(chat): stop the model picker reloading on /clear, quieten composer chrome

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -61,6 +61,7 @@ import {
   type TaskContextValue,
   type TokenUsage,
 } from "./chatShared";
+import { useModelCatalog } from "./modelCatalog";
 import { RunningIndicator } from "./MessageRow";
 import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
@@ -384,15 +385,12 @@ export function ChatPanel({
   // ===== ChatPanel-own state (not extracted to hooks) =====
   const [error, setError] = useState<string | null>(null);
   const [showThinking, setShowThinking] = useState(false);
-  // Available models + server default (pre-fetched on mount, not lazy — so
-  // the footer can show a meaningful model name before the first response,
-  // and clicking the picker doesn't flash a "Loading…" row). Selection is
-  // per-session and persists via localStorage.
-  const [models, setModels] = useState<OpencodeModel[] | null>(null);
-  const [defaultModel, setDefaultModel] = useState<{
-    providerID: string;
-    modelID: string;
-  } | null>(null);
+  // Available models + server default. The catalog is box-level, not
+  // per-session, so it lives in a shared module cache (`useModelCatalog`) — a
+  // panel mounted by `/clear` reads the already-known list synchronously and
+  // the picker never flashes "Loading…" for a list that didn't change.
+  // Selection, by contrast, IS per-session and persists via localStorage.
+  const { models, defaultModel } = useModelCatalog();
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
     readSavedModel(sessionId) ?? configDefaultModel ?? null,
   );
@@ -908,26 +906,6 @@ export function ChatPanel({
     },
     [refreshQuestions],
   );
-
-  // Pre-fetch models + default on session mount so the footer shows the
-  // actual model (not just "opencode") before the first response, and the
-  // dropdown opens populated. Idempotent: skipped when both are already loaded.
-  useEffect(() => {
-    let cancelled = false;
-    if (models == null) {
-      window.api
-        .opencodeModels()
-        .then((list) => { if (!cancelled) setModels(list); })
-        .catch(() => { /* non-fatal */ });
-    }
-    if (defaultModel == null) {
-      window.api
-        .opencodeDefaultModel()
-        .then((d) => { if (!cancelled) setDefaultModel(d); })
-        .catch(() => { /* non-fatal */ });
-    }
-    return () => { cancelled = true; };
-  }, [sessionId, models, defaultModel]);
 
   // Kept for the picker button's onOpen — no-op now that we pre-fetch.
   const ensureModels = useCallback(async () => { /* noop */ }, []);

--- a/src/renderer/Chip.test.tsx
+++ b/src/renderer/Chip.test.tsx
@@ -14,8 +14,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mount, type Harness } from "./testHarness";
 import { Chip, SplitChip } from "./Chip";
 
-const CHIP_SHELL =
-  "inline-flex items-center h-[29px] rounded-md border whitespace-nowrap text-meta font-medium leading-none transition-colors";
+const CHIP_BASE =
+  "inline-flex items-center h-[29px] rounded-md border whitespace-nowrap text-meta leading-none transition-colors";
+// Single chip = medium (a labelled action). Split chip = regular (a status
+// readout). The divergence is deliberate — see Chip.tsx's header.
+const CHIP_SHELL = `${CHIP_BASE} font-medium`;
+const SPLIT_SHELL = `${CHIP_BASE} font-normal`;
 const CHIP_REST = "border-border bg-bg-soft text-text-muted";
 const CHIP_HOVER = "hover:border-border-strong hover:text-text";
 const CHIP_ON = "border-accent bg-accent-bg text-accent-tx";
@@ -95,7 +99,7 @@ describe("SplitChip", () => {
       />,
     );
     const shell = h.container.firstElementChild as HTMLElement;
-    expect(shell.className).toBe(`${CHIP_SHELL} p-0 overflow-hidden ${CHIP_REST}`);
+    expect(shell.className).toBe(`${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`);
     const [l, r] = buttons();
     expect(l.className).toBe(`inline-flex items-center ${CHIP_PAD} h-full hover:bg-fill-hover hover:text-text`);
     expect(r.className).toBe(`inline-flex items-center ${CHIP_PAD} h-full border-l border-border hover:bg-fill-hover`);
@@ -124,7 +128,7 @@ describe("SplitChip", () => {
     expect(r.className).toContain("hover:bg-fill-hover");
   });
 
-  it("adds accent-tx + semibold to the right segment only when rightAccent", () => {
+  it("adds accent-tx — COLOUR ONLY, no weight bump — to the right segment only when rightAccent", () => {
     h = mount(
       <SplitChip
         left={<span>L</span>}
@@ -136,7 +140,9 @@ describe("SplitChip", () => {
     );
     const [l, r] = buttons();
     expect(r.className).toContain("text-accent-tx");
-    expect(r.className).toContain("font-semibold");
+    // The accent carries the emphasis; a weight bump on top made the effort
+    // label the heaviest text in the composer.
+    expect(r.className).not.toContain("font-semibold");
     expect(l.className).not.toContain("text-accent-tx");
 
     h.unmount();

--- a/src/renderer/Chip.test.tsx
+++ b/src/renderer/Chip.test.tsx
@@ -83,6 +83,25 @@ describe("SplitChip", () => {
     return Array.from(els) as HTMLButtonElement[];
   }
 
+  // Every case below mounts the same two-segment baseline and varies ONE prop,
+  // so the four required props are supplied here once. Re-mounting inside a
+  // case (the "absent the prop, nothing leaks" half of several tests) goes
+  // through the same helper, which unmounts the previous harness for you.
+  type SplitProps = Partial<Parameters<typeof SplitChip>[0]>;
+  function mountSplit(props: SplitProps = {}): HTMLElement {
+    h?.unmount();
+    h = mount(
+      <SplitChip
+        left={<span>L</span>}
+        right={<span>R</span>}
+        onLeftClick={() => {}}
+        onRightClick={() => {}}
+        {...props}
+      />,
+    );
+    return h.container.firstElementChild as HTMLElement;
+  }
+
   it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
     // @ts-expect-error — SplitChip must NOT accept className (M527 decision 3)
     void <SplitChip left={<>l</>} right={<>r</>} onLeftClick={() => {}} onRightClick={() => {}} className="bg-red-500" />;
@@ -90,15 +109,7 @@ describe("SplitChip", () => {
   });
 
   it("renders the split shell (rest chrome, no padding) around two segments", () => {
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-      />,
-    );
-    const shell = h.container.firstElementChild as HTMLElement;
+    const shell = mountSplit();
     expect(shell.className).toBe(`${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`);
     const [l, r] = buttons();
     expect(l.className).toBe(`inline-flex items-center ${CHIP_PAD} h-full hover:bg-fill-hover hover:text-text`);
@@ -110,17 +121,8 @@ describe("SplitChip", () => {
     h = mount(<Chip>Hello</Chip>);
     expect(button(h).className).toContain("hover:border-border-strong");
 
-    h.unmount();
     // The split control's shell carries NO outline hover; both segments fill.
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-      />,
-    );
-    const shell = h.container.firstElementChild as HTMLElement;
+    const shell = mountSplit();
     expect(shell.className).not.toContain("hover:border-border-strong");
     expect(shell.className).not.toContain("hover:text-text");
     const [l, r] = buttons();
@@ -129,15 +131,7 @@ describe("SplitChip", () => {
   });
 
   it("adds accent-tx — COLOUR ONLY, no weight bump — to the right segment only when rightAccent", () => {
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-        rightAccent
-      />,
-    );
+    mountSplit({ rightAccent: true });
     const [l, r] = buttons();
     expect(r.className).toContain("text-accent-tx");
     // The accent carries the emphasis; a weight bump on top made the effort
@@ -145,29 +139,14 @@ describe("SplitChip", () => {
     expect(r.className).not.toContain("font-semibold");
     expect(l.className).not.toContain("text-accent-tx");
 
-    h.unmount();
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-      />,
-    );
+    mountSplit();
     expect(buttons()[1].className).not.toContain("text-accent-tx");
   });
 
   it("fires onLeftClick and onRightClick independently", () => {
     let l = 0;
     let r = 0;
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => l++}
-        onRightClick={() => r++}
-      />,
-    );
+    mountSplit({ onLeftClick: () => l++, onRightClick: () => r++ });
     const [bl, br] = buttons();
     bl.click();
     expect(l).toBe(1);
@@ -178,33 +157,17 @@ describe("SplitChip", () => {
   });
 
   it("sets leftTitle and rightTitle", () => {
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-        leftTitle="model"
-        rightTitle="effort"
-      />,
-    );
+    mountSplit({ leftTitle: "model", rightTitle: "effort" });
     const [l, r] = buttons();
     expect(l.title).toBe("model");
     expect(r.title).toBe("effort");
   });
 
   it("applies leftHook/rightHook identity classes to the segment buttons, not just the shell (BET-635)", () => {
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-        leftHook="manta-model-picker-btn"
-        rightHook="manta-effort-picker-btn"
-      />,
-    );
-    const shell = h.container.firstElementChild as HTMLElement;
+    const shell = mountSplit({
+      leftHook: "manta-model-picker-btn",
+      rightHook: "manta-effort-picker-btn",
+    });
     const [l, r] = buttons();
     // The coverage registry scans the aria-haspopup segment buttons for a
     // `manta-*` class, so the hooks must land on the buttons, not the shell.
@@ -213,74 +176,31 @@ describe("SplitChip", () => {
     expect(l.className).toContain("manta-model-picker-btn");
     expect(r.className).toContain("manta-effort-picker-btn");
     // Absent the props, no hook class leaks onto the buttons.
-    h.unmount();
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-      />,
-    );
+    mountSplit();
     expect(buttons()[0].className).not.toContain("manta-");
     expect(buttons()[1].className).not.toContain("manta-");
   });
 
   it("sets aria-expanded per segment only when the caller provides it (BET-635)", () => {
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-        popup
-        leftExpanded
-        rightExpanded={false}
-      />,
-    );
+    mountSplit({ popup: true, leftExpanded: true, rightExpanded: false });
     const [l, r] = buttons();
     expect(l.getAttribute("aria-expanded")).toBe("true");
     expect(r.getAttribute("aria-expanded")).toBe("false");
     // Absent the props, no aria-expanded leaks onto the buttons — a non-popup
     // or stateless adopter stays clean.
-    h.unmount();
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-        popup
-      />,
-    );
+    mountSplit({ popup: true });
     const [pl, pr] = buttons();
     expect(pl.hasAttribute("aria-expanded")).toBe(false);
     expect(pr.hasAttribute("aria-expanded")).toBe(false);
   });
 
   it("does NOT assume popup semantics: aria-haspopup is absent unless popup is opted in", () => {
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-      />,
-    );
+    mountSplit();
     const [l, r] = buttons();
     expect(l.hasAttribute("aria-haspopup")).toBe(false);
     expect(r.hasAttribute("aria-haspopup")).toBe(false);
 
-    h.unmount();
-    h = mount(
-      <SplitChip
-        left={<span>L</span>}
-        right={<span>R</span>}
-        onLeftClick={() => {}}
-        onRightClick={() => {}}
-        popup
-      />,
-    );
+    mountSplit({ popup: true });
     const [pl, pr] = buttons();
     expect(pl.getAttribute("aria-haspopup")).toBe("listbox");
     expect(pr.getAttribute("aria-haspopup")).toBe("listbox");

--- a/src/renderer/Chip.tsx
+++ b/src/renderer/Chip.tsx
@@ -11,11 +11,13 @@
 // Chrome contract (BET-529 inventory): 29px hit area (`h-[29px]`), `--r-md`
 // radius (`rounded-md`), 11px inline padding (`px-[11px]`) and a 6px gap
 // (`gap-[6px]`) — the two off-grid px this primitive carries — plus `text-meta`
-// medium chrome. `Chip` toggles between the rest tone (`CHIP_REST`, a bordered
-// soft chip) and the "on" tone (`CHIP_ON`, accent border on an accent-bg
-// surface — e.g. an enabled worktree). `SplitChip` takes the rest tone for its
-// shell and divides it with a `border-l` divider; `rightAccent` colours the
-// right segment with `--accent-tx` + semibold.
+// chrome. Weight is the one place the two diverge: `Chip` is medium (it is a
+// labelled ACTION), `SplitChip` is regular (it is a status readout you glance
+// at). `Chip` toggles between the rest tone (`CHIP_REST`, a bordered soft chip)
+// and the "on" tone (`CHIP_ON`, accent border on an accent-bg surface — e.g. an
+// enabled worktree). `SplitChip` takes the rest tone for its shell and divides
+// it with a `border-l` divider; `rightAccent` colours the right segment with
+// `--accent-tx` (colour only — no weight change).
 //
 // Split rule (BET-634): the shell hover is the SINGLE chip's (`hover:border
 // -border-strong hover:text-text`) — a split control leaves its shell border
@@ -30,9 +32,15 @@
 
 import type { ReactNode } from "react";
 
-const CHIP_SHELL =
+const CHIP_BASE =
   "inline-flex items-center h-[29px] rounded-md border whitespace-nowrap " +
-  "text-meta font-medium leading-none transition-colors";
+  "text-meta leading-none transition-colors";
+const CHIP_SHELL = `${CHIP_BASE} font-medium`;
+// The SPLIT shell runs one weight lighter than the single chip. A split
+// control is a STATUS readout you change occasionally (the model you're on,
+// the effort it runs at), not a labelled action, and at medium it competed
+// with the transcript for attention every time your eye crossed the composer.
+const SPLIT_SHELL = `${CHIP_BASE} font-normal`;
 const CHIP_REST = "border-border bg-bg-soft text-text-muted";
 const CHIP_HOVER = "hover:border-border-strong hover:text-text";
 const CHIP_ON = "border-accent bg-accent-bg text-accent-tx";
@@ -162,19 +170,40 @@ export function SplitChip({
   const leftAria = leftExpanded !== undefined ? { "aria-expanded": leftExpanded } : {};
   const rightAria = rightExpanded !== undefined ? { "aria-expanded": rightExpanded } : {};
   const leftClass = `${leftHook ? `${leftHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full hover:bg-fill-hover hover:text-text`;
-  const rightClass = `${rightHook ? `${rightHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border hover:bg-fill-hover${rightAccent ? " text-accent-tx font-semibold" : ""}`;
+  // `rightAccent` is a COLOUR accent only. It used to add `font-semibold` too,
+  // which made the effort label the heaviest text in the composer — the accent
+  // already carries the emphasis, and the extra weight only shouted.
+  const rightClass = `${rightHook ? `${rightHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border hover:bg-fill-hover${rightAccent ? " text-accent-tx" : ""}`;
   // The toggle segment shares the divider + padding of the right segment, so
-  // the three read as one control. Its tone is the only difference: on =
-  // accent (matching CHIP_ON's text), disabled = --tx4 with no hover.
+  // the three read as one control. Only its TONE differs, across three states
+  // that must be told apart at a glance:
+  //
+  //   on        → accent (matching CHIP_ON's text)
+  //   off       → --tx3, and it lights up on hover — the affordance IS the hover
+  //   disabled  → --tx4 AND half-opacity, no hover, `cursor-not-allowed`
+  //
+  // Colour alone was not enough: --tx3 vs --tx4 is one step apart and the
+  // toggle read as merely "off" when it was actually unavailable, so people
+  // clicked it and nothing happened. Opacity is the second, unmistakable
+  // channel (the caller is expected to swap the glyph too — see ModelPicker's
+  // Zap/ZapOff). Tone is resolved BEFORE the disabled check so a control that
+  // is on-but-frozen keeps its accent and dims, instead of flattening to grey
+  // and lying about its state.
+  const extraTone = extraPressed
+    ? "text-accent-tx"
+    : extraDisabled
+      ? "text-text-quiet"
+      : "text-text-faint";
+  const extraInteraction = extraDisabled
+    ? "opacity-50 cursor-not-allowed"
+    : extraPressed
+      ? "hover:bg-fill-hover"
+      : "hover:bg-fill-hover hover:text-text";
   const extraClass =
     `${extraHook ? `${extraHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border ` +
-    (extraDisabled
-      ? "text-text-quiet cursor-not-allowed"
-      : extraPressed
-        ? "text-accent-tx hover:bg-fill-hover"
-        : "text-text-faint hover:bg-fill-hover hover:text-text");
+    `${extraTone} ${extraInteraction}`;
   return (
-    <div className={`${hook ? `${hook} ` : ""}${CHIP_SHELL} p-0 overflow-hidden ${CHIP_REST}`}>
+    <div className={`${hook ? `${hook} ` : ""}${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`}>
       <button type="button" onClick={onLeftClick} title={leftTitle} className={leftClass} {...listbox} {...leftAria}>
         {left}
       </button>

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -276,11 +276,17 @@ export function InputArea({
       <div
         className={
           "manta-composer-input-row mb-2 rounded-lg border bg-bg-soft flex flex-col gap-2 px-4 py-3 " +
+          // Resting border is `border-subtle`, the SAME token the tool cards
+          // use. It was `border-strong`, which is a control-boundary tone —
+          // on the light canvas that reads as a noticeably heavier rule than
+          // every card on the screen, so the composer looked outlined rather
+          // than contained. Definition now comes from the fill + --shadow-sm;
+          // focus-within still paints the accent border.
           (voiceActive
             ? "manta-recording"
             : refreshing
               ? "border-accent"
-              : "border-border-strong")
+              : "border-border-subtle")
         }
         // Route every non-control click in the box to the message field. This
         // is what makes the composer focusable on Windows, where a click could
@@ -459,7 +465,11 @@ export function InputArea({
         <button
           onClick={() => setChatAutoAllow(!chatAutoAllow)}
           className={
-            "inline-flex items-center gap-2 text-[11.5px] leading-none font-medium py-[6px] px-0 " +
+            // Smaller + regular weight (was 11.5px medium): this is an ambient
+            // state line under the composer, not a call to action. The danger
+            // colour is what makes the bypassing state read — the type does
+            // not need to carry it too.
+            "inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 " +
             (chatAutoAllow
               ? "text-danger hover:text-danger"
               : "text-text-quiet hover:text-text-muted")

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -13,7 +13,7 @@
 // raw id is sent back via onSelect.
 
 import { useMemo, useRef, useState } from "react";
-import { ChevronDown, Sparkles, Zap } from "lucide-react";
+import { ChevronDown, Sparkles, Zap, ZapOff } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import { type ModelSelection, resolveActiveModel } from "./chatShared";
 import { hideFastSiblingGroups, resolveFastToggle, titleCase } from "./chatUtils";
@@ -174,7 +174,22 @@ export function ModelPicker({
           setModelOpen(false);
           setVariantOpen((v) => !v);
         }}
-        extra={<Zap size={13} aria-hidden="true" fill={fast.on ? "currentColor" : "none"} />}
+        // Three states, three glyphs — "unavailable" gets its OWN icon rather
+        // than a dimmer copy of the "off" one. A greyed Zap is indistinguishable
+        // from an un-toggled Zap at 13px, which is why this model has no fast
+        // twin / no fast twin at this effort read as "fast mode is simply off"
+        // and people kept clicking a dead segment. ZapOff says unavailable;
+        // hollow Zap says available-but-off; filled Zap says on. (`fast.on`
+        // wins over availability so an on-but-frozen toggle still shows as on.)
+        extra={
+          fast.on ? (
+            <Zap size={13} aria-hidden="true" fill="currentColor" />
+          ) : fast.available ? (
+            <Zap size={13} aria-hidden="true" fill="none" />
+          ) : (
+            <ZapOff size={13} aria-hidden="true" />
+          )
+        }
         onExtraClick={() => {
           if (!fast.available || !fast.target) return;
           setModelOpen(false);

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -456,9 +456,11 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
         <div
           className={
             "manta-composer-input-row rounded-lg border bg-bg-soft flex items-start gap-3 px-4 py-3 " +
+            // Resting tone matches the session composer (border-subtle, the
+            // tool-card token) — the two must not diverge.
             (voiceRecording
               ? "manta-recording"
-              : "border-border-strong")
+              : "border-border-subtle")
           }
         >
           <textarea

--- a/src/renderer/modelCatalog.ts
+++ b/src/renderer/modelCatalog.ts
@@ -1,0 +1,103 @@
+// Shared model catalog — the model list + server default, cached ONCE for the
+// whole renderer instead of per ChatPanel.
+//
+// WHY THIS EXISTS. The catalog is a box-level resource: it does not depend on
+// which session is open. But it used to be fetched by each ChatPanel from its
+// own `useState(null)`, and `/clear` swaps in a NEW opencode session id, which
+// mounts a BRAND-NEW ChatPanel. So every clear restarted the fetch from
+// `models == null` and the composer's model control fell back to its stub label
+// while the dropdown showed "Loading…" — a visible flash of an empty picker on
+// an action that changed nothing about the available models.
+//
+// The cache is module-level so a freshly-mounted panel renders the already-known
+// catalog synchronously on its first paint. A background re-fetch still runs
+// when the cached copy is older than STALE_MS, so a model added in Settings
+// shows up shortly after without a reload — it just never blanks the UI while
+// it's in flight.
+
+import { useEffect, useState } from "react";
+import type { OpencodeModel } from "../shared/types";
+
+export type ServerDefaultModel = { providerID: string; modelID: string } | null;
+
+type Snapshot = {
+  models: OpencodeModel[] | null;
+  defaultModel: ServerDefaultModel;
+};
+
+// How long a cached catalog is served without a background refresh. Short
+// enough that a Settings change lands on the next session switch; long enough
+// that flipping between sessions doesn't hammer the box.
+const STALE_MS = 10_000;
+
+let cache: Snapshot = { models: null, defaultModel: null };
+let fetchedAt = 0;
+let inFlight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+// Fetch both halves, deduped: concurrent callers share one round trip.
+//
+// GUARD (same reason as NewSessionScreen's): both methods live ONLY on
+// httpApi. On a fresh/unpaired desktop boot `window.api` is still the raw
+// preload OS-bridge subset where they are undefined, and calling them throws
+// synchronously from the commit phase — which `.catch` cannot see and which
+// unmounts the whole tree.
+function load(): void {
+  if (inFlight) return;
+  // The `as` cast is deliberate: the `Api` type declares both as present, but
+  // the pre-pairing preload subset installed on `window.api` does not have
+  // them, so the runtime check is real even though TS thinks it is redundant.
+  const api = window.api as Partial<typeof window.api>;
+  if (!api.opencodeModels || !api.opencodeDefaultModel) return;
+  inFlight = Promise.allSettled([
+    window.api.opencodeModels(),
+    window.api.opencodeDefaultModel(),
+  ])
+    .then(([modelsRes, defaultRes]) => {
+      // Keep the previous value for whichever half failed — a transient error
+      // must not blank a catalog we already have.
+      const next: Snapshot = {
+        models: modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
+        defaultModel: defaultRes.status === "fulfilled" ? defaultRes.value : cache.defaultModel,
+      };
+      const changed =
+        next.models !== cache.models || next.defaultModel !== cache.defaultModel;
+      cache = next;
+      // Only mark fresh once something actually resolved, so a fully-failed
+      // attempt retries on the next mount instead of caching the failure.
+      if (modelsRes.status === "fulfilled" || defaultRes.status === "fulfilled") {
+        fetchedAt = Date.now();
+      }
+      if (changed) emit();
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+}
+
+/**
+ * The shared catalog. Returns the cached value synchronously on first render
+ * (so a remount — e.g. after `/clear` — never flashes an empty picker) and
+ * re-renders when a background refresh brings something new.
+ */
+export function useModelCatalog(): Snapshot {
+  const [snapshot, setSnapshot] = useState<Snapshot>(cache);
+  useEffect(() => {
+    const onChange = () => setSnapshot(cache);
+    listeners.add(onChange);
+    if (cache.models == null || Date.now() - fetchedAt > STALE_MS) load();
+    // Adopt anything that landed between this component's render and its
+    // effect (another panel's in-flight fetch resolving).
+    if (cache !== snapshot) onChange();
+    return () => {
+      listeners.delete(onChange);
+    };
+    // Mount-only: the catalog is session-independent, so nothing here varies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return snapshot;
+}


### PR DESCRIPTION
Four composer complaints, one of them a real bug.

## The bug — the model picker reloads on `/clear`

`/clear` mints a NEW opencode session id, and App renders one ChatPanel per
session id — so a clear mounts a brand-new panel. The model list was fetched
from each panel's own `useState(null)`, so every clear restarted the fetch from
empty: the picker fell back to its stub label and the dropdown showed
"Loading…" for a second, on an action that changes nothing about which models
are available.

The catalog is a box-level resource, not a per-session one, so it moves into a
single module cache (`src/renderer/modelCatalog.ts`). A freshly-mounted panel
reads the already-known list synchronously on its first paint. A background
refresh still runs when the cached copy is older than 10s, so a model added in
Settings shows up on the next session switch — it just never blanks the control
while it checks. Fetch failures keep the previous value rather than clearing it.

## The other three — type and tone

**Composer border.** Both borders were already 1px; the difference was tone.
The composer used `border-strong` (the control-boundary token), which reads as a
noticeably heavier rule than every card on screen — outlined rather than
contained. It now uses `border-subtle`, the same token the tool cards use, in
both the session composer and the new-session screen. Definition comes from the
fill + `--shadow-sm`; focus-within still paints the accent border, and the
recording / refetch treatments are untouched.

**Weight.** `SplitChip` now runs regular weight while the single `Chip` stays
medium — a split chip is a status readout you glance at, a single chip is a
labelled action. `rightAccent` becomes colour-only: the accent already carries
the emphasis, and the added semibold made the effort label the heaviest text in
the composer. The trust line follows the same logic (11.5px medium → 11px
regular); it is ambient state, and the danger colour is what makes "bypassing"
read.

**Fast mode: unavailable vs off.** These were one step of grey apart
(`--tx4` vs `--tx3`), so "this model has no fast twin" / "no fast twin at this
effort" looked identical to "fast mode is simply off" — people clicked a dead
segment and nothing happened. Unavailable now gets its own glyph (`ZapOff`
instead of a dimmer copy of the same `Zap`) plus half-opacity and
`cursor-not-allowed`. Hollow bolt = available but off, filled bolt = on. The
tone resolves pressed-first so the on-but-frozen case (fast model whose base
vanished) keeps its accent and dims, instead of flattening to grey and
misreporting its own state.

## Verification

`npm run typecheck` clean, `npm test` green (2123 vitest + 1481 node:test).
`Chip.test.tsx` is updated to pin the new contract — the split shell's regular
weight, and `rightAccent` asserted to NOT add `font-semibold`.