### PR TITLE
BET-641: Delete orphaned bulletStyle helper + its test block

### DIFF
--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -16,7 +16,7 @@ import { memo, useState } from "react";
 import { motion } from "framer-motion";
 import { MESSAGE_IN_ENTER, MESSAGE_IN_IDLE } from "./chatMotion";
 import type { OpencodePart } from "../shared/types";
-import { resolveToolOutput, cssVar } from "./chatUtils";
+import { resolveToolOutput } from "./chatUtils";
 import { type ToolState } from "./chatShared";
 import { renderMarkdown } from "./MarkdownBody";
 import {
@@ -44,19 +44,6 @@ export function formatFileDiff(additions: number, deletions: number): React.Reac
       {deletions > 0 && <span className="text-danger">−{deletions}</span>}
     </>
   );
-}
-
-// Bullet color/animation by part kind + tool status. Text gets grey; tools
-// blink grey while running/pending, turn green on completion, red on error.
-export function bulletStyle(part: OpencodePart): { color: string; pulse: boolean } {
-  if (part.type !== "tool") {
-    return { color: cssVar("--tx4"), pulse: false };           // text/other: grey
-  }
-  const status = String(((part as Record<string, unknown>).state as { status?: string } | undefined)?.status ?? "");
-  if (status === "completed") return { color: cssVar("--ok"), pulse: false }; // green
-  if (status === "error") return { color: cssVar("--danger"), pulse: false };     // red
-  // "running" / "pending" / unknown-but-active → blinking grey
-  return { color: cssVar("--tx4"), pulse: true };
 }
 
 // Memoized so re-renders of a memo'd MessageRow whose parts haven't

--- a/src/renderer/toolRendering.test.tsx
+++ b/src/renderer/toolRendering.test.tsx
@@ -1,14 +1,12 @@
 // @vitest-environment jsdom
 //
-// Pure-rendering tests for tool part rendering. The `bulletStyle` cases live
-// in the default (node) test env and run unchanged. The `TaskBody` cases
+// Pure-rendering tests for tool part rendering. The `TaskBody` cases
 // below need jsdom because they mount a real React subtree via
 // `./testHarness`.
 
 import { act, useState } from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cssVar } from "./chatUtils";
-import { AssistantPart, bulletStyle, ToolCall, formatFileDiff } from "./ToolCall";
+import { AssistantPart, ToolCall, formatFileDiff } from "./ToolCall";
 import {
   installMockApi,
   mount,
@@ -29,11 +27,6 @@ function expandAll(container: Element) {
   }
 }
 
-// Build a tool part with a given lifecycle status.
-function toolPart(status?: string): OpencodePart {
-  return { type: "tool", tool: "bash", state: status ? { status } : {} } as unknown as OpencodePart;
-}
-
 // A minimal task tool part that extractSubagentInfo accepts (it requires
 // state.metadata.sessionId to be present, otherwise it returns null and the
 // TaskBody card doesn't render at all).
@@ -49,27 +42,6 @@ function taskPart(input: Record<string, unknown> = {}): OpencodePart {
     },
   } as unknown as OpencodePart;
 }
-
-describe("bulletStyle", () => {
-  it("grey, no pulse for non-tool parts", () => {
-    const text = { type: "text", text: "hi" } as unknown as OpencodePart;
-    expect(bulletStyle(text)).toEqual({ color: cssVar("--tx4"), pulse: false });
-  });
-
-  it("green, no pulse for a completed tool", () => {
-    expect(bulletStyle(toolPart("completed"))).toEqual({ color: cssVar("--ok"), pulse: false });
-  });
-
-  it("red, no pulse for an errored tool", () => {
-    expect(bulletStyle(toolPart("error"))).toEqual({ color: cssVar("--danger"), pulse: false });
-  });
-
-  it("grey + pulse for running / pending / unknown-active tools", () => {
-    expect(bulletStyle(toolPart("running"))).toEqual({ color: cssVar("--tx4"), pulse: true });
-    expect(bulletStyle(toolPart("pending"))).toEqual({ color: cssVar("--tx4"), pulse: true });
-    expect(bulletStyle(toolPart(undefined))).toEqual({ color: cssVar("--tx4"), pulse: true });
-  });
-});
 
 describe("formatFileDiff", () => {
   let h: Harness | null = null;


### PR DESCRIPTION
**Refactor only.** Removes the now test-only `bulletStyle` export in `src/renderer/ToolCall.tsx` (its only production caller, the per-part text/tool bullet gutter, was removed in BET-637), plus its now-unused `cssVar` import, the unused `toolPart` test helper, and the `bulletStyle` describe block in `src/renderer/toolRendering.test.tsx`. Behavior-neutral — nothing renders it.

**Files changed:** 2
- `src/renderer/ToolCall.tsx`
- `src/renderer/toolRendering.test.tsx`

**Verification results:**
- typecheck: exit 0, no errors
- test: exit 0, 1553 pass / 0 fail / 0 skip
- Base: origin/main @ dd312c8f

No follow-ups filed — this is the complete cleanup of the orphaned helper.