### PR TITLE
feat(chat): unify message entry animation on framer-motion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
+        "framer-motion": "^11.18.2",
         "lucide-react": "^1.28.0",
         "node-pty": "^1.0.0",
         "node-sqlite3-wasm": "^0.8.59",
@@ -7461,6 +7462,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -10439,6 +10467,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11641,7 +11684,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -12280,7 +12323,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -13094,7 +13137,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
+    "framer-motion": "^11.18.2",
     "lucide-react": "^1.28.0",
     "node-pty": "^1.0.0",
     "node-sqlite3-wasm": "^0.8.59",

--- a/src/renderer/MessageBubble.test.tsx
+++ b/src/renderer/MessageBubble.test.tsx
@@ -43,16 +43,17 @@ describe("MessageBubble", () => {
   });
 
   // The send animation must be OPT-IN. It shipped unconditional, so opening
-  // any session popped every bubble in the transcript at once.
+  // any session popped every bubble in the transcript at once. `entering`
+  // drives `initial={false}` (no animation) vs the framer-motion pop.
   it("does not animate by default — a loaded transcript stays still", () => {
     h = mount(<MessageBubble>Hello</MessageBubble>);
     const bubble = h.container.querySelector(".flex.justify-end > div") as HTMLElement;
-    expect(bubble.className).not.toContain("manta-bubble-in");
+    expect(bubble.getAttribute("data-motion")).toBeNull();
   });
 
   it("animates the send only when the message arrived live", () => {
     h = mount(<MessageBubble entering>Hello</MessageBubble>);
     const bubble = h.container.querySelector(".flex.justify-end > div") as HTMLElement;
-    expect(bubble.className).toContain("manta-bubble-in");
+    expect(bubble.getAttribute("data-motion")).toBe("bubble");
   });
 });

--- a/src/renderer/MessageBubble.tsx
+++ b/src/renderer/MessageBubble.tsx
@@ -26,6 +26,8 @@
 // surface need it.
 
 import type { ReactNode } from "react";
+import { motion } from "framer-motion";
+import { MESSAGE_IN_ENTER, MESSAGE_IN_IDLE } from "./chatMotion";
 
 export const BUBBLE_CHROME =
   "bg-fill border border-border-subtle rounded-lg px-4 py-[11px] text-prose text-text " +
@@ -37,17 +39,25 @@ export function MessageBubble({
 }: {
   children: ReactNode;
   // The iMessage-style send pop, and the ONE thing that must stay gated: this
-  // class used to be unconditional, so every bubble in a transcript the user
-  // merely opened popped on mount and a session switch replayed every send
-  // they had ever made. Only a message that arrives while they are watching
-  // animates (decided in Transcript, see `updateEntryMotion`).
+  // used to be unconditional, so every bubble in a transcript the user merely
+  // opened popped on mount and a session switch replayed every send they had
+  // ever made. Only a message that arrives while they are watching animates
+  // (decided in Transcript, see `updateEntryMotion`). When false the bubble
+  // renders `initial={false}` — it appears instantly, history stays still.
   entering?: boolean;
 }) {
   return (
     <div className="flex justify-end">
-      <div className={entering ? BUBBLE_CHROME + " manta-bubble-in" : BUBBLE_CHROME}>
+      <motion.div
+        className={BUBBLE_CHROME}
+        // Test hook: present exactly when this bubble is animating (live), so
+        // the history-still gate is assertable without depending on framer-
+        // motion internals or a real CSS class.
+        data-motion={entering ? "bubble" : undefined}
+        {...(entering ? MESSAGE_IN_ENTER : MESSAGE_IN_IDLE)}
+      >
         {children}
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -12,7 +12,9 @@
 //     module cycle that is safe because both references are used only at
 //     render time).
 
-import { memo, useRef, useState } from "react";
+import { memo, useState } from "react";
+import { motion } from "framer-motion";
+import { MESSAGE_IN_ENTER, MESSAGE_IN_IDLE } from "./chatMotion";
 import type { OpencodePart } from "../shared/types";
 import { resolveToolOutput, cssVar } from "./chatUtils";
 import { type ToolState } from "./chatShared";
@@ -71,50 +73,37 @@ export const AssistantPart = memo(function AssistantPart({
   part: OpencodePart;
   showThinking: boolean;
   // True ONLY for the text part currently being written (last part of the last
-  // assistant message while the turn runs). Adds `manta-streaming`, which owns
-  // the per-block slide-in and the trailing caret in index.css. A primitive so
-  // the memo chain is untouched; false everywhere else, so a settled transcript
-  // never animates and never shows a caret.
+  // assistant message while the turn runs). Carries the trailing caret; a
+  // settled transcript never shows one.
   streaming?: boolean;
   // True when the parent message ARRIVED while the user was watching, so this
-  // part should slide up as it appears (transcript-motion). This is where the
-  // "cards slide in" effect actually lives: during a turn the parts of one
-  // assistant message mount one at a time, so the PART is the unit that enters,
-  // not the row. A loaded transcript passes false and stays still.
+  // part pops in as it appears. Every part of a live message does the SAME
+  // animation (MESSAGE_IN) — a streaming text reply pops like the prompt,
+  // and a tool card pops the same way — so a turn assembles itself in one
+  // consistent visual language. A loaded transcript passes false and stays
+  // still (`initial={false}` → nothing moves).
   entering?: boolean;
 }) {
   const body = renderAssistantPart(part, showThinking, streaming);
-  // Whether this part slides in is DECIDED ONCE, at mount, and frozen in a ref.
-  // Two reasons it cannot be a plain per-render expression:
-  //   1. `streaming` flips to false the moment the NEXT part arrives (only the
-  //      last part of the running message is streaming). Re-evaluating the slide
-  //      then would add the class long after the card appeared — replaying the
-  //      animation at the wrong moment.
-  //   2. Swapping between `body` and a wrapped `body` changes the element TYPE
-  //      at this position, so React unmounts and remounts the card subtree —
-  //      replaying the slide AND throwing away its local expanded state
-  //      (ToolCall / CollapsibleLines useState). So we always render a stable
-  //      wrapper element and only vary its className.
-  //
-  // The streaming TEXT part is exempt — it slides PER MARKDOWN BLOCK instead,
-  // via `.manta-streaming > *`, which runs the very same keyframes. Prose
-  // arrives paragraph by paragraph over many seconds, so the block is its unit
-  // of arrival the way the part is a card's; sliding the container on top of
-  // that would move the same content twice, 8px inside another 8px. A tool card
-  // has no such per-block motion, so the card itself must slide — which the old
-  // `streaming` guard wrongly suppressed (a tool card is always the last, and
-  // therefore "streaming", part at the instant it appears).
-  //
-  // The slide goes on a WRAPPER rather than the part's own root because the
-  // roots are shared primitives (ToolCard, OutputWell) that deliberately expose
-  // no className escape hatch. The wrapper is a plain block inside the row's
-  // existing flex column, so it inherits the gap and changes no layout.
-  const slideRef = useRef<boolean | null>(null);
-  if (slideRef.current === null) {
-    slideRef.current = entering && !(streaming && part.type === "text");
-  }
   if (body == null) return null;
-  return <div className={slideRef.current ? "manta-part-in" : undefined}>{body}</div>;
+  // The motion goes on an ALWAYS-PRESENT wrapper rather than the part's own
+  // root because the roots are shared primitives (ToolCard, OutputWell) that
+  // deliberately expose no className escape hatch. Keeping the element type
+  // stable (never swapping a plain div for a motion.div) means React never
+  // unmounts the card subtree, so the pop plays once at mount and a settling
+  // turn (or canonical refetch) can never replay it or throw away a part's
+  // local expanded state.
+  return (
+    <motion.div
+      // Test hook: present exactly when this part is animating (live), so the
+      // history-still gate is assertable without depending on framer-motion
+      // internals or a real CSS class.
+      data-motion={entering ? "part" : undefined}
+      {...(entering ? MESSAGE_IN_ENTER : MESSAGE_IN_IDLE)}
+    >
+      {body}
+    </motion.div>
+  );
 });
 
 function renderAssistantPart(

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -77,8 +77,11 @@ function props(messages: OpencodeMessage[], running = false): TranscriptProps {
   };
 }
 
-const bubblesIn = (h: Harness) => h.container.querySelectorAll(".manta-bubble-in").length;
-const partsIn = (h: Harness) => h.container.querySelectorAll(".manta-part-in").length;
+// `data-motion` is the framer-motion gate hook: "bubble" on a live user
+// bubble, "part" on a live assistant part (tool card, streaming text). Absent
+// means the element stayed still (history). See MessageBubble / AssistantPart.
+const bubblesIn = (h: Harness) => h.container.querySelectorAll('[data-motion="bubble"]').length;
+const partsIn = (h: Harness) => h.container.querySelectorAll('[data-motion="part"]').length;
 
 // The transcript a session opens with: already on screen, never animated.
 const HISTORY = [msg("u1", "user", "first"), msg("a1", "assistant", "reply")];
@@ -133,44 +136,41 @@ describe("Transcript entry motion", () => {
     expect(bubblesIn(h)).toBe(0);
   });
 
-  it("slides in a tool card that arrives live, immediately at mount", () => {
+  it("pops in a tool card that arrives live, immediately at mount", () => {
     // A tool card is ALWAYS the last (streaming) part at the instant it
-    // appears. The slide decision is frozen at mount: `entering && !(streaming
-    // && text)` — a tool part is not text, so it slides right away and keeps
-    // sliding through the re-render storm (the class is stable, never re-derived
-    // when `streaming` later flips false and the card remounts is avoided by the
-    // always-present wrapper). This is the bug the old `streaming` guard caused:
-    // the tool card was exempted and never slid.
+    // appears. `entering` is frozen at mount: once a part is marked, the
+    // framer-motion wrapper keeps `initial`/`animate` through the re-render
+    // storm (motion plays once on mount), and settling the turn never
+    // re-derives it onto a remounted wrapper — the always-present motion.div
+    // avoids the unmount/remount that would replay the pop.
     h = open();
     render(h, [...HISTORY, OPTIMISTIC], true);
 
     const streaming = [...HISTORY, OPTIMISTIC, toolMsg("a_new", "bash")];
     render(h, streaming, true);
-    expect(partsIn(h)).toBe(1); // slid immediately, mid-stream
+    expect(partsIn(h)).toBe(1); // popped immediately, mid-stream
 
     render(h, streaming, false); // turn settles — still exactly one, no remount
     expect(partsIn(h)).toBe(1);
   });
 
-  it("slides the live text part PER BLOCK, not as a container", () => {
-    // Prose is not exempt from the motion — only from the CONTAINER slide. It
-    // carries `.manta-streaming`, whose `> *` rule runs the same keyframes on
-    // each markdown block as it arrives, so prose and cards slide identically.
-    // Wrapping the container too would move the same content twice, 8px inside
-    // another 8px. Both halves are asserted: no container slide, and the class
-    // that supplies the per-block slide IS present — without that second
-    // assertion this test would still pass if prose animated not at all.
+  it("animates the live streaming text part with the same motion as a card", () => {
+    // Prose is NOT exempt from the motion anymore — every part of a live
+    // message (streaming text included) pops with the same framer-motion
+    // entry, so the AI reply reads like the prompt. The container plays once
+    // on mount; the `.manta-streaming` class still supplies the trailing
+    // caret. Settling the turn must not retro-add a second pop.
     h = open();
     render(h, [...HISTORY, OPTIMISTIC], true);
 
     const streaming = [...HISTORY, OPTIMISTIC, msg("a_new", "assistant", "writing")];
     render(h, streaming, true);
-    expect(partsIn(h)).toBe(0);
+    expect(partsIn(h)).toBe(1);
     expect(h.container.querySelectorAll(".manta-streaming").length).toBe(1);
 
-    // Frozen at mount: settling the turn must not retro-add a container slide.
+    // Frozen at mount: settling the turn must not replay the pop.
     render(h, streaming, false);
-    expect(partsIn(h)).toBe(0);
+    expect(partsIn(h)).toBe(1);
   });
 
   it("leaves history still even after new messages have arrived", () => {

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -28,6 +28,7 @@
 
 import type { OpencodeMessage, QuestionRequest } from "../shared/types";
 import { useRef } from "react";
+import { MotionConfig } from "framer-motion";
 import { TaskContext, type TaskContextValue } from "./chatShared";
 import { MeasureColumn } from "./MeasureColumn";
 import { ActiveTodos, MessageRow } from "./MessageRow";
@@ -100,6 +101,10 @@ export function Transcript({
   );
 
   return (
+    // Wrap in reducedMotion="user" so framer-motion disables every chat entry
+    // animation for users who prefer reduced motion — the library-native
+    // replacement for the old `prefers-reduced-motion` CSS blocks.
+    <MotionConfig reducedMotion="user">
     <div
       ref={scrollRef}
       className="flex-1 overflow-y-auto overflow-x-hidden"
@@ -219,5 +224,6 @@ export function Transcript({
         </ErrorBoundary>
       </TaskContext.Provider>
     </div>
+    </MotionConfig>
   );
 }

--- a/src/renderer/chatMotion.ts
+++ b/src/renderer/chatMotion.ts
@@ -1,0 +1,52 @@
+// M527.chatMotion — the single entry animation for chat message appearance.
+//
+// There used to be three separate hand-rolled CSS keyframe animations
+// (manta-bubble-in for the prompt, manta-part-in for cards, manta-streaming
+// for per-block streamed text) plus a data-* gate. They were consolidated into
+// ONE framer-motion animation, "variant A": every assistant reply, tool card
+// and user prompt that arrives while the user is watching performs the same
+// short rise with a slight scale overshoot (spring physics), so message
+// appearance reads as one consistent "pop" — iMessage/WhatsApp style — instead
+// of each surface having its own bespoke motion.
+//
+// The gate that decides WHAT animates still lives in `updateEntryMotion`
+// (chatUtils.ts): only messages that arrive LIVE are marked `entering`, and a
+// transcript the user merely loads passes `entering=false`, for which the
+// consuming components render the IDLE props so nothing moves. See the
+// `entering` prop docs on MessageBubble / AssistantPart. The single source of
+// the animation values lives here so the bubble and the streaming reply cannot
+// drift apart again.
+//
+// NOTE on typing: the ENTER/IDLE split exists for the compiler as much as the
+// runtime. framer-motion's `initial`/`animate` prop types are a deep recursive
+// union, and a JSX ternary like `{...(entering ? hidden : visible)}` forces TS
+// to normalize `false | TargetAndTransition`, which exceeds its union
+// complexity limit (TS2590). Spreading two fully-typed `Pick<MotionProps,…>`
+// objects sidesteps that — each branch is already the exact prop shape.
+
+import type { MotionProps } from "framer-motion";
+
+type EntryMotionProps = Pick<MotionProps, "initial" | "animate" | "transition">;
+
+/**
+ * The "pop": a 14px rise with a scale 0.9 -> 1.02 -> 1 overshoot driven by
+ * spring physics. Applied identically to the user bubble, the streaming AI
+ * reply, and tool cards when their message arrived live. The overshoot is the
+ * point — a hard snap would be a static stamp; the spring makes it a single
+ * "pop" the text lands in.
+ */
+export const MESSAGE_IN_ENTER: EntryMotionProps = {
+  initial: { opacity: 0, y: 14, scale: 0.9 },
+  animate: { opacity: 1, y: 0, scale: 1 },
+  transition: { type: "spring", stiffness: 380, damping: 26, mass: 0.8 },
+};
+
+/**
+ * No motion (history): `initial={false}` renders at the shown state with zero
+ * animation, so a transcript the user merely loads stays perfectly still.
+ */
+export const MESSAGE_IN_IDLE: EntryMotionProps = {
+  initial: false,
+  animate: undefined,
+  transition: undefined,
+};

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -156,37 +156,16 @@ html, body, #root {
   .manta-loader-ring-in { animation: none; }
 }
 
-/* Streaming assistant text (BET-649).
-   Two effects, both scoped to the ONE message currently being written, so
-   nothing in the settled transcript animates or carries a caret.
-
-   1. Block slide-in. Each markdown block enters with the SAME motion a tool
-      card uses (see manta-part-in below) — same distance, duration and easing —
-      so prose and cards arrive identically and a turn assembles itself in one
-      visual language. It fires on MOUNT, so an already-rendered paragraph that
-      merely grows does not re-animate, and the canonical refetch (which
-      reconciles rather than remounts) does not re-fire it.
-
-      The motion is the "layered drift" used across the transcript: new material
-      glides up from a comfortable vertical distance on a long, calm ease
-      (cubic-bezier(0.16, 1, 0.3, 1)) so it reads as the turn settling into
-      place rather than snapping in. Uniform for prose and cards.
-
-      It used to be its own weaker `manta-chunk-in` (3px / 0.18s), then a shared
-      8px / 0.22s rise. At those distances the rise is below the threshold
-      where it reads as movement — reported as "prose never slides in". The
-      further drift + longer ease is what makes it legible.
-
-      NOTE the block is the unit here, and the container is deliberately NOT
-      also slid (AssistantPart exempts the live text part): sliding both would
-      move the same content twice.
-   2. Trailing caret. A thin accent block after the last block's last line,
-      marking where output is being written. Drawn with ::after on the last
-      child so it sits INLINE at the end of the text — a sibling element would
-      break onto its own line after a block-level <p>. */
-.manta-streaming > * {
-  animation: manta-part-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
+/* Streaming assistant text — trailing caret only (BET-649, M527).
+   Entry motion for chat messages now lives in framer-motion
+   (`src/renderer/chatMotion.ts`, applied by MessageBubble / AssistantPart), so
+   the per-block and per-card CSS slide-ins are gone. What remains here is the
+   trailing caret that marks the ONE message currently being written: a thin
+   accent block after the last block's last line, drawn with ::after on the
+   last child so it sits INLINE at the end of the text — a sibling element
+   would break onto its own line after a block-level <p>. Nothing in the
+   settled transcript carries a caret, and the entry animation itself is
+   reduced-motion-handled by MotionConfig reducedMotion="user" in Transcript. */
 .manta-streaming > *:last-child::after {
   content: "";
   display: inline-block;
@@ -199,60 +178,7 @@ html, body, #root {
   animation: blink-cursor 1s step-start infinite;
 }
 @media (prefers-reduced-motion: reduce) {
-  .manta-streaming > * { animation: none; }
   .manta-streaming > *:last-child::after { animation: none; }
-}
-
-/* Transcript entry motion (transcript-motion).
-   A tool card / text block that appears while the user is watching glides up
-   from a comfortable distance with a fade, so a turn assembles itself instead
-   of each piece teleporting into place. Transform + opacity only
-   (compositor-friendly), `both` fill so the one-shot play holds its end state.
-
-   THE PART IS THE UNIT, not the row. During a turn the parts of a single
-   assistant message mount one at a time over many seconds, so animating the
-   row would mean sliding a container that is already on screen — which is
-   why the earlier whole-row version could never fire: the row was always
-   exempt as "currently streaming" when it mounted, and no longer new by the
-   time it settled. The live-streaming text part is still exempt here because
-   its markdown blocks already run these same keyframes one at a time via
-   .manta-streaming (BET-649) — it slides per block, not as a container.
-
-   `entering` (decided in Transcript.tsx by updateEntryMotion) is what keeps
-   history still: a transcript the user merely loaded animates nothing. */
-@keyframes manta-part-in {
-  0%   { opacity: 0; transform: translateY(22px) scale(0.985); }
-  100% { opacity: 1; transform: none; }
-}
-.manta-part-in {
-  animation: manta-part-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-/* User bubble send (transcript-motion). Layered-drift style: the bubble glides
-   up from just below where the composer sits — same motion family as incoming
-   material (22px rise, gentle 0.985 settle, long calm ease) so the transcript
-   reads as one continuous upward flow rather than the send being a different
-   "language" from the reply. Origin is the bottom-right corner (where a send
-   originates) so the rise scales toward the transcript, not the gutter.
-
-   Applied ONLY when the message arrived live (see MessageBubble): this class
-   was once unconditional, which made every bubble in an opened transcript move
-   and replayed the user's whole send history on a session switch. */
-@keyframes manta-bubble-in {
-  0%   { opacity: 0; transform: translateY(22px) scale(0.985); }
-  100% { opacity: 1; transform: none; }
-}
-.manta-bubble-in {
-  animation: manta-bubble-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
-  transform-origin: bottom right;
-}
-
-/* Vestibular safety (MDN prefers-reduced-motion): with reduce set, the
-   transcript never slides — rows and bubbles simply appear. State is
-   unaffected; only the motion is removed. */
-@media (prefers-reduced-motion: reduce) {
-  .manta-part-in,
-  .manta-bubble-in { animation: none; }
 }
 
 /* Artifacts tab switch (links/images/files). The SELECTED highlight is a

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -33,6 +33,30 @@ import { SessionHeader } from "./SessionHeader";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
+// framer-motion mounts motion.div components in jsdom and probes browser APIs
+// jsdom lacks. Without these shims a framer-motion render throws on mount.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+if (typeof window !== "undefined" && !window.matchMedia) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
 // A subscriber registered via the mocked `window.api.onOpencodeEvent`.
 type EventListener = (ev: OpencodeEvent) => void;
 


### PR DESCRIPTION
## What

Replaces the three hand-rolled CSS keyframe animations (`manta-bubble-in`, `manta-part-in`, `.manta-streaming > *` per-block slide) with a single framer-motion entry animation applied identically to the user prompt, the streaming AI reply, and tool cards: a 14px rise + scale 0.9→1.02→1 spring pop ("variant A").

## Why

The instructions-driven goal: one consistent iMessage/WhatsApp-style appearance for live chat content instead of several bespoke CSS animations, delivered via a maintained library rather than hand-rolled keyframes.

## Behavior preserved (critical)

- **History stays still** — the `updateEntryMotion` live-arrival gate is unchanged; idle/loaded messages render `initial={false}` so nothing animates on session load.
- **Streaming caret** kept as the only CSS remainder (typing indicator).
- **Reduced motion** preserved via `MotionConfig reducedMotion="user"` in `Transcript` (replaces the old `prefers-reduced-motion` blocks).
- Entry motion plays once at mount and never replays on canonical refetch / re-render storm.

## Files

- new `src/renderer/chatMotion.ts` — single source of the animation
- `MessageBubble.tsx`, `ToolCall.tsx` — convert to `motion.div`
- `Transcript.tsx` — `MotionConfig`
- `index.css` — remove the chat entry keyframes
- `MessageBubble\|Transcript`.test.tsx — assert the `data-motion` gate
- `testHarness.tsx` — jsdom shims for framer-motion

## Verification

- `npm run typecheck` ✓
- `npm test`: renderer 1108 pass · server 1496 pass ✓