### PR TITLE
fix(chat): optimistic new-session transcript actually populates

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -147,6 +147,11 @@ type Props = {
   // Optional so test harnesses that construct ChatPanel directly omit them.
   artifactsOpen?: boolean;
   onToggleArtifacts?: () => void;
+  // A prompt to send through the panel's OWN submit path once, on mount —
+  // used by the optimistic "new session" flow so the first prompt + running
+  // indicator appear immediately in the real chat view. Optional; present
+  // only on the transient panel rendered while the tmux window is created.
+  autoSubmit?: { text: string; model?: ModelSelection };
 };
 
 export function ChatPanel({
@@ -162,6 +167,7 @@ export function ChatPanel({
   availableLaunchers = [],
   artifactsOpen = false,
   onToggleArtifacts = () => {},
+  autoSubmit,
 }: Props) {
   const chatAutoAllow = useStore((s) => s.chatAutoAllow);
   const setChatAutoAllow = useStore((s) => s.setChatAutoAllow);
@@ -851,6 +857,24 @@ export function ChatPanel({
   // latest version without adding submit to the effect's dependency array
   // (which would re-arm the effect on every keystroke).
   submitRef.current = submit;
+
+  // Optimistic "new session" auto-submit: seed the composer with the draft's
+  // prompt and fire the panel's OWN submit once, on mount. Going through submit
+  // (rather than calling opencodePrompt directly) gives the optimistic user
+  // message + running indicator immediately, exactly like a normal send. The
+  // defer is load-bearing: setInput runs synchronously, and submit is deferred
+  // so the re-render reassigns submitRef.current to a closure holding the new
+  // input (same rule as the queued-drain effect). A ref guard keeps it to one
+  // submission even if the autoSubmit prop identity churns.
+  const autoSubmitted = useRef(false);
+  useEffect(() => {
+    if (!autoSubmit || autoSubmitted.current) return;
+    autoSubmitted.current = true;
+    setModelOverride(autoSubmit.model ?? null);
+    setInput(autoSubmit.text);
+    const t = setTimeout(() => submitRef.current?.(), 0);
+    return () => clearTimeout(t);
+  }, [autoSubmit, setModelOverride, setInput]);
 
   // When the AI goes idle (running flips false) and there are queued
   // messages, dispatch the next one. We restore it into `input` and call

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -290,12 +290,10 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       }
       createdSid = sess.sessionId;
 
-      // 2. Optimistically show the real chat view; then send the prompt so the
-      //    running indicator streams in. Yield a frame so the panel has mounted
-      //    + subscribed to its session's events first.
+      // 2. Optimistically render the real chat view; its ChatPanel auto-submits
+      //    the first prompt through its OWN path (optimistic user message +
+      //    running indicator appear immediately).
       setCommitting({ sid: createdSid, cwd: dir });
-      await new Promise((r) => setTimeout(r, 0));
-      window.api.opencodePrompt(createdSid, text, draft.model ?? undefined).catch(() => {});
 
       // 3. Create the tmux window/session behind the user's view and stamp it
       //    with the same session id, then reconcile.
@@ -467,6 +465,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           windowIndex={null}
           cwd={committing.cwd}
           isActive
+          autoSubmit={{ text: draft.input.trim(), model: draft.model ?? undefined }}
         />
       </div>
     );


### PR DESCRIPTION
Follow-up to #643. The optimistic flow now lands in the real chat view, but the transcript stayed empty because the first prompt was sent via `window.api.opencodePrompt` directly — **bypassing ChatPanel's own submit path** (the optimistic user-message append + running flag). So the panel mounted empty and never showed the prompt or the "Musing…" indicator.

Fix: the transient panel is given an `autoSubmit` prop and sends the first prompt through **ChatPanel's own `submit`** on mount — it seeds the composer and fires `submitRef` (using the same defer rule as the queued-drain effect), so the user message and running indicator appear immediately in the real transcript view, exactly like a normal send. The tmux window is still created behind it and reconciled after.

Files: `ChatPanel.tsx` (new optional `autoSubmit` prop + one-shot effect), `NewSessionScreen.tsx` (pass `autoSubmit`, drop the direct `opencodePrompt` call).

Verified: `npm run typecheck` clean; vitest 2186 passed; node:test 1498 passed.