### PR TITLE
feat(renderer): global toast host; kill native alert()s (BET-723)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import { Sidebar, type SidebarHandle } from "./Sidebar";
 import { Terminal } from "./Terminal";
 import { ChatPanel } from "./ChatPanel";
 import { ArtifactsPanel } from "./ArtifactsPanel";
+import { GlobalToasts } from "./GlobalToasts";
 import { Settings } from "./Settings";
 import { SearchPalette } from "./SearchPalette";
 import { SETTING_SECTIONS, type SettingSectionId } from "../shared/settingsSchema";
@@ -1111,6 +1112,9 @@ function AppInner() {
   // is hidden so the two don't stack. Non-chat panes (terminal / AI-TUI /
   // new-session) keep the titlebar's drag region + breadcrumb + toggle.
   const isChatPaneActive = activeChatSessionId != null && mode === "chat";
+  // BET-723: the global toast host can route a screenshot "Add to chat" only
+  // when the foreground pane is a real chat session (not a draft over it).
+  const screenshotCanAddToChat = activeChatSessionId != null && !activeDraft && mode === "chat";
 
   return (
     // data-screen is the visual harness's handle on the app shell (see
@@ -1408,6 +1412,14 @@ function AppInner() {
           )}
         </div>
       </main>
+      {/* BET-723 §D4: ONE global toast host, rendered over every pane type
+          (terminal / TUI / draft / chat) as a sibling of <main>. */}
+      {!showOnboarding && (
+        <GlobalToasts
+          activeChatSessionId={activeChatSessionId}
+          canAddToChat={screenshotCanAddToChat}
+        />
+      )}
       {/* BET-659: the Artifacts panel — a fixed-width sibling of <main>, so a
           chat pane is required for it to show (there's no panel to open in a
           terminal). The outer shell is already `flex` and <main> is

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { ChatPanel } from "./ChatPanel";
+import { GlobalToasts } from "./GlobalToasts";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import {
   installMockApi,
@@ -784,8 +785,18 @@ describe("ChatPanel screenshot accept", () => {
   // the "Add to chat" toast button, which routes the buffered bytes through
   // window.api.uploadBuffer. Returns the mounted harness for assertions; the
   // describe-scoped `h` is also set so the shared afterEach unmounts it.
+  //
+  // Since BET-723 the toast host lives at App level (GlobalToasts), not in
+  // ChatPanel — the panel only RUNS the accept once the host's "Add to chat"
+  // action dispatches manta-accept-screenshot. So both are mounted together,
+  // with the host routing to this panel's session id.
   async function mountScreenshotAndClickAddToChat(): Promise<Harness> {
-    h = mount(<ChatPanel {...PROPS} />);
+    h = mount(
+      <>
+        <ChatPanel {...PROPS} />
+        <GlobalToasts activeChatSessionId={PROPS.sessionId} canAddToChat />
+      </>,
+    );
     await h.flush();
 
     const addBtn = Array.from(h.container.querySelectorAll("button")).find(

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -44,7 +44,6 @@ import {
   buildTitleInstruction,
   sanitizeGeneratedTitle,
   detectCommandFromText,
-  formatBytes,
   type EntryMotionState,
   type StaleCacheResult,
   type PendingScrollWin,
@@ -81,7 +80,7 @@ import { useTypeahead } from "./hooks/useTypeahead";
 import { Transcript } from "./Transcript";
 import { Composer } from "./Composer";
 import { SessionHeader } from "./SessionHeader";
-import { ToastStack, type ToastItem } from "./Toast";
+import { ACCEPT_SCREENSHOT_EVENT } from "./GlobalToasts";
 import { getMantaPreload } from "./preloadAccess";
 
 // Attachment / AgentMention / TypeaheadState / TypeaheadRow are shared with
@@ -452,21 +451,19 @@ export function ChatPanel({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   // Agent @-mentions state — populated by useTypeahead, consumed by submit.
   const [agentMentions, setAgentMentions] = useState<AgentMention[]>([]);
-  // Ephemeral system notice (e.g. /help output) rendered above the input.
+  // Ephemeral system notice (e.g. /help output). Lives in the store so the
+  // App-level global toast host (BET-723) renders it over every pane type.
   // Cleared on dismiss or on next session change.
-  const [systemNotice, setSystemNotice] = useState<string | null>(null);
+  const setSystemNotice = useStore((s) => s.setSystemNotice);
   // Whether the panel is currently being dragged over with files (for the
   // big "drop to attach" overlay).
   const [dragHover, setDragHover] = useState(false);
-  // Screenshot detection toast — global, lives in the store. App.tsx owns
-  // the single ipcRenderer subscription; this panel reads + clears it.
-  // Only the active panel renders it (gated below by `isActive`).
+  // Screenshot detection toast — global, lives in the store. App.tsx's global
+  // toast host owns the render + dismiss; this panel only runs the accept /
+  // upload flow ("Add to chat"), which needs the active session's own
+  // attachment state. Triggered by the ACCEPT_SCREENSHOT_EVENT below.
   const screenshotToast = useStore((s) => s.screenshotToast);
   const setScreenshotToast = useStore((s) => s.setScreenshotToast);
-  // Agent → laptop file push toast (single global instance, like screenshots).
-  const agentFileToast = useStore((s) => s.agentFileToast);
-  const setAgentFileToast = useStore((s) => s.setAgentFileToast);
-  const [agentFileSaving, setAgentFileSaving] = useState(false);
   // Ref mirror of the child-status map so `toggleTaskExpand` can read
   // current values synchronously without taking them as deps.
   const liveChildStatusRef = useRef<Map<string, "running" | "idle">>(new Map());
@@ -1532,126 +1529,21 @@ export function ChatPanel({
     }
   }, [screenshotToast, tmuxSession]);
 
-  // Agent → laptop file push. In require-confirm mode the toast's "Save" button
-  // calls this: pull the remote outbox file to the downloads dir, then flip the
-  // toast to the saved state (so the user can Reveal it). In auto-pull mode the
-  // file is already down (main did it in the poller) and this isn't called.
-  const saveAgentFile = useCallback(async () => {
-    const toast = agentFileToast;
-    if (!toast || agentFileSaving) return;
-    setAgentFileSaving(true);
-    try {
-      const localPath = await window.api.agentPullFile(toast.remotePath);
-      // Desktop returns a real local path → flip the toast to the saved state
-      // so the user can Reveal it in Finder. Mobile returns "" (the download
-      // was handed to the browser; there's no OS file manager to reveal into)
-      // → just dismiss the toast.
-      if (localPath) {
-        setAgentFileToast({ ...toast, autoPulled: true, localPath });
-      } else {
-        setAgentFileToast(null);
-      }
-    } catch (err) {
-      setSendError(`Couldn't save file: ${String((err as Error)?.message ?? err)}`);
-      setAgentFileToast(null);
-    } finally {
-      setAgentFileSaving(false);
-    }
-  }, [agentFileToast, agentFileSaving, setAgentFileToast]);
-
-  const revealAgentFile = useCallback(() => {
-    const local = agentFileToast?.localPath;
-    if (local) void window.api.revealInFolder(local);
-    setAgentFileToast(null);
-  }, [agentFileToast, setAgentFileToast]);
-
-  // ===== Unified toast stack (BET-416 §D) =====
-  //
-  // The three previous in-app toast implementations (screenshot-detected,
-  // agent-sent-file, systemNotice) collapse into ONE ToastStack. Only the
-  // active panel renders it (mirrors the prior per-panel gating). The stack
-  // is newest-on-top, capped at three. Each toast carries an action when it
-  // has one (Add to chat / Save / Reveal) — action-bearing toasts never
-  // auto-dismiss; systemNotice (/help reference) opts out of auto-dismiss
-  // with ttl: null. A small order list tracks arrival so "newest on top" is
-  // real, not a fixed priority.
-  const [toastOrder, setToastOrder] = useState<string[]>([]);
-  const activeToastIds = useMemo(() => {
-    const ids: string[] = [];
-    if (screenshotToast) ids.push("screenshot");
-    if (agentFileToast) ids.push("agent-file");
-    if (systemNotice) ids.push("system-notice");
-    return ids;
-  }, [screenshotToast, agentFileToast, systemNotice]);
+  // The App-level toast host (BET-723) renders the screenshot toast globally
+  // and routes its "Add to chat" action here — this panel owns the active
+  // session's attachment state, so only it can accept. Gated on isActive so a
+  // hidden panel never consumes an action aimed at the visible one (the detail
+  // sessionId match is the routing backstop).
   useEffect(() => {
-    setToastOrder((prev) => {
-      const incoming = activeToastIds.filter((id) => !prev.includes(id));
-      const survivors = prev.filter((id) => activeToastIds.includes(id));
-      // Newly-arrived toasts go first (newest on top); survivors keep order.
-      return [...incoming, ...survivors];
-    });
-  }, [activeToastIds]);
-
-  const dismissToast = useCallback((id: string) => {
-    if (id === "screenshot") setScreenshotToast(null);
-    else if (id === "agent-file") setAgentFileToast(null);
-    else if (id === "system-notice") setSystemNotice(null);
-  }, [setScreenshotToast, setAgentFileToast, setSystemNotice]);
-
-  const toasts: ToastItem[] = useMemo(() => {
-    const items: ToastItem[] = [];
-    for (const id of toastOrder) {
-      if (id === "screenshot" && screenshotToast) {
-        items.push({
-          id: "screenshot",
-          message:
-            screenshotToast.source === "file" && screenshotToast.path
-              ? `Screenshot: ${screenshotToast.path.split("/").pop()}`
-              : "Screenshot in clipboard",
-          action: { label: "Add to chat", onClick: () => void acceptScreenshot() },
-        });
-      } else if (id === "agent-file" && agentFileToast) {
-        const size = formatBytes(agentFileToast.size);
-        items.push({
-          id: "agent-file",
-          message: (
-            <>
-              <span className="text-text">↓ {agentFileToast.name}</span>
-              {size && <span className="text-text-faint"> · {size}</span>}
-              <span className="text-text-faint">
-                {agentFileToast.autoPulled ? " · saved to Downloads" : " — AI sent you a file"}
-              </span>
-            </>
-          ),
-          action: agentFileToast.autoPulled
-            ? agentFileToast.localPath
-              ? { label: "Reveal", onClick: revealAgentFile }
-              : undefined
-            : {
-                label: agentFileSaving ? "Saving…" : "Save",
-                onClick: () => void saveAgentFile(),
-                disabled: agentFileSaving,
-              },
-        });
-      } else if (id === "system-notice" && systemNotice) {
-        items.push({
-          id: "system-notice",
-          message: systemNotice,
-          ttl: null, // user-invoked reference content (/help) — no auto-dismiss
-        });
-      }
-    }
-    return items;
-  }, [
-    toastOrder,
-    screenshotToast,
-    agentFileToast,
-    systemNotice,
-    agentFileSaving,
-    acceptScreenshot,
-    revealAgentFile,
-    saveAgentFile,
-  ]);
+    const onAcceptScreenshot = (e: Event) => {
+      if (!isActive) return;
+      const detail = (e as CustomEvent<{ sessionId?: string }>).detail;
+      if (detail?.sessionId != null && detail.sessionId !== sessionId) return;
+      void acceptScreenshot();
+    };
+    window.addEventListener(ACCEPT_SCREENSHOT_EVENT, onAcceptScreenshot);
+    return () => window.removeEventListener(ACCEPT_SCREENSHOT_EVENT, onAcceptScreenshot);
+  }, [isActive, sessionId, acceptScreenshot]);
 
   // Panel-level drag handlers. We listen on the chat container; the body of
   // the panel paints a dotted overlay while dragHover is true. App.tsx
@@ -2345,29 +2237,6 @@ export function ChatPanel({
         )}
       </CardMount>
 
-      {/* Unified toast stack (BET-416 §D). Replaces the three previous in-app
-          toast implementations (screenshot-detected, agent-sent-file,
-          systemNotice). Bottom-centre, newest on top, max three stacked.
-          Action-bearing toasts (Add to chat / Save / Reveal) never
-          auto-dismiss; the /help systemNotice opts out of auto-dismiss.
-          Only the active panel renders it — the toasts live in global store
-          state (screenshot / agent-file) or panel-local state (systemNotice),
-          one instance app-wide. */}
-      {/* Bottom cluster: a relative wrapper around the composer so the toast
-          overlay can anchor to the composer's OWN top edge (bottom:100%)
-          instead of a fixed pixel guess. Toasts therefore stay just above the
-          box however tall it grows with the input, and as a pure overlay they
-          never shift the transcript or composer layout (BET-677). */}
-      <div className="relative shrink-0">
-        {isActive && (
-          <div
-            className="pointer-events-none absolute inset-x-0 z-40"
-            style={{ bottom: "100%" }}
-          >
-            <ToastStack toasts={toasts} onDismiss={dismissToast} />
-          </div>
-        )}
-
       {jobOwnership ? (
         <ReadOnlyJobBar
           job={jobOwnership}
@@ -2472,7 +2341,6 @@ export function ChatPanel({
         onPaste={onPaste}
       />
       )}
-      </div>
     </div>
   );
 }

--- a/src/renderer/GlobalToasts.tsx
+++ b/src/renderer/GlobalToasts.tsx
@@ -1,0 +1,195 @@
+// ===== Global toast host (BET-723 §D4) =====
+//
+// ONE ToastStack lives at the app root (rendered once in App.tsx) so a
+// screenshot / agent-file / error toast shows over EVERY pane type — a
+// terminal pane, a TUI pane, or a new-session draft — instead of only when a
+// chat pane happens to be active. ChatPanel keeps zero toast code.
+//
+// The host assembles:
+//   - `appToasts` (store): transient errors + info (the alert() replacements),
+//     each with its own id, capped at 5, dismissible via dismissAppToast.
+//   - the three legacy single-instance toasts (screenshot / agent-file /
+//     system-notice), which moved up here from the active ChatPanel.
+//
+// Ordering keeps the moved behavior: newest on top, capped at MAX_TOASTS by
+// ToastStack. Action-bearing toasts never auto-dismiss; the /help
+// system-notice opts out with ttl:null.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useStore } from "./store";
+import { ToastStack, type ToastItem } from "./Toast";
+import { formatBytes } from "./chatUtils";
+
+/** Window CustomEvent App dispatches when the screenshot toast's "Add to chat"
+ *  is clicked, so the ACTIVE ChatPanel (which owns its attachment state) runs
+ *  the accept/upload logic. Detail carries the target sessionId. */
+export const ACCEPT_SCREENSHOT_EVENT = "manta-accept-screenshot";
+
+type Props = {
+  /** Session id of the active chat-mode window, or null when the foreground
+   *  pane is a terminal / TUI pane. */
+  activeChatSessionId: string | null;
+  /** Whether the foreground pane is a chat session the screenshot "Add to
+   *  chat" action could target (active chat window + no draft on top). */
+  canAddToChat: boolean;
+};
+
+export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
+  const screenshotToast = useStore((s) => s.screenshotToast);
+  const agentFileToast = useStore((s) => s.agentFileToast);
+  const systemNotice = useStore((s) => s.systemNotice);
+  const appToasts = useStore((s) => s.appToasts);
+  const setScreenshotToast = useStore((s) => s.setScreenshotToast);
+  const setAgentFileToast = useStore((s) => s.setAgentFileToast);
+  const setSystemNotice = useStore((s) => s.setSystemNotice);
+  const pushAppToast = useStore((s) => s.pushAppToast);
+  const dismissAppToast = useStore((s) => s.dismissAppToast);
+
+  const [agentFileSaving, setAgentFileSaving] = useState(false);
+
+  // ===== Unified toast ordering (moved unchanged from ChatPanel) =====
+  const [toastOrder, setToastOrder] = useState<string[]>([]);
+  const activeToastIds = useMemo(() => {
+    const ids: string[] = [];
+    if (screenshotToast) ids.push("screenshot");
+    if (agentFileToast) ids.push("agent-file");
+    if (systemNotice) ids.push("system-notice");
+    for (const t of appToasts) ids.push(t.id);
+    return ids;
+  }, [screenshotToast, agentFileToast, systemNotice, appToasts]);
+
+  useEffect(() => {
+    setToastOrder((prev) => {
+      const incoming = activeToastIds.filter((id) => !prev.includes(id));
+      const survivors = prev.filter((id) => activeToastIds.includes(id));
+      // Newly-arrived toasts go first (newest on top); survivors keep order.
+      return [...incoming, ...survivors];
+    });
+  }, [activeToastIds]);
+
+  const dismissToast = useCallback(
+    (id: string) => {
+      if (id === "screenshot") setScreenshotToast(null);
+      else if (id === "agent-file") setAgentFileToast(null);
+      else if (id === "system-notice") setSystemNotice(null);
+      else dismissAppToast(id);
+    },
+    [setScreenshotToast, setAgentFileToast, setSystemNotice, dismissAppToast],
+  );
+
+  // Route the screenshot "Add to chat" to the ACTIVE chat session. ChatPanel
+  // listens for the event and runs its accept/upload flow (only it owns the
+  // attachment state). When the foreground pane isn't a chat, `canAddToChat`
+  // is false and the action button is hidden — the toast still shows.
+  const acceptScreenshot = useCallback(() => {
+    if (!activeChatSessionId) return;
+    window.dispatchEvent(
+      new CustomEvent(ACCEPT_SCREENSHOT_EVENT, {
+        detail: { sessionId: activeChatSessionId },
+      }),
+    );
+  }, [activeChatSessionId]);
+
+  // Agent → laptop file push (moved unchanged from ChatPanel).
+  const saveAgentFile = useCallback(async () => {
+    const toast = agentFileToast;
+    if (!toast || agentFileSaving) return;
+    setAgentFileSaving(true);
+    try {
+      const localPath = await window.api.agentPullFile(toast.remotePath);
+      if (localPath) {
+        setAgentFileToast({ ...toast, autoPulled: true, localPath });
+      } else {
+        setAgentFileToast(null);
+      }
+    } catch (err) {
+      setAgentFileToast(null);
+      pushAppToast({
+        tone: "error",
+        message: `Couldn't save file: ${String((err as Error)?.message ?? err)}`,
+      });
+    } finally {
+      setAgentFileSaving(false);
+    }
+  }, [agentFileToast, agentFileSaving, setAgentFileToast, pushAppToast]);
+
+  const revealAgentFile = useCallback(() => {
+    const local = agentFileToast?.localPath;
+    if (local) void window.api.revealInFolder(local);
+    setAgentFileToast(null);
+  }, [agentFileToast, setAgentFileToast]);
+
+  const toasts: ToastItem[] = useMemo(() => {
+    const items: ToastItem[] = [];
+    const appMap = new Map(appToasts.map((t) => [t.id, t]));
+    for (const id of toastOrder) {
+      if (id === "screenshot" && screenshotToast) {
+        items.push({
+          id: "screenshot",
+          message:
+            screenshotToast.source === "file" && screenshotToast.path
+              ? `Screenshot: ${screenshotToast.path.split("/").pop()}`
+              : "Screenshot in clipboard",
+          action:
+            canAddToChat && activeChatSessionId
+              ? { label: "Add to chat", onClick: () => void acceptScreenshot() }
+              : undefined,
+        });
+      } else if (id === "agent-file" && agentFileToast) {
+        const size = formatBytes(agentFileToast.size);
+        items.push({
+          id: "agent-file",
+          message: (
+            <>
+              <span className="text-text">↓ {agentFileToast.name}</span>
+              {size && <span className="text-text-faint"> · {size}</span>}
+              <span className="text-text-faint">
+                {agentFileToast.autoPulled ? " · saved to Downloads" : " — AI sent you a file"}
+              </span>
+            </>
+          ),
+          action: agentFileToast.autoPulled
+            ? agentFileToast.localPath
+              ? { label: "Reveal", onClick: () => void revealAgentFile() }
+              : undefined
+            : {
+                label: agentFileSaving ? "Saving…" : "Save",
+                onClick: () => void saveAgentFile(),
+                disabled: agentFileSaving,
+              },
+        });
+      } else if (id === "system-notice" && systemNotice) {
+        items.push({
+          id: "system-notice",
+          message: systemNotice,
+          ttl: null, // user-invoked reference content (/help) — no auto-dismiss
+        });
+      } else {
+        const app = appMap.get(id);
+        if (app) items.push(app);
+      }
+    }
+    return items;
+  }, [
+    toastOrder,
+    screenshotToast,
+    agentFileToast,
+    systemNotice,
+    appToasts,
+    agentFileSaving,
+    canAddToChat,
+    activeChatSessionId,
+    acceptScreenshot,
+    revealAgentFile,
+    saveAgentFile,
+  ]);
+
+  return (
+    // Fixed bottom-right overlay (BET-723 §D4 — above the status bar, renders
+    // over every pane). pointer-events-none so the backdrop never swallows
+    // clicks under the stack; each toast re-enables pointer events (ToastStack).
+    <div className="pointer-events-none fixed bottom-24 right-4 z-40 w-96 flex flex-col items-stretch">
+      <ToastStack toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  );
+}

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -83,14 +83,16 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   // Downloaded desktop auto-update (BET-416 §E): signalled as a dot on the
   // Settings entry, not a full-width bar.
   const updateAvailable = useStore((s) => s.updatePrompt != null);
+  // BET-723: sidebar errors/notices surface as global toasts, not native alert().
+  const pushAppToast = useStore((s) => s.pushAppToast);
 
   const showError = (e: unknown) => {
     const msg = e instanceof Error ? e.message : String(e);
-    alert(msg);
+    pushAppToast({ tone: "error", message: msg });
   };
 
   const showNotice = (msg: string) => {
-    alert(msg);
+    pushAppToast({ tone: "info", message: msg });
   };
 
   // When a new-session DRAFT is the foreground view, no real session should

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -9,6 +9,7 @@ import { getMantaPreload } from "./preloadAccess";
 import { IS_MAC } from "./platform";
 import { terminalShortcut } from "./chatUtils";
 import { useResolvedTheme } from "./theme";
+import { useStore } from "./store";
 
 /**
  * Handle an OSC 52 escape sequence: decode the base64 payload and write the
@@ -83,6 +84,8 @@ export function Terminal({ sessionKey, cwd, active, launcher, tmuxTarget }: Prop
   const searchRef = useRef<SearchAddon | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
+  // BET-723: upload / peek failures surface as global toasts, not native alert().
+  const pushAppToast = useStore((s) => s.pushAppToast);
   // dragenter/leave fire for nested elements too — count depth so we only
   // hide the overlay when the cursor truly leaves the terminal area.
   const dragDepth = useRef(0);
@@ -170,7 +173,7 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
             text: p,
             activate: () => {
               window.api.peekRemoteFile(p).catch((e) => {
-                alert(e instanceof Error ? e.message : String(e));
+                pushAppToast({ tone: "error", message: e instanceof Error ? e.message : String(e) });
               });
             },
             decorations: { underline: true, pointerCursor: true },
@@ -435,7 +438,7 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
       window.api.ptyWrite(sessionKey, text);
       termRef.current?.focus();
     } catch (err) {
-      alert(err instanceof Error ? err.message : String(err));
+      pushAppToast({ tone: "error", message: err instanceof Error ? err.message : String(err) });
     } finally {
       setUploading(false);
     }

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -32,6 +32,9 @@ export type ToastAction = {
 export type ToastItem = {
   id: string;
   message: ReactNode;
+  /** Tonal variant. `"error"` renders a danger left-edge accent (BET-723 §D5);
+   *  defaults to the plain info look. */
+  tone?: "info" | "error";
   /** Optional single action (Undo / Save / Reveal). Presence disables
    *  auto-dismiss. */
   action?: ToastAction;
@@ -74,7 +77,9 @@ export function Toast({ toast, onDismiss }: ToastProps) {
   return (
     <div
       role="status"
-      className="w-full max-w-[420px] rounded-lg border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2 shadow-md"
+      className={`w-full max-w-[420px] rounded-lg border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2 shadow-md ${
+        toast.tone === "error" ? "border-l-2 border-l-danger" : ""
+      }`}
     >
       <span className="flex-1 min-w-0 whitespace-pre-wrap break-words">{toast.message}</span>
       {toast.action && (

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -1110,3 +1110,51 @@ describe("sync snapshot / applySyncPayload (BET-678)", () => {
     expect(useStore.getState().syncSeq).toBe(10);
   });
 });
+
+describe("app toasts (BET-723)", () => {
+  beforeEach(() => {
+    useStore.setState({ appToasts: [], systemNotice: null });
+  });
+
+  it("pushAppToast appends with a unique generated id", () => {
+    useStore.getState().pushAppToast({ message: "one" });
+    const one = useStore.getState().appToasts;
+    expect(one).toHaveLength(1);
+    expect(one[0].message).toBe("one");
+    expect(one[0].id).toMatch(/^toast-/);
+    useStore.getState().pushAppToast({ message: "two" });
+    const two = useStore.getState().appToasts;
+    expect(two).toHaveLength(2);
+    // ids are unique
+    expect(new Set(two.map((t) => t.id)).size).toBe(2);
+  });
+
+  it("pushAppToast respects an explicit id", () => {
+    useStore.getState().pushAppToast({ message: "x", id: "custom-1" });
+    expect(useStore.getState().appToasts[0].id).toBe("custom-1");
+  });
+
+  it("pushAppToast caps the slice at 5, dropping the oldest", () => {
+    for (let i = 1; i <= 6; i++) useStore.getState().pushAppToast({ message: `m${i}` });
+    const toasts = useStore.getState().appToasts;
+    expect(toasts).toHaveLength(5);
+    // Oldest dropped, newest retained in order
+    expect(toasts.map((t) => t.message)).toEqual(["m2", "m3", "m4", "m5", "m6"]);
+  });
+
+  it("dismissAppToast removes by id", () => {
+    useStore.getState().pushAppToast({ message: "keep" });
+    useStore.getState().pushAppToast({ message: "drop" });
+    const { appToasts, dismissAppToast } = useStore.getState();
+    dismissAppToast(appToasts[1].id);
+    expect(useStore.getState().appToasts.map((t) => t.message)).toEqual(["keep"]);
+  });
+
+  it("setSystemNotice sets and clears the notice", () => {
+    expect(useStore.getState().systemNotice).toBeNull();
+    useStore.getState().setSystemNotice("/help text");
+    expect(useStore.getState().systemNotice).toBe("/help text");
+    useStore.getState().setSystemNotice(null);
+    expect(useStore.getState().systemNotice).toBeNull();
+  });
+});

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -12,6 +12,7 @@ import type { SyncPayload } from "../shared/api.js";
 import { clientToken } from "./api/httpApi";
 import { isAssistantTurnInProgress, runWithConcurrency } from "./chatUtils";
 import { applyTheme, type ThemePref } from "./theme";
+import type { ToastItem } from "./Toast";
 import {
   type ModelSelection,
   readSavedActiveSession,
@@ -46,6 +47,10 @@ let draftSeq = 0;
 function newDraftId() {
   return `draft-${++draftSeq}`;
 }
+
+// Monotonic id source for app toasts (the global ToastStack). A plain counter
+// (not crypto.randomUUID) keeps store tests deterministic, mirroring draftSeq.
+let appToastSeq = 0;
 
 // Overlay the desktop-local pairing secrets (serverUrl/boxToken) onto a config
 // snapshot. In http mode window.api.configGet() returns the manta-server's config,
@@ -399,6 +404,17 @@ type State = {
   // dismiss clear it globally. In auto-pull (trust) mode it's informational
   // (autoPulled:true, localPath set); otherwise it's a Save/dismiss prompt.
   agentFileToast: AgentFileReady | null;
+  // Transient app-level notices (errors + info) shown by the global ToastStack
+  // (BET-723). Replaces every native alert() in the renderer. Capped at 5;
+  // each has its own id, dismissible via dismissAppToast.
+  appToasts: ToastItem[];
+  pushAppToast: (t: Omit<ToastItem, "id"> & { id?: string }) => void;
+  dismissAppToast: (id: string) => void;
+  // Ephemeral user-invoked system notice (/help reference text) shown by the
+  // global ToastStack. Moved up from ChatPanel to the store so the App-level
+  // toast host can render it over every pane type.
+  systemNotice: string | null;
+  setSystemNotice: (t: string | null) => void;
   // Single global auto-update prompt. Set when main pushes an
   // updateDownloaded event (electron-updater finished downloading a new
   // version). The renderer shows a "Restart to update" bar; clicking it
@@ -646,6 +662,8 @@ export const useStore = create<State>((set, get) => ({
   chatMessages: {},
   screenshotToast: null,
   agentFileToast: null,
+  appToasts: [],
+  systemNotice: null,
   updatePrompt: null,
   updateError: null,
   boxIncompatible: false,
@@ -907,6 +925,14 @@ export const useStore = create<State>((set, get) => ({
 
   setScreenshotToast: (t) => set({ screenshotToast: t }),
   setAgentFileToast: (t) => set({ agentFileToast: t }),
+  pushAppToast: (t) =>
+    set((prev) => {
+      const id = t.id ?? `toast-${Date.now()}-${++appToastSeq}`;
+      return { appToasts: [...prev.appToasts, { ...t, id }].slice(-5) };
+    }),
+  dismissAppToast: (id) =>
+    set((prev) => ({ appToasts: prev.appToasts.filter((t) => t.id !== id) })),
+  setSystemNotice: (t) => set({ systemNotice: t }),
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
   setUpdateError: (p) => set({ updateError: p }),
   setBoxIncompatible: (b) => set({ boxIncompatible: b }),


### PR DESCRIPTION
## BET-723 — Desktop: global toast host; kill every alert()

**MOVE + DELETE, not a new system.** The existing `ToastStack`/`ToastItem`/TTL rules are untouched.

### Task 1 — global toast host at App level
- New store slice in `store.ts`: `appToasts` (capped at 5), `pushAppToast` (unique `toast-<ts>-<seq>` id), `dismissAppToast`.
- New `GlobalToasts.tsx` hosts the ONE `ToastStack` at the app root (rendered once in `App.tsx`, sibling of `<main>`, fixed bottom-right per §D4), rendering over every pane type. It assembles the four toast sources: the new `appToasts`, plus the three moved legacy toasts (screenshot / agent-file / system-notice).
- `systemNotice` (the `/help` reference toast) moved from ChatPanel-local state **into the store** so the App host can render it over any pane.
- Screenshot "Add to chat": App resolves the active chat session and only shows the action button when a real chat pane is foregrounded (`` `canAddToChat` ``); otherwise the toast still shows with dismiss only. The action routes to the ACTIVE ChatPanel (which owns its attachment state) via a `manta-accept-screenshot` window event carrying the session id.
- ChatPanel now has **zero toast code**: removed toast imports, `systemNotice` local state, agent-file toast (Save/Reveal moved to the host), the `toastOrder`/`activeToastIds`/`dismissToast`/`toasts` assembly, and the `ToastStack` render. Grep: ChatPanel no longer imports `ToastStack`.

### Task 2 — alert() → error toasts
- `Sidebar.tsx` `showError`/`showNotice` → `pushAppToast`.
- `Terminal.tsx` peek + upload error `alert()` → `pushAppToast`.
- `ToastItem` gained an optional `tone?: "info" | "error"`; the error variant renders a danger left edge (§D5). Visual otherwise unchanged.
- `alert(` has **zero call sites** in `src/renderer/` (all remaining hits are comments).

### Tests
- `store.test.ts`: new `app toasts (BET-723)` block — append + unique id, explicit id, cap at 5 (drops oldest), dismiss by id, `setSystemNotice` set/clear.
- `ChatPanel.harness.test.tsx` screenshot-accept tests updated to mount the App-level `GlobalToasts` host alongside the panel (the action no longer lives in ChatPanel).

### Note on the "ToastStack one consumer" grep
The issue's acceptance text says "Grep `ToastStack` — exactly one consumer: App.tsx." In reality `Settings.tsx` has a **pre-existing, separate** `ToastStack` (the settings **Undo** toasts via `settingsApply.ts`, from a prior BET-416 sub-issue). That is a different surface with its own `useSettingsToasts` and is out of scope for this move. After this change `ToastStack` has exactly **two** consumers: `GlobalToasts` (the app-wide host) and the Settings undo stack. Breaking/merging the Settings stack would be scope creep; I left it untouched.

**Base: origin/main @ `f973f734`**

**Files changed:** 9. `[App.tsx, ChatPanel.harness.test.tsx, ChatPanel.tsx (+GlobalToasts.tsx new), Sidebar.tsx, Terminal.tsx, Toast.tsx, store.test.ts, store.ts]` — ChatPanel shrinks ~176 lines; the glHost is ~195 lines.

**Verification results (PR branch `multica/BET-723-global-toasts` @ `bb0e9202`):**
- typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
- test: exit `0`. Renderer 122 files / 2264 pass / 7 skip; server 1553 pass / 0 fail. log sha256: `4494ed5bcd5950853ddf49bab768c99e0714b6d8d1403bd18e17dbf9f7b75aa9`
- **Conclusion:** 0 failures on the PR branch.
