### PR TITLE
fix(artifacts): jump-to-message, image-tile actions, file label, link chip

### DIFF
--- a/docs/screens/artifacts/mockup.html
+++ b/docs/screens/artifacts/mockup.html
@@ -382,7 +382,7 @@
           <div class="fic"><svg viewBox="0 0 24 24" stroke="var(--ok)"><path d="M14 3H7a2 2 0 00-2 2v14a2 2 0 002 2h10a2 2 0 002-2V8z"/><path d="M14 3v5h5"/></svg></div>
           <div class="fmeta">
             <div class="fname">cohort-analysis.csv</div>
-            <div class="fsub"><svg class="dirglyph down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></svg><span>842 KB · generated</span></div>
+            <div class="fsub"><svg class="dirglyph down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></svg><span>842 KB</span></div>
           </div>
         </div>
 
@@ -400,7 +400,7 @@
           <div class="fic"><svg viewBox="0 0 24 24" stroke="var(--danger)"><path d="M14 3H7a2 2 0 00-2 2v14a2 2 0 002 2h10a2 2 0 002-2V8z"/><path d="M14 3v5h5"/></svg></div>
           <div class="fmeta">
             <div class="fname">retention-report.pdf</div>
-            <div class="fsub"><svg class="dirglyph down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></svg><span>1.1 MB · generated</span></div>
+            <div class="fsub"><svg class="dirglyph down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></svg><span>1.1 MB</span></div>
           </div>
         </div>
 
@@ -408,7 +408,7 @@
           <div class="fic"><svg viewBox="0 0 24 24" stroke="var(--accent)"><path d="M14 3H7a2 2 0 00-2 2v14a2 2 0 002 2h10a2 2 0 002-2V8z"/><path d="M14 3v5h5"/></svg></div>
           <div class="fmeta">
             <div class="fname">migration-notes.md</div>
-            <div class="fsub"><svg class="dirglyph down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></svg><span>12 KB · generated</span></div>
+            <div class="fsub"><svg class="dirglyph down" viewBox="0 0 24 24"><path d="M12 5v14M5 12l7 7 7-7"/></svg><span>12 KB</span></div>
           </div>
         </div>
       </div>

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -170,7 +170,7 @@ function ActionButton({
       title={title}
       onClick={onClick}
       disabled={disabled}
-      className="flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-fill-hover hover:text-text disabled:pointer-events-none disabled:opacity-40"
+      className="pointer-events-auto flex h-6 w-6 items-center justify-center rounded-sm text-text-muted hover:bg-fill-hover hover:text-text disabled:pointer-events-none disabled:opacity-40"
     >
       {icon}
     </button>
@@ -228,9 +228,9 @@ function LinkCard({
   onOpen: (el: HTMLElement) => void;
   onJump: () => void;
 }) {
-  const state = pageState(artifact.expiresAt, now);
+  const state = artifact.expiresAt != null ? pageState(artifact.expiresAt, now) : null;
   const expired = state === "expired";
-  const isHosted = artifact.expiresAt != null;
+  const isHosted = artifact.isHosted ?? false;
   const hasContext = artifact.context != null;
 
   return (
@@ -259,13 +259,21 @@ function LinkCard({
             <span className="min-w-0 truncate text-meta font-semibold text-text">
               {artifact.label}
             </span>
-            {isHosted &&
-              state != null && (
-                <ExpiryPill
-                  state={state}
-                  label={state === "expired" ? "expired" : expiryLabel(artifact.expiresAt, now)}
-                />
-              )}
+            {/* Expiry chip — present on every hosted page (serve_page), incl. a
+                no-expiry one, so it is never hidden by a long title; the label
+                truncates above. External/pasted links never get a chip. */}
+            {isHosted && (
+              <ExpiryPill
+                state={state ?? "live"}
+                label={
+                  state === "expired"
+                    ? "expired"
+                    : artifact.expiresAt != null
+                      ? expiryLabel(artifact.expiresAt, now)
+                      : "no expiry"
+                }
+              />
+            )}
           </div>
           <div className="mt-1 truncate font-mono text-micro text-text-quiet">
             {artifact.kind === "link" ? artifact.href.replace(/^https?:\/\//, "") : artifact.href}
@@ -381,9 +389,11 @@ function FileRow({
           <DirectionGlyph origin={artifact.origin} />
           <span>
             {size != null && formatBytes(size)}
-            {size != null && " · "}
-            {artifact.origin === "user" ? "you sent this" : "generated"}
+            {size != null && artifact.origin === "user" && " · "}
+            {artifact.origin === "user" && "you sent this"}
           </span>
+          {/* Outbox files carry a TTL and are swept (not deleted) on download,
+              so they render a live/soon/expired pill just like hosted pages. */}
           {expiry && artifact.expiresAt != null && (
             <ExpiryPill
               state={expiry}

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -131,6 +131,28 @@ describe("deriveArtifacts", () => {
     expect(new Set(out.map((a) => a.id)).size).toBe(2);
   });
 
+  it("file part carries its owning message id (jump target)", () => {
+    const messages = [msg("u", "user", [filePart()])];
+    const out = deriveArtifacts(messages, [], "ses_a");
+    expect(out[0].messageId).toBe("u");
+  });
+
+  it("a pasted user link carries its owning message id, and is not hosted", () => {
+    const messages = [msg("u", "user", [textPart("see https://example.com/x")])];
+    const out = deriveArtifacts(messages, [], "ses_a");
+    expect(out[0].kind).toBe("link");
+    expect(out[0].messageId).toBe("u");
+    expect(out[0].isHosted).toBeFalsy();
+  });
+
+  it("a hosted page artifact is flagged isHosted (chip always present)", () => {
+    const pages = [
+      page({ subdomain: "preview", url: "https://box/pages/preview", sessionID: "ses_a", createdAt: 100 }),
+    ];
+    const out = deriveArtifacts([], pages, "ses_a");
+    expect(out[0].isHosted).toBe(true);
+  });
+
   it("assistant text part with a URL → NO artifact", () => {
     const messages = [msg("a", "assistant", [textPart("docs at https://example.com/docs")])];
     expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -13,9 +13,13 @@ export type Artifact = {
   mime: string | null; // null for links
   size: number | null; // byte size for files/images when known (formatBytes), null otherwise
   at: number; // epoch ms, for sorting and day grouping
-  messageId: string | null; // null for pages with no matching message
+  messageId: string | null; // owning message; null for outbox files / pages with no announcing message
   context: string | null; // surrounding message text, links only
   expiresAt: number | null; // hosted pages only; null otherwise
+  // True only for pages the agent published (serve_page). Distinct from
+  // `expiresAt` so a hosted page with no expiry (ttlHours:0) still gets the
+  // expiry chip — external/pasted links never do.
+  isHosted?: boolean;
 };
 
 const URL_RE = /https?:\/\/[^\s<>]+/g;
@@ -65,7 +69,7 @@ function deriveFileArtifact(msg: OpencodeMessage, part: OpencodePart): Artifact 
     mime,
     size: typeof part.size === "number" ? part.size : null,
     at: messageCreated(msg),
-    messageId: null,
+    messageId: msg.info.id,
     context: null,
     expiresAt: null,
   };
@@ -89,7 +93,7 @@ function deriveLinkArtifact(msg: OpencodeMessage, part: OpencodePart, url: strin
     mime: null,
     size: null,
     at: messageCreated(msg),
-    messageId: null,
+    messageId: msg.info.id,
     context: linkContext(part.text ?? "", url),
     expiresAt: null,
   };
@@ -160,6 +164,7 @@ function derivePageArtifact(page: ServedPageMeta, matched: OpencodeMessage | nul
     messageId: matched ? matched.info.id : null,
     context: matched ? collapseAndTrim(messageText(matched)) : null,
     expiresAt: page.expiresAt,
+    isHosted: true,
   };
 }
 


### PR DESCRIPTION
Fixes four artifacts-panel issues found in live testing.

1. **Jump to message didn't work** — most artifacts carried `messageId: null`, so the chevron was disabled (and hosted pages only had it when the announcing message echoed the URL). Now user uploads (file parts) and pasted links carry their owning message id, so jumping scrolls + flashes the source message. Outbox files stay null (no owning message). The scroll/flash path (ChatPanel `manta-scroll-to-message` listener + `data-message-id`) already existed and is unchanged.

2. **Image tile attach/download/jump were dead** — the tile's hover scrim is `pointer-events-none` and wrapped the buttons, swallowing every click. `ActionButton` now sets `pointer-events-auto`, unlocking the tile actions. (The opened-preview header buttons were already correctly wired.)

3. **Files tab** — dropped the "· generated" label on agent-pushed rows (keep "· you sent this" for uploads). Mockup updated to match.

4. **Links chip** — now based on a new `isHosted` flag instead of `expiresAt != null`, so every hosted page always shows the expiry pill (incl. a "no expiry" pill for `ttl:0`), never hidden by a long title (label truncates, pill is `shrink-0`). External/pasted links still get no chip.

Tests added for messageId (file + link), isHosted (page true / link falsy).
