### PR TITLE
fix(artifacts): download/attach self-contained (data URI) artifacts

### DIFF
--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -37,21 +37,55 @@ import {
   type ArtifactKind,
   type ArtifactOrigin,
 } from "./artifacts";
-import { expiryLabel, formatBytes, resolvePreviewType } from "./chatUtils";
+import { decodeDataUri, expiryLabel, formatBytes, resolvePreviewType } from "./chatUtils";
 import { IconButton } from "./IconButton";
 import { ArtifactPreview } from "./ArtifactPreview";
 import { authHeaders, clientToken, serverBase } from "./api/httpApi";
 
-// Download an artifact to the user's machine. Read-only: fetches the bytes
-// from /api/peek (no source deletion — unlike the outbox /api/download path)
-// and hands a blob: URL to a synthetic <a download>, the same save pattern
-// httpApi's agentPullFile uses. BET-660's rows reuse this; do not reimplement.
+// Resolve an artifact's bytes to a Blob. An artifact's `href` is not always a
+// box filesystem path: a self-contained image part carries a `data:` URI (its
+// bytes are IN the href — no network), and a remote URL is a public resource.
+// Only an absolute box path can be streamed through /api/peek.
+async function artifactToBlob(artifact: Artifact): Promise<Blob | null> {
+  const href = artifact.href;
+  if (href.startsWith("data:")) {
+    const decoded = decodeDataUri(href);
+    if (!decoded) return null;
+    const ab = decoded.data.buffer.slice(
+      decoded.data.byteOffset,
+      decoded.data.byteOffset + decoded.data.byteLength,
+    ) as ArrayBuffer;
+    return new Blob([ab], { type: decoded.mime });
+  }
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    // Remote/private URL — fetch without the box token (it is not a box
+    // resource). Non-ok or cross-origin-refused → null (caller bails).
+    try {
+      const res = await fetch(href);
+      return res.ok ? res.blob() : null;
+    } catch {
+      return null;
+    }
+  }
+  // Absolute box path → stream via /api/peek (non-destructive).
+  try {
+    const url = `${serverBase()}/api/peek?path=${encodeURIComponent(href)}`;
+    const res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
+    return res.ok ? res.blob() : null;
+  } catch {
+    return null;
+  }
+}
+
+// Download an artifact to the user's machine. Read-only: resolves the bytes
+// (data URI / remote URL / box path via /api/peek — no source deletion, unlike
+// the outbox /api/download path) and hands a blob: URL to a synthetic <a
+// download>, the same save pattern httpApi's agentPullFile uses. BET-660's
+// rows reuse this; do not reimplement.
 export async function downloadArtifact(artifact: Artifact): Promise<void> {
   try {
-    const url = `${serverBase()}/api/peek?path=${encodeURIComponent(artifact.href)}`;
-    const res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
-    if (!res.ok) return;
-    const blob = await res.blob();
+    const blob = await artifactToBlob(artifact);
+    if (!blob) return;
     const objectUrl = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = objectUrl;
@@ -66,16 +100,14 @@ export async function downloadArtifact(artifact: Artifact): Promise<void> {
   }
 }
 
-// Re-attach an artifact into the session's composer. Fetches the bytes and
+// Re-attach an artifact into the session's composer. Resolves the bytes and
 // hands a File to the existing `manta-attach-files` bridge, which renders the
 // uploading→ready chip and converts it into a FilePart on submit — the same
 // pipeline as every other attach. BET-660's rows reuse this; do not reimplement.
 export async function attachArtifact(artifact: Artifact, sessionId: string): Promise<void> {
   try {
-    const url = `${serverBase()}/api/peek?path=${encodeURIComponent(artifact.href)}`;
-    const res = await fetch(url, { method: "GET", headers: authHeaders(clientToken()) });
-    if (!res.ok) return;
-    const blob = await res.blob();
+    const blob = await artifactToBlob(artifact);
+    if (!blob) return;
     const file = new File([blob], artifact.label, {
       type: artifact.mime ?? "application/octet-stream",
     });

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -84,6 +84,7 @@ import {
   countPreviewLines,
   previewLanguage,
   previewOriginWord,
+  decodeDataUri,
 } from "./chatUtils";
 
 import type { OpencodeModel } from "../shared/types";
@@ -2968,5 +2969,26 @@ describe("artifact preview footer + metadata (BET-661)", () => {
   it("origin word matches the file rows", () => {
     expect(previewOriginWord("user")).toBe("you sent this");
     expect(previewOriginWord("agent")).toBe("generated");
+  });
+});
+
+describe("decodeDataUri", () => {
+  it("decodes a base64 data URI into its mime + bytes", () => {
+    const r = decodeDataUri("data:image/png;base64,aGk="); // base64("hi")
+    expect(r).not.toBeNull();
+    expect(r!.mime).toBe("image/png");
+    expect(Array.from(r!.data)).toEqual([0x68, 0x69]); // "hi"
+  });
+  it("decodes a url-encoded (non-base64) data URI", () => {
+    const r = decodeDataUri("data:text/plain,hello%20world");
+    expect(r!.mime).toBe("text/plain");
+    expect(Array.from(r!.data)).toEqual(Array.from(new TextEncoder().encode("hello world")));
+  });
+  it("returns null for a non-data URI", () => {
+    expect(decodeDataUri("/home/dev/shot.png")).toBeNull();
+    expect(decodeDataUri("https://example.com/x.png")).toBeNull();
+  });
+  it("returns null for a malformed data URI", () => {
+    expect(decodeDataUri("data:image/png")).toBeNull();
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -206,6 +206,29 @@ export function formatBytes(n: number): string {
   return `${val < 10 ? val.toFixed(1).replace(/\.0$/, "") : Math.round(val)} ${units[i]}`;
 }
 
+// Decode a `data:<mime>;base64,<payload>` (or url-encoded) URI into its MIME
+// type and raw bytes. Used by the artifacts panel so a self-contained inline
+// image (href is a data URI, not a box path) can be downloaded/attached
+// without a network round-trip. Returns null for anything that isn't a data
+// URI. `atob` / `TextEncoder` are global in the browser and Node 16+.
+export function decodeDataUri(dataUri: string): { mime: string; data: Uint8Array } | null {
+  if (!dataUri.startsWith("data:")) return null;
+  const comma = dataUri.indexOf(",");
+  if (comma < 0) return null;
+  const meta = dataUri.slice(5, comma);
+  const mime = /^[^;]+/.exec(meta)?.[0] ?? "application/octet-stream";
+  const payload = dataUri.slice(comma + 1);
+  let data: Uint8Array;
+  if (meta.includes(";base64")) {
+    const bin = atob(payload);
+    data = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) data[i] = bin.charCodeAt(i);
+  } else {
+    data = new TextEncoder().encode(decodeURIComponent(payload));
+  }
+  return { mime, data };
+}
+
 // Short expiry label for a hosted-page state pill: "23h" / "2h" for live/soon
 // pages (whole hours, floor at 1 so a fresh page never reads "0h"), "" for an
 // expired or unexpiring artifact (the pill is omitted entirely then).


### PR DESCRIPTION
Fixes download & attach from the artifacts panel for self-contained images.

**Root cause:** the failing request was `GET /api/peek?path=<huge-base64>` — the image's `href` was a **data URI** (its bytes inline in the URL), but `downloadArtifact`/`attachArtifact` blindly sent it as a filesystem `path=` to `/api/peek`, which expects a box path. That produced the malformed oversized URL (HTTP2 protocol error) and the cross-origin-looking failure. CORS itself is server-side for all routes.

**Fix:** a new `artifactToBlob` resolves bytes by href shape —
- `data:` URI → decoded locally to a Blob (no network);
- `http(s):` → plain fetch (no box token — external resource);
- absolute box path → `/api/peek` (non-destructive, unchanged).

`downloadArtifact` and `attachArtifact` both use it.

`decodeDataUri` (pure, in `chatUtils.ts`) parses base64 + url-encoded data URIs; unit-tested (base64 / url-encoded / non-data / malformed).

Green: typecheck, full suite, duplication gate.
