### PR TITLE
fix(ios): loadEarlier crash on duplicate row ids + markdown table/inline-code styling

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -483,15 +483,19 @@ final class ChatSessionStore: ObservableObject {
     /// visible duplicate, not a harmless overlap. The tail is emptied by the
     /// retirement step in `fetchTranscript`; nothing else may append to it.
     private func rebuildBlocks() {
+        // `uniqueTranscriptRows` (not a bare `stableScrollID` map) is
+        // load-bearing: content-derived ids can collide across a long history,
+        // and a duplicate id traps inside MessagingUI's diff the moment
+        // `loadEarlier()` widens the window over the colliding pair.
         let newRows: [TranscriptRow]
         if inProgressText.isEmpty {
             blocks = transcript
-            newRows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+            newRows = uniqueTranscriptRows(transcript)
         } else {
             // The live tail has no completion time yet — it gets one when the
             // turn ends and the canonical refetch replaces this block.
             blocks = transcript + [.prose(inProgressText, at: nil)]
-            newRows = transcript.map { TranscriptRow(id: $0.stableScrollID, block: $0) }
+            newRows = uniqueTranscriptRows(transcript)
                 + [TranscriptRow(id: streamingTailID, block: .prose(inProgressText, at: nil))]
         }
         rows = newRows

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -78,14 +78,59 @@ struct MantaProse: View {
             .font(.system(size: Metrics.type.body, weight: .semibold), for: .h5)
             .font(.system(size: Metrics.type.body, weight: .semibold), for: .h6)
             .font(.system(size: Metrics.type.xs, design: .monospaced), for: .codeBlock)
+            // Tables run at the small size, not body — on a phone column a
+            // body-size table wraps every cell into a tower. Header gets the
+            // semibold weight like desktop's th.
+            .font(.system(size: Metrics.type.small, weight: .semibold), for: .tableHeader)
+            .font(.system(size: Metrics.type.small), for: .tableBody)
             .foregroundColor(tokens.tx1)
             .lineSpacing(pointsFor(multiplier: Metrics.type.proseLineHeight, size: Metrics.type.body))
             .tint(tokens.accent, for: .link)
+            // Inline code: the library renders `code` spans as tint-colored
+            // text on tint@10% background (MarkdownView 3.0.0 exposes no
+            // inline-code FONT slot, so mono isn't reachable here). Untinted it
+            // used the loud system accent; tx2 gives the subtle grey-on-grey
+            // treatment desktop uses.
+            .tint(tokens.tx2, for: .inlineCodeBlock)
+            // Blockquote bar in the border grey (desktop: 2px var(--border)),
+            // not the default accent.
+            .tint(tokens.border, for: .blockQuote)
+            .markdownTableStyle(MantaMarkdownTableStyle(tokens: tokens))
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, Metrics.spacing.sp3)
             .padding(.bottom, Metrics.spacing.sp3)
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("assistant-prose")
+    }
+}
+
+// MARK: - Markdown table style
+//
+// Token-mapped GFM table, mirroring desktop's MarkdownBody table treatment:
+// hairline `borderSubtle` rules between cells, a `border` outline, header row
+// on `fill`, cell padding on the spacing grid (sp2 × sp1 ≈ desktop's px-3
+// py-1 scaled for the phone column). The library's default style is what made
+// tables read huge — body-size text inside 8pt cell padding inside a 12pt
+// frame inside a 20pt-radius outline.
+struct MantaMarkdownTableStyle: MarkdownTableStyle {
+    let tokens: Tokens
+
+    func makeBody(configuration: Configuration) -> some View {
+        Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+            configuration.table.header
+                .markdownTableRowBackgroundStyle(AnyShapeStyle(tokens.fill))
+            ForEach(Array(configuration.table.rows.enumerated()), id: \.offset) { _, row in
+                row
+            }
+        }
+        .markdownTableCellOverlay {
+            Rectangle().strokeBorder(tokens.borderSubtle)
+        }
+        .markdownTableCellPadding(.horizontal, Metrics.spacing.sp2)
+        .markdownTableCellPadding(.vertical, Metrics.spacing.sp1)
+        .overlay {
+            Rectangle().strokeBorder(tokens.border)
+        }
     }
 }
 

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -48,6 +48,31 @@ extension TranscriptBlock {
     }
 }
 
+/// Wraps blocks in rows whose ids are GUARANTEED unique within the array.
+///
+/// `stableScrollID` is content-derived, and wire content is allowed to repeat:
+/// two identical prose parts completing at the same message timestamp, two
+/// identical user prompts with a missing `time.created`, a re-emitted tool
+/// callID — all yield the same id. MessagingUI's `ListDataSource.apply` builds
+/// `Dictionary(uniqueKeysWithValues:)` over row ids on its diff path, which
+/// TRAPS on a duplicate. The first fetch takes the no-check replace shortcut,
+/// so duplicates living in older history only enter the diff when
+/// `loadEarlier()` widens the window — i.e. the app crashed exactly when
+/// scrolling up after loading previous messages.
+///
+/// Dedup is positional: the first occurrence keeps the bare id, later ones get
+/// an occurrence suffix. Deterministic for a given block order, so a refetch of
+/// the same window reproduces the same ids and the diff stays stable.
+func uniqueTranscriptRows(_ blocks: [TranscriptBlock]) -> [TranscriptRow] {
+    var seen: [String: Int] = [:]
+    return blocks.map { block in
+        let base = block.stableScrollID
+        let occurrence = seen[base, default: 0]
+        seen[base] = occurrence + 1
+        return TranscriptRow(id: occurrence == 0 ? base : "\(base)#dup\(occurrence)", block: block)
+    }
+}
+
 extension StepGroupContent {
     /// The rows of a step group, whether plain or rolled up. Used only to
     /// derive a stable id from the rows' own stable ids.

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -402,4 +402,58 @@ final class ChatTranscriptTests: XCTestCase {
         XCTAssertEqual(Array(preserved), before,
                        "pre-existing step ids must be preserved when a new message is appended")
     }
+
+    // MARK: - Row id uniqueness (loadEarlier crash regression)
+    //
+    // `stableScrollID` is content-derived and wire content repeats: identical
+    // prose sharing a message timestamp, identical user prompts with no
+    // `time.created`. A duplicate row id traps MessagingUI's diff
+    // (`Dictionary(uniqueKeysWithValues:)`) the moment loadEarlier() widens
+    // the window over the colliding pair — the "crash when scrolling up after
+    // loading previous messages" bug. `uniqueTranscriptRows` must therefore
+    // never emit two rows with the same id, whatever the blocks contain.
+
+    func testDuplicateProseBlocksGetUniqueRowIDs() {
+        let at = Date(timeIntervalSince1970: 1_700_000_000)
+        let blocks: [TranscriptBlock] = [
+            .prose("Done.", at: at),
+            .prose("Done.", at: at),
+            .prose("Done.", at: at),
+        ]
+        let rows = uniqueTranscriptRows(blocks)
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(Set(rows.map(\.id)).count, 3,
+                       "identical prose blocks must not share a row id")
+    }
+
+    func testDuplicateUserBlocksWithNilTimeGetUniqueRowIDs() {
+        let blocks: [TranscriptBlock] = [
+            .user("yes", at: nil),
+            .user("yes", at: nil),
+        ]
+        let rows = uniqueTranscriptRows(blocks)
+        XCTAssertEqual(Set(rows.map(\.id)).count, 2,
+                       "identical user prompts with missing timestamps must not share a row id")
+    }
+
+    func testUniqueRowIDsAreDeterministicAcrossRebuilds() {
+        let at = Date(timeIntervalSince1970: 1_700_000_000)
+        let blocks: [TranscriptBlock] = [
+            .user("go", at: nil),
+            .prose("Done.", at: at),
+            .prose("Done.", at: at),
+        ]
+        let first = uniqueTranscriptRows(blocks).map(\.id)
+        let second = uniqueTranscriptRows(blocks).map(\.id)
+        XCTAssertEqual(first, second,
+                       "the same block order must reproduce the same row ids so the diff stays stable")
+    }
+
+    func testUniqueRowIDsKeepBareIdForFirstOccurrence() {
+        let at = Date(timeIntervalSince1970: 1_700_000_000)
+        let blocks: [TranscriptBlock] = [.prose("A", at: at), .prose("B", at: at)]
+        let rows = uniqueTranscriptRows(blocks)
+        XCTAssertEqual(rows.map(\.id), blocks.map(\.stableScrollID),
+                       "non-colliding blocks must keep their content-stable ids unchanged")
+    }
 }


### PR DESCRIPTION
## Crash when scrolling up after loading previous messages

Confirmed against a device crash report (SIGTRAP, thread 0):
`Dictionary(uniqueKeysWithValues:)` trapping inside MessagingUI's `ListDataSource.apply`, called from `ChatSessionStore.rebuildBlocks`.

`stableScrollID` is content-derived and wire content repeats — two identical prose parts sharing a message timestamp, identical user prompts with a missing `time.created`. The first fetch takes the diff-free `replace` shortcut, so duplicates living in older history only enter the diff when `loadEarlier()` widens the window: crash exactly on scroll-up pagination.

Fix: `uniqueTranscriptRows()` guarantees id uniqueness within the row array (first occurrence keeps the bare id, later ones get a positional suffix; deterministic across rebuilds so the diff stays stable). `rebuildBlocks` routes through it. 4 regression tests.

## Markdown rendering (MantaProse)

- **Tables**: were library-default — body-size text, 8pt cell padding, 12pt frame, 20pt-radius outline — huge on a phone column. New token-mapped `MantaMarkdownTableStyle`: small-size text, semibold header on `fill`, hairline `borderSubtle` cell rules, `border` outline, sp2×sp1 padding (mirrors desktop's MarkdownBody table).
- **Inline code**: untinted, so it rendered in the loud system accent. Now `tx2` → subtle grey text + grey 10% wash. (MarkdownView 3.0.0 exposes no inline-code *font* slot, so a mono face isn't reachable without forking the library — color/background now match desktop, font stays body.)
- **Blockquote**: bar tinted `border` grey instead of default accent.

## Verification

Mac gate `ios-mantaui test-unit` on `55bd302`: job completed (the gate step hard-fails the job on any compile/test failure).