### PR TITLE
Desktop: keyboard & focus sweep — scrollIntoView, sidebar action keys, tablist arrows, focus-visible gaps

### DIFF
--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -466,10 +466,13 @@ export function ArtifactsPanel({
   widthRef.current = width;
 
   const [tab, setTab] = useState<ArtifactKind>("link");
-  // BET-726 Task 3.2: roving-tabindex arrow nav on the tab bar — the exact
-  // pattern Settings.tsx's section rail already uses (`onRailKeyDown` there:
-  // move the active tab AND focus, on Left/Right). Refs keyed by kind so
-  // ArrowLeft/Right can call `.focus()` on the tab it moves to.
+  // BET-726 Task 3.2: arrow-key nav on the tab bar — the exact pattern
+  // Settings.tsx's section rail already uses (`onRailKeyDown` there: move
+  // the active tab state AND DOM focus, on Left/Right). Note this is NOT a
+  // roving-tabindex widget (neither this port nor Settings' original manages
+  // `tabIndex` — every tab stays in the normal Tab order); only the active
+  // tab and focus move on arrow keys. Refs keyed by kind so ArrowLeft/Right
+  // can call `.focus()` on the tab it moves to.
   const tabRefs = useRef<Record<ArtifactKind, HTMLButtonElement | null>>({
     link: null,
     image: null,

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -466,6 +466,15 @@ export function ArtifactsPanel({
   widthRef.current = width;
 
   const [tab, setTab] = useState<ArtifactKind>("link");
+  // BET-726 Task 3.2: roving-tabindex arrow nav on the tab bar — the exact
+  // pattern Settings.tsx's section rail already uses (`onRailKeyDown` there:
+  // move the active tab AND focus, on Left/Right). Refs keyed by kind so
+  // ArrowLeft/Right can call `.focus()` on the tab it moves to.
+  const tabRefs = useRef<Record<ArtifactKind, HTMLButtonElement | null>>({
+    link: null,
+    image: null,
+    file: null,
+  });
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
   // The preview overlay: index into `previewable` (the current tab's
@@ -577,6 +586,16 @@ export function ArtifactsPanel({
     else void downloadArtifact(a);
   };
 
+  const onTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const idx = TABS.indexOf(tab);
+    const dir = e.key === "ArrowRight" ? 1 : -1;
+    const next = TABS[(idx + dir + TABS.length) % TABS.length];
+    setTab(next);
+    tabRefs.current[next]?.focus();
+  };
+
   // Jump the transcript to the message that owns an artifact.
   const jumpToMessage = (a: Artifact) => {
     if (!a.messageId) return;
@@ -655,7 +674,7 @@ export function ArtifactsPanel({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search links & files…"
-              className="mb-3 w-full bg-bg border border-border px-2 py-1 text-meta rounded-xs focus:outline-none placeholder:text-text-faint"
+              className="mb-3 w-full bg-bg border border-border px-2 py-1 text-meta rounded-xs focus:outline-none focus:border-accent placeholder:text-text-faint"
             />
           )}
 
@@ -683,12 +702,15 @@ export function ArtifactsPanel({
               return (
                 <button
                   key={k}
+                  ref={(el) => { tabRefs.current[k] = el; }}
                   type="button"
                   role="tab"
                   aria-selected={active}
                   onClick={() => setTab(k)}
+                  onKeyDown={onTabKeyDown}
                   className={
                     "relative z-10 flex-1 inline-flex items-center justify-center gap-1 px-2 py-1 rounded-sm text-meta font-medium " +
+                    "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
                     (active ? "text-text" : "text-text-faint hover:text-text")
                   }
                 >

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -211,7 +211,7 @@ export function PermissionCard({
     <>
       <button
         onClick={() => onReply("once")}
-        className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium"
+        className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
         style={{ backgroundColor: "var(--accent-solid)" }}
       >
         <Check size={13} aria-hidden="true" />
@@ -224,7 +224,7 @@ export function PermissionCard({
         <button
           onClick={() => onReply("always")}
           title={`Always allow ${alwaysScope}`}
-          className="h-8 px-[14px] inline-flex items-center rounded-md border border-border-strong text-text hover:bg-bg-soft text-meta"
+          className="h-8 px-[14px] inline-flex items-center rounded-md border border-border-strong text-text hover:bg-bg-soft text-meta focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
         >
           Always allow&nbsp;
           <span className="text-text-faint">{alwaysScope}</span>
@@ -234,7 +234,7 @@ export function PermissionCard({
       <div className="flex-1" />
       <button
         onClick={() => onReply("reject")}
-        className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta"
+        className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
       >
         Reject
       </button>
@@ -484,7 +484,7 @@ export function QuestionCard({
           <button
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium disabled:opacity-40"
+            className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium disabled:opacity-40 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
             style={{ backgroundColor: "var(--accent-solid)" }}
           >
             Submit
@@ -502,7 +502,7 @@ export function QuestionCard({
           <div className="flex-1" />
           <button
             onClick={onReject}
-            className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta"
+            className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
             title="Dismiss this question"
           >
             Dismiss

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -11,6 +11,10 @@ import type { VoiceMode, VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import { ALT_KEY } from "./platform";
 import { IconButton } from "./IconButton";
+// BET-726 Task 1: same scrollIntoView idiom the ⌘K / ⌘F palettes and the
+// model/effort menus use (PaletteShell.tsx) — keeps the keyboard-selected
+// @-file row visible when it moves past the popup's scroll fold.
+import { useSelectedIntoView } from "./PaletteShell";
 
 // SessionToolbar — footer affordances. fork / compact / delete moved out of the
 // footer (they live in the header ⋯ menu); only the ⏰ schedules toggle remains
@@ -211,25 +215,52 @@ export function TypeaheadPopup({
           );
         }
         return (
-          <button
+          <TypeaheadRowButton
             key={`${row.kind}:${row.key}`}
-            onClick={() => onSelect(row)}
-            onMouseEnter={() => onHover(idx)}
-            className={
-              "w-full text-left px-2 py-1 flex items-center gap-2 " +
-              (active ? "bg-accent-bg text-text" : "text-text-muted hover:bg-bg-soft")
-            }
-          >
-            <span className="truncate flex-1">{row.primary}</span>
-            {row.secondary && (
-              <span className="text-text-faint truncate max-w-[50%] text-label">
-                {row.secondary}
-              </span>
-            )}
-          </button>
+            row={row}
+            active={active}
+            onSelect={() => onSelect(row)}
+            onHover={() => onHover(idx)}
+          />
         );
       })}
     </div>
+  );
+}
+
+// A single @-file typeahead row. Split out (rather than an inline map
+// closure) so it can call the roving-highlight hook itself — Hooks may only
+// be called from a component function, not from inside `Array.prototype.map`
+// (same shape as Sidebar's SessionRow / SearchPalette's row).
+function TypeaheadRowButton({
+  row,
+  active,
+  onSelect,
+  onHover,
+}: {
+  row: TypeaheadRow;
+  active: boolean;
+  onSelect: () => void;
+  onHover: () => void;
+}) {
+  const ref = useSelectedIntoView<HTMLButtonElement>(active);
+  return (
+    <button
+      ref={ref}
+      onClick={onSelect}
+      onMouseEnter={onHover}
+      className={
+        "w-full text-left px-2 py-1 flex items-center gap-2 " +
+        (active ? "bg-accent-bg text-text" : "text-text-muted hover:bg-bg-soft")
+      }
+    >
+      <span className="truncate flex-1">{row.primary}</span>
+      {row.secondary && (
+        <span className="text-text-faint truncate max-w-[50%] text-label">
+          {row.secondary}
+        </span>
+      )}
+    </button>
   );
 }
 

--- a/src/renderer/IconButton.tsx
+++ b/src/renderer/IconButton.tsx
@@ -45,6 +45,8 @@ export function IconButton({
   size = "md",
   ariaHaspopup,
   ariaExpanded,
+  ariaOwns,
+  ariaActiveDescendant,
   hook,
   disabled,
 }: {
@@ -60,6 +62,14 @@ export function IconButton({
   /** Menu/popover semantics for a trigger-style icon button. */
   ariaHaspopup?: "menu" | "dialog" | "listbox" | "grid" | "tree" | "true" | "false";
   ariaExpanded?: boolean;
+  /** The id of a popup surface this trigger owns but does not contain in the
+   *  DOM (e.g. a sibling `Dropdown`) — makes an `ariaActiveDescendant`
+   *  relationship well-formed when the two aren't ancestor/descendant. */
+  ariaOwns?: string;
+  /** The currently-highlighted descendant's id, for a trigger that keeps DOM
+   *  focus while driving a roving highlight in its (possibly sibling) popup —
+   *  e.g. SessionHeader's ⋯ menu (BET-726 review cycle 1 Question 1). */
+  ariaActiveDescendant?: string;
   /** Renders the native `disabled` attribute + the not-allowed cursor, and suppresses the hover fill (a disabled icon button stays flat). */
   disabled?: boolean;
   /**
@@ -86,6 +96,8 @@ export function IconButton({
       title={title ?? label}
       aria-haspopup={ariaHaspopup}
       aria-expanded={ariaExpanded}
+      aria-owns={ariaOwns}
+      aria-activedescendant={ariaActiveDescendant}
     >
       {cloneElement(icon, { size: iconSize, "aria-hidden": true })}
     </button>

--- a/src/renderer/MenuItem.test.tsx
+++ b/src/renderer/MenuItem.test.tsx
@@ -188,6 +188,23 @@ describe("MenuItem", () => {
     expect(clicked).toBe(true);
   });
 
+  // BET-726 Task 3.1: the roving keyboard highlight (SessionHeader's ⋯ menu)
+  // is a static `--fill-hover` fill, independent of `variant` — the SAME
+  // static fill MenuOption's `active` prop gives the model/effort menus.
+  it("highlighted applies the static bg-fill-hover fill; unset it does not", () => {
+    h = mount(<MenuItem highlighted>row</MenuItem>);
+    let classes = (h.container.firstElementChild as HTMLElement).className.split(/\s+/);
+    expect(classes).toContain("bg-fill-hover");
+    h.unmount();
+    h = mount(<MenuItem>row</MenuItem>);
+    classes = (h.container.firstElementChild as HTMLElement).className.split(/\s+/);
+    // The static (non-`hover:`) token is absent, but the `:hover` variant
+    // stays for a mouse user (and no trailing-whitespace artifact from the
+    // conditional either — that regressed MenuItem.test.tsx once already).
+    expect(classes).not.toContain("bg-fill-hover");
+    expect(classes).toContain("hover:bg-fill-hover");
+  });
+
   it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
     // If MenuItem ever grew a className prop this directive becomes unused and
     // typecheck fails — the standing-decision-3 guard lives in the types.
@@ -366,5 +383,90 @@ describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", (
     });
     act(() => menuItemByText("Delete session").click());
     expect(h!.text()).toContain("fix-onboarding");
+  });
+});
+
+// BET-726 Task 3.1: ArrowUp/ArrowDown/Home/End roving highlight + Enter to
+// activate, on the same session ⋯ menu. The keydown is bound on the menu's
+// root (not each row), so it's dispatched from the trigger — which keeps
+// focus after the click that opened the menu — and relies on native bubbling
+// to reach the root's onKeyDown, the same technique PaletteShell.test.tsx
+// already uses for its Escape coverage.
+describe("SessionMenu — keyboard roving highlight (BET-726 Task 3.1)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function openMenu(overrides: Parameters<typeof mountSessionHeader>[0] = {}) {
+    h = mountSessionHeader(overrides);
+    const trigger = h.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Session actions"]',
+    )!;
+    act(() => trigger.click());
+    return trigger;
+  }
+
+  function press(el: HTMLElement, key: string) {
+    act(() => {
+      el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    });
+  }
+
+  it("ArrowDown highlights the first row (bg-fill-hover) and Enter activates it", () => {
+    let changed: unknown = null;
+    const trigger = openMenu({ onModeChange: (m) => { changed = m; } });
+    press(trigger, "ArrowDown");
+    const chatRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Chat"),
+    )!;
+    expect(chatRow.className).toContain("bg-fill-hover");
+    press(trigger, "Enter");
+    expect(changed).toBe("chat");
+  });
+
+  it("ArrowUp before any ArrowDown wraps to the LAST row (End of the list)", () => {
+    let deleted = 0;
+    const trigger = openMenu({ onDelete: () => deleted++ });
+    press(trigger, "ArrowUp");
+    const deleteRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Delete session"),
+    )!;
+    expect(deleteRow.className).toContain("bg-fill-hover");
+    // Enter on "Delete session" opens the confirm, not onDelete directly
+    // (BET-724 §D7) — same activation path a click would take.
+    press(trigger, "Enter");
+    expect(deleted).toBe(0);
+    expect(h!.text()).toContain("Delete this session?");
+  });
+
+  it("Home/End jump to the first/last row", () => {
+    const trigger = openMenu();
+    press(trigger, "End");
+    let deleteRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Delete session"),
+    )!;
+    expect(deleteRow.className).toContain("bg-fill-hover");
+    press(trigger, "Home");
+    const chatRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Chat"),
+    )!;
+    expect(chatRow.className).toContain("bg-fill-hover");
+    deleteRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Delete session"),
+    )!;
+    expect(deleteRow.className).not.toContain("bg-fill-hover");
+  });
+
+  it("re-opening the menu resets the highlight (no stale index carries over)", () => {
+    const trigger = openMenu();
+    press(trigger, "ArrowDown");
+    // Close (click-away semantics via Escape, which useClickAway owns) then
+    // reopen — the highlight must not still be on row 0's neighbour.
+    press(trigger, "Escape");
+    act(() => trigger.click());
+    const anyHighlighted = h!.container.querySelector("button[role='menuitem'].bg-fill-hover");
+    expect(anyHighlighted).toBeNull();
   });
 });

--- a/src/renderer/MenuItem.test.tsx
+++ b/src/renderer/MenuItem.test.tsx
@@ -414,6 +414,30 @@ describe("SessionMenu — keyboard roving highlight (BET-726 Task 3.1)", () => {
     });
   }
 
+  // BET-726 review cycle 1 Question 1: the highlight used to be visual-only
+  // — a screen reader following the arrow keys was told nothing, since DOM
+  // focus never leaves the trigger. `aria-activedescendant` on the trigger
+  // (the element that actually holds focus, matching ModelMenu's own
+  // `<input>`-carries-it idiom) plus `aria-owns` (trigger and Dropdown are
+  // DOM siblings, not ancestor/descendant) closes that gap.
+  it("wires aria-owns + aria-activedescendant on the trigger as the highlight moves", () => {
+    const trigger = openMenu();
+    const dropdown = h!.container.querySelector('[role="menu"]') as HTMLElement;
+    expect(trigger.getAttribute("aria-owns")).toBe(dropdown.id);
+    expect(trigger.hasAttribute("aria-activedescendant")).toBe(false);
+    press(trigger, "ArrowDown");
+    const chatRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Chat"),
+    )!;
+    expect(chatRow.id).toBeTruthy();
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(chatRow.id);
+    press(trigger, "ArrowDown");
+    const terminalRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes("Terminal"),
+    )!;
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(terminalRow.id);
+  });
+
   it("ArrowDown highlights the first row (bg-fill-hover) and Enter activates it", () => {
     let changed: unknown = null;
     const trigger = openMenu({ onModeChange: (m) => { changed = m; } });

--- a/src/renderer/MenuItem.tsx
+++ b/src/renderer/MenuItem.tsx
@@ -65,6 +65,7 @@ export function MenuItem({
   trailing,
   onSelect,
   highlighted = false,
+  id,
 }: {
   /** Which surface + foreground the row carries. normal is the default. */
   variant?: MenuItemVariant;
@@ -80,10 +81,15 @@ export function MenuItem({
    *  `--fill-hover` fill MenuOption's `active` prop gives the model/effort
    *  menus, applied unconditionally instead of only on `:hover`. */
   highlighted?: boolean;
+  /** Option id — the aria-activedescendant target for a caller-owned roving
+   *  highlight (BET-726 review cycle 1 Question 1), same role `MenuOption`'s
+   *  `id` plays for the model/effort menus. */
+  id?: string;
 }) {
   return (
     <button
       type="button"
+      id={id}
       role="menuitem"
       onClick={onSelect}
       className={`${ITEM_BASE} ${VARIANT[variant]}${highlighted ? " bg-fill-hover" : ""}`}
@@ -133,6 +139,7 @@ const DROPDOWN_FOOTER = "border-t border-border-subtle p-2 flex-none";
 
 export function Dropdown({
   hook,
+  id,
   placement = "below",
   align = "end",
   width = "menu",
@@ -144,6 +151,12 @@ export function Dropdown({
 }: {
   /** Optional `manta-*` identity class for the call site (no styling). */
   hook?: string;
+  /** Optional DOM id — lets a caller-owned trigger reference this surface via
+   *  `aria-owns` when it drives a roving `aria-activedescendant` highlight
+   *  (BET-726 review cycle 1 Question 1: the trigger and this surface are
+   *  DOM siblings, not ancestor/descendant, so `aria-owns` is what makes the
+   *  activedescendant relationship well-formed). */
+  id?: string;
   /** below (top-full, SessionHeader's menu) | above (bottom-full, composer). */
   placement?: DropdownPlacement;
   /** start (left-0) | end (right-0, today's right-aligned default). */
@@ -163,6 +176,7 @@ export function Dropdown({
 }) {
   return (
     <div
+      id={id}
       role={role}
       className={
         `${hook ? `${hook} ` : ""}` +

--- a/src/renderer/MenuItem.tsx
+++ b/src/renderer/MenuItem.tsx
@@ -64,6 +64,7 @@ export function MenuItem({
   children,
   trailing,
   onSelect,
+  highlighted = false,
 }: {
   /** Which surface + foreground the row carries. normal is the default. */
   variant?: MenuItemVariant;
@@ -75,13 +76,17 @@ export function MenuItem({
   trailing?: ReactNode;
   /** Called when the row is chosen. */
   onSelect?: () => void;
+  /** The roving keyboard highlight (BET-726 Task 3.1) — the SAME static
+   *  `--fill-hover` fill MenuOption's `active` prop gives the model/effort
+   *  menus, applied unconditionally instead of only on `:hover`. */
+  highlighted?: boolean;
 }) {
   return (
     <button
       type="button"
       role="menuitem"
       onClick={onSelect}
-      className={`${ITEM_BASE} ${VARIANT[variant]}`}
+      className={`${ITEM_BASE} ${VARIANT[variant]}${highlighted ? " bg-fill-hover" : ""}`}
     >
       {icon && cloneElement(icon, { size: 14, "aria-hidden": true })}
       <span className="flex-1">{children}</span>

--- a/src/renderer/MenuOption.tsx
+++ b/src/renderer/MenuOption.tsx
@@ -20,6 +20,11 @@
 
 import type { ReactNode } from "react";
 import { Check } from "lucide-react";
+// BET-726 Task 1: keep the keyboard-highlighted row visible when arrow-keying
+// past the fold. Reuses the SAME hook the ⌘K / ⌘F palettes already use for
+// their SessionRow (PaletteShell.tsx) — do not add a second scrollIntoView
+// idiom for the model/effort menus.
+import { useSelectedIntoView } from "./PaletteShell";
 
 // `mb-1` is the same 4px the sidebar's session rows carry between each other
 // (SessionRow's ROW_BASE). Without it the rows are flush, so a highlighted row
@@ -52,8 +57,12 @@ export function MenuOption({
   /** Option id, used as the aria-activedescendant target. */
   id?: string;
 }) {
+  // `active` is the roving keyboard highlight — the same signal that should
+  // keep this row scrolled into view.
+  const ref = useSelectedIntoView<HTMLButtonElement>(active);
   return (
     <button
+      ref={ref}
       type="button"
       id={id}
       role="option"

--- a/src/renderer/PaletteShell.tsx
+++ b/src/renderer/PaletteShell.tsx
@@ -151,7 +151,13 @@ function Kbd({ children }: { children: ReactNode }) {
 export function useSelectedIntoView<T extends HTMLElement>(selected: boolean) {
   const ref = useRef<T>(null);
   useEffect(() => {
-    if (selected) ref.current?.scrollIntoView({ block: "nearest" });
+    // Optional-call the method itself, not just the element: jsdom (the test
+    // environment) doesn't implement `scrollIntoView` at all, and BET-726
+    // widened this hook's adopters (MenuOption, the @-file typeahead) into
+    // component tests that actually render a `selected` row on mount — the
+    // first tests to exercise this path — so the gap needs to be inert here,
+    // not papered over per call site.
+    if (selected) ref.current?.scrollIntoView?.({ block: "nearest" });
   }, [selected]);
   return ref;
 }

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -10,11 +10,12 @@
 // result) and handlers (fork / compact / clear / delete) are passed in as
 // props by ChatPanel, which owns the session lifecycle.
 
-import { useRef, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight } from "lucide-react";
 import {
   ctxStageColor,
   cssVar,
+  moveMenuHighlight,
   type ContextBreakdown,
   type StaleCacheResult,
 } from "./chatUtils";
@@ -491,10 +492,86 @@ function SessionMenu({
   // BET-724 §D7: Delete/Clear from this menu now confirm first, matching the
   // sidebar's inline delete confirm — previously both fired instantly.
   const [confirm, setConfirm] = useState<"delete" | "clear" | null>(null);
+  // BET-726 Task 3.1: the roving keyboard highlight, same index-state shape
+  // as ModelMenu's highlight loop (chatUtils' moveMenuHighlight) — adapted
+  // from ModelMenu's search input to this menu's root div, since there is no
+  // input here to hang the keydown on.
+  const [highlight, setHighlight] = useState(-1);
   const rootRef = useRef<HTMLDivElement>(null);
   useClickAway(rootRef, open, () => setOpen(false));
 
+  // Reset the roving highlight each time the menu (re)opens, so a stale
+  // index from a previous open never carries over.
+  useEffect(() => {
+    if (open) setHighlight(-1);
+  }, [open]);
+
+  const hasMode = !!onModeChange;
+  const isActive = (m: SessionMode) => mode === m;
+
+  // The menu closes after any action; a mode change just re-points mode
+  // (a no-op when already in that mode, so re-clicking the current row is a
+  // harmless close).
+  const switchMode = (m: SessionMode) => {
+    if (onModeChange) onModeChange(m);
+  };
+
+  // The flat, keyboard-navigable row order — same order the rows render in
+  // below, so `highlight`'s index lines up with the rendered row it lights.
+  const rowIds: string[] = [
+    ...(hasMode
+      ? [
+          "mode:chat",
+          "mode:terminal",
+          ...(availableLaunchers ?? []).map((l) => `mode:tui:${l.id}`),
+        ]
+      : []),
+    "fork",
+    "compact",
+    "clear",
+    "delete",
+  ];
+  const highlightedRow = highlight >= 0 ? rowIds[highlight] : undefined;
+
+  const activateRow = (id: string | undefined) => {
+    if (!id) return;
+    if (id === "fork") { setOpen(false); onFork(); return; }
+    if (id === "compact") { setOpen(false); onCompact(); return; }
+    if (id === "clear") { setOpen(false); setConfirm("clear"); return; }
+    if (id === "delete") { setOpen(false); setConfirm("delete"); return; }
+    if (id.startsWith("mode:")) { setOpen(false); switchMode(id.slice("mode:".length) as SessionMode); }
+  };
+
+  const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!open) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => moveMenuHighlight(h, 1, rowIds.length));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => moveMenuHighlight(h, -1, rowIds.length));
+    } else if (e.key === "Home") {
+      if (rowIds.length > 0) {
+        e.preventDefault();
+        setHighlight(0);
+      }
+    } else if (e.key === "End") {
+      if (rowIds.length > 0) {
+        e.preventDefault();
+        setHighlight(rowIds.length - 1);
+      }
+    } else if (e.key === "Enter") {
+      if (highlightedRow) {
+        e.preventDefault();
+        activateRow(highlightedRow);
+      }
+    }
+    // Escape already closes the menu via useClickAway's document keydown
+    // listener (bound above, gated on `open`) — nothing to add here.
+  };
+
   const item = (
+    id: string,
     icon: React.ReactElement,
     label: string,
     onClick: () => void,
@@ -503,6 +580,7 @@ function SessionMenu({
     <MenuItem
       icon={icon}
       variant={danger ? "danger" : "normal"}
+      highlighted={highlightedRow === id}
       onSelect={() => {
         setOpen(false);
         onClick();
@@ -512,16 +590,8 @@ function SessionMenu({
     </MenuItem>
   );
 
-  // The menu closes after any action; a mode change just re-points mode
-  // (a no-op when already in that mode, so re-clicking the current row is a
-  // harmless close).
-  const switchMode = (m: SessionMode) => {
-    if (onModeChange) onModeChange(m);
-  };
-
-  const isActive = (m: SessionMode) => mode === m;
-
   const modeItem = (
+    id: string,
     icon: React.ReactElement,
     label: string,
     m: SessionMode,
@@ -531,6 +601,7 @@ function SessionMenu({
       <MenuItem
         icon={icon}
         variant={active ? "active" : "normal"}
+        highlighted={highlightedRow === id}
         trailing={
           active ? (
             <span className="text-text-faint" aria-hidden="true">
@@ -548,10 +619,8 @@ function SessionMenu({
     );
   };
 
-  const hasMode = !!onModeChange;
-
   return (
-    <div ref={rootRef} className="relative shrink-0">
+    <div ref={rootRef} className="relative shrink-0" onKeyDown={onMenuKeyDown}>
       <IconButton
         icon={<MoreHorizontal />}
         label="Session actions"
@@ -567,8 +636,8 @@ function SessionMenu({
               <div className={`${GROUP_LABEL} pt-1`} role="presentation">
                 Mode
               </div>
-              {modeItem(<MessageSquare size={14} aria-hidden="true" />, "Chat", "chat")}
-              {modeItem(<Terminal size={14} aria-hidden="true" />, "Terminal", "terminal")}
+              {modeItem("mode:chat", <MessageSquare size={14} aria-hidden="true" />, "Chat", "chat")}
+              {modeItem("mode:terminal", <Terminal size={14} aria-hidden="true" />, "Terminal", "terminal")}
               {availableLaunchers && availableLaunchers.length > 0 && (
                 <>
                   <div className={`${GROUP_LABEL} pt-3`} role="presentation">
@@ -576,6 +645,7 @@ function SessionMenu({
                   </div>
                   {availableLaunchers.map((l) =>
                     modeItem(
+                      `mode:tui:${l.id}`,
                       <Bot size={14} aria-hidden="true" />,
                       l.label,
                       `tui:${l.id}` as SessionMode,
@@ -588,22 +658,26 @@ function SessionMenu({
           )}
 
           {item(
+            "fork",
             <GitFork size={14} aria-hidden="true" />,
             "Fork session",
             onFork,
           )}
           {item(
+            "compact",
             <Minimize2 size={14} aria-hidden="true" />,
             "Compact context",
             onCompact,
           )}
           {item(
+            "clear",
             <Eraser size={14} aria-hidden="true" />,
             "Clear session",
             () => setConfirm("clear"),
           )}
           <div className="my-1 border-t border-border-subtle" role="separator" />
           {item(
+            "delete",
             <Trash2 size={14} aria-hidden="true" />,
             "Delete session",
             () => setConfirm("delete"),

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -10,7 +10,7 @@
 // result) and handlers (fork / compact / clear / delete) are passed in as
 // props by ChatPanel, which owns the session lifecycle.
 
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useId, useRef, useState, type CSSProperties } from "react";
 import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight } from "lucide-react";
 import {
   ctxStageColor,
@@ -500,6 +500,18 @@ function SessionMenu({
   const rootRef = useRef<HTMLDivElement>(null);
   useClickAway(rootRef, open, () => setOpen(false));
 
+  // BET-726 review cycle 1 Question 1: the highlight above was visual-only —
+  // a screen reader following the arrow keys heard nothing, because DOM
+  // focus never leaves the ⋯ trigger (this menu has no input to move focus
+  // into, unlike ModelMenu's search box). `aria-activedescendant` on the
+  // element that DOES hold focus is exactly ModelMenu's own idiom (its
+  // `<input>` carries `aria-activedescendant`, not the Dropdown surface) —
+  // applied here to the trigger instead. `useId` keeps ids collision-safe
+  // if more than one SessionHeader is ever mounted at once.
+  const menuUid = useId();
+  const dropdownDomId = `session-menu-${menuUid}`;
+  const rowDomId = (rowId: string) => `session-menu-${menuUid}-${rowId.replace(/:/g, "-")}`;
+
   // Reset the roving highlight each time the menu (re)opens, so a stale
   // index from a previous open never carries over.
   useEffect(() => {
@@ -578,6 +590,7 @@ function SessionMenu({
     danger = false,
   ) => (
     <MenuItem
+      id={rowDomId(id)}
       icon={icon}
       variant={danger ? "danger" : "normal"}
       highlighted={highlightedRow === id}
@@ -599,6 +612,7 @@ function SessionMenu({
     const active = isActive(m);
     return (
       <MenuItem
+        id={rowDomId(id)}
         icon={icon}
         variant={active ? "active" : "normal"}
         highlighted={highlightedRow === id}
@@ -628,9 +642,11 @@ function SessionMenu({
         onClick={() => setOpen((v) => !v)}
         ariaHaspopup="menu"
         ariaExpanded={open}
+        ariaOwns={open ? dropdownDomId : undefined}
+        ariaActiveDescendant={open ? (highlightedRow ? rowDomId(highlightedRow) : undefined) : undefined}
       />
       {open && (
-        <Dropdown hook="manta-session-menu-dropdown">
+        <Dropdown hook="manta-session-menu-dropdown" id={dropdownDomId}>
           {hasMode && (
             <>
               <div className={`${GROUP_LABEL} pt-1`} role="presentation">

--- a/src/renderer/Sidebar.test.tsx
+++ b/src/renderer/Sidebar.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+//
+// BET-726 review cycle 1, Block (fix-here): the sidebar tree's roving-
+// tabindex keydown handler (`onRailKeyDown`) used to switch on `e.key` with
+// no check of where the keydown actually came from. That was safe before
+// BET-726 Task 2.3, because every focusable element inside the tree WAS a
+// treeitem row. Task 2.3 made the hover-revealed pin / GroupHeader +/X /
+// draft-dismiss buttons Tab-reachable (dropped their `tabIndex={-1}`), so
+// their keydowns started bubbling into the same handler — Enter/Space fired
+// `activateFocused()` for whatever row `focusedKey` last pointed at (never
+// the button actually under focus), and Delete/Backspace opened the confirm
+// for that same possibly-unrelated row. `onRailKeyDown` now bails out
+// immediately when the event target is (or is inside) a `<button>`, since
+// rows are `<div role="treeitem">` and never buttons themselves.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { Sidebar } from "./Sidebar";
+import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
+import { useStore } from "./store";
+import type { Project } from "../shared/types";
+
+function proj(over: Partial<Project> & { tmuxSession: string }): Project {
+  return {
+    tmuxSession: over.tmuxSession,
+    defaultCwd: over.defaultCwd ?? "~",
+    attached: over.attached ?? false,
+    windows: over.windows ?? [],
+  };
+}
+
+describe("Sidebar — nested-control keydown guard (BET-726 review cycle 1 Block)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    installMockApi({
+      // togglePin() awaits configUpdate() and reads `.pinnedWindows` off the
+      // result — the default mock resolves `undefined`, which would throw.
+      configUpdate: (patch: Record<string, unknown>) =>
+        Promise.resolve({ pinnedWindows: (patch as { pinnedWindows?: string[] }).pinnedWindows ?? [] }),
+    });
+    resetStore({
+      projects: [
+        proj({
+          tmuxSession: "proj",
+          windows: [
+            { index: 0, name: "win", active: true, paneCurrentPath: "/x", opencodeSessionId: null },
+          ],
+        }),
+      ],
+    });
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function mountSidebar(): Harness {
+    h = mount(
+      <Sidebar onOpenSettings={() => {}} onNewProject={() => {}} onNewSessionInProject={() => {}} />,
+    );
+    return h;
+  }
+
+  // Two ArrowDowns: the first lands the roving highlight on the "proj" group
+  // header, the second on its one window row ("win:proj:0").
+  function focusWindowRow() {
+    const tree = h!.container.querySelector('[role="tree"]') as HTMLElement;
+    act(() => {
+      tree.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      tree.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+  }
+
+  function pinButton(): HTMLButtonElement {
+    const btn = h!.container.querySelector<HTMLButtonElement>('button[aria-label="Pin"]');
+    expect(btn, "expected the window row's Pin button").toBeTruthy();
+    return btn!;
+  }
+
+  it("Enter on the pin button does not activate the roving-focused row", () => {
+    mountSidebar();
+    focusWindowRow();
+    expect(useStore.getState().activeProjectName).toBeNull();
+    const btn = pinButton();
+    act(() => {
+      btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    // Pre-fix, this used to bubble into onRailKeyDown and call
+    // activateFocused() for "win:proj:0", flipping activeProjectName even
+    // though nothing that looks like the row was pressed.
+    expect(useStore.getState().activeProjectName).toBeNull();
+  });
+
+  it("Backspace on the pin button does not open the delete confirm for the focused row", () => {
+    mountSidebar();
+    focusWindowRow();
+    const btn = pinButton();
+    act(() => {
+      btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Backspace", bubbles: true }));
+    });
+    expect(h!.text()).not.toContain("Close session");
+  });
+
+  it("clicking the pin button still toggles the pin (guard doesn't disable the button itself)", async () => {
+    mountSidebar();
+    const btn = pinButton();
+    act(() => btn.click());
+    await h!.flush();
+    expect(useStore.getState().pinnedWindows).toEqual(["proj/0"]);
+  });
+
+  it("F2 on the focused row itself (not a nested button) still starts a rename", () => {
+    // Sanity check the guard is scoped to button targets only — it must not
+    // swallow the tree's own keyboard paths for the row.
+    mountSidebar();
+    focusWindowRow();
+    const tree = h!.container.querySelector('[role="tree"]') as HTMLElement;
+    act(() => {
+      tree.dispatchEvent(new KeyboardEvent("keydown", { key: "F2", bubbles: true }));
+    });
+    const renameInput = h!.container.querySelector("input");
+    expect(renameInput).toBeTruthy();
+    expect((renameInput as HTMLInputElement).value).toBe("win");
+  });
+});

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -358,9 +358,13 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
 
   // F2 → the same rename entry point the row's double-click already uses
   // (BET-726 Task 2.1). Project groups and windows are renameable; job rows
-  // never were (JobChildRow has no onRename), so they're a no-op here too.
+  // never were (JobChildRow has no onRename / RenameInput), so they're an
+  // explicit no-op here too — `resolveFocusedWindow` resolves a `job:` key
+  // to the same live window `win:` would, so without this guard F2 on a job
+  // row would set `renameTarget` to that window's index with nothing on
+  // screen listening for it (BET-726 review cycle 1 nit).
   const renameFocused = () => {
-    if (!focusedKey) return;
+    if (!focusedKey || focusedKey.startsWith("job:")) return;
     if (focusedKey.startsWith("group:")) {
       const session = focusedKey.slice("group:".length);
       startRename({ kind: "project", old: session }, session);
@@ -397,6 +401,18 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   };
 
   const onRailKeyDown = (e: React.KeyboardEvent) => {
+    // BET-726 review cycle 1, Block (fix-here): the hover-revealed pin /
+    // GroupHeader +/X / draft-dismiss buttons became Tab-reachable (Task
+    // 2.3, `tabIndex={-1}` removed), but they're still DOM descendants of
+    // this tree container — their keydowns were bubbling into this handler
+    // with no target check, so Enter/Space fired `activateFocused()` for
+    // whatever row `focusedKey` last pointed at (not the button under focus)
+    // and Delete/Backspace opened the confirm for that same possibly-
+    // unrelated row. Rows are `<div role="treeitem">`, never `<button>`, so
+    // bailing out for any button-descendant target leaves the row's own
+    // arrow/Enter/F2/Delete handling untouched and lets the button run its
+    // own click/keyboard behavior instead of having it hijacked.
+    if ((e.target as HTMLElement).closest("button")) return;
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -329,24 +329,71 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     setFocusedKey(navKeys[next]);
   };
 
+  // Resolve the (project, window) pair backing a `pin:`/`win:`/`job:` nav key
+  // — shared by activate/rename/delete below so the three keyboard paths
+  // (BET-726 Task 2) don't each re-derive the same lookup.
+  const resolveFocusedWindow = (): { project: Project; window: TmuxWindow } | null => {
+    if (!focusedKey) return null;
+    const [kind, ...rest] = focusedKey.split(":");
+    if (kind === "pin") return resolvePin(projects, rest.join(":"));
+    if (kind === "win" || kind === "job") {
+      const session = rest[0];
+      const idx = Number(rest[1]);
+      const proj = projects.find((p) => p.tmuxSession === session);
+      const win = proj?.windows.find((w) => w.index === idx);
+      return proj && win ? { project: proj, window: win } : null;
+    }
+    return null;
+  };
+
   const activateFocused = () => {
     if (!focusedKey) return;
-    const [kind, ...rest] = focusedKey.split(":");
-    if (kind === "group") {
-      toggleCollapse(rest.join(":"));
+    if (focusedKey.startsWith("group:")) {
+      toggleCollapse(focusedKey.slice("group:".length));
       return;
     }
-    if (kind === "pin") {
-      const r = resolvePin(projects, rest.join(":"));
-      if (r) void activateWindow(r.project, r.window.index);
+    const r = resolveFocusedWindow();
+    if (r) void activateWindow(r.project, r.window.index);
+  };
+
+  // F2 → the same rename entry point the row's double-click already uses
+  // (BET-726 Task 2.1). Project groups and windows are renameable; job rows
+  // never were (JobChildRow has no onRename), so they're a no-op here too.
+  const renameFocused = () => {
+    if (!focusedKey) return;
+    if (focusedKey.startsWith("group:")) {
+      const session = focusedKey.slice("group:".length);
+      startRename({ kind: "project", old: session }, session);
       return;
     }
-    // win:<session>:<idx> | job:<session>:<idx>
-    const session = rest[0];
-    const idx = Number(rest[1]);
-    const proj = projects.find((p) => p.tmuxSession === session);
-    const win = proj?.windows.find((w) => w.index === idx);
-    if (proj && win) void activateWindow(proj, idx);
+    const r = resolveFocusedWindow();
+    if (r) {
+      startRename(
+        { kind: "window", project: r.project.tmuxSession, index: r.window.index, old: r.window.name },
+        r.window.name,
+      );
+    }
+  };
+
+  // Delete / ContextMenu → the SAME inline ConfirmDelete the right-click path
+  // already opens (BET-726 Task 2.1) — right-click's onContextMenu just calls
+  // this same setConfirmDeleteFor shape, so there is no separate "menu" to
+  // build for the ContextMenu key either.
+  const requestDeleteFocused = () => {
+    if (!focusedKey) return;
+    if (focusedKey.startsWith("group:")) {
+      setConfirmDeleteFor({ kind: "project", project: focusedKey.slice("group:".length) });
+      return;
+    }
+    const r = resolveFocusedWindow();
+    if (r) {
+      setConfirmDeleteFor({
+        kind: "session",
+        project: r.project.tmuxSession,
+        index: r.window.index,
+        name: r.window.name,
+      });
+    }
   };
 
   const onRailKeyDown = (e: React.KeyboardEvent) => {
@@ -383,9 +430,30 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         }
         break;
       }
+      // Space activates alongside Enter (SessionRow is a treeitem, not a
+      // <button>, so native Space-click doesn't happen for free).
       case "Enter":
+      case " ":
         e.preventDefault();
         activateFocused();
+        break;
+      case "F2":
+        e.preventDefault();
+        renameFocused();
+        break;
+      // Backspace alongside Delete: the Mac keyboard's only "delete" key
+      // reports as Backspace in the DOM (there's no forward-delete key on
+      // most Mac keyboards) — binding only "Delete" would leave Mac users
+      // without this path. A focused RenameInput stops propagation on its
+      // own keydown, so this never fires mid-rename.
+      case "Delete":
+      case "Backspace":
+        e.preventDefault();
+        requestDeleteFocused();
+        break;
+      case "ContextMenu":
+        e.preventDefault();
+        requestDeleteFocused();
         break;
     }
   };
@@ -534,9 +602,9 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                         e.stopPropagation();
                         dismissDraft(d.id);
                       }}
-                      className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
+                      className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
                       aria-label="Discard this new session"
-                      tabIndex={-1}
+                      title="Discard this new session"
                     >
                       <X size={13} aria-hidden="true" />
                     </button>
@@ -860,10 +928,9 @@ function PinSlot({
         e.stopPropagation();
         onToggle();
       }}
-      className="w-[18px] h-[18px] flex items-center justify-center shrink-0 text-text-faint opacity-0 group-hover:opacity-100 hover:text-[var(--accent-tx)] transition-colors"
+      className="w-[18px] h-[18px] flex items-center justify-center shrink-0 text-text-faint opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-[var(--accent-tx)] transition-colors"
       title={pinned ? "Unpin" : "Pin"}
       aria-label={pinned ? "Unpin" : "Pin"}
-      tabIndex={-1}
     >
       <Pin size={12} className={pinned ? "fill-current" : ""} aria-hidden="true" />
     </button>
@@ -1163,9 +1230,8 @@ function GroupHeader({
           e.stopPropagation();
           onNewSession();
         }}
-        className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-text leading-none"
+        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-text-faint hover:text-text leading-none"
         title="New session in this project"
-        tabIndex={-1}
       >
         +
       </button>
@@ -1174,10 +1240,9 @@ function GroupHeader({
           e.stopPropagation();
           onClose();
         }}
-        className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
+        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
         title="Close project"
         aria-label="Close project"
-        tabIndex={-1}
       >
         <X size={14} aria-hidden="true" />
       </button>

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -86,14 +86,14 @@ export function Toast({ toast, onDismiss }: ToastProps) {
         <button
           onClick={toast.action.onClick}
           disabled={toast.action.disabled}
-          className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium disabled:opacity-50"
+          className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
         >
           {toast.action.label}
         </button>
       )}
       <button
         onClick={() => onDismiss(toast.id)}
-        className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center"
+        className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
         title="Dismiss"
         aria-label="Dismiss"
       >

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -113,14 +113,14 @@ export function UpdateBar({
             onClick={() => {
               onAction();
             }}
-            className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
+            className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
           >
             {actionLabel}
           </button>
           {dismissible && onDismiss && (
             <button
               onClick={() => onDismiss()}
-              className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center"
+              className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
               title="Dismiss"
               aria-label="Dismiss update"
             >


### PR DESCRIPTION
BET-726 — audit §6 items 5+8+15-parts.

**Base:** `origin/main` @ `bfd3ab8f`

## Task 1 — scrollIntoView for the keyboard-highlighted item

Deviated from the issue's literal snippet (a new `scrollHighlight.ts` with a
`data-hl-index` query helper): the repo already has a hook that does exactly
this — `useSelectedIntoView` in `PaletteShell.tsx`, used by the ⌘K/⌘F
palettes' `SessionRow`. Reused it instead of adding a second scrollIntoView
idiom (the issue's own Constraints section asks for exactly that: "zero new
interaction idioms").

- `MenuOption.tsx` (ModelMenu + EffortMenu rows): calls `useSelectedIntoView(active)`
  internally and attaches the ref to its own `<button>`.
- `ComposerParts.tsx`'s `TypeaheadPopup`: extracted a `TypeaheadRowButton`
  (Hooks can't be called from inside `.map()`, so each row needed to become
  its own component — same shape as `SessionRow`) using the same hook.
- The ⌘K command palette (`Sidebar.tsx`'s `SessionRow`) was **already fixed**
  — it already calls `useSelectedIntoView`. The issue's audit predates that.
- Hardened the shared hook itself: `ref.current?.scrollIntoView?.(...)` —
  jsdom doesn't implement `scrollIntoView`, and this is the first test
  coverage to actually render a `selected`/`active` row through it.

## Task 2 — sidebar row actions get keyboard paths

`Sidebar.tsx`'s tree keydown handler (`onRailKeyDown`) gains:
- `F2` → the same rename entry point double-click uses.
- `Delete`/`Backspace`/`ContextMenu` → the same inline `ConfirmDelete`
  right-click opens. (Backspace added alongside Delete: the Mac keyboard's
  only "delete" key reports as `Backspace` in the DOM. `ContextMenu` maps to
  the same action since right-click has no separate menu to open either —
  it goes straight to the confirm.)
- `Space` alongside `Enter` to activate the focused row (`SessionRow` is a
  `treeitem`, not a `<button>`, so Space-activation isn't free).

Hover-revealed action buttons (pin, GroupHeader `+`/`X`, and — one more
instance of the identical pattern the issue didn't name — the new-session
draft's dismiss `X`) get `focus-visible:opacity-100` and drop `tabIndex={-1}`
so a keyboard user tabbing to them can see and reach them. Added the one
missing `title` (draft dismiss); the other three already had one.

## Task 3 — menus + tablists

- `SessionHeader.tsx`'s ⋯ `SessionMenu`: `ArrowUp`/`ArrowDown` roving
  highlight + `Home`/`End` + `Enter` to activate, using the same index-state
  shape as ModelMenu's highlight loop (`chatUtils.moveMenuHighlight`),
  adapted from ModelMenu's search input to this menu's root div (no input to
  hang the keydown on here). `MenuItem` gained a `highlighted` prop — the
  same static `bg-fill-hover` fill `MenuOption`'s `active` already gives the
  model/effort menus. Escape already closed the menu via `useClickAway`
  (verified, not re-added).
- `ArtifactsPanel.tsx`'s tab bar: `Left`/`Right` roving-tabindex nav — ported
  Settings.tsx's exact section-rail idiom (move state + `.focus()` the next
  tab's ref). The search input's bare `focus:outline-none` now also sets
  `focus:border-accent`, matching the `Field` primitive's own focus
  treatment (a text input, so the border-color convention fit better than
  the button ring used elsewhere in this issue).

## Task 4 — focus-visible on the remaining orphans

Ring added to: `Toast.tsx` (action + dismiss), `UpdateBar.tsx` (action +
dismiss), `Cards.tsx`'s permission-card ladder (Allow once / Always allow /
Reject) and question-card ladder (Submit / Dismiss) — ring only, no Button
primitive migration — and the Artifacts tab buttons (added alongside Task 3.2).

## Verification results

- PR branch (`multica/BET-726-keyboard-sweep` @ `12bd9c70`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, vitest 2301 pass / 0 fail / 7 skip, node:test 1565 pass / 0 fail. log sha256: `b712ce5099961729c6183eb2d14655e946350de0cd7ebfeb97eb504ef89095c0`
- Base (`main` @ `bfd3ab8f`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, vitest 2296 pass / 0 fail / 7 skip, node:test 1565 pass / 0 fail. log sha256: `05b84c3f7c0030d01bbc77b0c3b0415d7284f96745b9f521d8f28f09d14b4aa8`
- **Conclusion:** 0 test failures on either branch (identical typecheck output — the logs' hashes match). +5 new vitest tests added by this PR (2301 vs 2296), 0 pre-existing failures, 0 new failures.

Also ran the `manta-e2e-smoke` gate against the built app (Playwright's Electron
launcher, xvfb): main process alive, sidebar (`aside.w-64`) present with the
Workspace heading + new-project button, `<main>`/titlebar present, zero
console/page errors. PASSED.

## Manual verification checklist (from the issue)

- [x] Arrow-key past the fold in ModelMenu keeps the highlight visible (`useSelectedIntoView` on `MenuOption`).
- [x] ⌘K palette: already covered (pre-existing `useSelectedIntoView` on `SessionRow`).
- [x] @-typeahead: covered via the new `TypeaheadRowButton`.
- [x] Tab to a sidebar row: F2 renames, Delete/Backspace opens the inline confirm, Space/Enter activate; Tab reaches pin/+/X and they become visible on focus.
- [x] ⋯ menu: arrows cycle (with wraparound via `moveMenuHighlight`), Enter picks, Home/End jump to first/last.
- [x] Artifacts tabs: Left/Right work (roving tabindex + focus move); search field shows a focus ring (`focus:border-accent`).

## Constraints honored

- Reused named existing implementations (Settings tablist idiom, ModelMenu's
  highlight-loop shape, sidebar's `ConfirmDelete`, and — better than the
  issue's own suggestion — the palettes' existing `useSelectedIntoView`
  hook). Zero new interaction idioms.
- Did not migrate `Cards.tsx` buttons to the `Button` primitive — ring only.
