### PR TITLE
BET-725: feat(renderer): Send→Stop morph while running, honest disabled state, focus-visible on composer controls

### DIFF
--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -10,6 +10,7 @@ import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip } from "lucide-react";
 import type { VoiceMode, VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import { ALT_KEY } from "./platform";
+import { IconButton } from "./IconButton";
 
 // SessionToolbar — footer affordances. fork / compact / delete moved out of the
 // footer (they live in the header ⋯ menu); only the ⏰ schedules toggle remains
@@ -36,7 +37,8 @@ export function SessionToolbar({
   // so they can't drift; the count badge carries its own mono type. Matches
   // the mockup's `.mbtn` (27px hit, --r-sm radius, --tx3 rest tone).
   const mbtn =
-    "inline-flex items-center gap-[6px] h-[27px] px-2 rounded-sm text-text-faint hover:bg-fill-hover hover:text-text transition-colors";
+    "inline-flex items-center gap-[6px] h-[27px] px-2 rounded-sm text-text-faint hover:bg-fill-hover hover:text-text transition-colors " +
+    "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
   const cnum =
     "font-mono text-[11px] leading-none font-semibold text-text-muted tabular-nums";
   return (
@@ -89,15 +91,11 @@ export function AttachButton({ onFiles }: { onFiles: (files: File[]) => void }) 
   const inputRef = useRef<HTMLInputElement>(null);
   return (
     <>
-      <button
-        type="button"
+      <IconButton
+        label="Attach files"
+        icon={<Paperclip />}
         onClick={() => inputRef.current?.click()}
-        title="Attach files"
-        aria-label="Attach files"
-        className="shrink-0 leading-none bg-transparent text-text-faint hover:text-text-muted transition-colors"
-      >
-        <Paperclip size={16} aria-hidden="true" />
-      </button>
+      />
       <input
         ref={inputRef}
         type="file"
@@ -398,6 +396,7 @@ export function MicButton({
       // get the pointerup even if the user drifts off.
       className={
         "select-none pt-px shrink-0 leading-none bg-transparent " +
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
         (busy
           ? `${activeColor} cursor-progress`
           : recording

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -17,7 +17,7 @@
 // a focus state instead of hairline dividers around a naked textarea.
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Mic, Send, Shield } from "lucide-react";
+import { Mic, Send, Shield, Square } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import type { VoiceMode, VoicePhase } from "./voice";
 import {
@@ -392,15 +392,20 @@ export function InputArea({
         {/* Send button — sits beside the textarea in the composer box (BET-620
             change 4). Accent when there's text to send, muted fill when empty. */}
         <button
-          onClick={submit}
-          aria-label="Send message"
-          title="Send (Enter)"
+          onClick={running ? abort : submit}
+          disabled={!running && !input.trim()}
+          aria-label={running ? "Stop the running turn" : "Send message"}
+          title={running ? "Stop (Esc)" : "Send (Enter)"}
           className={
-            "w-7 h-7 rounded-sm grid place-items-center shrink-0 " +
-            (input.trim() ? "bg-accent text-on-accent" : "bg-fill text-text-faint")
+            "w-7 h-7 rounded-sm grid place-items-center shrink-0 transition-colors " +
+            "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
+            "disabled:cursor-default " +
+            (running || input.trim()
+              ? "bg-accent text-on-accent hover:opacity-90"
+              : "bg-fill text-text-faint")
           }
         >
-          <Send size={14} aria-hidden="true" />
+          {running ? <Square size={12} aria-hidden="true" /> : <Send size={14} aria-hidden="true" />}
         </button>
         </div>
       </div>


### PR DESCRIPTION
## BET-725: Desktop composer — Send→Stop morph while running; honest disabled state; focus-visible on composer controls

Base: origin/main @ 71d10854

### Task 1 — the Send/Stop button (`InputArea.tsx`)

- Click routes to `abort` while running (same effect as Esc), `submit` otherwise.
- `disabled` when idle and empty — an honest disabled state instead of a
  no-op click.
- Icon swaps to a `Square` (Stop) while running; `Send` otherwise. Labels/
  titles follow suit ("Stop the running turn" / "Stop (Esc)" vs "Send
  message" / "Send (Enter)").
- Added `hover` + `focus-visible` ring + `transition-colors`.
- **Deviation from the issue's literal snippet:** used `hover:opacity-90`
  instead of `hover:brightness-110`. `hover:brightness-110` is
  chrome-owned exclusively by `Button.tsx` in the `primitives.test.ts` D4
  chrome-ownership allowlist (`"hover:brightness-110": ["Button.tsx"]`) —
  using it in `InputArea.tsx` fails that test (`no non-owner file contains
  a primitive's owned chrome`), and the test's own comment says never add a
  file to a row just to turn it green. `hover:opacity-90` on
  `bg-accent-solid text-on-accent` is an existing idiom already used at two
  other raw call sites (`NewSessionScreen.tsx`, `FolderPickerModal.tsx`) for
  the same "solid accent button" hover affordance, so it's not a new
  pattern.

### Task 2 — focus-visible on composer icon controls (`ComposerParts.tsx`)

- `SessionToolbar`'s shared `mbtn` class (schedules/secrets/webhooks) gets
  the same focus-visible ring classes.
- `MicButton` (inline/non-floating variant) gets the ring. Left the mobile
  PTT FAB (`floating` variant, `.mobile-ptt-fab` CSS class) untouched —
  it's mobile-only and out of scope for a "desktop composer" issue.
- `AttachButton`'s hand-rolled `<button>` swapped for the `IconButton`
  primitive (drop-in — same `onClick`/label/icon, no prop surgery), which
  already carries the focus-visible ring plus its own hover-fill chrome.

### Tests

No existing DOM-render test for `InputArea`/`ComposerParts` (the only
`InputArea.test.tsx` covers the pure `isComposerControlTarget` predicate
against a synthetic DOM tree, not a rendered component) — per the issue's
own instruction, skipped adding a new harness for one button.

### Verification results

- PR branch (`multica/BET-725-send-stop` @ `45eeedfa`):
  - typecheck: exit `0`. Errors: none.
  - test (`vitest run && node:test`): exit `0`. vitest 2296 pass / 7 skip
    (0 fail); node:test 1565 pass / 0 fail.
- Conclusion: 0 failures on either suite; no pre-existing failures observed.

### Constraints honored

- No change to queueing/drain behavior, the Esc handler, or the placeholder
  copy.
- No new props through `ChatPanel` — `running`/`abort` were already wired.
