### PR TITLE
fix(renderer): stop the working row from overlapping the last message (BET-691)

### DIFF
--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -24,7 +24,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { act, createRef } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
 import { mount, installMockApi, type Harness } from "./testHarness";
-import { Transcript, type TranscriptProps } from "./Transcript";
+import { Transcript, TranscriptList, type TranscriptProps } from "./Transcript";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import type { OpencodeMessage } from "../shared/types";
 import type { EntryMotionState } from "./chatUtils";
@@ -209,6 +209,27 @@ describe("Transcript virtualization (react-virtuoso)", () => {
     const rows = h.container.querySelectorAll("[data-message-id]").length;
     expect(rows).toBeGreaterThan(0);
     expect(rows).toBeLessThan(many.length);
+    h.unmount();
+  });
+});
+
+describe("TranscriptList padding pass-through (BET-691)", () => {
+  it("leaves Virtuoso's vertical offsets intact on the list element", () => {
+    // react-virtuoso writes the virtualization offsets into this element's
+    // inline style as paddingTop/paddingBottom. The list adapter must never
+    // overwrite them, or the Footer (the working row) is drawn inside the last
+    // rendered row instead of below it.
+    const h = mount(
+      <TranscriptList
+        data-testid="transcript-list"
+        style={{ paddingTop: 111, paddingBottom: 222 }}
+      >
+        <span>row</span>
+      </TranscriptList>,
+    );
+    const el = h.container.firstElementChild as HTMLElement;
+    expect(el.style.paddingTop).toBe("111px");
+    expect(el.style.paddingBottom).toBe("222px");
     h.unmount();
   });
 });

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -75,11 +75,17 @@ const TRANSCRIPT_INSET: React.CSSProperties = {
 
 // ===== List (spacing) =====
 //
-// Preserves the reading-column layout the hand-rolled scroller drew: the
-// messages are laid out as a flex column with `--turn-gap` between rows, plus
-// the reading inset and the vertical breathing room at the ends of the run
-// (both formerly on the Virtuoso root, where they were silently inert).
-const TranscriptList = forwardRef<HTMLDivElement, ListProps>(function TranscriptList(
+// Preserves the reading-column layout: messages laid out as a flex column with
+// `--turn-gap` between rows, plus the reading inset.
+//
+// NEVER set paddingTop / paddingBottom / paddingBlock / padding here.
+// react-virtuoso writes the virtualization offsets into THIS element's inline
+// style (`paddingTop: offsetTop`, `paddingBottom: offsetBottom`); overwriting
+// them makes the list report a box shorter than its content, and the Footer is
+// then drawn inside the last rendered row (the "loader overlaps the last
+// message" bug). The transcript's vertical breathing room lives on Header and
+// Footer instead, where padding is ours to set.
+export const TranscriptList = forwardRef<HTMLDivElement, ListProps>(function TranscriptList(
   props,
   ref,
 ) {
@@ -95,7 +101,6 @@ const TranscriptList = forwardRef<HTMLDivElement, ListProps>(function Transcript
         gap: "var(--turn-gap)",
         maxWidth: "100%",
         ...TRANSCRIPT_INSET,
-        paddingBlock: "var(--sp-6)",
       }}
     >
       {children}
@@ -146,7 +151,7 @@ export function LoadEarlierHeader({
 // component stays inset-free so TaskCard can render it inside an already-
 // inset column.
 const LoadEarlier = ({ context }: { context: TranscriptContext }) => (
-  <div style={TRANSCRIPT_INSET}>
+  <div style={{ ...TRANSCRIPT_INSET, paddingTop: "var(--sp-6)" }}>
     <LoadEarlierHeader
       showLoadEarlier={context.showLoadEarlier}
       loadingEarlier={context.loadingEarlier}
@@ -168,10 +173,9 @@ export function WorkingIndicator({ running }: { running: boolean }) {
       className="manta-working-indicator flex items-center gap-2 shrink-0"
       style={{
         height: 28,
-        // Sit flush under the last message: cancel the transcript column's
-        // inter-row `--turn-gap` so the reserved idle slot is EXACTLY its own
-        // 28px, not 28px + the turn gap (a stray extra band when idle).
-        marginTop: "calc(var(--turn-gap) * -1)",
+        // Virtuoso renders Footer OUTSIDE List, so the List's flex `gap` never
+        // applies between the last row and this one — this margin IS that gap.
+        marginTop: "var(--block-gap)",
         visibility: running ? "visible" : "hidden",
       }}
       aria-hidden={!running}


### PR DESCRIPTION
Fixes the "working row overlaps the last message" bug in the chat transcript.

## Root cause (two additive causes)
1. `TranscriptList` (the `components.List` adapter) clobbered react-virtuoso's
   virtualization offsets by spreading `...style` and then setting
   `paddingBlock: var(--sp-6)`. `paddingBlock` is a shorthand that overwrites
   both `paddingTop`/`paddingBottom` — the exact longhands Virtuoso writes into
   this element's inline style. With rows unrendered, the list reported a box
   shorter than its content and the Footer (the implicit list-end element that
   holds `WorkingIndicator`) was laid out inside the last rendered row. The same
   clobber mispositioned content when scrolled up.
2. `WorkingIndicator` carried `marginTop: calc(var(--turn-gap) * -1)`, a −24px
   pull-up. The comment's claim (cancelling the column's flex gap) was wrong:
   Virtuoso renders Footer OUTSIDE List, so the List's `gap` never applies
   between the last row and the footer — it was a straight pull-up.

## Changes (all in `src/renderer/Transcript.tsx`)
- Delete the `paddingBlock` clobber from `TranscriptList`. Virtuoso's
  `paddingTop`/`paddingBottom` now survive to the DOM. (`paddingInline` from
  `TRANSCRIPT_INSET` is untouched.)
- `LoadEarlier` header: restored the top breathing room the deleted
  `paddingBlock` used to provide (`paddingTop: var(--sp-6)`).
- `WorkingIndicator`: replaced the negative margin with a normal
  `marginTop: var(--block-gap)` — Footer renders outside List, so this margin
  IS the inter-block gap.
- Exported `TranscriptList` as a named export (previously module-private) for
  the regression test.

## Regression test
`src/renderer/Transcript.test.tsx` — new `TranscriptList padding
pass-through` case renders `TranscriptList` directly with
`style={{ paddingTop: 111, paddingBottom: 222 }}` and asserts the rendered
element's inline style still carries both values. This is the exact contract
that broke.

## Verification
- typecheck: exit 0, no errors
- test: vitest 2223 pass / 7 skip, node:test 1526 pass / 0 fail
- No visual baselines touched (the standing rule is not to run/record
  visual baselines as verification).

Base: origin/main @ cd741d95
