### PR TITLE
fix(ui): dismissable todo card + keep model todo list current

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -298,3 +298,25 @@ Install: `cp <repo>/docs/opencode-tools/send-file.ts
 ~/.config/opencode/tools/send-file.ts` and restart `opencode-serve`.
 **Install/update is a COPY, never a symlink** (same `@opencode-ai/plugin`
 resolution gotcha as the other manta tools).
+
+## manta todo hygiene
+
+Your `todowrite` checklist is pinned in the user's chat panel wherever it is
+non-empty, so keep it current and trustworthy — it is shared UI, not private
+scratch space.
+
+- **Every task you finish: mark it `completed`.** Do not leave a done item
+  sitting `in_progress` or `pending`; the card stops showing the list once
+  every item is terminal and the user sends their next prompt.
+- **When a step becomes irrelevant** (requirements changed, you found a better
+  path, the model you switched to needs different work), **cancel or remove it
+  rather than leaving it to linger** — call `todowrite` again with that item
+  `cancelled` (or drop it from the list entirely). A stale, never-done item is
+  worse than a clear list: it is how an abandoned plan keeps surfacing as
+  "still open" long after it stopped mattering.
+- **Prefer editing the existing list over stacking**: the UI shows your most
+  recent list, so rewrite it as a whole when the plan changes rather than
+  appending a parallel list that contradicts the first.
+- **Don't over-create.** Reserve todos for genuinely multi-step work (≈3+
+  distinct actions). A single-step request doesn't need a checklist, and a
+  wall of noise makes the real items easier to miss.

--- a/src/renderer/ActiveTodos.test.tsx
+++ b/src/renderer/ActiveTodos.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+//
+// Component tests for the ActiveTodos checklist card — specifically the manual
+// dismiss affordance: the "×" that lets a user hide a STALE list whose items
+// aren't all terminal (the auto-dismiss path only fires once every item is
+// completed/cancelled and the user submits again).
+//
+// jsdom loads no stylesheet, so assertions target the dismiss button (by
+// aria-label) and the callback it invokes, not visual chrome.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { ActiveTodos } from "./MessageRow";
+
+function todos() {
+  return [
+    { content: "Still relevant", status: "in_progress" },
+    { content: "Done task", status: "completed" },
+  ];
+}
+
+function dismissButton(h: Harness): HTMLButtonElement | null {
+  return h.container.querySelector(
+    'button[aria-label="Dismiss todo list"]',
+  ) as HTMLButtonElement | null;
+}
+
+describe("ActiveTodos", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders no dismiss button when no onDismiss is supplied (existing behavior)", () => {
+    h = mount(<ActiveTodos todos={todos()} />);
+    expect(dismissButton(h)).toBeNull();
+  });
+
+  it("renders a dismiss button when onDismiss is supplied", () => {
+    h = mount(<ActiveTodos todos={todos()} onDismiss={() => {}} />);
+    expect(dismissButton(h)).toBeTruthy();
+  });
+
+  it("calls onDismiss when the dismiss button is clicked", () => {
+    const onDismiss = vi.fn();
+    h = mount(<ActiveTodos todos={todos()} onDismiss={onDismiss} />);
+    dismissButton(h)!.click();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -365,6 +365,11 @@ export function ChatPanel({
     setInput,
   });
 
+  // Manual dismiss of the pinned todo card — the user's escape hatch for a
+  // stale list that's non-terminal. Mirrors the auto-dismiss path in submit().
+  // Stable identity so it doesn't defeat ActiveTodos' React.memo.
+  const dismissTodos = useCallback(() => setTodosDismissed(true), [setTodosDismissed]);
+
   // BET-418 §A5: ref mirror of permissions so the approval poll can read the
   // latest always[] grants without taking permissions as a dep (which would
   // reset the poll timer on every permission change).
@@ -2038,6 +2043,7 @@ export function ChatPanel({
         running={running}
         isActive={isActive}
         activeTodos={activeTodos}
+        onDismissTodos={dismissTodos}
         // BET-418 §D: a job session is read-only — never show its (anyway
         // impossible) question cards. Defensive: a job's pre-flight ruleset
         // means it never generates asks.

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -142,7 +142,7 @@ export const ActiveTodos = memo(function ActiveTodos({
             onClick={onDismiss}
             title="Dismiss todo list"
             aria-label="Dismiss todo list"
-            className="text-text-faint hover:text-text transition-colors -mr-1 rounded-xs p-0.5 hover:bg-bg-soft"
+            className="text-text-faint hover:text-text transition-colors -mr-1 rounded-xs p-1 hover:bg-bg-soft"
           >
             <X size={12} aria-hidden="true" />
           </button>

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -13,7 +13,7 @@
 // module cycle.
 
 import { memo, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
 import type { OpencodeMessage } from "../shared/types";
 import {
   describeTruncation,
@@ -109,8 +109,10 @@ function TodoMark({ status }: { status: TodoStatus }) {
 
 export const ActiveTodos = memo(function ActiveTodos({
   todos,
+  onDismiss,
 }: {
   todos: Array<Record<string, unknown>>;
+  onDismiss?: () => void;
 }) {
   // Render at most VISIBLE_TODOS_CAP items inline. Order: current
   // (in_progress) → pending → done so the row the model is actively
@@ -134,6 +136,17 @@ export const ActiveTodos = memo(function ActiveTodos({
         >
           {progress.label}
         </span>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            title="Dismiss todo list"
+            aria-label="Dismiss todo list"
+            className="text-text-faint hover:text-text transition-colors -mr-1 rounded-xs p-0.5 hover:bg-bg-soft"
+          >
+            <X size={12} aria-hidden="true" />
+          </button>
+        )}
       </div>
       {/* Two-segment progress rail. Settled runs green, the in-flight item
           runs amber; the remainder is the track showing through. 2px so it

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -56,6 +56,7 @@ export type TranscriptProps = {
   // third arg). See the comment on `updateEntryMotion` in chatUtils.
   isActive: boolean;
   activeTodos: Array<Record<string, unknown>> | null;
+  onDismissTodos?: () => void;
   questions: QuestionRequest[];
   // Per-message derived lookups (all memoized at ChatPanel scope so the
   // React.memo on MessageRow isn't defeated by fresh object identities).
@@ -76,6 +77,7 @@ export function Transcript({
   running,
   isActive,
   activeTodos,
+  onDismissTodos,
   questions,
   turnInfo,
   finishByMessageId,
@@ -193,7 +195,7 @@ export function Transcript({
               {/* assistant). Anchoring it here keeps it at the bottom of the */}
               {/* transcript in every state. */}
               {activeTodos && activeTodos.length > 0 && (
-                <ActiveTodos todos={activeTodos} />
+                <ActiveTodos todos={activeTodos} onDismiss={onDismissTodos} />
               )}
               {/* Pending question cards. Rendered INSIDE the scroll */}
               {/* container at the tail of the transcript so they scroll */}


### PR DESCRIPTION
## Summary
Two changes for stale todos in the chat panel:

1. **Manual dismiss on the ActiveTodos card** — a small "×" header button hides the card even when items aren't terminal. Previously the card could only auto-dismiss once *every* item was completed/cancelled and the user submitted again, so one stale \`in_progress\` item pinned the list forever with no way to hide it.
2. **Model-side todo hygiene guidance** — a "manta todo hygiene" section in `docs/opencode-tools/AGENTS.md` (appended to the global `~/.config/opencode/AGENTS.md`) telling the model to keep the checklist current: mark finished items `completed`, cancel/remove steps that become irrelevant, rewrite the list as a whole rather than stacking, and avoid over-creating.

## Wiring
Dismiss flows through the existing `todosDismissed` state (same path as auto-dismiss). A fresh `todo.updated` from the model re-surfaces the card. The handler is a stable `useCallback` so it doesn't defeat the card's `React.memo`.

## What it doesn't change
- The existing "completed → next prompt clears it" behavior is untouched.
- `node_modules` symlink churn from the environment was deliberately left out of the diff.

## Tests
`typecheck` + `ActiveTodos`, `useSseBus`, `Transcript` suites green. New component tests cover the dismiss button (absent without handler, present with, fires on click).