### PR TITLE
feat(ios): scroll-to-bottom control aligned with model chip, round + smaller

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -88,10 +88,10 @@ private struct ChatScreenContent: View {
         autoScrollsToBottomOnAppend: true,
         scrollsToBottomOnReplace: true
     )
-    /// Whether the transcript has been scrolled up far enough that the
-    /// "scroll to bottom" chip should float, bottom-trailing, over it. Driven
-    /// purely by scroll geometry (see `transcript`); it does not touch
-    /// auto-follow, which stays constant so new messages pin smoothly.
+    /// Whether the transcript has been scrolled up far enough that the round
+    /// "scroll to bottom" control (rendered in ComposerView's model-selection
+    /// row) should be shown. Driven purely by scroll geometry; it does not
+    /// touch auto-follow, which stays constant so new messages pin smoothly.
     @State private var showScrollToBottom = false
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
@@ -205,7 +205,12 @@ private struct ChatScreenContent: View {
                     projectName: projectName,
                     api: MantaAPIClient.live(),
                     store: store,
-                    modelStore: modelStore
+                    modelStore: modelStore,
+                    showScrollToBottom: showScrollToBottom,
+                    onScrollToBottom: {
+                        scrollPosition.scrollTo(edge: .bottom, animated: true)
+                        showScrollToBottom = false
+                    }
                 )
             }
         }
@@ -457,9 +462,10 @@ private struct ChatScreenContent: View {
         .typingIndicator(.indicator(isVisible: store.running) {
             RunningIndicator(store: store)
         })
-        // The floating "scroll to bottom" control. It appears only once the
-        // user has scrolled up (pointsFromBottom above the threshold) — at the
-        // bottom there is nowhere to return to, so the button would be noise.
+        // The "scroll to bottom" control (rendered in ComposerView's
+        // model-selection row). It shows only once the user has scrolled up
+        // (pointsFromBottom above the threshold) — at the bottom there is
+        // nowhere to return to, so the button would be noise.
         //
         // Auto-follow is left constant (see init) so new messages pin to the
         // newest turn smoothly. It must NOT be toggled from this geometry
@@ -481,43 +487,11 @@ private struct ChatScreenContent: View {
         // A tap on the transcript lowers the keyboard. (TiledView handles the
         // scroll-driven interactive keyboard dismiss itself.)
         .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
-        .overlay(alignment: .bottomTrailing) {
-            if showScrollToBottom { scrollToBottomButton }
-        }
     }
-
     /// How far above the bottom the user must scroll for the down-arrow to
     /// appear. Same magnitude MessagingUI uses internally for its own "near
     /// bottom" checks.
     private static let scrollToBottomThreshold: CGFloat = 100
-
-    /// The small glass "scroll to bottom" chip, bottom-TRAILING over the
-    /// transcript. Sized to match the model-selection chip (same glass capsule,
-    /// same padding), not the 38pt header buttons — it is a secondary affordance
-    /// that must not compete with the composer controls.
-    ///
-    /// Tapping it returns to the newest message. Only ever rendered while
-    /// `showScrollToBottom` is true, so it floats only when the user has
-    /// actually scrolled up.
-    @ViewBuilder
-    private var scrollToBottomButton: some View {
-        Button {
-            scrollPosition.scrollTo(edge: .bottom, animated: true)
-            showScrollToBottom = false
-        } label: {
-            Image(systemName: "arrow.down")
-                .font(.system(size: Metrics.type.xs, weight: .semibold))
-                .foregroundColor(tokens.tx1)
-                .padding(.horizontal, Metrics.spacing.sp2)
-                .padding(.vertical, Metrics.spacing.sp1)
-        }
-        .buttonStyle(.glass)
-        .clipShape(.capsule)
-        .accessibilityLabel("Scroll to bottom")
-        .padding(.bottom, Metrics.spacing.sp4)
-        .padding(.trailing, Metrics.spacing.sp3)
-        .shadow(color: .black.opacity(0.12), radius: Metrics.spacing.sp2, y: Metrics.spacing.sp1)
-    }
 
     /// Lower the keyboard by asking whoever holds first responder to give it
     /// up. The composer's focus binding lives inside ComposerView, and routing

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -42,6 +42,11 @@ struct ComposerView: View {
     let api: MantaAPIClient
     @ObservedObject var store: ChatSessionStore
     @ObservedObject var modelStore: ChatModelStore
+    /// Whether the transcript is scrolled up far enough that the round
+    /// "scroll to bottom" control — in the model-selection row — should show.
+    var showScrollToBottom: Bool = false
+    /// Tapped → scroll the transcript to the newest message.
+    var onScrollToBottom: (() -> Void)? = nil
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var text = ""
@@ -81,10 +86,15 @@ struct ComposerView: View {
             // exactly how attaching a file came to do nothing at all.
             pickerAnchor
             expandAnchor
-            // Model chip sits above the input box on its own row.
+            // Model chip sits above the input box on its own row, with the
+            // round scroll-to-bottom control TRAILING in the same row so the
+            // two read as one aligned line of secondary chrome.
             HStack(spacing: Metrics.spacing.sp1) {
                 modelPill
                 Spacer(minLength: 0)
+                if showScrollToBottom {
+                    scrollToBottomChip
+                }
             }
             inputBox
         }
@@ -436,6 +446,32 @@ struct ComposerView: View {
         .accessibilityLabel("Model picker")
         .accessibilityIdentifier("model-picker")
     }
+
+    // MARK: - Scroll to bottom
+
+    /// The round glass "scroll to bottom" control, trailing in the
+    /// model-selection row so it is aligned with the chip. Round and sized to
+    /// the chip's height (not the 38pt header buttons) — it is a secondary
+    /// affordance that must not compete with the composer controls.
+    private var scrollToBottomChip: some View {
+        Button {
+            onScrollToBottom?()
+        } label: {
+            Image(systemName: "arrow.down")
+                .font(.system(size: Metrics.type.xs, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+                .frame(width: Self.scrollChipDiameter, height: Self.scrollChipDiameter)
+        }
+        .buttonStyle(.glass)
+        .clipShape(.circle)
+        .accessibilityLabel("Scroll to bottom")
+    }
+
+    /// Diameter of the round scroll control — the model chip's height (one
+    /// line of its small text plus its vertical padding), so chip and control
+    /// read as one aligned row.
+    private static let scrollChipDiameter: CGFloat =
+        UIFont.systemFont(ofSize: Metrics.type.small).lineHeight + Metrics.spacing.sp1 * 2
 
     // MARK: - Attach
 


### PR DESCRIPTION
## Change
The scroll-to-bottom control is no longer a floating overlay. It now lives in **ComposerView's model-selection row** (trailing side), so it is literally **aligned with the model chip**. It is a **small round glass button** sized to the chip's height (not the 38pt header buttons), using the same glass circle treatment as the chip.

ChatScreen still drives visibility from scroll geometry and the scroll-to-bottom action via new `showScrollToBottom` / `onScrollToBottom` props. Auto-follow stays constant (no up/down jump from the previous fix).

No web/renderer changes.