### PR TITLE
feat(ios): in-app QR scanner + paired 'Switch box?' re-pair flow (BET-702)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		C414F36E83344076CE4F1ACD /* TerminalModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */; };
 		C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */; };
 		CC6A77686B936B4DB6026466 /* ChatModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */; };
+		D3E89E0419EE12C59BEA62A9 /* MantaQRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4D07F9EBDCD8A693C141FF /* MantaQRScanner.swift */; };
 		D776E336456236DC1493565F /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229392FD3405558D301D0809 /* ChatModel.swift */; };
 		D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */; };
 		D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42691C89906181C99929354 /* ComposerView.swift */; };
@@ -135,6 +136,7 @@
 		4F7631E09B6FF7B150392A83 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
 		570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaChatSurfaceCaptureUITests.swift; sourceTree = "<group>"; };
 		57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsTests.swift; sourceTree = "<group>"; };
+		5B4D07F9EBDCD8A693C141FF /* MantaQRScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaQRScanner.swift; sourceTree = "<group>"; };
 		5C02DA420B52094269A88E80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5D71EC917661085ED10E0867 /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
 		5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIOverflowCaptureUITests.swift; sourceTree = "<group>"; };
@@ -310,6 +312,7 @@
 				8C8240F1954861B4846E279D /* MantaModels.swift */,
 				4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */,
 				3531B9EF3162D19FB6C30756 /* MantaPairingModels.swift */,
+				5B4D07F9EBDCD8A693C141FF /* MantaQRScanner.swift */,
 				772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */,
 				39978655A14BFA5D39336286 /* MantaSettingsModels.swift */,
 				ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */,
@@ -552,6 +555,7 @@
 				01871023D47544D64443194D /* MantaModels.swift in Sources */,
 				6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */,
 				3354E683F0CE92566A77C7D3 /* MantaPairingModels.swift in Sources */,
+				D3E89E0419EE12C59BEA62A9 /* MantaQRScanner.swift in Sources */,
 				EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */,
 				1B9026B4F0286A5186FD5197 /* MantaSettingsModels.swift in Sources */,
 				9055A7DECF435A0A430D6FAB /* MantaSettingsStore.swift in Sources */,

--- a/mobile/native/MantaUI/Info.plist
+++ b/mobile/native/MantaUI/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Scan the pairing code shown by the Manta desktop app.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -18,9 +18,18 @@ struct MantaAppRoot: View {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var flow: MantaOnboardingFlow
     @State private var paired: Bool
+    /// A pairing payload that arrived while already paired — pending the
+    /// "Switch box?" confirmation (BET-702).
+    @State private var switchRequest: MantaPairing.PairPayload?
 
     init() {
-        let isPaired = (try? KeychainCredentialStore.shared.load()) != nil
+        // UI-test / verification seam (BET-702): `MANTA_UI_FORCE_PAIRED` makes
+        // the app boot into the paired destination WITHOUT touching the real
+        // Keychain, so the "Switch box?" re-pair path is reachable from a
+        // UITest with no persistent credentials write.
+        let env = ProcessInfo.processInfo.environment
+        let forcedPaired = env["MANTA_UI_FORCE_PAIRED"] == "1"
+        let isPaired = forcedPaired ? true : (try? KeychainCredentialStore.shared.load()) != nil
         _paired = State(initialValue: isPaired)
         _flow = StateObject(wrappedValue: MantaOnboardingFlow(onPaired: {}))
     }
@@ -47,11 +56,7 @@ struct MantaAppRoot: View {
                 MantaOnboardingRoot(flow: flow, tokens: tokens)
                     .onAppear { flow.prepare(onboardingScene: scene) }
                     .onAppear {
-                        flow.onPaired = {
-                            paired = true
-                            store.start()
-                            MantaPushService.registerAfterPairing()
-                        }
+                        flow.onPaired = commitPairing
                     }
             } else if let scene, scene == "chat-overflow-clear" {
                 // BET-628 capture scene — raises the real ChatOverflowSheet so
@@ -81,11 +86,7 @@ struct MantaAppRoot: View {
             } else {
                 MantaOnboardingRoot(flow: flow, tokens: tokens)
                     .onAppear {
-                        flow.onPaired = {
-                            paired = true
-                            store.start()
-                            MantaPushService.registerAfterPairing()
-                        }
+                        flow.onPaired = commitPairing
                     }
             }
         }
@@ -112,10 +113,70 @@ struct MantaAppRoot: View {
         }
         .onReceive(MantaPairingRouter.shared.$pendingPayload) { payload in
             guard let payload else { return }
-            flow.receive(payload: payload)
-            // The staged payload is consumed by `receive` — clear it so link
-            // handling isn't state-dependent (the same link must stage once).
+            // The staged payload is consumed here — clear it so link handling
+            // isn't state-dependent (the same link must stage once).
             MantaPairingRouter.shared.pendingPayload = nil
+            if paired {
+                // Paired device + a pairing link = a re-pair onto a different
+                // box. Present the "Switch box?" confirmation instead of
+                // silently ignoring the link (BET-702).
+                switchRequest = payload
+            } else {
+                flow.receive(payload: payload)
+            }
         }
+        .sheet(isPresented: Binding(
+            get: { switchRequest != nil },
+            set: { if !$0 { switchRequest = nil } }
+        )) {
+            if let request = switchRequest {
+                MantaSwitchBoxSheet(
+                    tokens: tokens,
+                    currentHost: currentBoxHost,
+                    newHost: newBoxHost(for: request),
+                    onCancel: { switchRequest = nil },
+                    onSwitch: { beginSwitch(request) }
+                )
+            }
+        }
+    }
+
+    /// Shared completion for a successful pairing, fresh or re-pair. When the
+    /// flow is in "Switch box" mode, first tear down the old box's event
+    /// stream and wipe its session list so nothing from the previous box
+    /// bleeds into the new one (BET-702).
+    private var commitPairing: () -> Void {
+        {
+            if flow.isSwitching {
+                store.stop()
+                sessionStore.resetForBoxChange()
+            }
+            paired = true
+            store.start()
+            MantaPushService.registerAfterPairing()
+        }
+    }
+
+    private var currentBoxHost: String {
+        // The same verification seam feeds a synthetic current host so the
+        // Switch box sheet has a real value to compare even without credentials.
+        if let h = ProcessInfo.processInfo.environment["MANTA_UI_PAIR_HOST"], !h.isEmpty {
+            return h
+        }
+        return (try? KeychainCredentialStore.shared.load())?.serverUrl ?? ""
+    }
+
+    private func newBoxHost(for payload: MantaPairing.PairPayload) -> String {
+        MantaPairing.claimBaseURL(payload)?.absoluteString ?? ""
+    }
+
+    /// Begin the re-pair: route the new payload through the EXISTING claim
+    /// path by mounting the onboarding flow (which renders linking + the typed
+    /// failure screens). `flow.isSwitching` makes a success reset local state.
+    private func beginSwitch(_ payload: MantaPairing.PairPayload) {
+        switchRequest = nil
+        flow.isSwitching = true
+        flow.receive(payload: payload)
+        paired = false
     }
 }

--- a/mobile/native/MantaUI/MantaOnboarding.swift
+++ b/mobile/native/MantaUI/MantaOnboarding.swift
@@ -40,6 +40,11 @@ final class MantaOnboardingFlow: ObservableObject {
 
     @Published var phase: Phase = .entry
 
+    /// BET-702: present the in-app QR scanner sheet. Set by the entry screen's
+    /// "Scan QR code" button AND by the `onboarding-scan` capture scene; the
+    /// onboarding root owns the sheet (so it can be deterministically mounted).
+    @Published var scanRequested = false
+
     // Manual-entry inputs.
     @Published var code = ""
     @Published var boxId = ""
@@ -52,6 +57,12 @@ final class MantaOnboardingFlow: ObservableObject {
     // Credentials returned by a SUCCESSFUL claim, held so a Keychain-save
     // retry can re-attempt ONLY the save (never re-claim a burned code).
     private var savedCredentials: MantaCredentials?
+
+    /// True while the flow is re-pairing a PAIRED device onto a new box (the
+    /// BET-702 "Switch box?" path). A successful claim then completes
+    /// immediately (skip the notifications priming — the device is already a
+    /// Manta client) and `onPaired` is responsible for resetting local state.
+    var isSwitching = false
 
     // No hardcoded ring: the linking progress stages are all resolved through
     // the copy table; there is no positional/color literal anywhere in app code.
@@ -159,6 +170,9 @@ final class MantaOnboardingFlow: ObservableObject {
         let box = "0123abcd0123abcd0123abcd0123abcd"
         let suffix = name.hasPrefix("onboarding-") ? String(name.dropFirst("onboarding-".count)) : name
         switch suffix {
+        case "scan":
+            phase = .entry
+            scanRequested = true
         case "linking":
             pending = MantaPairing.PairPayload(boxId: box, code: "123456", serverUrl: nil)
             activeLinkingStage = 0
@@ -220,7 +234,14 @@ final class MantaOnboardingFlow: ObservableObject {
                 try KeychainCredentialStore.shared.save(credentials)
                 // Stage 3: the Keychain save succeeded.
                 activeLinkingStage = 2
-                phase = .notifications
+                if isSwitching {
+                    // Re-pair onto a new box: the old device is already a
+                    // Manta client — skip the notifications primer and hand off
+                    // so `onPaired` resets the session list + event stream.
+                    onPaired()
+                } else {
+                    phase = .notifications
+                }
             } catch {
                 phase = .failure(.saveFailed)
             }
@@ -313,6 +334,24 @@ struct MantaManualEntryView: View {
             header(title: "Enter the code",
                    subtitle: "Read the six digits off your desktop, or run `manta pair` on the box.")
             VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+                // BET-702: in-app QR scan sits above the manual fields. A
+                // decoded Manta payload routes through the SAME `flow.receive`
+                // path as a deep link. The sheet itself is presented by the
+                // onboarding root via `flow.scanRequested`.
+                Button(action: { flow.scanRequested = true }) {
+                    HStack(spacing: Metrics.spacing.sp3) {
+                        Image(systemName: "qrcode.viewfinder")
+                            .font(.system(size: Metrics.type.body))
+                        Text("Scan QR code")
+                            .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                    }
+                    .foregroundColor(tokens.onAccent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Metrics.spacing.sp3)
+                    .background(tokens.accentSolid, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("onboarding-scan-button")
                 OTPField(value: $flow.code, placeholder: "000000", tokens: tokens)
                     .accessibilityIdentifier("onboarding-otp")
                 TextField("Box ID (32 hex)", text: $flow.boxId)
@@ -582,6 +621,14 @@ struct MantaOnboardingRoot: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("onboarding-root")
+        .sheet(isPresented: Binding(
+            get: { flow.scanRequested },
+            set: { if !$0 { flow.scanRequested = false } }
+        )) {
+            MantaQRScannerSheet(tokens: tokens) { payload in
+                flow.receive(payload: payload)
+            }
+        }
     }
 
     @ViewBuilder
@@ -618,6 +665,67 @@ struct MantaOnboardingRoot: View {
             }
         }
         .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Paired re-pair confirmation (BET-702 "Switch box?")
+
+/// Presenting view for a pairing link that arrives while the device is ALREADY
+/// paired. Shows the current box vs. the new box and lets the user confirm the
+/// re-pair (Switch) or back out (Cancel). On Switch the existing claim path
+/// runs and, on success, replaces the Keychain credentials + resets local state.
+struct MantaSwitchBoxSheet: View {
+    var tokens: Tokens
+    let currentHost: String
+    let newHost: String
+    let onCancel: () -> Void
+    let onSwitch: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+                Text("Switch box?")
+                    .font(.system(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .foregroundColor(tokens.tx1)
+                Text("A Manta pairing link arrived while you're connected to another box. Switching re-pairs this phone to the new one.")
+                    .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                    .foregroundColor(tokens.tx3)
+            }
+            MantaCard(tokens: tokens) {
+                VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+                    hostRow(label: "Current box", host: currentHost)
+                    hostRow(label: "New box", host: newHost)
+                }
+            }
+            MantaPrimaryButton(title: "Switch", disabled: false,
+                               action: onSwitch, tokens: tokens)
+            HStack {
+                Spacer()
+                MantaTextButton(title: "Cancel", tokens: tokens) { onCancel() }
+                Spacer()
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Metrics.spacing.sp6)
+        .padding(.top, Metrics.spacing.sp6)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("switch-box-sheet")
+    }
+
+    private func hostRow(label: String, host: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing.sp3) {
+            Text(label)
+                .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                .foregroundColor(tokens.tx4)
+            Spacer(minLength: Metrics.spacing.sp4)
+            Text(host)
+                .font(.system(size: Metrics.type.small, design: .monospaced))
+                .foregroundColor(tokens.tx1)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(label == "Current box" ? "switch-box-current" : "switch-box-new")
     }
 }
 

--- a/mobile/native/MantaUI/MantaQRScanner.swift
+++ b/mobile/native/MantaUI/MantaQRScanner.swift
@@ -1,0 +1,220 @@
+import AVFoundation
+@preconcurrency import AVFoundation
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// BET-702 — in-app QR scanner for the S2 pairing entry screen.
+//
+// AVCaptureMetadataOutput with `.qr` metadata — deliberately NOT
+// `DataScannerViewController` and no added dependency (AVCapture is the
+// decision). The scanner is a full-screen sheet with its own Cancel button.
+//
+// Responsibilities are split:
+//   • MantaQRScannerViewController — owns the AVCaptureSession + preview, and
+//     reports raw decoded strings + camera-permission state. It does NOT parse.
+//   • MantaQRScannerSheet — the SwiftUI shell: renders the camera, the Cancel
+//     button, a transient "Not a Manta pairing code" hint for a non-payload QR,
+//     and an inline permission-denied hint pointing at the manual code entry.
+//     It feeds a decoded string through the EXISTING MantaPairing.parsePairPayload
+//     and only a parsed payload is handed to the onboarding flow.
+// ===========================================================================
+
+final class MantaQRScannerViewController: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
+    var onScan: ((String) -> Void)?
+    var onPermissionDenied: (() -> Void)?
+
+    private let session = AVCaptureSession()
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            configureAndStart()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        self?.configureAndStart()
+                    } else {
+                        self?.onPermissionDenied?()
+                    }
+                }
+            }
+        default:
+            // Denied / restricted — no camera feed; the sheet surfaces the
+            // "type the code instead" hint.
+            onPermissionDenied?()
+        }
+    }
+
+    private func configureAndStart() {
+        guard let device = AVCaptureDevice.default(for: .video) else {
+            onPermissionDenied?()
+            return
+        }
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            guard session.canAddInput(input) else { onPermissionDenied?(); return }
+            session.addInput(input)
+
+            let output = AVCaptureMetadataOutput()
+            guard session.canAddOutput(output) else { onPermissionDenied?(); return }
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(self, queue: .main)
+            output.metadataObjectTypes = [.qr]
+        } catch {
+            onPermissionDenied?()
+            return
+        }
+        let previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        previewLayer.videoGravity = .resizeAspectFill
+        let bounds = view.bounds
+        let wasEmpty = bounds.isEmpty
+        previewLayer.frame = bounds
+        view.layer.insertSublayer(previewLayer, at: 0)
+        self.previewLayer = previewLayer
+        guard !wasEmpty else { return }
+        // startRunning() blocks; run it off the main thread. Capture the session
+        // so the background closure doesn't cross into main-actor isolation.
+        let session = self.session
+        DispatchQueue.global(qos: .userInitiated).async {
+            session.startRunning()
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    // MARK: - AVCaptureMetadataOutputObjectsDelegate
+    // The metadata delegate is a nonisolated protocol requirement. The queue is
+    // `.main`, so the callback genuinely runs on the main actor — assume it.
+    // The non-Sendable AV objects stay in this nonisolated scope; only the
+    // Sendable String crosses to the main actor.
+
+    nonisolated func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        for obj in metadataObjects {
+            if let readable = obj as? AVMetadataMachineReadableCodeObject,
+               readable.type == .qr,
+               let value = readable.stringValue {
+                MainActor.assumeIsolated {
+                    onScan?(value)
+                }
+            }
+        }
+    }
+}
+
+struct MantaQRScannerView: UIViewControllerRepresentable {
+    var onScan: (String) -> Void
+    var onPermissionDenied: () -> Void
+
+    func makeUIViewController(context: Context) -> MantaQRScannerViewController {
+        let vc = MantaQRScannerViewController()
+        vc.onScan = onScan
+        vc.onPermissionDenied = onPermissionDenied
+        return vc
+    }
+
+    func updateUIViewController(_ vc: MantaQRScannerViewController, context: Context) {
+        // Re-sync the closures on every render so a late-started capture session
+        // (permission resolved after an initial `make`) reports back to the
+        // CURRENT handler, not the one captured at creation time.
+        vc.onScan = onScan
+        vc.onPermissionDenied = onPermissionDenied
+    }
+}
+
+/// Reference-backed scanner state. The AVCapture delegate callbacks are handed
+/// closures that mutate THIS shared instance (not a value-copied `@State`),
+/// which is what lets the sheet re-render from a backgrounded representable.
+@MainActor
+final class MantaQRScannerModel: ObservableObject {
+    @Published var permissionDenied = false
+    @Published var nonMantaHint = false
+}
+
+struct MantaQRScannerSheet: View {
+    var tokens: Tokens
+    /// Invoked with a parsed Manta pairing payload (never a non-payload scan).
+    var onPayload: (MantaPairing.PairPayload) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var model = MantaQRScannerModel()
+    @State private var hideHintTask: Task<Void, Never>?
+
+    var body: some View {
+        ZStack {
+            MantaQRScannerView(
+                onScan: handleScan,
+                onPermissionDenied: { model.permissionDenied = true }
+            )
+            .ignoresSafeArea()
+
+            VStack {
+                HStack {
+                    Spacer()
+                    Button("Cancel") { dismiss() }
+                        .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
+                        .foregroundColor(tokens.onAccent)
+                        .padding(.horizontal, Metrics.spacing.sp4)
+                        .padding(.vertical, Metrics.spacing.sp2)
+                        .background(tokens.inset, in: Capsule())
+                }
+                .padding(Metrics.spacing.sp4)
+                Spacer()
+                if model.permissionDenied {
+                    Text("Camera access is off — enter the code by hand instead.")
+                        .font(.system(size: Metrics.type.small))
+                        .foregroundColor(tokens.tx2)
+                        .padding(Metrics.spacing.sp4)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(tokens.card, in: RoundedRectangle(cornerRadius: Metrics.radius.lg))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Metrics.radius.lg)
+                                .stroke(tokens.border, lineWidth: Metrics.spacing.spPx)
+                        )
+                        .padding(.horizontal, Metrics.spacing.sp6)
+                        .padding(.bottom, Metrics.spacing.sp8)
+                        .accessibilityIdentifier("scanner-permission-hint")
+                } else if model.nonMantaHint {
+                    Text("Not a Manta pairing code")
+                        .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                        .foregroundColor(tokens.tx1)
+                        .padding(.horizontal, Metrics.spacing.sp4)
+                        .padding(.vertical, Metrics.spacing.sp3)
+                        .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.lg))
+                        .accessibilityIdentifier("scanner-nonmanta-hint")
+                        .padding(.bottom, Metrics.spacing.sp8)
+                }
+            }
+        }
+    }
+
+    private func handleScan(_ value: String) {
+        if let payload = MantaPairing.parsePairPayload(value) {
+            // Dismiss the sheet, then hand the payload to the flow — the same
+            // receive path a deep link uses. Deferred so the sheet is fully
+            // gone before the flow's phase advances.
+            dismiss()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                onPayload(payload)
+            }
+        } else {
+            // Not a Manta payload — keep scanning, show a transient hint.
+            model.nonMantaHint = true
+            hideHintTask?.cancel()
+            hideHintTask = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                if !Task.isCancelled { model.nonMantaHint = false }
+            }
+        }
+    }
+}

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -325,4 +325,26 @@ final class SessionListStore: ObservableObject {
             Task { @MainActor in await self?.refresh() }
         }
     }
+
+    // MARK: - Reset on credential change (BET-702 Switch box)
+
+    /// Wipe per-box state after a re-pair switches this device onto a NEW box.
+    /// The old box's project list and per-session status bookkeeping must not
+    /// bleed into the new box; the next `refresh()` repopulates from it. This
+    /// is the single reset path for a credential change — reused by the
+    /// "Switch box?" re-pair flow, never duplicated.
+    func resetForBoxChange() {
+        projects = []
+        loading = false
+        loadError = nil
+        loadedOnce = false
+        pendingDeletes = [:]
+        for (_, timer) in undoTimers { timer.invalidate() }
+        undoTimers = [:]
+        runningSince = [:]
+        attentionSessions = []
+        modelLabels = [:]
+        pinnedWindows = []
+        hapticsEnabled = true
+    }
 }

--- a/mobile/native/MantaUIUITests/MantaDeepLinkUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaDeepLinkUITests.swift
@@ -1,11 +1,16 @@
 import XCTest
 
-// S8 (BET-600): a pairing link opens the app. This exercises the app-side of
-// the custom-scheme / universal-link entry: the system hands the app the URL
-// and onOpenURL routes it into the S2 onboarding flow (the pairing code is the
-// secret — no confirm step). A stray `verify` param is ignored. Deterministic
-// gate: only runs on a fresh-install (unpaired) launch — a device that is
-// already paired skips, since a pairing link is consumed by onboarding.
+// S8 (BET-600) + BET-702: a pairing link opens the app. This exercises the
+// app-side of the custom-scheme / universal-link entry: the system hands the
+// app the URL and onOpenURL routes it into the pairing machinery.
+//
+// Two regimes (BET-702):
+//   • UNPAIRED launch — the link routes into the S2 onboarding flow and claims
+//     directly (the pairing code is the secret — no confirm step). A stray
+//     `verify` param is ignored.
+//   • PAIRED launch — the link is a re-pair onto a different box and must
+//     present the "Switch box?" confirmation sheet (the old dead behavior was
+//     to silently ignore it because the onboarding root wasn't mounted).
 final class MantaDeepLinkUITests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -42,5 +47,41 @@ final class MantaDeepLinkUITests: XCTestCase {
         if failure.exists {
             print("PAIR-LINK consumed: unreachable host — \(failure.label)")
         }
+    }
+
+    // BET-702: a pairing link while PAIRED must surface the "Switch box?" sheet
+    // instead of being silently dropped. `MANTA_UI_FORCE_PAIRED` boots the app
+    // into the paired destination without writing the real Keychain, so this
+    // works on a fresh simulator without polluting it.
+    func testPairLinkWhilePairedPresentsSwitchBox() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["MANTA_UI_FORCE_PAIRED"] = "1"
+        app.launchEnvironment["MANTA_UI_PAIR_HOST"] = "https://currentbox.boxes.mantaui.com"
+        app.launch()
+
+        // Wait for the paired destination to appear before delivering the link.
+        let sessions = app.staticTexts["Sessions"]
+        _ = sessions.waitForExistence(timeout: 8)
+
+        let newBox = "0123abcd0123abcd0123abcd0123abcd"
+        let url = URL(string: "manta://pair?box=\(newBox)&code=123456")!
+        XCUIDevice.shared.system.open(url)
+
+        // The "Switch box?" sheet must present with both the current and the
+        // new box host.
+        let title = app.staticTexts["Switch box?"]
+        XCTAssertTrue(title.waitForExistence(timeout: 5),
+                      "a paired device did not present the Switch box sheet for an incoming pair link")
+
+        let currentRow = app.descendants(matching: .any)["switch-box-current"].firstMatch
+        let newRow = app.descendants(matching: .any)["switch-box-new"].firstMatch
+        XCTAssertTrue(currentRow.exists, "Switch box sheet is missing the current box host")
+        XCTAssertTrue(newRow.exists, "Switch box sheet is missing the new box host")
+        XCTAssertTrue(newRow.label.contains(newBox), "new box row does not carry the new box id")
+        print("SWITCH-BOX current=\(currentRow.label) new=\(newRow.label)")
+
+        // Cancel must dismiss the sheet and leave the app paired.
+        app.buttons["Cancel"].firstMatch.tap()
+        XCTAssertFalse(title.waitForExistence(timeout: 2), "Cancel did not dismiss the Switch box sheet")
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-702-ios-qr-repair`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-702.