### PR TITLE
feat(server) BET-675: materialized sync state + cursor snapshot RPC

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -40,6 +40,7 @@ import { createBus, handleEventsRequest, attachEventsWs } from "./events.mjs";
 import { attachPtyWs } from "./ptyWs.mjs";
 import { buildHandlers, handleRpcRequest } from "./rpc.mjs";
 import { startStatusPoller } from "./status.mjs";
+import { createSyncState } from "./syncState.mjs";
 import { createStreamInterpreter } from "./streamInterp.mjs";
 import { startOutboxPoller, pushArtifact, createArtifactSweep } from "./outbox.mjs";
 import { startUploadCleanupPoller } from "./uploads.mjs";
@@ -108,6 +109,18 @@ const streamInterp = createStreamInterpreter({ publish: (evt) => bus.publish(evt
 // store entry uses this same deps object.
 const BUS_PUBLISH_DEPS = { publish: (evt) => bus.publish(evt) };
 
+// BET-675: materialized in-memory session/config state. tmux:list is served
+// from memory (never a per-request tmux shell-out), and `sync` deltas are
+// published on the bus as state changes so clients can recover just what they
+// missed. `refreshNow()` is driven by the poller below; `tmux:list` lazily
+// guarantees a first tick before serving anything.
+const syncState = createSyncState({
+  listProjects: () => tmux.listProjects(),
+  publish: (env) => bus.publish(env),
+});
+// Seed the config baseline at startup so the first snapshot already carries it.
+syncState.applyConfig(await local.configGet());
+
 // DELETE handler for /api/<store> endpoints: `?id=<id>` → store.deleteFn(id,
 // BUS_PUBLISH_DEPS) → 200 {deleted:bool}. The boilerplate (id-required 400,
 // the await + publish-deps call, the success response) is identical across
@@ -156,6 +169,25 @@ push.setDesktopSink((payload) =>
 // mobile sidebar's activity/attention dots work (parity with desktop status.ts).
 // eslint-disable-next-line no-unused-vars
 const { stop: stopStatusPoller } = startStatusPoller(bus, { intervalMs: 2000 });
+
+// BET-675: sync-state poller — materialize tmux session/config state in memory
+// every 2s. Follows the exact shape of the other pollers (in-flight guard +
+// unref'd timer so the poller alone never holds the process open). Fire one
+// tick immediately at startup (not awaited) so state is warm without waiting a
+// full interval.
+let syncInFlight = false;
+async function syncTick() {
+  if (syncInFlight) return;
+  syncInFlight = true;
+  try {
+    await syncState.refreshNow();
+  } finally {
+    syncInFlight = false;
+  }
+}
+void syncTick();
+const syncTimer = setInterval(() => void syncTick(), 2000);
+syncTimer.unref();
 
 // Agent → device file push: watch ~/.manta-outbox/ for files the AI drops and
 // publish `agentFile` bus events so connected devices show a "Save" toast
@@ -315,6 +347,7 @@ rpcHandlers = buildHandlers({
   pty,
   bus,
   local,
+  syncState,
   authPair: () => authEngine.pair(),
   push,
   serverVersion: SERVER_VERSION,

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -198,6 +198,7 @@ export function buildHandlers({
   pty,
   bus,
   local,
+  syncState,
   authPair,
   push,
   serverVersion,
@@ -258,7 +259,13 @@ export function buildHandlers({
     "config:get": () => local.configGet(),
 
     // preload: ipcRenderer.invoke(IPC.configUpdate, patch)  → args[0] = patch (Partial<AppConfig>)
-    "config:update": (patch) => local.configUpdate(patch),
+    // BET-675: after a successful write, push the new config into syncState so
+    // the materialized config delta is published for sync subscribers.
+    "config:update": async (patch) => {
+      const next = await local.configUpdate(patch);
+      syncState.applyConfig(next);
+      return next;
+    },
 
     // preload: ipcRenderer.invoke(IPC.projectMetaDelete, tmuxSession)  → args[0] = tmuxSession (string)
     "project:meta:delete": (tmuxSession) => local.projectMetaDelete(tmuxSession),
@@ -345,7 +352,25 @@ export function buildHandlers({
     "upload:files": (input) => local.uploadFiles(input),
 
     // ---- tmux (8 channels) ----
-    "tmux:list": () => tmux.listProjects(),
+    // BET-675: serve tmux:list from the materialized in-memory sync state
+    // instead of shelling out to tmux on every request. A transient tmux
+    // failure used to be misclassified as "zero sessions" (empty sidebar,
+    // pruned ownership sidecar). From memory we always have a last-known-good
+    // list, plus a `stale` flag. Guard: until ANY listProjects tick has ever
+    // succeeded, do a synchronous refresh so the first call doesn't return a
+    // hardcoded empty list to a box that just booted.
+    "tmux:list": async () => {
+      if (!syncState.everSucceeded()) {
+        await syncState.refreshNow();
+      }
+      return syncState.snapshot().projects;
+    },
+    // BET-675: cursor snapshot/delta RPC. Client passes its last-seen
+    // { sinceSeq, sinceGen }; the server returns { gen, seq, changed } with
+    // only the fields whose version is newer than sinceSeq (or a full
+    // snapshot when the cursor is absent / stale generation / impossible).
+    "sync:snapshot": ({ sinceSeq, sinceGen } = {}) =>
+      syncState.payloadSince(sinceSeq, sinceGen),
     // chatMode (BET-113): when the new-session dialog's "chat mode (opencode)"
     // toggle is on, tmux.newSession must create an opencode session, launch a
     // holder pane, and stamp @manta-session-id — so it needs the `oc` client.
@@ -371,6 +396,8 @@ export function buildHandlers({
       // projects } so callers can navigate + send the first prompt to the
       // RIGHT session (previously they re-located by name, which mixed new
       // sessions up with existing ones on name collisions).
+      // BET-675: refresh materialized state so the sync delta publishes now.
+      await syncState.refreshNow();
       return result;
     },
     // Resolve cwd: prefer explicit cwd in input, then fall back to the
@@ -379,12 +406,31 @@ export function buildHandlers({
     // tmux's default cwd (usually $HOME) instead of the workspace path.
     // Pass `oc` so a chatMode window creates + stamps an opencode session
     // (BET-113 regression: this used to silently drop chatMode).
-    "tmux:new-window": async (i) =>
-      tmux.newWindow({ ...i, cwd: await resolveProjectCwd(i.sessionName, i.cwd), oc }),
-    "tmux:rename-session": (i) => tmux.renameSession(i),
-    "tmux:rename-window": (i) => tmux.renameWindow(i),
-    "tmux:kill-session": (n) => tmux.killSession(n),
-    "tmux:kill-window": (i) => tmux.killWindow(i),
+    "tmux:new-window": async (i) => {
+      const result = await tmux.newWindow({ ...i, cwd: await resolveProjectCwd(i.sessionName, i.cwd), oc });
+      await syncState.refreshNow();
+      return result;
+    },
+    "tmux:rename-session": async (i) => {
+      const result = await tmux.renameSession(i);
+      await syncState.refreshNow();
+      return result;
+    },
+    "tmux:rename-window": async (i) => {
+      const result = await tmux.renameWindow(i);
+      await syncState.refreshNow();
+      return result;
+    },
+    "tmux:kill-session": async (n) => {
+      const result = await tmux.killSession(n);
+      await syncState.refreshNow();
+      return result;
+    },
+    "tmux:kill-window": async (i) => {
+      const result = await tmux.killWindow(i);
+      await syncState.refreshNow();
+      return result;
+    },
     "tmux:select-window": (i) => tmux.selectWindow(i),
 
     // ---- opencode: simple pass-throughs ----
@@ -557,6 +603,8 @@ export function buildHandlers({
       const windowIndex = await tmux.newWindowGetIndex(sessionName, windowName, resolvedCwd);
       await tmux.restampSessionId(sessionName, windowIndex, forked.id);
       const projects = await tmux.listProjects();
+      // BET-675: refresh materialized state so the new window's delta publishes now.
+      await syncState.refreshNow();
       return { newSessionId: forked.id, projects };
     },
 
@@ -572,6 +620,8 @@ export function buildHandlers({
       const sess = await oc.createSession({ directory, title });
       await tmux.restampSessionId(sessionName, windowIndex, sess.id);
       const projects = await tmux.listProjects();
+      // BET-675: refresh materialized state so the change publishes now.
+      await syncState.refreshNow();
       return { newSessionId: sess.id, projects };
     },
 
@@ -585,7 +635,10 @@ export function buildHandlers({
     "opencode:delete-session": async ({ sessionId, sessionName, windowIndex }) => {
       await oc.deleteSessionRaw(sessionId);
       await tmux.killWindow({ sessionName, windowIndex }).catch(() => {});
-      return tmux.listProjects();
+      const projects = await tmux.listProjects();
+      // BET-675: refresh materialized state so the removed window publishes now.
+      await syncState.refreshNow();
+      return projects;
     },
 
     // BET-421: bare session lifecycle for the onboarding verifier. create

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -63,6 +63,16 @@ function makeDeps(projects, liveProjects = []) {
       },
       pty: {},
       bus: {},
+      // BET-675: minimal syncState stub — the cwd-resolution tests only need
+      // it to not throw; the materialized-state behaviour is covered by the
+      // dedicated syncState.test.mjs.
+      syncState: {
+        refreshNow: async () => {},
+        applyConfig: () => {},
+        snapshot: () => ({ projects: liveProjects }),
+        payloadSince: (s, g) => ({ gen: g, seq: 0, changed: {} }),
+        everSucceeded: () => true,
+      },
       local: {
         configGet: async () => ({ projects }),
         // BET-307: server-side projectMetaUpsert fires from tmux:new-session

--- a/src/server/syncState.mjs
+++ b/src/server/syncState.mjs
@@ -1,0 +1,119 @@
+// Materialized in-memory sync state for the manta box (BET-675).
+//
+// manta-server previously shelled out to tmux on EVERY `tmux:list` request. A
+// transient tmux failure (mid-restart, socket race) was misclassified as "zero
+// sessions", so the client got a confident empty list, the sidebar emptied,
+// and the ownership sidecar got pruned. This module materializes the session
+// list + config in memory with a monotonic sequence cursor, serves snapshots
+// instantly from memory, and publishes `sync` deltas on the event bus as
+// state changes.
+//
+// PURE + injected-I/O only: all external effects (listProjects + publish) are
+// injected. No tmux / fs imports, no live bus here — the poller in index.mjs
+// drives refreshNow().
+//
+// Cursor model:
+//   - `gen`: random 8-hex string, generated once per createSyncState call.
+//     Identifies a server process generation. A client that reconnects to a
+//     NEW server process sees gen mismatch → full snapshot.
+//   - `seq`: integer, starts at 1. Any state change → seq += 1, and the
+//     changed field's version is recorded in `versions` (each field holds the
+//     seq at which it last changed).
+//   - `payloadSince(sinceSeq, sinceGen)` returns only the fields whose version
+//     is > sinceSeq, so a client can recover just the deltas it missed.
+
+import { randomBytes } from "node:crypto";
+
+function defaultGenId() {
+  return randomBytes(4).toString("hex"); // 8-char hex
+}
+
+/**
+ * @param {object} deps
+ * @param {() => Promise<Array>} deps.listProjects   one tmux listing tick
+ * @param {(env: object) => void} deps.publish        pushes `{kind:"sync",…}` envelopes on the bus
+ * @param {() => string} [deps.genId]                 injectable gen generator (default: crypto)
+ */
+export function createSyncState({ listProjects, publish, genId = defaultGenId }) {
+  const gen = genId();
+  let seq = 1;
+  let projects = [];
+  let config = null;
+  let stale = false;
+  let everSucceeded = false;
+  const versions = { projects: 0, config: 0, stale: 0 };
+
+  function bump(field, value) {
+    seq += 1;
+    versions[field] = seq;
+    publish({ kind: "sync", gen, seq, changed: { [field]: value } });
+  }
+
+  // Dedupe concurrent refreshes: if a refresh is already in flight, await the
+  // SAME promise rather than issuing a second listProjects tick.
+  let refreshPromise = null;
+
+  async function refreshNow() {
+    if (refreshPromise) return refreshPromise;
+    refreshPromise = (async () => {
+      try {
+        const p = await listProjects();
+        everSucceeded = true;
+        if (JSON.stringify(p) !== JSON.stringify(projects)) {
+          projects = p;
+          bump("projects", projects);
+        }
+        if (stale) {
+          stale = false;
+          bump("stale", false);
+        }
+      } catch {
+        // A fault is recorded as stale but NEVER clobbers the last-known-good
+        // projects — the client keeps serving the last good list, flagged.
+        if (!stale) {
+          stale = true;
+          bump("stale", true);
+        }
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+    return refreshPromise;
+  }
+
+  function applyConfig(cfg) {
+    if (JSON.stringify(cfg) !== JSON.stringify(config)) {
+      config = cfg;
+      bump("config", config);
+    }
+  }
+
+  function snapshot() {
+    return { gen, seq, projects, config, stale };
+  }
+
+  function payloadSince(sinceSeq, sinceGen) {
+    // Full-snapshot case: no cursor, a different process generation, or an
+    // impossible future seq → return everything and let the client rebase.
+    if (sinceSeq == null || sinceSeq > seq || sinceGen !== gen) {
+      return { gen, seq, changed: { projects, config, stale } };
+    }
+    const changed = {};
+    if (versions.projects > sinceSeq) changed.projects = projects;
+    if (versions.config > sinceSeq) changed.config = config;
+    if (versions.stale > sinceSeq) changed.stale = stale;
+    return { gen, seq, changed };
+  }
+
+  function everSucceededFn() {
+    return everSucceeded;
+  }
+
+  return {
+    refreshNow,
+    applyConfig,
+    snapshot,
+    payloadSince,
+    everSucceeded: everSucceededFn,
+  };
+}

--- a/src/server/syncState.test.mjs
+++ b/src/server/syncState.test.mjs
@@ -1,0 +1,168 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createSyncState } from "./syncState.mjs";
+
+const P1 = [{ tmuxSession: "alpha", windows: [], attached: false, mantaOwned: true }];
+const P2 = [
+  ...P1,
+  { tmuxSession: "beta", windows: [], attached: false, mantaOwned: false },
+];
+
+function makeFixture() {
+  const published = [];
+  let nextProjects = P1;
+  let listCalls = 0;
+  let failList = false;
+  const state = createSyncState({
+    listProjects: async () => {
+      listCalls += 1;
+      if (failList) throw new Error("tmux fault");
+      return nextProjects;
+    },
+    publish: (e) => published.push(e),
+    genId: () => "aabbccdd",
+  });
+  return { state, published, setProjects: (p) => (nextProjects = p), setFail: (f) => (failList = f), getCalls: () => listCalls };
+}
+
+test("seq starts at 1; applying identical projects twice bumps seq once", async () => {
+  const { state, published } = makeFixture();
+  assert.equal(state.snapshot().seq, 1);
+  state.applyConfig({ foo: 1 });
+  assert.equal(state.snapshot().seq, 2);
+  state.applyConfig({ foo: 1 }); // identical — no bump
+  assert.equal(state.snapshot().seq, 2);
+  assert.equal(published.length, 1);
+  assert.deepEqual(published[0].changed, { config: { foo: 1 } });
+});
+
+test("applyConfig publishes only on change", () => {
+  const { state, published } = makeFixture();
+  state.applyConfig({ a: 1 });
+  state.applyConfig({ a: 1 });
+  state.applyConfig({ a: 2 });
+  assert.equal(published.length, 2);
+  assert.deepEqual(published.map((p) => p.changed), [{ config: { a: 1 } }, { config: { a: 2 } }]);
+});
+
+test("refreshNow success applies projects change + a fresh tick is a no-op", async () => {
+  const { state, published, setProjects } = makeFixture();
+  await state.refreshNow();
+  await state.refreshNow(); // identical — no change
+  assert.equal(state.snapshot().projects, P1);
+  assert.equal(state.snapshot().stale, false);
+  assert.equal(published.length, 1);
+  assert.deepEqual(published[0].changed, { projects: P1 });
+
+  setProjects(P2);
+  await state.refreshNow();
+  assert.equal(published.length, 2);
+  assert.deepEqual(published[1].changed, { projects: P2 });
+});
+
+test("refreshNow failure → stale=true, last-known-good kept, publish changed.stale", async () => {
+  const { state, published, setFail } = makeFixture();
+  await state.refreshNow(); // success: projects = P1
+  const before = state.snapshot().seq;
+  setFail(true);
+  await state.refreshNow(); // failure
+  const snap = state.snapshot();
+  assert.equal(snap.stale, true);
+  assert.equal(snap.projects, P1); // last-known-good untouched
+  assert.ok(snap.seq > before);
+  const last = published[published.length - 1];
+  assert.deepEqual(last.changed, { stale: true });
+});
+
+test("refreshNow success after failure → stale=false published", async () => {
+  const { state, published, setFail } = makeFixture();
+  setFail(true);
+  await state.refreshNow(); // stale=true (no prior good)
+  assert.equal(state.snapshot().stale, true);
+  setFail(false);
+  await state.refreshNow(); // recovery
+  assert.equal(state.snapshot().stale, false);
+  const last = published[published.length - 1];
+  assert.deepEqual(last.changed, { stale: false });
+});
+
+test("payloadSince(null) includes all fields", async () => {
+  const { state } = makeFixture();
+  await state.refreshNow();
+  const { gen, seq } = state.snapshot();
+  const out = state.payloadSince(null, gen);
+  assert.equal(out.gen, gen);
+  assert.equal(out.seq, seq);
+  assert.ok("projects" in out.changed);
+  assert.ok("config" in out.changed);
+  assert.ok("stale" in out.changed);
+});
+
+test("payloadSince with current seq returns empty changed", async () => {
+  const { state } = makeFixture();
+  await state.refreshNow();
+  const { gen, seq } = state.snapshot();
+  const out = state.payloadSince(seq, gen);
+  assert.deepEqual(out.changed, {});
+});
+
+test("payloadSince with older seq returns only fields changed since", async () => {
+  const { state, setProjects } = makeFixture();
+  await state.refreshNow(); // projects set at seq N
+  const before = state.snapshot().seq;
+  setProjects(P2);
+  await state.refreshNow(); // projects changed
+  const { gen, seq } = state.snapshot();
+  const out = state.payloadSince(before, gen);
+  assert.equal(out.seq, seq);
+  assert.deepEqual(Object.keys(out.changed), ["projects"]);
+  assert.deepEqual(out.changed.projects, P2);
+});
+
+test("payloadSince with mismatched gen returns all fields", async () => {
+  const { state } = makeFixture();
+  await state.refreshNow();
+  const { seq } = state.snapshot();
+  const out = state.payloadSince(seq, "deadbeef"); // different process gen
+  assert.ok("projects" in out.changed);
+  assert.ok("config" in out.changed);
+  assert.ok("stale" in out.changed);
+});
+
+test("payloadSince with sinceSeq > seq returns all fields", async () => {
+  const { state } = makeFixture();
+  await state.refreshNow();
+  const { gen, seq } = state.snapshot();
+  const out = state.payloadSince(seq + 100, gen);
+  assert.ok("projects" in out.changed);
+  assert.ok("config" in out.changed);
+  assert.ok("stale" in out.changed);
+});
+
+test("concurrent refreshNow calls dedupe (listProjects called once)", async () => {
+  const { state, getCalls } = makeFixture();
+  await Promise.all([state.refreshNow(), state.refreshNow(), state.refreshNow()]);
+  assert.equal(getCalls(), 1);
+});
+
+test("everSucceeded reflects whether a tick ever succeeded", async () => {
+  const { state, setFail } = makeFixture();
+  setFail(true);
+  await state.refreshNow();
+  assert.equal(state.everSucceeded(), false);
+  setFail(false);
+  await state.refreshNow();
+  assert.equal(state.everSucceeded(), true);
+});
+
+test("publish envelope shape is pinned {kind, gen, seq, changed}", async () => {
+  const { state, published } = makeFixture();
+  await state.refreshNow();
+  const env = published[0];
+  assert.equal(env.kind, "sync");
+  assert.equal(env.gen, "aabbccdd");
+  assert.equal(typeof env.seq, "number");
+  assert.deepEqual(Object.keys(env), ["kind", "gen", "seq", "changed"]);
+  assert.ok("projects" in env.changed);
+  assert.equal(env.seq, state.snapshot().seq);
+});

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -7,6 +7,13 @@ import { atomicWrite } from "./storeUtils.mjs";
 
 const FS = "\t";
 
+// Upper bound on any single tmux child-process invocation. A wedged tmux
+// binary (e.g. a server mid-crash holding the socket with no progress) would
+// otherwise hang the server forever — `tmux:list` and the sync poller would
+// stall on the child. On expiry we SIGKILL the child and reject with a fault
+// error so the caller treats it as a tmux failure rather than an empty box.
+const SPAWN_TIMEOUT_MS = 10_000;
+
 /**
  * The environment tmux must be invoked with.
  *
@@ -38,12 +45,22 @@ function spawnRun(cmd, args) {
   return new Promise((resolve, reject) => {
     const p = cpSpawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], env: tmuxSpawnEnv() });
     let stdout = "", stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      try { p.kill("SIGKILL"); } catch { /* already gone */ }
+      settled = true;
+      reject(new Error("tmux timed out after 10s"));
+    }, SPAWN_TIMEOUT_MS);
+    timeout.unref();
+    const finish = () => { if (!settled) { settled = true; clearTimeout(timeout); } };
     p.stdout.on("data", (b) => (stdout += b.toString()));
     p.stderr.on("data", (b) => (stderr += b.toString()));
-    p.on("error", reject);
-    p.on("exit", (code) =>
+    p.on("error", (e) => { finish(); reject(e); });
+    p.on("exit", (code) => {
+      finish();
       code === 0 ? resolve({ stdout, stderr })
-                 : reject(new Error(`${cmd} exited ${code}: ${stderr.trim() || stdout.trim()}`)));
+                 : reject(new Error(`${cmd} exited ${code}: ${stderr.trim() || stdout.trim()}`));
+    });
   });
 }
 
@@ -257,14 +274,19 @@ export function parseSessions(sessStdout, winStdout, owned = new Set()) {
 // (or no session) to talk to — i.e. the box really does have zero sessions.
 // Anything else is a FAULT and must not be reported as "zero sessions".
 //
+// We deliberately match ONLY "no server running" and "no sessions". The
+// `error connecting to … (No such file or directory)` / `Connection refused`
+// variants are NOT genuine-empty: they indicate a restarted server or a
+// socket race, so they must surface as a fault (throw) rather than masquerade
+// as an empty box (BET-675).
+//
 // Pure + exported for tests.
 export function isNoTmuxServerError(err) {
   const msg = typeof err?.message === "string" ? err.message : "";
   if (!msg) return false;
   return (
     /no server running on/i.test(msg) ||
-    /no sessions?$/im.test(msg) ||
-    /error connecting to .*(no such file or directory|connection refused)/i.test(msg)
+    /no sessions?$/im.test(msg)
   );
 }
 

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -357,10 +357,14 @@ test("isNoTmuxServerError separates 'no tmux server' from a real fault", () => {
     isNoTmuxServerError(new Error("tmux exited 1: no server running on /tmp/tmux-1000/default")),
     true,
   );
+  // BET-675: "error connecting … (No such file or directory)" / "Connection
+  // refused" indicate a restarted server / socket race, NOT a genuinely empty
+  // box — so they are no longer treated as "no tmux server".
   assert.equal(
     isNoTmuxServerError(new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)")),
-    true,
+    false,
   );
+  assert.equal(isNoTmuxServerError(new Error("tmux exited 1: no sessions")), true);
   assert.equal(isNoTmuxServerError(new Error("spawn tmux ENOENT")), false);
   assert.equal(isNoTmuxServerError(new Error("tmux exited 1: lost server")), false);
   assert.equal(isNoTmuxServerError(undefined), false);
@@ -387,6 +391,22 @@ test("listProjects THROWS on a tmux fault rather than reporting zero sessions", 
   });
   try {
     await assert.rejects(() => listProjects(), /ENOENT/);
+  } finally {
+    _setRun(null);
+    _resetOwnedSessionsCache();
+  }
+});
+
+// BET-675: a socket race ("error connecting … (No such file or directory)")
+// is a FAULT, not an empty box — it must throw out of listProjects, never
+// quietly return an empty list.
+test("listProjects THROWS on a tmux socket-race fault, not empty", async () => {
+  _resetOwnedSessionsCache();
+  _setRun(async () => {
+    throw new Error("tmux exited 1: error connecting to /tmp/tmux-1000/default (No such file or directory)");
+  });
+  try {
+    await assert.rejects(() => listProjects(), /No such file or directory/);
   } finally {
     _setRun(null);
     _resetOwnedSessionsCache();


### PR DESCRIPTION
## BET-675 — Sync core: materialized session/config state + cursor snapshot RPC on manta-server

SERVER-ONLY. No `src/renderer/` changes (sibling renderer issue consumes the new `sync:snapshot` channel).

### What changed

1. **`tmux.mjs` — reclassify errors (step 1).** `isNoTmuxServerError` now matches ONLY genuinely-empty: `no server running on …` and `no sessions`. The `error connecting to … (No such file or directory)` and `Connection refused` variants are now a FAULT and throw out of `tmuxListOutput`/`listProjects` instead of returning `""` — so a socket race / mid-restart can no longer masquerade as "zero sessions" (empty sidebar + pruned ownership sidecar).
2. **`tmux.mjs` — child timeout (step 2).** `spawnRun` now has `SPAWN_TIMEOUT_MS = 10_000`; a wedged tmux child is SIGKILL'd and rejected with `tmux timed out after 10s`. Timer unref'd, cleared on normal exit. No dedicated test (would need a wedged tmux binary).
3. **`syncState.mjs` (new, step 3).** Pure + injected-I/O materialized state `{gen, seq, projects, config, stale}` with monotonic cursor, deduped `refreshNow()`, `applyConfig`, `snapshot()`, `payloadSince()`, `everSucceeded()`. Publishes `{kind:"sync", gen, seq, changed:{<field>}}` single-field deltas.
4. **`index.mjs` (step 4).** Constructs `createSyncState`, seeds config at startup, a 2s sync poller (in-flight guard + unref'd timer, one immediate tick at boot), and passes `syncState` into `buildHandlers`.
5. **`rpc.mjs` — `sync:snapshot` channel (step 5).** `{ sinceSeq?, sinceGen? }` → `syncState.payloadSince(...)` (full snapshot on absent/older-gen/impossible cursor).
6. **`rpc.mjs` — `tmux:list` from memory (step 6).** Returns `snapshot().projects`; guarantees one `refreshNow()` before serving if never succeeded. Channel kept.
7. **`rpc.mjs` — fresh state after mutations (step 7).** `await refreshNow()` before returning for: `tmux:new-session`, `tmux:new-window`, `tmux:kill-session`, `tmux:kill-window`, `tmux:rename-session`, `tmux:rename-window`, and the window paths of `opencode:fork-session` / `opencode:clear-session`. Also added to `opencode:delete-session` (it kills a window — same intent).
8. **`rpc.mjs` — config changes publish (step 8).** `config:update` now calls `syncState.applyConfig(next)` after the write succeeds.
9. **Bus `/events` forwarding (step 9).** Confirmed `events.mjs` forwards every envelope `{kind,payload}` with no kind-filtering — `sync` envelopes flow through unmodified. No change needed.

### Follow-ups
- `tmux:select-window` flips `active` flags but isn't in the refresh list, so the active-window delta rides the 2s poller instead of publishing instantly. Parked as a follow-up (minor, benign).

### Verification results
- PR branch (`multica/BET-675-sync-core` @ `4b5a95db`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1515 pass / 0 fail / 0 skip. Failures: none. log sha256: `72122f8bced81f8d1c9b446cbd31c66a3ba3ad6d1a40f832f9ea9dd11f0578b7`
- Base (`main` @ `bbae0475`): no independent re-run — PR is additive (new module + wiring); 0 failures on PR branch.
- **Conclusion:** 0 new failures.

Logs cached at `/tmp/tc-pr.log`, `/tmp/test-pr.log`.
