### PR TITLE
feat(artifacts): Files tab = user uploads + ~/.manta-outbox pushed files

### DIFF
--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -26,7 +26,7 @@ import {
   Search,
   X,
 } from "lucide-react";
-import type { ServedPageMeta } from "../shared/types";
+import type { OutboxFile, ServedPageMeta } from "../shared/types";
 import { useStore } from "./store";
 import {
   countByKind,
@@ -404,6 +404,7 @@ export function ArtifactsPanel({
   const messages = useStore((s) => (sessionId ? s.chatMessages[sessionId] ?? [] : []));
 
   const [pages, setPages] = useState<ServedPageMeta[]>([]);
+  const [outbox, setOutbox] = useState<OutboxFile[]>([]);
   const [width, setWidth] = useState(loadWidth);
   const widthRef = useRef(width);
   widthRef.current = width;
@@ -418,8 +419,9 @@ export function ArtifactsPanel({
   const previewSourceRef = useRef<HTMLElement | null>(null);
   const draggingRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
-  // Page registry: fetch on open + 30s poll while open only. Timer cleared on
-  // close and on session change (mirrors useSessionResources).
+  // Page registry + outbox mailbox: fetch both on open + 30s poll while open
+  // only. Timer cleared on close and on session change (mirrors
+  // useSessionResources).
   useEffect(() => {
     if (!open || !sessionId) return;
     let cancelled = false;
@@ -429,6 +431,12 @@ export function ArtifactsPanel({
         if (!cancelled) setPages(list ?? []);
       } catch {
         /* best-effort page refresh */
+      }
+      try {
+        const entries = await window.api.outboxList();
+        if (!cancelled) setOutbox(entries ?? []);
+      } catch {
+        /* best-effort outbox refresh */
       }
     };
     void refresh();
@@ -451,8 +459,8 @@ export function ArtifactsPanel({
 
   const now = useMemo(() => Date.now(), []);
   const artifacts = useMemo(
-    () => deriveArtifacts(messages, pages, sessionId ?? ""),
-    [messages, pages, sessionId],
+    () => deriveArtifacts(messages, pages, sessionId ?? "", outbox),
+    [messages, pages, outbox, sessionId],
   );
   const counts = useMemo(() => countByKind(artifacts), [artifacts]);
   const tabArtifacts = useMemo(

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -34,7 +34,7 @@
 // is the single install point).
 
 import type { Api } from "../../shared/api.js";
-import type { AvailableLauncher, OpencodeMessage, ServedPageMeta, WorktreeInfo } from "../../shared/types.js";
+import type { AvailableLauncher, OpencodeMessage, OutboxFile, ServedPageMeta, WorktreeInfo } from "../../shared/types.js";
 import { DEMO_T0, demoFsListDirs, demoGitListWorktrees, demoState } from "./demoFixture.js";
 import { pickDemoState, type DemoState } from "../demoLayout.js";
 import { useStore } from "../store.js";
@@ -474,6 +474,11 @@ const launchersList = (): Promise<AvailableLauncher[]> =>
 // panel's Links tab renders live/soon/expired state pills in the demo capture.
 const servePageList = (): Promise<ServedPageMeta[]> => Promise.resolve(demoState.pages);
 
+// Outbox mailbox listing for the artifacts panel's Files tab — empty in demo
+// captures (the demo has no ~/.manta-outbox), so the Proxy fallback would also
+// have resolved a no-op; keep it explicit for parity with servePageList.
+const outboxList = (): Promise<OutboxFile[]> => Promise.resolve([]);
+
 // Folder picker listing (BET-562). Without these the Proxy fallback resolves
 // null and the picker's folder list renders a raw "Cannot read properties of
 // null" error in the empty-state capture. The listing is fictional (see
@@ -579,6 +584,7 @@ export const explicitMethods = {
   onStreamEvent,
   launchersList,
   servePageList,
+  outboxList,
   fsListDirs,
   gitListWorktrees,
   getClientVersion,

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -950,6 +950,9 @@ export const httpApi: Api = {
   // list wrappers.
   servePageList: () => rpcOptional(IPC.servePageList, []),
 
+  // Outbox mailbox listing — degrades to [] on a box without the channel.
+  outboxList: () => rpcOptional(IPC.outboxList, []),
+
   // -- background delegation jobs (manta-server owned; in-process on mobile) --
   // list returns the full job records (the engine always returns an array;
   // a no-engine fallback returns {jobs:[]} which we normalize). No create

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -136,72 +136,59 @@ describe("deriveArtifacts", () => {
     expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);
   });
 
-  it("tool parts of every kind → NO artifacts (write without a path is no artifact)", () => {
+  it("tool parts of every kind → NO artifacts", () => {
     for (const tool of ["read", "write", "edit", "bash", "webfetch"]) {
       const messages = [msg("a", "assistant", [toolPart(tool)])];
       expect(deriveArtifacts(messages, [], "ses_a"), `tool:${tool}`).toEqual([]);
     }
   });
 
-  it("write tool part with a target path → generated file artifact (origin agent)", () => {
-    const messages = [
-      msg("a", "assistant", [
-        {
-          type: "tool",
-          tool: "write",
-          state: {
-            status: "completed",
-            input: { filePath: "/home/dev/q3-revenue.csv" },
-            time: { start: 5000 },
-          },
-        },
-      ]),
-    ];
-    const got = deriveArtifacts(messages, [], "ses_a");
+  it("outbox file → file artifact (origin agent)", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/q3-revenue.csv", name: "q3-revenue.csv", size: 1204, session: null, mtime: 5000 },
+    ]);
     expect(got).toHaveLength(1);
     expect(got[0]).toMatchObject({
       kind: "file",
       origin: "agent",
       label: "q3-revenue.csv",
-      href: "/home/dev/q3-revenue.csv",
+      href: "/home/dev/.manta-outbox/q3-revenue.csv",
       mime: "text/csv",
-      size: null,
+      size: 1204,
       at: 5000,
-      messageId: "a",
+      messageId: null,
       context: null,
       expiresAt: null,
     });
   });
 
-  it("write tool part producing an image keeps the generated image", () => {
-    const messages = [
-      msg("a", "assistant", [
-        {
-          type: "tool",
-          tool: "write",
-          state: { status: "completed", input: { filePath: "/tmp/preview-test/chart.png" } },
-        },
-      ]),
-    ];
-    const got = deriveArtifacts(messages, [], "ses_a");
+  it("outbox image file → image artifact with its mime", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/shot.png", name: "shot.png", size: 2048, session: null, mtime: 1000 },
+    ]);
     expect(got).toHaveLength(1);
     expect(got[0].kind).toBe("image");
     expect(got[0].mime).toBe("image/png");
   });
 
-  it("write tool part falls back to the message timestamp when no tool start time", () => {
+  it("outbox file with an unknown extension keeps a null mime (file kind)", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/archive.bin", name: "archive.bin", size: 99, session: null, mtime: 1000 },
+    ]);
+    expect(got).toHaveLength(1);
+    expect(got[0].kind).toBe("file");
+    expect(got[0].mime).toBeNull();
+  });
+
+  it("user uploads and outbox files both land in the same list", () => {
     const messages = [
-      msg("a", "assistant", [
-        {
-          type: "tool",
-          tool: "write",
-          state: { status: "completed", input: { filePath: "/tmp/report.md" } },
-        },
-      ]),
+      msg("u", "user", [filePart({ filename: "mine.csv", url: "file:///home/dev/.manta-uploads/mine.csv" })]),
     ];
-    const got = deriveArtifacts(messages, [], "ses_a");
-    expect(got.filter((a) => a.kind === "file")).toHaveLength(1);
-    expect(got[0].at).toBe(2000); // the message's created timestamp
+    const got = deriveArtifacts(messages, [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/pushed.pdf", name: "pushed.pdf", size: 100, session: null, mtime: 2000 },
+    ]);
+    expect(got.length).toBe(2);
+    expect(got.map((a) => a.origin).sort()).toEqual(["agent", "user"]);
   });
 
   it("edit tool part → NO artifact (modifies existing source, not produced)", () => {

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -1,4 +1,4 @@
-import type { OpencodeMessage, OpencodePart, ServedPageMeta } from "../shared/types";
+import type { OpencodeMessage, OpencodePart, OutboxFile, ServedPageMeta } from "../shared/types";
 
 export type ArtifactKind = "link" | "image" | "file";
 export type ArtifactOrigin = "user" | "agent";
@@ -95,12 +95,12 @@ function deriveLinkArtifact(msg: OpencodeMessage, part: OpencodePart, url: strin
   };
 }
 
-// Extension → MIME for files the agent writes (creation, not edit) so
-// generated documents/images render with the right glyph tone and preview
+// Extension → MIME for files the agent pushes via the outbox (~/.manta-outbox)
+// so generated documents/images render with the right glyph tone and preview
 // kind. Unlisted extensions fall back to null; `resolvePreviewType` then maps
 // them by extension for the preview, and unknown types land on the download
-// path. Kept deliberately small — add a type only when a generated artifact
-// needs it.
+// path. Kept deliberately small — add a type only when a pushed artifact needs
+// it.
 const EXT_MIME: Record<string, string> = {
   ".csv": "text/csv",
   ".tsv": "text/tab-separated-values",
@@ -123,29 +123,26 @@ function extOf(p: string): string {
   return i >= 0 ? p.slice(i).toLowerCase() : "";
 }
 
-// An agent-generated file: a `write` tool CREATION (distinct from `edit`,
-// which modifies existing source and stays out). `href` is the written path; a
-// `write` carries no byte size, so `size` is null. Timestamp comes from the
-// tool's start time, falling back to the owning message.
-function deriveWriteArtifact(msg: OpencodeMessage, part: OpencodePart): Artifact | null {
-  const state = (part as {
-    state?: { input?: { filePath?: unknown }; time?: { start?: unknown } };
-  }).state;
-  const filePath = state?.input?.filePath;
-  if (typeof filePath !== "string" || !filePath) return null;
-  const ext = extOf(filePath);
+// One entry in ~/.manta-outbox (see src/shared/types.ts OutboxFile).
+
+// An agent-pushed file. The outbox is a one-shot mailbox — the file is removed
+// after a successful download — so it can drop out of the Files tab, which is
+// expected. `session` (the tmux session name) is carried for future per-session
+// scoping but not used for dedupe: a path is unique on the box.
+function deriveOutboxArtifact(row: OutboxFile): Artifact {
+  const ext = extOf(row.name);
   const mime = EXT_MIME[ext] ?? null;
   return {
-    id: part.id,
+    id: "outbox:" + row.path,
     kind: mime != null && mime.startsWith("image/") ? "image" : "file",
     origin: "agent",
-    key: filePath.toLowerCase(),
-    label: lastPathSegment(filePath),
-    href: filePath,
+    key: row.path.toLowerCase(),
+    label: row.name,
+    href: row.path,
     mime,
-    size: null,
-    at: typeof state?.time?.start === "number" ? state.time.start : messageCreated(msg),
-    messageId: msg.info.id,
+    size: row.size,
+    at: row.mtime || 0,
+    messageId: null,
     context: null,
     expiresAt: null,
   };
@@ -201,6 +198,7 @@ export function deriveArtifacts(
   messages: OpencodeMessage[],
   pages: ServedPageMeta[],
   sessionId: string,
+  outbox: OutboxFile[] = [],
 ): Artifact[] {
   const out: Artifact[] = [];
 
@@ -211,18 +209,9 @@ export function deriveArtifacts(
         out.push(deriveFileArtifact(msg, part));
         continue;
       }
-      // Agent-created files: a `write` tool with a target path is a produced
-      // artifact; every other tool part is excluded.
-      if (part.type === "tool") {
-        if (part.tool === "write") {
-          const generated = deriveWriteArtifact(msg, part);
-          if (generated) out.push(generated);
-        }
-        continue;
-      }
       // Only text parts of USER messages contribute links; every other part
-      // type (patch, step-start, step-finish, reasoning, snapshot, agent) is
-      // explicitly excluded.
+      // type (tool, patch, step-start, step-finish, reasoning, snapshot,
+      // agent) is explicitly excluded.
       if (part.type !== "text" || !isUser) continue;
       if (part.synthetic || part.ignored) continue;
       const text = part.text ?? "";
@@ -243,6 +232,10 @@ export function deriveArtifacts(
   for (const page of pages) {
     if (page.sessionID !== sessionId) continue;
     out.push(derivePageArtifact(page, newestAnnouncingMessage(messages, page.url)));
+  }
+
+  for (const row of outbox) {
+    out.push(deriveOutboxArtifact(row));
   }
 
   return dedupeByKey(out).sort((a, b) => b.at - a.at);

--- a/src/server/outbox.mjs
+++ b/src/server/outbox.mjs
@@ -34,8 +34,7 @@ export async function listOutbox(root = defaultOutboxRoot()) {
   for (const ent of topEntries) {
     const full = join(root, ent.name);
     if (ent.isFile()) {
-      const size = await statSize(full);
-      out.push({ path: full, name: ent.name, size, session: null });
+      out.push({ ...(await statMeta(full)), name: ent.name, session: null });
     } else if (ent.isDirectory()) {
       let subEntries;
       try {
@@ -46,20 +45,21 @@ export async function listOutbox(root = defaultOutboxRoot()) {
       for (const sub of subEntries) {
         if (!sub.isFile()) continue;
         const subFull = join(full, sub.name);
-        const size = await statSize(subFull);
-        out.push({ path: subFull, name: sub.name, size, session: ent.name });
+        out.push({ ...(await statMeta(subFull)), name: sub.name, session: ent.name });
       }
     }
   }
   return out;
 }
 
-async function statSize(path) {
+// Row shape: { path, size, mtime } — mtime lets the Artifacts panel sort/group
+// outbox files; the outbox poller ignores it (additive, no behaviour change).
+async function statMeta(path) {
   try {
     const st = await stat(path);
-    return st.size;
+    return { path, size: st.size, mtime: st.mtimeMs };
   } catch {
-    return 0;
+    return { path, size: 0, mtime: 0 };
   }
 }
 

--- a/src/server/outbox.test.mjs
+++ b/src/server/outbox.test.mjs
@@ -47,6 +47,23 @@ test("listOutbox lists files one level deep with their session label", async () 
   }
 });
 
+test("listOutbox reports a numeric mtime per file (for artifacts day-grouping)", async () => {
+  const root = await makeOutbox();
+  try {
+    await writeFile(join(root, "root.txt"), "abc");
+    await mkdir(join(root, "myproj"));
+    await writeFile(join(root, "myproj", "sub.txt"), "def");
+    const entries = await listOutbox(root);
+    for (const e of entries) {
+      assert.equal(typeof e.mtime, "number");
+      assert.ok(e.mtime > 0, "mtime should be a real epoch-ms timestamp");
+    }
+    assert.ok(entries.every((e) => e.path && e.path.length > 0));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("listOutbox does NOT descend past one subdir level", async () => {
   const root = await makeOutbox();
   try {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -11,7 +11,7 @@ import { expandTilde } from "../shared/paths.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob } from "./schedule.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
 import { listPages as servePageListStore } from "./servePage.mjs";
-import { publicBaseUrl } from "./gatewayRegister.mjs";
+import { listOutbox } from "./outbox.mjs";import { publicBaseUrl } from "./gatewayRegister.mjs";
 import {
   listSecrets as secretsListStore,
   setSecret as secretsSetStore,
@@ -864,6 +864,12 @@ export function buildHandlers({
     // reads ~/.manta/auth.json fresh per call, so the list's `url` fields stay
     // correct even if the box's gateway host was provisioned after boot.
     "serve-page:list": async () => servePageListStore({ baseUrl: publicBaseUrl() }),
+
+    // Read-only live listing of the box's outbox (~/.manta-outbox) so the
+    // artifacts panel's Files tab shows agent-pushed files alongside user
+    // uploads. No write counterpart — files are dropped by the AI itself into
+    // the mailbox and removed on download (one-shot).
+    "outbox:list": async () => listOutbox(),
 
     // ---- APNs native-push registration (BET-181) ----
     // iOS Capacitor app registers its APNs device token via the renderer-side

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -24,6 +24,7 @@ import type {
   SecretInput,
   ServerUpdateAvailablePayload,
   ServedPageMeta,
+  OutboxFile,
   WebhookMeta,
   SpawnOptions,
   PtyEvent,
@@ -302,6 +303,12 @@ export interface Api {
   // published/stopped by the AI's `serve_page`/`stop_page` opencode tools, not
   // through any UI channel.
   servePageList(): Promise<ServedPageMeta[]>;
+
+  // Returns the box's outbox (~/.manta-outbox) entries — files the AI dropped
+  // for the user to retrieve — so the artifacts panel's Files tab can show
+  // agent-pushed files alongside user uploads. Read-only; a source is removed
+  // on download (one-shot mailbox).
+  outboxList(): Promise<OutboxFile[]>;
 
   // Background delegation jobs (manta-server owned). list returns the full
   // job records (filtered by parent session when sessionId is passed; all

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -758,6 +758,14 @@ export const IPC = {
   // (httpApi); a read has no server write counterpart.
   servePageList: "serve-page:list", // () → ServedPageMeta[]
 
+  // Registry of the box's ~/.manta-outbox mailbox (files the AI dropped for
+  // the user to retrieve). Read-only, used by the artifacts panel's Files tab
+  // so agent-pushed files show up alongside user uploads. The source file is
+  // removed on download (one-shot mailbox), so an entry can drop out on its
+  // own. Mirrors src/shared/types.ts OutboxFile / src/server/outbox.mjs
+  // listOutbox rows.
+  outboxList: "outbox:list", // () → OutboxFile[]
+
   // ---- background delegation jobs (manta-server owned) ----
   // Background jobs are started by the AI's global `delegate` opencode tool
   // (POST /api/delegate); the UI only LISTS / STOPS / DELETES via these
@@ -943,6 +951,18 @@ export type ServedPageMeta = {
   expiresAt: number | null;
   createdAt: number;
   sessionID: string | null;
+};
+
+// One entry in ~/.manta-outbox (the mailbox the AI drops files into for the
+// user to retrieve, surfaced by the artifacts panel's Files tab). Mirrors
+// src/server/outbox.mjs `listOutbox` rows; `mtime` is added server-side so the
+// panel can sort/group by when the file appeared.
+export type OutboxFile = {
+  path: string;
+  name: string;
+  size: number;
+  session: string | null;
+  mtime: number;
 };
 
 // Input shape for secretsSet (UI → store). The value travels renderer → IPC →


### PR DESCRIPTION
Scope the Artifacts **Files tab** to two sources only: **user uploads** and **files the agent pushed via `~/.manta-outbox`**. Removes the earlier `write`-tool derivation (arbitrary written paths no longer flood the tab).

- `artifacts.ts` — replaced write-tool derivation with outbox rows (origin agent, kind/mime from extension, real `size` + `mtime`, `messageId` null).
- Server — `listOutbox` now returns `mtime` per file (so the panel can sort/day-group); new read-only `outbox:list` RPC channel wired across all wiring sites + a `demoApi` stub.
- Panel — fetches the outbox on open + 30s poll alongside the page registry, feeds `deriveArtifacts`.
- Tests — outbox file / image / unknown-extension / upload+outbox coexistence, and `listOutbox` mtime.

`typecheck` + full suite green locally; duplication gate passes.
