### PR TITLE
fix(ui): land on the last-used session on boot, retry slow session load

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -270,16 +270,37 @@ function AppInner() {
     // for an otherwise-"http" config; a successful re-claim persists a fresh
     // token and finishOnboarding() re-runs the bootstrap. SSH mode never throws
     // this (no Bearer gate), so this is a no-op there.
-    refresh().catch((e: unknown) => {
-      const isAuth =
-        (e as { name?: string })?.name === "AuthRequiredError" ||
-        (e as { status?: number })?.status === 401;
-      if (isAuth) {
-        void useStore.getState().relaunchOnboarding();
+    //
+    // Non-auth bootstrap failures are retried with backoff: on a cold box the
+    // server / tmux may not be up on the very first fetch, and the session list
+    // would otherwise sit empty until the user manually reloads. Each retry
+    // runs applyProjects (which preserves the current selection and drops the
+    // zero-state draft once projects arrive), so the UI heals in place rather
+    // than requiring a second Cmd+R.
+    let cancelled = false;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 6;
+    const backoff = (n: number) => Math.min(1000 * 2 ** n, 15000);
+    const attempt = async (): Promise<void> => {
+      try {
+        await refresh();
+      } catch (e) {
+        const isAuth =
+          (e as { name?: string })?.name === "AuthRequiredError" ||
+          (e as { status?: number })?.status === 401;
+        if (isAuth) {
+          void useStore.getState().relaunchOnboarding();
+          return;
+        }
+        // Non-auth failure — retry with backoff, bounded, until success/abort.
+        if (cancelled || ++attempts >= MAX_ATTEMPTS) return;
+        setTimeout(() => void attempt(), backoff(attempts));
       }
-      // Non-auth bootstrap failures (SSH unreachable, etc.) keep the existing
-      // behavior — the app renders its empty/needs-config state.
-    });
+    };
+    void attempt();
+    return () => {
+      cancelled = true;
+    };
   }, [refresh]);
 
   useEffect(() => {

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -911,4 +911,38 @@ describe("last-active session restore (refresh / relaunch)", () => {
     expect(s.activeProjectName).toBe("alpha");
     expect(s.activeWindowByProject.alpha).toBe(0);
   });
+
+  it("applyProjects clears the auto-created zero-state draft once projects arrive", () => {
+    // Boot races: loaded flips true while projects is still [], which auto-
+    // creates a "welcome" new-project draft. When applyProjects then loads real
+    // sessions, that draft must go away — otherwise its NewSessionScreen
+    // overlay keeps covering the restored session.
+    const id = useStore.getState().createDraft("new-project");
+    useStore.setState({
+      projects: [],
+      activeProjectName: null,
+      activeWindowByProject: {},
+      activeDraftId: id,
+      drafts: useStore.getState().drafts,
+    });
+    writeSavedActiveSession({ project: "alpha", window: 1 });
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.projects.length).toBeGreaterThan(0);
+    expect(s.activeDraftId).toBeNull();
+    expect(s.drafts).toEqual([]);
+    // and it still lands on the restored session, not the composer
+    expect(s.activeProjectName).toBe("alpha");
+    expect(s.activeWindowByProject.alpha).toBe(1);
+  });
+
+  it("applyProjects does NOT clear a draft when projects already exist (normal refresh)", () => {
+    useStore.setState({ projects: sessions(), activeProjectName: "alpha" });
+    const id = useStore.getState().createDraft({ projectName: "beta" });
+    // a refresh with an active deliberate draft must keep it
+    useStore.getState().applyProjects(sessions());
+    const s = useStore.getState();
+    expect(s.activeDraftId).toBe(id);
+    expect(s.drafts.some((d) => d.id === id)).toBe(true);
+  });
 });

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1115,6 +1115,12 @@ export const useStore = create<State>((set, get) => ({
 
   applyProjects: (projects) =>
     set((prev) => {
+      // If the app had NO projects and now has some (the normal boot path:
+      // loaded flips true before the first tmuxList resolves), the auto-created
+      // zero-state "welcome" draft — whose NewSessionScreen overlay renders on
+      // top of the restored session — is stale. Drop it so the user lands on
+      // their last-used session, not the composer.
+      const clearZeroStateDrafts = prev.projects.length === 0 && projects.length > 0;
       // Clamp activeProjectName to one that still exists; clamp window choice too.
       let activeProjectName = prev.activeProjectName;
       // A window to force for the actively-restored project. When we land on a
@@ -1155,7 +1161,12 @@ export const useStore = create<State>((set, get) => ({
       for (const k of Object.keys(activeWindowByProject)) {
         if (!projects.find((p) => p.tmuxSession === k)) delete activeWindowByProject[k];
       }
-      return { projects, activeProjectName, activeWindowByProject };
+      return {
+        projects,
+        activeProjectName,
+        activeWindowByProject,
+        ...(clearZeroStateDrafts ? { activeDraftId: null, drafts: [] } : {}),
+      };
     }),
 }));
 


### PR DESCRIPTION
Two related boot issues.

**1. Still landing on the new-session screen.** On boot, `loaded` flips true while the project list is still `[]` (awaiting the first `tmuxList`), so the zero-state effect auto-creates a "welcome" new-project draft. Once real sessions load, `applyProjects` populated them but never cleared that draft — its NewSessionScreen overlay kept covering the restored session. `applyProjects` now clears the auto-created draft + `activeDraftId` when it transitions from *no projects → having projects`. A deliberate in-flight draft during an existing-session refresh is left untouched.

**2. Sometimes the session list never loads until a manual reload.** The bootstrap `refresh()` was a single fire-once fetch; on a cold/slow box the first fetch can fail and nothing populates (empty state) until the user hits Cmd+R a second time. The bootstrap now retries with exponential backoff (1s→15s, bounded at 6 attempts) on non-auth failures. Each retry runs `applyProjects`, so the UI heals in place — and these two fixes compose: once sessions finally load, the phantom draft is cleared and the user lands on their last-used session.

## Testing
- New store tests: clear-the-zero-state-draft-on-arrival, and don't-touch-a-deliberate-draft-on-normal-refresh.
- `npm run typecheck` clean; full suite green (1498 node + 2204 vitest).