### PR TITLE
fix(ios): make BottomBarHeightKey defaultValue concurrency-safe

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -67,7 +67,9 @@ struct ChatScreen: View {
 /// Carries the floating bottom bar's measured height up from its overlay so the
 /// transcript can reserve exactly that much space (see `loadedLayout`).
 private struct BottomBarHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
+    // Computed, not stored: a stored `static var` is nonisolated global shared
+    // mutable state and fails Swift 6 concurrency checking.
+    static var defaultValue: CGFloat { 0 }
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
     }


### PR DESCRIPTION
Follow-up to #630 (merged): the device build failed to compile under Swift 6 — a stored `static var defaultValue` is nonisolated global shared mutable state.

Fix: make it a computed property (`static var defaultValue: CGFloat { 0 }`).

Only `mobile/native/MantaUI/ChatScreen.swift`.