### PR TITLE
fix(chat): draft session highlight + reliably send first prompt

### DIFF
--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -48,10 +48,28 @@ import { useVoiceRecorder, type VoiceResult } from "./voice";
 import type { VoiceMode, VoicePhase } from "./voice";
 import type {
   OpencodeModel,
+  Project,
   TmuxCreateResult,
   WorktreeInfo,
 } from "../shared/types";
 import { type ModelSelection, resolveActiveModel } from "./chatShared";
+
+// Normalise the tmux:new-session / new-window response. The (merged) server
+// returns { sessionId, windowIndex, projects }; tolerate an older server that
+// returned just the projects array so submitting a draft never silently drops
+// the first prompt.
+function normalizeCreate(
+  result: TmuxCreateResult | Project[],
+): { sessionId: string | null; windowIndex: number | undefined; projects: Project[] } {
+  if (Array.isArray(result)) {
+    return { sessionId: null, windowIndex: undefined, projects: result };
+  }
+  return {
+    sessionId: result.sessionId ?? null,
+    windowIndex: result.windowIndex,
+    projects: result.projects,
+  };
+}
 
 type Props = {
   // The id of the store draft this composer edits (see NewSessionDraft). The
@@ -93,6 +111,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   if (!draft) return null;
   const refresh = useStore((s) => s.refresh);
   const setActive = useStore((s) => s.setActive);
+  const applyProjects = useStore((s) => s.applyProjects);
   const updateDraft = useStore((s) => s.updateDraft);
   const dismissDraft = useStore((s) => s.dismissDraft);
   const deactivatedMainModels = useStore((s) => s.deactivatedMainModels);
@@ -262,21 +281,37 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
         });
       }
 
-      await refresh();
+      // Apply the server's refreshed listing directly — no separate (slow)
+      // global re-list — so the view switches to the new transcript right away.
+      const created = normalizeCreate(result);
+      applyProjects(created.projects);
 
-      // Navigate to the new session (this also exits the draft view) and send
-      // the first prompt. The server told us the exact window, so no lookup.
-      setActive(sessionName, result.windowIndex);
-      try {
-        await window.api.tmuxSelectWindow({
-          sessionName,
-          windowIndex: result.windowIndex,
-        });
-      } catch { /* non-fatal */ }
+      // Navigate to the new session (this exits the draft view) and send the
+      // first prompt. The server told us the exact window; the session id is
+      // taken from the create result, falling back to the window's stamped id
+      // (covers older servers that return only the projects array).
+      const proj = useStore
+        .getState()
+        .projects.find((p) => p.tmuxSession === sessionName);
+      const win =
+        created.windowIndex != null
+          ? proj?.windows.find((w) => w.index === created.windowIndex)
+          : proj?.windows.find((w) => w.active) ?? proj?.windows[0];
+      const sessionId = created.sessionId ?? win?.opencodeSessionId ?? null;
 
-      if (result.sessionId) {
+      setActive(sessionName, win?.index ?? created.windowIndex);
+      if (win) {
+        try {
+          await window.api.tmuxSelectWindow({
+            sessionName,
+            windowIndex: win.index,
+          });
+        } catch { /* non-fatal */ }
+      }
+
+      if (sessionId) {
         await window.api.opencodePrompt(
-          result.sessionId,
+          sessionId,
           text,
           draft.model ?? undefined,
         );
@@ -333,18 +368,32 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
 
       await refresh();
 
-      // The initial window of the new session is the created window.
-      setActive(sessionName, created.windowIndex);
-      try {
-        await window.api.tmuxSelectWindow({
-          sessionName,
-          windowIndex: created.windowIndex,
-        });
-      } catch { /* non-fatal */ }
+      // The initial window of the new session is the created window. The
+      // session id comes from the create result, with a window lookup fallback
+      // for older servers that return only the projects array.
+      const createdNorm = normalizeCreate(created);
+      const proj = useStore
+        .getState()
+        .projects.find((p) => p.tmuxSession === sessionName);
+      const win =
+        createdNorm.windowIndex != null
+          ? proj?.windows.find((w) => w.index === createdNorm.windowIndex)
+          : proj?.windows.find((w) => w.active) ?? proj?.windows[0];
+      const sessionId = createdNorm.sessionId ?? win?.opencodeSessionId ?? null;
 
-      if (created.sessionId && text) {
+      setActive(sessionName, win?.index ?? createdNorm.windowIndex);
+      if (win) {
+        try {
+          await window.api.tmuxSelectWindow({
+            sessionName,
+            windowIndex: win.index,
+          });
+        } catch { /* non-fatal */ }
+      }
+
+      if (sessionId && text) {
         await window.api.opencodePrompt(
-          created.sessionId,
+          sessionId,
           text,
           draft.model ?? undefined,
         );

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -541,31 +541,30 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                 ? `"${d.input.trim().slice(0, 40)}" · ${target}`
                 : target;
               return (
-                <div
+                <SessionRow
                   key={d.id}
-                  role="button"
-                  aria-selected={isActive}
-                  onClick={() => setActiveDraft(d.id)}
-                  className={`group flex items-center gap-1 px-1 py-1 rounded-xs text-meta cursor-pointer select-none ${
-                    isActive
-                      ? "bg-bg-soft text-text"
-                      : "text-text-muted hover:bg-bg-soft hover:text-text"
-                  }`}
+                  // A draft is never running/blocking — the at-rest "default"
+                  // dot keeps the row chrome identical to a resting session.
+                  status="default"
+                  selected={isActive}
+                  name={<span className="italic">new session</span>}
                   title={`New session — ${hint}`}
-                >
-                  <span className="flex-1 min-w-0 truncate italic">new session</span>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      dismissDraft(d.id);
-                    }}
-                    className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-danger leading-none"
-                    aria-label="Discard this new session"
-                    tabIndex={-1}
-                  >
-                    <X size={13} aria-hidden="true" />
-                  </button>
-                </div>
+                  ariaSelected={isActive}
+                  onClick={() => setActiveDraft(d.id)}
+                  trailing={
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        dismissDraft(d.id);
+                      }}
+                      className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
+                      aria-label="Discard this new session"
+                      tabIndex={-1}
+                    >
+                      <X size={13} aria-hidden="true" />
+                    </button>
+                  }
+                />
               );
             })}
           </div>


### PR DESCRIPTION
Follow-ups from testing the draft new-session feature (PR #632):

1. **Highlight** — a "new session" draft selected in the sidebar now renders through the shared `SessionRow`, so it gets the exact same highlight (raised surface + accent marker) as a selected regular session.

2. **Immediate switch** — committing a draft applies the server's returned `projects` directly (instead of a second, slower full re-list), so the view switches to the new transcript right after creation.

3. **First prompt reliably sent** — the session id is taken from the create result with a fallback to the new window's stamped opencode id (covers older servers that only return the projects array). Previously a draft could submit into an empty transcript with the prompt never actually sent.

Verified: `npm run typecheck` clean; vitest 2186 passed; node:test 1496 passed.