### PR TITLE
fix(ui): fail fast on a stalled bootstrap session load

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -271,12 +271,14 @@ function AppInner() {
     // token and finishOnboarding() re-runs the bootstrap. SSH mode never throws
     // this (no Bearer gate), so this is a no-op there.
     //
-    // Non-auth bootstrap failures are retried with backoff: on a cold box the
-    // server / tmux may not be up on the very first fetch, and the session list
-    // would otherwise sit empty until the user manually reloads. Each retry
-    // runs applyProjects (which preserves the current selection and drops the
-    // zero-state draft once projects arrive), so the UI heals in place rather
-    // than requiring a second Cmd+R.
+    // Non-auth bootstrap failures are retried with backoff. The bootstrap
+    // metadata RPCs (configGet + tmuxList) carry a hard timeout in httpApi, so
+    // a stalled first connection FAILS FAST instead of hanging forever — which
+    // is what makes this retry actually fire (a hanging fetch never rejected,
+    // so the pre-fix shell sat empty until a manual Cmd+R). On a cold box the
+    // first attempt may time out before the server/tmux is up; a short retry
+    // recovers in place. Each retry runs applyProjects (which preserves the
+    // current selection and drops the zero-state draft once projects arrive).
     let cancelled = false;
     let attempts = 0;
     const MAX_ATTEMPTS = 6;

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -368,3 +368,57 @@ describe("httpApi auto-update delegation", () => {
     off();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bootstrap metadata RPC fail-fast timeout
+// ---------------------------------------------------------------------------
+//
+// Root-cause fix for "sessions sometimes take forever to load / need a second
+// refresh": configGet + tmuxList (the calls that gate the whole app shell) used
+// plain `rpc()` with NO timeout, so a stalled first connection hung forever with
+// no fail-fast and no recovery — the shell stayed empty until a manual Cmd+R.
+// These two now use a bounded RPC so a stall rejects and the bootstrap's retry
+// can recover. Genuinely long-running RPCs (model catalog, message/session
+// lists, worktree creation, delegation) must stay unbounded.
+
+function jsonResponse(result: unknown): Response {
+  return new Response(JSON.stringify({ result }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+function stubFetch(): ReturnType<typeof vi.fn<FetchFn>> {
+  const mock = vi.fn<FetchFn>();
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+describe("httpApi bootstrap metadata fail-fast timeout", () => {
+  beforeEach(() => {
+    mockLocalStorage["manta_server"] = "https://example.com";
+    mockLocalStorage["manta_token"] = HEX32;
+  });
+
+  it("configGet and tmuxList pass a timeout AbortSignal so a stall fails fast", async () => {
+    const fetchMock = stubFetch().mockImplementation(async () => jsonResponse({}));
+
+    await httpApi.configGet();
+    await httpApi.tmuxList();
+
+    const calls = fetchMock.mock.calls;
+    expect(calls.length).toBe(2);
+    for (const [, init] of calls) {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("long-running rpc calls stay unbounded (no timeout signal)", async () => {
+    const fetchMock = stubFetch().mockImplementation(async () => jsonResponse([]));
+
+    await httpApi.opencodeModels();
+
+    expect(fetchMock.mock.calls[0][1]?.signal).toBeUndefined();
+  });
+});

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -257,23 +257,35 @@ async function claimAgainst(
 // Generic JSON-RPC helper
 // ---------------------------------------------------------------------------
 
-async function rpc<T>(channel: string, ...args: unknown[]): Promise<T> {
+// Shared RPC dispatch. `timeoutMs` optional: when set, the fetch is wrapped in
+// fetchWithTimeout so a stalled connection FAILS FAST (aborts at `timeoutMs`)
+// instead of hanging forever. When unset (the default `rpc()`), the fetch is
+// unbounded — for genuinely long-running operations (model catalog refresh,
+// message/session list fetch, worktree creation, delegation) where a hard
+// timeout would abort real work.
+async function rpcInner<T>(
+  channel: string,
+  args: unknown[],
+  timeoutMs: number | undefined,
+): Promise<T> {
   // BET-187: track timing so we can ship one structured warn event when an
   // RPC call exceeds the 1s slow-call threshold. The instrumentation lives
   // here (single dispatch path — rpcOptional delegates) so every call site
   // is covered without per-call edits. Failures rethrow as before so the
   // existing UI auth/network error handling is untouched.
   const t0 = Date.now();
+  const url = `${serverBase()}/rpc/${encodeURIComponent(channel)}`;
+  const init: RequestInit = {
+    method: "POST",
+    headers: authHeaders(clientToken(), { "content-type": "application/json" }),
+    body: JSON.stringify({ args }),
+  };
   let res: Response;
   try {
-    res = await fetch(
-      `${serverBase()}/rpc/${encodeURIComponent(channel)}`,
-      {
-        method: "POST",
-        headers: authHeaders(clientToken(), { "content-type": "application/json" }),
-        body: JSON.stringify({ args }),
-      },
-    );
+    res =
+      timeoutMs != null
+        ? await fetchWithTimeout(url, init, timeoutMs)
+        : await fetch(url, init);
   } catch (err) {
     ship("error", "rpc failed", { channel, ms: Date.now() - t0, error: String(err) });
     throw err;
@@ -291,6 +303,23 @@ async function rpc<T>(channel: string, ...args: unknown[]): Promise<T> {
   }
   if (ms > 1000) ship("warn", "rpc slow", { channel, ms });
   return json.result as T;
+}
+
+// Default path — unbounded, matching historical behavior (long-lived ops).
+async function rpc<T>(channel: string, ...args: unknown[]): Promise<T> {
+  return rpcInner(channel, args, undefined);
+}
+
+// Time-bounded variant — for the fast metadata calls that gate the whole app
+// shell (config + project list). A stall here should fail fast and be retried,
+// not pin the empty/new-session screen until a manual reload.
+const RPC_METADATA_TIMEOUT_MS = 15000;
+async function rpcWithTimeout<T>(
+  channel: string,
+  timeoutMs: number,
+  ...args: unknown[]
+): Promise<T> {
+  return rpcInner(channel, args, timeoutMs);
 }
 
 /**
@@ -610,14 +639,18 @@ function on<T>(kind: Kind, cb: (p: T) => void): () => any {
 
 export const httpApi: Api = {
   // -- config --
-  configGet: () => rpc(IPC.configGet),
+  // configGet gates the app shell; a stalled connection must fail fast (and be
+  // retried) rather than hang forever on a cold tunnel / waking box.
+  configGet: () => rpcWithTimeout(IPC.configGet, RPC_METADATA_TIMEOUT_MS),
   configUpdate: (patch) => rpc(IPC.configUpdate, patch),
 
   // -- project metadata --
   projectMetaDelete: (tmuxSession) => rpc(IPC.projectMetaDelete, tmuxSession),
 
   // -- tmux operations --
-  tmuxList: () => rpc(IPC.tmuxList),
+  // tmuxList is the bootstrap session load — same fail-fast rationale as
+  // configGet.
+  tmuxList: () => rpcWithTimeout(IPC.tmuxList, RPC_METADATA_TIMEOUT_MS),
   tmuxNewSession: (input) => rpc(IPC.tmuxNewSession, input),
   tmuxNewWindow: (input) => rpc(IPC.tmuxNewWindow, input),
   tmuxRenameSession: (input) => rpc(IPC.tmuxRenameSession, input),


### PR DESCRIPTION
## Diagnosis (not a backoff band-aid)

The session list sometimes never appeared until a second Cmd+R. Root cause: the **bootstrap metadata RPCs had no timeout**, so a stalled first connection **hung forever** — `refresh()` never resolved and never rejected, there was no fail-fast and no automatic recovery, and the shell sat empty until a manual reload. A retry loop alone couldn't help because a hanging fetch never rejects.

Evidence:
- The box is healthy — **no error-level server events** in the last 14d for the failed loads (checked via Axiom). A server 500 would log; there was none, so this is a client-side stall, not a server fault.
- The desktop ships **no telemetry** (no build-time Axiom token), so nothing captured the client error — consistent with a hang rather than an exception.

## Fix

- **`rpc()` internals** (httpApi.ts): extracted a shared dispatch with an **optional hard timeout** (AbortController, reusing the pairing path's `fetchWithTimeout` 15s).
- **`configGet` + `tmuxList`** — the two calls that gate the whole app shell — now use the bounded RPC, so a stalled connection fails fast and `refresh()` rejects.
- **Bootstrap retry** (App.tsx) now actually works: with a real timeout the fetch rejects, so the bounded backoff recovers in place instead of a hang.
- **Genuinely long-running RPCs** (model catalog, message/session lists, worktree creation, delegation) keep their existing unbounded behavior — no blanket timeout that would abort real work.

## Testing

- New httpApi tests: configGet/tmuxList carry an AbortSignal; a long-running RPC (opencodeModels) stays unbounded.
- `npm run typecheck` clean; full suite green (1501 node + 2210 vitest).