### PR TITLE
fix(renderer): re-run app-level subscriptions after in-session transport swap (BET-708)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -161,6 +161,20 @@ function AppInner() {
   useEffect(() => {
     if (enterOnboarding && !onboardingLatched) setOnboardingLatched(true);
   }, [enterOnboarding, onboardingLatched]);
+
+  // BET-708: first-time pairing swaps window.api in place with no reload
+  // (transportInstall), so an app-level effect that guards on an httpApi-only
+  // method (onSyncDelta, onStatusEvent, onOpencodeEvent,
+  // delegateList/onDelegateUpdated, onAgentFileReady, onServerUpdateProgress)
+  // bails at mount and never re-subscribes for the whole first session.
+  // transportInstall dispatches `manta-api-installed` after every swap; bump
+  // this generation to re-run exactly those effects (added below).
+  const [apiGeneration, setApiGeneration] = useState(0);
+  useEffect(() => {
+    const bump = () => setApiGeneration((g) => g + 1);
+    window.addEventListener("manta-api-installed", bump);
+    return () => window.removeEventListener("manta-api-installed", bump);
+  }, []);
   const showOnboarding = enterOnboarding || onboardingLatched;
   const [settingsOpen, setSettingsOpen] = useState(false);
   // ⌘F conversation search palette (SearchPalette). Only reachable in chat
@@ -385,13 +399,13 @@ function AppInner() {
       useStore.getState().applySyncPayload(delta as SyncPayload);
     });
     return off;
-  }, [refresh]);
+  }, [refresh, apiGeneration]);
 
   useEffect(() => {
     if (!window.api.onStatusEvent) return;
     const off = window.api.onStatusEvent(applyStatusBatch);
     return off;
-  }, [applyStatusBatch]);
+  }, [applyStatusBatch, apiGeneration]);
 
   // Startup attention replay. opencode SSE is forward-only, so a chat window
   // already blocked on a question/permission when the app (re)connects never
@@ -475,7 +489,7 @@ function AppInner() {
       clearInterval(poll);
       if (off) off();
     };
-  }, []);
+  }, [apiGeneration]);
 
   // Screenshot detection — subscribe ONCE at the app level. Every ChatPanel
   // used to register its own listener, so a single detection fanned out into
@@ -550,7 +564,7 @@ function AppInner() {
       useStore.getState().setAgentFileToast(ev);
     });
     return off;
-  }, []);
+  }, [apiGeneration]);
 
   // Auto-update: main checks for updates on launch and pushes
   // updateAvailable / updateDownloaded events to the renderer. We only care
@@ -618,7 +632,7 @@ function AppInner() {
       useStore.getState().setServerUpdateProgress(p);
     });
     return off;
-  }, []);
+  }, [apiGeneration]);
 
   // Version-skew guard (BET-225 stage 3 Part C). After the renderer is
   // mounted, fetch the client + server version pair ONCE (no second poll,
@@ -724,12 +738,12 @@ function AppInner() {
         ev.type === "permission.rejected"
       ) {
         const sid = typeof props.sessionID === "string" ? props.sessionID : "";
-        if (sid) useStore.getState().setChatAttention(sid, null);
+        if (sid)         useStore.getState().setChatAttention(sid, null);
         return;
       }
     });
     return off;
-  }, []);
+  }, [apiGeneration]);
 
   // Desktop OS notifications. manta-server's router (push.mjs) decides WHICH
   // device(s) get a notification (no duplicates) and forwards a desktop directive

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -41,6 +41,10 @@ import { loadPersistedSnapshot } from "./store";
 // shell that used to branch on `!preload`) is retired — a browser without a
 // preload is now only reachable through `?demo` for the visual gates and
 // marketing shots, which never run the real boot path.
+// TODO(BET-audit L10): this cast widens the ~25-method preload subset to the
+// full `Api` type; the preload shim and httpApi should eventually share one
+// typed contract rather than relying on the renderer assuming the subset
+// masks missing methods.
 const preload = (window as unknown as { __mantaPreload?: Api }).__mantaPreload;
 
 // Demo mode (BET-302): parsed once at module load so the demo branch is

--- a/src/renderer/transportInstall.test.ts
+++ b/src/renderer/transportInstall.test.ts
@@ -68,6 +68,22 @@ describe("installHttpTransport", () => {
     setItemSpy.mockRestore();
     warn.mockRestore();
   });
+
+  it("swaps window.api AND dispatches manta-api-installed on a successful seed", () => {
+    const listener = vi.fn();
+    window.addEventListener("manta-api-installed", listener);
+    try {
+      const result = installHttpTransport({
+        manta_server: "https://x.boxes.mantaui.com",
+        manta_token: "y",
+      });
+      expect(result).toBe(true);
+      expect(window.api).toBe(httpApiSentinel);
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("manta-api-installed", listener);
+    }
+  });
 });
 
 describe("setWindowApi", () => {
@@ -81,5 +97,17 @@ describe("setWindowApi", () => {
     // Must remain writable so a later boot path / pairing can swap it again.
     (window as unknown as { api: unknown }).api = { tag: "third" };
     expect(window.api).toEqual({ tag: "third" });
+  });
+
+  it("dispatches manta-api-installed so app-level effects can re-subscribe", () => {
+    const listener = vi.fn();
+    window.addEventListener("manta-api-installed", listener);
+    try {
+      setWindowApi({ tag: "next" });
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].type).toBe("manta-api-installed");
+    } finally {
+      window.removeEventListener("manta-api-installed", listener);
+    }
   });
 });

--- a/src/renderer/transportInstall.ts
+++ b/src/renderer/transportInstall.ts
@@ -23,6 +23,12 @@ export function setWindowApi(next: unknown): void {
     configurable: true,
     enumerable: true,
   });
+  // BET-708: signal app-level effects that a transport swap just happened
+  // (first-time pairing does this in-session with no reload). App.tsx bumps
+  // `apiGeneration` on this event to re-run the effects that guard on an
+  // httpApi-only method. Dispatched at boot too (before React mounts, no
+  // listener yet — harmless).
+  window.dispatchEvent(new CustomEvent("manta-api-installed"));
 }
 
 /**


### PR DESCRIPTION
## BET-708 — re-run app-level subscriptions after the in-session transport swap

**Root cause fix.** On first-ever pairing, `window.api` is swapped in place with no reload (BET-254). App-level effects guard on httpApi-only methods (`onSyncDelta`, `onStatusEvent`, `onOpencodeEvent`, `delegateList`/`onDelegateUpdated`, `onAgentFileReady`, `onServerUpdateProgress`) and bail at mount — so for the entire first session after onboarding, none of those subscriptions fire. Self-heals on restart, which is why it evaded notice.

**Fix (the repo's established CustomEvent bridge pattern, cf. `manta-open-schedules`):**
- `src/renderer/transportInstall.ts` — `setWindowApi()` now dispatches `manta-api-installed` after the `Object.defineProperty` swap. Boot dispatches before React mounts (no listener yet) → harmless, effects still run on mount with generation 0.
- `src/renderer/App.tsx` — `AppInner` holds `apiGeneration` state; a mount effect subscribes to `manta-api-installed` and bumps it on every swap. `apiGeneration` added to the dependency array of EXACTLY the six effects that guard on a preload-subset-lacking method (located by method name, not cd741d9 line number). Each already returns its unsubscribe cleanup, so re-running never double-subscribes.
- `src/renderer/main.tsx` — one-line `// TODO(BET-audit L10)` at the preload→`Api` cast (typing fix out of scope per the issue).
- `src/renderer/transportInstall.test.ts` — added two tests: `setWindowApi` dispatches the event; a successful `installHttpTransport(seed)` swaps `window.api` AND dispatches it.

**No `location.reload()`. Boot-time swap in main.tsx left unchanged.**

**Base:** origin/main @ `250354f6`

**Files changed (4):** only the files the issue permits — App.tsx, transportInstall.ts, transportInstall.test.ts, main.tsx.

**Verification results:**
- PR branch (`multica/BET-708-transport-generation` @ `889dafb2`):
  - typecheck: exit 0, no errors. log sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 0 fail. node:test summary 1526 pass / 0 fail. log sha256 `bed1c69bfad12a8c5f4b01aad2def30ff428fbcdb4b87833d12d23e7595da448`
- Base (`main` @ `250354f6`):
  - typecheck: exit 0, no errors. log sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 0 fail. node:test summary 1526 pass / 0 fail. log sha256 `590b42423d3706601582946d15fcd5d14ada2603bd1b4d0c9a69e5db97abf0ba`
- **Conclusion:** 0 new failures; renderer vitest includes the new transportInstall cases (5/5 pass).

Logs cached at /tmp/typecheck-pr.log, /tmp/typecheck-main.log, /tmp/test-pr.log, /tmp/test-main.log.
