### PR TITLE
BET-686: build: untrack broken node_modules symlink and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 out/
 dist/
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/dev/projects/better-ui/node_modules


### PR DESCRIPTION
## BET-686 — Untrack the broken node_modules symlink

The tracked `node_modules` symlink pointed at a broken/self-referential target
(`/home/dev/projects/better-ui/node_modules`, empty), so a fresh `git pull` /
checkout had no working toolchain. It also invited accidental commits (`npm
install` makes the tracked entry look deleted — what cost BET-676 a review
cycle).

**Changes (2 files):**
- `.gitignore`: `node_modules/` → `node_modules` (no trailing slash).
  The trailing-slash pattern only matches a *directory*; the broken symlink
  (a non-directory) slipped past it and showed as untracked, able to be
  re-added by `git add -A`. The slash-less pattern matches both the real
  directory and the symlink.
- `node_modules` removal from the index (mode 120000 symlink gone).

**Verified reproducibility:** from this clean branch, `npm ci` produced a real
`node_modules`, and a working toolchain resulted:

```
npm run typecheck  # exit 0, no errors
npm test           # 1523 pass / 0 fail / 0 skip
```

`git ls-files | grep node_modules` → 0; `git check-ignore node_modules` →
ignored. `npm ci` touched no tracked files on the branch.

**Base: origin/main @ 87c0e0e0**

No functional change to `src/` or `src/server/`.
