### PR TITLE
fix(update): don't show 'failed to fetch' banner on a successful box upgrade

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,7 +18,7 @@ import {
   writeSavedMode,
   resolveLauncherFlags,
 } from "./chatShared";
-import { chooseUpdateSkewVariant, isUnknownChannelError, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
+import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { Modal } from "./Modal";
@@ -537,6 +537,7 @@ function AppInner() {
   //   - "match"        → hide the card.
   // The `serverVersion` is the SAME field MobileSettings already reads
   // for "Server vX.Y.Z" under the URL field — single source of truth.
+  const [updateRefreshKey, setUpdateRefreshKey] = useState(0);
   const {
     clientVersion,
     serverVersion,
@@ -544,7 +545,7 @@ function AppInner() {
     variant: compatibilityVariant,
     showCard: showCompatibilityCard,
     dismiss,
-  } = useCompatibilityCard();
+  } = useCompatibilityCard(updateRefreshKey);
 
   // Sidebar status for chat-mode windows. The PTY-pane poller
   // (src/main/status.ts) can't see chat-mode state — the holder pane
@@ -914,13 +915,45 @@ function AppInner() {
     }
   }, [artifactsOpen]);
 
+  // BET-713 fix: a SUCCESSFUL box self-upgrade restarts manta-server before the
+  // `server:update-apply` RPC resolves, so the renderer's fetch dies with a bare
+  // "Failed to fetch". That restart is the success signal, not a failure — we
+  // only raise the update-failed banner for a STRUCTURED early failure
+  // (`{ok:false, error}`) the RPC reports. To reconcile the real outcome after
+  // the box comes back, we bump `updateRefreshKey` on reconnect (re-fetches the
+  // server version via `useCompatibilityCard`) and clear a stale updateError
+  // once the box is no longer "behind".
+  const [updateAttempted, setUpdateAttempted] = useState(false);
+
+  useEffect(() => {
+    if (connectionState.state !== "connected" && connectionState.state !== "idle") return;
+    if (!updateAttempted) return;
+    setUpdateAttempted(false);
+    setUpdateRefreshKey((k) => k + 1);
+  }, [connectionState.state, updateAttempted]);
+
+  // Once the box has advanced (variant is no longer "behind"), any pending
+  // update-failed banner is stale — the upgrade landed. A REAL early failure
+  // leaves the box behind, so `compatibilityVariant` stays "behind" and the
+  // banner correctly persists.
+  useEffect(() => {
+    if (updateError && (compatibilityVariant === "match" || compatibilityVariant === "unknown")) {
+      setUpdateError(null);
+    }
+  }, [updateError, compatibilityVariant]);
+
   const applyServerUpdate = async () => {
+    setUpdateAttempted(true);
     try {
       const res = await window.api.serverUpdateApply();
       if (res && res.ok === false) {
         setUpdateError({ message: res.error || "Server update failed", raw: res.error ?? "" });
       }
     } catch (e) {
+      // A bare connection error is the box restarting itself mid-update (the
+      // success path) — swallow it; the reconnect + version re-check above
+      // resolves the real outcome. Structured failures still raise the banner.
+      if (isTransientUpdateNetworkError(e)) return;
       setUpdateError({
         message: e instanceof Error ? e.message : String(e),
         raw: String(e),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -42,6 +42,7 @@ import {
   shouldReconnectOnAppStateChange,
   runWithConcurrency,
   chooseUpdateSkewVariant,
+  isTransientUpdateNetworkError,
   arrowUpNavigatesHistory,
   arrowDownNavigatesHistory,
   parseDeviceCode,
@@ -1551,6 +1552,35 @@ describe("chooseUpdateSkewVariant", () => {
     expect(chooseUpdateSkewVariant("1.x.3", "0.0.0")).toBe("ok");
     // But once one side has a real version, the compare takes over.
     expect(chooseUpdateSkewVariant("abc", "0.0.1")).toBe("outdated");
+  });
+});
+
+// ===== isTransientUpdateNetworkError =====
+describe("isTransientUpdateNetworkError", () => {
+  it("treats a browser connection-drop during a box upgrade as transient", () => {
+    // A successful self-upgrade restarts manta-server before the RPC resolves,
+    // so the fetch dies with a bare network error — NOT a real failure.
+    expect(isTransientUpdateNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("Failed to fetch"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("NetworkError when attempting to fetch resource."))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("The operation was aborted"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("Load failed"))).toBe(true);
+  });
+
+  it("does NOT treat a real server-reported early failure as transient", () => {
+    // Genuine failures come back as structured strings from the RPC result,
+    // not as connection errors — these must still raise the update-failed banner.
+    expect(isTransientUpdateNetworkError(new Error("self-update: manifest fetch failed: https://mantaui.com/releases/"))).toBe(false);
+    expect(isTransientUpdateNetworkError(new Error("self-update: manifest is malformed"))).toBe(false);
+    expect(isTransientUpdateNetworkError(new Error("self-update: bad tarball — missing src/server/index.mjs"))).toBe(false);
+    expect(isTransientUpdateNetworkError(new Error("spawn /abs/scripts/self-update.sh EACCES"))).toBe(false);
+  });
+
+  it("is tolerant of null/undefined and arbitrary input", () => {
+    expect(isTransientUpdateNetworkError(null)).toBe(false);
+    expect(isTransientUpdateNetworkError(undefined)).toBe(false);
+    expect(isTransientUpdateNetworkError("")).toBe(false);
+    expect(isTransientUpdateNetworkError(42)).toBe(false);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1178,6 +1178,45 @@ export function chooseUpdateSkewVariant(
   return isClientTooOld(clientVersion, minClient) ? "outdated" : "ok";
 }
 
+// ===== Box self-update: transient network failure vs real failure =====
+//
+// When a box self-upgrade SUCCEEDS, `scripts/self-update.sh` restarts
+// manta-server (its final step) BEFORE the `/rpc/server:update-apply` promise
+// resolves. The renderer's fetch therefore dies mid-flight with a bare
+// `TypeError: Failed to fetch` — an unavoidable side-effect of the success
+// path, NOT a sign the update failed. Surfacing that as the update-failed
+// banner made every successful upgrade look broken.
+//
+// This predicate distinguishes that benign connection-drop from a GENUINE
+// early failure (which the RPC reports as a structured `{ok:false, error}`
+// string, e.g. "self-update: manifest fetch failed: ..."). App.tsx uses it in
+// `applyServerUpdate`'s catch: a transient network error is swallowed (the
+// reconnect + version re-check resolves the real outcome); anything else is a
+// real failure and still raises the banner.
+//
+// Browser fetch throws `TypeError: Failed to fetch` (Chrome) / `Load failed`
+// (Safari) / `NetworkError` (older WebKit) on connection loss; a reconnecting
+// SSE can also surface wrapped variants. The match is deliberately loose but
+// never matches a structured server error string.
+export function isTransientUpdateNetworkError(err: unknown): boolean {
+  if (err == null) return false;
+  const msg = String(err instanceof Error ? err.message : err).toLowerCase();
+  // The box's own structured self-update reports ("self-update: manifest
+  // fetch failed: ...", "self-update: bad tarball ...") are GENUINE early
+  // failures and must never be classified transient — the banner-relevant
+  // resolver's `res.ok === false` branch surfaces them for real.
+  if (msg.includes("self-update:")) return false;
+  return (
+    msg.includes("failed to fetch") ||
+    msg.includes("fetch failed") ||
+    msg.includes("load failed") ||
+    msg.includes("networkerror") ||
+    msg.includes("network error") ||
+    msg.includes("cancelled") ||
+    msg.includes("aborted")
+  );
+}
+
 // ===== Composer arrow-key: history vs caret navigation =====
 //
 // The OLD logic scanned for `\n` before/after the caret to decide "first/last

--- a/src/renderer/hooks/useCompatibilityCard.ts
+++ b/src/renderer/hooks/useCompatibilityCard.ts
@@ -23,12 +23,17 @@ export type CompatibilityCard = {
   showCard: boolean;
 };
 
-export function useCompatibilityCard(): CompatibilityCard {
+export function useCompatibilityCard(refreshKey?: number): CompatibilityCard {
   const [clientVersion, setClientVersion] = useState<string | null>(null);
   const [serverMinClient, setServerMinClient] = useState<string | null>(null);
   const [serverVersion, setServerVersion] = useState<string | null>(null);
   const [dismissed, setDismissed] = useState(false);
 
+  // `refreshKey` (optional) lets the caller force a re-fetch of the version
+  // pair — App passes a value bumped after the box reconnects following a
+  // self-upgrade, so the compatibility check re-reads the box's NEW version
+  // and the "behind" banner clears once the upgrade lands. MobileApp omits it
+  // (no upgrade flow), so default behaviour is unchanged.
   useEffect(() => {
     let cancelled = false;
     void Promise.all([
@@ -43,7 +48,7 @@ export function useCompatibilityCard(): CompatibilityCard {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [refreshKey]);
 
   const variant = isCompatible({
     desktopVersion: clientVersion,


### PR DESCRIPTION
## Problem

Clicking **Upgrade box** triggers the box self-upgrade, which works — but a successful upgrade restarts `manta-server` before the `server:update-apply` RPC resolves. The renderer's fetch dies with a bare `Failed to fetch`, and the app wrongly shows the **update-failed** banner with a **Download** button, even though the box upgraded fine.

Reproduced end-to-end on a test box: box upgraded 0.0.19 → 0.0.21 successfully, yet the desktop showed "failed to fetch / Download" after reconnecting.

## Fix

Treat the connection-drop during an upgrade as the **success signal**, not a failure:

- **`chatUtils.ts`**: new pure `isTransientUpdateNetworkError` distinguishes a bare connection error (box restarting = success) from a genuine early failure (`self-update: ...` structured reports, which still raise the banner).
- **`useCompatibilityCard.ts`**: optional `refreshKey` param re-fetches the desktop↔box version pair.
- **`App.tsx`**: `applyServerUpdate` swallows transient network errors; on reconnect `updateRefreshKey` bumps → version re-fetched → once the box is no longer "behind", any stale error/banner clears.

## Result

- Upgrade **succeeds** → no false banner; app re-checks and settles quietly.
- Upgrade **fails early** (`manifest fetch failed`, bad tarball) → update-failed banner still appears, as intended.

## Tests

- `isTransientUpdateNetworkError` unit tests (transient, real-failure, and null/undefined cases).
- `npm run typecheck` clean; full `npm test` green (1498 pass).