### PR TITLE
fix(ios): the running turn's text survives re-opening a session, and running stops latching

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -334,10 +334,19 @@ final class ChatSessionStore: ObservableObject {
                     // source (BET-655). Read the pruned text back synchronously:
                     // the event-store sink lands on a later run-loop turn, too
                     // late for the rebuild happening right here.
+                    //
+                    // Cover ONLY completed messages: a chunk may be retired only
+                    // once its message is COMPLETE, because ChatTranscriptMapper
+                    // skips an assistant message that is still in flight
+                    // (`time.completed == nil`). opencode:messages returns the
+                    // in-flight message with no `time.completed`, so naming it
+                    // here would delete the only copy of the running turn's text
+                    // — the transcript refuses to draw it — leaving the screen
+                    // silent until the turn finishes.
                     if !didFail {
                         eventStore.retireCoveredStreamText(
                             sessionId: sessionId,
-                            covered: Set(loaded.map(\.info.id))
+                            covered: Set(loaded.filter { $0.info.time?.completed != nil }.map(\.info.id))
                         )
                         inProgressText = eventStore.sessionStates[sessionId]?.liveText ?? ""
                     }

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -110,7 +110,17 @@ enum MantaStreamRouter {
         case "running":
             if let p = try? frame.decodedPayload(StreamRunningPayload.self) { s.running = p.running }
         case "turnComplete":
-            if let p = try? frame.decodedPayload(StreamTurnCompletePayload.self) { s.turnComplete = p.complete }
+            if let p = try? frame.decodedPayload(StreamTurnCompletePayload.self) {
+                s.turnComplete = p.complete
+                // The box only ever publishes `running:true` on the `running`
+                // sub — the end of a turn is carried HERE, by turnComplete's own
+                // `running` field (`session.idle` emits
+                // turnComplete{complete:true, running:false} and no `running`
+                // frame at all). Ignoring it left `running` latched true for the
+                // life of the session, so the working row and session-list timer
+                // never stopped.
+                s.running = p.running
+            }
         case "truncation":
             s.truncation = try? frame.decodedPayload(StreamTruncationPayload.self)
         case "context":
@@ -134,15 +144,24 @@ enum MantaStreamRouter {
     /// Retire the live chunks whose message the canonical transcript now
     /// carries. Pure so the retirement rule is testable without a socket.
     ///
-    /// The chunk for the message STILL STREAMING is kept even when the fetch
-    /// covered it: a mid-turn transcript holds only the prose written before
-    /// that fetch, so retiring the live copy there would split one answer
-    /// across two blocks and drop everything that arrived since. Once the turn
-    /// ends, the next fetch retires it for real.
+    /// The contract is caller-enforced: `covered` names ONLY the message ids
+    /// the canonical transcript actually renders — i.e. COMPLETED assistant
+    /// messages (`ChatTranscriptMapper` skips any assistant message still in
+    /// flight, and `opencode:messages` returns the running one with no
+    /// `time.completed`). So a chunk is retired exactly when a second,
+    /// permanent copy of its prose already exists in the transcript, and the
+    /// still-streaming message is protected simply by never appearing in
+    /// `covered`.
+    ///
+    /// This replaces a "keep the last chunk while running" guard that was wrong
+    /// twice over: one turn is SEVERAL assistant messages (one per step), so
+    /// the last chunk is frequently a completed step rather than the streaming
+    /// one; and it read `running`, a flag that latches true (the box only ever
+    /// publishes `running:true` on the `running` sub — see `applying`), so the
+    /// guard fired against a stale value. Kept pure, same signature, idempotent.
     static func retiring(_ state: MantaSessionStreamState, covered: Set<String>) -> MantaSessionStreamState {
         var s = state
-        let inFlight = s.running == true ? s.chunks.last?.messageID : nil
-        s.chunks.removeAll { covered.contains($0.messageID) && $0.messageID != inFlight }
+        s.chunks.removeAll { covered.contains($0.messageID) }
         return s
     }
 }

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -254,7 +254,33 @@ final class MantaEventStreamRouterTests: XCTestCase {
         XCTAssertEqual(state.running, true)
         state = MantaStreamRouter.applying(complete, to: state)
         XCTAssertEqual(state.turnComplete, true)
-        XCTAssertEqual(state.running, true) // running is only set by `running` sub
+        // turnComplete ALSO clears `running`: the box never sends running:false
+        // on the `running` sub, so turnComplete's own `running` field is the
+        // only end-of-turn signal (otherwise the flag latches true forever).
+        XCTAssertEqual(state.running, false)
+    }
+
+    /// FINDING: the box never sends `running:false` on the `running` sub —
+    /// every `running` frame observed on a live `/events` capture carried
+    /// `running:true`. The end of a turn is announced ONLY by turnComplete's
+    /// own `running` field, so this is the sole signal that lowers the flag.
+    /// Ignoring it (the old behaviour) latched `running` true for the life of
+    /// the session, keeping the working row and the list timer running forever.
+    func testTurnCompleteLowersTheLatchedRunningFlag() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#),
+            to: state
+        )
+        XCTAssertEqual(state.running, true)
+
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#),
+            to: state
+        )
+
+        XCTAssertEqual(state.running, false)
+        XCTAssertEqual(state.turnComplete, true)
     }
 
     func testNonStreamFrameLeavesStateUntouched() throws {
@@ -311,20 +337,37 @@ final class MantaEventStreamRouterTests: XCTestCase {
         XCTAssertEqual(retired.liveText, "brand new")
     }
 
-    /// A mid-turn transcript holds only the prose written before the fetch, so
-    /// retiring the streaming message there would split one answer in two and
-    /// drop whatever arrived since. It is kept until the turn ends.
-    func testKeepsTheStreamingMessageEvenWhenCovered() throws {
+    /// The streaming message is protected by the CALLER, not by `retiring`:
+    /// `covered` names only COMPLETED messages (the transcript mapper skips an
+    /// assistant message still in flight), so the in-flight one never appears
+    /// and its live text survives. Here msg_2 completed and is covered; msg_7
+    /// is still streaming and is absent from `covered`, so its tail stays.
+    func testKeepsTextForAMessageTheTranscriptDoesNotRenderYet() throws {
+        var state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "done earlier"), to: nil)
+        state = MantaStreamRouter.applying(try flush("msg_7", "part_2", "still writing"), to: state)
+
+        let retired = MantaStreamRouter.retiring(state, covered: ["msg_2"])
+
+        XCTAssertEqual(retired.liveText, "still writing")
+    }
+
+    /// REGRESSION (BUG A): retirement must NOT depend on the `running` flag.
+    /// A chunk whose message the transcript renders must retire whatever
+    /// `running` says — the old guard kept the last chunk while running, and
+    /// with `running` latched true (BUG B) that left the finished answer live,
+    /// so it rendered twice. `running:true` is applied here to prove it is
+    /// ignored: msg_2 is covered, so it retires and the tail empties.
+    func testRetirementIgnoresTheRunningFlag() throws {
         var state = MantaStreamRouter.applying(
             try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#),
             to: nil
         )
-        state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "done earlier"), to: state)
-        state = MantaStreamRouter.applying(try flush("msg_7", "part_2", "still writing"), to: state)
+        state = MantaStreamRouter.applying(try flush("msg_2", "part_1", "the answer"), to: state)
 
-        let retired = MantaStreamRouter.retiring(state, covered: ["msg_2", "msg_7"])
+        let retired = MantaStreamRouter.retiring(state, covered: ["msg_2"])
 
-        XCTAssertEqual(retired.liveText, "still writing")
+        XCTAssertTrue(retired.chunks.isEmpty)
+        XCTAssertEqual(retired.liveText, "")
     }
 
     /// Retirement runs after every fetch, so it must be idempotent — a second
@@ -594,10 +637,14 @@ final class ChatSessionStoreRetirementTests: XCTestCase {
         )
     }
 
-    /// A canonical transcript carrying one assistant message with `text`.
+    /// A canonical transcript carrying one COMPLETED assistant message. The
+    /// `time.completed` is load-bearing: the transcript mapper skips an
+    /// assistant message without it, and retirement now covers only completed
+    /// messages, so an in-flight message (no `completed`) is neither drawn nor
+    /// retired — exactly what protects the running turn's live tail.
     private func transcriptResult(messageID: String, text: String) -> String {
         """
-        {"result":[{"info":{"id":"\(messageID)","sessionID":"ses_1","role":"assistant"},\
+        {"result":[{"info":{"id":"\(messageID)","sessionID":"ses_1","role":"assistant","time":{"created":1750000000000,"completed":1750000001000}},\
         "parts":[{"type":"text","id":"part_3","messageID":"\(messageID)","text":"\(text)"}]}]}
         """
     }


### PR DESCRIPTION
Two defects in how the phone consumes the box's interpreted stream. Both were
confirmed against a live box rather than inferred from the code.

### 1. Leaving a session mid-turn and coming back showed nothing until the turn ended

The phone assembles the transcript from two sources: the canonical message list
fetched from the box, and the live `stream:flush` text for the turn in flight.
`ChatTranscriptMapper` deliberately SKIPS an assistant message that has not
completed, because its prose is arriving live instead. After every fetch the
store retires the live copies the transcript now carries.

It was retiring them by id of EVERY fetched message. Verified against a running
turn on a real box: `opencode:messages` DOES return the still-streaming
assistant message, with no `time.completed`. So the retirement named a message
the mapper then refused to draw — deleting the only copy of the running turn's
text. The screen sat silent until the turn finished and the message finally
came back complete.

A guard was supposed to prevent this (`keep the last chunk while running`), and
it was wrong twice over:

* **One turn is several assistant messages.** opencode opens a new one per
  step — confirmed live: four consecutive assistant messages, three completed
  and one still running. The last chunk is therefore frequently a finished step
  rather than the streaming one.
* **It read `running`, which latches** — see below.

`covered` now names only messages the transcript actually RENDERS (completed
ones), and `retiring` drops its heuristic entirely: a chunk retires exactly
when a second, permanent copy of its prose exists. The streaming message is
protected by never appearing in `covered`, which is a fact rather than a guess.

### 2. `running` latched true for the life of the session

Tapping the box's own `/events` stream for 90 seconds across several complete
turns: every `stream:running` frame carried `{"running": true}` — twelve of
them, not one `false`. The end of a turn is announced ONLY as
`turnComplete{complete:true, running:false}` (`session.idle` emits no `running`
frame at all). The router set `turnComplete` from that payload and ignored its
`running` field, which `StreamTurnCompletePayload` already decodes.

So the flag went true on the first turn and never came down: the chat screen's
working row stayed on screen forever, the session-list row showed the session
as permanently running with a forever-counting timer, and the retirement guard
above was reading a value that is always true.

### Tests

`testKeepsTheStreamingMessageEvenWhenCovered` encoded the old contract and is
rewritten to the new one. Added a regression test that retirement ignores
`running`, and one that `turnComplete` lowers the latched flag. Two existing
tests needed correcting for the new behaviour — `testSetsRunningAndTurnComplete`
asserted the latch, and the `ChatSessionStoreRetirementTests` transcript stub
modelled a "completed" message with no `time.completed`, which was benign under
the id-only contract and is load-bearing now.