### PR TITLE
fix(chat): stop cancelling the new-session auto-submit it schedules

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -870,11 +870,17 @@ export function ChatPanel({
   useEffect(() => {
     if (!autoSubmit || autoSubmitted.current) return;
     autoSubmitted.current = true;
-    // Consume the one-shot so re-mounting/re-navigating never re-sends it.
-    useStore.getState().setAutoSubmitPrompt(null);
-    setModelOverride(autoSubmit.model ?? null);
-    setInput(autoSubmit.text);
-    const t = setTimeout(() => submitRef.current?.(), 0);
+    const { text, model } = autoSubmit;
+    setModelOverride(model ?? null);
+    setInput(text);
+    // Clear the one-shot INSIDE the fired timeout, never in the effect body.
+    // Clearing the store flips autoSubmit → undefined, which re-runs this
+    // effect's cleanup (clearTimeout) and would cancel the deferred submit
+    // before it fires — the exact "prompt never sent / blank session" bug.
+    const t = setTimeout(() => {
+      useStore.getState().setAutoSubmitPrompt(null);
+      submitRef.current?.();
+    }, 0);
     return () => clearTimeout(t);
   }, [autoSubmit, setModelOverride, setInput]);
 


### PR DESCRIPTION
Fixes the "new session doesn't appear at all" symptom from #647.

The auto-submit effect cleared the one-shot store value (`setAutoSubmitPrompt(null)`) in its **body**. Clearing the store flips the `autoSubmit` prop → `undefined`, which re-runs the effect's cleanup (`clearTimeout`) and **cancels the deferred `submitRef` call before it fires** — so a fresh session's first prompt was never sent and the panel rendered nothing.

Fix: clear the store **inside the already-fired timeout**, right alongside the submit. The prop-flip's cleanup then runs too late to cancel the send; the one-shot is still consumed so re-navigating never re-sends.

Verified: `npm run typecheck` clean; renderer vitest 1108 passed.