### PR TITLE
BET-677: feat(renderer): zero layout shift — CardMount, overlay toasts, restored working indicator

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/dev/projects/better-ui/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/dev/projects/better-ui/node_modules

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { MotionConfig } from "framer-motion";
 import { Terminal as TerminalIcon } from "lucide-react";
 import { Sidebar, type SidebarHandle } from "./Sidebar";
 import { Terminal } from "./Terminal";
@@ -73,7 +74,13 @@ export function App() {
         </div>
       )}
     >
-      <AppInner />
+      {/* App-level reduced motion (BET-677): wraps the whole tree so EVERY
+          framer-motion animation — chat entry, CardMount card mounts, toast
+          in/out — respects the OS `prefers-reduced-motion` setting, not just
+          the transcript's. The old transcript-local duplicate was removed. */}
+      <MotionConfig reducedMotion="user">
+        <AppInner />
+      </MotionConfig>
     </ErrorBoundary>
   );
 }

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2347,7 +2347,20 @@ export function ChatPanel({
           Only the active panel renders it — the toasts live in global store
           state (screenshot / agent-file) or panel-local state (systemNotice),
           one instance app-wide. */}
-      {isActive && <ToastStack toasts={toasts} onDismiss={dismissToast} />}
+      {/* Bottom cluster: a relative wrapper around the composer so the toast
+          overlay can anchor to the composer's OWN top edge (bottom:100%)
+          instead of a fixed pixel guess. Toasts therefore stay just above the
+          box however tall it grows with the input, and as a pure overlay they
+          never shift the transcript or composer layout (BET-677). */}
+      <div className="relative shrink-0">
+        {isActive && (
+          <div
+            className="pointer-events-none absolute inset-x-0 z-40"
+            style={{ bottom: "100%" }}
+          >
+            <ToastStack toasts={toasts} onDismiss={dismissToast} />
+          </div>
+        )}
 
       {jobOwnership ? (
         <ReadOnlyJobBar
@@ -2453,6 +2466,7 @@ export function ChatPanel({
         onPaste={onPaste}
       />
       )}
+      </div>
     </div>
   );
 }

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -66,6 +66,7 @@ import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
 import { CompactionCard, PermissionCard, RetryCard } from "./Cards";
 import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
+import { CardMount } from "./components/CardMount";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
 import { useTranscriptState } from "./hooks/useTranscriptState";
@@ -2108,7 +2109,8 @@ export function ChatPanel({
       {/* so they're hard to miss — tool execution pauses until reply. */}
       {/* Hidden for a job session (BET-418 §D: a job's pre-flight ruleset */}
       {/* means it never generates asks, but gate defensively anyway). */}
-      {!jobOwnership && permissions.length > 0 && (
+      {!jobOwnership && (
+      <CardMount show={permissions.length > 0} k="permission">
         <div className="shrink-0 px-4 pt-2">
           {/* BET-458: the permission card is a block in the conversation, not
               an overlay — bound it to the same 72ch measure the transcript
@@ -2124,20 +2126,23 @@ export function ChatPanel({
             ))}
           </div>
         </div>
+      </CardMount>
       )}
 
       {/* Retry status — surfaces session.status "retry" so the user can */}
       {/* see WHY the spinner is still spinning (rate limit, transient API */}
       {/* failure, etc) instead of assuming the AI is stalled. */}
-      {retryInfo && (
-        <div className="shrink-0 px-4 pt-2">
-          <RetryCard info={retryInfo} />
-        </div>
-      )}
+      <CardMount show={!!retryInfo} k="retry">
+        {retryInfo && (
+          <div className="shrink-0 px-4 pt-2">
+            <RetryCard info={retryInfo} />
+          </div>
+        )}
+      </CardMount>
 
       {/* Transcript-loading card removed (BET-251). The warm-stale-reopen */}
       {/* refetch is now surfaced as an ambient orange sweep on the composer's */}
-      {/* top divider — see InputArea + `manta-loading-divider` in index.css. */}
+      {/* top divider — see InputArea. */}
       {/* Cold-load (`messages === null`) is still covered by the full-screen */}
       {/* "Connecting to session…" spinner above. */}
       {/* `refreshing` is still threaded into the composer below. */}
@@ -2145,124 +2150,137 @@ export function ChatPanel({
       {/* Live compaction progress. Streams the summary as it's produced and */}
       {/* flips to a brief "Compacted" confirmation after .ended; clears on */}
       {/* a timer (session.compacted refetch has already landed by then). */}
-      {compactionState && (
-        <div className="shrink-0 px-4 pt-2">
-          <CompactionCard state={compactionState} />
-        </div>
-      )}
+      <CardMount show={!!compactionState} k="compaction">
+        {compactionState && (
+          <div className="shrink-0 px-4 pt-2">
+            <CompactionCard state={compactionState} />
+          </div>
+        )}
+      </CardMount>
 
       {/* BET-418 §A: pre-flight background-job approval. Shown in the parent's */}
       {/* panel when a `delegate` call declared tools and trust mode is OFF. */}
       {/* Hidden for a job session (read-only view). */}
-      {!jobOwnership && pendingApproval && (
-        <div className="shrink-0 px-4 pt-2 pb-2">
-          <DelegateApprovalCard
-            approval={pendingApproval}
-            onApprove={(tools: DelegateApprovalTool[]) => {
-              const id = pendingApproval.id;
-              setPendingApproval(null);
-              void window.api.delegateApprove(id, tools).catch(() => { /* best-effort */ });
-            }}
-            onDecline={() => {
-              const id = pendingApproval.id;
-              setPendingApproval(null);
-              void window.api.delegateDecline(id).catch(() => { /* best-effort */ });
-            }}
-          />
-        </div>
+      {!jobOwnership && (
+      <CardMount show={!!pendingApproval} k="delegate-approval">
+        {pendingApproval && (
+          <div className="shrink-0 px-4 pt-2 pb-2">
+            <DelegateApprovalCard
+              approval={pendingApproval}
+              onApprove={(tools: DelegateApprovalTool[]) => {
+                const id = pendingApproval.id;
+                setPendingApproval(null);
+                void window.api.delegateApprove(id, tools).catch(() => { /* best-effort */ });
+              }}
+              onDecline={() => {
+                const id = pendingApproval.id;
+                setPendingApproval(null);
+                void window.api.delegateDecline(id).catch(() => { /* best-effort */ });
+              }}
+            />
+          </div>
+        )}
+      </CardMount>
       )}
 
       {/* Scheduled-tasks management card. Toggled by the ⏰ toolbar button */}
       {/* (desktop) or the ⋯ sheet (mobile). Refetch-driven while open. */}
       {/* pb-2 gives the card breathing room above the composer border so it */}
       {/* doesn't sit flush against the chat divider. Hidden for a job session. */}
-      {!jobOwnership && showSchedules && (
-        <div className="shrink-0 px-4 pt-2 pb-2">
-          <ScheduledTasksCard
-            jobs={schedules}
-            error={scheduleError}
-            onClose={() => setShowSchedules(false)}
-            onDelete={(id) => {
-              setSchedules((prev) => prev.filter((j) => j.id !== id));
-              window.api
-                .scheduleDelete(id)
-                .then(() => refreshSchedules())
-                .catch((e: unknown) => {
-                  setScheduleError(
-                    e instanceof Error ? e.message : "delete failed",
-                  );
-                  void refreshSchedules();
-                });
-            }}
-          />
-        </div>
-      )}
+      <CardMount show={!jobOwnership && showSchedules} k="schedules">
+        {!jobOwnership && showSchedules && (
+          <div className="shrink-0 px-4 pt-2 pb-2">
+            <ScheduledTasksCard
+              jobs={schedules}
+              error={scheduleError}
+              onClose={() => setShowSchedules(false)}
+              onDelete={(id) => {
+                setSchedules((prev) => prev.filter((j) => j.id !== id));
+                window.api
+                  .scheduleDelete(id)
+                  .then(() => refreshSchedules())
+                  .catch((e: unknown) => {
+                    setScheduleError(
+                      e instanceof Error ? e.message : "delete failed",
+                    );
+                    void refreshSchedules();
+                  });
+              }}
+            />
+          </div>
+        )}
+      </CardMount>
 
       {/* Secrets management card. Toggled by the 🔑 toolbar button (desktop) or */}
       {/* the ⋯ sheet (mobile). The value never appears here — list is metadata */}
       {/* only. Hidden for a job session (read-only view). */}
-      {!jobOwnership && showSecrets && (
-        <div className="shrink-0 px-4 pt-2 pb-2">
-          <SecretsCard
-            secrets={secrets}
-            error={secretError}
-            sessionId={sessionId}
-            onClose={() => setShowSecrets(false)}
-            onSave={(input) => {
-              return window.api
-                .secretsSet(input)
-                .then((r) => {
-                  if (r && r.ok === false) {
-                    setSecretError(r.error || "save failed");
+      <CardMount show={!jobOwnership && showSecrets} k="secrets">
+        {!jobOwnership && showSecrets && (
+          <div className="shrink-0 px-4 pt-2 pb-2">
+            <SecretsCard
+              secrets={secrets}
+              error={secretError}
+              sessionId={sessionId}
+              onClose={() => setShowSecrets(false)}
+              onSave={(input) => {
+                return window.api
+                  .secretsSet(input)
+                  .then((r) => {
+                    if (r && r.ok === false) {
+                      setSecretError(r.error || "save failed");
+                      return false;
+                    }
+                    void refreshSecrets();
+                    setSecretError(null);
+                    return true;
+                  })
+                  .catch((e: unknown) => {
+                    setSecretError(e instanceof Error ? e.message : "save failed");
                     return false;
-                  }
-                  void refreshSecrets();
-                  setSecretError(null);
-                  return true;
-                })
-                .catch((e: unknown) => {
-                  setSecretError(e instanceof Error ? e.message : "save failed");
-                  return false;
-                });
-            }}
-            onDelete={(id) => {
-              setSecrets((prev) => prev.filter((s) => s.id !== id));
-              window.api
-                .secretsDelete(id)
-                .then(() => refreshSecrets())
-                .catch((e: unknown) => {
-                  setSecretError(e instanceof Error ? e.message : "delete failed");
-                  void refreshSecrets();
-                });
-            }}
-          />
-        </div>
-      )}
+                  });
+              }}
+              onDelete={(id) => {
+                setSecrets((prev) => prev.filter((s) => s.id !== id));
+                window.api
+                  .secretsDelete(id)
+                  .then(() => refreshSecrets())
+                  .catch((e: unknown) => {
+                    setSecretError(e instanceof Error ? e.message : "delete failed");
+                    void refreshSecrets();
+                  });
+              }}
+            />
+          </div>
+        )}
+      </CardMount>
 
       {/* Inbound-webhook management card. Toggled by the 🪝 toolbar button */}
       {/* (desktop) or the ⋯ sheet (mobile). List is metadata only (no signing */}
       {/* secret); creation is the AI's job via the `webhook` opencode tool. */}
       {/* Hidden for a job session (read-only view). */}
-      {!jobOwnership && showWebhooks && (
-        <div className="shrink-0 px-4 pt-2 pb-2">
-          <WebhooksCard
-            hooks={webhooks}
-            error={webhookError}
-            onClose={() => setShowWebhooks(false)}
-            onDelete={(id) => {
-              setWebhooks((prev) => prev.filter((h) => h.id !== id));
-              window.api
-                .webhookDelete(id)
-                .then(() => refreshWebhooks())
-                .catch((e: unknown) => {
-                  setWebhookError(e instanceof Error ? e.message : "delete failed");
-                  void refreshWebhooks();
-                });
-            }}
-          />
-        </div>
-      )}
+      <CardMount show={!jobOwnership && showWebhooks} k="webhooks">
+        {!jobOwnership && showWebhooks && (
+          <div className="shrink-0 px-4 pt-2 pb-2">
+            <WebhooksCard
+              hooks={webhooks}
+              error={webhookError}
+              onClose={() => setShowWebhooks(false)}
+              onDelete={(id) => {
+                setWebhooks((prev) => prev.filter((h) => h.id !== id));
+                window.api
+                  .webhookDelete(id)
+                  .then(() => refreshWebhooks())
+                  .catch((e: unknown) => {
+                    setWebhookError(e instanceof Error ? e.message : "delete failed");
+                    void refreshWebhooks();
+                  });
+              }}
+            />
+          </div>
+        )}
+      </CardMount>
 
+      <CardMount show={running && messageQueue.length > 0} k="queued">
       {running && messageQueue.length > 0 && (
             // Queued prompts are about to be submitted, so the notice belongs
             // to the composer stack — default ("measure") MeasureColumn, which
@@ -2289,34 +2307,37 @@ export function ChatPanel({
               </div>
             </MeasureColumn>
           )}
+      </CardMount>
 
       {/* Send error banner — surfaced from both client-side capability */}
       {/* checks and server-side session.error events. Dismissable. For an */}
       {/* auth-error (BET-316) the banner also renders a [Reconnect] button */}
       {/* that dispatches `manta-open-subscriptions` — a no-op until the */}
       {/* Settings → AI → Subscriptions card lands (BET-314). */}
-      {sendError && (
-        <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded-xs break-words flex items-start gap-2">
-          <span className="flex-1">⚠ {sendError}</span>
-          {authReconnect && (
+      <CardMount show={!!sendError} k="send-error">
+        {sendError && (
+          <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded-xs break-words flex items-start gap-2">
+            <span className="flex-1">⚠ {sendError}</span>
+            {authReconnect && (
+              <button
+                onClick={openAuthReconnect}
+                className="text-danger hover:text-danger underline leading-none px-1"
+                title={`Reconnect ${authReconnect}`}
+              >
+                Reconnect
+              </button>
+            )}
             <button
-              onClick={openAuthReconnect}
-              className="text-danger hover:text-danger underline leading-none px-1"
-              title={`Reconnect ${authReconnect}`}
+              onClick={() => setSendError(null)}
+              className="text-danger hover:text-danger leading-none px-1 inline-flex items-center"
+              title="Dismiss"
+              aria-label="Dismiss error"
             >
-              Reconnect
+              <X size={14} aria-hidden="true" />
             </button>
-          )}
-          <button
-            onClick={() => setSendError(null)}
-            className="text-danger hover:text-danger leading-none px-1 inline-flex items-center"
-            title="Dismiss"
-            aria-label="Dismiss error"
-          >
-            <X size={14} aria-hidden="true" />
-          </button>
-        </div>
-      )}
+          </div>
+        )}
+      </CardMount>
 
       {/* Unified toast stack (BET-416 §D). Replaces the three previous in-app
           toast implementations (screenshot-detected, agent-sent-file,

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -275,7 +275,7 @@ export function InputArea({
           padding is --sp-4 (16px) per the BET-423 spacing ruling. */}
       <div
         className={
-          "manta-composer-input-row mb-2 rounded-lg border bg-bg-soft flex flex-col gap-2 px-4 py-3 " +
+          "manta-composer-input-row mb-2 rounded-lg border bg-bg-soft flex flex-col gap-2 px-4 py-3 transition-colors duration-200 " +
           // Resting border is `border-subtle`, the SAME token the tool cards
           // use. It was `border-strong`, which is a control-boundary tone —
           // on the light canvas that reads as a noticeably heavier rule than

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -107,30 +107,21 @@ export type ToastStackProps = {
 /** Max simultaneous toasts (spec: three stacked). */
 export const MAX_TOASTS = 3;
 
-// How far above the bottom of the chat column the toast stack floats. This is
-// the composer cluster's approximate height, so a toast hovers JUST ABOVE the
-// composer (input box + model/effort row) instead of covering it. The stack is
-// absolutely positioned, so this is a pure overlay — it never shifts the
-// layout of the transcript or composer (BET-677).
-const TOAST_BOTTOM = 112;
-
 export function ToastStack({ toasts, onDismiss }: ToastStackProps) {
   // Newest on top, capped at MAX_TOASTS.
   const visible = toasts.slice(0, MAX_TOASTS);
   return (
-    // Overlay (BET-677): no longer an in-flow row that pushes the composer
-    // down. Anchored just above the composer, horizontally centred, above the
-    // transcript's z-order. The container is pointer-events-none so it never
-    // blocks clicks on what it floats over; only each toast re-enables
-    // pointer events. The safe-area inset keeps it clear of the bottom edge on
-    // devices with a home indicator.
-    <div
-      className="pointer-events-none absolute inset-x-0 z-40 flex flex-col items-center gap-2 px-4"
-      style={{
-        bottom: TOAST_BOTTOM,
-        paddingBottom: "max(env(safe-area-inset-bottom, 0px), 0px)",
-      }}
-    >
+    // Layout-neutral stack (BET-677): it does NOT position itself absolutely.
+    // Surface-specific overlay framing — the fixed/absolute container, its
+    // bottom anchor and z-order — belongs to the CALLER so the same component
+    // serves both the chat column (where the overlay floats just above the
+    // composer) and the Settings dialog (which supplies its own fixed
+    // bottom-of-dialog wrapper). What this component owns is the framed list:
+    // centred, capped at 420px, each toast animating in/out. The per-toast
+    // `pointer-events-auto` keeps a toast interactive when its caller sets
+    // `pointer-events-none` on the overlay container (toasts only, never the
+    // dead backdrop).
+    <div className="shrink-0 w-full flex flex-col items-center gap-2 px-4 pt-1 pb-2">
       <AnimatePresence initial={false}>
         {visible.map((t) => (
           <motion.div
@@ -139,7 +130,7 @@ export function ToastStack({ toasts, onDismiss }: ToastStackProps) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 8 }}
             transition={{ duration: 0.2 }}
-            className="pointer-events-auto flex w-full justify-center"
+            className="pointer-events-auto w-full max-w-[420px]"
           >
             <Toast toast={t} onDismiss={onDismiss} />
           </motion.div>

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -20,6 +20,7 @@
 // unit-tested without mounting the component.
 
 import { useEffect, type ReactNode } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
 
 export type ToastAction = {
@@ -106,20 +107,44 @@ export type ToastStackProps = {
 /** Max simultaneous toasts (spec: three stacked). */
 export const MAX_TOASTS = 3;
 
+// How far above the bottom of the chat column the toast stack floats. This is
+// the composer cluster's approximate height, so a toast hovers JUST ABOVE the
+// composer (input box + model/effort row) instead of covering it. The stack is
+// absolutely positioned, so this is a pure overlay — it never shifts the
+// layout of the transcript or composer (BET-677).
+const TOAST_BOTTOM = 112;
+
 export function ToastStack({ toasts, onDismiss }: ToastStackProps) {
-  if (toasts.length === 0) return null;
   // Newest on top, capped at MAX_TOASTS.
   const visible = toasts.slice(0, MAX_TOASTS);
   return (
-    // Bottom-centre stack. pb-2 + safe-area inset so it clears the composer on
-    // mobile; the stack sits above the composer (rendered before it in flow).
+    // Overlay (BET-677): no longer an in-flow row that pushes the composer
+    // down. Anchored just above the composer, horizontally centred, above the
+    // transcript's z-order. The container is pointer-events-none so it never
+    // blocks clicks on what it floats over; only each toast re-enables
+    // pointer events. The safe-area inset keeps it clear of the bottom edge on
+    // devices with a home indicator.
     <div
-      className="shrink-0 w-full flex flex-col items-center gap-2 px-4 pt-1 pb-2"
-      style={{ paddingBottom: "max(env(safe-area-inset-bottom, 0px), 8px)" }}
+      className="pointer-events-none absolute inset-x-0 z-40 flex flex-col items-center gap-2 px-4"
+      style={{
+        bottom: TOAST_BOTTOM,
+        paddingBottom: "max(env(safe-area-inset-bottom, 0px), 0px)",
+      }}
     >
-      {visible.map((t) => (
-        <Toast key={t.id} toast={t} onDismiss={onDismiss} />
-      ))}
+      <AnimatePresence initial={false}>
+        {visible.map((t) => (
+          <motion.div
+            key={t.id}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ duration: 0.2 }}
+            className="pointer-events-auto flex w-full justify-center"
+          >
+            <Toast toast={t} onDismiss={onDismiss} />
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -117,11 +117,17 @@ export function ToastStack({ toasts, onDismiss }: ToastStackProps) {
     // serves both the chat column (where the overlay floats just above the
     // composer) and the Settings dialog (which supplies its own fixed
     // bottom-of-dialog wrapper). What this component owns is the framed list:
-    // centred, capped at 420px, each toast animating in/out. The per-toast
-    // `pointer-events-auto` keeps a toast interactive when its caller sets
-    // `pointer-events-none` on the overlay container (toasts only, never the
-    // dead backdrop).
-    <div className="shrink-0 w-full flex flex-col items-center gap-2 px-4 pt-1 pb-2">
+    // centred, capped at 420px, each toast animating in/out.
+    //
+    // The root is `pointer-events-none` even though the stack is always
+    // rendered (it must stay mounted so the LAST toast's exit animation
+    // plays). The empty container still carries its padding, so at the
+    // Settings call site — where it sits inside a click-catching wrapper —
+    // that padding would otherwise read as a permanent invisible strip that
+    // swallows clicks on whatever scrolls under it. Each toast re-enables
+    // pointer events, so both surfaces keep fully interactive toasts and the
+    // dead backdrop never captures a click.
+    <div className="pointer-events-none shrink-0 w-full flex flex-col items-center gap-2 px-4 pt-1 pb-2">
       <AnimatePresence initial={false}>
         {visible.map((t) => (
           <motion.div

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -28,10 +28,10 @@
 
 import type { OpencodeMessage, QuestionRequest } from "../shared/types";
 import { useRef, useState } from "react";
-import { MotionConfig } from "framer-motion";
 import { TaskContext, type TaskContextValue } from "./chatShared";
 import { MeasureColumn } from "./MeasureColumn";
 import { ActiveTodos, MessageRow } from "./MessageRow";
+import { MantaLoader } from "./MantaLoader";
 import { QuestionCard } from "./Cards";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
@@ -112,6 +112,24 @@ export function LoadEarlier({
   );
 }
 
+// The live "working" indicator (BET-677). A constant-height row at the tail of
+// the transcript that is ALWAYS rendered and toggles `visibility` instead of
+// mounting/unmounting — so flipping `running` on send never reflows the
+// reading column (the exact reflow the deleted pre-BET-664 indicator caused).
+// The slot stays 28px whether a turn is in flight or not.
+export function WorkingIndicator({ running }: { running: boolean }) {
+  return (
+    <div
+      className="manta-working-indicator flex items-center gap-2 shrink-0"
+      style={{ height: 28, visibility: running ? "visible" : "hidden" }}
+      aria-hidden={!running}
+    >
+      <MantaLoader />
+      <span className="text-text-faint text-xs">Working…</span>
+    </div>
+  );
+}
+
 export type TranscriptProps = {
   messages: OpencodeMessage[];
   scrollRef: React.RefObject<HTMLDivElement>;
@@ -186,10 +204,6 @@ export function Transcript({
   );
 
   return (
-    // Wrap in reducedMotion="user" so framer-motion disables every chat entry
-    // animation for users who prefer reduced motion — the library-native
-    // replacement for the old `prefers-reduced-motion` CSS blocks.
-    <MotionConfig reducedMotion="user">
     <div
       ref={scrollRef}
       className="flex-1 overflow-y-auto overflow-x-hidden"
@@ -271,6 +285,12 @@ export function Transcript({
                   />
                 );
               })}
+              {/* The live working indicator (BET-677): always-rendered, */}
+              {/* constant-height row whose visibility tracks `running`. Placed */}
+              {/* at the transcript tail so it reads as part of the */}
+              {/* conversation; the reserved 28px slot means toggling running */}
+              {/* never shifts the reading column. */}
+              <WorkingIndicator running={running} />
               {/* The todo checklist — rendered INSIDE the scroll container at */}
               {/* the tail of the transcript, so it scrolls with the rest of */}
               {/* the chat instead of sitting in a shrink-0 row above the */}
@@ -319,6 +339,5 @@ export function Transcript({
         </ErrorBoundary>
       </TaskContext.Provider>
     </div>
-    </MotionConfig>
   );
 }

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -121,7 +121,14 @@ export function WorkingIndicator({ running }: { running: boolean }) {
   return (
     <div
       className="manta-working-indicator flex items-center gap-2 shrink-0"
-      style={{ height: 28, visibility: running ? "visible" : "hidden" }}
+      style={{
+        height: 28,
+        // Sit flush under the last message: cancel the transcript column's
+        // inter-row `--turn-gap` so the reserved idle slot is EXACTLY its own
+        // 28px, not 28px + the turn gap (a stray extra band when idle).
+        marginTop: "calc(var(--turn-gap) * -1)",
+        visibility: running ? "visible" : "hidden",
+      }}
       aria-hidden={!running}
     >
       <MantaLoader />

--- a/src/renderer/WorkingIndicator.test.tsx
+++ b/src/renderer/WorkingIndicator.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+//
+// Component tests for WorkingIndicator (BET-677). The requirement is the
+// zero-reflow contract: the row is ALWAYS rendered at a constant height and
+// only toggles `visibility`, so flipping `running` on send never resizes the
+// transcript. We assert the style/class, not pixels.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { WorkingIndicator } from "./Transcript";
+
+describe("WorkingIndicator", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function row(): HTMLElement {
+    const el = h!.container.querySelector(".manta-working-indicator") as HTMLElement;
+    expect(el).toBeTruthy();
+    return el;
+  }
+
+  it("keeps a constant 28px height whether running or idle", () => {
+    h = mount(<WorkingIndicator running />);
+    expect(row().style.height).toBe("28px");
+    h.unmount();
+    h = mount(<WorkingIndicator running={false} />);
+    expect(row().style.height).toBe("28px");
+  });
+
+  it("is visible while running", () => {
+    h = mount(<WorkingIndicator running />);
+    expect(row().style.visibility).toBe("visible");
+  });
+
+  it("toggles to hidden when idle, still allocated in layout", () => {
+    h = mount(<WorkingIndicator running={false} />);
+    expect(row().style.visibility).toBe("hidden");
+    // Height stays reserved — hidden, not removed — so there is no reflow.
+    expect(row().style.height).toBe("28px");
+  });
+
+  it("shows the Working… label and a loader", () => {
+    h = mount(<WorkingIndicator running />);
+    expect(h!.text()).toContain("Working…");
+    expect(h!.container.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/src/renderer/components/CardMount.test.tsx
+++ b/src/renderer/components/CardMount.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// Component tests for CardMount (BET-677) — the single shared mount/unmount
+// animation for composer-stack cards. The contract: it renders its children
+// while `show` is true, animates out, and finally removes them from the tree
+// after the exit (so no card ever lingers). The `.shrink`-free motion.div that
+// wraps them must set `overflow: hidden` to keep the height animation from
+// leaking.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
+import { mount, type Harness } from "../testHarness";
+import { CardMount } from "./CardMount";
+
+describe("CardMount", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders children while show is true", () => {
+    h = mount(
+      <CardMount show k="perm">
+        <div>card body</div>
+      </CardMount>,
+    );
+    expect(h.text()).toContain("card body");
+  });
+
+  it("renders nothing when show is false", () => {
+    h = mount(
+      <CardMount show={false} k="perm">
+        <div>card body</div>
+      </CardMount>,
+    );
+    expect(h.text()).not.toContain("card body");
+  });
+
+  it("removes children from the tree after the exit animation completes", async () => {
+    h = mount(
+      <CardMount show k="perm">
+        <div>card body</div>
+      </CardMount>,
+    );
+    expect(h.text()).toContain("card body");
+    h.rerender(
+      <CardMount show={false} k="perm">
+        <div>card body</div>
+      </CardMount>,
+    );
+    // Let the 0.22s exit animation (height/opacity → 0) run to completion, then
+    // AnimatePresence drops the node. 400ms comfortably exceeds the duration.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+    expect(h.text()).not.toContain("card body");
+  });
+
+  it("wraps children in an overflow-hidden row so height animation stays contained", () => {
+    h = mount(
+      <CardMount show k="perm">
+        <div>card body</div>
+      </CardMount>,
+    );
+    // The only div wrapping children that this component controls carries the
+    // overflow:hidden inline style that makes the 0 → auto height tween smooth
+    // instead of bleeding content.
+    const wrapper = h.container.querySelector("div[style]") as HTMLElement | null;
+    expect(wrapper?.style.overflow).toBe("hidden");
+  });
+});

--- a/src/renderer/components/CardMount.tsx
+++ b/src/renderer/components/CardMount.tsx
@@ -1,0 +1,49 @@
+// ===== CardMount (BET-677) =====
+//
+// ONE shared mount/unmount animation for everything that appears and
+// disappears in the composer stack (permission / retry / compaction /
+// approval / schedules / secrets / webhooks / queued prompts / send-error)
+// and, via a sibling issue, tool-card expansion.
+//
+// Layout-shift-free by construction: mounting a card animates its height
+// 0 → auto (and opacity 0 → 1) instead of popping into the flow in one
+// frame, so the transcript and composer never jump. Unmounting reverses it
+// (height auto → 0) before the card is removed from the tree.
+//
+// `initial={false}` on <AnimatePresence> means the FIRST render of a card
+// shows it instantly with no entrance animation — only later show/hide
+// transitions animate, which is what "no reflow on load" wants. `key` is
+// stable per slot so React identifies each mount target across toggles.
+//
+// Deliberately generic: it owns no card-specific styling — a sibling issue
+// reuses it for tool-card expansion.
+
+import { motion, AnimatePresence } from "framer-motion";
+import type { ReactNode } from "react";
+
+export type CardMountProps = {
+  /** Whether the card is currently visible. */
+  show: boolean;
+  /** Stable identity for this mount slot (e.g. "permission"). */
+  k: string;
+  children: ReactNode;
+};
+
+export function CardMount({ show, k, children }: CardMountProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {show && (
+        <motion.div
+          key={k}
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: "auto", opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.22, ease: [0.25, 0.1, 0.25, 1] }}
+          style={{ overflow: "hidden" }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -136,7 +136,7 @@ html, body, #root {
    last child so it sits INLINE at the end of the text — a sibling element
    would break onto its own line after a block-level <p>. Nothing in the
    settled transcript carries a caret, and the entry animation itself is
-   reduced-motion-handled by MotionConfig reducedMotion="user" in Transcript. */
+   reduced-motion-handled by the app-root MotionConfig reducedMotion="user". */
 .manta-streaming > *:last-child::after {
   content: "";
   display: inline-block;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -90,35 +90,6 @@ html, body, #root {
   animation: onboardingFadeSlideIn 350ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
-/* Ambient transcript-refetch indicator (BET-251): the composer's top hairline
-   becomes a slow orange gradient sweeping L→R while the canonical transcript
-   syncs in the background (replaces the prior full-row loading card).
-   Border-only, no layout shift. Voice recording still takes visual priority
-   (red pulse) in InputArea. */
-.manta-loading-divider {
-  /* Paint a real 1px-high gradient line. A `border-top` with a transparent
-     color plus a background-image does NOT render — the content box is 0px
-     tall so the background has no surface to fill. Use an explicit height +
-     background instead so the orange sweep is actually visible. */
-  height: 1px;
-  background-image: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--accent) 15%, transparent),
-    color-mix(in srgb, var(--accent) 85%, transparent),
-    color-mix(in srgb, var(--accent) 15%, transparent)
-  );
-  background-size: 200% 100%;
-  background-repeat: no-repeat;
-  animation: manta-loading-divider-sweep 1.5s ease-in-out infinite;
-}
-@keyframes manta-loading-divider-sweep {
-  0%   { background-position: 0% 0; }
-  100% { background-position: 200% 0; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .manta-loading-divider { animation: none; background-position: 50% 0; }
-}
-
 /* Recording indicator (BET-416 §A). Voice recording is signalled by the
    composer box's own border — a fourth border treatment alongside resting /
    focus / error. The pulse animates ONLY the border colour, never the fill,


### PR DESCRIPTION
**BET-677 — Feel: zero layout shift — working indicator, overlay toasts, animated card mounts**

Renderer-only. `framer-motion` was already a dependency; no new packages.

Rebased onto current `origin/main` (`7f2b9bf4`) and reconciled a `Transcript.tsx` conflict with main's parallel `LoadEarlier` feature (both retained — `LoadEarlier` above the first row, this PR's `WorkingIndicator` tail below all messages).

### What changed
1. **`CardMount`** (`src/renderer/components/CardMount.tsx`) — one shared mount/unmount animation (height `0 ⇄ auto` + opacity, 0.22s, `initial={false}`). Deliberately generic (no card styling) for the sibling tool-card-expansion issue to reuse.
2. **ChatPanel** — every composer-stack conditional mount animates through `CardMount`: PermissionCard, RetryCard, CompactionCard, DelegateApprovalCard, ScheduledTasksCard, SecretsCard, WebhooksCard, queued-messages list, sendError banner. Stale `manta-loading-divider` comment removed.
3. **ToastStack → overlay:** `ToastStack` is **layout-neutral** — it owns only the per-toast framer-motion in/out animation (root is `pointer-events-none`, each toast `pointer-events-auto` so no surface loses clickability). The overlay framing lives in **ChatPanel**: a `relative` composer wrapper anchors the overlay to the composer's **real top edge** (`bottom: 100%`), so toasts hover just above the box however tall the input grows — and never affect layout. The Settings dialog keeps its own pre-existing `fixed` bottom wrapper.
4. **WorkingIndicator restored** — an always-rendered `28px` transcript-tail row toggling `visibility` (never mounts/unmounts), `MantaLoader` + `Working…`. Reserved slot is exactly its own 28px (turn-gap canceled). Send→first-token never dead air, never reflows.
5. **Composer border** `transition-colors duration-200`.
6. **Deleted** dead `.manta-loading-divider` CSS + its stale ChatPanel comment.
7. **Reduced motion** moved to the app root (`MotionConfig` wraps App), transcript-local duplicate removed.

### Tests
`CardMount` (render / remove-after-exit / overflow-hidden), `WorkingIndicator` (constant 28px + visibility toggle).

Follow-up filed: **BET-684** (parked, doc-only — drop the now-stale `manta-loading-divider` mentions from `AGENTS.md`).

**Verification results:**
- PR branch (`multica/BET-677-layout-shift` @ `4bd72f4e`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0. Renderer 2224 pass / 0 fail / 7 skip; server 1523 pass / 0 fail.
- Base: rebased onto `origin/main @ 7f2b9bf4`. **Conclusion: 0 new failures.**
