### PR TITLE
fix(chat): keep the new-session prompt visible when the initial fetch races it

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -135,6 +135,41 @@ describe("ChatPanel render harness", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]?.[1]).toBe("build the login page");
   });
+
+  it("keeps the auto-submitted prompt in the transcript when the initial fetch races it", async () => {
+    // Model the real race: the mount-time transcript fetch resolves with the
+    // PRE-prompt snapshot (empty) AFTER submit already appended the optimistic
+    // user message. It must NOT clobber the just-sent prompt out of the
+    // transcript (the loader/running indicator would show, but no prompt).
+    let resolveInitial!: (m: unknown[]) => void;
+    const initialFetch = new Promise<unknown[]>((res) => { resolveInitial = res; });
+    let messagesCalls = 0;
+    const { api } = installMockApi({
+      opencodeMessages: () => {
+        messagesCalls++;
+        return messagesCalls === 1 ? initialFetch : Promise.resolve([]);
+      },
+    });
+    resetStore();
+    h = mount(
+      <ChatPanel
+        {...PROPS}
+        autoSubmit={{ text: "draw the wireframes", model: undefined }}
+      />,
+    );
+    // Let the deferred (setTimeout 0) auto-submit run. The optimistic user
+    // message is now in the transcript, but the initial fetch is still pending.
+    await h.flush();
+    expect(h.text()).toContain("draw the wireframes");
+
+    // The initial fetch lands with the pre-prompt empty snapshot now.
+    act(() => resolveInitial([]));
+    await h.flush();
+
+    // The prompt must still be on screen — the send went through.
+    expect(h.text()).toContain("draw the wireframes");
+    expect(api.calls.opencodePrompt?.[0]?.[1]).toBe("draw the wireframes");
+  });
 });
 
 // ===== useSessionResources integration (via the mounted ChatPanel) =====

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -633,7 +633,13 @@ export function useSseBus(params: {
     // so the initial load flashed nothing and the indicator "disappeared".
     setRefreshing(true);
     void window.api.opencodeMessages(sessionId).then((m) => {
-      setMessages(m);
+      // Only seed messages if nothing has been written yet. On a fresh session
+      // with a queued auto-submit, submit() appends its OPTIMISTIC user message
+      // before this fetch resolves; this snapshot predates the prompt POST, so
+      // overwriting would clobber the just-sent prompt out of the transcript
+      // (loader shows, prompt missing). The post-prompt canonical refetch (SSE
+      // + the self-heal below) lands the real message instead.
+      setMessages((prev) => (prev === null ? m : prev));
       for (const cid of collectChildSessionIds(m)) {
         childSessionIds.current.add(cid);
       }


### PR DESCRIPTION
Fixes the follow-up bug from the new-session flow: on a fresh session the loader now shows (prompt is sent) but the prompt text doesn't appear in the transcript.

## Root cause
The ChatPanel mounts and the auto-submit fires in the same commit. `submit()` appends the **optimistic** user message and starts the prompt, but the mount-time transcript fetch (`useSseBus` initial fetch) resolves with a **pre-prompt** snapshot and unconditionally `setMessages()` over it — clobbering the just-sent prompt out of the transcript while the loader keeps spinning.

## Fix
Guard the initial fetch so it only seeds `messages` when nothing has been written yet (`prev === null`). The optimistic prompt survives to be replaced by the post-prompt canonical refetch (self-heal + SSE) that includes it.

## Verification
- New regression test models the race with a deferred initial fetch resolving to the empty pre-prompt snapshot after the optimistic append. **Red (prompt gone) without the guard, green with it.**
- Full suite green (2188 tests), typecheck clean, duplication-gate passes.