### PR TITLE
feat(chat): show output-token count in the turn footer

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1813,11 +1813,17 @@ export function ChatPanel({
 
   // Turn boundary metadata: which assistant messages are the FINAL one of
   // their turn (i.e., immediately followed by a user message or end-of-list),
-  // and the cumulative duration of that turn (first assistant `created` →
-  // last assistant `completed`). Intermediate assistant messages within a
-  // multi-step turn don't get a duration footer — only the final one does.
+  // the cumulative duration of that turn (first assistant `created` →
+  // last assistant `completed`), and the turn's total output tokens (read off
+  // the last assistant message's `info.tokens.output` — the same persisted,
+  // transcript-derived source the context bar uses, so it survives refresh).
+  // Intermediate assistant messages within a multi-step turn get no footer —
+  // only the final one does.
   const turnInfo = useMemo(() => {
-    const out = new Map<string, { turnDurationMs: number | null }>();
+    const out = new Map<
+      string,
+      { turnDurationMs: number | null; outputTokens: number | null }
+    >();
     if (!messages) return out;
     let i = 0;
     while (i < messages.length) {
@@ -1826,11 +1832,18 @@ export function ChatPanel({
         let j = i + 1;
         let firstStart: number | null = null;
         let lastEnd: number | null = null;
+        let lastOutput: number | null = null;
         let lastAssistantId: string | null = null;
         while (j < messages.length && messages[j].info.role === "assistant") {
           const t = messages[j].info.time;
           if (firstStart == null && t?.created != null) firstStart = t.created;
           if (t?.completed != null) lastEnd = t.completed;
+          // OpencodeMessageInfo doesn't surface `tokens` directly — read it
+          // off the underlying record the same way `latestTokens` does.
+          const tok = (
+            messages[j].info as unknown as { tokens?: TokenUsage }
+          ).tokens;
+          if (tok && typeof tok.output === "number") lastOutput = tok.output;
           lastAssistantId = messages[j].info.id;
           j++;
         }
@@ -1840,6 +1853,7 @@ export function ChatPanel({
               firstStart != null && lastEnd != null && lastEnd > firstStart
                 ? lastEnd - firstStart
                 : null,
+            outputTokens: lastOutput,
           });
         }
         i = j;

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -19,6 +19,7 @@ import {
   describeTruncation,
   formatClockTime,
   formatDuration,
+  formatTokens,
   formatHiddenTodosSummary,
   selectVisibleTodos,
   summarizeTodoProgress,
@@ -243,6 +244,7 @@ export const MessageRow = memo(function MessageRow({
   msg,
   showThinking,
   turnDurationMs,
+  outputTokens,
   truncation,
   commandInfo,
   streaming = false,
@@ -254,7 +256,10 @@ export const MessageRow = memo(function MessageRow({
   // whole turn (all consecutive assistant messages since the last user msg).
   // Intermediate messages get null so they don't show a footer at all.
   turnDurationMs: number | null;
-  // Per-message truncation classification from finishByMessageId. Drives
+  // Output tokens produced by this whole turn (the final assistant message's
+  // `info.tokens.output`). Appended to the duration footer. Transcript-derived,
+  // so it survives refresh. null/0 → omitted.
+  outputTokens: number | null;  // Per-message truncation classification from finishByMessageId. Drives
   // the "truncated" badge appended to the turn-duration footer (or as a
   // standalone footer when there's no duration, e.g. mid-turn assistant
   // messages within a multi-step turn that hit max_tokens). null = no
@@ -423,9 +428,9 @@ export const MessageRow = memo(function MessageRow({
       {/* (most common case: end-of-turn truncation). For mid-turn step */}
       {/* truncations there's no duration footer, so the badge renders on */}
       {/* its own row using the same baseline style. */}
-      {/* Sans, not mono: this is a sentence about the turn ("Brewed for 40s"), */}
-      {/* not a command or a path. In mono it read as terminal output that had */}
-      {/* leaked into the transcript. */}
+      {/* Sans, not mono: this is a sentence about the turn ("Ruminated for
+          1m44s · 12.4k output"), not a command or a path. In mono it read as
+          terminal output that had leaked into the transcript. */}
       {(turnDurationMs != null || truncation != null) && (
         <div className="text-label text-text-muted">
           {turnDurationMs != null && (
@@ -434,6 +439,12 @@ export const MessageRow = memo(function MessageRow({
                   around, held still — the arcs are what meant "in flight". */}
               <MantaMark size={12} />{" "}
               {pastVerbFor(msg.info.id)} for {formatDuration(turnDurationMs)}
+              {outputTokens != null && outputTokens > 0 && (
+                <>
+                  {" · "}
+                  {formatTokens(outputTokens)}
+                </>
+              )}
             </>
           )}
           {truncation != null && (

--- a/src/renderer/TaskCard.tsx
+++ b/src/renderer/TaskCard.tsx
@@ -132,6 +132,7 @@ export function TaskCard({ state }: { state: ToolState }) {
                   // the turn-duration / truncation overlays designed for the
                   // top-level conversation.
                   turnDurationMs={null}
+                  outputTokens={null}
                   truncation={null}
                   commandInfo={null}
                 />

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -60,7 +60,10 @@ export type TranscriptProps = {
   questions: QuestionRequest[];
   // Per-message derived lookups (all memoized at ChatPanel scope so the
   // React.memo on MessageRow isn't defeated by fresh object identities).
-  turnInfo: Map<string, { turnDurationMs: number | null }>;
+  turnInfo: Map<
+    string,
+    { turnDurationMs: number | null; outputTokens: number | null }
+  >;
   finishByMessageId: Map<string, import("./chatUtils").TruncationKind>;
   userCommandInfo: Map<string, { name: string; arguments: string }>;
   onReplyQuestion: (q: QuestionRequest, answers: string[][]) => void;
@@ -169,6 +172,7 @@ export function Transcript({
                     msg={m}
                     showThinking={showThinking}
                     turnDurationMs={turnInfo.get(m.info.id)?.turnDurationMs ?? null}
+                    outputTokens={turnInfo.get(m.info.id)?.outputTokens ?? null}
                     truncation={finishByMessageId.get(m.info.id) ?? null}
                     commandInfo={cmdInfo}
                     // The message being written right now: last in the

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -103,7 +103,7 @@ export const TaskContext = createContext<TaskContextValue | null>(null);
 
 // Present-tense verb pool for the running indicator. Picked once per turn
 // so the verb doesn't shuffle between renders. Past-tense pair (same index)
-// is used in the post-turn footer (`✻ Brewed for 1m 44s`).
+// is used in the post-turn footer (`✻ Ruminated for 1m44s`).
 export const SPINNER_VERBS = [
   "Cogitating",
   "Ruminating",

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -271,16 +271,16 @@ describe("formatDuration", () => {
     expect(formatDuration(59_000)).toBe("59s");
   });
 
-  it("returns minutes and seconds", () => {
-    expect(formatDuration(60_000)).toBe("1m 0s");
-    expect(formatDuration(90_000)).toBe("1m 30s");
-    expect(formatDuration(104_000)).toBe("1m 44s");
+  it("returns minutes and seconds (no spaces)", () => {
+    expect(formatDuration(60_000)).toBe("1m0s");
+    expect(formatDuration(90_000)).toBe("1m30s");
+    expect(formatDuration(104_000)).toBe("1m44s");
   });
 
-  it("returns hours, minutes, and seconds", () => {
-    expect(formatDuration(3_600_000)).toBe("1h 0m 0s");
-    expect(formatDuration(3_661_000)).toBe("1h 1m 1s");
-    expect(formatDuration(7_384_000)).toBe("2h 3m 4s");
+  it("returns hours, minutes, and seconds (no spaces)", () => {
+    expect(formatDuration(3_600_000)).toBe("1h0m0s");
+    expect(formatDuration(3_661_000)).toBe("1h1m1s");
+    expect(formatDuration(7_384_000)).toBe("2h3m4s");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -238,14 +238,17 @@ export function expiryLabel(expiresAt: number | null | undefined, now: number): 
   return `${Math.max(1, hours)}h`;
 }
 
+// Compact wall-clock duration (no spaces): "59s", "1m44s", "2h3m4s".
+// Used by the turn footer (`✻ 1m44s · 12.4k`) and the live running row so
+// the two read identically.
 export function formatDuration(ms: number): string {
   if (ms < 1000) return "<1s";
   const totalSec = Math.round(ms / 1000);
   const h = Math.floor(totalSec / 3600);
   const m = Math.floor((totalSec % 3600) / 60);
   const s = totalSec % 60;
-  if (h > 0) return `${h}h ${m}m ${s}s`;
-  if (m > 0) return `${m}m ${s}s`;
+  if (h > 0) return `${h}h${m}m${s}s`;
+  if (m > 0) return `${m}m${s}s`;
   return `${s}s`;
 }
 


### PR DESCRIPTION
Adds the turn's output token count to the end-of-turn footer, alongside the compacted duration.

**Changes**
- Footer now reads `✻ Ruminated for 1m44s · 12.4k tokens`
- Output tokens come from the final assistant message's `info.tokens.output` — persisted in the opencode transcript, so the value survives refresh/reopen (no new persistence layer).
- Duration compacted to no spaces (`1m44s`) via `formatDuration`.
- Kept the verb wording and end-of-turn-only footer (no live running indicator).

**Verification**
- `npm run typecheck` clean
- `npm test` green (2216 tests)