### PR TITLE
fix(ios): the opened session stays on its newest message until you scroll away

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -79,16 +79,18 @@ private struct ChatScreenContent: View {
     @State private var overflowDestination: OverflowDestination?
     /// Live scheduled-task count for the overflow sheet's badge (BET-627).
     @State private var scheduleCount = 0
-    /// Height of the scroll content at the last measurement, so a CHANGE can
-    /// drive the landing (see `landIfContentGrew`).
+    /// Height of the scroll CONTENT at the last landing, so a change can drive
+    /// the next one (see `relandIfArmed`).
     @State private var landedContentHeight: CGFloat = 0
-    /// When the landing window closes. The landing is content-driven, but a
-    /// transcript that never stops resizing (a turn streaming into the session
-    /// you just opened) must not re-land forever.
-    @State private var landingDeadline: Date?
-    /// Set when the user scrolls during the landing window. Their scroll wins
-    /// immediately — re-landing over a deliberate scroll is the exact behaviour
-    /// the pin-to-bottom work spent four revisions removing.
+    /// Height of the VIEWPORT at the last landing. Tracked separately because
+    /// the composer resizes it after the screen is already up — the model chip
+    /// appears when the model list loads, the mic when the config check
+    /// returns — and each of those moves the transcript's bottom edge without
+    /// changing a single row of content.
+    @State private var landedViewportHeight: CGFloat = 0
+    /// Set when the user scrolls. Their scroll wins, permanently: re-landing
+    /// over a deliberate scroll is the exact behaviour the pin-to-bottom work
+    /// spent four revisions removing.
     @State private var landingCancelled = false
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
@@ -462,13 +464,31 @@ private struct ChatScreenContent: View {
                 // The measured content height drives the landing: each time the
                 // lazy rows materialise and the height jumps, that is the moment
                 // the previous landing became wrong and the moment to re-land.
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.height
+                .onGeometryChange(for: CGFloat.self) { geometry in
+                    geometry.size.height
                 } action: { height in
-                    landIfContentGrew(to: height, proxy: proxy)
+                    guard height != landedContentHeight else { return }
+                    landedContentHeight = height
+                    relandIfArmed(proxy)
                 }
             }
             .scrollClipDisabled(false)
+            // The VIEWPORT's height matters just as much as the content's, and
+            // it is the half this routine used to miss. The composer is no
+            // longer a plain input: its model chip appears when the model list
+            // loads, its mic when the config check returns, and it sits in the
+            // screen's bottom safe-area inset — so each of those late arrivals
+            // shrinks the transcript's viewport a beat AFTER the session opened,
+            // moving the bottom out from under a landing that had already run.
+            // That is why this bug arrived with the composer's enrichment and
+            // not before.
+            .onGeometryChange(for: CGFloat.self) { geometry in
+                geometry.size.height
+            } action: { height in
+                guard height != landedViewportHeight else { return }
+                landedViewportHeight = height
+                relandIfArmed(proxy)
+            }
             // Scoped to `.sizeChanges` — the same correction the subagent screen
             // already carries, for the same reason plus one more:
             //
@@ -504,41 +524,47 @@ private struct ChatScreenContent: View {
         }
     }
 
-    /// Put the freshly-opened session at its newest message, and KEEP it there
-    /// until the content stops resizing.
+    /// Put the freshly-opened session on its newest message, and KEEP it there
+    /// until the user scrolls away.
     ///
-    /// The transcript is a LazyVStack, so at first layout SwiftUI has measured
-    /// only the rows on screen and estimates the rest. A single jump to the end
-    /// therefore aims at an estimated height that is wrong the moment the real
-    /// rows materialise — it overshoots into empty space past the content, which
-    /// is the blank transcript that only the user's own scrolling repairs.
+    /// Called whenever the scroll CONTENT or the VIEWPORT changes height, which
+    /// between them cover every way the bottom can move out from under a
+    /// landing that already ran.
     ///
-    /// This used to be three scrolls on a fixed 0/50/250ms ladder: a fixed time
-    /// budget racing a variable amount of layout work. It won on a fast Mac's
-    /// simulator and lost on a real iPhone, which is the definition of a race
-    /// rather than a delay to tune. Re-landing on every HEIGHT CHANGE removes the
-    /// clock: each change is precisely the moment the previous landing became
-    /// wrong, and when the height stops changing there is nothing left to fix.
+    /// Two failed designs preceded this, and both failed the same way — they
+    /// tried to finish the landing at a moment they picked in advance:
+    ///
+    ///  * Three scrolls on a fixed 0/50/250ms ladder. A fixed time budget racing
+    ///    a variable amount of layout work: it won on a fast Mac's simulator and
+    ///    lost on a real iPhone.
+    ///  * Content-height-driven, but armed for only 3s and blind to the
+    ///    viewport. The screen's FIRST render happens before `onAppear` starts
+    ///    the fetch, so the window opened against an empty store and could
+    ///    expire before the messages arrived; and the composer's own late
+    ///    resizes never reached it at all.
+    ///
+    /// There is no deadline now. "Stay on the newest message until the reader
+    /// deliberately leaves it" is simply what a chat transcript should do, so
+    /// the only thing that ends it is the reader — and a turn streaming into an
+    /// open session keeps following the tail, which is wanted rather than a
+    /// side effect to bound.
+    ///
+    /// Cheap to leave armed: `scrollTo` changes neither height, so this cannot
+    /// feed back into itself, and a session that is already at its bottom is
+    /// re-pinned to where it already is.
+    ///
     /// `@MainActor` because it drives a `ScrollViewProxy`. Only `View.body`
     /// carries that isolation implicitly, and this is a plain helper reached
-    /// from a geometry callback — the annotation is a no-op if the isolation is
-    /// inferred and a compile fix if it is not.
+    /// from a geometry callback.
     @MainActor
-    private func landIfContentGrew(to height: CGFloat, proxy: ScrollViewProxy) {
+    private func relandIfArmed(_ proxy: ScrollViewProxy) {
         guard !landingCancelled else { return }
-        let deadline = landingDeadline ?? Date().addingTimeInterval(Self.landingWindow)
-        if landingDeadline == nil { landingDeadline = deadline }
-        guard Date() < deadline else { return }
-        guard height != landedContentHeight else { return }
-        landedContentHeight = height
+        // Nothing to land ON yet. The first render builds this transcript
+        // against an empty store, and aiming at the end marker there would
+        // both waste the landing and, in the previous design, start its clock.
+        guard !store.blocks.isEmpty else { return }
         proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
     }
-
-    /// How long the landing keeps correcting itself. Generous, because it costs
-    /// nothing while the height is stable, and a slow device measuring a long
-    /// transcript is the case this exists for. A streaming turn keeps the height
-    /// moving indefinitely, which is why there is a stop at all.
-    private static let landingWindow: TimeInterval = 3
 
     /// Lower the keyboard by asking whoever holds first responder to give it
     /// up. The composer's focus binding lives inside ComposerView, and routing


### PR DESCRIPTION
The transcript still opened BLANK on a real iPhone after #594. Two designs have
now tried to land it and both failed the same way: each picked in advance a
moment at which the landing was finished, and the layout was not.

* **#593 and earlier — three scrolls on a fixed 0/50/250ms ladder.** A fixed
  time budget racing a variable amount of layout work. It won on a fast Mac's
  simulator and lost on the phone.
* **#594 — content-height-driven, 3s window.** Better, but it armed the window
  on the screen's FIRST render, which happens before `onAppear` starts the
  fetch — so the clock opened against an empty store and, on a slow link, had
  expired before the messages arrived. It was also blind to the half that
  matters most here.

### What the reporter's own timeline gave away

This started during the work that turned the composer from a plain input into
real chrome. That is not a coincidence and it is the missing half:

* the model chip appears when the model list loads;
* the mic appears when the config check returns;
* the whole stack sits in the screen's bottom `safeAreaInset`.

So the composer shrinks the transcript's VIEWPORT a beat AFTER the session
opened, moving the bottom out from under a landing that had already run. No
content-only signal can see that — not one row of content changed.

### The fix

Re-land on a change to EITHER height, content or viewport, and drop the
deadline entirely.

Staying on the newest message until the reader deliberately leaves it is simply
what a chat transcript should do, so the only thing that ends the landing is
the reader's own scroll (already wired, `DragGesture(minimumDistance: 8)`). A
turn streaming into an open session keeps following the tail, which is wanted
rather than a side effect to bound — and it is what `.defaultScrollAnchor(
.bottom, for: .sizeChanges)` is doing anyway.

Cheap to leave armed: `scrollTo` changes neither height, so it cannot feed back
into itself, and a session already at its bottom is re-pinned to where it
already is. The landing is also skipped while `blocks` is empty — the first
render builds the transcript against an empty store, and that phantom pass is
what poisoned #594's clock.

Unchanged: nothing is added below the bottom anchor (#593), the scroll anchor
keeps its `.sizeChanges` scoping, and the transcript stays lazy (BET-481).