### PR TITLE
feat(chat): new-session drafts — lossless pre-session composer

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -100,6 +100,7 @@ function AppInner() {
     serverUpdateProgress,
     connectionState,
     launcherFlags,
+    createDraft,
   } = useStore();
 
   // Entry gating: a fresh config (no host, no boxToken, not skipped) resolves
@@ -130,20 +131,31 @@ function AppInner() {
   // (a box that can't implement the jobs endpoint will 500 on every 30s tick).
   const incompatibleFlaggedRef = useRef(false);
 
-  // BET-417: the new-session screen replaces the old inline forms. null =
-  // not shown. { mode: "new-project" } = new-project (creates a tmux
-  // session). { mode: "new-session", projectName } = new window in an
-  // existing project. The zero-project state (projects.length === 0) shows
-  // it full-panel instead of a dead placeholder.
-  const [newSessionScreen, setNewSessionScreen] = useState<
-    | null
-    | { mode: "new-project" }
-    | { mode: "new-session"; projectName: string }
-  >(null);
-
-  const openNewProject = () => setNewSessionScreen({ mode: "new-project" });
+  // BET-417 (draft model): a "new session" is an in-memory store DRAFT, not an
+  // overlay. Clicking + / ⌘N / ⌘T creates a draft (createDraft) and makes it
+  // the ACTIVE view (activeDraftId). The draft renders as a layer over the
+  // always-mounted session panels, so switching to a real session (setActive
+  // clears activeDraftId) reveals the session with its state intact, and
+  // switching back re-mounts the composer from the stored draft. The
+  // zero-project state (projects.length === 0) auto-creates a new-project
+  // draft so the composer is never a dead placeholder.
+  const activeDraft = useStore((s) =>
+    s.activeDraftId != null
+      ? s.drafts.find((d) => d.id === s.activeDraftId) ?? null
+      : null,
+  );
+  const openNewProject = () => createDraft("new-project");
   const openNewSessionInProject = (name: string) =>
-    setNewSessionScreen({ mode: "new-session", projectName: name });
+    createDraft({ projectName: name });
+
+  // Zero-project state: ensure a new-project draft exists so the composer
+  // (welcome screen) is always the visible view. Re-creates it if the user
+  // abandons the only draft while there are still no projects.
+  useEffect(() => {
+    if (loaded && projects.length === 0 && !activeDraft) {
+      createDraft("new-project");
+    }
+  }, [loaded, projects.length, activeDraft, createDraft]);
 
   // Same pattern for chat-mode windows: mount a ChatPanel for each opencode
   // session we've ever opened, keep it mounted so scroll position + in-flight
@@ -1102,12 +1114,14 @@ function AppInner() {
             // Zero-project state (BET-416 §F / BET-417 §A): the new-session
             // composer IS the app's zero state. An unpaired config routes to
             // onboarding, so this branch is only reached when the box IS
-            // paired but has no projects yet.
-            <NewSessionScreen
-              projectName={null}
-              onDone={() => setNewSessionScreen(null)}
-              onCancel={() => setNewSessionScreen(null)}
-            />
+            // paired but has no projects yet. The auto-create effect above
+            // guarantees an active new-project draft here; use it when present
+            // (and render a blank for the one frame before it lands).
+            activeDraft ? (
+              <NewSessionScreen draftId={activeDraft.id} />
+            ) : (
+              <div className="h-full" />
+            )
           ) : (
             <>
               {/* Terminal / AI-TUI layer (BET-138, BET-347): one per
@@ -1178,20 +1192,15 @@ function AppInner() {
                   </div>
                 );
               })}
-              {/* New-session screen overlay (BET-417): shown over the panel
-                  when the user hits + or Cmd+N/T. Covers the panel area
-                  (sidebar stays visible so the user can click away). */}
-              {newSessionScreen && (
+              {/* New-session DRAFT layer: shown over the always-mounted
+                  session panels when a draft is the active view (user hit +
+                  / Cmd+N/T). The session panels below stay mounted, so
+                  switching back to a real session (setActive clears
+                  activeDraftId) reveals it with state intact. The sidebar
+                  stays visible so the user can click another session. */}
+              {activeDraft && (
                 <div className="absolute inset-0 z-30 bg-bg">
-                  <NewSessionScreen
-                    projectName={
-                      newSessionScreen.mode === "new-project"
-                        ? null
-                        : newSessionScreen.projectName
-                    }
-                    onDone={() => setNewSessionScreen(null)}
-                    onCancel={() => setNewSessionScreen(null)}
-                  />
+                  <NewSessionScreen draftId={activeDraft.id} />
                 </div>
               )}
             </>

--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -22,13 +22,33 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
 import { NewSessionScreen } from "./NewSessionScreen";
+import type { NewSessionDraft } from "./store";
 
 // The two methods that live ONLY on httpApi and are therefore absent from
 // the preload bridge a fresh desktop boot starts on.
 const HTTP_ONLY = ["opencodeModels", "opencodeDefaultModel"];
 
-function noop() {
-  /* the tests assert on mount behaviour, not the callbacks */
+// A minimal new-project draft the composer reads from the store. The screen is
+// draft-backed (NewSessionDraft holds the persisted composer workspace), so
+// every mount under test provisions one and passes its id.
+function draft(overrides: Partial<NewSessionDraft> = {}): NewSessionDraft {
+  return {
+    id: "draft-1",
+    mode: "new-project",
+    cwd: "~",
+    wantWorktree: false,
+    worktreeBranch: "worktree",
+    model: null,
+    modelTouched: false,
+    input: "",
+    ...overrides,
+  };
+}
+
+function mountDraft(overrides: Partial<NewSessionDraft> = {}): Harness {
+  const d = draft(overrides);
+  resetStore({ activeDraftId: d.id, drafts: [d] });
+  return mount(<NewSessionScreen draftId={d.id} />);
 }
 
 describe("NewSessionScreen mount against an unpaired window.api", () => {
@@ -49,9 +69,7 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
     expect(api.opencodeModels).toBeUndefined();
     expect(api.opencodeDefaultModel).toBeUndefined();
 
-    h = mount(
-      <NewSessionScreen projectName={null} onDone={noop} onCancel={noop} />,
-    );
+    h = mountDraft();
     await h.flush();
 
     // The screen is still mounted — the pre-fix behaviour was an exception
@@ -68,14 +86,11 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
     installMockApi();
     resetStore({ projects: [], worktreePerSession: true });
 
-    h = mount(
-      <NewSessionScreen projectName={null} onDone={noop} onCancel={noop} />,
-    );
+    h = mountDraft();
     await h.flush();
 
     // The worktree toggle is now the Checkbox primitive (BET-589); its input
-    // carries the same accessible name it always did, so select it that way
-    // (the previous selector matched on the checkbox type attribute).
+    // carries the same accessible name it always did, so select it that way.
     const checkbox = h.container.querySelector(
       'input[aria-label="Create in a fresh git worktree"]',
     ) as HTMLInputElement;
@@ -87,9 +102,7 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
   it("still fetches models when window.api IS the paired httpApi", async () => {
     const { api } = installMockApi();
 
-    h = mount(
-      <NewSessionScreen projectName={null} onDone={noop} onCancel={noop} />,
-    );
+    h = mountDraft();
     await h.flush();
 
     // The guard must not have silently disabled the happy path.

--- a/src/renderer/NewSessionScreen.test.ts
+++ b/src/renderer/NewSessionScreen.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deriveProjectName } from "./NewSessionScreen";
+import { deriveProjectName, promptWindowName } from "./NewSessionScreen";
 
 describe("deriveProjectName", () => {
   it("extracts the basename from a path", () => {
@@ -24,5 +24,23 @@ describe("deriveProjectName", () => {
 
   it("handles single-segment relative", () => {
     expect(deriveProjectName("foo")).toBe("foo");
+  });
+});
+
+describe("promptWindowName", () => {
+  it("derives a readable name from the first word of the prompt", () => {
+    expect(promptWindowName("Deploy the billing service")).toBe("deploy");
+    expect(promptWindowName("fix-login bug")).toBe("fix-login");
+  });
+
+  it("lowercases + strips non [a-z0-9_-] characters", () => {
+    expect(promptWindowName("   ExplODE  ")).toBe("explode");
+    expect(promptWindowName("'quote'")).toBe("quote");
+  });
+
+  it("falls back to 'session' for an empty / non-alphanumeric first word", () => {
+    expect(promptWindowName("")).toBe("session");
+    expect(promptWindowName("   ")).toBe("session");
+    expect(promptWindowName("!!!!")).toBe("session");
   });
 });

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -1,16 +1,25 @@
-// NewSessionScreen.tsx — the pre-session composer (BET-417 §A).
+// NewSessionScreen.tsx — the pre-session composer (BET-417 §A), now
+// draft-backed.
 //
 // Before a session exists, the composer IS the setup form. This is also the
 // app's zero state (BET-416 §F). Two chips only: folder, and a split
 // branch/worktree chip. No host chip — the box connection is already
 // established.
 //
+// The composer edits a STORE DRAFT (NewSessionDraft) rather than owning its
+// own state, so the typed prompt + folder/model/worktree choices survive
+// navigating away and back. A draft is NOT a tmux window or opencode session
+// yet — submit() is what creates them.
+//
 // On submit:
-//   - new-project mode (projectName === null): create a tmux session + first
-//     chat window, derive the project name from the folder basename, then
-//     send the typed prompt as the first message.
-//   - new-session mode (projectName set): create a tmux window in the
-//     existing project, then send the prompt.
+//   - new-project mode (mode === "new-project"): create a tmux session + first
+//     chat window, derive the project name from the folder basename, then send
+//     the typed prompt as the first message.
+//   - new-session mode (mode.projectName set): create a tmux window in that
+//     project, then send the prompt.
+//   The server returns the created window's { sessionId, windowIndex, projects }
+//   so we navigate + send the prompt to the RIGHT session — never a name
+//   lookup (which mixed new sessions up with existing ones on name collision).
 //
 // The folder chip opens FolderPickerModal (§B). Worktree fan-out is asked
 // inside the picker, not as a post-Create interstitial.
@@ -37,18 +46,21 @@ import { FolderPickerModal } from "./FolderPickerModal";
 import { worktreeName } from "./folderPicker";
 import { useVoiceRecorder, type VoiceResult } from "./voice";
 import type { VoiceMode, VoicePhase } from "./voice";
-import type { OpencodeModel, WorktreeInfo } from "../shared/types";
+import type {
+  OpencodeModel,
+  TmuxCreateResult,
+  WorktreeInfo,
+} from "../shared/types";
 import { type ModelSelection, resolveActiveModel } from "./chatShared";
 
 type Props = {
-  // null = new-project mode (creates a tmux session). A string = new-session
-  // mode (creates a tmux window in that project).
-  projectName: string | null;
-  // Called after the session is created + the first prompt is sent. The
-  // parent closes the screen and navigates to the new session.
-  onDone: () => void;
-  // Called when the user cancels (Esc / clicks away). The parent closes.
-  onCancel: () => void;
+  // The id of the store draft this composer edits (see NewSessionDraft). The
+  // draft holds the persisted composer workspace; the active view renders this
+  // screen while the draft is active.
+  draftId: string;
+  // Fired after a successful submit. The store has already navigated to the
+  // new session; this lets the caller run any post-commit bookkeeping.
+  onDone?: () => void;
 };
 
 // Derive a tmux session name from a folder path: the basename, fallback to
@@ -61,42 +73,42 @@ export function deriveProjectName(cwd: string): string {
   return parts[parts.length - 1] || "project";
 }
 
-export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
+// A readable, largely-unique window name derived from the first word of the
+// typed prompt (e.g. "Deploy the billing service" → "deploy"). This avoids the
+// old constant "worktree"/"session" that produced a sidebar full of identical
+// rows. Falls back to "session" on a non-alphanumeric or empty first word.
+export function promptWindowName(input: string): string {
+  const clean = (input.trim().split(/\s+/)[0] ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "");
+  return clean ? clean.slice(0, 24) : "session";
+}
+
+export function NewSessionScreen({ draftId, onDone }: Props) {
+  // The draft this composer edits. The App only ever renders this screen for a
+  // draft that exists (activeDraftId always points at a live draft), so a
+  // missing draft is unreachable in practice; the guard keeps TypeScript's
+  // narrowing happy and safely no-ops on the impossible case.
+  const draft = useStore((s) => s.drafts.find((d) => d.id === draftId));
+  if (!draft) return null;
   const refresh = useStore((s) => s.refresh);
   const setActive = useStore((s) => s.setActive);
-  const configDefaultModel = useStore((s) => s.defaultModel);
+  const updateDraft = useStore((s) => s.updateDraft);
+  const dismissDraft = useStore((s) => s.dismissDraft);
   const deactivatedMainModels = useStore((s) => s.deactivatedMainModels);
   const existingProjects = useStore((s) => s.projects);
-  const worktreePerSession = useStore((s) => s.worktreePerSession);
 
+  const projectName =
+    draft.mode === "new-project" ? null : draft.mode.projectName;
   const isNewProject = projectName === null;
 
-  // Folder state — the selected working directory.
-  const [cwd, setCwd] = useState<string>(isNewProject ? "~" : "");
+  // ---- local (non-persisted) UI state ----
   const [pickerOpen, setPickerOpen] = useState(false);
-
-  // Branch / worktree chip state. Starts OFF in new-project mode: the
-  // composer opens on "~" (never a git repo), so pre-arming the worktree
-  // intent from config would ship a "checked but can't be honored" chip
-  // (BET-445). It stays config-driven for new-session mode, where the cwd is
-  // a real project folder.
-  const [wantWorktree, setWantWorktree] = useState(
-    isNewProject ? false : worktreePerSession,
-  );
   const [worktrees, setWorktrees] = useState<WorktreeInfo[] | null>(null);
   const [isGitRepo, setIsGitRepo] = useState(false);
-  // BET-417 §A: "Ticking worktree makes the branch field editable." When
-  // wantWorktree is true, this is the editable branch name passed to
-  // gitAddWorktree (which deriveWorktree turns into the new branch). Defaults
-  // to a derived name; the user can type over it.
-  const [worktreeBranch, setWorktreeBranch] = useState("worktree");
   // BET-417 §B: fan-out from the folder picker. When set, the picker returned
-  // multiple worktrees and the user chose "One per worktree" — we create one
-  // session with one window per worktree (worktreeName(w) as window name).
+  // multiple worktrees and the user chose "One per worktree".
   const [fanOutWorktrees, setFanOutWorktrees] = useState<WorktreeInfo[] | null>(null);
-
-  // Composer state.
-  const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -107,14 +119,6 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
     providerID: string;
     modelID: string;
   } | null>(null);
-  const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    configDefaultModel ?? null,
-  );
-  // Whether the user has explicitly picked a model this session. Until they
-  // do, the pill reads "Auto" (the server default is in effect) even though
-  // `modelOverride` is seeded from the configured default — presentational
-  // only, does not change what model is applied to the new session.
-  const [modelTouched, setModelTouched] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -122,9 +126,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
     // live ONLY on httpApi. On a fresh/unpaired desktop boot `window.api` is
     // still the raw preload OS-bridge subset, where they are undefined —
     // calling them throws synchronously from the commit phase, which `.catch`
-    // cannot see and which unmounts the whole tree. App gates this screen on
-    // `loaded` so it should not mount that early; this keeps a future caller
-    // from re-opening the same hole.
+    // cannot see and which unmounts the whole tree.
     if (window.api.opencodeModels) {
       window.api
         .opencodeModels()
@@ -141,32 +143,32 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
   }, []);
 
   const activeModel = useMemo(
-    () => resolveActiveModel(models, modelOverride, serverDefault),
-    [models, modelOverride, serverDefault],
+    () => resolveActiveModel(models, draft.model, serverDefault),
+    [models, draft.model, serverDefault],
   );
-  void activeModel; // used by ModelPicker via models + modelOverride
+  void activeModel; // used by ModelPicker via models + draft.model
 
   // ---- resolve cwd for new-session mode ----
   // In new-session mode, the cwd defaults to the project's cwd (inherited
   // server-side). The user can still browse to a subfolder.
   useEffect(() => {
-    if (!isNewProject && projectName && !cwd) {
+    if (!isNewProject && projectName && !draft.cwd) {
       const proj = existingProjects.find((p) => p.tmuxSession === projectName);
       const dir = proj?.defaultCwd || proj?.windows[0]?.paneCurrentPath || "";
-      if (dir) setCwd(dir);
+      if (dir) updateDraft(draftId, { cwd: dir });
     }
-  }, [isNewProject, projectName, existingProjects, cwd]);
+  }, [isNewProject, projectName, existingProjects, draft.cwd, draftId, updateDraft]);
 
   // ---- probe git state for the current cwd ----
   useEffect(() => {
-    if (!cwd || cwd === "~") {
+    if (!draft.cwd || draft.cwd === "~") {
       setIsGitRepo(false);
       setWorktrees(null);
       return;
     }
     let cancelled = false;
     window.api
-      .gitListWorktrees(cwd)
+      .gitListWorktrees(draft.cwd)
       .then((wts) => {
         if (cancelled) return;
         setWorktrees(wts);
@@ -178,7 +180,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
         setWorktrees(null);
       });
     return () => { cancelled = true; };
-  }, [cwd]);
+  }, [draft.cwd]);
 
   const branchName = useMemo(() => {
     if (!worktrees || worktrees.length === 0) return null;
@@ -190,10 +192,9 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
     onResult: (r: VoiceResult) => {
       const text = r.mode === "dictate" ? r.text : "";
       if (!text) return;
-      setInput((prev) => {
-        const sep = prev && !prev.endsWith(" ") ? " " : "";
-        return prev + sep + text;
-      });
+      const prev = useStore.getState().drafts.find((d) => d.id === draftId)?.input ?? "";
+      const sep = prev && !prev.endsWith(" ") ? " " : "";
+      updateDraft(draftId, { input: prev + sep + text });
       requestAnimationFrame(() => {
         const el = inputRef.current;
         if (el) {
@@ -215,18 +216,18 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
   // ---- submit: create session + send first prompt ----
   const submit = async () => {
     if (sending) return;
-    const text = input.trim();
+    const text = draft.input.trim();
     if (!text) return;
     setSending(true);
     setError(null);
 
     try {
       let sessionName: string;
-      let windowName: string;
+      let result: TmuxCreateResult;
       let worktreePath: string | undefined;
 
       if (isNewProject) {
-        sessionName = deriveProjectName(cwd);
+        sessionName = deriveProjectName(draft.cwd);
         // Avoid name collision with existing sessions.
         const taken = new Set(existingProjects.map((p) => p.tmuxSession));
         if (taken.has(sessionName)) {
@@ -234,30 +235,28 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
           while (taken.has(`${sessionName}-${i}`)) i++;
           sessionName = `${sessionName}-${i}`;
         }
-        windowName = "default";
 
-        if (wantWorktree && isGitRepo) {
-          const wt = await window.api.gitAddWorktree({ cwd, name: worktreeBranch });
+        if (draft.wantWorktree && isGitRepo) {
+          const wt = await window.api.gitAddWorktree({ cwd: draft.cwd, name: draft.worktreeBranch });
           worktreePath = wt.path;
         }
 
-        await window.api.tmuxNewSession({
+        result = await window.api.tmuxNewSession({
           name: sessionName,
-          cwd: worktreePath ?? cwd,
-          windowName,
+          cwd: worktreePath ?? draft.cwd,
+          windowName: "default",
           chatMode: true,
           ...(worktreePath ? {} : { createDir: true }),
         });
       } else {
         sessionName = projectName!;
-        windowName = worktreeBranch || "session";
-        if (wantWorktree && isGitRepo) {
-          const wt = await window.api.gitAddWorktree({ cwd, name: worktreeBranch });
+        if (draft.wantWorktree && isGitRepo) {
+          const wt = await window.api.gitAddWorktree({ cwd: draft.cwd, name: draft.worktreeBranch });
           worktreePath = wt.path;
         }
-        await window.api.tmuxNewWindow({
+        result = await window.api.tmuxNewWindow({
           sessionName,
-          windowName,
+          windowName: promptWindowName(text),
           ...(worktreePath ? { cwd: worktreePath, worktreePath } : {}),
           chatMode: true,
         });
@@ -265,29 +264,27 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
 
       await refresh();
 
-      // Find the new window's opencode session id.
-      const proj = useStore.getState().projects.find(
-        (p) => p.tmuxSession === sessionName,
-      );
-      const win = proj?.windows.find((w) => w.name === windowName);
-      const sessionId = win?.opencodeSessionId;
+      // Navigate to the new session (this also exits the draft view) and send
+      // the first prompt. The server told us the exact window, so no lookup.
+      setActive(sessionName, result.windowIndex);
+      try {
+        await window.api.tmuxSelectWindow({
+          sessionName,
+          windowIndex: result.windowIndex,
+        });
+      } catch { /* non-fatal */ }
 
-      if (sessionId) {
-        setActive(sessionName, win!.index);
-        try {
-          await window.api.tmuxSelectWindow({
-            sessionName,
-            windowIndex: win!.index,
-          });
-        } catch { /* non-fatal */ }
-        // Send the first prompt.
+      if (result.sessionId) {
         await window.api.opencodePrompt(
-          sessionId,
+          result.sessionId,
           text,
-          modelOverride ?? undefined,
+          draft.model ?? undefined,
         );
       }
-      onDone();
+
+      // Abandon the draft — it is now a real session.
+      dismissDraft(draftId);
+      onDone?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setSending(false);
@@ -295,13 +292,12 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
   };
 
   // ---- fan-out submit: one session, one window per worktree ----
-  // Relocates the old Sidebar createProject("all") logic that was deleted
-  // with the inline forms (BET-417 §B4). Each window is named worktreeName(w)
-  // (path basename, not branch) — so "leasebot" not "main" shows in the
-  // sidebar. The first prompt goes to the first window.
+  // Each window is named worktreeName(w) (path basename, not branch) — so
+  // "leasebot" not "main" shows in the sidebar. The first prompt goes to the
+  // first window.
   const submitFanOut = async (baseCwd: string, wts: WorktreeInfo[]) => {
     if (sending) return;
-    const text = input.trim();
+    const text = draft.input.trim();
     setSending(true);
     setError(null);
     try {
@@ -315,7 +311,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
       })();
 
       const [first, ...rest] = wts;
-      await window.api.tmuxNewSession({
+      const created = await window.api.tmuxNewSession({
         name: sessionName,
         cwd: first.path,
         windowName: worktreeName(first),
@@ -336,27 +332,26 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
       }
 
       await refresh();
-      const proj = useStore.getState().projects.find(
-        (p) => p.tmuxSession === sessionName,
-      );
-      const win = proj?.windows.find((w) => w.name === worktreeName(first));
-      if (win?.opencodeSessionId) {
-        setActive(sessionName, win.index);
-        try {
-          await window.api.tmuxSelectWindow({
-            sessionName,
-            windowIndex: win.index,
-          });
-        } catch { /* non-fatal */ }
-        if (text) {
-          await window.api.opencodePrompt(
-            win.opencodeSessionId,
-            text,
-            modelOverride ?? undefined,
-          );
-        }
+
+      // The initial window of the new session is the created window.
+      setActive(sessionName, created.windowIndex);
+      try {
+        await window.api.tmuxSelectWindow({
+          sessionName,
+          windowIndex: created.windowIndex,
+        });
+      } catch { /* non-fatal */ }
+
+      if (created.sessionId && text) {
+        await window.api.opencodePrompt(
+          created.sessionId,
+          text,
+          draft.model ?? undefined,
+        );
       }
-      onDone();
+
+      dismissDraft(draftId);
+      onDone?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setSending(false);
@@ -371,33 +366,29 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
     }
     if (e.key === "Escape") {
       e.preventDefault();
-      onCancel();
+      dismissDraft(draftId);
       return;
     }
   };
 
   const folderLabel = useMemo(() => {
-    if (!cwd || cwd === "~") return "Home";
-    const parts = cwd.split("/").filter(Boolean);
-    return parts[parts.length - 1] || cwd;
-  }, [cwd]);
+    if (!draft.cwd || draft.cwd === "~") return "Home";
+    const parts = draft.cwd.split("/").filter(Boolean);
+    return parts[parts.length - 1] || draft.cwd;
+  }, [draft.cwd]);
 
   // Empty state (BET-445): new-project mode opens on "~", which is never a
   // git repo, so the worktree intent can't be honored yet. Render the chip
-  // unchecked and enabled so the picker can choose a folder first — matching
-  // the mockup. Outside this state the chip is gated on isGitRepo.
+  // unchecked and enabled so the picker can choose a folder first.
   const emptyWorktree = isNewProject && !isGitRepo;
   const worktreeChipEnabled = emptyWorktree || isGitRepo;
 
   return (
     // data-screen is the visual harness's handle on this screen (see
     // scripts/visual/screens.mjs). One stable attribute per screen root, so
-    // the harness never depends on a class name or DOM position — both of
-    // which a redesign is expected to change.
+    // the harness never depends on a class name or DOM position.
     <div data-screen="welcome" className="h-full flex flex-col items-center justify-center px-8">
       <div className="w-full max-w-[720px] rounded-xl border border-border-subtle bg-bg-elev px-6 py-10 flex flex-col gap-2">
-        {/* Heading — the only element centred on the screen; the chip row and
-            the controls row below are both left-aligned to the composer. */}
         <div className="text-center space-y-1 mb-4">
           <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
           <p className="text-body text-text-faint">
@@ -405,33 +396,28 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
           </p>
         </div>
 
-        {/* Chip row — folder, then branch + worktree as ONE segmented control
-            (shared border, no gap). Left-aligned: it reads as a property bar
-            belonging to the composer below, not a second heading. */}
+        {/* Chip row — folder, then branch + worktree as ONE segmented control. */}
         <div className="flex items-center gap-2 self-start">
-          <Chip onClick={() => setPickerOpen(true)} title={cwd || "Select folder"}>
+          <Chip
+            onClick={() => setPickerOpen(true)}
+            title={draft.cwd || "Select folder"}
+          >
             <FolderIcon size={13} className="shrink-0 text-text-muted" aria-hidden="true" />
             <span className="truncate max-w-[200px]">{folderLabel}</span>
             <ChevronDown size={13} className="shrink-0 text-text-faint" aria-hidden="true" />
           </Chip>
 
-          {/* Branch / worktree. The branch is a Chip (display) — or a plain,
-              un-nested input while worktree is being named (BET-417 §A). The
-              worktree toggle stays the Checkbox primitive. Neither the input
-              nor the checkbox is wrapped in a <button>: that keeps valid HTML
-              and avoids loading SplitChip's opt-in popup semantics onto a
-              non-popup control. */}
-          {wantWorktree && isGitRepo ? (
+          {draft.wantWorktree && isGitRepo ? (
             <input
-              value={worktreeBranch}
-              onChange={(e) => setWorktreeBranch(e.target.value)}
+              value={draft.worktreeBranch}
+              onChange={(e) => updateDraft(draftId, { worktreeBranch: e.target.value })}
               spellCheck={false}
               className="h-8 w-[132px] rounded-md border border-accent bg-bg-soft px-3 text-meta font-mono text-text outline-none focus:border-accent"
               placeholder="branch-name"
               aria-label="Worktree branch name"
             />
           ) : (
-            <Chip on={wantWorktree} onClick={() => {}} title="Current git branch">
+            <Chip on={draft.wantWorktree} onClick={() => {}} title="Current git branch">
               <GitBranch size={13} className="shrink-0" aria-hidden="true" />
               {branchName ? (
                 <span className="truncate max-w-[120px]">{branchName}</span>
@@ -442,32 +428,26 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
           )}
 
           <Checkbox
-            checked={wantWorktree}
+            checked={draft.wantWorktree}
             disabled={!worktreeChipEnabled}
-            onChange={(v) => setWantWorktree(v)}
+            onChange={(v) => updateDraft(draftId, { wantWorktree: v })}
             label="worktree"
             ariaLabel="Create in a fresh git worktree"
           />
         </div>
 
-        {/* Composer — a single tall input card. The submit affordance sits
-            INSIDE the input on the trailing edge, top-aligned, so the input
-            can grow downward without moving it. */}
+        {/* Composer — a single tall input card. */}
         <div
           className={
             "manta-composer-input-row rounded-lg border bg-bg-soft flex items-start gap-3 px-4 py-3 " +
-            // Resting tone matches the session composer (border-subtle, the
-            // tool-card token) — the two must not diverge.
-            (voiceRecording
-              ? "manta-recording"
-              : "border-border-subtle")
+            (voiceRecording ? "manta-recording" : "border-border-subtle")
           }
         >
           <textarea
             ref={inputRef}
             autoFocus
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
+            value={draft.input}
+            onChange={(e) => updateDraft(draftId, { input: e.target.value })}
             onKeyDown={onKeyDown}
             placeholder="Describe a task or ask a question"
             rows={3}
@@ -477,12 +457,12 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
 
           <button
             onClick={() => void submit()}
-            disabled={sending || !input.trim()}
+            disabled={sending || !draft.input.trim()}
             aria-label="Start a session"
             title={
               sending
                 ? "Starting…"
-                : input.trim()
+                : draft.input.trim()
                   ? "Start a session"
                   : "Describe a task to start"
             }
@@ -496,25 +476,25 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
           </button>
         </div>
 
-        {/* Controls row — model ▸ effort, then attach + dictate. Left-aligned
-            to the composer. */}
+        {/* Controls row — model ▸ effort, then attach + dictate. */}
         <div className="flex items-center gap-2 self-start">
           <ModelPicker
             modelLabel={null}
             models={models}
-            modelOverride={modelOverride}
+            modelOverride={draft.model}
             defaultModel={serverDefault}
             deactivatedMainModels={deactivatedMainModels}
             onOpen={() => {}}
-            onSelect={(m) => {
-              setModelTouched(true);
-              setModelOverride(m);
+            onSelect={(m: ModelSelection | null) => {
+              // null = clear back to the server default ("Auto").
+              updateDraft(draftId, {
+                model: m,
+                modelTouched: m != null,
+              });
             }}
-            labelOverride={modelTouched ? null : "Auto"}
+            labelOverride={draft.modelTouched ? null : "Auto"}
           />
 
-          {/* Attach — no implementation on this screen yet (welcome is
-              create-first). Rendered disabled, per the UI-only constraint. */}
           <IconButton
             icon={<Paperclip />}
             label="Attach a file"
@@ -532,9 +512,6 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
               onCancel={voiceRecorder.cancel}
             />
           ) : (
-            /* Dictate — no voice configured on this box yet (no Groq key).
-               Rendered disabled to match the attach button, so the controls
-               row agrees with the mockup whether or not voice is set up. */
             <IconButton
               icon={<Mic />}
               label="Dictate"
@@ -554,14 +531,14 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
 
       {pickerOpen && (
         <FolderPickerModal
-          initialPath={cwd || "~"}
+          initialPath={draft.cwd || "~"}
           onSelect={(path) => {
-            setCwd(path);
+            updateDraft(draftId, { cwd: path });
             setPickerOpen(false);
           }}
           onFanOut={(baseCwd, wts) => {
             setFanOutWorktrees(wts);
-            setCwd(baseCwd);
+            updateDraft(draftId, { cwd: baseCwd });
             setPickerOpen(false);
           }}
           onCancel={() => setPickerOpen(false)}
@@ -586,7 +563,7 @@ export function NewSessionScreen({ projectName, onDone, onCancel }: Props) {
             </ul>
             <div className="flex gap-2">
               <button
-                onClick={() => void submitFanOut(cwd, fanOutWorktrees)}
+                onClick={() => void submitFanOut(draft.cwd, fanOutWorktrees)}
                 disabled={sending}
                 className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90 disabled:opacity-50"
               >

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -76,6 +76,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     recentWindows,
     togglePin,
     worktreeCleanOnClose,
+    drafts,
+    activeDraftId,
+    setActiveDraft,
+    dismissDraft,
   } = useStore();
   // Downloaded desktop auto-update (BET-416 §E): signalled as a dot on the
   // Settings entry, not a full-width bar.
@@ -89,6 +93,11 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   const showNotice = (msg: string) => {
     alert(msg);
   };
+
+  // When a new-session DRAFT is the foreground view, no real session should
+  // read as "active" in the rail — the draft row is the highlighted one
+  // (e.g. creating a session over a chat must not leave the old chat lit up).
+  const draftForeground = activeDraftId != null;
 
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
 
@@ -515,6 +524,53 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         data-density="comfortable"
         onKeyDown={onRailKeyDown}
       >
+        {/* New-session drafts (BET draft model): in-memory composers for
+            sessions that don't exist yet. Shown at the TOP of the rail, not
+            nested under any project — a draft is a bare "new session" until it
+            commits. Clicking one makes it the active view (renders the
+            composer); the X abandons it (dismisses, prompt not yet sent). */}
+        {drafts.length > 0 && (
+          <div className="mb-3 space-y-px">
+            {drafts.map((d) => {
+              const isActive = activeDraftId === d.id;
+              const target =
+                d.mode === "new-project"
+                  ? "will create a new project"
+                  : `will open in "${d.mode.projectName}"`;
+              const hint = d.input.trim()
+                ? `"${d.input.trim().slice(0, 40)}" · ${target}`
+                : target;
+              return (
+                <div
+                  key={d.id}
+                  role="button"
+                  aria-selected={isActive}
+                  onClick={() => setActiveDraft(d.id)}
+                  className={`group flex items-center gap-1 px-1 py-1 rounded-xs text-meta cursor-pointer select-none ${
+                    isActive
+                      ? "bg-bg-soft text-text"
+                      : "text-text-muted hover:bg-bg-soft hover:text-text"
+                  }`}
+                  title={`New session — ${hint}`}
+                >
+                  <span className="flex-1 min-w-0 truncate italic">new session</span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      dismissDraft(d.id);
+                    }}
+                    className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-danger leading-none"
+                    aria-label="Discard this new session"
+                    tabIndex={-1}
+                  >
+                    <X size={13} aria-hidden="true" />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
         {projects.length === 0 && (
           <div className="px-2 py-3 text-meta text-text-faint">
             No projects yet. Click + or press {MOD_KEY}N.
@@ -534,6 +590,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                   project={r.project}
                   window={r.window}
                   isActive={
+                    !draftForeground &&
                     activeProjectName === r.project.tmuxSession &&
                     activeWindowByProject[r.project.tmuxSession] === r.window.index
                   }
@@ -582,7 +639,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         {projects.map((p) => {
           const isCollapsed = collapsed.has(p.tmuxSession);
           const activeWinIdx = activeWindowByProject[p.tmuxSession];
-          const isProjectActive = activeProjectName === p.tmuxSession;
+          const isProjectActive = !draftForeground && activeProjectName === p.tmuxSession;
           const n = nesting.get(p.tmuxSession)!;
           const topWindows = p.windows.filter(
             (w) =>

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -724,3 +724,84 @@ describe("deep-link pairing error", () => {
     expect(useStore.getState().pairLinkError).toBeNull();
   });
 });
+
+// ===== New-session drafts (BET draft model) =====
+//
+// A "new session" is an in-memory store draft until it commits. The draft
+// holds the composer workspace; navigating away/back must not lose it, and
+// navigating to a real session (setActive) must exit any draft view.
+
+describe("new-session drafts", () => {
+  beforeEach(() => {
+    useStore.setState({ activeDraftId: null, drafts: [] });
+  });
+
+  it("createDraft adds a draft and makes it the active view", () => {
+    const id = useStore.getState().createDraft("new-project");
+    const s = useStore.getState();
+    expect(s.drafts.map((d) => d.id)).toEqual([id]);
+    expect(s.activeDraftId).toBe(id);
+    const d = s.drafts[0];
+    expect(d.mode).toBe("new-project");
+    expect(d.cwd).toBe("~");
+    expect(d.input).toBe("");
+    expect(d.wantWorktree).toBe(false);
+  });
+
+  it("createDraft new-session mode targets the project and seeds cwd from config", () => {
+    useStore.setState({ worktreePerSession: true });
+    useStore.getState().createDraft({ projectName: "better-ui" });
+    const d = useStore.getState().drafts[0];
+    expect(d.mode).toEqual({ projectName: "better-ui" });
+    // new-session cwd starts empty (resolved from the project later)
+    expect(d.cwd).toBe("");
+    // wantWorktree seeds from the worktreePerSession config for new-session mode
+    expect(d.wantWorktree).toBe(true);
+  });
+
+  it("updateDraft patches only the matching draft", () => {
+    const a = useStore.getState().createDraft("new-project");
+    const b = useStore.getState().createDraft({ projectName: "x" });
+    useStore.getState().updateDraft(a, { input: "hello" });
+    const s = useStore.getState();
+    expect(s.drafts.find((d) => d.id === a)!.input).toBe("hello");
+    expect(s.drafts.find((d) => d.id === b)!.input).toBe("");
+  });
+
+  it("dismissDraft removes it and re-points the active view at another draft", () => {
+    const a = useStore.getState().createDraft("new-project");
+    const b = useStore.getState().createDraft({ projectName: "x" });
+    // dismiss the first (not active) — active stays b
+    useStore.getState().dismissDraft(a);
+    expect(useStore.getState().drafts.map((d) => d.id)).toEqual([b]);
+    expect(useStore.getState().activeDraftId).toBe(b);
+  });
+
+  it("dismissing the ACTIVE draft falls back to a surviving draft, else null", () => {
+    const a = useStore.getState().createDraft("new-project");
+    const s = useStore.getState();
+    expect(s.activeDraftId).toBe(a);
+    useStore.getState().dismissDraft(a);
+    expect(useStore.getState().activeDraftId).toBeNull();
+    expect(useStore.getState().drafts).toEqual([]);
+  });
+
+  it("setActive (a real session) clears the active draft view", () => {
+    useStore.setState({
+      projects: [
+        proj({
+          tmuxSession: "manta",
+          windows: [
+            { index: 0, name: "w", active: true, paneCurrentPath: "/x", opencodeSessionId: "ses_a" },
+          ],
+        }),
+      ],
+    });
+    const id = useStore.getState().createDraft({ projectName: "manta" });
+    expect(useStore.getState().activeDraftId).toBe(id);
+    useStore.getState().setActive("manta", 0);
+    expect(useStore.getState().activeDraftId).toBeNull();
+    // the draft itself is untouched — it stays in the sidebar for later use
+    expect(useStore.getState().drafts.some((d) => d.id === id)).toBe(true);
+  });
+});

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -11,6 +11,7 @@ import type { ConnectionState } from "../shared/net/state.js";
 import { clientToken } from "./api/httpApi";
 import { isAssistantTurnInProgress, runWithConcurrency } from "./chatUtils";
 import { applyTheme, type ThemePref } from "./theme";
+import type { ModelSelection } from "./chatShared";
 
 // Background-delegation jobs, keyed by the job's child opencode session id.
 // The renderer learns which sidebar windows are jobs (and their per-row
@@ -33,6 +34,13 @@ export type JobRow = {
 // Cap on simultaneous in-flight requests for the startup opencode fan-outs
 // (`replayChatAttention`, `backfillLastMessageTimes`) — see BET-135.
 const OPENCODE_FANOUT_CONCURRENCY = 4;
+
+// Monotonic id source for new-session drafts. A plain counter (not
+// crypto.randomUUID) keeps store tests deterministic and needs no crypto stub.
+let draftSeq = 0;
+function newDraftId() {
+  return `draft-${++draftSeq}`;
+}
 
 // Overlay the desktop-local pairing secrets (serverUrl/boxToken) onto a config
 // snapshot. In http mode window.api.configGet() returns the manta-server's config,
@@ -61,6 +69,25 @@ function mergeLocalPairing(cfg: AppConfig): AppConfig {
 export type ActiveSession = {
   projectName: string;
   windowIndex: number;
+};
+
+// A pre-commit "new session" draft: an in-memory composer that owns the typed
+// prompt + folder/model/worktree choices BEFORE any tmux window or opencode
+// session exists. It lives in the store (not component state) so navigating
+// away from it and back loses nothing. `mode` decides what commit creates:
+// "new-project" = a new tmux session (project); { projectName } = a window in
+// an existing project. The ACTIVE view is either a real session
+// (activeProjectName / activeWindowByProject) or a draft (activeDraftId).
+export type NewSessionDraft = {
+  id: string;
+  mode: "new-project" | { projectName: string };
+  cwd: string;
+  wantWorktree: boolean;
+  worktreeBranch: string;
+  // null = auto / not explicitly picked (presentational only until submit).
+  model: ModelSelection | null;
+  modelTouched: boolean;
+  input: string;
 };
 
 // Per-window UI status: live `running`/`subagents` from the poller, plus an
@@ -204,6 +231,11 @@ type State = {
   projects: Project[];
   activeProjectName: string | null;
   activeWindowByProject: Record<string, number>; // projectName -> windowIndex
+  // ACTIVE new-session draft id (see NewSessionDraft), or null when the active
+  // view is a real session. Mutually exclusive with the session active state in
+  // the sense that navigating to a real session (setActive) clears it.
+  activeDraftId: string | null;
+  drafts: NewSessionDraft[];
   // sessionName -> windowIndex -> status
   status: Record<string, Record<number, WindowStatusUI>>;
   // Background-delegation jobs keyed by childSessionID (BET-381). Drives the
@@ -300,6 +332,15 @@ type State = {
   configSnapshot: () => Partial<AppConfig>;
   // ----- mutations -----
   setActive: (projectName: string, windowIndex?: number) => void;
+  // New-session draft lifecycle (see NewSessionDraft). createDraft makes +
+  // activates a fresh draft; updateDraft patches one (typed prompt, folder,
+  // model…); dismissDraft abandons it (committed or cancelled) and re-points
+  // the active view; setActiveDraft brings a draft to the foreground. Note
+  // setActive (below) exits any draft view by clearing activeDraftId.
+  createDraft: (mode: NewSessionDraft["mode"]) => string;
+  updateDraft: (id: string, patch: Partial<NewSessionDraft>) => void;
+  dismissDraft: (id: string) => void;
+  setActiveDraft: (id: string) => void;
   refresh: () => Promise<void>;
   // Onboarding lifecycle. `skipOnboarding` persists onboardingSkipped (so the
   // flow doesn't re-trigger) and clears the forced flag. `relaunchOnboarding`
@@ -441,6 +482,8 @@ export const useStore = create<State>((set, get) => ({
   projects: [],
   activeProjectName: null,
   activeWindowByProject: {},
+  activeDraftId: null,
+  drafts: [],
   status: {},
   jobs: {},
   chatMessages: {},
@@ -504,10 +547,53 @@ export const useStore = create<State>((set, get) => ({
           ...prev.activeWindowByProject,
           [projectName]: w,
         },
+        // Navigating to a real session exits any "new session" draft view.
+        activeDraftId: null,
         status,
         recentWindows,
       };
     }),
+
+  createDraft: (mode) => {
+    const id = newDraftId();
+    const worktreePerSession = get().worktreePerSession;
+    set((prev) => ({
+      drafts: [
+        ...prev.drafts,
+        {
+          id,
+          mode,
+          cwd: mode === "new-project" ? "~" : "",
+          wantWorktree: mode === "new-project" ? false : worktreePerSession ?? true,
+          worktreeBranch: "worktree",
+          model: null,
+          modelTouched: false,
+          input: "",
+        },
+      ],
+      activeDraftId: id,
+    }));
+    return id;
+  },
+  updateDraft: (id, patch) =>
+    set((prev) => ({
+      drafts: prev.drafts.map((d) => (d.id === id ? { ...d, ...patch } : d)),
+    })),
+  dismissDraft: (id) =>
+    set((prev) => {
+      const drafts = prev.drafts.filter((d) => d.id !== id);
+      let activeDraftId = prev.activeDraftId;
+      if (activeDraftId === id) {
+        // Re-point the active view at another draft (prefer a surviving
+        // new-project draft), else fall back to the session view (null).
+        activeDraftId =
+          drafts.find((d) => d.mode === "new-project")?.id ??
+          drafts[0]?.id ??
+          null;
+      }
+      return { drafts, activeDraftId };
+    }),
+  setActiveDraft: (id) => set({ activeDraftId: id }),
 
   refresh: async () => {
     const cfg = await window.api.configGet();

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -343,7 +343,10 @@ export async function startJob(input, deps = {}) {
       throw new Error(`could not resolve the tmux session owning ${parentSessionID}`);
     }
     tmuxSession = owner.tmuxSession;
-    const projects = await newWindow({
+    // 6b. The create returns the new window's identity (sessionId +
+    // windowIndex) directly — no need to re-locate it by name from the
+    // refreshed listing (which could catch a same-named sibling window).
+    const created = await newWindow({
       sessionName: tmuxSession,
       windowName: name,
       cwd,
@@ -352,18 +355,14 @@ export async function startJob(input, deps = {}) {
       oc: deps.oc,
       permission: input?.permission,
     });
-    const owner2 = resolveOwner(projects, parentSessionID);
-    const proj = (projects || []).find((p) => p.tmuxSession === tmuxSession);
-    const win = (proj?.windows || []).find(
-      (w) => w.name === name && w.opencodeSessionId,
-    );
-    childSessionID = win?.opencodeSessionId ?? null;
-    windowIndex = win?.index ?? null;
-    // Sanity: if we somehow failed to read the child session id back, abort.
+    const owner2 = resolveOwner(created.projects, parentSessionID);
+    childSessionID = created.sessionId ?? null;
+    windowIndex = created.windowIndex ?? null;
+    void owner2;
+    // Sanity: if we somehow failed to resolve the child session id, abort.
     if (!childSessionID) {
       throw new Error("could not read the new window's opencode session id");
     }
-    void owner2;
   } catch (e) {
     // Undo step 4 in reverse: remove the worktree (force:false, best-effort).
     if (worktree && deps.gitRemoveWorktree) {

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -380,9 +380,11 @@ test("startJob allows nesting when the blocking job is terminal", async () => {
   const parentWin = { index: 1, name: "p", opencodeSessionId: "child_done", paneCurrentPath: "/repo" };
   const childWin = { index: 5, name: "nested-work", opencodeSessionId: "c2", paneCurrentPath: "/repo" };
   h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
-  h.deps.newWindow = async (input) => [
-    { tmuxSession: input.sessionName, windows: [parentWin, childWin] },
-  ];
+  h.deps.newWindow = async (input) => ({
+    sessionId: "c2",
+    windowIndex: 5,
+    projects: [{ tmuxSession: input.sessionName, windows: [parentWin, childWin] }],
+  });
   const res = await startJob(
     { prompt: "nested work", parentSessionID: "child_done", parentDirectory: "/repo" },
     h.deps,
@@ -613,9 +615,11 @@ test("startJob happy path (non-git cwd) persists a running job and delivers the 
   const parentWin = { index: 1, name: "parent-h", opencodeSessionId: "parent-h", paneCurrentPath: "/repo" };
   const childWin = { index: 2, name: "fix-the-login-bug", opencodeSessionId: "child-h", paneCurrentPath: "/repo" };
   h.deps.listProjects = async () => [{ tmuxSession: "proj", windows: [parentWin] }];
-  h.deps.newWindow = async (input) => [
-    { tmuxSession: input.sessionName, windows: [parentWin, childWin] },
-  ];
+  h.deps.newWindow = async (input) => ({
+    sessionId: "child-h",
+    windowIndex: 2,
+    projects: [{ tmuxSession: input.sessionName, windows: [parentWin, childWin] }],
+  });
   const res = await startJob(
     { prompt: "Fix the login bug please", parentSessionID: "parent-h", parentDirectory: "/repo" },
     h.deps,
@@ -792,7 +796,11 @@ function approvalEngineHarness(initialJobs = []) {
     listProjects: async () => [{ tmuxSession: "proj", windows: [parentWin] }],
     newWindow: async (input) => {
       newWindowCalls.push(input);
-      return [{ tmuxSession: input.sessionName, windows: [parentWin, { ...childWin, name: input.windowName }] }];
+      return {
+        sessionId: "ses_child",
+        windowIndex: 2,
+        projects: [{ tmuxSession: input.sessionName, windows: [parentWin, { ...childWin, name: input.windowName }] }],
+      };
     },
     oc: {
       createSession: async (input) => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -360,14 +360,18 @@ export function buildHandlers({
     // issue is about.
     "tmux:new-session": async (i) => {
       const cwd = await resolveProjectCwd(i.name, i.cwd);
-      const projects = await tmux.newSession({ ...i, cwd, oc });
+      const result = await tmux.newSession({ ...i, cwd, oc });
       await local
         .projectMetaUpsert({
           tmuxSession: i.name,
           defaultCwd: expandTilde(cwd),
         })
         .catch(() => {});
-      return projects;
+      // BET: the create returns the new window's { sessionId, windowIndex,
+      // projects } so callers can navigate + send the first prompt to the
+      // RIGHT session (previously they re-located by name, which mixed new
+      // sessions up with existing ones on name collisions).
+      return result;
     },
     // Resolve cwd: prefer explicit cwd in input, then fall back to the
     // project's stored defaultCwd (set when the workspace was created).

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -39,8 +39,14 @@ function makeDeps(projects, liveProjects = []) {
     deps: {
       tmux: {
         listProjects: async () => liveProjects,
-        newWindow: async (i) => { calls.newWindow.push(i); return []; },
-        newSession: async (i) => { calls.newSession.push(i); return []; },
+        newWindow: async (i) => {
+          calls.newWindow.push(i);
+          return { sessionId: null, windowIndex: 1, projects: liveProjects };
+        },
+        newSession: async (i) => {
+          calls.newSession.push(i);
+          return { sessionId: "ses_new", windowIndex: 1, projects: [] };
+        },
         newWindowGetIndex: async (sessionName, windowName, cwd, chatMode) => {
           // BET-307: tmux.newWindowGetIndex now takes an optional 4th chatMode
           // arg (default false). Mirror the production arity so callers and
@@ -348,7 +354,28 @@ test("tmux:new-session swallows projectMetaUpsert failures (best-effort)", async
     windowName: "default",
     chatMode: true,
   });
-  assert.deepEqual(result, [], "tmux.newSession result returned (no throw)");
+  // tmux.newSession result returned (no throw), NOT unboxed to projects.
+  assert.deepEqual(result, { sessionId: "ses_new", windowIndex: 1, projects: [] });
+});
+
+// The create return contract: the renderer needs the newly-created window's
+// identity (sessionId + windowIndex) from the RPC response so it can navigate
+// + send the first prompt to the RIGHT session (previously it re-located by
+// name, which mixed new sessions up with existing ones on name collisions).
+test("tmux:new-window surfaces the created window's sessionId + windowIndex", async () => {
+  const { deps, calls } = makeDeps([{ tmuxSession: "better-ui", defaultCwd: "/home/dev/projects/better-ui" }]);
+  const handlers = buildHandlers(deps);
+  const out = await handlers["tmux:new-window"]({
+    sessionName: "better-ui",
+    windowName: "chat",
+    cwd: "",
+    chatMode: true,
+  });
+  assert.equal(out.sessionId, null);
+  assert.equal(out.windowIndex, 1);
+  assert.deepEqual(out.projects, []);
+  // the window's cwd was resolved before hitting tmux.newWindow
+  assert.equal(calls.newWindow.at(-1).cwd, "/home/dev/projects/better-ui");
 });
 
 // ---- BET-309 follow-up (BET-318): opencode:provider-auth `status` -------

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -441,7 +441,7 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, o
   // honored — without this the write would silently land on the
   // production default.
   await addOwnedSession(name, { path: ownedSessionsCachePath });
-  return listProjects();
+  return { sessionId: sid ?? null, windowIndex: idx, projects: await listProjects() };
 }
 export async function newWindow({ sessionName, windowName, cwd, chatMode, worktreePath, oc, permission }) {
   // THE tmux-side chokepoint. Resolves before we opencode-create or tmux-call,
@@ -468,7 +468,7 @@ export async function newWindow({ sessionName, windowName, cwd, chatMode, worktr
   // restampSessionId pattern — separate option name so the two stamps
   // never collide.
   if (worktreePath) await stampWorktreePath(sessionName, idx, worktreePath);
-  return listProjects();
+  return { sessionId: sid ?? null, windowIndex: idx, projects: await listProjects() };
 }
 
 export async function renameSession({ oldName, newName }) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -19,6 +19,7 @@ import type {
   PermissionRequest,
   QuestionRequest,
   Project,
+  TmuxCreateResult,
   ScheduledJob,
   SecretMeta,
   SecretInput,
@@ -76,13 +77,18 @@ export interface Api {
 
   // tmux operations on the remote
   tmuxList(): Promise<Project[]>;
+  // The create RPCs return the newly-created window's identity (sessionId +
+  // windowIndex) alongside the refreshed projects list, so callers can
+  // navigate + send the first prompt to the RIGHT session instead of
+  // re-locating it by name (which mixed new sessions up with existing ones
+  // on name collisions).
   tmuxNewSession(input: {
     name: string;
     cwd: string;
     windowName?: string;
     chatMode?: boolean;
     createDir?: boolean;
-  }): Promise<Project[]>;
+  }): Promise<TmuxCreateResult>;
   tmuxNewWindow(input: {
     sessionName: string;
     windowName: string;
@@ -92,7 +98,7 @@ export interface Api {
     // on `@manta-worktree-path` so clean-on-close knows it owns this
     // worktree. Optional — omitted for non-worktree windows.
     worktreePath?: string;
-  }): Promise<Project[]>;
+  }): Promise<TmuxCreateResult>;
   tmuxRenameSession(input: { oldName: string; newName: string }): Promise<Project[]>;
   tmuxRenameWindow(input: {
     sessionName: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -244,6 +244,17 @@ export type Project = {
   mantaOwned?: boolean;
 };
 
+// Return shape of the tmux:new-session / tmux:new-window RPCs. Carries the
+// newly-created window's identity (sessionId + windowIndex) so the caller can
+// navigate + send the first prompt to the RIGHT window — instead of
+// re-locating it by name, which mixed new sessions up with existing ones on
+// name collisions. `projects` is the refreshed listing.
+export type TmuxCreateResult = {
+  sessionId: string | null;
+  windowIndex: number;
+  projects: Project[];
+};
+
 export type TmuxConfigStatus = {
   mantaManaged: boolean;   // ~/.tmux.conf currently has manta's config
   backupExists: boolean; // ~/.tmux.conf.pre-manta exists (restore is possible)


### PR DESCRIPTION
## Summary
A "new session" is now an **in-memory store draft** (in `store.ts`: `drafts` + `activeDraftId`) instead of a modal overlay. This resolves four reportings:

1. **Sessions "mixed up"** — submitting re-located the new window by *name* (`find(w => w.name === windowName)`), which collided when windows shared the default name and mis-routed the prompt/highlight to an old session. The server create RPCs now return the created window's identity, and both the composer and the delegation engine use it directly.
2. **Old session stays highlighted** — the sidebar now highlights the active draft's italic "new session" row; the previously-active session no longer reads as active while a draft is foreground.
3. **Can't navigate back** — the composer is no longer a blocking overlay; the store's active view drives it, and clicking any real session (setActive) exits the draft view. Multiple drafts coexist and switching loses nothing.
4. **Special loader vs transcript** — submitting a draft navigates straight to the new session's transcript, where the prompt shows the normal running indicator.

## Server contract change
`tmux:new-session` / `tmux:new-window` now return `{ sessionId, windowIndex, projects }` (new `TmuxCreateResult` type). The delegation engine reads the returned identity too. New windows are named from the first word of the prompt instead of a constant.

## Verification
- `npm run typecheck` — clean
- Renderer (vitest) — 2186 passed
- Server (node:test) — 1496 passed

## Note
`node_modules` is an accidentally-tracked symlink on `main`; it is untouched by this PR (the working-tree state on the dev box differs only locally).