### PR TITLE
fix(renderer): replace broken modal find with in-pane find bar (BET-710)

### DIFF
--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -87,12 +87,24 @@ export function Terminal({ sessionKey, cwd, active, launcher, tmuxTarget }: Prop
   // hide the overlay when the cursor truly leaves the terminal area.
   const dragDepth = useRef(0);
 
+  // BET-710: in-pane find bar. SearchAddon machinery already runs in the
+  // xterm effect; this just swaps the broken modal input for an in-pane
+  // overlay driving the same addon through searchRef.
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const findInputRef = useRef<HTMLInputElement | null>(null);
+
   // BET-409: the terminal pane stays dark in BOTH themes (no light xterm
   // theme). In light mode the pane is a fixed #0B1020 so a dark inset surface
   // reads deliberately inside a light window; in dark it uses --inset. The
   // surrounding chrome (sidebar/header/composer) follows the theme normally.
   // The hook re-themes the pane live when the app theme flips.
   const resolvedTheme = useResolvedTheme();
+
+  // Focus the find input when the bar opens.
+  useEffect(() => {
+    if (findOpen) findInputRef.current?.focus();
+  }, [findOpen]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -299,8 +311,7 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
           });
           return false;
         case "find": {
-          const q = window.prompt("Find:");
-          if (q) search.findNext(q);
+          setFindOpen(true);
           return false;
         }
         case "clear":
@@ -430,6 +441,13 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
     }
   };
 
+  const closeFind = () => {
+    setFindOpen(false);
+    setFindQuery("");
+    searchRef.current?.clearDecorations();
+    termRef.current?.focus();
+  };
+
   return (
     <div
       className="relative h-full w-full"
@@ -454,6 +472,38 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
       {(dragOver || uploading) && (
         <div className="absolute inset-2 z-10 flex items-center justify-center rounded-sm border-2 border-dashed border-accent bg-bg/70 text-text text-sm pointer-events-none">
           {uploading ? "Uploading…" : "Drop to share with Claude"}
+        </div>
+      )}
+      {findOpen && (
+        <div className="absolute top-2 right-2 z-20 flex items-center gap-1 rounded-sm border border-border bg-bg px-2 py-1 shadow-md">
+          <input
+            ref={findInputRef}
+            value={findQuery}
+            onChange={(e) => {
+              setFindQuery(e.target.value);
+              if (e.target.value) searchRef.current?.findNext(e.target.value, { incremental: true });
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && e.shiftKey) {
+                e.preventDefault();
+                if (findQuery) searchRef.current?.findPrevious(findQuery);
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                if (findQuery) searchRef.current?.findNext(findQuery);
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                closeFind();
+              }
+            }}
+            placeholder="Find…"
+            className="w-40 bg-transparent text-sm text-text outline-none placeholder:text-text-faint"
+          />
+          <button className="px-1 text-text-muted hover:text-text" title="Previous (Shift+Enter)"
+            onClick={() => findQuery && searchRef.current?.findPrevious(findQuery)}>‹</button>
+          <button className="px-1 text-text-muted hover:text-text" title="Next (Enter)"
+            onClick={() => findQuery && searchRef.current?.findNext(findQuery)}>›</button>
+          <button className="px-1 text-text-muted hover:text-text" title="Close (Esc)"
+            onClick={closeFind}>×</button>
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes BET-710: terminal find (⌘F / Ctrl+Shift+F) threw on `window.prompt` in Electron's xterm key handler — the feature never worked.

**Change:** `Terminal.tsx` only (1 file). Replaces the throwing modal input with an absolutely-positioned in-pane find bar that drives the already-wired `SearchAddon` (`searchRef`). Incremental find on typing, Enter / Shift+Enter cycle next/prev, Esc closes and refocuses the terminal, prev/next/close buttons. No container structure change, no chatUtils / PaletteShell / ChatPanel changes, no new deps, no new files.

**Self-check:**
- `case "find"` opens the bar, returns false → 10/10
- focus effect on open → 10/10
- bar rendered as last child of the root relative div (after the drag overlay) with the specified JSX → 10/10
- `closeFind` clears query + `clearDecorations()` (verified present in `@xterm/addon-search` 0.15.0) + refocuses → 10/10
- no `window.prompt(` call left in `src/renderer/` → 9/10 (weakness: a pre-existing prose mention remains in a `chatUtils.ts` comment, which the issue's "Terminal.tsx only" constraint forbids touching)
- constraints respected (Terminal.tsx only, no deps, no new files) → 10/10
- typecheck + `npm test` green → 10/10

**Files changed:** `1` file. `src/renderer/Terminal.tsx`

**Verification results:**
- PR branch (`multica/BET-710-terminal-in-pane-find` @ `61fee7f7`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, `1551` pass / `0` fail / `0` skip. Failures: none. log sha256: `72f2f783e690238b4eb8ca8eefde050ce20bb0f911f89fa0f297a9fc117fe71e`
- Base (`main` @ `2f176c90`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, `1551` pass / `0` fail / `0` skip. Failures: none. log sha256: `68d3f363e319019745ea631e55de290e2bc1c6cd0163b086c78f40db1c8cbfec`
- **Conclusion:** `0` test failures are pre-existing, `0` failures are new/caused by this PR. typecheck + test identical between branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `2f176c90`**
