### PR TITLE
fix(server): sync:snapshot first-tick everSucceeded guard (BET-685)

### DIFF
--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -369,8 +369,16 @@ export function buildHandlers({
     // { sinceSeq, sinceGen }; the server returns { gen, seq, changed } with
     // only the fields whose version is newer than sinceSeq (or a full
     // snapshot when the cursor is absent / stale generation / impossible).
-    "sync:snapshot": ({ sinceSeq, sinceGen } = {}) =>
-      syncState.payloadSince(sinceSeq, sinceGen),
+    // BET-685: same first-tick guard as tmux:list. Until ANY syncTick has
+    // succeeded, do a synchronous refresh so a client that calls sync:snapshot
+    // right after server boot (BET-678's cold+boot load path) never receives a
+    // confident zero-project snapshot.
+    "sync:snapshot": async ({ sinceSeq, sinceGen } = {}) => {
+      if (!syncState.everSucceeded()) {
+        await syncState.refreshNow();
+      }
+      return syncState.payloadSince(sinceSeq, sinceGen);
+    },
     // chatMode (BET-113): when the new-session dialog's "chat mode (opencode)"
     // toggle is on, tmux.newSession must create an opencode session, launch a
     // holder pane, and stamp @manta-session-id — so it needs the `oc` client.

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -804,3 +804,38 @@ test("serve-page:list returns an empty list when the store is empty", async () =
   const pages = await handlers["serve-page:list"]();
   assert.deepEqual(pages, []);
 });
+
+// BET-685: sync:snapshot must carry the same first-tick guard as tmux:list.
+// A box that just booted (`everSucceeded() === false`) must do a synchronous
+// refresh before serving its snapshot, so the renderer's boot load never
+// receives a confident zero-project snapshot.
+function makeSnapshotDeps({ everSucceeded, refreshNow }) {
+  const calls = { refreshNow: 0 };
+  const base = makeDeps([]);
+  base.deps.syncState = {
+    refreshNow: async () => {
+      calls.refreshNow += 1;
+      if (refreshNow) await refreshNow();
+    },
+    applyConfig: () => {},
+    snapshot: () => ({ projects: [], config: null, stale: false }),
+    payloadSince: () => ({ gen: "g", seq: 0, changed: [] }),
+    everSucceeded: () => everSucceeded,
+  };
+  return { deps: base.deps, calls };
+}
+
+test("sync:snapshot triggers a synchronous refresh when never succeeded", async () => {
+  const { deps, calls } = makeSnapshotDeps({ everSucceeded: false });
+  const handlers = buildHandlers(deps);
+  await handlers["sync:snapshot"]({});
+  assert.equal(calls.refreshNow, 1);
+});
+
+test("sync:snapshot serves from memory (no refresh) once a tick has succeeded", async () => {
+  const { deps, calls } = makeSnapshotDeps({ everSucceeded: true });
+  const handlers = buildHandlers(deps);
+  const out = await handlers["sync:snapshot"]({ sinceSeq: 1, sinceGen: "g" });
+  assert.equal(calls.refreshNow, 0);
+  assert.deepEqual(out.changed, []);
+});


### PR DESCRIPTION
## Summary

`sync:snapshot` was serving the in-memory sync state immediately, with no first-tick guard. A box that had just booted (between `listen()` and the first `syncTick()` resolving) answered a cursorless `sync:snapshot` with `{ gen, seq, changed: { projects: [], config, stale: false } }`, so the renderer's cold+boot load (BET-678 moved it onto this RPC) landed on the zero-project `NewSessionScreen`, then repainted when the delta arrived.

This gives `sync:snapshot` the same first-tick guard `tmux:list` already has: when `syncState.everSucceeded()` is false, it awaits `syncState.refreshNow()` before returning the payload. Pure server-side; the renderer path is untouched.

## Files changed

- `src/server/rpc.mjs` — `sync:snapshot` handler: await one synchronous refresh on first call.
- `src/server/rpc.test.mjs` — 2 regression tests: refresh fires when never succeeded; no refresh once a tick has succeeded.

**Base: origin/main @ `8ecd9fb5`**

## Verification results

- PR branch (`multica/BET-685-snapshot-first-tick` @ `db28e8d`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1525 pass / 0 fail. Failures: none. log sha256: `f905db0f71e35ac1f5cbe7ce4e0189cc13255fe88642b54ceb7a6f2bf4bdaa57`
- Conclusion: 0 new failures; full suite green on the PR branch.

No follow-ups surfaced — this completes the guard the ticket described; no renderer changes needed.
