### PR TITLE
fix(server): one invalid APNs token no longer silences push for every device

### DIFF
--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -66,6 +66,21 @@ async function loadApnsTokens(path = APNS_TOKENS_PATH) {
   return Array.isArray(arr) ? arr : [];
 }
 
+/**
+ * Token-shape gate. MUST stay in sync with the gateway's `isHexToken`
+ * (src/gateway/index.mjs): the gateway 400s the ENTIRE /push batch when ANY
+ * token fails its check, so one bad stored token silences push for every
+ * real device and — because pruning only runs on a 200 — the bad entry can
+ * never self-heal. Concretely: the iOS Simulator "registers" 80-byte
+ * (160-hex-char) pseudo-tokens that APNs cannot route; real APNs device
+ * tokens are 32 bytes (64 hex chars) today, and Apple documents the length
+ * may change — hence the same 1..128 bound the gateway enforces, not a
+ * hardcoded 64.
+ */
+export function isValidApnsToken(t) {
+  return typeof t === "string" && /^[0-9a-fA-F]{1,128}$/.test(t);
+}
+
 async function saveApnsTokens(tokens, path = APNS_TOKENS_PATH) {
   await writeJsonAtomic(path, JSON.stringify(tokens, null, 2));
 }
@@ -76,6 +91,15 @@ async function saveApnsTokens(tokens, path = APNS_TOKENS_PATH) {
 export async function addApnsToken(token, { store } = {}) {
   if (typeof token !== "string" || !token) {
     throw new Error("token must be a non-empty string");
+  }
+  if (!isValidApnsToken(token)) {
+    // Reject at the single registration chokepoint (both the HTTP route and
+    // the rpc channel funnel here) — see isValidApnsToken for why one bad
+    // token in the store kills push for every device.
+    throw new Error(
+      `token rejected: not a 1-128 char hex APNs device token (len=${token.length}); ` +
+        "simulator pseudo-tokens are not registrable",
+    );
   }
   const path = store ?? APNS_TOKENS_PATH;
   const tokens = await loadApnsTokens(path);
@@ -693,7 +717,22 @@ export async function sendApnsFanout(payload, opts = {}) {
     ? _loadApnsTokensOverride()
     : loadApnsTokens());
   if (!Array.isArray(tokens) || tokens.length === 0) return;
-  const tokenValues = tokens.map((t) => t?.token).filter((t) => typeof t === "string");
+  const allValues = tokens.map((t) => t?.token).filter((t) => typeof t === "string");
+  // Self-heal: drop store entries the gateway would reject — one invalid
+  // token 400s the WHOLE batch (see isValidApnsToken), so a store poisoned
+  // before registration validation existed would otherwise silence push
+  // forever. Remove them here so the next send is clean.
+  const invalid = allValues.filter((t) => !isValidApnsToken(t));
+  if (invalid.length > 0) {
+    const remove = _removeApnsTokenOverride ?? removeApnsToken;
+    for (const t of invalid) {
+      await remove(t).catch(() => {});
+    }
+    console.warn(
+      `[push] pruned ${invalid.length} invalid stored token(s) the gateway would reject`,
+    );
+  }
+  const tokenValues = allValues.filter((t) => isValidApnsToken(t));
   if (tokenValues.length === 0) return;
 
   // Resolve the box identity + gateway_token from auth.json.

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -983,6 +983,36 @@ test("sendApnsFanout: gateway 200 with malformed JSON body → warn + no excepti
 // validation existed.
 // ---------------------------------------------------------------------------
 
+// Shared harness for the validation fanout tests: installs the standard
+// identity/gateway fakes, records POSTs + prunes, runs `fn`, and always
+// resets. Keeps the fake wiring in ONE place instead of per-test copies.
+async function withValidationFanout({ storeTokens }, fn) {
+  _resetFanoutFakesForTest();
+  const calls = [];
+  const pruned = [];
+  _setFanoutFakesForTest({
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return { ok: true, status: 200, json: async () => ({ results: [] }) };
+    },
+    loadApnsTokens: async () => storeTokens,
+    removeApnsToken: async (tok) => {
+      pruned.push(tok);
+      return { ok: true, count: 0 };
+    },
+    readBoxGatewayIdentity: async () => ({
+      box_id: FANOUT_BOX_ID,
+      gateway_token: FANOUT_GATEWAY_TOKEN,
+    }),
+    gatewayBase: "https://gateway.test.local",
+  });
+  try {
+    await fn({ calls, pruned });
+  } finally {
+    _resetFanoutFakesForTest();
+  }
+}
+
 test("isValidApnsToken: mirrors the gateway's isHexToken bounds", () => {
   assert.equal(isValidApnsToken("a1".repeat(32)), true, "64-hex real token");
   assert.equal(isValidApnsToken("a1".repeat(64)), true, "128-hex upper bound");
@@ -1005,65 +1035,31 @@ test("register-apns REGRESSION: rejects a 160-hex simulator pseudo-token and non
 });
 
 test("sendApnsFanout REGRESSION: filters + prunes invalid stored tokens instead of poisoning the batch", async () => {
-  _resetFanoutFakesForTest();
   const badToken = "80".repeat(80); // 160 hex chars — gateway would 400 the batch
-  const calls = [];
-  const pruned = [];
-  _setFanoutFakesForTest({
-    fetchImpl: async (url, init) => {
-      calls.push({ url, init });
-      return { ok: true, status: 200, json: async () => ({ results: [] }) };
+  await withValidationFanout(
+    {
+      storeTokens: [
+        { kind: "apns", token: "beef1111", registeredAt: 1 },
+        { kind: "apns", token: badToken, registeredAt: 2 },
+      ],
     },
-    loadApnsTokens: async () => [
-      { kind: "apns", token: "beef1111", registeredAt: 1 },
-      { kind: "apns", token: badToken, registeredAt: 2 },
-    ],
-    removeApnsToken: async (tok) => {
-      pruned.push(tok);
-      return { ok: true, count: 1 };
+    async ({ calls, pruned }) => {
+      await sendApnsFanout({ kind: "done", title: "T", body: "B" });
+      assert.equal(calls.length, 1, "batch still sent for the valid token");
+      const body = JSON.parse(calls[0].init.body);
+      assert.deepEqual(body.tokens, ["beef1111"], "invalid token excluded from the batch");
+      assert.deepEqual(pruned, [badToken], "invalid token pruned from the store");
     },
-    readBoxGatewayIdentity: async () => ({
-      box_id: FANOUT_BOX_ID,
-      gateway_token: FANOUT_GATEWAY_TOKEN,
-    }),
-    gatewayBase: "https://gateway.test.local",
-  });
-  try {
-    await sendApnsFanout({ kind: "done", title: "T", body: "B" });
-    assert.equal(calls.length, 1, "batch still sent for the valid token");
-    const body = JSON.parse(calls[0].init.body);
-    assert.deepEqual(body.tokens, ["beef1111"], "invalid token excluded from the batch");
-    assert.deepEqual(pruned, [badToken], "invalid token pruned from the store");
-  } finally {
-    _resetFanoutFakesForTest();
-  }
+  );
 });
 
 test("sendApnsFanout: all-invalid store prunes everything and sends nothing", async () => {
-  _resetFanoutFakesForTest();
-  let fetchCalls = 0;
-  const pruned = [];
-  _setFanoutFakesForTest({
-    fetchImpl: async () => {
-      fetchCalls++;
-      return { ok: true, status: 200, json: async () => ({ results: [] }) };
+  await withValidationFanout(
+    { storeTokens: [{ kind: "apns", token: "80".repeat(80), registeredAt: 1 }] },
+    async ({ calls, pruned }) => {
+      await sendApnsFanout({ kind: "done" });
+      assert.equal(calls.length, 0, "no POST when nothing valid remains");
+      assert.equal(pruned.length, 1);
     },
-    loadApnsTokens: async () => [{ kind: "apns", token: "80".repeat(80), registeredAt: 1 }],
-    removeApnsToken: async (tok) => {
-      pruned.push(tok);
-      return { ok: true, count: 0 };
-    },
-    readBoxGatewayIdentity: async () => ({
-      box_id: FANOUT_BOX_ID,
-      gateway_token: FANOUT_GATEWAY_TOKEN,
-    }),
-    gatewayBase: "https://gateway.test.local",
-  });
-  try {
-    await sendApnsFanout({ kind: "done" });
-    assert.equal(fetchCalls, 0, "no POST when nothing valid remains");
-    assert.equal(pruned.length, 1);
-  } finally {
-    _resetFanoutFakesForTest();
-  }
+  );
 });

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -780,106 +780,63 @@ test("sendApnsFanout: prunes every token classified prune:true", async () => {
   }
 });
 
-test("sendApnsFanout: network throw → warn + return (no exception, no prune)", async () => {
-  _resetFanoutFakesForTest();
-  const warns = [];
-  const origWarn = console.warn;
-  console.warn = (...a) => warns.push(a.join(" "));
-  let removeCalls = 0;
-  const fakeFetch = async () => {
-    throw new Error("socket reset");
-  };
-  _setFanoutFakesForTest({
-    fetchImpl: fakeFetch,
-    loadApnsTokens: async () => [
-      { kind: "apns", token: "f1a1", registeredAt: 1 },
-    ],
-    removeApnsToken: async () => {
-      removeCalls++;
-      return { ok: true, count: 0 };
+// The three delivery-failure modes (network throw, 401, 500) share one
+// contract: warn + return, no exception, no prune. Table-driven so the
+// fake wiring and warn-capture scaffolding exist once.
+const FANOUT_FAILURE_CASES = [
+  {
+    label: "network throw",
+    fetchImpl: async () => {
+      throw new Error("socket reset");
     },
-    readBoxGatewayIdentity: async () => ({
-      box_id: FANOUT_BOX_ID,
-      gateway_token: FANOUT_GATEWAY_TOKEN,
-    }),
-    gatewayBase: "https://gateway.test.local",
-  });
-  try {
-    await assert.doesNotReject(() =>
-      sendApnsFanout({ kind: "done", title: "T", body: "B" }),
-    );
-    assert.equal(removeCalls, 0, "no prune on network throw");
-    assert.ok(
-      warns.some((w) => /gateway send failed/.test(w) && /socket reset/.test(w)),
-      "warn mentions the underlying failure",
-    );
-  } finally {
-    console.warn = origWarn;
-    _resetFanoutFakesForTest();
-  }
-});
-
-test("sendApnsFanout: gateway 401 → warn + return (no exception, no prune)", async () => {
-  _resetFanoutFakesForTest();
-  const warns = [];
-  const origWarn = console.warn;
-  console.warn = (...a) => warns.push(a.join(" "));
-  let removeCalls = 0;
-  _setFanoutFakesForTest({
+    warnChecks: [/gateway send failed/, /socket reset/],
+  },
+  {
+    label: "gateway 401",
     fetchImpl: async () => ({ ok: false, status: 401, json: async () => ({}) }),
-    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
-    removeApnsToken: async () => {
-      removeCalls++;
-      return { ok: true, count: 0 };
-    },
-    readBoxGatewayIdentity: async () => ({
-      box_id: FANOUT_BOX_ID,
-      gateway_token: FANOUT_GATEWAY_TOKEN,
-    }),
-    gatewayBase: "https://gateway.test.local",
-  });
-  try {
-    await assert.doesNotReject(() =>
-      sendApnsFanout({ kind: "done", title: "T", body: "B" }),
-    );
-    assert.equal(removeCalls, 0);
-    assert.ok(warns.some((w) => /status=401/.test(w)), "warn mentions 401");
-  } finally {
-    console.warn = origWarn;
-    _resetFanoutFakesForTest();
-  }
-});
-
-test("sendApnsFanout: gateway 500 → warn + return (no exception, no prune)", async () => {
-  _resetFanoutFakesForTest();
-  const warns = [];
-  const origWarn = console.warn;
-  console.warn = (...a) => warns.push(a.join(" "));
-  let removeCalls = 0;
-  _setFanoutFakesForTest({
+    warnChecks: [/status=401/],
+  },
+  {
+    label: "gateway 500",
     fetchImpl: async () => ({ ok: false, status: 500, json: async () => ({}) }),
-    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
-    removeApnsToken: async () => {
-      removeCalls++;
-      return { ok: true, count: 0 };
-    },
-    readBoxGatewayIdentity: async () => ({
-      box_id: FANOUT_BOX_ID,
-      gateway_token: FANOUT_GATEWAY_TOKEN,
-    }),
-    gatewayBase: "https://gateway.test.local",
-  });
-  try {
-    await assert.doesNotReject(() =>
-      sendApnsFanout({ kind: "done", title: "T", body: "B" }),
-    );
-    assert.equal(removeCalls, 0);
-    assert.ok(warns.some((w) => /status=500/.test(w)), "warn mentions 500");
-  } finally {
-    console.warn = origWarn;
+    warnChecks: [/status=500/],
+  },
+];
+
+for (const c of FANOUT_FAILURE_CASES) {
+  test(`sendApnsFanout: ${c.label} → warn + return (no exception, no prune)`, async () => {
     _resetFanoutFakesForTest();
-  }
-});
+    const warns = [];
+    const origWarn = console.warn;
+    console.warn = (...a) => warns.push(a.join(" "));
+    let removeCalls = 0;
+    _setFanoutFakesForTest({
+      fetchImpl: c.fetchImpl,
+      loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
+      removeApnsToken: async () => {
+        removeCalls++;
+        return { ok: true, count: 0 };
+      },
+      readBoxGatewayIdentity: async () => ({
+        box_id: FANOUT_BOX_ID,
+        gateway_token: FANOUT_GATEWAY_TOKEN,
+      }),
+      gatewayBase: "https://gateway.test.local",
+    });
+    try {
+      await assert.doesNotReject(() =>
+        sendApnsFanout({ kind: "done", title: "T", body: "B" }),
+      );
+      assert.equal(removeCalls, 0, "no prune on delivery failure");
+      for (const re of c.warnChecks) {
+        assert.ok(warns.some((w) => re.test(w)), `warn matches ${re}`);
+      }
+    } finally {
+      console.warn = origWarn;
+      _resetFanoutFakesForTest();
+    }
+  });
+}
 
 test("sendApnsFanout: missing gateway_token in auth.json → warn + no request sent", async () => {
   _resetFanoutFakesForTest();

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -18,6 +18,7 @@ import {
   _pendingEscalationTags,
   _resetPushState,
   addApnsToken,
+  isValidApnsToken,
   removeApnsToken,
   sendApnsFanout,
   _loadApnsTokensForTest,
@@ -615,15 +616,15 @@ function makeApnsStorePath(label) {
 test("register-apns upsert: addApnsToken round-trip via temp store", async () => {
   const store = makeApnsStorePath("upsert");
   try {
-    const r1 = await addApnsToken("tok-aaa", { store });
+    const r1 = await addApnsToken("aaaa1111", { store });
     assert.equal(r1.ok, true);
     assert.equal(r1.count, 1);
-    const r2 = await addApnsToken("tok-bbb", { store });
+    const r2 = await addApnsToken("bbbb2222", { store });
     assert.equal(r2.count, 2);
     const tokens = await _loadApnsTokensForTest(store);
     assert.deepEqual(
       tokens.map((t) => t.token).sort(),
-      ["tok-aaa", "tok-bbb"],
+      ["aaaa1111", "bbbb2222"],
     );
     for (const t of tokens) {
       assert.equal(t.kind, "apns");
@@ -638,12 +639,12 @@ test("register-apns upsert: addApnsToken round-trip via temp store", async () =>
 test("register-apns: re-registering same token DE-DUPES (upsert, not append)", async () => {
   const store = makeApnsStorePath("dedupe");
   try {
-    await addApnsToken("tok-dup", { store });
-    await addApnsToken("tok-dup", { store });
-    await addApnsToken("tok-dup", { store });
+    await addApnsToken("dddd1111", { store });
+    await addApnsToken("dddd1111", { store });
+    await addApnsToken("dddd1111", { store });
     const tokens = await _loadApnsTokensForTest(store);
     assert.equal(tokens.length, 1);
-    assert.equal(tokens[0].token, "tok-dup");
+    assert.equal(tokens[0].token, "dddd1111");
   } finally {
     await rm(store, { force: true });
   }
@@ -658,15 +659,15 @@ test("register-apns: rejects an empty / non-string token", async () => {
 test("removeApnsToken: removes a registered token", async () => {
   const store = makeApnsStorePath("remove");
   try {
-    await addApnsToken("tok-keep", { store });
-    await addApnsToken("tok-drop", { store });
-    const r = await removeApnsToken("tok-drop", { store });
+    await addApnsToken("cafe1111", { store });
+    await addApnsToken("cafe2222", { store });
+    const r = await removeApnsToken("cafe2222", { store });
     assert.equal(r.ok, true);
     assert.equal(r.count, 1);
     const tokens = await _loadApnsTokensForTest(store);
     assert.deepEqual(
       tokens.map((t) => t.token),
-      ["tok-keep"],
+      ["cafe1111"],
     );
   } finally {
     await rm(store, { force: true });
@@ -676,8 +677,8 @@ test("removeApnsToken: removes a registered token", async () => {
 test("removeApnsToken: no-op on unknown token (returns count unchanged)", async () => {
   const store = makeApnsStorePath("remove-noop");
   try {
-    await addApnsToken("tok-only", { store });
-    const r = await removeApnsToken("tok-ghost", { store });
+    await addApnsToken("ab01", { store });
+    const r = await removeApnsToken("cd02", { store });
     assert.equal(r.count, 1);
     const tokens = await _loadApnsTokensForTest(store);
     assert.equal(tokens.length, 1);
@@ -710,11 +711,11 @@ test("sendApnsFanout: sends exactly one POST to ${GATEWAY_BASE}/push with Bearer
   const calls = [];
   const fakeFetch = async (url, init) => {
     calls.push({ url, init });
-    return okJson({ results: [{ token: "t1", ok: true, prune: false }] });
+    return okJson({ results: [{ token: "f1a1", ok: true, prune: false }] });
   };
   _setFanoutFakesForTest({
     fetchImpl: fakeFetch,
-    loadApnsTokens: async () => [{ kind: "apns", token: "t1", registeredAt: 1 }],
+    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
     removeApnsToken: async () => ({ ok: true, count: 0 }),
     readBoxGatewayIdentity: async () => ({
       box_id: FANOUT_BOX_ID,
@@ -734,7 +735,7 @@ test("sendApnsFanout: sends exactly one POST to ${GATEWAY_BASE}/push with Bearer
     );
     const body = JSON.parse(calls[0].init.body);
     assert.equal(body.box_id, FANOUT_BOX_ID);
-    assert.deepEqual(body.tokens, ["t1"]);
+    assert.deepEqual(body.tokens, ["f1a1"]);
     assert.equal(body.payload.kind, "done");
   } finally {
     _resetFanoutFakesForTest();
@@ -747,19 +748,19 @@ test("sendApnsFanout: prunes every token classified prune:true", async () => {
   const fakeFetch = async () =>
     okJson({
       results: [
-        { token: "t-keep", ok: true, prune: false },
-        { token: "t-gone", ok: false, prune: true },
-        { token: "t-bad",  ok: false, prune: true },
-        { token: "t-other", ok: false, prune: false }, // 500-style, keep
+        { token: "beef1111", ok: true, prune: false },
+        { token: "beef2222", ok: false, prune: true },
+        { token: "beef3333",  ok: false, prune: true },
+        { token: "beef4444", ok: false, prune: false }, // 500-style, keep
       ],
     });
   _setFanoutFakesForTest({
     fetchImpl: fakeFetch,
     loadApnsTokens: async () => [
-      { kind: "apns", token: "t-keep", registeredAt: 1 },
-      { kind: "apns", token: "t-gone", registeredAt: 1 },
-      { kind: "apns", token: "t-bad",  registeredAt: 1 },
-      { kind: "apns", token: "t-other", registeredAt: 1 },
+      { kind: "apns", token: "beef1111", registeredAt: 1 },
+      { kind: "apns", token: "beef2222", registeredAt: 1 },
+      { kind: "apns", token: "beef3333",  registeredAt: 1 },
+      { kind: "apns", token: "beef4444", registeredAt: 1 },
     ],
     removeApnsToken: async (tok) => {
       pruned.push(tok);
@@ -773,7 +774,7 @@ test("sendApnsFanout: prunes every token classified prune:true", async () => {
   });
   try {
     await sendApnsFanout({ kind: "done", title: "T", body: "B" });
-    assert.deepEqual(pruned.sort(), ["t-bad", "t-gone"]);
+    assert.deepEqual(pruned.sort(), ["beef2222", "beef3333"]);
   } finally {
     _resetFanoutFakesForTest();
   }
@@ -791,7 +792,7 @@ test("sendApnsFanout: network throw → warn + return (no exception, no prune)",
   _setFanoutFakesForTest({
     fetchImpl: fakeFetch,
     loadApnsTokens: async () => [
-      { kind: "apns", token: "t1", registeredAt: 1 },
+      { kind: "apns", token: "f1a1", registeredAt: 1 },
     ],
     removeApnsToken: async () => {
       removeCalls++;
@@ -826,7 +827,7 @@ test("sendApnsFanout: gateway 401 → warn + return (no exception, no prune)", a
   let removeCalls = 0;
   _setFanoutFakesForTest({
     fetchImpl: async () => ({ ok: false, status: 401, json: async () => ({}) }),
-    loadApnsTokens: async () => [{ kind: "apns", token: "t1", registeredAt: 1 }],
+    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
     removeApnsToken: async () => {
       removeCalls++;
       return { ok: true, count: 0 };
@@ -857,7 +858,7 @@ test("sendApnsFanout: gateway 500 → warn + return (no exception, no prune)", a
   let removeCalls = 0;
   _setFanoutFakesForTest({
     fetchImpl: async () => ({ ok: false, status: 500, json: async () => ({}) }),
-    loadApnsTokens: async () => [{ kind: "apns", token: "t1", registeredAt: 1 }],
+    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
     removeApnsToken: async () => {
       removeCalls++;
       return { ok: true, count: 0 };
@@ -891,7 +892,7 @@ test("sendApnsFanout: missing gateway_token in auth.json → warn + no request s
       fetchCalls++;
       return okJson({ results: [] });
     },
-    loadApnsTokens: async () => [{ kind: "apns", token: "t1", registeredAt: 1 }],
+    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
     removeApnsToken: async () => ({ ok: true, count: 0 }),
     readBoxGatewayIdentity: async () => null, // gateway_token not persisted yet
     gatewayBase: "https://gateway.test.local",
@@ -949,7 +950,7 @@ test("sendApnsFanout: gateway 200 with malformed JSON body → warn + no excepti
         throw new Error("unexpected token");
       },
     }),
-    loadApnsTokens: async () => [{ kind: "apns", token: "t1", registeredAt: 1 }],
+    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
     removeApnsToken: async () => {
       removeCalls++;
       return { ok: true, count: 0 };
@@ -968,6 +969,101 @@ test("sendApnsFanout: gateway 200 with malformed JSON body → warn + no excepti
     assert.ok(warns.some((w) => /malformed JSON/.test(w)));
   } finally {
     console.warn = origWarn;
+    _resetFanoutFakesForTest();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// APNs token-shape validation (2026-08-07). One invalid stored token makes
+// the gateway 400 the ENTIRE /push batch (its isHexToken caps at 128 hex
+// chars) and pruning only runs on a 200 — so a single simulator
+// pseudo-token (80 bytes = 160 hex chars) silenced push for every real
+// device, permanently. Regression tests: the registration chokepoint
+// rejects them, and the fanout self-heals a store poisoned before the
+// validation existed.
+// ---------------------------------------------------------------------------
+
+test("isValidApnsToken: mirrors the gateway's isHexToken bounds", () => {
+  assert.equal(isValidApnsToken("a1".repeat(32)), true, "64-hex real token");
+  assert.equal(isValidApnsToken("a1".repeat(64)), true, "128-hex upper bound");
+  assert.equal(isValidApnsToken("a1".repeat(80)), false, "160-hex simulator pseudo-token");
+  assert.equal(isValidApnsToken("tok-aaa"), false, "non-hex");
+  assert.equal(isValidApnsToken(""), false);
+  assert.equal(isValidApnsToken(null), false);
+});
+
+test("register-apns REGRESSION: rejects a 160-hex simulator pseudo-token and non-hex junk", async () => {
+  const store = makeApnsStorePath("reject-invalid");
+  try {
+    await assert.rejects(() => addApnsToken("80".repeat(80), { store }), /rejected/);
+    await assert.rejects(() => addApnsToken("tok-not-hex", { store }), /rejected/);
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 0, "nothing persisted");
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApnsFanout REGRESSION: filters + prunes invalid stored tokens instead of poisoning the batch", async () => {
+  _resetFanoutFakesForTest();
+  const badToken = "80".repeat(80); // 160 hex chars — gateway would 400 the batch
+  const calls = [];
+  const pruned = [];
+  _setFanoutFakesForTest({
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return { ok: true, status: 200, json: async () => ({ results: [] }) };
+    },
+    loadApnsTokens: async () => [
+      { kind: "apns", token: "beef1111", registeredAt: 1 },
+      { kind: "apns", token: badToken, registeredAt: 2 },
+    ],
+    removeApnsToken: async (tok) => {
+      pruned.push(tok);
+      return { ok: true, count: 1 };
+    },
+    readBoxGatewayIdentity: async () => ({
+      box_id: FANOUT_BOX_ID,
+      gateway_token: FANOUT_GATEWAY_TOKEN,
+    }),
+    gatewayBase: "https://gateway.test.local",
+  });
+  try {
+    await sendApnsFanout({ kind: "done", title: "T", body: "B" });
+    assert.equal(calls.length, 1, "batch still sent for the valid token");
+    const body = JSON.parse(calls[0].init.body);
+    assert.deepEqual(body.tokens, ["beef1111"], "invalid token excluded from the batch");
+    assert.deepEqual(pruned, [badToken], "invalid token pruned from the store");
+  } finally {
+    _resetFanoutFakesForTest();
+  }
+});
+
+test("sendApnsFanout: all-invalid store prunes everything and sends nothing", async () => {
+  _resetFanoutFakesForTest();
+  let fetchCalls = 0;
+  const pruned = [];
+  _setFanoutFakesForTest({
+    fetchImpl: async () => {
+      fetchCalls++;
+      return { ok: true, status: 200, json: async () => ({ results: [] }) };
+    },
+    loadApnsTokens: async () => [{ kind: "apns", token: "80".repeat(80), registeredAt: 1 }],
+    removeApnsToken: async (tok) => {
+      pruned.push(tok);
+      return { ok: true, count: 0 };
+    },
+    readBoxGatewayIdentity: async () => ({
+      box_id: FANOUT_BOX_ID,
+      gateway_token: FANOUT_GATEWAY_TOKEN,
+    }),
+    gatewayBase: "https://gateway.test.local",
+  });
+  try {
+    await sendApnsFanout({ kind: "done" });
+    assert.equal(fetchCalls, 0, "no POST when nothing valid remains");
+    assert.equal(pruned.length, 1);
+  } finally {
     _resetFanoutFakesForTest();
   }
 });

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -801,6 +801,17 @@ const FANOUT_FAILURE_CASES = [
     fetchImpl: async () => ({ ok: false, status: 500, json: async () => ({}) }),
     warnChecks: [/status=500/],
   },
+  {
+    label: "gateway 200 with malformed JSON body",
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("unexpected token");
+      },
+    }),
+    warnChecks: [/malformed JSON/],
+  },
 ];
 
 for (const c of FANOUT_FAILURE_CASES) {
@@ -889,43 +900,6 @@ test("sendApnsFanout: empty token store → no request sent", async () => {
     await sendApnsFanout({ kind: "done", title: "T", body: "B" });
     assert.equal(fetchCalls, 0);
   } finally {
-    _resetFanoutFakesForTest();
-  }
-});
-
-test("sendApnsFanout: gateway 200 with malformed JSON body → warn + no exception", async () => {
-  _resetFanoutFakesForTest();
-  const warns = [];
-  const origWarn = console.warn;
-  console.warn = (...a) => warns.push(a.join(" "));
-  let removeCalls = 0;
-  _setFanoutFakesForTest({
-    fetchImpl: async () => ({
-      ok: true,
-      status: 200,
-      json: async () => {
-        throw new Error("unexpected token");
-      },
-    }),
-    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
-    removeApnsToken: async () => {
-      removeCalls++;
-      return { ok: true, count: 0 };
-    },
-    readBoxGatewayIdentity: async () => ({
-      box_id: FANOUT_BOX_ID,
-      gateway_token: FANOUT_GATEWAY_TOKEN,
-    }),
-    gatewayBase: "https://gateway.test.local",
-  });
-  try {
-    await assert.doesNotReject(() =>
-      sendApnsFanout({ kind: "done", title: "T", body: "B" }),
-    );
-    assert.equal(removeCalls, 0);
-    assert.ok(warns.some((w) => /malformed JSON/.test(w)));
-  } finally {
-    console.warn = origWarn;
     _resetFanoutFakesForTest();
   }
 });


### PR DESCRIPTION
The gateway 400s the ENTIRE /push batch when ANY token fails its isHexToken
check (1-128 hex chars), and pruning only runs on a 200 — so a single iOS
Simulator pseudo-token (80 bytes = 160 hex chars) registered into
~/.manta/apns-tokens.json killed APNs fanout permanently ('[push] gateway
send failed: status=400' on every send).

- addApnsToken (the single registration chokepoint for both the HTTP route
  and the rpc channel) now rejects tokens the gateway would reject, with a
  message naming simulator pseudo-tokens.
- sendApnsFanout filters invalid stored tokens out of the batch AND prunes
  them from the store, self-healing registries poisoned before this
  validation existed.
- isValidApnsToken mirrors the gateway bound (1-128 hex, not hardcoded 64 —
  Apple documents token length may change).

Existing tests' non-hex fixture tokens updated to hex; 4 new regression
tests.
