### PR TITLE
BET-684: docs: drop stale manta-loading-divider mentions from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,9 +470,7 @@ shell it rendered — `mobile/mobile.css` no longer exists. BET-578 stripped
 the inert `manta-*` hooks this guidance used to recommend as precedent
 (`manta-session-toolbar`, `manta-stale-full`/`-min`, `manta-ctx-track`,
 `manta-session-branch`); do not reintroduce `manta-*` classes as mobile CSS
-hooks (see the "Mobile CSS hook-class contract — RETIRED" section). The only
-surviving example, `manta-loading-divider`, is a live desktop class in
-`src/renderer/index.css`, not a mobile hook.
+hooks (see the "Mobile CSS hook-class contract — RETIRED" section).
 
 ## Desktop transport (HTTP-only)
 
@@ -2731,7 +2729,7 @@ gate first:
 - `manta-session-header`, `manta-ctx-pill`, `manta-ctx-popover`,
   `manta-session-menu-trigger`, `manta-session-menu-dropdown` (SessionHeader) —
   gate regions + coverage
-- `manta-composer-input-row`, `manta-loading-divider`, `manta-recording` —
+- `manta-composer-input-row`, `manta-recording` —
   live desktop CSS in `src/renderer/index.css`
 - `manta-folder-picker` (FolderPickerModal) — gate region/snapshot
 


### PR DESCRIPTION
## What

Doc-only correction for BET-684. Removes the two stale `manta-loading-divider` mentions from `AGENTS.md` (the class was deleted in BET-677):

- "Mobile CSS hook-class contract" paragraph: deleted the entire sentence that existed only to name `manta-loading-divider` as a surviving example.
- Bullet list ("live desktop CSS"): removed `manta-loading-divider, ` from the list, kept `manta-composer-input-row` and `manta-recording`.

Confirmed via `grep -rn manta-loading-divider AGENTS.md src/renderer/index.css src/renderer/ChatPanel.tsx` that the class is gone from code and both `AGENTS.md` mentions are now removed (grep returns nothing).

No code change, no test impact.

**Verification results:**
- PR branch (`multica/BET-684-agents-md-divider` @ `2d9aecaf`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1553 pass / 0 fail / 0 skip.
- Base (`main` @ `bf0690ad`): doc-only change to AGENTS.md → no code/test difference expected.

Base: origin/main @ bf0690ad
