### PR TITLE
feat(ios): running 'Musing…' row as transcript typing indicator (not floating)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -194,21 +194,12 @@ private struct ChatScreenContent: View {
         // NO opaque backdrop on the inset. A scroll view still DRAWS its
         // content underneath a safe-area inset while scrolling, so the
         // transcript visibly slides beneath the glass composer (which blurs
-        // it) instead of behind a solid bar. The running-state row and the
-        // todos card are pinned to the BOTTOM of this stack (ordinary content
-        // in the transcript area, not glass), the todo list directly below the
-        // running row.
+        // it) instead of behind a solid bar. The todos card is pinned to the
+        // bottom of this stack, in the transcript area; the running-state row
+        // lives INSIDE the transcript as its typing indicator (see
+        // `transcript`), so it is not duplicated here.
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
-                // BET-630 (D1): the running-state working row — plain text,
-                // pinned to the bottom of the transcript rather than the
-                // composer. Shown only while a turn runs; the ambient refetch
-                // sweep lives on the composer's border and means a different
-                // thing, so the two never share an indicator. Not shown during
-                // a background refetch.
-                if store.running {
-                    RunningIndicator(store: store)
-                }
                 bottomCards
                 ComposerView(
                     sessionId: store.sessionId,
@@ -456,6 +447,16 @@ private struct ChatScreenContent: View {
             isProcessing: store.loadingEarlier
         ) {
             LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {}
+        })
+        // The running-state working row rendered as MessagingUI's typing
+        // indicator: a genuine row BELOW the last message, inside the scroll
+        // content — not floating chrome. It pins to the bottom because that is
+        // where the newest content sits, appears only while a turn runs, and
+        // vanishes when it ends. (BET-630 D1; the ambient refetch sweep lives
+        // on the composer's border and means a different thing, so the two
+        // never share an indicator.)
+        .typingIndicator(.indicator(isVisible: store.running) {
+            RunningIndicator(store: store)
         })
         // The floating "scroll to bottom" arrow. It appears only once the user
         // has scrolled up (pointsFromBottom above the threshold) — at the


### PR DESCRIPTION
## Problem
The `Musing…` loading text still read as **floating** — earlier iterations put it in the bottom stack (above the composer) or as an overlay, both of which hovered over/around the transcript.

## Fix
Render it as MessagingUI's **`typingIndicator`**: a genuine row **below the last message** that reserves space inside the scroll content — ordinary text in the transcript area, impossible to float. Shows only while a turn runs, vanishes on completion. The todos card stays pinned in the bottom stack below it (order: messages → Musing… → todos → permission/question → glass composer).

No web/renderer changes.