### PR TITLE
BET-698: one server-side SQLite query for conversation search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1316,6 +1316,18 @@ top, talking to an opencode session over HTTP (via manta-server).
 **Recognition**: presence of `@manta-session-id` tmux user-option on the window
 is THE signal the renderer uses to show `ChatPanel` instead of `Terminal`.
 
+**Conversation search (⌘F, BET-698) is ONE server-side SQLite query** over
+opencode's own store (`src/server/messageSearch.mjs` → `opencode:search-messages`),
+scoped to exactly the chat windows in the sidebar and covering each one's FULL
+history. The renderer (`src/renderer/SearchPalette.tsx`) holds no search logic —
+it sends `{ query, sessionIds }` (active session first, then every other chat
+window in sidebar order) and renders the flat returned hits grouped by session.
+This replaced the old client-side transcript-not download fan-out (which capped
+at 5 sessions per keystroke) and fixed the current-conversation tail-only gap. It
+requires the **Node 24 box runtime** (`node:sqlite`); on an older box the channel
+degrades to `{ supported:false }` and the palette shows "update the box". The DB
+handle is read-only, always.
+
 **Architecture** (HTTP-only — opencode session mgmt + SSE live server-side):
 - opencode runs as a `systemd --user` service (`opencode-serve`) on the Linux
   box, port 4096, bound to 127.0.0.1. manta-server proxies it over HTTP

--- a/src/renderer/SearchPalette.tsx
+++ b/src/renderer/SearchPalette.tsx
@@ -1,14 +1,13 @@
 // SearchPalette.tsx — ⌘F conversation search on the shared PaletteShell.
 //
-// Data flow:
-//   - ACTIVE conversation: the live transcript already mirrored into the
-//     store by ChatPanel (store.chatMessages, BET-659) — zero fetch, filtered
-//     synchronously per keystroke.
-//   - OTHER conversations: chat-mode windows from flatSessions(projects),
-//     searched 150ms-debounced. Only the first MAX_LIVE_FETCHES candidates get
-//     a live opencodeMessages fetch per keystroke; the rest are skipped (never
-//     hammer opencode with a dozen full-transcript pulls per keystroke). A seq
-//     guard discards stale async results.
+// Data flow (BET-698): the palette is a DUMB RENDERER of a single server-side
+// query. On query change (120ms debounced) it sends ONE
+// `window.api.opencodeSearchMessages({ query, sessionIds })` — the server
+// searches opencode's own SQLite over ALL of the chat windows' full history —
+// and renders whatever comes back. The old client-side "download N transcripts
+// over HTTP and scan them" fan-out (which capped at 5 sessions/keystroke) is
+// gone, and the active conversation is searched by the same call (fixing the
+// old tail-only gap). The renderer holds no search logic.
 //
 // Jump semantics:
 //   - same session → dispatch the existing `manta-scroll-to-message`
@@ -19,29 +18,40 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { PaletteShell, useSelectedIntoView } from "./PaletteShell";
-import { useStore, flatSessions, resolveSessionOwner } from "./store";
-import type { Project } from "../shared/types";
+import { flatSessions, resolveSessionOwner } from "./store";
+import type { Project, TranscriptHit } from "../shared/types";
 import {
   formatAge,
-  searchTranscript,
   type PendingScrollWin,
-  type TranscriptHit,
 } from "./chatUtils";
-import type { OpencodeMessage } from "../shared/types";
 
 const MIN_QUERY_CHARS = 2;
-const CROSS_SEARCH_DEBOUNCE_MS = 150;
-const MAX_OTHER_SESSIONS = 15; // chat windows scanned, sidebar order
-const MAX_LIVE_FETCHES = 5; // candidates that get a live transcript fetch
-const MAX_HITS_CURRENT = 50;
-const MAX_HITS_PER_OTHER = 3;
+const SEARCH_DEBOUNCE_MS = 120;
 
-type OtherSection = {
+type Section = {
   sessionId: string;
-  workspace: string; // project.tmuxSession
-  session: string; // window.name
   hits: TranscriptHit[];
 };
+
+type FlatRow = { sessionId: string; hit: TranscriptHit };
+
+// Group a flat, server-ordered hit list by sessionId in first-appearance order
+// (the server already returns primary-first, then sessions in sidebar order,
+// so the group order follows). The group whose id equals the active session is
+// the "This conversation" section; the rest render under "other conversations".
+function groupHits(hits: TranscriptHit[]): Section[] {
+  const sections: Section[] = [];
+  const seen = new Set<string>();
+  for (const h of hits) {
+    if (seen.has(h.sessionId)) continue;
+    seen.add(h.sessionId);
+    sections.push({
+      sessionId: h.sessionId,
+      hits: hits.filter((x) => x.sessionId === h.sessionId),
+    });
+  }
+  return sections;
+}
 
 export function SearchPalette({
   sessionId,
@@ -56,90 +66,71 @@ export function SearchPalette({
 }) {
   const [query, setQuery] = useState("");
   const [sel, setSel] = useState(0);
-  const chatMessages = useStore((s) => s.chatMessages);
-  const currentMessages = chatMessages[sessionId] ?? null;
 
   const q = query.trim();
   const active = q.length >= MIN_QUERY_CHARS;
 
-  const currentHits = useMemo(
-    () =>
-      active && currentMessages
-        ? searchTranscript(currentMessages, q, MAX_HITS_CURRENT)
-        : [],
-    [active, currentMessages, q],
-  );
+  // Search scope: the active session first, then every OTHER chat-mode window
+  // with an opencodeSessionId, in sidebar order, de-duplicated. No cap.
+  const sessionIds = useMemo(() => {
+    const seen = new Set<string>([sessionId]);
+    const ids = [sessionId];
+    for (const f of flatSessions(projects)) {
+      const sid = f.window.opencodeSessionId;
+      if (sid && !seen.has(sid)) {
+        seen.add(sid);
+        ids.push(sid);
+      }
+    }
+    return ids;
+  }, [projects, sessionId]);
 
-  const candidates = useMemo(
-    () =>
-      flatSessions(projects)
-        .filter(
-          (f) =>
-            f.window.opencodeSessionId != null &&
-            f.window.opencodeSessionId !== sessionId,
-        )
-        .slice(0, MAX_OTHER_SESSIONS),
-    [projects, sessionId],
-  );
+  // workspace › session label lookup per sessionId (for section headers).
+  const ownerBySession = useMemo(() => {
+    const m = new Map<string, { tmuxSession: string; name: string }>();
+    for (const f of flatSessions(projects)) {
+      const sid = f.window.opencodeSessionId;
+      if (sid) m.set(sid, { tmuxSession: f.project.tmuxSession, name: f.window.name });
+    }
+    return m;
+  }, [projects]);
 
-  const [otherSections, setOtherSections] = useState<OtherSection[]>([]);
-  const [otherLoading, setOtherLoading] = useState(false);
+  const [groups, setGroups] = useState<Section[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [supported, setSupported] = useState(true);
   const seqRef = useRef(0);
+
   useEffect(() => {
     const seq = ++seqRef.current;
     if (!active) {
-      setOtherSections([]);
-      setOtherLoading(false);
+      setGroups([]);
+      setLoading(false);
       return;
     }
-    setOtherLoading(true);
+    setLoading(true);
     const timer = window.setTimeout(async () => {
-      const found: OtherSection[] = [];
-      await Promise.all(
-        candidates.map(async (c, i) => {
-          const sid = c.window.opencodeSessionId as string;
-          if (i >= MAX_LIVE_FETCHES) return;
-          let messages: OpencodeMessage[] | null = null;
-          try {
-            messages = await window.api.opencodeMessages(sid);
-          } catch {
-            messages = null;
-          }
-          if (!messages) return;
-          const hits = searchTranscript(messages, q, MAX_HITS_PER_OTHER);
-          if (hits.length > 0) {
-            found.push({
-              sessionId: sid,
-              workspace: c.project.tmuxSession,
-              session: c.window.name,
-              hits,
-            });
-          }
-        }),
-      );
-      if (seqRef.current !== seq) return; // stale — a newer query superseded us
-      // Deterministic section order: sidebar (flatSessions) order.
-      const rank = new Map(
-        candidates.map((c, i) => [c.window.opencodeSessionId, i]),
-      );
-      found.sort(
-        (a, b) => (rank.get(a.sessionId) ?? 0) - (rank.get(b.sessionId) ?? 0),
-      );
-      setOtherSections(found);
-      setOtherLoading(false);
-    }, CROSS_SEARCH_DEBOUNCE_MS);
+      try {
+        const res = await window.api.opencodeSearchMessages({ query: q, sessionIds });
+        if (seqRef.current !== seq) return; // stale — a newer query superseded us
+        setSupported(res.supported);
+        setGroups(res.supported ? groupHits(res.hits) : []);
+      } catch {
+        // A transport failure surfaces as no results rather than a new error UI.
+        if (seqRef.current !== seq) return;
+        setGroups([]);
+      } finally {
+        if (seqRef.current === seq) setLoading(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
-  }, [active, q, candidates]);
+  }, [active, q, sessionIds]);
 
-  // Flat row list = keyboard-navigation order: current conversation's hits,
-  // then each other-conversation section in render order.
-  type FlatRow = { sessionId: string; hit: TranscriptHit };
+  // Flat row list = keyboard-navigation order across all groups as rendered.
   const flatRows = useMemo<FlatRow[]>(() => {
-    const rows: FlatRow[] = currentHits.map((hit) => ({ sessionId, hit }));
-    for (const s of otherSections)
-      for (const hit of s.hits) rows.push({ sessionId: s.sessionId, hit });
+    const rows: FlatRow[] = [];
+    for (const g of groups) for (const hit of g.hits) rows.push({ sessionId: g.sessionId, hit });
     return rows;
-  }, [currentHits, otherSections, sessionId]);
+  }, [groups]);
 
   useEffect(() => {
     if (sel >= flatRows.length) setSel(0);
@@ -163,8 +154,10 @@ export function SearchPalette({
     onJumpToWindow(owner.tmuxSession, owner.windowIndex);
   };
 
+  const currentGroup = groups.find((g) => g.sessionId === sessionId);
+  const otherGroups = groups.filter((g) => g.sessionId !== sessionId);
   const total = flatRows.length;
-  const convCount = (currentHits.length > 0 ? 1 : 0) + otherSections.length;
+  const convCount = groups.length;
 
   return (
     <PaletteShell
@@ -198,17 +191,24 @@ export function SearchPalette({
             </div>
           );
         }
+        if (!supported) {
+          return (
+            <div className="px-3 py-3 text-label text-text-faint">
+              Search needs a newer box runtime — update the box.
+            </div>
+          );
+        }
         const nodes: ReactNode[] = [];
         let idx = 0;
-        if (currentHits.length > 0) {
+        if (currentGroup && currentGroup.hits.length > 0) {
           nodes.push(
             <SectionHeader
               key="cur-head"
               session="This conversation"
-              count={`${currentHits.length} match${currentHits.length === 1 ? "" : "es"}`}
+              count={`${currentGroup.hits.length} match${currentGroup.hits.length === 1 ? "" : "es"}`}
             />,
           );
-          for (const hit of currentHits) {
+          for (const hit of currentGroup.hits) {
             const i = idx++;
             nodes.push(
               <HitRow
@@ -221,7 +221,7 @@ export function SearchPalette({
             );
           }
         }
-        if (otherSections.length > 0 || otherLoading) {
+        if (otherGroups.length > 0 || loading) {
           nodes.push(
             <div
               key="other-div"
@@ -233,20 +233,21 @@ export function SearchPalette({
             </div>,
           );
         }
-        for (const s of otherSections) {
+        for (const g of otherGroups) {
+          const owner = ownerBySession.get(g.sessionId);
           nodes.push(
             <SectionHeader
-              key={`head-${s.sessionId}`}
-              workspace={s.workspace}
-              session={s.session}
-              count={String(s.hits.length)}
+              key={`head-${g.sessionId}`}
+              workspace={owner?.tmuxSession}
+              session={owner?.name ?? g.sessionId}
+              count={String(g.hits.length)}
             />,
           );
-          for (const hit of s.hits) {
+          for (const hit of g.hits) {
             const i = idx++;
             nodes.push(
               <HitRow
-                key={`${s.sessionId}-${hit.messageId}`}
+                key={`${g.sessionId}-${hit.messageId}`}
                 hit={hit}
                 selected={i === sel}
                 onEnter={() => setSel(i)}
@@ -255,7 +256,7 @@ export function SearchPalette({
             );
           }
         }
-        if (otherLoading) {
+        if (loading) {
           nodes.push(
             <div key="other-loading" className="px-3 py-2 text-meta text-text-faint">
               Searching other conversations…

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -83,6 +83,7 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeQuestionReply",
   "opencodeRestart",
   "opencodeRunCommand",
+  "opencodeSearchMessages",
   "opencodeSetProviders",
   "opencodeSetSubagents",
   "opencodeSyncSubagents",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1060,6 +1060,7 @@ export const httpApi: Api = {
   opencodeCommands: () => rpc(IPC.opencodeCommands),
   opencodeAgents: () => rpc(IPC.opencodeAgents),
   opencodeFindFiles: (input) => rpc(IPC.opencodeFindFiles, input),
+  opencodeSearchMessages: (input) => rpc(IPC.opencodeSearchMessages, input),
 
   // -- slash-command execution --
   opencodeRunCommand: (input) => rpc(IPC.opencodeRunCommand, input),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -84,10 +84,9 @@ import {
   previewOriginWord,
   decodeDataUri,
   fetchTranscriptWithRetry,
-  searchTranscript,
 } from "./chatUtils";
 
-import type { OpencodeModel, OpencodeMessage } from "../shared/types";
+import type { OpencodeModel } from "../shared/types";
 
 
 
@@ -3120,100 +3119,3 @@ describe("computeTurnInfo", () => {
   });
 });
 
-// ===== searchTranscript =====
-
-describe("searchTranscript", () => {
-  const textPart = (
-    text: string,
-    extra: { synthetic?: boolean; ignored?: boolean } = {},
-  ) => ({ type: "text", id: "p", messageID: "m", text, ...extra } as never);
-  const toolPart = () => ({ type: "tool", id: "p", messageID: "m" } as never);
-  const msg = (id: string, role: "user" | "assistant", parts: unknown[], created?: number) =>
-    ({
-      info: { id, role, time: created != null ? { created } : undefined },
-      parts,
-    } as unknown as OpencodeMessage);
-
-  it("finds a match in a text part, preserving original casing while matching case-insensitively", () => {
-    const messages = [msg("m1", "assistant", [textPart("Please retry the request")], 100)];
-    const hits = searchTranscript(messages, "RETRY", 10);
-    expect(hits).toHaveLength(1);
-    expect(hits[0].messageId).toBe("m1");
-    expect(hits[0].match).toBe("retry");
-    expect(hits[0].pre).toBe("Please ");
-    expect(hits[0].post).toBe(" the request");
-    expect(hits[0].role).toBe("assistant");
-  });
-
-  it("ranks newest message first", () => {
-    const messages = [
-      msg("m1", "user", [textPart("first contains alpha")], 100),
-      msg("m2", "assistant", [textPart("alpha check")], 200),
-      msg("m3", "user", [textPart("alpha again")], 300),
-    ];
-    const hits = searchTranscript(messages, "alpha", 10);
-    expect(hits.map((h) => h.messageId)).toEqual(["m3", "m2", "m1"]);
-  });
-
-  it("returns one hit per message even when two parts (or two occurrences) match", () => {
-    const messages = [
-      msg("m1", "user", [textPart("alpha and alpha again"), toolPart(), textPart("more alpha")], 100),
-    ];
-    const hits = searchTranscript(messages, "alpha", 10);
-    expect(hits).toHaveLength(1);
-    expect(hits[0].messageId).toBe("m1");
-    expect(hits[0].match).toBe("alpha");
-    expect(hits[0].post).toBe(" and alpha again");
-  });
-
-  it("skips non-text parts and synthetic/ignored text parts", () => {
-    const messages = [
-      msg("m1", "assistant", [textPart("skip me", { synthetic: true })], 100),
-      msg("m2", "assistant", [textPart("also skip", { ignored: true })], 200),
-      msg("m3", "user", [textPart("real match here")], 300),
-    ];
-    const hits = searchTranscript(messages, "skip", 10);
-    expect(hits).toHaveLength(0);
-    const real = searchTranscript(messages, "real", 10);
-    expect(real).toHaveLength(1);
-    expect(real[0].messageId).toBe("m3");
-  });
-
-  it("truncates long prefixes with '…' and collapses whitespace runs", () => {
-    const long = "word ".repeat(30); // 150 chars, match at the very end
-    const messages = [msg("m1", "assistant", [textPart(`${long}needle here`)], 100)];
-    const hits = searchTranscript(messages, "needle", 10);
-    expect(hits[0].pre).toMatch(/^…/);
-    expect(hits[0].pre.length).toBeLessThanOrEqual(61);
-    expect(hits[0].pre).not.toContain("\n");
-    expect(hits[0].pre).not.toContain("  ");
-  });
-
-  it("collapses multiple whitespace in pre/match/post", () => {
-    const messages = [msg("m1", "assistant", [textPart("a  b\n\nc needle d")], 100)];
-    const hits = searchTranscript(messages, "needle", 10);
-    expect(hits[0].pre).toBe("a b c ");
-    expect(hits[0].match).toBe("needle");
-    expect(hits[0].post).toBe(" d");
-  });
-
-  it("respects maxHits and returns [] for empty query", () => {
-    const messages = [
-      msg("m1", "user", [textPart("needle one")], 100),
-      msg("m2", "user", [textPart("needle two")], 200),
-      msg("m3", "user", [textPart("needle three")], 300),
-    ];
-    expect(searchTranscript(messages, "needle", 2)).toHaveLength(2);
-    expect(searchTranscript(messages, "", 10)).toEqual([]);
-  });
-
-  it("passes through timeCreated, null when info.time absent", () => {
-    const messages = [
-      msg("m1", "user", [textPart("needle")], 123),
-      msg("m2", "user", [textPart("needle")]),
-    ];
-    const hits = searchTranscript(messages, "needle", 10);
-    expect(hits[0].timeCreated).toBeNull();
-    expect(hits[1].timeCreated).toBe(123);
-  });
-});

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2396,19 +2396,6 @@ export function computeLiveTurn(messages: OpencodeMessage[] | null): LiveTurn | 
   return { startedAt, tokens, verbSeedId: verbSeedId ?? userInfo.id };
 }
 
-// ⌘F conversation search. Pure transcript scan over text parts: newest
-// message first, case-insensitive, ONE hit per message (the first matching
-// text part) so the result list stays scannable. Snippet is split into
-// pre/match/post so the renderer can highlight without dangerouslySetInnerHTML.
-export type TranscriptHit = {
-  messageId: string;
-  role: "user" | "assistant";
-  pre: string; // up to SNIPPET_PRE_CHARS before the match, "…"-prefixed when truncated
-  match: string; // the matched text, original casing
-  post: string; // up to 200 chars after (CSS line-clamp does the final trim)
-  timeCreated: number | null;
-};
-
 // Cross-file contract for the ⌘F cross-conversation jump: SearchPalette sets
 // this global, ChatPanel consumes it once the target session's transcript has
 // rendered. Same pre-mount-bridge pattern as __mantaScrollQuestionSession.
@@ -2416,38 +2403,3 @@ export type PendingMessageScroll = { sessionId: string; messageId: string };
 export type PendingScrollWin = Window & {
   __mantaPendingMessageScroll?: PendingMessageScroll | null;
 };
-
-const SNIPPET_PRE_CHARS = 60;
-
-export function searchTranscript(
-  messages: OpencodeMessage[],
-  query: string,
-  maxHits: number,
-): TranscriptHit[] {
-  const q = query.toLowerCase();
-  if (!q) return [];
-  const clean = (s: string) => s.replace(/\s+/g, " ");
-  const hits: TranscriptHit[] = [];
-  // Newest first: walk the chronological transcript from the end.
-  for (let mi = messages.length - 1; mi >= 0 && hits.length < maxHits; mi--) {
-    const m = messages[mi];
-    for (const part of m.parts) {
-      if (part.type !== "text") continue;
-      const p = part as { text?: string; synthetic?: boolean; ignored?: boolean };
-      if (p.synthetic || p.ignored || typeof p.text !== "string") continue;
-      const idx = p.text.toLowerCase().indexOf(q);
-      if (idx < 0) continue;
-      const start = Math.max(0, idx - SNIPPET_PRE_CHARS);
-      hits.push({
-        messageId: m.info.id,
-        role: m.info.role === "user" ? "user" : "assistant",
-        pre: (start > 0 ? "…" : "") + clean(p.text.slice(start, idx)),
-        match: clean(p.text.slice(idx, idx + query.length)),
-        post: clean(p.text.slice(idx + query.length, idx + query.length + 200)),
-        timeCreated: m.info.time?.created ?? null,
-      });
-      break; // one hit per message
-    }
-  }
-  return hits;
-}

--- a/src/server/messageSearch.mjs
+++ b/src/server/messageSearch.mjs
@@ -1,0 +1,210 @@
+// messageSearch.mjs — ⌘F conversation search over opencode's own SQLite.
+//
+// BET-698 replaces the client-side "download N transcripts over HTTP and
+// scan them" fan-out with ONE server-side query against opencode's
+// `opencode.db`. The renderer batches nothing; it sends (query, sessionIds)
+// and we return the ordered hits. The active conversation is searched by the
+// same query (sessionIds[0] = primary), which also fixes the old
+// tail-only-current gap (it previously scanned the ~last 100 loaded
+// messages, not full history).
+//
+// Cap semantics (defaults kept server-side; the renderer never overrides):
+//   maxPrimary     = hit cap for sessionIds[0] (the active conversation)
+//   maxPerSession  = hit cap for every other session
+//   maxTotal       = overall hit cap
+//
+// Degradation: a box that has not taken the Node 24 runtime yet has no
+// `node:sqlite`, or there is no opencode.db — both return
+// { supported:false, hits:[] } and the UI shows "update the box". searchMessages
+// NEVER throws; DB errors are logged once, the handle is closed+nulled so the
+// next call reopens, and we return { supported:true, hits:[] }.
+//
+// The schema (verified live; do not re-derive):
+//   part(id TEXT PK, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)
+//   message(id TEXT PK, session_id TEXT, time_created INTEGER, data TEXT)
+// part.data / message.data are JSON blobs.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+const SNIPPET_PRE_CHARS = 60;
+const SNIPPET_POST_CHARS = 200;
+// SQLite's LIKE is ASCII case-insensitive; we re-check in JS anyway. The
+// MAX_LIMIT over-fetch bounds a LIKE scan before the JS text-part filter
+// drops non-text rows (tool arguments etc.).
+const MAX_LIMIT = 800;
+
+let dbHandle = null;
+
+// Resolve opencode's SQLite path. First existing wins; a test/override hook
+// (`MANTA_OPENCODE_DB`) is used as-is. null → the box cannot search.
+export function resolveDbPath() {
+  if (process.env.MANTA_OPENCODE_DB) return process.env.MANTA_OPENCODE_DB;
+  if (process.env.XDG_DATA_HOME) {
+    const p = join(process.env.XDG_DATA_HOME, "opencode", "opencode.db");
+    if (existsSync(p)) return p;
+    return null;
+  }
+  const p = join(homedir(), ".local", "share", "opencode", "opencode.db");
+  if (existsSync(p)) return p;
+  return null;
+}
+
+// Lazily open node:sqlite read-only. The import lives in a try/catch because
+// on a box that hasn't taken the Node 24 runtime yet it throws — that must
+// degrade to { supported:false }, not crash the server. Null handle on any
+// failure.
+async function getDb() {
+  if (dbHandle) return dbHandle;
+  const path = resolveDbPath();
+  if (!path) return null;
+  try {
+    const { DatabaseSync } = await import("node:sqlite");
+    dbHandle = new DatabaseSync(path, { readOnly: true });
+    return dbHandle;
+  } catch (e) {
+    console.warn("[messageSearch] node:sqlite unavailable:", e?.message ?? e);
+    dbHandle = null;
+    return null;
+  }
+}
+
+// The only exported entry point used by rpc.mjs.
+export async function searchMessages({
+  query,
+  sessionIds,
+  maxPrimary = 50,
+  maxPerSession = 3,
+  maxTotal = 200,
+} = {}) {
+  const q = typeof query === "string" ? query : "";
+  const scope = Array.isArray(sessionIds) ? sessionIds.filter(Boolean) : [];
+  if (q.trim() === "" || scope.length === 0) {
+    return { supported: true, hits: [] };
+  }
+  const db = await getDb();
+  if (!db) return { supported: false, hits: [] };
+
+  try {
+    const pattern = likePattern(q);
+    const placeholders = scope.map(() => "?").join(", ");
+    const limit = Math.min(maxTotal * 4, MAX_LIMIT);
+    const sql = `
+      SELECT p.session_id, p.message_id, p.data AS part_data,
+             m.data AS msg_data, p.time_created
+      FROM part p
+      JOIN message m ON m.id = p.message_id
+      WHERE p.session_id IN (${placeholders})
+        AND p.data LIKE ? ESCAPE '\\'
+      ORDER BY p.time_created DESC
+      LIMIT ?`;
+    const rows = db.prepare(sql).all(...scope, pattern, limit);
+    const hits = buildHits(rows, q, {
+      sessionIds: scope,
+      primarySessionId: scope[0],
+      maxPrimary,
+      maxPerSession,
+      maxTotal,
+    });
+    return { supported: true, hits };
+  } catch (e) {
+    // Query error: log once, drop the handle so the next call reopens, and
+    // degrade to an empty (but supported) result — never an exception.
+    console.error("[messageSearch] query failed:", e?.message ?? e);
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+    dbHandle = null;
+    return { supported: true, hits: [] };
+  }
+}
+
+// Pure: build a SQLite LIKE pattern for `query`, escaping `\`, `%` and `_`
+// and wrapping in %…%. Parameterised only — never concatenate user input.
+export function likePattern(query) {
+  return "%" + String(query).replace(/[\\%_]/g, (c) => "\\" + c) + "%";
+}
+
+// Pure: turn raw SQLite rows (already newest-first by time_created) into a
+// flat, ordered TranscriptHit[].
+export function buildHits(rows, query, opts = {}) {
+  const {
+    sessionIds = [],
+    primarySessionId = sessionIds[0] ?? null,
+    maxPrimary = 50,
+    maxPerSession = 3,
+    maxTotal = 200,
+  } = opts;
+  const q = String(query ?? "").toLowerCase();
+  if (!q) return [];
+
+  const clean = (s) => String(s ?? "").replace(/\s+/g, " ");
+  const rankOf = new Map(sessionIds.map((s, i) => [s, i]));
+  const perSession = new Map(); // session_id -> hit count produced
+  const byMessage = new Set(); // message_id already produced a hit
+
+  const hits = [];
+  for (const row of rows) {
+    if (hits.length >= maxTotal) break;
+
+    // part_data → text part only.
+    let part;
+    try {
+      part = JSON.parse(row.part_data);
+    } catch {
+      continue;
+    }
+    if (!part || part.type !== "text") continue;
+    if (typeof part.text !== "string") continue;
+    if (part.synthetic || part.ignored) continue;
+
+    // One hit per message — first match wins.
+    if (byMessage.has(row.message_id)) continue;
+
+    const idx = part.text.toLowerCase().indexOf(q);
+    if (idx < 0) continue;
+
+    // role from message blob; a parse failure elsewhere skips this row but
+    // must never throw.
+    let role = "assistant";
+    let msg = null;
+    try {
+      msg = JSON.parse(row.msg_data);
+    } catch {
+      continue;
+    }
+    if (!msg || typeof msg !== "object") continue;
+    role = msg.role === "user" ? "user" : "assistant";
+
+    // Per-session hit cap.
+    const sid = row.session_id;
+    const cap = sid === primarySessionId ? maxPrimary : maxPerSession;
+    const count = perSession.get(sid) ?? 0;
+    if (count >= cap) continue;
+    perSession.set(sid, count + 1);
+    byMessage.add(row.message_id);
+
+    // Snippet fields — same contract as the deleted renderer searchTranscript.
+    const start = Math.max(0, idx - SNIPPET_PRE_CHARS);
+    hits.push({
+      sessionId: sid,
+      messageId: row.message_id,
+      role,
+      pre: (start > 0 ? "…" : "") + clean(part.text.slice(start, idx)),
+      match: clean(part.text.slice(idx, idx + query.length)),
+      post: clean(
+        part.text.slice(idx + query.length, idx + query.length + SNIPPET_POST_CHARS),
+      ),
+      timeCreated: row.time_created ?? null,
+    });
+  }
+
+  // Final order: by the session's index in sessionIds, then time_created
+  // descending within a session (stable sort preserves the input order, and
+  // the input is already time-descending per session).
+  hits.sort((a, b) => (rankOf.get(a.sessionId) ?? 0) - (rankOf.get(b.sessionId) ?? 0));
+  return hits;
+}

--- a/src/server/messageSearch.test.mjs
+++ b/src/server/messageSearch.test.mjs
@@ -1,0 +1,272 @@
+// Tests for messageSearch.mjs pure logic — no database, no live opencode,
+// no node:sqlite. Run via `npm run test:server` (node:test).
+//
+// searchMessages itself touches node:sqlite + the filesystem and is NOT
+// covered here (as the issue specifies: "pure only"). Everything testable
+// is in likePattern + buildHits.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { likePattern, buildHits } from "./messageSearch.mjs";
+
+// ---------------------------------------------------------------------------
+// likePattern
+// ---------------------------------------------------------------------------
+
+test("likePattern escapes \\, % and _ and wraps in %…%", () => {
+  assert.equal(likePattern("foo"), "%foo%");
+  assert.equal(likePattern("100%"), "%100\\%%");
+  assert.equal(likePattern("a_b"), "%a\\_b%");
+  assert.equal(likePattern("a\\b"), "%a\\\\b%");
+  assert.equal(likePattern("x%y_z\\q"), "%x\\%y\\_z\\\\q%");
+});
+
+test("likePattern escapes all special chars and keeps matches literal", () => {
+  // A query containing % must not act as a SQLite wildcard after escaping.
+  const pattern = likePattern("50%");
+  assert.ok(pattern.includes("\\%"));
+  assert.ok(!pattern.slice(1, -1).replace(/\\[%_]/, "").includes("%"));
+});
+
+// ---------------------------------------------------------------------------
+// buildHits — row shape
+// ---------------------------------------------------------------------------
+
+function part(d, override = {}) {
+  return JSON.stringify({ type: "text", text: d, ...override });
+}
+function msg(role = "user") {
+  return JSON.stringify({ role });
+}
+// row is what buildHits receives: session_id, message_id, part_data (JSON
+// string), msg_data (JSON string), time_created.
+function row(sid, mid, partData, msgData, timeCreated) {
+  return {
+    session_id: sid,
+    message_id: mid,
+    part_data: partData,
+    msg_data: msgData,
+    time_created: timeCreated,
+  };
+}
+
+const OPS = { sessionIds: ["a", "b"] };
+
+// ---------------------------------------------------------------------------
+// text-part filtering
+// ---------------------------------------------------------------------------
+
+test("buildHits skips non-text parts", () => {
+  const rows = [
+    row("a", "m1", JSON.stringify({ type: "tool", text: "hello world" }), msg(), 1),
+  ];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+test("buildHits skips synthetic parts", () => {
+  const rows = [
+    row("a", "m1", part("hello world", { synthetic: true }), msg(), 1),
+  ];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+test("buildHits skips ignored parts", () => {
+  const rows = [
+    row("a", "m1", part("hello world", { ignored: true }), msg(), 1),
+  ];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+test("buildHits skips parts with non-string text", () => {
+  const rows = [
+    row("a", "m1", JSON.stringify({ type: "text", text: 42 }), msg(), 1),
+  ];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+test("buildHits skips rows whose part_data is unparseable JSON", () => {
+  const rows = [row("a", "m1", "{not json", msg(), 1)];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+test("buildHits skips rows whose msg_data is unparseable JSON without throwing", () => {
+  const rows = [row("a", "m1", part("hello world"), "{bad", 1)];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+test("buildHits skips rows with empty query", () => {
+  assert.deepEqual(buildHits([row("a", "m1", part("hello"), msg(), 1)], "", OPS), []);
+});
+
+// ---------------------------------------------------------------------------
+// one-hit-per-message + case-insensitive matching
+// ---------------------------------------------------------------------------
+
+test("buildHits produces one hit per message, first match wins", () => {
+  const rows = [
+    row("a", "m1", part("first hello one"), msg(), 3),
+    row("a", "m1", part("helloooo second"), msg(), 2),
+    row("a", "m2", part("single hello"), msg(), 1),
+  ];
+  const hits = buildHits(rows, "hello", OPS);
+  assert.equal(hits.length, 2);
+  assert.deepEqual(
+    hits.map((h) => h.messageId),
+    ["m1", "m2"],
+  );
+});
+
+test("buildHits matches case-insensitively but reports original casing", () => {
+  const rows = [row("a", "m1", part("Say HELLO there"), msg(), 1)];
+  const hits = buildHits(rows, "hello", OPS);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].match, "HELLO");
+});
+
+test("buildHits skips rows without a case-insensitive match", () => {
+  const rows = [row("a", "m1", part("nothing here"), msg(), 1)];
+  assert.deepEqual(buildHits(rows, "hello", OPS), []);
+});
+
+// ---------------------------------------------------------------------------
+// role normalization
+// ---------------------------------------------------------------------------
+
+test("buildHits normalizes role: user stays user, everything else is assistant", () => {
+  const rows = [
+    row("a", "m1", part("hello user"), msg("user"), 2),
+    row("a", "m2", part("hello asst"), msg("assistant"), 1),
+  ];
+  const hits = buildHits(rows, "hello", OPS);
+  assert.equal(hits.find((h) => h.messageId === "m1").role, "user");
+  assert.equal(hits.find((h) => h.messageId === "m2").role, "assistant");
+});
+
+// ---------------------------------------------------------------------------
+// snippets
+// ---------------------------------------------------------------------------
+
+test("snippet pre is prefixed with … and truncated to 60 chars when the match sits deep", () => {
+  const before = "x".repeat(120);
+  const rows = [row("a", "m1", part(before + "hello"), msg(), 1)];
+  const [h] = buildHits(rows, "hello", OPS);
+  assert.ok(h.pre.startsWith("…"));
+  assert.equal(h.pre.length, 1 + 60); // … + 60 chars before the match
+  assert.equal(h.match, "hello");
+  assert.equal(h.post, "");
+});
+
+test("snippet pre has no … when the match is within the first 60 chars", () => {
+  const before = "y".repeat(20);
+  const rows = [row("a", "m1", part(before + "hello"), msg(), 1)];
+  const [h] = buildHits(rows, "hello", OPS);
+  assert.ok(!h.pre.startsWith("…"));
+  assert.equal(h.pre, before);
+});
+
+test("snippet post is truncated to 200 chars", () => {
+  const after = "z".repeat(300);
+  const rows = [row("a", "m1", part("hello" + after), msg(), 1)];
+  const [h] = buildHits(rows, "hello", OPS);
+  assert.equal(h.post.length, 200);
+});
+
+test("snippet pre/match/post collapse whitespace runs to a single space", () => {
+  const rows = [row("a", "m1", part("a   b\n\n xhello\t world"), msg(), 1)];
+  const [h] = buildHits(rows, "hello", OPS);
+  assert.equal(h.pre, "a b x");
+  assert.equal(h.match, "hello");
+  assert.equal(h.post, " world");
+});
+
+// ---------------------------------------------------------------------------
+// caps
+// ---------------------------------------------------------------------------
+
+test("maxPrimary caps the primary session independently of maxPerSession", () => {
+  const rows = [];
+  for (let i = 1; i <= 10; i++) {
+    rows.push(row("a", `u${i}`, part(`hello slot${i}`), msg(), i));
+  }
+  const hits = buildHits(rows, "hello", {
+    sessionIds: ["a", "b"],
+    primarySessionId: "a",
+    maxPrimary: 2,
+    maxPerSession: 3,
+  });
+  assert.equal(hits.length, 2);
+  assert.ok(hits.every((h) => h.sessionId === "a"));
+});
+
+test("maxPerSession caps every non-primary session", () => {
+  const rows = [];
+  for (let i = 1; i <= 10; i++) {
+    rows.push(row("b", `v${i}`, part(`hello slot${i}`), msg(), i));
+  }
+  const hits = buildHits(rows, "hello", {
+    sessionIds: ["a", "b"],
+    primarySessionId: "a",
+    maxPerSession: 3,
+  });
+  assert.equal(hits.length, 3);
+  assert.ok(hits.every((h) => h.sessionId === "b"));
+});
+
+test("maxTotal caps hits overall", () => {
+  const rows = [];
+  for (let i = 1; i <= 10; i++) {
+    rows.push(row("a", `u${i}`, part(`hello slot${i}`), msg(), i));
+  }
+  const hits = buildHits(rows, "hello", {
+    sessionIds: ["a"],
+    primarySessionId: "a",
+    maxPrimary: 100,
+    maxTotal: 4,
+  });
+  assert.equal(hits.length, 4);
+});
+
+// ---------------------------------------------------------------------------
+// session ordering + time-descending within a session
+// ---------------------------------------------------------------------------
+
+test("buildHits orders by session index, then time_created descending within a session", () => {
+  // Input order is time-descending globally, interleaved across sessions:
+  // row a(5), row b(50), row b(40), row a(4), row b(30)
+  const rows = [
+    row("a", "a5", part("hello five"), msg(), 5),
+    row("b", "b5", part("hello fifty"), msg(), 50),
+    row("b", "b4", part("hello fourty"), msg(), 40),
+    row("a", "a4", part("hello four"), msg(), 4),
+    row("b", "b3", part("hello thirty"), msg(), 30),
+  ];
+  const hits = buildHits(rows, "hello", { sessionIds: ["b", "a"], primarySessionId: "b" });
+  // sessionIds = ["b","a"] → all b hits first, then a; within each, newest first.
+  assert.deepEqual(
+    hits.map((h) => h.messageId),
+    ["b5", "b4", "b3", "a5", "a4"],
+  );
+});
+
+test("buildHits primary (sessionIds[0]) sorts first", () => {
+  const rows = [
+    row("b", "b1", part("hello bee"), msg(), 2),
+    row("a", "a1", part("hello ay"), msg(), 2),
+    row("a", "a2", part("hello ay2"), msg(), 1),
+  ];
+  const hits = buildHits(rows, "hello", { sessionIds: ["a", "b"], primarySessionId: "a" });
+  assert.deepEqual(
+    hits.map((h) => h.sessionId),
+    ["a", "a", "b"],
+  );
+});
+
+test("timeCreated is carried through (null-safe)", () => {
+  const rows = [
+    row("a", "m1", part("hello world"), msg(), 1234),
+    row("a", "m2", part("hello again"), msg(), null),
+  ];
+  const hits = buildHits(rows, "hello", OPS);
+  assert.equal(hits.find((h) => h.messageId === "m1").timeCreated, 1234);
+  assert.equal(hits.find((h) => h.messageId === "m2").timeCreated, null);
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -26,6 +26,7 @@ import { pollClaudeLogin, claudeCliStatus } from "./opencode.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
+import { searchMessages } from "./messageSearch.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 
 // Same dirname derivation as src/server/index.mjs (line 83) so the script
@@ -587,6 +588,13 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.opencodeFindFiles, { query, directory })
     // → args[0] = { query, directory }; opencode.mjs findFiles expects same shape
     "opencode:find-files": (input) => oc.findFiles(input),
+
+    // BET-698: server-side conversation search over opencode's SQLite
+    // (messageSearch.mjs). Args { query, sessionIds } — sessionIds[0] is the
+    // active conversation. Degrades to { supported:false } on a box that
+    // hasn't taken the Node 24 runtime yet.
+    // preload: ipcRenderer.invoke(IPC.opencodeSearchMessages, { query, sessionIds })
+    "opencode:search-messages": (input) => searchMessages(input ?? {}),
 
     // preload: ipcRenderer.invoke(IPC.opencodeRunCommand, { sessionId, command, arguments, model?, attachments? })
     // → args[0] = that object; opencode.mjs runCommand expects same shape

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -43,6 +43,7 @@ import type {
   SubagentDef,
   SubagentInput,
   PluginRegistryRow,
+  TranscriptHit,
 } from "./types.js";
 import type { ClaimOutcome } from "./claim.mjs";
 
@@ -419,6 +420,14 @@ export interface Api {
   opencodeCommands(): Promise<OpencodeCommand[]>;
   opencodeAgents(): Promise<OpencodeAgent[]>;
   opencodeFindFiles(input: { query: string; directory: string }): Promise<string[]>;
+  // BET-698: server-side conversation search. `sessionIds` is the search scope
+  // in priority order (sessionIds[0] = the active conversation). Hit caps stay
+  // server-side defaults. `supported:false` = the box can't search (needs the
+  // Node 24 runtime / opencode.db).
+  opencodeSearchMessages(input: {
+    query: string;
+    sessionIds: string[];
+  }): Promise<{ supported: boolean; hits: TranscriptHit[] }>;
 
   // Slash-command execution.
   opencodeRunCommand(input: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -641,6 +641,9 @@ export const IPC = {
   opencodeCommands: "opencode:commands",
   opencodeAgents: "opencode:agents",
   opencodeFindFiles: "opencode:find-files",
+  // BET-698: server-side conversation search over opencode's SQLite
+  // (messageSearch.mjs). Returns { supported, hits }.
+  opencodeSearchMessages: "opencode:search-messages",
   // Slash-command execution: invokes POST /session/{id}/command. Distinct
   // from opencode:prompt — the server treats commands specially (templates,
   // configured agent/model, etc.).
@@ -935,6 +938,21 @@ export const IPC = {
   //   { kind: "error", handleId, message }
   installerEvent: "installer:event",
 } as const;
+
+// BET-698: a ⌘F conversation search hit returned by the server-side
+// messageSearch query (`opencode:search-messages`). Crosses the wire, so it
+// lives in shared/types (moved verbatim from the deleted renderer
+// searchTranscript — the UI is unchanged); `sessionId` is new (the server
+// returns a flat list the client groups by).
+export type TranscriptHit = {
+  sessionId: string;
+  messageId: string;
+  role: "user" | "assistant";
+  pre: string;
+  match: string;
+  post: string;
+  timeCreated: number | null;
+};
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the
 // value (manta-server strips it; only secret_provide materializes the value, to a


### PR DESCRIPTION
## BET-698 — Conversation search: one server-side SQLite query

Replaces the client-side transcript-download fan-out in `SearchPalette` (capped at 5 sessions/keystroke, candidates silently skipped) with ONE `opencode:search-messages` RPC backed by a new `src/server/messageSearch.mjs` module that queries opencode's own `opencode.db` read-only. The active conversation is searched by the same call — fixes the old tail-only (last ~100 messages) gap. Renderer line count goes **down**.

- New `messageSearch.mjs` (searchMessages + pure `likePattern`/`buildHits`), `messageSearch.test.mjs` (23 tests).
- Degrades to `{supported:false}` on a box without the Node 24 runtime (`node:sqlite` dynamic import in try/catch) or with no db file. Never throws.
- Renderer `SearchPalette` is a dumb renderer of `{supported, hits}` grouped by sessionId; no search logic retained.
- Deleted renderer `searchTranscript` + `TranscriptHit` + `SNIPPET_PRE_CHARS` (moved `TranscriptHit` to shared/types — it now crosses the wire with a new `sessionId` field).

**Files touched (issue list + one necessary):** the 9 files the issue names, plus `src/renderer/api/demoCoverage.test.ts` — its `DEMO_UNIMPLEMENTED` set must record every `Api` method without a demo stub, so `npm test` was red without adding `opencodeSearchMessages` to it (1-line, mechanical, required for the suite to pass).

**Cross-cutting:** new IPC channel `opencode:search-messages` wired at all sites (types IPC map + `TranscriptHit` type, `Api` contract, `httpApi`, `rpc.mjs` dispatch).

**Base: origin/main @ `7cddf53c`**

### Manual check (dev box, listed acceptance — not run by agent)
The live-dev-box manual check (search a word in a far-down sidebar conversation / in the pre-tail region of the current conversation) requires the Node 24 box runtime + the real `opencode.db` on the dev box, which this Linux agent box does not have. The SQL wiring was smoke-tested locally against a fabricated `opencode.db` with the exact schema (primary-first ordering, per-session caps, empty-scope degradation all verified). The on-device check remains for the reviewer/human.
