### PR TITLE
refactor(models): single source of truth — drop desktop-only client merge

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -24,11 +24,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Pencil, X } from "lucide-react";
 import { describeModel } from "../shared/modelGuide.mjs";
-import {
-  applyModelOverride,
-  formatModelContextSize,
-  mergeModelOverrides,
-} from "./chatUtils";
+import { formatModelContextSize } from "./chatUtils";
 import { useStore } from "./store";
 import type { ModelOverride, OpencodeModel } from "../shared/types";
 import { Checkbox } from "./Checkbox";
@@ -203,15 +199,14 @@ export function ModelsCard() {
       ]);
       const deactivatedMainList = cfg.deactivatedMainModels ?? [];
       const deactivatedSubList = cfg.deactivatedSubagents ?? [];
-      // Apply display overrides CLIENT-SIDE too (idempotent with any server-side
-      // merge) so the table reflects them across reloads even if the running
-      // manta-server predates the server-side merge.
-      const withOverrides = mergeModelOverrides(modelList, cfg.modelOverrides);
+      // The server (opencode:models) is the single source of truth for display
+      // overrides, so the model list it returns is already overridden — use it
+      // as-is.
       const agents = await window.api.opencodeSyncSubagents({
-        models: withOverrides ?? modelList,
+        models: modelList,
         deactivated: deactivatedSubList,
       });
-      setModels(withOverrides);
+      setModels(modelList);
       setDeactivatedMain(new Set(deactivatedMainList));
       setDeactivatedSub(new Set(deactivatedSubList));
       // Result ignored — the consolidated table doesn't show per-agent
@@ -337,12 +332,12 @@ export function ModelsCard() {
   );
 
   // Save a model display override (name / description / context) drafted in the
-  // edit modal. Writes the full modelOverrides map to config, then updates the
-  // local table state in the SAME tick (so the row reflects the change without
-  // waiting for a refetch) and forces the shared model catalog to re-fetch so
-  // the composer's model dropdown picks it up immediately.
+  // edit modal. Writes the full modelOverrides map to config, then re-fetches
+  // the model list from the server (the single source of truth, which applies
+  // the override in opencode:models) so both the table and the composed model
+  // catalog reflect the change in the same tick.
   const saveOverride = useCallback(
-    async (key: string, model: OpencodeModel, override: ModelOverride) => {
+    async (key: string, _model: OpencodeModel, override: ModelOverride) => {
       if (busy) return;
       setBusy(key);
       setGlobalError(null);
@@ -352,16 +347,10 @@ export function ModelsCard() {
         const next = { ...existing };
         if (Object.keys(override).length === 0) delete next[key];
         else next[key] = override;
-        const updated = await window.api.configUpdate({ modelOverrides: next });
-        const resolved = updated.modelOverrides ?? next;
-        setModels(
-          (prev) =>
-            prev?.map((m) =>
-              m.providerID === model.providerID && m.id === model.id
-                ? applyModelOverride(m, resolved[`${model.providerID}/${model.id}`] ?? undefined)
-                : m,
-            ) ?? prev,
-        );
+        await window.api.configUpdate({ modelOverrides: next });
+        // Server re-reads config per opencode:models call, so a fresh fetch is
+        // already overridden.
+        setModels(await window.api.opencodeModels());
         setEditing(null);
         refreshModelCatalog();
       } catch (e) {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -78,8 +78,6 @@ import {
   resolveFastToggle,
   filterModelGroups,
   moveMenuHighlight,
-  applyModelOverride,
-  mergeModelOverrides,
   MAX_PREVIEW_BYTES,
   resolvePreviewType,
   isWithinPreviewSize,
@@ -328,60 +326,6 @@ describe("ctxStageColor", () => {
   it("returns danger from 90% and above", () => {
     expect(ctxStageColor(90)).toBe(cssVar("--danger"));
     expect(ctxStageColor(100)).toBe(cssVar("--danger"));
-  });
-});
-
-// ===== model overrides (applyModelOverride / mergeModelOverrides) =====
-
-describe("applyModelOverride", () => {
-  const base: OpencodeModel = {
-    id: "claude-sonnet-4-6",
-    providerID: "anthropic",
-    name: "Claude Sonnet 4.6",
-    limit: { context: 200_000, output: 64_000 },
-  };
-
-  it("trims + merges name, description and context, preserving untouched fields", () => {
-    const out = applyModelOverride(base, {
-      name: "  My Sonnet  ",
-      description: "  Custom  ",
-      context: 1_000_000,
-    });
-    expect(out).not.toBe(base);
-    expect(out.name).toBe("My Sonnet");
-    expect(out.description).toBe("Custom");
-    expect(out.limit?.context).toBe(1_000_000);
-    expect(out.limit?.output).toBe(64_000);
-    // input untouched
-    expect(base.name).toBe("Claude Sonnet 4.6");
-    expect(base.limit?.context).toBe(200_000);
-  });
-
-  it("ignores empty/invalid fields and returns input unchanged for no override", () => {
-    const out = applyModelOverride(base, { name: "   ", description: "", context: 0 });
-    expect(out).toBe(base);
-    expect(applyModelOverride(base, undefined)).toBe(base);
-  });
-});
-
-describe("mergeModelOverrides", () => {
-  const models: OpencodeModel[] = [
-    { id: "a", providerID: "p", name: "A" },
-    { id: "b", providerID: "p", name: "B" },
-  ];
-
-  it("returns the same array reference when nothing applies", () => {
-    expect(mergeModelOverrides(models, undefined)).toBe(models);
-    expect(mergeModelOverrides(models, {})).toBe(models);
-    expect(mergeModelOverrides(models, { "q/x": { name: "Nope" } })).toBe(models);
-  });
-
-  it("applies matching overrides by providerID/id and leaves others untouched", () => {
-    const out = mergeModelOverrides(models, { "p/b": { name: "B2", context: 99 } });
-    expect(out).not.toBe(models);
-    expect(out?.[0]).toBe(models[0]); // untouched model keeps its identity
-    expect(out?.[1].name).toBe("B2");
-    expect(out?.[1].limit?.context).toBe(99);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -4,7 +4,7 @@
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { DelegateApprovalTool, ModelOverride, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
+import type { DelegateApprovalTool, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
@@ -147,53 +147,6 @@ export function titleCase(id: string): string {
     .split(/[-_]/)
     .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
     .join(" ");
-}
-
-// Merge a user-supplied Settings → Models display override (name / description
-// / context size) onto an OpencodeModel. Mirrors the server's applyModelOverride
-// (src/server/opencode.mjs) so the renderer can honor overrides CLIENT-SIDE —
-// this makes the feature work regardless of whether the running box's
-// manta-server has the server-side merge deployed. Applying the same override
-// twice (renderer + server) is idempotent. Returns a new model object; a falsy
-// or empty override returns `m` unchanged.
-export function applyModelOverride(
-  m: OpencodeModel,
-  override: ModelOverride | undefined,
-): OpencodeModel {
-  if (!override) return m;
-  let next = m;
-  if (typeof override.name === "string" && override.name.trim() !== "") {
-    next = { ...next, name: override.name.trim() };
-  }
-  if (typeof override.description === "string" && override.description.trim() !== "") {
-    next = { ...next, description: override.description.trim() };
-  }
-  const ctx = override.context;
-  if (typeof ctx === "number" && Number.isFinite(ctx) && ctx > 0) {
-    next = { ...next, limit: { ...(m.limit ?? {}), context: ctx } };
-  }
-  return next;
-}
-
-// Apply a full "providerID/modelID" → override map onto a model list. Pure and
-// memo-friendly: returns a new array only when an override actually applies.
-export function mergeModelOverrides(
-  models: OpencodeModel[] | null,
-  overrides: Record<string, ModelOverride> | undefined,
-): OpencodeModel[] | null {
-  if (!models || !overrides) return models;
-  const keys = Object.keys(overrides);
-  if (keys.length === 0) return models;
-  const byKey = new Map(keys.map((k) => [k, overrides[k] ?? {}] as const));
-  let changed = false;
-  const out = models.map((m) => {
-    const o = byKey.get(`${m.providerID}/${m.id}`);
-    if (!o) return m;
-    const merged = applyModelOverride(m, o);
-    if (merged !== m) changed = true;
-    return merged;
-  });
-  return changed ? out : models;
 }
 
 // Client-side filter over already-grouped models for the model menu's search

--- a/src/renderer/modelCatalog.ts
+++ b/src/renderer/modelCatalog.ts
@@ -17,7 +17,6 @@
 
 import { useEffect, useState } from "react";
 import type { OpencodeModel } from "../shared/types";
-import { mergeModelOverrides } from "./chatUtils";
 
 export type ServerDefaultModel = { providerID: string; modelID: string } | null;
 
@@ -57,21 +56,12 @@ function load(): void {
   inFlight = Promise.allSettled([
     window.api.opencodeModels(),
     window.api.opencodeDefaultModel(),
-    window.api.configGet(),
   ])
-    .then(([modelsRes, defaultRes, cfgRes]) => {
+    .then(([modelsRes, defaultRes]) => {
       // Keep the previous value for whichever half failed — a transient error
       // must not blank a catalog we already have.
-      // Model display overrides are applied CLIENT-SIDE (in addition to any
-      // server-side merge) so the composer picker reflects them even when the
-      // box's manta-server predates the server-side merge. Idempotent.
-      const overrides =
-        cfgRes.status === "fulfilled" ? cfgRes.value?.modelOverrides : undefined;
       const next: Snapshot = {
-        models: mergeModelOverrides(
-          modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
-          overrides,
-        ),
+        models: modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
         defaultModel: defaultRes.status === "fulfilled" ? defaultRes.value : cache.defaultModel,
       };
       const changed =
@@ -79,11 +69,7 @@ function load(): void {
       cache = next;
       // Only mark fresh once something actually resolved, so a fully-failed
       // attempt retries on the next mount instead of caching the failure.
-      if (
-        modelsRes.status === "fulfilled" ||
-        defaultRes.status === "fulfilled" ||
-        cfgRes.status === "fulfilled"
-      ) {
+      if (modelsRes.status === "fulfilled" || defaultRes.status === "fulfilled") {
         fetchedAt = Date.now();
       }
       if (changed) emit();


### PR DESCRIPTION
Removes the renderer-side override application added in #659, leaving the **server's** `opencode:models` merge as the only place overrides are applied. Simpler: one source of truth, and desktop + mobile now behave identically (both read the server's already-overridden model list).

**What's removed**
- `chatUtils.applyModelOverride` / `mergeModelOverrides` + their tests.
- The shared catalog (`modelCatalog.ts`) fetching config and merging overrides client-side.
- `ModelsCard.refresh()` merging overrides client-side; `saveOverride` now just writes config then re-fetches the model list from the server.

**Why**
The desktop-only client merge existed only to paper over an un-updated box server, and it made desktop diverge from mobile (mobile always read the server). After this, both clients honor the override purely server-side.

**Note:** after merge, restart the box's manta-server so the (already-merged-in-main) `opencode:models` override logic is live — desktop no longer compensates for a stale server.

Verified: typecheck ✅ · server suite (1007) ✅ · renderer suite (2202) ✅ · duplication gate ✅