### PR TITLE
fix(settings): model edit modal keeps focus while typing

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -61,6 +61,14 @@ function formatTimeout(ms: number): string {
 // ===== Dialog semantics (BET-419 §C): focus trap + Esc + focus restore =====
 function useDialog(onClose: () => void) {
   const ref = useRef<HTMLDivElement | null>(null);
+  // `onClose` is an inline arrow from App (recreated on every App render), so
+  // the effect MUST NOT key off its identity — otherwise ANY App re-render
+  // (e.g. a background SSE/window-status update ticking in every few seconds)
+  // re-runs it and steals focus back to the dialog's first element, yanking
+  // the caret out of whatever the user is typing (e.g. the model-edit modal's
+  // fields). Keep the latest callback in a ref and run the setup ONCE.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   useEffect(() => {
     const root = ref.current;
     if (!root) return;
@@ -68,7 +76,7 @@ function useDialog(onClose: () => void) {
     const firstFocusable = root.querySelector<HTMLElement>("h2[tabindex], button, input, select, textarea, a[href]");
     (firstFocusable ?? root).focus();
     const onKey = (e: globalThis.KeyboardEvent) => {
-      if (e.key === "Escape") { e.preventDefault(); onClose(); return; }
+      if (e.key === "Escape") { e.preventDefault(); onCloseRef.current(); return; }
       if (e.key !== "Tab") return;
       const focusables = root.querySelectorAll<HTMLElement>(
         'button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])',
@@ -85,7 +93,8 @@ function useDialog(onClose: () => void) {
       document.removeEventListener("keydown", onKey, true);
       if (opener && typeof opener.focus === "function") opener.focus();
     };
-  }, [onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return ref;
 }
 


### PR DESCRIPTION
Fixes the model-edit modal (and any other field) losing focus after a few seconds, making typing impossible.

**Root cause**
- AppInner subscribes to the entire zustand store and re-renders every ~2s (the window-status SSE poller calls `applyStatusBatch`).
- That recreates Settings' `onClose` inline arrow on every App render.
- Settings' `useDialog` focus trap keyed its mount effect off `onClose` identity, so every re-render re-ran it and re-focused the dialog's first element — stealing focus from the field the user was typing in.

**Fix**
- Run the `useDialog` trap setup once (mount-only) and read the latest `onClose` through a ref, so unrelated App re-renders no longer re-claim focus. Tab-trap and Esc handling are unchanged.

**Verification**
- `npm run typecheck` ✅
- renderer suite (2191 tests) ✅