### PR TITLE
BET-681: fix(server): publish sync delta on tmux:select-window

### DIFF
--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -439,7 +439,11 @@ export function buildHandlers({
       await syncState.refreshNow();
       return result;
     },
-    "tmux:select-window": (i) => tmux.selectWindow(i),
+    "tmux:select-window": async (i) => {
+      const result = await tmux.selectWindow(i);
+      await syncState.refreshNow();
+      return result;
+    },
 
     // ---- opencode: simple pass-throughs ----
 

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -839,3 +839,16 @@ test("sync:snapshot serves from memory (no refresh) once a tick has succeeded", 
   assert.equal(calls.refreshNow, 0);
   assert.deepEqual(out.changed, []);
 });
+
+// BET-681: tmux:select-window must publish its materialized-state delta
+// immediately (mirrors the create/kill/rename handlers from BET-675). The
+// switch changes which window is `active` in the projects payload, so the
+// sync delta should fire now instead of at the next 2s poller tick.
+test("tmux:select-window triggers exactly one syncState.refreshNow", async () => {
+  const { deps, calls } = makeSnapshotDeps({ everSucceeded: true });
+  deps.tmux.selectWindow = async (i) => ({ selected: i });
+  const handlers = buildHandlers(deps);
+  const out = await handlers["tmux:select-window"]({ sessionName: "s", windowIndex: 2 });
+  assert.equal(calls.refreshNow, 1);
+  assert.deepEqual(out, { selected: { sessionName: "s", windowIndex: 2 } });
+});


### PR DESCRIPTION
Fixes BET-681.

`tmux:select-window` was the one tmux-mutating RPC handler that didn't call `syncState.refreshNow()`. It switches the focused window, which lives in the materialized `projects` payload, so the renderer's synced state showed the previous window as active until the 2s poller's next tick. This matches the exact shape of neighboring handlers (`tmux:kill-window` is the template) — the select still returns the tmux result, the sync delta now publishes immediately.

**Files changed:** 2 files. `src/server/rpc.mjs` (+6/-1), `src/server/rpc.test.mjs` (+13).

**Verification results:**
- PR branch (`multica/BET-681-select-window-sync` @ `41175084`):
  - typecheck: exit 0. Errors: none. log sha256: `91f955813bcfb46469b3d233dbdc18e3167df08aee427c152fa66bc5651d5ff3`
  - test: exit 0, 1526 pass / 0 fail / 0 skip. Failures: none. log sha256: `657537fac297c65bfaea38446eb9a18e8cddb602cb979030cd03b3c90a3a050a`
- Base (`main` @ `fba8f45a`):
  - typecheck: exit 0. Errors: none. log sha256: `91f955813bcfb46469b3d233dbdc18e3167df08aee427c152fa66bc5651d5ff3`
  - test: exit 0, 1525 pass / 0 fail / 0 skip. Failures: none. log sha256: `7daef8e8ad864fe3b25b6cda350fa53e4fdfd63a55310c8182ed4bc49b6b5052`
- **Conclusion:** 0 failures pre-existing; the +1 test (select-window refreshNow assertion) is the only difference.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `fba8f45a`**