### PR TITLE
feat(ios) BET-666: stable transcript step-row identity (stop turn-boundary flash)

### DIFF
--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -231,8 +231,8 @@ enum ChatTranscriptMapper {
                 // text. The box itself keys turn completion on time.completed.
                 guard msg.info.time?.completed != nil else { continue }
                 let at = ChatClock.date(epochMs: msg.info.time?.completed)
-                for part in msg.parts {
-                    process(part, at: at, pending: &pending, blocks: &blocks)
+                for (index, part) in msg.parts.enumerated() {
+                    process(part, index: index, at: at, pending: &pending, blocks: &blocks)
                 }
                 flush(&pending, into: &blocks)
             default:
@@ -253,7 +253,7 @@ enum ChatTranscriptMapper {
         pending = []
     }
 
-    private static func process(_ part: OpencodePart, at: Date?, pending: inout [StepGroupRow], blocks: inout [TranscriptBlock]) {
+    private static func process(_ part: OpencodePart, index: Int, at: Date?, pending: inout [StepGroupRow], blocks: inout [TranscriptBlock]) {
         if part.ignored == true || part.synthetic == true { return }
         switch part.type {
         case "text":
@@ -273,7 +273,7 @@ enum ChatTranscriptMapper {
                     pending.append(.subagent(agent))
                 }
             } else {
-                pending.append(.step(step(from: part, tool: tool)))
+                pending.append(.step(step(from: part, tool: tool, indexWithinMessage: index)))
             }
         default:
             // reasoning / file / etc. — no §8 block type renders it; skip.
@@ -298,7 +298,8 @@ enum ChatTranscriptMapper {
         text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private static func step(from part: OpencodePart, tool: String) -> ToolStep {
+    private static func step(from part: OpencodePart, tool: String, indexWithinMessage: Int) -> ToolStep {
+        let id = stepIdentity(part: part, indexWithinMessage: indexWithinMessage)
         let state = ChatJSON.object(part.extra["state"])
         let statusRaw = ChatJSON.string(state?["status"])
         let status = StepStatusFromTool.status(statusRaw)
@@ -314,7 +315,22 @@ enum ChatTranscriptMapper {
             duration = ""
         }
         let output = ChatJSON.string(state?["output"])
-        return ToolStep(verb: verb, target: target, duration: duration, status: status, output: output)
+        return ToolStep(id: id, verb: verb, target: target, duration: duration, status: status, output: output)
+    }
+
+    /// Deterministic step identity derived from the wire data so a step's id
+    /// survives a canonical refetch (the turn-boundary flash fix, BET-666).
+    /// Priority: the tool part's `callID` when present → the part's own id →
+    /// `\(messageID)-step-\(indexWithinMessage)` as a last resort. No freshly
+    /// minted random id anywhere on this mapping path.
+    private static func stepIdentity(part: OpencodePart, indexWithinMessage: Int) -> String {
+        if let callID = ChatJSON.string(part.extra["callID"]), !callID.isEmpty {
+            return callID
+        }
+        if !part.id.isEmpty {
+            return part.id
+        }
+        return "\(part.messageID)-step-\(indexWithinMessage)"
     }
 
     private static func durationSeconds(state: [String: JSONValue]?, time: [String: JSONValue]?) -> Double? {

--- a/mobile/native/MantaUI/RootView.swift
+++ b/mobile/native/MantaUI/RootView.swift
@@ -92,7 +92,7 @@ struct RootView: View {
             .user("check bet-520 and see if it's blocked correctly", at: nil),
             .prose("Checking its metadata and the blocker chain.", at: nil),
             .steps(.rows([
-                .step(ToolStep(verb: "Ran", target: "multica issue get BET-520", duration: "0.4s", status: .done, output: nil)),
+                .step(ToolStep(id: "fixture-ran-1", verb: "Ran", target: "multica issue get BET-520", duration: "0.4s", status: .done, output: nil)),
             ])),
             .prose("Blocked correctly — waiting_on names both PoC issues. Now fanning out to audit the three sweeps.", at: nil),
             .steps(.rows([
@@ -104,10 +104,10 @@ struct RootView: View {
             .steps(.rollup(
                 summary: "▸ 4 steps · read 3 files, 1 search",
                 rows: [
-                    .step(ToolStep(verb: "Read", target: "pr-body.md", duration: "0.2s", status: .done, output: nil)),
-                    .step(ToolStep(verb: "Read", target: "src/main/auth.ts", duration: "0.2s", status: .done, output: nil)),
-                    .step(ToolStep(verb: "Read", target: "src/renderer/mobile/setupLogic.ts", duration: "0.2s", status: .done, output: nil)),
-                    .step(ToolStep(verb: "Search", target: "gh pr view 429 --json files", duration: "0.9s", status: .running, output: nil)),
+                    .step(ToolStep(id: "fixture-read-1", verb: "Read", target: "pr-body.md", duration: "0.2s", status: .done, output: nil)),
+                    .step(ToolStep(id: "fixture-read-2", verb: "Read", target: "src/main/auth.ts", duration: "0.2s", status: .done, output: nil)),
+                    .step(ToolStep(id: "fixture-read-3", verb: "Read", target: "src/renderer/mobile/setupLogic.ts", duration: "0.2s", status: .done, output: nil)),
+                    .step(ToolStep(id: "fixture-search-1", verb: "Search", target: "gh pr view 429 --json files", duration: "0.9s", status: .running, output: nil)),
                 ]
             )),
         ]
@@ -119,8 +119,8 @@ struct RootView: View {
         [
             .prose("Reading the close-on-merge workflow and its CI posture.", at: nil),
             .steps(.rows([
-                .step(ToolStep(verb: "Read", target: "multica-close-on-merge.yml", duration: "0.3s", status: .done, output: nil)),
-                .step(ToolStep(verb: "Ran", target: "node scripts/multica-unblock.mjs --dry-run", duration: "1.8s", status: .running, output: nil)),
+                .step(ToolStep(id: "fixture-read-clm", verb: "Read", target: "multica-close-on-merge.yml", duration: "0.3s", status: .done, output: nil)),
+                .step(ToolStep(id: "fixture-ran-sweep", verb: "Ran", target: "node scripts/multica-unblock.mjs --dry-run", duration: "1.8s", status: .running, output: nil)),
             ])),
             .prose("The sweep flips a blocked issue to todo the moment its blockers clear.", at: nil),
         ]

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -574,12 +574,27 @@ enum StepStatus: Hashable {
 }
 
 struct ToolStep: Identifiable, Hashable {
-    let id = UUID()
+    /// STABLE across rebuilds — the mapper derives it deterministically from
+    /// the wire data (see `ChatTranscriptMapper.step(from:...)`), so a step's
+    /// identity survives a canonical refetch. It used to be a fresh random id
+    /// minted on every mapping pass, which made the diffing list see every
+    /// step as removed+reinserted at each turn boundary and made the rows
+    /// flash/jump (same bug the subagent rows already fixed).
+    let id: String
     let verb: String
     let target: String
     let duration: String
     let status: StepStatus
     let output: String?
+
+    init(id: String, verb: String, target: String, duration: String, status: StepStatus, output: String?) {
+        self.id = id
+        self.verb = verb
+        self.target = target
+        self.duration = duration
+        self.status = status
+        self.output = output
+    }
 }
 
 struct StepRowView: View {
@@ -654,7 +669,7 @@ enum StepGroupRow: Identifiable, Equatable {
 
     var id: String {
         switch self {
-        case .step(let step): return step.id.uuidString
+        case .step(let step): return step.id
         case .subagent(let agent): return agent.id
         }
     }

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -36,8 +36,13 @@ extension TranscriptBlock {
     /// instead of this one (see `streamingTailID`).
     var stableScrollID: String {
         switch self {
-        case .user(let text, let at): return "u\(text)@\(at?.timeIntervalSince1970 ?? 0)"
-        case .prose(let text, let at): return "p\(text)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .user(let text, let at):
+            // `text.hashValue` is process-stable, which is all scroll identity
+            // needs — embedding the whole text made ids huge for long prose and
+            // let two identical texts sharing a timestamp collide.
+            return "u\(text.hashValue)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .prose(let text, let at):
+            return "p\(text.hashValue)@\(at?.timeIntervalSince1970 ?? 0)"
         case .steps(let content): return "s" + content.rows.map(\.id).joined(separator: "|")
         }
     }

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -470,4 +470,45 @@ final class ChatTranscriptTests: XCTestCase {
             .paragraph("second para"),
         ])
     }
+
+    // MARK: - Stable step identity (BET-666)
+    //
+    // The diffing list treats a removed+reinserted row as a flash/jump at every
+    // turn boundary. A step's id must therefore be deterministic across refetch
+    // (derived from the wire data, not a fresh random id).
+
+    private func stepIDs(from blocks: [TranscriptBlock]) -> [String] {
+        blocks.flatMap { block -> [String] in
+            guard case .steps(let content) = block else { return [] }
+            return content.rows.compactMap { row in
+                guard case .step(let step) = row else { return nil }
+                return step.id
+            }
+        }
+    }
+
+    func testStepIdsAreIdenticalAcrossRefetch() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("run tests")]),
+            toolPart("t2", "m1", tool: "read", status: "completed", input: ["filePath": str("a.ts")]),
+        ])]
+        let first = stepIDs(from: ChatTranscriptMapper.blocks(from: msgs))
+        let second = stepIDs(from: ChatTranscriptMapper.blocks(from: msgs))
+        XCTAssertFalse(first.isEmpty, "expected at least one step id")
+        XCTAssertEqual(first, second, "mapping the same transcript twice must yield identical step ids")
+    }
+
+    func testStepIdsSurviveAppendingANewMessage() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("run tests")]),
+        ])]
+        let before = stepIDs(from: ChatTranscriptMapper.blocks(from: msgs))
+        let extended = msgs + [message(id: "m2", role: "assistant", parts: [
+            toolPart("t3", "m2", tool: "read", status: "completed", input: ["filePath": str("b.ts")]),
+        ])]
+        let after = stepIDs(from: ChatTranscriptMapper.blocks(from: extended))
+        let preserved = after.prefix(before.count)
+        XCTAssertEqual(Array(preserved), before,
+                       "pre-existing step ids must be preserved when a new message is appended")
+    }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-666-stable-step-identity`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-666.