### PR TITLE
BET-713: refactor(renderer): one openPanel state for schedules/secrets/webhooks cards

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -383,6 +383,106 @@ describe("ChatPanel session resources", () => {
   });
 });
 
+// ===== Panel card toggle + mutual exclusion (BET-713) =====
+//
+// The three resource cards (schedules / secrets / webhooks) are ONE surface:
+// the toolbar button opens its card, clicking it again closes it, and opening
+// one closes whichever other was open. These drive the REAL toolbar buttons by
+// their stable aria-labels (ComposerParts).
+describe("ChatPanel panel cards one-open-at-a-time", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  async function clickToolbar(panel: Harness, label: string) {
+    const btn = Array.from(panel.container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === label,
+    ) as HTMLButtonElement | undefined;
+    expect(btn).toBeTruthy();
+    await act(async () => {
+      btn!.click();
+    });
+    // CardMount's AnimatePresence plays a 220ms exit animation before an
+    // outgoing card leaves the DOM; let it finish so "is gone" is assertable
+    // rather than racing the transition.
+    await new Promise((r) => setTimeout(r, 300));
+    await panel.flush();
+  }
+
+  // Distinguishable, stable on-screen markers per card (their empty states).
+  const SCHEDULES = "No scheduled tasks in this session.";
+  const WEBHOOKS = "No webhooks in this session.";
+
+  it("clicking the same toolbar button twice closes the card (schedules)", async () => {
+    installMockApi({ scheduleList: () => Promise.resolve([]) });
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    expect(h.text()).not.toContain(SCHEDULES);
+    await clickToolbar(h, "schedules");
+    expect(h.text()).toContain(SCHEDULES);
+    await clickToolbar(h, "schedules");
+    expect(h.text()).not.toContain(SCHEDULES);
+  });
+
+  it("clicking the same toolbar button twice closes the card (webhooks)", async () => {
+    installMockApi({ webhookList: () => Promise.resolve([]) });
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    expect(h.text()).not.toContain(WEBHOOKS);
+    await clickToolbar(h, "webhooks");
+    expect(h.text()).toContain(WEBHOOKS);
+    await clickToolbar(h, "webhooks");
+    expect(h.text()).not.toContain(WEBHOOKS);
+  });
+
+  it("clicking the same toolbar button twice closes the card (secrets)", async () => {
+    installMockApi({ secretsList: () => Promise.resolve([]) });
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    expect(h.container.querySelector("input[type=password]")).toBeNull();
+    await clickToolbar(h, "secrets");
+    expect(h.container.querySelector("input[type=password]")).not.toBeNull();
+    await clickToolbar(h, "secrets");
+    expect(h.container.querySelector("input[type=password]")).toBeNull();
+  });
+
+  it("opening secrets closes the schedules card", async () => {
+    installMockApi({
+      scheduleList: () => Promise.resolve([]),
+      secretsList: () => Promise.resolve([]),
+    });
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    await clickToolbar(h, "schedules");
+    expect(h.text()).toContain(SCHEDULES);
+    await clickToolbar(h, "secrets");
+    expect(h.container.querySelector("input[type=password]")).not.toBeNull();
+    expect(h.text()).not.toContain(SCHEDULES);
+  });
+
+  it("opening schedules closes the webhooks card", async () => {
+    installMockApi({
+      scheduleList: () => Promise.resolve([]),
+      webhookList: () => Promise.resolve([]),
+    });
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    await clickToolbar(h, "webhooks");
+    expect(h.text()).toContain(WEBHOOKS);
+    await clickToolbar(h, "schedules");
+    expect(h.text()).toContain(SCHEDULES);
+    expect(h.text()).not.toContain(WEBHOOKS);
+  });
+});
+
 // ===== Transcript rendering (via the mounted ChatPanel) =====
 //
 // Verifies the extracted <Transcript> renders a fetched transcript: a user

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -190,22 +190,19 @@ export function ChatPanel({
   // (BET-63) because none of it touches the SSE / pin-to-bottom / message core.
   const resources = useSessionResources(sessionId, isActive);
   const {
-    showSchedules,
-    setShowSchedules,
+    openPanel,
+    togglePanel,
+    closePanel,
     schedules,
     setSchedules,
     scheduleError,
     setScheduleError,
     refreshSchedules,
-    showSecrets,
-    setShowSecrets,
     secrets,
     setSecrets,
     secretError,
     setSecretError,
     refreshSecrets,
-    showWebhooks,
-    setShowWebhooks,
     webhooks,
     setWebhooks,
     webhookError,
@@ -2196,13 +2193,13 @@ export function ChatPanel({
       {/* (desktop) or the ⋯ sheet (mobile). Refetch-driven while open. */}
       {/* pb-2 gives the card breathing room above the composer border so it */}
       {/* doesn't sit flush against the chat divider. Hidden for a job session. */}
-      <CardMount show={!jobOwnership && showSchedules} k="schedules">
-        {!jobOwnership && showSchedules && (
+      <CardMount show={!jobOwnership && openPanel === "schedules"} k="schedules">
+        {!jobOwnership && openPanel === "schedules" && (
           <div className="shrink-0 px-4 pt-2 pb-2">
             <ScheduledTasksCard
               jobs={schedules}
               error={scheduleError}
-              onClose={() => setShowSchedules(false)}
+              onClose={closePanel}
               onDelete={(id) => {
                 setSchedules((prev) => prev.filter((j) => j.id !== id));
                 window.api
@@ -2223,14 +2220,14 @@ export function ChatPanel({
       {/* Secrets management card. Toggled by the 🔑 toolbar button (desktop) or */}
       {/* the ⋯ sheet (mobile). The value never appears here — list is metadata */}
       {/* only. Hidden for a job session (read-only view). */}
-      <CardMount show={!jobOwnership && showSecrets} k="secrets">
-        {!jobOwnership && showSecrets && (
+      <CardMount show={!jobOwnership && openPanel === "secrets"} k="secrets">
+        {!jobOwnership && openPanel === "secrets" && (
           <div className="shrink-0 px-4 pt-2 pb-2">
             <SecretsCard
               secrets={secrets}
               error={secretError}
               sessionId={sessionId}
-              onClose={() => setShowSecrets(false)}
+              onClose={closePanel}
               onSave={(input) => {
                 return window.api
                   .secretsSet(input)
@@ -2267,13 +2264,13 @@ export function ChatPanel({
       {/* (desktop) or the ⋯ sheet (mobile). List is metadata only (no signing */}
       {/* secret); creation is the AI's job via the `webhook` opencode tool. */}
       {/* Hidden for a job session (read-only view). */}
-      <CardMount show={!jobOwnership && showWebhooks} k="webhooks">
-        {!jobOwnership && showWebhooks && (
+      <CardMount show={!jobOwnership && openPanel === "webhooks"} k="webhooks">
+        {!jobOwnership && openPanel === "webhooks" && (
           <div className="shrink-0 px-4 pt-2 pb-2">
             <WebhooksCard
               hooks={webhooks}
               error={webhookError}
-              onClose={() => setShowWebhooks(false)}
+              onClose={closePanel}
               onDelete={(id) => {
                 setWebhooks((prev) => prev.filter((h) => h.id !== id));
                 window.api
@@ -2436,9 +2433,9 @@ export function ChatPanel({
         onOpenModels={ensureModels}
         onSelectModel={selectModel}
         scheduleCount={schedules.length}
-        onSchedules={() => setShowSchedules((v) => !v)}
-        onSecrets={() => setShowSecrets((v) => !v)}
-        onWebhooks={() => setShowWebhooks((v) => !v)}
+        onSchedules={() => togglePanel("schedules")}
+        onSecrets={() => togglePanel("secrets")}
+        onWebhooks={() => togglePanel("webhooks")}
         typeaheadOpen={typeahead != null && typeaheadRows.length > 0}
         typeaheadExactMatch={(() => {
           if (!typeahead || typeaheadRows.length === 0) return false;

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -10,7 +10,7 @@
 // All three are cards (not footer items) so they render on BOTH desktop and
 // mobile with no mobile-CSS edits.
 
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { Clock, Webhook, Key, Bot, ArrowLeft, Square, X } from "lucide-react";
 import type {
   DelegateApproval,
@@ -38,27 +38,8 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
   onDelete: (id: string) => void;
   onClose: () => void;
 }) {
-  // Click-outside-to-dismiss: the close (×) button sits directly above the
-  // first row's cancel button, so a mis-tap on the close used to delete a job.
-  // Dismissing by clicking anywhere outside the card removes that hazard.
-  const cardRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    const onDown = (e: MouseEvent) => {
-      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    // Defer registration to the next tick so the same click that opened the
-    // card (from the toolbar button) doesn't immediately close it.
-    const t = setTimeout(() => document.addEventListener("mousedown", onDown), 0);
-    return () => {
-      clearTimeout(t);
-      document.removeEventListener("mousedown", onDown);
-    };
-  }, [onClose]);
   return (
     <div
-      ref={cardRef}
       className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
@@ -71,7 +52,7 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
         <button
           onClick={onClose}
           className="ml-auto px-2 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
-          title="Close (or click outside)"
+          title="Close"
           aria-label="Close"
         >
           <X size={16} aria-hidden="true" />
@@ -137,18 +118,7 @@ export const WebhooksCard = memo(function WebhooksCard({
   onDelete: (id: string) => void;
   onClose: () => void;
 }) {
-  const cardRef = useRef<HTMLDivElement | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
-  useEffect(() => {
-    const onDown = (e: MouseEvent) => {
-      if (cardRef.current && !cardRef.current.contains(e.target as Node)) onClose();
-    };
-    const t = setTimeout(() => document.addEventListener("mousedown", onDown), 0);
-    return () => {
-      clearTimeout(t);
-      document.removeEventListener("mousedown", onDown);
-    };
-  }, [onClose]);
   const copyUrl = (url: string, id: string) => {
     void navigator.clipboard?.writeText(url).then(
       () => {
@@ -160,7 +130,6 @@ export const WebhooksCard = memo(function WebhooksCard({
   };
   return (
     <div
-      ref={cardRef}
       className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
       style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
     >
@@ -173,7 +142,7 @@ export const WebhooksCard = memo(function WebhooksCard({
         <button
           onClick={onClose}
           className="ml-auto px-2 rounded-xs text-text-faint hover:text-text-muted inline-flex items-center"
-          title="Close (or click outside)"
+          title="Close"
           aria-label="Close"
         >
           <X size={16} aria-hidden="true" />

--- a/src/renderer/hooks/useSessionResources.ts
+++ b/src/renderer/hooks/useSessionResources.ts
@@ -4,8 +4,8 @@
 // resource" cards that hang off a chat session — scheduled prompts (⏰),
 // secrets (🔑), and inbound webhooks (🪝). Each is the same shape:
 //
-//   - a `show*` toggle (opened by the composer toolbar or a mobile ⋯-sheet
-//     `manta-open-*` window CustomEvent),
+//   - a single `openPanel` surface shared by all three cards (opened by the
+//     composer toolbar or a mobile ⋯-sheet `manta-open-*` window CustomEvent),
 //   - a list of metadata + an error string,
 //   - a `refresh*` callback that re-fetches over the `schedule:*` / `secrets:*`
 //     / `webhook:*` window.api channels,
@@ -26,10 +26,25 @@
 import { useCallback, useEffect, useState } from "react";
 import type { ScheduledJob, SecretMeta, WebhookMeta } from "../../shared/types";
 
+/** The three server-owned resource cards that hang off a chat session. */
+export type PanelName = "schedules" | "secrets" | "webhooks";
+
 export type SessionResources = {
+  // ----- The card surface -----
+  //
+  // ONE state for all three cards, not three booleans. "at most one card is
+  // open" is then a property of the state's shape rather than a rule some
+  // caller has to remember to enforce, and every button goes through the same
+  // toggle. Do not split this back into per-card flags.
+  /** Which card is open, or null when none is. */
+  openPanel: PanelName | null;
+  /** Toolbar click: open `name`, or close it if it is already the open one.
+   *  Opening one closes whichever other was open — implicitly. */
+  togglePanel: (name: PanelName) => void;
+  /** A card's × button, and the session-change reset. */
+  closePanel: () => void;
+
   // Scheduled prompts (⏰).
-  showSchedules: boolean;
-  setShowSchedules: React.Dispatch<React.SetStateAction<boolean>>;
   schedules: ScheduledJob[];
   setSchedules: React.Dispatch<React.SetStateAction<ScheduledJob[]>>;
   scheduleError: string | null;
@@ -37,8 +52,6 @@ export type SessionResources = {
   refreshSchedules: () => Promise<void>;
 
   // Secrets (🔑).
-  showSecrets: boolean;
-  setShowSecrets: React.Dispatch<React.SetStateAction<boolean>>;
   secrets: SecretMeta[];
   setSecrets: React.Dispatch<React.SetStateAction<SecretMeta[]>>;
   secretError: string | null;
@@ -46,8 +59,6 @@ export type SessionResources = {
   refreshSecrets: () => Promise<void>;
 
   // Inbound webhooks (🪝).
-  showWebhooks: boolean;
-  setShowWebhooks: React.Dispatch<React.SetStateAction<boolean>>;
   webhooks: WebhookMeta[];
   setWebhooks: React.Dispatch<React.SetStateAction<WebhookMeta[]>>;
   webhookError: string | null;
@@ -56,12 +67,29 @@ export type SessionResources = {
 };
 
 export function useSessionResources(sessionId: string, isActive: boolean): SessionResources {
+  // ----- The card surface -----
+  // One piece of state governs all three cards (see the type comment above).
+  const [openPanel, setOpenPanel] = useState<PanelName | null>(null);
+  const togglePanel = useCallback(
+    (name: PanelName) => setOpenPanel((cur) => (cur === name ? null : name)),
+    [],
+  );
+  const closePanel = useCallback(() => setOpenPanel(null), []);
+
+  // Derived per-card flags, used ONLY as effect dependencies below. They are
+  // booleans, so an effect that watches one re-runs when THAT card opens or
+  // closes — not every time any card changes. Depending on `openPanel`
+  // directly would, for example, refetch schedules every time the secrets card
+  // opened.
+  const schedulesOpen = openPanel === "schedules";
+  const secretsOpen = openPanel === "secrets";
+  const webhooksOpen = openPanel === "webhooks";
+
   // ----- Scheduled prompts (the ⏰ ScheduledTasksCard) -----
   // Jobs are server-owned (manta-server fires them); here we only list + delete
   // via the schedule:* window.api channels. Refetch-driven (open + open-poll +
   // post-delete) — NOT a bus event, because desktop's renderer isn't wired to
   // the server bus. See docs/manta-tools-scheduler.md.
-  const [showSchedules, setShowSchedules] = useState(false);
   const [schedules, setSchedules] = useState<ScheduledJob[]>([]);
   const [scheduleError, setScheduleError] = useState<string | null>(null);
   const refreshSchedules = useCallback(() => {
@@ -83,7 +111,6 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   // Refetch-driven like schedules. The card shows shared secrets + this
   // session's scoped ones (sessionId is passed so the agent-visible view
   // matches what tools will resolve).
-  const [showSecrets, setShowSecrets] = useState(false);
   const [secrets, setSecrets] = useState<SecretMeta[]>([]);
   const [secretError, setSecretError] = useState<string | null>(null);
   const refreshSecrets = useCallback(() => {
@@ -103,7 +130,6 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   // + revoke via the webhook:* channels (creation is the AI's job via the
   // `webhook` opencode tool, which returns the one-time signing secret).
   // Refetch-driven like schedules/secrets. See docs/manta-tools-webhook.md.
-  const [showWebhooks, setShowWebhooks] = useState(false);
   const [webhooks, setWebhooks] = useState<WebhookMeta[]>([]);
   const [webhookError, setWebhookError] = useState<string | null>(null);
   const refreshWebhooks = useCallback(() => {
@@ -118,20 +144,18 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
       });
   }, [sessionId]);
 
-  // Close the schedules card + clear its state on session change.
+  // Session change closes whatever card is open and drops every cached list.
+  // One effect for all three — the three near-identical copies this replaces
+  // had already drifted (secrets' was added later, with a comment about the
+  // inconsistency).
   useEffect(() => {
-    setShowSchedules(false);
+    setOpenPanel(null);
     setSchedules([]);
     setScheduleError(null);
-  }, [sessionId]);
-
-  // Close the secrets card + clear its state on session change. Schedules and
-  // webhooks already had this reset; secrets did not — an inconsistency, not
-  // an intentional choice. All four resources now follow the same shape.
-  useEffect(() => {
-    setShowSecrets(false);
     setSecrets([]);
     setSecretError(null);
+    setWebhooks([]);
+    setWebhookError(null);
   }, [sessionId]);
 
   // Keep the toolbar schedule count fresh whether or not the card is open:
@@ -145,87 +169,63 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   useEffect(() => {
     if (!isActive) return;
     void refreshSchedules();
-    const intervalMs = showSchedules ? 10_000 : 30_000;
+    const intervalMs = schedulesOpen ? 10_000 : 30_000;
     const poll = setInterval(() => void refreshSchedules(), intervalMs);
     return () => clearInterval(poll);
-  }, [showSchedules, refreshSchedules, isActive]);
+  }, [schedulesOpen, refreshSchedules, isActive]);
 
   // Secrets are only fetched while the card is open (no toolbar count badge to
   // keep current in the background — unlike schedules). Refetch on open + 10s
   // poll so a secret added on another device shows up.
   useEffect(() => {
-    if (!showSecrets) return;
+    if (!secretsOpen) return;
     void refreshSecrets();
     const poll = setInterval(() => void refreshSecrets(), 10_000);
     return () => clearInterval(poll);
-  }, [showSecrets, refreshSecrets]);
-
-  // Close the webhooks card + clear its state on session change.
-  useEffect(() => {
-    setShowWebhooks(false);
-    setWebhooks([]);
-    setWebhookError(null);
-  }, [sessionId]);
+  }, [secretsOpen, refreshSecrets]);
 
   // Webhooks fetched only while the card is open (creation is agent-driven; the
   // count isn't surfaced on the toolbar, so no background poll). Refetch on open
   // + 10s poll so a model-created hook / a fresh delivery shows up.
   useEffect(() => {
-    if (!showWebhooks) return;
+    if (!webhooksOpen) return;
     void refreshWebhooks();
     const poll = setInterval(() => void refreshWebhooks(), 10_000);
     return () => clearInterval(poll);
-  }, [showWebhooks, refreshWebhooks]);
+  }, [webhooksOpen, refreshWebhooks]);
 
-  // Mobile entry point for the schedules card: the ⋯ sheet (outside ChatPanel)
-  // dispatches a window CustomEvent rather than reaching into this component's
-  // state. Mirrors the manta-scroll-to-question bridge.
+  // Entry point for an out-of-panel opener (the mobile ⋯ sheet dispatched these;
+  // the listeners are the documented bridge and are covered by tests). One loop
+  // over the three names replaces three copy-pasted effects. Open-only — never
+  // a toggle, because the dispatcher has no idea what is currently open.
   useEffect(() => {
-    const onOpenSchedules = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
-      if (detail?.sessionId === sessionId) setShowSchedules(true);
-    };
-    window.addEventListener("manta-open-schedules", onOpenSchedules);
-    return () => window.removeEventListener("manta-open-schedules", onOpenSchedules);
-  }, [sessionId]);
-
-  // Mobile entry point for the secrets card (mirror of manta-open-schedules).
-  useEffect(() => {
-    const onOpenSecrets = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
-      if (detail?.sessionId === sessionId) setShowSecrets(true);
-    };
-    window.addEventListener("manta-open-secrets", onOpenSecrets);
-    return () => window.removeEventListener("manta-open-secrets", onOpenSecrets);
-  }, [sessionId]);
-
-  // Mobile entry point for the webhooks card (mirror of manta-open-schedules).
-  useEffect(() => {
-    const onOpenWebhooks = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
-      if (detail?.sessionId === sessionId) setShowWebhooks(true);
-    };
-    window.addEventListener("manta-open-webhooks", onOpenWebhooks);
-    return () => window.removeEventListener("manta-open-webhooks", onOpenWebhooks);
+    const names: PanelName[] = ["schedules", "secrets", "webhooks"];
+    const offs = names.map((name) => {
+      const type = `manta-open-${name}`;
+      const onOpen = (e: Event) => {
+        const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
+        if (detail?.sessionId === sessionId) setOpenPanel(name);
+      };
+      window.addEventListener(type, onOpen);
+      return () => window.removeEventListener(type, onOpen);
+    });
+    return () => offs.forEach((off) => off());
   }, [sessionId]);
 
   return {
-    showSchedules,
-    setShowSchedules,
+    openPanel,
+    togglePanel,
+    closePanel,
     schedules,
     setSchedules,
     scheduleError,
     setScheduleError,
     refreshSchedules,
-    showSecrets,
-    setShowSecrets,
     secrets,
     setSecrets,
     secretError,
     setSecretError,
     refreshSecrets,
-    showWebhooks,
-    setShowWebhooks,
     webhooks,
     setWebhooks,
     webhookError,


### PR DESCRIPTION
## What

The three server-owned resource cards (schedules / secrets / webhooks) become
ONE surface with three faces. At most one is open at a time; the owning toolbar
button opens it and toggles it back closed.

## How

- `useSessionResources`: replaced the three `show*`/`setShow*` boolean pairs
  with a single `openPanel: PanelName | null` state + `togglePanel`/`closePanel`.
  Collapsed the three session-change reset effects into one and the three
  `manta-open-*` listeners into one loop. Poll cadences unchanged.
- `ChatPanel.tsx`: call sites now use `openPanel`/`togglePanel`/`closePanel`.
- `PanelCards.tsx`: deleted the two click-outside `mousedown` effects and their
  refs; close-button titles now say `Close` (matching SecretsCard).

Source is a net deletion: 86 insertions / 120 deletions across the three source
files. Tests added: same-button-toggles-closed ×3, mutual-exclusion ×2 (the
three existing `manta-open-*` bridge tests pass unchanged).

Base: origin/main @ 25abe6a9

**Files changed:** 4. `ChatPanel.tsx`, `PanelCards.tsx`,
`hooks/useSessionResources.ts`, `ChatPanel.harness.test.tsx`

**Verification results:**
- PR branch (`multica/BET-713-panel-cards-one-open` @ `165ff340`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1553 pass / 0 fail / 0 skip. Failures: none. log sha256: `4b6b37ae079db40648fdf14c533e0cfa4be40d4b97e240548af1263a3b8a0aa0`
- Base (`main` @ `25abe6a9`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1553 pass / 0 fail / 0 skip. Failures: none. log sha256: `15bd1a9d5f7dc32cb753fce29427b5a5cc7ce05fc88ee935ebaf3e1eecbb6fb6`
- **Conclusion:** 0 new failures, 0 pre-existing — identical pass counts between branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.