### PR TITLE
fix(update): handle the box-restart phase of a self-upgrade gracefully

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -919,34 +919,63 @@ function AppInner() {
   // `server:update-apply` RPC resolves, so the renderer's fetch dies with a bare
   // "Failed to fetch". That restart is the success signal, not a failure — we
   // only raise the update-failed banner for a STRUCTURED early failure
-  // (`{ok:false, error}`) the RPC reports. To reconcile the real outcome after
-  // the box comes back, we bump `updateRefreshKey` on reconnect (re-fetches the
-  // server version via `useCompatibilityCard`) and clear a stale updateError
-  // once the box is no longer "behind".
-  const [updateAttempted, setUpdateAttempted] = useState(false);
+  // (`{ok:false, error}`) the RPC reports.
+  //
+  // The graceful flow: while `boxUpgrading` the server-update banner renders an
+  // in-flight state (determinate steps while the box streams them, then an
+  // indeterminate "Restarting the box…" once the restart drops the connection —
+  // the frozen-step look is avoided because the server properly dies mid-step
+  // 5/6 and the bar must not sit on a stale step). On reconnect we re-fetch the
+  // version; once the box is no longer "behind" the whole banner + any stale
+  // error/progress clear.
+  const [boxUpgrading, setBoxUpgrading] = useState(false);
 
+  // Reconnect after a box self-upgrade → re-fetch the version pair so the
+  // compatibility check re-evaluates against the box's NEW version. `boxUpgrading`
+  // stays true until the refetch confirms the box advanced (bind in the reconcile
+  // effect below) so the banner never flashes back to a re-clickable state mid-restart.
   useEffect(() => {
     if (connectionState.state !== "connected" && connectionState.state !== "idle") return;
-    if (!updateAttempted) return;
-    setUpdateAttempted(false);
+    if (!boxUpgrading) return;
     setUpdateRefreshKey((k) => k + 1);
-  }, [connectionState.state, updateAttempted]);
+  }, [connectionState.state, boxUpgrading]);
 
-  // Once the box has advanced (variant is no longer "behind"), any pending
-  // update-failed banner is stale — the upgrade landed. A REAL early failure
-  // leaves the box behind, so `compatibilityVariant` stays "behind" and the
-  // banner correctly persists.
+  // Once the box has advanced (variant is no longer "behind"), end the in-flight
+  // state and clear any stale update-failed banner + frozen progress — the upgrade
+  // landed. A REAL early failure leaves the box behind, so `compatibilityVariant`
+  // stays "behind", `boxUpgrading` is cleared directly in applyServerUpdate, and
+  // the actionable banner persists for retry.
   useEffect(() => {
-    if (updateError && (compatibilityVariant === "match" || compatibilityVariant === "unknown")) {
+    if (!boxUpgrading) return;
+    if (compatibilityVariant === "match" || compatibilityVariant === "unknown") {
+      setBoxUpgrading(false);
+      useStore.getState().setServerUpdateProgress(null);
       setUpdateError(null);
     }
-  }, [updateError, compatibilityVariant]);
+  }, [boxUpgrading, compatibilityVariant]);
+
+  // Safety net: never leave the banner stuck in the in-flight state (e.g. the box
+  // reconnected but somehow never advanced). Cap it; the user can then retry.
+  useEffect(() => {
+    if (!boxUpgrading) return;
+    const t = setTimeout(() => {
+      setBoxUpgrading(false);
+      useStore.getState().setServerUpdateProgress(null);
+    }, 120_000);
+    return () => clearTimeout(t);
+  }, [boxUpgrading]);
+
+  // True while the box is restarting mid-upgrade (connection dropped). Drives the
+  // indeterminate "Restarting the box…" presentation instead of a frozen step.
+  const boxRestarting =
+    boxUpgrading && connectionState.state !== "connected" && connectionState.state !== "idle";
 
   const applyServerUpdate = async () => {
-    setUpdateAttempted(true);
+    setBoxUpgrading(true);
     try {
       const res = await window.api.serverUpdateApply();
       if (res && res.ok === false) {
+        setBoxUpgrading(false);
         setUpdateError({ message: res.error || "Server update failed", raw: res.error ?? "" });
       }
     } catch (e) {
@@ -954,6 +983,7 @@ function AppInner() {
       // success path) — swallow it; the reconnect + version re-check above
       // resolves the real outcome. Structured failures still raise the banner.
       if (isTransientUpdateNetworkError(e)) return;
+      setBoxUpgrading(false);
       setUpdateError({
         message: e instanceof Error ? e.message : String(e),
         raw: String(e),
@@ -1058,7 +1088,9 @@ function AppInner() {
             actionLabel="Update & restart"
             onAction={() => setConfirmServerUpdate(true)}
             onDismiss={() => setServerUpdatePrompt(null)}
-            progress={serverUpdateProgress ?? undefined}
+            busy={boxUpgrading}
+            progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
+            busyLabel={boxRestarting ? "Restarting the box…" : "Updating the box…"}
           />
         )}
         {!showOnboarding &&
@@ -1078,7 +1110,9 @@ function AppInner() {
               actionLabel="Upgrade box"
               onAction={() => setConfirmServerUpdate(true)}
               onDismiss={dismiss}
-              progress={serverUpdateProgress ?? undefined}
+              busy={boxUpgrading}
+              progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
+              busyLabel={boxRestarting ? "Restarting the box…" : "Updating the box…"}
             />
           )}
         {!isChatPaneActive && (

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -42,6 +42,14 @@ export type UpdateBarProps = {
   /** When set, the bar renders a determinate progress bar in place of the
    *  action button. */
   progress?: { step: number; total: number; label: string };
+  /** When true, the bar is in an IN-FLIGHT state: it renders an indeterminate
+   *  progress bar (or the determinate `progress` if supplied) and NO action /
+   *  dismiss buttons. Used while a box self-upgrade is running, so the restart
+   *  phase shows a graceful "Restarting…" state instead of a frozen step. */
+  busy?: boolean;
+  /** Label shown when `busy` is true and `progress` is absent (e.g. a
+   *  determinate step wouldn't make sense during the restart). */
+  busyLabel?: string;
 };
 
 /**
@@ -56,7 +64,14 @@ export function UpdateBar({
   onDismiss,
   dismissible = true,
   progress,
+  busy = false,
+  busyLabel = "Updating…",
 }: UpdateBarProps) {
+  const statusLabel = progress
+    ? `${progress.label} (${progress.step}/${progress.total})`
+    : busy
+      ? busyLabel
+      : text;
   return (
     // `pr-[…]` (not `px-3`) reserves the OS caption-button strip: this bar
     // renders ABOVE the titlebar row, so on Windows (titleBarOverlay) the
@@ -67,16 +82,19 @@ export function UpdateBar({
     // macOS/Linux (neither defines the `titlebar-area-*` env vars), so this is
     // exactly `px-3` everywhere else.
     <div className="shrink-0 bg-accent/10 border-b border-accent/30 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2">
-      <span className="flex-1 truncate">
-        {progress ? (
-          <>
-            {progress.label} ({progress.step}/{progress.total})
-          </>
-        ) : (
-          text
-        )}
-      </span>
-      {progress ? (
+      <span className="flex-1 truncate">{statusLabel}</span>
+      {busy ? (
+        <div
+          className="shrink-0 w-32 h-1.5 rounded-full bg-accent/20 overflow-hidden"
+          role="progressbar"
+          aria-label={busyLabel}
+        >
+          <div
+            className="h-full bg-accent animate-pulse"
+            style={{ width: progress ? `${(progress.step / progress.total) * 100}%` : "55%" }}
+          />
+        </div>
+      ) : progress ? (
         <div
           className="shrink-0 w-32 h-1.5 rounded-full bg-accent/20 overflow-hidden"
           role="progressbar"


### PR DESCRIPTION
## Problem

A box self-upgrade streams `MANTA_PROGRESS` steps (1–6) to the banner, but the final steps (5/6 restart opencode, 6/6 restart box) are emitted right as `manta-server` restarts itself. The SSE stream dies first, so the bar froze on whatever step arrived last — e.g. staying on **"Refreshing AI tools (4/6)"** through the restart. Not graceful.

## Fix

- **`UpdateBar`**: new in-flight `busy` mode — renders an indeterminate progress bar + a status label and **no** action button, so the banner can't be mis-clicked mid-restart.
- **`App`**: a `boxUpgrading` state set at click. While upgrading, the server-update banner shows the determinate steps; once the restart drops the connection it switches to an indeterminate **"Restarting the box…"** instead of a frozen step. On reconnect the version is re-fetched; once the box is no longer "behind", the banner + any stale progress/error clear. Genuine early failures still raise the update-failed banner. A 2-minute cap guarantees the in-flight banner can never stick.

Builds on #652 (transient `Failed to fetch` swallowed on a successful upgrade).

## Verification

- `npm run typecheck` clean; full `npm test` green (renderer 2189 + server 1498, 0 fail).
- End-to-end on a test box: upgrade ran, banner showed progress, then cleared cleanly instead of freezing on a mid step.