### PR TITLE
fix(ios): under-composer fade starts at the glass edge; composer reads as real glass

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -214,14 +214,16 @@ private struct ChatScreenContent: View {
         // the composer's GLASS BOX only — reported by ComposerView via
         // `composerGlassHeight`, not the whole floating stack — so the
         // jump-to-bottom chip and the pinned cards above the box do not
-        // extend it: the fade begins right under the composer's own top
-        // edge, ChatGPT-style, instead of dimming readable transcript text
-        // sitting above the glass.
+        // extend it. `fadeInsideContainer: true` puts the fade band AT the
+        // glass box's top edge instead of hanging above it, so the fade
+        // begins right at the composer's own top edge and dissolves content
+        // BEHIND the glass — everything above the box (transcript text,
+        // chip, cards) stays fully readable.
         .overlay(alignment: .bottom) {
             Color.clear
                 .frame(height: composerGlassHeight)
                 .background(alignment: .bottom) {
-                    Scrim(edge: .bottom, tokens: tokens, overhang: Self.scrimOverhang)
+                    Scrim(edge: .bottom, tokens: tokens, overhang: Self.scrimOverhang, fadeInsideContainer: true)
                 }
                 .allowsHitTesting(false)
         }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -96,9 +96,18 @@ private struct ChatScreenContent: View {
     /// touch auto-follow, which stays constant so new messages pin smoothly.
     @State private var showScrollToBottom = false
 
-    /// Measured height of the floating bottom bar (cards + composer), used to
-    /// size the under-composer scrim so it always covers the glass region.
+    /// Measured height of the floating bottom bar (cards + composer), fed to
+    /// the transcript's `additionalContentInset` bottom inset so the newest
+    /// message rests above the whole floating stack, not just the composer.
     @State private var bottomBarHeight: CGFloat = 0
+
+    /// Measured height of the composer's glass input box alone (plus the
+    /// composer's own bottom padding), reported by `ComposerView` via
+    /// `onGlassBoxHeightChange`. Used to size the under-composer scrim so its
+    /// fade starts at the glass box's top edge — not at the top of the whole
+    /// bottom stack (pinned cards / jump-to-bottom chip / picker anchors sit
+    /// above the glass box and must stay undimmed).
+    @State private var composerGlassHeight: CGFloat = 0
 
     /// How far the under-composer scrim reaches past the safe area, so content
     /// scrolling into the home-indicator strip stays dimmed too.
@@ -199,9 +208,23 @@ private struct ChatScreenContent: View {
         // messages genuinely pass under it while scrolling. The measured
         // `bottomBarHeight` of that floating stack feeds the transcript's
         // `additionalContentInset` bottom inset, so at rest the newest message
-        // rests readable above the composer. The bottom scrim rides as the
-        // composer's own background, so its fade (and its solid canvas) tracks
-        // the top of whatever chrome is showing with no measurement.
+        // rests readable above the whole stack.
+        //
+        // Scrim FIRST so it draws beneath the composer stack. It is sized to
+        // the composer's GLASS BOX only — reported by ComposerView via
+        // `composerGlassHeight`, not the whole floating stack — so the
+        // jump-to-bottom chip and the pinned cards above the box do not
+        // extend it: the fade begins right under the composer's own top
+        // edge, ChatGPT-style, instead of dimming readable transcript text
+        // sitting above the glass.
+        .overlay(alignment: .bottom) {
+            Color.clear
+                .frame(height: composerGlassHeight)
+                .background(alignment: .bottom) {
+                    Scrim(edge: .bottom, tokens: tokens, overhang: Self.scrimOverhang)
+                }
+                .allowsHitTesting(false)
+        }
         .overlay(alignment: .bottom) {
             GlassEffectContainer(spacing: 0) {
                 VStack(spacing: 0) {
@@ -216,7 +239,8 @@ private struct ChatScreenContent: View {
                         onScrollToBottom: {
                             scrollPosition.scrollTo(edge: .bottom, animated: true)
                             showScrollToBottom = false
-                        }
+                        },
+                        onGlassBoxHeightChange: { composerGlassHeight = $0 }
                     )
                 }
                 // Feeds the transcript's bottom content inset its height. Safe
@@ -227,9 +251,6 @@ private struct ChatScreenContent: View {
                 } action: { height in
                     bottomBarHeight = height
                 }
-            }
-            .background {
-                Scrim(edge: .bottom, tokens: tokens, overhang: Self.scrimOverhang)
             }
         }
         .navigationDestination(for: SubagentSession.self) { agent in

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -47,6 +47,13 @@ struct ComposerView: View {
     var showScrollToBottom: Bool = false
     /// Tapped → scroll the transcript to the newest message.
     var onScrollToBottom: (() -> Void)? = nil
+    /// Reports the height of the glass input box PLUS the composer's own
+    /// bottom padding — i.e. the distance from the glass box's top edge to
+    /// the bottom of this view. ChatScreen sizes the under-composer scrim
+    /// from this, so the fade starts exactly at the glass box's top edge,
+    /// not at the top of the whole bottom stack (chip / cards / anchors
+    /// excluded).
+    var onGlassBoxHeightChange: (CGFloat) -> Void = { _ in }
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var text = ""
@@ -200,7 +207,7 @@ struct ComposerView: View {
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
-        .modifier(BoxChrome(cornerRadius: cornerRadius, stroke: borderColor, tint: tokens.panel.opacity(0.9)))
+        .modifier(BoxChrome(cornerRadius: cornerRadius, stroke: borderColor, tint: tokens.panel.opacity(0.35)))
         // The expand control is an OVERLAY, not a row: it must sit in the top
         // right corner whether or not there are chips to share a line with, and
         // as an overlay it costs no vertical space when there are none.
@@ -210,6 +217,11 @@ struct ComposerView: View {
                     .padding(.top, Metrics.spacing.sp2)
                     .padding(.trailing, Metrics.spacing.sp3)
             }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            onGlassBoxHeightChange(height + Metrics.spacing.sp2)
         }
     }
 
@@ -862,9 +874,11 @@ struct ComposerView: View {
 private struct BoxChrome: ViewModifier {
     let cornerRadius: CGFloat
     let stroke: Color
-    /// A semi-opaque fill laid UNDER the glass so the box reads less
-    /// transparent — the Liquid Glass stays, but what shows through it is
-    /// dimmed by this panel colour.
+    /// A LIGHT wash laid UNDER the glass so the box reads slightly less
+    /// transparent without smothering the material — the Liquid Glass blur
+    /// has to stay dominant. At higher opacities (this used to be 0.9) the
+    /// box read as a solid panel instead of glass, defeating the whole
+    /// point of the effect.
     let tint: Color
 
     func body(content: Content) -> some View {

--- a/mobile/native/MantaUI/Scrim.swift
+++ b/mobile/native/MantaUI/Scrim.swift
@@ -46,6 +46,14 @@ struct Scrim: View {
     /// keyboard, where there is nothing to dim anyway.
     var overhang: CGFloat = 0
 
+    /// Bottom edge only. When true, the fade band begins AT the container's
+    /// top edge and runs DOWN INTO it, instead of hanging above it — so
+    /// content passing under a glass control stays fully readable until the
+    /// control's edge and dissolves behind the glass (ChatGPT-style). The
+    /// default keeps the fade above the container, which is what the
+    /// session list's search capsule wants.
+    var fadeInsideContainer: Bool = false
+
     /// How tall the fade above the control is. Fixed in POINTS, deliberately
     /// NOT a fraction of the control's height: a fraction is exactly what made
     /// the visible part of the ramp shrink to nothing as the control grew.
@@ -89,8 +97,10 @@ struct Scrim: View {
         }
         // The fade hangs ABOVE the container, so content fades while still
         // fully visible rather than behind the glass where it could not be
-        // seen.
-        .padding(.top, -Self.fadeHeight)
+        // seen. With `fadeInsideContainer` set, the band instead occupies the
+        // top of the container itself, so content stays fully readable right
+        // up to the container's edge and dissolves behind the glass.
+        .padding(.top, fadeInsideContainer ? 0 : -Self.fadeHeight)
         // Solid canvas continues below the container into the overhang strip.
         .padding(.bottom, -overhang)
         // Purely decorative: it sits over a scroll view, so without this it


### PR DESCRIPTION
Two issues on the native iOS chat screen (screenshots from device):

1. **The bottom fade began well above the composer.** The scrim rode as the background of the entire floating bottom stack (pinned cards + jump-to-bottom chip + composer), with its 96pt fade band hanging above THAT — so readable transcript text was dimmed far above the glass. `ComposerView` now reports the glass input box's own height (`onGlassBoxHeightChange`), the scrim host is sized to exactly that, and a new `Scrim.fadeInsideContainer` option moves the fade band to the top of the container itself: text stays fully readable right up to the composer's edge and dissolves BEHIND the glass, ChatGPT-style. The session list's search capsule keeps the fade-above default.

2. **The composer read as a solid panel, not glass.** `BoxChrome` laid `panel.opacity(0.9)` under the Liquid Glass, smothering it. Dropped to 0.35 so the blur stays dominant.

`bottomBarHeight` (transcript bottom inset, BET-689/690) is untouched — it keeps feeding `additionalContentInset`.

Verification: Swift is not compiled in CI; will build via the `ios-mantaui` Mac plugin against this branch before merge.