### PR TITLE
feat(renderer): snapshot-first boot + sync deltas + persisted cache (BET-678)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import {
   writeSavedMode,
   resolveLauncherFlags,
 } from "./chatShared";
+import type { SyncPayload } from "../shared/api";
 import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
@@ -28,6 +29,7 @@ import { pickBanner, type BannerState } from "./bannerPriority";
 import { parsePairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { MantaLoader } from "./MantaLoader";
 import type { AvailableLauncher } from "../shared/types";
 
 // BET-373 (channel-aware wire format): the deep-link URL the OS hands this
@@ -101,6 +103,7 @@ function AppInner() {
     connectionState,
     launcherFlags,
     createDraft,
+    boxStale,
   } = useStore();
 
   // Entry gating: a fresh config (no host, no boxToken, not skipped) resolves
@@ -262,47 +265,73 @@ function AppInner() {
   activeChatRef.current = activeChatSessionId;
 
   useEffect(() => {
-    // Bootstrap. In HTTP mode (paired to a manta-server) refresh() can reject
-    // with AuthRequiredError when the box answers 401 — a revoked/rotated
-    // box_token mid-session. Route that to the pairing screen (onboarding step
-    // 1) instead of letting the app sit dead with no sessions and no
-    // explanation. relaunchOnboarding() forces the full-screen flow open even
-    // for an otherwise-"http" config; a successful re-claim persists a fresh
-    // token and finishOnboarding() re-runs the bootstrap. SSH mode never throws
-    // this (no Bearer gate), so this is a no-op there.
+    // Bootstrap (BET-678). The first paint is INSTANT — read from the persisted
+    // local snapshot restored in main.tsx (zero round trips). This effect only
+    // needs to SYNC the cursor with the box: one refresh() on mount, retried on
+    // a plain 10s interval while it fails (cleared on first success). After the
+    // first success, live `sync` deltas + the reconnect marker (below) own
+    // freshness — no polling.
     //
-    // Non-auth bootstrap failures are retried with backoff. The bootstrap
-    // metadata RPCs (configGet + tmuxList) carry a hard timeout in httpApi, so
-    // a stalled first connection FAILS FAST instead of hanging forever — which
-    // is what makes this retry actually fire (a hanging fetch never rejected,
-    // so the pre-fix shell sat empty until a manual Cmd+R). On a cold box the
-    // first attempt may time out before the server/tmux is up; a short retry
-    // recovers in place. Each retry runs applyProjects (which preserves the
-    // current selection and drops the zero-state draft once projects arrive).
+    // refresh() can still reject with AuthRequiredError when the box answers
+    // 401 — a revoked/rotated box_token mid-session. Route that to the pairing
+    // screen (onboarding step 1) instead of letting the app sit dead with no
+    // sessions and no explanation. relaunchOnboarding() forces the full-screen
+    // flow open even for an otherwise-"http" config; a successful re-claim
+    // persists a fresh token and finishOnboarding() re-runs the bootstrap.
     let cancelled = false;
-    let attempts = 0;
-    const MAX_ATTEMPTS = 6;
-    const backoff = (n: number) => Math.min(1000 * 2 ** n, 15000);
-    const attempt = async (): Promise<void> => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const attempt = async (): Promise<boolean> => {
       try {
         await refresh();
+        return true;
       } catch (e) {
         const isAuth =
           (e as { name?: string })?.name === "AuthRequiredError" ||
           (e as { status?: number })?.status === 401;
         if (isAuth) {
           void useStore.getState().relaunchOnboarding();
-          return;
+          return true; // onboarding owns the flow now — stop the retry loop
         }
-        // Non-auth failure — retry with backoff, bounded, until success/abort.
-        if (cancelled || ++attempts >= MAX_ATTEMPTS) return;
-        setTimeout(() => void attempt(), backoff(attempts));
+        return false; // transient failure — keep retrying
       }
     };
-    void attempt();
+    void attempt().then((ok) => {
+      if (cancelled) return;
+      if (!ok) {
+        timer = setInterval(() => {
+          if (cancelled) return;
+          void attempt().then((ok2) => {
+            if (ok2 && timer) {
+              clearInterval(timer);
+              timer = null;
+            }
+          });
+        }, 10_000);
+      }
+    });
     return () => {
       cancelled = true;
+      if (timer) clearInterval(timer);
     };
+  }, [refresh]);
+
+  useEffect(() => {
+    // BET-678: live sync deltas own freshness after the initial sync. The box
+    // publishes `{kind:"sync"}` envelopes (full current values for changed
+    // fields); the events stream ALSO fires a synthetic `{ resync: true }`
+    // marker on every reconnect so we re-pull from our cursor for anything we
+    // missed while disconnected.
+    if (!window.api.onSyncDelta) return;
+    const off = window.api.onSyncDelta((delta) => {
+      const isResync = "resync" in delta && delta.resync === true;
+      if (isResync) {
+        void refresh();
+        return;
+      }
+      // applySyncPayload owns the stale-envelope guard (same gen, lower seq).
+      useStore.getState().applySyncPayload(delta as SyncPayload);
+    });
+    return off;
   }, [refresh]);
 
   useEffect(() => {
@@ -1164,6 +1193,23 @@ function AppInner() {
                   · {describeConnection(connectionState)}
                 </span>
               )}
+            {/* BET-678: the box's tmux is unreachable — its last refresh tick
+                failed. Keep serving the last-known session list but surface a
+                subtle amber marker so "stale data" isn't read as "the box is
+                empty". */}
+            {boxStale && (
+              <span
+                className="shrink-0 inline-flex items-center gap-1 text-text-faint"
+                title="The box's tmux is unreachable — showing the last known session list."
+              >
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                  style={{ backgroundColor: "#f59e0b" }}
+                  aria-hidden="true"
+                />
+                last known state
+              </span>
+            )}
           </div>
 
           {/* Session-mode toggle (BET-459): a terminal glyph that swaps
@@ -1202,7 +1248,9 @@ function AppInner() {
             // unmounting the tree BEFORE onboarding could ever render (the
             // whole app went blank on first launch). Onboarding needs `loaded`
             // too, so neither branch may render until config is in.
-            <div className="h-full" />
+            <div className="h-full w-full flex items-center justify-center">
+              <MantaLoader size="screen" />
+            </div>
           ) : projects.length === 0 ? (
             // Zero-project state (BET-416 §F / BET-417 §A): the new-session
             // composer IS the app's zero state. An unpaired config routes to
@@ -1213,7 +1261,9 @@ function AppInner() {
             activeDraft ? (
               <NewSessionScreen draftId={activeDraft.id} />
             ) : (
-              <div className="h-full" />
+              <div className="h-full w-full flex items-center justify-center">
+                <MantaLoader />
+              </div>
             )
           ) : (
             <>

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1051,7 +1051,7 @@ export function ChatPanel({
 
   // Session ops. All three depend on tmuxSession/windowIndex being non-null
   // (the panel hides the buttons otherwise). The store will pick up the new
-  // project list automatically via the next refresh / tmuxList call.
+  // project list automatically via the next refresh / sync delta call.
   const refresh = useStore((s) => s.refresh);
 
   const forkSession = useCallback(async () => {

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -148,8 +148,8 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   // Order is load-bearing: the transport swap MUST happen before
   // store.refresh(). On the SSH auto-claim path the credentials are persisted
   // by main and window.api is still the Electron preload bridge, which has no
-  // tmuxList — so refresh() would throw before the swap ever happened, and the
-  // wizard would never leave step 1.
+  // syncSnapshot — so refresh() would throw before the swap ever happened, and
+  // the wizard would never leave step 1.
   //
   // window.api.configGet() is what makes the freshly-minted boxToken visible
   // here; it exists on BOTH transports. In http mode it returns the manta

--- a/src/renderer/api/demoApi.test.ts
+++ b/src/renderer/api/demoApi.test.ts
@@ -161,7 +161,10 @@ describe("demo fixture — config (transport-mode resolver lands on 'http')", ()
 
 describe("demoApi — Proxy fallback", () => {  it("explicit methods return the fixture values", async () => {
     expect(await demoApi.configGet()).toBe(demoState.config);
-    expect(await demoApi.tmuxList()).toEqual(demoState.projects);
+    const snap = await demoApi.syncSnapshot({});
+    expect((snap as { changed: { projects: unknown[] } }).changed.projects).toEqual(
+      demoState.projects,
+    );
     const messages = await demoApi.opencodeMessages(demoState.activeSessionId);
     expect(messages).toBe(demoState.messages);
     expect(await demoApi.opencodeQuestions(demoState.activeSessionId)).toEqual([

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -320,8 +320,27 @@ if (DEMO_STATE === "stream" && typeof window !== "undefined") {
 const configGet = (): Promise<typeof demoState.config> =>
   Promise.resolve(demoState.config);
 
-const tmuxList = (): Promise<typeof demoState.projects> =>
-  Promise.resolve(DEMO_STATE === "empty" ? [] : demoState.projects);
+// BET-678: refresh() now boots + resyncs via the single syncSnapshot RPC
+// instead of configGet→tmuxList. The demo transport must satisfy it with a
+// full fixture snapshot so the bootstrap effect paints the sidebar.
+const syncSnapshot = (): Promise<{
+  gen: string;
+  seq: number;
+  changed: {
+    projects: unknown[];
+    config: typeof demoState.config;
+    stale: boolean;
+  };
+}> =>
+  Promise.resolve({
+    gen: "demo",
+    seq: 1,
+    changed: {
+      projects: DEMO_STATE === "empty" ? [] : demoState.projects,
+      config: demoState.config,
+      stale: false,
+    },
+  });
 
 // SSE-style push subscription. The renderer (App.tsx) registers one
 // onStatusEvent listener; we call it back once with the full fixture status
@@ -567,7 +586,7 @@ const claudeLoginCancel = (_sessionKey: string): Promise<{ ok: boolean }> => {
 // ===========================================================================
 export const explicitMethods = {
   configGet,
-  tmuxList,
+  syncSnapshot,
   onStatusEvent,
   opencodeMessages,
   opencodeMessagesCached,

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -60,6 +60,7 @@ export const DEMO_UNIMPLEMENTED = [
   "onScreenshotDetected",
   "onServerUpdateAvailable",
   "onServerUpdateProgress",
+  "onSyncDelta",
   "openExternal",
   "opencodeAbort",
   "opencodeAgents",

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -401,11 +401,11 @@ describe("httpApi bootstrap metadata fail-fast timeout", () => {
     mockLocalStorage["manta_token"] = HEX32;
   });
 
-  it("configGet and tmuxList pass a timeout AbortSignal so a stall fails fast", async () => {
+  it("configGet and syncSnapshot pass a timeout AbortSignal so a stall fails fast", async () => {
     const fetchMock = stubFetch().mockImplementation(async () => jsonResponse({}));
 
     await httpApi.configGet();
-    await httpApi.tmuxList();
+    await httpApi.syncSnapshot({});
 
     const calls = fetchMock.mock.calls;
     expect(calls.length).toBe(2);

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -441,7 +441,6 @@ function fireResync() {
       const marker: SyncDelta = { resync: true };
       for (const fn of sync) { try { fn(marker); } catch { /* listener error — ignore */ } }
     }
-    if (set.size === 0 && sync.size === 0) return; // no listeners yet — nothing to do
   }, 0);
   ship("info", "ws resync");
 }

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -14,7 +14,7 @@ import {
   type StreamEnvelope,
   type WindowStatus,
 } from "../../shared/types.js";
-import type { Api } from "../../shared/api.js";
+import type { Api, SyncDelta } from "../../shared/api.js";
 // BET-559: httpApi used to pull these claim helpers through the (now-retired)
 // mobile shell's pairingLogic re-export. The shared, process-boundary-safe
 // origin is src/shared/claim.mjs — desktop main (src/main/auth.ts) and the
@@ -363,7 +363,8 @@ type Kind =
   | "serverUpdateAvailable"
   | "serverUpdateProgress"
   | "delegate.updated"
-  | "stream";
+  | "stream"
+  | "sync";
 
 // Stream-kind listeners receive the DERIVED envelope `{sub, sessionId, payload}`
 // (see dispatchFrame), not just `payload` — the bus event carries the extra
@@ -380,6 +381,7 @@ const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   serverUpdateProgress: new Set(),
   "delegate.updated": new Set(),
   stream: new Set(),
+  sync: new Set(),
 };
 
 // The live event stream is a WebSocket (not SSE/EventSource): iOS standalone
@@ -429,9 +431,17 @@ function fireResync() {
   setTimeout(() => {
     _resyncing = false;
     const set = listeners.opencode;
-    if (set.size === 0) return; // no listeners yet — nothing to do
     const ev: OpencodeEvent = { type: "server.connected", properties: {} };
     for (const fn of set) { try { fn(ev); } catch { /* listener error — ignore, see onmessage */ } }
+    // BET-678: also tell the app-layer sync listener to re-pull its snapshot
+    // from its persisted cursor — live deltas were issued while we were
+    // disconnected, so the in-place store state may have missed some.
+    const sync = listeners.sync;
+    if (sync.size > 0) {
+      const marker: SyncDelta = { resync: true };
+      for (const fn of sync) { try { fn(marker); } catch { /* listener error — ignore */ } }
+    }
+    if (set.size === 0 && sync.size === 0) return; // no listeners yet — nothing to do
   }, 0);
   ship("info", "ws resync");
 }
@@ -648,9 +658,11 @@ export const httpApi: Api = {
   projectMetaDelete: (tmuxSession) => rpc(IPC.projectMetaDelete, tmuxSession),
 
   // -- tmux operations --
-  // tmuxList is the bootstrap session load — same fail-fast rationale as
-  // configGet.
-  tmuxList: () => rpcWithTimeout(IPC.tmuxList, RPC_METADATA_TIMEOUT_MS),
+  // BET-678: syncSnapshot is the bootstrap + resync session/config load —
+  // same fail-fast rationale as configGet (a stalled connection must fail
+  // fast and be retried rather than pin the empty screen).
+  syncSnapshot: (args) =>
+    rpcWithTimeout(IPC.syncSnapshot, RPC_METADATA_TIMEOUT_MS, args),
   tmuxNewSession: (input) => rpc(IPC.tmuxNewSession, input),
   tmuxNewWindow: (input) => rpc(IPC.tmuxNewWindow, input),
   tmuxRenameSession: (input) => rpc(IPC.tmuxRenameSession, input),
@@ -875,6 +887,13 @@ export const httpApi: Api = {
 
   // -- window status --
   onStatusEvent: (cb) => on<WindowStatus[]>("status", cb),
+
+  // -- sync deltas (BET-678) --
+  // Live `{kind:"sync"}` bus envelopes (full current values for the changed
+  // fields) plus the synthetic `{ resync: true }` marker fired on reconnect
+  // (see fireResync). The app layer routes envelope → applySyncPayload and
+  // marker → refresh() from its cursor.
+  onSyncDelta: (cb) => on<SyncDelta>("sync", cb),
 
   // -- opencode chat --
   opencodeMessages: (sessionId) => rpc(IPC.opencodeMessages, sessionId),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -116,8 +116,10 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
       // BET-678: restore the persisted local snapshot BEFORE the React root
       // renders so the first paint is instant (zero round trips). Only on the
       // paired/http path — there is no snapshot to restore pre-pairing. The
-      // App bootstrap effect then syncs the cursor with the box.
-      loadPersistedSnapshot();
+      // App bootstrap effect then syncs the cursor with the box. boxId scopes
+      // the cache so a re-pair to another box never replays the old box's
+      // sessions/config.
+      loadPersistedSnapshot(config.boxId);
     }
   } catch (e) {
     console.warn("[bui] configGet failed at entry:", e);

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -14,6 +14,7 @@ import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { installHttpTransport, setWindowApi } from "./transportInstall";
 import { applyTheme } from "./theme";
 import { pinDemoClock } from "./clock";
+import { loadPersistedSnapshot } from "./store";
 
 // Demo mode (BET-302): `?demo` in the URL swaps the real httpApi for a
 // fixture-backed transport and skips pairing / config / credential logic
@@ -112,6 +113,11 @@ async function chooseDesktopTransport(realPreload: Api): Promise<void> {
       // SAME session. On localStorage failure it falls back to the preload
       // bridge (window.api stays as-is).
       installHttpTransport(seed);
+      // BET-678: restore the persisted local snapshot BEFORE the React root
+      // renders so the first paint is instant (zero round trips). Only on the
+      // paired/http path — there is no snapshot to restore pre-pairing. The
+      // App bootstrap effect then syncs the cursor with the box.
+      loadPersistedSnapshot();
     }
   } catch (e) {
     console.warn("[bui] configGet failed at entry:", e);

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -850,6 +850,15 @@ describe("last-active session restore (refresh / relaunch)", () => {
     ];
   }
 
+  // Shared restore path: the saved last-used session is alpha/window 1 and the
+  // tree has alpha/beta. Used by several tests below whose saved-cursor differs
+  // only by what surrounds the applyProjects call.
+  function savedAlphaAfterApply() {
+    writeSavedActiveSession({ project: "alpha", window: 1 });
+    useStore.getState().applyProjects(sessions());
+    return useStore.getState();
+  }
+
   it("setActive persists the pin to localStorage", () => {
     useStore.setState({ projects: sessions() });
     useStore.getState().setActive("beta", 0);
@@ -859,9 +868,7 @@ describe("last-active session restore (refresh / relaunch)", () => {
   });
 
   it("applyProjects with no prior selection restores the saved last-used session", () => {
-    writeSavedActiveSession({ project: "alpha", window: 1 });
-    useStore.getState().applyProjects(sessions());
-    const s = useStore.getState();
+    const s = savedAlphaAfterApply();
     expect(s.activeProjectName).toBe("alpha");
     expect(s.activeWindowByProject.alpha).toBe(1);
   });
@@ -898,9 +905,7 @@ describe("last-active session restore (refresh / relaunch)", () => {
   it("applyProjects restores the saved window over the tmux-active one", () => {
     // alpha's tmux-active window is 0, but the user last used window 1 —
     // restore must win so they land exactly where they left off.
-    writeSavedActiveSession({ project: "alpha", window: 1 });
-    useStore.getState().applyProjects(sessions());
-    const s = useStore.getState();
+    const s = savedAlphaAfterApply();
     expect(s.activeProjectName).toBe("alpha");
     expect(s.activeWindowByProject.alpha).toBe(1);
   });
@@ -1056,5 +1061,52 @@ describe("sync snapshot / applySyncPayload (BET-678)", () => {
     expect(useStore.getState().syncSeq).toBe(9);
     expect(useStore.getState().syncGen).toBe("g3");
     (window as unknown as { api?: unknown }).api = prev;
+  });
+
+  it("persists and replays the stale flag (cold boot against an unreachable box)", async () => {
+    useStore.setState({ boxId: "boxA", boxStale: false });
+    useStore.getState().applySyncPayload({ gen: "g", seq: 5, changed: { stale: true } });
+    // flush the 1s debounced write
+    await new Promise((r) => setTimeout(r, 1100));
+    const saved = JSON.parse(localStorage.getItem("manta:sync:snapshot")!) as { stale: boolean };
+    expect(saved.stale).toBe(true);
+    // a cold boot must replay boxStale instead of hardcoding "not stale" —
+    // otherwise the restored cursor would make the box withhold stale and the
+    // amber "last known state" pill would silently never appear.
+    useStore.setState({ boxStale: false, syncGen: null, syncSeq: null, projects: [], loaded: false });
+    loadPersistedSnapshot("boxA");
+    expect(useStore.getState().boxStale).toBe(true);
+  });
+
+  it("loadPersistedSnapshot drops a snapshot owned by a different box (re-pair bleed guard)", () => {
+    localStorage.setItem(
+      "manta:sync:snapshot",
+      JSON.stringify({
+        gen: "g",
+        seq: 1,
+        boxId: "boxA",
+        projects: [proj({ tmuxSession: "a" })],
+        config: {},
+      }),
+    );
+    loadPersistedSnapshot("boxB");
+    expect(localStorage.getItem("manta:sync:snapshot")).toBeNull();
+    expect(useStore.getState().projects).toEqual([]);
+  });
+
+  it("loadPersistedSnapshot restores a snapshot owned by the same box", () => {
+    localStorage.setItem(
+      "manta:sync:snapshot",
+      JSON.stringify({
+        gen: "g",
+        seq: 2,
+        boxId: "boxA",
+        projects: [proj({ tmuxSession: "a" })],
+        config: {},
+      }),
+    );
+    loadPersistedSnapshot("boxA");
+    expect(useStore.getState().projects.map((p) => p.tmuxSession)).toEqual(["a"]);
+    expect(useStore.getState().syncSeq).toBe(2);
   });
 });

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -1063,12 +1063,22 @@ describe("sync snapshot / applySyncPayload (BET-678)", () => {
     (window as unknown as { api?: unknown }).api = prev;
   });
 
+  // Drive the REAL write path (loadPersistedSnapshot → applySyncPayload →
+  // debounced persist), so the fields the snapshot carries are exactly what
+  // schedulePersist writes — not a value planted by hand. `boxId` seeds the
+  // desktop-local spawn ref, mirroring main.tsx's loadPersistedSnapshot(config.boxId).
+  async function seedSnapshot(boxId: string, changed: { stale?: boolean; projects?: Project[] }) {
+    loadPersistedSnapshot(boxId);
+    useStore.getState().applySyncPayload({ gen: "g", seq: 10, changed });
+    await new Promise((r) => setTimeout(r, 1100)); // flush the 1s debounce
+  }
+
   it("persists and replays the stale flag (cold boot against an unreachable box)", async () => {
-    useStore.setState({ boxId: "boxA", boxStale: false });
-    useStore.getState().applySyncPayload({ gen: "g", seq: 5, changed: { stale: true } });
-    // flush the 1s debounced write
-    await new Promise((r) => setTimeout(r, 1100));
-    const saved = JSON.parse(localStorage.getItem("manta:sync:snapshot")!) as { stale: boolean };
+    await seedSnapshot("boxA", { stale: true });
+    const saved = JSON.parse(localStorage.getItem("manta:sync:snapshot")!) as {
+      stale: boolean;
+      boxId: string;
+    };
     expect(saved.stale).toBe(true);
     // a cold boot must replay boxStale instead of hardcoding "not stale" —
     // otherwise the restored cursor would make the box withhold stale and the
@@ -1078,35 +1088,25 @@ describe("sync snapshot / applySyncPayload (BET-678)", () => {
     expect(useStore.getState().boxStale).toBe(true);
   });
 
-  it("loadPersistedSnapshot drops a snapshot owned by a different box (re-pair bleed guard)", () => {
-    localStorage.setItem(
-      "manta:sync:snapshot",
-      JSON.stringify({
-        gen: "g",
-        seq: 1,
-        boxId: "boxA",
-        projects: [proj({ tmuxSession: "a" })],
-        config: {},
-      }),
-    );
+  it("write path stamps the desktop-local boxId, and a different box's snapshot is dropped", async () => {
+    await seedSnapshot("boxA", { projects: [proj({ tmuxSession: "a" })] });
+    // The persisted stamp must be the desktop-local boxId passed to
+    // loadPersistedSnapshot — this would be "" if the write path read
+    // store.boxId (empty in http mode), which is the exact dead-code bug.
+    const saved = JSON.parse(localStorage.getItem("manta:sync:snapshot")!) as { boxId: string };
+    expect(saved.boxId).toBe("boxA");
+    // Re-pair to a different box: the guard must drop the old box's snapshot.
+    useStore.setState({ projects: [], syncGen: null, syncSeq: null, loaded: false });
     loadPersistedSnapshot("boxB");
     expect(localStorage.getItem("manta:sync:snapshot")).toBeNull();
     expect(useStore.getState().projects).toEqual([]);
   });
 
-  it("loadPersistedSnapshot restores a snapshot owned by the same box", () => {
-    localStorage.setItem(
-      "manta:sync:snapshot",
-      JSON.stringify({
-        gen: "g",
-        seq: 2,
-        boxId: "boxA",
-        projects: [proj({ tmuxSession: "a" })],
-        config: {},
-      }),
-    );
+  it("loadPersistedSnapshot restores a snapshot owned by the same box", async () => {
+    await seedSnapshot("boxA", { projects: [proj({ tmuxSession: "a" })] });
+    useStore.setState({ projects: [], syncGen: null, syncSeq: null, loaded: false });
     loadPersistedSnapshot("boxA");
     expect(useStore.getState().projects.map((p) => p.tmuxSession)).toEqual(["a"]);
-    expect(useStore.getState().syncSeq).toBe(2);
+    expect(useStore.getState().syncSeq).toBe(10);
   });
 });

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -4,7 +4,7 @@
 // writeSavedActiveSession). The rest of the file doesn't care — the nodenv
 // differences are confined to the persistence helpers' try/catch.
 import { describe, it, expect, beforeEach } from "vitest";
-import { resolveSessionOwner, useStore } from "./store";
+import { loadPersistedSnapshot, resolveSessionOwner, useStore } from "./store";
 import { writeSavedActiveSession } from "./chatShared";
 import type { Project } from "../shared/types";
 
@@ -944,5 +944,117 @@ describe("last-active session restore (refresh / relaunch)", () => {
     const s = useStore.getState();
     expect(s.activeDraftId).toBe(id);
     expect(s.drafts.some((d) => d.id === id)).toBe(true);
+  });
+});
+
+// ===== Sync snapshot / delta persistence (BET-678) =====
+//
+// applySyncPayload is the single choke point that routes sync snapshots +
+// live deltas into the store (projects/config/stale), advances the cursor,
+// and schedules the persisted snapshot write. loadPersistedSnapshot restores
+// it on cold boot. refresh() drives syncSnapshot with the stored cursor.
+
+describe("sync snapshot / applySyncPayload (BET-678)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useStore.setState({
+      projects: [],
+      activeProjectName: null,
+      activeWindowByProject: {},
+      loaded: false,
+      syncGen: null,
+      syncSeq: null,
+      boxStale: false,
+    });
+  });
+
+  it("routes config + projects, advances the cursor, clears boxStale", () => {
+    useStore.getState().applySyncPayload({
+      gen: "g1",
+      seq: 5,
+      changed: {
+        projects: [proj({ tmuxSession: "s1" })],
+        config: { serverUrl: "u", chatAutoAllow: true, projects: [] },
+        stale: false,
+      },
+    });
+    const s = useStore.getState();
+    expect(s.syncGen).toBe("g1");
+    expect(s.syncSeq).toBe(5);
+    expect(s.boxStale).toBe(false);
+    expect(s.loaded).toBe(true);
+    expect(s.projects.map((p) => p.tmuxSession)).toEqual(["s1"]);
+  });
+
+  it("sets boxStale when a stale field is present and true", () => {
+    useStore.getState().applySyncPayload({ gen: "g", seq: 1, changed: { stale: true } });
+    expect(useStore.getState().boxStale).toBe(true);
+  });
+
+  it("ignores a stale-seq envelope (same gen, lower/equal seq)", () => {
+    const st = useStore.getState();
+    st.applySyncPayload({ gen: "g", seq: 10, changed: { projects: [proj({ tmuxSession: "a" })] } });
+    const before = useStore.getState().projects;
+    st.applySyncPayload({ gen: "g", seq: 8, changed: { projects: [proj({ tmuxSession: "b" })] } });
+    const s = useStore.getState();
+    expect(s.projects).toEqual(before);
+    expect(s.syncSeq).toBe(10);
+  });
+
+  it("persisted snapshot round-trips: apply → save → load applies projects/config", async () => {
+    useStore.getState().applySyncPayload({
+      gen: "g2",
+      seq: 3,
+      changed: {
+        projects: [proj({ tmuxSession: "persisted" })],
+        config: { chatAutoAllow: true, projects: [] },
+      },
+    });
+    // flush the 1s debounced write
+    await new Promise((r) => setTimeout(r, 1100));
+    expect(localStorage.getItem("manta:sync:snapshot")).toBeTruthy();
+
+    // wipe in-memory state, then restore from the persisted snapshot
+    useStore.setState({
+      projects: [],
+      loaded: false,
+      syncGen: null,
+      syncSeq: null,
+      boxStale: false,
+    });
+    loadPersistedSnapshot();
+    const s = useStore.getState();
+    expect(s.syncGen).toBe("g2");
+    expect(s.syncSeq).toBe(3);
+    expect(s.projects.map((p) => p.tmuxSession)).toEqual(["persisted"]);
+    expect(s.loaded).toBe(true);
+  });
+
+  it("corrupt JSON in the snapshot key is removed and does not throw", () => {
+    localStorage.setItem("manta:sync:snapshot", "{not json");
+    expect(() => loadPersistedSnapshot()).not.toThrow();
+    expect(localStorage.getItem("manta:sync:snapshot")).toBeNull();
+  });
+
+  it("refresh() sends the stored cursor and applies the response", async () => {
+    const calls: Array<{ sinceSeq?: number; sinceGen?: string }> = [];
+    const prev = (window as unknown as { api?: unknown }).api;
+    (window as unknown as { api: unknown }).api = {
+      syncSnapshot: async (args: { sinceSeq?: number; sinceGen?: string }) => {
+        calls.push(args);
+        return {
+          gen: "g3",
+          seq: 9,
+          changed: { projects: [proj({ tmuxSession: "r" })] },
+        };
+      },
+    };
+    useStore.setState({ syncGen: "g3", syncSeq: 7 });
+    await useStore.getState().refresh();
+    expect(calls).toEqual([{ sinceSeq: 7, sinceGen: "g3" }]);
+    expect(useStore.getState().projects.map((p) => p.tmuxSession)).toEqual(["r"]);
+    expect(useStore.getState().syncSeq).toBe(9);
+    expect(useStore.getState().syncGen).toBe("g3");
+    (window as unknown as { api?: unknown }).api = prev;
   });
 });

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -8,6 +8,7 @@ import type {
   WindowStatus,
 } from "../shared/types";
 import type { ConnectionState } from "../shared/net/state.js";
+import type { SyncPayload } from "../shared/api.js";
 import { clientToken } from "./api/httpApi";
 import { isAssistantTurnInProgress, runWithConcurrency } from "./chatUtils";
 import { applyTheme, type ThemePref } from "./theme";
@@ -67,6 +68,92 @@ function mergeLocalPairing(cfg: AppConfig): AppConfig {
     serverUrl: serverUrl || cfg.serverUrl,
     boxToken: boxToken || cfg.boxToken,
   };
+}
+
+// BET-678: persisted local snapshot of the last known sync state, so the
+// renderer paints instantly from it on cold boot (zero round trips), then
+// syncs via the server's cursor protocol (`syncSnapshot` with the stored
+// cursor) and applies live `sync` deltas / reconnect markers.
+//
+// `lastRaw*` hold the last RAW payload values so the debounced write
+// serializes exactly what was applied. config is stored PRE local-pairing
+// overlay (the device-local serverUrl/boxToken are re-derived on load via
+// applyConfig→mergeLocalPairing, never baked into the cache).
+const SNAPSHOT_KEY = "manta:sync:snapshot";
+let lastRawProjects: Project[] = [];
+let lastRawConfig: AppConfig | null = null;
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Debounced 1s after each applySyncPayload — coalesces a burst of deltas (a
+// reconnect re-pull + a follow-up live delta) into one write rather than
+// hammering localStorage per envelope.
+function schedulePersist(): void {
+  if (persistTimer) clearTimeout(persistTimer);
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    const { syncGen, syncSeq } = useStore.getState();
+    if (syncGen == null || syncSeq == null) return;
+    const snapshot = {
+      gen: syncGen,
+      seq: syncSeq,
+      projects: lastRawProjects,
+      config: lastRawConfig,
+      savedAt: Date.now(),
+    };
+    try {
+      localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
+    } catch {
+      /* localStorage unavailable (private mode / SSR) — cache is best-effort */
+    }
+  }, 1000);
+}
+
+// Cold-boot restore: parse the persisted snapshot and apply it through
+// applySyncPayload so the cursor + projects/config/boxStale all come up in
+// one shot. Any parse/shape error drops the key and returns null (fall back
+// to a normal server boot). Called from main.tsx BEFORE the React root
+// renders, only on the paired/http path.
+export function loadPersistedSnapshot(): void {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(SNAPSHOT_KEY);
+  } catch {
+    return; // localStorage unavailable — nothing to restore
+  }
+  if (!raw) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    try { localStorage.removeItem(SNAPSHOT_KEY); } catch { /* ignore */ }
+    return;
+  }
+  const s = parsed as {
+    gen?: unknown;
+    seq?: unknown;
+    projects?: unknown;
+    config?: unknown;
+  };
+  if (
+    typeof s?.gen !== "string" ||
+    typeof s?.seq !== "number" ||
+    !Array.isArray(s.projects) ||
+    typeof s.config !== "object" ||
+    s.config === null
+  ) {
+    // Corrupt/incomplete shape — drop it and fall back to a server boot.
+    try { localStorage.removeItem(SNAPSHOT_KEY); } catch { /* ignore */ }
+    return;
+  }
+  useStore.getState().applySyncPayload({
+    gen: s.gen,
+    seq: s.seq,
+    changed: {
+      projects: s.projects as Project[],
+      config: s.config as AppConfig,
+      stale: false,
+    },
+  });
 }
 
 // "Active session" in our UI = (projectName, windowIndex) tuple
@@ -137,6 +224,14 @@ export type ScreenshotToast = {
 
 type State = {
   loaded: boolean;
+  // BET-678: the sync cursor + stale flag. `syncGen`/`syncSeq` are the client's
+  // last-confirmed cursor, sent back to the box on every syncSnapshot call so
+  // it returns only the deltas we missed. `boxStale` is true when the box's
+  // last refresh tick couldn't reach tmux — the sidebar shows an amber "last
+  // known state" indicator and keeps serving the last good list.
+  syncGen: string | null;
+  syncSeq: number | null;
+  boxStale: boolean;
   // ----- HTTP transport + onboarding (M6, BET-49) -----
   // Mirrored from AppConfig so App.tsx can resolve the transport mode
   // (resolveTransportMode) and the onboarding shell can resume. `boxToken`
@@ -369,6 +464,11 @@ type State = {
   setDefaultModel: (model: { providerID: string; modelID: string }) => Promise<void>;
   applyProjects: (projects: Project[]) => void;
   applyConfig: (c: AppConfig) => void;
+  // BET-678: apply one sync payload — routes each changed field to the right
+  // applier, updates the cursor cursor, and schedules the persisted snapshot
+  // write. Ignores nothing; callers are expected to guard for stale envelopes
+  // (same gen, lower seq) before calling when they care.
+  applySyncPayload: (p: SyncPayload) => void;
   // Reflect a successful onboarding claim (BET-49-T2) into store state so
   // resolveTransportMode reads "http" immediately. main already persisted these
   // to config.json via the auth:claim handler; this just mirrors them so the
@@ -464,6 +564,9 @@ type State = {
 
 export const useStore = create<State>((set, get) => ({
   loaded: false,
+  syncGen: null,
+  syncSeq: null,
+  boxStale: false,
   serverUrl: "",
   boxId: "",
   boxToken: "",
@@ -614,17 +717,39 @@ export const useStore = create<State>((set, get) => ({
   setAutoSubmitPrompt: (p) => set({ autoSubmitPrompt: p }),
 
   refresh: async () => {
-    const cfg = await window.api.configGet();
-    // In http mode window.api.configGet() returns the manta-SERVER's config,
-    // which structurally lacks the desktop-local pairing secrets
-    // (serverUrl/boxId/boxToken). Those live only on this desktop — mirrored
-    // into localStorage["manta_server"]/["manta_token"] by main.tsx at boot (and by
-    // the pairing step via applyPairing). Overlay them so applyConfig doesn't
-    // blank the pairing and flip the app back into onboarding on every refresh.
-    get().applyConfig(mergeLocalPairing(cfg));
-    // Un-gated: always fetch projects via httpApi (SSH main path gone, BET-82).
-    const projects = await window.api.tmuxList();
-    get().applyProjects(projects);
+    // BET-678: single cursor RPC. Pass the last-confirmed cursor so the box
+    // returns only the deltas we missed (or a full snapshot when the cursor
+    // is absent / a new server generation). ApplySyncPayload routes each
+    // changed field, updates the cursor, and persists the snapshot.
+    const payload = await window.api.syncSnapshot({
+      sinceSeq: get().syncSeq ?? undefined,
+      sinceGen: get().syncGen ?? undefined,
+    });
+    get().applySyncPayload(payload);
+  },
+
+  applySyncPayload: (p) => {
+    // Ignore stale envelopes: the same generation at a lower/equal seq has
+    // already been applied (or a newer snapshot supersedes it).
+    const cur = get();
+    if (p.gen === cur.syncGen && (cur.syncSeq == null || p.seq <= cur.syncSeq)) return;
+    if (p.changed.config) {
+      lastRawConfig = p.changed.config;
+      // The box's config structurally lacks the desktop-local pairing secrets;
+      // overlay them so applyConfig doesn't blank the pairing and flip the app
+      // back into onboarding on every refresh. The overlay is NOT persisted
+      // (lastRawConfig holds the raw value; secrets are device-local).
+      get().applyConfig(mergeLocalPairing(p.changed.config));
+    }
+    if (p.changed.projects) {
+      lastRawProjects = p.changed.projects;
+      get().applyProjects(p.changed.projects);
+    }
+    if ("stale" in p.changed) {
+      set({ boxStale: !!p.changed.stale });
+    }
+    set({ syncSeq: p.seq, syncGen: p.gen });
+    schedulePersist();
   },
 
   skipOnboarding: async () => {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -75,6 +75,18 @@ function mergeLocalPairing(cfg: AppConfig): AppConfig {
 // syncs via the server's cursor protocol (`syncSnapshot` with the stored
 // cursor) and applies live `sync` deltas / reconnect markers.
 //
+// The payload ALSO persists `stale` (the box-reported unreachability flag)
+// so the amber "last known state" indicator survives a cold boot: without it,
+// the restored cursor would be sent to the box, which — still being in the
+// same stale state — would withhold `stale` (versions.stale === sinceSeq, not
+// `> sinceSeq`) and the client would come back looking healthy with no warning.
+// Persisting + replaying the flag keeps step 8 honest across restarts.
+//
+// The cache is scoped by `boxId` so a re-pair to a DIFFERENT box never replays
+// the previous box's project list/config on first paint (the cursor protocol
+// would self-correct within one round trip, but the surprise paint is worth
+// preventing).
+//
 // `lastRaw*` hold the last RAW payload values so the debounced write
 // serializes exactly what was applied. config is stored PRE local-pairing
 // overlay (the device-local serverUrl/boxToken are re-derived on load via
@@ -91,14 +103,15 @@ function schedulePersist(): void {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = setTimeout(() => {
     persistTimer = null;
-    const { syncGen, syncSeq } = useStore.getState();
+    const { syncGen, syncSeq, boxStale, boxId } = useStore.getState();
     if (syncGen == null || syncSeq == null) return;
     const snapshot = {
       gen: syncGen,
       seq: syncSeq,
+      boxId,
       projects: lastRawProjects,
       config: lastRawConfig,
-      savedAt: Date.now(),
+      stale: boxStale,
     };
     try {
       localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
@@ -110,10 +123,12 @@ function schedulePersist(): void {
 
 // Cold-boot restore: parse the persisted snapshot and apply it through
 // applySyncPayload so the cursor + projects/config/boxStale all come up in
-// one shot. Any parse/shape error drops the key and returns null (fall back
-// to a normal server boot). Called from main.tsx BEFORE the React root
-// renders, only on the paired/http path.
-export function loadPersistedSnapshot(): void {
+// one shot, then the box takes over via the cursor RPC. Any parse/shape error
+// drops the key and returns null (fall back to a normal server boot). A
+// snapshot stamped for a DIFFERENT boxId is dropped too (re-pair — see above).
+// Called from main.tsx BEFORE the React root renders, only on the paired/http
+// path, passing the paired box's boxId.
+export function loadPersistedSnapshot(currentBoxId?: string): void {
   let raw: string | null = null;
   try {
     raw = localStorage.getItem(SNAPSHOT_KEY);
@@ -133,6 +148,8 @@ export function loadPersistedSnapshot(): void {
     seq?: unknown;
     projects?: unknown;
     config?: unknown;
+    boxId?: unknown;
+    stale?: unknown;
   };
   if (
     typeof s?.gen !== "string" ||
@@ -145,13 +162,25 @@ export function loadPersistedSnapshot(): void {
     try { localStorage.removeItem(SNAPSHOT_KEY); } catch { /* ignore */ }
     return;
   }
+  // Cross-box bleed guard: a snapshot owned by a different box must not
+  // briefly show that box's sessions/config. Drop it (no restore).
+  if (
+    typeof s.boxId === "string" &&
+    s.boxId !== "" &&
+    typeof currentBoxId === "string" &&
+    currentBoxId !== "" &&
+    s.boxId !== currentBoxId
+  ) {
+    try { localStorage.removeItem(SNAPSHOT_KEY); } catch { /* ignore */ }
+    return;
+  }
   useStore.getState().applySyncPayload({
     gen: s.gen,
     seq: s.seq,
     changed: {
       projects: s.projects as Project[],
       config: s.config as AppConfig,
-      stale: false,
+      stale: typeof s.stale === "boolean" ? s.stale : false,
     },
   });
 }
@@ -465,9 +494,10 @@ type State = {
   applyProjects: (projects: Project[]) => void;
   applyConfig: (c: AppConfig) => void;
   // BET-678: apply one sync payload — routes each changed field to the right
-  // applier, updates the cursor cursor, and schedules the persisted snapshot
-  // write. Ignores nothing; callers are expected to guard for stale envelopes
-  // (same gen, lower seq) before calling when they care.
+  // applier, advances the cursor, and schedules the persisted snapshot write.
+  // Owns the stale-envelope guard: envelopes at the same generation with a
+  // lower/equal seq are ignored (already applied, or superseded by a newer
+  // snapshot).
   applySyncPayload: (p: SyncPayload) => void;
   // Reflect a successful onboarding claim (BET-49-T2) into store state so
   // resolveTransportMode reads "http" immediately. main already persisted these

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -95,6 +95,13 @@ const SNAPSHOT_KEY = "manta:sync:snapshot";
 let lastRawProjects: Project[] = [];
 let lastRawConfig: AppConfig | null = null;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
+// The boxId the snapshot is scoped to. This is the DESKTOP-LOCAL boxId (from
+// the pairing config), NOT store.boxId — in http mode the box's own config has
+// no boxId (it's a desktop-local field), so store.boxId is "" in normal paired
+// operation. Seeded by loadPersistedSnapshot(currentBoxId) at boot; the persist
+// path stamps it so the cross-box guard in loadPersistedSnapshot has a real
+// value to compare against.
+let snapshotBoxId = "";
 
 // Debounced 1s after each applySyncPayload — coalesces a burst of deltas (a
 // reconnect re-pull + a follow-up live delta) into one write rather than
@@ -103,12 +110,12 @@ function schedulePersist(): void {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = setTimeout(() => {
     persistTimer = null;
-    const { syncGen, syncSeq, boxStale, boxId } = useStore.getState();
+    const { syncGen, syncSeq, boxStale } = useStore.getState();
     if (syncGen == null || syncSeq == null) return;
     const snapshot = {
       gen: syncGen,
       seq: syncSeq,
-      boxId,
+      boxId: snapshotBoxId,
       projects: lastRawProjects,
       config: lastRawConfig,
       stale: boxStale,
@@ -127,8 +134,14 @@ function schedulePersist(): void {
 // drops the key and returns null (fall back to a normal server boot). A
 // snapshot stamped for a DIFFERENT boxId is dropped too (re-pair — see above).
 // Called from main.tsx BEFORE the React root renders, only on the paired/http
-// path, passing the paired box's boxId.
+// path, passing the paired box's desktop-local boxId. On a subsequent launch
+// after a re-pair, main.tsx passes the NEW box's boxId, so any snapshot stamped
+// for the previous box is dropped by the guard below.
 export function loadPersistedSnapshot(currentBoxId?: string): void {
+  // Record the box the CURRENT boot is scoped to — used by schedulePersist to
+  // stamp the write, and by the guard below to detect a re-pair. Must be set
+  // even when there's nothing to restore, so a later persist uses the right id.
+  snapshotBoxId = currentBoxId ?? "";
   let raw: string | null = null;
   try {
     raw = localStorage.getItem(SNAPSHOT_KEY);
@@ -167,9 +180,8 @@ export function loadPersistedSnapshot(currentBoxId?: string): void {
   if (
     typeof s.boxId === "string" &&
     s.boxId !== "" &&
-    typeof currentBoxId === "string" &&
-    currentBoxId !== "" &&
-    s.boxId !== currentBoxId
+    snapshotBoxId !== "" &&
+    s.boxId !== snapshotBoxId
   ) {
     try { localStorage.removeItem(SNAPSHOT_KEY); } catch { /* ignore */ }
     return;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -53,6 +53,28 @@ type PromptAgentMention = {
   source: { value: string; start: number; end: number };
 };
 
+// BET-675/678: the sync cursor/delta payload a client exchanges with the box.
+// `syncSnapshot({sinceSeq, sinceGen})` returns this; `sync` bus envelopes on
+// the events stream carry the same shape. `changed` holds only the fields
+// newer than the client's cursor (or a full snapshot when the cursor is
+// absent / a different server generation).
+export type SyncPayload = {
+  gen: string;
+  seq: number;
+  changed: {
+    projects?: Project[];
+    config?: AppConfig;
+    stale?: boolean;
+  };
+};
+
+// The synthetic resync marker httpApi fires on every events-stream reconnect
+// (mirror of fireResync's `server.connected` for opencode). `{ resync: true }`
+// tells the app layer to re-pull its snapshot from its cursor.
+export type SyncDelta =
+  | SyncPayload
+  | { resync: true };
+
 /**
  * The full `window.api` contract.
  *
@@ -73,10 +95,19 @@ export interface Api {
   configGet(): Promise<AppConfig>;
   configUpdate(patch: Partial<AppConfig>): Promise<AppConfig>;
 
+  // BET-678: cursor snapshot/delta — the single bootstrap + resync RPC.
+  // Pass the client's last-seen { sinceSeq, sinceGen }; the box returns only
+  // the fields newer than the cursor (or a full snapshot when the cursor is
+  // absent / stale generation). Same 15s fail-fast timeout as configGet.
+  syncSnapshot(args: { sinceSeq?: number; sinceGen?: string }): Promise<SyncPayload>;
+  // Live `sync` bus envelopes {@link SyncPayload} as state changes on the box,
+  // plus a synthetic `{ resync: true }` marker on events-stream reconnect so
+  // the app layer re-pulls from its cursor.
+  onSyncDelta(cb: (delta: SyncDelta) => void): () => void;
+
   projectMetaDelete(tmuxSession: string): Promise<AppConfig>;
 
   // tmux operations on the remote
-  tmuxList(): Promise<Project[]>;
   // The create RPCs return the newly-created window's identity (sessionId +
   // windowIndex) alongside the refreshed projects list, so callers can
   // navigate + send the first prompt to the RIGHT session instead of

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -463,6 +463,9 @@ export const IPC = {
   configGet: "config:get",
   configUpdate: "config:update",
 
+  // BET-678: sync cursor snapshot/delta RPC (the single bootstrap + resync).
+  syncSnapshot: "sync:snapshot",
+
   // Project metadata (local-only)
   projectMetaDelete: "project:meta:delete",
 


### PR DESCRIPTION
## Summary

Snapshot-first boot for the desktop renderer (depends on BET-675's `sync:snapshot` RPC + `kind:"sync"` bus envelopes, both merged to main).

The renderer now paints instantly from a persisted local snapshot (zero round trips), syncs via the server's cursor protocol, applies live deltas from the events stream, and resumes from its cursor on reconnect.

**Base:** origin/main @ `5cee2a0f`

## What changed

- **Types** (`src/shared/api.ts`): `SyncPayload` + `SyncDelta`, `syncSnapshot()`, `onSyncDelta(cb)`.
- **httpApi** (`src/renderer/api/httpApi.ts`): `syncSnapshot` (15s `rpcWithTimeout`), `onSyncDelta` wired to a new `sync` listener kind, and `fireResync` now also fires `{ resync: true }` to sync listeners.
- **Store** (`src/renderer/store.ts`): new `syncGen`/`syncSeq`/`boxStale` state + `applySyncPayload` (routes changed fields, advances cursor, ignores stale-seq envelopes, schedules persist). `refresh()` rewritten to the single `syncSnapshot` cursor call. Debounced (1s) `localStorage["manta:sync:snapshot"]` persist + `loadPersistedSnapshot()` (corrupt JSON → dropped, no throw).
- **main.tsx**: `loadPersistedSnapshot()` before the React root renders on the paired/http path.
- **App.tsx**: bootstrap effect replaced with attempt-once + 10s retry-once-succeeded (AuthRequiredError → pairing routing kept); `onSyncDelta` subscription (marker→refresh, envelope→applySyncPayload); amber "last known state" indicator; cold-start `<MantaLoader/>`.
- **Cleanup**: `tmuxList` removed from the Api type, httpApi, demoApi (+ tests); `configGet` kept (still used by Settings/Onboarding/ModelsCard).

## Cross-cutting

Renderer + shared only; `src/server/` untouched (consumes BET-675's existing surface).

## Verification results

**Files changed:** 10 files (`src/renderer/App.tsx`, `src/renderer/api/demoApi.test.ts`, `src/renderer/api/demoApi.ts`, `src/renderer/api/demoCoverage.test.ts`, `src/renderer/api/httpApi.test.ts`, `src/renderer/api/httpApi.ts`, `src/renderer/main.tsx`, `src/renderer/store.test.ts`, `src/renderer/store.ts`, `src/shared/api.ts`, `src/shared/types.ts`)

- PR branch (`multica/BET-678-snapshot-boot`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0 — vitest 2215 pass / 7 skip / 0 fail; node:test 1515 pass / 0 fail.
- Base (`main` @ `5cee2a0f`): typecheck exit 0; test green (node:test 1515 pass/0 fail; vitest passed).
- **Conclusion:** 0 new failures (both suites green).

Logs captured at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.

New tests: `applySyncPayload` routing / cursor advance / stale-seq ignore; persisted snapshot round-trip; corrupt-JSON removal; `refresh()` sends stored cursor + applies response.

Manual sanity note: cold boot with empty localStorage still reaches a populated sidebar (refresh → full snapshot); killing tmux on the box flips the amber pill without emptying the sidebar (stale field preserves last-known projects).
