### PR TITLE
fix(ios): send button morphs into Stop while a turn runs (BET-711 task 1)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -565,6 +565,12 @@ private struct ChatScreenContent: View {
     @ViewBuilder
     private var bottomCards: some View {
         VStack(spacing: Metrics.spacing.sp3) {
+            if let err = store.sessionError {
+                ChatNoticeRow(text: err.message, color: tokens.danger, tokens: tokens)
+            }
+            if let trunc = store.truncation, !store.running {
+                ChatNoticeRow(text: trunc.label ?? "Response truncated", color: tokens.warn, tokens: tokens)
+            }
             if let todos = store.todos, !(todos.visible?.visible ?? todos.active ?? []).isEmpty {
                 TodosCard(payload: todos, tokens: tokens)
             }
@@ -968,5 +974,27 @@ private struct QuestionCard: View {
                 customText: customText
             )
         )
+    }
+}
+
+// MARK: - Shared notice row (session errors / truncation)
+
+private struct ChatNoticeRow: View {
+    let text: String
+    let color: Color
+    let tokens: Tokens
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: Metrics.type.xs, weight: .semibold))
+                .foregroundColor(color)
+            Text(text)
+                .font(.system(size: Metrics.type.xs))
+                .foregroundColor(color)
+                .lineLimit(3)
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
     }
 }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -155,6 +155,7 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var context: StreamContextPayload?
     @Published private(set) var cache: StreamCachePayload?
     @Published private(set) var truncation: StreamTruncationPayload?
+    @Published private(set) var sessionError: StreamSessionErrorPayload?
     @Published private(set) var todos: StreamTodosPayload?
     @Published private(set) var questions: [QuestionRequest] = []
     @Published private(set) var permissions: [PermissionRequest] = []
@@ -355,6 +356,7 @@ final class ChatSessionStore: ObservableObject {
         context = s.context
         cache = s.cache
         truncation = s.truncation
+        sessionError = s.sessionError
         todos = s.todos
         subagents = s.subagents
 
@@ -719,6 +721,7 @@ final class ChatSessionStore: ObservableObject {
         running = true
         optimisticRunning = true
         turnComplete = false
+        sessionError = nil
         if runningSince == nil {
             runningSince = Date()
             // A send starts a turn directly (no stream running transition to

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -760,16 +760,16 @@ struct ComposerView: View {
     // MARK: - Send
 
     private var sendButton: some View {
-        Button(action: submit) {
-            Image(systemName: "arrow.up")
+        Button(action: { store.running ? store.abort() : submit() }) {
+            Image(systemName: store.running ? "stop.fill" : "arrow.up")
                 .font(.system(size: Metrics.type.body, weight: .semibold))
-                .foregroundColor(canSend ? tokens.onAccent : tokens.tx4)
+                .foregroundColor(store.running || canSend ? tokens.onAccent : tokens.tx4)
                 .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
-                .background(canSend ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.inset), in: Circle())
+                .background(store.running || canSend ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.inset), in: Circle())
         }
         .buttonStyle(.plain)
-        .disabled(!canSend)
-        .accessibilityLabel("Send")
+        .disabled(!store.running && !canSend)
+        .accessibilityLabel(store.running ? "Stop" : "Send")
         .accessibilityIdentifier("send-button")
     }
 

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -67,6 +67,9 @@ struct ComposerView: View {
     @FocusState private var inputFocused: Bool
     @StateObject private var recorder = VoiceRecorder()
     @State private var micMode: VoiceMode = .dictate
+    /// High-water flag for a press whose permission prompt is still resolving —
+    /// lets `micPress` re-check the finger is still down after the await.
+    @State private var micPressActive = false
     /// Auto-dismiss task for the currently shown hint — tied to the hint's own
     /// identity so a new hint cancels and restarts the 4 s timer.
     @State private var hintDismissTask: Task<Void, Never>?
@@ -664,13 +667,21 @@ struct ComposerView: View {
 
     private func micPress() {
         guard micAvailable, recorder.phase != .recording, recorder.phase != .processing else { return }
+        // onChanged fires repeatedly during the permission await — one Task only.
+        guard !micPressActive else { return }
+        micPressActive = true
         Task {
             let granted = await recorder.requestPermission()
             guard granted else {
+                micPressActive = false
                 recorder.fail("Microphone permission needed")
                 hintState("Microphone permission is required")
                 return
             }
+            // The finger may have lifted while the permission prompt was up —
+            // starting now would record with no press and wedge the phase guard
+            // (desktop parity: "cancel checked AFTER getUserMedia resolves").
+            guard micPressActive else { return }
             micMode = .dictate
             recorder.start()
         }
@@ -682,6 +693,7 @@ struct ComposerView: View {
     }
 
     private func micRelease() {
+        micPressActive = false
         guard recorder.phase != .processing else { return }
         guard let data = recorder.stop() else {
             // Too short — treat as an accidental tap, not an error (§ desktop

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -48,6 +48,7 @@ struct MantaSessionStreamState: Equatable, Sendable {
     var context: StreamContextPayload?
     var cache: StreamCachePayload?
     var truncation: StreamTruncationPayload?
+    var sessionError: StreamSessionErrorPayload?
     var todos: StreamTodosPayload?
     var questions: StreamQuestionsPayload?
     var subagents: [StreamSubagentPayload] = []
@@ -108,7 +109,11 @@ enum MantaStreamRouter {
                 s.appending(p)
             }
         case "running":
-            if let p = try? frame.decodedPayload(StreamRunningPayload.self) { s.running = p.running }
+            if let p = try? frame.decodedPayload(StreamRunningPayload.self) {
+                s.running = p.running
+                // A new turn clears any stale error surfaced by the previous one.
+                if p.running { s.sessionError = nil }
+            }
         case "turnComplete":
             if let p = try? frame.decodedPayload(StreamTurnCompletePayload.self) {
                 s.turnComplete = p.complete
@@ -123,6 +128,8 @@ enum MantaStreamRouter {
             }
         case "truncation":
             s.truncation = try? frame.decodedPayload(StreamTruncationPayload.self)
+        case "sessionError":
+            s.sessionError = try? frame.decodedPayload(StreamSessionErrorPayload.self)
         case "context":
             s.context = try? frame.decodedPayload(StreamContextPayload.self)
         case "cache":

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -172,6 +172,12 @@ struct StreamTruncationPayload: Codable, Equatable, Sendable {
     var messageID: String?
 }
 
+/// `sub: "sessionError"` — a real turn failure (aborts are filtered box-side).
+struct StreamSessionErrorPayload: Codable, Equatable, Sendable {
+    var name: String?
+    var message: String
+}
+
 /// `sub: "context"` — computeContextBreakdown output (all box-computed).
 struct StreamContextSegment: Codable, Equatable, Sendable {
     var kind: String

--- a/mobile/native/MantaUI/TerminalWebView.swift
+++ b/mobile/native/MantaUI/TerminalWebView.swift
@@ -246,7 +246,7 @@ final class TerminalContainerController: UIViewController {
 
         let config = WKWebViewConfiguration()
         let controller = WKUserContentController()
-        controller.add(self, name: "manta")
+        controller.add(WeakScriptMessageHandler(self), name: "manta")
         config.userContentController = controller
         config.allowsInlineMediaPlayback = true
         webView = WKWebView(frame: .zero, configuration: config)
@@ -509,6 +509,7 @@ final class TerminalContainerController: UIViewController {
     }
 
     deinit {
+        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "manta")
         NotificationCenter.default.removeObserver(self)
     }
 }
@@ -577,5 +578,18 @@ struct TerminalContainerView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: TerminalContainerController, context: Context) {
         // The controller owns its socket; nothing to push from SwiftUI here.
+    }
+}
+
+/// WKUserContentController retains its message handler STRONGLY, which would
+/// cycle controller → controller-VC → webView → controller and leak a
+/// WKWebView per terminal visit. The proxy holds the real handler weakly so
+/// the view controller can deallocate; its deinit then detaches the handler.
+private final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    private weak var delegate: WKScriptMessageHandler?
+    init(_ delegate: WKScriptMessageHandler) { self.delegate = delegate }
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        delegate?.userContentController(userContentController, didReceive: message)
     }
 }

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -264,6 +264,23 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
         emit(sid, "turnComplete", { complete: true, running: false });
         return;
       }
+      case "session.error": {
+        // MessageAbortedError is an intentional abort (user Stop, or the
+        // desktop's queued-drain abort) — NOT a failure. Same name-check the
+        // push pump uses (src/server/push.mjs, classifyPushEvent session.error
+        // branch): the abort carries no other marker, the name is the only
+        // signal. Do NOT emit it.
+        const err = evt.properties?.error;
+        const name = typeof err?.name === "string" ? err.name : null;
+        if (name === "MessageAbortedError") return;
+        st.running = false;
+        const message =
+          typeof err?.data?.message === "string" ? err.data.message :
+          typeof err?.message === "string" ? err.message : "The turn failed.";
+        emit(sid, "sessionError", { name, message });
+        emit(sid, "turnComplete", { complete: true, running: false });
+        return;
+      }
       case "session.next.step.ended": {
         // truncation classification + context arithmetic
         const props = evt.properties ?? {};

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -263,6 +263,37 @@ test("session.idle emits turnComplete true", () => {
   assert.equal(ev.payload.complete, true);
 });
 
+test("session.error emits sessionError with name+message AND turnComplete running false", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.error",
+    properties: {
+      sessionID: SID,
+      error: { name: "ProviderAuthError", data: { message: "Bad key" } },
+    },
+  });
+  const err = events.find((e) => e.sub === "sessionError");
+  assert.ok(err, "a sessionError frame was emitted");
+  assert.equal(err.payload.name, "ProviderAuthError");
+  assert.equal(err.payload.message, "Bad key");
+  const done = events.find((e) => e.sub === "turnComplete");
+  assert.ok(done, "a turnComplete frame was emitted so the spinner stops");
+  assert.equal(done.payload.complete, true);
+  assert.equal(done.payload.running, false);
+});
+
+test("session.error with a MessageAbortedError name emits NOTHING", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.error",
+    properties: {
+      sessionID: SID,
+      error: { name: "MessageAbortedError", message: "aborted" },
+    },
+  });
+  assert.equal(events.length, 0, "an abort is not a failure — no frames emitted");
+});
+
 test("session.status retry reports running true (parity with pre-S1b renderer)", () => {
   const { interp, events } = make();
   interp.interpret({


### PR DESCRIPTION
Opened automatically for `multica/BET-711-ios-p0-fixes`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-711.