### PR TITLE
Desktop: Modal primitive owns Escape + focus trap + restore; confirm Delete/Clear from the ⋯ menu (BET-724)

### DIFF
--- a/src/renderer/ConfirmModal.test.tsx
+++ b/src/renderer/ConfirmModal.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+//
+// Component tests for the shared destructive-action confirm dialog
+// (BET-724 Task 3 / D7). Built on Modal, so most dialog mechanics (Escape,
+// backdrop, focus trap) are already covered by Modal.test.tsx — this file
+// covers ConfirmModal's own contract: title/body render, Cancel/Confirm fire
+// the right callback, and Escape/backdrop route to Cancel (never Confirm).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { ConfirmModal } from "./ConfirmModal";
+
+describe("ConfirmModal", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function buttons(harness: Harness): HTMLButtonElement[] {
+    return [...harness.container.querySelectorAll("button")] as HTMLButtonElement[];
+  }
+
+  it("renders the title and body when open", () => {
+    h = mount(
+      <ConfirmModal
+        open
+        title="Delete this session?"
+        body="This can't be undone."
+        confirmLabel="Delete session"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(h.text()).toContain("Delete this session?");
+    expect(h.text()).toContain("This can't be undone.");
+  });
+
+  it("renders nothing when closed", () => {
+    h = mount(
+      <ConfirmModal
+        open={false}
+        title="Delete this session?"
+        body="This can't be undone."
+        confirmLabel="Delete session"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(h.text()).not.toContain("Delete this session?");
+  });
+
+  it("Cancel fires onCancel, not onConfirm", () => {
+    let cancelled = 0;
+    let confirmed = 0;
+    h = mount(
+      <ConfirmModal
+        open
+        title="Clear this conversation?"
+        body="The session keeps running but its context is gone."
+        confirmLabel="Clear"
+        onConfirm={() => confirmed++}
+        onCancel={() => cancelled++}
+      />,
+    );
+    const cancelBtn = buttons(h).find((b) => b.textContent === "Cancel")!;
+    expect(cancelBtn).toBeTruthy();
+    cancelBtn.click();
+    expect(cancelled).toBe(1);
+    expect(confirmed).toBe(0);
+  });
+
+  it("the confirm button fires onConfirm, not onCancel", () => {
+    let cancelled = 0;
+    let confirmed = 0;
+    h = mount(
+      <ConfirmModal
+        open
+        title="Delete this session?"
+        body="This can't be undone."
+        confirmLabel="Delete session"
+        onConfirm={() => confirmed++}
+        onCancel={() => cancelled++}
+      />,
+    );
+    const confirmBtn = buttons(h).find((b) => b.textContent === "Delete session")!;
+    expect(confirmBtn).toBeTruthy();
+    confirmBtn.click();
+    expect(confirmed).toBe(1);
+    expect(cancelled).toBe(0);
+  });
+
+  it("Escape routes to onCancel, never onConfirm (Modal's onDismiss = Cancel)", () => {
+    let cancelled = 0;
+    let confirmed = 0;
+    h = mount(
+      <ConfirmModal
+        open
+        title="Delete this session?"
+        body="This can't be undone."
+        confirmLabel="Delete session"
+        onConfirm={() => confirmed++}
+        onCancel={() => cancelled++}
+      />,
+    );
+    const dialog = h.container.querySelector('div[role="dialog"]')!;
+    dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(cancelled).toBe(1);
+    expect(confirmed).toBe(0);
+  });
+
+  it("the confirm button uses the danger tone, Cancel uses the default tone", () => {
+    h = mount(
+      <ConfirmModal
+        open
+        title="Delete this session?"
+        body="This can't be undone."
+        confirmLabel="Delete session"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const cancelBtn = buttons(h).find((b) => b.textContent === "Cancel")!;
+    const confirmBtn = buttons(h).find((b) => b.textContent === "Delete session")!;
+    expect(confirmBtn.className).toContain("text-danger");
+    expect(cancelBtn.className).not.toContain("text-danger");
+  });
+});

--- a/src/renderer/ConfirmModal.tsx
+++ b/src/renderer/ConfirmModal.tsx
@@ -1,0 +1,44 @@
+// ConfirmModal.tsx — the shared confirm dialog for destructive actions
+// reached from a menu (BET-724 Task 3 / design decision D7).
+//
+// Built on the Modal primitive, which now owns Escape/backdrop/focus trap
+// (BET-724 Task 1) — so Escape and backdrop click both mean Cancel here,
+// never Confirm. Typography matches the two pre-existing in-app confirms
+// (App.tsx's "Update the box?", Settings.tsx's "Remove box?" / "Reset all
+// settings?") rather than inventing a new type scale.
+
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+
+export function ConfirmModal({
+  open,
+  title,
+  body,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title: string;
+  body: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <Modal size="sm" open={open} onDismiss={onCancel} label={title}>
+      <div className="space-y-4">
+        <h3 className="text-title font-semibold">{title}</h3>
+        <div className="text-body text-text-faint">{body}</div>
+        <div className="flex justify-end gap-2">
+          <Button tone="default" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button tone="danger" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/renderer/FolderPickerModal.test.tsx
+++ b/src/renderer/FolderPickerModal.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// Regression test for BET-724 review cycle 1's Question: FolderPickerModal's
+// path input used to dismiss a live inline path-completion suggestion on the
+// FIRST Escape press and only close the dialog on a SECOND, suggestion-free
+// press. Deleting the hand-rolled handler (so Modal's own Escape ownership
+// takes over unconditionally) silently lost that two-stage behavior. This
+// restores it via a local `stopPropagation` when a suggestion is live, and
+// pins the restored behavior here.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
+import { installMockApi, mount, type Harness } from "./testHarness";
+import { FolderPickerModal } from "./FolderPickerModal";
+
+function typeInto(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("first Escape dismisses a live suggestion; second Escape closes the dialog", async () => {
+    let cancelled = 0;
+    installMockApi({
+      fsListDirs: (dir: unknown) =>
+        dir === "/home/dev/pro"
+          ? Promise.resolve(["/home/dev/projects"])
+          : Promise.resolve(["/home/dev"]),
+      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
+    });
+    h = mount(
+      <FolderPickerModal
+        open
+        initialPath="/home/dev"
+        onSelect={() => {}}
+        onCancel={() => cancelled++}
+      />,
+    );
+    await h.flush();
+
+    const input = h.container.querySelector("input") as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    act(() => {
+      typeInto(input, "/home/dev/pro");
+    });
+    // The suggestion fetch is debounced 80ms; give it (and the state update
+    // it triggers) room to land.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 150));
+    });
+    expect(h.text()).toContain("jects/"); // the ghost-text tail of "/home/dev/projects/"
+
+    // First Escape: dismisses the suggestion, dialog stays open.
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(cancelled).toBe(0);
+    expect(h.text()).not.toContain("jects/");
+
+    // Second Escape, no suggestion live: bubbles to Modal and closes.
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(cancelled).toBe(1);
+  });
+
+  it("Escape with no suggestion closes on the first press (unchanged case)", async () => {
+    let cancelled = 0;
+    installMockApi({
+      fsListDirs: () => Promise.resolve([]),
+      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
+    });
+    h = mount(
+      <FolderPickerModal
+        open
+        initialPath="/home/dev"
+        onSelect={() => {}}
+        onCancel={() => cancelled++}
+      />,
+    );
+    await h.flush();
+
+    const input = h.container.querySelector("input") as HTMLInputElement;
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(cancelled).toBe(1);
+  });
+});

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -334,9 +334,17 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
                         void select();
                         return;
                       }
-                      // Escape is handled by Modal (BET-724): it always
+                      // Escape is otherwise handled by Modal (BET-724): it
                       // dismisses regardless of which inner element has
-                      // focus, including this input with a live suggestion.
+                      // focus. But with a live inline suggestion, the FIRST
+                      // Escape should just dismiss the ghost-text completion
+                      // — restored per review (BET-724 cycle 1 Question) —
+                      // so stop it here and only let a second, suggestion-
+                      // free Escape bubble up to Modal and close the dialog.
+                      if (e.key === "Escape" && suggestion) {
+                        e.stopPropagation();
+                        setSuggestion(null);
+                      }
                     }}
                     spellCheck={false}
                     autoComplete="off"

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -334,10 +334,9 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
                         void select();
                         return;
                       }
-                      if (e.key === "Escape") {
-                        if (suggestion) setSuggestion(null);
-                        else onCancel();
-                      }
+                      // Escape is handled by Modal (BET-724): it always
+                      // dismisses regardless of which inner element has
+                      // focus, including this input with a live suggestion.
                     }}
                     spellCheck={false}
                     autoComplete="off"

--- a/src/renderer/MenuItem.test.tsx
+++ b/src/renderer/MenuItem.test.tsx
@@ -279,3 +279,92 @@ describe("MenuItem migration — SessionMenu call sites (BET-535)", () => {
     expect(row.className).not.toContain("px-3");
   });
 });
+
+describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function openMenuWith(overrides: Parameters<typeof mountSessionHeader>[0]) {
+    h = mountSessionHeader(overrides);
+    const trigger = h.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Session actions"]',
+    );
+    expect(trigger).toBeTruthy();
+    act(() => trigger!.click());
+  }
+
+  // The menu row and the confirm's own action button can share a label
+  // ("Delete session") — this only searches the DROPDOWN's menuitem rows.
+  function menuItemByText(text: string): HTMLElement {
+    const menu = h!.container.querySelector('[role="menu"]') as HTMLElement;
+    expect(menu).toBeTruthy();
+    const rows = [...menu.querySelectorAll<HTMLElement>("button[role='menuitem']")];
+    const el = rows.find((b) => b.textContent?.trim().includes(text));
+    expect(el, `expected a "${text}" menu row`).toBeTruthy();
+    return el!;
+  }
+
+  // The confirm's own action button lives inside the Modal's dialog panel —
+  // this only searches there, never the dropdown's menuitem rows.
+  function confirmButtonByText(text: string): HTMLButtonElement {
+    const dialog = h!.container.querySelector('div[role="dialog"]') as HTMLElement;
+    expect(dialog).toBeTruthy();
+    const el = [...dialog.querySelectorAll("button")].find(
+      (b) => b.textContent === text,
+    ) as HTMLButtonElement | undefined;
+    expect(el, `expected a "${text}" confirm button`).toBeTruthy();
+    return el!;
+  }
+
+  it("Delete session opens a confirm instead of calling onDelete immediately", () => {
+    let deleted = 0;
+    openMenuWith({ onDelete: () => deleted++ });
+    act(() => menuItemByText("Delete session").click());
+    expect(deleted).toBe(0);
+    expect(h!.text()).toContain("Delete this session?");
+  });
+
+  it("confirming Delete calls onDelete exactly once", () => {
+    let deleted = 0;
+    openMenuWith({ onDelete: () => deleted++ });
+    act(() => menuItemByText("Delete session").click());
+    act(() => confirmButtonByText("Delete session").click());
+    expect(deleted).toBe(1);
+  });
+
+  it("cancelling the Delete confirm does not call onDelete", () => {
+    let deleted = 0;
+    openMenuWith({ onDelete: () => deleted++ });
+    act(() => menuItemByText("Delete session").click());
+    act(() => confirmButtonByText("Cancel").click());
+    expect(deleted).toBe(0);
+  });
+
+  it("Clear session opens a confirm instead of calling onClear immediately", () => {
+    let cleared = 0;
+    openMenuWith({ onClear: () => cleared++ });
+    act(() => menuItemByText("Clear session").click());
+    expect(cleared).toBe(0);
+    expect(h!.text()).toContain("Clear this conversation?");
+  });
+
+  it("confirming Clear calls onClear exactly once", () => {
+    let cleared = 0;
+    openMenuWith({ onClear: () => cleared++ });
+    act(() => menuItemByText("Clear session").click());
+    act(() => confirmButtonByText("Clear").click());
+    expect(cleared).toBe(1);
+  });
+
+  it("the Delete confirm names the session from the breadcrumb window", () => {
+    openMenuWith({
+      breadcrumb: { project: "better-ui", window: "fix-onboarding" },
+      onDelete: () => {},
+    });
+    act(() => menuItemByText("Delete session").click());
+    expect(h!.text()).toContain("fix-onboarding");
+  });
+});

--- a/src/renderer/Modal.test.tsx
+++ b/src/renderer/Modal.test.tsx
@@ -126,3 +126,100 @@ describe("Modal", () => {
     expect(h.container.querySelector('div[role="dialog"]')).toBeNull();
   });
 });
+
+// ===== Escape + focus trap + restore (BET-724) =====
+describe("Modal — Escape + focus trap + restore (BET-724)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("calls onDismiss on Escape, regardless of which inner element has focus", () => {
+    let dismissed = 0;
+    h = mount(
+      <Modal label="L" onDismiss={() => dismissed++}>
+        <button>ok</button>
+      </Modal>,
+    );
+    const btn = h.container.querySelector("button")!;
+    act(() => {
+      btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(dismissed).toBe(1);
+  });
+
+  it("does nothing on Escape when onDismiss is omitted", () => {
+    h = mount(
+      <Modal label="L">
+        <button>ok</button>
+      </Modal>,
+    );
+    const btn = h.container.querySelector("button")!;
+    expect(() => {
+      act(() => {
+        btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      });
+    }).not.toThrow();
+    expect(h.text()).toContain("ok");
+    expect(h.container.querySelector('div[role="dialog"]')).toBeTruthy();
+  });
+
+  it("focuses the first focusable element inside the panel on open", () => {
+    h = mount(
+      <Modal label="L">
+        <div>
+          <span>not focusable</span>
+          <button>first</button>
+          <button>second</button>
+        </div>
+      </Modal>,
+    );
+    const buttons = h.container.querySelectorAll("button");
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("falls back to focusing the panel itself (tabIndex=-1) when nothing inside is focusable", () => {
+    h = mount(<Modal label="L">plain text</Modal>);
+    const panel = h.container.querySelector('div[role="dialog"]') as HTMLElement;
+    expect(panel).toBeTruthy();
+    expect(document.activeElement).toBe(panel);
+    expect(panel.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("traps Tab within the panel (wraps last → first)", () => {
+    h = mount(
+      <Modal label="L">
+        <button>first</button>
+        <button>second</button>
+      </Modal>,
+    );
+    const buttons = [...h.container.querySelectorAll("button")] as HTMLButtonElement[];
+    buttons[1].focus();
+    act(() => {
+      buttons[1].dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("restores focus to the opener on unmount", () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    h = mount(
+      <Modal label="L">
+        <button>inside</button>
+      </Modal>,
+    );
+    expect(document.activeElement).not.toBe(opener);
+
+    h.unmount();
+    h = null;
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+});

--- a/src/renderer/Modal.test.tsx
+++ b/src/renderer/Modal.test.tsx
@@ -222,4 +222,35 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
     expect(document.activeElement).toBe(opener);
     opener.remove();
   });
+
+  // BET-724 review cycle 1 Block: the trap used to force-focus the first
+  // focusable element from a passive effect, which runs AFTER React applies
+  // `autoFocus` during commit — so it clobbered `autoFocus` (stealing focus
+  // onto e.g. a Close button rendered before the autofocused field) and, by
+  // reading `document.activeElement` too late, captured the panel's OWN
+  // autofocused child as the "opener" instead of the real one, so
+  // focus-restore silently no-op'd. Regression-guards both halves.
+  it("respects a child's autoFocus instead of stealing it, and still restores the real opener on unmount", () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    h = mount(
+      <Modal label="L">
+        <button aria-label="Close">x</button>
+        {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+        <input autoFocus placeholder="path" />
+      </Modal>,
+    );
+    const input = h.container.querySelector("input")!;
+    // Focus stayed on the autofocused input, NOT the earlier Close button.
+    expect(document.activeElement).toBe(input);
+
+    h.unmount();
+    h = null;
+    // Restored to the REAL pre-open opener, not the autofocused input.
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
 });

--- a/src/renderer/Modal.tsx
+++ b/src/renderer/Modal.tsx
@@ -8,15 +8,21 @@
 //   size      — fixed panel width: "sm" 420px | "md" 480px | "lg" 560px
 //   padded    — true → p-4; false → the child owns its own insets
 //   tall      — true → max-h-[80vh] + flex flex-col + clips (list dialogs)
-//   onDismiss — overlay click; omit for a modal that must be answered
+//   onDismiss — overlay click AND Escape; omit for a modal that must be
+//               answered (no dismiss path at all)
 //
-// Escape handling stays at the call sites (two of them already bind it;
-// owning it here would double-handle). The five migrating dialogs are the
-// adopter set that clears the two-adopter rule (Sidebar / NewSessionScreen /
-// Settings ×2 / FolderPickerModal).
+// BET-724: Modal now OWNS Escape + focus trap + restore — every dialog built
+// on it inherits this for free, rather than each call site hand-rolling its
+// own (inconsistent) Escape handler. Escape is handled overlay-scoped (a
+// plain `onKeyDown` on the backdrop div): the focus trap below guarantees
+// focus never leaves the panel while it's open, so a bubble-phase handler on
+// the overlay is sufficient to catch it regardless of which inner element is
+// focused. Focus trap + initial focus + restore are the shared
+// `useFocusTrap` hook (lifted from Settings' `useDialog`, BET-419 §C).
 
 import { motion, AnimatePresence } from "framer-motion";
-import type { MouseEvent, ReactNode } from "react";
+import { useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { useFocusTrap } from "./useFocusTrap";
 
 const SIZES = {
   sm: "w-[420px]",
@@ -54,6 +60,9 @@ export function Modal({
   open?: boolean;
   children?: ReactNode;
 }) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(panelRef, open);
+
   const panel = [
     "bg-bg-elev border border-border rounded-lg shadow-lg max-w-[92vw]",
     SIZES[size],
@@ -62,18 +71,28 @@ export function Modal({
   ]
     .filter(Boolean)
     .join(" ");
+  const onOverlayKeyDown = onDismiss
+    ? (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onDismiss();
+        }
+      }
+    : undefined;
   return (
     <AnimatePresence>
       {open && (
         <motion.div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
           onClick={onDismiss}
+          onKeyDown={onOverlayKeyDown}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={MODAL_BACKDROP_TRANSITION}
         >
           <motion.div
+            ref={panelRef}
             role="dialog"
             aria-modal="true"
             aria-label={label}

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -96,15 +96,9 @@ function EditModelModal({
 
   return (
     <Modal open={open} size="md" onDismiss={onCancel} label={`Edit ${model.name}`}>
-      <div
-        className="space-y-4"
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            e.stopPropagation();
-            onCancel();
-          }
-        }}
-      >
+      {/* Escape is owned by Modal (BET-724) via onDismiss above — no
+          hand-rolled handler needed here. */}
+      <div className="space-y-4">
         <div className="flex items-start justify-between gap-2">
           <div>
             <div className="text-body font-semibold text-text">Edit model</div>

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -583,7 +583,12 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           onCancel={() => setPickerOpen(false)}
         />
 
-      <Modal open={!!fanOutWorktrees} size="md" label="Fan-out confirmed">
+      <Modal
+          open={!!fanOutWorktrees}
+          size="md"
+          label="Fan-out confirmed"
+          onDismiss={sending ? undefined : () => setFanOutWorktrees(null)}
+        >
           <div className="space-y-3">
             <div className="text-body font-semibold text-text">Fan-out confirmed</div>
             <div className="text-meta text-text-muted">

--- a/src/renderer/PaletteShell.test.tsx
+++ b/src/renderer/PaletteShell.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+//
+// Component test for PaletteShell's Escape handling (BET-724). Before this
+// change, the Escape/ArrowUp/ArrowDown/Enter `onKeyDown` handler lived on the
+// search `<input>` only, so Escape closed the palette exclusively while that
+// input was focused. It's now bound on the overlay so it fires regardless of
+// which inner element has focus, matching Modal's Escape ownership (BET-724
+// Task 1) for the sibling full-window overlay primitive.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
+import { mount, type Harness } from "./testHarness";
+import { PaletteShell } from "./PaletteShell";
+
+describe("PaletteShell — Escape (BET-724)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function render(onClose: () => void) {
+    h = mount(
+      <PaletteShell
+        label="Test palette"
+        placeholder="Search…"
+        query=""
+        setQuery={() => {}}
+        itemCount={1}
+        sel={0}
+        setSel={() => {}}
+        onPick={() => {}}
+        onClose={onClose}
+      >
+        {() => <button>row</button>}
+      </PaletteShell>,
+    );
+  }
+
+  it("Escape closes while the search input is focused (existing behavior)", async () => {
+    let closed = 0;
+    render(() => closed++);
+    const input = h!.container.querySelector("input")!;
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    // requestClose defers the actual onClose call by CLOSE_MS (100ms) so the
+    // exit animation can play.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 150));
+    });
+    expect(closed).toBe(1);
+  });
+
+  it("Escape closes even when focus is on a row, not the input (the bug this fixes)", async () => {
+    let closed = 0;
+    render(() => closed++);
+    const row = h!.container.querySelector("button")!;
+    row.focus();
+    expect(document.activeElement).toBe(row);
+    act(() => {
+      row.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 150));
+    });
+    expect(closed).toBe(1);
+  });
+});

--- a/src/renderer/PaletteShell.test.tsx
+++ b/src/renderer/PaletteShell.test.tsx
@@ -66,4 +66,47 @@ describe("PaletteShell — Escape (BET-724)", () => {
     });
     expect(closed).toBe(1);
   });
+
+  // BET-724 review cycle 1 nit: moving the handler to the overlay meant Enter
+  // was intercepted for ANY focused element, including the "ESC" chip button
+  // — `e.preventDefault()` there suppressed the chip's own click (which calls
+  // requestClose), so Tabbing to it and pressing Enter silently ran pick(sel)
+  // instead. Enter/Arrow navigation is now scoped to the search input only.
+  it("Enter on the ESC chip does not pick a row (only the input's Enter does)", () => {
+    let picked: number | null = null;
+    h = mount(
+      <PaletteShell
+        label="Test palette"
+        placeholder="Search…"
+        query=""
+        setQuery={() => {}}
+        itemCount={1}
+        sel={0}
+        setSel={() => {}}
+        onPick={(i) => {
+          picked = i;
+        }}
+        onClose={() => {}}
+      >
+        {() => <button>row</button>}
+      </PaletteShell>,
+    );
+    const escChip = h.container.querySelector('button[title="Close (Esc)"]') as HTMLButtonElement;
+    expect(escChip).toBeTruthy();
+    escChip.focus();
+    act(() => {
+      escChip.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+      );
+    });
+    expect(picked).toBeNull();
+
+    const input = h.container.querySelector("input")!;
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+      );
+    });
+    expect(picked).toBe(0);
+  });
 });

--- a/src/renderer/PaletteShell.tsx
+++ b/src/renderer/PaletteShell.tsx
@@ -60,9 +60,19 @@ export function PaletteShell({
   };
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Escape") {
+      // Always closes, regardless of which inner element has focus.
       e.preventDefault();
       requestClose();
-    } else if (e.key === "ArrowDown") {
+      return;
+    }
+    // Arrow/Enter navigation only makes sense while the search input itself
+    // is focused. Bound here (not on the input) so Escape still works
+    // regardless of focus (above), but leave native button activation (e.g.
+    // Tabbing to the "ESC" chip and pressing Enter) alone otherwise — review
+    // cycle 1 nit: intercepting Enter here for a focused button suppressed
+    // its own click (requestClose) and ran pick(sel) instead.
+    if (e.target !== inputRef.current) return;
+    if (e.key === "ArrowDown") {
       e.preventDefault();
       if (itemCount > 0) setSel((sel + 1) % itemCount);
     } else if (e.key === "ArrowUp") {

--- a/src/renderer/PaletteShell.tsx
+++ b/src/renderer/PaletteShell.tsx
@@ -77,6 +77,10 @@ export function PaletteShell({
     <div
       className={`fixed inset-0 z-50 flex items-start justify-center pt-[16vh] bg-black/40 manta-palette-overlay ${closing ? "manta-palette-overlay-out" : ""}`}
       onClick={requestClose}
+      // BET-724: bound on the overlay (not just the input below) so Escape
+      // closes the palette regardless of which inner element has focus —
+      // previously it only fired while the search input itself was focused.
+      onKeyDown={onKeyDown}
     >
       <div
         role="dialog"
@@ -91,7 +95,6 @@ export function PaletteShell({
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={onKeyDown}
             placeholder={placeholder}
             spellCheck={false}
             autoComplete="off"

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -26,6 +26,7 @@ import { IconButton } from "./IconButton";
 import { Pill } from "./Pill";
 import { Tag } from "./Tag";
 import { Dropdown, MenuItem } from "./MenuItem";
+import { ConfirmModal } from "./ConfirmModal";
 
 // Cache-segment colors for the header pill.
 const CACHE_WRITE_COLOR = cssVar("--warn");
@@ -114,6 +115,9 @@ export function SessionHeader({
       ? `${breadcrumb.project} / ${breadcrumb.window}`
       : breadcrumb.project
     : "";
+  // BET-724 §D7: the confirm dialogs for Delete/Clear name the session — the
+  // window name reads better than the full "project / window" breadcrumb.
+  const sessionName = breadcrumb?.window ?? breadcrumb?.project ?? "this session";
 
   return (
     <div
@@ -194,6 +198,7 @@ export function SessionHeader({
             onCompact={onCompact}
             onClear={onClear}
             onDelete={onDelete}
+            sessionName={sessionName}
           />
         )}
       </div>
@@ -470,6 +475,7 @@ function SessionMenu({
   onCompact,
   onClear,
   onDelete,
+  sessionName,
 }: {
   mode?: SessionMode;
   onModeChange?: (m: SessionMode) => void;
@@ -478,8 +484,13 @@ function SessionMenu({
   onCompact: () => void;
   onClear: () => void;
   onDelete: () => void;
+  // BET-724 §D7: names the session in the Delete confirm's body copy.
+  sessionName: string;
 }) {
   const [open, setOpen] = useState(false);
+  // BET-724 §D7: Delete/Clear from this menu now confirm first, matching the
+  // sidebar's inline delete confirm — previously both fired instantly.
+  const [confirm, setConfirm] = useState<"delete" | "clear" | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   useClickAway(rootRef, open, () => setOpen(false));
 
@@ -589,17 +600,39 @@ function SessionMenu({
           {item(
             <Eraser size={14} aria-hidden="true" />,
             "Clear session",
-            onClear,
+            () => setConfirm("clear"),
           )}
           <div className="my-1 border-t border-border-subtle" role="separator" />
           {item(
             <Trash2 size={14} aria-hidden="true" />,
             "Delete session",
-            onDelete,
+            () => setConfirm("delete"),
             true,
           )}
         </Dropdown>
       )}
+      <ConfirmModal
+        open={confirm === "delete"}
+        title="Delete this session?"
+        body={`“${sessionName}” and its tmux window will be killed on the box. This can't be undone.`}
+        confirmLabel="Delete session"
+        onConfirm={() => {
+          setConfirm(null);
+          onDelete();
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+      <ConfirmModal
+        open={confirm === "clear"}
+        title="Clear this conversation?"
+        body="The session keeps running but its context is gone."
+        confirmLabel="Clear"
+        onConfirm={() => {
+          setConfirm(null);
+          onClear();
+        }}
+        onCancel={() => setConfirm(null)}
+      />
     </div>
   );
 }

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { useStore } from "./store";
 import { Modal } from "./Modal";
+import { useFocusTrap } from "./useFocusTrap";
 import { Checkbox } from "./Checkbox";
 import { Toggle } from "./Toggle";
 import { ProvidersCard } from "./ProvidersCard";
@@ -58,9 +59,18 @@ function formatTimeout(ms: number): string {
   return `${Math.round(ms / 60_000)}m`;
 }
 
-// ===== Dialog semantics (BET-419 §C): focus trap + Esc + focus restore =====
+// ===== Dialog semantics (BET-419 §C, BET-724): focus trap + Esc + focus
+// restore. The trap/initial-focus/restore piece is the shared `useFocusTrap`
+// hook (BET-724 lifted it out of here into Modal.tsx's shared implementation
+// — this is the one remaining caller of the "own top-level dialog" flavor).
+// Escape-to-close stays local to Settings, since Settings itself isn't built
+// on the Modal primitive; it defers to a nested Modal (e.g. the "Remove box?"
+// / "Reset all settings?" confirms rendered inline below, or a portal'd
+// dialog like the model-edit modal) whenever one is open, so Escape closes
+// only the innermost dialog instead of closing all of Settings around it.
 function useDialog(onClose: () => void) {
   const ref = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(ref, true);
   // `onClose` is an inline arrow from App (recreated on every App render), so
   // the effect MUST NOT key off its identity — otherwise ANY App re-render
   // (e.g. a background SSE/window-status update ticking in every few seconds)
@@ -72,34 +82,25 @@ function useDialog(onClose: () => void) {
   useEffect(() => {
     const root = ref.current;
     if (!root) return;
-    const opener = document.activeElement as HTMLElement | null;
-    const firstFocusable = root.querySelector<HTMLElement>("h2[tabindex], button, input, select, textarea, a[href]");
-    (firstFocusable ?? root).focus();
     const onKey = (e: globalThis.KeyboardEvent) => {
-      // Only respond to events originating INSIDE this dialog. A portal'd
-      // nested modal (e.g. the model-edit dialog, rendered into document.body)
-      // lives outside `root`, so its Esc/Tab must be handled by the modal
-      // itself — otherwise Settings would steal Esc and close itself while
-      // the user is typing in (or dismissing) the nested modal.
-      if (e.target instanceof Node && !root.contains(e.target)) return;
-      if (e.key === "Escape") { e.preventDefault(); onCloseRef.current(); return; }
-      if (e.key !== "Tab") return;
-      const focusables = root.querySelectorAll<HTMLElement>(
-        'button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusables.length === 0) return;
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey && active === first) { e.preventDefault(); last.focus(); }
-      else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus(); }
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      // A portal'd nested modal (e.g. the model-edit dialog, rendered into
+      // document.body) lives outside `root` in the DOM — its own Escape
+      // handler owns it, not Settings'.
+      if (target instanceof Node && !root.contains(target)) return;
+      // An INLINE nested modal (e.g. the "Remove box?" / "Reset all
+      // settings?" confirms, rendered as normal children of this dialog) IS
+      // inside `root` — but if focus is currently inside ITS panel, that
+      // modal's own Escape ownership (Modal.tsx, BET-724) should win, not
+      // Settings'. Bail so Settings never steals Escape from an open confirm.
+      const nestedDialog = target?.closest('[role="dialog"]');
+      if (nestedDialog && nestedDialog !== root) return;
+      e.preventDefault();
+      onCloseRef.current();
     };
     document.addEventListener("keydown", onKey, true);
-    return () => {
-      document.removeEventListener("keydown", onKey, true);
-      if (opener && typeof opener.focus === "function") opener.focus();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => document.removeEventListener("keydown", onKey, true);
   }, []);
   return ref;
 }
@@ -919,7 +920,7 @@ export function Settings({
       </div>
 
       {/* In-app confirm: Remove box (replaces window.confirm — BET-419 §D). */}
-      <Modal open={confirmRemove} size="md" label="Remove this box?">
+      <Modal open={confirmRemove} size="md" label="Remove this box?" onDismiss={() => setConfirmRemove(false)}>
           <div className="space-y-4">
             <h3 className="text-title font-semibold">Remove this box?</h3>
             <div className="text-body text-text-faint">The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts.</div>
@@ -931,7 +932,7 @@ export function Settings({
         </Modal>
 
       {/* In-app confirm: Reset all settings (BET-419 §B.3). */}
-      <Modal open={confirmReset} size="md" label="Reset all settings?">
+      <Modal open={confirmReset} size="md" label="Reset all settings?" onDismiss={() => setConfirmReset(false)}>
           <div className="space-y-4">
             <h3 className="text-title font-semibold">Reset all settings?</h3>
             <div className="text-body text-text-faint">Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.</div>

--- a/src/renderer/useFocusTrap.ts
+++ b/src/renderer/useFocusTrap.ts
@@ -1,0 +1,81 @@
+// useFocusTrap.ts — focus trap + initial focus + restore (BET-724 Task 1).
+//
+// Lifted out of Settings.tsx's `useDialog` (BET-419 §C), which already
+// implemented this correctly for Settings' own top-level dialog chrome. The
+// Modal primitive (`Modal.tsx`) previously had NO focus management at all —
+// every Modal dialog could be Tabbed behind the overlay. Both now share this
+// one implementation instead of Settings carrying a second copy.
+//
+// On activation (`active` flips/starts true): remembers the element that had
+// focus, focuses the first focusable element inside the container (falling
+// back to the container itself, made programmatically focusable via
+// `tabIndex=-1`), and traps Tab/Shift+Tab within it. On deactivation (or
+// unmount): restores focus to the element that had it before, if it's still
+// attached to the document.
+//
+// Nested dialogs (e.g. a confirm Modal rendered inline inside Settings'
+// full-screen dialog — NOT portaled) get their OWN trap on their OWN panel.
+// To avoid the outer container's trap fighting the inner one over Tab, the
+// handler bails out whenever the focused element's nearest `[role="dialog"]`
+// ancestor isn't this hook's own container — the innermost open dialog owns
+// Tab, matching how Escape ownership works in Modal.tsx.
+
+import { useEffect, type RefObject } from "react";
+
+// Elements that participate in the natural Tab cycle.
+const FOCUSABLE_SELECTOR =
+  'button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])';
+// Initial-focus target additionally allows a heading carrying `tabIndex={-1}`
+// (the "focus the dialog title" a11y pattern Settings uses for its own <h2>)
+// even though such a heading isn't part of the Tab cycle above.
+const INITIAL_FOCUS_SELECTOR = `h2[tabindex], ${FOCUSABLE_SELECTOR}`;
+
+export function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+) {
+  useEffect(() => {
+    if (!active) return;
+    const root = ref.current;
+    if (!root) return;
+
+    const opener = document.activeElement as HTMLElement | null;
+    const firstFocusable = root.querySelector<HTMLElement>(INITIAL_FOCUS_SELECTOR);
+    if (firstFocusable) {
+      firstFocusable.focus();
+    } else {
+      root.tabIndex = -1;
+      root.focus();
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const target = e.target as HTMLElement | null;
+      // Defer to a nested dialog's own trap when focus is inside one that
+      // isn't this container itself (see file header).
+      const nestedDialog = target?.closest('[role="dialog"]');
+      if (nestedDialog && nestedDialog !== root) return;
+
+      const focusables = root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const current = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && current === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && current === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => {
+      root.removeEventListener("keydown", onKey);
+      if (opener && typeof opener.focus === "function" && document.contains(opener)) {
+        opener.focus();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+}

--- a/src/renderer/useFocusTrap.ts
+++ b/src/renderer/useFocusTrap.ts
@@ -7,11 +7,34 @@
 // one implementation instead of Settings carrying a second copy.
 //
 // On activation (`active` flips/starts true): remembers the element that had
-// focus, focuses the first focusable element inside the container (falling
-// back to the container itself, made programmatically focusable via
-// `tabIndex=-1`), and traps Tab/Shift+Tab within it. On deactivation (or
-// unmount): restores focus to the element that had it before, if it's still
-// attached to the document.
+// focus, focuses the first focusable element inside the container UNLESS
+// something inside it is already focused (e.g. a child with `autoFocus` —
+// see the BET-724 review-cycle-1 Block note below), falling back to the
+// container itself (made programmatically focusable via `tabIndex=-1`) when
+// there's nothing focusable at all, and traps Tab/Shift+Tab within it. On
+// deactivation (or unmount): restores focus to the element that had it
+// before, if it's still attached to the document.
+//
+// BET-724 review cycle 1 Block: the original version read
+// `document.activeElement` and force-focused the first focusable element
+// from inside a passive `useEffect`. React applies `autoFocus` during the
+// commit phase, which always runs BEFORE passive effects (and even before
+// `useLayoutEffect`, for host-component autoFocus specifically) — so for any
+// panel that autofocuses a field (e.g. FolderPickerModal's path input), the
+// trap ran second, stole focus onto whatever the panel's first focusable
+// element happened to be (its Close button), AND captured that same,
+// already-wrong element as the "opener", making focus-restore silently
+// no-op on close. Fixed by:
+//   1. Capturing the opener SYNCHRONOUSLY DURING RENDER (not in an effect) —
+//      render always runs before commit/autoFocus, so `document.activeElement`
+//      read there is still the real pre-open opener. This is the same
+//      "adjusting state during render" pattern React's docs use for
+//      previous-value tracking (a ref compared/updated in the render body,
+//      guarded so it only fires on the false→true transition).
+//   2. Skipping the forced initial-focus entirely when something inside the
+//      container is ALREADY focused when the effect runs — an `autoFocus`ed
+//      child already satisfies "focus starts inside the panel"; forcing a
+//      different element here would be the regression, not a fix.
 //
 // Nested dialogs (e.g. a confirm Modal rendered inline inside Settings'
 // full-screen dialog — NOT portaled) get their OWN trap on their OWN panel.
@@ -20,11 +43,15 @@
 // ancestor isn't this hook's own container — the innermost open dialog owns
 // Tab, matching how Escape ownership works in Modal.tsx.
 
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 
-// Elements that participate in the natural Tab cycle.
+// Elements that participate in the natural Tab cycle. Excludes disabled/
+// hidden controls — focusing one is a silent no-op that would leave focus on
+// `<body>` and defeat the trap (BET-724 review cycle 1 nit).
 const FOCUSABLE_SELECTOR =
-  'button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])';
+  'button:not([disabled]):not([hidden]), input:not([disabled]):not([hidden]), ' +
+  'select:not([disabled]):not([hidden]), textarea:not([disabled]):not([hidden]), ' +
+  'a[href]:not([hidden]), [tabindex]:not([tabindex="-1"]):not([hidden])';
 // Initial-focus target additionally allows a heading carrying `tabIndex={-1}`
 // (the "focus the dialog title" a11y pattern Settings uses for its own <h2>)
 // even though such a heading isn't part of the Tab cycle above.
@@ -34,18 +61,31 @@ export function useFocusTrap(
   ref: RefObject<HTMLElement | null>,
   active: boolean,
 ) {
+  const openerRef = useRef<HTMLElement | null>(null);
+  const wasActiveRef = useRef(false);
+  // Capture the pre-open opener DURING RENDER, on the false→true transition
+  // only — see the file header for why an effect is too late.
+  if (active && !wasActiveRef.current) {
+    openerRef.current = document.activeElement as HTMLElement | null;
+  }
+  wasActiveRef.current = active;
+
   useEffect(() => {
     if (!active) return;
     const root = ref.current;
     if (!root) return;
 
-    const opener = document.activeElement as HTMLElement | null;
-    const firstFocusable = root.querySelector<HTMLElement>(INITIAL_FOCUS_SELECTOR);
-    if (firstFocusable) {
-      firstFocusable.focus();
-    } else {
-      root.tabIndex = -1;
-      root.focus();
+    // Leave focus alone if something inside the panel already has it (e.g.
+    // an `autoFocus`ed field) — that already satisfies "focus starts inside
+    // the panel". Only force it when nothing inside claimed it.
+    if (!root.contains(document.activeElement)) {
+      const firstFocusable = root.querySelector<HTMLElement>(INITIAL_FOCUS_SELECTOR);
+      if (firstFocusable) {
+        firstFocusable.focus();
+      } else {
+        root.tabIndex = -1;
+        root.focus();
+      }
     }
 
     const onKey = (e: KeyboardEvent) => {
@@ -72,6 +112,7 @@ export function useFocusTrap(
     root.addEventListener("keydown", onKey);
     return () => {
       root.removeEventListener("keydown", onKey);
+      const opener = openerRef.current;
       if (opener && typeof opener.focus === "function" && document.contains(opener)) {
         opener.focus();
       }


### PR DESCRIPTION
BET-724 — audit §6 items 3+4. Design pre-approved on the companion page (§D6/§D7).

**Base:** `origin/main` @ `6b2ee744` (rebased in review cycle 2; was `901c06d6`)

## Task 1 — Modal.tsx owns Escape + focus trap + restore
- Escape: overlay-scoped `onKeyDown` on the backdrop calls `onDismiss()` when provided — the focus trap guarantees focus never escapes the panel, so a bubble-phase handler on the overlay catches Escape regardless of which inner element is focused.
- Focus trap + initial focus + restore: extracted into a new shared `useFocusTrap` hook (lifted from Settings' `useDialog`, which already had this correct).
- Header comment retired the stale "Escape stays at call sites" rationale.

## Task 2 — call-site deletions
- `FolderPickerModal.tsx`, `ModelsCard.tsx` (EditModelModal): deleted hand-rolled Escape handlers now redundant with Modal's own.
- `Settings.tsx`'s `useDialog`: now consumes the shared `useFocusTrap` (duplicated trap logic deleted). Its own Escape-close now **defers to a nested open dialog** — portal'd (the model-edit modal, existing check) OR inline (the "Remove box?"/"Reset all settings?" confirms, new check via `closest('[role="dialog"]') !== root`) — instead of stealing Escape and closing all of Settings around an open confirm. (Note: a plain `stopPropagation()` in Modal's handler alone can't fix this, since Settings' listener is a `document`-level *capture* listener that always runs before any bubble-phase handler — the `closest()` check is the mechanism that actually makes "innermost wins" true regardless of propagation-order subtleties.)
- Settings' two confirm Modals (`confirmRemove`, `confirmReset`) now get `onDismiss` — previously neither Escape nor backdrop-click dismissed them.
- `PaletteShell.tsx` (⌘K CommandPalette / ⌘F SearchPalette): Escape moved from the search `<input>` to the overlay div, so it now closes regardless of which inner element has focus (previously only worked while the input itself was focused).
- `NewSessionScreen.tsx`'s fan-out confirm Modal: added `onDismiss` for the same "every dialog inherits it" consistency (disabled while `sending`, matching its Cancel button).
- App.tsx's "Update the box?" Modal already had `onDismiss` and no competing hand-rolled Escape handler — it inherits the fix with no changes needed there.
- Left untouched (explicitly out of scope): `ArtifactPreview.tsx` (not Modal-based, already correct), Sidebar's `RenameInput`/`ConfirmDelete` (not Modal-based), Terminal's find-bar Escape, InputArea/useVoice Escape (unrelated composer/voice shortcuts).

## Task 3 — shared ConfirmModal for the ⋯ menu
- New `ConfirmModal.tsx`, built on `Modal` (`size="sm"`) + `Button` (`tone="default"` Cancel / `tone="danger"` confirm — no new Button tone added).
- Wired into `SessionHeader.tsx`'s `SessionMenu` for **Delete session** and **Clear session**: the menu row now opens the confirm instead of firing instantly. Copy matches the issue spec, session name pulled from the breadcrumb window.
- Sidebar's inline delete confirm is untouched (explicit constraint).

## Tests
- `Modal.test.tsx`: extended with Escape→onDismiss, no-onDismiss no-op, initial focus (first focusable / panel fallback with `tabIndex=-1`), Tab trap wrap, focus restore on unmount.
- New `ConfirmModal.test.tsx`: render/hide, Cancel vs Confirm callbacks, Escape→Cancel (never Confirm), danger-tone chrome.
- New `PaletteShell.test.tsx`: Escape closes from the input (existing) and from a non-input focused row (the bug this fixes).
- `MenuItem.test.tsx`: new suite for Delete/Clear opening the confirm instead of firing immediately, Cancel not firing, session name interpolation.

Filed **BET-736** (follow-up, parked, unassigned): `Settings.tsx` has no component-mount test harness anywhere in this repo, so the nested-dialog Escape-defer fix (the trickiest part of this PR) is covered by reasoning + a green typecheck + the generic Modal/ConfirmModal tests, not a Settings-specific regression test.

## Review cycle 1 → fixes (full detail in the PR comment thread)
- **Block** — `useFocusTrap` force-focused the first focusable element and captured the opener from inside a passive `useEffect`, which runs AFTER React applies `autoFocus` during commit. For any panel that autofocuses a field (FolderPickerModal's path input), this clobbered `autoFocus` (landing on the Close button) and captured the panel's own autofocused child as the "opener", so focus-restore silently no-op'd. Fixed: opener is now captured synchronously during render (before commit/`autoFocus` can move it), and the forced initial focus is skipped entirely when something inside the panel already has focus. New `Modal.test.tsx` case with an `autoFocus` child covers both halves.
- **Question** — FolderPicker's two-stage Escape (dismiss the live suggestion first, close on the next press) was restored via a local `stopPropagation` when a suggestion is live. New `FolderPickerModal.test.tsx` covers both cases.
- **Nits** — PaletteShell's Enter no longer swallows the "ESC" chip's own click (Arrow/Enter now scoped to the search input; Escape stays overlay-scoped); `FOCUSABLE_SELECTOR` excludes disabled/hidden controls; rebased onto fresh `origin/main`.

## Verification results
- PR branch (`multica/BET-724-modal-behavior` @ `fcf549b2`, rebased onto `origin/main` @ `6b2ee744`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test (`npm test` — vitest + node:test): exit `0`, vitest 2296 pass / 0 fail / 7 skip (125 files); node:test 1565 pass / 0 fail / 0 skip. log sha256: `376b469b43b1c752751a45c96fe2ecdcd7c663fcaee0f67cc7f87f8c97a4286a`
- Base freshness: `git diff --stat origin/main...HEAD` — 14 files, all additions/modifications this PR owns, zero deletions.

Logs cached at `/tmp/typecheck-pr2.log`, `/tmp/test-pr2.log` for reviewer spot-check.

