### PR TITLE
fix(ios) BET-669: permission poll survives subagent drill-in (store lifecycle)

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -208,6 +208,11 @@ final class ChatSessionStore: ObservableObject {
     /// reports running at all, the snapshot is authoritative.
     private var optimisticRunning = false
     private var didRunOnce = false
+    /// Test seams (internal, readable via `@testable`): count one-time vs
+    /// resumable work so tests can assert the split without touching live
+    /// timers or the network.
+    private(set) var transcriptFetchCount = 0
+    private(set) var permissionPollStartedCount = 0
     private var lastRunning: Bool?
     private var lastComplete: Bool?
     /// How many recent messages the CURRENT window covers. Every refetch reuses
@@ -250,11 +255,16 @@ final class ChatSessionStore: ObservableObject {
     // MARK: - Lifecycle
 
     /// Begin loading the session and (for the parent) start the light
-    /// permission poll. Idempotent.
+    /// permission poll. One-time setup is split from resumable work: the
+    /// initial transcript fetch runs once under the `didRunOnce` guard, while
+    /// the permission poll is (re)started whenever it is not already running,
+    /// so a subagent push (`stop`) then pop (`start`) keeps polling without a
+    /// re-fetch.
     func start() {
-        guard !didRunOnce else { return }
-        didRunOnce = true
-        load()
+        if !didRunOnce {
+            didRunOnce = true
+            load()
+        }
         if !isReadOnly {
             startPermissionPoll()
         }
@@ -492,6 +502,7 @@ final class ChatSessionStore: ObservableObject {
     /// unreachable box can hang a request for the URLSession default (a minute
     /// or more), leaving the screen on its skeleton with no way out.
     private func fetchTranscript(isFirstLoad: Bool) async {
+        transcriptFetchCount += 1
         if fetchInFlight {
             fetchPending = true
             return
@@ -554,6 +565,8 @@ final class ChatSessionStore: ObservableObject {
     // MARK: - Permissions (S1a answerable)
 
     private func startPermissionPoll() {
+        guard permissionPoll == nil else { return }
+        permissionPollStartedCount += 1
         let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
             Task { @MainActor in await self?.refreshPermissions() }
         }

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -209,6 +209,46 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertEqual(userBlocks.count, 0, "a failed send must not leave the message in the transcript")
     }
 
+    // MARK: - Permission poll lifecycle (BET-669)
+
+    private func makeLifecycleStore() -> ChatSessionStore {
+        ChatSessionStore(
+            sessionId: "ses",
+            eventStore: MantaEventStore(stream: TestStreamControl(), tokenProvider: { nil }, serverProvider: { nil }),
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+    }
+
+    /// start → stop → start leaves exactly one active poll: the poll is
+    /// resumable work, so `stop()` clears it and the resumed `start()`
+    /// creates a fresh single poll — and an extra `start()` does not pile on a
+    /// second one.
+    func testStartStopStartLeavesOneActivePoll() async {
+        let store = makeLifecycleStore()
+        store.start()
+        XCTAssertEqual(store.permissionPollStartedCount, 1)
+        store.stop()
+        store.start()
+        XCTAssertEqual(store.permissionPollStartedCount, 2,
+                       "stop() then start() must resume the poll as a new single one")
+        store.start()
+        XCTAssertEqual(store.permissionPollStartedCount, 2,
+                       "restarting an already-running poll must not create a second timer")
+    }
+
+    /// start → start must not double the one-time work: one transcript fetch
+    /// and one poll, even when the loading branch fires twice in a row.
+    func testStartTwiceCreatesOnePollAndOneFetch() async {
+        let store = makeLifecycleStore()
+        store.start()
+        store.start()
+        for _ in 0..<5 { await Task.yield() }
+        XCTAssertEqual(store.transcriptFetchCount, 1,
+                       "start() twice must not double-fetch the transcript")
+        XCTAssertEqual(store.permissionPollStartedCount, 1,
+                       "start() twice must not create two poll timers")
+    }
+
     // MARK: - Mock transport
 
     private static func failingSession() -> URLSession {


### PR DESCRIPTION
Opened automatically for `multica/BET-669-store-lifecycle`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-669.