### PR TITLE
feat(ios): context percent pill in the chat header; delete dead headerSubtitle (BET-716 task 1)

### DIFF
--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -375,23 +375,3 @@ enum ChatQuestionAnswers {
     }
 }
 
-// MARK: - Header subtitle (§8 "running · 2m · 8%" / idle)/// The §8 chat-header subtitle: while running, `running · <elapsed> · <N>%`;
-/// while idle, `idle · <N>%` (the context number matters most before sending),
-/// falling back to `idle` when no context is established yet. Token-aware on
-/// the surrounding prose only; the string is assembled here so the view stays a
-/// thin token resolver.
-enum ChatHeaderSubtitle {
-    static func text(running: Bool, elapsed: TimeInterval, contextPct: Double?) -> String {
-        if running {
-            let elapsed = SessionTimerFormat.elapsed(elapsed)
-            if let pct = contextPct {
-                return "running · \(elapsed) · \(Int(pct.rounded()))%"
-            }
-            return "running · \(elapsed)"
-        }
-        if let pct = contextPct {
-            return "idle · \(Int(pct.rounded()))%"
-        }
-        return "idle"
-    }
-}

--- a/mobile/native/MantaUI/ChatOverflowCaptureScene.swift
+++ b/mobile/native/MantaUI/ChatOverflowCaptureScene.swift
@@ -31,7 +31,6 @@ struct ChatOverflowCaptureScene: View {
                     branch: "main",
                     onSchedules: {},
                     onSecrets: {},
-                    onWebhooks: {},
                     onCompact: {},
                     onClear: {},
                     onFork: {},

--- a/mobile/native/MantaUI/ChatOverflowSheet.swift
+++ b/mobile/native/MantaUI/ChatOverflowSheet.swift
@@ -26,7 +26,6 @@ struct ChatOverflowSheet: View {
 
     var onSchedules: () -> Void
     var onSecrets: () -> Void
-    var onWebhooks: () -> Void
     var onCompact: () -> Void
     var onClear: () -> Void
     var onFork: () -> Void
@@ -51,7 +50,6 @@ struct ChatOverflowSheet: View {
                 Section {
                     row("Scheduled tasks", systemImage: "clock", badge: scheduleCount, action: onSchedules)
                     row("Secrets", systemImage: "key", action: onSecrets)
-                    row("Webhooks", systemImage: "bolt.horizontal", action: onWebhooks)
                 }
                 Section {
                     row("Compact session", systemImage: "arrow.down.right.and.arrow.up.left", action: onCompact)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -325,6 +325,24 @@ private struct ChatScreenContent: View {
                 .frame(height: Self.headerReservedHeight + Metrics.spacing.sp6)
         }
         .overlay(alignment: .top) { header }
+        // Offline must not read as "the model is quiet": a slim banner pinned
+        // just below the floating header, declared AFTER the header so it draws
+        // on top of it. It offsets by the exact height the transcript reserves
+        // (`headerReservedHeight`) plus a gap, so it never overlaps the two
+        // header buttons. It disappears on its own when `degraded` flips false.
+        .overlay(alignment: .top) {
+            if store.degraded {
+                Text("Connection lost — reconnecting…")
+                    .font(.system(size: Metrics.type.xs, weight: .semibold))
+                    .foregroundColor(tokens.danger)
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .background(tokens.danger.opacity(0.12), in: Capsule())
+                    .padding(.top, Self.headerReservedHeight + Metrics.spacing.sp2)
+                    .transition(.opacity)
+                    .accessibilityIdentifier("connection-banner")
+            }
+        }
         .sheet(isPresented: $showOverflow) { overflowSheet }
         .sheet(item: $overflowDestination) { destination in
             destinationCard(destination)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -414,10 +414,22 @@ private struct ChatScreenContent: View {
     /// and re-point it at the new id; the transcript comes back empty because
     /// the session really is new.
     private func clearSession() async {
-        guard let w = sessionWindow else { return }
-        let newId = try? await MantaAPIClient.live().clearSession(
-            sessionName: w.name, windowIndex: w.index, cwd: w.cwd, title: title)
-        guard let newId, !newId.isEmpty else { return }
+        guard let w = sessionWindow else {
+            store.actionHint = "Can't clear — session's window not found. Go back and reopen from the list."
+            return
+        }
+        let newId: String?
+        do {
+            newId = try await MantaAPIClient.live().clearSession(
+                sessionName: w.name, windowIndex: w.index, cwd: w.cwd, title: title)
+        } catch {
+            await MainActor.run { store.actionHint = "Clear failed — the session is still there" }
+            return
+        }
+        guard let newId, !newId.isEmpty else {
+            await MainActor.run { store.actionHint = "Clear failed — the session is still there" }
+            return
+        }
         // Carry the chosen model + effort to the new session id before the
         // wrapper rebuilds the stores against it (matching the desktop's clear,
         // which copies the override into the new session's key). The catalog
@@ -427,11 +439,23 @@ private struct ChatScreenContent: View {
     }
 
     private func forkSession() async {
-        guard let w = sessionWindow else { return }
-        let newSessionId = try? await MantaAPIClient.live().forkSession(
-            sessionId: store.sessionId, sessionName: w.name,
-            windowName: "\(title)-fork", cwd: w.cwd)
-        guard let newSessionId, !newSessionId.isEmpty else { return }
+        guard let w = sessionWindow else {
+            store.actionHint = "Can't fork — session's window not found. Go back and reopen from the list."
+            return
+        }
+        let newSessionId: String?
+        do {
+            newSessionId = try await MantaAPIClient.live().forkSession(
+                sessionId: store.sessionId, sessionName: w.name,
+                windowName: "\(title)-fork", cwd: w.cwd)
+        } catch {
+            await MainActor.run { store.actionHint = "Fork failed — nothing was created" }
+            return
+        }
+        guard let newSessionId, !newSessionId.isEmpty else {
+            await MainActor.run { store.actionHint = "Fork failed — nothing was created" }
+            return
+        }
         // Fork = a full copy of the session in a fresh window. Land on the
         // fork: push the new session as the next destination (sessionId is
         // present, so it opens the forked chat). The original stays one pop
@@ -446,17 +470,27 @@ private struct ChatScreenContent: View {
     /// navigationDestination routes it to the native terminal instead of the
     /// chat screen.
     private func openTerminal() async {
-        guard let w = sessionWindow else { return }
+        guard let w = sessionWindow else {
+            store.actionHint = "Can't open terminal — session's window not found. Go back and reopen from the list."
+            return
+        }
         await MainActor.run {
             path.append(SessionOpenTarget(project: projectName, windowIndex: w.index, name: title, sessionId: nil))
         }
     }
 
     private func deleteSession() async {
-        guard let w = sessionWindow else { return }
-        try? await MantaAPIClient.live().deleteSession(
-            sessionId: store.sessionId, sessionName: w.name, windowIndex: w.index)
-        await MainActor.run { dismiss() }
+        guard let w = sessionWindow else {
+            store.actionHint = "Can't delete — session's window not found."
+            return
+        }
+        do {
+            try await MantaAPIClient.live().deleteSession(
+                sessionId: store.sessionId, sessionName: w.name, windowIndex: w.index)
+            await MainActor.run { dismiss() }
+        } catch {
+            await MainActor.run { store.actionHint = "Delete failed — the session is still there" }
+        }
     }
 
     // MARK: - Header (§8)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -481,6 +481,25 @@ private struct ChatScreenContent: View {
 
                 Spacer(minLength: 0)
 
+                // Context percent pill — a centred, non-interactive capsule that
+                // appears once the box reports context stats for this session.
+                // It deliberately keeps the header at its two glass CONTROL
+                // buttons (BET-627) plus this informational element; a plain
+                // material capsule (not `.glassEffect` on a Text, which the
+                // header buttons' note warns can eat touches) is the approved
+                // non-interactive treatment.
+                if let ctx = store.context {
+                    Text("\(Int(ctx.pct.rounded()))% ctx")
+                        .font(.system(size: Metrics.type.xs, weight: .semibold))
+                        .foregroundColor(ctxColor(ctx.pct))
+                        .padding(.horizontal, Metrics.spacing.sp2)
+                        .frame(height: Metrics.type.chatHeaderBtn)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .accessibilityLabel("Context \(Int(ctx.pct.rounded())) percent used")
+                }
+
+                Spacer(minLength: 0)
+
                 // Trailing 38×38 glass button (§8) — the overflow sheet, which is
                 // where every session action lives (DECISIONS.md:667-670).
                 Button {
@@ -498,6 +517,15 @@ private struct ChatScreenContent: View {
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
+    }
+
+    /// Same stage thresholds as the desktop ctx bar: calm → warn at 70 → hot at
+    /// 90. `tokens` has no `warning` token, so the mid stage uses `warn` (the
+    /// amber the todos card uses).
+    private func ctxColor(_ pct: Double) -> Color {
+        if pct >= 90 { return tokens.danger }
+        if pct >= 70 { return tokens.warn }
+        return tokens.tx2
     }
 
     // MARK: - Transcript (BET-481 container; anchor + landing corrected)

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -358,7 +358,6 @@ private struct ChatScreenContent: View {
             branch: branch,
             onSchedules: { overflowDestination = .schedules },
             onSecrets: { overflowDestination = .secrets },
-            onWebhooks: {},
             onCompact: { store.compact() },
             onClear: { Task { await clearSession() } },
             onFork: { Task { await forkSession() } },

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -163,6 +163,11 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var childStores: [String: ChatSessionStore] = [:]
     @Published private(set) var loading = false
     @Published private(set) var loadFailed = false
+    /// True while the box was connected and the stream dropped (mirrors
+    /// MantaEventStore.degraded). Drives the chat screen's "Connection lost —
+    /// reconnecting…" banner so an offline hit does not read as "the model is
+    /// quiet". Consumed only; reconnect machinery is owned by the event store.
+    @Published private(set) var degraded = false
     /// True while a canonical transcript refetch (or the initial load) is in
     /// flight. Drives the ambient hairline sweep on the composer's top divider
     /// (BET-630, D1) — distinct from `running`, which drives the working row.
@@ -266,6 +271,13 @@ final class ChatSessionStore: ObservableObject {
         eventStore.$connectionState
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in self?.handleConnection(state) }
+            .store(in: &cancellables)
+
+        // Degraded state feeds the chat banner; distinct values only, so a
+        // republished identical value does not re-render the banner.
+        eventStore.$degraded
+            .removeDuplicates()
+            .sink { [weak self] d in self?.degraded = d }
             .store(in: &cancellables)
     }
 

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -168,6 +168,11 @@ final class ChatSessionStore: ObservableObject {
     /// reconnecting…" banner so an offline hit does not read as "the model is
     /// quiet". Consumed only; reconnect machinery is owned by the event store.
     @Published private(set) var degraded = false
+    /// A one-shot user-facing message bus for failed chat actions: views set it,
+    /// the composer surfaces it through its existing hint capsule and clears it.
+    /// It is deliberately settable from views because it is a bus, not store
+    /// state — a failed abort/compact/clear/fork/delete must not fail silently.
+    @Published var actionHint: String?
     /// True while a canonical transcript refetch (or the initial load) is in
     /// flight. Drives the ambient hairline sweep on the composer's top divider
     /// (BET-630, D1) — distinct from `running`, which drives the working row.
@@ -785,12 +790,18 @@ final class ChatSessionStore: ObservableObject {
 
     /// Interrupt the running turn (voice `abort`).
     func abort() {
-        Task { try? await api.abort(sessionId: sessionId) }
+        Task {
+            do { try await api.abort(sessionId: sessionId) }
+            catch { await MainActor.run { actionHint = "Couldn't stop the turn — check the connection" } }
+        }
     }
 
     /// Compact the session to free context (voice `compact`).
     func compact() {
-        Task { try? await api.compactSession(sessionId: sessionId) }
+        Task {
+            do { try await api.compactSession(sessionId: sessionId) }
+            catch { await MainActor.run { actionHint = "Compact failed — check the connection" } }
+        }
     }
 
     /// Dispatch a store-level voice action. Returns a human hint string when

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -892,10 +892,4 @@ final class ChatSessionStore: ObservableObject {
     /// live elapsed against its own 1s tick rather than stream-state changes
     /// (BET-630, D1).
     var runningStart: Date? { runningSince }
-
-    /// §8 header subtitle ("running · 2m · 8%" / "idle").
-    var headerSubtitle: String {
-        let elapsed = runningSince.map { Date().timeIntervalSince($0) } ?? 0
-        return ChatHeaderSubtitle.text(running: running, elapsed: elapsed, contextPct: context?.pct)
-    }
 }

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -130,6 +130,11 @@ struct ComposerView: View {
         .onChange(of: photoItems) { _ in
             Task { await processPhotos() }
         }
+        .onChange(of: store.actionHint) { _, hint in
+            guard let hint else { return }
+            surfaceHint(hint)
+            store.actionHint = nil
+        }
         .onAppear {
             modelStore.load()
             checkMicAvailability()

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -299,24 +299,6 @@ final class ChatTranscriptTests: XCTestCase {
         XCTAssertTrue(blocks.isEmpty)
     }
 
-    // MARK: - Header subtitle (§8)
-
-    func testHeaderSubtitleRunningWithContext() {
-        XCTAssertEqual(ChatHeaderSubtitle.text(running: true, elapsed: 61, contextPct: 8.4), "running · 1m · 8%")
-    }
-
-    func testHeaderSubtitleRunningNoContext() {
-        XCTAssertEqual(ChatHeaderSubtitle.text(running: true, elapsed: 0, contextPct: nil), "running · 0s")
-    }
-
-    func testHeaderSubtitleIdleWithContext() {
-        XCTAssertEqual(ChatHeaderSubtitle.text(running: false, elapsed: 0, contextPct: 12.6), "idle · 13%")
-    }
-
-    func testHeaderSubtitleIdle() {
-        XCTAssertEqual(ChatHeaderSubtitle.text(running: false, elapsed: 0, contextPct: nil), "idle")
-    }
-
     // MARK: - Question answers (§7.5)
 
     private func q(_ question: String, options: [String], multiple: Bool = false) -> QuestionInfo {


### PR DESCRIPTION
Opened automatically for `multica/BET-716-chat-visibility`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-716.