### PR TITLE
BET-683: feat(renderer): tail-first loading for subagent child transcripts

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -289,9 +289,12 @@ export function ChatPanel({
     applyStreamFlush,
     scheduleRefetch,
     spliceMessage,
+    loadEarlierChildTranscript,
     toggleTaskExpand,
     loadedAllRef,
     fetchOpts,
+    childLoadedAllRef,
+    loadingChildEarlier,
   } = useTranscriptState({ sessionId, isActive, motionStateRef });
 
   // ===== Virtualized scroll (BET-679) =====
@@ -1953,6 +1956,9 @@ export function ChatPanel({
       expanded: expandedTasks,
       toggle: toggleTaskExpand,
       childMessages,
+      childLoadedAllRef,
+      loadEarlierChild: loadEarlierChildTranscript,
+      loadingChildEarlier,
       liveStatus: liveChildStatus,
       showThinking,
     }),
@@ -1960,6 +1966,8 @@ export function ChatPanel({
       expandedTasks,
       toggleTaskExpand,
       childMessages,
+      loadEarlierChildTranscript,
+      loadingChildEarlier,
       liveChildStatus,
       showThinking,
     ],

--- a/src/renderer/TaskCard.tsx
+++ b/src/renderer/TaskCard.tsx
@@ -35,6 +35,8 @@ import { MessageRow } from "./MessageRow";
 import { ToolOutput } from "./ToolBodies";
 import { StatusDot } from "./StatusDot";
 import { ToolCard } from "./ToolCard";
+import { LoadEarlierHeader } from "./Transcript";
+import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 
 export function TaskCard({ state }: { state: ToolState }) {
   const ctx = useContext(TaskContext);
@@ -63,6 +65,17 @@ export function TaskCard({ state }: { state: ToolState }) {
   }
   const isExpanded = ctx?.expanded.has(info.childSessionId) ?? false;
   const childMsgs = childMsgsForSummary;
+  // Tail-first loading (BET-683): once the child's tail fetch has filled the
+  // card (>= TRANSCRIPT_TAIL_LIMIT) and the FULL history hasn't been pulled,
+  // show the same "Load earlier messages" header the main transcript uses.
+  // The children render inline inside the parent's card (which lives in the
+  // parent Virtuoso), so like the main path post-BET-679 there is no manual
+  // scroll math — Virtuoso anchors the parent's item as the card grows upward.
+  const showChildLoadEarlier =
+    !!ctx &&
+    childMsgs != null &&
+    childMsgs.length >= TRANSCRIPT_TAIL_LIMIT &&
+    !ctx.childLoadedAllRef.current.get(info.childSessionId);
   const liveState = ctx?.liveStatus.get(info.childSessionId);
   // Prefer live SSE status over the parent's transcript snapshot (which lags
   // by one refetch cycle). Maps "running" → still going, "idle" → finished.
@@ -123,6 +136,13 @@ export function TaskCard({ state }: { state: ToolState }) {
         <div className="px-4 pb-3 border-l-2 border-border flex flex-col" style={{ gap: "var(--sp-2)" }}>
           {childMsgs && childMsgs.length > 0 && (
             <div className="flex flex-col gap-2">
+              {showChildLoadEarlier && (
+                <LoadEarlierHeader
+                  showLoadEarlier
+                  loadingEarlier={ctx.loadingChildEarlier.has(info.childSessionId)}
+                  onLoadEarlier={() => ctx.loadEarlierChild(info.childSessionId)}
+                />
+              )}
               {childMsgs.map((m) => (
                 <MessageRow
                   key={m.info.id}

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -85,26 +85,50 @@ const TranscriptList = forwardRef<HTMLDivElement, ListProps>(function Transcript
 
 // ===== Header: Load earlier =====
 //
-// Renders the slim centered "Load earlier messages" button once the
-// tail-first fetch has filled the panel (messages.length >=
-// TRANSCRIPT_TAIL_LIMIT) and the full history hasn't been loaded yet. On click
-// it pulls the WHOLE transcript and splices it in via `firstItemIndex`, so the
-// user's vertical position is preserved by Virtuoso (no scroll math here).
-function LoadEarlierHeader({ context }: { context: TranscriptContext }) {
-  if (!context.showLoadEarlier) return null;
+// The slim centered "Load earlier messages" button shown once a tail-first
+// fetch has filled the list (>= TRANSCRIPT_TAIL_LIMIT) and the full history
+// hasn't been loaded yet. On click it pulls the WHOLE transcript.
+//
+// Shared additively between the main transcript (which passes the current
+// tail state from its Virtuoso context) and TaskCard's child transcript
+// (which passes a per-child bound context) — one component, never forked.
+// The main transcript's prepend is preserved via Virtuoso's firstItemIndex;
+// the child's lives inline inside the parent's card (see TaskCard).
+export type LoadEarlierHeaderProps = {
+  showLoadEarlier: boolean;
+  loadingEarlier: boolean;
+  onLoadEarlier: () => void;
+};
+export function LoadEarlierHeader({
+  showLoadEarlier,
+  loadingEarlier,
+  onLoadEarlier,
+}: LoadEarlierHeaderProps) {
+  if (!showLoadEarlier) return null;
   return (
     <div className="flex justify-center py-3">
       <button
         type="button"
-        onClick={context.onLoadEarlier}
-        disabled={context.loadingEarlier}
+        onClick={onLoadEarlier}
+        disabled={loadingEarlier}
         className="rounded-full border border-border px-4 py-2 text-meta text-text-muted hover:bg-bg-soft disabled:cursor-not-allowed disabled:opacity-60"
       >
-        {context.loadingEarlier ? "Loading…" : "Load earlier messages"}
+        {loadingEarlier ? "Loading…" : "Load earlier messages"}
       </button>
     </div>
   );
 }
+
+// Virtuoso Header adapter: Virtuoso invokes its Header component with the
+// TranscriptContext (the `context` prop), so bridge it to the shared
+// LoadEarlierHeader's discrete props.
+const LoadEarlier = ({ context }: { context: TranscriptContext }) => (
+  <LoadEarlierHeader
+    showLoadEarlier={context.showLoadEarlier}
+    loadingEarlier={context.loadingEarlier}
+    onLoadEarlier={context.onLoadEarlier}
+  />
+);
 
 // The live "working" indicator (BET-677). A constant-height row at the tail of
 // the transcript that is ALWAYS rendered and toggles `visibility` instead of
@@ -394,7 +418,7 @@ export function Transcript({
               alignToBottom
               increaseViewportBy={{ top: 600, bottom: 200 }}
               components={{
-                Header: LoadEarlierHeader,
+                Header: LoadEarlier,
                 Footer: TranscriptTail,
                 List: TranscriptList,
               }}

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -92,6 +92,13 @@ export type TaskContextValue = {
   // has no cached messages yet; TaskBody renders its collapsed header only in
   // that case (no separate loading/fetch state is tracked here).
   childMessages: Map<string, OpencodeMessage[]>;
+  // Tail-first loading for the child transcript (BET-683). Maps each childId
+  // to whether its FULL history has been pulled (via "Load earlier"); until
+  // true, child fetches pull only TRANSCRIPT_TAIL_LIMIT. Drives the "Load
+  // earlier" header on an expanded TaskCard.
+  childLoadedAllRef: React.MutableRefObject<Map<string, boolean>>;
+  loadEarlierChild: (childId: string) => void;
+  loadingChildEarlier: Set<string>;
   // Live child running/idle from session.status / session.idle events.
   // Overrides the parent's stale `state.status` for the running pulse.
   liveStatus: Map<string, "running" | "idle">;

--- a/src/renderer/hooks/useTranscriptState.test.tsx
+++ b/src/renderer/hooks/useTranscriptState.test.tsx
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { ChatPanel } from "../ChatPanel";
+import { useTranscriptState, TRANSCRIPT_TAIL_LIMIT } from "./useTranscriptState";
 import {
   installMockApi,
   resetStore,
@@ -249,6 +250,106 @@ describe("useTranscriptState via ChatPanel", () => {
 
     // Component should still be mounted.
     expect(h.container.querySelector("textarea")).not.toBeNull();
+  });
+});
+
+// ===== Child transcript tail-first loading (BET-683) =====
+//
+// Mirrors the main-session tail-first policy for subagent child transcripts:
+// fetchChildTranscript passes { limit: TRANSCRIPT_TAIL_LIMIT } until the
+// expanded TaskCard's "Load earlier" pulls the full history (which flips the
+// per-child flag so later fetches stay full). The per-child flag is cleared on
+// session change.
+describe("useTranscriptState child tail-first", () => {
+  type Probe = {
+    fetch: (id: string) => void;
+    loadAll: (id: string) => void;
+    ref: React.MutableRefObject<Map<string, boolean>>;
+  };
+  let probe: Probe | null = null;
+  let h: ReturnType<typeof mount> | null = null;
+
+  // A minimal component that owns the hook and exposes its child functions so
+  // a test can drive them precisely (the repo has no @testing-library).
+  function ChildProbe({ sessionId }: { sessionId: string }) {
+    const {
+      fetchChildTranscript,
+      loadEarlierChildTranscript,
+      childLoadedAllRef,
+    } = useTranscriptState({ sessionId, isActive: true });
+    probe = {
+      fetch: fetchChildTranscript,
+      loadAll: loadEarlierChildTranscript,
+      ref: childLoadedAllRef,
+    };
+    return <div data-testid="child-probe" />;
+  }
+
+  beforeEach(() => {
+    probe = null;
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("fetches a child tail-first, then full after loadEarlier, then stays full", async () => {
+    const fetchCalls: Array<[string, unknown]> = [];
+    installMockApi({
+      opencodeMessages: (sessionId: string, opts?: { limit?: number }) => {
+        fetchCalls.push([sessionId, opts]);
+        return Promise.resolve([]);
+      },
+    });
+    resetStore();
+    h = mount(<ChildProbe sessionId="ses_a" />);
+    await h.flush();
+
+    // Fresh ref: first child fetch pulls the tail.
+    act(() => probe!.fetch("child_1"));
+    await h.flush();
+    expect(fetchCalls.at(-1)).toEqual(["child_1", { limit: TRANSCRIPT_TAIL_LIMIT }]);
+
+    // "Load earlier" pulls the whole history and marks the child loaded-all.
+    act(() => probe!.loadAll("child_1"));
+    await h.flush();
+    expect(fetchCalls.at(-1)).toEqual(["child_1", {}]);
+    expect(probe!.ref.current.get("child_1")).toBe(true);
+
+    // A subsequent fetch for the loaded-all child stays full (no tail cut).
+    act(() => probe!.fetch("child_1"));
+    await h.flush();
+    expect(fetchCalls.at(-1)).toEqual(["child_1", {}]);
+  });
+
+  it("clears childLoadedAllRef on session change so a fresh fetch is tail-limited again", async () => {
+    const fetchCalls: Array<[string, unknown]> = [];
+    installMockApi({
+      opencodeMessages: (sessionId: string, opts?: { limit?: number }) => {
+        fetchCalls.push([sessionId, opts]);
+        return Promise.resolve([]);
+      },
+    });
+    resetStore();
+    h = mount(<ChildProbe sessionId="ses_a" />);
+    await h.flush();
+
+    act(() => probe!.loadAll("child_1"));
+    await h.flush();
+    expect(probe!.ref.current.get("child_1")).toBe(true);
+
+    // Switching sessions clears the per-child loaded-all flags.
+    await act(async () => {
+      h!.rerender(<ChildProbe sessionId="ses_b" />);
+    });
+    await h.flush();
+    expect(probe!.ref.current.get("child_1")).toBeFalsy();
+
+    // A fresh child fetch after the switch is tail-limited again.
+    act(() => probe!.fetch("child_1"));
+    await h.flush();
+    expect(fetchCalls.at(-1)).toEqual(["child_1", { limit: TRANSCRIPT_TAIL_LIMIT }]);
   });
 });
 

--- a/src/renderer/hooks/useTranscriptState.ts
+++ b/src/renderer/hooks/useTranscriptState.ts
@@ -45,6 +45,17 @@ export type TranscriptState = {
   setExpandedTasks: React.Dispatch<React.SetStateAction<Set<string>>>;
   expandedTasksRef: React.MutableRefObject<Set<string>>;
   childMessagesRef: React.MutableRefObject<Map<string, OpencodeMessage[]>>;
+  loadedAllRef: React.MutableRefObject<boolean>;
+  // The options for the next transcript fetch: { limit: TRANSCRIPT_TAIL_LIMIT }
+  // until loadedAllRef flips, then {} (full history).
+  fetchOpts: () => { limit: number } | {};
+  // Tail-first loading for CHILD transcripts (BET-683). `childLoadedAllRef`
+  // maps each childSessionId to whether its FULL history has been pulled (via
+  // "Load earlier"); until true, child fetches pass { limit:
+  // TRANSCRIPT_TAIL_LIMIT }. `loadingChildEarlier` tracks in-flight full-pulls
+  // so the TaskCard's "Load earlier" button can disable + show feedback.
+  childLoadedAllRef: React.MutableRefObject<Map<string, boolean>>;
+  loadingChildEarlier: Set<string>;
   isActiveRef: React.MutableRefObject<boolean>;
   refetchOwedWhileInactive: React.MutableRefObject<boolean>;
   wantQuestionScroll: React.MutableRefObject<boolean>;
@@ -61,14 +72,11 @@ export type TranscriptState = {
   scheduleRefetch: () => void;
   spliceMessage: (messageId: string) => void;
   fetchChildTranscript: (childId: string) => void;
+  // Pull the FULL child transcript once the user clicks "Load earlier" on an
+  // expanded TaskCard. Flips childLoadedAllRef for that child and replaces
+  // the tail with the whole history.
+  loadEarlierChildTranscript: (childId: string) => void;
   toggleTaskExpand: (childId: string) => void;
-  // Whether the full transcript has been loaded (via "Load earlier"). Drives
-  // fetchOpts: until true, fetches pull the tail; once true they pull the
-  // whole history so no earlier message is dropped.
-  loadedAllRef: React.MutableRefObject<boolean>;
-  // The options for the next transcript fetch: { limit: TRANSCRIPT_TAIL_LIMIT }
-  // until loadedAllRef flips, then {} (full history).
-  fetchOpts: () => { limit: number } | {};
 };
 
 export function useTranscriptState(params: {
@@ -122,6 +130,14 @@ export function useTranscriptState(params: {
   useEffect(() => {
     childMessagesRef.current = childMessages;
   }, [childMessages]);
+  // Tail-first loading for child transcripts (BET-683). Mirrors loadedAllRef
+  // but per-child: until an expanded TaskCard's "Load earlier" is clicked, a
+  // child fetch passes { limit: TRANSCRIPT_TAIL_LIMIT }; once clicked it pulls
+  // the full history and sets this child's flag so later refetches stay full.
+  const childLoadedAllRef = useRef<Map<string, boolean>>(new Map());
+  const [loadingChildEarlier, setLoadingChildEarlier] = useState<Set<string>>(
+    () => new Set(),
+  );
   // childRefetchTimers are managed by the ChatPanel caller (see scheduleChildRefetch param).
   const wantQuestionScroll = useRef(false);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -246,8 +262,15 @@ export function useTranscriptState(params: {
   }, [sessionId, scheduleRefetch]);
 
   const fetchChildTranscript = useCallback((childId: string) => {
+    // Tail-first, matching the main session: the first fetch pulls only the
+    // tail unless "Load earlier" has already pulled the full history.
     window.api
-      .opencodeMessages(childId)
+      .opencodeMessages(
+        childId,
+        childLoadedAllRef.current.get(childId)
+          ? {}
+          : { limit: TRANSCRIPT_TAIL_LIMIT },
+      )
       .then((m) => {
         setChildMessages((prev) => {
           const next = new Map(prev);
@@ -256,6 +279,24 @@ export function useTranscriptState(params: {
         });
       })
       .catch(() => { /* non-fatal */ });
+  }, []);
+
+  const loadEarlierChildTranscript = useCallback((childId: string) => {
+    setLoadingChildEarlier((prev) => new Set(prev).add(childId));
+    window.api
+      .opencodeMessages(childId, {})
+      .then((m) => {
+        childLoadedAllRef.current.set(childId, true);
+        setChildMessages((prev) => new Map(prev).set(childId, m));
+      })
+      .catch(() => { /* non-fatal — keep the tail; the button can be retried */ })
+      .finally(() => {
+        setLoadingChildEarlier((prev) => {
+          const next = new Set(prev);
+          next.delete(childId);
+          return next;
+        });
+      });
   }, []);
 
   const toggleTaskExpand = useCallback((childId: string) => {
@@ -274,6 +315,8 @@ export function useTranscriptState(params: {
   // Session-change reset
   useEffect(() => {
     loadedAllRef.current = false;
+    childLoadedAllRef.current.clear();
+    setLoadingChildEarlier(new Set());
     // Cancel any in-flight per-message splice from the PREVIOUS session so a
     // late timer can't refetch + write a stale message into the new session's
     // list. Also clear the max-wait bookkeeping.
@@ -314,8 +357,11 @@ export function useTranscriptState(params: {
     scheduleRefetch,
     spliceMessage,
     fetchChildTranscript,
+    loadEarlierChildTranscript,
     toggleTaskExpand,
     loadedAllRef,
     fetchOpts,
+    childLoadedAllRef,
+    loadingChildEarlier,
   };
 }

--- a/src/renderer/toolRendering.test.tsx
+++ b/src/renderer/toolRendering.test.tsx
@@ -5,8 +5,8 @@
 // below need jsdom because they mount a real React subtree via
 // `./testHarness`.
 
-import { act } from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { act, useState } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { cssVar } from "./chatUtils";
 import { AssistantPart, bulletStyle, ToolCall, formatFileDiff } from "./ToolCall";
 import {
@@ -14,7 +14,10 @@ import {
   mount,
   type Harness,
 } from "./testHarness";
-import type { OpencodePart } from "../shared/types";
+import { TaskCard } from "./TaskCard";
+import { TaskContext, type TaskContextValue, type ToolState } from "./chatShared";
+import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
+import type { OpencodePart, OpencodeMessage } from "../shared/types";
 
 // Tool-call cards start COLLAPSED. Mounting a <ToolCall> hides its body until
 // the disclosure is clicked, so tests that assert on the body expand first.
@@ -331,5 +334,119 @@ describe("TaskBody subagent row", () => {
     // string "subagent"; the badge text is the only place that string can
     // appear when subagent_type is absent.
     expect(h.text()).toContain("subagent");
+  });
+});
+
+// ===== TaskCard child-transcript "Load earlier" header (BET-683) =====
+//
+// Once a child's tail-first fetch fills the expanded card (>= TRANSCRIPT_TAIL_LIMIT)
+// and the full history hasn't been pulled, TaskCard renders the shared
+// LoadEarlierHeader above the first child message. Clicking it calls
+// loadEarlierChild(childId); the header hides once the full fetch resolves
+// (childLoadedAllRef flips true). This drives TaskCard directly via a
+// TaskContext.Provider with controlled values.
+describe("TaskCard child 'Load earlier' header", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function childMsg(i: number): OpencodeMessage {
+    return {
+      info: {
+        id: `cmsg_${i}`,
+        sessionID: "ses_child",
+        role: "assistant",
+        time: { created: i, completed: i + 1 },
+      },
+      parts: [
+        { type: "text", id: `prt_${i}`, messageID: `cmsg_${i}`, text: `child message ${i}` },
+      ],
+    } as OpencodeMessage;
+  }
+
+  // A TailHarness owns the childMessages + loadedAll ref so a test can flip the
+  // "full history loaded" state and watch the header appear/disappear.
+  function TailHarness({
+    load,
+  }: {
+    load: (id: string) => void;
+  }) {
+    const [msgs, setMsgs] = useState<OpencodeMessage[]>(() =>
+      Array.from({ length: TRANSCRIPT_TAIL_LIMIT }, (_, i) => childMsg(i)),
+    );
+    const [loadedAll] = useState<{ current: Map<string, boolean> }>(() => ({
+      current: new Map<string, boolean>(),
+    }));
+    const ctx: TaskContextValue = {
+      expanded: new Set(["ses_child"]),
+      toggle: () => {},
+      childMessages: new Map([["ses_child", msgs]]),
+      childLoadedAllRef: loadedAll,
+      loadEarlierChild: (id) => {
+        load(id);
+        loadedAll.current.set(id, true);
+        // Force a re-render so the header re-evaluates (full history resolved).
+        setMsgs((prev) => prev.slice());
+      },
+      loadingChildEarlier: new Set(),
+      liveStatus: new Map(),
+      showThinking: false,
+    };
+    return (
+      <TaskContext.Provider value={ctx}>
+        <TaskCard state={taskPart({ description: "subagent", subagent_type: "explore" }).state as ToolState} />
+      </TaskContext.Provider>
+    );
+  }
+
+  it("shows the header on a full tail, calls loadEarlierChild on click, and hides it when the full fetch resolves", async () => {
+    const load = vi.fn();
+    installMockApi();
+    h = mount(<TailHarness load={load} />);
+    await h.flush();
+
+    // Tail fill (>= TRANSCRIPT_TAIL_LIMIT) + not loaded-all → header renders.
+    expect(h.text()).toContain("Load earlier messages");
+
+    const btn = Array.from(h.container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Load earlier"),
+    ) as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    act(() => btn.click());
+    await h.flush();
+
+    // Clicking calls loadEarlierChild with the child's session id.
+    expect(load).toHaveBeenCalledWith("ses_child");
+    // Full history resolved → the header disappears.
+    expect(h.text()).not.toContain("Load earlier messages");
+  });
+
+  it("does not render the header for a child transcript under the tail limit", async () => {
+    // A sub-tail child transcript (no "Load earlier" affordance).
+    function UnderLimitHarness() {
+      const msgs = Array.from({ length: 3 }, (_, i) => childMsg(i));
+      const ctx: TaskContextValue = {
+        expanded: new Set(["ses_child"]),
+        toggle: () => {},
+        childMessages: new Map([["ses_child", msgs]]),
+        childLoadedAllRef: { current: new Map<string, boolean>() },
+        loadEarlierChild: () => {},
+        loadingChildEarlier: new Set(),
+        liveStatus: new Map(),
+        showThinking: false,
+      };
+      return (
+        <TaskContext.Provider value={ctx}>
+          <TaskCard state={taskPart({ description: "subagent", subagent_type: "explore" }).state as ToolState} />
+        </TaskContext.Provider>
+      );
+    }
+    installMockApi();
+    h = mount(<UnderLimitHarness />);
+    await h.flush();
+    expect(h.text()).not.toContain("Load earlier messages");
   });
 });


### PR DESCRIPTION
Applies the main-session tail-first policy (BET-676) to subagent child transcripts.

## What changed
- `fetchChildTranscript` now passes `{ limit: TRANSCRIPT_TAIL_LIMIT }` until the expanded TaskCard's "Load earlier" pulls the full history, instead of always fetching the whole transcript in one shot (a long-running subagent no longer downloads its full history when peeked).
- New `loadEarlierChildTranscript` in `useTranscriptState`, exposed via the hook. Per-child `childLoadedAllRef` marks when a child's full history has been pulled; cleared on session change.
- `LoadEarlierHeader` factored into a shared, additive component (discrete `showLoadEarlier`/`loadingEarlier`/`onLoadEarlier` props) reused by both the main transcript (via a Virtuoso Header adapter) and the TaskCard — not forked.
- TaskCard renders the "Load earlier" header above the first child message when the tail fills and the full history hasn't been loaded.

No scroll math added for the child: children render inline inside the parent's card within the parent Virtuoso, which anchors the parent's item as the card grows upward — matching the main path post-BET-679. No server-side changes; the `setChildMessages`/`toggleTaskExpand`/SSE splice paths are untouched.

Base: origin/main @ `fba8f45a`

## Verification results
**Files changed:** 7 files. `chatShared.tsx`, `ChatPanel.tsx`, `Transcript.tsx`, `TaskCard.tsx`, `useTranscriptState.ts`, `useTranscriptState.test.tsx`, `toolRendering.test.tsx`

- PR branch (`multica/BET-683-child-tail` @ `1116aac0`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2214 pass / 0 fail / 7 skip. Failures: none. log sha256: `49497004008b16340d02f6a312637a19cab7a51ff30bd78f813a8d351537b476`
- Base (`main` @ `fba8f45a`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 1, 2209 pass / 1 fail / 7 skip. Failures: `tests/unit/e2e-smoke.test.ts > should confirm Playwright is installed` (environmental Playwright-binary check; passed on the PR branch, unrelated to this renderer change). log sha256: `5a5712e79f3afb46174ff2634ed5571fdaf3f5a0e4b72a6c131e4061687d39e6`
- **Conclusion:** 0 new failures on the PR branch; the single base-branch failure is a pre-existing environmental flake (Playwright install check), unrelated to this change.

Follow-up filed: none — scope-guard respected, no new actionable gaps surfaced.