### PR TITLE
chore(release): bump version to 0.0.22 for windows build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,1 +1,5 @@
-{ "version": "0.0.21", "notes_url": "https://mantaui.com/releases", "min_client": "0.0.0" }
+{
+ "version": "0.0.22",
+ "notes_url": "https://mantaui.com/releases",
+ "min_client": "0.0.0"
+}


### PR DESCRIPTION
Bump `package.json` to 0.0.22 so the Windows desktop build (tag-driven) emits a versioned installer distinct from the shipped 0.0.21.