### PR TITLE
feat(server): adopt backgrounded subagents as delegate job rows (BET-721)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -34,6 +34,7 @@ import {
   summarizeTranscript,
   describeChatActivity,
 } from "./peers.mjs";
+import { extractSubagentInfo } from "../shared/streamInterpretation.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (mirrors capabilities.mjs exactly — reuse, do not diverge)
@@ -248,6 +249,116 @@ export async function getJob(id, { load = loadJobs } = {}) {
 // {ok:false, error} — never leave a half-created job.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// registerJob — the shared "window + record + publish" half of startJob
+// (formerly steps 6 and 7). Registers an existing-or-new opencode session into
+// a chat-mode tmux window and persists the record. `existingSessionId` adopts
+// an already-running session (the backgrounded-subagent path); undefined
+// creates a fresh one (the delegate path). The ONLY place that builds a job
+// record or calls newWindow. On a window-creation throw it undoes the worktree
+// (best-effort) and returns {ok:false, error}.
+// ---------------------------------------------------------------------------
+
+async function registerJob(
+  {
+    parentSessionID,
+    parentDirectory,
+    name,
+    prompt,
+    model,
+    cwd,
+    worktree,
+    branch,
+    baseSha,
+    existingSessionId,
+    origin,
+    permission,
+  },
+  deps = {},
+) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    newWindow,
+    listProjects,
+    gitRemoveWorktree,
+    oc,
+    now = () => Date.now(),
+  } = deps;
+
+  let childSessionID = null;
+  let tmuxSession = null;
+  let windowIndex = null;
+  try {
+    const owner = resolveOwner(await listProjects(), parentSessionID);
+    if (!owner) {
+      throw new Error(`could not resolve the tmux session owning ${parentSessionID}`);
+    }
+    tmuxSession = owner.tmuxSession;
+    const created = await newWindow({
+      sessionName: tmuxSession,
+      windowName: name,
+      cwd,
+      chatMode: true,
+      existingSessionId,
+      worktreePath: worktree,
+      oc,
+      permission,
+    });
+    childSessionID = created.sessionId ?? existingSessionId ?? null;
+    windowIndex = created.windowIndex ?? null;
+    if (!childSessionID) {
+      throw new Error("could not read the new window's opencode session id");
+    }
+  } catch (e) {
+    // Undo the worktree in reverse (best-effort) — mirrors the old startJob
+    // rollback on a window-creation throw.
+    if (worktree && gitRemoveWorktree) {
+      try {
+        await gitRemoveWorktree({ path: worktree, force: false });
+      } catch {
+        /* best-effort cleanup; the start failure is the headline error */
+      }
+    }
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+
+  // Persist the record with status "running", startedAt = now.
+  const id = genId();
+  const job = {
+    id,
+    name,
+    prompt,
+    model: model ?? null,
+    parentSessionID,
+    parentDirectory,
+    childSessionID,
+    tmuxSession,
+    windowIndex,
+    worktree,
+    branch,
+    baseSha,
+    origin,
+    status: "running",
+    activity: null,
+    createdAt: now(),
+    startedAt: now(),
+    finishedAt: null,
+    result: null,
+    error: null,
+    filesChanged: null,
+  };
+  {
+    const jobs = await load();
+    jobs.push(job);
+    await save(jobs);
+  }
+  publish?.({ kind: "delegate.updated", payload: { id, status: "running" } });
+
+  return { ok: true, job };
+}
+
 /**
  * @param {{prompt:string, model?:string, parentSessionID:string, parentDirectory:string}} input
  * @param {object} deps injected I/O (load/save/publish/deliver/listProjects/
@@ -256,14 +367,9 @@ export async function getJob(id, { load = loadJobs } = {}) {
 export async function startJob(input, deps = {}) {
   const {
     load = loadJobs,
-    save = saveJobs,
-    publish,
     deliver,
-    listProjects,
-    newWindow,
     gitAddWorktree,
     gitRun,
-    now = () => Date.now(),
   } = deps;
 
   const prompt = String(input?.prompt ?? "");
@@ -329,87 +435,30 @@ export async function startJob(input, deps = {}) {
     }
   }
 
-  // 6. Create the window. Because chatMode is true, newWindow already creates
-  //    the opencode session and stamps @manta-session-id; read the new
-  //    window's opencodeSessionId back out of the returned project list —
-  //    that is childSessionID. On throw, undo step 4 (remove the worktree)
-  //    and return {ok:false, error}.
-  let childSessionID = null;
-  let tmuxSession = null;
-  let windowIndex = null;
-  try {
-    const owner = resolveOwner(await listProjects(), parentSessionID);
-    if (!owner) {
-      throw new Error(`could not resolve the tmux session owning ${parentSessionID}`);
-    }
-    tmuxSession = owner.tmuxSession;
-    // 6b. The create returns the new window's identity (sessionId +
-    // windowIndex) directly — no need to re-locate it by name from the
-    // refreshed listing (which could catch a same-named sibling window).
-    const created = await newWindow({
-      sessionName: tmuxSession,
-      windowName: name,
+  // 6+7. Register the window + record + publish.
+  const reg = await registerJob(
+    {
+      parentSessionID,
+      parentDirectory,
+      name,
+      prompt,
+      model: input?.model,
       cwd,
-      chatMode: true,
-      worktreePath: worktree,
-      oc: deps.oc,
+      worktree,
+      branch,
+      baseSha,
+      existingSessionId: undefined,
+      origin: "delegate",
       permission: input?.permission,
-    });
-    const owner2 = resolveOwner(created.projects, parentSessionID);
-    childSessionID = created.sessionId ?? null;
-    windowIndex = created.windowIndex ?? null;
-    void owner2;
-    // Sanity: if we somehow failed to resolve the child session id, abort.
-    if (!childSessionID) {
-      throw new Error("could not read the new window's opencode session id");
-    }
-  } catch (e) {
-    // Undo step 4 in reverse: remove the worktree (force:false, best-effort).
-    if (worktree && deps.gitRemoveWorktree) {
-      try {
-        await deps.gitRemoveWorktree({ path: worktree, force: false });
-      } catch {
-        /* best-effort cleanup; the start failure is the headline error */
-      }
-    }
-    return { ok: false, error: String(e?.message ?? e) };
-  }
-
-  // 7. Persist the record with status "running", startedAt = now.
-  const id = genId();
-  const job = {
-    id,
-    name,
-    prompt,
-    model: input?.model ?? null,
-    parentSessionID,
-    parentDirectory,
-    childSessionID,
-    tmuxSession,
-    windowIndex,
-    worktree,
-    branch,
-    baseSha,
-    status: "running",
-    activity: null,
-    createdAt: now(),
-    startedAt: now(),
-    finishedAt: null,
-    result: null,
-    error: null,
-    filesChanged: null,
-  };
-  {
-    const jobs = await load();
-    jobs.push(job);
-    await save(jobs);
-  }
-  publish?.({ kind: "delegate.updated", payload: { id, status: "running" } });
+    },
+    deps,
+  );
+  if (!reg.ok) return reg;
 
   // 8. Send the opening prompt via the shared delivery module's deliver.
   try {
     await deliver({
-      sessionId: childSessionID,
+      sessionId: reg.job.childSessionID,
       text: buildJobPrompt({ prompt, worktree, branch }),
     });
   } catch (e) {
@@ -419,7 +468,64 @@ export async function startJob(input, deps = {}) {
     console.warn("[delegate] opening prompt delivery failed:", e?.message ?? e);
   }
 
-  return { ok: true, job };
+  return { ok: true, job: reg.job };
+}
+
+// ---------------------------------------------------------------------------
+// adoptSubagentJob — promote an opencode background subagent into a delegate
+// job record (BET-721). opencode has ALREADY started the child session (the
+// parent's `task` tool ran with background:true), so this entry point adopts
+// that session into the store + a window rather than creating anything. The
+// detecting event fires repeatedly as the tool part updates, so adoption must
+// be idempotent.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {{parentSessionID:string, parentDirectory:string, childSessionID:string,
+ *          name:string, prompt:string, model?:object}} input
+ * @param {object} deps injected I/O (load/save/publish/newWindow/listProjects)
+ * @returns {Promise<{ok:true, job:object}|{ok:true, alreadyAdopted:true}|{ok:false, error:string}>}
+ */
+export async function adoptSubagentJob(
+  { parentSessionID, parentDirectory, childSessionID, name, prompt, model },
+  deps = {},
+) {
+  const { load = loadJobs } = deps;
+
+  if (!parentSessionID || !parentDirectory || !childSessionID) {
+    return { ok: false, error: "parentSessionID, parentDirectory and childSessionID are required" };
+  }
+
+  // Idempotent — the detecting event fires repeatedly as the tool part updates.
+  {
+    const jobs = await load();
+    const exists = jobs.find((j) => j.childSessionID === childSessionID);
+    if (exists) {
+      return { ok: true, alreadyAdopted: true };
+    }
+  }
+
+  // We deliberately do NOT enforce MAX_RUNNING_JOBS and do NOT enforce the
+  // no-nesting rule: opencode has already started this subagent, so refusing
+  // to record it would only make it invisible — the exact bug this fixes.
+  // We also do NOT create a worktree (the session is adopted, not created)
+  // and do NOT call deliver() — opencode already sent the child its prompt.
+  return registerJob(
+    {
+      parentSessionID,
+      parentDirectory,
+      name,
+      prompt,
+      model,
+      cwd: parentDirectory,
+      worktree: null,
+      branch: null,
+      baseSha: null,
+      existingSessionId: childSessionID,
+      origin: "subagent",
+    },
+    deps,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -441,6 +547,46 @@ export async function observeEvent(evt, deps = {}, sawBusy = new Map()) {
   if (typeof sid !== "string" || !sid) return;
   const { load = loadJobs } = deps;
   const jobs = await load();
+
+  // BET-721: passively adopt a background subagent into the job store so it
+  // appears as a nested sidebar row. Detection is passive (events never carry
+  // `background:true` unless the capability is on) and must never throw into
+  // the pump.
+  if (evt.type === "message.part.updated") {
+    try {
+      const info = extractSubagentInfo(evt?.properties?.part);
+      if (
+        info &&
+        info.background === true &&
+        (info.status === "running" || info.status === "pending")
+      ) {
+        const projects = deps.listProjects ? await deps.listProjects() : [];
+        const owner = resolveOwner(projects, evt?.properties?.sessionID);
+        if (!owner) {
+          console.warn(
+            "[delegate] could not resolve the owning window to adopt background subagent:",
+            evt?.properties?.sessionID,
+          );
+          return;
+        }
+        await adoptSubagentJob(
+          {
+            parentSessionID: evt?.properties?.sessionID,
+            parentDirectory: owner.cwd,
+            childSessionID: info.childSessionId,
+            name: info.description || info.agent,
+            prompt: info.prompt,
+            model: info.model,
+          },
+          deps,
+        );
+        return;
+      }
+    } catch (e) {
+      console.warn("[delegate] background-subagent adoption failed:", e?.message ?? e);
+    }
+  }
+
   const job = jobs.find((j) => j.childSessionID === sid && j.status === "running");
   if (!job) {
     // Not a tracked background job — but still keep the sawBusy flag honest so
@@ -622,7 +768,12 @@ export async function finishJob(job, status, error, deps = {}, sawBusy) {
   // Deliver the completion message to the parent session (deferred until idle
   // by the shared delivery engine). Swallow a failure — the job is terminal
   // regardless.
-  if (deliver && job.parentSessionID) {
+  //
+  // BET-721: skip the deliver for adopted subagents — opencode ALREADY injects
+  // the <task ...> result into the parent when the child finishes, so
+  // delivering ours too would report the same job twice. A missing `origin`
+  // (records written before this change) means `delegate` and still delivers.
+  if (deliver && job.parentSessionID && job.origin !== "subagent") {
     try {
       await deliver({
         sessionId: job.parentSessionID,

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -16,6 +16,7 @@ import {
   createApprovalState,
   MAX_RUNNING_JOBS,
   createDelegateEngine,
+  adoptSubagentJob,
 } from "./delegate.mjs";
 
 // ----------------------------------------------------------------------------
@@ -512,6 +513,161 @@ test("observeEvent ignores events for untracked sessions", async () => {
   const sawBusy = new Map();
   await observeEvent({ type: "session.idle", properties: { sessionID: "other" } }, h.deps, sawBusy);
   assert.equal(h.jobs[0].status, "running");
+});
+
+// ----------------------------------------------------------------------------
+// BET-721: background subagent → delegate job adoption
+// ----------------------------------------------------------------------------
+
+function adoptHarness(initialJobs = []) {
+  const h = harness(initialJobs);
+  const newWindowCalls = [];
+  let gitAddWorktree = 0;
+  h.deps.listProjects = async () => [
+    { tmuxSession: "proj", windows: [{ index: 0, opencodeSessionId: "ses_parent", paneCurrentPath: "/repo" }] },
+  ];
+  h.deps.newWindow = async (input) => {
+    newWindowCalls.push(input);
+    return {
+      sessionId: input.existingSessionId ?? `ses_created_${newWindowCalls.length}`,
+      windowIndex: 3,
+      projects: [],
+    };
+  };
+  h.deps.gitAddWorktree = async () => {
+    gitAddWorktree += 1;
+    throw new Error("adoptSubagentJob must never create a worktree");
+  };
+  h.newWindowCalls = newWindowCalls;
+  Object.defineProperty(h, "gitAddWorktreeCalls", {
+    get: () => gitAddWorktree,
+    enumerable: true,
+  });
+  return h;
+}
+
+const ADOPT_INPUT = {
+  parentSessionID: "ses_parent",
+  parentDirectory: "/repo",
+  childSessionID: "ses_child",
+  name: "explore",
+  prompt: "go explore",
+  model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+};
+
+test("adoptSubagentJob adopts a window with existingSessionId, no worktree, origin subagent", async () => {
+  const a = adoptHarness();
+  const res = await adoptSubagentJob(ADOPT_INPUT, a.deps);
+  assert.equal(res.ok, true);
+  assert.equal(a.newWindowCalls.length, 1);
+  assert.equal(a.newWindowCalls[0].existingSessionId, "ses_child");
+  assert.equal(a.gitAddWorktreeCalls, 0, "no worktree is created");
+  const stored = a.jobs[0];
+  assert.equal(stored.childSessionID, "ses_child");
+  assert.equal(stored.worktree, null);
+  assert.equal(stored.branch, null);
+  assert.equal(stored.baseSha, null);
+  assert.equal(stored.origin, "subagent");
+  assert.equal(stored.status, "running");
+});
+
+test("adoptSubagentJob never delivers the opening prompt", async () => {
+  const a = adoptHarness();
+  await adoptSubagentJob(ADOPT_INPUT, a.deps);
+  assert.equal(a.delivered.length, 0);
+});
+
+test("adoptSubagentJob is idempotent for the same childSessionID", async () => {
+  const a = adoptHarness();
+  const first = await adoptSubagentJob(ADOPT_INPUT, a.deps);
+  assert.equal(first.ok, true);
+  const second = await adoptSubagentJob(ADOPT_INPUT, a.deps);
+  assert.equal(second.ok, true);
+  assert.equal(second.alreadyAdopted, true);
+  assert.equal(a.newWindowCalls.length, 1, "newWindow called only once");
+  assert.equal(a.jobs.length, 1);
+});
+
+test("adoptSubagentJob ignores the running cap and the no-nesting rule", async () => {
+  const atCap = adoptHarness(Array.from({ length: MAX_RUNNING_JOBS }, (_, i) => runningJob(i)));
+  const resCap = await adoptSubagentJob(
+    { ...ADOPT_INPUT, childSessionID: "ses_capchild" },
+    atCap.deps,
+  );
+  assert.equal(resCap.ok, true, "adopts even at the running cap");
+  assert.equal(
+    atCap.jobs.filter((j) => j.status === "running").length,
+    MAX_RUNNING_JOBS + 1,
+  );
+
+  // Parent is itself a running job's child → startJob would refuse nesting, but adoption allows it.
+  const nestedParent = runningJob(0).childSessionID; // e.g. "child0"
+  const nested = adoptHarness([runningJob(0)]);
+  nested.deps.listProjects = async () => [
+    { tmuxSession: "proj", windows: [{ index: 0, opencodeSessionId: nestedParent, paneCurrentPath: "/repo" }] },
+  ];
+  const resNested = await adoptSubagentJob(
+    { ...ADOPT_INPUT, parentSessionID: nestedParent, childSessionID: "ses_nestedchild" },
+    nested.deps,
+  );
+  assert.equal(resNested.ok, true, "adopts even when the parent is a running job's child");
+});
+
+function backgroundPart(overrides = {}) {
+  return {
+    type: "tool",
+    tool: "task",
+    state: {
+      status: "running",
+      input: { subagent_type: "explore", description: "go explore", prompt: "go explore" },
+      metadata: { sessionId: "ses_child", background: true },
+    },
+    ...overrides,
+  };
+}
+
+test("observeEvent adopts a running background:true subagent from a message.part.updated", async () => {
+  const a = adoptHarness();
+  const evt = { type: "message.part.updated", properties: { sessionID: "ses_parent", part: backgroundPart() } };
+  await observeEvent(evt, a.deps, new Map());
+  assert.equal(a.jobs.length, 1);
+  assert.equal(a.jobs[0].childSessionID, "ses_child");
+  assert.equal(a.jobs[0].origin, "subagent");
+  assert.equal(a.jobs[0].status, "running");
+  assert.equal(a.newWindowCalls[0].existingSessionId, "ses_child");
+});
+
+test("observeEvent adopts nothing when background is absent from the part", async () => {
+  const a = adoptHarness();
+  const part = backgroundPart();
+  delete part.state.metadata.background;
+  const evt = { type: "message.part.updated", properties: { sessionID: "ses_parent", part } };
+  await observeEvent(evt, a.deps, new Map());
+  assert.equal(a.jobs.length, 0);
+  assert.equal(a.newWindowCalls.length, 0);
+});
+
+test("observeEvent adopts nothing for a completed background task", async () => {
+  const a = adoptHarness();
+  const evt = { type: "message.part.updated", properties: { sessionID: "ses_parent", part: backgroundPart({ state: { ...backgroundPart().state, status: "completed" } }) } };
+  await observeEvent(evt, a.deps, new Map());
+  assert.equal(a.jobs.length, 0);
+  assert.equal(a.newWindowCalls.length, 0);
+});
+
+test("finishJob does not deliver for origin subagent, but still does for delegate and legacy", async () => {
+  const sub = harness([{ ...runningObserverJob(), id: "sub", worktree: null, origin: "subagent" }]);
+  await finishJob(sub.jobs[0], "done", null, sub.deps, new Map());
+  assert.equal(sub.delivered.length, 0, "opencode already injects the <task> result for adopted subagents");
+
+  for (const job of [
+    { ...runningObserverJob(), id: "del", worktree: null, origin: "delegate" },
+    { ...runningObserverJob(), id: "legacy", worktree: null }, // no origin field (pre-change record)
+  ]) {
+    const h = harness([job]);
+    await finishJob(h.jobs[0], "done", null, h.deps, new Map());
+    assert.equal(h.delivered.length, 1, `delivers for ${job.id}`);
+  }
 });
 
 // ----------------------------------------------------------------------------

--- a/src/shared/streamInterpretation.d.mts
+++ b/src/shared/streamInterpretation.d.mts
@@ -163,6 +163,7 @@ export type SubagentInfo = {
   title: string | null;
   output: string | null;
   truncated: boolean;
+  background: boolean;
   durationMs: number | null;
   model: { providerID: string; modelID: string } | null;
 };

--- a/src/shared/streamInterpretation.mjs
+++ b/src/shared/streamInterpretation.mjs
@@ -704,6 +704,7 @@ export function extractSubagentInfo(part) {
     title: typeof state.title === "string" ? state.title : null,
     output: typeof state.output === "string" ? state.output : null,
     truncated: meta.truncated === true,
+    background: meta.background === true,
     durationMs,
     model,
   };

--- a/src/shared/streamInterpretation.test.ts
+++ b/src/shared/streamInterpretation.test.ts
@@ -1275,6 +1275,7 @@ describe("extractSubagentInfo", () => {
       title: "Find skill loading code",
       output: "I found that skills load from…",
       truncated: false,
+      background: false,
       durationMs: 12500,
       model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
     });
@@ -1325,6 +1326,21 @@ describe("extractSubagentInfo", () => {
       state: { status: "completed", input: {}, metadata: { sessionId: "ses_x", truncated: "yes" as unknown } },
     };
     expect(extractSubagentInfo(p2)?.truncated).toBe(false);
+  });
+
+  it("background is true when stamped in metadata, false when absent", () => {
+    const bg = {
+      type: "tool",
+      tool: "task",
+      state: { status: "running", input: {}, metadata: { sessionId: "ses_x", background: true } },
+    };
+    expect(extractSubagentInfo(bg)?.background).toBe(true);
+    const plain = {
+      type: "tool",
+      tool: "task",
+      state: { status: "running", input: {}, metadata: { sessionId: "ses_x" } },
+    };
+    expect(extractSubagentInfo(plain)?.background).toBe(false);
   });
 });
 


### PR DESCRIPTION
Server-only change (BET-721). No `src/renderer/**` touched.

## What
A backgrounded subagent (`task` tool with `background:true`) is now **adopted** into the delegate job store + a chat-mode tmux window, so it appears in the sidebar as a nested job row with a live activity line — identical surface to a `delegate` job, one records concept.

- `startJob` split: new `registerJob` helper is the **only** place that builds a job record or calls `newWindow` (steps 6+7 verbatim, with `existingSessionId`/`origin` params). `startJob` keeps steps 1–5 and 8; its net line count went down.
- New `adoptSubagentJob` entry point: idempotent, no worktree (`worktree/branch/baseSha: null, cwd: parentDirectory`), no cap, no no-nesting rule (opencode already started the child — refusing would just make it invisible), no `deliver()` (opencode already sent the prompt). One new record field: `origin: "delegate" | "subagent"`.
- `observeEvent` passively detects `message.part.updated` with a running/pending `background:true` task part, resolves the parent dir via `resolveOwner`, and adopts. All inside try/catch — never throws into the pump. No capability probing (off boxes just emit no `background:true`).
- `finishJob` skips the completion `deliver` for `origin === "subagent"` (opencode already injects the `<task ...>` result); a missing `origin` (legacy records) still delivers.
- `extractSubagentInfo` surfaces `background`.

## Caveats on the diffstat
The net is above the ~150-line soft guidance, driven by the three required new paths: `registerJob` (the extraction), `adoptSubagentJob`, and the `observeEvent` detection block — plus the 7 requested tests. There is **no duplication**: `registerJob` is the verbatim extraction of the old steps 6+7, and nothing copies it. The jscpd duplication-gate is clean.

## Manual check (recorded)
1. `curl -s 127.0.0.1:4096/experimental/capabilities` → `{"backgroundSubagents":true}` (opened-serve restarted to pick up the BET-726 flag; a live unit reports the capability on).
2-6. Live subagent adoption requires driving a real opencode chat + background `task` on this box — not runnable in a unit/sandboxed context here. The adoption logic is covered by the injected-IO unit tests below (window stamped with `existingSessionId`, record `origin:"subagent"`/`status:"running"`, idempotency, no worktree/deliver, no cap/nesting, `observeEvent` detection, finishJob deliver suppression). The end-to-end sidebar rendering is unchanged renderer code and was deliberately not exercised server-side.

## Diffstat
```
src/server/delegate.mjs                 | 315 +++++++++++++++++++++++---------
src/server/delegate.test.mjs            | 156 ++++++++++++++++
src/shared/streamInterpretation.d.mts   |   1 +
src/shared/streamInterpretation.mjs     |   1 +
src/shared/streamInterpretation.test.ts |  16 ++
5 files changed, 407 insertions(+), 82 deletions(-)
net +325
```

**Base: origin/main @ `bf0690ad`**

**Verification results:**
- PR branch (`multica/BET-721-backgrounded-subagents-job-row`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. Server 1561/1561 pass, 0 fail; Vitest 2243 pass / 7 skip. log sha256: `feb4b6bffcba37287f3f6560a9980430c3518ceaef4fdae9b5f71e0a06d07196`
- The 3 pre-existing server failures (`capabilities.test.mjs`, `pairPage.test.mjs`, `pty.test.mjs`) are identical on a clean `main` checkout (verified via stash) — not caused by this PR.
