### PR TITLE
feat(server): permissions ride the interpreted stream — applyPermissionEvent + permissions frames (BET-715)

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -16,11 +16,11 @@ import MessagingUI
 //      (`stream:flush`), running/turnComplete, context/tokens, todos,
 //      truncation, questions, and live subagent status.
 //
-// Permissions are fetched via `opencode:permissions` and lightly polled while
-// the screen is active; questions arrive on the interpreted stream. Both are
-// answerable from the phone (S1a reply/reject RPCs). Parent and children are
-// each their own store; a child store is read-only (no permission poll) —
-// §8a v1.
+// Permissions and questions both arrive on the interpreted stream (`sub:
+// "permissions"` / `sub: "questions"`); `opencode:permissions` is only the
+// seed/resync path (the 2.5s poll is gone). Both are answerable from the phone
+// (S1a reply/reject RPCs). Parent and children are each their own store; a
+// child store is read-only (§8a v1).
 //
 // Deliberately does NOT touch the event store's single-owner `rawFrameHandler`
 // or `resyncHandler`; resync + attention are derived from the @Published stream
@@ -191,7 +191,6 @@ final class ChatSessionStore: ObservableObject {
     private let api: MantaAPIClient
     private let eventStore: MantaEventStore
     private var cancellables: Set<AnyCancellable> = []
-    private var permissionPoll: Timer?
     private var runningSince: Date?
     /// Stable id for the streaming `.prose` tail, fixed for the life of one
     /// turn. The tail's TEXT grows every delta, so a content-derived id would
@@ -213,7 +212,6 @@ final class ChatSessionStore: ObservableObject {
     /// resumable work so tests can assert the split without touching live
     /// timers or the network.
     private(set) var transcriptFetchCount = 0
-    private(set) var permissionPollStartedCount = 0
     private var lastRunning: Bool?
     private var lastComplete: Bool?
     /// How many recent messages the CURRENT window covers. Every refetch reuses
@@ -265,19 +263,13 @@ final class ChatSessionStore: ObservableObject {
 
     // MARK: - Lifecycle
 
-    /// Begin loading the session and (for the parent) start the light
-    /// permission poll. One-time setup is split from resumable work: the
-    /// initial transcript fetch runs once under the `didRunOnce` guard, while
-    /// the permission poll is (re)started whenever it is not already running,
-    /// so a subagent push (`stop`) then pop (`start`) keeps polling without a
-    /// re-fetch.
+    /// Begin loading the session. One-time setup is split from resumable work:
+    /// the initial transcript fetch runs once under the `didRunOnce` guard, so
+    /// a subagent push (`stop`) then pop (`start`) does not re-fetch.
     func start() {
         if !didRunOnce {
             didRunOnce = true
             load()
-        }
-        if !isReadOnly {
-            startPermissionPoll()
         }
         // Register as an observer so the event store knows a consumer is
         // attached (BET-672): a session it completes with NO observer has its
@@ -286,8 +278,6 @@ final class ChatSessionStore: ObservableObject {
     }
 
     func stop() {
-        permissionPoll?.invalidate()
-        permissionPoll = nil
         // The session is leaving the screen: it is no longer a consumer of
         // this session's stream chunks, and its subagent stores can all go
         // (BET-672). Dropping the dictionary here is the teardown-path half of
@@ -388,6 +378,12 @@ final class ChatSessionStore: ObservableObject {
             locallyAnsweredQuestionIDs.formIntersection(Set(incoming.map(\.id)))
             questions = incoming.filter { !locallyAnsweredQuestionIDs.contains($0.id) }
         }
+
+        // --- permissions: live updates ride the interpreted stream. Unlike
+        // questions there is no locally-answered tombstone filter — the box
+        // removes a replied permission via the stream frame, and the optimistic
+        // local removal in `replyPermission` covers the sub-second window.
+        if let p = s.permissions { permissions = p.permissions }
 
         // --- the turn lifecycle (`turnComplete` flag + streaming-tail RESET)
         // is per-frame: only a genuine `turnComplete` frame clears the tail.
@@ -623,16 +619,8 @@ final class ChatSessionStore: ObservableObject {
 
     // MARK: - Permissions (S1a answerable)
 
-    private func startPermissionPoll() {
-        guard permissionPoll == nil else { return }
-        permissionPollStartedCount += 1
-        let timer = Timer(timeInterval: 2.5, repeats: true) { [weak self] _ in
-            Task { @MainActor in await self?.refreshPermissions() }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        permissionPoll = timer
-    }
-
+    /// Seed + resync only — live updates arrive on the interpreted stream;
+    /// the 2.5s poll is gone.
     func refreshPermissions() async {
         let perms = (try? await api.permissions(sessionId: sessionId)) ?? []
         await MainActor.run { permissions = perms }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -380,10 +380,17 @@ final class ChatSessionStore: ObservableObject {
         }
 
         // --- permissions: live updates ride the interpreted stream. Unlike
-        // questions there is no locally-answered tombstone filter — the box
-        // removes a replied permission via the stream frame, and the optimistic
-        // local removal in `replyPermission` covers the sub-second window.
-        if let p = s.permissions { permissions = p.permissions }
+        // questions there is no locally-answered tombstone filter — instead
+        // the accumulated snapshot is only applied on the frame that actually
+        // carries `sub: "permissions"`. Without that stamp check, this sink
+        // fires on every stream change (text delta, `running`, todos, ...)
+        // and would reapply the sticky snapshot each time, clobbering
+        // whatever `refreshPermissions()` just repaired on reconnect and
+        // briefly resurrecting an answered permission before its
+        // `permission.replied` frame lands.
+        if stamp?.sessionId == sessionId, stamp?.sub == "permissions", let p = s.permissions {
+            permissions = p.permissions
+        }
 
         // --- the turn lifecycle (`turnComplete` flag + streaming-tail RESET)
         // is per-frame: only a genuine `turnComplete` frame clears the tail.

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -214,6 +214,14 @@ final class ChatSessionStore: ObservableObject {
     private(set) var transcriptFetchCount = 0
     private var lastRunning: Bool?
     private var lastComplete: Bool?
+    /// The permissions payload most recently folded into `permissions`. The
+    /// accumulated snapshot is sticky and this sink fires on every stream change,
+    /// so applying it unconditionally would clobber whatever `refreshPermissions()`
+    /// (seed/resync) just wrote. Edge-triggering on the VALUE — rather than on the
+    /// frame stamp, a single slot that a later frame or a transcript retirement can
+    /// overwrite before this deferred sink reads it — applies every genuine
+    /// permissions frame exactly once and nothing else.
+    private var lastAppliedPermissions: StreamPermissionsPayload?
     /// How many recent messages the CURRENT window covers. Every refetch reuses
     /// it, so a turn-boundary refresh never silently collapses a window the
     /// user widened.
@@ -381,14 +389,17 @@ final class ChatSessionStore: ObservableObject {
 
         // --- permissions: live updates ride the interpreted stream. Unlike
         // questions there is no locally-answered tombstone filter — instead
-        // the accumulated snapshot is only applied on the frame that actually
-        // carries `sub: "permissions"`. Without that stamp check, this sink
-        // fires on every stream change (text delta, `running`, todos, ...)
-        // and would reapply the sticky snapshot each time, clobbering
-        // whatever `refreshPermissions()` just repaired on reconnect and
-        // briefly resurrecting an answered permission before its
-        // `permission.replied` frame lands.
-        if stamp?.sessionId == sessionId, stamp?.sub == "permissions", let p = s.permissions {
+        // the payload is edge-triggered against `lastAppliedPermissions`
+        // (see its doc comment for why the frame stamp alone is not a safe
+        // trigger). Applying it unconditionally would clobber whatever
+        // `refreshPermissions()` just repaired on reconnect and briefly
+        // resurrect an answered permission before its `permission.replied`
+        // frame lands; gating on the stamp instead can silently DROP a
+        // genuine permissions frame if a later frame or a transcript
+        // retirement overwrites the stamp before this deferred sink reads
+        // it. Edge-triggering on the value has neither failure mode.
+        if let p = s.permissions, p != lastAppliedPermissions {
+            lastAppliedPermissions = p
             permissions = p.permissions
         }
 

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -51,6 +51,7 @@ struct MantaSessionStreamState: Equatable, Sendable {
     var sessionError: StreamSessionErrorPayload?
     var todos: StreamTodosPayload?
     var questions: StreamQuestionsPayload?
+    var permissions: StreamPermissionsPayload?
     var subagents: [StreamSubagentPayload] = []
 
     init(sessionId: String) {
@@ -138,6 +139,8 @@ enum MantaStreamRouter {
             s.todos = try? frame.decodedPayload(StreamTodosPayload.self)
         case "questions":
             s.questions = try? frame.decodedPayload(StreamQuestionsPayload.self)
+        case "permissions":
+            s.permissions = try? frame.decodedPayload(StreamPermissionsPayload.self)
         case "subagent":
             if let p = try? frame.decodedPayload(StreamSubagentPayload.self) {
                 // Upsert keyed by the subagent's child-session id (BET-672): a

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -241,6 +241,13 @@ struct StreamQuestionsPayload: Codable, Equatable, Sendable {
     var questions: [QuestionRequest]
 }
 
+/// `sub: "permissions"` — the pending permission requests for the session.
+/// Same wire shape as the `opencode:permissions` RPC, so the existing
+/// PermissionRequest Codable decodes both.
+struct StreamPermissionsPayload: Codable, Equatable, Sendable {
+    var permissions: [PermissionRequest]
+}
+
 /// `sub: "subagent"` — extractSubagentInfo + runningCount.
 struct StreamSubagentPayload: Codable, Equatable, Sendable {
     var childSessionId: String

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -269,6 +269,32 @@ final class ChatStreamMergeTests: XCTestCase {
                        "a non-permissions frame must not resurrect a permission cleared by resync")
     }
 
+    /// A permissions frame followed immediately by an unrelated frame for the
+    /// SAME session must not lose the permission. `lastStreamFrame` is a
+    /// single mutable slot read one run-loop turn later than the frame that
+    /// set it (the sink is `receive(on: .main)`), so a following frame can
+    /// overwrite that slot before the deferred sink observes it. Gating the
+    /// apply on the stamp (the cycle-1 fix) fails this case — the permissions
+    /// frame is silently dropped and the card never renders. Edge-triggering
+    /// on the payload VALUE instead is immune to this ordering.
+    func testPermissionsFrameSurvivesImmediatelyFollowingFrame() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+
+        stream.inject(#"{"kind":"stream","sub":"permissions","sessionId":"ses","payload":{"permissions":[{"id":"perm_1","sessionID":"ses","permission":"Bash","patterns":["~/secrets.json"]}]}}"#)
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+
+        XCTAssertEqual(store.permissions.map(\.id), ["perm_1"],
+                       "a permissions frame must not be lost when a following frame for the same session arrives before the deferred sink runs")
+    }
+
     /// start() twice must not double the one-time work: one transcript fetch,
     /// even when the loading branch fires twice in a row.
     func testStartTwiceCreatesOneFetch() async {

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -237,6 +237,38 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertEqual(store.permissions, [], "a replied/removed permission must clear on the stream frame")
     }
 
+    /// The accumulated snapshot only republishes on a genuine `permissions`
+    /// frame. A frame of any other sub (running, todos, ...) must not
+    /// reapply the sticky snapshot — otherwise it would clobber whatever
+    /// `refreshPermissions()` (seed/resync) just wrote, or resurrect a
+    /// permission that was just cleared, before the box's own frame lands.
+    func testNonPermissionsFrameDoesNotResurrectClearedPermission() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        stream.inject(#"{"kind":"stream","sub":"permissions","sessionId":"ses","payload":{"permissions":[{"id":"perm_1","sessionID":"ses","permission":"Bash","patterns":["~/secrets.json"]}]}}"#)
+
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+        XCTAssertEqual(store.permissions.map(\.id), ["perm_1"])
+
+        // The accumulated snapshot still carries perm_1 (no permissions frame
+        // has cleared it yet), but a reconnect just resynced the truth to
+        // empty via refreshPermissions().
+        await store.refreshPermissions()
+        XCTAssertEqual(store.permissions, [], "refreshPermissions must win immediately after resync")
+
+        // An unrelated frame (e.g. `running`) must not reapply the stale
+        // snapshot over the resync.
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        XCTAssertEqual(store.permissions, [],
+                       "a non-permissions frame must not resurrect a permission cleared by resync")
+    }
+
     /// start() twice must not double the one-time work: one transcript fetch,
     /// even when the loading branch fires twice in a row.
     func testStartTwiceCreatesOneFetch() async {

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -209,44 +209,47 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertEqual(userBlocks.count, 0, "a failed send must not leave the message in the transcript")
     }
 
-    // MARK: - Permission poll lifecycle (BET-669)
+    // MARK: - Permissions routing (BET-715)
 
-    private func makeLifecycleStore() -> ChatSessionStore {
-        ChatSessionStore(
+    // BET-669's original concern — a 2.5s permission poll timer leaking or
+    // piling up across subagent drill-in (`start() → stop() → start()`) — is
+    // MOOT: the poll is gone (BET-715). Permissions now ride the interpreted
+    // stream as `sub: "permissions"` frames, so this section pins the frame
+    // → `store.permissions` routing instead of timer lifecycle.
+
+    func testPermissionsFramePopulatesAndClears() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        stream.inject(#"{"kind":"stream","sub":"permissions","sessionId":"ses","payload":{"permissions":[{"id":"perm_1","sessionID":"ses","permission":"Bash","patterns":["~/secrets.json"]}]}}"#)
+
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+        XCTAssertEqual(store.permissions.map(\.id), ["perm_1"],
+                       "a permissions frame must surface the pending permission")
+
+        // A replied-removal frame clears it.
+        stream.inject(#"{"kind":"stream","sub":"permissions","sessionId":"ses","payload":{"permissions":[]}}"#)
+        await Task.yield()
+        XCTAssertEqual(store.permissions, [], "a replied/removed permission must clear on the stream frame")
+    }
+
+    /// start() twice must not double the one-time work: one transcript fetch,
+    /// even when the loading branch fires twice in a row.
+    func testStartTwiceCreatesOneFetch() async {
+        let store = ChatSessionStore(
             sessionId: "ses",
             eventStore: MantaEventStore(stream: TestStreamControl(), tokenProvider: { nil }, serverProvider: { nil }),
             api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
         )
-    }
-
-    /// start → stop → start leaves exactly one active poll: the poll is
-    /// resumable work, so `stop()` clears it and the resumed `start()`
-    /// creates a fresh single poll — and an extra `start()` does not pile on a
-    /// second one.
-    func testStartStopStartLeavesOneActivePoll() async {
-        let store = makeLifecycleStore()
-        store.start()
-        XCTAssertEqual(store.permissionPollStartedCount, 1)
-        store.stop()
-        store.start()
-        XCTAssertEqual(store.permissionPollStartedCount, 2,
-                       "stop() then start() must resume the poll as a new single one")
-        store.start()
-        XCTAssertEqual(store.permissionPollStartedCount, 2,
-                       "restarting an already-running poll must not create a second timer")
-    }
-
-    /// start → start must not double the one-time work: one transcript fetch
-    /// and one poll, even when the loading branch fires twice in a row.
-    func testStartTwiceCreatesOnePollAndOneFetch() async {
-        let store = makeLifecycleStore()
         store.start()
         store.start()
         for _ in 0..<5 { await Task.yield() }
         XCTAssertEqual(store.transcriptFetchCount, 1,
                        "start() twice must not double-fetch the transcript")
-        XCTAssertEqual(store.permissionPollStartedCount, 1,
-                       "start() twice must not create two poll timers")
     }
 
     // MARK: - Mock transport

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -32,6 +32,7 @@ import {
   selectActiveTodos,
   selectVisibleTodos,
   applyQuestionEvent,
+  applyPermissionEvent,
   isAssistantTurnComplete,
   registerChildSessionFromCreated,
   extractSubagentInfo,
@@ -76,6 +77,7 @@ function newSessionState() {
     childSessionIds: new Set(),
     liveChildStatus: new Map(),
     questions: [],             // QuestionLike[]
+    permissions: [],           // PermissionLike[] (pending permission requests)
     lastCompleted: null,
     cachedTokens: 0,
     running: false,
@@ -333,6 +335,21 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
       case "question.rejected": {
         st.questions = applyQuestionEvent(st.questions, evt.type, evt.properties, sid);
         emit(sid, "questions", { questions: st.questions });
+        return;
+      }
+      // Permissions get the identical treatment to questions: they ride the
+      // interpreted stream as a `permissions` frame. Trust-mode note: this
+      // interpret() runs in the opencode pump BEFORE the chatAutoAllow
+      // auto-allow branch in src/server/index.mjs, so under trust mode the
+      // phone briefly receives a pending permission that the box answers
+      // milliseconds later — the `permission.replied` opencode then emits
+      // flows through this same case and clears it. That transient matches the
+      // desktop sidebar's semantics; leave it.
+      case "permission.asked":
+      case "permission.replied":
+      case "permission.rejected": {
+        st.permissions = applyPermissionEvent(st.permissions, evt.type, evt.properties, sid);
+        emit(sid, "permissions", { permissions: st.permissions });
         return;
       }
       default:

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -255,6 +255,40 @@ test("question.asked hydrates pending questions", () => {
   assert.equal(ev2.payload.questions.length, 0);
 });
 
+test("permission.asked hydrates pending permissions; replied removes it; other-session asked ignored", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "permission.asked",
+    properties: {
+      sessionID: SID,
+      id: "perm_1",
+      prompt: "Allow reading ~/secrets.json?",
+    },
+  });
+  const ev = events.find((e) => e.sub === "permissions");
+  assert.ok(ev);
+  assert.equal(ev.payload.permissions.length, 1);
+  assert.equal(ev.payload.permissions[0].id, "perm_1");
+  // replied removes it
+  interp.interpret({
+    type: "permission.replied",
+    properties: { sessionID: SID, id: "perm_1" },
+  });
+  const ev2 = events[events.length - 1];
+  assert.equal(ev2.sub, "permissions");
+  assert.equal(ev2.payload.permissions.length, 0);
+  // an ask for a different session never leaks into this session's state
+  interp.interpret({
+    type: "permission.asked",
+    properties: { sessionID: "ses_other", id: "perm_2", prompt: "p" },
+  });
+  const frame = events[events.length - 1];
+  assert.equal(frame.sub, "permissions");
+  assert.equal(frame.sessionId, "ses_other");
+  assert.equal(frame.payload.permissions.length, 1); // its own session's frame
+  assert.equal(interp.getState(SID).permissions.length, 0); // SID untouched
+});
+
 test("session.idle emits turnComplete true", () => {
   const { interp, events } = make();
   interp.interpret({ type: "session.idle", properties: { sessionID: SID } });

--- a/src/shared/streamInterpretation.d.mts
+++ b/src/shared/streamInterpretation.d.mts
@@ -145,6 +145,17 @@ export function applyQuestionEvent(
   viewedSessionId: string,
 ): QuestionLike[];
 
+// The permission record is the whole `properties` object — the same wire shape
+// `opencode:permissions` returns (`{ id: "perm_…", sessionID, prompt, … }`).
+export type PermissionLike = Record<string, unknown>;
+
+export function applyPermissionEvent(
+  prev: PermissionLike[] | undefined,
+  eventType: string,
+  properties: Record<string, unknown> | undefined,
+  viewedSessionId: string,
+): PermissionLike[];
+
 export function hydrateQuestion(server: {
   id: string;
   sessionID: string;

--- a/src/shared/streamInterpretation.mjs
+++ b/src/shared/streamInterpretation.mjs
@@ -611,6 +611,32 @@ export function applyQuestionEvent(prev, eventType, properties, viewedSessionId)
 }
 
 /**
+ * Fold a permission lifecycle event into the pending-permissions list.
+ * The permission twin of applyQuestionEvent, simpler because a permission has
+ * no tool/callID indirection: `properties.id` (perm_…) is both the store key
+ * and the reply key.
+ *
+ * - permission.asked    → append (dedupe on id; ignore other sessions)
+ * - permission.replied / permission.rejected → remove by id
+ */
+export function applyPermissionEvent(prev, eventType, properties, viewedSessionId) {
+  const p = properties ?? {};
+  const id = typeof p.id === "string" ? p.id : "";
+  if (eventType === "permission.replied" || eventType === "permission.rejected") {
+    if (!id) return prev;
+    return prev.filter((perm) => perm?.id !== id);
+  }
+  if (eventType === "permission.asked") {
+    if (!id) return prev;
+    const sessionID = typeof p.sessionID === "string" ? p.sessionID : "";
+    if (sessionID !== viewedSessionId) return prev;
+    const without = prev.filter((perm) => perm?.id !== id);
+    return [...without, p];
+  }
+  return prev;
+}
+
+/**
  * Normalize a server `GET /question` response row into the QuestionLike shape
  * used by applyQuestionEvent's output. The server returns
  * `{id: "que_…", sessionID, questions, tool}`; the caller keeps a separate

--- a/src/shared/streamInterpretation.test.ts
+++ b/src/shared/streamInterpretation.test.ts
@@ -7,6 +7,7 @@ import {
   STALE_CACHE_MIN_TOKENS,
   VISIBLE_TODOS_CAP,
   allTodosTerminal,
+  applyPermissionEvent,
   applyQuestionEvent,
   buildTitlePromptInput,
   classifyCacheAge,
@@ -1119,6 +1120,66 @@ describe("applyQuestionEvent — BET-112 live-path stacking/requestId", () => {
     expect(state).toHaveLength(1);
     expect(state[0].id).toBe("toolu_2");
     expect(state[0].requestId).toBe("que_2");
+  });
+});
+
+describe("applyPermissionEvent", () => {
+  const SID = "ses_view";
+  const askedProps = {
+    id: "perm_1",
+    sessionID: SID,
+    prompt: "Allow reading ~/secrets.json?",
+  };
+
+  it("permission.asked appends the permission (whole properties object is the record)", () => {
+    const next = applyPermissionEvent([], "permission.asked", askedProps, SID);
+    expect(next).toHaveLength(1);
+    // The stored record is the raw wire payload — the same shape
+    // `opencode:permissions` returns, so iOS decodes it with PermissionRequest.
+    expect(next[0]).toEqual(askedProps);
+  });
+
+  it("permission.replied removes the answered permission", () => {
+    const prev = [askedProps];
+    expect(
+      applyPermissionEvent(prev, "permission.replied", { id: "perm_1", sessionID: SID }, SID),
+    ).toEqual([]);
+  });
+
+  it("permission.rejected removes the dismissed permission", () => {
+    const prev = [askedProps];
+    expect(
+      applyPermissionEvent(prev, "permission.rejected", { id: "perm_1", sessionID: SID }, SID),
+    ).toEqual([]);
+  });
+
+  it("permission.asked for a DIFFERENT session is ignored", () => {
+    const other = { ...askedProps, id: "perm_2", sessionID: "ses_other" };
+    expect(applyPermissionEvent([], "permission.asked", other, SID)).toEqual([]);
+  });
+
+  it("re-asking the same id dedupes (no duplicate rows)", () => {
+    const first = applyPermissionEvent([], "permission.asked", askedProps, SID);
+    const second = applyPermissionEvent(first, "permission.asked", askedProps, SID);
+    expect(second).toHaveLength(1);
+  });
+
+  it("preserves unrelated pending permissions when one is replied", () => {
+    const p2 = { ...askedProps, id: "perm_2" };
+    const prev = [askedProps, p2];
+    const next = applyPermissionEvent(prev, "permission.replied", { id: "perm_1", sessionID: SID }, SID);
+    expect(next).toEqual([p2]);
+  });
+
+  it("missing id is a no-op for asked / replied / rejected", () => {
+    expect(applyPermissionEvent([], "permission.asked", { sessionID: SID }, SID)).toEqual([]);
+    expect(applyPermissionEvent(undefined, "permission.asked", undefined, SID)).toBeUndefined();
+    expect(
+      applyPermissionEvent([askedProps], "permission.replied", { sessionID: SID }, SID),
+    ).toEqual([askedProps]);
+    expect(
+      applyPermissionEvent([askedProps], "permission.rejected", {}, SID),
+    ).toEqual([askedProps]);
   });
 });
 


### PR DESCRIPTION
Opened automatically for `multica/BET-715-perm-stream`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-715.