### PR TITLE
ci(ios): add iOS compile gate workflow (BET-651)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,51 @@
+# iOS compile gate (BET-651). Compiles the native app + BOTH test bundles for
+# any PR that touches mobile/native. build-for-testing, never `test` —
+# execution stays on the Mac plugin; this gate only proves the Swift compiles.
+# NOT in required-checks.json: the paths filter means most PRs never produce
+# this context, and requiring it would block them all (see AGENTS.md).
+name: iOS Build
+
+on:
+  pull_request:
+    paths:
+      - "mobile/native/**"
+      - ".github/workflows/ios-build.yml"
+
+concurrency:
+  group: ios-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios-build:
+    runs-on: macos-14
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: mobile/native
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache SPM packages + DerivedData
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            ~/Library/Caches/org.swift.swiftpm
+          key: ios-build-${{ runner.os }}-${{ hashFiles('mobile/native/project.yml') }}
+          restore-keys: |
+            ios-build-${{ runner.os }}-
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project (project.yml is the source of truth)
+        run: xcodegen generate
+
+      - name: Compile app + test bundles
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing \
+            -project MantaUI.xcodeproj \
+            -scheme MantaUI \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -3,6 +3,12 @@
 # execution stays on the Mac plugin; this gate only proves the Swift compiles.
 # NOT in required-checks.json: the paths filter means most PRs never produce
 # this context, and requiring it would block them all (see AGENTS.md).
+#
+# runs-on: macos-26 (not macos-14). project.yml declares deploymentTarget
+# "26.0" + Swift 6.0, and the generated project is Xcode project format 77,
+# which only Xcode 26 can read; macos-14's Xcode 15.4 cannot open it at all
+# ("future Xcode project file format (77)" — verified live on the first run).
+# macos-26 ships Xcode 26 on a standard (free) runner.
 name: iOS Build
 
 on:
@@ -17,7 +23,7 @@ concurrency:
 
 jobs:
   ios-build:
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 30
     defaults:
       run:

--- a/mobile/native/MantaUI/MantaLoader.swift
+++ b/mobile/native/MantaUI/MantaLoader.swift
@@ -103,3 +103,6 @@ struct MantaLoader: View {
             .frame(width: diameter * Self.markRatio, height: diameter * Self.markRatio)
     }
 }
+
+// deliberate syntax error for BET-651 RED proof
+let broken =

--- a/mobile/native/MantaUI/MantaLoader.swift
+++ b/mobile/native/MantaUI/MantaLoader.swift
@@ -103,6 +103,3 @@ struct MantaLoader: View {
             .frame(width: diameter * Self.markRatio, height: diameter * Self.markRatio)
     }
 }
-
-// deliberate syntax error for BET-651 RED proof
-let broken =


### PR DESCRIPTION
## BET-651 — iOS compile gate

Adds a new workflow `.github/workflows/ios-build.yml` that runs **only for PRs
touching `mobile/native/**`** (or the workflow file itself). It compiles the
native app **and both test bundles** (`build-for-testing`) so that Swift that
has never been near a compiler can no longer go green.

**Decisions locked by the issue, followed except where noted below:**
- NEW workflow file, not a job in `ci.yml` (path-gating is a workflow-level
  `paths` filter; shares no setup with `typecheck-test`).
- **NOT** added to `required-checks.json` / the ruleset — the paths filter
  means most PRs never produce this context, and requiring it would block
  every non-iOS PR.
- `xcodebuild build-for-testing` — compiles the app AND `MantaUITests` +
  `MantaUIUITests` (both declared under `test:` in `project.yml:114-127`).
  Never runs `test` — test execution stays on the Mac plugin.
- `CODE_SIGNING_ALLOWED=NO` (compile gate, never an archive; codemagic.yaml
  untouched).
- `xcodegen generate` before building (project.yml is source of truth).
- DerivedData + SPM cache keyed on `project.yml` hash.
- No billing caveats (public repo, standard runners).

**Deviation from the locked spec (required to make the gate work):**
`runs-on` is **`macos-26`, not `macos-14`**. `project.yml` declares
`deploymentTarget "26.0"` + Swift 6.0 and xcodegen emits Xcode project format
77, which `macos-14`'s Xcode 15.4 cannot open at all (verified live: the first
run failed with `xcodebuild: error: unable to read project ... future Xcode
project file format (77)`). Codemagic's release build uses `xcode: latest`
(Xcode 26), i.e. the project genuinely requires Xcode 26. `macos-26` is a
standard (free) runner shipping Xcode 26. `macos-14` is also deprecated as an
image. This is why the smoke-test workflow's `macos-14` usage was not a valid
precedent — that workflow never builds the iOS project.

Out of scope per the issue: making this check required, the `ios-mantaui`
plugin, anything outside `.github/workflows/ios-build.yml`. The final diff is
workflow-file-only.

Base: `origin/main` @ `0fcb1556`

## Acceptance evidence

1. **GREEN** — workflow triggers on itself; ios-build passes
   ([/actions/runs/31681767303](https://github.com/antoinedc/MantaUI/actions/runs/31681767303)): `** TEST BUILD SUCCEEDED **` (app + both test bundles compiled).
2. **RED** — temporary commit `29051a37` added `let broken =` to `MantaLoader.swift`; ios-build **failed**
   ([/actions/runs/31682060331](https://github.com/antoinedc/MantaUI/actions/runs/31682060331)): `MantaLoader.swift:108:13: error: expected initial value after '='` → `** TEST BUILD FAILED **`. Then reverted (`4b110b25`).
3. **GREEN again** — after the revert
   ([/actions/runs/31682159918](https://github.com/antoinedc/MantaUI/actions/runs/31682159918)).
4. **Path-gating** — filter is `mobile/native/**` + `.github/workflows/ios-build.yml` (GitHub evaluates `on.pull_request.paths` server-side). The repo-wide ios-build run list shows zero runs outside this mobile/native-touching PR; the recent server/renderer-only PRs (#709–#716) produced no iOS Build run.
