### PR TITLE
feat(artifacts): include agent-generated files, tighten header + expiry pill

### DIFF
--- a/docs/screens/artifacts/mockup.html
+++ b/docs/screens/artifacts/mockup.html
@@ -67,9 +67,9 @@
               flex-direction: column; background: var(--panel);
               border-left: 1px solid var(--border); }
 
-  .mk-head { flex: none; padding: 11px var(--sp-3) 0; }
+  .mk-head { flex: none; padding: var(--sp-3) var(--sp-3) 0; }
   .mk-top  { display: flex; align-items: center; justify-content: space-between;
-             margin-bottom: 11px; }
+             margin-bottom: var(--sp-3); }
   .mk-title { font-size: var(--font-size-small); font-weight: var(--weight-semibold); }
   .mk-icons { display: flex; gap: var(--sp-px); }
 

--- a/docs/screens/artifacts/mockup.html
+++ b/docs/screens/artifacts/mockup.html
@@ -67,9 +67,9 @@
               flex-direction: column; background: var(--panel);
               border-left: 1px solid var(--border); }
 
-  .mk-head { flex: none; padding: var(--sp-3) var(--sp-3) 0; }
+  .mk-head { flex: none; padding: 11px var(--sp-3) 0; }
   .mk-top  { display: flex; align-items: center; justify-content: space-between;
-             margin-bottom: var(--sp-3); }
+             margin-bottom: 11px; }
   .mk-title { font-size: var(--font-size-small); font-weight: var(--weight-semibold); }
   .mk-icons { display: flex; gap: var(--sp-px); }
 

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -177,6 +177,28 @@ function ActionButton({
   );
 }
 
+// The three shared row actions (attach / download / jump) used by both the
+// image tiles and the file rows, so the button cluster is defined once.
+function RowActions({
+  onAttach,
+  onDownload,
+  onJump,
+  canJump,
+}: {
+  onAttach: () => void;
+  onDownload: () => void;
+  onJump: () => void;
+  canJump: boolean;
+}) {
+  return (
+    <>
+      <ActionButton icon={<Paperclip className="h-3.5 w-3.5" />} label="Attach to message" title="Attach to message" onClick={onAttach} />
+      <ActionButton icon={<Download className="h-3.5 w-3.5" />} label="Download" title="Download" onClick={onDownload} />
+      <ActionButton icon={<ChevronRight className="h-3.5 w-3.5" />} label="Jump to message" title="Jump to message" onClick={onJump} disabled={!canJump} />
+    </>
+  );
+}
+
 // ===== Tab 1 — Links =======================================================
 
 function ExpiryPill({ state, label }: { state: "live" | "soon" | "expired"; label: string }) {
@@ -302,9 +324,12 @@ function ImageTile({
       </span>
       {/* Bottom gradient scrim + hover actions, bottom-right at 26px. */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-end bg-gradient-to-t from-black/40 to-transparent px-2 py-2 opacity-0 transition-opacity group-hover:opacity-100">
-        <ActionButton icon={<Paperclip className="h-3.5 w-3.5" />} label="Attach to message" title="Attach to message" onClick={onAttach} />
-        <ActionButton icon={<Download className="h-3.5 w-3.5" />} label="Download" title="Download" onClick={onDownload} />
-        <ActionButton icon={<ChevronRight className="h-3.5 w-3.5" />} label="Jump to message" title="Jump to message" onClick={onJump} disabled={!artifact.messageId} />
+        <RowActions
+          onAttach={onAttach}
+          onDownload={onDownload}
+          onJump={onJump}
+          canJump={!!artifact.messageId}
+        />
       </div>
     </div>
   );
@@ -355,9 +380,12 @@ function FileRow({
         </div>
       </button>
       <div className="flex flex-none gap-px opacity-0 transition-opacity group-hover:opacity-100">
-        <ActionButton icon={<Paperclip className="h-3.5 w-3.5" />} label="Attach to message" title="Attach to message" onClick={onAttach} />
-        <ActionButton icon={<Download className="h-3.5 w-3.5" />} label="Download" title="Download" onClick={onDownload} />
-        <ActionButton icon={<ChevronRight className="h-3.5 w-3.5" />} label="Jump to message" title="Jump to message" onClick={onJump} disabled={!artifact.messageId} />
+        <RowActions
+          onAttach={onAttach}
+          onDownload={onDownload}
+          onJump={onJump}
+          canJump={!!artifact.messageId}
+        />
       </div>
     </div>
   );
@@ -597,7 +625,7 @@ export function ArtifactsPanel({
                 <div className="sticky top-0 bg-bg-elev px-3 pt-3 pb-[7px] text-micro font-semibold text-text-faint">
                   {g.label}
                 </div>
-                {tab === "link" && (
+                {tab === "link" ? (
                   <div className="px-3 pb-3">
                     {g.items.map((a) => (
                       <LinkCard
@@ -609,33 +637,23 @@ export function ArtifactsPanel({
                       />
                     ))}
                   </div>
-                )}
-                {tab === "image" && (
-                  <div className="grid grid-cols-2 gap-1 px-3 pb-3">
-                    {g.items.map((a) => (
-                      <ImageTile
-                        key={a.id}
-                        artifact={a}
-                        onOpen={(el) => openRow(a, el)}
-                        onAttach={() => void attachArtifact(a, sessionId ?? "")}
-                        onDownload={() => void downloadArtifact(a)}
-                        onJump={() => jumpToMessage(a)}
-                      />
-                    ))}
-                  </div>
-                )}
-                {tab === "file" && (
-                  <div className="px-2 pb-3">
-                    {g.items.map((a) => (
-                      <FileRow
-                        key={a.id}
-                        artifact={a}
-                        onOpen={(el) => openRow(a, el)}
-                        onAttach={() => void attachArtifact(a, sessionId ?? "")}
-                        onDownload={() => void downloadArtifact(a)}
-                        onJump={() => jumpToMessage(a)}
-                      />
-                    ))}
+                ) : (
+                  // Image tiles and file rows take the same props, so they
+                  // share one render path (the container class differs).
+                  <div className={tab === "image" ? "grid grid-cols-2 gap-1 px-3 pb-3" : "px-2 pb-3"}>
+                    {g.items.map((a) => {
+                      const Row = tab === "image" ? ImageTile : FileRow;
+                      return (
+                        <Row
+                          key={a.id}
+                          artifact={a}
+                          onOpen={(el) => openRow(a, el)}
+                          onAttach={() => void attachArtifact(a, sessionId ?? "")}
+                          onDownload={() => void downloadArtifact(a)}
+                          onJump={() => jumpToMessage(a)}
+                        />
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -513,10 +513,10 @@ export function ArtifactsPanel({
         />
 
         {/* Header: title + actions, then the tab bar. Compact and borderless to
-            match the design's `.phead`/`.ptop` rhythm (11px top, 11px gap to
+            match the design's `.phead`/`.ptop` rhythm (sp-3 top, sp-3 gap to
             the tabs) — not a 44px titlebar with a divider. */}
-        <div className="shrink-0 px-3 pt-[11px]">
-          <div className="mb-[11px] flex items-center justify-between">
+        <div className="shrink-0 px-3 pt-3">
+          <div className="mb-3 flex items-center justify-between">
             <span className="min-w-0 truncate text-label font-semibold text-text">
               Artifacts
             </span>
@@ -537,7 +537,7 @@ export function ArtifactsPanel({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search links, images, files…"
-              className="mb-[11px] w-full bg-bg border border-border px-2 py-1 text-meta rounded-xs focus:outline-none placeholder:text-text-faint"
+              className="mb-3 w-full bg-bg border border-border px-2 py-1 text-meta rounded-xs focus:outline-none placeholder:text-text-faint"
             />
           )}
 

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -188,7 +188,7 @@ function ExpiryPill({ state, label }: { state: "live" | "soon" | "expired"; labe
         : "bg-danger-bg text-danger";
   return (
     <span
-      className={`ml-1 inline-flex items-center gap-1 rounded-full px-2 py-[2px] text-micro font-semibold align-middle ${cls}`}
+      className={`ml-1 inline-flex shrink-0 items-center gap-1 rounded-full px-[6px] py-[2px] text-[9.5px] font-semibold align-middle ${cls}`}
     >
       {label}
     </span>
@@ -230,8 +230,13 @@ function LinkCard({
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="line-clamp-2 text-meta font-semibold text-text">
-            {artifact.label}
+          {/* Title + expiry pill on ONE line: the label truncates with an
+              ellipsis when tight; the pill is a shrink-0 sibling so name and
+              expiry never wrap to a second line. */}
+          <div className="flex min-w-0 items-center gap-1">
+            <span className="min-w-0 truncate text-meta font-semibold text-text">
+              {artifact.label}
+            </span>
             {isHosted &&
               state != null && (
                 <ExpiryPill
@@ -507,39 +512,43 @@ export function ArtifactsPanel({
           }}
         />
 
-        {/* Header row: title, search toggle, close. */}
-        <div className="flex items-center gap-1 pl-3 pr-2 h-11 border-b border-border shrink-0">
-          <span className="text-label font-semibold text-text flex-1 min-w-0 truncate">
-            Artifacts
-          </span>
-          <IconButton
-            icon={<Search />}
-            label={searchOpen ? "Hide search" : "Search artifacts"}
-            title={searchOpen ? "Hide search" : "Search"}
-            onClick={() => setSearchOpen((v) => !v)}
-          />
-          <IconButton icon={<X />} label="Close artifacts panel" title="Close" onClick={onClose} />
-        </div>
+        {/* Header: title + actions, then the tab bar. Compact and borderless to
+            match the design's `.phead`/`.ptop` rhythm (11px top, 11px gap to
+            the tabs) — not a 44px titlebar with a divider. */}
+        <div className="shrink-0 px-3 pt-[11px]">
+          <div className="mb-[11px] flex items-center justify-between">
+            <span className="min-w-0 truncate text-label font-semibold text-text">
+              Artifacts
+            </span>
+            <div className="flex items-center gap-px">
+              <IconButton
+                icon={<Search />}
+                label={searchOpen ? "Hide search" : "Search artifacts"}
+                title={searchOpen ? "Hide search" : "Search"}
+                onClick={() => setSearchOpen((v) => !v)}
+              />
+              <IconButton icon={<X />} label="Close artifacts panel" title="Close" onClick={onClose} />
+            </div>
+          </div>
 
-        {searchOpen && (
-          <div className="px-2 py-2 border-b border-border shrink-0">
+          {searchOpen && (
             <input
               autoFocus
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search links, images, files…"
-              className="w-full bg-bg border border-border px-2 py-1 text-meta rounded-xs focus:outline-none placeholder:text-text-faint"
+              className="mb-[11px] w-full bg-bg border border-border px-2 py-1 text-meta rounded-xs focus:outline-none placeholder:text-text-faint"
             />
-          </div>
-        )}
+          )}
 
-        {/* Tab bar: Links / Images / Files with counts, Links always the
-            default. Segmented control per the design `.mk-tabs`. */}
-        <div
-          className="mx-3 mb-3 flex gap-px p-px bg-inset border border-border-subtle rounded-md shrink-0"
-          role="tablist"
-          aria-label="Artifact kind"
-        >
+          {/* Tab bar: Links / Images / Files with counts, Links always the
+              default. Segmented control per the design `.mk-tabs`. The 12px
+              gap to the content below comes from the body's own top padding. */}
+          <div
+            className="flex gap-px p-px bg-inset border border-border-subtle rounded-md"
+            role="tablist"
+            aria-label="Artifact kind"
+          >
           {TABS.map((k) => {
             const active = tab === k;
             return (
@@ -567,11 +576,11 @@ export function ArtifactsPanel({
             );
           })}
         </div>
+        </div>{/* close the px-3 pt-[11px] header wrapper */}
 
         {/* Body: day-grouped, sticky headers, newest first, one renderer per
             tab. */}
-        <div className="flex-1 overflow-y-auto min-h-0">
-          {groups.length === 0 ? (
+        <div className="flex-1 overflow-y-auto min-h-0">          {groups.length === 0 ? (
             <div className="px-4 py-8 text-center">
               {query ? (
                 <div className="text-label text-text-muted">No matches for “{query}”</div>

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -136,11 +136,85 @@ describe("deriveArtifacts", () => {
     expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);
   });
 
-  it("tool parts of every kind → NO artifacts", () => {
+  it("tool parts of every kind → NO artifacts (write without a path is no artifact)", () => {
     for (const tool of ["read", "write", "edit", "bash", "webfetch"]) {
       const messages = [msg("a", "assistant", [toolPart(tool)])];
       expect(deriveArtifacts(messages, [], "ses_a"), `tool:${tool}`).toEqual([]);
     }
+  });
+
+  it("write tool part with a target path → generated file artifact (origin agent)", () => {
+    const messages = [
+      msg("a", "assistant", [
+        {
+          type: "tool",
+          tool: "write",
+          state: {
+            status: "completed",
+            input: { filePath: "/home/dev/q3-revenue.csv" },
+            time: { start: 5000 },
+          },
+        },
+      ]),
+    ];
+    const got = deriveArtifacts(messages, [], "ses_a");
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({
+      kind: "file",
+      origin: "agent",
+      label: "q3-revenue.csv",
+      href: "/home/dev/q3-revenue.csv",
+      mime: "text/csv",
+      size: null,
+      at: 5000,
+      messageId: "a",
+      context: null,
+      expiresAt: null,
+    });
+  });
+
+  it("write tool part producing an image keeps the generated image", () => {
+    const messages = [
+      msg("a", "assistant", [
+        {
+          type: "tool",
+          tool: "write",
+          state: { status: "completed", input: { filePath: "/tmp/preview-test/chart.png" } },
+        },
+      ]),
+    ];
+    const got = deriveArtifacts(messages, [], "ses_a");
+    expect(got).toHaveLength(1);
+    expect(got[0].kind).toBe("image");
+    expect(got[0].mime).toBe("image/png");
+  });
+
+  it("write tool part falls back to the message timestamp when no tool start time", () => {
+    const messages = [
+      msg("a", "assistant", [
+        {
+          type: "tool",
+          tool: "write",
+          state: { status: "completed", input: { filePath: "/tmp/report.md" } },
+        },
+      ]),
+    ];
+    const got = deriveArtifacts(messages, [], "ses_a");
+    expect(got.filter((a) => a.kind === "file")).toHaveLength(1);
+    expect(got[0].at).toBe(2000); // the message's created timestamp
+  });
+
+  it("edit tool part → NO artifact (modifies existing source, not produced)", () => {
+    const messages = [
+      msg("a", "assistant", [
+        {
+          type: "tool",
+          tool: "edit",
+          state: { status: "completed", input: { filePath: "/home/dev/q3-revenue.csv" } },
+        },
+      ]),
+    ];
+    expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);
   });
 
   it("patch part → NO artifact", () => {

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -95,6 +95,62 @@ function deriveLinkArtifact(msg: OpencodeMessage, part: OpencodePart, url: strin
   };
 }
 
+// Extension → MIME for files the agent writes (creation, not edit) so
+// generated documents/images render with the right glyph tone and preview
+// kind. Unlisted extensions fall back to null; `resolvePreviewType` then maps
+// them by extension for the preview, and unknown types land on the download
+// path. Kept deliberately small — add a type only when a generated artifact
+// needs it.
+const EXT_MIME: Record<string, string> = {
+  ".csv": "text/csv",
+  ".tsv": "text/tab-separated-values",
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".json": "application/json",
+  ".pdf": "application/pdf",
+  ".html": "text/html",
+  ".htm": "text/html",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+};
+
+function extOf(p: string): string {
+  const i = p.lastIndexOf(".");
+  return i >= 0 ? p.slice(i).toLowerCase() : "";
+}
+
+// An agent-generated file: a `write` tool CREATION (distinct from `edit`,
+// which modifies existing source and stays out). `href` is the written path; a
+// `write` carries no byte size, so `size` is null. Timestamp comes from the
+// tool's start time, falling back to the owning message.
+function deriveWriteArtifact(msg: OpencodeMessage, part: OpencodePart): Artifact | null {
+  const state = (part as {
+    state?: { input?: { filePath?: unknown }; time?: { start?: unknown } };
+  }).state;
+  const filePath = state?.input?.filePath;
+  if (typeof filePath !== "string" || !filePath) return null;
+  const ext = extOf(filePath);
+  const mime = EXT_MIME[ext] ?? null;
+  return {
+    id: part.id,
+    kind: mime != null && mime.startsWith("image/") ? "image" : "file",
+    origin: "agent",
+    key: filePath.toLowerCase(),
+    label: lastPathSegment(filePath),
+    href: filePath,
+    mime,
+    size: null,
+    at: typeof state?.time?.start === "number" ? state.time.start : messageCreated(msg),
+    messageId: msg.info.id,
+    context: null,
+    expiresAt: null,
+  };
+}
+
 function derivePageArtifact(page: ServedPageMeta, matched: OpencodeMessage | null): Artifact {
   return {
     id: "page:" + page.subdomain,
@@ -155,9 +211,18 @@ export function deriveArtifacts(
         out.push(deriveFileArtifact(msg, part));
         continue;
       }
+      // Agent-created files: a `write` tool with a target path is a produced
+      // artifact; every other tool part is excluded.
+      if (part.type === "tool") {
+        if (part.tool === "write") {
+          const generated = deriveWriteArtifact(msg, part);
+          if (generated) out.push(generated);
+        }
+        continue;
+      }
       // Only text parts of USER messages contribute links; every other part
-      // type (tool, patch, step-start, step-finish, reasoning, snapshot,
-      // agent) is explicitly excluded.
+      // type (patch, step-start, step-finish, reasoning, snapshot, agent) is
+      // explicitly excluded.
       if (part.type !== "text" || !isUser) continue;
       if (part.synthetic || part.ignored) continue;
       const text = part.text ?? "";


### PR DESCRIPTION
Follow-up on the Artifacts panel (BET-655..661):

1. **Generated files now appear.** `deriveArtifacts` lifts files the agent CREATED via the `write` tool into Files/Images (origin agent, keyed by written path, timestamped from tool start). `edit` (modifies existing source) stays out, matching the design's "produced a document, not edited repo source" rule.
2. **Header spacing** aligned to the design: compact borderless header (was a 44px bordered titlebar), 12px title->tabs gap, and the doubled tabs->content gap removed (was 24px, now 12px). Snapped to `sp-3`.
3. **Expiry pill** smaller (9.5px/6px) and the link title is now single-line — label truncates, pill is a shrink-0 sibling.

Includes tests (write->file, write->image, edit excluded, timestamp fallback) and the conformance-mockup header update.
