### PR TITLE
fix(ui): restore the last-active session on refresh/relaunch

### DIFF
--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -20,6 +20,8 @@ import {
   appendPromptHistory,
   mergePromptHistory,
   resolveActiveModel,
+  readSavedActiveSession,
+  writeSavedActiveSession,
 } from "./chatShared";
 import type { OpencodeModel } from "../shared/types";
 
@@ -346,5 +348,37 @@ describe("mergePromptHistory", () => {
     expect(mergePromptHistory([], ["a"])).toEqual(["a"]);
     expect(mergePromptHistory(["a"], [])).toEqual(["a"]);
     expect(mergePromptHistory([], [])).toEqual([]);
+  });
+});
+
+describe("last-active session persistence (restored on refresh/relaunch)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when nothing is saved", () => {
+    expect(readSavedActiveSession()).toBeNull();
+  });
+
+  it("round-trips a saved pin", () => {
+    writeSavedActiveSession({ project: "better-ui", window: 3 });
+    expect(readSavedActiveSession()).toEqual({ project: "better-ui", window: 3 });
+  });
+
+  it("writeSavedActiveSession(null) clears the saved pin", () => {
+    writeSavedActiveSession({ project: "better-ui", window: 1 });
+    writeSavedActiveSession(null);
+    expect(readSavedActiveSession()).toBeNull();
+  });
+
+  it("rejects a corrupt or malformed stored value", () => {
+    localStorage.setItem("manta:lastActiveSession", "{not json");
+    expect(readSavedActiveSession()).toBeNull();
+    localStorage.setItem("manta:lastActiveSession", JSON.stringify({ project: 5, window: 0 }));
+    expect(readSavedActiveSession()).toBeNull();
+    localStorage.setItem("manta:lastActiveSession", JSON.stringify({ project: "p", window: -1 }));
+    expect(readSavedActiveSession()).toBeNull();
+    localStorage.setItem("manta:lastActiveSession", JSON.stringify({ project: "p", window: 1.5 }));
+    expect(readSavedActiveSession()).toBeNull();
   });
 });

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -327,6 +327,48 @@ export function writeSavedMode(sessionId: string, m: SessionMode): void {
   } catch { /* quota / disabled storage */ }
 }
 
+// ===== Last-active session (restored on refresh / relaunch) =====
+//
+// Persisted in localStorage so a renderer reload / app relaunch lands on the
+// session the user was last using instead of defaulting to the first project.
+// Keyed by the tmux WINDOW (project + window index), the stable identity
+// across opencode sessionIds (a /clear swaps the session id but not the
+// window). Written on every setActive; read by applyProjects when there is no
+// valid selection to restore yet.
+
+export type ActiveSessionPin = { project: string; window: number };
+
+export function activeSessionKey(): string {
+  return "manta:lastActiveSession";
+}
+
+export function readSavedActiveSession(): ActiveSessionPin | null {
+  try {
+    const raw = localStorage.getItem(activeSessionKey());
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed.project === "string" &&
+      typeof parsed.window === "number" &&
+      Number.isInteger(parsed.window) &&
+      parsed.window >= 0
+    ) {
+      return { project: parsed.project, window: parsed.window };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSavedActiveSession(pin: ActiveSessionPin | null): void {
+  try {
+    if (pin) localStorage.setItem(activeSessionKey(), JSON.stringify(pin));
+    else localStorage.removeItem(activeSessionKey());
+  } catch { /* quota / disabled storage */ }
+}
+
 // Merge a launcher's flag schema with the user's saved overrides (from
 // AppConfig.launcherFlags), falling back to each flag's registry default for
 // keys the user never touched.

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -1,5 +1,11 @@
+// @vitest-environment jsdom
+// jsdom required because applyProjects/setActive persist + restore the
+// last-active session via localStorage (readSavedActiveSession /
+// writeSavedActiveSession). The rest of the file doesn't care — the nodenv
+// differences are confined to the persistence helpers' try/catch.
 import { describe, it, expect, beforeEach } from "vitest";
 import { resolveSessionOwner, useStore } from "./store";
+import { writeSavedActiveSession } from "./chatShared";
 import type { Project } from "../shared/types";
 
 function proj(over: Partial<Project> & { tmuxSession: string }): Project {
@@ -803,5 +809,106 @@ describe("new-session drafts", () => {
     expect(useStore.getState().activeDraftId).toBeNull();
     // the draft itself is untouched — it stays in the sidebar for later use
     expect(useStore.getState().drafts.some((d) => d.id === id)).toBe(true);
+  });
+});
+
+// ===== Last-active session restore =====
+//
+// activeProjectName starts null on a fresh boot / renderer reload. Without
+// restore, applyProjects defaulted to projects[0] — landing the user on an
+// arbitrary/first session instead of the one they last used. These tests pin
+// the persistence (setActive writes) + restore (applyProjects reads).
+
+describe("last-active session restore (refresh / relaunch)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useStore.setState({
+      projects: [],
+      activeProjectName: null,
+      activeWindowByProject: {},
+      recentWindows: [],
+    });
+  });
+
+  function sessions() {
+    return [
+      proj({
+        tmuxSession: "alpha",
+        defaultCwd: "~/alpha",
+        windows: [
+          { index: 0, name: "w0", active: true, paneCurrentPath: "/alpha/0", opencodeSessionId: null },
+          { index: 1, name: "w1", active: false, paneCurrentPath: "/alpha/1", opencodeSessionId: null },
+        ],
+      }),
+      proj({
+        tmuxSession: "beta",
+        defaultCwd: "~/beta",
+        windows: [
+          { index: 0, name: "w0", active: true, paneCurrentPath: "/beta/0", opencodeSessionId: null },
+        ],
+      }),
+    ];
+  }
+
+  it("setActive persists the pin to localStorage", () => {
+    useStore.setState({ projects: sessions() });
+    useStore.getState().setActive("beta", 0);
+    expect(localStorage.getItem("manta:lastActiveSession")).toBe(
+      JSON.stringify({ project: "beta", window: 0 }),
+    );
+  });
+
+  it("applyProjects with no prior selection restores the saved last-used session", () => {
+    writeSavedActiveSession({ project: "alpha", window: 1 });
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.activeProjectName).toBe("alpha");
+    expect(s.activeWindowByProject.alpha).toBe(1);
+  });
+
+  it("applyProjects keeps an existing valid selection (mid-session refresh)", () => {
+    useStore.setState({
+      activeProjectName: "beta",
+      activeWindowByProject: { beta: 0 },
+    });
+    writeSavedActiveSession({ project: "alpha", window: 1 });
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    // a live refresh must NOT yank the user off the session they're on
+    expect(s.activeProjectName).toBe("beta");
+    expect(s.activeProjectName).not.toBe("alpha");
+  });
+
+  it("applyProjects falls back to projects[0] when the saved session is gone", () => {
+    writeSavedActiveSession({ project: "vanished", window: 0 });
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.activeProjectName).toBe("alpha");
+  });
+
+  it("applyProjects falls back to projects[0] when the saved window no longer exists", () => {
+    writeSavedActiveSession({ project: "alpha", window: 9 });
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.activeProjectName).toBe("alpha");
+    // window 9 doesn't exist — clamp to the tmux-active / first window
+    expect(s.activeWindowByProject.alpha).toBe(0);
+  });
+
+  it("applyProjects restores the saved window over the tmux-active one", () => {
+    // alpha's tmux-active window is 0, but the user last used window 1 —
+    // restore must win so they land exactly where they left off.
+    writeSavedActiveSession({ project: "alpha", window: 1 });
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.activeProjectName).toBe("alpha");
+    expect(s.activeWindowByProject.alpha).toBe(1);
+  });
+
+  it("applyProjects with no saved pin and no valid selection falls back to projects[0]", () => {
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.activeProjectName).toBe("alpha");
+    expect(s.activeWindowByProject.alpha).toBe(0);
   });
 });

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -11,7 +11,11 @@ import type { ConnectionState } from "../shared/net/state.js";
 import { clientToken } from "./api/httpApi";
 import { isAssistantTurnInProgress, runWithConcurrency } from "./chatUtils";
 import { applyTheme, type ThemePref } from "./theme";
-import type { ModelSelection } from "./chatShared";
+import {
+  type ModelSelection,
+  readSavedActiveSession,
+  writeSavedActiveSession,
+} from "./chatShared";
 
 // Background-delegation jobs, keyed by the job's child opencode session id.
 // The renderer learns which sidebar windows are jobs (and their per-row
@@ -534,15 +538,19 @@ export const useStore = create<State>((set, get) => ({
     return { projectName: s.activeProjectName, windowIndex: idx };
   },
 
-  setActive: (projectName, windowIndex) =>
+  setActive: (projectName, windowIndex) => {
+    const prev = get();
+    const proj = prev.projects.find((p) => p.tmuxSession === projectName);
+    const w =
+      windowIndex ??
+      prev.activeWindowByProject[projectName] ??
+      proj?.windows.find((x) => x.active)?.index ??
+      proj?.windows[0]?.index ??
+      0;
+    // Remember where the user is so a refresh / relaunch can restore it
+    // (applyProjects reads this when there's no valid selection yet).
+    writeSavedActiveSession({ project: projectName, window: w });
     set((prev) => {
-      const proj = prev.projects.find((p) => p.tmuxSession === projectName);
-      const w =
-        windowIndex ??
-        prev.activeWindowByProject[projectName] ??
-        proj?.windows.find((x) => x.active)?.index ??
-        proj?.windows[0]?.index ??
-        0;
       // Opening a window clears its "needs attention" flag.
       const status = clearAttention(prev.status, projectName, w);
       // BET-414: bump this window to the front of the recency list (⌘K palette
@@ -560,7 +568,8 @@ export const useStore = create<State>((set, get) => ({
         status,
         recentWindows,
       };
-    }),
+    });
+  },
 
   createDraft: (mode) => {
     const id = newDraftId();
@@ -1108,11 +1117,34 @@ export const useStore = create<State>((set, get) => ({
     set((prev) => {
       // Clamp activeProjectName to one that still exists; clamp window choice too.
       let activeProjectName = prev.activeProjectName;
+      // A window to force for the actively-restored project. When we land on a
+      // selection from the saved last-active session, seed this so the window
+      // loop below keeps the saved window instead of picking the tmux-active one.
+      let restoredWindow: number | undefined;
       if (!activeProjectName || !projects.find((p) => p.tmuxSession === activeProjectName)) {
-        activeProjectName = projects[0]?.tmuxSession ?? null;
+        // No valid prior selection (fresh boot / relaunch, or the previously
+        // selected project disappeared) — restore the last-used session so a
+        // refresh lands on where the user left off, not the first project.
+        // Falls back to the first project when the saved window no longer
+        // exists (box wiped, project deleted, session list reset).
+        const saved = readSavedActiveSession();
+        if (saved) {
+          const savedProj = projects.find((p) => p.tmuxSession === saved.project);
+          if (savedProj && savedProj.windows.some((w) => w.index === saved.window)) {
+            activeProjectName = saved.project;
+            restoredWindow = saved.window;
+          }
+        }
+        if (!activeProjectName) activeProjectName = projects[0]?.tmuxSession ?? null;
       }
       const activeWindowByProject = { ...prev.activeWindowByProject };
       for (const p of projects) {
+        // The restored selection wins unconditionally — land the user exactly
+        // on the window they last used, never the tmux-active/first one.
+        if (restoredWindow !== undefined && p.tmuxSession === activeProjectName) {
+          activeWindowByProject[p.tmuxSession] = restoredWindow;
+          continue;
+        }
         const cur = activeWindowByProject[p.tmuxSession];
         if (cur === undefined || !p.windows.find((w) => w.index === cur)) {
           const tmuxActive = p.windows.find((w) => w.active)?.index;


### PR DESCRIPTION
## What

When refreshing or relaunching MantaUI, the app landed on the **first** project/session instead of the one the user was last using — so it often dropped you somewhere unexpected (a fresh/other session). This persists the last-used project + window and restores it on load.

## How

- **** now writes the active `project/window` to localStorage on every navigation.
- **** (run on refresh + boot) restores that saved session when there's no valid prior selection, instead of defaulting to `projects[0]`. Falls back to the first project only when the saved session no longer exists (wiped box / deleted project). A mid-session refresh with a valid selection keeps it — no yank.

Persistence is keyed to the tmux **window** (stable across an opencode `/clear`, which swaps the session id).

## Testing

- New unit tests in `chatShared.test.ts` (round-trip, clear, corrupt-value rejection) and `store.test.ts` (setActive persists, applyProjects restores / keeps-during-refresh / falls back when gone).
- `npm run typecheck` clean; full suite green (1498 node + 2202 vitest).