### PR TITLE
fix(install): detect off-PATH opencode; run privileged TLS section as root without sudo (BET-706)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -713,6 +713,12 @@ main() {
   # We use opencode's official installer; no version pinning in v1 — the
   # installer is the source of truth for "current". Re-running is a no-op
   # when the binary is already on PATH.
+  # An existing install may be off-PATH in this non-login shell (the app's
+  # ssh -tt install path) — probe the known install dirs before deciding to
+  # reinstall. Mirrors the post-install PATH fixup below.
+  for _ocdir in "$HOME/.opencode/bin" "$HOME/.local/bin"; do
+    if [ -x "$_ocdir/opencode" ]; then export PATH="$_ocdir:$PATH"; break; fi
+  done
   OPENCODE_BIN="$(command -v opencode || true)"
   if [ -n "$OPENCODE_BIN" ]; then
     ok "opencode already installed ($("$OPENCODE_BIN" --version 2>/dev/null | head -n1 || echo "$OPENCODE_BIN"))."
@@ -1263,21 +1269,29 @@ main() {
     # Passwordless sudo is required because the install runs unattended
     # from `curl | bash`.
     if [ "$PRIVILEGED_SECTION_SKIP" = "0" ]; then
-      if ! command -v sudo >/dev/null 2>&1; then
-        warn "Caddy/gateway section skipped: \`sudo\` is not installed."
-        warn "  install sudo + grant $USER passwordless sudo, or run the
+      if [ "$(id -u)" = "0" ]; then
+        # Root needs no sudo. If the binary is absent, shim it so the section's
+        # `sudo <cmd>` invocations run bare — zero changes to the commands below.
+        if ! command -v sudo >/dev/null 2>&1; then
+          sudo() { "$@"; }
+        fi
+      else
+        if ! command -v sudo >/dev/null 2>&1; then
+          warn "Caddy/gateway section skipped: \`sudo\` is not installed."
+          warn "  install sudo + grant $USER passwordless sudo, or run the
   install with sudo available. To finish this section by hand:"
-        warn "    sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl"
-        warn "    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg"
-        warn "    echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/ubuntu noble main' | sudo tee /etc/apt/sources.list.d/caddy-stable.list"
-        warn "    sudo apt update && sudo apt install caddy"
-        warn "  then re-run the installer (the gateway + DNS + Caddyfile steps re-run cleanly)."
-        PRIVILEGED_SECTION_SKIP=1
-      elif ! sudo -n true 2>/dev/null; then
-        warn "Caddy/gateway section skipped: passwordless sudo is not configured for $USER."
-        warn "  either configure \`$USER ALL=(ALL) NOPASSWD:ALL\` in /etc/sudoers.d/ and re-run,"
-        warn "  or install Caddy by hand (commands in the previous message) and re-run the installer."
-        PRIVILEGED_SECTION_SKIP=1
+          warn "    sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl"
+          warn "    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg"
+          warn "    echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/ubuntu noble main' | sudo tee /etc/apt/sources.list.d/caddy-stable.list"
+          warn "    sudo apt update && sudo apt install caddy"
+          warn "  then re-run the installer (the gateway + DNS + Caddyfile steps re-run cleanly)."
+          PRIVILEGED_SECTION_SKIP=1
+        elif ! sudo -n true 2>/dev/null; then
+          warn "Caddy/gateway section skipped: passwordless sudo is not configured for $USER."
+          warn "  either configure \`$USER ALL=(ALL) NOPASSWD:ALL\` in /etc/sudoers.d/ and re-run,"
+          warn "  or install Caddy by hand (commands in the previous message) and re-run the installer."
+          PRIVILEGED_SECTION_SKIP=1
+        fi
       fi
     fi
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1270,10 +1270,16 @@ main() {
     # from `curl | bash`.
     if [ "$PRIVILEGED_SECTION_SKIP" = "0" ]; then
       if [ "$(id -u)" = "0" ]; then
-        # Root needs no sudo. If the binary is absent, shim it so the section's
-        # `sudo <cmd>` invocations run bare — zero changes to the commands below.
+        # Root needs no sudo. Every privileged call in this section is
+        # `sudo -n <cmd>`; as root the `-n` flag is meaningless and the sudo
+        # binary may be absent entirely (minimal VPS). When it's missing,
+        # shim sudo to drop the leading `-n` and run the command bare — zero
+        # changes to the commands below.
         if ! command -v sudo >/dev/null 2>&1; then
-          sudo() { "$@"; }
+          sudo() {
+            if [ "${1:-}" = "-n" ]; then shift; fi
+            "$@"
+          }
         fi
       else
         if ! command -v sudo >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes BET-706 — two independent installer fixes in `scripts/install.sh`.

## (a) opencode reinstalled when it's merely off-PATH
Before the existing `OPENCODE_BIN="$(command -v opencode || true)"` line, probe
the known install dirs (`$HOME/.opencode/bin`, `$HOME/.local/bin`) and prepend
the first one containing an `opencode` binary to PATH. This mirrors the
post-install PATH fixup and makes the "already installed" branch fire over the
app's `ssh -tt` non-login-shell install path, where `~/.opencode/bin` is not on
PATH.

## (b) Root VPS without the sudo binary silently loses public TLS
The privileged Caddy/gateway section now checks `id -u = 0` FIRST. When running
as root, a missing `sudo` binary is shimmed with a function that **drops the
leading `-n` flag** and runs the command bare. This is load-bearing: every
privileged call in the section is `sudo -n <cmd>` (`sudo -n apt-get`, `|
sudo -n gpg`, `sudo -n install` via the `sudo_install` helper, `sudo -n
systemctl reload caddy`), so a plain `sudo() { "$@"; }` would run `-n <cmd>` and
die with `-n: command not found`. The shim is:

```sh
sudo() {
  if [ "${1:-}" = "-n" ]; then shift; fi
  "$@"
}
```

(skip the `-n` if present, then run bare). Non-root keeps the two original
warn+skip branches (missing binary / no passwordless sudo) unchanged. Grep
confirms every executed privileged command in the section goes through `sudo -n`
— no bare privileged command exists.

## (c) Confirmed — no claude CLI re-add
`scripts/install.sh` does NOT install the claude CLI. The A2 block is removed
(BET-421 §E); nothing in the script re-adds it.

**Files changed:** 1 file. `scripts/install.sh`.

**Verification results** (re-run on the corrected branch):
- PR branch (`multica/BET-706-install-sh-fixes`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1554 pass / 0 fail / 0 skip.
- `bash -n scripts/install.sh`: passes.
- Shim functionally verified: `sudo -n echo hi` and `sudo echo hi` both run
  bare under the shim.
- NOTE: this PR touches `scripts/install.sh`, which triggers the
  `macos-install-smoke` workflow (runs the BRANCH copy end-to-end). A red run
  there is a real finding — read its log before assuming flake.

**Base:** origin/main @ `0fcb155`
