### PR TITLE
fix(models): persist display overrides across reloads & show them in the picker

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -24,7 +24,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Pencil, X } from "lucide-react";
 import { describeModel } from "../shared/modelGuide.mjs";
-import { formatModelContextSize } from "./chatUtils";
+import {
+  applyModelOverride,
+  formatModelContextSize,
+  mergeModelOverrides,
+} from "./chatUtils";
 import { useStore } from "./store";
 import type { ModelOverride, OpencodeModel } from "../shared/types";
 import { Checkbox } from "./Checkbox";
@@ -42,25 +46,6 @@ const TIER_CLASS: Record<string, string> = {
   balanced: "bg-accent-bg text-accent-tx",
   deep: "bg-accent-bg text-accent-tx",
 };
-
-// Mirror of the server's applyModelOverride (src/server/opencode.mjs): merge a
-// user-supplied Settings override onto an OpencodeModel for LOCAL, same-tick
-// display in the table. The server applies the same override when it serves
-// opencodeModels(), so a subsequent full refresh is consistent with this.
-function applyOverrideLocally(m: OpencodeModel, override: ModelOverride | undefined): OpencodeModel {
-  if (!override) return m;
-  let next = m;
-  if (typeof override.name === "string" && override.name.trim() !== "") {
-    next = { ...next, name: override.name.trim() };
-  }
-  if (typeof override.description === "string" && override.description.trim() !== "") {
-    next = { ...next, description: override.description.trim() };
-  }
-  if (typeof override.context === "number" && Number.isFinite(override.context) && override.context > 0) {
-    next = { ...next, limit: { ...(m.limit ?? {}), context: override.context } };
-  }
-  return next;
-}
 
 // The overlay dialog for editing a model's display name / description /
 // context size. Prefilled from the model's current effective values; Save
@@ -218,11 +203,15 @@ export function ModelsCard() {
       ]);
       const deactivatedMainList = cfg.deactivatedMainModels ?? [];
       const deactivatedSubList = cfg.deactivatedSubagents ?? [];
+      // Apply display overrides CLIENT-SIDE too (idempotent with any server-side
+      // merge) so the table reflects them across reloads even if the running
+      // manta-server predates the server-side merge.
+      const withOverrides = mergeModelOverrides(modelList, cfg.modelOverrides);
       const agents = await window.api.opencodeSyncSubagents({
-        models: modelList,
+        models: withOverrides ?? modelList,
         deactivated: deactivatedSubList,
       });
-      setModels(modelList);
+      setModels(withOverrides);
       setDeactivatedMain(new Set(deactivatedMainList));
       setDeactivatedSub(new Set(deactivatedSubList));
       // Result ignored — the consolidated table doesn't show per-agent
@@ -369,7 +358,7 @@ export function ModelsCard() {
           (prev) =>
             prev?.map((m) =>
               m.providerID === model.providerID && m.id === model.id
-                ? applyOverrideLocally(m, resolved[`${model.providerID}/${model.id}`] ?? undefined)
+                ? applyModelOverride(m, resolved[`${model.providerID}/${model.id}`] ?? undefined)
                 : m,
             ) ?? prev,
         );

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -78,6 +78,8 @@ import {
   resolveFastToggle,
   filterModelGroups,
   moveMenuHighlight,
+  applyModelOverride,
+  mergeModelOverrides,
   MAX_PREVIEW_BYTES,
   resolvePreviewType,
   isWithinPreviewSize,
@@ -329,8 +331,61 @@ describe("ctxStageColor", () => {
   });
 });
 
-// ===== formatModelContextSize =====
+// ===== model overrides (applyModelOverride / mergeModelOverrides) =====
 
+describe("applyModelOverride", () => {
+  const base: OpencodeModel = {
+    id: "claude-sonnet-4-6",
+    providerID: "anthropic",
+    name: "Claude Sonnet 4.6",
+    limit: { context: 200_000, output: 64_000 },
+  };
+
+  it("trims + merges name, description and context, preserving untouched fields", () => {
+    const out = applyModelOverride(base, {
+      name: "  My Sonnet  ",
+      description: "  Custom  ",
+      context: 1_000_000,
+    });
+    expect(out).not.toBe(base);
+    expect(out.name).toBe("My Sonnet");
+    expect(out.description).toBe("Custom");
+    expect(out.limit?.context).toBe(1_000_000);
+    expect(out.limit?.output).toBe(64_000);
+    // input untouched
+    expect(base.name).toBe("Claude Sonnet 4.6");
+    expect(base.limit?.context).toBe(200_000);
+  });
+
+  it("ignores empty/invalid fields and returns input unchanged for no override", () => {
+    const out = applyModelOverride(base, { name: "   ", description: "", context: 0 });
+    expect(out).toBe(base);
+    expect(applyModelOverride(base, undefined)).toBe(base);
+  });
+});
+
+describe("mergeModelOverrides", () => {
+  const models: OpencodeModel[] = [
+    { id: "a", providerID: "p", name: "A" },
+    { id: "b", providerID: "p", name: "B" },
+  ];
+
+  it("returns the same array reference when nothing applies", () => {
+    expect(mergeModelOverrides(models, undefined)).toBe(models);
+    expect(mergeModelOverrides(models, {})).toBe(models);
+    expect(mergeModelOverrides(models, { "q/x": { name: "Nope" } })).toBe(models);
+  });
+
+  it("applies matching overrides by providerID/id and leaves others untouched", () => {
+    const out = mergeModelOverrides(models, { "p/b": { name: "B2", context: 99 } });
+    expect(out).not.toBe(models);
+    expect(out?.[0]).toBe(models[0]); // untouched model keeps its identity
+    expect(out?.[1].name).toBe("B2");
+    expect(out?.[1].limit?.context).toBe(99);
+  });
+});
+
+// ===== formatModelContextSize =====
 describe("formatModelContextSize", () => {
   it("formats a context limit as a rounded 'Nk' string below 1M", () => {
     expect(formatModelContextSize(200_000)).toBe("200k");

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -4,7 +4,7 @@
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { DelegateApprovalTool, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
+import type { DelegateApprovalTool, ModelOverride, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
@@ -147,6 +147,53 @@ export function titleCase(id: string): string {
     .split(/[-_]/)
     .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
     .join(" ");
+}
+
+// Merge a user-supplied Settings → Models display override (name / description
+// / context size) onto an OpencodeModel. Mirrors the server's applyModelOverride
+// (src/server/opencode.mjs) so the renderer can honor overrides CLIENT-SIDE —
+// this makes the feature work regardless of whether the running box's
+// manta-server has the server-side merge deployed. Applying the same override
+// twice (renderer + server) is idempotent. Returns a new model object; a falsy
+// or empty override returns `m` unchanged.
+export function applyModelOverride(
+  m: OpencodeModel,
+  override: ModelOverride | undefined,
+): OpencodeModel {
+  if (!override) return m;
+  let next = m;
+  if (typeof override.name === "string" && override.name.trim() !== "") {
+    next = { ...next, name: override.name.trim() };
+  }
+  if (typeof override.description === "string" && override.description.trim() !== "") {
+    next = { ...next, description: override.description.trim() };
+  }
+  const ctx = override.context;
+  if (typeof ctx === "number" && Number.isFinite(ctx) && ctx > 0) {
+    next = { ...next, limit: { ...(m.limit ?? {}), context: ctx } };
+  }
+  return next;
+}
+
+// Apply a full "providerID/modelID" → override map onto a model list. Pure and
+// memo-friendly: returns a new array only when an override actually applies.
+export function mergeModelOverrides(
+  models: OpencodeModel[] | null,
+  overrides: Record<string, ModelOverride> | undefined,
+): OpencodeModel[] | null {
+  if (!models || !overrides) return models;
+  const keys = Object.keys(overrides);
+  if (keys.length === 0) return models;
+  const byKey = new Map(keys.map((k) => [k, overrides[k] ?? {}] as const));
+  let changed = false;
+  const out = models.map((m) => {
+    const o = byKey.get(`${m.providerID}/${m.id}`);
+    if (!o) return m;
+    const merged = applyModelOverride(m, o);
+    if (merged !== m) changed = true;
+    return merged;
+  });
+  return changed ? out : models;
 }
 
 // Client-side filter over already-grouped models for the model menu's search

--- a/src/renderer/modelCatalog.ts
+++ b/src/renderer/modelCatalog.ts
@@ -17,6 +17,7 @@
 
 import { useEffect, useState } from "react";
 import type { OpencodeModel } from "../shared/types";
+import { mergeModelOverrides } from "./chatUtils";
 
 export type ServerDefaultModel = { providerID: string; modelID: string } | null;
 
@@ -56,12 +57,21 @@ function load(): void {
   inFlight = Promise.allSettled([
     window.api.opencodeModels(),
     window.api.opencodeDefaultModel(),
+    window.api.configGet(),
   ])
-    .then(([modelsRes, defaultRes]) => {
+    .then(([modelsRes, defaultRes, cfgRes]) => {
       // Keep the previous value for whichever half failed — a transient error
       // must not blank a catalog we already have.
+      // Model display overrides are applied CLIENT-SIDE (in addition to any
+      // server-side merge) so the composer picker reflects them even when the
+      // box's manta-server predates the server-side merge. Idempotent.
+      const overrides =
+        cfgRes.status === "fulfilled" ? cfgRes.value?.modelOverrides : undefined;
       const next: Snapshot = {
-        models: modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
+        models: mergeModelOverrides(
+          modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
+          overrides,
+        ),
         defaultModel: defaultRes.status === "fulfilled" ? defaultRes.value : cache.defaultModel,
       };
       const changed =
@@ -69,7 +79,11 @@ function load(): void {
       cache = next;
       // Only mark fresh once something actually resolved, so a fully-failed
       // attempt retries on the next mount instead of caching the failure.
-      if (modelsRes.status === "fulfilled" || defaultRes.status === "fulfilled") {
+      if (
+        modelsRes.status === "fulfilled" ||
+        defaultRes.status === "fulfilled" ||
+        cfgRes.status === "fulfilled"
+      ) {
         fetchedAt = Date.now();
       }
       if (changed) emit();


### PR DESCRIPTION
The save + server-side merge were correct, but the override wasn't reflected after a reload or in the composer's model dropdown: the data persisted to `~/.manta/config.json`, yet the running box's manta-server (older build, without the `listModels()` override merge in `opencode:models`) never applied it on read.

**Fix** — apply the overrides in the renderer too, idempotent with the server merge:
- `ModelsCard` / `chatUtils.ts`: shared `applyModelOverride` / `mergeModelOverrides` pure helpers; the settings table merges overrides on load (so it persists across reloads).
- `modelCatalog.ts`: the shared catalog merges overrides from config on every load, so the composer's model dropdown (name + context) reflects a saved override immediately and after reload.

Now the feature works regardless of whether the box server has the server-side merge deployed (kept as the single source of truth for when it's updated).

**Verification**
- typecheck ✅ · server suite (1007) ✅ · renderer suite (2206) ✅ · duplication gate ✅