### PR TITLE
feat(ios) BET-665: transcript bottom inset above composer; drop bounce-disabling hack

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -10,13 +10,14 @@
 		0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */; };
 		01871023D47544D64443194D /* MantaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8240F1954861B4846E279D /* MantaModels.swift */; };
 		0488B71F794FC6E64CDC0B23 /* TerminalKeyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */; };
+		1A55CBC343898856735AF0F8 /* MantaChatSurfaceCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */; };
 		1B9026B4F0286A5186FD5197 /* MantaSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39978655A14BFA5D39336286 /* MantaSettingsModels.swift */; };
-		1BDC4C2CBE50E2D18FD2AE3F /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E6DAC1364D09A1487B2DEE /* Theme.swift */; };
 		1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */; };
 		239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */; };
 		261925E9ADC090271FED15DE /* TerminalSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FE763828641B50BF496F4D /* TerminalSessionState.swift */; };
 		2727E78CDA096DC415008244 /* manta-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = B230F69A60CD3DBC416612B0 /* manta-logo.png */; };
 		2D0521ED1C9A66C89711D31F /* NativeActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA1F1EEE75DBB6A786FEE4F /* NativeActionSheet.swift */; };
+		2F0CAA1B1DC211D065AC4761 /* TranscriptRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A048582549409FE0949053 /* TranscriptRow.swift */; };
 		3354E683F0CE92566A77C7D3 /* MantaPairingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */; };
 		33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1306D325FEB295B7AB874E /* MantaEventStore.swift */; };
 		3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD646A4951E292E750890CCB /* MantaAppRoot.swift */; };
@@ -24,7 +25,9 @@
 		404DB0475FB78037D65B6734 /* SessionResourceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D178D08102AB83BF93B82D16 /* SessionResourceCards.swift */; };
 		431A66604F73FFBD59781D92 /* TerminalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942605E2D67D55C6DCCE83AC /* TerminalScreen.swift */; };
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
+		4F6D25AA2FFF73A8FE1321D3 /* EdgeSwipeRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E2CCAF6C565AEE489E1618 /* EdgeSwipeRestorer.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
+		51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */; };
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
 		5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
@@ -36,6 +39,7 @@
 		6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */; };
 		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
 		685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */; };
+		68760CC316BA947A82F360EE /* Scrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C440016971186430E8C464B /* Scrim.swift */; };
 		6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7631E09B6FF7B150392A83 /* ChatModels.swift */; };
 		74D756D48A7D2A5483170A8B /* MantaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872DDE9D9BAD041950DAC24A /* MantaLoader.swift */; };
 		754FEC92229B58783D516DC4 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C97C92B5E1ADA62F799D73 /* ModelPickerSheet.swift */; };
@@ -55,7 +59,7 @@
 		9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
 		9E9F0CED519AB1DF30516047 /* ChatOverflowCaptureScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */; };
-		A6574F4CA0C8390EFDC2D65E /* SettingsSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CF3C7F4C7BE1B86916D71A /* SettingsSchema.swift */; };
+		B46B35ED65EDB8F13002F091 /* MessagingUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2B48EABB4EC8AF086CA5C6AB /* MessagingUI */; };
 		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
 		B8B5D7BF1F4F22B9A3682FEA /* CrashReports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C78DF001E277064070853F /* CrashReports.swift */; };
 		B97905DC3BE32E36E682EF0C /* MantaLiveChatClearCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D5B31C8FB29B23AB2A577 /* MantaLiveChatClearCaptureUITests.swift */; };
@@ -66,19 +70,21 @@
 		D776E336456236DC1493565F /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229392FD3405558D301D0809 /* ChatModel.swift */; };
 		D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */; };
 		D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42691C89906181C99929354 /* ComposerView.swift */; };
+		D9C75533ECC7411285919C8C /* SettingsSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB51C8FD346EC94C79EA7A /* SettingsSchema.swift */; };
 		DB494E7C3511EA8E1D01F8B1 /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = FD13380CB87B92A40F879A1F /* CrashReporter */; };
 		E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9803742B79E4302F8813EFCC /* SessionModelsTests.swift */; };
 		E0DE29696DA12A52BE7FCD0D /* TerminalModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3C09F5D2FEAE01B1C9CF1E /* TerminalModels.swift */; };
 		E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436675A65BF149932C1EADE0 /* ChatScreen.swift */; };
+		E394FF8B718A3D7871EC749C /* ChatModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4098461F579869804595B0A3 /* ChatModelCatalog.swift */; };
 		EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */; };
 		ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */; };
 		ED03A3C1AAFA1094A92A9ECA /* MantaDeepLinkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A1F140660F9AC7AF07E00 /* MantaDeepLinkUITests.swift */; };
 		EDFF1716E461980191B71C85 /* MantaPairFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A1A5388E54F31462D616F /* MantaPairFixture.swift */; };
 		EE22C75492152C8594275C5C /* ChatOverflowSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA460F4E709501AE6C65D08A /* ChatOverflowSheet.swift */; };
+		EEB3F591860B779C1A17EBF9 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB8309A90D6F325B8BCB042 /* Theme.swift */; };
 		F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */; };
 		F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A94FE1BE824F438342AD /* MantaDeepLink.swift */; };
 		FF511A296958C8376966852F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */; };
-		A1B2C3D4E5F60718293A4B5C /* EdgeSwipeRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,8 +106,9 @@
 
 /* Begin PBXFileReference section */
 		0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVoice.swift; sourceTree = "<group>"; };
-		0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeSwipeRestorer.swift; sourceTree = "<group>"; };
 		0C1EE3F998CADE8487D2555E /* terminal */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminal; path = MantaUI/Resources/terminal; sourceTree = SOURCE_ROOT; };
+		0C440016971186430E8C464B /* Scrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrim.swift; sourceTree = "<group>"; };
+		17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaRunningStateCaptureUITests.swift; sourceTree = "<group>"; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
 		20C78DF001E277064070853F /* CrashReports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReports.swift; sourceTree = "<group>"; };
@@ -116,6 +123,7 @@
 		3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingModels.swift; sourceTree = "<group>"; };
 		35ECC10E3DB9A931F8EB5420 /* MantaUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MantaUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		39978655A14BFA5D39336286 /* MantaSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsModels.swift; sourceTree = "<group>"; };
+		4098461F579869804595B0A3 /* ChatModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelCatalog.swift; sourceTree = "<group>"; };
 		436675A65BF149932C1EADE0 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
 		4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowCaptureScene.swift; sourceTree = "<group>"; };
 		471BF240012879FDED5689C1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
@@ -123,6 +131,7 @@
 		4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecorder.swift; sourceTree = "<group>"; };
 		4EA1F1EEE75DBB6A786FEE4F /* NativeActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeActionSheet.swift; sourceTree = "<group>"; };
 		4F7631E09B6FF7B150392A83 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
+		570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaChatSurfaceCaptureUITests.swift; sourceTree = "<group>"; };
 		57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsTests.swift; sourceTree = "<group>"; };
 		5C02DA420B52094269A88E80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5D71EC917661085ED10E0867 /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
@@ -133,6 +142,8 @@
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
 		6E1D5B31C8FB29B23AB2A577 /* MantaLiveChatClearCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLiveChatClearCaptureUITests.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
+		72E2CCAF6C565AEE489E1618 /* EdgeSwipeRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeSwipeRestorer.swift; sourceTree = "<group>"; };
+		74A048582549409FE0949053 /* TranscriptRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRow.swift; sourceTree = "<group>"; };
 		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
 		7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyRow.swift; sourceTree = "<group>"; };
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
@@ -158,7 +169,6 @@
 		ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsStore.swift; sourceTree = "<group>"; };
 		AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingDriverUITests.swift; sourceTree = "<group>"; };
 		B230F69A60CD3DBC416612B0 /* manta-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "manta-logo.png"; sourceTree = "<group>"; };
-		B2E6DAC1364D09A1487B2DEE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreateSheet.swift; sourceTree = "<group>"; };
 		BA460F4E709501AE6C65D08A /* ChatOverflowSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowSheet.swift; sourceTree = "<group>"; };
 		C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineTextView.swift; sourceTree = "<group>"; };
@@ -168,13 +178,14 @@
 		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		D178D08102AB83BF93B82D16 /* SessionResourceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionResourceCards.swift; sourceTree = "<group>"; };
 		DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalModelsTests.swift; sourceTree = "<group>"; };
+		DBFB51C8FD346EC94C79EA7A /* SettingsSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSchema.swift; sourceTree = "<group>"; };
 		DC240598BDE45C3D43B46191 /* MantaUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MantaUI.entitlements; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
 		E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLoadingSkeleton.swift; sourceTree = "<group>"; };
 		EBC7D0BF807861DCCABC5A26 /* MantaResourceCardModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaResourceCardModelsTests.swift; sourceTree = "<group>"; };
 		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
-		F4CF3C7F4C7BE1B86916D71A /* SettingsSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSchema.swift; sourceTree = "<group>"; };
 		F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSocket.swift; sourceTree = "<group>"; };
+		FEB8309A90D6F325B8BCB042 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,6 +194,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DB494E7C3511EA8E1D01F8B1 /* CrashReporter in Frameworks */,
+				B46B35ED65EDB8F13002F091 /* MessagingUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,19 +211,10 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		04011C8608A1F0CB963849C7 /* better-ui */ = {
+		316B9A4B30B184F228A03894 /* generated */ = {
 			isa = PBXGroup;
 			children = (
-				1AB5E1FF766612B9C9309DAC /* generated */,
-			);
-			name = "better-ui";
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		1AB5E1FF766612B9C9309DAC /* generated */ = {
-			isa = PBXGroup;
-			children = (
-				A4AEEFF52F71D3F83FCE191E /* swift */,
+				D542284D2C621841629D8DB6 /* swift */,
 			);
 			path = generated;
 			sourceTree = "<group>";
@@ -246,7 +249,7 @@
 		855545FE3D464DDBA2B48C48 = {
 			isa = PBXGroup;
 			children = (
-				04011C8608A1F0CB963849C7 /* better-ui */,
+				B36D4927604F649B2C09BBB8 /* manta-bet665 */,
 				D7128F5AAFA315FE875EEC98 /* MantaUI */,
 				7168FDC00E99AA075ACA9698 /* MantaUITests */,
 				DF70760D7D88A6A31A5243DA /* MantaUIUITests */,
@@ -254,11 +257,20 @@
 			);
 			sourceTree = "<group>";
 		};
-		A4AEEFF52F71D3F83FCE191E /* swift */ = {
+		B36D4927604F649B2C09BBB8 /* manta-bet665 */ = {
 			isa = PBXGroup;
 			children = (
-				F4CF3C7F4C7BE1B86916D71A /* SettingsSchema.swift */,
-				B2E6DAC1364D09A1487B2DEE /* Theme.swift */,
+				316B9A4B30B184F228A03894 /* generated */,
+			);
+			name = "manta-bet665";
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		D542284D2C621841629D8DB6 /* swift */ = {
+			isa = PBXGroup;
+			children = (
+				DBFB51C8FD346EC94C79EA7A /* SettingsSchema.swift */,
+				FEB8309A90D6F325B8BCB042 /* Theme.swift */,
 			);
 			path = swift;
 			sourceTree = "<group>";
@@ -269,6 +281,7 @@
 				82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */,
 				E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */,
 				229392FD3405558D301D0809 /* ChatModel.swift */,
+				4098461F579869804595B0A3 /* ChatModelCatalog.swift */,
 				4F7631E09B6FF7B150392A83 /* ChatModels.swift */,
 				8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */,
 				4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */,
@@ -278,7 +291,7 @@
 				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
 				C42691C89906181C99929354 /* ComposerView.swift */,
 				20C78DF001E277064070853F /* CrashReports.swift */,
-				0FA5E1D2C3B4A59687706152 /* EdgeSwipeRestorer.swift */,
+				72E2CCAF6C565AEE489E1618 /* EdgeSwipeRestorer.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
 				5C02DA420B52094269A88E80 /* Info.plist */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
@@ -303,6 +316,7 @@
 				4EA1F1EEE75DBB6A786FEE4F /* NativeActionSheet.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */,
+				0C440016971186430E8C464B /* Scrim.swift */,
 				B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */,
 				24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */,
 				D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */,
@@ -316,6 +330,7 @@
 				F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */,
 				6BDC7F6FA94631DA4C55A948 /* TerminalWebView.swift */,
 				A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */,
+				74A048582549409FE0949053 /* TranscriptRow.swift */,
 				4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */,
 				6C581AFB55001DF333A22728 /* Resources */,
 			);
@@ -333,11 +348,13 @@
 		DF70760D7D88A6A31A5243DA /* MantaUIUITests */ = {
 			isa = PBXGroup;
 			children = (
+				570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */,
 				2B7A1F140660F9AC7AF07E00 /* MantaDeepLinkUITests.swift */,
 				6E1D5B31C8FB29B23AB2A577 /* MantaLiveChatClearCaptureUITests.swift */,
 				681F342360878481A0D8364F /* MantaOverflowCaptureUITests.swift */,
 				8D8A1A5388E54F31462D616F /* MantaPairFixture.swift */,
 				AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */,
+				17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 				5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */,
 			);
@@ -380,6 +397,7 @@
 			name = MantaUI;
 			packageProductDependencies = (
 				FD13380CB87B92A40F879A1F /* CrashReporter */,
+				2B48EABB4EC8AF086CA5C6AB /* MessagingUI */,
 			);
 			productName = MantaUI;
 			productReference = 35ECC10E3DB9A931F8EB5420 /* MantaUI.app */;
@@ -435,6 +453,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				47C82525F78B395F5BC96245 /* XCRemoteSwiftPackageReference "plcrashreporter" */,
+				E05AB3E0DD965872E0023A07 /* XCRemoteSwiftPackageReference "swiftui-messaging-ui" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0141B3CF9BBB5EB026BDA8C5 /* Products */;
@@ -466,11 +485,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A55CBC343898856735AF0F8 /* MantaChatSurfaceCaptureUITests.swift in Sources */,
 				ED03A3C1AAFA1094A92A9ECA /* MantaDeepLinkUITests.swift in Sources */,
 				B97905DC3BE32E36E682EF0C /* MantaLiveChatClearCaptureUITests.swift in Sources */,
 				C2C89BEF7843F4F3460A926F /* MantaOverflowCaptureUITests.swift in Sources */,
 				EDFF1716E461980191B71C85 /* MantaPairFixture.swift in Sources */,
 				D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */,
+				51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 				ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */,
 			);
@@ -500,6 +521,7 @@
 			files = (
 				959894A87F301CC717772BD3 /* ChatLoadingSkeleton.swift in Sources */,
 				D776E336456236DC1493565F /* ChatModel.swift in Sources */,
+				E394FF8B718A3D7871EC749C /* ChatModelCatalog.swift in Sources */,
 				CC6A77686B936B4DB6026466 /* ChatModelStore.swift in Sources */,
 				6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */,
 				9E9F0CED519AB1DF30516047 /* ChatOverflowCaptureScene.swift in Sources */,
@@ -509,7 +531,7 @@
 				C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */,
 				D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */,
 				B8B5D7BF1F4F22B9A3682FEA /* CrashReports.swift in Sources */,
-				A1B2C3D4E5F60718293A4B5C /* EdgeSwipeRestorer.swift in Sources */,
+				4F6D25AA2FFF73A8FE1321D3 /* EdgeSwipeRestorer.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
 				612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */,
@@ -532,12 +554,13 @@
 				2D0521ED1C9A66C89711D31F /* NativeActionSheet.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */,
+				68760CC316BA947A82F360EE /* Scrim.swift in Sources */,
 				239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */,
 				1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */,
 				94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */,
 				7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */,
 				404DB0475FB78037D65B6734 /* SessionResourceCards.swift in Sources */,
-				A6574F4CA0C8390EFDC2D65E /* SettingsSchema.swift in Sources */,
+				D9C75533ECC7411285919C8C /* SettingsSchema.swift in Sources */,
 				5E0226E9FAFF3F9CA9F45F8F /* SettingsScreen.swift in Sources */,
 				0488B71F794FC6E64CDC0B23 /* TerminalKeyRow.swift in Sources */,
 				E0DE29696DA12A52BE7FCD0D /* TerminalModels.swift in Sources */,
@@ -545,8 +568,9 @@
 				261925E9ADC090271FED15DE /* TerminalSessionState.swift in Sources */,
 				61062DC85A5139A0AB22BC24 /* TerminalSocket.swift in Sources */,
 				61441105C65E4D7385DAF363 /* TerminalWebView.swift in Sources */,
-				1BDC4C2CBE50E2D18FD2AE3F /* Theme.swift in Sources */,
+				EEB3F591860B779C1A17EBF9 /* Theme.swift in Sources */,
 				95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */,
+				2F0CAA1B1DC211D065AC4761 /* TranscriptRow.swift in Sources */,
 				98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -872,9 +896,22 @@
 				minimumVersion = 1.11.1;
 			};
 		};
+		E05AB3E0DD965872E0023A07 /* XCRemoteSwiftPackageReference "swiftui-messaging-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FluidGroup/swiftui-messaging-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2B48EABB4EC8AF086CA5C6AB /* MessagingUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E05AB3E0DD965872E0023A07 /* XCRemoteSwiftPackageReference "swiftui-messaging-ui" */;
+			productName = MessagingUI;
+		};
 		FD13380CB87B92A40F879A1F /* CrashReporter */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 47C82525F78B395F5BC96245 /* XCRemoteSwiftPackageReference "plcrashreporter" */;

--- a/mobile/native/MantaUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/native/MantaUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ca2b70622bceaacf465c6a2c4faed710abda8bd95f89c1332e1e2cdfe26063c1",
+  "originHash" : "d61e6d69d0199f6b85bc0b87ff9da2492289c79f2d593147e8330539987fc304",
   "pins" : [
     {
       "identity" : "plcrashreporter",
@@ -8,6 +8,42 @@
       "state" : {
         "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
         "version" : "1.12.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-rubber-banding",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidGroup/swift-rubber-banding",
+      "state" : {
+        "revision" : "f2dbd09829c6267db0a769e7c37fe332dab0b675",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-with-prerender",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidGroup/swift-with-prerender",
+      "state" : {
+        "revision" : "3ebae495b1c441edcf0850ec057f97be221dca0f",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swiftui-messaging-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidGroup/swiftui-messaging-ui",
+      "state" : {
+        "revision" : "6dc8e5561bc27f107123c5cf40f358d095537f57",
+        "version" : "1.6.0"
       }
     }
   ],

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -207,9 +207,10 @@ private struct ChatScreenContent: View {
         // `transcript`), so it is not duplicated here.
         // The composer FLOATS over the full-bleed transcript (an overlay, not
         // an inset), so messages genuinely pass under it while scrolling. A
-        // scrim sits directly beneath it dimming that passing content. Bounce
-        // is disabled on the transcript so nothing rubber-bands behind the
-        // glass (see `transcript`).
+        // scrim sits directly beneath it dimming that passing content. A
+        // bottom content margin on the transcript keeps the newest message
+        // resting above the composer at rest, and natural bounce returns (see
+        // `transcript`).
         // Scrim FIRST so it draws beneath the composer, sized to the composer
         // plus an overhang past the safe area — it dims content under the
         // composer and in the home-indicator strip below it.
@@ -517,11 +518,17 @@ private struct ChatScreenContent: View {
         // A tap on the transcript lowers the keyboard. (TiledView handles the
         // scroll-driven interactive keyboard dismiss itself.)
         .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
-        // The composer floats over the full-bleed transcript, so the transcript
-        // must NOT bounce at the bottom — otherwise it rubber-bands content
-        // behind the glass. `DisableScrollBounceHelper` turns off bounce on the
-        // underlying UIKit scroll view (TiledView is UIKit-backed).
-        .background(DisableScrollBounceHelper())
+        // Keep the transcript's bottom edge ABOVE the floating composer so at
+        // rest the newest message (and typing indicator) rests readable above
+        // it. A content margin, not a viewport shrink, so the viewport stays
+        // full-bleed; `bottomBarHeight` tracks the composer stack as it
+        // grows/shrinks and as cards appear, so the inset follows for free.
+        // Applied AFTER the TiledView-only chaining above — its type is already
+        // erased to some View here, so this plain `View` modifier no longer
+        // hides the TiledView-typed modifiers chained before it. Placing it
+        // here (after the TiledView chain) is what lets TiledScrollPosition's
+        // auto-scroll-to-bottom land the newest message above the composer.
+        .contentMargins(.bottom, bottomBarHeight, for: .scrollContent)
     }
     /// How far above the bottom the user must scroll for the down-arrow to
     /// appear. Same magnitude MessagingUI uses internally for its own "near
@@ -935,34 +942,5 @@ private struct QuestionCard: View {
                 customText: customText
             )
         )
-    }
-}
-
-/// Disables vertical bounce on the enclosing scroll view from the UIKit side,
-/// as a fallback for `.scrollBounceBehavior` (TiledView is UIKit-backed and may
-/// not honor the SwiftUI preference). Keeps the transcript from rubber-banding
-/// content behind the floating composer.
-struct DisableScrollBounceHelper: UIViewRepresentable {
-    func makeUIView(context: Context) -> some UIView {
-        let view = UIView(frame: .zero)
-        view.backgroundColor = .clear
-        view.isUserInteractionEnabled = false
-        // Give the scroll view a beat to materialise, then kill the bounce.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            view.owningScrollView()?.alwaysBounceVertical = false
-            view.owningScrollView()?.bounces = false
-        }
-        return view
-    }
-
-    func updateUIView(_ uiView: UIViewType, context: Context) {}
-}
-
-extension UIView {
-    /// The nearest `UIScrollView` in the view tree above (or including) self.
-    func owningScrollView() -> UIScrollView? {
-        if let sv = self as? UIScrollView { return sv }
-        if let vc = self as? UICollectionView { return vc }
-        return superview?.owningScrollView()
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-665-transcript-bottom-inset`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-665.