### PR TITLE
refactor(ios) BET-670: single transcript renderer, subagent on TiledView, restore timestamp gutter

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -172,45 +172,18 @@ private struct ChatScreenContent: View {
         Group {
             if store.loadFailed {
                 loadFailure
-            } else if store.loading {
-                loadingSkeleton
             } else {
                 transcript
             }
         }
         .background(tokens.canvas.ignoresSafeArea())
-        // The bottom stack is a safeAreaInset, which reserves its space by
-        // SHRINKING the scroll view. That is the whole point.
+        // The composer FLOATS as an overlay over the full-bleed transcript, so
+        // messages genuinely pass under it while scrolling. The measured
+        // `bottomBarHeight` of that floating stack feeds BOTH the scrim beneath
+        // it (which dims passing content and the home-indicator strip) and the
+        // transcript's `.contentMargins` bottom inset, so at rest the newest
+        // message rests readable above the composer.
         //
-        // Reserving the space the other way — by EXTENDING the scroll content
-        // (a trailing spacer, or a bottom contentMargin) — is what blanked the
-        // transcript on every keyboard open. The old scroll view carried
-        // `.defaultScrollAnchor(.bottom, for:.sizeChanges)` and re-pinned to
-        // the END of its content whenever it resized; with reserved space
-        // inside the content, the end was that blank space and the conversation
-        // scrolled off screen. MessagingUI's TiledView (see `transcript`)
-        // reserves this same space by shrinking the viewport rather than by
-        // extending content, which is the same principle.
-        //
-        // Accepted trade-off: because the inset shrinks the viewport, the
-        // composer now PUSHES the transcript's tail up as it grows a line at a
-        // time, rather than floating over it. The tail moving is the correct
-        // failure mode; a blank transcript is not.
-        //
-        // The composer is deliberately JUST its own glass elements — there is
-        // NO opaque backdrop on the inset. A scroll view still DRAWS its
-        // content underneath a safe-area inset while scrolling, so the
-        // transcript visibly slides beneath the glass composer (which blurs
-        // it) instead of behind a solid bar. The todos card is pinned to the
-        // bottom of this stack, in the transcript area; the running-state row
-        // lives INSIDE the transcript as its typing indicator (see
-        // `transcript`), so it is not duplicated here.
-        // The composer FLOATS over the full-bleed transcript (an overlay, not
-        // an inset), so messages genuinely pass under it while scrolling. A
-        // scrim sits directly beneath it dimming that passing content. A
-        // bottom content margin on the transcript keeps the newest message
-        // resting above the composer at rest, and natural bounce returns (see
-        // `transcript`).
         // Scrim FIRST so it draws beneath the composer, sized to the composer
         // plus an overhang past the safe area — it dims content under the
         // composer and in the home-indicator strip below it.
@@ -546,14 +519,11 @@ private struct ChatScreenContent: View {
 
     // MARK: - Loading skeleton (D2 / BET-631)
 
-    /// Transcript-shaped loading placeholder, shown while the session's first
-    /// transcript fetch is in flight. Renders the shared `ChatLoadingSkeleton`
-    /// (single source of truth — the same one the capture fixture uses) which
-    /// replaces the transcript in place: no layout shift, no full-screen
-    /// spinner.
-    private var loadingSkeleton: some View {
-        ChatLoadingSkeleton()
-    }
+    // The loading skeleton (`ChatLoadingSkeleton`) is no longer rendered from
+    // the chat screen — `content` already shows the full-screen loader while
+    // `store.loading`, so the in-place skeleton branch was unreachable. The
+    // skeleton is KEPT, but only as the harness scene `ChatLoadingScene`
+    // (MantaAppRoot) that the capture fixture drives.
 
     // MARK: - Live cards (todos / permission / question)
 
@@ -612,8 +582,12 @@ private struct ChatScreenContent: View {
 
 /// The pushed subagent screen. Unlike the S4b frozen fixture screen, this one
 /// binds to a LIVE ChatSessionStore for the child opencode session — the
-/// transcript streams while the child is open. Reuses the existing
-/// SubagentHeader + TranscriptView (no second renderer).
+/// transcript streams while the child is open. Built on the SAME TiledView +
+/// `TranscriptRow` machinery as the parent chat (BET-670): the child store
+/// produces rows exactly like the parent, so the wiring is identical — same
+/// scroll-position config, same `.headerContent` spacer pattern (for its own
+/// header), same cell, prepend loader and running indicator. No composer, no
+/// cards, no scrim — the child is read-only.
 struct ChatSubagentScreen: View {
     let title: String
     let subtitle: String
@@ -621,30 +595,47 @@ struct ChatSubagentScreen: View {
     let tokens: Tokens
     @Environment(\.dismiss) private var dismiss
 
+    /// Drives MessagingUI's `TiledView` scroll layer for the child transcript:
+    /// stays on the newest message as the child streams, and stops following
+    /// the moment the user scrolls away. Same config as the parent chat.
+    @State private var scrollPosition = TiledScrollPosition(
+        autoScrollsToBottomOnAppend: true,
+        scrollsToBottomOnReplace: true
+    )
+
+    /// Measured height of the subagent's own header, so the conversation rests
+    /// below it. The header floats as an overlay (reserving nothing itself), so
+    /// `.headerContent` reserves its space the same way the parent's does.
+    @State private var headerHeight: CGFloat = 0
+
     var body: some View {
-        VStack(spacing: 0) {
+        TiledView(dataSource: store.dataSource, scrollPosition: $scrollPosition) { row in
+            TranscriptBlockCell(item: row, tokens: tokens)
+        }
+        .headerContent(.header {
+            Color.clear.frame(height: headerHeight)
+        })
+        .prependLoader(.loader(
+            perform: { store.loadEarlier() },
+            isProcessing: store.loadingEarlier
+        ) {
+            LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {}
+        })
+        .typingIndicator(.indicator(isVisible: store.running) {
+            RunningIndicator(store: store)
+        })
+        .overlay(alignment: .top) {
             SubagentHeader(
                 title: title,
                 subtitle: subtitle,
                 onBack: { dismiss() },
                 tokens: tokens
             )
-            // `.bottom` ALONE also aligns SHORT content to the bottom, which
-            // is what put a screenful of dead space above a subagent report
-            // that does not fill the view. Scoping the anchor to `.sizeChanges`
-            // keeps the useful half — the view sticks to the bottom as the
-            // child streams — while content that fits simply starts at the top.
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    if store.hasEarlier {
-                        LoadEarlierRow(loading: store.loadingEarlier, tokens: tokens) {
-                            store.loadEarlier()
-                        }
-                    }
-                    TranscriptView(blocks: store.blocks, tokens: tokens)
-                }
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { height in
+                headerHeight = height
             }
-            .defaultScrollAnchor(.bottom, for: .sizeChanges)
         }
         .background(tokens.canvas.ignoresSafeArea())
         .navigationBarBackButtonHidden(true)

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -823,13 +823,6 @@ struct TranscriptView: View {
     let blocks: [TranscriptBlock]
     let tokens: Tokens
 
-    /// How far the transcript slides, and therefore how wide the revealed
-    /// timestamp strip is.
-    private static let gutterWidth: CGFloat = 58
-    /// Finger travel needed for a full reveal. Longer than the strip itself, so
-    /// the strip arrives damped instead of slamming open on a flick.
-    private static let gutterTravel: CGFloat = 96
-
     /// Live drag offset, negative (leftward) and clamped to the strip width.
     /// `@GestureState` resets itself the instant the finger lifts, which is what
     /// springs the transcript back with no release handler of our own.
@@ -847,7 +840,7 @@ struct TranscriptView: View {
             // crash on opening a session: the first refetch lands while the
             // first render is still in flight.
             ForEach(Array(blocks.enumerated()), id: \.offset) { pair in
-                blockView(pair.element)
+                transcriptBlockView(pair.element, tokens: tokens)
                     // The timestamp rides WITH its own block rather than living
                     // in a parallel column, so it stays aligned to the thing it
                     // describes no matter how tall that thing is. An overlay
@@ -858,10 +851,10 @@ struct TranscriptView: View {
                     .overlay(alignment: .trailing) {
                         TimestampGutterLabel(
                             date: pair.element.timestamp,
-                            width: Self.gutterWidth,
+                            width: TranscriptGutter.gutterWidth,
                             tokens: tokens
                         )
-                        .offset(x: Self.gutterWidth)
+                        .offset(x: TranscriptGutter.gutterWidth)
                     }
             }
         }
@@ -888,28 +881,9 @@ struct TranscriptView: View {
                     state = 0
                     return
                 }
-                let progress = min(1, -dx / Self.gutterTravel)
-                state = -Self.gutterWidth * progress
+                let progress = min(1, -dx / TranscriptGutter.gutterTravel)
+                state = -TranscriptGutter.gutterWidth * progress
             }
-    }
-
-    @ViewBuilder
-    private func blockView(_ block: TranscriptBlock) -> some View {
-        switch block {
-        case .user(let text, _):
-            UserBand(text: text, tokens: tokens)
-                .padding(.bottom, Metrics.spacing.sp4)
-        case .prose(let text, _):
-            AssistantProse(text: text, tokens: tokens)
-        case .steps(let content):
-            // Machinery is inset to the same margin as prose. Only the USER
-            // band is full-bleed (§8) — that edge-to-edge treatment is what
-            // marks a turn boundary, so letting tool cards share it made every
-            // step group read as a message.
-            StepGroupView(content: content, tokens: tokens)
-                .padding(.horizontal, Metrics.spacing.sp3)
-                .padding(.bottom, Metrics.spacing.sp3)
-        }
     }
 }
 

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -64,6 +64,12 @@ extension StepGroupContent {
 /// Renders ONE transcript block inside `TiledView`, reusing the same
 /// `UserBand` / `AssistantProse` / `StepGroupView` components the rest of the
 /// chat uses — this is not a parallel renderer.
+///
+/// The wall-clock timestamp gutter rides WITH the cell: an overlay parks it off
+/// the trailing edge, and the `TranscriptGutterReveal` gesture (ported verbatim
+/// from the legacy TranscriptView) slides the cell left to reveal it on a
+/// leftward drag. Every TiledView surface shares this cell, so both the parent
+/// chat and the subagent drill-in get the gutter with no per-screen code.
 struct TranscriptBlockCell: TiledCellContent {
     typealias StateValue = Void
 
@@ -71,35 +77,94 @@ struct TranscriptBlockCell: TiledCellContent {
     let tokens: Tokens
 
     func body(context: CellContext<Void>) -> some View {
-        blockView(item.block)
-            // The wall-clock timestamp gutter, exactly as the previous
-            // TranscriptView drew it per block (see TranscriptComponents).
-            .overlay(alignment: .trailing) {
-                TimestampGutterLabel(
-                    date: item.block.timestamp,
-                    width: TranscriptBlockCell.gutterWidth,
-                    tokens: tokens
-                )
-                .offset(x: TranscriptBlockCell.gutterWidth)
-                .allowsHitTesting(false)
-            }
-    }
-
-    @ViewBuilder
-    private func blockView(_ block: TranscriptBlock) -> some View {
-        switch block {
-        case .user(let text, _):
-            UserBand(text: text, tokens: tokens)
-                .padding(.bottom, Metrics.spacing.sp4)
-        case .prose(let text, _):
-            AssistantProse(text: text, tokens: tokens)
-        case .steps(let content):
-            StepGroupView(content: content, tokens: tokens)
-                .padding(.horizontal, Metrics.spacing.sp3)
-                .padding(.bottom, Metrics.spacing.sp3)
+        TranscriptGutterReveal {
+            transcriptBlockView(item.block, tokens: tokens)
+                // The timestamp strip, drawn off-screen at rest (see
+                // TranscriptComponents) and brought in by the reveal gesture.
+                .overlay(alignment: .trailing) {
+                    TimestampGutterLabel(
+                        date: item.block.timestamp,
+                        width: TranscriptGutter.gutterWidth,
+                        tokens: tokens
+                    )
+                    .offset(x: TranscriptGutter.gutterWidth)
+                    .allowsHitTesting(false)
+                }
         }
     }
+}
 
-    /// How far the timestamp strip reaches, matching the old TranscriptView.
-    private static let gutterWidth: CGFloat = 58
+/// The ONE transcript block renderer, shared by every surface — the live
+/// TiledView cell (`TranscriptBlockCell`) and the legacy `TranscriptView` the
+/// capture fixture still uses. There is deliberately no second switch anywhere.
+@ViewBuilder
+func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens) -> some View {
+    switch block {
+    case .user(let text, _):
+        UserBand(text: text, tokens: tokens)
+            .padding(.bottom, Metrics.spacing.sp4)
+    case .prose(let text, _):
+        AssistantProse(text: text, tokens: tokens)
+    case .steps(let content):
+        // Machinery is inset to the same margin as prose. Only the USER
+        // band is full-bleed (§8) — that edge-to-edge treatment is what
+        // marks a turn boundary, so letting tool cards share it made every
+        // step group read as a message.
+        StepGroupView(content: content, tokens: tokens)
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.bottom, Metrics.spacing.sp3)
+    }
+}
+
+/// Gutter geometry, defined ONCE and shared by the cell's reveal gesture and the
+/// legacy TranscriptView (no duplicate constants).
+enum TranscriptGutter {
+    /// Width of the revealed timestamp strip / how far the cell slides.
+    static let gutterWidth: CGFloat = 58
+    /// Finger travel needed for a full reveal. Longer than the strip itself,
+    /// so the strip arrives damped instead of slamming open on a flick.
+    static let gutterTravel: CGFloat = 96
+}
+
+/// Applies the legacy swipe-to-reveal-timestamp gesture to a single cell,
+/// ported VERBATIM from the old TranscriptView: same finger-travel threshold,
+/// same offset math, same spring.
+///
+/// A wrapper View so the `@GestureState` lives in a SwiftUI-backed view — the
+/// cell itself is a `TiledCellContent` (not a `View`), and `@GestureState`
+/// needs real DynamicProperty storage. The gesture is simultaneous with the
+/// scroll view's own pan and deliberately inert unless the movement is clearly
+/// sideways and leftward, so neither gesture steals from the other.
+struct TranscriptGutterReveal<Content: View>: View {
+    private let content: Content
+
+    /// Live drag offset, negative (leftward) and clamped to the strip width.
+    /// `@GestureState` resets itself the instant the finger lifts, which is what
+    /// springs the cell back with no release handler of our own.
+    @GestureState private var gutterReveal: CGFloat = 0
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .offset(x: gutterReveal)
+            .animation(.interactiveSpring(response: 0.28, dampingFraction: 0.86), value: gutterReveal)
+            .simultaneousGesture(gutterGesture)
+    }
+
+    private var gutterGesture: some Gesture {
+        DragGesture(minimumDistance: 16)
+            .updating($gutterReveal) { value, state, _ in
+                let dx = value.translation.width
+                let dy = value.translation.height
+                guard dx < 0, -dx > abs(dy) * 1.5 else {
+                    state = 0
+                    return
+                }
+                let progress = min(1, -dx / TranscriptGutter.gutterTravel)
+                state = -TranscriptGutter.gutterWidth * progress
+            }
+    }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-670-one-transcript-renderer`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-670.