### PR TITLE
feat(server): permission push carries requestId + static reply actions (BET-714 task 1)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import UserNotifications
 import MessagingUI
 
 // ===========================================================================
@@ -157,9 +158,16 @@ private struct ChatScreenContent: View {
                 // window/branch lookup.
                 store.start()
                 modelStore.load()
+                MantaPushRouter.shared.visibleSessionID = store.sessionId
+                Task { try? await MantaAPIClient.live().reportFocus(sessionId: store.sessionId, visible: true) }
+                clearDeliveredNotifications(for: store.sessionId)
                 Task { await resolveWindowAndBranch() }
             }
-            .onDisappear { store.stop() }
+            .onDisappear {
+                store.stop()
+                MantaPushRouter.shared.visibleSessionID = nil
+                Task { try? await MantaAPIClient.live().reportFocus(sessionId: nil, visible: false) }
+            }
             // BET-673: fire one success haptic when a turn completes while the
             // user has scrolled up (scroll-to-bottom chip showing) and the scene
             // is active and haptics are enabled. `onChange` fires exactly once
@@ -174,6 +182,24 @@ private struct ChatScreenContent: View {
                     hapticsEnabled: sessionStore.hapticsEnabled
                 ) {
                     SessionHaptics.fire(.success, enabled: true)
+                }
+            }
+            .onChange(of: scenePhase) { _, phase in
+                // Mirror foreground state to the box so it suppresses redundant
+                // pushes for this session, and clear delivered notifications
+                // when the user comes back to the screen. On background the
+                // screen is still the top of the stack when the app returns,
+                // so visibleSessionID stays set — only the box is told it's
+                // not visible.
+                switch phase {
+                case .active:
+                    MantaPushRouter.shared.visibleSessionID = store.sessionId
+                    Task { try? await MantaAPIClient.live().reportFocus(sessionId: store.sessionId, visible: true) }
+                    clearDeliveredNotifications(for: store.sessionId)
+                case .background, .inactive:
+                    Task { try? await MantaAPIClient.live().reportFocus(sessionId: nil, visible: false) }
+                default:
+                    break
                 }
             }
             .accessibilityElement(children: .contain)
@@ -193,6 +219,20 @@ private struct ChatScreenContent: View {
         } else {
             loadedLayout
         }
+    }
+
+    /// Drop the delivered notifications for a session the user just opened
+    /// (or returned to) and zero the app-icon badge — the user is reading
+    /// that session, so its notifications are consumed.
+    private func clearDeliveredNotifications(for sessionId: String) {
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { list in
+            let ids = list
+                .filter { ($0.request.content.userInfo["sessionId"] as? String) == sessionId }
+                .map(\.request.identifier)
+            if !ids.isEmpty { center.removeDeliveredNotifications(withIdentifiers: ids) }
+        }
+        center.setBadgeCount(0)
     }
 
     private var loadedLayout: some View {

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -368,6 +368,22 @@ final class MantaAPIClient: Sendable {
         }
     }
 
+    /// `POST /push/focus` — tell the box which session the user is looking at so
+    /// its router suppresses redundant pushes (mirrors the desktop's presence
+    /// heartbeat; the endpoint + suppression logic already exist server-side).
+    func reportFocus(sessionId: String?, visible: Bool) async throws {
+        var request = URLRequest(url: serverURL.appendingPathComponent("push/focus"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let tokenValue = tokenProvider(), !tokenValue.isEmpty {
+            request.setValue("Bearer \(tokenValue)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "sessionId": sessionId as Any, "visible": visible,
+        ])
+        _ = try await session.data(for: request)
+    }
+
     // MARK: - Transport + envelope
 
     static func makeRequest(serverURL: URL, channel: String, args: [Any], token: String?) throws -> URLRequest {

--- a/mobile/native/MantaUI/MantaAppDelegate.swift
+++ b/mobile/native/MantaUI/MantaAppDelegate.swift
@@ -29,8 +29,24 @@ final class MantaAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency U
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        Self.registerNotificationCategories()
         MantaPushService.applyRegistrationState()
         return true
+    }
+
+    private static func registerNotificationCategories() {
+        let permission = UNNotificationCategory(
+            identifier: "MANTA_PERMISSION",
+            actions: [
+                // No .foreground option: the reply runs in the background without
+                // opening the app — that is the entire point of the feature.
+                UNNotificationAction(identifier: "allow-once", title: "Allow once"),
+                UNNotificationAction(identifier: "allow-always", title: "Always allow"),
+                UNNotificationAction(identifier: "deny", title: "Deny", options: [.destructive]),
+            ],
+            intentIdentifiers: []
+        )
+        UNUserNotificationCenter.current().setNotificationCategories([permission])
     }
 
     func application(
@@ -85,7 +101,30 @@ final class MantaAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency U
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
-        if let sessionID = userInfo["sessionId"] as? String, !sessionID.isEmpty {
+        let sessionID = userInfo["sessionId"] as? String
+        let requestID = userInfo["requestId"] as? String
+        let reply: PermissionReply?
+        switch response.actionIdentifier {
+        case "allow-once": reply = .once
+        case "allow-always": reply = .always
+        case "deny": reply = .reject
+        default: reply = nil
+        }
+        if let reply, let requestID, !requestID.isEmpty {
+            // Background reply — the app is NOT foregrounded. completionHandler
+            // must run after the network call so iOS keeps us alive for it. The
+            // handler is `sending`/non-Sendable, so a @Sendable Task can't
+            // capture it directly — box it (UNUserNotificationCenter handlers
+            // are safe to call from any thread, which is what the box does).
+            let done = NotificationCompletionHandler(completionHandler)
+            Task {
+                try? await MantaAPIClient.live().permissionReply(
+                    requestId: requestID, reply: reply, sessionId: sessionID)
+                done.run()
+            }
+            return
+        }
+        if let sessionID, !sessionID.isEmpty {
             Task { @MainActor in
                 MantaPushRouter.shared.open(sessionID: sessionID)
             }
@@ -140,12 +179,26 @@ enum MantaPushService {
     }
 
     private static func register(_ token: String) {
-        // No box to register with until pairing saves credentials.
         let client = MantaAPIClient.live()
         guard KeychainCredentialStore.shared.serverURL != nil,
               KeychainCredentialStore.shared.boxToken != nil else {
             return
         }
+        Task {
+            try? await client.registerApnsToken(token)
+        }
+    }
+}
+
+/// UNUserNotificationCenter's completion handlers are safe to call from any
+/// thread, but they're typed as `sending` (non-Sendable), so a @Sendable Task
+/// can't capture one directly. Box it so the background permission reply can
+/// invoke the handler after its network call. The annotation is needed only
+/// because the handler's type is non-Sendable by protocol fiat, not by meaning.
+private final class NotificationCompletionHandler: @unchecked Sendable {
+    let run: () -> Void
+    init(_ run: @escaping () -> Void) { self.run = run }
+}
         Task {
             try? await client.registerApnsToken(token)
         }

--- a/mobile/native/MantaUI/MantaAppDelegate.swift
+++ b/mobile/native/MantaUI/MantaAppDelegate.swift
@@ -195,7 +195,13 @@ enum MantaPushService {
             return
         }
         Task {
-            try? await client.registerApnsToken(token)
+            // 3 attempts, 5s then 30s apart — a box that is down longer gets the
+            // token on the next foreground (applyRegistrationState re-runs there).
+            for delay in [0.0, 5.0, 30.0] {
+                if delay > 0 { try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
+                if (try? await client.registerApnsToken(token)) != nil { return }
+            }
+            NSLog("[push] APNs token registration failed after 3 attempts")
         }
     }
 }
@@ -208,9 +214,4 @@ enum MantaPushService {
 private final class NotificationCompletionHandler: @unchecked Sendable {
     let run: () -> Void
     init(_ run: @escaping () -> Void) { self.run = run }
-}
-        Task {
-            try? await client.registerApnsToken(token)
-        }
-    }
 }

--- a/mobile/native/MantaUI/MantaAppDelegate.swift
+++ b/mobile/native/MantaUI/MantaAppDelegate.swift
@@ -89,7 +89,17 @@ final class MantaAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency U
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        completionHandler([.banner, .list, .sound])
+        let sessionID = notification.request.content.userInfo["sessionId"] as? String
+        // UNUserNotificationCenter invokes its delegate on the main thread, so
+        // the (MainActor-isolated) visible-session bookkeeping is readable here
+        // directly — keeping completionHandler in the synchronous nonisolated
+        // frame avoids escaping a `sending` parameter into a Task.
+        let visible = MainActor.assumeIsolated { MantaPushRouter.shared.visibleSessionID }
+        if let sessionID, !sessionID.isEmpty, sessionID == visible {
+            completionHandler([.list])
+        } else {
+            completionHandler([.banner, .list, .sound])
+        }
     }
 
     // Tap → deep-link to the session that fired the notification. The APNs

--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -104,6 +104,7 @@ struct MantaAppRoot: View {
         // which is precisely the "kill and restart and they're back" symptom.
         .onChange(of: scenePhase) { phase in
             guard phase == .active, paired else { return }
+            MantaPushService.applyRegistrationState()
             store.resume()
             Task { await sessionStore.refresh() }
         }

--- a/mobile/native/MantaUI/MantaDeepLink.swift
+++ b/mobile/native/MantaUI/MantaDeepLink.swift
@@ -27,6 +27,11 @@ final class MantaPushRouter: ObservableObject {
     /// once it has pushed the matching ChatScreen onto its NavigationStack).
     @Published var pendingSessionID: String?
 
+    /// The opencode sessionId of the ChatScreen currently on screen, nil when
+    /// none is. Written by ChatScreen appear/disappear; read by the notification
+    /// delegate (foreground suppression) and mirrored to the box (/push/focus).
+    @Published var visibleSessionID: String?
+
     private init() {}
 
     func open(sessionID: String) {

--- a/src/gateway/apns.mjs
+++ b/src/gateway/apns.mjs
@@ -152,9 +152,22 @@ export function buildApnsPayload(payload) {
     typeof payload?.sessionId === "string" && payload.sessionId
       ? payload.sessionId
       : null;
+  const kind = typeof payload?.kind === "string" ? payload.kind : null;
+  const requestId =
+    typeof payload?.requestId === "string" && payload.requestId
+      ? payload.requestId
+      : null;
   const aps = { alert: { title, body } };
   if (sessionId) aps["thread-id"] = sessionId;
-  return { aps, sessionId };
+  // Category names an iOS-side pre-registered UNNotificationCategory. Only
+  // permission has one: its three reply actions are static. Question answers
+  // have per-ask titles, which APNs categories cannot express — questions
+  // stay tap-through on iOS.
+  if (kind === "permission" && requestId) aps.category = "MANTA_PERMISSION";
+  const envelope = { aps, sessionId };
+  if (kind) envelope.kind = kind;
+  if (requestId) envelope.requestId = requestId;
+  return envelope;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gateway/apns.test.mjs
+++ b/src/gateway/apns.test.mjs
@@ -97,6 +97,43 @@ test("buildApnsPayload: no sessionId → no thread-id, still shaped right", () =
   assert.equal(out.sessionId, null);
 });
 
+test("buildApnsPayload: permission + requestId → MANTA_PERMISSION category, kind/requestId at root", () => {
+  const out = buildApnsPayload({
+    title: "default / my-chat",
+    body: "Permission needed — Claude wants to run a tool.",
+    sessionId: "ses_abc",
+    kind: "permission",
+    requestId: "per_1",
+    actions: [
+      { action: "allow-once", title: "Allow once" },
+      { action: "allow-always", title: "Always allow" },
+      { action: "deny", title: "Deny" },
+    ],
+  });
+  assert.equal(out.aps.category, "MANTA_PERMISSION");
+  assert.equal(out.aps["thread-id"], "ses_abc");
+  assert.equal(out.kind, "permission");
+  assert.equal(out.requestId, "per_1");
+});
+
+test("buildApnsPayload: no kind/requestId → byte-identical to legacy envelope (regression pin)", () => {
+  const out = buildApnsPayload({
+    title: "default / my-chat",
+    body: "Permission needed — Claude wants to run a tool.",
+    sessionId: "ses_abc",
+  });
+  assert.deepEqual(out, {
+    aps: {
+      alert: {
+        title: "default / my-chat",
+        body: "Permission needed — Claude wants to run a tool.",
+      },
+      "thread-id": "ses_abc",
+    },
+    sessionId: "ses_abc",
+  });
+});
+
 test("buildApnsRequest: host/path/headers/body shape (HTTP/2 style)", () => {
   const deviceToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
   const req = buildApnsRequest({

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -323,8 +323,9 @@ export function classifyPushEvent(evt, ctx) {
   const titleOr = (fallback) => label ?? fallback;
 
   switch (type) {
-    case "permission.asked":
-      return {
+    case "permission.asked": {
+      const requestId = typeof props.id === "string" ? props.id : null;
+      const out = {
         kind: "permission",
         title: titleOr("Permission needed"),
         body: label
@@ -333,6 +334,19 @@ export function classifyPushEvent(evt, ctx) {
         sessionId,
         tag: `perm-${tagBase}`,
       };
+      if (requestId) {
+        out.requestId = requestId;
+        // Static action set — permission replies are always these three, so the
+        // client can pre-register them as a fixed notification category (unlike
+        // question answers, whose titles vary per ask).
+        out.actions = [
+          { action: "allow-once", title: "Allow once" },
+          { action: "allow-always", title: "Always allow" },
+          { action: "deny", title: "Deny" },
+        ];
+      }
+      return out;
+    }
     case "question.asked": {
       // The event's properties IS the QuestionRequest: { id: que_…, sessionID,
       // questions: [{ question, header, options:[{label}], multiple?, custom? }] }.

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -41,6 +41,28 @@ test("permission.asked → permission notification", () => {
   assert.equal(p?.tag, "perm-ses_1");
 });
 
+test("permission.asked carries requestId + the 3 static reply actions (single-select)", () => {
+  const p = classifyPushEvent(
+    { type: "permission.asked", properties: { sessionID: "ses_1", id: "per_1" } },
+    NOFOCUS,
+  );
+  assert.equal(p?.requestId, "per_1");
+  assert.deepEqual(p?.actions, [
+    { action: "allow-once", title: "Allow once" },
+    { action: "allow-always", title: "Always allow" },
+    { action: "deny", title: "Deny" },
+  ]);
+});
+
+test("permission.asked without id → no requestId, no actions (unchanged legacy shape)", () => {
+  const p = classifyPushEvent(
+    { type: "permission.asked", properties: { sessionID: "ses_1" } },
+    NOFOCUS,
+  );
+  assert.equal(p?.requestId, undefined);
+  assert.equal(p?.actions, undefined);
+});
+
 test("question.asked → question notification", () => {
   const p = classifyPushEvent(
     { type: "question.asked", properties: { sessionID: "ses_2" } },


### PR DESCRIPTION
Opened automatically for `multica/BET-714-actionable-push`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-714.