### PR TITLE
fix(chat): drop the live running indicator, keep only the final turn duration

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -62,7 +62,6 @@ import {
   type TokenUsage,
 } from "./chatShared";
 import { useModelCatalog } from "./modelCatalog";
-import { RunningIndicator } from "./MessageRow";
 import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
 import { CompactionCard, PermissionCard, RetryCard } from "./Cards";
@@ -2208,22 +2207,6 @@ export function ChatPanel({
           />
         </div>
       )}
-
-      {/* Working indicator. This is the LAST row of the transcript flow, so it
-          aligns with assistant rows — the transcript's full width (BET-646),
-          its own horizontal padding dropped. It is ALWAYS rendered, with the
-          spinner toggled via `visibility` rather than mounted/unmounted: the
-          indicator sits BELOW the transcript scroll container in the fixed
-          composer stack, so conditionally mounting it resized the reading
-          column and pushed the user's prompt up/down every time the turn's
-          running state toggled on send / before streaming. Keeping the slot a
-          constant height means toggling running never reflows the transcript.
-          Hidden (invisible, layout preserved) when idle. */}
-      <MeasureColumn width="full">
-        <div style={{ visibility: running ? "visible" : "hidden" }}>
-          <RunningIndicator tokens={latestTokens} atBottom={pinnedToBottom.current} />
-        </div>
-      </MeasureColumn>
 
       {running && messageQueue.length > 0 && (
             // Queued prompts are about to be submitted, so the notice belongs

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -7,20 +7,18 @@
 //   - UserCommandBar: collapsed `/name args` pill for slash-command turns.
 //   - ActiveTodos: the TodoWrite checklist card, mounted once at the tail of
 //     the transcript by Transcript.tsx (running or idle).
-//   - RunningIndicator: the ✻ spinner + elapsed / token line.
 //
 // AssistantPart lives in ./ToolCall; importing it here (and MessageRow back
 // there for subagent transcripts) forms an intentional, render-time-only
 // module cycle.
 
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { OpencodeMessage } from "../shared/types";
 import {
   describeTruncation,
   formatClockTime,
   formatDuration,
-  formatTokens,
   formatHiddenTodosSummary,
   selectVisibleTodos,
   summarizeTodoProgress,
@@ -28,71 +26,10 @@ import {
   type TodoStatus,
   type TruncationKind,
 } from "./chatUtils";
-import {
-  pastVerbFor,
-  SPINNER_VERBS,
-  type TokenUsage,
-} from "./chatShared";
+import { pastVerbFor } from "./chatShared";
 import { AssistantPart } from "./ToolCall";
-import { MantaLoader, MantaMark } from "./MantaLoader";
+import { MantaMark } from "./MantaLoader";
 import { MessageBubble } from "./MessageBubble";
-import { nowMs } from "./clock";
-
-// The working row. The mark inside its two counter-rotating arcs (the app's
-// one waiting image — see MantaLoader), the verb, and the run's numbers.
-//
-// The row appears the moment a prompt is submitted, not when the box reports
-// the turn busy (ChatPanel's submit sets `running` optimistically), so the
-// send → first-token window is never silent. That is why there is no skeleton
-// placeholder here: the loader plus its verb IS the placeholder.
-//
-// Type: all sans — the verb is prose and the elapsed/token readout is chrome,
-// not output, so neither wants the mono face the transcript reserves for
-// commands and tool output. `tabular-nums` (which Inter supports) is what stops
-// the digits jittering as they tick; the mono face was never doing that job.
-export function RunningIndicator({ tokens, atBottom }: { tokens: TokenUsage | null; atBottom: boolean }) {
-  // Tick once per second to drive the elapsed-time re-render.
-  const [, setTick] = useState(0);
-  // `nowMs()` returns the demo mode's deterministic clock when the hero
-  // video is rendering (see src/renderer/clock.ts). Real apps fall back to
-  // Date.now(). This is the *reference* timestamp the elapsed-time label
-  // measures against, so two consecutive renders of the same frame use
-  // the same value (no `Date.now()` label drift).
-  const startRef = useRef<number>(nowMs());
-  // Pick a verb once per indicator mount so it doesn't shuffle between
-  // renders.
-  const verb = useRef<string>(
-    SPINNER_VERBS[Math.floor(Math.random() * SPINNER_VERBS.length)],
-  );
-
-  useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  const elapsedMs = nowMs() - startRef.current;
-
-  const outTokens = tokens != null ? tokens.output + tokens.reasoning : 0;
-
-  // pt-0 + pb-3: the scroll container above already has pb-3 (12px), so
-  // dropping the indicator's top padding gives 12px between the last
-  // message and the ✻ glyph. pb-3 matches it on the other side (12px
-  // between context bar / ✻ line and the input divider). No horizontal
-  // padding: the indicator sits inside a MeasureColumn (padded 28px) so it
-  // shares the reading column's left edge with the transcript (BET-637).
-  return (
-    <div className={`shrink-0 pb-3 ${atBottom ? "pt-0" : "pt-1"}`}>
-      <div className="flex items-center gap-2">
-        <MantaLoader />
-        <span className="text-label text-text-muted">{verb.current}…</span>
-        <span className="text-meta tabular-nums text-text-faint">
-          {formatDuration(elapsedMs)}
-          {outTokens > 0 && <> · ↓ {formatTokens(outTokens)}</>}
-        </span>
-      </div>
-    </div>
-  );
-}
 
 // ===== Active todos =====
 //


### PR DESCRIPTION
## Summary
Removes the live `RunningIndicator` row (the tick-per-second spinner + elapsed 'mused for 30s' + live token count) that renders below the transcript while a chat turn is in flight.

## What stays
The per-turn footer ("Brewed for Ns") at the end of each finished turn is untouched — elapsed time now appears once, only when the AI is done working.

## Changes
- `ChatPanel.tsx`: removed the always-rendered indicator block and its import.
- `MessageRow.tsx`: deleted the now-orphaned `RunningIndicator` component + its dead imports.

## Verification
- `npm run typecheck`: clean
- `npm test`: 1501 pass, 0 fail

Note: the native iOS client has its own copy (`mobile/native/MantaUI/RunningIndicator.swift`) — out of scope here.