### PR TITLE
fix(models): honor display overrides client-side so they persist each load

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -24,7 +24,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Pencil, X } from "lucide-react";
 import { describeModel } from "../shared/modelGuide.mjs";
-import { formatModelContextSize } from "./chatUtils";
+import { formatModelContextSize, mergeModelOverrides } from "./chatUtils";
 import { useStore } from "./store";
 import type { ModelOverride, OpencodeModel } from "../shared/types";
 import { Checkbox } from "./Checkbox";
@@ -200,13 +200,17 @@ export function ModelsCard() {
       const deactivatedMainList = cfg.deactivatedMainModels ?? [];
       const deactivatedSubList = cfg.deactivatedSubagents ?? [];
       // The server (opencode:models) is the single source of truth for display
-      // overrides, so the model list it returns is already overridden — use it
-      // as-is.
+      // overrides, so the model list it returns is already overridden. Apply
+      // overrides CLIENT-SIDE too (idempotent with any server-side merge) so
+      // the table reflects them across reloads even if the running box's
+      // manta-server predates the server-side merge (the persisted override
+      // would otherwise be ignored on read and revert to the provider values).
+      const withOverrides = mergeModelOverrides(modelList, cfg.modelOverrides);
       const agents = await window.api.opencodeSyncSubagents({
         models: modelList,
         deactivated: deactivatedSubList,
       });
-      setModels(modelList);
+      setModels(withOverrides);
       setDeactivatedMain(new Set(deactivatedMainList));
       setDeactivatedSub(new Set(deactivatedSubList));
       // Result ignored — the consolidated table doesn't show per-agent
@@ -348,9 +352,11 @@ export function ModelsCard() {
         if (Object.keys(override).length === 0) delete next[key];
         else next[key] = override;
         await window.api.configUpdate({ modelOverrides: next });
-        // Server re-reads config per opencode:models call, so a fresh fetch is
-        // already overridden.
-        setModels(await window.api.opencodeModels());
+        // Re-fetch from the server (single source of truth), then also apply
+        // the override CLIENT-SIDE (idempotent) so the table reflects it in
+        // the same tick even if the running box's manta-server predates the
+        // server-side merge.
+        setModels(mergeModelOverrides(await window.api.opencodeModels(), next));
         setEditing(null);
         refreshModelCatalog();
       } catch (e) {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -78,6 +78,8 @@ import {
   resolveFastToggle,
   filterModelGroups,
   moveMenuHighlight,
+  applyModelOverride,
+  mergeModelOverrides,
   MAX_PREVIEW_BYTES,
   resolvePreviewType,
   isWithinPreviewSize,
@@ -354,6 +356,94 @@ describe("formatModelContextSize", () => {
   });
 });
 
+// ===== applyModelOverride / mergeModelOverrides =====
+
+function ovModel(id: string, providerID: string, context = 200_000): OpencodeModel {
+  return {
+    id,
+    providerID,
+    name: id,
+    status: "active" as const,
+    capabilities: {},
+    family: "",
+    limit: { context, output: 8000 },
+  };
+}
+
+describe("applyModelOverride", () => {
+  it("returns the model unchanged for a falsy or empty override", () => {
+    const m = ovModel("opus", "anthropic");
+    expect(applyModelOverride(m, undefined)).toBe(m);
+    expect(applyModelOverride(m, {})).toBe(m);
+  });
+
+  it("merges name / description / context onto a NEW object, never mutating", () => {
+    const m = ovModel("default", "voska", 1000);
+    const out = applyModelOverride(m, {
+      name: "  My Model  ",
+      description: "  tuned  ",
+      context: 500_000,
+    });
+    expect(out).not.toBe(m);
+    expect(out.name).toBe("My Model");
+    expect(out.description).toBe("tuned");
+    expect(out.limit?.context).toBe(500_000);
+    // Input untouched, other fields preserved.
+    expect(m.name).toBe("default");
+    expect(m.limit?.context).toBe(1000);
+    expect(out.id).toBe("default");
+    expect(out.providerID).toBe("voska");
+  });
+
+  it("ignores blank / non-positive / non-finite override fields", () => {
+    const m = ovModel("opus", "anthropic");
+    const out = applyModelOverride(m, {
+      name: "   ",
+      description: "",
+      context: 0,
+    });
+    // No field applied → returns the SAME object reference.
+    expect(out).toBe(m);
+  });
+
+  it("keeps the provider's limit shape when only context overrides", () => {
+    const m = ovModel("opus", "anthropic", 200_000);
+    const out = applyModelOverride(m, { context: 500_000 });
+    expect(out.limit).toEqual({ ...m.limit, context: 500_000 });
+  });
+});
+
+describe("mergeModelOverrides", () => {
+  it("returns null/input unchanged when there are no models or no overrides", () => {
+    expect(mergeModelOverrides(null, { a: { name: "x" } })).toBeNull();
+    const list = [ovModel("a", "p")];
+    expect(mergeModelOverrides(list, undefined)).toBe(list);
+    expect(mergeModelOverrides(list, {})).toBe(list);
+  });
+
+  it("applies overrides keyed by providerID/modelID and returns a new array only when something changed", () => {
+    const a = ovModel("a", "p");
+    const b = ovModel("b", "p");
+    const c = ovModel("c", "q");
+    const out = mergeModelOverrides(
+      [a, b, c],
+      { "p/a": { name: "A!" }, "q/c": { context: 999 } },
+    )!;
+    expect(out).not.toBe([a, b, c]);
+    expect(out[0].name).toBe("A!");
+    expect(out[2].limit?.context).toBe(999);
+    // Unmatched model untouched and reference-identical.
+    expect(out[1]).toBe(b);
+    // Non-matching keys are ignored.
+    expect(out).toHaveLength(3);
+  });
+
+  it("returns the same array reference when no override applies (memo-friendly)", () => {
+    const list = [ovModel("a", "p"), ovModel("b", "p")];
+    expect(mergeModelOverrides(list, { "zzz/nope": { name: "x" } })).toBe(list);
+  });
+});
+
 // ===== filterModelGroups =====
 
 function model(id: string, providerID: string): OpencodeModel {
@@ -361,7 +451,10 @@ function model(id: string, providerID: string): OpencodeModel {
     id,
     providerID,
     name: id,
-    limit: { context: 200_000 },
+    status: "active" as const,
+    capabilities: {},
+    family: "",
+    limit: { context: 200_000, output: 8000 },
   };
 }
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -4,7 +4,7 @@
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { DelegateApprovalTool, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
+import type { DelegateApprovalTool, ModelOverride, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
@@ -147,6 +147,58 @@ export function titleCase(id: string): string {
     .split(/[-_]/)
     .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
     .join(" ");
+}
+
+// Merge a user-supplied Settings → Models display override (name / description
+// / context size) onto an OpencodeModel. Mirrors the server's applyModelOverride
+// (src/server/opencode.mjs) so the renderer can honor overrides CLIENT-SIDE —
+// this makes the model display persist across reloads and in the composer
+// picker even when the running box's manta-server predates the server-side
+// merge (the persisted ~/.manta/config.json override, if never applied on
+// read, reverts to the provider's original values — BET-644 regression).
+// Applying the same override twice (renderer + a current server) is
+// idempotent. Returns a new model object; a falsy / empty override returns
+// `m` unchanged.
+export function applyModelOverride(
+  m: OpencodeModel,
+  override: ModelOverride | undefined,
+): OpencodeModel {
+  if (!override) return m;
+  let next = m;
+  if (typeof override.name === "string" && override.name.trim() !== "") {
+    next = { ...next, name: override.name.trim() };
+  }
+  if (typeof override.description === "string" && override.description.trim() !== "") {
+    next = { ...next, description: override.description.trim() };
+  }
+  const ctx = override.context;
+  if (typeof ctx === "number" && Number.isFinite(ctx) && ctx > 0) {
+    next = { ...next, limit: { ...(m.limit ?? {}), context: ctx } };
+  }
+  return next;
+}
+
+// Apply a full "providerID/modelID" → override map onto a model list. Pure and
+// memo-friendly: returns a new array only when an override actually applies,
+// otherwise returns the input array by reference (so a no-op doesn't break a
+// `===` memo comparison downstream).
+export function mergeModelOverrides(
+  models: OpencodeModel[] | null,
+  overrides: Record<string, ModelOverride> | undefined,
+): OpencodeModel[] | null {
+  if (!models || !overrides) return models;
+  const keys = Object.keys(overrides);
+  if (keys.length === 0) return models;
+  const byKey = new Map(keys.map((k) => [k, overrides[k] ?? {}] as const));
+  let changed = false;
+  const out = models.map((m) => {
+    const o = byKey.get(`${m.providerID}/${m.id}`);
+    if (!o) return m;
+    const merged = applyModelOverride(m, o);
+    if (merged !== m) changed = true;
+    return merged;
+  });
+  return changed ? out : models;
 }
 
 // Client-side filter over already-grouped models for the model menu's search

--- a/src/renderer/modelCatalog.ts
+++ b/src/renderer/modelCatalog.ts
@@ -17,6 +17,7 @@
 
 import { useEffect, useState } from "react";
 import type { OpencodeModel } from "../shared/types";
+import { mergeModelOverrides } from "./chatUtils";
 
 export type ServerDefaultModel = { providerID: string; modelID: string } | null;
 
@@ -52,16 +53,27 @@ function load(): void {
   // the pre-pairing preload subset installed on `window.api` does not have
   // them, so the runtime check is real even though TS thinks it is redundant.
   const api = window.api as Partial<typeof window.api>;
-  if (!api.opencodeModels || !api.opencodeDefaultModel) return;
+  if (!api.opencodeModels || !api.opencodeDefaultModel || !api.configGet) return;
   inFlight = Promise.allSettled([
     window.api.opencodeModels(),
     window.api.opencodeDefaultModel(),
+    window.api.configGet(),
   ])
-    .then(([modelsRes, defaultRes]) => {
+    .then(([modelsRes, defaultRes, cfgRes]) => {
       // Keep the previous value for whichever half failed — a transient error
       // must not blank a catalog we already have.
+      // Model display overrides are applied CLIENT-SIDE (in addition to any
+      // server-side merge) so the composer picker reflects persisted
+      // name/description/context overrides even when the running box's
+      // manta-server predates the server-side merge. Idempotent — a current
+      // server that already merged them yields a no-op here.
+      const overrides =
+        cfgRes.status === "fulfilled" ? cfgRes.value?.modelOverrides : undefined;
       const next: Snapshot = {
-        models: modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
+        models: mergeModelOverrides(
+          modelsRes.status === "fulfilled" ? modelsRes.value : cache.models,
+          overrides,
+        ),
         defaultModel: defaultRes.status === "fulfilled" ? defaultRes.value : cache.defaultModel,
       };
       const changed =
@@ -69,7 +81,11 @@ function load(): void {
       cache = next;
       // Only mark fresh once something actually resolved, so a fully-failed
       // attempt retries on the next mount instead of caching the failure.
-      if (modelsRes.status === "fulfilled" || defaultRes.status === "fulfilled") {
+      if (
+        modelsRes.status === "fulfilled" ||
+        defaultRes.status === "fulfilled" ||
+        cfgRes.status === "fulfilled"
+      ) {
         fetchedAt = Date.now();
       }
       if (changed) emit();


### PR DESCRIPTION
## What

Model display overrides (name / description / context size, set via Settings → Models → edit) don't persist across reloads for the user.

## Root cause

The override save correctly persists to `~/.manta/config.json`, but the running box's manta-server predates the server-side merge in `opencode:models` — so the persisted override is **never applied on read**. After a reload (and in the composer picker) the provider's original name/description/context shows again. Confirmed live: `voska/default` has a saved `context: 500000`, but the server returns `context: 0`.

This is the exact scenario that `6ac26bc` guarded against client-side, which PR #663 ("server is single source of truth") later removed — that removal assumed the deployed server always has the merge, which the live box doesn't.

## Fix

Re-apply the display overrides **client-side**, idempotent with any server-side merge, so display honors the saved override regardless of the running server's version:

- `src/renderer/chatUtils.ts` — pure `applyModelOverride` + `mergeModelOverrides` (mirror of the server logic).
- `src/renderer/ModelsCard.tsx` — the Settings table applies them at load and same-tick after save.
- `src/renderer/modelCatalog.ts` — the composer picker applies them at load.

## CI (run manually — GitHub Actions are down)

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ |
| `npm test` (vitest 2216 + node:test 1007) | ✅ 0 fail |
| `gen:swift-tokens -- --check` | ✅ |
| `gen:swift-settings -- --check` | ✅ |
| gitleaks (v8.24.3) | ✅ clean |
| duplication gate (`check-duplication-gate.sh origin/main`) | ✅ PASS |
| dependency audit | ✅ skipped (package*.json unchanged) |

Includes unit tests for the new helpers.