### PR TITLE
fix(server): injectable file-read + direct tests for readProviderApiKey (BET-740)

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1296,7 +1296,13 @@ export function parseProviderApiKey(rawFileText, providerId) {
   try {
     const parsed = JSON.parse(rawFileText);
     const entry = parsed?.[providerId];
-    return typeof entry?.key === "string" && entry.key.length > 0 ? entry.key : "";
+    // Discriminate on `type === "api"` before trusting any `key` value: the
+    // key is used directly as a `Bearer` header, so a non-api entry (e.g. an
+    // oauth one) must never supply it even if it happens to carry a `key`
+    // field.
+    return entry?.type === "api" && typeof entry?.key === "string" && entry.key.length > 0
+      ? entry.key
+      : "";
   } catch {
     return "";
   }

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1313,17 +1313,22 @@ export function parseProviderApiKey(rawFileText, providerId) {
  * returning `""` — NEVER throws, so a caller can `await` this
  * unconditionally. The parse itself is `parseProviderApiKey` above.
  *
+ * The file-read function is injectable (`readFile`), defaulting to the real
+ * `readFileSync`, so tests can drive the missing-file / unparseable cases
+ * with a fake reader and never touch a real auth store on a live box.
+ *
  * SECURITY: this resolves a LIVE credential. It must never log, echo, or
  * return the key anywhere but to its direct caller, and a caller must never
  * fold it into an error message.
  *
  * @param {string} providerId
+ * @param {{ readFile?: (file: string, encoding: string) => string }} [opts]
  * @returns {Promise<string>}
  */
-export async function readProviderApiKey(providerId) {
+export async function readProviderApiKey(providerId, { readFile = readFileSync } = {}) {
   let raw;
   try {
-    raw = readFileSync(opencodeAuthPath(), "utf-8");
+    raw = readFile(opencodeAuthPath(), "utf-8");
   } catch {
     return "";
   }

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -77,6 +77,15 @@ test("parseProviderApiKey returns \"\" for an oauth-type entry (no `key` field)"
   assert.equal(parseProviderApiKey(raw, "kimi-for-coding"), "");
 });
 
+test("parseProviderApiKey returns \"\" for a non-api entry even when it carries a non-empty `key` (type gate)", () => {
+  // type === "api" is the discriminant — a stray `key` on an oauth/common
+  // entry must never be trusted as a Bearer credential.
+  const raw = JSON.stringify({ "kimi-for-coding": { type: "oauth", key: "should-not-leak", access: "x" } });
+  assert.equal(parseProviderApiKey(raw, "kimi-for-coding"), "");
+  const rawCoding = JSON.stringify({ "kimi-for-coding": { key: "still-no-type" } });
+  assert.equal(parseProviderApiKey(rawCoding, "kimi-for-coding"), "");
+});
+
 test("parseProviderApiKey returns \"\" for an empty-string key", () => {
   const raw = JSON.stringify({ "kimi-for-coding": { type: "api", key: "" } });
   assert.equal(parseProviderApiKey(raw, "kimi-for-coding"), "");
@@ -124,6 +133,13 @@ test("readProviderApiKey returns \"\" for a provider with no entry", async () =>
 test("readProviderApiKey returns \"\" for an oauth-type entry (no `key` field)", async () => {
   assert.equal(
     await readVia(JSON.stringify({ "kimi-for-coding": { type: "oauth", access: "x", refresh: "y" } })),
+    "",
+  );
+});
+
+test("readProviderApiKey returns \"\" for a non-api entry even when it carries a non-empty `key` (type gate)", async () => {
+  assert.equal(
+    await readVia(JSON.stringify({ "kimi-for-coding": { type: "oauth", key: "should-not-leak", access: "x" } })),
     "",
   );
 });

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -37,6 +37,7 @@ import {
   listModels,
   claudeCliStatus,
   parseProviderApiKey,
+  readProviderApiKey,
   opencodeAuthPath,
 } from "./opencode.mjs";
 import { homedir } from "node:os";
@@ -58,8 +59,7 @@ test("parseSseFrame returns null for comments/keepalive", () => {
 // ---------------------------------------------------------------------------
 // parseProviderApiKey (BET-737) — pure parse of opencode's own auth store,
 // same split as parseCredentials/readCredsSnapshot. Never touches a real
-// file; readProviderApiKey (the IO wrapper) is intentionally NOT unit-tested
-// here, mirroring readCredsSnapshot's own convention.
+// file.
 // ---------------------------------------------------------------------------
 
 test("parseProviderApiKey extracts the key from an api-type entry", () => {
@@ -96,6 +96,43 @@ test("parseProviderApiKey never echoes the key into an exception (it doesn't thr
   assert.equal(parseProviderApiKey("null", "kimi-for-coding"), "");
   assert.equal(parseProviderApiKey("[]", "kimi-for-coding"), "");
   assert.equal(parseProviderApiKey('"just a string"', "kimi-for-coding"), "");
+});
+
+// readProviderApiKey (BET-740) — the IO wrapper around parseProviderApiKey,
+// driven with an INJECTED reader so no case here can touch a real auth store
+// on the live box. Missing file / unparseable bytes / absent provider / oauth
+// entry all degrade to "" (never throw); a valid api entry returns the key.
+const readVia = (text) => readProviderApiKey("kimi-for-coding", {
+  readFile: () => text,
+});
+
+test("readProviderApiKey returns \"\" when the auth store file is missing (reader throws)", async () => {
+  assert.equal(
+    await readProviderApiKey("kimi-for-coding", { readFile: () => { throw new Error("ENOENT"); } }),
+    "",
+  );
+});
+
+test("readProviderApiKey returns \"\" for unparseable JSON", async () => {
+  assert.equal(await readVia("not json{"), "");
+});
+
+test("readProviderApiKey returns \"\" for a provider with no entry", async () => {
+  assert.equal(await readVia(JSON.stringify({ anthropic: { type: "oauth", access: "x" } })), "");
+});
+
+test("readProviderApiKey returns \"\" for an oauth-type entry (no `key` field)", async () => {
+  assert.equal(
+    await readVia(JSON.stringify({ "kimi-for-coding": { type: "oauth", access: "x", refresh: "y" } })),
+    "",
+  );
+});
+
+test("readProviderApiKey returns the key for a valid api-type entry", async () => {
+  assert.equal(
+    await readVia(JSON.stringify({ "kimi-for-coding": { type: "api", key: "kimi-provider-key" } })),
+    "kimi-provider-key",
+  );
 });
 
 // opencodeAuthPath (review cycle 2 Nit): mirrors messageSearch.mjs's


### PR DESCRIPTION
BET-740 — Kimi usage adapter: read the key from the provider connection, not the secrets store.

## What this does

BET-737's review cycle already shipped most of this correction (the Kimi adapter now reads via `readProviderApiKey`, `providerIDs` is exactly `["kimi-for-coding"]`, the secrets-store lookup is gone). BET-740 closes the remaining gaps against the spec:

1. **`readProviderApiKey(providerId)` in `src/server/opencode.mjs`** — now takes the file-read function as an **injectable** parameter (default: real `readFileSync`), so tests never touch a real auth store on the live box. Never throws: missing file / unparseable JSON / absent provider / non-api entry all degrade to `""`. Returns the key only to its direct caller; never logged.
2. **`type === "api"` discriminant** in `parseProviderApiKey` — only an api-type entry with a non-empty `key` supplies the credential (used as a `Bearer` header); a stray `key` on an oauth / type-less entry is ignored. (Review Block, this cycle.)
3. **Direct tests** (`opencode.test.mjs`) with injected readers for `readProviderApiKey`: missing file → `""`, unparseable JSON → `""`, provider absent → `""`, oauth/type-less-w/-key → `""` (type gate, both parse and read level), valid api entry → key.

The Kimi adapter already sources the key from the connect-card store with an injectable `readKey`, and `providerIDs` deep-equals `["kimi-for-coding"]` (asserted in `usage.test.mjs`). `grep -rn "KIMI_CODE_API_KEY\|resolveSecret" src/server/usageAdapters/` returns nothing.

**Files changed:** 2. `src/server/opencode.mjs`, `src/server/opencode.test.mjs`.

**Base: origin/main @ `24235af`**

**Verification results:**
- PR branch (`multica/BET-740-kimi-provider-key` @ `407e340`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0 — vitest 2303 pass / 0 fail; node:test 1615 pass / 0 fail.
- The `duplication-gate` failure the earlier body flagged as pre-existing does **not** reproduce here (full suite exits 0); the review + CI confirm it.
