### PR TITLE
feat(renderer): working row shows verb + live elapsed + tokens, animated mount, per-interval ticker (BET-694)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -7,7 +7,8 @@
 //   - Markdown for text parts (inline code, bold/italic, fenced code blocks,
 //     lists, headers)
 //   - Reasoning rendered as a dimmed italic `✻ Thinking…` block
-//   - Running state shows a cycling spinner glyph + verb + elapsed seconds
+//   - Running state shows a cycling loader + present-tense verb + live
+//     elapsed seconds + tokens so far at the tail of the transcript
 //   - Input is a single bordered box with a `>` prompt prefix
 //
 // No Electron-only deps — only `window.api.*` (the mobile HTTP server will
@@ -36,6 +37,7 @@ import {
   STALE_CACHE_MIN_TOKENS,
   countRunningSubagents,
   computeTurnInfo,
+  computeLiveTurn,
   shouldAutoRename,
   countUserTurns,
   buildTitlePromptInput,
@@ -1857,6 +1859,11 @@ export function ChatPanel({
     [messages, running],
   );
 
+  // Live metrics of the in-flight turn (startedAt, tokens, verb seed) for the
+  // working row at the transcript tail. Recomputes on every messages change;
+  // the row's per-second clock tick advances its elapsed label in place.
+  const liveTurn = useMemo(() => computeLiveTurn(messages), [messages]);
+
   // Slash-command provenance per USER message id. Two-source resolution:
   //
   //   (1) Live: opencode emits `command.executed.messageID` pointing at the
@@ -2067,6 +2074,7 @@ export function ChatPanel({
         taskContextValue={taskContextValue}
         showThinking={showThinking}
         running={running}
+        liveTurn={liveTurn}
         isActive={isActive}
         activeTodos={activeTodos}
         onDismissTodos={dismissTodos}

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -76,6 +76,7 @@ function props(messages: OpencodeMessage[], running = false): TranscriptProps {
     } as unknown as TranscriptProps["taskContextValue"],
     showThinking: false,
     running,
+    liveTurn: null,
     // Entry-motion tests assume the panel is being watched (a hidden panel
     // never animates — that is the session-switch fix).
     isActive: true,

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -21,9 +21,11 @@
 import { forwardRef, useEffect, useState } from "react";
 import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import { Virtuoso, type ListProps, type VirtuosoHandle } from "react-virtuoso";
-import { TaskContext, type TaskContextValue } from "./chatShared";
+import { TaskContext, type TaskContextValue, presentVerbFor } from "./chatShared";
 import { ActiveTodos, MessageRow } from "./MessageRow";
 import { MantaLoader } from "./MantaLoader";
+import { CardMount } from "./components/CardMount";
+import { WORKING_TICK_MS, nowMs, useClockTick } from "./clock";
 import { QuestionCard } from "./Cards";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
@@ -32,7 +34,10 @@ import {
   createEntryMotionState,
   isBackgroundJobCompletionTurn,
   updateEntryMotion,
+  formatDuration,
+  formatTokens,
   type EntryMotionState,
+  type LiveTurn,
 } from "./chatUtils";
 
 // ===== Virtuoso context =====
@@ -45,6 +50,7 @@ import {
 
 type TranscriptContext = {
   running: boolean;
+  liveTurn: LiveTurn | null;
   showLoadEarlier: boolean;
   loadingEarlier: boolean;
   onLoadEarlier: () => void;
@@ -160,29 +166,60 @@ const LoadEarlier = ({ context }: { context: TranscriptContext }) => (
   </div>
 );
 
-// The live "working" indicator (BET-677). A constant-height row at the tail of
-// the transcript that is ALWAYS rendered and toggles `visibility` instead of
-// mounting/unmounting — so flipping `running` on send never reflows the
-// reading column (the exact reflow the deleted pre-BET-664 indicator caused).
-// The slot stays 28px whether a turn is in flight or not. Lives in the
-// virtualized footer (BET-679) so it sits at the tail and scrolls with the
-// conversation, exactly where the hand-rolled scroller drew it.
-export function WorkingIndicator({ running }: { running: boolean }) {
+// The live "working" indicator (BET-677). A real status line at the tail of
+// the transcript, rendered only while a turn is in flight: the loader, a
+// present-tense verb, the elapsed time ticking once per second, and the
+// turn's tokens so far. It mounts and unmounts (animated by CardMount) rather
+// than reserving a permanent slot, so the idle transcript collapses to zero
+// extra height — the opposite of the pre-BET-664 reserved-band design. Lives
+// in the virtualized footer (BET-679) so it sits at the tail and scrolls with
+// the conversation. Deliberately presentational: `running` comes from the
+// event stream, `liveTurn` (the trailing turn's metrics) from computeLiveTurn
+// — this component only renders.
+export function WorkingIndicator({
+  running,
+  liveTurn,
+}: {
+  running: boolean;
+  liveTurn: LiveTurn | null;
+}) {
+  // Re-render (and thus re-read the clock during render) once per second so
+  // the elapsed label advances on its own. The component is only mounted
+  // while running — CardMount unmounts it when idle — so no ticker runs
+  // between turns.
+  useClockTick(WORKING_TICK_MS);
   return (
-    <div
-      className="manta-working-indicator flex items-center gap-2 shrink-0"
-      style={{
-        height: 28,
-        // Virtuoso renders Footer OUTSIDE List, so the List's flex `gap` never
-        // applies between the last row and this one — this margin IS that gap.
-        marginTop: "var(--block-gap)",
-        visibility: running ? "visible" : "hidden",
-      }}
-      aria-hidden={!running}
-    >
-      <MantaLoader />
-      <span className="text-text-faint text-xs">Working…</span>
-    </div>
+    <CardMount show={running} k="working">
+      <div
+        className="manta-working-indicator flex items-center gap-2 shrink-0"
+        style={{
+          // Virtuoso renders Footer OUTSIDE List, so the List's flex `gap`
+          // never applies between the last row and this one — this margin IS
+          // that gap. It sits INSIDE CardMount so the gap collapses along with
+          // the row.
+          marginTop: "var(--block-gap)",
+        }}
+      >
+        <MantaLoader />
+        <span className="text-text-faint text-xs">
+          {liveTurn ? (
+            <>
+              {presentVerbFor(liveTurn.verbSeedId)}…
+              {" · "}
+              {formatDuration(nowMs() - liveTurn.startedAt)}
+              {liveTurn.tokens > 0 && (
+                <>
+                  {" · "}
+                  {formatTokens(liveTurn.tokens)}
+                </>
+              )}
+            </>
+          ) : (
+            "Working…"
+          )}
+        </span>
+      </div>
+    </CardMount>
   );
 }
 
@@ -200,7 +237,7 @@ function TranscriptTail({ context }: { context: TranscriptContext }) {
     // so it needs its own copy of the reading inset (see TRANSCRIPT_INSET) and
     // the trailing gap the scroller's now-removed padding used to imply.
     <div style={{ ...TRANSCRIPT_INSET, paddingBottom: "var(--sp-6)" }}>
-      <WorkingIndicator running={context.running} />
+      <WorkingIndicator running={context.running} liveTurn={context.liveTurn} />
       {context.activeTodos && context.activeTodos.length > 0 && (
         <ActiveTodos todos={context.activeTodos} onDismiss={context.onDismissTodos} />
       )}
@@ -236,6 +273,7 @@ export type TranscriptProps = {
   taskContextValue: TaskContextValue;
   showThinking: boolean;
   running: boolean;
+  liveTurn: LiveTurn | null;
   // Whether the user is actually viewing this panel. App.tsx keeps every
   // ChatPanel mounted and hides the inactive ones with display:none. Entry
   // motion is gated on this — a turn landing in a hidden panel is absorbed as
@@ -275,6 +313,7 @@ export function Transcript({
   taskContextValue,
   showThinking,
   running,
+  liveTurn,
   isActive,
   activeTodos,
   onDismissTodos,
@@ -330,6 +369,7 @@ export function Transcript({
 
   const virtuosoContext: TranscriptContext = {
     running,
+    liveTurn,
     showLoadEarlier:
       !loadedAllRef.current && messages.length >= TRANSCRIPT_TAIL_LIMIT,
     loadingEarlier,

--- a/src/renderer/WorkingIndicator.test.tsx
+++ b/src/renderer/WorkingIndicator.test.tsx
@@ -1,50 +1,67 @@
 // @vitest-environment jsdom
 //
-// Component tests for WorkingIndicator (BET-677). The requirement is the
-// zero-reflow contract: the row is ALWAYS rendered at a constant height and
-// only toggles `visibility`, so flipping `running` on send never resizes the
-// transcript. We assert the style/class, not pixels.
+// Component tests for WorkingIndicator (BET-694). The row is a real status
+// line while a turn runs — loader + present-tense verb + live elapsed + token
+// count — and it mounts/unmounts (animated by CardMount) instead of reserving
+// a permanent slot, so idle renders NO row. We assert the rendered text, not
+// pixels.
 
 import { describe, it, expect, afterEach } from "vitest";
 import { mount, type Harness } from "./testHarness";
 import { WorkingIndicator } from "./Transcript";
+import { presentVerbFor } from "./chatShared";
+import type { LiveTurn } from "./chatUtils";
+import { pinDemoClock } from "./clock";
+import { useStore } from "./store";
+
+// A fixed clock anchor; the elapsed label is a function of this, not the wall
+// clock. startedAt is 103s before the anchor so formatDuration renders "1m43s".
+const T0 = 1_700_000_000_000;
+
+function makeLiveTurn(overrides: Partial<LiveTurn> = {}): LiveTurn {
+  return { startedAt: T0 - 103_000, tokens: 432, verbSeedId: "msg_1", ...overrides };
+}
 
 describe("WorkingIndicator", () => {
   let h: Harness | null = null;
   afterEach(() => {
     h?.unmount();
     h = null;
+    useStore.setState({ videoRenderNow: null });
   });
 
-  function row(): HTMLElement {
-    const el = h!.container.querySelector(".manta-working-indicator") as HTMLElement;
-    expect(el).toBeTruthy();
-    return el;
-  }
-
-  it("keeps a constant 28px height whether running or idle", () => {
-    h = mount(<WorkingIndicator running />);
-    expect(row().style.height).toBe("28px");
-    h.unmount();
-    h = mount(<WorkingIndicator running={false} />);
-    expect(row().style.height).toBe("28px");
+  it("renders the present verb, live elapsed, and token count while running", () => {
+    pinDemoClock(T0);
+    const liveTurn = makeLiveTurn();
+    h = mount(<WorkingIndicator running liveTurn={liveTurn} />);
+    const expected = `${presentVerbFor(liveTurn.verbSeedId)}… · 1m43s · 432 tokens`;
+    // Collapse whitespace: the row interleaves segments as separate text
+    // nodes within a flex span, so text() joins without the " · " separators
+    // except where they are literal strings. Match on a normalized form.
+    expect(h!.text().replace(/\s+/g, " ").trim()).toContain(expected);
+    // The loader is still there (existing assertion).
+    expect(h!.container.querySelector("svg")).toBeTruthy();
   });
 
-  it("is visible while running", () => {
-    h = mount(<WorkingIndicator running />);
-    expect(row().style.visibility).toBe("visible");
+  it("renders NO token segment when tokens is 0", () => {
+    pinDemoClock(T0);
+    const liveTurn = makeLiveTurn({ tokens: 0 });
+    h = mount(<WorkingIndicator running liveTurn={liveTurn} />);
+    const text = h!.text();
+    expect(text).toContain(`${presentVerbFor(liveTurn.verbSeedId)}… · 1m43s`);
+    expect(text).not.toContain("tokens");
   });
 
-  it("toggles to hidden when idle, still allocated in layout", () => {
-    h = mount(<WorkingIndicator running={false} />);
-    expect(row().style.visibility).toBe("hidden");
-    // Height stays reserved — hidden, not removed — so there is no reflow.
-    expect(row().style.height).toBe("28px");
-  });
-
-  it("shows the Working… label and a loader", () => {
-    h = mount(<WorkingIndicator running />);
+  it("falls back to the loader + label when running but liveTurn is null", () => {
+    h = mount(<WorkingIndicator running liveTurn={null} />);
     expect(h!.text()).toContain("Working…");
     expect(h!.container.querySelector("svg")).toBeTruthy();
+    expect(h!.text()).not.toContain("NaN");
+    expect(h!.text()).not.toContain("undefined");
+  });
+
+  it("renders no row when idle — no reserved slot above the composer", () => {
+    h = mount(<WorkingIndicator running={false} liveTurn={null} />);
+    expect(h!.container.querySelector(".manta-working-indicator")).toBeNull();
   });
 });

--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -264,8 +264,8 @@ export const demoBranch = BRANCH;
 //
 // The last assistant message has NO `time.completed` so
 // `isAssistantTurnInProgress` returns true → replayChatAttention latches
-// attention correctly, the running indicator / ✻ Ruminating… line is
-// rendered, and the last step's token usage drives the context bar.
+// attention correctly, the working row at the transcript tail is rendered,
+// and the last step's token usage drives the context bar.
 // =============================================================================
 export const demoMessages: OpencodeMessage[] = [
   // User turn — the developer asked for a CSV export endpoint.
@@ -1050,8 +1050,8 @@ function beatState(t: number): {
   // The currently-rendered question request (or null when resolved).
   currentQuestion: typeof demoQuestion | null;
   // Whether the in-flight assistant message is still running (no
-  // `time.completed`) or has finished (time.completed set). Drives the
-  // running dot + "Ruminating…" line.
+  // `time.completed`) or has finished (time.completed set). Drives whether
+  // the working row shows the in-flight state at the transcript tail.
   assistantRunning: boolean;
 } {
   // Default: Beat 1 / desktop / running / pending permission.
@@ -1213,7 +1213,7 @@ export function applyDemoStateAt(t: number): typeof demoState {
   demoState.permission = next.permission as typeof demoState.permission;
   // Stamp a `time.completed` on the in-flight assistant message when the
   // assistant is no longer running. The renderer checks this to decide
-  // whether to render the "Ruminating…" line / pulsing running dot.
+  // whether the working row shows the in-flight state at the transcript tail.
   if (!next.activeSessionId) {
     // No active session; leave the message alone.
   } else if (demoMessages[1].info) {

--- a/src/renderer/clock.test.ts
+++ b/src/renderer/clock.test.ts
@@ -3,7 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createElement } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { AGE_TICK_MS, nowMs, pinDemoClock, useAgeTick } from "./clock";
+import {
+  AGE_TICK_MS,
+  WORKING_TICK_MS,
+  nowMs,
+  pinDemoClock,
+  useAgeTick,
+  useClockTick,
+} from "./clock";
 import { useStore } from "./store";
 import { DEMO_T0 } from "./api/demoFixture";
 
@@ -130,5 +137,31 @@ describe("age ticker", () => {
 
   it("is bounded well under a minute so a whole-minute label can't lag visibly", () => {
     expect(AGE_TICK_MS).toBeLessThan(60_000);
+  });
+
+  it("keeps different intervals on independent tickers, and useAgeTick still ticks at AGE_TICK_MS", () => {
+    vi.useFakeTimers();
+    try {
+      const age = mountHook(() => useAgeTick());
+      const work = mountHook(() => useClockTick(WORKING_TICK_MS));
+      const age0 = age.latest()!;
+      const work0 = work.latest()!;
+      // Within the 10s bucket (4.5s) only the 1s bucket fires — independence,
+      // not a shared global tick.
+      act(() => {
+        vi.advanceTimersByTime(4500);
+      });
+      expect(age.latest()).toBe(age0);
+      expect(work.latest()).toBe(work0 + 4);
+      // Cross an AGE_TICK_MS boundary: the 10s bucket ticks exactly once.
+      act(() => {
+        vi.advanceTimersByTime(AGE_TICK_MS - 4500);
+      });
+      expect(age.latest()).toBe(age0 + 1);
+      age.unmount();
+      work.unmount();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/renderer/clock.ts
+++ b/src/renderer/clock.ts
@@ -7,18 +7,18 @@
 // seeds `videoRenderNow` to `DEMO_T0` and `useFrameSync` updates it
 // per-frame from `DEMO_T0 - t*1000`. With this seam, every elapsed-time
 // label that used to read `Date.now()` — Sidebar's session-age chip
-// (`Sidebar.tsx`), ChatPanel's running-indicator "X seconds ago"
-// (`MessageRow.tsx:RunningIndicator`) — becomes a function of the
+// (`Sidebar.tsx`) and the transcript's working row
+// (`Transcript.tsx:WorkingIndicator`) — becomes a function of the
 // fixture's anchored time, not the wall clock. Two consecutive renders
 // are byte-identical for that frame.
 //
 // The renderer was already designed to subscribe to per-frame store
 // updates (via `useStore()` at the top of `Sidebar`), so pushing
 // `videoRenderNow` per-frame from the composition triggers the
-// expected re-renders. `MessageRow.tsx`'s `setInterval(() => setTick)` is
-// now a no-op for elapsed-time purposes (the deterministic clock drives
-// the label) but is kept so the tick-and-re-render cycle continues to
-// run — stripping it would change unrelated behavior.
+// expected re-renders. The working row subscribes to the shared ticker
+// via `useClockTick(WORKING_TICK_MS)` for its elapsed label; under the
+// deterministic clock those ticking re-renders are also byte-identical
+// for the elapsed-time parts of the label.
 import { useSyncExternalStore } from "react";
 import { useStore } from "./store";
 
@@ -59,44 +59,83 @@ export function nowMs(): number {
 // minute boundary to 10s while costing one shallow re-render per 10s.
 export const AGE_TICK_MS = 10_000;
 
-const tickListeners = new Set<() => void>();
-let tickTimer: ReturnType<typeof setInterval> | null = null;
-let tickVersion = 0;
+// The working row's cadence: its elapsed label is second-granular, so it
+// re-renders (and re-reads the clock) once per second while a turn is in
+// flight. Because the row subscribes only while mounted and CardMount unmounts
+// it when idle, no 1s ticker runs between turns.
+export const WORKING_TICK_MS = 1_000;
 
-function subscribeTick(onChange: () => void): () => void {
-  tickListeners.add(onChange);
-  if (tickTimer == null) {
-    tickTimer = setInterval(() => {
-      tickVersion++;
-      for (const fn of tickListeners) {
+// ONE shared interval PER TICK INTERVAL (keyed by intervalMs) — not one per
+// row and not one global — so the 10s age subscribers and the 1s working-row
+// subscriber each own their own timer instead of dragging onto one cadence. N
+// subscribers on the same interval cost N re-renders on one tick, and each
+// bucket is torn down when its last subscriber unmounts. The tick only forces
+// a re-render — the value still comes from `nowMs()`, so demo mode stays
+// deterministic: with `videoRenderNow` pinned, ticking re-renders are
+// byte-identical and the visual baselines are unaffected.
+type TickerBucket = {
+  listeners: Set<() => void>;
+  timer: ReturnType<typeof setInterval> | null;
+  version: number;
+};
+const tickerBuckets = new Map<number, TickerBucket>();
+
+function bucketFor(intervalMs: number): TickerBucket {
+  let b = tickerBuckets.get(intervalMs);
+  if (!b) {
+    b = { listeners: new Set(), timer: null, version: 0 };
+    tickerBuckets.set(intervalMs, b);
+  }
+  return b;
+}
+
+function subscribeTick(intervalMs: number, onChange: () => void): () => void {
+  const b = bucketFor(intervalMs);
+  b.listeners.add(onChange);
+  if (b.timer == null) {
+    b.timer = setInterval(() => {
+      b.version++;
+      for (const fn of b.listeners) {
         try {
           fn();
         } catch {
           /* a listener throwing must not kill the shared ticker */
         }
       }
-    }, AGE_TICK_MS);
+    }, intervalMs);
     // Never hold a test runner (or the process) open for the ticker alone.
-    (tickTimer as { unref?: () => void }).unref?.();
+    (b.timer as { unref?: () => void }).unref?.();
   }
   return () => {
-    tickListeners.delete(onChange);
-    if (tickListeners.size === 0 && tickTimer != null) {
-      clearInterval(tickTimer);
-      tickTimer = null;
+    b.listeners.delete(onChange);
+    if (b.listeners.size === 0 && b.timer != null) {
+      clearInterval(b.timer);
+      b.timer = null;
     }
   };
 }
 
-const readTickVersion = (): number => tickVersion;
+const readTickVersion = (intervalMs: number): number => bucketFor(intervalMs).version;
 
 /**
- * Subscribe the calling component to the shared age ticker so any label
- * derived from `nowMs()` advances on its own. Returns the tick version purely
- * so the subscription is observable in tests; callers normally ignore it.
+ * Subscribe the calling component to the shared ticker for `intervalMs` so any
+ * label derived from `nowMs()` advances on its own at that cadence. Returns
+ * the tick version purely so the subscription is observable in tests; callers
+ * normally ignore it.
+ */
+export function useClockTick(intervalMs: number): number {
+  return useSyncExternalStore(
+    (onChange) => subscribeTick(intervalMs, onChange),
+    () => readTickVersion(intervalMs),
+    () => readTickVersion(intervalMs),
+  );
+}
+
+/**
+ * 10s age tick for the sidebar's session-age labels. See AGE_TICK_MS.
  */
 export function useAgeTick(): number {
-  return useSyncExternalStore(subscribeTick, readTickVersion, readTickVersion);
+  return useClockTick(AGE_TICK_MS);
 }
 
 /**


### PR DESCRIPTION
## BET-694 — Chat working row: verb + live elapsed + live tokens, animated mount (no reserved slot)

The transcript tail's working row is now a real status line. While a turn runs it shows:

`<loader> <Verb>… · 1m43s · 432 tokens`

- **Verb**: `presentVerbFor(liveTurn.verbSeedId)` from BET-693 — same seed as the footer's past-tense verb, so the in-flight row and the finished footer agree.
- **Elapsed**: `formatDuration(nowMs() - liveTurn.startedAt)`, ticking once per second.
- **Tokens**: `formatTokens(liveTurn.tokens)`, rendered only when `> 0` so the first seconds read `Ruminating… · 3s`.
- Fallback to `Working…` (loader + label only) while `running` is optimistic and no message exists yet.

### No reserved slot — animated mount
The idempotent `visibility`-toggle design is replaced by `CardMount show={running} k="working"` (the existing shared mount animation already used by every card above the composer). The `marginTop: var(--block-gap)` stays on the inner row so the gap collapses with it. The idle transcript now renders zero row — no static 28px band above the composer. Old tests asserting `height: 28px` / `visibility` are deleted.

### One shared ticker, per-interval
`clock.ts`'s single-interval age ticker is generalised into a per-interval registry keyed by `intervalMs` (`tickerBuckets: Map`). New `useClockTick(intervalMs)` carries the old behaviour; `useAgeTick()` is a one-line wrapper and every existing caller is untouched. `WORKING_TICK_MS = 1_000` lets the working row re-render once per second. The row subscribes only while mounted, so no ticker runs between turns. No raw `setInterval` in a component.

### Wiring (same path `running`/`activeTodos` already travel)
- `ChatPanel.tsx`: `const liveTurn = useMemo(() => computeLiveTurn(messages), [messages])` next to `turnInfo`, passed to `<Transcript liveTurn={liveTurn} />`.
- `Transcript.tsx`: `liveTurn` added to `TranscriptProps` + `TranscriptContext`, set in `virtuosoContext`, read in `TranscriptTail`.

### Comment cleanup
Rewrote the stale comments that described the deleted reserved-slot / spinner design (`ChatPanel.tsx:10`, `clock.ts` header, three in `demoFixture.ts`). `chatShared.tsx` / `chatUtils.ts` / `MantaLoader.tsx` comments were already accurate after this change and left as-is. `AGENTS.md` untouched.

### Known risk (reported, not fixed, per issue)
Virtuoso's `followOutput` observes footer-size changes, so the animated mount/unmount height at the tail can fight the auto-scroll — if the transcript visibly stutters at turn start/end, this is the known risk. No alternative animation was substituted on judgement; the implementation matches the owner's spec. Live turn-stability (no blink/collapse between tool calls) rests on BET-692's trustworthy `running` signal and should be confirmed by watching a real multi-tool turn.

### Verification results
- `npm run typecheck`: **exit 0**, no errors
- `npm test`: **1526 passed / 0 failed / 0 skipped** (includes rewritten `WorkingIndicator.test.tsx` — verb/elapsed/tokens, no-token-at-0, `liveTurn:null` fallback, no-row-when-idle — and a new `clock.test.ts` case proving independent per-interval tickers + `useAgeTick` at `AGE_TICK_MS`)
- No `tests/visual` baselines touched (visual/pixel-baseline verification is retired).

**Base: `origin/main` @ `f719cc96`**
