### PR TITLE
feat(chat): optimistic new-session — real chat view appears instantly

### DIFF
--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -53,42 +53,7 @@ import type {
   WorktreeInfo,
 } from "../shared/types";
 import { type ModelSelection, resolveActiveModel } from "./chatShared";
-import { formatDuration } from "./chatUtils";
-import { MantaLoader } from "./MantaLoader";
-
-// Optimistic "starting a new session" panel. It replaces the composer the
-// INSTANT a draft is submitted, while the session is created in the background
-// (tmux + opencode round-trip takes a couple of seconds). Reuses the app's
-// waiting image + running-verb so it reads as "your prompt was sent and it's
-// working" — mirroring the transcript's running state, so when the real
-// session lands and the panel mounts the real transcript, it continues
-// seamlessly. If creation fails, NewSessionScreen returns to the composer with
-// the error (the draft + typed prompt are preserved).
-function StartingPanel({ input }: { input: string }) {
-  const [elapsed, setElapsed] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setElapsed((s) => s + 1), 1000);
-    return () => clearInterval(id);
-  }, []);
-  return (
-    <div className="h-full flex flex-col justify-end px-8 pb-10">
-      <div className="w-full max-w-[680px] mx-auto space-y-4">
-        <div className="flex justify-end">
-          <div className="max-w-[70%] whitespace-pre-wrap rounded-xl bg-fill px-4 py-2 text-prose text-text">
-            {input || "…"}
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <MantaLoader />
-          <span className="text-label text-text-muted">Musing on this…</span>
-          <span className="text-meta tabular-nums text-text-faint">
-            {formatDuration(elapsed * 1000)}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { ChatPanel } from "./ChatPanel";
 
 // Normalise the tmux:new-session / new-window response. The (merged) server
 // returns { sessionId, windowIndex, projects }; tolerate an older server that
@@ -166,6 +131,11 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const [fanOutWorktrees, setFanOutWorktrees] = useState<WorktreeInfo[] | null>(null);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Optimistic commit: once the opencode session exists we leave the composer
+  // and render the REAL ChatPanel (transcript + composer) with the first prompt
+  // streaming, while the tmux window is created behind it. `cwd` is the folder
+  // the session was created in (worktree path when one was requested).
+  const [committing, setCommitting] = useState<{ sid: string; cwd: string } | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // Model state — fetched on mount (same pattern as ChatPanel).
@@ -268,7 +238,18 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const groqApiKey = useStore((s) => s.groqApiKey);
   const voiceEnabled = !!groqApiKey && typeof MediaRecorder !== "undefined";
 
-  // ---- submit: create session + send first prompt ----
+  // ---- submit: create session + send first prompt (optimistic) ----
+  //
+  // The flow is split so the user sees their prompt being processed immediately:
+  //   1. create the opencode session FIRST (a fast web call) → its directory is
+  //      remembered server-side, which opens the scoped SSE stream,
+  //   2. optimistically render the REAL ChatPanel (transcript + composer) for
+  //      that session and send the first prompt → prompt + running indicator
+  //      appear right away,
+  //   3. create the tmux window/session and stamp it with the SAME session id,
+  //      then reconcile (apply the listing + hand off to the App's session
+  //      layer). If anything fails we roll back the orphan and drop to the
+  //      composer with the error.
   const submit = async () => {
     if (sending) return;
     const text = draft.input.trim();
@@ -276,89 +257,94 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     setSending(true);
     setError(null);
 
+    let createdSid: string | null = null;
     try {
-      let sessionName: string;
-      let result: TmuxCreateResult;
+      // Resolve folder + (optionally) a fresh worktree once, up front.
       let worktreePath: string | undefined;
-
-      if (isNewProject) {
-        sessionName = deriveProjectName(draft.cwd);
-        // Avoid name collision with existing sessions.
-        const taken = new Set(existingProjects.map((p) => p.tmuxSession));
-        if (taken.has(sessionName)) {
-          let i = 2;
-          while (taken.has(`${sessionName}-${i}`)) i++;
-          sessionName = `${sessionName}-${i}`;
-        }
-
-        if (draft.wantWorktree && isGitRepo) {
-          const wt = await window.api.gitAddWorktree({ cwd: draft.cwd, name: draft.worktreeBranch });
-          worktreePath = wt.path;
-        }
-
-        result = await window.api.tmuxNewSession({
-          name: sessionName,
-          cwd: worktreePath ?? draft.cwd,
-          windowName: "default",
-          chatMode: true,
-          ...(worktreePath ? {} : { createDir: true }),
-        });
-      } else {
-        sessionName = projectName!;
-        if (draft.wantWorktree && isGitRepo) {
-          const wt = await window.api.gitAddWorktree({ cwd: draft.cwd, name: draft.worktreeBranch });
-          worktreePath = wt.path;
-        }
-        result = await window.api.tmuxNewWindow({
-          sessionName,
-          windowName: promptWindowName(text),
-          ...(worktreePath ? { cwd: worktreePath, worktreePath } : {}),
-          chatMode: true,
-        });
+      if (draft.wantWorktree && isGitRepo) {
+        const wt = await window.api.gitAddWorktree({ cwd: draft.cwd, name: draft.worktreeBranch });
+        worktreePath = wt.path;
       }
+      const dir = worktreePath ?? draft.cwd;
+      const newProject = isNewProject;
+      const sessionName = newProject
+        ? (() => {
+            const base = deriveProjectName(draft.cwd);
+            const taken = new Set(existingProjects.map((p) => p.tmuxSession));
+            if (!taken.has(base)) return base;
+            let i = 2;
+            while (taken.has(`${base}-${i}`)) i++;
+            return `${base}-${i}`;
+          })()
+        : projectName!;
 
-      // Apply the server's refreshed listing directly — no separate (slow)
-      // global re-list — so the view switches to the new transcript right away.
-      const created = normalizeCreate(result);
-      applyProjects(created.projects);
+      // 1. Fast opencode session creation first.
+      const sess = await window.api.opencodeCreateEphemeralSession({
+        directory: dir,
+        title: newProject
+          ? `${sessionName} / default`
+          : `${sessionName} / ${promptWindowName(text)}`,
+      });
+      if (!sess.ok || !sess.sessionId) {
+        throw new Error(sess.error || "could not start the session");
+      }
+      createdSid = sess.sessionId;
 
-      // Navigate to the new session (this exits the draft view) and send the
-      // first prompt. The server told us the exact window; the session id is
-      // taken from the create result, falling back to the window's stamped id
-      // (covers older servers that return only the projects array).
+      // 2. Optimistically show the real chat view; then send the prompt so the
+      //    running indicator streams in. Yield a frame so the panel has mounted
+      //    + subscribed to its session's events first.
+      setCommitting({ sid: createdSid, cwd: dir });
+      await new Promise((r) => setTimeout(r, 0));
+      window.api.opencodePrompt(createdSid, text, draft.model ?? undefined).catch(() => {});
+
+      // 3. Create the tmux window/session behind the user's view and stamp it
+      //    with the same session id, then reconcile.
+      const created = newProject
+        ? await window.api.tmuxNewSession({
+            name: sessionName,
+            cwd: dir,
+            windowName: "default",
+            chatMode: true,
+            existingSessionId: createdSid,
+            ...(worktreePath ? {} : { createDir: true }),
+          })
+        : await window.api.tmuxNewWindow({
+            sessionName,
+            windowName: promptWindowName(text),
+            cwd: dir,
+            chatMode: true,
+            existingSessionId: createdSid,
+            ...(worktreePath ? { worktreePath } : {}),
+          });
+      const createdNorm = normalizeCreate(created);
+      applyProjects(createdNorm.projects);
+
+      // 4. Reconcile: hand the panel off to the App's session layer (same
+      //    session id, same view) and drop the draft.
       const proj = useStore
         .getState()
         .projects.find((p) => p.tmuxSession === sessionName);
       const win =
-        created.windowIndex != null
-          ? proj?.windows.find((w) => w.index === created.windowIndex)
+        createdNorm.windowIndex != null
+          ? proj?.windows.find((w) => w.index === createdNorm.windowIndex)
           : proj?.windows.find((w) => w.active) ?? proj?.windows[0];
-      const sessionId = created.sessionId ?? win?.opencodeSessionId ?? null;
-
-      setActive(sessionName, win?.index ?? created.windowIndex);
+      setActive(sessionName, win?.index ?? createdNorm.windowIndex);
       if (win) {
         try {
-          await window.api.tmuxSelectWindow({
-            sessionName,
-            windowIndex: win.index,
-          });
+          await window.api.tmuxSelectWindow({ sessionName, windowIndex: win.index });
         } catch { /* non-fatal */ }
       }
-
-      if (sessionId) {
-        await window.api.opencodePrompt(
-          sessionId,
-          text,
-          draft.model ?? undefined,
-        );
-      }
-
+      setCommitting(null);
       // Abandon the draft — it is now a real session.
       dismissDraft(draftId);
       onDone?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      // Roll back: drop the orphaned opencode session (if we created one) and
+      // return to the composer. The draft + typed prompt are preserved.
+      if (createdSid) window.api.opencodeDeleteSessionRaw(createdSid).catch(() => {});
+      setCommitting(null);
       setSending(false);
+      setError(e instanceof Error ? e.message : String(e));
     }
   };
 
@@ -468,11 +454,23 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const emptyWorktree = isNewProject && !isGitRepo;
   const worktreeChipEnabled = emptyWorktree || isGitRepo;
 
-  // Optimistic: the moment a draft is submitted (sending flips true
-  // synchronously), leave the composer and show the prompt + running indicator
-  // immediately, while the session is created behind it. On failure `sending`
-  // returns to false and this re-renders the composer with the error.
-  if (sending) return <StartingPanel input={draft.input} />;
+  // Optimistic: the instant the opencode session exists, leave the composer
+  // and render the REGULAR chat view (transcript + composer) so the first
+  // prompt + running indicator appear immediately, while the tmux window is
+  // created behind the scenes. The real session hand-off happens in submit().
+  if (committing) {
+    return (
+      <div className="h-full w-full bg-bg">
+        <ChatPanel
+          sessionId={committing.sid}
+          tmuxSession={null}
+          windowIndex={null}
+          cwd={committing.cwd}
+          isActive
+        />
+      </div>
+    );
+  }
 
   return (
     // data-screen is the visual harness's handle on this screen (see

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -410,7 +410,7 @@ export async function newWindowGetIndex(sessionName, windowName, cwd, chatMode =
 // @param {boolean} [input.chatMode]    create an opencode chat-mode window
 // @param {object} [input.oc]           opencode client (required when chatMode)
 // @param {Array} [input.permission]    opencode permission ruleset (chatMode jobs)
-export async function newSession({ name, cwd, windowName, createDir, chatMode, oc, permission }) {
+export async function newSession({ name, cwd, windowName, createDir, chatMode, existingSessionId, oc, permission }) {
   // Onboarding's first-project step opts into auto-creation via createDir: a
   // missing ~/projects/<name> should be created, not silently swallowed. tmux
   // new-session -c falls back to $HOME for a non-existent dir, so the mkdir -p
@@ -425,10 +425,14 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, o
   // Chat-mode: create the opencode session BEFORE the tmux window so we can
   // stamp @manta-session-id on it. Without the stamp the renderer sees
   // opencodeSessionId === null and renders Terminal instead of ChatPanel —
-  // this was the BET-113 regression.
-  const sid = await maybeCreateChatSession(
-    oc, chatMode, dir, `${name} / ${windowName ?? "default"}`, permission,
-  );
+  // this was the BET-113 regression. `existingSessionId` (from the draft's
+  // optimistic create) reuses an already-created opencode session instead of
+  // making a second one.
+  const sid =
+    existingSessionId ??
+    (await maybeCreateChatSession(
+      oc, chatMode, dir, `${name} / ${windowName ?? "default"}`, permission,
+    ));
   const idx = await newSessionGetIndex(name, dir, windowName, !!chatMode);
   await applySessionSurvivability(name);
   if (sid) await restampSessionId(name, idx, sid);
@@ -443,13 +447,15 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, o
   await addOwnedSession(name, { path: ownedSessionsCachePath });
   return { sessionId: sid ?? null, windowIndex: idx, projects: await listProjects() };
 }
-export async function newWindow({ sessionName, windowName, cwd, chatMode, worktreePath, oc, permission }) {
+export async function newWindow({ sessionName, windowName, cwd, chatMode, existingSessionId, worktreePath, oc, permission }) {
   // THE tmux-side chokepoint. Resolves before we opencode-create or tmux-call,
   // so a bad cwd throws before we orphan an opencode session.
   const dir = resolveCwdOrThrow(cwd);
-  const sid = await maybeCreateChatSession(
-    oc, chatMode, dir, `${sessionName} / ${windowName}`, permission,
-  );
+  const sid =
+    existingSessionId ??
+    (await maybeCreateChatSession(
+      oc, chatMode, dir, `${sessionName} / ${windowName}`, permission,
+    ));
   let idx;
   try {
     idx = await newWindowGetIndex(sessionName, windowName, dir, !!chatMode);

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -245,6 +245,58 @@ test("newSession chatMode:false stays a plain session — no session create, no 
   assert.equal(findSetSid(cmds), undefined, "no @manta-session-id stamp for a plain session");
 });
 
+// ---- optimistic draft flow: reuse an existing opencode session id ----------
+// When the draft's submit creates the opencode session first (so the chat view
+// appears immediately) and then asks for a tmux window, the window must reuse
+// that session id rather than create a second one.
+
+test("newWindow with existingSessionId reuses the id and creates no new session", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc();
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-nw-exist-"));
+  try {
+    const out = await newWindow({
+      sessionName: "better-ui",
+      windowName: "chat",
+      cwd,
+      chatMode: true,
+      existingSessionId: "ses_preexisting",
+      oc,
+    });
+    assert.equal(oc.created.length, 0, "no new opencode session created");
+    assert.equal(out.sessionId, "ses_preexisting");
+    const stamp = findSetSid(cmds);
+    assert.ok(stamp, "@manta-session-id stamped");
+    assert.ok(stamp.args.includes("ses_preexisting"), "stamp carries the existing id");
+  } finally {
+    _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("newSession with existingSessionId reuses the id and creates no new session", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc();
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-ns-exist-"));
+  try {
+    const out = await newSession({
+      name: "newproj",
+      cwd,
+      windowName: "default",
+      chatMode: true,
+      existingSessionId: "ses_preexisting",
+      oc,
+    });
+    assert.equal(oc.created.length, 0, "no new opencode session created");
+    assert.equal(out.sessionId, "ses_preexisting");
+    const stamp = findSetSid(cmds);
+    assert.ok(stamp && stamp.args.includes("ses_preexisting"), "stamp carries the existing id");
+  } finally {
+    _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("newWindow chatMode:true throws when no opencode client is injected", async () => {
   installFakeTmux();
   try {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -88,6 +88,10 @@ export interface Api {
     windowName?: string;
     chatMode?: boolean;
     createDir?: boolean;
+    // When set, reuse this opencode session id (already created optimistically
+    // by the draft flow) instead of creating a new one, and stamp it on the
+    // new tmux window.
+    existingSessionId?: string;
   }): Promise<TmuxCreateResult>;
   tmuxNewWindow(input: {
     sessionName: string;
@@ -98,6 +102,9 @@ export interface Api {
     // on `@manta-worktree-path` so clean-on-close knows it owns this
     // worktree. Optional — omitted for non-worktree windows.
     worktreePath?: string;
+    // As above: reuse an optimistically-created opencode session id and stamp
+    // it on the new window.
+    existingSessionId?: string;
   }): Promise<TmuxCreateResult>;
   tmuxRenameSession(input: { oldName: string; newName: string }): Promise<Project[]>;
   tmuxRenameWindow(input: {


### PR DESCRIPTION
Follow-up to #638 (the bespoke "starting session" panel). That panel hit the feedback that a new session should land directly in the **real** chat view — transcript + composer below — with the first prompt already sent and the loading indicator showing, not a separate layout that bounces between screens.

This splits the draft create so that happens:

1. **Create the opencode session first** (a fast web call). `createSession` remembers its directory server-side, which opens the scoped SSE stream its panel subscribes to.
2. **Optimistically render the real `ChatPanel`** for that session and send the first prompt — the prompt + "Musing…" running indicator appear immediately in the actual transcript view.
3. **Create the tmux window/session behind it**, reusing the same session id, stamp the window, then **reconcile** by handing the panel off to the App's session layer (same id, same view — no remount of a different layout).

On failure it rolls back the orphaned opencode session (`opencodeDeleteSessionRaw`) and returns to the composer with the error; the draft + typed prompt are preserved.

**Server:** `tmux.newSession`/`newWindow` accept `existingSessionId` to reuse an already-created opencode session instead of making a second one (tests added in `tmux.test.mjs`).

Verified: `npm run typecheck` clean; vitest 2186 passed; node:test 1498 passed.