### PR TITLE
fix(renderer): drain queued prompts via submit(textOverride), one per idle edge (BET-709)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -400,7 +400,6 @@ export function ChatPanel({
       null,
     submit: () => {}, // placeholder — ChatPanel's submit is used below
     submitRef,
-    setInput,
   });
 
   // Manual dismiss of the pinned todo card — the user's escape hatch for a

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -479,10 +479,10 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
     el.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
-  async function queueASecondMessage(container: HTMLElement) {
+  async function queueASecondMessage(container: HTMLElement, text = "second message") {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
     await act(async () => {
-      typeInto(textarea, "second message");
+      typeInto(textarea, text);
     });
     await act(async () => {
       textarea.dispatchEvent(
@@ -637,6 +637,83 @@ describe("useSseBus queued-message drain on tool step boundary", () => {
     );
     expect(promptCalls.length).toBe(1);
   });
+
+  // REGRESSION (BET-709): queue drain silently dropped all but the last queued
+  // prompt. The old drain did `setInput(queued)` then deferred the actual
+  // submit to `setTimeout(0)`; with ≥2 items queued at the running→false edge,
+  // the effect re-ran (React's scheduler beats setTimeout(0)) and the second
+  // run overwrote the input before the first submit fired — "a" was never
+  // sent, with no error. The drain now submits the queued text EXPLICITLY via
+  // submitRef(textOverride), one item per idle edge, so every can be drained.
+  it("drains ≥2 queued messages exactly once, in FIFO order (no first-message loss)", async () => {
+    h = await mountDrainHarness();
+
+    // Turn running; queue TWO distinct messages mid-turn.
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
+    });
+    await queueASecondMessage(h.container, "first queued");
+    await queueASecondMessage(h.container, "second queued");
+    await h.flush();
+
+    // A tool completes → drain-abort fires opencodeAbort.
+    await emitAndFlush(bus, h, {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        part: { type: "tool", state: { status: "completed" } },
+      },
+    });
+    // The abort flips the session idle; wait out the settle window then flush
+    // so the FIRST drain edge runs.
+    await emitStreamAndFlush(bus, h, {
+      sub: "turnComplete",
+      sessionId: "ses_test",
+      payload: { complete: true, running: false },
+    });
+    await new Promise((r) => setTimeout(r, TURN_SETTLE_MS + 50));
+    await h.flush();
+
+    // First idle edge: the FIRST queued text is submitted exactly once, the
+    // second not at all yet. submit() flips running true synchronously, so the
+    // drain effect re-arms and the second item waits for the NEXT idle edge.
+    let firstCalls = (api.calls.opencodePrompt ?? []).filter((args) =>
+      JSON.stringify(args).includes("first queued"),
+    );
+    const secondCallsSoFar = (api.calls.opencodePrompt ?? []).filter((args) =>
+      JSON.stringify(args).includes("second queued"),
+    );
+    expect(firstCalls.length).toBe(1);
+    expect(secondCallsSoFar.length).toBe(0);
+
+    // Start a second turn, then let it complete idle.
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
+    });
+    await emitStreamAndFlush(bus, h, {
+      sub: "turnComplete",
+      sessionId: "ses_test",
+      payload: { complete: true, running: false },
+    });
+    await new Promise((r) => setTimeout(r, TURN_SETTLE_MS + 50));
+    await h.flush();
+
+    // Second idle edge: the SECOND queued text is now submitted exactly once,
+    // and the first is still exactly once (no double send).
+    firstCalls = (api.calls.opencodePrompt ?? []).filter((args) =>
+      JSON.stringify(args).includes("first queued"),
+    );
+    const secondCalls = (api.calls.opencodePrompt ?? []).filter((args) =>
+      JSON.stringify(args).includes("second queued"),
+    );
+    expect(firstCalls.length).toBe(1);
+    expect(secondCalls.length).toBe(1);
+  });
 });
 
 // BET-692 — running must only flip false on a SETTLED completion. The box
@@ -678,7 +755,6 @@ describe("useSseBus running settle on turnComplete (BET-692)", () => {
       providerID: null,
       submit: () => {},
       submitRef,
-      setInput: () => {},
     });
     probe = { running: sse.running };
     return <div data-testid="running-probe" />;

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -17,7 +17,7 @@
 // Dependencies injected via params:
 //   - setMessages (from useTranscriptState)
 //   - scheduleRefetch / spliceMessage / etc. (from useTranscriptState)
-//   - input, setInput (for submit)
+//   - input (for submit)
 //   - inputRef (for submit)
 //   - running, setRunning (owned by this hook)
 //   - messageQueue, setMessageQueue (owned by this hook)
@@ -139,7 +139,7 @@ export type SseBus = {
   branch: string | null;
   refreshBranch: (cwd: string) => void;
   submit: () => void;
-  submitRef: React.RefObject<() => void>;
+  submitRef: React.RefObject<(textOverride?: string) => void>;
   abort: () => void;
   replyPermission: (id: string, reply: "once" | "always" | "reject") => void;
   replyQuestion: (q: QuestionRequest, answers: string[][]) => void;
@@ -191,8 +191,7 @@ export function useSseBus(params: {
   // through to the raw-message path.
   providerID: string | null;
   submit: () => void;
-  submitRef: React.RefObject<() => void>;
-  setInput: (v: string) => void;
+  submitRef: React.RefObject<(textOverride?: string) => void>;
 }): SseBus {
   const {
     sessionId,
@@ -210,7 +209,6 @@ export function useSseBus(params: {
     providerID,
     submit,
     submitRef,
-    setInput,
   } = params;
 
   const [running, setRunning] = useState(false);
@@ -226,6 +224,7 @@ export function useSseBus(params: {
     messageQueueRef.current = messageQueue;
   }, [messageQueue]);
   const drainAbortRef = useRef(false);
+  const drainingRef = useRef(false);
   const [permissions, setPermissions] = useState<PermissionRequest[]>([]);
   const [questions, setQuestions] = useState<QuestionRequest[]>([]);
   const questionsRef = useRef<QuestionRequest[]>([]);
@@ -832,27 +831,26 @@ export function useSseBus(params: {
   }, [sessionId]);
 
   // Drain effect: when running flips false and there's a queued prompt, submit
-  // it. This is the SOLE drain effect (a duplicate in ChatPanel was removed —
-  // both fired on the same running→false edge and double-submitted).
-  //
-  // Ordering matters: setInput(queued) runs NOW (synchronously in this effect),
-  // and the actual submit is deferred to a setTimeout(0). The gap lets React
-  // re-render so submitRef.current is reassigned to a fresh submit() closure
-  // that captures the new `input` — submit() reads `input` from its render
-  // closure (not a ref), so calling it before the input-set re-render would
-  // read the stale empty value and no-op. Do NOT collapse setInput into the
-  // timeout alongside submitRef.current() — that reintroduces the stale-closure
-  // bug where the queued prompt is silently dropped.
+  // it — EXACTLY ONE item per idle edge. The queued text is passed explicitly
+  // via submit's textOverride (same pattern as ChatPanel's autoSubmit), so the
+  // old setInput + setTimeout(0) re-render dance is gone and a second queued
+  // item can no longer overwrite the first before its deferred submit fires.
+  // drainingRef gates re-entrancy: setMessageQueue re-triggers this effect
+  // synchronously (before running flips true), and without the gate the second
+  // item would submit mid-turn. It re-arms when running goes true (submit sets
+  // it synchronously on the non-error path). This is the SOLE drain effect (a
+  // duplicate in ChatPanel was removed — see the "no double send" test).
   useEffect(() => {
-    if (!running && messageQueue.length > 0) {
-      const queued = messageQueue[0];
-      setMessageQueue((prev) => prev.slice(1));
-      drainAbortRef.current = false;
-      setInput(queued);
-      setTimeout(() => {
-        submitRef.current?.();
-      }, 0);
+    if (running) {
+      drainingRef.current = false;
+      return;
     }
+    if (drainingRef.current || messageQueue.length === 0) return;
+    drainingRef.current = true;
+    const queued = messageQueue[0];
+    setMessageQueue((prev) => prev.slice(1));
+    drainAbortRef.current = false;
+    submitRef.current?.(queued);
   }, [running, messageQueue]);
 
   return {


### PR DESCRIPTION
**Files changed:** `3` files.

- `src/renderer/hooks/useSseBus.ts` — sole drain effect now submits exactly one queued item per idle edge via `submitRef(queued)` (submit's existing `textOverride` path, same as ChatPanel's autoSubmit). `drainingRef` gates re-entrancy so the second queue re-trigger can't submit mid-turn; it re-arms when `running` goes true. Removed the now-unused `setInput` (param field + destructure + header-comment mention + ChatPanel call-site arg). As a necessary corollary, `submitRef`'s type in the hook was `React.RefObject<() => void>` at HEAD (not `(textOverride?: string) => void` as the issue described), so I typed it to accept the override — the drain passes queued text through it.
- `src/renderer/ChatPanel.tsx` — dropped the `setInput` arg at the `useSseBus(...)` call site. `submit`/`submitRef` untouched.
- `src/renderer/hooks/useSseBus.test.tsx` — added a `text` param (default `"second message"`) to `queueASecondMessage` so the existing tests are unchanged; added a regression test: two queued items each drain exactly once, in FIFO order, across two idle edges.

The drain-ABORT logic (`shouldAbortForQueuedDrain`/`maybeDrainQueuedPrompt`/`isDrainAbortError`) is untouched. No second drain effect introduced.

**Verification results:**
- PR branch (`multica/BET-709-drain-submit-textoverride` @ `97157ec`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, `1551` pass / `0` fail / `0` skip. Failures: none. log sha256: `4eae71cbdae4e8c74c0ff4adab5a5665984be270e3b7a5fa347f4ac836feab90`
  - renderer vitest `useSseBus.test.tsx`: 29 pass (incl. the new two-item FIFO regression and the unchanged "no double send" test)
- Base (`main` @ `2f176c9 = origin/main`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, `1551` pass / `0` fail / `0` skip. Failures: none. log sha256: `aaae098833417c7b1102c7109dc60e2d6f9936c4548c675d1e12b676efbc556c`
- **Conclusion:** 0 new failures caused by this PR, 0 resolved. The added test is renderer-only; server `node:test` totals are identical between branches (1551/0).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Base:** `origin/main @ 2f176c9`
