### PR TITLE
fix(installer): robust SSH install cancel/reload/claim (BET-705)

### DIFF
--- a/src/main/installer/handlers.test.ts
+++ b/src/main/installer/handlers.test.ts
@@ -308,6 +308,49 @@ describe("registerInstallerHandlers — installerStart preflight fold (BET-383)"
   });
 });
 
+// BET-705 b: installerState exposes the active handle id (so a remount can
+// restore Cancel) and the stored install target (so the auto-claim resolves
+// against the host that was actually installed, never the picker's current
+// selection).
+describe("registerInstallerHandlers — activeHandleId + target (BET-705 b)", () => {
+  it("installerState reports the active handle id and the stored target after a start", async () => {
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const stateHandler = ipcState.handlers.get(IPC.installerState);
+
+    await startHandler!(null, { alias: "prod.example.com" });
+    const state = (await stateHandler!(null, undefined)) as {
+      active: boolean;
+      activeHandleId: string | null;
+      target: unknown;
+    };
+    expect(state.active).toBe(true);
+    expect(state.activeHandleId).toMatch(/^install-/);
+    expect(state.target).toBe("prod.example.com");
+    await flushMicrotasks();
+  });
+
+  it("installerMintAndClaim prefers the stored install target over the renderer's alias", async () => {
+    const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+    registerInstallerHandlers(() => win as never, vi.fn());
+    const startHandler = ipcState.handlers.get(IPC.installerStart);
+    const claimHandler = ipcState.handlers.get(IPC.installerMintAndClaim);
+
+    // Install ran against origin.example.com, then finished (clears the
+    // active handle but NOT the stored target — the claim comes after done).
+    await startHandler!(null, { alias: "origin.example.com" });
+    await flushMicrotasks();
+
+    // The renderer (post-remount host-picker reset) passes a stale alias —
+    // main must still claim against the stored target.
+    await claimHandler!(null, { alias: "wrong.example.com" });
+    const [targetArg] = mintState.mintAndClaim.mock.calls[0];
+    expect(targetArg).toBe("origin.example.com");
+    await flushMicrotasks();
+  });
+});
+
 // BET-361: a never-seen host pauses the install for a trust decision.
 // The handler must (a) emit a `fingerprint` event, (b) hold the slot while
 // waiting, (c) resume into runInstall after a Trust answer + successful

--- a/src/main/installer/handlers.ts
+++ b/src/main/installer/handlers.ts
@@ -42,6 +42,12 @@ const LOG_TAIL_MAX = 200;
 let nextHandleSeq = 0;
 // Most recent preflight verdict, read back by IPC.installerState.
 let activePreflight: PreflightResult | null = null;
+// BET-705 b: the SshTarget the most recent installerStart was asked to
+// install. It's the SINGLE source of truth for the auto-claim after `done` —
+// the claim must go against the same host the install used, even after a
+// renderer remount reset the host picker. Overwritten on each new install
+// start; NOT cleared on completion (the claim runs after `done`).
+let lastInstallTarget: SshTarget | null = null;
 
 // BET-361: when preflight hits a never-seen host, the install PAUSES here
 // waiting for the renderer's "Trust this host" answer. The deferred is
@@ -175,6 +181,11 @@ export function registerInstallerHandlers(
     stage: activeStage,
     logTail: [...logTail],
     preflight: activePreflight,
+    // BET-705 b: expose the active handle id so a renderer remount can
+    // restore it (needed for Cancel), and the stored install target so the
+    // auto-claim is always against the host that was actually installed.
+    activeHandleId: activeHandle?.handleId ?? null,
+    target: lastInstallTarget,
     // BET-361: mirror the trust-pause so a renderer remount re-shows the
     // fingerprint prompt and routes its answer to the right handle.
     waitingForTrust: waitingForTrust !== null,
@@ -203,6 +214,9 @@ export function registerInstallerHandlers(
     // (BET-384) is already normalized by resolveInstallTarget on the
     // renderer side, so there's nothing further to trim on an object.
     const alias = typeof input.alias === "string" ? input.alias.trim() : input.alias;
+    // BET-705 b: record the target this install is actually installing —
+    // the auto-claim that follows `done` must go against THIS host.
+    lastInstallTarget = alias;
     const handleId = `install-${++nextHandleSeq}-${Date.now()}`;
     activeStage = "preflight";
     logTail.length = 0;
@@ -400,9 +414,17 @@ export function registerInstallerHandlers(
 
   ipcMain.handle(IPC.installerMintAndClaim, async (
     _e,
-    input: { alias: SshTarget; claimUrlOverride?: string },
+    input: { alias?: SshTarget; claimUrlOverride?: string },
   ) => {
-    const result = await mintAndClaim(input.alias, {
+    // BET-705 b: prefer the stored install target (the single source of
+    // truth — survives renderer remounts/host-picker resets); fall back to
+    // the renderer-passed alias only when no install target is stored (e.g.
+    // the app restarted between install and claim).
+    const target = lastInstallTarget ?? input?.alias;
+    if (target == null) {
+      throw new Error("no install target to claim");
+    }
+    const result = await mintAndClaim(target, {
       persist,
       claimUrlOverride: input.claimUrlOverride,
       askpassEnv: activeAskpass?.env,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -231,7 +231,7 @@ const api = {
   // renderer treats success and failure the same way regardless of which
   // entry point produced them.
   installerMintAndClaim: (input: {
-    alias: SshTarget;
+    alias?: SshTarget;
     claimUrlOverride?: string;
   }): Promise<ClaimOutcome> =>
     ipcRenderer.invoke(IPC.installerMintAndClaim, input),

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -43,7 +43,7 @@ import {
   sshTargetLabel,
   type HostFieldSelection,
 } from "../shared/sshTarget";
-import type { ClaimOutcome } from "../shared/claim.mjs";
+import { claimWithRetry } from "./claimRetry";
 
 const ACCENT = "var(--accent)";
 const ACCENT_SOLID = "var(--accent-solid)"; // filled buttons (BET-409 AA)
@@ -59,16 +59,6 @@ const LOG_LINES_MAX = 500;
 // cycle 1 nit).
 const JUST_REFRESHED_DECAY_MS = 60_000;
 
-// BET-390 amendment: the install's final act starts/restarts the box service,
-// and the auto-claim fires the instant the install process exits — so the
-// first mint can race a service that isn't listening on loopback yet. A
-// single retry after this wait fixes the observed non-deterministic failure;
-// the retry is bounded to one extra attempt and the final failure still
-// surfaces the real message. Only transient kinds (network / server_error)
-// are retried — a wrong_code or invalid_response won't be fixed by trying
-// again.
-const CLAIM_RETRY_DELAY_MS = 3_000;
-
 const INITIAL_STAGE: InstallStageId = "preflight";
 const INITIAL_STAGE_INFO = currentStageInfo(INITIAL_STAGE);
 
@@ -80,13 +70,6 @@ const INSTALL_STAGE_LABELS: string[] = INSTALL_STAGES.map((s) => s.label);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
-}
-
-// BET-390: only failure kinds that can be caused by the box service not being
-// ready yet are worth a retry. A wrong/expired code or a malformed response
-// won't change on a second attempt.
-function isTransientClaimFailure(outcome: ClaimOutcome): boolean {
-  return !outcome.ok && (outcome.kind === "network" || outcome.kind === "server_error");
 }
 
 export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
@@ -164,6 +147,22 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   const [passphraseInput, setPassphraseInput] = useState("");
   const [claimRunning, setClaimRunning] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
+  // BET-705 c: while the auto-claim is retrying a transient failure, how many
+  // seconds have elapsed so far — drives the "the box is starting up (Ns)"
+  // banner. null when not mid-retry.
+  const [claimElapsed, setClaimElapsed] = useState<number | null>(null);
+  // True after the user cancels an install, until the next install starts —
+  // renders a neutral "Install cancelled." card instead of a failure one.
+  const [cancelled, setCancelled] = useState(false);
+
+  // BET-705 a: handles whose install is over (cancelled, or finished) and must
+  // never affect the UI again. Guards against a late `done`/`error` from an
+  // old install flipping a NEW install's UI during the null-handle window
+  // between startInstall and the installerStart response. Never cleared — it
+  // stays valid for the app session and is bounded by install attempts.
+  const deadHandlesRef = useRef<Set<string>>(new Set());
+  // BET-705 d: set when the user cancels; reset on the next install start.
+  const cancelRequestedRef = useRef(false);
 
   // ---------- Host list load (mount + manual refresh share this) ----------
   //
@@ -289,6 +288,10 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       if (s.active) {
         const info = currentStageInfo(s.stage);
         setRunning(true);
+        // BET-705 b: restore the active handle so Cancel works after a
+        // renderer remount (previously this was never restored, so cancel
+        // no-opped).
+        setActiveHandle(s.activeHandleId);
         setStage(s.stage);
         setStageIndex(info.index);
         setLines(s.logTail);
@@ -307,7 +310,10 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     const unsub = preload.onInstallerEvent((evt: InstallerEvent) => {
       // Only react to events from the CURRENT handle — stale events from a
       // previous install (after the user clicked Cancel + tried again) must
-      // not update the new install's UI.
+      // not update the new install's UI. A dead handle (cancelled, or already
+      // finished) is ignored outright, even while activeHandle is null in the
+      // window between startInstall and the installerStart response (BET-705 a).
+      if (deadHandlesRef.current.has(evt.handleId)) return;
       if (activeHandle !== null && evt.handleId !== activeHandle) return;
       switch (evt.kind) {
         case "line":
@@ -333,6 +339,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setFingerprintPrompt(null);
           setPassphrasePrompt(null);
           setPassphraseInput("");
+          // A finished handle can't speak again (BET-705 a).
+          deadHandlesRef.current.add(evt.handleId);
           break;
         case "fingerprint":
           // The install is paused waiting for a trust decision — show the
@@ -352,13 +360,21 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setPassphraseInput("");
           break;
         case "done":
+          // BET-705 d: a cancel surfaces as a done with !ok and the
+          // SIGTERM signal — render a neutral "Install cancelled." card
+          // instead of the failure copy, and skip the auto-claim.
+          if (!evt.ok && cancelRequestedRef.current) {
+            setCancelled(true);
+          }
           setDone({ ok: evt.ok, code: evt.code, signal: evt.signal });
           setRunning(false);
           setActiveHandle(null);
           setFingerprintPrompt(null);
           setPassphrasePrompt(null);
           setPassphraseInput("");
-          if (evt.ok) {
+          // A finished handle can't speak again (BET-705 a).
+          deadHandlesRef.current.add(evt.handleId);
+          if (evt.ok && !cancelRequestedRef.current) {
             // Auto-claim on success — the whole point of the flow. The
             // user typed a host, nothing else.
             void runClaim();
@@ -371,6 +387,8 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
           setFingerprintPrompt(null);
           setPassphrasePrompt(null);
           setPassphraseInput("");
+          // A finished handle can't speak again (BET-705 a).
+          deadHandlesRef.current.add(evt.handleId);
           break;
       }
     });
@@ -425,6 +443,9 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     setLines([]);
     setDone(null);
     setClaimError(null);
+    setClaimElapsed(null);
+    setCancelled(false);
+    cancelRequestedRef.current = false;
     // Clear the previous handle so the event guard doesn't discard this
     // install's events (esp. a `preflight-failed` push, which main sends
     // BEFORE the installerStart invoke below resolves) while it's still
@@ -453,6 +474,22 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     // process abort instead of silently no-oping (BET-361/360).
     const handleId = activeHandle ?? fingerprintPrompt?.handleId ?? passphrasePrompt?.handleId;
     if (!handleId) return;
+    // BET-705 d: this is a user-initiated cancel, not a real failure — a
+    // late `done` from the SIGTERM must render "Install cancelled." not the
+    // failed card (and must never re-run the auto-claim).
+    cancelRequestedRef.current = true;
+    // BET-705 a: the cancelled handle is dead — its late `done` / `error`
+    // (or a `preflight-failed` from a paused-prompt abort) must not be able
+    // to hijack a subsequent install.
+    deadHandlesRef.current.add(handleId);
+    // Reflect the cancellation immediately — the terminal `done` for this
+    // handle is now dropped by the dead-handle guard, so flip the UI here.
+    setRunning(false);
+    setActiveHandle(null);
+    setFingerprintPrompt(null);
+    setPassphrasePrompt(null);
+    setPassphraseInput("");
+    setCancelled(true);
     await preload.installerCancel({ handleId });
   }
 
@@ -498,43 +535,41 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   }
 
   async function runClaim() {
+    // BET-705 b: the claim target now lives in MAIN (the SshTarget passed to
+    // installerStart), so a renderer remount that reset the host picker can't
+    // claim against the wrong host. We still resolve the current selection as
+    // a passed-through FALLBACK (keeps the IPC arg shape; used only when no
+    // install target is stored, e.g. app restarted between install + claim) —
+    // but we never bail on an invalid current selection, because main's
+    // stored target is the source of truth.
     const resolved = resolveInstallTarget(currentSelection());
-    if (!resolved.ok) {
-      setClaimError(resolved.error);
-      return;
-    }
     setClaimRunning(true);
     setClaimError(null);
+    setClaimElapsed(0);
+    // Tick the "(Ns)" countdown once a second while retrying.
+    const tick = setInterval(() => setClaimElapsed((s) => (s ?? 0) + 1), 1000);
     try {
-      const outcome = await preload.installerMintAndClaim({
-        alias: resolved.target,
-      });
+      const attempt = () =>
+        preload.installerMintAndClaim({
+          alias: resolved.ok ? resolved.target : undefined,
+        });
+      // BET-705 c: retry transient failures (the box service not listening
+      // yet) every few seconds up to a 45s budget, with a visible countdown.
+      const { outcome } = await claimWithRetry(attempt, { sleep, now: Date.now });
       if (outcome.ok) {
         // Mirror the manual PairStep onPaired — advances onboarding to
         // step 2 exactly as a typed pairing code would.
         onPaired();
         return;
       }
-      // BET-390 amendment: a transient failure (the box service not yet
-      // listening) is retried once after a short wait. claimRunning stays
-      // true across the wait so the banner keeps reading "Pairing…".
-      if (isTransientClaimFailure(outcome)) {
-        await sleep(CLAIM_RETRY_DELAY_MS);
-        const retry = await preload.installerMintAndClaim({
-          alias: resolved.target,
-        });
-        if (retry.ok) {
-          onPaired();
-          return;
-        }
-        setClaimError(`Pairing failed: ${retry.message}`);
-      } else {
-        setClaimError(`Pairing failed: ${outcome.message}`);
-      }
+      // Non-transient failure, or the retry budget exhausted → the real error.
+      setClaimError(`Pairing failed: ${outcome.message}`);
     } catch (e) {
       setClaimError(e instanceof Error ? e.message : String(e));
     } finally {
+      clearInterval(tick);
       setClaimRunning(false);
+      setClaimElapsed(null);
     }
   }
 
@@ -930,9 +965,20 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       )}
 
       {/* In-flight claim only. There is no success message: a successful
-          claim advances onboarding to step 2, which unmounts this step. */}
-      {claimRunning && <section className="text-body">Pairing…</section>}
-      {done && !done.ok && (
+          claim advances onboarding to step 2, which unmounts this step.
+          BET-705 c: while retrying a transient failure we show the elapsed
+          countdown ("the box is starting up"). */}
+      {claimRunning && (
+        <section className="text-body">
+          {claimElapsed !== null && claimElapsed > 0
+            ? `Pairing… the box is starting up (${claimElapsed}s)`
+            : "Pairing…"}
+        </section>
+      )}
+      {/* BET-705 d: a user cancel is not a failure — render a neutral card and
+          let the normal "Install & pair" affordance reset the flow. */}
+      {cancelled && <section className="text-body">Install cancelled.</section>}
+      {done && !done.ok && !cancelled && (
         <section
           className="text-body space-y-2"
           style={{ color: DANGER }}

--- a/src/renderer/claimRetry.test.ts
+++ b/src/renderer/claimRetry.test.ts
@@ -1,0 +1,81 @@
+// claimRetry.test.ts — tests for the BET-705 §c claim auto-retry loop.
+
+import { describe, it, expect, vi } from "vitest";
+import type { ClaimOutcome } from "../shared/claim.mjs";
+import {
+  claimWithRetry,
+  isTransientClaimFailure,
+  CLAIM_RETRY_DELAY_MS,
+  CLAIM_RETRY_TOTAL_MS,
+  type ClaimRetryDeps,
+} from "./claimRetry";
+
+function okOutcome(): ClaimOutcome {
+  return { ok: true, boxId: "a".repeat(32), boxToken: "b".repeat(32) };
+}
+type FailureKind = Extract<ClaimOutcome, { ok: false }>["kind"];
+
+function fail(kind: FailureKind): ClaimOutcome {
+  return { ok: false, kind, message: "x" } as ClaimOutcome & { ok: false };
+}
+
+function makeClock(): { deps: ClaimRetryDeps; t: { value: number } } {
+  const t = { value: 0 };
+  const deps: ClaimRetryDeps = {
+    sleep: async (ms) => {
+      t.value += ms;
+    },
+    now: () => t.value,
+  };
+  return { deps, t };
+}
+
+describe("claimWithRetry (BET-705 c)", () => {
+  it("transient failure → retries → succeeds on the next attempt", async () => {
+    const { deps } = makeClock();
+    const attempt = vi
+      .fn<() => Promise<ClaimOutcome>>()
+      .mockResolvedValueOnce(fail("network"))
+      .mockResolvedValueOnce(okOutcome());
+    const { outcome, elapsedMs } = await claimWithRetry(attempt, deps);
+    expect(outcome.ok).toBe(true);
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(elapsedMs).toBe(CLAIM_RETRY_DELAY_MS);
+    // The single retry wait advanced the injected clock by one delay.
+    expect(deps.now()).toBe(CLAIM_RETRY_DELAY_MS);
+  });
+
+  it("transient forever → gives up once the 45s budget is exhausted", async () => {
+    const { deps } = makeClock();
+    const attempt = vi.fn(async () => fail("server_error"));
+    const { outcome, elapsedMs } = await claimWithRetry(attempt, deps);
+    expect(outcome.ok).toBe(false);
+    // Attempt 0 runs at t=0, and one more attempt per delay while under budget.
+    const expectedAttempts = Math.floor(CLAIM_RETRY_TOTAL_MS / CLAIM_RETRY_DELAY_MS) + 1;
+    expect(attempt).toHaveBeenCalledTimes(expectedAttempts);
+    expect(elapsedMs).toBeLessThanOrEqual(CLAIM_RETRY_TOTAL_MS + CLAIM_RETRY_DELAY_MS);
+    // The last attempt happened after the budget was effectively reached.
+    expect(elapsedMs).toBeGreaterThanOrEqual(CLAIM_RETRY_TOTAL_MS);
+  });
+
+  it("non-transient failure → no retry", async () => {
+    const { deps } = makeClock();
+    const attempt = vi.fn(async () => fail("wrong_code"));
+    const { outcome, elapsedMs } = await claimWithRetry(attempt, deps);
+    expect(outcome.ok).toBe(false);
+    expect((outcome as { kind: string }).kind).toBe("wrong_code");
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(elapsedMs).toBe(0);
+  });
+});
+
+describe("isTransientClaimFailure", () => {
+  it("true only for network and server_error", () => {
+    expect(isTransientClaimFailure(fail("network"))).toBe(true);
+    expect(isTransientClaimFailure(fail("server_error"))).toBe(true);
+    expect(isTransientClaimFailure(fail("wrong_code"))).toBe(false);
+    expect(isTransientClaimFailure(fail("rate_limited"))).toBe(false);
+    expect(isTransientClaimFailure(fail("invalid_response"))).toBe(false);
+    expect(isTransientClaimFailure(okOutcome())).toBe(false);
+  });
+});

--- a/src/renderer/claimRetry.ts
+++ b/src/renderer/claimRetry.ts
@@ -1,0 +1,65 @@
+// claimRetry.ts — pure helpers for the SSH installer's auto-claim retry loop
+// (BET-705 §c).
+//
+// The box's `manta pair` mints the code the moment the install process exits,
+// and the auto-claim fires immediately after — so the first claim can race a
+// box service that isn't listening on loopback yet. A few seconds of waiting
+// usually fixes it, but only TRANSIENT failure kinds (the box service not
+// ready) are worth retrying: a wrong/expired code or a malformed response
+// won't change by waiting, and retrying it just delays the real error.
+//
+// This module is pure (injected sleep/now/attempt) so the retry policy is
+// unit-testable without a real claim, clock, or Electron bridge.
+
+import type { ClaimOutcome } from "../shared/claim.mjs";
+
+// How long to wait between transient-failure claim retries.
+export const CLAIM_RETRY_DELAY_MS = 3_000;
+
+// Total budget for retrying a transient claim failure before giving up and
+// surfacing the real error. The box service can legitimately take a while to
+// come up; beyond this the user should drop to the manual `manta pair` path.
+export const CLAIM_RETRY_TOTAL_MS = 45_000;
+
+/**
+ * True when a failed claim might be fixed by waiting — i.e. the box service
+ * isn't up yet, not that the pairing code or response is wrong.
+ */
+export function isTransientClaimFailure(outcome: ClaimOutcome): boolean {
+  return !outcome.ok && (outcome.kind === "network" || outcome.kind === "server_error");
+}
+
+/** Injectables so the retry loop's clock + wait are test-controllable. */
+export type ClaimRetryDeps = {
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+};
+
+export type ClaimRetryResult = {
+  /** The final outcome — `ok` on success, or the last failure after giving up. */
+  outcome: ClaimOutcome;
+  /** Total wall-clock time spent across all attempts, in ms. */
+  elapsedMs: number;
+};
+
+/**
+ * Run the claim, retrying on transient failures every CLAIM_RETRY_DELAY_MS up
+ * to CLAIM_RETRY_TOTAL_MS of total budget. Returns the first `ok` outcome, or
+ * the last non-transient outcome / the final transient outcome once the budget
+ * is exhausted. Non-transient failures are never retried.
+ */
+export async function claimWithRetry(
+  attempt: (n: number) => Promise<ClaimOutcome>,
+  deps: ClaimRetryDeps,
+): Promise<ClaimRetryResult> {
+  const start = deps.now();
+  let outcome = await attempt(0);
+  let n = 0;
+  while (!outcome.ok && isTransientClaimFailure(outcome)) {
+    if (deps.now() - start >= CLAIM_RETRY_TOTAL_MS) break;
+    await deps.sleep(CLAIM_RETRY_DELAY_MS);
+    n += 1;
+    outcome = await attempt(n);
+  }
+  return { outcome, elapsedMs: deps.now() - start };
+}

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -78,6 +78,8 @@ function makeFakePreload(): MantaPreload {
       pendingFingerprint: null,
       waitingForPassphrase: false,
       passphraseHandleId: null,
+      activeHandleId: null,
+      target: null,
     })),
     installerGetDiagnostics: vi.fn(async () => ""),
     onInstallerEvent: vi.fn(() => vi.fn()),

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -163,7 +163,7 @@ export interface MantaPreload {
   // same way regardless of which entry point produced them. Persists
   // credentials through main's existing claim path (single config writer).
   installerMintAndClaim(input: {
-    alias: SshTarget;
+    alias?: SshTarget;
     claimUrlOverride?: string;
   }): Promise<ClaimOutcome>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,7 @@
 // Type-only, erased at compile time (preloadAccess.ts does the same).
 import type { PreflightResult, PreflightFailure } from "../main/installer/preflight.js";
 import type { HostFingerprint } from "../main/installer/fingerprint.js";
+import type { SshTarget } from "./sshTarget.js";
 
 // ----- Local app config -----
 // Source of truth for sessions/windows is tmux on the remote. We only persist
@@ -440,6 +441,14 @@ export type InstallerState = {
   waitingForPassphrase: boolean;
   // The handle id the paused passphrase prompt belongs to, or null.
   passphraseHandleId: string | null;
+  // BET-705 b: the currently-active install's handle id, or null. The renderer
+  // restores `activeHandle` from this on remount so Cancel still works after a
+  // page refresh (previously activeHandle was never recovered).
+  activeHandleId: string | null;
+  // BET-705 b: the SshTarget the active install targets, or null. Retained so
+  // the auto-claim after `done` resolves against the SAME host even after a
+  // renderer remount reset the host picker to a different selection.
+  target: SshTarget | null;
 };
 
 // Desktop auto-update (electron-updater) payloads, shared by the preload


### PR DESCRIPTION
Implements all four fixes in the SSH auto-install flow (BET-705) with one PR. Line refs re-verified at HEAD.

## Changes

**(a) Stale-event race** (`src/renderer/SshInstallStep.tsx`)
- Added `deadHandlesRef` (a `useRef<Set<string>>`). `cancelInstall` adds the handle it cancels (running, or trust/passphrase fallback handles); the `done`, `error`, and `preflight-failed` cases add the handle after processing.
- Event guard now drops `deadHandlesRef.current.has(evt.handleId)` in addition to the existing `activeHandle !== null && handleId !== activeHandle` check. The set is never cleared on `startInstall`.
- This closes the null-handle window between `startInstall` and the `installerStart` response, where a late `done`/`error` from a previously cancelled install used to flip the new install's UI.

**(b) Renderer reload mid-install** (`handlers.ts`, renderer, types, preload)
- Claim target moves to **main** as the single source of truth: `handlers.ts` stores the `SshTarget` passed to `installerStart` in `lastInstallTarget` (overwritten on each new start, NOT cleared on completion).
- `installerState` now returns `activeHandleId` (the module's active handle) and `target` (the stored SshTarget).
- `installerMintAndClaim` prefers the stored target; falls back to the renderer-passed alias only when none is stored (app restarted between install + claim). IPC signature unchanged for alias — made it optional.
- Renderer: `runClaim()` no longer resolves the target from UI state and no longer bails on an invalid current selection — it passes the current resolution only as the documented fallback. The recovery effect restores `activeHandle` from `state.activeHandleId`, so Cancel works after a remount.

**(c) Claim auto-retry with countdown**
- New pure helper `src/renderer/claimRetry.ts` (`claimWithRetry`) with injected `sleep`/`now`/`attempt`; constants `CLAIM_RETRY_DELAY_MS` (3s) and `CLAIM_RETRY_TOTAL_MS` (45s) live beside each other. Retries transient failures every 3s up to a 45s budget.
- Banner shows "Pairing… the box is starting up (Ns)" with N = elapsed seconds while retrying.
- Unit tests: transient→retry→success; transient-forever→gives up at 45s; non-transient→no retry.

**(d) Honest cancel copy**
- `cancelInstall` sets `cancelRequestedRef` (reset in `startInstall`) and marks the handle dead. Cancellation renders a neutral "Install cancelled." card (no exit-code/signal line) and re-enables Install & pair. The `done` case also honors the flag defensively.

## Files changed (7 + 2 new)
- `src/renderer/SshInstallStep.tsx`
- `src/renderer/claimRetry.ts` (new), `src/renderer/claimRetry.test.ts` (new)
- `src/main/installer/handlers.ts`, `src/main/installer/handlers.test.ts`
- `src/preload/index.ts`, `src/renderer/preloadAccess.ts`
- `src/shared/types.ts` (InstallerState: `activeHandleId`, `target`)

All edits stay within the installer flow (SshInstallStep + installer handlers + the preload/types/state plumbing they need); no refactors beyond the spec.

**Files changed:** 9 (7 modified + 2 new).

**Verification results:**
- PR branch (`multica/BET-705-installer-robustness` @ `579a5c8`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2249 pass / 0 fail / 7 skip. Failures: none. log sha256: `bed1c69bfad12a8c5f4b01aad2def30ff428fbcdb4b87833d12d23e7595da448`
- Base (`main` @ `0c5f292`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2243 pass / 0 fail / 7 skip. Failures: none. log sha256: `cf0ff146c39a57d7ad8472c389891686841e4155ed76f29bb39d3b8390969a0e`
- **Conclusion:** 0 new test failures; 6 new tests added by this PR (claimRetry 4 + handlers 2), 1 new test file. The single failure seen once in a full-suite run (`useSseBus` no-double-send drain) is a timing flake — it passes consistently in isolation on both main and this branch.

**Base: origin/main @ `0c5f292`**
