### PR TITLE
BET-695: feat(renderer): extract shared PaletteShell and port ⌘K onto it

### DIFF
--- a/src/renderer/PaletteShell.tsx
+++ b/src/renderer/PaletteShell.tsx
@@ -1,0 +1,144 @@
+// PaletteShell.tsx — the shared palette chrome (⌘K session switcher, ⌘F
+// conversation search). The palette-pattern counterpart to Modal.tsx: Modal
+// owns centered DIALOG chrome; PaletteShell owns the top-anchored, animated
+// input+list+footer palette. Like Modal, there is NO className escape hatch:
+// consumers supply rows via the children render-prop and nothing else about
+// the chrome can be sheared per-consumer.
+//
+// Owns ALL open/close/keyboard mechanics:
+//   - enter/exit animation (manta-palette-* classes in index.css); exit is a
+//     100ms `closing` phase before onClose unmounts us
+//   - Esc / overlay click / ESC chip → requestClose
+//   - ArrowUp/ArrowDown with wraparound; Enter → pick(sel)
+//   - pick(i) = onPick(i) then requestClose. Rows receive the SAME pick via
+//     the children render-prop, so mouse click and keyboard Enter share one
+//     activation path. Consumers must NOT call onClose themselves.
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Search } from "lucide-react";
+
+const CLOSE_MS = 100; // matches the manta-palette-*-out animation duration
+
+export function PaletteShell({
+  label,
+  placeholder,
+  query,
+  setQuery,
+  itemCount,
+  sel,
+  setSel,
+  onPick,
+  onClose,
+  footerExtra,
+  children,
+}: {
+  label: string;
+  placeholder: string;
+  query: string;
+  setQuery: (v: string) => void;
+  itemCount: number;
+  sel: number;
+  setSel: (n: number) => void;
+  onPick: (index: number) => void;
+  onClose: () => void;
+  footerExtra?: ReactNode;
+  children: (pick: (index: number) => void) => ReactNode;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [closing, setClosing] = useState(false);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+  const requestClose = () => {
+    if (closing) return;
+    setClosing(true);
+    window.setTimeout(onClose, CLOSE_MS);
+  };
+  const pick = (i: number) => {
+    onPick(i);
+    requestClose();
+  };
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      requestClose();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (itemCount > 0) setSel((sel + 1) % itemCount);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (itemCount > 0) setSel((sel - 1 + itemCount) % itemCount);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (itemCount > 0) pick(sel);
+    }
+  };
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-start justify-center pt-[16vh] bg-black/40 manta-palette-overlay ${closing ? "manta-palette-overlay-out" : ""}`}
+      onClick={requestClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        className={`manta-palette-panel w-[620px] max-w-[92vw] bg-bg-elev border border-border rounded-lg shadow-lg overflow-hidden ${closing ? "manta-palette-panel-out" : ""}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-border-subtle">
+          <Search size={16} className="text-text-faint shrink-0" aria-hidden="true" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={placeholder}
+            spellCheck={false}
+            autoComplete="off"
+            className="flex-1 bg-transparent text-prose text-text outline-none placeholder:text-text-faint"
+          />
+          <button
+            onClick={requestClose}
+            title="Close (Esc)"
+            className="font-mono text-micro text-text-faint hover:text-text border border-border-subtle rounded-sm px-1 py-px"
+          >
+            ESC
+          </button>
+        </div>
+        <div className="max-h-[50vh] overflow-y-auto px-2 py-1">{children(pick)}</div>
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-border-subtle bg-inset text-meta text-text-faint">
+          <span>
+            <Kbd>↑↓</Kbd> navigate
+          </span>
+          <span>
+            <Kbd>↵</Kbd> select
+          </span>
+          <span>
+            <Kbd>esc</Kbd> close
+          </span>
+          {footerExtra != null && <span className="ml-auto">{footerExtra}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <kbd className="font-mono text-micro text-text-faint bg-raised border border-border-subtle rounded-xs px-1">
+      {children}
+    </kbd>
+  );
+}
+
+// Keeps the selected row visible when arrow keys move the selection past the
+// scroll fold. Rows are consumer-rendered, so consumers attach this ref to
+// their row element. (The old ⌘K palette lacked this — arrowing below the
+// fold left the selection off-screen.)
+export function useSelectedIntoView<T extends HTMLElement>(selected: boolean) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    if (selected) ref.current?.scrollIntoView({ block: "nearest" });
+  }, [selected]);
+  return ref;
+}

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -4,14 +4,13 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import type { ReactElement, ReactNode } from "react";
 import { ChevronRight, ChevronDown, X, Pin, Search } from "lucide-react";
 import { useStore, flatSessions, type WindowStatusUI } from "./store";
 import { nowMs, useAgeTick } from "./clock";
-import { Modal } from "./Modal";
+import { PaletteShell, useSelectedIntoView } from "./PaletteShell";
 import type { Project, TmuxWindow } from "../shared/types";
 import {
   classifyCacheAge,
@@ -24,7 +23,7 @@ import {
   windowPinId,
 } from "./chatUtils";
 import { IS_WINDOWS, MOD_KEY } from "./platform";
-import { SessionRow, type SessionStatus } from "./SessionRow";
+import { SessionRow as RailSessionRow, type SessionStatus } from "./SessionRow";
 
 const COLLAPSE_KEY = "manta:collapsed-projects";
 
@@ -422,30 +421,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     if (paletteSel >= paletteResults.length) setPaletteSel(0);
   }, [paletteResults.length, paletteSel]);
 
-  const onPaletteKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      setPaletteOpen(false);
-    } else if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setPaletteSel((s) =>
-        paletteResults.length === 0 ? 0 : (s + 1) % paletteResults.length,
-      );
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setPaletteSel((s) =>
-        paletteResults.length === 0 ? 0 : (s - 1 + paletteResults.length) % paletteResults.length,
-      );
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      const target = paletteResults[paletteSel];
-      if (target) {
-        void activateWindow(target.project, target.window.index);
-        setPaletteOpen(false);
-      }
-    }
-  };
-
   // Row-indexed status lookup helper.
   const statusFor = (session: string, idx: number): WindowStatusUI | undefined =>
     status[session]?.[idx];
@@ -541,7 +516,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                 ? `"${d.input.trim().slice(0, 40)}" · ${target}`
                 : target;
               return (
-                <SessionRow
+                <RailSessionRow
                   key={d.id}
                   // A draft is never running/blocking — the at-rest "default"
                   // dot keeps the row chrome identical to a resting session.
@@ -791,8 +766,8 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         </button>
       </div>
 
-      <CommandPalette
-          open={paletteOpen}
+      {paletteOpen && (
+        <CommandPalette
           query={paletteQuery}
           setQuery={(v) => {
             setPaletteQuery(v);
@@ -801,13 +776,12 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
           results={paletteResults}
           sel={paletteSel}
           setSel={setPaletteSel}
-          onKeyDown={onPaletteKeyDown}
           onClose={() => setPaletteOpen(false)}
           onActivate={(proj, idx) => {
             void activateWindow(proj, idx);
-            setPaletteOpen(false);
           }}
         />
+      )}
     </aside>
   );
 });
@@ -1004,7 +978,7 @@ function WindowRow({
   return (
     <DeletableSessionRow
       row={
-        <SessionRow
+        <RailSessionRow
           status={dot.variant}
           statusTitle={dot.title}
           selected={isActive}
@@ -1091,7 +1065,7 @@ function JobChildRow({
   return (
     <DeletableSessionRow
       row={
-        <SessionRow
+        <RailSessionRow
           status={dot.variant}
           statusTitle={dot.title}
           selected={isActive}
@@ -1213,77 +1187,90 @@ function GroupHeader({
 // Esc closes, arrows move. Reuses flatSessions(projects) for ordering — no
 // second flattener. Empty query shows the full list; no match shows a plain
 // "No sessions match" row.
+// ⌘K session palette on the shared PaletteShell. Fuzzy match on session +
+// workspace name; Enter/click activates, Esc closes, arrows move (wraps).
+// Reuses flatSessions(projects) for ordering — no second flattener. Empty
+// query shows the full list; no match shows a plain "No sessions match" row.
 function CommandPalette({
-  open,
   query,
   setQuery,
   results,
   sel,
   setSel,
-  onKeyDown,
   onClose,
   onActivate,
 }: {
-  open: boolean;
   query: string;
   setQuery: (v: string) => void;
   results: Array<{ project: Project; window: TmuxWindow; score: number }>;
   sel: number;
   setSel: (n: number) => void;
-  onKeyDown: (e: React.KeyboardEvent) => void;
   onClose: () => void;
   onActivate: (project: Project, windowIndex: number) => void;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  // The palette stays MOUNTED (so Modal can play its exit), so grab focus only
-  // when it actually opens — otherwise the always-mounted input would steal
-  // focus on every Sidebar mount.
-  useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
   return (
-    <Modal open={open} size="sm" padded={false} onDismiss={onClose} label="Command palette">
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
-          <Search size={14} className="text-text-faint" aria-hidden="true" />
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={onKeyDown}
-            placeholder="Search sessions…"
-            spellCheck={false}
-            autoComplete="off"
-            className="flex-1 bg-transparent text-meta outline-none placeholder:text-text-faint"
-          />
-          <button
-            onClick={onClose}
-            className="text-text-faint hover:text-text text-meta"
-            title="Close (Esc)"
-          >
-            Esc
-          </button>
-        </div>
-        <div className="max-h-[50vh] overflow-y-auto py-1">
-          {results.length === 0 ? (
-            <div className="px-3 py-3 text-meta text-text-faint">No sessions match</div>
-          ) : (
-            results.map((r, i) => (
-              <button
-                key={`${r.project.tmuxSession}/${r.window.index}`}
-                onMouseEnter={() => setSel(i)}
-                onClick={() => onActivate(r.project, r.window.index)}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-meta ${
-                  i === sel ? "bg-bg-soft text-text" : "text-text-muted hover:bg-bg-soft"
-                }`}
-              >
-                <span className="w-[10px] h-[7px] shrink-0" aria-hidden />
-                <span className="flex-1 min-w-0 truncate">{r.window.name}</span>
-                <span className="text-text-faint truncate">{r.project.tmuxSession}</span>
-              </button>
-            ))
-          )}
-        </div>
-    </Modal>
+    <PaletteShell
+      label="Command palette"
+      placeholder="Search sessions…"
+      query={query}
+      setQuery={setQuery}
+      itemCount={results.length}
+      sel={sel}
+      setSel={setSel}
+      onPick={(i) => {
+        const r = results[i];
+        if (r) onActivate(r.project, r.window.index);
+      }}
+      onClose={onClose}
+    >
+      {(pick) =>
+        results.length === 0 ? (
+          <div className="px-3 py-3 text-label text-text-faint">No sessions match</div>
+        ) : (
+          results.map((r, i) => (
+            <SessionRow
+              key={`${r.project.tmuxSession}/${r.window.index}`}
+              name={r.window.name}
+              workspace={r.project.tmuxSession}
+              selected={i === sel}
+              onEnter={() => setSel(i)}
+              onClick={() => pick(i)}
+            />
+          ))
+        )
+      }
+    </PaletteShell>
+  );
+}
+
+function SessionRow({
+  name,
+  workspace,
+  selected,
+  onEnter,
+  onClick,
+}: {
+  name: string;
+  workspace: string;
+  selected: boolean;
+  onEnter: () => void;
+  onClick: () => void;
+}) {
+  const ref = useSelectedIntoView<HTMLButtonElement>(selected);
+  return (
+    <button
+      ref={ref}
+      onMouseEnter={onEnter}
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 px-3 py-3 rounded-md text-left text-label border-l-2 ${
+        selected
+          ? "bg-bg-soft border-l-accent text-text"
+          : "border-l-transparent text-text-muted hover:bg-bg-soft"
+      }`}
+    >
+      <span className="flex-1 min-w-0 truncate">{name}</span>
+      <span className="text-meta text-text-faint truncate">{workspace}</span>
+    </button>
   );
 }
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -196,3 +196,20 @@ html, body, #root {
 @media (prefers-reduced-motion: reduce) {
   .manta-message-flash { animation: none; }
 }
+
+/* PaletteShell enter/exit (⌘K switcher, ⌘F search). 140ms in / 100ms out —
+   the 100ms must match CLOSE_MS in PaletteShell.tsx. */
+.manta-palette-overlay { animation: manta-palette-fade-in 140ms ease-out; }
+.manta-palette-panel { animation: manta-palette-pop-in 140ms cubic-bezier(0.16, 1, 0.3, 1); }
+.manta-palette-overlay-out { animation: manta-palette-fade-out 100ms ease-in forwards; }
+.manta-palette-panel-out { animation: manta-palette-pop-out 100ms ease-in forwards; }
+@keyframes manta-palette-fade-in { from { opacity: 0; } }
+@keyframes manta-palette-fade-out { to { opacity: 0; } }
+@keyframes manta-palette-pop-in { from { opacity: 0; transform: translateY(-8px) scale(0.985); } }
+@keyframes manta-palette-pop-out { to { opacity: 0; transform: translateY(-8px) scale(0.985); } }
+@media (prefers-reduced-motion: reduce) {
+  .manta-palette-overlay,
+  .manta-palette-panel,
+  .manta-palette-overlay-out,
+  .manta-palette-panel-out { animation: none; }
+}

--- a/src/renderer/primitives.test.ts
+++ b/src/renderer/primitives.test.ts
@@ -298,8 +298,8 @@ describe("M527 primitive rules", () => {
     // this epic exists to close (BET-580). Add a row when a primitive lands;
     // never add a file to a row to make a red test green.
     const CHROME_OWNERS: Record<string, string[]> = {
-      "bg-black/40": ["Modal.tsx"], // the modal overlay tint
-      "shadow-lg": ["Modal.tsx", "MenuItem.tsx", "ArtifactPreview.tsx"], // the window-level floating surface (Modal) and the dropdown menu surface (Dropdown, BET-644) — two real owners, declared with their primitives; plus the preview overlay's centred card, another full-window floating surface whose shadow is mandated by its conformance mockup (`.pv` → `--shadow-lg`, BET-661)
+      "bg-black/40": ["Modal.tsx", "PaletteShell.tsx"], // the modal overlay tint — Modal (centered dialog) and PaletteShell (top-anchored palette), the two sibling full-window overlay primitives
+      "shadow-lg": ["Modal.tsx", "MenuItem.tsx", "ArtifactPreview.tsx", "PaletteShell.tsx"], // the window-level floating surface (Modal) and the dropdown menu surface (Dropdown, BET-644) — two real owners, declared with their primitives; plus the preview overlay's centred card, another full-window floating surface whose shadow is mandated by its conformance mockup (`.pv` → `--shadow-lg`, BET-661); and the palette panel surface shared by the ⌘K/⌘F PaletteShell (the palette-pattern counterpart to Modal)
       "peer-focus-visible:outline-accent": ["Checkbox.tsx"], // checkbox focus ring (BET-589)
       "hover:brightness-110": ["Button.tsx"], // primary button hover brighten (BET-614)
       "h-[29px]": ["Chip.tsx"], // chip hit-area height — the one off-grid value both Chip + SplitChip carry (BET-615)
@@ -310,7 +310,7 @@ describe("M527 primitive rules", () => {
       "tracking-[.1em]": ["Eyebrow.tsx"], // the eyebrow's letter-spaced uppercase signature (BET-614)
       "last:border-b-0": ["SettingsRow.tsx"], // the settings-row trailing-border removal — the .setrow row-divider signature (BET-614)
       "w-[6px]": ["StatusDot.tsx"], // the real 6px status dot — `.tool-h .g` (BET-636)
-      "bg-inset": ["OutputWell.tsx", "ArtifactsPanel.tsx", "ArtifactPreview.tsx"], // the recessed output well — `.tool-b`/`.ask-cmd` (BET-636); plus the Artifacts panel's segmented tab track, which uses the same recessed-inset surface per its conformance mockup (`.mk-tabs`, BET-659); and the preview overlay's image body — the recessed viewport mandated by the same mockup (`.pvbody` → `--inset`, BET-661)
+      "bg-inset": ["OutputWell.tsx", "ArtifactsPanel.tsx", "ArtifactPreview.tsx", "PaletteShell.tsx"], // the recessed output well — `.tool-b`/`.ask-cmd` (BET-636); plus the Artifacts panel's segmented tab track, which uses the same recessed-inset surface per its conformance mockup (`.mk-tabs`, BET-659); the preview overlay's image body — the recessed viewport mandated by the same mockup (`.pvbody` → `--inset`, BET-661); and the PaletteShell footer key-legend strip (BET-695)
       "px-[28px]": ["MeasureColumn.tsx"], // the 28px reading-column side inset — `.wrap`/`.comp-in` (BET-637)
       "max-w-[min(88%,var(--measure))]": ["MessageBubble.tsx"], // the user bubble's 88%/measure min() cap — `.umsg` (BET-637, BET-646)
       "text-[12.5px]": ["ToolCard.tsx", "OutputWell.tsx", "Button.tsx", "SettingsRow.tsx"], // the 12.5px mono chrome — ToolCard header + OutputWell well (BET-636), plus the pre-existing Button label and SettingsRow help which already owned it before this primitive tracked it


### PR DESCRIPTION
## Summary
Extracts the top-anchored, animated palette-pattern chrome (input + results + footer key-legend) into a shared **`PaletteShell`** component and ports the ⌘K session switcher (`CommandPalette`) onto it. No ⌘F search functionality here — a follow-up issue consumes the same shell. The switcher gets the visual upgrade (fade+pop animation, selection scroll-into-view, footer legend) as a side effect; behavior unchanged.

Sibling to `Modal.tsx` (the centered-dialog primitive) with the same no-escape-hatch philosophy. `Modal.tsx`, `App.tsx`, `ChatPanel.tsx`, `src/server/**` untouched.

**Files changed:** 4 — `src/renderer/PaletteShell.tsx` (new), `src/renderer/Sidebar.tsx` (⌘K ported onto the shell, bespoke chrome + keyboard handler deleted), `src/renderer/index.css` (palette enter/exit keyframes), `src/renderer/primitives.test.ts` (chrome-ownership gate, see note).

**Deviation from "exactly three files" — palette chrome ownership (transparency):** The spec's design-fidelity table mandates `bg-black/40`, `shadow-lg`, and `bg-inset` in the shell — all three are gated by the BET-588 chrome-ownership allowlist. To keep `npm test` green (also a DoD requirement) I registered `PaletteShell` as a legitimate co-owner of those shared floating-surface chrome classes. PaletteShell is the named sibling-pattern primitive to Modal (this is the "add a row when a primitive lands" maintenance path, not an inline re-implementation being white-listed). This was the only path that satisfied both the mandated classes AND the green-tests DoD.

**Base:** origin/main @ `ed793000`

**Follow-up filed:** none closed here; the ⌘F conversation-search consumer is the already-filed follow-up issue (out of scope by design).

## Verification results
- PR branch (`multica/BET-695-palette-shell` @ `f4d99f80`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2235 pass / 0 fail / 7 skip. Failures: none. log sha256: `8df64b2669e83d4184a9a0c61fb993d7bfedf73cb7304a6aa69ce4c6c4449989`
- Base (`main` @ `ed793000`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2235 pass / 0 fail / 7 skip. Failures: none. log sha256: `debaf8c36a8fca7d699ac59692181d208dd829867753fa84654f336d14cb794d`
- **Conclusion:** 0 new test failures; 0 pre-existing; identical counts between branches. The only behavioral delta from main is the PaletteShell/⌘K port + new primitive.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.