### PR TITLE
BET-699: /pair web page validate-only — add non-consuming /auth/check

### DIFF
--- a/llms-install.md
+++ b/llms-install.md
@@ -202,8 +202,12 @@ before the user enters it, mint a fresh one:
 Tell the user, in this order:
 
 1. The **pair page** as the single clickable entry point — the box hosts a
-   3-step wizard that walks them through downloading the desktop app,
-   connecting it, and (optionally) installing the mobile app:
+   3-step wizard that shows them where to get the desktop app and how to
+   connect it (and, optionally, installs the mobile app). Opening it with the
+   code in the URL **checks that the code is valid** and shows install
+   instructions — it does NOT complete the linking. The user finishes by
+   entering the code in the desktop app (or the phone app), which performs the
+   actual claim:
 
    - **Linux box:** [Open this link to connect your devices](https://<box_id>.boxes.mantaui.com/pair#box=<box_id>&code=<code>)
    - **macOS box:** the installer prints the tailnet URL (or the loopback

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -106,8 +106,9 @@ export function parseBearer(headerValue) {
 // /push/*, static assets — is gated.
 //
 // Rationale for each exemption:
-//   /auth/pair, /auth/claim — bootstrap; you can't present a token you don't
-//     have yet. Rate-limited + code-gated instead.
+//   /auth/pair, /auth/claim, /auth/check — bootstrap; you can't present a
+//     token you don't have yet. Rate-limited + code-gated instead. check is
+//     the /pair page's NON-consuming validation (it never mints or claims).
 //   /auth/revoke            — per-device "remove this box" handshake (BET-357 §2).
 //     The caller MUST present a valid token, but the standard gate collapses
 //     malformed-token and missing-token into the same 401, which loses a
@@ -130,7 +131,7 @@ export function parseBearer(headerValue) {
 // caller's token is valid, so it must run through the gate.
 export function isExemptPath(path) {
   if (typeof path !== "string") return false;
-  if (path === "/auth/pair" || path === "/auth/claim" || path === "/auth/revoke") return true;
+  if (path === "/auth/pair" || path === "/auth/claim" || path === "/auth/check" || path === "/auth/revoke") return true;
   if (path === "/pair" || path === "/pair/qr.png" || path === "/pair/logo.png") return true;
   if (path === "/hook/" || path.startsWith("/hook/")) return true;
   if (path === "/pages/" || path.startsWith("/pages/")) return true;
@@ -376,6 +377,25 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
     return ok;
   }
 
+  // Non-consuming validation: does `code` match the single active, unexpired
+  // code? Same gates + constant-time compare as `consume()`, but it NEVER
+  // clears `active` — a correct answer leaves the code claimable. Used by the
+  // /pair web page (BET-699) so the page can confirm a code is good without
+  // burning it or being handed the box token. Deliberately does NOT
+  // distinguish "wrong code" from "expired" — like `verifyMatches`/`claim`, a
+  // guesser learns only "no".
+  function check(code) {
+    if (!isValidPairingCode(code)) return false;
+    if (!active) return false;
+    if (now() > active.expiresAt) {
+      active = null;
+      return false;
+    }
+    const a = Buffer.from(active.code, "utf-8");
+    const b = Buffer.from(String(code), "utf-8");
+    return a.length === b.length && timingSafeEqual(a, b);
+  }
+
   // Two-factor confirm check (the "matches" affordance carried back in the
   // claim): does `verify` match the four characters minted alongside `code`?
   // Non-consumeing — a mismatch must NOT burn the one-time code (a wrong
@@ -405,7 +425,7 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
     return !!active && now() <= active.expiresAt;
   }
 
-  return { issue, consume, verifyMatches, clear, hasActive };
+  return { issue, consume, verifyMatches, check, clear, hasActive };
 }
 
 // ---------------------------------------------------------------------------
@@ -574,6 +594,21 @@ export function createAuthEngine({
     };
   }
 
+  // Handle POST /auth/check — NON-consuming validation for the /pair web page
+  // (BET-699). Tells the page whether a code is good so it can say "enter it
+  // in the app" WITHOUT burning the one-time code or ever exposing the box
+  // token to a throwaway browser. Mirrors claim()'s first branch: a malformed
+  // code is a 400, a wrong/expired code is an indistinguishable 403.
+  function check({ pairing_code } = {}) {
+    if (!isValidPairingCode(pairing_code)) {
+      return { ok: false, status: 400, error: "invalid pairing code" };
+    }
+    if (!pairing.check(pairing_code)) {
+      return { ok: false, status: 403, error: "invalid or expired code" };
+    }
+    return { ok: true, box_id: auth.box_id };
+  }
+
   // Handle DELETE /auth/revoke — two modes:
   //   • PER-DEVICE (device_id supplied): kill only that device's token, leaving
   //     every other device (and the primary box_token holder) working. This is
@@ -656,6 +691,7 @@ export function createAuthEngine({
     authorize,
     pair,
     claim,
+    check,
     revoke,
     listDevices,
     // exposed for /auth/status and tests

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -94,6 +94,7 @@ test("parseBearer extracts token from Authorization header", () => {
 test("isExemptPath exempts only /auth pairing + /pair onboarding + /hook delivery + /pages hosting", () => {
   assert.equal(isExemptPath("/auth/pair"), true);
   assert.equal(isExemptPath("/auth/claim"), true);
+  assert.equal(isExemptPath("/auth/check"), true);
   assert.equal(isExemptPath("/pair"), true);
   assert.equal(isExemptPath("/pair/qr.png"), true);
   assert.equal(isExemptPath("/pair/logo.png"), true);
@@ -446,6 +447,67 @@ test("claim rejects an expired code", () => {
   const r = eng.claim({ pairing_code });
   assert.equal(r.ok, false);
   assert.equal(r.status, 403);
+});
+
+// ----------------------------------------------------------------------------
+// auth engine — check (BET-699: /pair page validates WITHOUT consuming)
+// ----------------------------------------------------------------------------
+
+test("check approves the active code and does NOT consume it", () => {
+  const eng = engine({ auth: AUTH });
+  const { pairing_code } = eng.pair();
+
+  const c = eng.check({ pairing_code });
+  assert.equal(c.ok, true);
+  assert.equal(c.box_id, AUTH.box_id);
+
+  // The code is still claimable after check — proving it was never consumed.
+  const claim = eng.claim({ pairing_code });
+  assert.equal(claim.ok, true);
+  assert.equal(claim.box_token, AUTH.box_token);
+});
+
+test("check rejects a wrong code but the active code still claims afterwards", () => {
+  const eng = engine({ auth: AUTH });
+  const { pairing_code } = eng.pair();
+
+  const wrong = eng.check({ pairing_code: "999999" });
+  assert.equal(wrong.ok, false);
+  assert.equal(wrong.status, 403);
+
+  // A non-matching check must NOT consume the real code.
+  const claim = eng.claim({ pairing_code });
+  assert.equal(claim.ok, true);
+});
+
+test("check rejects an expired code", () => {
+  let t = 0;
+  const eng = engine({ auth: AUTH, ttlMs: 100, now: () => t });
+  const { pairing_code } = eng.pair();
+  t = 200; // past TTL
+  const r = eng.check({ pairing_code });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 403);
+});
+
+test("check rejects a malformed code", () => {
+  const eng = engine({ auth: AUTH });
+  const r = eng.check({ pairing_code: "abc" });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+});
+
+test("repeated check calls never consume the code", () => {
+  const eng = engine({ auth: AUTH });
+  const { pairing_code } = eng.pair();
+
+  for (let i = 0; i < 5; i++) {
+    const c = eng.check({ pairing_code });
+    assert.equal(c.ok, true);
+  }
+  // Still claimable after 5 good checks.
+  const claim = eng.claim({ pairing_code });
+  assert.equal(claim.ok, true);
 });
 
 // ----------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -766,6 +766,9 @@ const handleRequest = async (req, res) => {
   //                                `verify` (BET-493): when the joiner echoes the
   //                                four characters it provisions a DISTINCT
   //                                Stage-2 device; absent → legacy primary token.
+  // POST   /auth/check {pairing_code} → {box_id}
+  //                                NON-consuming validation for the /pair web
+  //                                page; the code stays claimable (BET-699).
   // DELETE /auth/revoke           → 200 on success; 400/401 on bad token.
   //                                "Remove this box from the device that holds
   //                                the current box_token" (BET-357 §2). Mints
@@ -776,6 +779,7 @@ const handleRequest = async (req, res) => {
   if (
     path === "/auth/pair" ||
     path === "/auth/claim" ||
+    path === "/auth/check" ||
     path === "/auth/revoke"
   ) {
     const ip =
@@ -838,6 +842,17 @@ const handleRequest = async (req, res) => {
           box_id: result.box_id,
           device_id: result.device_id ?? null,
         });
+        return;
+      }
+      if (req.method === "POST" && path === "/auth/check") {
+        const body = await readJsonBody(req);
+        const pairing_code = body?.pairing_code ?? body?.code;
+        const result = authEngine.check({ pairing_code });
+        if (!result.ok) {
+          respondJson(res, result.status ?? 400, { error: result.error });
+          return;
+        }
+        respondJson(res, 200, { box_id: result.box_id });
         return;
       }
       if (req.method === "DELETE" && path === "/auth/revoke") {

--- a/src/server/pair.html
+++ b/src/server/pair.html
@@ -204,7 +204,7 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
       <div class="action">
         <button class="btn btn-primary" type="button" onclick="goFinish()">Continue</button>
       </div>
-      <p class="hint">Nothing was linked yet — install Manta on this phone to finish.</p>
+      <p class="hint">Nothing was linked yet — the code stays valid. Install Manta on this phone and enter it there to finish.</p>
     </div>
   </section>
 
@@ -214,14 +214,14 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
       <div class="picon warn">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
       </div>
-      <h1>That code expired</h1>
-      <p class="lead">Codes last five minutes. <b>Nothing was linked and nothing changed.</b></p>
+      <h1>That code didn't work</h1>
+      <p class="lead">It may have expired or been mistyped. <b>Nothing was linked and nothing changed.</b></p>
       <div class="causecard">
         <div class="cause-row">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
           <div>
-            <div class="cr-t">Your desktop already has a new one</div>
-            <div class="cr-s">It refreshes on its own. Scan it again.</div>
+            <div class="cr-t">Get a fresh code</div>
+            <div class="cr-s">From the desktop app, or by running <code>manta pair</code> on the box.</div>
           </div>
         </div>
       </div>
@@ -257,7 +257,7 @@ footer{text-align:center;font-size:12px;color:var(--slate-300);padding:0 24px 28
         </div>
       </div>
       <div class="action btn-row">
-        <button class="btn btn-primary" type="button" onclick="retryClaim()">Try again</button>
+        <button class="btn btn-primary" type="button" onclick="retryCheck()">Try again</button>
         <button class="btn btn-ghost" type="button" onclick="copyDiagnostics()">Copy diagnostics</button>
       </div>
     </div>
@@ -288,7 +288,7 @@ function parseFragment(){
 
 function claimEndpointFor(origin){
   var o=(origin||"").trim();
-  return (o? o.replace(/\/+$/,"") : location.origin)+"/auth/claim";
+  return (o? o.replace(/\/+$/,"") : location.origin)+"/auth/check";
 }
 
 function resolveHost(){
@@ -339,14 +339,14 @@ function digtarget(){
   return cells[5];
 }
 
-// --- claim ---
+// --- check (non-consuming: the code stays claimable in the app) ---
 function submitCode(){
   var s=gather();
   if(!/^\d{6}$/.test(s)) return;
-  doClaim(s);
+  doCheck(s);
 }
 
-function doClaim(code){
+function doCheck(code){
   show("checking");
   var origin=$("server-url")? $("server-url").value : "";
   claimOrigin=origin;
@@ -360,28 +360,28 @@ function doClaim(code){
     return r.text();
   }).then(function(txt){
     try{ body=JSON.parse(txt); }catch(e){ body=null; }
-    presentClaimResult(res, body);
+    presentCheckResult(res, body);
   }).catch(function(){
     threw=true;
-    presentClaimResult(null, null);
+    presentCheckResult(null, null);
   });
 }
 
-function presentClaimResult(res, body){
+function presentCheckResult(res, body){
   if(res && res.ok && body && body.box_id){
     $("found-host").textContent=resolveHost();
     show("found");
     return;
   }
-  // The page only ever receives a server rejection or a network failure.
-  // §5.4 "codes don't match" needs the human to compare against what the
-  // DESKTOP shows — a box-served page cannot know that (renderer-side
-  // no-op), so an unknown rejection is shown as "expired", never with the
-  // desktop-comparator copy.
+  // Any server rejection (403 wrong/expired, 400 malformed, 429 rate-limit)
+  // lands on the same "didn't work" view — the page can never tell a typo
+  // from an expired code, and must not claim one. A network failure is the
+  // separate "unreachable" view. Nothing here consumes the code or holds a
+  // token: this is validation only, so the code stays valid in the app.
   show(res ? "expired" : "unreachable");
 }
 
-function retryClaim(){ submitCode(); }
+function retryCheck(){ submitCode(); }
 
 // --- misc ---
 function goScanAgain(){
@@ -440,7 +440,7 @@ function copyDiagnostics(){
     show("manual");
     setCells(f.code);
     $("landing-code").textContent=(f.code.slice(0,3)+" "+f.code.slice(3));
-    doClaim(f.code);
+    doCheck(f.code);
   } else {
     show("landing");
   }

--- a/src/server/pairPage.test.mjs
+++ b/src/server/pairPage.test.mjs
@@ -396,23 +396,25 @@ test("readPairAsset returns pair-logo.png bytes (PNG magic)", () => {
 // manual entry sends only the six digits, the server resolves the box (§5.2.9).
 // The /auth/claim server half (code → resolved box) is already covered by
 // auth.test.mjs; this pins that the page wires to that same endpoint.
-test("manual-entry mailbox: shipped page claims the fragment code against /auth/claim (BET-489)", () => {
+test("manual-entry mailbox: shipped page checks the fragment code against /auth/check (BET-699)", () => {
   const html = readPairAsset("pair.html").toString("utf-8");
-  // The claim endpoint is built by claimEndpointFor — it must resolve to the
-  // EXISTING /auth/claim path, never a new route.
+  // The check endpoint is built by claimEndpointFor — it must resolve to the
+  // NON-consuming /auth/check path, never /auth/claim (which would burn the
+  // one-time code and leak the box token to the browser).
   const endpoint = html.match(/function claimEndpointFor\(origin\)\{([\s\S]*?)\n\}/);
   assert.ok(endpoint, "the page must define claimEndpointFor(origin)");
-  assert.match(endpoint[1], /\/auth\/claim/, "the endpoint must reuse /auth/claim");
-  assert.match(endpoint[1], /"\/auth\/claim";/, "endpoint is exactly <origin>/auth/claim");
-  assert.doesNotMatch(endpoint[1], /"\/auth\/claim\?/, "no query appended after /auth/claim");
+  assert.match(endpoint[1], /\/auth\/check/, "the endpoint must be /auth/check");
+  assert.match(endpoint[1], /"\/auth\/check";/, "endpoint is exactly <origin>/auth/check");
+  assert.doesNotMatch(endpoint[1], /"\/auth\/check\?/, "no query appended after /auth/check");
   assert.doesNotMatch(endpoint[1], /[?&]code\s*=/i, "no code in a query string");
-  // doClaim POSTs only {code} to that endpoint — the code travels in the body.
-  const doClaim = html.match(/function doClaim\(code\)\{([\s\S]*?)\n\}/);
-  assert.ok(doClaim, "the page must define doClaim(code)");
-  assert.match(doClaim[1], /fetch\(claimEndpointFor\(origin\)/, "claims via the built endpoint");
-  assert.match(doClaim[1], /method:\s*"POST"/, "must be a POST");
-  assert.match(doClaim[1], /JSON\.stringify\(\{\s*code:\s*code\s*\}\)/, "body carries {code}");
-  assert.doesNotMatch(doClaim[1], /box\s*:/, "manual entry sends no box id");
+  assert.doesNotMatch(endpoint[1], /\/auth\/claim/, "must NOT reuse the consuming /auth/claim");
+  // doCheck POSTs only {code} to that endpoint — the code travels in the body.
+  const doCheck = html.match(/function doCheck\(code\)\{([\s\S]*?)\n\}/);
+  assert.ok(doCheck, "the page must define doCheck(code)");
+  assert.match(doCheck[1], /fetch\(claimEndpointFor\(origin\)/, "checks via the built endpoint");
+  assert.match(doCheck[1], /method:\s*"POST"/, "must be a POST");
+  assert.match(doCheck[1], /JSON\.stringify\(\{\s*code:\s*code\s*\}\)/, "body carries {code}");
+  assert.doesNotMatch(doCheck[1], /box\s*:/, "manual entry sends no box id");
 });
 
 // Fragment-only: the code must never be placed in a path/query the server
@@ -423,30 +425,36 @@ test("the page never puts the code in a path/query the server could log (fragmen
   // The code is sourced only from the URL fragment.
   assert.match(html, /location\.hash/, "code must be read from the fragment");
   // No path/query construction that would surface the code to a proxy log.
-  assert.doesNotMatch(html, /"\/auth\/claim\?"/, "no code-carrying claim URL query");
+  assert.doesNotMatch(html, /"\/auth\/check\?"/, "no code-carrying check URL query");
   assert.doesNotMatch(html, /&code=|&box=/, "no query-string code/box usage");
 });
 
-// The resolved-box card is fed by a claim that resolved the box (the server
-// returns box_id on success). The page must key the "Box found" card off
-// that resolved response — not off any client-side assumption.
-test("resolved-box card is fed by a successful /auth/claim that resolved the box (BET-489)", () => {
+// The resolved-box card is fed by a successful check (the server returns
+// box_id on success). The page must key the "Box found" card off that
+// resolved response — not off any client-side assumption — and the check must
+// NEVER hand back a box_token (validation only; the code stays claimable).
+test("resolved-box card is fed by a successful /auth/check that resolved the box (BET-699)", () => {
   const html = readPairAsset("pair.html").toString("utf-8");
-  const present = html.match(/function presentClaimResult\(res, body\)\{([\s\S]*?)\n\}/);
-  assert.ok(present, "presentClaimResult must exist");
+  const present = html.match(/function presentCheckResult\(res, body\)\{([\s\S]*?)\n\}/);
+  assert.ok(present, "presentCheckResult must exist");
   assert.match(present[1], /res\s*&&\s*res\.ok/, "only a successful response shows the card");
   assert.match(present[1], /body\s*\.\s*box_id/, "keys off the server-resolved box_id");
+  assert.doesNotMatch(present[1], /box_token/, "check must never reference a box_token");
   assert.match(html, /Box found/, "the resolved-box card heading");
+  assert.match(html, /the code stays valid/, "confirms the code is still claimable");
 });
 
-// Failure-state copy renders per §5.4 — the verbatim {cause, action} pairs.
+// Failure-state copy renders per §5.4 — the {cause, action} pairs. The page
+// cannot distinguish a typo from an expired code, so both land on the same
+// "That code didn't work" view (BET-699).
 test("pair.html renders the §5.4 failure-state copy verbatim (BET-489)", () => {
   const html = readPairAsset("pair.html").toString("utf-8");
-  // Expired
-  assert.match(html, /That code expired/);
-  assert.match(html, /Codes last five minutes/);
+  // Validation rejection (wrong/expired/malformed/rate-limited)
+  assert.match(html, /That code didn't work/);
+  assert.match(html, /It may have expired or been mistyped/);
   assert.match(html, /Nothing was linked and nothing changed/);
-  assert.match(html, /Your desktop already has a new one/);
+  assert.match(html, /Get a fresh code/);
+  assert.match(html, /manta pair/);
   assert.match(html, /Scan again/);
   assert.match(html, /Enter a code instead/);
   // Unreachable


### PR DESCRIPTION
## BET-699 — /pair web page: validate-only

The box-served `/pair` page no longer auto-claims the pairing code. It POSTs to a new **non-consuming** `/auth/check` endpoint and tells the user the code is good + to finish in the app. All claim/token plumbing is removed from the page.

### Changes
- **`src/server/auth.mjs`**
  - `createPairingRegistry`: new non-consuming `check(code)` — same gates + constant-time compare as `consume()` but never clears `active`; deliberately indistinguishable wrong-vs-expired.
  - `createAuthEngine`: new `check({ pairing_code })` → 400 malformed / 403 wrong-or-expired / `{ok, box_id}`; exported.
  - `isExemptPath`: `/auth/check` exempt (like `/auth/claim`).
- **`src/server/index.mjs`**: `POST /auth/check {pairing_code|code}` under the shared `/auth/*` rate-limiter; route-comment updated.
- **`src/server/pair.html`**: `doClaim`→`doCheck` (→ `/auth/check`), `presentClaimResult`→`presentCheckResult`, `retryClaim`→`retryCheck`; all `box_token` handling removed. "found" hint now truthful: *the code stays valid — enter it in the app to finish*. Any rejection (403/400/429) → "That code didn't work" (fixes §3.3 sev-3 #12: no more claiming "expired" for a typo). Unreachable view unchanged.
- **`llms-install.md`**: Step 6 clarifies the link checks the code + shows install instructions — it does not complete linking.
- **Tests**: `auth.test.mjs` (5: check approves w/o consuming, wrong code leaves active claimable, expired→403, malformed→400, 5× never consumes) + `isExemptPath("/auth/check")`; `pairPage.test.mjs` updated to pin the /auth/check wiring + new copy.

**Base: origin/main @ `0c5f292a`**

**Files changed:** `6` files. `llms-install.md`, `src/server/auth.mjs`, `src/server/auth.test.mjs`, `src/server/index.mjs`, `src/server/pair.html`, `src/server/pairPage.test.mjs`

**Verification results:**
- PR branch (`multica/BET-699-pair-validate-only` @ `25b172ef`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1531 pass / 0 fail / 0 skip. Failures: none. log sha256: `c9ce6b2a8a4f3e981b08da92a23e34da5eac36ea274b238f025b533d229f2344`
- Base (`main` @ `0c5f292a`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1526 pass / 0 fail / 0 skip. Failures: none. log sha256: `b59b698ca0a3b199a4d2c2d6b58ea1500faae53bd7f26a5337fb500c98415729`
- **Conclusion:** 0 new failures; 5 new tests added by this PR (1531 vs 1526). `npm run test:server` also passes (1037/0).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
