### PR TITLE
feat(pairing): universal-link QR + 2-field tailnet manual pairing (BET-703)

### DIFF
--- a/src/renderer/AddPhonePanel.tsx
+++ b/src/renderer/AddPhonePanel.tsx
@@ -7,10 +7,10 @@
 // helpers in ./pairPanel.ts (repo pattern: chatUtils.ts). This component only
 // mints via the existing `auth:pair` RPC channel and renders.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AuthPairResult } from "../shared/types";
 import { PairingQR, PairingCountdown } from "./PairingQR";
-import { shouldRefreshPairCode } from "./pairPanel";
+import { resolveQrServerOverride, shouldRefreshPairCode } from "./pairPanel";
 
 // 1s tick drives the live countdown + re-evaluates expiry so the code
 // auto-rotates the moment it elapses while the panel stays open (§6.4). The
@@ -59,6 +59,24 @@ export function AddPhonePanel() {
     }
   }, [tick, pairing, mint]);
 
+  // BET-703 (tailnet box): when this desktop's configured server URL differs
+  // from the box's derived public hostname AND is a private/tailnet address,
+  // the scanned QR must carry `server=` so the phone claims against the real
+  // listener instead of a non-existent public host. Computed here (where the
+  // mint result feeds the QR) via the pure `resolveQrServerOverride` helper;
+  // the configured URL is read via the existing `manta_server` localStorage
+  // key — same accessor the transport layer and store overlay use.
+  const qrServerUrl = useMemo(() => {
+    if (!pairing?.ok) return undefined;
+    let configured: string | undefined;
+    try {
+      configured = localStorage.getItem("manta_server") ?? undefined;
+    } catch {
+      configured = undefined; // localStorage unavailable — omit override
+    }
+    return resolveQrServerOverride(pairing.boxId, configured);
+  }, [pairing]);
+
   return (
     <div className="space-y-4">
       <div className="text-body text-text-faint">
@@ -77,12 +95,17 @@ export function AddPhonePanel() {
               <PairingQR
                 boxId={pairing.boxId}
                 pairingCode={pairing.pairingCode}
+                serverUrl={qrServerUrl}
               />
             </div>
             <div className="flex-1 space-y-2">
               <div className="text-body">
                 <span className="text-text-muted">Code:</span>{" "}
                 <span className="font-mono text-text">{pairing.pairingCode}</span>
+              </div>
+              <div className="text-body">
+                <span className="text-text-muted">Box ID:</span>{" "}
+                <span className="font-mono text-text break-all">{pairing.boxId}</span>
               </div>
               <PairingCountdown expiry={new Date(pairing.expiresAt)} />
             </div>
@@ -100,8 +123,9 @@ export function AddPhonePanel() {
       )}
 
       <div className="text-body text-text-faint">
-        Prefer to type it? Enter the {pairing?.ok ? "six digits above" : "six-digit code"} on
-        your phone instead of scanning.
+        {pairing?.ok
+          ? "Prefer to type it? Enter the six digits and the box ID above on your phone instead of scanning."
+          : "Prefer to type it? Enter the six-digit code on your phone instead of scanning."}
       </div>
     </div>
   );

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -231,7 +231,10 @@ function ManualPairForm({
             htmlFor="pair-box-id"
             className="text-label font-medium text-text-muted"
           >
-            Box ID
+            Box ID{" "}
+            <span className="font-normal text-text-faint">
+              (optional if Host set)
+            </span>
           </label>
           <input
             id="pair-box-id"

--- a/src/renderer/PairingQR.tsx
+++ b/src/renderer/PairingQR.tsx
@@ -1,38 +1,31 @@
 // PairingQR — renders a QR code image for mobile device pairing.
 //
-// The QR encodes the CANONICAL box-form `<scheme>://pair?box=<boxId>&code=<6-digit>`
-// payload produced by the SHARED `buildPairPayload` helper
-// (src/shared/pairPayload.ts). BET-237 removed the deprecated
-// serverUrl / id forms — `parsePairPayload` rejects anything other than
-// `box=<boxId>&code=<6-digit>`. The canonical form is the SAME shape `manta
-// pair` prints + the install heredoc + the deep-link handler in
-// MobileApp.tsx parses.
+// The QR encodes the UNIVERSAL-LINK https form produced by the SHARED
+// `buildUniversalPairLink` helper (src/shared/pairPayload.ts):
+//   https://app.mantaui.com/m?box=<boxId>&code=<code>[&server=<url>]
+// A camera scan of a universal link opens a URL even when the app is NOT yet
+// installed (the OS resolves it and hands off to the App Store / app once the
+// associated domains resolve) — scanning a custom `manta://` scheme did
+// nothing without the app (BET-703). `buildUniversalPairLink` shares the
+// single `UNIVERSAL_LINK_HOST` with the iOS parser, and is deliberately NOT
+// parameterized by channel (universal links have one registered host).
+//
+// The optional `serverUrl` prop (BET-703) lets a tailnet / macOS box (no
+// public hostname) ship a QR that carries its private listener — see
+// `resolveQrServerOverride` in pairPanel.ts, which the AddPhonePanel feeds.
+// The caller passes the desktop's configured server URL in; when it equals
+// the box's derived public hostname, `serverUrl` is omitted (today's
+// behavior).
 //
 // We use the `qrcode` npm package to generate a data URL, then render it as
 // an <img> tag. The data URL is memoized so we don't regenerate on every
 // render (QR generation is CPU-bound).
 //
-// This is a desktop-only feature (BET-80). The mobile app consumes the same
-// URL scheme but generates the QR on the desktop side.
-//
-// BET-373 (channel-aware wire format): the QR uses THIS channel's URL scheme
-// (`channelConfig(__MANTA_CHANNEL__).urlScheme`, the same source the main
-// process uses to register `setAsDefaultProtocolClient(...)` and to build
-// `PAIR_PREFIX`). A staging desktop scans a QR with `manta-staging://…` so
-// the OS routes the open back to staging, not to whichever channel got
-// registered last for `manta://`. `__MANTA_CHANNEL__` is baked into the
-// renderer at build time (electron.vite.config.ts renderer `define`).
+// This is a desktop-only feature (BET-80). The mobile app generates the QR on
+// the desktop side but consumes the same URL scheme.
 
 import { useEffect, useMemo, useState } from "react";
-import { buildPairPayload } from "../shared/pairPayload";
-import { channelConfig } from "../shared/channel.mjs";
-
-// Channel-aware scheme for the QR prefix. The baked `__MANTA_CHANNEL__`
-// comes from the renderer `define` (electron.vite.config.ts); channelConfig
-// does the same unknown-id → prod fallback the main process relies on, so a
-// stale/garbage baked value still produces a usable scheme rather than
-// throwing at render time.
-const PAIR_SCHEME = channelConfig(__MANTA_CHANNEL__).urlScheme;
+import { buildUniversalPairLink } from "../shared/pairPayload";
 
 // Lazy-load qrcode so the renderer doesn't pay the bundle cost if this
 // component is never rendered (Settings is a modal, only open on demand).
@@ -44,20 +37,21 @@ async function loadQrCode() {
 export function PairingQR({
   boxId,
   pairingCode,
+  serverUrl,
 }: {
   boxId: string;
   pairingCode: string;
+  serverUrl?: string;
 }) {
   const [dataUrl, setDataUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const url = useMemo(() => {
-    // Canonical box-form payload — shared with the install heredoc, `manta pair`
-    // output, and the mobile deep-link parser. Single source: pairPayload.ts.
-    // BET-373: `PAIR_SCHEME` keys the QR to this channel's OS-registered URL
-    // scheme so the OS routes the open back to the channel that scanned it.
-    return buildPairPayload({ boxId, code: pairingCode }, PAIR_SCHEME);
-  }, [boxId, pairingCode]);
+    // Universal-link https form — the QR is what gets scanned by a camera, so
+    // it must open a URL whether or not the app is installed. Single source:
+    // pairPayload.ts. No channel scheme: universal links have one host.
+    return buildUniversalPairLink({ boxId, code: pairingCode, serverUrl });
+  }, [boxId, pairingCode, serverUrl]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/renderer/pairPanel.test.ts
+++ b/src/renderer/pairPanel.test.ts
@@ -4,7 +4,43 @@ import {
   shouldRefreshPairCode,
   msUntilRefresh,
   isValidManualPairCode,
+  resolveQrServerOverride,
 } from "./pairPanel";
+import { boxDirectUrl } from "../shared/transport.mjs";
+
+const BOX = "7f3a9c1e0b8d4a62f1c9e5b7d0a4f8c2"; // 32 hex
+
+describe("resolveQrServerOverride (BET-703)", () => {
+  it("omits the override when the configured URL equals the box's public hostname", () => {
+    expect(resolveQrServerOverride(BOX, boxDirectUrl(BOX))).toBeUndefined();
+  });
+
+  it("omits the override when no configured URL is present", () => {
+    expect(resolveQrServerOverride(BOX, undefined)).toBeUndefined();
+    expect(resolveQrServerOverride(BOX, null)).toBeUndefined();
+    expect(resolveQrServerOverride(BOX, "")).toBeUndefined();
+  });
+
+  it("carries a private/tailnet URL that differs from the public hostname", () => {
+    expect(resolveQrServerOverride(BOX, "http://100.64.1.5:8787")).toBe(
+      "http://100.64.1.5:8787",
+    );
+    expect(resolveQrServerOverride(BOX, "https://mybox.ts.net")).toBe(
+      "https://mybox.ts.net",
+    );
+  });
+
+  it("omits a custom PUBLIC domain that differs from the public hostname", () => {
+    // The iOS parser refuses non-private server= by design (crafted-link
+    // guard) — the QR must not include a public override it would reject.
+    expect(resolveQrServerOverride(BOX, "https://box.example.com")).toBeUndefined();
+  });
+
+  it("omits a malformed configured URL", () => {
+    expect(resolveQrServerOverride(BOX, "100.64.1.5:8787")).toBeUndefined();
+    expect(resolveQrServerOverride(BOX, "ftp://100.x.y.z")).toBeUndefined();
+  });
+});
 
 describe("isPairCodeExpired", () => {
   it("is alive before expiry", () => {

--- a/src/renderer/pairPanel.ts
+++ b/src/renderer/pairPanel.ts
@@ -6,6 +6,9 @@
 // edge cases are unit-tested (repo pattern: chatUtils.ts → chatUtils.test.ts)
 // without DOM or timers. The React component (AddPhonePanel) calls these.
 
+import { boxDirectUrl, isPrivateServerUrl } from "../shared/transport.mjs";
+import { normalizeServerUrl } from "../shared/setupLogic";
+
 // Is the code expired at `now`? Expiry is inclusive: at/after expiresAt it's
 // dead (a joiner claiming it would get 403).
 export function isPairCodeExpired(expiresAt: number, now: number): boolean {
@@ -37,4 +40,31 @@ export function msUntilRefresh(
 // phone types them. Validate the exact 6-digit code shape.
 export function isValidManualPairCode(code: string): boolean {
   return typeof code === "string" && /^\d{6}$/.test(code);
+}
+
+/**
+ * Decide whether the "Add a phone" QR should carry a `server=` override
+ * (BET-703). On a tailnet / macOS box (no public `boxes.mantaui.com`
+ * hostname), a scanned QR that omits `server=` sends the phone to a
+ * non-existent public host → "Can't reach your box" with no hint. So when
+ * the desktop's configured server URL differs from the box's derived public
+ * hostname, we include it as `serverUrl` — but ONLY when that URL is a
+ * private/tailnet address (`isPrivateServerUrl`): a custom PUBLIC domain
+ * must stay out because the iOS parser refuses non-private `server=` by
+ * design (the crafted-link guard). Returns `undefined` when no override
+ * should be attached: configured URL missing, identical to the public
+ * hostname, or a non-private custom domain.
+ *
+ * Pure — the caller (AddPhonePanel) feeds the desktop's configured server
+ * URL read from `localStorage["manta_server"]`.
+ */
+export function resolveQrServerOverride(
+  boxId: string,
+  configuredServerUrl: string | undefined | null,
+): string | undefined {
+  const direct = boxDirectUrl(boxId.trim());
+  const configured = normalizeServerUrl(configuredServerUrl);
+  if (configured === null || configured === direct) return undefined;
+  if (!isPrivateServerUrl(configured)) return undefined;
+  return configured;
 }

--- a/src/shared/pairPayload.test.ts
+++ b/src/shared/pairPayload.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   parsePairPayload,
   buildPairPayload,
+  buildUniversalPairLink,
+  UNIVERSAL_LINK_HOST,
   type PairPayload,
 } from "./pairPayload";
 import { CHANNELS, CHANNEL_IDS } from "./channel.mjs";
@@ -400,6 +402,58 @@ describe("buildPairPayload", () => {
         );
       });
     }
+  });
+});
+
+describe("buildUniversalPairLink", () => {
+  it("produces the universal-link https form (BET-703)", () => {
+    expect(buildUniversalPairLink({ boxId: BOX, code: "847291" })).toBe(
+      `https://${UNIVERSAL_LINK_HOST}/m?box=${encodeURIComponent(BOX)}&code=847291`,
+    );
+  });
+
+  it("URL-encodes the box value", () => {
+    expect(buildUniversalPairLink({ boxId: BOX, code: "000000" })).toContain(
+      encodeURIComponent(BOX),
+    );
+  });
+
+  it("appends &server=<url-encoded serverUrl> when present (BET-703)", () => {
+    expect(
+      buildUniversalPairLink({
+        boxId: BOX,
+        code: "847291",
+        serverUrl: "http://100.64.1.5:8787",
+      }),
+    ).toBe(
+      `https://${UNIVERSAL_LINK_HOST}/m?box=${encodeURIComponent(BOX)}&code=847291&server=${encodeURIComponent("http://100.64.1.5:8787")}`,
+    );
+  });
+
+  it("omits the server param when serverUrl is absent or empty", () => {
+    const without = buildUniversalPairLink({ boxId: BOX, code: "847291" });
+    expect(without).not.toContain("server=");
+    const empty = buildUniversalPairLink({ boxId: BOX, code: "847291", serverUrl: "" });
+    expect(empty).not.toContain("server=");
+  });
+
+  it("round-trips through parsePairPayload (universal form is a pairing payload)", () => {
+    expect(
+      parsePairPayload(buildUniversalPairLink({ boxId: BOX, code: "847291" })),
+    ).toEqual({ boxId: BOX, code: "847291" });
+    expect(
+      parsePairPayload(
+        buildUniversalPairLink({
+          boxId: BOX,
+          code: "847291",
+          serverUrl: "http://192.168.1.10:8787",
+        }),
+      ),
+    ).toEqual({
+      boxId: BOX,
+      code: "847291",
+      serverUrl: "http://192.168.1.10:8787",
+    });
   });
 });
 

--- a/src/shared/pairPayload.ts
+++ b/src/shared/pairPayload.ts
@@ -212,3 +212,36 @@ export function buildPairPayload(p: PairPayload, scheme: string = "manta"): stri
   }
   return base;
 }
+
+/**
+ * The accepted host for the Manta universal (https) pairing link. Universal
+ * links have ONE registered host — there is deliberately no per-channel
+ * variant (BET-703). Reused here so `buildUniversalPairLink` and the Swift
+ * parser share the literal even though they live in different repos.
+ */
+export const UNIVERSAL_LINK_HOST = "app.mantaui.com";
+
+/**
+ * Build the deferred-deeplink https form of a pairing payload:
+ *   https://<UNIVERSAL_LINK_HOST>/m?box=<url-encoded box_id>&code=<code>[&server=<url-encoded serverUrl>]
+ *
+ * This is what a camera scan of a QR opens when the Manta app is NOT yet
+ * installed — the OS resolves the universal link and hands off to the App
+ * Store / app (BET-703). The path is `/m` (the Swift parser accepts both
+ * `/m` and `/m/`), and the host is the single `UNIVERSAL_LINK_HOST` — never
+ * parameterized by channel, unlike the custom-scheme `buildPairPayload`.
+ *
+ * BET-336: when the payload carries a `serverUrl` (Tailscale / tailnet
+ * path, a box with no public hostname), a `server=<url-encoded serverUrl>`
+ * query param is appended so the receiving device claims against the
+ * private/tailnet listener instead of the derived public hostname. As with
+ * `buildPairPayload`, callers only feed server URLs that already passed
+ * `isPrivateServerUrl`, so we do NOT re-validate here (thin encoder).
+ */
+export function buildUniversalPairLink(p: PairPayload): string {
+  let base = `https://${UNIVERSAL_LINK_HOST}/m?box=${encodeURIComponent(p.boxId)}&code=${p.code}`;
+  if (p.serverUrl) {
+    base += `&server=${encodeURIComponent(p.serverUrl)}`;
+  }
+  return base;
+}

--- a/src/shared/setupLogic.test.ts
+++ b/src/shared/setupLogic.test.ts
@@ -85,6 +85,53 @@ describe("canConnectSetup", () => {
       }),
     ).toBe(false);
   });
+
+  // BET-703 (2-field tailnet manual pairing): a valid serverUrl + 6-digit
+  // code is sufficient on its own — the Box ID becomes OPTIONAL because the
+  // claim can run against the explicit URL and backfill box_id from the
+  // response.
+  it("enables Connect with a valid serverUrl + code and NO box id (BET-703)", () => {
+    expect(
+      canConnectSetup({ ...base, boxId: "", code: "123456", serverUrl: TAILNET }),
+    ).toBe(true);
+  });
+
+  it("trims a whitespace-only box id out — still connectable with a serverUrl (BET-703)", () => {
+    expect(
+      canConnectSetup({
+        ...base,
+        boxId: "   ",
+        code: "123456",
+        serverUrl: TAILNET,
+      }),
+    ).toBe(true);
+  });
+
+  it("still requires a box id when no serverUrl is present (BET-703)", () => {
+    expect(canConnectSetup({ ...base, boxId: "", code: "123456" })).toBe(false);
+    expect(
+      canConnectSetup({ ...base, boxId: " ", code: "123456", serverUrl: "" }),
+    ).toBe(false);
+  });
+
+  it("still blocks when an empty box id meets an INVALID serverUrl (BET-703)", () => {
+    expect(
+      canConnectSetup({
+        ...base,
+        boxId: "",
+        code: "123456",
+        serverUrl: "100.64.1.5:8787",
+      }),
+    ).toBe(false);
+    expect(
+      canConnectSetup({
+        ...base,
+        boxId: BAD_BOX,
+        code: "123456",
+        serverUrl: "ftp://nope",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("buildSetupClaimInput", () => {

--- a/src/shared/setupLogic.ts
+++ b/src/shared/setupLogic.ts
@@ -41,18 +41,21 @@ export function normalizeServerUrl(raw: string | undefined | null): string | nul
  *
  * - Never while a request is in flight.
  * - Always requires a submittable (6-digit) code.
- * - Always requires a valid 32-hex Box ID — the box's public hostname
- *   (`https://<boxId>.boxes.mantaui.com`, see `boxDirectUrl`) is derived from
- *   it; the box is reached directly via this hostname.
- * - When the user has typed a non-empty `serverUrl` (Advanced), it must be a
- *   valid `http(s)://` URL — otherwise the inline error renders and submit is
- *   blocked. An absent/empty `serverUrl` is the default path (no override).
+ * - When the user has typed a non-empty `serverUrl` (Advanced / Host), it
+ *   must be a valid `http(s)://` URL, AND it is sufficient on its own — the
+ *   Box ID becomes OPTIONAL because the claim can run against that explicit
+ *   URL and backfill `box_id` from the claim response (BET-703). A malformed
+ *   `serverUrl` still blocks submit (the inline error renders).
+ * - When NO `serverUrl` is present (the default direct-hostname path), a
+ *   valid 32-hex Box ID is still required — the box's public hostname
+ *   (`https://<boxId>.boxes.mantaui.com`, see `boxDirectUrl`) is derived
+ *   from it and the box is reached directly via that hostname.
  */
 export function canConnectSetup(input: SetupFields): boolean {
   if (input.submitting) return false;
   if (!isSubmittableCode(input.code)) return false;
   if (input.serverUrl !== undefined && input.serverUrl.trim() !== "") {
-    if (normalizeServerUrl(input.serverUrl) === null) return false;
+    return normalizeServerUrl(input.serverUrl) !== null;
   }
   return isValidBoxToken(input.boxId.trim());
 }


### PR DESCRIPTION
## BET-703 — Desktop pairing: universal-link QR + 2-field tailnet manual pairing

**Base: origin/main @ `b054b09`**

### What changed

1. **QR now encodes the universal link, not the custom scheme.** `PairingQR.tsx` switched from `buildPairPayload`/`PAIR_SCHEME`/channel to `buildUniversalPairLink` (`src/shared/pairPayload.ts`), so a camera scan opens `https://app.mantaui.com/m?box=…&code=…` — a URL the OS resolves even without the app installed (hands off to App Store / app once associated domains resolve). Added `UNIVERSAL_LINK_HOST` const (single source; the accepted `app.mantaui.com` host had previously lived only in the Swift parser). Not parameterized by channel — universal links have one registered host. The desktop's own `manta://` deep-link prefill path (App.tsx) is untouched.

2. **QR carries `server=` on a non-public box.** New pure helper `resolveQrServerOverride` (`src/renderer/pairPanel.ts`) + wiring in `AddPhonePanel.tsx`: it reads the desktop's configured `localStorage["manta_server"]` (existing accessor), and when that differs from `boxDirectUrl(boxId)` AND is a private/tailnet URL (`isPrivateServerUrl`), passes it as `serverUrl` into the QR payload. Identical-to-public → omitted; non-private custom domain → omitted (iOS parser refuses non-private `server=` by design — not weakened).

3. **Tailnet manual pairing: 4 fields → 2.** `canConnectSetup` (`src/shared/setupLogic.ts`) relaxed: a valid `serverUrl` + 6-digit code is now sufficient, Box ID optional. No `serverUrl` → Box ID still required. Invalid `serverUrl` still blocks. `claimBox` (`pairClaim.ts`) already persists the claim **response** `box_id` (`applyPairing({ boxId: result.boxId })`) — verified `src/main/auth.ts` returns it; no second persistence path added. `PairStep.tsx` Box ID label now reads "(optional if Host set)".

4. **AddPhonePanel copy.** Added a copyable `font-mono` Box ID line (same styling as the code line) and reworded the hint to "Enter the six digits and the box ID above on your phone instead of scanning."

Uses only existing helpers (`boxDirectUrl`, `isPrivateServerUrl`, `normalizeServerUrl`) — no new URL logic. Files touched: `pairPayload.ts`, `PairingQR.tsx`, `AddPhonePanel.tsx`, `setupLogic.ts`, `PairStep.tsx`, `pairPanel.ts` + their tests.

### Verification results
- PR (`multica/BET-703-universal-qr` @ `0917f0c`):
  - typecheck: exit 0, errors none. log sha256 `75342603966d…`
  - vitest: 2255 passed / 7 skipped / 0 failed. node --test: 1553 pass / 0 fail. log sha256 `dff4ebaaf121…`
- Base (`main` @ `b054b09`):
  - typecheck: exit 0, errors none. log sha256 `75342603966d…`
  - vitest: 2241 passed / 7 skipped / 0 failed. node --test: 1553 pass / 0 fail. log sha256 `eaa42f03…`
- **Conclusion:** 14 new passing tests, 0 new failures (PR vitest 2255 = main 2241 + 14). No pre-existing failures affected.
