### PR TITLE
BET-712: Transcript tail — container owns the vertical gaps

### DIFF
--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -48,7 +48,7 @@ import {
 // render, while still letting them read the live tail state (todos, question
 // cards, the working indicator) and the load-earlier state.
 
-type TranscriptContext = {
+export type TranscriptContext = {
   running: boolean;
   liveTurn: LiveTurn | null;
   showLoadEarlier: boolean;
@@ -190,16 +190,7 @@ export function WorkingIndicator({
   useClockTick(WORKING_TICK_MS);
   return (
     <CardMount show={running} k="working">
-      <div
-        className="manta-working-indicator flex items-center gap-2 shrink-0"
-        style={{
-          // Virtuoso renders Footer OUTSIDE List, so the List's flex `gap`
-          // never applies between the last row and this one — this margin IS
-          // that gap. It sits INSIDE CardMount so the gap collapses along with
-          // the row.
-          marginTop: "var(--block-gap)",
-        }}
-      >
+      <div className="manta-working-indicator flex items-center gap-2 shrink-0">
         <MantaLoader />
         <span className="text-text-faint text-xs">
           {liveTurn ? (
@@ -231,18 +222,40 @@ export function WorkingIndicator({
 // in a shrink-0 row above the input (see the comment history in the old
 // Transcript for the design decision — anchoring them at the tail keeps them at
 // the bottom of the transcript in every state).
-function TranscriptTail({ context }: { context: TranscriptContext }) {
+export function TranscriptTail({ context }: { context: TranscriptContext }) {
   return (
     // Inset + bottom breathing room: Virtuoso renders Footer OUTSIDE the List,
     // so it needs its own copy of the reading inset (see TRANSCRIPT_INSET) and
     // the trailing gap the scroller's now-removed padding used to imply.
-    <div style={{ ...TRANSCRIPT_INSET, paddingBottom: "var(--sp-6)" }}>
+    <div
+      style={{
+        ...TRANSCRIPT_INSET,
+        // The tail is a stacked column and owns the spacing between its own
+        // children — the working row, the todo checklist and the question
+        // cards — exactly like TranscriptList owns --turn-gap between message
+        // rows. Do NOT push this back onto a child as a margin: a child-owned
+        // gap disappears with that child (the working row unmounts when the
+        // turn ends, and its margin used to take the whole tail's spacing with
+        // it) and only ever spaces one side.
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--block-gap)",
+        // `gap` only applies BETWEEN children, so the gap to the last message
+        // row above is padding on the container. It is needed because Virtuoso
+        // renders Footer OUTSIDE List, so the List's flex gap never crosses
+        // into here. Unconditional on purpose — one code path, no "does the
+        // tail have content" branch that would have to fight CardMount's
+        // 220ms exit animation.
+        paddingTop: "var(--block-gap)",
+        paddingBottom: "var(--sp-6)",
+      }}
+    >
       <WorkingIndicator running={context.running} liveTurn={context.liveTurn} />
       {context.activeTodos && context.activeTodos.length > 0 && (
         <ActiveTodos todos={context.activeTodos} onDismiss={context.onDismissTodos} />
       )}
       {context.questions.length > 0 && (
-        <div className="space-y-2 pt-1">
+        <div className="flex flex-col" style={{ gap: "var(--block-gap)" }}>
           {context.questions.map((q) => (
             // A malformed question payload must not kill the app — each card
             // gets its own boundary so a bad card degrades to an inline error

--- a/src/renderer/TranscriptTail.test.tsx
+++ b/src/renderer/TranscriptTail.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { TranscriptTail, type TranscriptContext } from "./Transcript";
+
+const ctx = (over: Partial<TranscriptContext> = {}): TranscriptContext => ({
+  running: false,
+  liveTurn: null,
+  showLoadEarlier: false,
+  loadingEarlier: false,
+  onLoadEarlier: () => {},
+  activeTodos: null,
+  questions: [],
+  onReplyQuestion: () => {},
+  onRejectQuestion: () => {},
+  ...over,
+});
+
+describe("TranscriptTail", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("is a flex column that owns the gap between its children", () => {
+    h = mount(<TranscriptTail context={ctx()} />);
+    const root = h.container.firstElementChild as HTMLElement;
+    expect(root.style.display).toBe("flex");
+    expect(root.style.flexDirection).toBe("column");
+    expect(root.style.gap).toBe("var(--block-gap)");
+  });
+
+  it("separates the tail from the last message row without depending on the working row", () => {
+    // The working row unmounts when the turn ends; the gap above the tail must
+    // not unmount with it (that was the "Reflected for … touches the TODO card"
+    // bug). It lives on the container, so it is there in BOTH states.
+    for (const running of [true, false]) {
+      h?.unmount();
+      h = mount(<TranscriptTail context={ctx({ running })} />);
+      const root = h.container.firstElementChild as HTMLElement;
+      expect(root.style.paddingTop).toBe("var(--block-gap)");
+    }
+  });
+});

--- a/src/renderer/WorkingIndicator.test.tsx
+++ b/src/renderer/WorkingIndicator.test.tsx
@@ -64,4 +64,12 @@ describe("WorkingIndicator", () => {
     h = mount(<WorkingIndicator running={false} liveTurn={null} />);
     expect(h!.container.querySelector(".manta-working-indicator")).toBeNull();
   });
+
+  it("owns no vertical margin — the tail container's gap does the spacing", () => {
+    h = mount(<WorkingIndicator running liveTurn={makeLiveTurn()} />);
+    const row = h!.container.querySelector(".manta-working-indicator") as HTMLElement;
+    expect(row).toBeTruthy();
+    expect(row.style.marginTop).toBe("");
+    expect(row.style.marginBottom).toBe("");
+  });
 });


### PR DESCRIPTION
## BET-712 — Transcript tail: container owns the vertical gaps

Fixes both tail-spacing bugs at once by moving the spacing from the child to
the container, exactly as the issue prescribes:

- **`TranscriptTail`'s root** is now a flex column with `gap: var(--block-gap)` and
  `paddingTop: var(--block-gap)` — the working row, the TODO card and the question
  cards are all separated by the container's `gap`, and the gap between the last
  message row and the tail no longer depends on the working row existing.
- **Deleted the working row's `style` prop** (the `marginTop` that only ever
  spaced what was above it and unmounted with the row → 0px between `Reflected
  for …` and the TODO card when idle).
- **Deleted the questions block's `pt-1` / `space-y-2`** — one `gap` mechanism
  for the whole tail instead of three ad-hoc ones.

Three spacing mechanisms (a child margin, `pt-1`, `space-y-2`) → **one** (`gap`
on the container). No new margins added anywhere. `TranscriptTail` and
`TranscriptContext` are exported for the two new tests.

**Files changed:** 3 files. `src/renderer/Transcript.tsx`, new
`src/renderer/TranscriptTail.test.tsx`, `src/renderer/WorkingIndicator.test.tsx`.

**Base: origin/main @ b054b095**

### Verification results
- PR branch (`multica/BET-712-transcript-tail-gaps` @ 129af9a6):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, renderer 2244 pass / 7 skip / 0 fail; server 1553 pass / 0 fail.
    Failures: none. (3 new renderer tests: 1 in WorkingIndicator, 2 in TranscriptTail.)
- Base (`main` @ b054b095):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, renderer 2241 pass / 7 skip / 0 fail; server 1553 pass / 0 fail.
    Failures: none.
- **Conclusion:** 0 failures on either branch; the PR adds 3 passing tests, 0 new failures.

### On the issue's visual-baseline step
The issue asks to regenerate the `session` / `session-stream` pixel baselines.
That step is **retired** per the current repo guidance (2026-08-07): pixel-baseline
verification was deliberately dropped as inaccurate, and re-recording baselines is
no longer part of verification. Verification is typecheck + unit tests, both green
above. No baselines were re-recorded.
