### PR TITLE
BET-704: feat(renderer): desktop onboarding clipboard pair-link prefill

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -404,6 +404,12 @@ function registerHandlers(): void {
     return buf ? buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) : null;
   });
 
+  // Read the current clipboard TEXT (BET-704: onboarding pair-link
+  // clipboard prefill). PairStep calls this on mount + window focus to
+  // offer a one-tap prefill when a pairing link is sitting in the
+  // clipboard — never polled, never auto-claims.
+  ipcMain.handle(IPC.clipboardReadText, () => clipboard.readText());
+
   // Read an arbitrary local (Mac) file's bytes. Used for Desktop screenshot
   // detection (screenshotDetected source:"file") — only main can touch the
   // OS filesystem; the renderer funnels the bytes into uploadBuffer from there.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -67,6 +67,11 @@ const api = {
     ipcRenderer.invoke(IPC.clipboardWriteText, text),
   clipboardReadImage: (): Promise<ArrayBuffer | null> =>
     ipcRenderer.invoke(IPC.clipboardReadImage),
+  // BET-704: onboarding pair-link clipboard prefill. Read on PairStep mount
+  // + window focus so a link copied elsewhere (chat, terminal) can be
+  // offered as a one-tap prefill — never polled.
+  readClipboardText: (): Promise<string> =>
+    ipcRenderer.invoke(IPC.clipboardReadText),
   readLocalFile: (path: string): Promise<ArrayBuffer> =>
     ipcRenderer.invoke(IPC.readLocalFile, path),
 

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -29,6 +29,7 @@ import {
   normalizeServerUrl,
   prefillFromPairLink,
 } from "../shared/setupLogic";
+import { detectPairClipboard } from "../shared/pairPayload";
 import { PairingCodeInput } from "./PairingCodeInput";
 import { isValidBoxToken } from "../shared/transport.mjs";
 import { claimBox } from "./pairClaim";
@@ -74,6 +75,54 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
   // empty shell.
   const showSshPicker = hasSshInstaller && !prefill;
 
+  // Clipboard pair-link detection (BET-704): a user who received a pairing
+  // link elsewhere (chat message, terminal copy) shouldn't have to retype
+  // it. Checked on mount AND on window focus while this step is shown — no
+  // polling/intervals. A hit renders a dismissible banner; "Use it" routes
+  // through the SAME pendingPairLink mechanism the OS deep-link handler
+  // uses (App.tsx's onPairLink → setPendingPairLink → prefillFromPairLink),
+  // so there is exactly one prefill code path. The user still clicks
+  // Connect — this never auto-claims.
+  const lastClipboardRef = useRef<string | null>(null);
+  const [clipboardHit, setClipboardHit] = useState<string | null>(null);
+
+  useEffect(() => {
+    const preload = getMantaPreload();
+    if (!preload) return;
+
+    const check = () => {
+      void (async () => {
+        let text: string;
+        try {
+          text = await preload.readClipboardText();
+        } catch {
+          return; // clipboard read failed — silently no banner
+        }
+        const trimmed = (text ?? "").trim();
+        if (!trimmed || trimmed === lastClipboardRef.current) return;
+        if (!detectPairClipboard(trimmed, PAIR_PREFILL_SCHEME)) return;
+        setClipboardHit(trimmed);
+      })();
+    };
+
+    check();
+    window.addEventListener("focus", check);
+    return () => window.removeEventListener("focus", check);
+  }, []);
+
+  const dismissClipboardHit = () => {
+    lastClipboardRef.current = clipboardHit;
+    setClipboardHit(null);
+  };
+
+  const useClipboardHit = () => {
+    if (!clipboardHit) return;
+    lastClipboardRef.current = clipboardHit;
+    useStore.getState().setPendingPairLink(clipboardHit);
+    setClipboardHit(null);
+    setDisclosureOpen(true);
+  };
+
   return (
     <div>
       <h2 className="text-display font-semibold tracking-tight text-text mb-2">
@@ -97,8 +146,39 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
       >
         {disclosureOpen ? "Hide" : "Pair to an existing box"}
       </button>
+      {clipboardHit && (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded-sm border border-border bg-bg-soft px-3 py-2 text-body text-text">
+          <span>Pairing link detected</span>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={useClipboardHit}
+              className="text-body font-medium text-accent hover:underline"
+            >
+              Use it
+            </button>
+            <button
+              type="button"
+              onClick={dismissClipboardHit}
+              aria-label="Dismiss"
+              className="text-text-faint hover:text-text-muted"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
       {disclosureOpen && (
-        <ManualPairForm prefill={prefill} onPaired={onPaired} />
+        // Keyed on pendingPairLink so a clipboard "Use it" click prefills a
+        // manual form that is ALREADY open (a fresh mount is the only way
+        // this component's useState-seeded fields pick up a new prefill —
+        // the same mechanism the deep-link path already relies on, just
+        // made to also work when the form was open before the link arrived).
+        <ManualPairForm
+          key={pendingPairLink ?? "no-prefill"}
+          prefill={prefill}
+          onPaired={onPaired}
+        />
       )}
     </div>
   );

--- a/src/renderer/preloadAccess.test.ts
+++ b/src/renderer/preloadAccess.test.ts
@@ -22,6 +22,11 @@ function makeFakePreload(): MantaPreload {
     onPairLink: vi.fn((_cb: (url: string) => void) => vi.fn()),
     clipboardWriteText: vi.fn(async () => {}),
     clipboardReadImage: vi.fn(async () => null),
+    // BET-704: onboarding pair-link clipboard prefill. Minimal stub —
+    // per-method behavior is exercised by pairPayload.test.ts
+    // (detectPairClipboard) and PairStep's own wiring is untested by
+    // design (issue ground rules).
+    readClipboardText: vi.fn(async () => ""),
     readLocalFile: vi.fn(async () => new ArrayBuffer(0)),
     openExternal: vi.fn(async () => {}),
     revealInFolder: vi.fn(async () => {}),

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -47,6 +47,12 @@ export interface MantaPreload {
   // main can touch the OS clipboard — this must go through the preload, NOT
   // window.api (which is httpApi in HTTP mode and has no OS access).
   clipboardReadImage(): Promise<ArrayBuffer | null>;
+  // Read the current clipboard TEXT (BET-704: onboarding pair-link
+  // clipboard prefill). PairStep calls this on mount + window focus and
+  // runs the result through `detectPairClipboard` — a hit offers a
+  // one-tap "Use it" prefill of the manual pairing form. Never polled,
+  // never auto-claims; the user still clicks Connect.
+  readClipboardText(): Promise<string>;
   // Read an arbitrary local (Mac) file's bytes — e.g. a Desktop screenshot
   // detected by main's fs.watch. Only main can touch the OS filesystem.
   readLocalFile(path: string): Promise<ArrayBuffer>;

--- a/src/shared/pairPayload.test.ts
+++ b/src/shared/pairPayload.test.ts
@@ -3,6 +3,7 @@ import {
   parsePairPayload,
   buildPairPayload,
   buildUniversalPairLink,
+  detectPairClipboard,
   UNIVERSAL_LINK_HOST,
   type PairPayload,
 } from "./pairPayload";
@@ -469,6 +470,52 @@ const ROUND_TRIP_CASES: PairPayload[] = [
   { boxId: BOX, code: "000000", serverUrl: "http://192.168.1.10:8787" },
   { boxId: BOX, code: "987654", serverUrl: "https://mybox.ts.net" },
 ];
+
+// BET-704: clipboard-prefill detection. `detectPairClipboard` is the pure
+// core of the "a pairing link is sitting in the clipboard" affordance —
+// PairStep.tsx owns the actual clipboard read + banner wiring (untested by
+// design), this file pins the detection logic itself.
+describe("detectPairClipboard", () => {
+  it("detects the manta://pair?... custom-scheme form", () => {
+    expect(
+      detectPairClipboard(`manta://pair?box=${BOX}&code=847291`),
+    ).toEqual({ boxId: BOX, code: "847291" });
+  });
+
+  it("detects the universal-link https form (BET-703)", () => {
+    const link = buildUniversalPairLink({ boxId: BOX, code: "847291" });
+    expect(detectPairClipboard(link)).toEqual({ boxId: BOX, code: "847291" });
+  });
+
+  it("trims surrounding whitespace before detecting", () => {
+    expect(
+      detectPairClipboard(`  manta://pair?box=${BOX}&code=847291  `),
+    ).toEqual({ boxId: BOX, code: "847291" });
+  });
+
+  it("returns null for a bare 6-digit code (no box id, can't claim alone)", () => {
+    expect(detectPairClipboard("847291")).toBeNull();
+  });
+
+  it("returns null for garbage / unrelated clipboard text", () => {
+    expect(detectPairClipboard("hello world")).toBeNull();
+    expect(detectPairClipboard("")).toBeNull();
+    expect(detectPairClipboard("   ")).toBeNull();
+    expect(detectPairClipboard("https://example.com")).toBeNull();
+    expect(
+      detectPairClipboard(`manta://connect?box=${BOX}&code=847291`),
+    ).toBeNull();
+  });
+
+  it("respects a non-default scheme (channel-aware, matching prefillFromPairLink)", () => {
+    const link = `manta-staging://pair?box=${BOX}&code=847291`;
+    expect(detectPairClipboard(link)).toBeNull(); // wrong scheme for default
+    expect(detectPairClipboard(link, "manta-staging")).toEqual({
+      boxId: BOX,
+      code: "847291",
+    });
+  });
+});
 
 describe("round-trip", () => {
   it("parsePairPayload(buildPairPayload(p)) deep-equals p for valid canonical inputs", () => {

--- a/src/shared/pairPayload.ts
+++ b/src/shared/pairPayload.ts
@@ -245,3 +245,37 @@ export function buildUniversalPairLink(p: PairPayload): string {
   }
   return base;
 }
+
+/**
+ * Detect whether a raw clipboard-read string is a pairing payload — the pure
+ * core of the "clipboard prefill" affordance (BET-704): a user who received
+ * a pairing link (chat message, terminal copy) and opens the desktop app
+ * shouldn't have to retype it.
+ *
+ * Trims the input and delegates to `parsePairPayload`, which — since
+ * BET-703 — already accepts BOTH the custom-scheme form
+ * (`<scheme>://pair?box=…&code=…`) and the deferred-deeplink https form
+ * (including the universal-link host `buildUniversalPairLink` emits, since
+ * the parser's https branch only checks the `/m` path, not the host).
+ * Returns null for anything that isn't a recognized pairing URL, including
+ * a bare 6-digit code — a code alone carries no box id and can never claim
+ * on its own, so it is never treated as a hit.
+ *
+ * `scheme` defaults to `"manta"`, matching `parsePairPayload` /
+ * `prefillFromPairLink` — pass the channel's own scheme (e.g.
+ * `PAIR_PREFILL_SCHEME` in PairStep.tsx) so a staging/dev desktop detects
+ * its own channel's custom-scheme links, not just prod's.
+ *
+ * Pure — no DOM, no clipboard access. The caller (PairStep.tsx) is
+ * responsible for the actual `navigator`/preload clipboard read and for
+ * deciding when to offer the detected payload (mount + focus, never a
+ * poll — see PairStep.tsx).
+ */
+export function detectPairClipboard(
+  raw: string,
+  scheme: string = "manta",
+): PairPayload | null {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) return null;
+  return parsePairPayload(trimmed, scheme);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -509,6 +509,10 @@ export const IPC = {
   // Read the current clipboard image as PNG ArrayBuffer (null if no image).
   // Called on demand after a screenshotDetected event — not polled.
   clipboardReadImage: "clipboard:read-image",
+  // Read the current clipboard TEXT (BET-704: onboarding pair-link
+  // clipboard prefill). Called on PairStep mount + window focus — never
+  // polled. Only main can touch the OS clipboard.
+  clipboardReadText: "clipboard:read-text",
   // Read an arbitrary local (Mac) file's raw bytes. Only main can touch the
   // OS filesystem — this is how the renderer gets bytes for a Desktop
   // screenshot detection (screenshotDetected source:"file") so it can then


### PR DESCRIPTION
Closes BET-704.

## What
On the pairing step, if the clipboard holds a valid pairing payload (custom-scheme `manta://pair?...` or the universal-link `https://app.mantaui.com/m?...` form), a dismissible banner offers a one-tap prefill of the manual pairing form. The user still clicks Connect — no auto-claim from the clipboard.

## How
- `src/shared/pairPayload.ts`: `detectPairClipboard(text, scheme?)` — pure detector delegating to `parsePairPayload` (already accepts both wire forms since BET-703; no parser change needed).
- `src/shared/types.ts` / `src/preload/index.ts` / `src/main/index.ts`: new `clipboard:read-text` IPC channel + `readClipboardText()` preload method, same pattern as the existing `clipboardWriteText`/`clipboardReadImage`.
- `src/renderer/preloadAccess.ts`: `MantaPreload.readClipboardText`.
- `src/renderer/PairStep.tsx`: checks the clipboard on mount + `window` focus (no polling). A hit renders a "Pairing link detected" banner with "Use it" / dismiss. "Use it" routes through the SAME `setPendingPairLink` → `prefillFromPairLink` mechanism the OS deep-link handler already uses — one prefill code path. `ManualPairForm` is now keyed on `pendingPairLink` so "Use it" also prefills correctly when the manual form was already open (previously only worked if the form mounted fresh). A ref tracks the last-seen/dismissed clipboard string so it's never re-offered.

## Tests
- `src/shared/pairPayload.test.ts`: `detectPairClipboard` — manta:// form, universal-link form, whitespace, bare 6-digit code → null, garbage → null, channel-scheme awareness.
- `src/renderer/preloadAccess.test.ts`: fake preload updated with `readClipboardText` stub (type-contract only).
- UI wiring is untested by design (per issue ground rules).

Base: `origin/main` @ `e36abd8d`

## Verification results
- PR branch (`multica/BET-704-clipboard-prefill` @ `358c32d0`):
  - typecheck: exit `0`. Errors: none. log sha256: `753426...622e1f`
  - test: exit `0`, vitest 2267 pass / 0 fail / 7 skip; node:test 1565 pass / 0 fail. log sha256: `878e5c...94b6`
- Base (`main` @ `e36abd8d`):
  - typecheck: exit `0`. Errors: none. log sha256: `753426...622e1f` (identical — no typecheck delta)
  - test: exit `0`, vitest 2261 pass / 0 fail / 7 skip; node:test 1565 pass / 0 fail. log sha256: `bb6b23...4d7f83`
- **Conclusion:** 0 pre-existing failures, 0 new failures. The +6 vitest test delta (2267 vs 2261) is exactly the 6 new `detectPairClipboard` cases added in this PR.

Logs at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` on the implementer's box for reviewer spot-check.
