### PR TITLE
fix(chat): welcome sits at the transcript bottom; drop empty markdown table headers

### DIFF
--- a/src/renderer/MarkdownBody.test.tsx
+++ b/src/renderer/MarkdownBody.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+//
+// Component tests for MarkdownBody's table rendering.
+//
+// GFM's grammar makes a header row MANDATORY: the `|---|---|` delimiter line is
+// what promotes the block to a table at all. So the natural markdown for "a
+// grid of labelled rows with no column titles" — a blank first row — does not
+// yield a header-less table, it yields a table with an EMPTY header, which
+// rendered as a blank bordered strip above the data. These pin the drop rule
+// and, just as importantly, that a real header still renders.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { MarkdownBody } from "./MarkdownBody";
+
+describe("MarkdownBody tables", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("drops the header when every header cell is blank", () => {
+    h = mount(
+      <MarkdownBody
+        text={["|  |  |", "|---|---|", "| In progress | BET-708 |", "| Queue | BET-700 |"].join("\n")}
+      />,
+    );
+    expect(h.container.querySelector("table")).not.toBeNull();
+    expect(h.container.querySelector("thead")).toBeNull();
+    // The data rows survive — this drops the empty header, not the table.
+    expect(h.container.querySelectorAll("tbody tr")).toHaveLength(2);
+    expect(h.container.textContent).toContain("BET-708");
+  });
+
+  it("keeps a real header", () => {
+    h = mount(
+      <MarkdownBody text={["| Lane | Work |", "|---|---|", "| Queue | BET-700 |"].join("\n")} />,
+    );
+    expect(h.container.querySelector("thead")).not.toBeNull();
+    expect(h.container.querySelector("thead")?.textContent).toContain("Lane");
+  });
+
+  it("keeps a partially-filled header — one labelled column is still a header", () => {
+    h = mount(
+      <MarkdownBody text={["| Lane |  |", "|---|---|", "| Queue | BET-700 |"].join("\n")} />,
+    );
+    expect(h.container.querySelector("thead")).not.toBeNull();
+  });
+});

--- a/src/renderer/MarkdownBody.tsx
+++ b/src/renderer/MarkdownBody.tsx
@@ -168,6 +168,17 @@ const MD_COMPONENTS: MarkdownComponents = {
       <table className="text-prose border-collapse">{children}</table>
     </div>
   ),
+  // A GFM table is REQUIRED to have a header row — the `|---|---|` delimiter
+  // line is what makes the block a table at all — so the common "just give me a
+  // grid of labelled rows" markdown (`|  |  |` on the first line) does not
+  // produce a header-less table. It produces a table whose header cells are
+  // blank, and remark faithfully emits a <thead> of empty <th>s. Rendered, that
+  // is a blank bordered strip sitting above the data, which reads as a
+  // rendering bug rather than as a deliberately unlabelled table. When EVERY
+  // header cell is empty, drop the <thead> entirely; a partially-filled header
+  // is a real header and is left alone.
+  thead: ({ children }) =>
+    childrenToString(children).trim() === "" ? null : <thead>{children}</thead>,
   th: ({ children }) => (
     <th
       className="px-3 py-1 text-left text-text font-medium bg-bg-soft"

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -417,16 +417,25 @@ export function Transcript({
             transition={{ type: "tween", duration: 0.15 }}
           >
             {/* Empty state: full width, matching the populated flow below so
-                both states share a left edge (BET-646). */}
+                both states share a left edge (BET-646).
+
+                It sits at the BOTTOM of the empty transcript, right above the
+                composer — the transcript grows upward from the composer, so the
+                first line of a conversation must start where every later line
+                will be, not stranded at the top of an empty panel. `mt-auto` in
+                a flex column is what does it: unlike `justify-end` it survives
+                on a scroll container (a taller-than-viewport child stays
+                reachable) and, unlike `min-height:100%`, it needs no percentage
+                to resolve against the flex-sized parent. */}
             <div
-              className="flex-1 overflow-y-auto overflow-x-hidden"
+              className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col"
               style={{
                 padding: "var(--sp-6) 0",
                 marginBottom: "var(--sp-2)",
                 paddingInline: "var(--transcript-inset)",
               }}
             >
-              <div className="text-text-faint">
+              <div className="mt-auto text-text-faint">
                 <span style={{ color: "var(--accent)" }}>✻</span>{" "}
                 Welcome. Type a message below to start.
               </div>


### PR DESCRIPTION
Two small, independent transcript rendering fixes reported from the desktop app.

## 1. The empty-transcript "Welcome" line rendered at the top

The transcript grows upward from the composer, so the first line of a
conversation belongs where every later line will be — at the bottom, right above
the input. It was rendering at the top of an empty panel instead.

BET-680 split the empty state out of the (now virtualized) populated list into
its own plain-block branch, and it lost the bottom anchoring the shared
container used to have.

Re-anchored with `mt-auto` in a flex column rather than the old `justify-end` +
`min-height:100%`: `mt-auto` keeps a taller-than-viewport child reachable on a
scroll container, and needs no percentage to resolve against the flex-sized
parent.

Verified by rendering the built app and measuring — the line now sits directly
above the composer.

## 2. A markdown table with a blank header row rendered an empty bordered strip

GFM requires a header row — the `|---|---|` delimiter line is what makes the
block a table at all — so the natural markdown for an unlabelled grid does not
produce a header-less table. It produces a table whose header cells are blank,
and remark faithfully emits a `<thead>` of empty `<th>`s. Rendered, that is a
blank bordered strip above the data, which reads as a rendering bug.

The `<thead>` is now dropped when *every* header cell is blank. A
partially-filled header is a real header and is left alone.

## Tests

Three new cases in `src/renderer/MarkdownBody.test.tsx` (drop / keep /
partially-filled). `npm run typecheck` and the full suite pass.