### PR TITLE
BET-650: MantaMark single size 12 (drop unused default 14)

### DIFF
--- a/src/renderer/MantaLoader.test.tsx
+++ b/src/renderer/MantaLoader.test.tsx
@@ -86,7 +86,7 @@ describe("MantaLoader", () => {
   });
 
   it("MantaMark is the same mark with no arcs — the finished-turn form", () => {
-    h = mount(<MantaMark size={12} />);
+    h = mount(<MantaMark />);
     expect(h.container.querySelectorAll("circle").length).toBe(0);
     expect(h.container.querySelector("img")?.getAttribute("width")).toBe("12");
   });

--- a/src/renderer/MantaLoader.tsx
+++ b/src/renderer/MantaLoader.tsx
@@ -127,7 +127,7 @@ export function MantaLoader({
 // The same mark, held still, with no arcs. The arcs mean "in flight"; when a
 // turn ends the row keeps the mark and drops them, so the eye tracks ONE
 // object through the whole turn instead of two appearing and vanishing.
-export function MantaMark({ size = 14 }: { size?: number }) {
+export function MantaMark({ size = 12 }: { size?: number }) {
   return (
     <img
       src={mantaMark}

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -443,7 +443,7 @@ export const MessageRow = memo(function MessageRow({
             <>
               {/* The finished turn keeps the mark the working row was built
                   around, held still — the arcs are what meant "in flight". */}
-              <MantaMark size={12} />{" "}
+              <MantaMark />{" "}
               {pastVerbFor(verbSeedId ?? msg.info.id)} for {formatDuration(turnDurationMs)}
               {turnTokens != null && turnTokens > 0 && (
                 <>


### PR DESCRIPTION
Follow-up to BET-649: `MantaMark` declared a default `size = 14` that no adopter used — the only production adopter (the finished-turn footer in `MessageRow`) always passed `size={12}`.

**Change:**
- `MantaMark` default is now `12` (`src/renderer/MantaLoader.tsx`).
- Dropped the now-redundant `size={12}` at the `MessageRow` call site.
- `MantaLoader.test.tsx`'s finished-turn test drops its redundant `size={12}` and becomes a default-rendering assertion (still verifies rendered width = "12"). Grep confirmed `MessageRow` is the only production adopter of `MantaLoader`'s `MantaMark`; the `MantaMark` in `onboardingUi.tsx` is a separate function (takes `className`, not `size`) and was left untouched.

**Verification results:**
- PR branch (`multica/BET-650-mantamark-size` @ `f461d1f7`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1553 pass / 0 fail / 0 skip.
- Base: `main` @ `16fa83fc`
- **Conclusion:** 0 new failures. 3 files changed, 3 insertions(+), 3 deletions(−).

Base: origin/main @ 16fa83fc
