### PR TITLE
feat(ios) BET-668: single-writer stream merge, failed-send surfacing, main-queue delivery

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		959894A87F301CC717772BD3 /* ChatLoadingSkeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */; };
 		95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D71EC917661085ED10E0867 /* FolderPickerView.swift */; };
 		96F128D3EBC0D1432F603FDB /* ComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938AB4A14437119280E1B53A /* ComposerTests.swift */; };
+		2A3B4C5D6E7F8192A4B5C6D7 /* ChatStreamMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B4C5 /* ChatStreamMergeTests.swift */; };
 		98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */; };
 		9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
@@ -173,6 +174,7 @@
 		BA460F4E709501AE6C65D08A /* ChatOverflowSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowSheet.swift; sourceTree = "<group>"; };
 		C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineTextView.swift; sourceTree = "<group>"; };
 		C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708192A3B4C5 /* ChatStreamMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamMergeTests.swift; sourceTree = "<group>"; };
 		C42691C89906181C99929354 /* ComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerView.swift; sourceTree = "<group>"; };
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 			isa = PBXGroup;
 			children = (
 				C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */,
+				1A2B3C4D5E6F708192A3B4C5 /* ChatStreamMergeTests.swift */,
 				938AB4A14437119280E1B53A /* ComposerTests.swift */,
 				9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */,
 				989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */,
@@ -502,6 +505,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */,
+				2A3B4C5D6E7F8192A4B5C6D7 /* ChatStreamMergeTests.swift in Sources */,
 				96F128D3EBC0D1432F603FDB /* ComposerTests.swift in Sources */,
 				5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */,
 				0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */,

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -52,7 +52,7 @@ final class ChatModelStore: ObservableObject {
         self.loadFailed = catalog.loadFailed
         self.loaded = catalog.loaded
         catalog.objectWillChange
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.mirrorCatalog() }
             .store(in: &cancellables)
     }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -88,7 +88,12 @@ enum ChatStreamMerge {
         // without one (e.g. a context frame) must NOT flip the value back to
         // false — doing so used to reset `runningSince`, re-mint the tail id,
         // and flash the running row at every such frame.
-        if let r = frameRunning { s.running = r }
+        if let r = frameRunning {
+            s.running = r
+            // A real running frame starts a turn, so any completion flag left
+            // over from a previous turn no longer applies.
+            if r { s.turnComplete = false }
+        }
         if let t = frameTurnComplete { s.turnComplete = t }
 
         // Questions: filter incoming against the tombstone set. A tombstoned
@@ -103,12 +108,14 @@ enum ChatStreamMerge {
         // (no questions payload this frame: current questions + tombstones are
         //  left alone — nothing to clobber.)
 
-        // Tail identity: minted at most once per turn, reset ONLY on the
-        // turnComplete edge — never by a bare `running == false` write.
+        // Tail identity is minted at most once per turn and reset ONLY on the
+        // turnComplete EDGE carried by THIS frame (`frameTurnComplete`) — never
+        // by a bare `running == false` write, and never by a STALE accumulated
+        // turnComplete left over from a previous turn.
         var mintsNewTail = false
-        if s.turnComplete {
+        if frameTurnComplete == true {
             s.streamingTailID = ""
-        } else if s.running, s.streamingTailID.isEmpty {
+        } else if frameRunning == true, s.streamingTailID.isEmpty {
             mintsNewTail = true
         }
 
@@ -119,14 +126,57 @@ enum ChatStreamMerge {
     /// back so the UI doesn't sit on a forever-spinner. The user's prompt is
     /// NOT lost — `send()` echoed it optimistically into the transcript and
     /// the caller restores the input text — so this only clears the fake
-    /// "in progress" flags, leaving the transcript and question tombstones
-    /// untouched.
+    /// "in progress" flags, leaving the question tombstones untouched.
     static func afterSendFailure(to state: ChatStreamTurnState) -> ChatStreamTurnState {
         var s = state
         s.running = false
         s.turnComplete = false
         s.streamingTailID = ""
         return s
+    }
+}
+
+/// The per-frame turn-state fields a stream frame actually carried, derived
+/// from the frame's routing `sub` and whether it targeted this session. Used
+/// to separate the frame's DELTA from the accumulated `sessionStates` snapshot
+/// (which is sticky across turns and so cannot express "this frame carried no
+/// running field").
+struct ChatStreamFrameFields: Equatable {
+    var running: Bool?
+    var turnComplete: Bool?
+    var questions: [QuestionRequest]?
+}
+
+enum ChatStreamDelta {
+    /// Derived per-frame turn fields for the most recently applied stream
+    /// frame, given the accumulated snapshot's current values. `stateRunning`/
+    /// `stateTurnComplete`/`stateQuestions` are the snapshot values AFTER the
+    /// frame was routed, so for a carrying `sub` they equal exactly what THIS
+    /// frame delivered.
+    ///
+    /// Any non-carrying frame — or a frame aimed at a different session — yields
+    /// all-nil ("no opinion"): the merge then leaves the optimistic local values
+    /// alone instead of clobbering them with a sticky accumulated value.
+    static func turnFields(
+        sessionIsTarget: Bool,
+        sub: String?,
+        stateRunning: Bool?,
+        stateTurnComplete: Bool?,
+        stateQuestions: [QuestionRequest]?
+    ) -> ChatStreamFrameFields {
+        guard sessionIsTarget else {
+            return ChatStreamFrameFields(running: nil, turnComplete: nil, questions: nil)
+        }
+        switch sub {
+        case "running", "turnComplete":
+            // Both carry a running value in the accumulated snapshot; only
+            // `turnComplete` also carries the completion flag.
+            return ChatStreamFrameFields(running: stateRunning, turnComplete: sub == "turnComplete" ? stateTurnComplete : nil, questions: nil)
+        case "questions":
+            return ChatStreamFrameFields(running: nil, turnComplete: nil, questions: stateQuestions)
+        default:
+            return ChatStreamFrameFields(running: nil, turnComplete: nil, questions: nil)
+        }
     }
 }
 
@@ -321,10 +371,26 @@ final class ChatSessionStore: ObservableObject {
         // The turn-state fields (`running`, `turnComplete`, questions, tail
         // identity) have TWO writers — optimistic local mutations and the
         // stream — so they go through the pure single-writer merge.
+        //
+        // IMPORTANT: the merge must see what THIS frame actually carried, not
+        // the accumulated `sessionStates` snapshot (which is sticky across
+        // turns and would let an unrelated frame clobber an optimistic value).
+        // `lastStreamFrame` is that per-frame delta. It is only trusted when
+        // the frame targeted THIS session — the `$sessionStates` sink fires
+        // for every session's change, and replaying a stale sub from another
+        // session would be wrong.
+        let stamp = eventStore.lastStreamFrame
+        let fields = ChatStreamDelta.turnFields(
+            sessionIsTarget: stamp?.sessionId == sessionId,
+            sub: stamp?.sub,
+            stateRunning: s.running,
+            stateTurnComplete: s.turnComplete,
+            stateQuestions: s.questions?.questions
+        )
         let result = ChatStreamMerge.applying(
-            frameRunning: s.running,
-            frameTurnComplete: s.turnComplete,
-            frameQuestions: s.questions?.questions,
+            frameRunning: fields.running,
+            frameTurnComplete: fields.turnComplete,
+            frameQuestions: fields.questions,
             to: ChatStreamTurnState(
                 running: running,
                 turnComplete: turnComplete,
@@ -603,7 +669,9 @@ final class ChatSessionStore: ObservableObject {
         // the canonical refetch replaces this block), but without the echo the
         // screen sits completely unchanged after a send, which reads as "the
         // send did nothing".
+        var optimisticUserIndex: Int?
         if !text.isEmpty {
+            optimisticUserIndex = transcript.count
             transcript.append(.user(text, at: Date()))
             rebuildBlocks()
         }
@@ -637,6 +705,16 @@ final class ChatSessionStore: ObservableObject {
             running = rolledBack.running
             turnComplete = rolledBack.turnComplete
             streamingTailID = rolledBack.streamingTailID
+            // Remove THIS send's optimistic echo: the box never received the
+            // message, so it belongs back in the composer input (which the
+            // caller restores), not standing in the transcript as if sent.
+            // `fetchTranscript` can replace the whole array, so guard on the
+            // captured index still holding our echo before removing it.
+            if let idx = optimisticUserIndex, idx < transcript.count,
+               case .user(let echoed, _) = transcript[idx], echoed == text {
+                transcript.remove(at: idx)
+                rebuildBlocks()
+            }
             return false
         }
     }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -69,53 +69,33 @@ enum ChatStreamMerge {
         var mintsNewTail: Bool
     }
 
-    /// Apply one interpreted-stream frame's fields to the turn state.
+    /// Apply the per-frame lifecycle facts of one interpreted-stream frame to
+    /// the turn state.
     ///
-    /// - `frameRunning` / `frameTurnComplete`: nil means the frame carries no
-    ///   opinion for that field; the current value (including an optimistic
-    ///   one) is left alone.
-    /// - `frameQuestions`: nil means the frame carries no questions payload;
-    ///   the current questions are left alone.
+    /// - `frameTurnComplete`: non-nil ONLY when THIS frame carried a completion
+    ///   flag (a genuine `turnComplete` frame). This is the only thing that
+    ///   resets the streaming tail — never a bare `running == false` write and
+    ///   never a STALE accumulated completion left over from a previous turn.
+    /// - `frameStartedRunning`: true when THIS frame began a turn (a carrying
+    ///   `running` frame whose value was true) — clears any stale completion
+    ///   flag and mints a fresh tail id if none exists yet.
+    ///
+    /// `running` and `questions` are NOT touched here: they are read straight
+    /// from the accumulated snapshot in the store (the snapshot is authoritative
+    /// for both once an optimistic value is accounted for).
     static func applying(
-        frameRunning: Bool?,
         frameTurnComplete: Bool?,
-        frameQuestions: [QuestionRequest]?,
+        frameStartedRunning: Bool,
         to state: ChatStreamTurnState
     ) -> Result {
         var s = state
-
-        // `running` is written ONLY when the frame carries the field. A frame
-        // without one (e.g. a context frame) must NOT flip the value back to
-        // false — doing so used to reset `runningSince`, re-mint the tail id,
-        // and flash the running row at every such frame.
-        if let r = frameRunning {
-            s.running = r
-            // A real running frame starts a turn, so any completion flag left
-            // over from a previous turn no longer applies.
-            if r { s.turnComplete = false }
-        }
         if let t = frameTurnComplete { s.turnComplete = t }
+        if frameStartedRunning { s.turnComplete = false }
 
-        // Questions: filter incoming against the tombstone set. A tombstoned
-        // id is held back until the box actually stops publishing it; once an
-        // incoming payload no longer contains the id, the box has caught up
-        // and that tombstone is dropped.
-        if let incoming = frameQuestions {
-            let incomingIDs = Set(incoming.map(\.id))
-            s.locallyAnsweredQuestionIDs.formIntersection(incomingIDs)
-            s.questions = incoming.filter { !s.locallyAnsweredQuestionIDs.contains($0.id) }
-        }
-        // (no questions payload this frame: current questions + tombstones are
-        //  left alone — nothing to clobber.)
-
-        // Tail identity is minted at most once per turn and reset ONLY on the
-        // turnComplete EDGE carried by THIS frame (`frameTurnComplete`) — never
-        // by a bare `running == false` write, and never by a STALE accumulated
-        // turnComplete left over from a previous turn.
         var mintsNewTail = false
         if frameTurnComplete == true {
             s.streamingTailID = ""
-        } else if frameRunning == true, s.streamingTailID.isEmpty {
+        } else if frameStartedRunning, s.streamingTailID.isEmpty {
             mintsNewTail = true
         }
 
@@ -124,9 +104,8 @@ enum ChatStreamMerge {
 
     /// State after a FAILED `send()`: the optimistic running/tail is rolled
     /// back so the UI doesn't sit on a forever-spinner. The user's prompt is
-    /// NOT lost — `send()` echoed it optimistically into the transcript and
-    /// the caller restores the input text — so this only clears the fake
-    /// "in progress" flags, leaving the question tombstones untouched.
+    /// NOT lost — the caller restores the input text — so this only clears the
+    /// fake "in progress" flags, leaving the question tombstones untouched.
     static func afterSendFailure(to state: ChatStreamTurnState) -> ChatStreamTurnState {
         var s = state
         s.running = false
@@ -136,46 +115,32 @@ enum ChatStreamMerge {
     }
 }
 
-/// The per-frame turn-state fields a stream frame actually carried, derived
-/// from the frame's routing `sub` and whether it targeted this session. Used
-/// to separate the frame's DELTA from the accumulated `sessionStates` snapshot
-/// (which is sticky across turns and so cannot express "this frame carried no
-/// running field").
-struct ChatStreamFrameFields: Equatable {
-    var running: Bool?
-    var turnComplete: Bool?
-    var questions: [QuestionRequest]?
+/// Which per-frame lifecycle facts the most recently applied stream frame
+/// carried, derived from the routing `sub` and whether it targeted this
+/// session. Used to separate the frame's DELTA from the accumulated snapshot
+/// (which is sticky across turns).
+struct ChatStreamFrameCarried: Equatable {
+    /// True when this frame carried a running value (the `running` or
+    /// `turnComplete` sub).
+    var running: Bool
+    /// True when this frame carried a completion flag (the `turnComplete` sub).
+    var turnComplete: Bool
 }
 
 enum ChatStreamDelta {
-    /// Derived per-frame turn fields for the most recently applied stream
-    /// frame, given the accumulated snapshot's current values. `stateRunning`/
-    /// `stateTurnComplete`/`stateQuestions` are the snapshot values AFTER the
-    /// frame was routed, so for a carrying `sub` they equal exactly what THIS
-    /// frame delivered.
-    ///
-    /// Any non-carrying frame — or a frame aimed at a different session — yields
-    /// all-nil ("no opinion"): the merge then leaves the optimistic local values
-    /// alone instead of clobbering them with a sticky accumulated value.
-    static func turnFields(
-        sessionIsTarget: Bool,
-        sub: String?,
-        stateRunning: Bool?,
-        stateTurnComplete: Bool?,
-        stateQuestions: [QuestionRequest]?
-    ) -> ChatStreamFrameFields {
+    /// The carried facts of the most recently applied frame. A non-carrying
+    /// sub, or a frame aimed at a different session, yields neither flag —
+    /// so a republish that isn't a genuine turn-state frame (e.g. a retire or
+    /// a foreign-session frame) can't apply a stale value.
+    static func carried(sessionIsTarget: Bool, sub: String?) -> ChatStreamFrameCarried {
         guard sessionIsTarget else {
-            return ChatStreamFrameFields(running: nil, turnComplete: nil, questions: nil)
+            return ChatStreamFrameCarried(running: false, turnComplete: false)
         }
         switch sub {
         case "running", "turnComplete":
-            // Both carry a running value in the accumulated snapshot; only
-            // `turnComplete` also carries the completion flag.
-            return ChatStreamFrameFields(running: stateRunning, turnComplete: sub == "turnComplete" ? stateTurnComplete : nil, questions: nil)
-        case "questions":
-            return ChatStreamFrameFields(running: nil, turnComplete: nil, questions: stateQuestions)
+            return ChatStreamFrameCarried(running: true, turnComplete: sub == "turnComplete")
         default:
-            return ChatStreamFrameFields(running: nil, turnComplete: nil, questions: nil)
+            return ChatStreamFrameCarried(running: false, turnComplete: false)
         }
     }
 }
@@ -241,12 +206,17 @@ final class ChatSessionStore: ObservableObject {
     /// turn. The tail's TEXT grows every delta, so a content-derived id would
     /// change each time and thrash TiledView; this id doesn't. Reset when the
     /// turn ends and the tail is absorbed into the canonical transcript.
-    private var streamingTailID: String = ""
+    private(set) var streamingTailID: String = ""
     /// Question ids the user answered/rejected on-device. The incoming stream
     /// keeps publishing an answered question until the box catches up, so this
     /// tombstone set filters it out locally in the meantime (BET-668); an id
     /// leaves the set once the box stops publishing it.
     private var locallyAnsweredQuestionIDs: Set<String> = []
+    /// True between `send()` and the box's first running acknowledgment. While
+    /// set, the snapshot's accumulated `running` (still the previous turn's
+    /// `false`) must not clobber the optimistic `true` — but once the box
+    /// reports running at all, the snapshot is authoritative.
+    private var optimisticRunning = false
     private var didRunOnce = false
     private var lastRunning: Bool?
     private var lastComplete: Bool?
@@ -368,29 +338,43 @@ final class ChatSessionStore: ObservableObject {
         todos = s.todos
         subagents = s.subagents
 
-        // The turn-state fields (`running`, `turnComplete`, questions, tail
-        // identity) have TWO writers — optimistic local mutations and the
-        // stream — so they go through the pure single-writer merge.
-        //
-        // IMPORTANT: the merge must see what THIS frame actually carried, not
-        // the accumulated `sessionStates` snapshot (which is sticky across
-        // turns and would let an unrelated frame clobber an optimistic value).
-        // `lastStreamFrame` is that per-frame delta. It is only trusted when
-        // the frame targeted THIS session — the `$sessionStates` sink fires
-        // for every session's change, and replaying a stale sub from another
-        // session would be wrong.
+        // Which frame (if any) just changed this session's stream state. The
+        // `$sessionStates` sink fires on every republish, so the stamp only
+        // counts when it names THIS session; retirement nulls it so a stale
+        // frame never replays over optimistic state.
         let stamp = eventStore.lastStreamFrame
-        let fields = ChatStreamDelta.turnFields(
-            sessionIsTarget: stamp?.sessionId == sessionId,
-            sub: stamp?.sub,
-            stateRunning: s.running,
-            stateTurnComplete: s.turnComplete,
-            stateQuestions: s.questions?.questions
-        )
+        let carried = ChatStreamDelta.carried(sessionIsTarget: stamp?.sessionId == sessionId, sub: stamp?.sub)
+
+        // --- running: the accumulated snapshot is authoritative, seeded when
+        // a session is opened (a mid-turn session shows its working indicator),
+        // EXCEPT the optimistic `true` `send()` just set — which the snapshot's
+        // stale previous-turn `false` must not clobber while the box hasn't yet
+        // confirmed. Reading the snapshot (not a per-frame stamp) also makes
+        // this robust to frames that coalesce between publishes.
+        if optimisticRunning, (carried.running || s.running == true) {
+            optimisticRunning = false
+        }
+        running = optimisticRunning ? true : (s.running == true)
+
+        // --- questions: the accumulated snapshot's pending questions, filtered
+        // against the tombstone set (so an answered/rejected card is held until
+        // the box catches up) and aged only when an actual payload exists.
+        // Seeded on open — a session with a question already waiting shows its
+        // card immediately.
+        if let questionPayload = s.questions {
+            let incoming = questionPayload.questions
+            locallyAnsweredQuestionIDs.formIntersection(Set(incoming.map(\.id)))
+            questions = incoming.filter { !locallyAnsweredQuestionIDs.contains($0.id) }
+        }
+
+        // --- the turn lifecycle (`turnComplete` flag + streaming-tail identity)
+        // is per-frame: only a genuine `turnComplete` frame resets the tail, and
+        // only a genuine `running`-true frame starts a fresh turn. `running` and
+        // `questions` are NOT touched by this merge (handled above).
+        let frameStartedRunning = carried.running && (s.running == true)
         let result = ChatStreamMerge.applying(
-            frameRunning: fields.running,
-            frameTurnComplete: fields.turnComplete,
-            frameQuestions: fields.questions,
+            frameTurnComplete: carried.turnComplete ? s.turnComplete : nil,
+            frameStartedRunning: frameStartedRunning,
             to: ChatStreamTurnState(
                 running: running,
                 turnComplete: turnComplete,
@@ -399,21 +383,15 @@ final class ChatSessionStore: ObservableObject {
                 questions: questions
             )
         )
-        let merged = result.state
-        running = merged.running
-        turnComplete = merged.turnComplete
-        questions = merged.questions
-        locallyAnsweredQuestionIDs = merged.locallyAnsweredQuestionIDs
-        streamingTailID = merged.streamingTailID
-        // A fresh tail is minted exactly once per turn (first running
-        // false->true edge that finds no existing tail).
+        turnComplete = result.state.turnComplete
+        streamingTailID = result.state.streamingTailID
+        // A fresh tail id is minted exactly once per turn (when the turn begins
+        // running with no existing tail).
         if result.mintsNewTail {
             streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
         }
-        // runningSince tracks the turn that's running for the header timer;
-        // it follows the running flag (started when running, cleared when the
-        // turn stops — e.g. on turnComplete).
-        if merged.running {
+        // runningSince tracks the turn that's running for the header timer.
+        if running {
             if runningSince == nil { runningSince = Date() }
         } else {
             runningSince = nil
@@ -676,6 +654,7 @@ final class ChatSessionStore: ObservableObject {
             rebuildBlocks()
         }
         running = true
+        optimisticRunning = true
         turnComplete = false
         if runningSince == nil {
             runningSince = Date()
@@ -695,6 +674,7 @@ final class ChatSessionStore: ObservableObject {
             // Surface the failure instead of swallowing it: stop the running
             // state and clear the optimistic tail so the spinner doesn't stay
             // on forever, and let the caller restore the lost message.
+            optimisticRunning = false
             let rolledBack = ChatStreamMerge.afterSendFailure(to: ChatStreamTurnState(
                 running: running,
                 turnComplete: turnComplete,

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -28,6 +28,108 @@ import MessagingUI
 // handlers (owned by SessionListStore) are never clobbered.
 // ===========================================================================
 
+// ===========================================================================
+// Single-writer stream merge (BET-668).
+//
+// The chat screen has TWO writers for the same turn state — the optimistic
+// LOCAL updates (`send()`, `replyQuestion`/`rejectQuestion`) and the incoming
+// interpreted-stream frames — and the stream frame used to unconditionally
+// clobber the optimistic value. All the merge decisions below are PURE so
+// they are unit-testable; the store applies the returned state.
+// ===========================================================================
+
+/// The subset of turn state the stream-merge decisions own.
+struct ChatStreamTurnState: Equatable {
+    var running: Bool
+    var turnComplete: Bool
+    var streamingTailID: String
+    var locallyAnsweredQuestionIDs: Set<String>
+    var questions: [QuestionRequest]
+
+    init(
+        running: Bool = false,
+        turnComplete: Bool = false,
+        streamingTailID: String = "",
+        locallyAnsweredQuestionIDs: Set<String> = [],
+        questions: [QuestionRequest] = []
+    ) {
+        self.running = running
+        self.turnComplete = turnComplete
+        self.streamingTailID = streamingTailID
+        self.locallyAnsweredQuestionIDs = locallyAnsweredQuestionIDs
+        self.questions = questions
+    }
+}
+
+enum ChatStreamMerge {
+    struct Result: Equatable {
+        var state: ChatStreamTurnState
+        /// True when a NEW streaming-tail id must be minted (the first running
+        /// false->true edge of a turn). The store mints it (it needs a UUID).
+        var mintsNewTail: Bool
+    }
+
+    /// Apply one interpreted-stream frame's fields to the turn state.
+    ///
+    /// - `frameRunning` / `frameTurnComplete`: nil means the frame carries no
+    ///   opinion for that field; the current value (including an optimistic
+    ///   one) is left alone.
+    /// - `frameQuestions`: nil means the frame carries no questions payload;
+    ///   the current questions are left alone.
+    static func applying(
+        frameRunning: Bool?,
+        frameTurnComplete: Bool?,
+        frameQuestions: [QuestionRequest]?,
+        to state: ChatStreamTurnState
+    ) -> Result {
+        var s = state
+
+        // `running` is written ONLY when the frame carries the field. A frame
+        // without one (e.g. a context frame) must NOT flip the value back to
+        // false — doing so used to reset `runningSince`, re-mint the tail id,
+        // and flash the running row at every such frame.
+        if let r = frameRunning { s.running = r }
+        if let t = frameTurnComplete { s.turnComplete = t }
+
+        // Questions: filter incoming against the tombstone set. A tombstoned
+        // id is held back until the box actually stops publishing it; once an
+        // incoming payload no longer contains the id, the box has caught up
+        // and that tombstone is dropped.
+        if let incoming = frameQuestions {
+            let incomingIDs = Set(incoming.map(\.id))
+            s.locallyAnsweredQuestionIDs.formIntersection(incomingIDs)
+            s.questions = incoming.filter { !s.locallyAnsweredQuestionIDs.contains($0.id) }
+        }
+        // (no questions payload this frame: current questions + tombstones are
+        //  left alone — nothing to clobber.)
+
+        // Tail identity: minted at most once per turn, reset ONLY on the
+        // turnComplete edge — never by a bare `running == false` write.
+        var mintsNewTail = false
+        if s.turnComplete {
+            s.streamingTailID = ""
+        } else if s.running, s.streamingTailID.isEmpty {
+            mintsNewTail = true
+        }
+
+        return Result(state: s, mintsNewTail: mintsNewTail)
+    }
+
+    /// State after a FAILED `send()`: the optimistic running/tail is rolled
+    /// back so the UI doesn't sit on a forever-spinner. The user's prompt is
+    /// NOT lost — `send()` echoed it optimistically into the transcript and
+    /// the caller restores the input text — so this only clears the fake
+    /// "in progress" flags, leaving the transcript and question tombstones
+    /// untouched.
+    static func afterSendFailure(to state: ChatStreamTurnState) -> ChatStreamTurnState {
+        var s = state
+        s.running = false
+        s.turnComplete = false
+        s.streamingTailID = ""
+        return s
+    }
+}
+
 @MainActor
 final class ChatSessionStore: ObservableObject {
 
@@ -90,6 +192,11 @@ final class ChatSessionStore: ObservableObject {
     /// change each time and thrash TiledView; this id doesn't. Reset when the
     /// turn ends and the tail is absorbed into the canonical transcript.
     private var streamingTailID: String = ""
+    /// Question ids the user answered/rejected on-device. The incoming stream
+    /// keeps publishing an answered question until the box catches up, so this
+    /// tombstone set filters it out locally in the meantime (BET-668); an id
+    /// leaves the set once the box stops publishing it.
+    private var locallyAnsweredQuestionIDs: Set<String> = []
     private var didRunOnce = false
     private var lastRunning: Bool?
     private var lastComplete: Bool?
@@ -120,12 +227,12 @@ final class ChatSessionStore: ObservableObject {
         self.isReadOnly = isReadOnly
 
         eventStore.$sessionStates
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.applyStreamState() }
             .store(in: &cancellables)
 
         eventStore.$connectionState
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in self?.handleConnection(state) }
             .store(in: &cancellables)
     }
@@ -202,23 +309,48 @@ final class ChatSessionStore: ObservableObject {
 
         inProgressText = s.liveText
 
-        running = s.running == true
-        turnComplete = s.turnComplete == true
+        // Fields that are copied straight through from the latest frame (the
+        // stream is the single writer for these — no optimistic value to
+        // protect).
         context = s.context
         cache = s.cache
         truncation = s.truncation
         todos = s.todos
-        questions = s.questions?.questions ?? []
         subagents = s.subagents
 
-        // Track running-this-turn for the header timer, and mint the streaming
-        // tail's stable id exactly once per turn.
-        if running && runningSince == nil {
-            runningSince = Date()
+        // The turn-state fields (`running`, `turnComplete`, questions, tail
+        // identity) have TWO writers — optimistic local mutations and the
+        // stream — so they go through the pure single-writer merge.
+        let result = ChatStreamMerge.applying(
+            frameRunning: s.running,
+            frameTurnComplete: s.turnComplete,
+            frameQuestions: s.questions?.questions,
+            to: ChatStreamTurnState(
+                running: running,
+                turnComplete: turnComplete,
+                streamingTailID: streamingTailID,
+                locallyAnsweredQuestionIDs: locallyAnsweredQuestionIDs,
+                questions: questions
+            )
+        )
+        let merged = result.state
+        running = merged.running
+        turnComplete = merged.turnComplete
+        questions = merged.questions
+        locallyAnsweredQuestionIDs = merged.locallyAnsweredQuestionIDs
+        streamingTailID = merged.streamingTailID
+        // A fresh tail is minted exactly once per turn (first running
+        // false->true edge that finds no existing tail).
+        if result.mintsNewTail {
             streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
-        } else if !running {
+        }
+        // runningSince tracks the turn that's running for the header timer;
+        // it follows the running flag (started when running, cleared when the
+        // turn stops — e.g. on turnComplete).
+        if merged.running {
+            if runningSince == nil { runningSince = Date() }
+        } else {
             runningSince = nil
-            streamingTailID = ""
         }
 
         // Register a store for any subagent that has a child session id, so the
@@ -417,14 +549,17 @@ final class ChatSessionStore: ObservableObject {
             questions.removeAll { $0.id == request.id }
             return
         }
-        // Drop the card optimistically; restore it on failure so a real send
-        // error doesn't silently leave the question gone while the box stays
-        // blocked on it ("can't send messages").
+        // Drop the card optimistically and tombstone its id so the incoming
+        // stream can't flash it back before the box catches up; restore both
+        // on failure so a real send error doesn't silently leave the question
+        // gone while the box stays blocked on it ("can't send messages").
         questions.removeAll { $0.id == request.id }
+        locallyAnsweredQuestionIDs.insert(request.id)
         Task {
             do {
                 try await api.questionReply(requestId: requestId, answers: answers, sessionId: sessionId)
             } catch {
+                locallyAnsweredQuestionIDs.remove(request.id)
                 if !questions.contains(where: { $0.id == request.id }) {
                     questions.append(request)
                 }
@@ -438,10 +573,12 @@ final class ChatSessionStore: ObservableObject {
             return
         }
         questions.removeAll { $0.id == request.id }
+        locallyAnsweredQuestionIDs.insert(request.id)
         Task {
             do {
                 try await api.questionReject(requestId: requestId, sessionId: sessionId)
             } catch {
+                locallyAnsweredQuestionIDs.remove(request.id)
                 if !questions.contains(where: { $0.id == request.id }) {
                     questions.append(request)
                 }
@@ -454,7 +591,13 @@ final class ChatSessionStore: ObservableObject {
     /// Send a prompt for this session. `text` needs no trimming here (the
     /// composer trims); attachments + model are optional and flow through the
     /// unchanged `opencode:prompt` surface.
-    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?) {
+    ///
+    /// Returns `true` when the box accepted the prompt, `false` when the RPC
+    /// failed. On failure the optimistic running/tail state is rolled back so
+    /// the UI doesn't sit on a forever-spinner, and the caller is told so it
+    /// can restore the user's typed text.
+    @discardableResult
+    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?) async -> Bool {
         // Echo the message straight into the transcript and assume the turn is
         // running. The box confirms both within a second (running frame, then
         // the canonical refetch replaces this block), but without the echo the
@@ -472,13 +615,29 @@ final class ChatSessionStore: ObservableObject {
             // mint this from), so mint the streaming tail's stable id here too.
             streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
         }
-        Task {
-            try? await api.sendPrompt(SendPromptInput(
+        do {
+            try await api.sendPrompt(SendPromptInput(
                 sessionId: sessionId,
                 text: text,
                 model: model,
                 attachments: attachments.isEmpty ? nil : attachments
             ))
+            return true
+        } catch {
+            // Surface the failure instead of swallowing it: stop the running
+            // state and clear the optimistic tail so the spinner doesn't stay
+            // on forever, and let the caller restore the lost message.
+            let rolledBack = ChatStreamMerge.afterSendFailure(to: ChatStreamTurnState(
+                running: running,
+                turnComplete: turnComplete,
+                streamingTailID: streamingTailID,
+                locallyAnsweredQuestionIDs: locallyAnsweredQuestionIDs,
+                questions: questions
+            ))
+            running = rolledBack.running
+            turnComplete = rolledBack.turnComplete
+            streamingTailID = rolledBack.streamingTailID
+            return false
         }
     }
 

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -62,13 +62,6 @@ struct ChatStreamTurnState: Equatable {
 }
 
 enum ChatStreamMerge {
-    struct Result: Equatable {
-        var state: ChatStreamTurnState
-        /// True when a NEW streaming-tail id must be minted (the first running
-        /// false->true edge of a turn). The store mints it (it needs a UUID).
-        var mintsNewTail: Bool
-    }
-
     /// Apply the per-frame lifecycle facts of one interpreted-stream frame to
     /// the turn state.
     ///
@@ -78,28 +71,25 @@ enum ChatStreamMerge {
     ///   never a STALE accumulated completion left over from a previous turn.
     /// - `frameStartedRunning`: true when THIS frame began a turn (a carrying
     ///   `running` frame whose value was true) — clears any stale completion
-    ///   flag and mints a fresh tail id if none exists yet.
+    ///   flag from a previous turn.
     ///
-    /// `running` and `questions` are NOT touched here: they are read straight
-    /// from the accumulated snapshot in the store (the snapshot is authoritative
-    /// for both once an optimistic value is accounted for).
+    /// `running`, `questions` and the streaming-tail MINT are NOT handled here:
+    /// they are read straight from the accumulated snapshot / seeded in the
+    /// store. The store mints a tail id whenever a running turn has none, which
+    /// subsumes the old per-frame mint edge (BET-668 review cycle 3).
     static func applying(
         frameTurnComplete: Bool?,
         frameStartedRunning: Bool,
         to state: ChatStreamTurnState
-    ) -> Result {
+    ) -> ChatStreamTurnState {
         var s = state
         if let t = frameTurnComplete { s.turnComplete = t }
         if frameStartedRunning { s.turnComplete = false }
-
-        var mintsNewTail = false
+        // Reset the tail identity only on a genuine completion edge.
         if frameTurnComplete == true {
             s.streamingTailID = ""
-        } else if frameStartedRunning, s.streamingTailID.isEmpty {
-            mintsNewTail = true
         }
-
-        return Result(state: s, mintsNewTail: mintsNewTail)
+        return s
     }
 
     /// State after a FAILED `send()`: the optimistic running/tail is rolled
@@ -367,12 +357,12 @@ final class ChatSessionStore: ObservableObject {
             questions = incoming.filter { !locallyAnsweredQuestionIDs.contains($0.id) }
         }
 
-        // --- the turn lifecycle (`turnComplete` flag + streaming-tail identity)
-        // is per-frame: only a genuine `turnComplete` frame resets the tail, and
-        // only a genuine `running`-true frame starts a fresh turn. `running` and
-        // `questions` are NOT touched by this merge (handled above).
+        // --- the turn lifecycle (`turnComplete` flag + streaming-tail RESET)
+        // is per-frame: only a genuine `turnComplete` frame clears the tail.
+        // `running` and `questions` are NOT touched by this merge (handled
+        // above), and neither is the tail MINT (handled below).
         let frameStartedRunning = carried.running && (s.running == true)
-        let result = ChatStreamMerge.applying(
+        let merged = ChatStreamMerge.applying(
             frameTurnComplete: carried.turnComplete ? s.turnComplete : nil,
             frameStartedRunning: frameStartedRunning,
             to: ChatStreamTurnState(
@@ -383,11 +373,14 @@ final class ChatSessionStore: ObservableObject {
                 questions: questions
             )
         )
-        turnComplete = result.state.turnComplete
-        streamingTailID = result.state.streamingTailID
-        // A fresh tail id is minted exactly once per turn (when the turn begins
-        // running with no existing tail).
-        if result.mintsNewTail {
+        turnComplete = merged.turnComplete
+        streamingTailID = merged.streamingTailID
+        // Seed a stable tail id whenever a running turn has none — however we
+        // learned it is running: a fresh turn edge, a mid-turn session open
+        // (seeded from the snapshot), or a stamp nulled between a running frame
+        // and its deferred sink. A non-empty id is kept, so the streaming row
+        // is never replaced mid-turn.
+        if running, streamingTailID.isEmpty {
             streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
         }
         // runningSince tracks the turn that's running for the header timer.

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -779,7 +779,16 @@ struct ComposerView: View {
             guard let remotePath = attachment.remotePath else { return nil }
             return SendPromptInput.Attachment(remotePath: remotePath, mime: attachment.mime, filename: attachment.filename)
         }
-        store.send(text: trimmed, attachments: sendAttachments, model: model)
+        let sentText = trimmed
+        Task { @MainActor in
+            // On a failed send the store rolled its running state back; restore
+            // the user's message so it is never silently lost, and surface why.
+            let ok = await store.send(text: sentText, attachments: sendAttachments, model: model)
+            if !ok {
+                text = sentText
+                surfaceHint("Send failed — message restored")
+            }
+        }
         text = ""
         attachments = []
         // Return to the compact form explicitly rather than waiting for the

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -351,7 +351,13 @@ final class MantaEventStore: ObservableObject {
     func retireCoveredStreamText(sessionId: String, covered: Set<String>) {
         guard let state = sessionStates[sessionId] else { return }
         let next = MantaStreamRouter.retiring(state, covered: covered)
-        if next != state { sessionStates[sessionId] = next }
+        if next != state {
+            sessionStates[sessionId] = next
+            // This is a local republish, not a new stream frame — clear the
+            // frame stamp so a consumer doesn't replay the PREVIOUS frame's
+            // fields over a newer optimistic value (BET-668 review cycle 2).
+            lastStreamFrame = nil
+        }
     }
 
     private func handleReconnect() {

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -204,7 +204,20 @@ final class MantaEventStore: ObservableObject {
     @Published private(set) var connectionState: MantaConnectionState = .idle
     @Published private(set) var degraded = false
     @Published private(set) var sessionStates: [String: MantaSessionStreamState] = [:]
+    /// Routing stamp of the MOST RECENT stream frame the store applied: which
+    /// session it was for and which `sub` it carried. The `$sessionStates` sink
+    /// fires on any session's change with only the ACCUMULATED snapshot, which
+    /// can't tell a consumer which fields the frame just delivered. This is the
+    /// per-frame delta the single-writer merge (BET-668) feeds off.
+    private(set) var lastStreamFrame: StreamFrameStamp?
 
+    /// Which session the most recent stream frame targeted and the `sub` it
+    /// carried. `sub == nil` for a non-routed frame (nothing turn-state-related
+    /// changed).
+    struct StreamFrameStamp: Equatable {
+        var sessionId: String
+        var sub: String?
+    }
     /// Invoked on every healthy reconnect so the app re-fetches state that may
     /// have changed while disconnected (rather than assuming the stream
     /// resumed). S4 wires this to re-fetch sessions / messages / permissions /
@@ -326,6 +339,7 @@ final class MantaEventStore: ObservableObject {
         let sid = frame.sessionId ?? ""
         let next = MantaStreamRouter.applying(frame, to: sessionStates[sid])
         sessionStates[sid] = next
+        lastStreamFrame = StreamFrameStamp(sessionId: sid, sub: frame.sub)
     }
 
     /// Retire live stream text the canonical transcript now carries. A session

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -60,7 +60,7 @@ final class SessionListStore: ObservableObject {
             self?.trackAttention(frame: frame)
         }
         eventStore.$sessionStates
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.trackRunning(now: Date()) }
             .store(in: &cancellables)
     }

--- a/mobile/native/MantaUI/TerminalWebView.swift
+++ b/mobile/native/MantaUI/TerminalWebView.swift
@@ -339,7 +339,7 @@ final class TerminalContainerController: UIViewController {
         // derives `isRunning` from the session list store; the controller maps
         // it onto the accessory.
         state.$isRunning
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] running in self?.keyBar.escIsDanger = running }
             .store(in: &cancellables)
         keyBar.escIsDanger = state.isRunning

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -81,6 +81,28 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertFalse(second.mintsNewTail, "a turn that already has a tail must not mint again")
     }
 
+    /// A STALE `turnComplete == true` left over from a previous turn must not
+    /// suppress minting when a new turn starts running (a frame that carries
+    /// running but no completion). This is the box-started-turn case a passing
+    /// of the accumulated sticky snapshot used to break.
+    func testStickyTurnCompleteDoesNotSuppressMintOnRunningFrame() {
+        let state = turnState(running: false, turnComplete: true, tail: "")
+        let result = ChatStreamMerge.applying(frameRunning: true, frameTurnComplete: nil, frameQuestions: nil, to: state)
+        XCTAssertTrue(result.mintsNewTail, "a running frame must mint a tail even with a stale turnComplete")
+        XCTAssertFalse(result.state.turnComplete, "a running frame starts a turn, clearing the completion flag")
+    }
+
+    /// A context frame arriving AFTER a completed turn (accumulated running
+    /// false, turnComplete true) must not clear an optimistic running or
+    /// rest the tail — it carries no opinion.
+    func testContextFrameAfterCompletedTurnClobbersNeitherRunningNorTail() {
+        let state = turnState(running: true, turnComplete: false, tail: "tail")
+        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: nil, to: state)
+        XCTAssertTrue(result.state.running)
+        XCTAssertEqual(result.state.streamingTailID, "tail")
+        XCTAssertFalse(result.mintsNewTail)
+    }
+
     // MARK: - Question tombstoning
 
     /// An id the user answered locally is filtered out of the incoming payload
@@ -144,14 +166,14 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertFalse(ok, "a failed send must be reported as failed")
         XCTAssertFalse(store.running, "a failed send must stop the running state (no forever-spinner)")
 
+        // The optimistic echo is rolled back: the box never received the
+        // message, so it must NOT stand in the transcript as if sent — it
+        // belongs back in the input the caller restores.
         let userBlocks = store.transcript.filter {
             if case .user(_, _) = $0 { return true }
             return false
         }
-        XCTAssertEqual(userBlocks.count, 1, "the optimistically echoed prompt must not be lost")
-        if case .user(let text, _) = userBlocks[0] {
-            XCTAssertEqual(text, "hello", "the prompt text must be preserved for restoration")
-        }
+        XCTAssertEqual(userBlocks.count, 0, "a failed send must not leave the message in the transcript")
     }
 
     // MARK: - Mock transport that makes every request fail
@@ -190,4 +212,66 @@ private final class FailingSendStream: MantaEventStreamControl {
     func retryNow() {}
     func forceReconnect() {}
     func close(reason: String) {}
+}
+
+// MARK: - Per-frame delta extraction (the seam that fixes running-clobber on
+// turn 2+: the merge is fed what the frame CARRIED, not the sticky accumulator).
+
+@MainActor
+final class ChatStreamDeltaTests: XCTestCase {
+
+    /// A frame aimed at a DIFFERENT session must yield all-nil ("no opinion"),
+    /// so replaying another session's frame can't clobber this one's state.
+    func testForeignSessionYieldsNoOpinion() {
+        let fields = ChatStreamDelta.turnFields(
+            sessionIsTarget: false, sub: "running",
+            stateRunning: true, stateTurnComplete: true, stateQuestions: nil)
+        XCTAssertNil(fields.running)
+        XCTAssertNil(fields.turnComplete)
+        XCTAssertNil(fields.questions)
+    }
+
+    /// A non-carrying frame (e.g. `context`) must NOT report a running value —
+    /// even though the accumulated snapshot is sticky `false` after turn 1.
+    /// This is what lets an optimistic `send()` survive an unrelated frame on
+    /// turn 2+.
+    func testContextSubCarriesNoTurnFields() {
+        let fields = ChatStreamDelta.turnFields(
+            sessionIsTarget: true, sub: "context",
+            stateRunning: false, stateTurnComplete: true, stateQuestions: nil)
+        XCTAssertNil(fields.running)
+        XCTAssertNil(fields.turnComplete)
+        XCTAssertNil(fields.questions)
+    }
+
+    /// A `running` frame carries the running value but not completion/questions.
+    func testRunningSubCarriesRunningOnly() {
+        let fields = ChatStreamDelta.turnFields(
+            sessionIsTarget: true, sub: "running",
+            stateRunning: true, stateTurnComplete: nil, stateQuestions: nil)
+        XCTAssertEqual(fields.running, true)
+        XCTAssertNil(fields.turnComplete)
+        XCTAssertNil(fields.questions)
+    }
+
+    /// A `turnComplete` frame carries BOTH running and completion.
+    func testTurnCompleteSubCarriesRunningAndCompletion() {
+        let fields = ChatStreamDelta.turnFields(
+            sessionIsTarget: true, sub: "turnComplete",
+            stateRunning: false, stateTurnComplete: true, stateQuestions: nil)
+        XCTAssertEqual(fields.running, false)
+        XCTAssertEqual(fields.turnComplete, true)
+        XCTAssertNil(fields.questions)
+    }
+
+    /// A `questions` frame carries only the questions payload.
+    func testQuestionsSubCarriesQuestionsOnly() {
+        let q = QuestionRequest(id: "q1", sessionID: "ses", questions: [], tool: nil, requestId: nil)
+        let fields = ChatStreamDelta.turnFields(
+            sessionIsTarget: true, sub: "questions",
+            stateRunning: false, stateTurnComplete: false, stateQuestions: [q])
+        XCTAssertNil(fields.running)
+        XCTAssertNil(fields.turnComplete)
+        XCTAssertEqual(fields.questions?.map(\.id), ["q1"])
+    }
 }

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -35,32 +35,15 @@ final class ChatStreamMergeTests: XCTestCase {
     func testTurnCompleteResetsTailID() {
         let state = turnState(tail: "tail")
         let result = ChatStreamMerge.applying(frameTurnComplete: true, frameStartedRunning: false, to: state)
-        XCTAssertEqual(result.state.streamingTailID, "")
+        XCTAssertEqual(result.streamingTailID, "")
     }
 
-    /// The first running start of a turn requests a fresh tail id; a turn that
-    /// already has one never mints again (no mid-turn re-mint → no streaming row
-    /// replacement / flicker).
-    func testTailMintedOncePerTurn() {
-        let idle = turnState(tail: "")
-        let first = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: true, to: idle)
-        XCTAssertTrue(first.mintsNewTail)
-
-        // The store writes the actual id; a later running frame sees it and
-        // must not mint a second time.
-        var running = first.state
-        running.streamingTailID = "live-ses-UUID"
-        let second = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: true, to: running)
-        XCTAssertFalse(second.mintsNewTail, "a turn that already has a tail must not mint again")
-    }
-
-    /// A STALE `turnComplete == true` left over from a previous turn must not
-    /// suppress minting when a new turn starts running.
-    func testStickyTurnCompleteDoesNotSuppressMintOnRunningFrame() {
+    /// A STALE `turnComplete == true` left over from a previous turn clears
+    /// when a new turn starts running.
+    func testRunningStartClearsStaleComplete() {
         let state = turnState(turnComplete: true, tail: "")
         let result = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: true, to: state)
-        XCTAssertTrue(result.mintsNewTail, "a running frame must mint a tail even with a stale turnComplete")
-        XCTAssertFalse(result.state.turnComplete, "a running frame starts a turn, clearing the completion flag")
+        XCTAssertFalse(result.turnComplete, "a running frame starts a turn, clearing the completion flag")
     }
 
     /// A frame that carries neither a completion edge nor a turn start (e.g. a
@@ -69,9 +52,8 @@ final class ChatStreamMergeTests: XCTestCase {
     func testNonCarryingFrameClobbersNeitherTurnCompleteNorTail() {
         let state = turnState(turnComplete: false, tail: "tail")
         let result = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: false, to: state)
-        XCTAssertEqual(result.state.turnComplete, false)
-        XCTAssertEqual(result.state.streamingTailID, "tail")
-        XCTAssertFalse(result.mintsNewTail)
+        XCTAssertEqual(result.turnComplete, false)
+        XCTAssertEqual(result.streamingTailID, "tail")
     }
 
     // MARK: - Failed send
@@ -105,6 +87,16 @@ final class ChatStreamMergeTests: XCTestCase {
         )
         await Task.yield()
         XCTAssertTrue(store.running, "opening a mid-turn session must show its working indicator")
+        XCTAssertFalse(store.streamingTailID.isEmpty,
+                       "opening a mid-turn session must have a stable tail id")
+
+        // The tail id must be STABLE across later frames, so the streaming row
+        // is never replaced mid-turn (seeding, not a per-edge re-mint).
+        let minted = store.streamingTailID
+        stream.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses","payload":{"messageID":"m2","partID":"p2","field":"text","text":"more"}}"#)
+        await Task.yield()
+        XCTAssertEqual(store.streamingTailID, minted,
+                       "a running turn's tail id must not change across frames")
     }
 
     /// Block 1: opening a session with a question already waiting must show the

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -2,19 +2,15 @@ import XCTest
 @testable import MantaUI
 
 // BET-668 — the single-writer stream merge. The chat screen has two writers
-// for turn state (optimistic local mutations vs incoming stream frames), and
-// these test the pure merge decisions so a frame can never clobber an
-// optimistic value. No HTTP/view/Keychain involved except the small store-
-// level failed-send seam (mocked transport).
+// for turn state (optimistic local mutations vs incoming stream frames). These
+// tests pin the pure merge/lifecycle decisions and the store seams (seeding on
+// open, optimistic-running protection, no stale replay on retirement) so a
+// frame can never clobber an optimistic value. Network is mocked.
 
 @MainActor
 final class ChatStreamMergeTests: XCTestCase {
 
     // MARK: - Fixtures
-
-    private func question(_ id: String) -> QuestionRequest {
-        QuestionRequest(id: id, sessionID: "ses", questions: [], tool: nil, requestId: nil)
-    }
 
     private func turnState(
         running: Bool = false,
@@ -32,126 +28,174 @@ final class ChatStreamMergeTests: XCTestCase {
         )
     }
 
-    // MARK: - Running: nil means "no opinion"
+    // MARK: - Tail identity: once per turn, reset only on the frame's turnComplete
 
-    /// A frame that carries no `running` field (e.g. a context frame) must NOT
-    /// flip an optimistic `running = true` back to false — that used to reset
-    /// `runningSince`, re-mint the tail id, and flash the running row.
-    func testFrameWithoutRunningKeepsOptimisticRunning() {
-        let state = turnState(running: true, tail: "tail")
-        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: nil, to: state)
-        XCTAssertTrue(result.state.running)
-        XCTAssertFalse(result.mintsNewTail)
-        XCTAssertEqual(result.state.streamingTailID, "tail")
-    }
-
-    /// A real `running: false` write is honoured — but on its own it must NOT
-    /// reset the tail id.
-    func testRunningFalseIsHonouredButDoesNotResetTailID() {
-        let state = turnState(running: true, tail: "tail")
-        let result = ChatStreamMerge.applying(frameRunning: false, frameTurnComplete: nil, frameQuestions: nil, to: state)
-        XCTAssertFalse(result.state.running)
-        XCTAssertEqual(result.state.streamingTailID, "tail",
-                       "a bare running==false write must never reset the tail id")
-        XCTAssertFalse(result.mintsNewTail)
-    }
-
-    // MARK: - Tail identity: once per turn, reset only on turnComplete
-
-    /// The `turnComplete` edge is the ONLY thing that resets the tail id.
+    /// The `turnComplete` EDGE carried by the frame is the only thing that
+    /// resets the tail id.
     func testTurnCompleteResetsTailID() {
-        let state = turnState(running: true, tail: "tail")
-        let result = ChatStreamMerge.applying(frameRunning: false, frameTurnComplete: true, frameQuestions: nil, to: state)
+        let state = turnState(tail: "tail")
+        let result = ChatStreamMerge.applying(frameTurnComplete: true, frameStartedRunning: false, to: state)
         XCTAssertEqual(result.state.streamingTailID, "")
     }
 
-    /// The first running false->true edge of a turn requests a fresh tail id;
-    /// a turn that already has one never mints again (no mid-turn re-mint →
-    /// no streaming row replacement / flicker).
+    /// The first running start of a turn requests a fresh tail id; a turn that
+    /// already has one never mints again (no mid-turn re-mint → no streaming row
+    /// replacement / flicker).
     func testTailMintedOncePerTurn() {
-        let idle = turnState(running: false, tail: "")
-        let first = ChatStreamMerge.applying(frameRunning: true, frameTurnComplete: nil, frameQuestions: nil, to: idle)
+        let idle = turnState(tail: "")
+        let first = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: true, to: idle)
         XCTAssertTrue(first.mintsNewTail)
 
         // The store writes the actual id; a later running frame sees it and
         // must not mint a second time.
         var running = first.state
         running.streamingTailID = "live-ses-UUID"
-        let second = ChatStreamMerge.applying(frameRunning: true, frameTurnComplete: nil, frameQuestions: nil, to: running)
+        let second = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: true, to: running)
         XCTAssertFalse(second.mintsNewTail, "a turn that already has a tail must not mint again")
     }
 
     /// A STALE `turnComplete == true` left over from a previous turn must not
-    /// suppress minting when a new turn starts running (a frame that carries
-    /// running but no completion). This is the box-started-turn case a passing
-    /// of the accumulated sticky snapshot used to break.
+    /// suppress minting when a new turn starts running.
     func testStickyTurnCompleteDoesNotSuppressMintOnRunningFrame() {
-        let state = turnState(running: false, turnComplete: true, tail: "")
-        let result = ChatStreamMerge.applying(frameRunning: true, frameTurnComplete: nil, frameQuestions: nil, to: state)
+        let state = turnState(turnComplete: true, tail: "")
+        let result = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: true, to: state)
         XCTAssertTrue(result.mintsNewTail, "a running frame must mint a tail even with a stale turnComplete")
         XCTAssertFalse(result.state.turnComplete, "a running frame starts a turn, clearing the completion flag")
     }
 
-    /// A context frame arriving AFTER a completed turn (accumulated running
-    /// false, turnComplete true) must not clear an optimistic running or
-    /// rest the tail — it carries no opinion.
-    func testContextFrameAfterCompletedTurnClobbersNeitherRunningNorTail() {
-        let state = turnState(running: true, turnComplete: false, tail: "tail")
-        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: nil, to: state)
-        XCTAssertTrue(result.state.running)
+    /// A frame that carries neither a completion edge nor a turn start (e.g. a
+    /// context/flush frame, or a retirement republish) leaves the tail alone —
+    /// it carries no opinion.
+    func testNonCarryingFrameClobbersNeitherTurnCompleteNorTail() {
+        let state = turnState(turnComplete: false, tail: "tail")
+        let result = ChatStreamMerge.applying(frameTurnComplete: nil, frameStartedRunning: false, to: state)
+        XCTAssertEqual(result.state.turnComplete, false)
         XCTAssertEqual(result.state.streamingTailID, "tail")
         XCTAssertFalse(result.mintsNewTail)
     }
 
-    // MARK: - Question tombstoning
-
-    /// An id the user answered locally is filtered out of the incoming payload
-    /// until the box catches up.
-    func testTombstonedQuestionIsFilteredAndStaysTombstonedWhilePublished() {
-        let state = turnState(tombstones: ["q1"])
-        let incoming = [question("q1"), question("q2")]
-        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: incoming, to: state)
-        XCTAssertEqual(result.state.questions.map(\.id), ["q2"])
-        XCTAssertEqual(result.state.locallyAnsweredQuestionIDs, Set(["q1"]),
-                       "a still-published id stays tombstoned so it cannot flash back")
-    }
-
-    /// Once the box stops publishing a tombstoned id, the tombstone is dropped.
-    func testTombstoneDropsWhenBoxStopsPublishingId() {
-        let state = turnState(tombstones: ["q1"])
-        let incoming = [question("q2")]
-        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: incoming, to: state)
-        XCTAssertEqual(result.state.locallyAnsweredQuestionIDs, Set())
-        XCTAssertEqual(result.state.questions.map(\.id), ["q2"])
-    }
-
-    /// A frame with no questions payload leaves the current questions alone
-    /// (the route that used to clobber optimistically-removed cards on every
-    /// non-question frame).
-    func testNoQuestionsPayloadKeepsCurrentQuestions() {
-        let state = turnState(questions: [question("q1")])
-        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: nil, to: state)
-        XCTAssertEqual(result.state.questions.map(\.id), ["q1"])
-    }
-
     // MARK: - Failed send
 
-    /// The pure rollback clears running + the tail, and leaves the
-    /// transcript-visible state (questions/tombstones) untouched.
+    /// The pure rollback clears running + the tail and leaves the question
+    /// tombstones untouched.
     func testAfterSendFailureRollsBackRunningAndPreservesState() {
-        let state = turnState(running: true, tail: "tail", tombstones: ["x"], questions: [question("q1")])
+        let state = turnState(running: true, tail: "tail", tombstones: ["x"], questions: [])
         let rolled = ChatStreamMerge.afterSendFailure(to: state)
         XCTAssertFalse(rolled.running)
         XCTAssertEqual(rolled.streamingTailID, "")
-        XCTAssertEqual(rolled.questions.map(\.id), ["q1"])
         XCTAssertEqual(rolled.locallyAnsweredQuestionIDs, Set(["x"]))
     }
 
-    /// Store-level seam: a send whose RPC throws must return false, roll the
-    /// running state back (no forever-spinner), and NOT lose the prompt — the
-    /// optimistic `.user` block stays in the transcript for the caller to
-    /// restore.
-    func testFailedSendResetsRunningAndPreservesPrompt() async {
+    // MARK: - Store seams (integration over a fake stream)
+
+    /// Block 1: opening a session that is already running must show the working
+    /// indicator. The accumulated snapshot's `running` is seeded even though the
+    /// most recent frame (a flush) carried no running field.
+    func testOpeningMidTurnSessionSeedsRunningFromSnapshot() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        // A later non-running frame must NOT erase the seeded running.
+        stream.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses","payload":{"messageID":"m","partID":"p","field":"text","text":"hi"}}"#)
+
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+        XCTAssertTrue(store.running, "opening a mid-turn session must show its working indicator")
+    }
+
+    /// Block 1: opening a session with a question already waiting must show the
+    /// card — questions are seeded from the accumulated snapshot.
+    func testOpeningSessionSeedsPendingQuestion() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        stream.inject(#"{"kind":"stream","sub":"questions","sessionId":"ses","payload":{"questions":[{"id":"q1","sessionID":"ses","questions":[]}]}}"#)
+
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+        XCTAssertEqual(store.questions.map(\.id), ["q1"], "a pending question must show on open")
+    }
+
+    /// The optimistic `running = true` `send()` set must NOT be clobbered by an
+    /// unrelated frame while the box hasn't yet confirmed running. Once the box
+    /// reports running, the snapshot is authoritative; a real turnComplete
+    /// stops it.
+    func testOptimisticRunningSurvivesUnrelatedFrameUntilBoxConfirms() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.succeedingSession())
+        )
+        await Task.yield()
+
+        let ok = await store.send(text: "hello", attachments: [], model: nil)
+        XCTAssertTrue(ok)
+        XCTAssertTrue(store.running, "a send reports running optimistically")
+
+        // Unrelated context frame while the box hasn't confirmed → keep running.
+        stream.inject(#"{"kind":"stream","sub":"context","sessionId":"ses","payload":{"freshInput":0,"cacheRead":0,"cacheWrite":0,"totalInput":0,"pct":0,"segments":[]}}"#)
+        await Task.yield()
+        XCTAssertTrue(store.running, "an unrelated frame must not clobber the optimistic running")
+
+        // Box confirms running → still running.
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        XCTAssertTrue(store.running)
+
+        // Genuine completion stops it.
+        stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
+        await Task.yield()
+        XCTAssertFalse(store.running)
+    }
+
+    /// Block 2: a local transcript-refetch republish (retireCoveredStreamText)
+    /// must NOT replay the previous frame's fields over an optimistic send — the
+    /// freshly-minted tail and optimistic running survive it.
+    func testRetirementRepublishDoesNotReplayStaleDelta() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        // A completed turn sits at the snapshot surface: some streamed text
+        // (a chunk) then a turnComplete (running false, complete true).
+        stream.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses","payload":{"messageID":"m1","partID":"p1","field":"text","text":"hi"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
+
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.succeedingSession())
+        )
+        await Task.yield()
+        XCTAssertFalse(store.running)
+        XCTAssertEqual(store.streamingTailID, "")
+
+        // User sends the next message before the refetch lands.
+        let ok = await store.send(text: "next", attachments: [], model: nil)
+        XCTAssertTrue(ok)
+        XCTAssertTrue(store.running)
+        let mintedTail = store.streamingTailID
+        XCTAssertFalse(mintedTail.isEmpty, "send() mints the streaming tail")
+
+        // The refetch's own republish (which retires the covered chunk) must
+        // not replay the stale turnComplete over the optimistic send.
+        eventStore.retireCoveredStreamText(sessionId: "ses", covered: ["m1"])
+        await Task.yield()
+        XCTAssertTrue(store.running, "a retire republish must not clobber optimistic running")
+        XCTAssertEqual(store.streamingTailID, mintedTail,
+                       "a retire republish must not reset the freshly-minted tail")
+    }
+
+    /// A failed send removes the optimistic user bubble so the message isn't
+    /// shown twice (restored input + transcript).
+    func testFailedSendResetsRunningAndRemovesBubble() async {
         let api = MantaAPIClient(
             serverURL: URL(string: "https://127.0.0.1")!,
             tokenProvider: { nil },
@@ -159,16 +203,13 @@ final class ChatStreamMergeTests: XCTestCase {
         )
         let store = ChatSessionStore(
             sessionId: "ses",
-            eventStore: MantaEventStore(stream: FailingSendStream(), tokenProvider: { nil }, serverProvider: { nil }),
+            eventStore: MantaEventStore(stream: TestStreamControl(), tokenProvider: { nil }, serverProvider: { nil }),
             api: api
         )
         let ok = await store.send(text: "hello", attachments: [], model: nil)
         XCTAssertFalse(ok, "a failed send must be reported as failed")
         XCTAssertFalse(store.running, "a failed send must stop the running state (no forever-spinner)")
 
-        // The optimistic echo is rolled back: the box never received the
-        // message, so it must NOT stand in the transcript as if sent — it
-        // belongs back in the input the caller restores.
         let userBlocks = store.transcript.filter {
             if case .user(_, _) = $0 { return true }
             return false
@@ -176,17 +217,23 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertEqual(userBlocks.count, 0, "a failed send must not leave the message in the transcript")
     }
 
-    // MARK: - Mock transport that makes every request fail
+    // MARK: - Mock transport
 
     private static func failingSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [FailingURLProtocol.self]
         return URLSession(configuration: config)
     }
+
+    private static func succeedingSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SucceedingURLProtocol.self]
+        return URLSession(configuration: config)
+    }
 }
 
-/// URLSession protocol that fails every request with a connection error, so a
-/// real `MantaAPIClient` reliably throws (as an unreachable box would).
+/// URLSession protocol that fails every request with a connection error (an
+/// unreachable box).
 private final class FailingURLProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -196,10 +243,25 @@ private final class FailingURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
-/// A stream control that never connects (so `MantaEventStore` never tries a
-/// real socket); sufficient for the store's `send` seam.
+/// URLSession protocol that succeeds with an empty RPC result, so `send()`
+/// reports success (as a reachable box would).
+private final class SucceedingURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let data = Data(#"{"result":{}}"#.utf8)
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+/// A stream control that never connects but can inject frames into the store,
+/// so tests can drive `sessionStates` deterministically.
 @MainActor
-private final class FailingSendStream: MantaEventStreamControl {
+private final class TestStreamControl: MantaEventStreamControl {
     var onState: ((MantaConnectionState) -> Void)?
     var onMessage: ((String) -> Void)?
     var onReconnect: (() -> Void)?
@@ -212,66 +274,41 @@ private final class FailingSendStream: MantaEventStreamControl {
     func retryNow() {}
     func forceReconnect() {}
     func close(reason: String) {}
+
+    func inject(_ text: String) { onMessage?(text) }
 }
 
-// MARK: - Per-frame delta extraction (the seam that fixes running-clobber on
-// turn 2+: the merge is fed what the frame CARRIED, not the sticky accumulator).
+// MARK: - Per-frame carried facts (which turn-state fields the frame carried)
 
 @MainActor
 final class ChatStreamDeltaTests: XCTestCase {
 
-    /// A frame aimed at a DIFFERENT session must yield all-nil ("no opinion"),
-    /// so replaying another session's frame can't clobber this one's state.
-    func testForeignSessionYieldsNoOpinion() {
-        let fields = ChatStreamDelta.turnFields(
-            sessionIsTarget: false, sub: "running",
-            stateRunning: true, stateTurnComplete: true, stateQuestions: nil)
-        XCTAssertNil(fields.running)
-        XCTAssertNil(fields.turnComplete)
-        XCTAssertNil(fields.questions)
+    /// A frame aimed at a DIFFERENT session carries nothing for this one.
+    func testForeignSessionCarriesNothing() {
+        let c = ChatStreamDelta.carried(sessionIsTarget: false, sub: "running")
+        XCTAssertFalse(c.running)
+        XCTAssertFalse(c.turnComplete)
     }
 
-    /// A non-carrying frame (e.g. `context`) must NOT report a running value —
-    /// even though the accumulated snapshot is sticky `false` after turn 1.
-    /// This is what lets an optimistic `send()` survive an unrelated frame on
-    /// turn 2+.
-    func testContextSubCarriesNoTurnFields() {
-        let fields = ChatStreamDelta.turnFields(
-            sessionIsTarget: true, sub: "context",
-            stateRunning: false, stateTurnComplete: true, stateQuestions: nil)
-        XCTAssertNil(fields.running)
-        XCTAssertNil(fields.turnComplete)
-        XCTAssertNil(fields.questions)
+    /// A non-carrying frame (e.g. `context`) carries no turn-state fields — even
+    /// though the accumulated snapshot is sticky after turn 1.
+    func testContextSubCarriesNothing() {
+        let c = ChatStreamDelta.carried(sessionIsTarget: true, sub: "context")
+        XCTAssertFalse(c.running)
+        XCTAssertFalse(c.turnComplete)
     }
 
-    /// A `running` frame carries the running value but not completion/questions.
+    /// A `running` frame carries a running value, not completion.
     func testRunningSubCarriesRunningOnly() {
-        let fields = ChatStreamDelta.turnFields(
-            sessionIsTarget: true, sub: "running",
-            stateRunning: true, stateTurnComplete: nil, stateQuestions: nil)
-        XCTAssertEqual(fields.running, true)
-        XCTAssertNil(fields.turnComplete)
-        XCTAssertNil(fields.questions)
+        let c = ChatStreamDelta.carried(sessionIsTarget: true, sub: "running")
+        XCTAssertTrue(c.running)
+        XCTAssertFalse(c.turnComplete)
     }
 
     /// A `turnComplete` frame carries BOTH running and completion.
     func testTurnCompleteSubCarriesRunningAndCompletion() {
-        let fields = ChatStreamDelta.turnFields(
-            sessionIsTarget: true, sub: "turnComplete",
-            stateRunning: false, stateTurnComplete: true, stateQuestions: nil)
-        XCTAssertEqual(fields.running, false)
-        XCTAssertEqual(fields.turnComplete, true)
-        XCTAssertNil(fields.questions)
-    }
-
-    /// A `questions` frame carries only the questions payload.
-    func testQuestionsSubCarriesQuestionsOnly() {
-        let q = QuestionRequest(id: "q1", sessionID: "ses", questions: [], tool: nil, requestId: nil)
-        let fields = ChatStreamDelta.turnFields(
-            sessionIsTarget: true, sub: "questions",
-            stateRunning: false, stateTurnComplete: false, stateQuestions: [q])
-        XCTAssertNil(fields.running)
-        XCTAssertNil(fields.turnComplete)
-        XCTAssertEqual(fields.questions?.map(\.id), ["q1"])
+        let c = ChatStreamDelta.carried(sessionIsTarget: true, sub: "turnComplete")
+        XCTAssertTrue(c.running)
+        XCTAssertTrue(c.turnComplete)
     }
 }

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+@testable import MantaUI
+
+// BET-668 — the single-writer stream merge. The chat screen has two writers
+// for turn state (optimistic local mutations vs incoming stream frames), and
+// these test the pure merge decisions so a frame can never clobber an
+// optimistic value. No HTTP/view/Keychain involved except the small store-
+// level failed-send seam (mocked transport).
+
+@MainActor
+final class ChatStreamMergeTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func question(_ id: String) -> QuestionRequest {
+        QuestionRequest(id: id, sessionID: "ses", questions: [], tool: nil, requestId: nil)
+    }
+
+    private func turnState(
+        running: Bool = false,
+        turnComplete: Bool = false,
+        tail: String = "",
+        tombstones: Set<String> = [],
+        questions: [QuestionRequest] = []
+    ) -> ChatStreamTurnState {
+        ChatStreamTurnState(
+            running: running,
+            turnComplete: turnComplete,
+            streamingTailID: tail,
+            locallyAnsweredQuestionIDs: tombstones,
+            questions: questions
+        )
+    }
+
+    // MARK: - Running: nil means "no opinion"
+
+    /// A frame that carries no `running` field (e.g. a context frame) must NOT
+    /// flip an optimistic `running = true` back to false — that used to reset
+    /// `runningSince`, re-mint the tail id, and flash the running row.
+    func testFrameWithoutRunningKeepsOptimisticRunning() {
+        let state = turnState(running: true, tail: "tail")
+        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: nil, to: state)
+        XCTAssertTrue(result.state.running)
+        XCTAssertFalse(result.mintsNewTail)
+        XCTAssertEqual(result.state.streamingTailID, "tail")
+    }
+
+    /// A real `running: false` write is honoured — but on its own it must NOT
+    /// reset the tail id.
+    func testRunningFalseIsHonouredButDoesNotResetTailID() {
+        let state = turnState(running: true, tail: "tail")
+        let result = ChatStreamMerge.applying(frameRunning: false, frameTurnComplete: nil, frameQuestions: nil, to: state)
+        XCTAssertFalse(result.state.running)
+        XCTAssertEqual(result.state.streamingTailID, "tail",
+                       "a bare running==false write must never reset the tail id")
+        XCTAssertFalse(result.mintsNewTail)
+    }
+
+    // MARK: - Tail identity: once per turn, reset only on turnComplete
+
+    /// The `turnComplete` edge is the ONLY thing that resets the tail id.
+    func testTurnCompleteResetsTailID() {
+        let state = turnState(running: true, tail: "tail")
+        let result = ChatStreamMerge.applying(frameRunning: false, frameTurnComplete: true, frameQuestions: nil, to: state)
+        XCTAssertEqual(result.state.streamingTailID, "")
+    }
+
+    /// The first running false->true edge of a turn requests a fresh tail id;
+    /// a turn that already has one never mints again (no mid-turn re-mint →
+    /// no streaming row replacement / flicker).
+    func testTailMintedOncePerTurn() {
+        let idle = turnState(running: false, tail: "")
+        let first = ChatStreamMerge.applying(frameRunning: true, frameTurnComplete: nil, frameQuestions: nil, to: idle)
+        XCTAssertTrue(first.mintsNewTail)
+
+        // The store writes the actual id; a later running frame sees it and
+        // must not mint a second time.
+        var running = first.state
+        running.streamingTailID = "live-ses-UUID"
+        let second = ChatStreamMerge.applying(frameRunning: true, frameTurnComplete: nil, frameQuestions: nil, to: running)
+        XCTAssertFalse(second.mintsNewTail, "a turn that already has a tail must not mint again")
+    }
+
+    // MARK: - Question tombstoning
+
+    /// An id the user answered locally is filtered out of the incoming payload
+    /// until the box catches up.
+    func testTombstonedQuestionIsFilteredAndStaysTombstonedWhilePublished() {
+        let state = turnState(tombstones: ["q1"])
+        let incoming = [question("q1"), question("q2")]
+        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: incoming, to: state)
+        XCTAssertEqual(result.state.questions.map(\.id), ["q2"])
+        XCTAssertEqual(result.state.locallyAnsweredQuestionIDs, Set(["q1"]),
+                       "a still-published id stays tombstoned so it cannot flash back")
+    }
+
+    /// Once the box stops publishing a tombstoned id, the tombstone is dropped.
+    func testTombstoneDropsWhenBoxStopsPublishingId() {
+        let state = turnState(tombstones: ["q1"])
+        let incoming = [question("q2")]
+        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: incoming, to: state)
+        XCTAssertEqual(result.state.locallyAnsweredQuestionIDs, Set())
+        XCTAssertEqual(result.state.questions.map(\.id), ["q2"])
+    }
+
+    /// A frame with no questions payload leaves the current questions alone
+    /// (the route that used to clobber optimistically-removed cards on every
+    /// non-question frame).
+    func testNoQuestionsPayloadKeepsCurrentQuestions() {
+        let state = turnState(questions: [question("q1")])
+        let result = ChatStreamMerge.applying(frameRunning: nil, frameTurnComplete: nil, frameQuestions: nil, to: state)
+        XCTAssertEqual(result.state.questions.map(\.id), ["q1"])
+    }
+
+    // MARK: - Failed send
+
+    /// The pure rollback clears running + the tail, and leaves the
+    /// transcript-visible state (questions/tombstones) untouched.
+    func testAfterSendFailureRollsBackRunningAndPreservesState() {
+        let state = turnState(running: true, tail: "tail", tombstones: ["x"], questions: [question("q1")])
+        let rolled = ChatStreamMerge.afterSendFailure(to: state)
+        XCTAssertFalse(rolled.running)
+        XCTAssertEqual(rolled.streamingTailID, "")
+        XCTAssertEqual(rolled.questions.map(\.id), ["q1"])
+        XCTAssertEqual(rolled.locallyAnsweredQuestionIDs, Set(["x"]))
+    }
+
+    /// Store-level seam: a send whose RPC throws must return false, roll the
+    /// running state back (no forever-spinner), and NOT lose the prompt — the
+    /// optimistic `.user` block stays in the transcript for the caller to
+    /// restore.
+    func testFailedSendResetsRunningAndPreservesPrompt() async {
+        let api = MantaAPIClient(
+            serverURL: URL(string: "https://127.0.0.1")!,
+            tokenProvider: { nil },
+            session: Self.failingSession()
+        )
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: MantaEventStore(stream: FailingSendStream(), tokenProvider: { nil }, serverProvider: { nil }),
+            api: api
+        )
+        let ok = await store.send(text: "hello", attachments: [], model: nil)
+        XCTAssertFalse(ok, "a failed send must be reported as failed")
+        XCTAssertFalse(store.running, "a failed send must stop the running state (no forever-spinner)")
+
+        let userBlocks = store.transcript.filter {
+            if case .user(_, _) = $0 { return true }
+            return false
+        }
+        XCTAssertEqual(userBlocks.count, 1, "the optimistically echoed prompt must not be lost")
+        if case .user(let text, _) = userBlocks[0] {
+            XCTAssertEqual(text, "hello", "the prompt text must be preserved for restoration")
+        }
+    }
+
+    // MARK: - Mock transport that makes every request fail
+
+    private static func failingSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FailingURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+/// URLSession protocol that fails every request with a connection error, so a
+/// real `MantaAPIClient` reliably throws (as an unreachable box would).
+private final class FailingURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+    }
+    override func stopLoading() {}
+}
+
+/// A stream control that never connects (so `MantaEventStore` never tries a
+/// real socket); sufficient for the store's `send` seam.
+@MainActor
+private final class FailingSendStream: MantaEventStreamControl {
+    var onState: ((MantaConnectionState) -> Void)?
+    var onMessage: ((String) -> Void)?
+    var onReconnect: (() -> Void)?
+    var onConfigError: ((Error) -> Void)?
+    var hasConnectedOnce = false
+    var currentState: MantaConnectionState = .idle
+
+    func ensure() {}
+    func markReconnectAndEnsure() {}
+    func retryNow() {}
+    func forceReconnect() {}
+    func close(reason: String) {}
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-668-single-writer-stream-merge`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-668.