### PR TITLE
feat(ios): running indicator pinned to transcript bottom; composer is pure glass

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -190,20 +190,16 @@ private struct ChatScreenContent: View {
         // time, rather than floating over it. The tail moving is the correct
         // failure mode; a blank transcript is not.
         //
-        // `.background(tokens.canvas)` is load-bearing: a scroll view still
-        // DRAWS its content underneath a safe-area inset while scrolling, so
-        // without an opaque backdrop the transcript slides visibly under the
-        // composer.
+        // The composer is deliberately JUST its own glass elements — there is
+        // NO opaque backdrop on the inset. A scroll view still DRAWS its
+        // content underneath a safe-area inset while scrolling, so the
+        // transcript visibly slides beneath the glass composer (which blurs
+        // it) instead of behind a solid bar. The running-state row used to
+        // live here; it now floats at the bottom of the transcript (see
+        // `transcript`), so the composer stays a pure glass object.
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
                 bottomCards
-                // BET-630 (D1): the running-state working row. Shown only while a
-                // turn runs; the ambient refetch sweep lives on the composer's
-                // border and means a different thing, so the two never share an
-                // indicator. Not shown during a background refetch.
-                if store.running {
-                    RunningIndicator(store: store)
-                }
                 ComposerView(
                     sessionId: store.sessionId,
                     projectName: projectName,
@@ -212,7 +208,6 @@ private struct ChatScreenContent: View {
                     modelStore: modelStore
                 )
             }
-            .background(tokens.canvas)
         }
         .navigationDestination(for: SubagentSession.self) { agent in
             if let child = store.store(for: agent.childSessionId) {
@@ -476,6 +471,20 @@ private struct ChatScreenContent: View {
         .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
         .overlay(alignment: .bottom) {
             if showScrollToBottom { scrollToBottomButton }
+        }
+        // BET-630 (D1): the running-state working row, pinned to the BOTTOM OF
+        // THE TRANSCRIPT — next to the newest message the user is waiting on,
+        // not on the composer (the composer is a pure glass object now). Shown
+        // only while a turn runs; the ambient refetch sweep lives on the
+        // composer's border and means a different thing, so the two never
+        // share an indicator. Not shown during a background refetch. It is an
+        // overlay so it floats over the transcript rather than shifting the
+        // conversation; a glass chip keeps it readable above message text.
+        .overlay(alignment: .bottom) {
+            if store.running {
+                RunningIndicator(store: store)
+                    .padding(.bottom, Metrics.spacing.sp2)
+            }
         }
     }
 

--- a/mobile/native/MantaUI/RunningIndicator.swift
+++ b/mobile/native/MantaUI/RunningIndicator.swift
@@ -52,6 +52,17 @@ struct RunningIndicator: View {
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
+        // A glass chip, not a bare row: the indicator now floats over the
+        // transcript (pinned to its bottom edge) rather than sitting on the
+        // opaque composer bar, so it needs a readable backdrop above message
+        // text. `.ultraThinMaterial` keeps it part of the same floating glass
+        // chrome as the composer and the header controls.
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .padding(.horizontal, Metrics.spacing.sp3)
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("running-indicator")


### PR DESCRIPTION
## Changes (native iOS, ChatScreen/RunningIndicator)

1. **`Musing…` row pinned to the bottom of the transcript**, not the composer.
   The running-state row moved out of the bottom safe-area inset and now floats as an overlay on the TiledView at its bottom edge — right where the newest message is. No longer pushes/attaches to the composer.
2. **Composer is just its glass elements.** Removed the `.background(tokens.canvas)` that painted a solid full-bleed bar under the composer inset, so the transcript visibly scrolls beneath the glass (model pill + input box are both already Liquid Glass) instead of behind a solid bar.
3. Running indicator is now a floating glass chip (`.ultraThinMaterial` rounded rect + hairline) so it stays readable above transcript text.

No web/renderer changes.