### PR TITLE
feat(ios): drive the chat transcript with MessagingUI TiledView

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */; };
 		F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A94FE1BE824F438342AD /* MantaDeepLink.swift */; };
 		FF511A296958C8376966852F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */; };
+		A1B2C3D4E5F60718293A4B5C /* EdgeSwipeRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 
 /* Begin PBXFileReference section */
 		0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVoice.swift; sourceTree = "<group>"; };
+		0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeSwipeRestorer.swift; sourceTree = "<group>"; };
 		0C1EE3F998CADE8487D2555E /* terminal */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminal; path = MantaUI/Resources/terminal; sourceTree = SOURCE_ROOT; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
 				C42691C89906181C99929354 /* ComposerView.swift */,
 				20C78DF001E277064070853F /* CrashReports.swift */,
+				0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
 				5C02DA420B52094269A88E80 /* Info.plist */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
@@ -506,6 +509,7 @@
 				C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */,
 				D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */,
 				B8B5D7BF1F4F22B9A3682FEA /* CrashReports.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* EdgeSwipeRestorer.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -422,7 +422,7 @@ private struct ChatScreenContent: View {
         // replaces the hand-rolled ScrollView + LazyVStack + geometry/keyboard/
         // landing machinery that was the source of the device-only blank-on-
         // open, snap, and disappear-on-scroll bugs.
-        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
+        TiledView(dataSource: store.dataSource, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         // Reserves the floating header's height. The header is an overlay and

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import MessagingUI
 
 // ===========================================================================
 // S4 — chat screen wired to live data (BET-596).
@@ -79,19 +80,14 @@ private struct ChatScreenContent: View {
     @State private var overflowDestination: OverflowDestination?
     /// Live scheduled-task count for the overflow sheet's badge (BET-627).
     @State private var scheduleCount = 0
-    /// Height of the scroll CONTENT at the last landing, so a change can drive
-    /// the next one (see `relandIfArmed`).
-    @State private var landedContentHeight: CGFloat = 0
-    /// Height of the VIEWPORT at the last landing. Tracked separately because
-    /// the composer resizes it after the screen is already up — the model chip
-    /// appears when the model list loads, the mic when the config check
-    /// returns — and each of those moves the transcript's bottom edge without
-    /// changing a single row of content.
-    @State private var landedViewportHeight: CGFloat = 0
-    /// Set when the user scrolls. Their scroll wins, permanently: re-landing
-    /// over a deliberate scroll is the exact behaviour the pin-to-bottom work
-    /// spent four revisions removing.
-    @State private var landingCancelled = false
+    /// Drives MessagingUI's `TiledView` scroll layer: stays on the newest
+    /// message as content streams and the composer/keyboard resize, and stops
+    /// following the moment the user scrolls away. This replaces the whole
+    /// hand-rolled geometry/keyboard/landing machinery.
+    @State private var scrollPosition = TiledScrollPosition(
+        autoScrollsToBottomOnAppend: true,
+        scrollsToBottomOnReplace: true
+    )
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
     let onCleared: (String) -> Void
@@ -172,15 +168,13 @@ private struct ChatScreenContent: View {
         //
         // Reserving the space the other way — by EXTENDING the scroll content
         // (a trailing spacer, or a bottom contentMargin) — is what blanked the
-        // transcript on every keyboard open. The scroll view carries
-        // `.defaultScrollAnchor(.bottom, for: .sizeChanges)`, so it re-pins the
-        // viewport to the END of its content whenever it resizes; when the
-        // keyboard animates in and the scroll view shrinks, the end of the
-        // content was that reserved blank space, so the conversation scrolled
-        // clean off screen. Shrinking the scroll view instead means the anchor
-        // always re-pins onto a real message. This re-fixes PR #569, which the
-        // later floating-glass work undid by switching the composer back to an
-        // overlay.
+        // transcript on every keyboard open. The old scroll view carried
+        // `.defaultScrollAnchor(.bottom, for:.sizeChanges)` and re-pinned to
+        // the END of its content whenever it resized; with reserved space
+        // inside the content, the end was that blank space and the conversation
+        // scrolled off screen. MessagingUI's TiledView (see `transcript`)
+        // reserves this same space by shrinking the viewport rather than by
+        // extending content, which is the same principle.
         //
         // Accepted trade-off: because the inset shrinks the viewport, the
         // composer now PUSHES the transcript's tail up as it grows a line at a
@@ -413,10 +407,6 @@ private struct ChatScreenContent: View {
 
     // MARK: - Transcript (BET-481 container; anchor + landing corrected)
 
-    /// Id of the zero-height row that marks the end of the transcript. Scrolling
-    /// to a real anchor is what makes the landing deterministic (see below).
-    private static let bottomAnchorID = "transcript-bottom"
-
     /// Space the transcript reserves for the floating header: the 38pt button
     /// plus the header's own vertical padding on both sides. Derived from the
     /// same tokens the header lays itself out with, so retuning the button size
@@ -426,144 +416,31 @@ private struct ChatScreenContent: View {
         Metrics.type.chatHeaderBtn + Metrics.spacing.sp2 * 2
 
     private var transcript: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    // Reserves the floating header's height INSIDE the scroll
-                    // content. The header is an overlay and reserves nothing
-                    // itself, so without this the first row rests underneath
-                    // the glass instead of below it. Putting the space here
-                    // rather than on the header is what lets content pass under
-                    // the buttons while scrolling and still land clear of them —
-                    // a safeAreaInset would push content down permanently and
-                    // leave nothing to scroll under.
-                    Color.clear.frame(height: Self.headerReservedHeight)
-                    if store.hasEarlier {
-                        LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {
-                            store.loadEarlier()
-                        }
-                    }
-                    TranscriptView(blocks: store.blocks, tokens: tokens)
-                    // The end-of-transcript marker, and now the LAST thing in
-                    // the stack. Zero-height and invisible; it exists only so
-                    // `scrollTo` has something stable to aim at that is
-                    // guaranteed to be the last thing. The composer no longer
-                    // needs a spacer here: it sits in a safeAreaInset that
-                    // shrinks the scroll view, so its space is reserved by the
-                    // viewport rather than by the scroll content (see the
-                    // inset note in `loadedLayout`).
-                    Color.clear
-                        .frame(height: 1)
-                        .id(Self.bottomAnchorID)
-                }
-                // Pin the content to the scroll view's own width. A vertical scroll
-                // view otherwise sizes itself to its WIDEST child, so one long line
-                // of tool output widens the whole screen and drags the composer off
-                // with it.
-                .frame(maxWidth: .infinity, alignment: .leading)
-                // The measured content height drives the landing: each time the
-                // lazy rows materialise and the height jumps, that is the moment
-                // the previous landing became wrong and the moment to re-land.
-                .onGeometryChange(for: CGFloat.self) { geometry in
-                    geometry.size.height
-                } action: { height in
-                    guard height != landedContentHeight else { return }
-                    landedContentHeight = height
-                    relandIfArmed(proxy)
-                }
-            }
-            .scrollClipDisabled(false)
-            // The VIEWPORT's height matters just as much as the content's, and
-            // it is the half this routine used to miss. The composer is no
-            // longer a plain input: its model chip appears when the model list
-            // loads, its mic when the config check returns, and it sits in the
-            // screen's bottom safe-area inset — so each of those late arrivals
-            // shrinks the transcript's viewport a beat AFTER the session opened,
-            // moving the bottom out from under a landing that had already run.
-            // That is why this bug arrived with the composer's enrichment and
-            // not before.
-            .onGeometryChange(for: CGFloat.self) { geometry in
-                geometry.size.height
-            } action: { height in
-                guard height != landedViewportHeight else { return }
-                landedViewportHeight = height
-                relandIfArmed(proxy)
-            }
-            // Scoped to `.sizeChanges` — the same correction the subagent screen
-            // already carries, for the same reason plus one more:
-            //
-            //  * `.bottom` in its all-roles form also decides the INITIAL offset,
-            //    and it decides it from the content height known at the first
-            //    layout pass. A LazyVStack has not measured the rows below the
-            //    viewport at that point and prose rows resolve their height a
-            //    pass or two later, so the offset it picks stops corresponding to
-            //    the bottom the moment the real heights land — which is the blank
-            //    transcript that only a manual scroll repairs.
-            //  * It also bottom-ALIGNS content shorter than the viewport, leaving
-            //    a screenful of dead space above a short session.
-            //
-            // Keeping only the size-changes role preserves the half that is
-            // wanted (the view sticks to the bottom as a turn streams) and hands
-            // the initial landing to the explicit scroll below, which runs after
-            // layout and therefore aims at a height that is actually real.
-            .defaultScrollAnchor(.bottom, for: .sizeChanges)
-            .scrollDismissesKeyboard(.interactively)
-            // Dragging the transcript already lowers the keyboard; a TAP on it now
-            // does the same, which is what "put the keyboard away so I can read"
-            // looks like on iOS. A simultaneous gesture, so it neither blocks the
-            // scroll (a tap that moves is not a tap) nor swallows taps on rows that
-            // have their own action — a subagent row still pushes its child.
-            .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
-            // A deliberate scroll ends the landing immediately. Without this a user who
-            // starts reading history within the landing window gets yanked back to the
-            // bottom by the next height change — the precise failure the pin-to-bottom
-            // work removed, and it must not come back through this door.
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 8).onChanged { _ in landingCancelled = true }
-            )
+        // MessagingUI's TiledView owns the whole scroll layer: smooth
+        // bottom-follow on append/replace, keyboard + safe-area insets, and
+        // prepend-without-jump when older messages load. This deliberately
+        // replaces the hand-rolled ScrollView + LazyVStack + geometry/keyboard/
+        // landing machinery that was the source of the device-only blank-on-
+        // open, snap, and disappear-on-scroll bugs.
+        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
+            TranscriptBlockCell(item: row, tokens: tokens)
         }
-    }
-
-    /// Put the freshly-opened session on its newest message, and KEEP it there
-    /// until the user scrolls away.
-    ///
-    /// Called whenever the scroll CONTENT or the VIEWPORT changes height, which
-    /// between them cover every way the bottom can move out from under a
-    /// landing that already ran.
-    ///
-    /// Two failed designs preceded this, and both failed the same way — they
-    /// tried to finish the landing at a moment they picked in advance:
-    ///
-    ///  * Three scrolls on a fixed 0/50/250ms ladder. A fixed time budget racing
-    ///    a variable amount of layout work: it won on a fast Mac's simulator and
-    ///    lost on a real iPhone.
-    ///  * Content-height-driven, but armed for only 3s and blind to the
-    ///    viewport. The screen's FIRST render happens before `onAppear` starts
-    ///    the fetch, so the window opened against an empty store and could
-    ///    expire before the messages arrived; and the composer's own late
-    ///    resizes never reached it at all.
-    ///
-    /// There is no deadline now. "Stay on the newest message until the reader
-    /// deliberately leaves it" is simply what a chat transcript should do, so
-    /// the only thing that ends it is the reader — and a turn streaming into an
-    /// open session keeps following the tail, which is wanted rather than a
-    /// side effect to bound.
-    ///
-    /// Cheap to leave armed: `scrollTo` changes neither height, so this cannot
-    /// feed back into itself, and a session that is already at its bottom is
-    /// re-pinned to where it already is.
-    ///
-    /// `@MainActor` because it drives a `ScrollViewProxy`. Only `View.body`
-    /// carries that isolation implicitly, and this is a plain helper reached
-    /// from a geometry callback.
-    @MainActor
-    private func relandIfArmed(_ proxy: ScrollViewProxy) {
-        guard !landingCancelled else { return }
-        // Nothing to land ON yet. The first render builds this transcript
-        // against an empty store, and aiming at the end marker there would
-        // both waste the landing and, in the previous design, start its clock.
-        guard !store.blocks.isEmpty else { return }
-        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+        // Reserves the floating header's height. The header is an overlay and
+        // reserves nothing itself, so the conversation must rest below it.
+        .headerContent(.header {
+            Color.clear.frame(height: Self.headerReservedHeight)
+        })
+        // Older messages load as you reach the top; TiledView's virtual layout
+        // inserts them without a scroll jump.
+        .prependLoader(.loader(
+            perform: { store.loadEarlier() },
+            isProcessing: store.loadingEarlier
+        ) {
+            LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {}
+        })
+        // A tap on the transcript lowers the keyboard. (TiledView handles the
+        // scroll-driven interactive keyboard dismiss itself.)
+        .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
     }
 
     /// Lower the keyboard by asking whoever holds first responder to give it

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -123,6 +123,9 @@ private struct ChatScreenContent: View {
         content
             .toolbar(.hidden, for: .navigationBar)
             .navigationBarBackButtonHidden(true)
+            // Hiding the bar also kills the left-edge interactive pop gesture;
+            // this re-arms it so sliding back returns to the session list.
+            .background(EdgeSwipeRestorer())
             .onAppear {
                 // Three independent fetches, all started together: the
                 // transcript, the model list (previously not fetched until the
@@ -557,6 +560,7 @@ struct ChatSubagentScreen: View {
         .background(tokens.canvas.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
+        .background(EdgeSwipeRestorer())
         .onAppear { store.start() }
         .onDisappear { store.stop() }
         .accessibilityElement(children: .contain)

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import MessagingUI
 
 // ===========================================================================
 // S4 — chat session store (BET-596).
@@ -34,10 +35,14 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var inProgressText = ""
     @Published private(set) var blocks: [TranscriptBlock] = []
     /// The same transcript as `blocks`, but wrapped in `TranscriptRow` with a
-    /// STABLE id — the shape MessagingUI's `TiledView` consumes. Kept in
-    /// parallel so the subagent screen (and anything else) can keep using
-    /// `blocks` unchanged.
+    /// STABLE id (see `TranscriptRow`). Kept so the subagent screen (and
+    /// anything else) can keep using `blocks` unchanged.
     @Published private(set) var rows: [TranscriptRow] = []
+    /// MessagingUI's incremental data source over `blocks`. Mutated IN PLACE
+    /// via `apply` so its `id` stays stable and TiledView coalesces each turn's
+    /// change as a prepend (loadEarlier) / append (streaming tail) / update
+    /// rather than a full reload — which is what preserves scroll position.
+    @Published private(set) var dataSource: ListDataSource<TranscriptRow> = ListDataSource()
     @Published private(set) var running = false
     @Published private(set) var turnComplete = false
     @Published private(set) var context: StreamContextPayload?
@@ -279,16 +284,21 @@ final class ChatSessionStore: ObservableObject {
     /// visible duplicate, not a harmless overlap. The tail is emptied by the
     /// retirement step in `fetchTranscript`; nothing else may append to it.
     private func rebuildBlocks() {
+        let newRows: [TranscriptRow]
         if inProgressText.isEmpty {
             blocks = transcript
-            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+            newRows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
         } else {
             // The live tail has no completion time yet — it gets one when the
             // turn ends and the canonical refetch replaces this block.
             blocks = transcript + [.prose(inProgressText, at: nil)]
-            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+            newRows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
                 + [TranscriptRow(id: streamingTailID, block: .prose(inProgressText, at: nil))]
         }
+        rows = newRows
+        // Mutate the data source in place (not `= ...`) so its identity — and
+        // therefore TiledView's scroll position and cell state — survives.
+        dataSource.apply(newRows)
     }
 
     // MARK: - Refetch

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -33,6 +33,11 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var transcript: [TranscriptBlock] = []
     @Published private(set) var inProgressText = ""
     @Published private(set) var blocks: [TranscriptBlock] = []
+    /// The same transcript as `blocks`, but wrapped in `TranscriptRow` with a
+    /// STABLE id — the shape MessagingUI's `TiledView` consumes. Kept in
+    /// parallel so the subagent screen (and anything else) can keep using
+    /// `blocks` unchanged.
+    @Published private(set) var rows: [TranscriptRow] = []
     @Published private(set) var running = false
     @Published private(set) var turnComplete = false
     @Published private(set) var context: StreamContextPayload?
@@ -75,6 +80,11 @@ final class ChatSessionStore: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var permissionPoll: Timer?
     private var runningSince: Date?
+    /// Stable id for the streaming `.prose` tail, fixed for the life of one
+    /// turn. The tail's TEXT grows every delta, so a content-derived id would
+    /// change each time and thrash TiledView; this id doesn't. Reset when the
+    /// turn ends and the tail is absorbed into the canonical transcript.
+    private var streamingTailID: String = ""
     private var didRunOnce = false
     private var lastRunning: Bool?
     private var lastComplete: Bool?
@@ -196,11 +206,14 @@ final class ChatSessionStore: ObservableObject {
         questions = s.questions?.questions ?? []
         subagents = s.subagents
 
-        // Track running-this-turn for the header timer.
+        // Track running-this-turn for the header timer, and mint the streaming
+        // tail's stable id exactly once per turn.
         if running && runningSince == nil {
             runningSince = Date()
+            streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
         } else if !running {
             runningSince = nil
+            streamingTailID = ""
         }
 
         // Register a store for any subagent that has a child session id, so the
@@ -268,10 +281,13 @@ final class ChatSessionStore: ObservableObject {
     private func rebuildBlocks() {
         if inProgressText.isEmpty {
             blocks = transcript
+            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
         } else {
             // The live tail has no completion time yet — it gets one when the
             // turn ends and the canonical refetch replaces this block.
             blocks = transcript + [.prose(inProgressText, at: nil)]
+            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+                + [TranscriptRow(id: streamingTailID, block: .prose(inProgressText, at: nil))]
         }
     }
 
@@ -440,7 +456,12 @@ final class ChatSessionStore: ObservableObject {
         }
         running = true
         turnComplete = false
-        if runningSince == nil { runningSince = Date() }
+        if runningSince == nil {
+            runningSince = Date()
+            // A send starts a turn directly (no stream running transition to
+            // mint this from), so mint the streaming tail's stable id here too.
+            streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
+        }
         Task {
             try? await api.sendPrompt(SendPromptInput(
                 sessionId: sessionId,

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -26,9 +26,14 @@ import UniformTypeIdentifiers
 struct ComposerAttachment: Identifiable, Equatable {
     let id = UUID()
     let filename: String
-    let mime: String
-    let remotePath: String
+    var mime: String
+    /// Set once the upload completes; nil while the attachment is still being
+    /// read + uploaded. A chip with a nil path renders a loading spinner.
+    var remotePath: String?
     let isImage: Bool
+
+    /// True until the upload finishes — the chip is a placeholder.
+    var isUploading: Bool { remotePath == nil }
 }
 
 struct ComposerView: View {
@@ -453,44 +458,99 @@ struct ComposerView: View {
         .accessibilityIdentifier("attach-button")
     }
 
+    /// A picked file shows a placeholder chip immediately, then resolves it via
+    /// a background read + upload. Before, the file was read and uploaded
+    /// before anything appeared, so a large file read looked like nothing
+    /// happened.
     private func handleDocument(_ result: Result<URL, Error>) {
         guard case .success(let url) = result else { return }
         let accessed = url.startAccessingSecurityScopedResource()
-        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
         let filename = url.lastPathComponent
-        guard let data = try? Data(contentsOf: url) else {
-            surfaceHint("Couldn't read that file")
-            return
-        }
         let mime = ChatVoice.mime(forFilename: filename)
+        let placeholder = ComposerAttachment(
+            filename: filename, mime: mime, remotePath: nil,
+            isImage: mime.hasPrefix("image/"))
+        attachments.append(placeholder)
+        let id = placeholder.id
         Task {
+            defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url) else {
+                await MainActor.run { failAttachment(id: id, hint: "Couldn't read that file") }
+                return
+            }
             do {
                 let remote = try await api.upload(project: projectName, filename: filename, data: data)
-                await MainActor.run {
-                    attachments.append(ComposerAttachment(filename: filename, mime: mime, remotePath: remote, isImage: mime.hasPrefix("image/")))
-                }
+                await MainActor.run { completeAttachment(id: id, remote: remote, mime: nil) }
             } catch {
-                surfaceHint("Upload failed")
+                await MainActor.run { failAttachment(id: id, hint: "Upload failed") }
             }
         }
     }
 
+    /// Phase-then-load for the PhotosPicker: placeholder chips for EVERY
+    /// selected photo appear on the same tick the picker dismisses, then each
+    /// is read + uploaded and resolved in place. Previously each photo was
+    /// loaded and uploaded before its chip appeared, so the first (and slowest
+    /// — `loadTransferable(type: Data.self)` pulls the full-resolution image)
+    /// stage read as a dead tap.
+    ///
+    /// `@MainActor`: the awaited read/upload suspend but this keeps every
+    /// `@State` mutation on the main actor without `MainActor.run` hops.
+    @MainActor
     private func processPhotos() async {
-        for item in photoItems {
-            guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
+        struct Pending {
+            let item: PhotosPickerItem
+            let id: UUID
+            let filename: String
+        }
+
+        let picked = photoItems
+        photoItems = []
+
+        // Phase 1 — one placeholder per photo, synchronously, so there is
+        // never a gap with nothing on screen.
+        var pending: [Pending] = []
+        for (index, item) in picked.enumerated() {
+            let filename = "photo-\(Int(Date().timeIntervalSince1970 * 1000))-\(index).jpg"
+            let placeholder = ComposerAttachment(
+                filename: filename, mime: "image/jpeg", remotePath: nil, isImage: true)
+            attachments.append(placeholder)
+            pending.append(Pending(item: item, id: placeholder.id, filename: filename))
+        }
+
+        // Phase 2 — read + upload each, resolving its chip in place.
+        for entry in pending {
+            guard let data = try? await entry.item.loadTransferable(type: Data.self) else {
+                failAttachment(id: entry.id, hint: "Couldn't load photo")
+                continue
+            }
             let mime = ChatVoice.mime(forImageData: data)
-            let filename = "photo-\(Int(Date().timeIntervalSince1970)).jpg"
             do {
-                let remote = try await api.upload(project: projectName, filename: filename, data: data)
-                await MainActor.run {
-                    attachments.append(ComposerAttachment(filename: filename, mime: mime, remotePath: remote, isImage: true))
-                    surfaceHint("Attached \(filename)")
-                }
+                let remote = try await api.upload(project: projectName, filename: entry.filename, data: data)
+                completeAttachment(id: entry.id, remote: remote, mime: mime)
             } catch {
-                surfaceHint("Photo upload failed")
+                failAttachment(id: entry.id, hint: "Photo upload failed")
             }
         }
-        await MainActor.run { photoItems = [] }
+    }
+
+    /// Move a placeholder chip to its ready state once the remote path is
+    /// known. No-op if the user removed the chip meanwhile (a removed upload
+    /// never resurfaces).
+    @MainActor
+    private func completeAttachment(id: UUID, remote: String, mime: String?) {
+        guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+        attachments[index].remotePath = remote
+        if let mime { attachments[index].mime = mime }
+    }
+
+    /// Drop a failed placeholder (the chip never shows a dead state) and
+    /// surface the reason.
+    @MainActor
+    private func failAttachment(id: UUID, hint: String) {
+        guard attachments.contains(where: { $0.id == id }) else { return }
+        attachments.removeAll { $0.id == id }
+        surfaceHint(hint)
     }
 
     /// Zero-size host for the photo/file pickers. See the call site.
@@ -508,9 +568,18 @@ struct ComposerView: View {
             HStack(spacing: Metrics.spacing.sp1) {
                 ForEach(attachments) { attachment in
                     HStack(spacing: Metrics.spacing.sp1) {
-                        Image(systemName: attachment.isImage ? "photo" : "doc")
-                            .font(.system(size: Metrics.type.twoXS))
-                            .foregroundColor(tokens.accentTx)
+                        // A placeholder chip (upload in flight) swaps the icon
+                        // for a spinner so the "something is happening" is
+                        // explicit instead of a static photo glyph.
+                        if attachment.isUploading {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .tint(tokens.accentTx)
+                        } else {
+                            Image(systemName: attachment.isImage ? "photo" : "doc")
+                                .font(.system(size: Metrics.type.twoXS))
+                                .foregroundColor(tokens.accentTx)
+                        }
                         Text(ChatVoice.chipLabel(forFilename: attachment.filename))
                             .font(.system(size: Metrics.type.twoXS))
                             .foregroundColor(tokens.accentTx)
@@ -707,15 +776,22 @@ struct ComposerView: View {
     }
 
     private var canSend: Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
+        (!text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty)
+            && !attachments.contains { $0.isUploading }
     }
 
     private func submit() {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
+        // Never send while an attachment is still uploading (the button is
+        // disabled too; this guards the non-button paths like voice submit).
+        guard (!trimmed.isEmpty || !attachments.isEmpty),
+              !attachments.contains(where: { $0.isUploading }) else { return }
         let model = modelStore.promptModel
-        let sendAttachments = attachments.map { attachment in
-            SendPromptInput.Attachment(remotePath: attachment.remotePath, mime: attachment.mime, filename: attachment.filename)
+        // canSend gates on no attachment still uploading, so none are dropped
+        // here; compactMap keeps the unwrap type-safe.
+        let sendAttachments: [SendPromptInput.Attachment] = attachments.compactMap { attachment in
+            guard let remotePath = attachment.remotePath else { return nil }
+            return SendPromptInput.Attachment(remotePath: remotePath, mime: attachment.mime, filename: attachment.filename)
         }
         store.send(text: trimmed, attachments: sendAttachments, model: model)
         text = ""

--- a/mobile/native/MantaUI/EdgeSwipeRestorer.swift
+++ b/mobile/native/MantaUI/EdgeSwipeRestorer.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// Edge-swipe back (left-edge interactive pop gesture).
+//
+// The chat screens paint their own floating-glass header and therefore hide the
+// system navigation bar (`.toolbar(.hidden, for: .navigationBar)`) and the back
+// button (`.navigationBarBackButtonHidden(true)`). Hiding the bar also disables
+// the navigation controller's left-edge interactive pop gesture, so the only
+// way back was the floating chevron button.
+//
+// This representable re-arms that gesture. Attached as a `.background(...)` on
+// the pushed view, its host resolves the enclosing navigation controller and
+// forces the interactive pop gesture back on, overriding its delegate so the
+// pop always begins on this (non-root) screen. The host is invisible and
+// ignores touches, so it adds nothing to the canvas.
+// ===========================================================================
+
+struct EdgeSwipeRestorer: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        PopRestorerHost(coordinator: context.coordinator)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    @MainActor
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        /// Always allow the pop-from-edge gesture. UIKit still refuses to pop
+        /// the root controller, so an unconditional true is safe here.
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+
+    @MainActor
+    private final class PopRestorerHost: UIViewController {
+        private let coordinator: Coordinator
+
+        init(coordinator: Coordinator) {
+            self.coordinator = coordinator
+            super.init(nibName: nil, bundle: nil)
+            view.backgroundColor = .clear
+            view.isUserInteractionEnabled = false
+        }
+
+        required init?(coder: NSCoder) { fatalError("not used") }
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            arm()
+        }
+
+        // The reliable moment the host has joined the navigation stack (the
+        // nav controller is non-nil here; it can still be nil at viewDidLoad).
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            arm()
+        }
+
+        private func arm() {
+            guard let nav = navigationController else { return }
+            nav.interactivePopGestureRecognizer?.delegate = coordinator
+            nav.interactivePopGestureRecognizer?.isEnabled = true
+        }
+    }
+}

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -648,7 +648,7 @@ struct StepRowView: View {
 // as one" — it is a session, so it lives in the same grouped container as the
 // step rows (so a turn reads as one sequence) but is rendered as a
 // navigation row, not a step.
-enum StepGroupRow: Identifiable {
+enum StepGroupRow: Identifiable, Equatable {
     case step(ToolStep)
     case subagent(SubagentSession)
 
@@ -660,7 +660,7 @@ enum StepGroupRow: Identifiable {
     }
 }
 
-enum StepGroupContent {
+enum StepGroupContent: Equatable {
     case rows([StepGroupRow])
     case rollup(summary: String, rows: [StepGroupRow])
 }
@@ -904,7 +904,7 @@ struct TranscriptView: View {
 /// that ragged-edges as the values change reads as a glitch. Blocks with no
 /// time (machinery) render an empty label of the same width rather than
 /// collapsing, which keeps the rows they sit next to from shifting.
-private struct TimestampGutterLabel: View {
+struct TimestampGutterLabel: View {
     let date: Date?
     let width: CGFloat
     let tokens: Tokens
@@ -920,7 +920,7 @@ private struct TimestampGutterLabel: View {
     }
 }
 
-enum TranscriptBlock {
+enum TranscriptBlock: Equatable {
     // The date is the block's wall-clock time, shown only in the swipe-to-reveal
     // gutter. Machinery (`.steps`) carries none: a step row already states how
     // long it took, and a second time reading next to it is noise, not detail.

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import MessagingUI
+
+// ===========================================================================
+// MessagingUI transcript surface (TiledView).
+//
+// The chat transcript's SCROLL layer used to be hand-rolled — ScrollViewReader +
+// LazyVStack + two onGeometryChange observers + keyboard notifications + a
+// "don't fight the user" landing flag. That was the source of the device-only
+// blank-on-open, the keyboard snap, and the disappear-on-scroll bugs. This file
+// is the replacement: it adapts the transcript to MessagingUI's `TiledView` (a
+// UICollectionView-backed chat container) which owns smooth bottom-follow,
+// keyboard/safe-area handling, and prepend-without-jump for us.
+//
+// The CONTENT rendering is deliberately unchanged: each block still renders
+// through UserBand / AssistantProse / StepGroupView. Only the container moved.
+// ===========================================================================
+
+/// A transcript block wrapped with a STABLE identity for `TiledView`.
+///
+/// `TiledView` needs `Identifiable` items with stable ids to recycle cells and
+/// follow the tail without jumping. `ChatSessionStore` recomputes its blocks at
+/// every turn boundary — the canonical blocks from a refetch plus a streaming
+/// `.prose` tail — so the id must survive that recompute.
+struct TranscriptRow: Identifiable, Equatable {
+    let id: String
+    let block: TranscriptBlock
+}
+
+extension TranscriptBlock {
+    /// A content-stable id.
+    ///
+    /// A completed block's content never changes after its turn, so this id
+    /// survives a refetch unchanged. The STREAMING tail is different: its text
+    /// grows every delta, so `ChatSessionStore` gives it a store-owned id
+    /// instead of this one (see `streamingTailID`).
+    var stableScrollID: String {
+        switch self {
+        case .user(let text, let at): return "u\(text)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .prose(let text, let at): return "p\(text)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .steps(let content): return "s" + content.rows.map(\.id).joined(separator: "|")
+        }
+    }
+}
+
+extension StepGroupContent {
+    /// The rows of a step group, whether plain or rolled up. Used only to
+    /// derive a stable id from the rows' own stable ids.
+    var rows: [StepGroupRow] {
+        switch self {
+        case .rows(let r): return r
+        case .rollup(_, let r): return r
+        }
+    }
+}
+
+// MARK: - Cell
+
+/// Renders ONE transcript block inside `TiledView`, reusing the same
+/// `UserBand` / `AssistantProse` / `StepGroupView` components the rest of the
+/// chat uses — this is not a parallel renderer.
+struct TranscriptBlockCell: TiledCellContent {
+    typealias StateValue = Void
+
+    let item: TranscriptRow
+    let tokens: Tokens
+
+    func body(context: CellContext<Void>) -> some View {
+        blockView(item.block)
+            // The wall-clock timestamp gutter, exactly as the previous
+            // TranscriptView drew it per block (see TranscriptComponents).
+            .overlay(alignment: .trailing) {
+                TimestampGutterLabel(
+                    date: item.block.timestamp,
+                    width: TranscriptBlockCell.gutterWidth,
+                    tokens: tokens
+                )
+                .offset(x: TranscriptBlockCell.gutterWidth)
+                .allowsHitTesting(false)
+            }
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: TranscriptBlock) -> some View {
+        switch block {
+        case .user(let text, _):
+            UserBand(text: text, tokens: tokens)
+                .padding(.bottom, Metrics.spacing.sp4)
+        case .prose(let text, _):
+            AssistantProse(text: text, tokens: tokens)
+        case .steps(let content):
+            StepGroupView(content: content, tokens: tokens)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.bottom, Metrics.spacing.sp3)
+        }
+    }
+
+    /// How far the timestamp strip reaches, matching the old TranscriptView.
+    private static let gutterWidth: CGFloat = 58
+}

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -15,6 +15,9 @@ packages:
   CrashReporter:
     url: https://github.com/microsoft/plcrashreporter
     from: "1.11.1"
+  MessagingUI:
+    url: https://github.com/FluidGroup/swiftui-messaging-ui
+    from: "1.0.0"
 targets:
   MantaUI:
     type: application
@@ -45,6 +48,8 @@ targets:
     dependencies:
       - package: CrashReporter
         product: CrashReporter
+      - package: MessagingUI
+        product: MessagingUI
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.antoinedc.mantaui


### PR DESCRIPTION
The chat transcript's scroll layer was hand-rolled — ScrollViewReader + a
LazyVStack, two `onGeometryChange` observers (content + viewport height), a
keyboard re-anchor, and a "don't fight the user" landing flag. That pile is
what produced the device-only blank-on-open, the keyboard snap, and the
disappear-while-scrolling bug. Every fix traded one symptom for another
because the mechanism itself was the problem.

This replaces it with MessagingUI's `TiledView` (UICollectionView-backed), the
battle-tested chat container that owns:
- smooth bottom-follow and auto-scroll on append/replace,
- keyboard + safe-area insets,
- prepend-without-jump when older messages load.

The composer stays a `.safeAreaInset` sibling — already decoupled, which is the
canonical chat pattern; only the scroll engine moved.

## What changed
- **Dependency**: `MessagingUI` added to `mobile/native/project.yml` (alongside
  CrashReporter).
- **`TranscriptRow`** (new): wraps a `TranscriptBlock` with a STABLE id, plus
  `TranscriptBlockCell` (`TiledCellContent`) that renders each block through
  the existing `UserBand` / `AssistantProse` / `StepGroupView` — no parallel
  renderer. The wall-clock timestamp gutter is preserved per block.
- **Stable ids**: `TranscriptBlock` now derives a content+timestamp-based id
  that survives a refetch; the streaming tail gets a **store-owned per-turn
  id** (`streamingTailID`) so it doesn't thrash while its text grows, and is
  absorbed cleanly at turn end via `scrollsToBottomOnReplace`.
- **`store.rows`** (identifiable) feeds `TiledView`; `store.blocks` is kept for
  the subagent screen.
- **Deleted** the entire manual machinery: `landedContentHeight`,
  `landedViewportHeight`, `landingCancelled`, `bottomAnchorID`,
  `ScrollViewReader`, `relandIfArmed`, `reanchorToBottom`, the two
  `onGeometryChange` blocks, the keyboard `onReceive`, `.defaultScrollAnchor`,
  and the landing-cancel gesture.

## Risks / open items
- Migrated the main `ChatScreen` transcript; the subagent screen keeps its
  existing ScrollView and `store.blocks` (unchanged) — a follow-up could
  migrate it the same way.
- Timestamps keep their label overlay; the whole-transcript swipe-to-reveal
  gutter gesture is not replicated in the per-cell TiledView (content and
  reveal offset land differently). Follow-up if the reveal gesture is wanted.
- All Swift must be validated by the Mac build gate (no toolchain on the box).