### PR TITLE
BET-657: expose serve-page registry over /rpc + HEAD on /api/peek

### DIFF
--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -100,6 +100,7 @@ export const DEMO_UNIMPLEMENTED = [
   "secretsDelete",
   "secretsList",
   "secretsSet",
+  "servePageList",
   "serverUpdateApply",
   "tmuxConfigStatus",
   "tmuxKillSession",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -944,6 +944,12 @@ export const httpApi: Api = {
   webhookList: (sessionId) => rpc(IPC.webhookList, sessionId),
   webhookDelete: (id) => rpc(IPC.webhookDelete, id),
 
+  // -- published serve-page registry (manta-server owned; read-only) --
+  // rpcOptional so an older box (no `serve-page:list` channel) degrades to an
+  // empty list instead of throwing — same resilience as the webhook/secrets
+  // list wrappers.
+  servePageList: () => rpcOptional(IPC.servePageList, []),
+
   // -- background delegation jobs (manta-server owned; in-process on mobile) --
   // list returns the full job records (the engine always returns an array;
   // a no-engine fallback returns {jobs:[]} which we normalize). No create

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -995,7 +995,7 @@ const handleRequest = async (req, res) => {
   // Path is resolved against the caller's home dir (~ expansion) and
   // constrained to stay inside it (path-traversal guard). Content-Type is
   // inferred from the file extension; falls back to application/octet-stream.
-  if (req.method === "GET" && path === "/api/peek") {
+  if ((req.method === "GET" || req.method === "HEAD") && path === "/api/peek") {
     const raw = url.searchParams.get("path") ?? "";
     if (!raw) {
       respondJson(res, 400, { error: "path is required" });
@@ -1034,6 +1034,11 @@ const handleRequest = async (req, res) => {
       "content-length": String(s.size),
       "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
     });
+    // HEAD reports the size via `content-length` without streaming the body.
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
     try {
       await pipeline(createReadStream(resolved), res);
     } catch (e) {

--- a/src/server/peek.test.mjs
+++ b/src/server/peek.test.mjs
@@ -32,6 +32,25 @@ function httpGet(url) {
   });
 }
 
+// Helper: make a HEAD request — same response shape, body expected empty.
+function httpHead(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, { method: "HEAD" }, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        resolve({
+          status: res.statusCode,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
+        });
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
 // Helper: start a minimal server with the peek route logic
 async function startPeekServer(testDir) {
   const { readFile, stat: fsStat } = await import("node:fs/promises");
@@ -52,7 +71,7 @@ async function startPeekServer(testDir) {
       const url = new URL(req.url, `http://${req.headers.host}`);
       const path = url.pathname;
 
-      if (req.method === "GET" && path === "/api/peek") {
+      if ((req.method === "GET" || req.method === "HEAD") && path === "/api/peek") {
         try {
           const raw = url.searchParams.get("path") ?? "";
           if (!raw) {
@@ -98,6 +117,10 @@ async function startPeekServer(testDir) {
             "content-length": String(s.size),
             "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
           });
+          if (req.method === "HEAD") {
+            res.end();
+            return;
+          }
           await pipeline(createReadStream(resolved), res);
         } catch (e) {
           if (!res.headersSent) {
@@ -231,5 +254,53 @@ test("/api/peek serves JSON with correct content-type", async () => {
     }
   } finally {
     await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek HEAD reports content-length without a body", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-head-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "hello world";
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`);
+      assert.equal(res.status, 200, `Response body: ${res.body.toString()}`);
+      assert.equal(res.headers["content-type"], "text/plain; charset=utf-8");
+      assert.equal(res.headers["content-length"], String(Buffer.byteLength(content)));
+      assert.equal(res.body.length, 0, "HEAD must not stream a body");
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek HEAD rejects path traversal with 403", async () => {
+  const { server, port } = await startPeekServer();
+  try {
+    // Node suppresses the body on HEAD responses; the status must match GET's 403.
+    const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=/etc/passwd`);
+    assert.equal(res.status, 403);
+    assert.equal(res.body.length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+test("/api/peek HEAD returns 404 for non-existent file", async () => {
+  const nonExistent = join(homedir(), "nonexistent-file-12345.txt");
+  const { server, port } = await startPeekServer();
+  try {
+    // Node suppresses the body on HEAD responses; the status must match GET's 404.
+    const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(nonExistent)}`);
+    assert.equal(res.status, 404);
+    assert.equal(res.body.length, 0);
+  } finally {
+    server.close();
   }
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -10,6 +10,8 @@ import { transcribeAudio, classifyVoiceCommand } from "../shared/groq.mjs";
 import { expandTilde } from "../shared/paths.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob } from "./schedule.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
+import { listPages as servePageListStore } from "./servePage.mjs";
+import { publicBaseUrl } from "./gatewayRegister.mjs";
 import {
   listSecrets as secretsListStore,
   setSecret as secretsSetStore,
@@ -852,6 +854,16 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.webhookDelete, id) → args[0] = id
     "webhook:delete": (id) =>
       webhookDeleteHook(id, { publish: (evt) => bus.publish(evt) }),
+
+    // ---- published serve-page registry (manta-server owned; read-only) ----
+    // The box already records every page `serve_page` publishes (tagged with
+    // the opencode session that created it); this exposes that registry so the
+    // artifacts panel can render it. No write counterpart — pages are
+    // published/stopped by the AI's global `serve_page`/`stop_page` opencode
+    // tools (POST /api/serve-page), not by a UI channel. `publicBaseUrl`
+    // reads ~/.manta/auth.json fresh per call, so the list's `url` fields stay
+    // correct even if the box's gateway host was provisioned after boot.
+    "serve-page:list": async () => servePageListStore({ baseUrl: publicBaseUrl() }),
 
     // ---- APNs native-push registration (BET-181) ----
     // iOS Capacitor app registers its APNs device token via the renderer-side

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -9,6 +9,8 @@ import {
   SELF_UPDATE_SCRIPT,
 } from "./rpc.mjs";
 import { gunzipSync } from "node:zlib";
+import { savePages } from "./servePage.mjs";
+import { statePath } from "../shared/paths.mjs";
 
 test("dispatch routes a known channel to its handler with args", async () => {
   const handlers = { "echo:it": async (a, b) => ({ sum: a + b }) };
@@ -733,4 +735,35 @@ test("a /rpc response is sent raw without a gzip Accept-Encoding, and when small
     assert.equal(res.headers["content-encoding"], undefined);
     assert.deepEqual(JSON.parse(res.body.toString("utf8")), { result: { ok: true } });
   }
+});
+
+test("serve-page:list exposes the published-page registry (read-only)", async () => {
+  // Seed the sandboxed store directly so the handler reads real entries.
+  const storePath = statePath("serve-page.json");
+  await savePages(
+    [
+      { subdomain: "preview", expiresAt: null, createdAt: 1700000000000, sessionID: "ses_1" },
+      { subdomain: "hero", expiresAt: 1700003600000, createdAt: 1700000001000, sessionID: null },
+    ],
+    storePath,
+  );
+  const { deps } = makeDeps([]);
+  const handlers = buildHandlers(deps);
+  const pages = await handlers["serve-page:list"]();
+  assert.equal(pages.length, 2);
+  assert.equal(pages[0].subdomain, "preview");
+  assert.equal(pages[0].sessionID, "ses_1");
+  assert.equal(pages[0].expiresAt, null);
+  assert.equal(pages[1].subdomain, "hero");
+  assert.equal(pages[1].sessionID, null);
+  assert.equal(pages[1].expiresAt, 1700003600000);
+  assert.ok(pages.every((p) => typeof p.url === "string" && typeof p.createdAt === "number"));
+});
+
+test("serve-page:list returns an empty list when the store is empty", async () => {
+  await savePages([], statePath("serve-page.json"));
+  const { deps } = makeDeps([]);
+  const handlers = buildHandlers(deps);
+  const pages = await handlers["serve-page:list"]();
+  assert.deepEqual(pages, []);
 });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -23,6 +23,7 @@ import type {
   SecretMeta,
   SecretInput,
   ServerUpdateAvailablePayload,
+  ServedPageMeta,
   WebhookMeta,
   SpawnOptions,
   PtyEvent,
@@ -294,6 +295,13 @@ export interface Api {
   // via the global `webhook` opencode tool, not a UI channel.
   webhookList(sessionId?: string): Promise<WebhookMeta[]>;
   webhookDelete(id: string): Promise<{ deleted: boolean }>;
+
+  // Published serve-page registry (manta-server owned; same box, read-only).
+  // Returns the box's published pages (subdomain, public url, expiry, created,
+  // originating session) so the artifacts panel can render them. Pages are
+  // published/stopped by the AI's `serve_page`/`stop_page` opencode tools, not
+  // through any UI channel.
+  servePageList(): Promise<ServedPageMeta[]>;
 
   // Background delegation jobs (manta-server owned). list returns the full
   // job records (filtered by parent session when sessionId is passed; all

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -750,6 +750,14 @@ export const IPC = {
   webhookList: "webhook:list", // (sessionId?) → WebhookMeta[]
   webhookDelete: "webhook:delete", // (id) → { deleted: boolean }
 
+  // ---- published serve-page registry (manta-server owned) ----
+  // Read-only: returns the box's published-page registry so the artifacts
+  // panel can render it. Pages are published/stopped by the AI's global
+  // `serve_page` / `stop_page` opencode tools (POST /api/serve-page), not by
+  // a UI channel. Desktop + mobile both reach the server store over /rpc
+  // (httpApi); a read has no server write counterpart.
+  servePageList: "serve-page:list", // () → ServedPageMeta[]
+
   // ---- background delegation jobs (manta-server owned) ----
   // Background jobs are started by the AI's global `delegate` opencode tool
   // (POST /api/delegate); the UI only LISTS / STOPS / DELETES via these
@@ -923,6 +931,18 @@ export type SecretMeta = {
   hasValue: boolean; // a value is stored (always true for persisted secrets)
   createdAt: number | null;
   updatedAt: number | null;
+};
+
+// A published serve-page registry entry — what the artifacts panel sees via
+// the read-only `serve-page:list` RPC channel. `url` is "" when the box has no
+// addressable base URL (publicBaseUrl() returned falsy); `sessionID` is the
+// opencode session that called `serve_page`. Store: ~/.manta/serve-page.json.
+export type ServedPageMeta = {
+  subdomain: string;
+  url: string;
+  expiresAt: number | null;
+  createdAt: number;
+  sessionID: string | null;
 };
 
 // Input shape for secretsSet (UI → store). The value travels renderer → IPC →


### PR DESCRIPTION
Implements BET-657.

**Files changed:** 8 files.
```
src/renderer/api/demoCoverage.test.ts |  1 +
src/renderer/api/httpApi.ts           |  6 +++
src/server/index.mjs                  |  7 +++-
src/server/peek.test.mjs              | 73 ++++++++++++++++++++++++++++++++++-
src/server/rpc.mjs                    | 12 ++++++
src/server/rpc.test.mjs               | 33 ++++++++++++++++
src/shared/api.ts                     |  8 ++++
src/shared/types.ts                   | 20 ++++++++++
```

## 1. serve-page:list RPC channel (read-only)
- `src/shared/types.ts`: `servePageList: "serve-page:list"` on the `IPC` object + `ServedPageMeta` type.
- `src/shared/api.ts`: `servePageList(): Promise<ServedPageMeta[]>` + import.
- `src/renderer/api/httpApi.ts`: `servePageList: () => rpcOptional(IPC.servePageList, [])` — degrades to `[]` on an older box.
- `src/server/rpc.mjs`: imports `listPages` from `servePage.mjs` and `publicBaseUrl` from `gatewayRegister.mjs` directly; handler `"serve-page:list": async () => servePageListStore({ baseUrl: publicBaseUrl() })` beside the webhook handlers. Imported `publicBaseUrl` directly rather than threading it through `buildHandlers` (the small edit).
- `src/renderer/api/demoCoverage.test.ts`: `servePageList` added to `DEMO_UNIMPLEMENTED`.
- No preload/main edits; the existing REST `/api/serve-page` route is untouched. Existing store function `listPages` is not modified.

## 2. HEAD on /api/peek
- `src/server/index.mjs`: dispatches HEAD at the same site as GET, reusing the same resolve+guard+stat+error mapping (single copy), writes the same header set, and `res.end()` without the stream pipeline. `GET /api/download` untouched.

**Base: origin/main @ 979d329** — recorded at branch cut.