### PR TITLE
feat(artifacts): durable, workspace-linked send-file artifacts with TTL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,17 +323,21 @@ empty session dirs. Threshold is `uploadCleanupHours` in config (default 1,
 staleness ≈ `uploadCleanupHours + 1h`.
 
 **Agent → laptop push (outbox / download).** The reverse of drag-in: the remote
-AI drops a file into `~/.manta-outbox/` (optionally `~/.manta-outbox/<session>/`)
-and MantaUI pulls it to the Mac's Downloads folder via `GET
-<serverUrl>/api/download?path=<relative>&session=<name>`. Detection is a 3s
-**outbox poller** in `src/main/index.ts` (`pollOutboxOnce` → `GET
-/api/outbox?session=<name>` → JSON listing); it mirrors the screenshot Desktop
-watcher's philosophy (cheap periodic check, push a toast). The outbox is a
-**one-shot mailbox** — the server `rm`s the remote source after a successful
-download, so files aren't re-pulled and don't accumulate. The poller keeps a
-`seenOutboxPaths` set (cleared on host change) reconciled against the live
-listing each tick so a require-confirm toast the user hasn't answered isn't
-re-offered every 3s.
+AI sends a file via the `send_file` tool, which manta-server copies into
+`~/.manta-outbox/<sessionID>/` (the workspace-linked artifact mailbox; the AI
+keeps its working copy). MantaUI detects it and can pull it to the Mac's
+Downloads folder via `GET <serverUrl>/api/download?path=<relative>`.
+Detection is a 3s **outbox poller** (`pollOutboxOnce` → `GET /api/outbox?session=<name>`
+→ JSON listing) / the server-side `startOutboxPoller`, mirroring the screenshot
+Desktop watcher's philosophy (cheap periodic check, push a toast). The outbox is
+a **durable, TTL'd artifact store**, NOT a one-shot mailbox: files are
+**not deleted on download** (both `/api/download` and the artifacts panel's
+`/api/peek` leave the source in place), they're workspace-linked (the subdir is
+the opencode session id, so each artifacts panel shows only its conversation's
+files), and a server sweep (`expireArtifacts`, every 5 min) removes them once
+their TTL elapses (default 7 days). The poller keeps a `seenOutboxPaths` set
+(cleared on host change) reconciled against the live listing each tick so a
+require-confirm toast the user hasn't answered isn't re-offered every 3s.
 
 - **Trust flag `allowAgentPush`** (AppConfig, default OFF, Settings UI). ON =
   download immediately + informational toast ("↓ name · saved to Downloads ·
@@ -347,12 +351,15 @@ re-offered every 3s.
   `agentFileToast` in the store, App.tsx owns the one `onAgentFileReady`
   listener, the active ChatPanel renders it. De-dupe on collision via
   `uniqueLocalPath` (`report.pdf` → `report (1).pdf`).
-- **The AI learns the convention** via the `/send-file` command
-  (`docs/opencode-commands/send-file.md`). Install on the remote opencode host:
-  `ln -sf <repo>/docs/opencode-commands/send-file.md
-  ~/.config/opencode/commands/send-file.md` then restart `opencode-serve`. The
-  command just tells the AI to `cp <file> ~/.manta-outbox/` — no MCP server, works
-  with any model.
+- **The AI sends files via the `send_file` tool** (`docs/opencode-tools/send-file.ts`,
+  a manta-native opencode tool like `serve_page`). It POSTs the file path + its
+  `context.sessionID` to `POST /api/outbox/push`, which copies the file into
+  `~/.manta-outbox/<sessionID>/` (workspace-linked) and hands it a TTL (default
+  7 days, or `ttlHours:0` for never). Install on the remote opencode host:
+  `cp <repo>/docs/opencode-tools/send-file.ts ~/.config/opencode/tools/send-file.ts`
+  then restart `opencode-serve`. The legacy `/send-file` markdown command
+  (`docs/opencode-commands/send-file.md`) still works for a bare `cp` to the
+  root, but that path is NOT workspace-linked.
 - **Mobile** has no Mac Downloads folder (the server IS the box). A server-side
   outbox poller (`src/server/outbox.mjs`, `startOutboxPoller` wired in
   `index.mjs`) `readdir`s `~/.manta-outbox/` locally every 3s and publishes
@@ -360,8 +367,9 @@ re-offered every 3s.
   subscribes to that kind. Every detection is a CONFIRM toast (`autoPulled:false`)
   — there's no silent disk write to a phone/browser. Tapping Save calls
   `agentPullFile`, which triggers a browser download via `GET /api/download`
-  (`src/server/index.mjs`, path-traversal-guarded to `~/.manta-outbox/`, deletes
-  the source on success — the one-shot mailbox). The mobile `agentPullFile`
+  (`src/server/index.mjs`, path-traversal-guarded to `~/.manta-outbox/`). The
+  download is **non-destructive** — the source stays until the TTL sweep
+  reclaims it. The mobile `agentPullFile`
   returns `""` (no OS path to reveal) so the toast dismisses instead of showing
   a dead "Reveal" button; `revealInFolder` is a no-op. `MobileApp.tsx` wires the
   `onAgentFileReady` listener (mirror of `App.tsx`). Pure scan logic

--- a/docs/opencode-commands/send-file.md
+++ b/docs/opencode-commands/send-file.md
@@ -1,37 +1,43 @@
 ---
-description: Send a file from this remote box down to the user's laptop (their Downloads folder)
+description: Send a file from this remote box down to the user's machine as a durable artifact
 ---
 
 # /send-file
 
-Deliver a file from this machine to the user's laptop. manta (the desktop app the
-user is running) watches a special outbox directory on this box and pulls any
-file that appears there down to the user's computer — the reverse of the user
-dragging a file into the chat.
+Deliver a file from this machine to the user's machine. manta keeps a durable,
+workspace-linked mailbox on this box (`~/.manta-outbox/<sessionID>/`) and
+announces anything that appears there as an "AI sent you a file" toast; the
+file also shows up in the app's Artifacts panel Files tab for this conversation.
 
-## How to send a file
+## Preferred: the `send_file` tool
 
-Copy the file into `~/.manta-outbox/` on this box. That's it — manta detects it
-within a few seconds and saves it to the user's Downloads folder (or, depending
-on the user's settings, asks them to confirm first). The file is removed from
-the outbox once it's been delivered.
+Use the `send_file` opencode tool (installed at
+`~/.config/opencode/tools/send-file.ts`) — it knows this session's id, so the
+file is automatically workspace-linked. It copies the file (your working copy
+is kept), sets a TTL (default 7 days), and records it in the Files tab.
+
+## Fallback: bare copy (rarely)
+
+Only if the tool is not installed. Copy the file into a subdir named by this
+session's id:
 
 ```bash
-mkdir -p ~/.manta-outbox
-cp /path/to/the/file.pdf ~/.manta-outbox/
+mkdir -p ~/.manta-outbox/<session_id>
+cp /path/to/the/file.pdf ~/.manta-outbox/<session_id>/
 ```
 
-Keep the original filename meaningful — it becomes the name of the file the user
-receives.
+Keep the original filename meaningful — it becomes the name the user receives.
 
-## Notes
+## Semantics
 
-- Only put files the user actually asked for (or that you generated for them)
-  into the outbox. It writes straight to their machine.
+- **Durable, not one-shot.** The file is NOT deleted when the user downloads
+  it; it stays retrievable until it expires (TTL, default 7 days), then the
+  box's sweep removes it.
+- **Workspace-linked.** Files under a `<sessionID>/` subdir show only in that
+  conversation's Artifacts Files tab. A bare copy to the mailbox root is NOT
+  workspace-linked and won't appear per-conversation.
+- Only send files the user actually asked for (or that you generated for them) —
+  it writes straight to their machine.
 - Don't copy huge files or whole directories — send the specific artifact.
-- Scope by session if useful: `~/.manta-outbox/<anything>/file.ext` also works;
-  the subdirectory is shown to the user as a label and otherwise ignored.
 - This is delivery only. To *read* a file the user sent you, look in
   `~/.manta-uploads/` (or use the absolute path manta pasted into the prompt).
-
-$ARGUMENTS

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -278,3 +278,23 @@ can watch them the same way you watch any session.
 `docs/opencode-tools/delegate.ts` to `~/.config/opencode/tools/delegate.ts`
 and run `systemctl --user restart opencode-serve`. A symlinked tool fails
 to resolve `@opencode-ai/plugin` and silently never registers.
+
+## manta send-file
+
+You have a `send_file` tool to hand a file to the user and record it as a
+durable, workspace-linked artifact. Use it whenever you produce or generate a
+file the user should keep — a CSV export, a report, a generated image/document.
+It is NOT a one-shot mailbox:
+
+- The file is copied into `~/.manta-outbox/<sessionID>/` (your working copy is
+  kept) and announced with an "AI sent you a file" toast.
+- It appears in the app's Artifacts panel Files tab **for this conversation**
+  (workspace-linked by the session id).
+- It is **not deleted on download** — it stays retrievable until it expires
+  (default 7 days, or `ttlHours:0` for no expiry), then the box's sweep removes
+  it, so users can re-download any time before then.
+
+Install: `cp <repo>/docs/opencode-tools/send-file.ts
+~/.config/opencode/tools/send-file.ts` and restart `opencode-serve`.
+**Install/update is a COPY, never a symlink** (same `@opencode-ai/plugin`
+resolution gotcha as the other manta tools).

--- a/docs/opencode-tools/send-file.ts
+++ b/docs/opencode-tools/send-file.ts
@@ -1,0 +1,116 @@
+// manta-native `send_file` tool — global opencode custom tool.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/send-file.ts ~/.config/opencode/tools/send-file.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// This tool is a THIN registrar. It validates the request and POSTs it to
+// manta-server (127.0.0.1:8787, same box — no SSH hop). manta-server copies
+// the file into ~/.manta-outbox/<sessionID>/ (the workspace-linked artifact
+// mailbox) and the box's outbox scanner announces it with an "AI sent you a
+// file" toast. The tool does NOT move or transform the file itself — the AI
+// keeps its working copy; execute() must return promptly.
+//
+// Durable artifact semantics (reconciled with the old one-shot mailbox):
+//   - Workspace-linked under the caller's opencode sessionID.
+//   - TTL (default 7 days) — NOT deleted on download; swept when it expires.
+//   - Re-downloadable until then.
+//
+// See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one tiny
+// local file) so a token rotation never requires an opencode-serve restart.
+// MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const send_file = tool({
+  description: [
+    "Send a file from this box to the user's machine and record it as a",
+    "durable artifact. Use when you generated or produced a file for the user",
+    "to keep (a CSV export, a report, a generated image/document). The file is",
+    "copied (your working copy is kept) into the workspace-linked mailbox,",
+    "announced with a toast, and shows up in the app's Artifacts panel Files",
+    "tab for this conversation. It is NOT deleted when the user downloads it —",
+    "it stays retrievable until it expires (default 7 days, which the user can",
+    "override per call), then the box's sweep removes it. Pass the absolute",
+    "path to an existing file.",
+  ].join(" "),
+  args: {
+    path: z
+      .string()
+      .describe(
+        "Absolute path to the file to send (e.g. '/tmp/export.csv'). Must be a " +
+          "regular file that exists on this box. The basename is used as the " +
+          "artifact name the user sees.",
+      ),
+    ttlHours: z
+      .number()
+      .optional()
+      .describe(
+        "Hours until the artifact expires (default 168 = 7 days). " +
+          "Set to a higher value for longer-lived artifacts, or 0 to disable expiry.",
+      ),
+  },
+  async execute(args, context) {
+    const result = await call("POST", "/api/outbox/push", {
+      filePath: args.path,
+      sessionID: context.sessionID,
+      ttlHours: args.ttlHours,
+    });
+    const ttl =
+      result.row?.expiresAt == null
+        ? "no expiry"
+        : `expires ${new Date(result.row.expiresAt).toISOString()}`;
+    return `Sent ${result.row?.name ?? "file"} to the user's machine (${ttl}). It is in the Artifacts panel Files tab for this conversation.`;
+  },
+});

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -26,7 +26,7 @@ import {
   Search,
   X,
 } from "lucide-react";
-import type { ServedPageMeta } from "../shared/types";
+import type { OutboxFile, ServedPageMeta } from "../shared/types";
 import { useStore } from "./store";
 import {
   countByKind,
@@ -305,6 +305,7 @@ function ImageTile({
   onJump,
 }: {
   artifact: Artifact;
+  now?: number; // shared with FileRow so image tiles span the same render path
   onOpen: (el: HTMLElement) => void;
   onAttach: () => void;
   onDownload: () => void;
@@ -346,18 +347,24 @@ function fileGlyphTone(mime: string | null): string {
 
 function FileRow({
   artifact,
+  now,
   onOpen,
   onAttach,
   onDownload,
   onJump,
 }: {
   artifact: Artifact;
+  now: number;
   onOpen: (el: HTMLElement) => void;
   onAttach: () => void;
   onDownload: () => void;
   onJump: () => void;
 }) {
   const size = artifact.size;
+  // Outbox files carry a TTL and are swept (not deleted) on download, so they
+  // render a live/soon/expired pill just like hosted pages.
+  const expiry =
+    artifact.expiresAt != null ? pageState(artifact.expiresAt, now) : null;
   return (
     <div className="group flex items-center gap-[9px] rounded-sm px-2 py-[7px] hover:bg-fill-hover">
       <button
@@ -377,6 +384,12 @@ function FileRow({
             {size != null && " · "}
             {artifact.origin === "user" ? "you sent this" : "generated"}
           </span>
+          {expiry && artifact.expiresAt != null && (
+            <ExpiryPill
+              state={expiry}
+              label={expiry === "expired" ? "expired" : expiryLabel(artifact.expiresAt, now)}
+            />
+          )}
         </div>
       </button>
       <div className="flex flex-none gap-px opacity-0 transition-opacity group-hover:opacity-100">
@@ -404,6 +417,7 @@ export function ArtifactsPanel({
   const messages = useStore((s) => (sessionId ? s.chatMessages[sessionId] ?? [] : []));
 
   const [pages, setPages] = useState<ServedPageMeta[]>([]);
+  const [outbox, setOutbox] = useState<OutboxFile[]>([]);
   const [width, setWidth] = useState(loadWidth);
   const widthRef = useRef(width);
   widthRef.current = width;
@@ -418,8 +432,9 @@ export function ArtifactsPanel({
   const previewSourceRef = useRef<HTMLElement | null>(null);
   const draggingRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
-  // Page registry: fetch on open + 30s poll while open only. Timer cleared on
-  // close and on session change (mirrors useSessionResources).
+  // Page registry + outbox mailbox: fetch both on open + 30s poll while open
+  // only. Timer cleared on close and on session change (mirrors
+  // useSessionResources).
   useEffect(() => {
     if (!open || !sessionId) return;
     let cancelled = false;
@@ -429,6 +444,12 @@ export function ArtifactsPanel({
         if (!cancelled) setPages(list ?? []);
       } catch {
         /* best-effort page refresh */
+      }
+      try {
+        const entries = await window.api.outboxList(sessionId ?? "");
+        if (!cancelled) setOutbox(entries ?? []);
+      } catch {
+        /* best-effort outbox refresh */
       }
     };
     void refresh();
@@ -451,8 +472,8 @@ export function ArtifactsPanel({
 
   const now = useMemo(() => Date.now(), []);
   const artifacts = useMemo(
-    () => deriveArtifacts(messages, pages, sessionId ?? ""),
-    [messages, pages, sessionId],
+    () => deriveArtifacts(messages, pages, sessionId ?? "", outbox),
+    [messages, pages, outbox, sessionId],
   );
   const counts = useMemo(() => countByKind(artifacts), [artifacts]);
   const tabArtifacts = useMemo(
@@ -647,6 +668,7 @@ export function ArtifactsPanel({
                         <Row
                           key={a.id}
                           artifact={a}
+                          now={now}
                           onOpen={(el) => openRow(a, el)}
                           onAttach={() => void attachArtifact(a, sessionId ?? "")}
                           onDownload={() => void downloadArtifact(a)}

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -34,7 +34,7 @@
 // is the single install point).
 
 import type { Api } from "../../shared/api.js";
-import type { AvailableLauncher, OpencodeMessage, ServedPageMeta, WorktreeInfo } from "../../shared/types.js";
+import type { AvailableLauncher, OpencodeMessage, OutboxFile, ServedPageMeta, WorktreeInfo } from "../../shared/types.js";
 import { DEMO_T0, demoFsListDirs, demoGitListWorktrees, demoState } from "./demoFixture.js";
 import { pickDemoState, type DemoState } from "../demoLayout.js";
 import { useStore } from "../store.js";
@@ -474,6 +474,11 @@ const launchersList = (): Promise<AvailableLauncher[]> =>
 // panel's Links tab renders live/soon/expired state pills in the demo capture.
 const servePageList = (): Promise<ServedPageMeta[]> => Promise.resolve(demoState.pages);
 
+// Outbox mailbox listing for the artifacts panel's Files tab — empty in demo
+// captures (the demo has no ~/.manta-outbox), so the Proxy fallback would also
+// have resolved a no-op; keep it explicit for parity with servePageList.
+const outboxList = (): Promise<OutboxFile[]> => Promise.resolve([]);
+
 // Folder picker listing (BET-562). Without these the Proxy fallback resolves
 // null and the picker's folder list renders a raw "Cannot read properties of
 // null" error in the empty-state capture. The listing is fictional (see
@@ -579,6 +584,7 @@ export const explicitMethods = {
   onStreamEvent,
   launchersList,
   servePageList,
+  outboxList,
   fsListDirs,
   gitListWorktrees,
   getClientVersion,

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -950,6 +950,10 @@ export const httpApi: Api = {
   // list wrappers.
   servePageList: () => rpcOptional(IPC.servePageList, []),
 
+  // Outbox mailbox listing, scoped to the active conversation — degrades to []
+  // on a box without the channel.
+  outboxList: (sessionId?: string) => rpcOptional(IPC.outboxList, [], sessionId),
+
   // -- background delegation jobs (manta-server owned; in-process on mobile) --
   // list returns the full job records (the engine always returns an array;
   // a no-engine fallback returns {jobs:[]} which we normalize). No create

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -136,72 +136,66 @@ describe("deriveArtifacts", () => {
     expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);
   });
 
-  it("tool parts of every kind → NO artifacts (write without a path is no artifact)", () => {
+  it("tool parts of every kind → NO artifacts", () => {
     for (const tool of ["read", "write", "edit", "bash", "webfetch"]) {
       const messages = [msg("a", "assistant", [toolPart(tool)])];
       expect(deriveArtifacts(messages, [], "ses_a"), `tool:${tool}`).toEqual([]);
     }
   });
 
-  it("write tool part with a target path → generated file artifact (origin agent)", () => {
-    const messages = [
-      msg("a", "assistant", [
-        {
-          type: "tool",
-          tool: "write",
-          state: {
-            status: "completed",
-            input: { filePath: "/home/dev/q3-revenue.csv" },
-            time: { start: 5000 },
-          },
-        },
-      ]),
-    ];
-    const got = deriveArtifacts(messages, [], "ses_a");
+  it("outbox file → file artifact (origin agent, scoped to its session)", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/q3-revenue.csv", name: "q3-revenue.csv", size: 1204, sessionID: "ses_a", mtime: 5000, expiresAt: 5000 + 604800000 },
+    ]);
     expect(got).toHaveLength(1);
     expect(got[0]).toMatchObject({
       kind: "file",
       origin: "agent",
       label: "q3-revenue.csv",
-      href: "/home/dev/q3-revenue.csv",
+      href: "/home/dev/.manta-outbox/q3-revenue.csv",
       mime: "text/csv",
-      size: null,
+      size: 1204,
       at: 5000,
-      messageId: "a",
+      messageId: null,
       context: null,
-      expiresAt: null,
+      expiresAt: 5000 + 604800000,
     });
   });
 
-  it("write tool part producing an image keeps the generated image", () => {
-    const messages = [
-      msg("a", "assistant", [
-        {
-          type: "tool",
-          tool: "write",
-          state: { status: "completed", input: { filePath: "/tmp/preview-test/chart.png" } },
-        },
-      ]),
-    ];
-    const got = deriveArtifacts(messages, [], "ses_a");
+  it("outbox files from another session are excluded (workspace-linked)", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/x.csv", name: "x.csv", size: 1, sessionID: "ses_OTHER", mtime: 1000, expiresAt: null },
+    ]);
+    expect(got).toEqual([]);
+  });
+
+  it("outbox image file → image artifact with its mime", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/shot.png", name: "shot.png", size: 2048, sessionID: "ses_a", mtime: 1000, expiresAt: null },
+    ]);
     expect(got).toHaveLength(1);
     expect(got[0].kind).toBe("image");
     expect(got[0].mime).toBe("image/png");
   });
 
-  it("write tool part falls back to the message timestamp when no tool start time", () => {
+  it("outbox file with an unknown extension keeps a null mime (file kind)", () => {
+    const got = deriveArtifacts([], [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/archive.bin", name: "archive.bin", size: 99, sessionID: "ses_a", mtime: 1000, expiresAt: null },
+    ]);
+    expect(got).toHaveLength(1);
+    expect(got[0].kind).toBe("file");
+    expect(got[0].mime).toBeNull();
+  });
+
+  it("user uploads and outbox files both land in the same list", () => {
     const messages = [
-      msg("a", "assistant", [
-        {
-          type: "tool",
-          tool: "write",
-          state: { status: "completed", input: { filePath: "/tmp/report.md" } },
-        },
-      ]),
+      msg("u", "user", [filePart({ filename: "mine.csv", url: "file:///home/dev/.manta-uploads/mine.csv" })]),
     ];
-    const got = deriveArtifacts(messages, [], "ses_a");
-    expect(got.filter((a) => a.kind === "file")).toHaveLength(1);
-    expect(got[0].at).toBe(2000); // the message's created timestamp
+    const got = deriveArtifacts(messages, [], "ses_a", [
+      { path: "/home/dev/.manta-outbox/pushed.pdf", name: "pushed.pdf", size: 100, sessionID: "ses_a", mtime: 2000, expiresAt: null },
+    ]);
+    expect(got.length).toBe(2);
+    expect(got.map((a) => a.origin).sort()).toEqual(["agent", "user"]);
   });
 
   it("edit tool part → NO artifact (modifies existing source, not produced)", () => {

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -1,4 +1,4 @@
-import type { OpencodeMessage, OpencodePart, ServedPageMeta } from "../shared/types";
+import type { OpencodeMessage, OpencodePart, OutboxFile, ServedPageMeta } from "../shared/types";
 
 export type ArtifactKind = "link" | "image" | "file";
 export type ArtifactOrigin = "user" | "agent";
@@ -95,12 +95,12 @@ function deriveLinkArtifact(msg: OpencodeMessage, part: OpencodePart, url: strin
   };
 }
 
-// Extension → MIME for files the agent writes (creation, not edit) so
-// generated documents/images render with the right glyph tone and preview
+// Extension → MIME for files the agent pushes via the outbox (~/.manta-outbox)
+// so generated documents/images render with the right glyph tone and preview
 // kind. Unlisted extensions fall back to null; `resolvePreviewType` then maps
 // them by extension for the preview, and unknown types land on the download
-// path. Kept deliberately small — add a type only when a generated artifact
-// needs it.
+// path. Kept deliberately small — add a type only when a pushed artifact needs
+// it.
 const EXT_MIME: Record<string, string> = {
   ".csv": "text/csv",
   ".tsv": "text/tab-separated-values",
@@ -123,31 +123,26 @@ function extOf(p: string): string {
   return i >= 0 ? p.slice(i).toLowerCase() : "";
 }
 
-// An agent-generated file: a `write` tool CREATION (distinct from `edit`,
-// which modifies existing source and stays out). `href` is the written path; a
-// `write` carries no byte size, so `size` is null. Timestamp comes from the
-// tool's start time, falling back to the owning message.
-function deriveWriteArtifact(msg: OpencodeMessage, part: OpencodePart): Artifact | null {
-  const state = (part as {
-    state?: { input?: { filePath?: unknown }; time?: { start?: unknown } };
-  }).state;
-  const filePath = state?.input?.filePath;
-  if (typeof filePath !== "string" || !filePath) return null;
-  const ext = extOf(filePath);
+// An agent-pushed file. The outbox is a durable, workspace-linked mailbox: the
+// row's `sessionID` scopes it to the conversation that pushed it, and
+// `expiresAt` is its TTL (default 7 days) — it is not deleted on download, and
+// drops out only when the box's sweep reclaims it.
+function deriveOutboxArtifact(row: OutboxFile): Artifact {
+  const ext = extOf(row.name);
   const mime = EXT_MIME[ext] ?? null;
   return {
-    id: part.id,
+    id: "outbox:" + row.path,
     kind: mime != null && mime.startsWith("image/") ? "image" : "file",
     origin: "agent",
-    key: filePath.toLowerCase(),
-    label: lastPathSegment(filePath),
-    href: filePath,
+    key: row.path.toLowerCase(),
+    label: row.name,
+    href: row.path,
     mime,
-    size: null,
-    at: typeof state?.time?.start === "number" ? state.time.start : messageCreated(msg),
-    messageId: msg.info.id,
+    size: row.size,
+    at: row.mtime || 0,
+    messageId: null,
     context: null,
-    expiresAt: null,
+    expiresAt: row.expiresAt,
   };
 }
 
@@ -201,6 +196,7 @@ export function deriveArtifacts(
   messages: OpencodeMessage[],
   pages: ServedPageMeta[],
   sessionId: string,
+  outbox: OutboxFile[] = [],
 ): Artifact[] {
   const out: Artifact[] = [];
 
@@ -211,18 +207,9 @@ export function deriveArtifacts(
         out.push(deriveFileArtifact(msg, part));
         continue;
       }
-      // Agent-created files: a `write` tool with a target path is a produced
-      // artifact; every other tool part is excluded.
-      if (part.type === "tool") {
-        if (part.tool === "write") {
-          const generated = deriveWriteArtifact(msg, part);
-          if (generated) out.push(generated);
-        }
-        continue;
-      }
       // Only text parts of USER messages contribute links; every other part
-      // type (patch, step-start, step-finish, reasoning, snapshot, agent) is
-      // explicitly excluded.
+      // type (tool, patch, step-start, step-finish, reasoning, snapshot,
+      // agent) is explicitly excluded.
       if (part.type !== "text" || !isUser) continue;
       if (part.synthetic || part.ignored) continue;
       const text = part.text ?? "";
@@ -243,6 +230,12 @@ export function deriveArtifacts(
   for (const page of pages) {
     if (page.sessionID !== sessionId) continue;
     out.push(derivePageArtifact(page, newestAnnouncingMessage(messages, page.url)));
+  }
+
+  for (const row of outbox) {
+    // Workspace-link: only the conversation that pushed the file sees it.
+    if (row.sessionID !== sessionId) continue;
+    out.push(deriveOutboxArtifact(row));
   }
 
   return dedupeByKey(out).sort((a, b) => b.at - a.at);

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -41,7 +41,7 @@ import { attachPtyWs } from "./ptyWs.mjs";
 import { buildHandlers, handleRpcRequest } from "./rpc.mjs";
 import { startStatusPoller } from "./status.mjs";
 import { createStreamInterpreter } from "./streamInterp.mjs";
-import { startOutboxPoller } from "./outbox.mjs";
+import { startOutboxPoller, pushArtifact, createArtifactSweep } from "./outbox.mjs";
 import { startUploadCleanupPoller } from "./uploads.mjs";
 import { startServerUpdatePoller } from "./serverUpdate.mjs";
 import { runServerSelfUpdate } from "./opencodeAdmin.mjs";
@@ -351,6 +351,12 @@ const { stop: stopServerUpdatePoller } = startServerUpdatePoller({
 // Cleanup sweep for expired pages (runs every 5 min).
 // eslint-disable-next-line no-unused-vars
 const { stop: stopServePageCleanup } = startCleanupPoller();
+
+// Sweep expired artifact-mailbox files (TTL past) every 5 min — non-destructive
+// otherwise: downloads do not delete, the sweep is what reclaims disk.
+// eslint-disable-next-line no-unused-vars
+const artifactSweep = createArtifactSweep();
+artifactSweep.start();
 
 // Proactive pre-expiry Claude credential refresh (BET-281): clocks
 // ~/.claude/.credentials.json every 10 min and refreshes ~30 min ahead of
@@ -667,8 +673,9 @@ async function handleUpload(req, res, url) {
 
 // Agent → device download: stream a file from ~/.manta-outbox/ back to the
 // device as a browser download. Path-traversal guarded — the resolved path
-// must stay inside OUTBOX_ROOT. Deletes the source on success so the outbox
-// stays a one-shot mailbox, matching the desktop pullToDownloads semantics.
+// must stay inside OUTBOX_ROOT. NON-destructive: the source is left in place;
+// the artifact's lifetime is its TTL, swept by `expireArtifacts`, not by a
+// download. Re-download is always allowed until then.
 async function handleDownload(req, res, url) {
   const raw = url.searchParams.get("path") ?? "";
   const resolved = resolve(raw);
@@ -685,8 +692,6 @@ async function handleDownload(req, res, url) {
       "content-disposition": `attachment; filename="${basename(resolved).replace(/"/g, "")}"`,
     });
     await pipeline(createReadStream(resolved), res);
-    // Best-effort one-shot cleanup (ignore failure — re-download is harmless).
-    await rm(resolved, { force: true }).catch(() => {});
   } catch (e) {
     if (!res.headersSent) {
       respondJson(res, 404, { error: String(e?.message ?? e) });
@@ -986,6 +991,26 @@ const handleRequest = async (req, res) => {
 
   if (req.method === "GET" && path === "/api/download") {
     return handleDownload(req, res, url);
+  }
+
+  // ---------- Push a file as a workspace artifact (send_file tool) ----------
+  // POST /api/outbox/push { filePath, sessionID, ttlHours? }
+  // Copies the AI-generated file into ~/.manta-outbox/<sessionID>/ so it shows
+  // in the artifacts panel's Files tab (workspace-linked, TTL'd, not deleted
+  // on download) and announces it via the outbox scanner's agentFile toast.
+  if (req.method === "POST" && path === "/api/outbox/push") {
+    let body;
+    try {
+      body = await readBody(req);
+    } catch {
+      return respondJson(res, 400, { error: "invalid JSON body" });
+    }
+    const result = await pushArtifact(body?.filePath, body?.sessionID, {
+      ttlHours: body?.ttlHours,
+    });
+    return result.ok
+      ? respondJson(res, 200, { ok: true, row: result.row })
+      : respondJson(res, 400, { error: result.error });
   }
 
   // ---------- File peek (HTTP-mode desktop) ----------

--- a/src/server/outbox.mjs
+++ b/src/server/outbox.mjs
@@ -1,42 +1,61 @@
-// Agent → device outbox poller for the mobile server.
+// Agent → device artifact mailbox (mobile + desktop).
 //
-// The mobile outbox poller — mobile + desktop both reach the same
-// /api/outbox listing over HTTPS, but the SCAN itself only runs on the box
-// (server IS the box, no SSH hop). The remote AI drops a file into
-// ~/.manta-outbox/ (optionally a session subdir) and we surface it to connected
-// devices as an `agentFile` bus event. Detection is a plain local `readdir`.
+// The box (server IS the box) keeps a durable, workspace-linked mailbox of
+// files the remote AI sends the user. The AI drops a file under
+// ~/.manta-outbox/<sessionID>/ (its opencode session id — the workspace) via
+// the `send_file` tool; a local scanner surfaces it to connected devices as an
+// `agentFile` bus event (the "AI sent you a file" toast). Detection is a plain
+// local `readdir`.
 //
-// IMPORTANT divergence from desktop: on a phone/browser there is no silent
-// "save straight to the user's disk" path — the device must trigger a browser
-// download (httpApi.agentPullFile → GET /api/download). So every detection
-// publishes a CONFIRM toast (autoPulled:false) regardless of allowAgentPush.
-// The actual delete of the remote source happens server-side in
-// /api/download's handler when the device fetches the file (one-shot mailbox),
-// not here — so a file the user never taps stays available across ticks.
+// Durability semantics (reconciled with the old one-shot mailbox):
+//   - WORKSPACE-LINKED: files live in a subdir named by the opencode session
+//     id, so the Artifacts panel shows each conversation only its own files.
+//   - TTL: a file expires `DEFAULT_TTL_MS` (7 days) after it appears and is
+//     swept by `expireArtifacts`. It is NOT deleted on download, so it can be
+//     retrieved any number of times until then — both the artifacts panel's
+//     download (/api/peek) and /api/download leave the source in place.
+//   - The arrival toast (`agentFile`) still fires on new files.
 
-import { readdir, stat } from "node:fs/promises";
+import { readdir, stat, copyFile, mkdir, rm } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { outboxRoot as defaultOutboxRoot } from "../shared/paths.mjs";
 
 const POLL_MS = 3000;
+// Default tenure of a pushed artifact (7 days). Overridable per push via
+// `send_file` ttlHours; `ttlHours === 0` means "never expires".
+export const DEFAULT_TTL_MS = 7 * 24 * 3600 * 1000;
+export const SWEEP_MS = 5 * 60 * 1000;
 
-// List every file in the outbox: loose files at the root plus one level of
-// session subdirs (matches the desktop `find -maxdepth 2 -type f`). Returns []
-// when the outbox doesn't exist yet (the steady state until the AI writes).
-export async function listOutbox(root = defaultOutboxRoot()) {
+function resolveExpiry(ttlHours, mtime) {
+  if (ttlHours === 0) return null;
+  const ttl =
+    typeof ttlHours === "number" && Number.isFinite(ttlHours) && ttlHours > 0
+      ? ttlHours * 3600 * 1000
+      : DEFAULT_TTL_MS;
+  return mtime + ttl;
+}
+
+// List the artifact mailbox. Each row is { path, name, size, sessionID, mtime,
+// expiresAt }. `sessionID` is the subdir name — the workspace the file belongs
+// to — or null for a loose root file (the old bare `cp` flow). When `sessionID`
+// is passed, only that workspace's files are returned (loose root files are
+// not workspace-linked and are omitted).
+export async function listOutbox(root = defaultOutboxRoot(), { sessionID } = {}) {
   const out = [];
   let topEntries;
   try {
     topEntries = await readdir(root, { withFileTypes: true });
   } catch {
-    return out; // ENOENT etc. — outbox not created yet.
+    return out; // ENOENT etc. — mailbox not created yet.
   }
+  const now = Date.now();
   for (const ent of topEntries) {
     const full = join(root, ent.name);
     if (ent.isFile()) {
-      const size = await statSize(full);
-      out.push({ path: full, name: ent.name, size, session: null });
+      if (sessionID != null && sessionID !== "") continue;
+      out.push(await statRow(full, ent.name, null, now));
     } else if (ent.isDirectory()) {
+      if (sessionID != null && ent.name !== sessionID) continue;
       let subEntries;
       try {
         subEntries = await readdir(full, { withFileTypes: true });
@@ -45,33 +64,139 @@ export async function listOutbox(root = defaultOutboxRoot()) {
       }
       for (const sub of subEntries) {
         if (!sub.isFile()) continue;
-        const subFull = join(full, sub.name);
-        const size = await statSize(subFull);
-        out.push({ path: subFull, name: sub.name, size, session: ent.name });
+        out.push(await statRow(join(full, sub.name), sub.name, ent.name, now));
       }
     }
   }
   return out;
 }
 
-async function statSize(path) {
+async function statRow(path, name, sessionID, now) {
   try {
     const st = await stat(path);
-    return st.size;
+    return {
+      path,
+      name,
+      size: st.size,
+      sessionID,
+      mtime: st.mtimeMs,
+      expiresAt: resolveExpiry(null, st.mtimeMs, now),
+    };
+  } catch {
+    return { path, name, size: 0, sessionID, mtime: 0, expiresAt: null };
+  }
+}
+
+// Copy a local file into the workspace-linked mailbox and return its row. The
+// source is NOT removed (the push is a copy; the AI keeps its working copy).
+// Used by the `send_file` tool via POST /api/outbox/push.
+export async function pushArtifact(
+  filePath,
+  sessionID,
+  { root = defaultOutboxRoot(), ttlHours } = {},
+) {
+  if (!sessionID || typeof sessionID !== "string" || !sessionID.trim()) {
+    return { ok: false, error: "sessionID is required" };
+  }
+  let src;
+  try {
+    src = await stat(filePath);
+    if (!src.isFile()) return { ok: false, error: `"${filePath}" is not a regular file` };
+  } catch {
+    return { ok: false, error: `Source file "${filePath}" not found or not readable` };
+  }
+  const safe = basename(filePath).replace(/["\\/]/g, "_");
+  const destDir = join(root, sessionID);
+  await mkdir(destDir, { recursive: true });
+  const dest = join(destDir, safe);
+  await copyFile(filePath, dest);
+  const row = await statRow(dest, safe, sessionID, Date.now());
+  if (ttlHours != null) row.expiresAt = resolveExpiry(ttlHours, row.mtime);
+  return { ok: true, row };
+}
+
+// Remove expired artifacts (TTL past) and prune now-empty session dirs.
+// Injectable now/ttlMs so tests need no timers.
+export async function expireArtifacts(
+  root = defaultOutboxRoot(),
+  { ttlMs = DEFAULT_TTL_MS, now = Date.now() } = {},
+) {
+  let topEntries;
+  try {
+    topEntries = await readdir(root, { withFileTypes: true });
   } catch {
     return 0;
   }
+  let removed = 0;
+  for (const ent of topEntries) {
+    if (!ent.isDirectory()) continue;
+    const full = join(root, ent.name);
+    try {
+      const subs = await readdir(full, { withFileTypes: true });
+      for (const sub of subs) {
+        if (!sub.isFile()) continue;
+        const subFull = join(full, sub.name);
+        let st;
+        try {
+          st = await stat(subFull);
+        } catch {
+          continue;
+        }
+        if (now - st.mtimeMs > ttlMs) {
+          await rm(subFull, { force: true });
+          removed++;
+        }
+      }
+      if ((await readdir(full, { withFileTypes: true })).length === 0) {
+        await rm(full, { recursive: true, force: true });
+      }
+    } catch {
+      /* per-dir best effort */
+    }
+  }
+  return removed;
+}
+
+// Thin poller wiring for the box (mirrors servePage's cleanup sweep).
+export function createArtifactSweep({
+  root = defaultOutboxRoot(),
+  intervalMs = SWEEP_MS,
+  ttlMs = DEFAULT_TTL_MS,
+} = {}) {
+  let timer = null;
+  let running = false;
+  const sweep = async () => {
+    if (running) return;
+    running = true;
+    try {
+      await expireArtifacts(root, { ttlMs });
+    } finally {
+      running = false;
+    }
+  };
+  return {
+    start() {
+      void sweep();
+      timer = setInterval(() => void sweep(), intervalMs);
+      if (timer.unref) timer.unref();
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+    sweep,
+  };
 }
 
 /**
  * Build a single outbox scan step (testable without timers). Returns an async
- * `tick()` that scans the outbox once, publishes one `agentFile` event per
+ * `tick()` that scans the mailbox once, publishes one `agentFile` event per
  * newly-seen file, and reconciles its internal seen-set against the live
- * listing (so a removed/downloaded file drops out and a future same-named push
- * is announced again). Re-entrancy guarded.
+ * listing (so a removed/expired file drops out and a future same-named push is
+ * announced again). Re-entrancy guarded.
  *
  * @param {object} bus  - event bus with .publish({ kind, payload })
- * @param {string} root - outbox dir
+ * @param {string} root - mailbox dir
  * @returns {{ tick: () => Promise<void> }}
  */
 export function createOutboxScanner(bus, root) {
@@ -98,8 +223,8 @@ export function createOutboxScanner(bus, root) {
             remotePath: entry.path,
             name: entry.name || basename(entry.path),
             size: entry.size,
-            sessionName: entry.session,
-            // Always a confirm toast on mobile — no silent disk write to a device.
+            sessionName: entry.sessionID,
+            // Always a confirm toast — no silent disk write to a device.
             autoPulled: false,
           },
         });

--- a/src/server/outbox.test.mjs
+++ b/src/server/outbox.test.mjs
@@ -1,9 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { listOutbox, createOutboxScanner } from "./outbox.mjs";
+import { listOutbox, createOutboxScanner, pushArtifact, expireArtifacts } from "./outbox.mjs";
 
 async function makeOutbox() {
   return mkdtemp(join(tmpdir(), "manta-outbox-test-"));
@@ -18,7 +18,7 @@ test("listOutbox returns [] when the dir doesn't exist", async () => {
   assert.deepEqual(entries, []);
 });
 
-test("listOutbox lists loose files at the root with size + null session", async () => {
+test("listOutbox lists loose files at the root with size + null sessionID", async () => {
   const root = await makeOutbox();
   try {
     await writeFile(join(root, "report.pdf"), "hello");
@@ -26,26 +26,45 @@ test("listOutbox lists loose files at the root with size + null session", async 
     assert.equal(entries.length, 1);
     assert.equal(entries[0].name, "report.pdf");
     assert.equal(entries[0].size, 5);
-    assert.equal(entries[0].session, null);
+    assert.equal(entries[0].sessionID, null);
     assert.equal(entries[0].path, join(root, "report.pdf"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("listOutbox lists files one level deep with their session label", async () => {
+test("listOutbox scopes to a sessionID and omits loose root files", async () => {
   const root = await makeOutbox();
   try {
-    await mkdir(join(root, "myproj"));
-    await writeFile(join(root, "myproj", "out.txt"), "abc");
-    const entries = await listOutbox(root);
-    assert.equal(entries.length, 1);
-    assert.equal(entries[0].name, "out.txt");
-    assert.equal(entries[0].session, "myproj");
+    await writeFile(join(root, "loose.txt"), "x");
+    await mkdir(join(root, "ses_a"));
+    await writeFile(join(root, "ses_a", "mine.txt"), "ab");
+    await mkdir(join(root, "ses_b"));
+    await writeFile(join(root, "ses_b", "theirs.txt"), "cd");
+    const mine = await listOutbox(root, { sessionID: "ses_a" });
+    assert.equal(mine.length, 1);
+    assert.equal(mine[0].name, "mine.txt");
+    assert.equal(mine[0].sessionID, "ses_a");
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("listOutbox reports mtime + a 7-day expiresAt per file", async () => {
+  const root = await makeOutbox();
+  try {
+    await mkdir(join(root, "ses_a"));
+    await writeFile(join(root, "ses_a", "sub.txt"), "def");
+    const entries = await listOutbox(root);
+    assert.equal(entries.length, 1);
+    assert.equal(typeof entries[0].mtime, "number");
+    assert.ok(entries[0].mtime > 0);
+    assert.equal(entries[0].expiresAt, entries[0].mtime + 7 * 24 * 3600 * 1000);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 
 test("listOutbox does NOT descend past one subdir level", async () => {
   const root = await makeOutbox();
@@ -125,3 +144,66 @@ test("scanner re-announces a same-named file after the prior one is removed", as
     await rm(root, { recursive: true, force: true });
   }
 });
+
+// pushArtifact — copies a source file into the workspace-linked mailbox
+test("pushArtifact copies the file under <sessionID>/ and returns its row", async () => {
+  const root = await makeOutbox();
+  const src = join(root, "..", "src-report.csv");
+  await writeFile(src, "a;b\n1;2\n");
+  try {
+    const res = await pushArtifact(src, "ses_abc", { root });
+    assert.equal(res.ok, true);
+    assert.equal(res.row.name, "src-report.csv");
+    assert.equal(res.row.sessionID, "ses_abc");
+    assert.ok(res.row.path.includes(join("ses_abc", "src-report.csv")));
+    assert.equal(typeof res.row.size, "number");
+    assert.equal(typeof res.row.expiresAt, "number");
+    // the source is kept, and a copy landed in the mailbox
+    const listed = await listOutbox(root, { sessionID: "ses_abc" });
+    assert.equal(listed.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});
+
+test("pushArtifact rejects a missing file and a blank sessionID", async () => {
+  const root = await makeOutbox();
+  try {
+    const missing = await pushArtifact(join(root, "nope.txt"), "ses_a", { root });
+    assert.equal(missing.ok, false);
+    const noblank = await pushArtifact(join(root, "nope.txt"), "  ", { root });
+    assert.equal(noblank.ok, false);
+    assert.equal(noblank.error, "sessionID is required");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// expireArtifacts — TTL sweep removes expired files + prunes empty dirs
+test("expireArtifacts removes files past TTL and prunes empty session dirs", async () => {
+  const root = await makeOutbox();
+  const ttl = 1000;
+  try {
+    await mkdir(join(root, "ses_a"));
+    await mkdir(join(root, "ses_b"));
+    await writeFile(join(root, "ses_a", "old.txt"), "x");
+    await writeFile(join(root, "ses_a", "fresh.txt"), "y");
+    await writeFile(join(root, "ses_b", "oldtoo.txt"), "z");
+    const now = Date.now();
+    // age `old.txt` beyond TTL by backdating its mtime
+    await touchMtime(join(root, "ses_a", "old.txt"), now - ttl - 1000);
+    await touchMtime(join(root, "ses_b", "oldtoo.txt"), now - ttl - 1000);
+    const removed = await expireArtifacts(root, { ttlMs: ttl, now });
+    assert.equal(removed, 2);
+    const remaining = await listOutbox(root);
+    const names = remaining.map((e) => e.name);
+    assert.deepEqual(names, ["fresh.txt"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function touchMtime(p, ms) {
+  await utimes(p, new Date(ms), new Date(ms));
+}

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -11,7 +11,7 @@ import { expandTilde } from "../shared/paths.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob } from "./schedule.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
 import { listPages as servePageListStore } from "./servePage.mjs";
-import { publicBaseUrl } from "./gatewayRegister.mjs";
+import { listOutbox } from "./outbox.mjs";import { publicBaseUrl } from "./gatewayRegister.mjs";
 import {
   listSecrets as secretsListStore,
   setSecret as secretsSetStore,
@@ -864,6 +864,18 @@ export function buildHandlers({
     // reads ~/.manta/auth.json fresh per call, so the list's `url` fields stay
     // correct even if the box's gateway host was provisioned after boot.
     "serve-page:list": async () => servePageListStore({ baseUrl: publicBaseUrl() }),
+
+    // Read-only live listing of the box's outbox (~/.manta-outbox) scoped to
+    // the given opencode session, so the artifacts panel's Files tab shows
+    // only the active conversation's agent-pushed files alongside user
+    // uploads. No write counterpart here — files land via the `send_file` tool
+    // (POST /api/outbox/push — see index.mjs). Non-destructive: entries expire
+    // via the box's TTL sweep, not on download.
+    "outbox:list": async (sessionId) => {
+      const list = await listOutbox();
+      const sid = typeof sessionId === "string" && sessionId ? sessionId : null;
+      return sid ? list.filter((r) => r.sessionID === sid) : list;
+    },
 
     // ---- APNs native-push registration (BET-181) ----
     // iOS Capacitor app registers its APNs device token via the renderer-side

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -24,6 +24,7 @@ import type {
   SecretInput,
   ServerUpdateAvailablePayload,
   ServedPageMeta,
+  OutboxFile,
   WebhookMeta,
   SpawnOptions,
   PtyEvent,
@@ -302,6 +303,13 @@ export interface Api {
   // published/stopped by the AI's `serve_page`/`stop_page` opencode tools, not
   // through any UI channel.
   servePageList(): Promise<ServedPageMeta[]>;
+
+  // Returns the box's outbox (~/.manta-outbox) entries — files the AI dropped
+  // for the user to retrieve — so the artifacts panel's Files tab can show
+  // agent-pushed files alongside user uploads, scoped to `sessionId` (the
+  // workspace). Read-only; entries carry an `expiresAt` TTL and are only
+  // removed by the box's expiry sweep, never by a download.
+  outboxList(sessionId?: string): Promise<OutboxFile[]>;
 
   // Background delegation jobs (manta-server owned). list returns the full
   // job records (filtered by parent session when sessionId is passed; all

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -758,6 +758,14 @@ export const IPC = {
   // (httpApi); a read has no server write counterpart.
   servePageList: "serve-page:list", // () → ServedPageMeta[]
 
+  // Registry of the box's ~/.manta-outbox mailbox (files the AI dropped for
+  // the user to retrieve). Read-only, used by the artifacts panel's Files tab
+  // so agent-pushed files show up alongside user uploads. The source file is
+  // removed on download (one-shot mailbox), so an entry can drop out on its
+  // own. Mirrors src/shared/types.ts OutboxFile / src/server/outbox.mjs
+  // listOutbox rows.
+  outboxList: "outbox:list", // () → OutboxFile[]
+
   // ---- background delegation jobs (manta-server owned) ----
   // Background jobs are started by the AI's global `delegate` opencode tool
   // (POST /api/delegate); the UI only LISTS / STOPS / DELETES via these
@@ -943,6 +951,21 @@ export type ServedPageMeta = {
   expiresAt: number | null;
   createdAt: number;
   sessionID: string | null;
+};
+
+// One entry in ~/.manta-outbox (the mailbox the AI drops files into for the
+// user to retrieve, surfaced by the artifacts panel's Files tab). Mirrors
+// src/server/outbox.mjs `listOutbox` rows. `sessionID` is the workspace the
+// file belongs to (the subdir name = the opencode session that pushed it);
+// `expiresAt` is its TTL (mtime + TTL, default 7 days) — files are NOT deleted
+// on download, only swept once the TTL elapses.
+export type OutboxFile = {
+  path: string;
+  name: string;
+  size: number;
+  sessionID: string | null;
+  mtime: number;
+  expiresAt: number | null;
 };
 
 // Input shape for secretsSet (UI → store). The value travels renderer → IPC →


### PR DESCRIPTION
Reconcile the outbox with artifacts: agent-sent files are now a **durable, workspace-linked, TTL'd store** shown in the Files tab — not a one-shot mailbox. Supersedes #612 (closed) and reuses its RPC/panel/derivation wiring.

**Server (the box owns the store)**
- `outbox.mjs`: files live under `~/.manta-outbox/<sessionID>/` (the workspace = the opencode session that pushed them). `listOutbox` is session-scoped and returns `expiresAt` (default **7-day TTL**). New `pushArtifact` (copy a source file in + return its row) and `expireArtifacts` / `createArtifactSweep` (expiry sweep, mirrors serve-page).
- `index.mjs`: `POST /api/outbox/push`; `/api/download` is now **non-destructive** (files kept until the TTL sweep); artifact sweep started every 5 min.
- `outbox:list` RPC scoped to the opencode session; types/api/httpApi carry `sessionID` + `expiresAt`.

**Renderer**
- `artifacts.ts`: outbox rows → session-filtered `file` artifacts (origin agent) carrying `expiresAt`.
- Panel: fetches `outboxList(sessionId)` on open + 30s poll; Files rows render live/soon/expired pills; download stays non-destructive (already via `/api/peek`).

**Tool + docs**
- New `send_file` opencode tool (`context.sessionID` → `POST /api/outbox/push`), mirroring `serve_page`.
- AGENTS.md + command + opencode-tools guide updated.

**Reconciliation summary:** user decides TTL (default 7d), files re-downloadable until then, workspace-linked per conversation, arrival toast preserved, user uploads still in Files.

Tests green locally (2170 renderer + server, duplication gate PASS).
