### PR TITLE
chore(ios): regenerate pbxproj from project.yml

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -59,11 +59,11 @@
 		96F128D3EBC0D1432F603FDB /* ComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938AB4A14437119280E1B53A /* ComposerTests.swift */; };
 		98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */; };
 		9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */; };
+		9C027B884D963083B775876C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CAD176AE6BC2E7A6024A5761 /* GoogleService-Info.plist */; };
 		9CF891D747797006729FDBD3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E84DF65831DE58599C53BD /* RootView.swift */; };
 		9E9F0CED519AB1DF30516047 /* ChatOverflowCaptureScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */; };
 		B46B35ED65EDB8F13002F091 /* MessagingUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2B48EABB4EC8AF086CA5C6AB /* MessagingUI */; };
 		B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */; };
-		B8B5D7BF1F4F22B9A3682FEA /* CrashReports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C78DF001E277064070853F /* CrashReports.swift */; };
 		B97905DC3BE32E36E682EF0C /* MantaLiveChatClearCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D5B31C8FB29B23AB2A577 /* MantaLiveChatClearCaptureUITests.swift */; };
 		BFC5BB268D33C67CB9C66A9E /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = F69CF621A0341F78A09CFF85 /* MarkdownView */; };
 		C2C89BEF7843F4F3460A926F /* MantaOverflowCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681F342360878481A0D8364F /* MantaOverflowCaptureUITests.swift */; };
@@ -73,7 +73,7 @@
 		D776E336456236DC1493565F /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229392FD3405558D301D0809 /* ChatModel.swift */; };
 		D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */; };
 		D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42691C89906181C99929354 /* ComposerView.swift */; };
-		DB494E7C3511EA8E1D01F8B1 /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = FD13380CB87B92A40F879A1F /* CrashReporter */; };
+		DB494E7C3511EA8E1D01F8B1 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3064D265FAB7F52B42389A28 /* FirebaseCrashlytics */; };
 		E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9803742B79E4302F8813EFCC /* SessionModelsTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
 		E0DE29696DA12A52BE7FCD0D /* TerminalModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3C09F5D2FEAE01B1C9CF1E /* TerminalModels.swift */; };
@@ -113,7 +113,6 @@
 		17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaRunningStateCaptureUITests.swift; sourceTree = "<group>"; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
-		20C78DF001E277064070853F /* CrashReports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReports.swift; sourceTree = "<group>"; };
 		229392FD3405558D301D0809 /* ChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModel.swift; sourceTree = "<group>"; };
 		24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListStore.swift; sourceTree = "<group>"; };
 		25870866D56CCE59805BCC0E /* MantaAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppDelegate.swift; sourceTree = "<group>"; };
@@ -179,6 +178,7 @@
 		C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptTests.swift; sourceTree = "<group>"; };
 		C42691C89906181C99929354 /* ComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerView.swift; sourceTree = "<group>"; };
 		C7F564F718747579264A4370 /* MantaUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MantaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAD176AE6BC2E7A6024A5761 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		D178D08102AB83BF93B82D16 /* SessionResourceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionResourceCards.swift; sourceTree = "<group>"; };
 		DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalModelsTests.swift; sourceTree = "<group>"; };
@@ -196,7 +196,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB494E7C3511EA8E1D01F8B1 /* CrashReporter in Frameworks */,
+				DB494E7C3511EA8E1D01F8B1 /* FirebaseCrashlytics in Frameworks */,
 				B46B35ED65EDB8F13002F091 /* MessagingUI in Frameworks */,
 				BFC5BB268D33C67CB9C66A9E /* MarkdownView in Frameworks */,
 			);
@@ -295,9 +295,9 @@
 				471BF240012879FDED5689C1 /* ChatSessionStore.swift */,
 				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
 				C42691C89906181C99929354 /* ComposerView.swift */,
-				20C78DF001E277064070853F /* CrashReports.swift */,
 				72E2CCAF6C565AEE489E1618 /* EdgeSwipeRestorer.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
+				CAD176AE6BC2E7A6024A5761 /* GoogleService-Info.plist */,
 				5C02DA420B52094269A88E80 /* Info.plist */,
 				6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */,
 				17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */,
@@ -394,6 +394,7 @@
 				85AE13C7C7852F37B78D84D2 /* Sources */,
 				A5BEBE3258625CF97C8CED67 /* Resources */,
 				FE7897AAE09BBE5E78CDE9BD /* Frameworks */,
+				7CE59D491F57F59EF7115E3D /* Crashlytics dSYM upload */,
 			);
 			buildRules = (
 			);
@@ -401,7 +402,7 @@
 			);
 			name = MantaUI;
 			packageProductDependencies = (
-				FD13380CB87B92A40F879A1F /* CrashReporter */,
+				3064D265FAB7F52B42389A28 /* FirebaseCrashlytics */,
 				2B48EABB4EC8AF086CA5C6AB /* MessagingUI */,
 				F69CF621A0341F78A09CFF85 /* MarkdownView */,
 			);
@@ -458,7 +459,7 @@
 			mainGroup = 855545FE3D464DDBA2B48C48;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				47C82525F78B395F5BC96245 /* XCRemoteSwiftPackageReference "plcrashreporter" */,
+				B9D086ECD156777ED11A795D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				B8F506AA56F1A90C2F5F7E32 /* XCRemoteSwiftPackageReference "MarkdownView" */,
 				E05AB3E0DD965872E0023A07 /* XCRemoteSwiftPackageReference "swiftui-messaging-ui" */,
 			);
@@ -480,12 +481,40 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF511A296958C8376966852F /* Assets.xcassets in Resources */,
+				9C027B884D963083B775876C /* GoogleService-Info.plist in Resources */,
 				2727E78CDA096DC415008244 /* manta-logo.png in Resources */,
 				8C965541FA4ABDFB2A2A319E /* terminal in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		7CE59D491F57F59EF7115E3D /* Crashlytics dSYM upload */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Crashlytics dSYM upload";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "UPLOAD=\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols\"\nDSYM=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"\nGSP=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\nif [ ! -x \"$UPLOAD\" ]; then\n  echo \"warning: Crashlytics upload-symbols not found at $UPLOAD — crashes will not symbolicate\"\nelif [ ! -d \"$DSYM\" ]; then\n  echo \"warning: Crashlytics found no dSYM at $DSYM (is DEBUG_INFORMATION_FORMAT dwarf-with-dsym?)\"\nelif [ ! -f \"$GSP\" ]; then\n  echo \"warning: Crashlytics found no GoogleService-Info.plist at $GSP\"\nelse\n  echo \"Crashlytics: uploading $DSYM\"\n  \"$UPLOAD\" -gsp \"$GSP\" -p ios \"$DSYM\" || echo \"warning: Crashlytics symbol upload failed (non-fatal)\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4724733D1545274205A1D812 /* Sources */ = {
@@ -538,7 +567,6 @@
 				8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */,
 				C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */,
 				D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */,
-				B8B5D7BF1F4F22B9A3682FEA /* CrashReports.swift in Sources */,
 				4F6D25AA2FFF73A8FE1321D3 /* EdgeSwipeRestorer.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,
 				67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */,
@@ -645,6 +673,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MantaUI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MantaUI;
@@ -659,6 +688,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;
 				SDKROOT = iphoneos;
@@ -750,6 +780,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MantaUI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MantaUI;
@@ -764,6 +795,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;
 				SDKROOT = iphoneos;
@@ -896,20 +928,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		47C82525F78B395F5BC96245 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/microsoft/plcrashreporter";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.11.1;
-			};
-		};
 		B8F506AA56F1A90C2F5F7E32 /* XCRemoteSwiftPackageReference "MarkdownView" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/LiYanan2004/MarkdownView";
 			requirement = {
 				kind = exactVersion;
 				version = 3.0.0;
+			};
+		};
+		B9D086ECD156777ED11A795D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.17.0;
 			};
 		};
 		E05AB3E0DD965872E0023A07 /* XCRemoteSwiftPackageReference "swiftui-messaging-ui" */ = {
@@ -928,15 +960,15 @@
 			package = E05AB3E0DD965872E0023A07 /* XCRemoteSwiftPackageReference "swiftui-messaging-ui" */;
 			productName = MessagingUI;
 		};
+		3064D265FAB7F52B42389A28 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9D086ECD156777ED11A795D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
 		F69CF621A0341F78A09CFF85 /* MarkdownView */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B8F506AA56F1A90C2F5F7E32 /* XCRemoteSwiftPackageReference "MarkdownView" */;
 			productName = MarkdownView;
-		};
-		FD13380CB87B92A40F879A1F /* CrashReporter */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 47C82525F78B395F5BC96245 /* XCRemoteSwiftPackageReference "plcrashreporter" */;
-			productName = CrashReporter;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
Regenerates `mobile/native/MantaUI.xcodeproj/project.pbxproj` with xcodegen on macOS.

The pbxproj is committed but can only be produced on a Mac, so the Crashlytics work in #729 — authored on the Linux box — left it stale. The committed file still wired up the **PLCrashReporter** package that PR removed.

```
PLCrashReporter refs, before : 4
PLCrashReporter refs, after  : 0
firebase refs, after         : 10
```

Single file, +53 / -21.

**This was never a build failure.** CI and the `ios-mantaui` plugin both run `xcodegen generate` before building, so every actual build already used the correct project. This only removes drift between the spec and its committed output, so that opening the project directly in Xcode matches what CI builds.

Generated by the `ios-regen-pbxproj` plugin (`action: push`), which resets the shared build clone to `origin/main` first and leaves it clean.