### PR TITLE
fix(models): edit modal keeps focus — portal out of Settings

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -20,7 +20,8 @@
 // opt-out semantics (configGet / configUpdate only, no store live mirroring
 // inside the card).
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Pencil, X } from "lucide-react";
 import { describeModel } from "../shared/modelGuide.mjs";
 import { formatModelContextSize } from "./chatUtils";
@@ -75,6 +76,7 @@ function EditModelModal({
   onCancel: () => void;
 }) {
   const info = describeModel(model.providerID, model.id);
+  const nameRef = useRef<HTMLInputElement | null>(null);
   const [name, setName] = useState(model.name);
   const [description, setDescription] = useState(
     model.description ?? info?.blurb ?? "",
@@ -82,6 +84,13 @@ function EditModelModal({
   const [context, setContext] = useState(
     typeof model.limit?.context === "number" ? String(model.limit.context) : "",
   );
+
+  // The dialog lives under a full-screen container that re-renders on store
+  // updates; `autoFocus` can be visually disrupted by sibling re-renders, so
+  // grab focus explicitly once on mount rather than relying on it.
+  useEffect(() => {
+    nameRef.current?.focus();
+  }, []);
 
   const save = () => {
     const override: ModelOverride = {};
@@ -102,7 +111,15 @@ function EditModelModal({
 
   return (
     <Modal size="md" onDismiss={onCancel} label={`Edit ${model.name}`}>
-      <div className="space-y-4">
+      <div
+        className="space-y-4"
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.stopPropagation();
+            onCancel();
+          }
+        }}
+      >
         <div className="flex items-start justify-between gap-2">
           <div>
             <div className="text-body font-semibold text-text">Edit model</div>
@@ -123,11 +140,11 @@ function EditModelModal({
         <label className="block">
           <span className="block text-micro font-semibold uppercase text-text-muted mb-1">Name</span>
           <input
+            ref={nameRef}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             className={fieldCls}
-            autoFocus
           />
         </label>
 
@@ -555,12 +572,18 @@ export function ModelsCard() {
       {editing && models && (() => {
         const target = models.find((m) => modelKey(m.providerID, m.id) === editing);
         if (!target) return null;
-        return (
+        // Render through a portal to document.body: the modal is the only one
+        // in the app nested inside the full-screen Settings dialog, and
+        // portaling it out of that frequently re-rendering subtree guarantees
+        // a store-driven Settings re-render can never remount it (which would
+        // drop focus from the field being typed in).
+        return createPortal(
           <EditModelModal
             model={target}
             onSave={(override) => void saveOverride(modelKey(target.providerID, target.id), target, override)}
             onCancel={() => setEditing(null)}
-          />
+          />,
+          document.body,
         );
       })()}
     </div>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -76,6 +76,12 @@ function useDialog(onClose: () => void) {
     const firstFocusable = root.querySelector<HTMLElement>("h2[tabindex], button, input, select, textarea, a[href]");
     (firstFocusable ?? root).focus();
     const onKey = (e: globalThis.KeyboardEvent) => {
+      // Only respond to events originating INSIDE this dialog. A portal'd
+      // nested modal (e.g. the model-edit dialog, rendered into document.body)
+      // lives outside `root`, so its Esc/Tab must be handled by the modal
+      // itself — otherwise Settings would steal Esc and close itself while
+      // the user is typing in (or dismissing) the nested modal.
+      if (e.target instanceof Node && !root.contains(e.target)) return;
       if (e.key === "Escape") { e.preventDefault(); onCloseRef.current(); return; }
       if (e.key !== "Tab") return;
       const focusables = root.querySelectorAll<HTMLElement>(


### PR DESCRIPTION
Follow-up to #657 (which reduced but did not eliminate the focus loss reported in the model edit modal).

**Root cause**
The edit modal was the app's **only** modal rendered *nested inside* the full-screen Settings dialog. Settings + AppInner both subscribe to the whole zustand store, and window-status SSE updates the store every few seconds — so the Settings subtree re-renders on a timer. A re-render of that subtree is what repeatedly dropped focus from the field being typed in (making it impossible to keep typing).

**Fix**
- Render the edit dialog through a **React portal to `document.body`**, so no Settings re-render can ever remount it (the modal's focus is now stable against the whole Settings/store re-render cycle).
- Grab focus on the name field explicitly on mount (more reliable than `autoFocus` for a dialog that mounts under a re-rendering container).
- Give the portal'd modal its own **Escape** handling, and gate Settings' global key trap to events originating inside its own root — so Settings neither steals Esc from the modal nor interferes with Tab inside it.

**Verification**
- `npm run typecheck` ✅
- server suite (1007) ✅
- renderer suite (2202) ✅