### PR TITLE
fix(ios): an unanswered tmux:list can no longer blank the session list

### DIFF
--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -140,7 +140,7 @@ final class MantaAPIClient: Sendable {
 
     /// `tmux:list` — the grouped session list (projects → windows).
     func projects() async throws -> [MantaProject] {
-        try await call("tmux:list", args: [], as: [MantaProject].self) ?? []
+        try await callRequired("tmux:list", args: [], as: [MantaProject].self)
     }
 
     /// `tmux:new-session` — create a new project (tmux session).
@@ -152,7 +152,7 @@ final class MantaAPIClient: Sendable {
             "createDir": input.createDir,
             "chatMode": input.chatMode,
         ]
-        return try await call("tmux:new-session", args: [dict], as: [MantaProject].self) ?? []
+        return try await callRequired("tmux:new-session", args: [dict], as: [MantaProject].self)
     }
 
     /// `tmux:new-window` — create a new session (window) in an existing project.
@@ -165,7 +165,7 @@ final class MantaAPIClient: Sendable {
             "chatMode": input.chatMode,
         ]
         if let cwd = input.cwd { dict["cwd"] = cwd }
-        return try await call("tmux:new-window", args: [dict], as: [MantaProject].self) ?? []
+        return try await callRequired("tmux:new-window", args: [dict], as: [MantaProject].self)
     }
 
     /// `tmux:kill-window` — delete a session (a row in the list).
@@ -407,6 +407,18 @@ final class MantaAPIClient: Sendable {
     private func call<D: Decodable>(_ channel: String, args: [Any], as type: D.Type) async throws -> D? {
         let data = try await transport(channel: channel, args: args)
         return try Self.decode(data, as: type)
+    }
+
+    /// Like `call`, but for a channel whose result is never legitimately
+    /// absent. `decode` returns nil for a missing-or-null `result`, and a
+    /// caller that folds that into an empty collection cannot tell a box that
+    /// answered "nothing" from one that did not answer at all — which is how a
+    /// box full of sessions came up blank, and reported as a success.
+    private func callRequired<D: Decodable>(_ channel: String, args: [Any], as type: D.Type) async throws -> D {
+        guard let value = try await call(channel, args: args, as: type) else {
+            throw MantaError.transport("\(channel) returned no result")
+        }
+        return value
     }
 
     private func callVoid(_ channel: String, args: [Any]) async throws -> VoidResult? {

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -123,6 +123,14 @@ final class SessionListStore: ObservableObject {
     /// so the caller resolves the new window against a list that contains it
     /// instead of the pre-create snapshot.
     func applyProjects(_ list: [MantaProject]) {
+        // A project list that has just been mutated CANNOT be empty — the
+        // window we created is in it. An empty one therefore means the reply
+        // was not the list we asked for, and adopting it would blank a list we
+        // had loaded fine. Re-fetch rather than believe it.
+        guard !list.isEmpty else {
+            Task { await refresh() }
+            return
+        }
         projects = list
         loadedOnce = true
         loadError = nil

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -124,15 +124,25 @@ struct SessionListView: View {
         .fullScreenCover(isPresented: $showSettings) {
             SettingsScreen()
         }
+        // Popping the last session off the stack lands us back on the list.
+        // Two jobs on that transition:
+        .onChange(of: path.count) { count in
+            guard count == 0 else { return }
+            // Back on the list means nothing is open, so nothing is highlighted.
+            openRow = nil
+            // …and it is the one moment the list is on screen again after an
+            // unknown amount of time inside a session, during which windows may
+            // have been created, renamed or killed. Nothing else fetches on this
+            // transition, so a list that went stale (or blank) while you were away
+            // stayed that way until a force-quit. `refresh()` coalesces with any
+            // in-flight fetch and never clears what is already on screen.
+            Task { await store.refresh() }
+        }
         // S8 (BET-600): a tapped notification opens the session that fired it,
         // not the list. The push router carries the opencode sessionId; we turn
         // it into the same openTarget the list rows use. onChange covers a
         // warm launch (view already mounted), onAppear the cold-start case
         // (the tap routed before the list appeared).
-        // Back on the list means nothing is open, so nothing is highlighted.
-        .onChange(of: path.count) { count in
-            if count == 0 { openRow = nil }
-        }
         .onAppear { consumePushLink() }
         .onChange(of: pushRouter.pendingSessionID) { _ in consumePushLink() }
     }

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -46,6 +46,13 @@ final class MantaActionRPCWireTests: XCTestCase {
 
     func testNewSessionSingleWraps() async throws {
         let client = makeClient()
+        // The create channels return the project LIST, and a reply carrying no
+        // result is now an error rather than an empty list (that laundering is
+        // what let an unanswered `tmux:list` blank the session list). These
+        // tests only assert the REQUEST shape, so they need a reply the method
+        // can actually return — the class-wide `{"result": null}` default is
+        // not one for these three.
+        CapturingURLProtocol.result = #"{"result": []}"#
         try await client.newSession(NewSessionInput(name: "p", cwd: "/d", windowName: "w", createDir: true, chatMode: true))
         assertSingleWrapped()
         XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:new-session")
@@ -53,6 +60,7 @@ final class MantaActionRPCWireTests: XCTestCase {
 
     func testNewWindowSingleWraps() async throws {
         let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": []}"#
         try await client.newWindow(NewWindowInput(sessionName: "p", windowName: "w", cwd: nil, chatMode: true))
         assertSingleWrapped()
         XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:new-window")
@@ -97,6 +105,7 @@ final class MantaActionRPCWireTests: XCTestCase {
 
     func testNewSessionCarriesCreateFields() async throws {
         let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": []}"#
         try await client.newSession(NewSessionInput(name: "proj", cwd: "~/x", windowName: "w", createDir: true, chatMode: false))
         let payload = CapturingURLProtocol.lastPayload()
         XCTAssertEqual(payload?["name"] as? String, "proj")

--- a/mobile/native/MantaUITests/MantaTransportTests.swift
+++ b/mobile/native/MantaUITests/MantaTransportTests.swift
@@ -163,6 +163,19 @@ final class MantaTransportTests: XCTestCase {
         XCTAssertNoThrow(try MantaAPIClient.decode(data, as: SendPromptResult.self))
     }
 
+    /// `callRequired` turns this nil into a throw. The distinction is the whole
+    /// bug: a null result folded into `[]` made an unanswered `tmux:list` look
+    /// like a box with no sessions.
+    func testNullResultDecodesToNilRatherThanAnEmptyList() throws {
+        let decoded = try MantaAPIClient.decode(json(#"{"result": null}"#), as: [MantaProject].self)
+        XCTAssertNil(decoded)
+    }
+
+    func testEmptyArrayResultDecodesToAnEmptyList() throws {
+        let decoded = try MantaAPIClient.decode(json(#"{"result": []}"#), as: [MantaProject].self)
+        XCTAssertEqual(decoded?.count, 0)
+    }
+
     func testDecodesServerErrorEnvelope() throws {
         let payload = #"{"error":"opencode sendPrompt 500: oops"}"#
         XCTAssertThrowsError(try MantaAPIClient.decode(json(payload), as: [OpencodeMessage].self)) { error in


### PR DESCRIPTION
The phone kept showing "No sessions yet. Tap + to create one." on a box that
has plenty of them, and only a force-quit or a manual pull-to-refresh brought
the list back. Three separate causes compound into that one symptom.

### 1. A missing RPC result was laundered into an empty list

`MantaAPIClient.decode` returns `nil` when the envelope carries no `result` (or
a null one) — and `projects()`, `newSession()` and `newWindow()` folded that
straight into `?? []`. For those three channels a null result is never a
truthful answer: the box either lists the projects or it fails. Folding it made
a transport non-answer INDISTINGUISHABLE from a genuinely empty box, so
`SessionListStore.fetchOnce` overwrote a good list, set `loadedOnce`, cleared
`loadError`, and the view rendered the inviting empty state. That is exactly
the reassuring-lie state the store's own comments already warn about — the
`?? []` is what defeated the guard.

`callRequired` now throws `MantaError.transport` for those three channels. A
failed fetch leaves the previously-loaded list on screen, which the store
already does correctly once it is actually told the fetch failed.

Every other `?? []` site is deliberately untouched: an empty result from
`opencode:messages` / `permissions` / `questions` / `list-sessions` IS truthful
(a fresh session really has no messages), and turning those into throws would
break the chat screen.

### 2. The post-create adopt could blank the list outright

`applyProjects` assigned unconditionally, so an empty reply from the create RPC
wiped the whole list — with nothing scheduled to re-fetch, it stayed wiped. A
just-mutated project list cannot be empty (the window we created is in it), so
it now refuses an empty one and re-fetches instead. Belt and braces with #1,
because the method is public and must not be able to blank the list whoever
calls it.

### 3. Nothing re-fetched when you came back to the list

The list is fetched at launch, on foreground, on pull-to-refresh and on stream
reconnect. Popping a session off the navigation stack fetched nothing — which
is the "when going back to the list" in the report. The existing pop handler
only cleared the row highlight; it now also calls `refresh()`, which coalesces
with any in-flight fetch and never clears what is already on screen.

### Tests

Two cases in `MantaTransportTests` pin the null-vs-empty-array distinction the
whole fix rests on: `{"result": null}` decodes to `nil`, `{"result": []}`
decodes to an empty list.