### PR TITLE
chore(multica): retire visual/pixel-baseline verification from agent instructions

### DIFF
--- a/.multica/agents/macos.md
+++ b/.multica/agents/macos.md
@@ -53,17 +53,16 @@ them, **stop and comment on the issue** rather than doing it.
 
 ## How to work
 
-**Determinism is the job.** A capture nobody can reproduce is worthless. Before
-capturing anything: pin the simulator device model and iOS version explicitly
-rather than accepting whatever is booted, override the simulator status bar to a
-fixed time and battery level, and disable UI animations. The status bar override
-is the one people forget, and without it the clock differs in every capture and
-every future baseline drifts.
-
-**Capture twice before you believe a capture.** If two consecutive runs differ,
-do not lower a tolerance, loosen a comparison or retry until it passes. Compare
-the two images' pixel dimensions first — differing dimensions mean a structural
-cause, which no threshold will ever fix. Find the cause and report it.
+**Visual/pixel-baseline verification is RETIRED (2026-08-07) — it was not
+accurate.** Do not run `mobile/native/capture.sh` / `measure.mjs` as a
+verification step, do not record or update files under
+`mobile/native/baseline/`, and do not treat a pixel or hierarchy diff as
+pass/fail evidence. Your verification for a change is: the app **builds** for
+the iOS Simulator destination, the **`MantaUITests` unit suite passes**, and —
+when the issue asks for it — you launch the app in the simulator and describe
+what you actually see. A screenshot may still be attached as *illustration*
+for a human, never as a gate; illustrative screenshots need no status-bar
+override or determinism ritual.
 
 **Report failures as findings, not as things to work around.** A build that will
 not compile, an effect that does not appear, a value the platform will not

--- a/.multica/agents/manta-reviewer.md
+++ b/.multica/agents/manta-reviewer.md
@@ -141,10 +141,10 @@ Therefore, before any PASS:
       - Reassign the issue to `manta-pm`: `multica issue assign BET-<N> --to manta-pm`
       - Set status `in_review`: `multica issue status BET-<N> in_review`
 
-      Exception — if this PR creates or re-records any visual baseline, the
-      hand-off goes to Antoine instead of `manta-pm` (see
-      `manta-pr-workflow` step 10); never route a baseline-routing PR back to
-      the PM.
+      (Visual/pixel-baseline verification is retired — it was not accurate.
+      Do not require capture-harness or baseline evidence in review, and do
+      not Block on a missing or drifted visual baseline. Review against code,
+      unit tests, and build results.)
 
     Do **NOT** flip the PR from draft to ready — that's the PM's call.
 

--- a/.multica/skills/manta-pr-workflow/SKILL.md
+++ b/.multica/skills/manta-pr-workflow/SKILL.md
@@ -100,18 +100,13 @@ The standard implementer workflow for the MANTA agents.
 
     Print the scores. If all 8+, you may submit.
 
-    > **If this PR creates or re-records ANY file under
-    > `tests/visual/screens.visual.ts-snapshots/`, the reviewer's hand-off goes
-    > to Antoine, not to the PM.** Run `npm run visual:baselines`, upload every
-    > generated `*.before-after.png` into a PR comment, and
-    > `multica issue assign <KEY> --to Antoine` with status `in_review`. Say in
-    > the comment what changed and what should have changed. A baseline is
-    > committed evidence and the two agents in this loop compare the app only
-    > to that evidence — a human looking at the picture once is the only thing
-    > that can catch a record taken from a broken render. Merging is his call;
-    > do not merge, and do not route back to the PM. Upload the images (a
-    > `raw.githubusercontent.com/.../<pr-branch>/...` branch link dies when
-    > `--delete-branch` runs at merge), never link them.
+    > **Visual/pixel-baseline verification is RETIRED (2026-08-07) — it was
+    > not accurate.** Do not run `npm run visual*`, the iOS capture harness
+    > (`mobile/native/capture.sh` / `measure.mjs`), or re-record any baseline
+    > as verification, and do not treat a baseline diff as evidence either
+    > way. Verification = typecheck + unit tests (+ a successful build for
+    > iOS work). Screenshots may still be attached as *illustration* for
+    > humans, never as a gate.
 
     Then: Post the PR URL on the Multica issue **with a structured
     `Verification results` block** (template below), stamp `loop_history`


### PR DESCRIPTION
Visual/pixel-baseline verification (iOS capture harness + web visual baselines) is retired as a gate — it was not accurate.

- `.multica/agents/macos.md`: capture-determinism ritual replaced with build + MantaUITests + described simulator behavior; no baseline recording.
- `.multica/agents/manta-reviewer.md`: baseline-routing exception replaced — reviewers must not Block on missing/drifted visual baselines.
- `.multica/skills/manta-pr-workflow/SKILL.md`: the visual-baseline → Antoine routing block replaced with the retirement note.

Cloud copies (the operative ones) were already pushed via the multica CLI. Docs-only change.

Related epic: BET-664 (iOS chat transcript & usability overhaul).