### PR TITLE
BET-673: success haptic on turn-complete while scrolled up

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -73,6 +73,8 @@ private struct ChatScreenContent: View {
     @StateObject private var modelStore: ChatModelStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.scenePhase) private var scenePhase
+    @EnvironmentObject private var sessionStore: SessionListStore
     @State private var showOverflow = false
     @State private var branch: String?
     @State private var sessionWindow: (name: String, index: Int, cwd: String)?
@@ -149,6 +151,22 @@ private struct ChatScreenContent: View {
                 Task { await resolveWindowAndBranch() }
             }
             .onDisappear { store.stop() }
+            // BET-673: fire one success haptic when a turn completes while the
+            // user has scrolled up (scroll-to-bottom chip showing) and the scene
+            // is active and haptics are enabled. `onChange` fires exactly once
+            // per false→true edge of `turnComplete`, so there is exactly one
+            // haptic per completion, none on `running` oscillations, and none
+            // when at the bottom.
+            .onChange(of: store.turnComplete) { _, completed in
+                if shouldFireTurnCompleteHaptic(
+                    turnCompleteEdge: completed,
+                    showScrollToBottom: showScrollToBottom,
+                    isActive: scenePhase == .active,
+                    hapticsEnabled: sessionStore.hapticsEnabled
+                ) {
+                    SessionHaptics.fire(.success, enabled: true)
+                }
+            }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("chat-screen")
     }

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -323,3 +323,19 @@ enum SessionHapticKind: Sendable, Equatable {
     case warning       // destructive confirm for a running session
     case success       // a delete finally lands
 }
+
+/// Pure decision for the BET-673 turn-complete success haptic. The chat fires
+/// ONE success haptic only when a turn just completed (the false→true edge of
+/// `turnComplete`) while the user has scrolled up (the scroll-to-bottom chip is
+/// showing) and the scene is foreground/active, and only while haptics are
+/// enabled. Mirrors the §7.4 attention model: no edge, chip, scene or setting
+/// → no haptic. No haptic when at the bottom (completion is visible) and no
+/// haptic from `running` oscillations — only the genuine completion edge.
+func shouldFireTurnCompleteHaptic(
+    turnCompleteEdge: Bool,
+    showScrollToBottom: Bool,
+    isActive: Bool,
+    hapticsEnabled: Bool
+) -> Bool {
+    turnCompleteEdge && showScrollToBottom && isActive && hapticsEnabled
+}

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -155,4 +155,31 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertEqual(WorktreeInfoLogic.gitStateLabel([wt("/a", branch: "main")]), "⎇ main")
         XCTAssertEqual(WorktreeInfoLogic.gitStateLabel([]), "")
     }
+
+    // MARK: - BET-673 turn-complete haptic (all four gates)
+
+    func testTurnCompleteHapticFiresWhenAllGatesPass() {
+        XCTAssertTrue(shouldFireTurnCompleteHaptic(
+            turnCompleteEdge: true, showScrollToBottom: true, isActive: true, hapticsEnabled: true))
+    }
+
+    func testTurnCompleteHapticNoEdge() {
+        XCTAssertFalse(shouldFireTurnCompleteHaptic(
+            turnCompleteEdge: false, showScrollToBottom: true, isActive: true, hapticsEnabled: true))
+    }
+
+    func testTurnCompleteHapticNoScrolledUp() {
+        XCTAssertFalse(shouldFireTurnCompleteHaptic(
+            turnCompleteEdge: true, showScrollToBottom: false, isActive: true, hapticsEnabled: true))
+    }
+
+    func testTurnCompleteHapticInactiveScene() {
+        XCTAssertFalse(shouldFireTurnCompleteHaptic(
+            turnCompleteEdge: true, showScrollToBottom: true, isActive: false, hapticsEnabled: true))
+    }
+
+    func testTurnCompleteHapticHapticsDisabled() {
+        XCTAssertFalse(shouldFireTurnCompleteHaptic(
+            turnCompleteEdge: true, showScrollToBottom: true, isActive: true, hapticsEnabled: false))
+    }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-673-turn-complete-haptic`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-673.