### PR TITLE
fix(chat): restore the transcript's right inset — Virtuoso ignores scroller padding

### DIFF
--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -55,13 +55,30 @@ type TranscriptContext = {
   onRejectQuestion: (q: QuestionRequest) => void;
 };
 
+// ===== The reading inset =====
+//
+// NEVER put horizontal padding on the <Virtuoso> root. Virtuoso renders its
+// viewport as `position: absolute` sized against the scroller's PADDING box:
+// with `padding-inline: 48px` on the scroller the viewport computes to
+// `left: 48px; right: -48px; width: <clientWidth>`. The left inset survives,
+// the RIGHT inset is cancelled, every row is 2×inset too wide, and the
+// scroller's own `overflow-x: hidden` clips the overhang — which reads as
+// "text cut off at the right edge with no margin" (measured 2026-08-07:
+// scroller clientWidth 1183 vs true content width 1087, scrollWidth 1268).
+// Padding was correct on the hand-rolled block scroller this replaced; it is
+// not on a Virtuoso root. The inset therefore lives on the IN-FLOW children —
+// List, Header, Footer — where padding behaves normally, and where it also
+// gives the hover timestamp its gutter instead of letting it overflow.
+const TRANSCRIPT_INSET: React.CSSProperties = {
+  paddingInline: "var(--transcript-inset)",
+};
+
 // ===== List (spacing) =====
 //
 // Preserves the reading-column layout the hand-rolled scroller drew: the
-// messages are laid out as a flex column with `--turn-gap` between rows. The
-// horizontal inset + vertical scroll padding live on the Virtuoso root (below);
-// this List only re-introduces the inter-row turn gap that the original single
-// `MeasureColumn stacked` flex container provided.
+// messages are laid out as a flex column with `--turn-gap` between rows, plus
+// the reading inset and the vertical breathing room at the ends of the run
+// (both formerly on the Virtuoso root, where they were silently inert).
 const TranscriptList = forwardRef<HTMLDivElement, ListProps>(function TranscriptList(
   props,
   ref,
@@ -77,6 +94,8 @@ const TranscriptList = forwardRef<HTMLDivElement, ListProps>(function Transcript
         flexDirection: "column",
         gap: "var(--turn-gap)",
         maxWidth: "100%",
+        ...TRANSCRIPT_INSET,
+        paddingBlock: "var(--sp-6)",
       }}
     >
       {children}
@@ -122,13 +141,18 @@ export function LoadEarlierHeader({
 
 // Virtuoso Header adapter: Virtuoso invokes its Header component with the
 // TranscriptContext (the `context` prop), so bridge it to the shared
-// LoadEarlierHeader's discrete props.
+// LoadEarlierHeader's discrete props. Carries the reading inset because
+// Virtuoso renders Header OUTSIDE the List (see TRANSCRIPT_INSET); the shared
+// component stays inset-free so TaskCard can render it inside an already-
+// inset column.
 const LoadEarlier = ({ context }: { context: TranscriptContext }) => (
-  <LoadEarlierHeader
-    showLoadEarlier={context.showLoadEarlier}
-    loadingEarlier={context.loadingEarlier}
-    onLoadEarlier={context.onLoadEarlier}
-  />
+  <div style={TRANSCRIPT_INSET}>
+    <LoadEarlierHeader
+      showLoadEarlier={context.showLoadEarlier}
+      loadingEarlier={context.loadingEarlier}
+      onLoadEarlier={context.onLoadEarlier}
+    />
+  </div>
 );
 
 // The live "working" indicator (BET-677). A constant-height row at the tail of
@@ -168,7 +192,10 @@ export function WorkingIndicator({ running }: { running: boolean }) {
 // the bottom of the transcript in every state).
 function TranscriptTail({ context }: { context: TranscriptContext }) {
   return (
-    <>
+    // Inset + bottom breathing room: Virtuoso renders Footer OUTSIDE the List,
+    // so it needs its own copy of the reading inset (see TRANSCRIPT_INSET) and
+    // the trailing gap the scroller's now-removed padding used to imply.
+    <div style={{ ...TRANSCRIPT_INSET, paddingBottom: "var(--sp-6)" }}>
       <WorkingIndicator running={context.running} />
       {context.activeTodos && context.activeTodos.length > 0 && (
         <ActiveTodos todos={context.activeTodos} onDismiss={context.onDismissTodos} />
@@ -189,7 +216,7 @@ function TranscriptTail({ context }: { context: TranscriptContext }) {
           ))}
         </div>
       )}
-    </>
+    </div>
   );
 }
 
@@ -347,6 +374,7 @@ export function Transcript({
               className="flex-1 overflow-y-auto overflow-x-hidden"
               style={{
                 padding: "var(--sp-6) 0",
+                marginBottom: "var(--sp-2)",
                 paddingInline: "var(--transcript-inset)",
               }}
             >
@@ -372,10 +400,12 @@ export function Transcript({
             <Virtuoso<OpencodeMessage, TranscriptContext>
               ref={virtuosoRef}
               className="flex-1 overflow-x-hidden max-w-full"
-              style={{
-                padding: "var(--sp-6) 0",
-                paddingInline: "var(--transcript-inset)",
-              }}
+              // NO padding here — Virtuoso's absolute viewport ignores it and
+              // the right inset is cancelled (see TRANSCRIPT_INSET). The inset
+              // and the vertical breathing room live on List/Header/Footer.
+              // `marginBottom` is safe (it is outside the scroller box) and is
+              // the gap between the transcript and the composer.
+              style={{ marginBottom: "var(--sp-2)" }}
               data={messages}
               context={virtuosoContext}
               computeItemKey={(_, m) => m.info.id}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -7,6 +7,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Wrap unbreakable tokens (URLs, long file paths) instead of overflowing.
+   Tailwind's `break-words` is `overflow-wrap: break-word`, which does NOT
+   break a long path/URL that has no break opportunity; `anywhere` does.
+   Applied globally so every surface behaves identically (BET-230).
+   Deleting this rule makes a pasted URL or a long `a/b/c/d.tsx` path run off
+   the right edge of the transcript — do not remove it again. */
+.break-words {
+  overflow-wrap: anywhere;
+}
+
 /* `overflow: clip`, NOT `hidden`. `hidden` still makes the box a SCROLL
    CONTAINER — it only removes the scrollbars — so the browser is free to
    scroll it programmatically while the user has no way to scroll it back.


### PR DESCRIPTION
Fixes the text-cutoff regression, the missing composer gap, and restores the URL/path wrapping rule that #693 removed on a wrong diagnosis (mine — the BET-687 spec asserted causes it had not measured).

## Root cause, measured not guessed

Built the renderer and measured the real layout in Chromium via the existing visual harness (demo session, 1440px viewport):

```
scroller  clientW=1183  scrollW=1268  padding-inline=48px  overflow-x=hidden
child     position=absolute  width=1183px  inset=0/-48px/0/48px
```

Virtuoso renders its viewport **`position: absolute`, sized against the scroller's padding box** — `left: 48px; right: -48px`. So the left inset survives, the **right inset is cancelled**, every row is 2×inset too wide, and the scroller's own `overflow-x: hidden` clips the overhang. That is exactly "text cut off at the right edge with no spacing".

Padding on the scroller was correct for the hand-rolled block scroller that BET-679 replaced; it is silently inert (and harmful) on a Virtuoso root. The vertical `padding: sp-6 0` was equally inert for the same reason.

## Fix

Move the reading inset + vertical breathing room onto the **in-flow children** — `List`, and the `Header`/`Footer` adapters (Virtuoso renders those outside the List) — via one shared `TRANSCRIPT_INSET` constant. The shared `LoadEarlierHeader` stays inset-free so TaskCard can keep rendering it inside an already-inset column.

Plus two restorations of things #693 removed:
- `.break-words { overflow-wrap: anywhere }` (BET-230) — without it a pasted URL or long path has no break opportunity and overflows.
- `margin-bottom: var(--sp-2)` on the transcript — the gap above the composer. Margin sits outside the scroller box, so unlike padding it is honoured.

## Verification (same harness, after)

| | before | after |
|---|---|---|
| left / right inset | 48px / **0px** | 48px / **48px** |
| horizontal overflow | 85px | **0px** |
| elements past content right edge | **135** | **0** |
| gap above composer | none | restored |

`npm run typecheck` clean; `npm test` green (2222 renderer, 1526 server).

Note for reviewers: this checkout could not run anything until the self-referencing `node_modules` symlink was removed — see #680, which untracks it.