### PR TITLE
feat(ios): scroll-to-bottom glass arrow on chat transcript

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -88,6 +88,12 @@ private struct ChatScreenContent: View {
         autoScrollsToBottomOnAppend: true,
         scrollsToBottomOnReplace: true
     )
+    /// Whether the transcript has been scrolled up far enough that the
+    /// "scroll to bottom" arrow should float above the composer. Driven by the
+    /// same geometry that toggles auto-follow: the arrow appears exactly when
+    /// following has stopped, and tapping it (which returns to the bottom)
+    /// makes both disappear together.
+    @State private var showScrollToBottom = false
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
     let onCleared: (String) -> Void
@@ -449,6 +455,51 @@ private struct ChatScreenContent: View {
         // A tap on the transcript lowers the keyboard. (TiledView handles the
         // scroll-driven interactive keyboard dismiss itself.)
         .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
+        // The floating "scroll to bottom" arrow. It appears only once the user
+        // has scrolled up (pointsFromBottom above the threshold) — at the
+        // bottom there is nowhere to scroll to, so the button would be noise.
+        // The SAME geometry also decides whether to keep auto-following new
+        // messages: stop following the moment the user reads history, and
+        // resume when they return to (or tap back to) the bottom — otherwise a
+        // streaming reply yanks a reader who has deliberately scrolled up back
+        // to the newest turn.
+        .onTiledScrollGeometryChange { geometry in
+            let isNearBottom = geometry.pointsFromBottom < Self.scrollToBottomThreshold
+            showScrollToBottom = !isNearBottom
+            scrollPosition.autoScrollsToBottomOnAppend = isNearBottom
+        }
+        .overlay(alignment: .bottom) {
+            if showScrollToBottom { scrollToBottomButton }
+        }
+    }
+
+    /// How far above the bottom the user must scroll for the arrow to appear
+    /// (and, in the same breath, for auto-follow to stop). Same magnitude
+    /// MessagingUI uses internally for its own "near bottom" checks.
+    private static let scrollToBottomThreshold: CGFloat = 100
+
+    /// The floating glass circle with the down-arrow, bottom-centre over the
+    /// transcript — the counterpart of the two floating glass header circles.
+    ///
+    /// Tapping it returns to the newest message; the geometry callback above
+    /// then re-enables auto-follow and hides the button itself. Only ever
+    /// rendered while `showScrollToBottom` is true, so it floats only when the
+    /// user has actually scrolled away.
+    @ViewBuilder
+    private var scrollToBottomButton: some View {
+        Button {
+            scrollPosition.scrollTo(edge: .bottom, animated: true)
+        } label: {
+            Image(systemName: "arrow.down")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+        }
+        .buttonStyle(.glass)
+        .clipShape(.circle)
+        .accessibilityLabel("Scroll to bottom")
+        .padding(.bottom, Metrics.spacing.sp4)
+        .shadow(color: .black.opacity(0.12), radius: Metrics.spacing.sp2, y: Metrics.spacing.sp1)
     }
 
     /// Lower the keyboard by asking whoever holds first responder to give it


### PR DESCRIPTION
## Summary
Adds a floating glass **down-arrow** at the bottom centre of the chat transcript (the counterpart of the two floating glass header circles). It appears only once the user scrolls up, and tapping it returns to the newest message.

## Behavior
- **Show**: appears when `pointsFromBottom > 100pt` (MessagingUI's `TiledScrollGeometry`), i.e. when the user has scrolled up from the bottom.
- **Tap**: `scrollPosition.scrollTo(edge: .bottom, animated: true)`.
- **Auto-follow**: the same geometry now toggles `autoScrollsToBottomOnAppend` — stop following while the user reads history; resume once they return to (or tap back to) the bottom. This prevents a streaming reply from yanking a reader who deliberately scrolled up back to the newest turn.

## Implementation
- Uses the existing MessagingUI `TiledScrollPosition` / `TiledScrollGeometry` API already driving the transcript (no new scroll machinery).
- Glass circle mirrors the header buttons (`.buttonStyle(.glass)` + `.clipShape(.circle)`), sized with the same `Metrics.type.chatHeaderBtn` token.
- Swift-only change to `mobile/native/MantaUI/ChatScreen.swift` (+51). No web/renderer changes.

## Verification
- No Swift toolchain on the CI/Linux side; verified against the MessagingUI 1.x public API (docs + source) that `onTiledScrollGeometryChange` / `TiledScrollPosition.scrollTo(edge:animated:)` / `TiledScrollGeometry.pointsFromBottom` are the correct, documented surfaces.
- UI tests/captures are unaffected: the arrow is only rendered while scrolled away from the bottom.