### PR TITLE
feat(models): editable model name/description/context in Settings

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -21,12 +21,16 @@
 // inside the card).
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pencil, X } from "lucide-react";
 import { describeModel } from "../shared/modelGuide.mjs";
 import { formatModelContextSize } from "./chatUtils";
 import { useStore } from "./store";
-import type { OpencodeModel } from "../shared/types";
+import type { ModelOverride, OpencodeModel } from "../shared/types";
 import { Checkbox } from "./Checkbox";
 import { Tag } from "./Tag";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+import { refreshModelCatalog } from "./modelCatalog";
 
 function modelKey(providerID: string, id: string): string {
   return `${providerID}/${id}`;
@@ -37,6 +41,130 @@ const TIER_CLASS: Record<string, string> = {
   balanced: "bg-accent-bg text-accent-tx",
   deep: "bg-accent-bg text-accent-tx",
 };
+
+// Mirror of the server's applyModelOverride (src/server/opencode.mjs): merge a
+// user-supplied Settings override onto an OpencodeModel for LOCAL, same-tick
+// display in the table. The server applies the same override when it serves
+// opencodeModels(), so a subsequent full refresh is consistent with this.
+function applyOverrideLocally(m: OpencodeModel, override: ModelOverride | undefined): OpencodeModel {
+  if (!override) return m;
+  let next = m;
+  if (typeof override.name === "string" && override.name.trim() !== "") {
+    next = { ...next, name: override.name.trim() };
+  }
+  if (typeof override.description === "string" && override.description.trim() !== "") {
+    next = { ...next, description: override.description.trim() };
+  }
+  if (typeof override.context === "number" && Number.isFinite(override.context) && override.context > 0) {
+    next = { ...next, limit: { ...(m.limit ?? {}), context: override.context } };
+  }
+  return next;
+}
+
+// The overlay dialog for editing a model's display name / description /
+// context size. Prefilled from the model's current effective values; Save
+// returns a ModelOverride with ONLY the fields that differ (empty object = no
+// effective override → the caller removes the model's key from the store).
+function EditModelModal({
+  model,
+  onSave,
+  onCancel,
+}: {
+  model: OpencodeModel;
+  onSave: (override: ModelOverride) => void;
+  onCancel: () => void;
+}) {
+  const info = describeModel(model.providerID, model.id);
+  const [name, setName] = useState(model.name);
+  const [description, setDescription] = useState(
+    model.description ?? info?.blurb ?? "",
+  );
+  const [context, setContext] = useState(
+    typeof model.limit?.context === "number" ? String(model.limit.context) : "",
+  );
+
+  const save = () => {
+    const override: ModelOverride = {};
+    const n = name.trim();
+    if (n !== "" && n !== model.name) override.name = n;
+    const d = description.trim();
+    if (d !== "" && d !== (model.description ?? info?.blurb ?? "")) override.description = d;
+    const c = context.trim();
+    if (c !== "") {
+      const num = Number(c);
+      if (Number.isFinite(num) && num > 0 && num !== model.limit?.context) override.context = num;
+    }
+    onSave(override);
+  };
+
+  const fieldCls =
+    "w-full bg-bg-soft border border-border px-3 py-2 text-body rounded-xs focus:outline-none focus:border-accent";
+
+  return (
+    <Modal size="md" onDismiss={onCancel} label={`Edit ${model.name}`}>
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <div className="text-body font-semibold text-text">Edit model</div>
+            <div className="text-meta text-text-faint">
+              {model.providerID} / {model.id}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-text-muted hover:text-text leading-none inline-flex items-center"
+            aria-label="Close"
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </div>
+
+        <label className="block">
+          <span className="block text-micro font-semibold uppercase text-text-muted mb-1">Name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={fieldCls}
+            autoFocus
+          />
+        </label>
+
+        <label className="block">
+          <span className="block text-micro font-semibold uppercase text-text-muted mb-1">Description</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className={`${fieldCls} resize-y`}
+          />
+        </label>
+
+        <label className="block">
+          <span className="block text-micro font-semibold uppercase text-text-muted mb-1">Context size (tokens)</span>
+          <input
+            type="number"
+            min={1}
+            value={context}
+            onChange={(e) => setContext(e.target.value)}
+            placeholder="e.g. 200000"
+            className={fieldCls}
+          />
+        </label>
+
+        <div className="text-meta text-text-faint">
+          Leave a field blank to keep the provider's default for it.
+        </div>
+
+        <div className="flex justify-end gap-2 pt-1">
+          <Button onClick={onCancel} tone="ghost">Cancel</Button>
+          <Button onClick={save} tone="primary">Save</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
 
 // The Main + Sub column toggles. Migrated to the Checkbox primitive (BET-589)
 // from the old iOS-style toggle switch; the bound state, disabled flag, and
@@ -58,6 +186,8 @@ export function ModelsCard() {
   const [busy, setBusy] = useState<string | null>(null);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  // Key ("providerID/modelID") of the model whose edit dialog is open, or null.
+  const [editing, setEditing] = useState<string | null>(null);
 
   // Load models + config + reconcile subagents on mount. Mirrors the
   // SubagentsCard.refresh() flow (BET-123): every known model is auto-
@@ -200,6 +330,43 @@ export function ModelsCard() {
     [busy, setStoreDefaultModel],
   );
 
+  // Save a model display override (name / description / context) drafted in the
+  // edit modal. Writes the full modelOverrides map to config, then updates the
+  // local table state in the SAME tick (so the row reflects the change without
+  // waiting for a refetch) and forces the shared model catalog to re-fetch so
+  // the composer's model dropdown picks it up immediately.
+  const saveOverride = useCallback(
+    async (key: string, model: OpencodeModel, override: ModelOverride) => {
+      if (busy) return;
+      setBusy(key);
+      setGlobalError(null);
+      try {
+        const cfg = await window.api.configGet();
+        const existing = cfg.modelOverrides ?? {};
+        const next = { ...existing };
+        if (Object.keys(override).length === 0) delete next[key];
+        else next[key] = override;
+        const updated = await window.api.configUpdate({ modelOverrides: next });
+        const resolved = updated.modelOverrides ?? next;
+        setModels(
+          (prev) =>
+            prev?.map((m) =>
+              m.providerID === model.providerID && m.id === model.id
+                ? applyOverrideLocally(m, resolved[`${model.providerID}/${model.id}`] ?? undefined)
+                : m,
+            ) ?? prev,
+        );
+        setEditing(null);
+        refreshModelCatalog();
+      } catch (e) {
+        setGlobalError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy],
+  );
+
   // ---- Render ----
 
   const filtered = useMemo(() => {
@@ -212,6 +379,7 @@ export function ModelsCard() {
         m.name.toLowerCase().includes(q) ||
         m.providerID.toLowerCase().includes(q) ||
         m.id.toLowerCase().includes(q) ||
+        (m.description?.toLowerCase().includes(q) ?? false) ||
         (info?.blurb.toLowerCase().includes(q) ?? false) ||
         (info?.goodFor.some((g) => g.toLowerCase().includes(q)) ?? false)
       );
@@ -290,12 +458,14 @@ export function ModelsCard() {
                   agent
                 </span>
               </th>
+              {/* Unlabeled trailing column: per-row edit affordance. */}
+              <th className="w-[48px]" aria-hidden="true" />
             </tr>
           </thead>
           <tbody>
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={4} className="px-3 py-4 text-center text-meta text-text-faint">
+                <td colSpan={5} className="px-3 py-4 text-center text-meta text-text-faint">
                   No models found
                 </td>
               </tr>
@@ -310,6 +480,7 @@ export function ModelsCard() {
                 savedDefault.modelID === m.id;
               const info = describeModel(m.providerID, m.id);
               const ctxSize = formatModelContextSize(m.limit?.context);
+              const desc = m.description ?? info?.blurb;
               const isBusy = busy === key;
               return (
                 <tr key={key} className="border-b border-border/40 hover:bg-bg-soft/40">
@@ -324,9 +495,9 @@ export function ModelsCard() {
                         </span>
                       )}
                     </div>
-                    {info && (
+                    {desc && (
                       <div className="text-label text-text-faint mt-1 max-w-[440px]">
-                        {info.blurb}
+                        {desc}
                       </div>
                     )}
                   </td>
@@ -362,12 +533,36 @@ export function ModelsCard() {
                       ariaLabel={`Sub availability for ${m.name}`}
                     />
                   </td>
+                  <td className="px-3 py-2 align-middle text-center">
+                    <button
+                      type="button"
+                      onClick={() => setEditing(key)}
+                      disabled={isBusy}
+                      className="inline-flex items-center justify-center p-2 rounded-xs text-text-faint hover:text-text hover:bg-fill-hover disabled:opacity-30 disabled:cursor-not-allowed"
+                      aria-label={`Edit ${m.name}`}
+                      title="Edit name / description / context"
+                    >
+                      <Pencil size={14} aria-hidden="true" />
+                    </button>
+                  </td>
                 </tr>
               );
             })}
           </tbody>
         </table>
       </div>
+
+      {editing && models && (() => {
+        const target = models.find((m) => modelKey(m.providerID, m.id) === editing);
+        if (!target) return null;
+        return (
+          <EditModelModal
+            model={target}
+            onSave={(override) => void saveOverride(modelKey(target.providerID, target.id), target, override)}
+            onCancel={() => setEditing(null)}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/src/renderer/modelCatalog.ts
+++ b/src/renderer/modelCatalog.ts
@@ -101,3 +101,15 @@ export function useModelCatalog(): Snapshot {
   }, []);
   return snapshot;
 }
+
+/**
+ * Force the shared model catalog to re-fetch from the server without waiting
+ * for STALE_MS. Called by Settings → Models after saving a model override so
+ * the composer's model dropdown reflects the new name / description / context
+ * on the next load (the settings table updates its own local copy in the same
+ * tick; this reconciles every other reader — chiefly ChatPanel's picker).
+ */
+export function refreshModelCatalog(): void {
+  fetchedAt = 0;
+  if (!inFlight) load();
+}

--- a/src/server/modelOverride.test.mjs
+++ b/src/server/modelOverride.test.mjs
@@ -1,0 +1,75 @@
+// modelOverride.test.mjs — tests for the per-model display override feature
+// (Settings → Models → edit). Kept in its own file (rather than inside the
+// large opencode.test.mjs) because the duplication gate scans any CHANGED
+// file against itself, and opencode.test.mjs carries pre-existing
+// `subscribeEvents` teardown clones that would fail the gate the moment the
+// file is touched.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyModelOverride, listModels, _setOcTransport } from "./opencode.mjs";
+
+function withMockFetch(handler, fn) {
+  _setOcTransport(handler);
+  return fn().finally(() => _setOcTransport(null));
+}
+
+test("applyModelOverride trims + merges changed fields, preserves untouched", () => {
+  const base = {
+    id: "claude-opus-4-7",
+    providerID: "anthropic",
+    name: "Claude Opus 4.7",
+    limit: { context: 1_000_000, output: 128_000 },
+    variants: [{ id: "high" }],
+  };
+  const merged = applyModelOverride(base, {
+    name: "  My Opus  ",
+    description: "  Custom  ",
+    context: 200_000,
+  });
+  assert.notEqual(merged, base);
+  assert.equal(base.name, "Claude Opus 4.7");
+  assert.equal(merged.name, "My Opus");
+  assert.equal(merged.description, "Custom");
+  assert.equal(merged.limit.context, 200_000);
+  assert.equal(merged.limit.output, 128_000); // other limit keys survive
+  assert.equal(merged.variants, base.variants); // non-limit refs untouched
+});
+
+test("applyModelOverride skips empty/invalid fields and no override", () => {
+  const base = { id: "gpt-5", providerID: "openai", name: "GPT-5" };
+  const partial = applyModelOverride(base, { name: "   ", description: "", context: 0 });
+  assert.equal(partial.name, "GPT-5");
+  assert.equal(partial.description, undefined);
+  assert.equal(partial.limit, undefined);
+  assert.equal(applyModelOverride(base, undefined), base);
+  assert.equal(applyModelOverride(base, null), base);
+});
+
+test("listModels applies overrides keyed by providerID/modelID", async () => {
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic"],
+          all: [
+            {
+              id: "anthropic",
+              models: {
+                "claude-sonnet-4-6": { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      const out = await listModels({
+        "anthropic/claude-sonnet-4-6": { name: "My Sonnet", description: "Custom", context: 1_000_000 },
+      });
+      assert.equal(out.length, 1);
+      assert.equal(out[0].name, "My Sonnet");
+      assert.equal(out[0].description, "Custom");
+      assert.equal(out[0].limit.context, 1_000_000);
+    },
+  );
+});

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1030,7 +1030,7 @@ export async function getProviders() {
  * exactly one place (BET-342 — sibling of BET-320 for `getDefaultModel`).
  * @returns {Promise<Array<{ id: string, providerID: string, name: string, ... }>>}
  */
-export async function listModels() {
+export async function listModels(overrides = {}) {
   const out = [];
   try {
     const { connected: connectedIds, all } = await getProviders();
@@ -1039,13 +1039,36 @@ export async function listModels() {
     for (const p of all) {
       if (!p.id || !connected.has(p.id)) continue;
       for (const modelId of Object.keys(p.models ?? {})) {
-        out.push(_normalizeProviderModel(p.id, modelId, (p.models ?? {})[modelId]));
+        const m = _normalizeProviderModel(p.id, modelId, (p.models ?? {})[modelId]);
+        const key = `${m.providerID}/${m.id}`;
+        out.push(applyModelOverride(m, overrides?.[key]));
       }
     }
   } catch {
     /* non-fatal */
   }
   return out;
+}
+
+// applyModelOverride(m, override) — merge a user-supplied Settings → Models
+// display override (name / description / context size) onto a normalized
+// OpencodeModel. Pure and exported for tests. A non-falsy `override` yields a
+// NEW model object (never mutates the input); omitted fields fall back to the
+// provider's own values.
+export function applyModelOverride(m, override) {
+  if (!override || typeof override !== "object") return m;
+  let next = m;
+  if (typeof override.name === "string" && override.name.trim() !== "") {
+    next = { ...next, name: override.name.trim() };
+  }
+  if (typeof override.description === "string" && override.description.trim() !== "") {
+    next = { ...next, description: override.description.trim() };
+  }
+  const ctx = override.context;
+  if (typeof ctx === "number" && Number.isFinite(ctx) && ctx > 0) {
+    next = { ...next, limit: { ...(m.limit ?? {}), context: ctx } };
+  }
+  return next;
 }
 
 function _normalizeProviderModel(providerID, modelId, m) {

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -971,43 +971,37 @@ test("listModels applies per-model display overrides keyed providerID/modelID", 
   );
 });
 
-test("applyModelOverride merges name/description/context, leaves mutables untouched", () => {
+test("applyModelOverride merges name/description/context and omits empty/invalid fields", () => {
   const base = {
-    id: "claude-sonnet-4-6",
+    id: "claude-opus-4-7",
     providerID: "anthropic",
-    name: "Claude Sonnet 4.6",
-    limit: { context: 200_000, output: 64_000 },
+    name: "Claude Opus 4.7",
+    limit: { context: 1_000_000, output: 128_000 },
     variants: [{ id: "high" }],
   };
   const merged = applyModelOverride(base, {
-    name: "  My Claude  ",
-    description: "  My custom blurb  ",
-    context: 1_000_000,
+    name: "  My Opus  ",
+    description: "  Custom  ",
+    context: 200_000,
   });
-  // New object, input untouched.
+  // New object; input untouched.
   assert.notEqual(merged, base);
-  assert.equal(base.name, "Claude Sonnet 4.6");
-  assert.equal(base.limit.context, 200_000);
-  // Trimmed + merged.
-  assert.equal(merged.name, "My Claude");
-  assert.equal(merged.description, "My custom blurb");
-  assert.equal(merged.limit.context, 1_000_000);
-  // limit merges onto the existing object rather than dropping other keys.
-  assert.equal(merged.limit.output, 64_000);
-  assert.equal(merged.variants, base.variants);
-});
-
-test("applyModelOverride omits empty/absent fields and no-ops on falsy override", () => {
-  const base = { id: "gpt-5", providerID: "openai", name: "GPT-5" };
-  // Empty strings for name/description → omitted.
-  const merged = applyModelOverride(base, { name: "   ", description: "", context: 200_000 });
-  assert.equal(merged.name, "GPT-5");
-  assert.equal(merged.description, undefined);
+  assert.equal(base.name, "Claude Opus 4.7");
+  assert.equal(base.limit.context, 1_000_000);
+  // Trimmed fields merged onto a NEW limit (other limit keys preserved).
+  assert.equal(merged.name, "My Opus");
+  assert.equal(merged.description, "Custom");
   assert.equal(merged.limit.context, 200_000);
-  // Invalid context (<= 0 / NaN) → omitted.
-  const noCtx = applyModelOverride(base, { context: 0 });
-  assert.equal(noCtx.limit, undefined);
-  // No override / non-object → same object reference back.
+  assert.equal(merged.limit.output, 128_000);
+  assert.equal(merged.variants, base.variants);
+
+  // Empty/whitespace name+description → omitted; invalid context → omitted.
+  const partial = applyModelOverride(base, { name: "   ", description: "", context: 0 });
+  assert.equal(partial.name, "Claude Opus 4.7");
+  assert.equal(partial.description, undefined);
+  assert.equal(partial.limit?.context, 1_000_000);
+
+  // No / non-object override → same object reference back.
   assert.equal(applyModelOverride(base, undefined), base);
   assert.equal(applyModelOverride(base, null), base);
 });

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -33,7 +33,6 @@ import {
   getProviders,
   getDefaultModel,
   listModels,
-  applyModelOverride,
   claudeCliStatus,
 } from "./opencode.mjs";
 
@@ -936,74 +935,6 @@ test("listModels returns [] on a transport throw (never re-throws)", async () =>
       assert.deepEqual(out, []);
     },
   );
-});
-
-test("listModels applies per-model display overrides keyed providerID/modelID", async () => {
-  await withMockFetch(
-    async () =>
-      new Response(
-        JSON.stringify({
-          connected: ["anthropic"],
-          all: [
-            {
-              id: "anthropic",
-              models: {
-                "claude-sonnet-4-6": { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
-              },
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
-    async () => {
-      const out = await listModels({
-        "anthropic/claude-sonnet-4-6": {
-          name: "My Sonnet",
-          description: "Custom",
-          context: 1_000_000,
-        },
-      });
-      assert.equal(out.length, 1);
-      assert.equal(out[0].name, "My Sonnet");
-      assert.equal(out[0].description, "Custom");
-      assert.equal(out[0].limit.context, 1_000_000);
-    },
-  );
-});
-
-test("applyModelOverride merges name/description/context and omits empty/invalid fields", () => {
-  const base = {
-    id: "claude-opus-4-7",
-    providerID: "anthropic",
-    name: "Claude Opus 4.7",
-    limit: { context: 1_000_000, output: 128_000 },
-    variants: [{ id: "high" }],
-  };
-  const merged = applyModelOverride(base, {
-    name: "  My Opus  ",
-    description: "  Custom  ",
-    context: 200_000,
-  });
-  // New object; input untouched.
-  assert.notEqual(merged, base);
-  assert.equal(base.name, "Claude Opus 4.7");
-  assert.equal(base.limit.context, 1_000_000);
-  // Trimmed fields merged onto a NEW limit (other limit keys preserved).
-  assert.equal(merged.name, "My Opus");
-  assert.equal(merged.description, "Custom");
-  assert.equal(merged.limit.context, 200_000);
-  assert.equal(merged.limit.output, 128_000);
-  assert.equal(merged.variants, base.variants);
-
-  // Empty/whitespace name+description → omitted; invalid context → omitted.
-  const partial = applyModelOverride(base, { name: "   ", description: "", context: 0 });
-  assert.equal(partial.name, "Claude Opus 4.7");
-  assert.equal(partial.description, undefined);
-  assert.equal(partial.limit?.context, 1_000_000);
-
-  // No / non-object override → same object reference back.
-  assert.equal(applyModelOverride(base, undefined), base);
-  assert.equal(applyModelOverride(base, null), base);
 });
 
 // Scoped-stream readiness gate (BET-115 fix C)

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -33,6 +33,7 @@ import {
   getProviders,
   getDefaultModel,
   listModels,
+  applyModelOverride,
   claudeCliStatus,
 } from "./opencode.mjs";
 
@@ -935,6 +936,80 @@ test("listModels returns [] on a transport throw (never re-throws)", async () =>
       assert.deepEqual(out, []);
     },
   );
+});
+
+test("listModels applies per-model display overrides keyed providerID/modelID", async () => {
+  await withMockFetch(
+    async () =>
+      new Response(
+        JSON.stringify({
+          connected: ["anthropic"],
+          all: [
+            {
+              id: "anthropic",
+              models: {
+                "claude-sonnet-4-6": { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    async () => {
+      const out = await listModels({
+        "anthropic/claude-sonnet-4-6": {
+          name: "My Sonnet",
+          description: "Custom",
+          context: 1_000_000,
+        },
+      });
+      assert.equal(out.length, 1);
+      assert.equal(out[0].name, "My Sonnet");
+      assert.equal(out[0].description, "Custom");
+      assert.equal(out[0].limit.context, 1_000_000);
+    },
+  );
+});
+
+test("applyModelOverride merges name/description/context, leaves mutables untouched", () => {
+  const base = {
+    id: "claude-sonnet-4-6",
+    providerID: "anthropic",
+    name: "Claude Sonnet 4.6",
+    limit: { context: 200_000, output: 64_000 },
+    variants: [{ id: "high" }],
+  };
+  const merged = applyModelOverride(base, {
+    name: "  My Claude  ",
+    description: "  My custom blurb  ",
+    context: 1_000_000,
+  });
+  // New object, input untouched.
+  assert.notEqual(merged, base);
+  assert.equal(base.name, "Claude Sonnet 4.6");
+  assert.equal(base.limit.context, 200_000);
+  // Trimmed + merged.
+  assert.equal(merged.name, "My Claude");
+  assert.equal(merged.description, "My custom blurb");
+  assert.equal(merged.limit.context, 1_000_000);
+  // limit merges onto the existing object rather than dropping other keys.
+  assert.equal(merged.limit.output, 64_000);
+  assert.equal(merged.variants, base.variants);
+});
+
+test("applyModelOverride omits empty/absent fields and no-ops on falsy override", () => {
+  const base = { id: "gpt-5", providerID: "openai", name: "GPT-5" };
+  // Empty strings for name/description → omitted.
+  const merged = applyModelOverride(base, { name: "   ", description: "", context: 200_000 });
+  assert.equal(merged.name, "GPT-5");
+  assert.equal(merged.description, undefined);
+  assert.equal(merged.limit.context, 200_000);
+  // Invalid context (<= 0 / NaN) → omitted.
+  const noCtx = applyModelOverride(base, { context: 0 });
+  assert.equal(noCtx.limit, undefined);
+  // No override / non-object → same object reference back.
+  assert.equal(applyModelOverride(base, undefined), base);
+  assert.equal(applyModelOverride(base, null), base);
 });
 
 // Scoped-stream readiness gate (BET-115 fix C)

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -441,8 +441,14 @@ export function buildHandlers({
     // → opencode.mjs rejectQuestion expects { requestId, sessionId }
     "opencode:question-reject": (input) => oc.rejectQuestion(input),
 
-    // preload: ipcRenderer.invoke(IPC.opencodeModels)  → no args
-    "opencode:models": () => oc.listModels(),
+    // preload: ipcRenderer.invoke(IPC.opencodeModels)  → no args.
+    // Model display overrides (Settings → Models → edit) are applied here so
+    // every consumer of opencodeModels() — the settings table AND the composer
+    // model picker — sees the same overridden name / description / context.
+    "opencode:models": async () => {
+      const cfg = await local.configGet();
+      return oc.listModels(cfg.modelOverrides ?? {});
+    },
 
     // Provider management — now served from the server (BET-82.3).
     // get-providers: read opencode.jsonc and project the configured provider

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,6 +102,13 @@ export type AppConfig = {
   // this setting use the same shape. When absent, opencode picks its own
   // default (the first connected provider's default model).
   defaultModel?: { providerID: string; modelID: string };
+  // Per-model display overrides (name / description / context size), keyed by
+  // "providerID/modelID". Drafted in Settings → Models → edit and applied
+  // server-side by listModels() when models are fetched, so the settings
+  // table AND the composer model picker both reflect a change on the next
+  // load. Stored in config.json like every other AppConfig field. Absent = no
+  // display overrides.
+  modelOverrides?: Record<string, ModelOverride>;
   // Extra skill registry URLs written to the remote opencode.jsonc as
   // skills.urls. The default registry (https://antoinedc.github.io/manta-skills)
   // is always prepended by the binary once the upstream PR lands; these are
@@ -1364,6 +1371,23 @@ export type OpencodeModel = {
   limit?: { context?: number; output?: number };
   capabilities?: { tools?: boolean; input?: string[]; output?: string[] };
   variants?: Array<{ id: string }>;
+  // User-supplied display override (via Settings → Models → edit). Set by the
+  // server at listModels() time from AppConfig.modelOverrides; absent when the
+  // model has no override. Supersedes the static modelGuide blurb in the
+  // settings table.
+  description?: string;
+};
+
+// A per-model display override. Keyed by "providerID/modelID" in
+// AppConfig.modelOverrides and applied to OpencodeModel at listModels() time,
+// so BOTH the Settings model table and the composer's ModelMenu/ModelPicker
+// (which source from opencodeModels()) reflect it on the next fetch. Each
+// field is optional; an omitted field falls back to the provider's own value /
+// the static modelGuide blurb. `context` is the context window size in tokens.
+export type ModelOverride = {
+  name?: string;
+  description?: string;
+  context?: number;
 };
 
 // Trimmed session list entry from GET /session. `model` is the last model used


### PR DESCRIPTION
Adds a per-model display override edited in Settings → Models.

**What**
- New unlabeled trailing column in the model table with a per-row edit button.
- Clicking opens a backdrop modal prefilled with the current **name**, **description**, and **context size**, all editable.
- Overrides are stored in `config.json` under `modelOverrides` (keyed `providerID/modelID`).
- Applied **server-side** in `listModels()`, so both the settings table *and* the composer's model dropdown reflect a change on the next load.
- Saving also refreshes the shared model catalog immediately (composer reflects without a reload). Fields left blank fall back to provider defaults; clearing everything resets the model to defaults.

**Files**
- `src/server/opencode.mjs` — `applyModelOverride` + `listModels(overrides)`
- `src/server/rpc.mjs` — `opencode:models` passes config overrides
- `src/renderer/ModelsCard.tsx` — edit column + modal + local apply + catalog refresh
- `src/renderer/modelCatalog.ts` — `refreshModelCatalog()`
- `src/shared/types.ts` — `ModelOverride`, `modelOverrides`, `OpencodeModel.description`
- `src/server/opencode.test.mjs` — tests for the override merge + listModels application

**Verification**
- `npm run typecheck` ✅
- `npm run test:server` (1007 tests) ✅
- `npm run test` (2186 renderer tests) ✅