### PR TITLE
fix(renderer): settle turnComplete before clearing running (BET-692)

### DIFF
--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -6,9 +6,11 @@
 // child-session routing, and state transitions. Uses the render harness to
 // mount ChatPanel and emit events through the mock bus.
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { act } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, useRef, useState } from "react";
 import { ChatPanel } from "../ChatPanel";
+import { useSseBus, TURN_SETTLE_MS, type SseBus } from "./useSseBus";
+import type { OpencodeMessage } from "../../shared/types";
 import {
   installMockApi,
   resetStore,
@@ -625,12 +627,119 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
       sessionId: "ses_test",
       payload: { complete: true, running: false },
     });
+    // BET-692: a turnComplete running:false is settled only after TURN_SETTLE_MS,
+    // so wait out the settle window before the drain effect can run.
+    await new Promise((r) => setTimeout(r, TURN_SETTLE_MS + 50));
     await h.flush();
 
     const promptCalls = (api.calls.opencodePrompt ?? []).filter((args) =>
       JSON.stringify(args).includes("second message"),
     );
     expect(promptCalls.length).toBe(1);
+  });
+});
+
+// BET-692 — running must only flip false on a SETTLED completion. The box
+// derives turnComplete from the transcript, so at every tool-step boundary the
+// just-finished step's message is momentarily the transcript tail and a
+// turnComplete with running:false fires mid-turn, re-armed by the next
+// session.status busy 0-134ms later. RunningProbe owns useSseBus directly so
+// the tests can assert the running boolean precisely.
+describe("useSseBus running settle on turnComplete (BET-692)", () => {
+  let probe: { running: boolean } | null = null;
+  let h: ReturnType<typeof mount> | null = null;
+  let bus: ReturnType<typeof installMockApi>["bus"];
+
+  function RunningProbe() {
+    const [, setMessages] = useState<OpencodeMessage[] | null>(null);
+    const childSessionIds = useRef<Set<string>>(new Set());
+    const childMessagesRef = useRef<Map<string, OpencodeMessage[]>>(new Map());
+    const expandedTasksRef = useRef<Set<string>>(new Set());
+    const childRefetchTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+    const isActiveRef = useRef<boolean>(true);
+    const refetchOwedWhileInactive = useRef<boolean>(false);
+    const submitRef = useRef<() => void>(() => {});
+    const sse: SseBus = useSseBus({
+      sessionId: "ses_test",
+      cwd: "/home/dev/projects/x",
+      setMessages,
+      setRefreshing: () => {},
+      scheduleRefetch: () => {},
+      fetchOpts: () => ({}),
+      spliceMessage: () => {},
+      scheduleChildRefetch: () => {},
+      childSessionIds,
+      childMessagesRef,
+      expandedTasksRef,
+      childRefetchTimers,
+      isActiveRef,
+      refetchOwedWhileInactive,
+      applyStreamFlush: () => 0,
+      providerID: null,
+      submit: () => {},
+      submitRef,
+      setInput: () => {},
+    });
+    probe = { running: sse.running };
+    return <div data-testid="running-probe" />;
+  }
+
+  const emit = (sub: "running" | "turnComplete", payload: { running: boolean; complete?: boolean }) =>
+    act(() => bus.emitStream({ sub, sessionId: "ses_test", payload }));
+
+  beforeEach(() => {
+    ({ bus } = installMockApi());
+    resetStore();
+    probe = null;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    vi.useRealTimers();
+  });
+
+  it("absorbs the mid-turn flicker at a tool-step boundary", () => {
+    h = mount(<RunningProbe />);
+
+    // Session busy.
+    emit("running", { running: true });
+    expect(probe!.running).toBe(true);
+
+    // Mid-turn tool-step boundary: the just-finished step's message is
+    // momentarily the transcript tail, so a turnComplete running:false fires.
+    emit("turnComplete", { complete: true, running: false });
+    act(() => { vi.advanceTimersByTime(100); });
+    // Not believed yet — the turn is still marked running.
+    expect(probe!.running).toBe(true);
+
+    // Next session.status busy re-arms running before the settle would fire.
+    emit("running", { running: true });
+    act(() => { vi.advanceTimersByTime(1000); });
+    // The settle timer was cancelled, not merely delayed.
+    expect(probe!.running).toBe(true);
+  });
+
+  it("ends the turn only after the settle window on a genuine completion", () => {
+    h = mount(<RunningProbe />);
+
+    emit("running", { running: true });
+    emit("turnComplete", { complete: true, running: false });
+    // Still pending within the settle window.
+    expect(probe!.running).toBe(true);
+
+    act(() => { vi.advanceTimersByTime(TURN_SETTLE_MS); });
+    expect(probe!.running).toBe(false);
+  });
+
+  it("honours the hard running signal immediately, with no settle delay", () => {
+    h = mount(<RunningProbe />);
+
+    emit("running", { running: true });
+    emit("running", { running: false });
+    // The authoritative running event clears immediately — no timer advance.
+    expect(probe!.running).toBe(false);
   });
 });
 

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -83,6 +83,16 @@ import { markFirstToken, markRendered } from "../firstTokenLatency";
 const INITIAL_FETCH_TIMEOUT_MS = 15_000;
 const INITIAL_FETCH_RETRY_DELAY_MS = 2_000;
 
+// A `turnComplete` with running:false is NOT proof the turn ended: the box
+// derives it from the transcript, and at every tool-step boundary the just-
+// finished step's message is momentarily the transcript tail, so it fires
+// mid-turn and is re-armed by the next `session.status busy` 0-134ms later
+// (measured on the live stream, 2026-08-07). Waiting this long before
+// believing it collapses that flicker, while still self-healing if the hard
+// `session.status {"type":"idle"}` signal is ever dropped.
+const TURN_SETTLE_MS = 400;
+export { TURN_SETTLE_MS };
+
 
 export type SseBus = {
   running: boolean;
@@ -229,6 +239,17 @@ export function useSseBus(params: {
     phase: "running" | "done";
   } | null>(null);
   const compactionClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Timer arming the delayed running→false flip on a `turnComplete` whose
+  // running flag is not yet authoritative (see TURN_SETTLE_MS). Any other
+  // writer of `running` cancels it first, so a stale settle never lands on a
+  // turn it does not belong to.
+  const turnSettleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelTurnSettle = () => {
+    if (turnSettleRef.current) {
+      clearTimeout(turnSettleRef.current);
+      turnSettleRef.current = null;
+    }
+  };
   const [liveTodos, setLiveTodos] = useState<
     Array<{ content: string; status: string; priority: string }> | null
   >(null);
@@ -377,6 +398,7 @@ export function useSseBus(params: {
       if (!shouldAbortForQueuedDrain(messageQueueRef.current.length, drainAbortRef.current)) {
         return;
       }
+      cancelTurnSettle();
       drainAbortRef.current = true;
       void window.api.opencodeAbort(sessionId)
         .catch(() => {
@@ -498,6 +520,7 @@ export function useSseBus(params: {
         const err = (props.error as { data?: { message?: string }; name?: string } | undefined);
         const raw = err?.data?.message ?? err?.name ?? "Unknown server error";
         if (isDrainAbortError(err?.name, drainAbortRef.current)) {
+          cancelTurnSettle();
           setRunning(false);
           return;
         }
@@ -513,6 +536,7 @@ export function useSseBus(params: {
         if (auth) {
           setSendError(`${auth.label} needs to be reconnected.`);
           setAuthReconnect(auth.label);
+          cancelTurnSettle();
           setRunning(false);
           return;
         }
@@ -535,6 +559,7 @@ export function useSseBus(params: {
         }
         setSendError(msg);
         setAuthReconnect(null);
+        cancelTurnSettle();
         setRunning(false);
       }
 
@@ -735,9 +760,29 @@ export function useSseBus(params: {
           if (unmatched > 0) scheduleRefetch();
           return;
         }
-        case "running":
-        case "turnComplete": {
+        case "running": {
+          // Authoritative in both directions: cancel any pending settle so a
+          // stale timer can't clobber this value, then apply it immediately.
+          cancelTurnSettle();
           setRunning((ev.payload as StreamRunningPayload).running);
+          return;
+        }
+        case "turnComplete": {
+          const { running: turnRunning } = ev.payload as StreamRunningPayload;
+          if (turnRunning === true) {
+            cancelTurnSettle();
+            setRunning(true);
+            return;
+          }
+          // running:false is not proof the turn ended — the box derives it from
+          // the transcript, so it fires at every tool-step boundary and is
+          // re-armed by the next `session.status busy`. Start (or restart) a
+          // settle timer; only the hard `running` signal or a genuine end clears
+          // it early.
+          cancelTurnSettle();
+          turnSettleRef.current = setTimeout(() => {
+            setRunning(false);
+          }, TURN_SETTLE_MS);
           return;
         }
         case "todos": {
@@ -781,6 +826,7 @@ export function useSseBus(params: {
     return () => {
       off();
       offStream();
+      cancelTurnSettle();
       if (compactionClearTimer.current) clearTimeout(compactionClearTimer.current);
     };
   }, [sessionId]);


### PR DESCRIPTION
Opened automatically for `multica/BET-692-running-settle`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-692.