### PR TITLE
feat(ios): running row + todos as plain content pinned to transcript bottom

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -194,11 +194,21 @@ private struct ChatScreenContent: View {
         // NO opaque backdrop on the inset. A scroll view still DRAWS its
         // content underneath a safe-area inset while scrolling, so the
         // transcript visibly slides beneath the glass composer (which blurs
-        // it) instead of behind a solid bar. The running-state row used to
-        // live here; it now floats at the bottom of the transcript (see
-        // `transcript`), so the composer stays a pure glass object.
+        // it) instead of behind a solid bar. The running-state row and the
+        // todos card are pinned to the BOTTOM of this stack (ordinary content
+        // in the transcript area, not glass), the todo list directly below the
+        // running row.
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
+                // BET-630 (D1): the running-state working row — plain text,
+                // pinned to the bottom of the transcript rather than the
+                // composer. Shown only while a turn runs; the ambient refetch
+                // sweep lives on the composer's border and means a different
+                // thing, so the two never share an indicator. Not shown during
+                // a background refetch.
+                if store.running {
+                    RunningIndicator(store: store)
+                }
                 bottomCards
                 ComposerView(
                     sessionId: store.sessionId,
@@ -471,20 +481,6 @@ private struct ChatScreenContent: View {
         .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
         .overlay(alignment: .bottom) {
             if showScrollToBottom { scrollToBottomButton }
-        }
-        // BET-630 (D1): the running-state working row, pinned to the BOTTOM OF
-        // THE TRANSCRIPT — next to the newest message the user is waiting on,
-        // not on the composer (the composer is a pure glass object now). Shown
-        // only while a turn runs; the ambient refetch sweep lives on the
-        // composer's border and means a different thing, so the two never
-        // share an indicator. Not shown during a background refetch. It is an
-        // overlay so it floats over the transcript rather than shifting the
-        // conversation; a glass chip keeps it readable above message text.
-        .overlay(alignment: .bottom) {
-            if store.running {
-                RunningIndicator(store: store)
-                    .padding(.bottom, Metrics.spacing.sp2)
-            }
         }
     }
 

--- a/mobile/native/MantaUI/RunningIndicator.swift
+++ b/mobile/native/MantaUI/RunningIndicator.swift
@@ -52,17 +52,9 @@ struct RunningIndicator: View {
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
-        // A glass chip, not a bare row: the indicator now floats over the
-        // transcript (pinned to its bottom edge) rather than sitting on the
-        // opaque composer bar, so it needs a readable backdrop above message
-        // text. `.ultraThinMaterial` keeps it part of the same floating glass
-        // chrome as the composer and the header controls.
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: Metrics.radius.md)
-                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
-        )
-        .padding(.horizontal, Metrics.spacing.sp3)
+        // Plain text, deliberately no glass / material backdrop: this row is
+        // pinned to the bottom of the transcript as ordinary content, not a
+        // floating chrome element.
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("running-indicator")


### PR DESCRIPTION
## Change
Follows up #610. The previous round made the `Musing…` running row a floating **glass** chip overlaid on the transcript. This round makes it **plain text pinned to the bottom of the transcript** (in the transparent bottom stack, just above the composer), with the **todos card directly below** it — both ordinary content in the transcript area, no glass.

Resulting bottom stack (top→bottom): running row → todos → permission/question → composer. No web/renderer changes.