### PR TITLE
fix(ios) BET-682: nil fast-toggle target when twin lacks selected effort

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -74,13 +74,16 @@ enum ChatModel {
             return off
         }
         let keepsVariant = variantId == nil || (counterpart.variants?.contains { $0.id == variantId } == true)
+        guard keepsVariant else {
+            return FastToggle(available: false, on: isFast, target: nil, title: "No fast mode at \(variantId ?? "") effort")
+        }
         return FastToggle(
-            available: keepsVariant,
+            available: true,
             on: isFast,
             target: (active.providerID, counterpartID),
             title: isFast
                 ? "You're in fast mode — tap to switch to the standard model"
-                : keepsVariant ? "Run this model in fast mode" : "No fast mode at \(variantId ?? "") effort"
+                : "Run this model in fast mode"
         )
     }
 

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -127,7 +127,7 @@ final class ComposerTests: XCTestCase {
     }
 
     func testFastToggleFastModelReportsOnAndTargetsBase() {
-        let models = [variantModel("openai", "gpt-5.6", variants: ["high"]), variantModel("openai", "gpt-5.6-fast", variants: ["high"])]
+        let models = [variantModel("openai", "gpt-5.6", variants: ["low"]), variantModel("openai", "gpt-5.6-fast", variants: ["low"])]
         let r = ChatModel.fastToggle(models: models, active: models[1], variantId: "low")
         XCTAssertTrue(r.available)
         XCTAssertTrue(r.on)
@@ -135,7 +135,7 @@ final class ComposerTests: XCTestCase {
     }
 
     func testFastToggleDisabledWhenTwinLacksSelectedEffort() {
-        let models = [variantModel("openai", "gpt-5.6", variants: ["low"]), variantModel("openai", "gpt-5.6-fast", variants: ["high"])]
+        let models = [variantModel("openai", "gpt-5.6", variants: ["high"]), variantModel("openai", "gpt-5.6-fast", variants: ["low"])]
         let r = ChatModel.fastToggle(models: models, active: models[0], variantId: "high")
         XCTAssertFalse(r.available)
         XCTAssertNil(r.target)


### PR DESCRIPTION
Opened automatically for `multica/BET-682-fix-composer-tests`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-682.