### PR TITLE
fix(artifacts): show expiry chip next to the file name (like links)

### DIFF
--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -288,7 +288,7 @@ function LinkCard({
               ellipsis when tight; the pill is a shrink-0 sibling so name and
               expiry never wrap to a second line. */}
           <div className="flex min-w-0 items-center gap-1">
-            <span className="min-w-0 truncate text-meta font-semibold text-text">
+            <span className="min-w-0 flex-1 truncate text-meta font-semibold text-text">
               {artifact.label}
             </span>
             {/* Expiry chip — present on every hosted page (serve_page), incl. a
@@ -420,7 +420,7 @@ function FileRow({
             an ellipsis when tight; the chip is a shrink-0 sibling so outbox
             files show their TTL next to the name, never wrapped. */}
         <div className="flex min-w-0 items-center gap-1">
-          <span className="min-w-0 truncate font-mono text-meta text-text">{artifact.label}</span>
+          <span className="min-w-0 flex-1 truncate font-mono text-meta text-text">{artifact.label}</span>
           {expiry && artifact.expiresAt != null && (
             <ExpiryPill
               state={expiry}

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -416,7 +416,18 @@ function FileRow({
         <FileText className={`h-3.5 w-3.5 ${fileGlyphTone(artifact.mime)}`} style={{ strokeWidth: 1.7 }} />
       </button>
       <button type="button" onClick={(e) => onOpen(e.currentTarget)} className="min-w-0 flex-1 text-left">
-        <div className="truncate font-mono text-meta text-text">{artifact.label}</div>
+        {/* Name + expiry chip on ONE line, like links: the label truncates with
+            an ellipsis when tight; the chip is a shrink-0 sibling so outbox
+            files show their TTL next to the name, never wrapped. */}
+        <div className="flex min-w-0 items-center gap-1">
+          <span className="min-w-0 truncate font-mono text-meta text-text">{artifact.label}</span>
+          {expiry && artifact.expiresAt != null && (
+            <ExpiryPill
+              state={expiry}
+              label={expiry === "expired" ? "expired" : expiryLabel(artifact.expiresAt, now)}
+            />
+          )}
+        </div>
         <div className="mt-px flex items-center gap-[5px] text-micro text-text-quiet">
           <DirectionGlyph origin={artifact.origin} />
           <span>
@@ -424,14 +435,6 @@ function FileRow({
             {size != null && artifact.origin === "user" && " · "}
             {artifact.origin === "user" && "you sent this"}
           </span>
-          {/* Outbox files carry a TTL and are swept (not deleted) on download,
-              so they render a live/soon/expired pill just like hosted pages. */}
-          {expiry && artifact.expiresAt != null && (
-            <ExpiryPill
-              state={expiry}
-              label={expiry === "expired" ? "expired" : expiryLabel(artifact.expiresAt, now)}
-            />
-          )}
         </div>
       </button>
       <div className="flex flex-none gap-px opacity-0 transition-opacity group-hover:opacity-100">


### PR DESCRIPTION
Move the outbox file's expiry chip onto the **file name line**, matching how links show theirs — instead of in the size/origin sub-line.

- Name row becomes `flex min-w-0 items-center gap-1`: label truncates with an ellipsis when tight; the chip is a `shrink-0` sibling so it shows next to the name and never wraps/hides.
- Removed the chip from the sub-line.

Green: typecheck, full suite, duplication gate.
