### PR TITLE
feat(box): enable opencode background subagents on every supervisor

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -971,19 +971,25 @@ main() {
   OC_UNIT="$UNIT_DIR/opencode-serve.service"
   [ -f "$OC_UNIT_SRC" ] || die "missing systemd template: $OC_UNIT_SRC"
   if command -v systemctl >/dev/null 2>&1; then
-    if systemctl --user is-active --quiet opencode-serve.service 2>/dev/null; then
-      ok "opencode-serve already active — skipping (re-run picks up unit upgrades via daemon-reload below)."
-    else
-      log "Installing opencode-serve systemd --user unit…"
-      mkdir -p "$UNIT_DIR"
-      rendered="$("$NODE" "$LIB" render-systemd-unit \
-        --template "$OC_UNIT_SRC" \
-        --placeholder OPENCODE_BIN="$OPENCODE_BIN" \
-        --placeholder AGENT_PATH="$(launchd_agent_path)")" \
-        || die "render-systemd-unit failed (see lib)"
-      printf '%s' "$rendered" > "$OC_UNIT"
-      systemctl --user daemon-reload
-      systemctl --user enable --now opencode-serve.service
+    # ALWAYS re-render, matching the manta-server branch in step 7. The old
+    # `is-active → skip` early-out meant an already-running box never picked up
+    # a unit change (self-update.sh does not render units either), so a new
+    # Environment= line would reach fresh installs only. `enable --now` does
+    # not restart an already-running unit, hence the explicit restart below —
+    # gated on MANTA_RESTART exactly like manta-server's.
+    log "Installing opencode-serve systemd --user unit…"
+    mkdir -p "$UNIT_DIR"
+    rendered="$("$NODE" "$LIB" render-systemd-unit \
+      --template "$OC_UNIT_SRC" \
+      --placeholder OPENCODE_BIN="$OPENCODE_BIN" \
+      --placeholder AGENT_PATH="$(launchd_agent_path)")" \
+      || die "render-systemd-unit failed (see lib)"
+    printf '%s' "$rendered" > "$OC_UNIT"
+    systemctl --user daemon-reload
+    systemctl --user enable --now opencode-serve.service
+    if [ "${MANTA_RESTART:-1}" = "1" ]; then
+      systemctl --user restart opencode-serve.service \
+        || warn "systemctl --user restart opencode-serve failed — run it manually"
     fi
   elif [ "$IS_MACOS" = "1" ]; then
     # macOS path (BET-277): proper LaunchAgent so opencode-serve survives
@@ -1003,7 +1009,9 @@ main() {
     else
       warn "systemctl not found. Starting opencode-serve in the background instead."
       warn "It will NOT survive reboot — set up your own supervisor for that."
-      ( nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
+      # Same background-subagent flag the systemd unit and the LaunchAgent
+      # carry — keep the three supervisors' environments identical.
+      ( OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true nohup "$OPENCODE_BIN" serve --port 4096 --hostname 127.0.0.1 >"$AUTH_DIR/opencode.log" 2>&1 & )
     fi
   fi
   # Health-wait: opencode is loopback-only on :4096. acceptAnyStatus:true is

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -41,6 +41,12 @@ import {
 
 const HOME = "/home/tester";
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Read a file shipped under scripts/ (a supervisor template, install.sh, …).
+// Every "the template must contain X" test wants exactly this, and repeating
+// the readFileSync(join(__dirname, …), "utf-8") triple is what tips the
+// duplication gate over its token threshold.
+const scriptFile = (...parts) => readFileSync(join(__dirname, ...parts), "utf-8");
 const INSTALL_SH = join(__dirname, "install.sh");
 
 // A canonical 32-lowercase-hex token — mirrors the test constants in
@@ -4587,20 +4593,16 @@ test("install.sh: scripts/systemd/*.service carries @@AGENT_PATH@@ placeholder (
   // token, otherwise render-systemd-unit won't substitute it. Without the
   // substitution, the supervisor-managed service inherits the bare
   // systemd default PATH and the `claude` spawn in doRefresh ENOENTs.
-  for (const f of [
-    join(__dirname, "systemd", "manta-server.service"),
-    join(__dirname, "systemd", "opencode-serve.service"),
-  ]) {
-    const text = readFileSync(f, "utf-8");
+  for (const f of ["manta-server.service", "opencode-serve.service"]) {
     assert.match(
-      text,
+      scriptFile("systemd", f),
       /Environment=PATH=@@AGENT_PATH@@/,
       `${f} must carry @@AGENT_PATH@@ for the unified PATH substitution`,
     );
   }
 });
 
-test("install.sh: every opencode-serve supervisor enables background subagents", () => {
+test("install.sh: opencode-serve gets background subagents, on every supervisor, on every run", () => {
   // opencode gates `task(background: true)` and the
   // POST /experimental/session/:id/background detach endpoint behind this env
   // var; without it /experimental/capabilities reports backgroundSubagents
@@ -4608,20 +4610,18 @@ test("install.sh: every opencode-serve supervisor enables background subagents",
   // (systemd unit, LaunchAgent, nohup fallback) must set it, or the box's
   // behaviour would depend on which one happened to start opencode.
   const VAR = "OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS";
-  const unit = readFileSync(join(__dirname, "systemd", "opencode-serve.service"), "utf-8");
-  assert.match(unit, new RegExp(`Environment=${VAR}=true`));
-  const plist = readFileSync(join(__dirname, "launchd", "com.mantaui.opencode.plist"), "utf-8");
-  assert.match(plist, new RegExp(`<key>${VAR}</key>\\s*<string>true</string>`));
-  const installSh = readFileSync(join(__dirname, "install.sh"), "utf-8");
+  const installSh = scriptFile("install.sh");
+  assert.match(scriptFile("systemd", "opencode-serve.service"), new RegExp(`Environment=${VAR}=true`));
+  assert.match(
+    scriptFile("launchd", "com.mantaui.opencode.plist"),
+    new RegExp(`<key>${VAR}</key>\\s*<string>true</string>`),
+  );
   assert.match(installSh, new RegExp(`${VAR}=true nohup`));
-});
-
-test("install.sh: the opencode-serve unit is re-rendered on every run", () => {
-  // The unit used to be skipped when already active, so an already-installed
-  // box never picked up a template change (self-update.sh renders no units
-  // either). Pin the always-render shape: no is-active early-out, and an
-  // explicit restart, because `enable --now` does not restart a running unit.
-  const installSh = readFileSync(join(__dirname, "install.sh"), "utf-8");
+  // …and the unit must be re-rendered on every run, or an already-installed
+  // box would never pick the line up: the systemd branch used to skip when
+  // already active, and self-update.sh renders no units either. Pin the
+  // always-render shape — no is-active early-out, plus an explicit restart
+  // because `enable --now` does not restart a running unit.
   assert.doesNotMatch(installSh, /is-active --quiet opencode-serve/);
   assert.match(installSh, /systemctl --user restart opencode-serve\.service/);
 });
@@ -4631,17 +4631,16 @@ test("install.sh: scripts/systemd/manta-server.service + scripts/launchd/com.man
   // sed substitution has nothing to replace and the box's own server
   // process would silently fall back to resolveBoxChannel()'s "prod"
   // default on every install, regardless of MANTA_CHANNEL.
-  const serverUnit = readFileSync(join(__dirname, "systemd", "manta-server.service"), "utf-8");
-  assert.match(serverUnit, /Environment=MANTA_CHANNEL=@@MANTA_CHANNEL@@/);
-  const serverPlist = readFileSync(join(__dirname, "launchd", "com.mantaui.server.plist"), "utf-8");
-  assert.match(serverPlist, /<key>MANTA_CHANNEL<\/key>\s*<string>@@MANTA_CHANNEL@@<\/string>/);
+  assert.match(scriptFile("systemd", "manta-server.service"), /Environment=MANTA_CHANNEL=@@MANTA_CHANNEL@@/);
+  assert.match(
+    scriptFile("launchd", "com.mantaui.server.plist"),
+    /<key>MANTA_CHANNEL<\/key>\s*<string>@@MANTA_CHANNEL@@<\/string>/,
+  );
   // opencode-serve.service / com.mantaui.opencode.plist are NOT
   // pair-link-emitting processes — MANTA_CHANNEL is deliberately scoped to
   // manta-server only.
-  const opencodeUnit = readFileSync(join(__dirname, "systemd", "opencode-serve.service"), "utf-8");
-  assert.doesNotMatch(opencodeUnit, /MANTA_CHANNEL/);
-  const opencodePlist = readFileSync(join(__dirname, "launchd", "com.mantaui.opencode.plist"), "utf-8");
-  assert.doesNotMatch(opencodePlist, /MANTA_CHANNEL/);
+  assert.doesNotMatch(scriptFile("systemd", "opencode-serve.service"), /MANTA_CHANNEL/);
+  assert.doesNotMatch(scriptFile("launchd", "com.mantaui.opencode.plist"), /MANTA_CHANNEL/);
 });
 
 test("install.sh systemd render: AGENT_PATH substitution materialises ~/.local/bin in both units (BET-353)", () => {

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4600,6 +4600,32 @@ test("install.sh: scripts/systemd/*.service carries @@AGENT_PATH@@ placeholder (
   }
 });
 
+test("install.sh: every opencode-serve supervisor enables background subagents", () => {
+  // opencode gates `task(background: true)` and the
+  // POST /experimental/session/:id/background detach endpoint behind this env
+  // var; without it /experimental/capabilities reports backgroundSubagents
+  // false and every subagent blocks its parent turn. All THREE supervisors
+  // (systemd unit, LaunchAgent, nohup fallback) must set it, or the box's
+  // behaviour would depend on which one happened to start opencode.
+  const VAR = "OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS";
+  const unit = readFileSync(join(__dirname, "systemd", "opencode-serve.service"), "utf-8");
+  assert.match(unit, new RegExp(`Environment=${VAR}=true`));
+  const plist = readFileSync(join(__dirname, "launchd", "com.mantaui.opencode.plist"), "utf-8");
+  assert.match(plist, new RegExp(`<key>${VAR}</key>\\s*<string>true</string>`));
+  const installSh = readFileSync(join(__dirname, "install.sh"), "utf-8");
+  assert.match(installSh, new RegExp(`${VAR}=true nohup`));
+});
+
+test("install.sh: the opencode-serve unit is re-rendered on every run", () => {
+  // The unit used to be skipped when already active, so an already-installed
+  // box never picked up a template change (self-update.sh renders no units
+  // either). Pin the always-render shape: no is-active early-out, and an
+  // explicit restart, because `enable --now` does not restart a running unit.
+  const installSh = readFileSync(join(__dirname, "install.sh"), "utf-8");
+  assert.doesNotMatch(installSh, /is-active --quiet opencode-serve/);
+  assert.match(installSh, /systemctl --user restart opencode-serve\.service/);
+});
+
 test("install.sh: scripts/systemd/manta-server.service + scripts/launchd/com.mantaui.server.plist carry @@MANTA_CHANNEL@@ placeholder (BET-392)", () => {
   // Belt-and-braces: without the placeholder in the template, install.sh's
   // sed substitution has nothing to replace and the box's own server

--- a/scripts/launchd/com.mantaui.opencode.plist
+++ b/scripts/launchd/com.mantaui.opencode.plist
@@ -54,6 +54,16 @@
   <dict>
     <key>PATH</key>
     <string>@@AGENT_PATH@@</string>
+    <!-- Background subagents. Unlocks `task(background: true)` — the tool
+         returns immediately and opencode injects the child's result back into
+         the parent session when it finishes — plus the
+         POST /experimental/session/:id/background detach endpoint. Without it
+         opencode reports `backgroundSubagents:false`, the `background`
+         argument hard-errors, and EVERY subagent blocks its parent turn.
+         Mirrors scripts/systemd/opencode-serve.service; unconditionally on,
+         so there is no placeholder to substitute. -->
+    <key>OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS</key>
+    <string>true</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/scripts/systemd/opencode-serve.service
+++ b/scripts/systemd/opencode-serve.service
@@ -39,6 +39,15 @@ ExecStart=@@OPENCODE_BIN@@ serve --port 4096 --hostname 127.0.0.1
 # dirs (tmux). install.sh substitutes the resolved list (see
 # launchd_agent_path()).
 Environment=PATH=@@AGENT_PATH@@
+# Background subagents (BET-XXX). Unlocks `task(background: true)` — the tool
+# returns immediately and opencode injects the child's result back into the
+# parent session when it finishes — plus the
+# POST /experimental/session/:id/background detach endpoint. Without this env
+# var opencode reports `backgroundSubagents:false` from
+# /experimental/capabilities, the `background` argument hard-errors, and EVERY
+# subagent blocks its parent turn. Not a placeholder: it is unconditionally on
+# for every Manta box, so there is nothing for install.sh to substitute.
+Environment=OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true
 Restart=on-failure
 RestartSec=2
 # Give opencode a moment to flush pending SSE frames on stop before SIGKILL.


### PR DESCRIPTION
## Why

opencode already ships background subagents; every Manta box has them switched off.

With `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS` unset:
- `GET /experimental/capabilities` → `{"backgroundSubagents": false}`
- `task({ background: true })` hard-errors ("Background subagents require …")
- the built-in task tool's description never mentions the background mode, so the model cannot know it exists
- `POST /experimental/session/:id/background` (detach the subagents currently blocking a session) is inert

Net effect: **every** subagent blocks its parent turn, and the model's only non-blocking option is `delegate`, which also costs a git worktree. That mismatch is why long, independent work keeps landing in a blocking `task` card.

With the flag on, opencode injects the child's result back into the parent session itself when the background job finishes — the same "you'll get it as a later message" contract `delegate` hand-rolls.

## What

- `scripts/systemd/opencode-serve.service` — `Environment=OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`
- `scripts/launchd/com.mantaui.opencode.plist` — same, in `EnvironmentVariables`
- `scripts/install.sh` — same on the nohup fallback, so behaviour never depends on which supervisor started opencode

Plus one fix without which the flag would reach fresh installs only: the systemd branch had an `is-active → skip` early-out, so an already-running box never re-rendered its unit, and `self-update.sh` renders no units either. The branch now matches manta-server's step-7 shape exactly — always render, `daemon-reload`, `enable --now`, then an explicit restart gated on `MANTA_RESTART` (`enable --now` does not restart a running unit). Net: one less code path.

## Tests

Two node:test cases in `scripts/install.test.mjs`:
- all three supervisors carry the env var
- the unit is always re-rendered (no `is-active` early-out, explicit restart present)

`npm run typecheck` clean; `scripts/install.test.mjs` 259/259.

## Follow-ups

Filed separately: unify the sidebar treatment of backgrounded subagents with delegate job rows, and rewrite the agent guidance for the resulting three-way choice.

## Rollback

Delete the three `Environment=` lines and restart opencode. Nothing else reads the flag.