### PR TITLE
BET-720: docs(renderer): fix stale window.prompt find prose in chatUtils comment

### DIFF
--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1346,7 +1346,7 @@ export function isPollExpired(
 // `terminalShortcut(ev, isMac)` is the pure matcher. Returns which terminal-
 // emulator action the keydown maps to (or null = "not ours, let it through").
 // The four actions map to the same four bodies xterm.js's custom key handler
-// already runs today (selection copy, clipboard paste, window.prompt find,
+// already runs today (selection copy, clipboard paste, in-pane find bar,
 // term.clear scrollback).
 //
 // `isMac` is passed in rather than read from `navigator` so the function is


### PR DESCRIPTION
Clean up the stale `window.prompt` find prose in the `chatUtils.ts` terminalShortcut comment.

Follow-up from BET-710 (which replaced the broken `window.prompt` find with an in-pane find bar in `Terminal.tsx` but was forbidden from touching `chatUtils.ts`). Updates the comment at `src/renderer/chatUtils.ts:~1349` to reference the in-pane find bar instead of the long-gone prompt-based find.

**Files changed:** `1` file. `src/renderer/chatUtils.ts` (1 comment line).

**Base: origin/main @ 45b6207e**

**Verification results:**
- PR branch (`multica/BET-720-stale-window-prompt-prose` @ `931be724`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 1, **2265 pass / 0 fail / 7 skip**, + 1 unhandled-rejection error in `useTypeahead.test.tsx` (`window is not defined` from a post-teardown timer). Failures: none. log sha256: `abf7a89c4c60cd9007709c5a4700ab9ca90f4c9d9221797c60bc475eb704a7d1`
- Base (`main` @ `45b6207e`): identical result by construction — the only diff between the branches is the single comment line in `chatUtils.ts`, which cannot affect `useTypeahead` or any other test.
- **Conclusion:** 0 new test failures. The sole `useTypeahead` unhandled-rejection is pre-existing/environmental (an async timer firing after test teardown), unrelated to this comment-only change; the pure functional suites (1561 server+renderer tests on the pre-rebase base, 2265 on the rebased head) all pass.

Grep for `window.prompt` in `src/renderer/` is now clean.
