### PR TITLE
fix(renderer): gate the turn footer on turn completion (BET-688)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -35,6 +35,7 @@ import {
   resolveContextLimit,
   STALE_CACHE_MIN_TOKENS,
   countRunningSubagents,
+  computeTurnInfo,
   shouldAutoRename,
   countUserTurns,
   buildTitlePromptInput,
@@ -1848,51 +1849,13 @@ export function ChatPanel({
   // the last assistant message's `info.tokens.output` — the same persisted,
   // transcript-derived source the context bar uses, so it survives refresh).
   // Intermediate assistant messages within a multi-step turn get no footer —
-  // only the final one does.
-  const turnInfo = useMemo(() => {
-    const out = new Map<
-      string,
-      { turnDurationMs: number | null; outputTokens: number | null }
-    >();
-    if (!messages) return out;
-    let i = 0;
-    while (i < messages.length) {
-      if (messages[i].info.role === "user") {
-        // Walk forward over the run of assistant messages that follow.
-        let j = i + 1;
-        let firstStart: number | null = null;
-        let lastEnd: number | null = null;
-        let lastOutput: number | null = null;
-        let lastAssistantId: string | null = null;
-        while (j < messages.length && messages[j].info.role === "assistant") {
-          const t = messages[j].info.time;
-          if (firstStart == null && t?.created != null) firstStart = t.created;
-          if (t?.completed != null) lastEnd = t.completed;
-          // OpencodeMessageInfo doesn't surface `tokens` directly — read it
-          // off the underlying record the same way `latestTokens` does.
-          const tok = (
-            messages[j].info as unknown as { tokens?: TokenUsage }
-          ).tokens;
-          if (tok && typeof tok.output === "number") lastOutput = tok.output;
-          lastAssistantId = messages[j].info.id;
-          j++;
-        }
-        if (lastAssistantId) {
-          out.set(lastAssistantId, {
-            turnDurationMs:
-              firstStart != null && lastEnd != null && lastEnd > firstStart
-                ? lastEnd - firstStart
-                : null,
-            outputTokens: lastOutput,
-          });
-        }
-        i = j;
-      } else {
-        i++;
-      }
-    }
-    return out;
-  }, [messages]);
+  // only the final one does. While the turn is running, the footer is gated off
+  // its still-streaming final assistant message (it would render behind the
+  // working indicator); it appears once running flips false.
+  const turnInfo = useMemo(
+    () => computeTurnInfo(messages, running),
+    [messages, running],
+  );
 
   // Slash-command provenance per USER message id. Two-source resolution:
   //

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -4,6 +4,7 @@ import {
   updateEntryMotion,
   markReconciledFromOptimistic,
   isOptimisticUserId,
+  computeTurnInfo,
   formatTokens,
   formatBytes,
   expiryLabel,
@@ -2933,5 +2934,90 @@ describe("transcript initial-fetch timeout + retry", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ===== computeTurnInfo (BET-688) =====
+
+describe("computeTurnInfo", () => {
+  const userMsg = (id: string) => ({
+    info: { role: "user", id },
+    parts: [],
+  });
+
+  const assistantMsg = (
+    id: string,
+    opts: { created?: number; completed?: number; output?: number } = {},
+  ) => ({
+    info: {
+      role: "assistant",
+      id,
+      time:
+        opts.created != null || opts.completed != null
+          ? { created: opts.created, completed: opts.completed }
+          : undefined,
+      tokens:
+        opts.output != null ? { input: 0, output: opts.output, reasoning: 0, cache: { read: 0, write: 0 } } : undefined,
+    } as never,
+    parts: [],
+  });
+
+  it("running: true, transcript ending in an assistant message → no footer entry for it", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 5000, output: 42 }),
+    ];
+    const info = computeTurnInfo(messages as never, true);
+    expect(info.size).toBe(0);
+    expect(info.has("a1")).toBe(false);
+  });
+
+  it("running: false, same transcript → footer entry with same duration/tokens", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 5000, output: 42 }),
+    ];
+    const info = computeTurnInfo(messages as never, false);
+    expect(info.has("a1")).toBe(true);
+    expect(info.get("a1")).toEqual({ turnDurationMs: 4000, outputTokens: 42 });
+  });
+
+  it("running: true, transcript ending with a USER message → completed turn footer PRESENT", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 5000, output: 9 }),
+      userMsg("u2"),
+    ];
+    const info = computeTurnInfo(messages as never, true);
+    expect(info.has("a1")).toBe(true);
+    expect(info.get("a1")).toEqual({ turnDurationMs: 4000, outputTokens: 9 });
+  });
+
+  it("multi-step turn, running: false → entry only on the final assistant message", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 2000, output: 3 }),
+      assistantMsg("a2", { created: 2000, completed: 6000, output: 20 }),
+    ];
+    const info = computeTurnInfo(messages as never, false);
+    expect(info.has("a1")).toBe(false);
+    expect(info.has("a2")).toBe(true);
+    expect(info.get("a2")).toEqual({ turnDurationMs: 5000, outputTokens: 20 });
+  });
+
+  it("multi-step turn, running: true → the still-streaming final assistant gets NO footer", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 2000, output: 3 }),
+      assistantMsg("a2", { created: 2000, completed: 6000, output: 20 }),
+    ];
+    const info = computeTurnInfo(messages as never, true);
+    expect(info.has("a1")).toBe(false);
+    expect(info.has("a2")).toBe(false);
+  });
+
+  it("returns empty map for a null transcript", () => {
+    expect(computeTurnInfo(null, false).size).toBe(0);
+    expect(computeTurnInfo(null, true).size).toBe(0);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -4,8 +4,8 @@
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { DelegateApprovalTool, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
-import type { SessionMode } from "./chatShared";
+import type { DelegateApprovalTool, OpencodeMessage, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow } from "../shared/types";
+import type { SessionMode, TokenUsage } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
 // shared/versionCompare.mjs so both src/server/*.mjs and the renderer share
@@ -2270,4 +2270,77 @@ export async function fetchTranscriptWithRetry<T>(
     await new Promise((r) => setTimeout(r, opts.retryDelayMs));
     return withTranscriptFetchTimeout(fetchOnce, opts.timeoutMs);
   }
+}
+
+// Turn boundary metadata: which assistant messages are the FINAL one of their
+// turn (i.e., immediately followed by a user message or end-of-list), the
+// cumulative duration of that turn (first assistant `created` → last assistant
+// `completed`), and the turn's total output tokens (read off the last assistant
+// message's `info.tokens.output` — the same persisted, transcript-derived source
+// the context bar uses, so it survives refresh). Intermediate assistant messages
+// within a multi-step turn get no footer — only the final one does.
+//
+// The `running` gate: while a turn is still in progress we do NOT stamp the
+// footer on its in-progress last assistant message — it would render behind the
+// working indicator at the transcript tail. When `running` flips false the turn
+// is complete and its footer computes normally. When the transcript's last
+// message is a USER message (just submitted), `lastAssistantId` belongs to the
+// previous, already-complete turn, so the gate's comparison is false and that
+// turn keeps its footer.
+export function computeTurnInfo(
+  messages: OpencodeMessage[] | null,
+  running: boolean,
+): Map<string, { turnDurationMs: number | null; outputTokens: number | null }> {
+  const out = new Map<
+    string,
+    { turnDurationMs: number | null; outputTokens: number | null }
+  >();
+  if (!messages) return out;
+  let i = 0;
+  while (i < messages.length) {
+    if (messages[i].info.role === "user") {
+      // Walk forward over the run of assistant messages that follow.
+      let j = i + 1;
+      let firstStart: number | null = null;
+      let lastEnd: number | null = null;
+      let lastOutput: number | null = null;
+      let lastAssistantId: string | null = null;
+      while (j < messages.length && messages[j].info.role === "assistant") {
+        const t = messages[j].info.time;
+        if (firstStart == null && t?.created != null) firstStart = t.created;
+        if (t?.completed != null) lastEnd = t.completed;
+        // OpencodeMessageInfo doesn't surface `tokens` directly — read it
+        // off the underlying record the same way `latestTokens` does.
+        const tok = (
+          messages[j].info as unknown as { tokens?: TokenUsage }
+        ).tokens;
+        if (tok && typeof tok.output === "number") lastOutput = tok.output;
+        lastAssistantId = messages[j].info.id;
+        j++;
+      }
+      // Mid-turn: don't stamp the footer on the in-progress turn's last
+      // assistant message — it renders behind the working indicator. It
+      // appears once running flips false (BET per owner decision).
+      if (
+        running &&
+        lastAssistantId === messages[messages.length - 1]?.info.id
+      ) {
+        i = j;
+        continue;
+      }
+      if (lastAssistantId) {
+        out.set(lastAssistantId, {
+          turnDurationMs:
+            firstStart != null && lastEnd != null && lastEnd > firstStart
+              ? lastEnd - firstStart
+              : null,
+          outputTokens: lastOutput,
+        });
+      }
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  return out;
 }


### PR DESCRIPTION
Leaf implementation of BET-688 — gate the turn footer (duration + output tokens) on turn completion so it no longer renders mid-turn behind the working indicator at the transcript tail.

## What changed

- Extracted the `turnInfo` useMemo's loop from `ChatPanel.tsx` into a new pure `computeTurnInfo(messages, running)` in `chatUtils.ts` (byte-for-byte loop preserved), and added ONE gate before `out.set(lastAssistantId, …)`: when `running` is true and the run's last assistant message is the transcript's final message, skip stamping it (footer suppressed mid-turn, appears once `running` flips false).
- `ChatPanel.tsx` now calls `useMemo(() => computeTurnInfo(messages, running), [messages, running])`.
- Added unit tests for the running gate (running/not, user-tail, multi-step) in `chatUtils.test.ts`.

Scope guards honored: no changes to MessageRow, Transcript, WorkingIndicator, `pastVerbFor`, truncation badge, haptic, or footer formatting; no opacity/visibility hacks (the fix is the absent turnInfo entry); no new dependencies.

Base: origin/main @ `53820a29`

**Files changed:** 3 files.
- `src/renderer/chatUtils.ts` (new `computeTurnInfo`)
- `src/renderer/ChatPanel.tsx` (useMemo → extracted helper)
- `src/renderer/chatUtils.test.ts` (6 new tests)

**Verification results:**
- PR branch (`multica/BET-688-gate-turn-footer` @ `59ffe1a3`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2222 pass / 0 fail / 7 skip. Failures: none. log sha256: `e8edd5b1c0e52a235ab32bb8fcaff5fe50b5e6f4e7fb4fc8042bac596e262d40`
- Base (`main` @ `53820a29`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2216 pass / 0 fail / 7 skip. Failures: none. log sha256: `adfd0c818d6fdad9e59f9946a754d5b235a097b5283890e7bf1f764f55057eb8`
- **Conclusion:** 0 new failures; 6 new tests added (the `computeTurnInfo` suite).

Manual note: while a turn streams, no "…for Ns" line renders anywhere; the moment the turn goes idle the footer appears on the final assistant message, and "Working…" no longer overlaps text.
