### PR TITLE
BET-672: per-session subscriptions, attention gating, subagent upsert, eviction

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -241,8 +241,18 @@ final class ChatSessionStore: ObservableObject {
         self.api = api
         self.isReadOnly = isReadOnly
 
+        // Per-session subscription (BET-672): sink on THIS session's state
+        // alone, filtered to distinct values. The whole-dictionary sink used to
+        // fire on every stream frame of ANY session — including backgrounded
+        // ones — so every flush elsewhere in the box forced a full
+        // `applyStreamState` → `rebuildBlocks` transcript re-map in the open
+        // chat. `MantaSessionStreamState` is value-typed and derives
+        // `Equatable`, so `removeDuplicates()` on the mapped per-session value
+        // emits only when THIS session's state actually changes.
         eventStore.$sessionStates
             .receive(on: DispatchQueue.main)
+            .compactMap { $0[sessionId] }
+            .removeDuplicates()
             .sink { [weak self] _ in self?.applyStreamState() }
             .store(in: &cancellables)
 
@@ -268,11 +278,21 @@ final class ChatSessionStore: ObservableObject {
         if !isReadOnly {
             startPermissionPoll()
         }
+        // Register as an observer so the event store knows a consumer is
+        // attached (BET-672): a session it completes with NO observer has its
+        // accumulated stream chunks evicted to bound memory.
+        eventStore.registerSession(sessionId)
     }
 
     func stop() {
         permissionPoll?.invalidate()
         permissionPoll = nil
+        // The session is leaving the screen: it is no longer a consumer of
+        // this session's stream chunks, and its subagent stores can all go
+        // (BET-672). Dropping the dictionary here is the teardown-path half of
+        // child-store eviction — the transcript-capped half runs per rebuild.
+        eventStore.unregisterSession(sessionId)
+        childStores.removeAll()
     }
 
     func load() {
@@ -478,6 +498,39 @@ final class ChatSessionStore: ObservableObject {
         // Mutate the data source in place (not `= ...`) so its identity — and
         // therefore TiledView's scroll position and cell state — survives.
         dataSource.apply(newRows)
+        // Cap the subagent stores at the children the CURRENT transcript can
+        // actually drill into; stores left over from a previous transcript no
+        // longer show a row the user could open (BET-672).
+        evictChildStores()
+    }
+
+    /// The child session ids present in the CURRENT transcript's subagent rows.
+    /// The drill-in only ever happens from these rows, so they are exactly the
+    /// set a live `childStores` needs to hold; anything else is a leak.
+    private var childIDsInTranscript: Set<String> {
+        var ids = Set<String>()
+        for block in transcript {
+            guard case .steps(let content) = block else { continue }
+            let rows: [StepGroupRow]
+            switch content {
+            case .rows(let r): rows = r
+            case .rollup(_, let r): rows = r
+            }
+            for row in rows {
+                if case .subagent(let agent) = row, let id = agent.childSessionId, !id.isEmpty {
+                    ids.insert(id)
+                }
+            }
+        }
+        return ids
+    }
+
+    private func evictChildStores() {
+        guard !childStores.isEmpty else { return }
+        let live = childIDsInTranscript
+        for id in childStores.keys where !live.contains(id) {
+            childStores.removeValue(forKey: id)
+        }
     }
 
     // MARK: - Refetch

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -132,7 +132,18 @@ enum MantaStreamRouter {
         case "questions":
             s.questions = try? frame.decodedPayload(StreamQuestionsPayload.self)
         case "subagent":
-            if let p = try? frame.decodedPayload(StreamSubagentPayload.self) { s.subagents.append(p) }
+            if let p = try? frame.decodedPayload(StreamSubagentPayload.self) {
+                // Upsert keyed by the subagent's child-session id (BET-672): a
+                // subagent that goes running→done would otherwise leave BOTH
+                // records, so the session list's running-count counts a stale
+                // "running" and the array grows without bound. An incoming
+                // payload replaces the record for its child, else appends.
+                if let i = s.subagents.firstIndex(where: { $0.childSessionId == p.childSessionId }) {
+                    s.subagents[i] = p
+                } else {
+                    s.subagents.append(p)
+                }
+            }
         case "subagent.child", "autoRename":
             break // registration / rename triggers consumed by later stages
         default:
@@ -232,6 +243,12 @@ final class MantaEventStore: ObservableObject {
     private let controller: any MantaEventStreamControl
     private var lastFrameAt: Date
     private var watchdog: Timer?
+    /// Sessions that have a live observer attached (a `ChatSessionStore` that
+    /// has `start()`ed and not yet `stop()`ed). The store clears a session's
+    /// accumulated stream chunks when its turn completes while NO observer is
+    /// attached — nothing would ever retire them, so they'd otherwise
+    /// accumulate without bound (BET-672).
+    private(set) var registeredSessionIDs: Set<String> = []
     /// No frame (heartbeats included) for this long means the socket is dead
     /// even if it claims otherwise. Shared by the watchdog and `resume()`.
     private let staleFrameMs: Double = 45_000
@@ -337,9 +354,30 @@ final class MantaEventStore: ObservableObject {
         // already-published state while unreachable.
         guard !degraded else { return }
         let sid = frame.sessionId ?? ""
-        let next = MantaStreamRouter.applying(frame, to: sessionStates[sid])
+        var next = MantaStreamRouter.applying(frame, to: sessionStates[sid])
+        // A turn that COMPLETED with no observer attached has no one who will
+        // retire its accumulated chunks (retirement lives in the observing
+        // ChatSessionStore's refetch path). Clear them here so an unopened
+        // session's stream text can't accumulate forever (BET-672). An OBSERVED
+        // session is never cleared — its live text is load-bearing for the open
+        // transcript.
+        if next.turnComplete == true, !registeredSessionIDs.contains(sid) {
+            next.chunks.removeAll()
+        }
         sessionStates[sid] = next
         lastStreamFrame = StreamFrameStamp(sessionId: sid, sub: frame.sub)
+    }
+
+    /// Mark a session as having a live observer. Only an observed session keeps
+    /// its accumulated chunks past a completed turn (BET-672).
+    func registerSession(_ sessionId: String) {
+        registeredSessionIDs.insert(sessionId)
+    }
+
+    /// Mark a session as no longer observed. Its turn-complete chunks become
+    /// eligible for eviction on the next routing pass.
+    func unregisterSession(_ sessionId: String) {
+        registeredSessionIDs.remove(sessionId)
     }
 
     /// Retire live stream text the canonical transcript now carries. A session

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -180,13 +180,22 @@ final class SessionListStore: ObservableObject {
     /// session "needs you" signal for the §7.1 warn dot + §7.1a subtitle.
     private func trackAttention(frame: MantaStreamFrame) {
         guard let kind = kind(frame), let sid = frame.sessionId else { return }
+        // Compute the new value first and publish ONLY when it actually differs
+        // from the stored one (BET-672): the raw frame surface carries a row
+        // for every raw event, so an unconditional `objectWillChange.send()`
+        // re-rendered the whole session list per frame even when the attention
+        // set did not change.
+        var changed = false
         if kind == "question.asked" || kind == "permission.asked" {
-            attentionSessions.insert(sid)
+            if !attentionSessions.contains(sid) {
+                attentionSessions.insert(sid)
+                changed = true
+            }
         } else if kind == "question.replied" || kind == "question.rejected"
             || kind == "permission.replied" || kind == "permission.rejected" {
-            attentionSessions.remove(sid)
+            changed = attentionSessions.remove(sid) != nil
         }
-        objectWillChange.send()
+        if changed { objectWillChange.send() }
     }
 
     private func kind(_ frame: MantaStreamFrame) -> String? {

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -290,6 +290,45 @@ final class MantaEventStreamRouterTests: XCTestCase {
         XCTAssertEqual(resulting, original)
     }
 
+    // MARK: - Subagent upsert (BET-672)
+
+    /// A subagent that goes running→done for the SAME child must leave exactly
+    /// one record with status `done`, and its running count over the array must
+    /// be 0 — the previous append left BOTH records and inflated the count.
+    func testSubagentUpsertReplacesByChildSessionID() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"subagent","sessionId":"ses_1","payload":{"childSessionId":"ses_child","status":"running","runningCount":1}}"#),
+            to: state
+        )
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"subagent","sessionId":"ses_1","payload":{"childSessionId":"ses_child","status":"done"}}"#),
+            to: state
+        )
+
+        XCTAssertEqual(state.subagents.count, 1)
+        XCTAssertEqual(state.subagents[0].childSessionId, "ses_child")
+        XCTAssertEqual(state.subagents[0].status, "done")
+        let running = state.subagents.filter { $0.status == "running" }
+        XCTAssertEqual(running.count, 0)
+    }
+
+    /// Distinct children still append — the upsert is keyed by child id, so two
+    /// different children coexist.
+    func testSubagentUpsertAppendsDistinctChildren() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"subagent","sessionId":"ses_1","payload":{"childSessionId":"ses_a","status":"running"}}"#),
+            to: state
+        )
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"subagent","sessionId":"ses_1","payload":{"childSessionId":"ses_b","status":"running"}}"#),
+            to: state
+        )
+
+        XCTAssertEqual(state.subagents.count, 2)
+    }
+
     // MARK: - Retiring covered text (BET-655)
 
     private func flush(_ messageID: String, _ partID: String, _ text: String, field: String = "text") throws -> MantaStreamFrame {
@@ -534,6 +573,62 @@ final class MantaEventStoreTests: XCTestCase {
         XCTAssertTrue(store.sessionStates.isEmpty)
     }
 
+    // MARK: - Turn-complete chunk eviction for unobserved sessions (BET-672)
+
+    /// A turn that COMPLETES with no observer attached has nobody to retire its
+    /// accumulated chunks, so the store must clear them or they accumulate
+    /// without bound for an unopened session.
+    func testTurnCompleteClearsChunksWhenSessionUnobserved() throws {
+        let fake = FakeStreamControl()
+        fake.drive(.connected)
+        let store = makeStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello"}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+
+        fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+
+        XCTAssertEqual(store.sessionStates["ses_1"]?.turnComplete, true)
+        XCTAssertTrue(store.sessionStates["ses_1"]?.chunks.isEmpty ?? false)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.liveText, "")
+    }
+
+    /// An OBSERVED session keeps its chunks past completion — the observing
+    /// ChatSessionStore owns retirement via its refetch, and the live text is
+    /// load-bearing for the open transcript.
+    func testTurnCompleteKeepsChunksWhenSessionObserved() throws {
+        let fake = FakeStreamControl()
+        fake.drive(.connected)
+        let store = makeStore(fake)
+        store.registerSession("ses_1")
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello"}}"#)
+        fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+
+        XCTAssertEqual(store.sessionStates["ses_1"]?.turnComplete, true)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+    }
+
+    /// Registration is un-done by unregistering, so a session that later stops
+    /// being observed becomes eligible again.
+    func testUnregisterSessionRestoresEviction() throws {
+        let fake = FakeStreamControl()
+        fake.drive(.connected)
+        let store = makeStore(fake)
+        store.registerSession("ses_1")
+
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"Hello"}}"#)
+        fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.textByPart["part_3"], "Hello")
+
+        store.unregisterSession("ses_1")
+        // A fresh turn streams + completes while unobserved -> chunks clear.
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_9","partID":"part_1","field":"text","text":"next"}}"#)
+        fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)
+
+        XCTAssertEqual(store.sessionStates["ses_1"]?.liveText, "")
+    }
+
     func testDegradedStopsNewInterpretationButKeepsDeliveredData() throws {
         let fake = FakeStreamControl()
         fake.hasConnectedOnce = true
@@ -702,6 +797,10 @@ final class ChatSessionStoreRetirementTests: XCTestCase {
         fake.hasConnectedOnce = true
         fake.drive(.connected)
         let eventStore = makeEventStore(fake)
+        // This test drives the refetch path, which lives in the observing
+        // ChatSessionStore — register the session as the observed consumer so
+        // turn-complete chunk eviction (BET-672) doesn't apply here.
+        eventStore.registerSession("ses_1")
 
         fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"msg_2","partID":"part_3","field":"text","text":"the answer"}}"#)
         fake.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#)


### PR DESCRIPTION
Opened automatically for `multica/BET-672-per-session-perf`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-672.