### PR TITLE
feat(ios): keep models across session clear + provider-sectioned picker with fast mode

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */; };
 		F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A94FE1BE824F438342AD /* MantaDeepLink.swift */; };
 		FF511A296958C8376966852F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */; };
+		A1B2C3D4E5F60718293A4B5C /* EdgeSwipeRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 
 /* Begin PBXFileReference section */
 		0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVoice.swift; sourceTree = "<group>"; };
+		0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeSwipeRestorer.swift; sourceTree = "<group>"; };
 		0C1EE3F998CADE8487D2555E /* terminal */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminal; path = MantaUI/Resources/terminal; sourceTree = SOURCE_ROOT; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
 				C42691C89906181C99929354 /* ComposerView.swift */,
 				20C78DF001E277064070853F /* CrashReports.swift */,
+				0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
 				5C02DA420B52094269A88E80 /* Info.plist */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
@@ -506,6 +509,7 @@
 				C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */,
 				D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */,
 				B8B5D7BF1F4F22B9A3682FEA /* CrashReports.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* EdgeSwipeRestorer.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,

--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -15,15 +15,109 @@ import Foundation
 
 enum ChatModel {
 
+    // MARK: - Fast-mode sibling models (desktop ⚡ toggle port)
+
+    /// Several providers ship a "fast" flavour of a model as a SEPARATE model id
+    /// with a `-fast` suffix rather than as a variant (`gpt-5.6` / `gpt-5.6-fast`).
+    /// The picker treats fast as a MODE of the base model: the `-fast` id is
+    /// hidden from the dropdown (as long as its base twin is also visible) and
+    /// reached instead through the fast-mode toggle. Mirrors the desktop's
+    /// `isFastModelId` / `baseModelId` / `fastModelId` / `resolveFastToggle`.
+    static let fastSuffix = "-fast"
+
+    /// True when `modelID` is the fast flavour of some base model.
+    static func isFastModelID(_ modelID: String) -> Bool {
+        modelID.count > fastSuffix.count && modelID.hasSuffix(fastSuffix)
+    }
+
+    /// `"gpt-5.6-fast"` → `"gpt-5.6"`; a non-fast id is returned unchanged.
+    static func baseModelID(_ modelID: String) -> String {
+        isFastModelID(modelID) ? String(modelID.dropLast(fastSuffix.count)) : modelID
+    }
+
+    /// `"gpt-5.6"` → `"gpt-5.6-fast"`; a fast id is returned unchanged.
+    static func fastModelID(_ modelID: String) -> String {
+        isFastModelID(modelID) ? modelID : "\(modelID)\(fastSuffix)"
+    }
+
+    /// The ⚡ fast-mode toggle state for the active model. Available only when
+    /// the counterpart model exists AND still offers the currently-selected
+    /// effort/variant — flipping to fast must never silently drop the effort.
+    /// With no variant selected, only the counterpart's existence matters.
+    /// Mirrors the desktop `resolveFastToggle`.
+    struct FastToggle {
+        /// The toggle can be clicked (a counterpart exists that keeps the effort).
+        let available: Bool
+        /// The active model IS the fast flavour.
+        let on: Bool
+        /// The model a click switches to; nil when unavailable.
+        let target: (providerID: String, modelID: String)?
+        /// Human copy explaining the current state.
+        let title: String
+    }
+
+    static func fastToggle(models: [OpencodeModel], active: OpencodeModel?, variantId: String?) -> FastToggle {
+        let off = FastToggle(available: false, on: false, target: nil, title: "No fast mode for this model")
+        guard let active else { return off }
+        let isFast = isFastModelID(active.id)
+        let counterpartID = isFast ? baseModelID(active.id) : fastModelID(active.id)
+        let counterpart = models.first {
+            $0.providerID == active.providerID &&
+            $0.id == counterpartID &&
+            $0.enabled != false &&
+            $0.status?.lowercased() != "deprecated"
+        }
+        guard let counterpart else {
+            if isFast {
+                return FastToggle(available: false, on: true, target: nil, title: "Fast mode on (no standard model available)")
+            }
+            return off
+        }
+        let keepsVariant = variantId == nil || (counterpart.variants?.contains { $0.id == variantId } == true)
+        return FastToggle(
+            available: keepsVariant,
+            on: isFast,
+            target: (active.providerID, counterpartID),
+            title: isFast
+                ? "You're in fast mode — tap to switch to the standard model"
+                : keepsVariant ? "Run this model in fast mode" : "No fast mode at \(variantId ?? "") effort"
+        )
+    }
+
+    // MARK: - Grouping & filtering (desktop `groups` + `filterModelGroups`)
+
     /// Group models by provider, providers ordered alphabetically (matching
-    /// the desktop `groups`). Enabled-only, deprecated excluded.
+    /// the desktop `groups`). Enabled-only, deprecated excluded, and `-fast`
+    /// siblings dropped where their base twin survives (a fast flavour is a
+    /// MODE of the base, reached through the ⚡ toggle — not a separate choice).
+    /// Groups left empty are dropped so a list never renders a provider heading
+    /// with nothing under it.
     static func groups(_ models: [OpencodeModel]) -> [(provider: String, models: [OpencodeModel])] {
         var map: [String: [OpencodeModel]] = [:]
         for m in models where isPickable(m) {
             map[m.providerID, default: []].append(m)
         }
         return map.keys.sorted().compactMap { provider in
-            map[provider].map { (provider, $0) }
+            guard let all = map[provider] else { return nil }
+            let ids = Set(all.map(\.id))
+            let kept = all.filter { !(isFastModelID($0.id) && ids.contains(baseModelID($0.id))) }
+            return kept.isEmpty ? nil : (provider, kept)
+        }
+    }
+
+    /// Filter already-grouped models by a case-insensitive query against the
+    /// model name, id, or provider. Empty/blank query returns everything.
+    /// Mirrors the desktop `filterModelGroups`.
+    static func filteredGroups(_ groups: [(provider: String, models: [OpencodeModel])], query: String) -> [(provider: String, models: [OpencodeModel])] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return groups }
+        return groups.compactMap { group in
+            let kept = group.models.filter {
+                $0.name.lowercased().contains(q) ||
+                $0.id.lowercased().contains(q) ||
+                group.provider.lowercased().contains(q)
+            }
+            return kept.isEmpty ? nil : (group.provider, kept)
         }
     }
 

--- a/mobile/native/MantaUI/ChatModelCatalog.swift
+++ b/mobile/native/MantaUI/ChatModelCatalog.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Combine
+
+// ===========================================================================
+// S5 — box-wide model catalog (BET-597).
+//
+// The model list + server-default are data about the BOX, not about any one
+// chat session — identical across sessions. So they are fetched once and shared
+// through a single app-wide catalog rather than refetched per ChatModelStore.
+//
+// This is what keeps the model list from reloading when a session is cleared:
+// clearing swaps the session id and rebuilds the screen's stores, but the
+// catalog has already loaded and `loadIfNeeded()` is a no-op, so the new store
+// seeds instantly from the same in-memory list. No second round-trip.
+// ===========================================================================
+
+@MainActor
+final class ChatModelCatalog: ObservableObject {
+
+    @Published private(set) var models: [OpencodeModel] = []
+    @Published private(set) var defaultModel: OpencodeModelID?
+    @Published private(set) var loadFailed = false
+    /// True once the model list has arrived (or failed). Drives the composer
+    /// pill's loading state and the picker's "Loading models…" placeholder.
+    @Published private(set) var loaded = false
+
+    static let shared = ChatModelCatalog()
+
+    private let api: MantaAPIClient
+    private var didStart = false
+
+    init(api: MantaAPIClient = .live()) {
+        self.api = api
+    }
+
+    /// Fetch the box's model list + default exactly once. Idempotent: a second
+    /// call while a fetch is in flight, or after one has completed, does
+    /// nothing — which is what lets every ChatModelStore (including a freshly
+    /// rebuilt one after a clear) share the same loaded list. A failed/empty
+    /// fetch still flips `loaded` (so the pill leaves its loading state); the
+    /// HTTP error is not distinguished from a genuinely empty box — matching
+    /// the prior per-store behaviour.
+    func loadIfNeeded() {
+        guard !didStart, !loaded else { return }
+        didStart = true
+        Task {
+            let modelsResult = (try? await api.models()) ?? []
+            let defaultResult = try? await api.defaultModel()
+            await MainActor.run {
+                self.models = modelsResult
+                self.defaultModel = defaultResult
+                self.loadFailed = modelsResult.isEmpty && defaultResult == nil
+                self.loaded = true
+            }
+        }
+    }
+}

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -4,12 +4,18 @@ import Combine
 // ===========================================================================
 // S5 — model store for the composer (BET-597).
 //
-// Owns the model list + per-session override. Box-side data comes from the
-// existing `opencode:models` / `opencode:default-model` RPCs; the per-session
-// override is a plain `providerID/modelID` string in UserDefaults (NOT a
-// credential — the raw string encodes provider+model ids only), mirroring the
-// desktop's `manta:chat:<sessionId>:model` localStorage key. Resolution
-// (override ?? default) is pure ChatModel logic, tested separately.
+// Owns the per-SESSION model override + effort variant; the box-wide model
+// list + server default come from the shared `ChatModelCatalog`, fetched once
+// and mirrored here. The per-session override is a plain `providerID/modelID`
+// string in UserDefaults (NOT a credential — the raw string encodes
+// provider+model ids only), mirroring the desktop's
+// `manta:chat:<sessionId>:model` localStorage key.
+//
+// The catalog is why clearing a session does NOT reload models: the clear
+// rebuilds this store for the new session id, but the list is already loaded
+// and shared, so there is no second fetch. The override/variant are carried to
+// the new id by `rebind(to:)` (matching the desktop's clear handler, which
+// copies the override into the new session's key).
 // ===========================================================================
 
 @MainActor
@@ -18,20 +24,44 @@ final class ChatModelStore: ObservableObject {
     @Published private(set) var models: [OpencodeModel] = []
     @Published private(set) var defaultModel: OpencodeModelID?
     @Published private(set) var override: OpencodeModelID?
+    @Published private(set) var loadFailed = false
+    /// True once the shared catalog has its list (mirrored from the catalog).
+    /// Drives the composer pill's loading state.
+    @Published private(set) var loaded = false
     /// Reasoning-effort variant for the selected model (opencode calls these
     /// model "variants"). Model-specific, so it is cleared whenever the model
     /// changes rather than carried onto a model that has no such setting.
     @Published private(set) var variant: String?
-    @Published private(set) var loadFailed = false
 
     let sessionId: String
-    private let api: MantaAPIClient
+    private let catalog: ChatModelCatalog
+    private var cancellables: Set<AnyCancellable> = []
 
-    init(sessionId: String, api: MantaAPIClient) {
+    init(sessionId: String, api: MantaAPIClient, catalog: ChatModelCatalog = .shared) {
         self.sessionId = sessionId
-        self.api = api
+        self.catalog = catalog
         self.override = Self.loadOverride(for: sessionId)
         self.variant = UserDefaults.standard.string(forKey: Self.variantKey(for: sessionId))
+
+        // Seed + mirror the shared catalog so the box-wide list, default and
+        // failure state are published here (keeps every existing caller reading
+        // `modelStore.models` unchanged). A clear rebuilds this store, but the
+        // catalog is already loaded, so it seeds instantly — no refetch.
+        self.models = catalog.models
+        self.defaultModel = catalog.defaultModel
+        self.loadFailed = catalog.loadFailed
+        self.loaded = catalog.loaded
+        catalog.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.mirrorCatalog() }
+            .store(in: &cancellables)
+    }
+
+    private func mirrorCatalog() {
+        models = catalog.models
+        defaultModel = catalog.defaultModel
+        loadFailed = catalog.loadFailed
+        loaded = catalog.loaded
     }
 
     /// The UserDefaults key mirroring the desktop's per-session model key.
@@ -44,14 +74,20 @@ final class ChatModelStore: ObservableObject {
     }
 
     func load() {
-        Task {
-            let modelsResult = (try? await api.models()) ?? []
-            let defaultResult = try? await api.defaultModel()
-            await MainActor.run {
-                self.models = modelsResult
-                self.defaultModel = defaultResult
-                self.loadFailed = modelsResult.isEmpty && defaultResult == nil
-            }
+        catalog.loadIfNeeded()
+    }
+
+    /// Carry the current override + variant to a NEW session id. Called just
+    /// before a clear swaps the id, so the rebuilt store for the new session
+    /// picks up the same model the user had chosen — matching the desktop,
+    /// which copies the override into the new session's key on /clear.
+    func rebind(to newSessionId: String) {
+        guard newSessionId != sessionId else { return }
+        if let override {
+            UserDefaults.standard.set(ChatModel.encode(override), forKey: Self.storageKey(for: newSessionId))
+        }
+        if let variant, !variant.isEmpty {
+            UserDefaults.standard.set(variant, forKey: Self.variantKey(for: newSessionId))
         }
     }
 

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -422,7 +422,7 @@ private struct ChatScreenContent: View {
         // replaces the hand-rolled ScrollView + LazyVStack + geometry/keyboard/
         // landing machinery that was the source of the device-only blank-on-
         // open, snap, and disappear-on-scroll bugs.
-        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
+        TiledView(dataSource: store.dataSource, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         // Reserves the floating header's height. The header is an overlay and

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -313,6 +313,11 @@ private struct ChatScreenContent: View {
         let newId = try? await MantaAPIClient.live().clearSession(
             sessionName: w.name, windowIndex: w.index, cwd: w.cwd, title: title)
         guard let newId, !newId.isEmpty else { return }
+        // Carry the chosen model + effort to the new session id before the
+        // wrapper rebuilds the stores against it (matching the desktop's clear,
+        // which copies the override into the new session's key). The catalog
+        // already holds the box-wide model list, so nothing reloads.
+        modelStore.rebind(to: newId)
         await MainActor.run { onCleared(newId) }
     }
 

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import MessagingUI
 
 // ===========================================================================
 // S4 — chat screen wired to live data (BET-596).
@@ -79,19 +80,14 @@ private struct ChatScreenContent: View {
     @State private var overflowDestination: OverflowDestination?
     /// Live scheduled-task count for the overflow sheet's badge (BET-627).
     @State private var scheduleCount = 0
-    /// Height of the scroll CONTENT at the last landing, so a change can drive
-    /// the next one (see `relandIfArmed`).
-    @State private var landedContentHeight: CGFloat = 0
-    /// Height of the VIEWPORT at the last landing. Tracked separately because
-    /// the composer resizes it after the screen is already up — the model chip
-    /// appears when the model list loads, the mic when the config check
-    /// returns — and each of those moves the transcript's bottom edge without
-    /// changing a single row of content.
-    @State private var landedViewportHeight: CGFloat = 0
-    /// Set when the user scrolls. Their scroll wins, permanently: re-landing
-    /// over a deliberate scroll is the exact behaviour the pin-to-bottom work
-    /// spent four revisions removing.
-    @State private var landingCancelled = false
+    /// Drives MessagingUI's `TiledView` scroll layer: stays on the newest
+    /// message as content streams and the composer/keyboard resize, and stops
+    /// following the moment the user scrolls away. This replaces the whole
+    /// hand-rolled geometry/keyboard/landing machinery.
+    @State private var scrollPosition = TiledScrollPosition(
+        autoScrollsToBottomOnAppend: true,
+        scrollsToBottomOnReplace: true
+    )
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
     let onCleared: (String) -> Void
@@ -172,15 +168,13 @@ private struct ChatScreenContent: View {
         //
         // Reserving the space the other way — by EXTENDING the scroll content
         // (a trailing spacer, or a bottom contentMargin) — is what blanked the
-        // transcript on every keyboard open. The scroll view carries
-        // `.defaultScrollAnchor(.bottom, for: .sizeChanges)`, so it re-pins the
-        // viewport to the END of its content whenever it resizes; when the
-        // keyboard animates in and the scroll view shrinks, the end of the
-        // content was that reserved blank space, so the conversation scrolled
-        // clean off screen. Shrinking the scroll view instead means the anchor
-        // always re-pins onto a real message. This re-fixes PR #569, which the
-        // later floating-glass work undid by switching the composer back to an
-        // overlay.
+        // transcript on every keyboard open. The old scroll view carried
+        // `.defaultScrollAnchor(.bottom, for:.sizeChanges)` and re-pinned to
+        // the END of its content whenever it resized; with reserved space
+        // inside the content, the end was that blank space and the conversation
+        // scrolled off screen. MessagingUI's TiledView (see `transcript`)
+        // reserves this same space by shrinking the viewport rather than by
+        // extending content, which is the same principle.
         //
         // Accepted trade-off: because the inset shrinks the viewport, the
         // composer now PUSHES the transcript's tail up as it grows a line at a
@@ -413,10 +407,6 @@ private struct ChatScreenContent: View {
 
     // MARK: - Transcript (BET-481 container; anchor + landing corrected)
 
-    /// Id of the zero-height row that marks the end of the transcript. Scrolling
-    /// to a real anchor is what makes the landing deterministic (see below).
-    private static let bottomAnchorID = "transcript-bottom"
-
     /// Space the transcript reserves for the floating header: the 38pt button
     /// plus the header's own vertical padding on both sides. Derived from the
     /// same tokens the header lays itself out with, so retuning the button size
@@ -426,144 +416,31 @@ private struct ChatScreenContent: View {
         Metrics.type.chatHeaderBtn + Metrics.spacing.sp2 * 2
 
     private var transcript: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    // Reserves the floating header's height INSIDE the scroll
-                    // content. The header is an overlay and reserves nothing
-                    // itself, so without this the first row rests underneath
-                    // the glass instead of below it. Putting the space here
-                    // rather than on the header is what lets content pass under
-                    // the buttons while scrolling and still land clear of them —
-                    // a safeAreaInset would push content down permanently and
-                    // leave nothing to scroll under.
-                    Color.clear.frame(height: Self.headerReservedHeight)
-                    if store.hasEarlier {
-                        LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {
-                            store.loadEarlier()
-                        }
-                    }
-                    TranscriptView(blocks: store.blocks, tokens: tokens)
-                    // The end-of-transcript marker, and now the LAST thing in
-                    // the stack. Zero-height and invisible; it exists only so
-                    // `scrollTo` has something stable to aim at that is
-                    // guaranteed to be the last thing. The composer no longer
-                    // needs a spacer here: it sits in a safeAreaInset that
-                    // shrinks the scroll view, so its space is reserved by the
-                    // viewport rather than by the scroll content (see the
-                    // inset note in `loadedLayout`).
-                    Color.clear
-                        .frame(height: 1)
-                        .id(Self.bottomAnchorID)
-                }
-                // Pin the content to the scroll view's own width. A vertical scroll
-                // view otherwise sizes itself to its WIDEST child, so one long line
-                // of tool output widens the whole screen and drags the composer off
-                // with it.
-                .frame(maxWidth: .infinity, alignment: .leading)
-                // The measured content height drives the landing: each time the
-                // lazy rows materialise and the height jumps, that is the moment
-                // the previous landing became wrong and the moment to re-land.
-                .onGeometryChange(for: CGFloat.self) { geometry in
-                    geometry.size.height
-                } action: { height in
-                    guard height != landedContentHeight else { return }
-                    landedContentHeight = height
-                    relandIfArmed(proxy)
-                }
-            }
-            .scrollClipDisabled(false)
-            // The VIEWPORT's height matters just as much as the content's, and
-            // it is the half this routine used to miss. The composer is no
-            // longer a plain input: its model chip appears when the model list
-            // loads, its mic when the config check returns, and it sits in the
-            // screen's bottom safe-area inset — so each of those late arrivals
-            // shrinks the transcript's viewport a beat AFTER the session opened,
-            // moving the bottom out from under a landing that had already run.
-            // That is why this bug arrived with the composer's enrichment and
-            // not before.
-            .onGeometryChange(for: CGFloat.self) { geometry in
-                geometry.size.height
-            } action: { height in
-                guard height != landedViewportHeight else { return }
-                landedViewportHeight = height
-                relandIfArmed(proxy)
-            }
-            // Scoped to `.sizeChanges` — the same correction the subagent screen
-            // already carries, for the same reason plus one more:
-            //
-            //  * `.bottom` in its all-roles form also decides the INITIAL offset,
-            //    and it decides it from the content height known at the first
-            //    layout pass. A LazyVStack has not measured the rows below the
-            //    viewport at that point and prose rows resolve their height a
-            //    pass or two later, so the offset it picks stops corresponding to
-            //    the bottom the moment the real heights land — which is the blank
-            //    transcript that only a manual scroll repairs.
-            //  * It also bottom-ALIGNS content shorter than the viewport, leaving
-            //    a screenful of dead space above a short session.
-            //
-            // Keeping only the size-changes role preserves the half that is
-            // wanted (the view sticks to the bottom as a turn streams) and hands
-            // the initial landing to the explicit scroll below, which runs after
-            // layout and therefore aims at a height that is actually real.
-            .defaultScrollAnchor(.bottom, for: .sizeChanges)
-            .scrollDismissesKeyboard(.interactively)
-            // Dragging the transcript already lowers the keyboard; a TAP on it now
-            // does the same, which is what "put the keyboard away so I can read"
-            // looks like on iOS. A simultaneous gesture, so it neither blocks the
-            // scroll (a tap that moves is not a tap) nor swallows taps on rows that
-            // have their own action — a subagent row still pushes its child.
-            .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
-            // A deliberate scroll ends the landing immediately. Without this a user who
-            // starts reading history within the landing window gets yanked back to the
-            // bottom by the next height change — the precise failure the pin-to-bottom
-            // work removed, and it must not come back through this door.
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 8).onChanged { _ in landingCancelled = true }
-            )
+        // MessagingUI's TiledView owns the whole scroll layer: smooth
+        // bottom-follow on append/replace, keyboard + safe-area insets, and
+        // prepend-without-jump when older messages load. This deliberately
+        // replaces the hand-rolled ScrollView + LazyVStack + geometry/keyboard/
+        // landing machinery that was the source of the device-only blank-on-
+        // open, snap, and disappear-on-scroll bugs.
+        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
+            TranscriptBlockCell(item: row, tokens: tokens)
         }
-    }
-
-    /// Put the freshly-opened session on its newest message, and KEEP it there
-    /// until the user scrolls away.
-    ///
-    /// Called whenever the scroll CONTENT or the VIEWPORT changes height, which
-    /// between them cover every way the bottom can move out from under a
-    /// landing that already ran.
-    ///
-    /// Two failed designs preceded this, and both failed the same way — they
-    /// tried to finish the landing at a moment they picked in advance:
-    ///
-    ///  * Three scrolls on a fixed 0/50/250ms ladder. A fixed time budget racing
-    ///    a variable amount of layout work: it won on a fast Mac's simulator and
-    ///    lost on a real iPhone.
-    ///  * Content-height-driven, but armed for only 3s and blind to the
-    ///    viewport. The screen's FIRST render happens before `onAppear` starts
-    ///    the fetch, so the window opened against an empty store and could
-    ///    expire before the messages arrived; and the composer's own late
-    ///    resizes never reached it at all.
-    ///
-    /// There is no deadline now. "Stay on the newest message until the reader
-    /// deliberately leaves it" is simply what a chat transcript should do, so
-    /// the only thing that ends it is the reader — and a turn streaming into an
-    /// open session keeps following the tail, which is wanted rather than a
-    /// side effect to bound.
-    ///
-    /// Cheap to leave armed: `scrollTo` changes neither height, so this cannot
-    /// feed back into itself, and a session that is already at its bottom is
-    /// re-pinned to where it already is.
-    ///
-    /// `@MainActor` because it drives a `ScrollViewProxy`. Only `View.body`
-    /// carries that isolation implicitly, and this is a plain helper reached
-    /// from a geometry callback.
-    @MainActor
-    private func relandIfArmed(_ proxy: ScrollViewProxy) {
-        guard !landingCancelled else { return }
-        // Nothing to land ON yet. The first render builds this transcript
-        // against an empty store, and aiming at the end marker there would
-        // both waste the landing and, in the previous design, start its clock.
-        guard !store.blocks.isEmpty else { return }
-        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+        // Reserves the floating header's height. The header is an overlay and
+        // reserves nothing itself, so the conversation must rest below it.
+        .headerContent(.header {
+            Color.clear.frame(height: Self.headerReservedHeight)
+        })
+        // Older messages load as you reach the top; TiledView's virtual layout
+        // inserts them without a scroll jump.
+        .prependLoader(.loader(
+            perform: { store.loadEarlier() },
+            isProcessing: store.loadingEarlier
+        ) {
+            LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {}
+        })
+        // A tap on the transcript lowers the keyboard. (TiledView handles the
+        // scroll-driven interactive keyboard dismiss itself.)
+        .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
     }
 
     /// Lower the keyboard by asking whoever holds first responder to give it

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -123,6 +123,9 @@ private struct ChatScreenContent: View {
         content
             .toolbar(.hidden, for: .navigationBar)
             .navigationBarBackButtonHidden(true)
+            // Hiding the bar also kills the left-edge interactive pop gesture;
+            // this re-arms it so sliding back returns to the session list.
+            .background(EdgeSwipeRestorer())
             .onAppear {
                 // Three independent fetches, all started together: the
                 // transcript, the model list (previously not fetched until the
@@ -557,6 +560,7 @@ struct ChatSubagentScreen: View {
         .background(tokens.canvas.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
+        .background(EdgeSwipeRestorer())
         .onAppear { store.start() }
         .onDisappear { store.stop() }
         .accessibilityElement(children: .contain)

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import MessagingUI
 
 // ===========================================================================
 // S4 — chat session store (BET-596).
@@ -34,10 +35,14 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var inProgressText = ""
     @Published private(set) var blocks: [TranscriptBlock] = []
     /// The same transcript as `blocks`, but wrapped in `TranscriptRow` with a
-    /// STABLE id — the shape MessagingUI's `TiledView` consumes. Kept in
-    /// parallel so the subagent screen (and anything else) can keep using
-    /// `blocks` unchanged.
+    /// STABLE id (see `TranscriptRow`). Kept so the subagent screen (and
+    /// anything else) can keep using `blocks` unchanged.
     @Published private(set) var rows: [TranscriptRow] = []
+    /// MessagingUI's incremental data source over `blocks`. Mutated IN PLACE
+    /// via `apply` so its `id` stays stable and TiledView coalesces each turn's
+    /// change as a prepend (loadEarlier) / append (streaming tail) / update
+    /// rather than a full reload — which is what preserves scroll position.
+    @Published private(set) var dataSource: ListDataSource<TranscriptRow> = ListDataSource()
     @Published private(set) var running = false
     @Published private(set) var turnComplete = false
     @Published private(set) var context: StreamContextPayload?
@@ -279,16 +284,21 @@ final class ChatSessionStore: ObservableObject {
     /// visible duplicate, not a harmless overlap. The tail is emptied by the
     /// retirement step in `fetchTranscript`; nothing else may append to it.
     private func rebuildBlocks() {
+        let newRows: [TranscriptRow]
         if inProgressText.isEmpty {
             blocks = transcript
-            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+            newRows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
         } else {
             // The live tail has no completion time yet — it gets one when the
             // turn ends and the canonical refetch replaces this block.
             blocks = transcript + [.prose(inProgressText, at: nil)]
-            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+            newRows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
                 + [TranscriptRow(id: streamingTailID, block: .prose(inProgressText, at: nil))]
         }
+        rows = newRows
+        // Mutate the data source in place (not `= ...`) so its identity — and
+        // therefore TiledView's scroll position and cell state — survives.
+        dataSource.apply(newRows)
     }
 
     // MARK: - Refetch

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -33,6 +33,11 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var transcript: [TranscriptBlock] = []
     @Published private(set) var inProgressText = ""
     @Published private(set) var blocks: [TranscriptBlock] = []
+    /// The same transcript as `blocks`, but wrapped in `TranscriptRow` with a
+    /// STABLE id — the shape MessagingUI's `TiledView` consumes. Kept in
+    /// parallel so the subagent screen (and anything else) can keep using
+    /// `blocks` unchanged.
+    @Published private(set) var rows: [TranscriptRow] = []
     @Published private(set) var running = false
     @Published private(set) var turnComplete = false
     @Published private(set) var context: StreamContextPayload?
@@ -75,6 +80,11 @@ final class ChatSessionStore: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var permissionPoll: Timer?
     private var runningSince: Date?
+    /// Stable id for the streaming `.prose` tail, fixed for the life of one
+    /// turn. The tail's TEXT grows every delta, so a content-derived id would
+    /// change each time and thrash TiledView; this id doesn't. Reset when the
+    /// turn ends and the tail is absorbed into the canonical transcript.
+    private var streamingTailID: String = ""
     private var didRunOnce = false
     private var lastRunning: Bool?
     private var lastComplete: Bool?
@@ -196,11 +206,14 @@ final class ChatSessionStore: ObservableObject {
         questions = s.questions?.questions ?? []
         subagents = s.subagents
 
-        // Track running-this-turn for the header timer.
+        // Track running-this-turn for the header timer, and mint the streaming
+        // tail's stable id exactly once per turn.
         if running && runningSince == nil {
             runningSince = Date()
+            streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
         } else if !running {
             runningSince = nil
+            streamingTailID = ""
         }
 
         // Register a store for any subagent that has a child session id, so the
@@ -268,10 +281,13 @@ final class ChatSessionStore: ObservableObject {
     private func rebuildBlocks() {
         if inProgressText.isEmpty {
             blocks = transcript
+            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
         } else {
             // The live tail has no completion time yet — it gets one when the
             // turn ends and the canonical refetch replaces this block.
             blocks = transcript + [.prose(inProgressText, at: nil)]
+            rows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+                + [TranscriptRow(id: streamingTailID, block: .prose(inProgressText, at: nil))]
         }
     }
 
@@ -440,7 +456,12 @@ final class ChatSessionStore: ObservableObject {
         }
         running = true
         turnComplete = false
-        if runningSince == nil { runningSince = Date() }
+        if runningSince == nil {
+            runningSince = Date()
+            // A send starts a turn directly (no stream running transition to
+            // mint this from), so mint the streaming tail's stable id here too.
+            streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
+        }
         Task {
             try? await api.sendPrompt(SendPromptInput(
                 sessionId: sessionId,

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -26,9 +26,14 @@ import UniformTypeIdentifiers
 struct ComposerAttachment: Identifiable, Equatable {
     let id = UUID()
     let filename: String
-    let mime: String
-    let remotePath: String
+    var mime: String
+    /// Set once the upload completes; nil while the attachment is still being
+    /// read + uploaded. A chip with a nil path renders a loading spinner.
+    var remotePath: String?
     let isImage: Bool
+
+    /// True until the upload finishes — the chip is a placeholder.
+    var isUploading: Bool { remotePath == nil }
 }
 
 struct ComposerView: View {
@@ -453,44 +458,99 @@ struct ComposerView: View {
         .accessibilityIdentifier("attach-button")
     }
 
+    /// A picked file shows a placeholder chip immediately, then resolves it via
+    /// a background read + upload. Before, the file was read and uploaded
+    /// before anything appeared, so a large file read looked like nothing
+    /// happened.
     private func handleDocument(_ result: Result<URL, Error>) {
         guard case .success(let url) = result else { return }
         let accessed = url.startAccessingSecurityScopedResource()
-        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
         let filename = url.lastPathComponent
-        guard let data = try? Data(contentsOf: url) else {
-            surfaceHint("Couldn't read that file")
-            return
-        }
         let mime = ChatVoice.mime(forFilename: filename)
+        let placeholder = ComposerAttachment(
+            filename: filename, mime: mime, remotePath: nil,
+            isImage: mime.hasPrefix("image/"))
+        attachments.append(placeholder)
+        let id = placeholder.id
         Task {
+            defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url) else {
+                await MainActor.run { failAttachment(id: id, hint: "Couldn't read that file") }
+                return
+            }
             do {
                 let remote = try await api.upload(project: projectName, filename: filename, data: data)
-                await MainActor.run {
-                    attachments.append(ComposerAttachment(filename: filename, mime: mime, remotePath: remote, isImage: mime.hasPrefix("image/")))
-                }
+                await MainActor.run { completeAttachment(id: id, remote: remote, mime: nil) }
             } catch {
-                surfaceHint("Upload failed")
+                await MainActor.run { failAttachment(id: id, hint: "Upload failed") }
             }
         }
     }
 
+    /// Phase-then-load for the PhotosPicker: placeholder chips for EVERY
+    /// selected photo appear on the same tick the picker dismisses, then each
+    /// is read + uploaded and resolved in place. Previously each photo was
+    /// loaded and uploaded before its chip appeared, so the first (and slowest
+    /// — `loadTransferable(type: Data.self)` pulls the full-resolution image)
+    /// stage read as a dead tap.
+    ///
+    /// `@MainActor`: the awaited read/upload suspend but this keeps every
+    /// `@State` mutation on the main actor without `MainActor.run` hops.
+    @MainActor
     private func processPhotos() async {
-        for item in photoItems {
-            guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
+        struct Pending {
+            let item: PhotosPickerItem
+            let id: UUID
+            let filename: String
+        }
+
+        let picked = photoItems
+        photoItems = []
+
+        // Phase 1 — one placeholder per photo, synchronously, so there is
+        // never a gap with nothing on screen.
+        var pending: [Pending] = []
+        for (index, item) in picked.enumerated() {
+            let filename = "photo-\(Int(Date().timeIntervalSince1970 * 1000))-\(index).jpg"
+            let placeholder = ComposerAttachment(
+                filename: filename, mime: "image/jpeg", remotePath: nil, isImage: true)
+            attachments.append(placeholder)
+            pending.append(Pending(item: item, id: placeholder.id, filename: filename))
+        }
+
+        // Phase 2 — read + upload each, resolving its chip in place.
+        for entry in pending {
+            guard let data = try? await entry.item.loadTransferable(type: Data.self) else {
+                failAttachment(id: entry.id, hint: "Couldn't load photo")
+                continue
+            }
             let mime = ChatVoice.mime(forImageData: data)
-            let filename = "photo-\(Int(Date().timeIntervalSince1970)).jpg"
             do {
-                let remote = try await api.upload(project: projectName, filename: filename, data: data)
-                await MainActor.run {
-                    attachments.append(ComposerAttachment(filename: filename, mime: mime, remotePath: remote, isImage: true))
-                    surfaceHint("Attached \(filename)")
-                }
+                let remote = try await api.upload(project: projectName, filename: entry.filename, data: data)
+                completeAttachment(id: entry.id, remote: remote, mime: mime)
             } catch {
-                surfaceHint("Photo upload failed")
+                failAttachment(id: entry.id, hint: "Photo upload failed")
             }
         }
-        await MainActor.run { photoItems = [] }
+    }
+
+    /// Move a placeholder chip to its ready state once the remote path is
+    /// known. No-op if the user removed the chip meanwhile (a removed upload
+    /// never resurfaces).
+    @MainActor
+    private func completeAttachment(id: UUID, remote: String, mime: String?) {
+        guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+        attachments[index].remotePath = remote
+        if let mime { attachments[index].mime = mime }
+    }
+
+    /// Drop a failed placeholder (the chip never shows a dead state) and
+    /// surface the reason.
+    @MainActor
+    private func failAttachment(id: UUID, hint: String) {
+        guard attachments.contains(where: { $0.id == id }) else { return }
+        attachments.removeAll { $0.id == id }
+        surfaceHint(hint)
     }
 
     /// Zero-size host for the photo/file pickers. See the call site.
@@ -508,9 +568,18 @@ struct ComposerView: View {
             HStack(spacing: Metrics.spacing.sp1) {
                 ForEach(attachments) { attachment in
                     HStack(spacing: Metrics.spacing.sp1) {
-                        Image(systemName: attachment.isImage ? "photo" : "doc")
-                            .font(.system(size: Metrics.type.twoXS))
-                            .foregroundColor(tokens.accentTx)
+                        // A placeholder chip (upload in flight) swaps the icon
+                        // for a spinner so the "something is happening" is
+                        // explicit instead of a static photo glyph.
+                        if attachment.isUploading {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .tint(tokens.accentTx)
+                        } else {
+                            Image(systemName: attachment.isImage ? "photo" : "doc")
+                                .font(.system(size: Metrics.type.twoXS))
+                                .foregroundColor(tokens.accentTx)
+                        }
                         Text(ChatVoice.chipLabel(forFilename: attachment.filename))
                             .font(.system(size: Metrics.type.twoXS))
                             .foregroundColor(tokens.accentTx)
@@ -707,15 +776,22 @@ struct ComposerView: View {
     }
 
     private var canSend: Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
+        (!text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty)
+            && !attachments.contains { $0.isUploading }
     }
 
     private func submit() {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
+        // Never send while an attachment is still uploading (the button is
+        // disabled too; this guards the non-button paths like voice submit).
+        guard (!trimmed.isEmpty || !attachments.isEmpty),
+              !attachments.contains(where: { $0.isUploading }) else { return }
         let model = modelStore.promptModel
-        let sendAttachments = attachments.map { attachment in
-            SendPromptInput.Attachment(remotePath: attachment.remotePath, mime: attachment.mime, filename: attachment.filename)
+        // canSend gates on no attachment still uploading, so none are dropped
+        // here; compactMap keeps the unwrap type-safe.
+        let sendAttachments: [SendPromptInput.Attachment] = attachments.compactMap { attachment in
+            guard let remotePath = attachment.remotePath else { return nil }
+            return SendPromptInput.Attachment(remotePath: remotePath, mime: attachment.mime, filename: attachment.filename)
         }
         store.send(text: trimmed, attachments: sendAttachments, model: model)
         text = ""

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -400,15 +400,23 @@ struct ComposerView: View {
             HStack(spacing: Metrics.spacing.sp1) {
                 Image(systemName: "sparkles")
                     .font(.system(size: Metrics.type.xs, weight: .medium))
-                Text(ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel))
-                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
-                    .lineLimit(1)
-                if let variant = modelStore.variant, !variant.isEmpty {
-                    Text("·")
-                        .font(.system(size: Metrics.type.small))
-                    Text(variant.capitalized)
+                if modelStore.loaded {
+                    Text(ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel))
                         .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                         .lineLimit(1)
+                    if let variant = modelStore.variant, !variant.isEmpty {
+                        Text("·")
+                            .font(.system(size: Metrics.type.small))
+                        Text(variant.capitalized)
+                            .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                            .lineLimit(1)
+                    }
+                } else {
+                    // Box-wide model list still arriving — show an explicit
+                    // loading state rather than a misleading "Default".
+                    ProgressView()
+                        .controlSize(.mini)
+                        .accessibilityLabel("Loading models")
                 }
             }
             .foregroundColor(tokens.accentTx)

--- a/mobile/native/MantaUI/EdgeSwipeRestorer.swift
+++ b/mobile/native/MantaUI/EdgeSwipeRestorer.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// Edge-swipe back (left-edge interactive pop gesture).
+//
+// The chat screens paint their own floating-glass header and therefore hide the
+// system navigation bar (`.toolbar(.hidden, for: .navigationBar)`) and the back
+// button (`.navigationBarBackButtonHidden(true)`). Hiding the bar also disables
+// the navigation controller's left-edge interactive pop gesture, so the only
+// way back was the floating chevron button.
+//
+// This representable re-arms that gesture. Attached as a `.background(...)` on
+// the pushed view, its host resolves the enclosing navigation controller and
+// forces the interactive pop gesture back on, overriding its delegate so the
+// pop always begins on this (non-root) screen. The host is invisible and
+// ignores touches, so it adds nothing to the canvas.
+// ===========================================================================
+
+struct EdgeSwipeRestorer: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        PopRestorerHost(coordinator: context.coordinator)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    @MainActor
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        /// Always allow the pop-from-edge gesture. UIKit still refuses to pop
+        /// the root controller, so an unconditional true is safe here.
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+
+    @MainActor
+    private final class PopRestorerHost: UIViewController {
+        private let coordinator: Coordinator
+
+        init(coordinator: Coordinator) {
+            self.coordinator = coordinator
+            super.init(nibName: nil, bundle: nil)
+            view.backgroundColor = .clear
+            view.isUserInteractionEnabled = false
+        }
+
+        required init?(coder: NSCoder) { fatalError("not used") }
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            arm()
+        }
+
+        // The reliable moment the host has joined the navigation stack (the
+        // nav controller is non-nil here; it can still be nil at viewDidLoad).
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            arm()
+        }
+
+        private func arm() {
+            guard let nav = navigationController else { return }
+            nav.interactivePopGestureRecognizer?.delegate = coordinator
+            nav.interactivePopGestureRecognizer?.isEnabled = true
+        }
+    }
+}

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -9,48 +9,83 @@ import SwiftUI
 // from the chosen model and is simply absent for a model that offers none —
 // rather than being a fixed set of levels that silently do nothing.
 //
-// Presented as ONE small sheet with two wheels side by side — model on the
-// left, effort on the right — so both choices are visible and adjustable
-// without navigating away. The effort wheel repopulates from whatever the
-// highlighted model offers, and reads "Not available" for a model with none.
+// Native iOS surface (HIG-aligned): a grouped Form/List in a sheet, ordered
+//                                ...
+//   - "Server default" row pinned first — the effective model when no per-
+//     session override is set.
+//   - A "Fast mode" Toggle, shown only when the active model has a fast twin
+//     available (desktop ⚡ logic). Fast flavours (`<id>-fast`) are a MODE of
+//     the base model, not a separate row, so they are hidden from the groups
+//     and reached through this toggle.
+//   - An "Effort" section listing the active model's variants (Default + each).
+//   - The model list grouped into Section per provider (the desktop menu's
+//     shape), with a search strip and a checkmark on the selected row.
+//
+// Tapping a model sets the per-session override; toggling Fast swaps the
+// override to the model's `-fast` twin (or back), carrying the chosen effort.
 // ===========================================================================
 
 struct ModelPickerSheet: View {
     @ObservedObject var modelStore: ChatModelStore
     @Environment(\.dismiss) private var dismiss
+    @State private var query = ""
 
-    /// `nil` = follow the box's configured default.
-    private var modelSelection: Binding<OpencodeModelID?> {
-        Binding(
-            get: { modelStore.override },
-            set: { modelStore.setOverride($0) }
-        )
+    private var groups: [(provider: String, models: [OpencodeModel])] {
+        ChatModel.filteredGroups(ChatModel.groups(modelStore.models), query: query)
     }
 
-    private var variantSelection: Binding<String?> {
-        Binding(
-            get: { modelStore.variant },
-            set: { modelStore.setVariant($0) }
-        )
+    private var activeModel: OpencodeModel? {
+        ChatModel.activeModel(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+    }
+
+    /// The fast-mode toggle state for the active model (desktop `resolveFastToggle`).
+    private var fast: ChatModel.FastToggle {
+        ChatModel.fastToggle(models: modelStore.models, active: activeModel, variantId: modelStore.variant)
+    }
+
+    private func isSelected(_ m: OpencodeModel) -> Bool {
+        guard let override = modelStore.override else { return false }
+        return override.providerID == m.providerID && override.modelID == m.id
+    }
+
+    private func select(_ m: OpencodeModel) {
+        modelStore.setOverride(OpencodeModelID(providerID: m.providerID, modelID: m.id))
+    }
+
+    /// Apply the fast-mode toggle: switch the override to the model's `-fast`
+    /// twin (or its base), carrying the currently-chosen effort across.
+    private func applyFastToggle(_ on: Bool) {
+        guard let target = fast.target else { return }
+        let currentVariant = modelStore.variant
+        modelStore.setOverride(OpencodeModelID(providerID: target.providerID, modelID: target.modelID))
+        if let currentVariant { modelStore.setVariant(currentVariant) }
     }
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                HStack(spacing: 8) {
-                    modelWheel
-                    effortWheel
-                        .frame(width: 116)
+            Group {
+                if modelStore.loaded {
+                    List {
+                        serverDefaultSection
+                        if fast.available || fast.on {
+                            fastSection
+                        }
+                        if !modelStore.activeVariants.isEmpty {
+                            effortSection
+                        }
+                        providerSections
+                    }
+                    .searchable(
+                        text: $query,
+                        placement: .navigationBarDrawer(displayMode: .always),
+                        prompt: "Search models"
+                    )
+                } else {
+                    // Box-wide model list still arriving — an explicit loading
+                    // state rather than an empty list.
+                    ProgressView("Loading models…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 12)
-
-                Text(footer)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
-                    .padding(.bottom, 12)
             }
             .navigationTitle("Model")
             .navigationBarTitleDisplayMode(.inline)
@@ -60,62 +95,96 @@ struct ModelPickerSheet: View {
                 }
             }
         }
-        .presentationDetents([.height(420)])
+        .presentationDetents([.large])
         .presentationDragIndicator(.visible)
         .onAppear { modelStore.load() }
     }
 
-    private var modelWheel: some View {
-        VStack(spacing: 2) {
+    /// The "Server default" row — the effective model when no override is set.
+    private var serverDefaultSection: some View {
+        Section {
+            Button { modelStore.setOverride(nil) } label: {
+                HStack {
+                    Text("Server default")
+                    Spacer()
+                    if modelStore.override == nil { checkmark }
+                }
+            }
+            .accessibilityIdentifier("model-server-default")
+        } header: {
             Text("Model")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Picker("Model", selection: modelSelection) {
-                Text("Default").tag(OpencodeModelID?.none)
-                ForEach(ChatModel.groups(modelStore.models), id: \.provider) { group in
-                    ForEach(group.models, id: \.id) { model in
-                        Text(model.name)
-                            .tag(Optional(OpencodeModelID(providerID: model.providerID, modelID: model.id)))
+        } footer: {
+            if modelStore.override == nil {
+                Text("Using the model your box is configured to use.")
+            }
+        }
+    }
+
+    /// Fast-mode toggle, present only when it can do something.
+    private var fastSection: some View {
+        Section {
+            Toggle(isOn: Binding(get: { fast.on }, set: applyFastToggle)) {
+                Label("Fast mode", systemImage: fast.on ? "bolt.fill" : "bolt")
+            }
+            .disabled(!fast.available)
+            .accessibilityIdentifier("model-fast-toggle")
+        } footer: {
+            Text(fast.title)
+        }
+    }
+
+    /// Effort/variant list for the ACTIVE model. Absent when it offers none.
+    private var effortSection: some View {
+        Section("Effort") {
+            Button { modelStore.setVariant(nil) } label: {
+                HStack {
+                    Text("Default")
+                    Spacer()
+                    if modelStore.variant == nil { checkmark }
+                }
+            }
+            ForEach(modelStore.activeVariants, id: \.id) { variant in
+                Button { modelStore.setVariant(variant.id) } label: {
+                    HStack {
+                        Text(variant.id.capitalized)
+                        Spacer()
+                        if modelStore.variant == variant.id { checkmark }
                     }
                 }
             }
-            .pickerStyle(.wheel)
-            .labelsHidden()
         }
-        .frame(maxWidth: .infinity)
     }
 
+    /// The model list, grouped into a Section per provider.
     @ViewBuilder
-    private var effortWheel: some View {
-        VStack(spacing: 2) {
-            Text("Effort")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            if modelStore.activeVariants.isEmpty {
-                Text("Not available")
-                    .font(.footnote)
-                    .foregroundStyle(.tertiary)
-                    .frame(maxHeight: .infinity)
-            } else {
-                Picker("Effort", selection: variantSelection) {
-                    Text("Default").tag(String?.none)
-                    ForEach(modelStore.activeVariants, id: \.id) { variant in
-                        Text(variant.id.capitalized).tag(Optional(variant.id))
+    private var providerSections: some View {
+        if groups.isEmpty {
+            if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Section {
+                    Text("No models match")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } else {
+            ForEach(groups, id: \.provider) { group in
+                Section(group.provider) {
+                    ForEach(group.models, id: \.id) { m in
+                        Button { select(m) } label: {
+                            HStack {
+                                Text(m.name)
+                                Spacer()
+                                if isSelected(m) { checkmark }
+                            }
+                        }
                     }
                 }
-                .pickerStyle(.wheel)
-                .labelsHidden()
             }
         }
-        .frame(maxWidth: .infinity)
     }
 
-    private var footer: String {
-        if modelStore.override == nil {
-            return "Using the model your box is configured to use."
-        }
-        return modelStore.activeVariants.isEmpty
-            ? "This model has no effort setting. Applies to this session only."
-            : "More effort means more reasoning time. Applies to this session only."
+    private var checkmark: some View {
+        Image(systemName: "checkmark")
+            .font(.system(size: Metrics.type.small, weight: .semibold))
+            .foregroundStyle(.tint)
     }
 }

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -648,7 +648,7 @@ struct StepRowView: View {
 // as one" — it is a session, so it lives in the same grouped container as the
 // step rows (so a turn reads as one sequence) but is rendered as a
 // navigation row, not a step.
-enum StepGroupRow: Identifiable {
+enum StepGroupRow: Identifiable, Equatable {
     case step(ToolStep)
     case subagent(SubagentSession)
 
@@ -660,7 +660,7 @@ enum StepGroupRow: Identifiable {
     }
 }
 
-enum StepGroupContent {
+enum StepGroupContent: Equatable {
     case rows([StepGroupRow])
     case rollup(summary: String, rows: [StepGroupRow])
 }
@@ -904,7 +904,7 @@ struct TranscriptView: View {
 /// that ragged-edges as the values change reads as a glitch. Blocks with no
 /// time (machinery) render an empty label of the same width rather than
 /// collapsing, which keeps the rows they sit next to from shifting.
-private struct TimestampGutterLabel: View {
+struct TimestampGutterLabel: View {
     let date: Date?
     let width: CGFloat
     let tokens: Tokens
@@ -920,7 +920,7 @@ private struct TimestampGutterLabel: View {
     }
 }
 
-enum TranscriptBlock {
+enum TranscriptBlock: Equatable {
     // The date is the block's wall-clock time, shown only in the swipe-to-reveal
     // gutter. Machinery (`.steps`) carries none: a step row already states how
     // long it took, and a second time reading next to it is noise, not detail.

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import MessagingUI
+
+// ===========================================================================
+// MessagingUI transcript surface (TiledView).
+//
+// The chat transcript's SCROLL layer used to be hand-rolled — ScrollViewReader +
+// LazyVStack + two onGeometryChange observers + keyboard notifications + a
+// "don't fight the user" landing flag. That was the source of the device-only
+// blank-on-open, the keyboard snap, and the disappear-on-scroll bugs. This file
+// is the replacement: it adapts the transcript to MessagingUI's `TiledView` (a
+// UICollectionView-backed chat container) which owns smooth bottom-follow,
+// keyboard/safe-area handling, and prepend-without-jump for us.
+//
+// The CONTENT rendering is deliberately unchanged: each block still renders
+// through UserBand / AssistantProse / StepGroupView. Only the container moved.
+// ===========================================================================
+
+/// A transcript block wrapped with a STABLE identity for `TiledView`.
+///
+/// `TiledView` needs `Identifiable` items with stable ids to recycle cells and
+/// follow the tail without jumping. `ChatSessionStore` recomputes its blocks at
+/// every turn boundary — the canonical blocks from a refetch plus a streaming
+/// `.prose` tail — so the id must survive that recompute.
+struct TranscriptRow: Identifiable, Equatable {
+    let id: String
+    let block: TranscriptBlock
+}
+
+extension TranscriptBlock {
+    /// A content-stable id.
+    ///
+    /// A completed block's content never changes after its turn, so this id
+    /// survives a refetch unchanged. The STREAMING tail is different: its text
+    /// grows every delta, so `ChatSessionStore` gives it a store-owned id
+    /// instead of this one (see `streamingTailID`).
+    var stableScrollID: String {
+        switch self {
+        case .user(let text, let at): return "u\(text)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .prose(let text, let at): return "p\(text)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .steps(let content): return "s" + content.rows.map(\.id).joined(separator: "|")
+        }
+    }
+}
+
+extension StepGroupContent {
+    /// The rows of a step group, whether plain or rolled up. Used only to
+    /// derive a stable id from the rows' own stable ids.
+    var rows: [StepGroupRow] {
+        switch self {
+        case .rows(let r): return r
+        case .rollup(_, let r): return r
+        }
+    }
+}
+
+// MARK: - Cell
+
+/// Renders ONE transcript block inside `TiledView`, reusing the same
+/// `UserBand` / `AssistantProse` / `StepGroupView` components the rest of the
+/// chat uses — this is not a parallel renderer.
+struct TranscriptBlockCell: TiledCellContent {
+    typealias StateValue = Void
+
+    let item: TranscriptRow
+    let tokens: Tokens
+
+    func body(context: CellContext<Void>) -> some View {
+        blockView(item.block)
+            // The wall-clock timestamp gutter, exactly as the previous
+            // TranscriptView drew it per block (see TranscriptComponents).
+            .overlay(alignment: .trailing) {
+                TimestampGutterLabel(
+                    date: item.block.timestamp,
+                    width: TranscriptBlockCell.gutterWidth,
+                    tokens: tokens
+                )
+                .offset(x: TranscriptBlockCell.gutterWidth)
+                .allowsHitTesting(false)
+            }
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: TranscriptBlock) -> some View {
+        switch block {
+        case .user(let text, _):
+            UserBand(text: text, tokens: tokens)
+                .padding(.bottom, Metrics.spacing.sp4)
+        case .prose(let text, _):
+            AssistantProse(text: text, tokens: tokens)
+        case .steps(let content):
+            StepGroupView(content: content, tokens: tokens)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.bottom, Metrics.spacing.sp3)
+        }
+    }
+
+    /// How far the timestamp strip reaches, matching the old TranscriptView.
+    private static let gutterWidth: CGFloat = 58
+}

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -94,6 +94,83 @@ final class ComposerTests: XCTestCase {
         XCTAssertNil(ChatModel.decode("no-slash"))
     }
 
+    // MARK: - Fast-mode helpers + grouped picker
+
+    private func variantModel(_ provider: String, _ id: String, variants: [String]) -> OpencodeModel {
+        OpencodeModel(
+            id: id,
+            providerID: provider,
+            name: id,
+            family: nil,
+            status: nil,
+            enabled: nil,
+            variants: variants.map { OpencodeModel.Variant(id: $0) }
+        )
+    }
+
+    func testFastIDArithmetic() {
+        XCTAssertTrue(ChatModel.isFastModelID("gpt-5.6-fast"))
+        XCTAssertFalse(ChatModel.isFastModelID("gpt-5.6"))
+        XCTAssertFalse(ChatModel.isFastModelID("fast"))
+        XCTAssertEqual(ChatModel.baseModelID("gpt-5.6-fast"), "gpt-5.6")
+        XCTAssertEqual(ChatModel.baseModelID("gpt-5.6"), "gpt-5.6")
+        XCTAssertEqual(ChatModel.fastModelID("gpt-5.6"), "gpt-5.6-fast")
+        XCTAssertEqual(ChatModel.fastModelID("gpt-5.6-fast"), "gpt-5.6-fast")
+    }
+
+    func testFastToggleBaseModelWithTwinIsAvailableAndOff() {
+        let models = [variantModel("openai", "gpt-5.6", variants: ["high"]), variantModel("openai", "gpt-5.6-fast", variants: ["high"])]
+        let r = ChatModel.fastToggle(models: models, active: models[0], variantId: "high")
+        XCTAssertTrue(r.available)
+        XCTAssertFalse(r.on)
+        XCTAssertEqual(r.target?.modelID, "gpt-5.6-fast")
+    }
+
+    func testFastToggleFastModelReportsOnAndTargetsBase() {
+        let models = [variantModel("openai", "gpt-5.6", variants: ["high"]), variantModel("openai", "gpt-5.6-fast", variants: ["high"])]
+        let r = ChatModel.fastToggle(models: models, active: models[1], variantId: "low")
+        XCTAssertTrue(r.available)
+        XCTAssertTrue(r.on)
+        XCTAssertEqual(r.target?.modelID, "gpt-5.6")
+    }
+
+    func testFastToggleDisabledWhenTwinLacksSelectedEffort() {
+        let models = [variantModel("openai", "gpt-5.6", variants: ["low"]), variantModel("openai", "gpt-5.6-fast", variants: ["high"])]
+        let r = ChatModel.fastToggle(models: models, active: models[0], variantId: "high")
+        XCTAssertFalse(r.available)
+        XCTAssertNil(r.target)
+    }
+
+    func testFastToggleNullAndNoTwin() {
+        XCTAssertFalse(ChatModel.fastToggle(models: [], active: nil, variantId: nil).available)
+        XCTAssertFalse(ChatModel.fastToggle(models: [variantModel("openai", "gpt-5.6", variants: [])], active: nil, variantId: nil).available)
+        let only = variantModel("openai", "gpt-5.6", variants: [])
+        XCTAssertFalse(ChatModel.fastToggle(models: [only], active: only, variantId: nil).available)
+    }
+
+    func testFastToggleTwinInDifferentProviderDoesNotCount() {
+        let base = variantModel("openai", "gpt-5.6", variants: [])
+        let twin = variantModel("other", "gpt-5.6-fast", variants: [])
+        let r = ChatModel.fastToggle(models: [base, twin], active: base, variantId: nil)
+        XCTAssertFalse(r.available)
+    }
+
+    func testGroupsDropsFastSiblingButKeepsOrphan() {
+        let withBase = [model("openai", "gpt-5.6"), model("openai", "gpt-5.6-fast")]
+        XCTAssertEqual(ChatModel.groups(withBase).first?.models.map(\.id), ["gpt-5.6"])
+        // An orphan fast model (no base) stays reachable via its own row.
+        let orphan = [model("openai", "solo-fast")]
+        XCTAssertEqual(ChatModel.groups(orphan).first?.models.map(\.id), ["solo-fast"])
+    }
+
+    func testFilteredGroupsMatchesNameIdAndProvider() {
+        let g = [("anthropic", [variantModel("anthropic", "claude-sonnet-4-6", variants: []), variantModel("anthropic", "haiku", variants: [])])]
+        XCTAssertEqual(ChatModel.filteredGroups(g, query: "sonnet").first?.models.count, 1)
+        XCTAssertEqual(ChatModel.filteredGroups(g, query: "anthropic").first?.models.count, 2)
+        XCTAssertEqual(ChatModel.filteredGroups(g, query: "nope").count, 0)
+        XCTAssertEqual(ChatModel.filteredGroups(g, query: "  ").first?.models.count, 2)
+    }
+
     // MARK: - ChatVoice.parse
 
     private func classify(_ kind: String, text: String? = nil, choice: String? = nil, query: String? = nil, index: Int? = nil, transcript: String? = nil) -> VoiceClassifyResult {

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -15,6 +15,9 @@ packages:
   CrashReporter:
     url: https://github.com/microsoft/plcrashreporter
     from: "1.11.1"
+  MessagingUI:
+    url: https://github.com/FluidGroup/swiftui-messaging-ui
+    from: "1.0.0"
 targets:
   MantaUI:
     type: application
@@ -45,6 +48,8 @@ targets:
     dependencies:
       - package: CrashReporter
         product: CrashReporter
+      - package: MessagingUI
+        product: MessagingUI
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.antoinedc.mantaui


### PR DESCRIPTION
## What
Native iOS model-picker improvements, mirroring the desktop `ModelPicker.tsx` logic.

**Models persist across session clear**
- New box-wide `ChatModelCatalog` fetches the model list + server default once and caches it. Clearing a session rebuilds the screen's stores, but the catalog no-ops instead of refetching — so models no longer reload on clear.
- `ChatModelStore` mirrors the catalog and gained `rebind(to:)` to carry the chosen model + effort to the new session id before the clear swaps it (matches the desktop clear handler).

**Loading state on the model chip**
- The composer model pill shows a native `ProgressView` while the box-wide list is still arriving, instead of a misleading "Default".

**Provider-sectioned picker + fast mode (native, HIG-aligned)**
- Replaced the two-wheel sheet with a grouped `Form`/`List`: pinned "Server default" row, an "Effort" section (active model's variants), and model rows grouped into a Section per provider with a checkmark + search.
- Added a fast-mode `Toggle`, shown only when the active model has a `-fast` twin available — ported `resolveFastToggle`/`hideFastSiblingGroups` into pure `ChatModel` helpers. Fast flavours are hidden from the model list and reached only via the toggle, which carries the chosen effort across.

## Tests
`ComposerTests.swift` gained cases for `ChatModel.fastToggle`, fast-id arithmetic, fast-sibling hiding in `groups`, and `filteredGroups`. (Swift suite must be run on a Mac via Xcode.)

## Note
Compiled changes were reviewed carefully but not built here (Xcode/macOS-only toolchain absent from this Linux box). CI runs `typecheck-test`; the iOS Swift suite is not part of it, so please run on a Mac before merge.