### PR TITLE
fix(renderer): report whole-turn tokens (output+reasoning), seed verb from first message, expose computeLiveTurn (BET-693)

### DIFF
--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -244,7 +244,8 @@ export const MessageRow = memo(function MessageRow({
   msg,
   showThinking,
   turnDurationMs,
-  outputTokens,
+  turnTokens,
+  verbSeedId,
   truncation,
   commandInfo,
   streaming = false,
@@ -256,11 +257,16 @@ export const MessageRow = memo(function MessageRow({
   // whole turn (all consecutive assistant messages since the last user msg).
   // Intermediate messages get null so they don't show a footer at all.
   turnDurationMs: number | null;
-  // Output tokens produced by this whole turn (the final assistant message's
-  // `info.tokens.output`). Appended to the duration footer. Transcript-derived,
+  // Tokens produced by this whole turn (`output + reasoning`, summed across
+  // every assistant step). Appended to the duration footer. Transcript-derived,
   // so it survives refresh. null/0 → omitted.
-  outputTokens: number | null;  // Per-message truncation classification from finishByMessageId. Drives
-  // the "truncated" badge appended to the turn-duration footer (or as a
+  turnTokens: number | null;
+  // Seed id the footer verb is derived from — the turn's FIRST assistant
+  // message, so the live working-row verb (seeded the same way) and the
+  // finished-footer verb agree for one turn.
+  verbSeedId: string | null;
+  // Per-message truncation classification from finishByMessageId. Drives the
+  // "truncated" badge appended to the turn-duration footer (or as a
   // standalone footer when there's no duration, e.g. mid-turn assistant
   // messages within a multi-step turn that hit max_tokens). null = no
   // truncation, no badge.
@@ -438,11 +444,11 @@ export const MessageRow = memo(function MessageRow({
               {/* The finished turn keeps the mark the working row was built
                   around, held still — the arcs are what meant "in flight". */}
               <MantaMark size={12} />{" "}
-              {pastVerbFor(msg.info.id)} for {formatDuration(turnDurationMs)}
-              {outputTokens != null && outputTokens > 0 && (
+              {pastVerbFor(verbSeedId ?? msg.info.id)} for {formatDuration(turnDurationMs)}
+              {turnTokens != null && turnTokens > 0 && (
                 <>
                   {" · "}
-                  {formatTokens(outputTokens)}
+                  {formatTokens(turnTokens)}
                 </>
               )}
             </>

--- a/src/renderer/TaskCard.tsx
+++ b/src/renderer/TaskCard.tsx
@@ -152,7 +152,8 @@ export function TaskCard({ state }: { state: ToolState }) {
                   // the turn-duration / truncation overlays designed for the
                   // top-level conversation.
                   turnDurationMs={null}
-                  outputTokens={null}
+                  turnTokens={null}
+                  verbSeedId={null}
                   truncation={null}
                   commandInfo={null}
                 />

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -249,7 +249,11 @@ export type TranscriptProps = {
   // React.memo on MessageRow isn't defeated by fresh object identities).
   turnInfo: Map<
     string,
-    { turnDurationMs: number | null; outputTokens: number | null }
+    {
+      turnDurationMs: number | null;
+      turnTokens: number | null;
+      verbSeedId: string | null;
+    }
   >;
   finishByMessageId: Map<string, import("./chatUtils").TruncationKind>;
   userCommandInfo: Map<string, { name: string; arguments: string }>;
@@ -435,7 +439,8 @@ export function Transcript({
                     msg={m}
                     showThinking={showThinking}
                     turnDurationMs={turnInfo.get(m.info.id)?.turnDurationMs ?? null}
-                    outputTokens={turnInfo.get(m.info.id)?.outputTokens ?? null}
+                    turnTokens={turnInfo.get(m.info.id)?.turnTokens ?? null}
+                    verbSeedId={turnInfo.get(m.info.id)?.verbSeedId ?? null}
                     truncation={finishByMessageId.get(m.info.id) ?? null}
                     commandInfo={cmdInfo}
                     // The message being written right now: last in the

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -8,6 +8,7 @@ import {
   SPINNER_VERBS,
   SPINNER_VERBS_PAST,
   pastVerbFor,
+  presentVerbFor,
   guessMime,
   mimeToInputMode,
   modelInputModes,
@@ -53,6 +54,16 @@ describe("pastVerbFor", () => {
     const seen = new Set<string>();
     for (let i = 0; i < 200; i++) seen.add(pastVerbFor(`id-${i}`));
     expect(seen.size).toBeGreaterThan(1);
+  });
+});
+
+describe("presentVerbFor / pastVerbFor", () => {
+  it("resolve to the SAME index of their respective pools for the same id", () => {
+    for (const id of ["msg-abc", "message-1", "", "🙂", "x".repeat(50)]) {
+      const presentIndex = SPINNER_VERBS.indexOf(presentVerbFor(id));
+      const pastIndex = SPINNER_VERBS_PAST.indexOf(pastVerbFor(id));
+      expect(presentIndex).toBe(pastIndex);
+    }
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -140,12 +140,21 @@ export const SPINNER_VERBS_PAST = [
   "Crafted",
 ];
 
-// Deterministic past-tense verb for a message — same id always picks the same
-// verb so the footer doesn't shuffle when the transcript refetches.
-export function pastVerbFor(messageId: string): string {
+// Deterministic verb for a message — same id always picks the same index so
+// neither the running indicator's present verb nor the footer's past verb
+// shuffles when the transcript refetches. One hash backs both accessors so a
+// single turn shows the SAME verb in flight ("Pondering…") and finished
+// ("Pondered"), rather than two different ones.
+function verbIndexFor(messageId: string): number {
   let h = 0;
   for (let i = 0; i < messageId.length; i++) h = (h * 31 + messageId.charCodeAt(i)) | 0;
-  return SPINNER_VERBS_PAST[Math.abs(h) % SPINNER_VERBS_PAST.length];
+  return Math.abs(h) % SPINNER_VERBS_PAST.length;
+}
+export function presentVerbFor(messageId: string): string {
+  return SPINNER_VERBS[verbIndexFor(messageId)];
+}
+export function pastVerbFor(messageId: string): string {
+  return SPINNER_VERBS_PAST[verbIndexFor(messageId)];
 }
 
 // Detect whether a model can accept file attachments. Two shapes in the wild:

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -5,6 +5,7 @@ import {
   markReconciledFromOptimistic,
   isOptimisticUserId,
   computeTurnInfo,
+  computeLiveTurn,
   formatTokens,
   formatBytes,
   expiryLabel,
@@ -2947,7 +2948,12 @@ describe("computeTurnInfo", () => {
 
   const assistantMsg = (
     id: string,
-    opts: { created?: number; completed?: number; output?: number } = {},
+    opts: {
+      created?: number;
+      completed?: number;
+      output?: number;
+      reasoning?: number;
+    } = {},
   ) => ({
     info: {
       role: "assistant",
@@ -2957,7 +2963,14 @@ describe("computeTurnInfo", () => {
           ? { created: opts.created, completed: opts.completed }
           : undefined,
       tokens:
-        opts.output != null ? { input: 0, output: opts.output, reasoning: 0, cache: { read: 0, write: 0 } } : undefined,
+        opts.output != null || opts.reasoning != null
+          ? {
+              input: 0,
+              output: opts.output ?? 0,
+              reasoning: opts.reasoning ?? 0,
+              cache: { read: 0, write: 0 },
+            }
+          : undefined,
     } as never,
     parts: [],
   });
@@ -2979,7 +2992,11 @@ describe("computeTurnInfo", () => {
     ];
     const info = computeTurnInfo(messages as never, false);
     expect(info.has("a1")).toBe(true);
-    expect(info.get("a1")).toEqual({ turnDurationMs: 4000, outputTokens: 42 });
+    expect(info.get("a1")).toEqual({
+      turnDurationMs: 4000,
+      turnTokens: 42,
+      verbSeedId: "a1",
+    });
   });
 
   it("running: true, transcript ending with a USER message → completed turn footer PRESENT", () => {
@@ -2990,7 +3007,11 @@ describe("computeTurnInfo", () => {
     ];
     const info = computeTurnInfo(messages as never, true);
     expect(info.has("a1")).toBe(true);
-    expect(info.get("a1")).toEqual({ turnDurationMs: 4000, outputTokens: 9 });
+    expect(info.get("a1")).toEqual({
+      turnDurationMs: 4000,
+      turnTokens: 9,
+      verbSeedId: "a1",
+    });
   });
 
   it("multi-step turn, running: false → entry only on the final assistant message", () => {
@@ -3002,7 +3023,11 @@ describe("computeTurnInfo", () => {
     const info = computeTurnInfo(messages as never, false);
     expect(info.has("a1")).toBe(false);
     expect(info.has("a2")).toBe(true);
-    expect(info.get("a2")).toEqual({ turnDurationMs: 5000, outputTokens: 20 });
+    expect(info.get("a2")).toEqual({
+      turnDurationMs: 5000,
+      turnTokens: 23,
+      verbSeedId: "a1",
+    });
   });
 
   it("multi-step turn, running: true → the still-streaming final assistant gets NO footer", () => {
@@ -3019,5 +3044,77 @@ describe("computeTurnInfo", () => {
   it("returns empty map for a null transcript", () => {
     expect(computeTurnInfo(null, false).size).toBe(0);
     expect(computeTurnInfo(null, true).size).toBe(0);
+  });
+
+  it("sums output + reasoning across ALL assistant steps of the turn (not the last step's output)", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 2000, output: 10, reasoning: 1 }),
+      assistantMsg("a2", { created: 2000, completed: 3000, output: 20, reasoning: 2 }),
+      assistantMsg("a3", { created: 3000, completed: 7000, output: 30, reasoning: 3 }),
+    ];
+    const info = computeTurnInfo(messages as never, false);
+    expect(info.get("a3")).toEqual({
+      turnDurationMs: 6000,
+      turnTokens: 66,
+      verbSeedId: "a1",
+    });
+  });
+
+  it("a turn with reasoning: 0 behaves as before (output-only arithmetic)", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 2000, output: 10, reasoning: 0 }),
+      assistantMsg("a2", { created: 2000, completed: 5000, output: 20, reasoning: 0 }),
+    ];
+    const info = computeTurnInfo(messages as never, false);
+    expect(info.get("a2")).toEqual({
+      turnDurationMs: 4000,
+      turnTokens: 30,
+      verbSeedId: "a1",
+    });
+  });
+
+  it("verbSeedId is the FIRST assistant message's id, not the last", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, completed: 2000, output: 5 }),
+      assistantMsg("a2", { created: 2000, completed: 3000, output: 7 }),
+      assistantMsg("a3", { created: 3000, completed: 6000, output: 9 }),
+    ];
+    const info = computeTurnInfo(messages as never, false);
+    expect(info.get("a3")?.verbSeedId).toBe("a1");
+  });
+
+  it("computeLiveTurn: happy path — start time, summed tokens, first-assistant seed id", () => {
+    const messages = [
+      userMsg("u1"),
+      assistantMsg("a1", { created: 1000, output: 10, reasoning: 1 }),
+      assistantMsg("a2", { created: 2000, output: 20, reasoning: 2 }),
+    ];
+    expect(computeLiveTurn(messages as never)).toEqual({
+      startedAt: 1000,
+      tokens: 33,
+      verbSeedId: "a1",
+    });
+  });
+
+  it("computeLiveTurn: no assistant message yet → falls back to the user message", () => {
+    const messages = [{ info: { role: "user", id: "u1", time: { created: 5000 } }, parts: [] }];
+    expect(computeLiveTurn(messages as never)).toEqual({
+      startedAt: 5000,
+      tokens: 0,
+      verbSeedId: "u1",
+    });
+  });
+
+  it("computeLiveTurn: null for an empty transcript", () => {
+    expect(computeLiveTurn([] as never)).toBeNull();
+    expect(computeLiveTurn(null)).toBeNull();
+  });
+
+  it("computeLiveTurn: null for a transcript with no user message", () => {
+    const messages = [assistantMsg("a1", { created: 1000, output: 4 })];
+    expect(computeLiveTurn(messages as never)).toBeNull();
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2275,10 +2275,13 @@ export async function fetchTranscriptWithRetry<T>(
 // Turn boundary metadata: which assistant messages are the FINAL one of their
 // turn (i.e., immediately followed by a user message or end-of-list), the
 // cumulative duration of that turn (first assistant `created` → last assistant
-// `completed`), and the turn's total output tokens (read off the last assistant
-// message's `info.tokens.output` — the same persisted, transcript-derived source
-// the context bar uses, so it survives refresh). Intermediate assistant messages
-// within a multi-step turn get no footer — only the final one does.
+// `completed`), the whole turn's token figure (sum of `output + reasoning`
+// across every assistant step — one ASSISTANT MESSAGE PER STEP, and each
+// message's `tokens` describes only that step, so reading the last one
+// under-reports by an order of magnitude), and the seed id (the turn's FIRST
+// assistant message) that both the live verb and the footer verb are derived
+// from. Intermediate assistant messages within a multi-step turn get no footer
+// — only the final one does.
 //
 // The `running` gate: while a turn is still in progress we do NOT stamp the
 // footer on its in-progress last assistant message — it would render behind the
@@ -2290,10 +2293,13 @@ export async function fetchTranscriptWithRetry<T>(
 export function computeTurnInfo(
   messages: OpencodeMessage[] | null,
   running: boolean,
-): Map<string, { turnDurationMs: number | null; outputTokens: number | null }> {
+): Map<
+  string,
+  { turnDurationMs: number | null; turnTokens: number | null; verbSeedId: string | null }
+> {
   const out = new Map<
     string,
-    { turnDurationMs: number | null; outputTokens: number | null }
+    { turnDurationMs: number | null; turnTokens: number | null; verbSeedId: string | null }
   >();
   if (!messages) return out;
   let i = 0;
@@ -2303,8 +2309,9 @@ export function computeTurnInfo(
       let j = i + 1;
       let firstStart: number | null = null;
       let lastEnd: number | null = null;
-      let lastOutput: number | null = null;
+      let turnTokens = 0;
       let lastAssistantId: string | null = null;
+      let verbSeedId: string | null = null;
       while (j < messages.length && messages[j].info.role === "assistant") {
         const t = messages[j].info.time;
         if (firstStart == null && t?.created != null) firstStart = t.created;
@@ -2314,7 +2321,8 @@ export function computeTurnInfo(
         const tok = (
           messages[j].info as unknown as { tokens?: TokenUsage }
         ).tokens;
-        if (tok && typeof tok.output === "number") lastOutput = tok.output;
+        if (tok) turnTokens += (tok.output ?? 0) + (tok.reasoning ?? 0);
+        if (verbSeedId == null) verbSeedId = messages[j].info.id;
         lastAssistantId = messages[j].info.id;
         j++;
       }
@@ -2334,7 +2342,8 @@ export function computeTurnInfo(
             firstStart != null && lastEnd != null && lastEnd > firstStart
               ? lastEnd - firstStart
               : null,
-          outputTokens: lastOutput,
+          turnTokens: turnTokens > 0 ? turnTokens : null,
+          verbSeedId,
         });
       }
       i = j;
@@ -2343,4 +2352,46 @@ export function computeTurnInfo(
     }
   }
   return out;
+}
+
+export type LiveTurn = { startedAt: number; tokens: number; verbSeedId: string };
+
+/**
+ * Metrics for the turn at the tail of the transcript, for the live working
+ * row. Deliberately does NOT decide whether a turn is in flight — the caller
+ * passes `running` from the event stream and only renders this when true.
+ * Returns null only when there is no trailing turn to describe.
+ */
+export function computeLiveTurn(messages: OpencodeMessage[] | null): LiveTurn | null {
+  if (!messages) return null;
+  let lastUserIndex = -1;
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].info.role === "user") lastUserIndex = i;
+  }
+  if (lastUserIndex < 0) return null;
+  const userInfo = messages[lastUserIndex].info;
+  let startedAt: number | null = null;
+  let tokens = 0;
+  let verbSeedId: string | null = null;
+  for (
+    let j = lastUserIndex + 1;
+    j < messages.length && messages[j].info.role === "assistant";
+    j++
+  ) {
+    if (verbSeedId == null) {
+      verbSeedId = messages[j].info.id;
+      const c = messages[j].info.time?.created;
+      if (typeof c === "number") startedAt = c;
+    }
+    const tok = (
+      messages[j].info as unknown as { tokens?: TokenUsage }
+    ).tokens;
+    if (tok) tokens += (tok.output ?? 0) + (tok.reasoning ?? 0);
+  }
+  if (startedAt == null) {
+    const c = userInfo.time?.created;
+    if (typeof c === "number") startedAt = c;
+  }
+  if (startedAt == null) return null;
+  return { startedAt, tokens, verbSeedId: verbSeedId ?? userInfo.id };
 }


### PR DESCRIPTION
## BET-693 — Chat turn metrics: report the whole turn's tokens and expose live-turn metrics

**Base: origin/main @ `2095ba8d`**

### Bug fixed
The finished-turn footer under-reported a turn's tokens by an order of magnitude. opencode creates one ASSISTANT message per step, and each message's `tokens` describes only that step; `computeTurnInfo` kept only the last step's `output`. `reasoning` is disjoint from `output` (`total === input + output + reasoning + cache.read + cache.write` verified 38/38), so it was also dropped entirely. The footer now sums `output + reasoning` across every assistant step of the turn (owner decision: every token figure shown for a turn is `output + reasoning`, summed turn-wide).

### Changes
- **`computeTurnInfo`** (`chatUtils.ts`): replaced `lastOutput` with a `turnTokens` accumulator summing `output + reasoning` over the turn's assistant run; added `verbSeedId` (the turn's FIRST assistant message id). Record type is now `{ turnDurationMs, turnTokens, verbSeedId }`. Renamed the field `outputTokens → turnTokens` at all 13 call sites (no `outputTokens` identifier remains in `src/renderer` — grepped). `running` gate left exactly as-is.
- **Verb seeding** (`chatShared.tsx`): refactored to one `verbIndexFor` hash backing both `presentVerbFor` and `pastVerbFor` (verb pools unchanged, `pastVerbFor` output unchanged — existing tests pass unedited). Footer now calls `pastVerbFor(verbSeedId ?? msg.info.id)` so the finished footer verb and the (dependent issue's) live verb agree for one turn.
- **`computeLiveTurn`** (`chatUtils.ts`): new exported pure helper returning live-turn metrics (`startedAt`, `tokens`, `verbSeedId`) for the tail turn. **It has NO consumer in this PR** — the dependent issue (the live working row) wires it in. This is intentional, not dead code.

### Not in scope (untouched)
The working row's verb/timer/live token count rendering, `useSseBus`, `src/server/**`, the header context pill token maths (`computeContextBreakdown` / `latestTokens` / `stepTokens`), `formatTokens`/`formatDuration` (reused), `mobile/native/**`.

### Follow-ups
None surfaced by this change. The live working row consuming `computeLiveTurn` + `presentVerbFor` is a separately-tracked dependent issue, not a follow-up.

### Verification
- typecheck: exit 0, no errors (log sha256 `65b6512ffe8623a02469c995e0b6e9686f188d55dcf31aeb69134e00ebb05ffc`)
- test: exit 0 — vitest 2234 passed / 7 skipped (119 files); node server suite 1526 passed / 0 fail (log sha256 `2e38e502516f668cd35eaa6971226b9155532c934fab03413ba561ff92890993`)
- Renderer-only change: server test suite unaffected; new unit tests added in `chatUtils.test.ts` (turn-token summing regression, reasoning:0 guard, verbSeedId-first, computeLiveTurn happy/fallback/null) and `chatShared.test.ts` (present/past same-index).
