### PR TITLE
BET-727: adopt Button primitive at hand-rolled stragglers; kill hover no-ops

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1457,12 +1457,12 @@ function AppInner() {
               running in any session. Any unsaved work in a running turn is lost.
             </div>
             <div className="flex justify-end gap-2">
-              <button
+              <Button
+                tone="ghost"
                 onClick={() => setConfirmServerUpdate(false)}
-                className="px-4 py-2 text-body text-text-muted hover:text-text"
               >
                 Cancel
-              </button>
+              </Button>
               <Button
                 tone="primary"
                 onClick={() => {

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -207,7 +207,7 @@ export function PermissionCard({
   //   Allow once — the FILLED accent primary, with a Check + ⏎ hint.
   //   Always allow <tool> — outlined secondary.
   //   (spacer)
-  //   Reject — ghost, pushed to the far right, gains --danger on hover.
+  //   Reject — danger text at rest, gains --danger-bg fill on hover (tone="danger").
   const actions = (
     <>
       <Button tone="primary" onClick={() => onReply("once")}>

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -19,6 +19,7 @@ import { buildQuestionAnswers, canSubmitQuestion } from "./chatUtils";
 import { Card } from "./Card";
 import { Pill } from "./Pill";
 import { OutputWell } from "./OutputWell";
+import { Button } from "./Button";
 
 // ===== Shared ask-card shell (BET-458) =====
 //
@@ -209,35 +210,28 @@ export function PermissionCard({
   //   Reject — ghost, pushed to the far right, gains --danger on hover.
   const actions = (
     <>
-      <button
-        onClick={() => onReply("once")}
-        className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-        style={{ backgroundColor: "var(--accent-solid)" }}
-      >
+      <Button tone="primary" onClick={() => onReply("once")}>
         <Check size={13} aria-hidden="true" />
         Allow once
         <span className="text-on-accent opacity-70" aria-hidden="true">
           ⏎
         </span>
-      </button>
+      </Button>
       {alwaysScope ? (
-        <button
+        <Button
+          tone="default"
           onClick={() => onReply("always")}
           title={`Always allow ${alwaysScope}`}
-          className="h-8 px-[14px] inline-flex items-center rounded-md border border-border-strong text-text hover:bg-bg-soft text-meta focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
         >
           Always allow&nbsp;
           <span className="text-text-faint">{alwaysScope}</span>
-        </button>
+        </Button>
       ) : null}
       {/* spacer pushes Reject to the far right */}
       <div className="flex-1" />
-      <button
-        onClick={() => onReply("reject")}
-        className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-      >
+      <Button tone="danger" onClick={() => onReply("reject")}>
         Reject
-      </button>
+      </Button>
     </>
   );
 
@@ -481,17 +475,12 @@ export function QuestionCard({
       actions={
         <>
           {/* Submit FIRST — the filled accent primary with a trailing ⏎ hint. */}
-          <button
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            className="h-8 px-[14px] inline-flex items-center gap-2 rounded-md text-on-accent text-meta font-medium disabled:opacity-40 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-            style={{ backgroundColor: "var(--accent-solid)" }}
-          >
+          <Button tone="primary" onClick={handleSubmit} disabled={!canSubmit}>
             Submit
             <span className="text-on-accent opacity-70" aria-hidden="true">
               ⏎
             </span>
-          </button>
+          </Button>
           {/* Multi-question progress — mono `.prog`. */}
           {isMulti && (
             <span className="text-text-faint text-meta font-mono ml-2">
@@ -500,13 +489,9 @@ export function QuestionCard({
           )}
           {/* spacer pushes Dismiss to the far right */}
           <div className="flex-1" />
-          <button
-            onClick={onReject}
-            className="h-8 px-[14px] inline-flex items-center rounded-md text-text-faint hover:text-danger hover:bg-danger-bg text-meta focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-            title="Dismiss this question"
-          >
+          <Button tone="ghost" onClick={onReject} title="Dismiss this question">
             Dismiss
-          </button>
+          </Button>
         </>
       }
     />

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -69,6 +69,7 @@ import { useModelCatalog } from "./modelCatalog";
 import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
 import { CompactionCard, PermissionCard, RetryCard } from "./Cards";
+import { Button } from "./Button";
 import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
 import { CardMount } from "./components/CardMount";
 import { useSessionResources } from "./hooks/useSessionResources";
@@ -1898,13 +1899,9 @@ export function ChatPanel({
           </pre>
           {transcriptLoadError && (
             <div className="mt-4 flex justify-center">
-              <button
-                type="button"
-                onClick={retryTranscriptLoad}
-                className="rounded-md border border-border px-4 py-2 text-body text-text hover:bg-bg-soft"
-              >
+              <Button type="button" tone="default" onClick={retryTranscriptLoad}>
                 Retry
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -345,9 +345,11 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
                     className="relative w-full bg-transparent border-0 px-3 py-2 text-meta rounded-xs focus:outline-none font-mono"
                   />
                 </div>
-                <Button tone="default" onClick={goNavigate}>
-                  Go
-                </Button>
+                <div className="shrink-0">
+                  <Button tone="default" onClick={goNavigate}>
+                    Go
+                  </Button>
+                </div>
               </div>
 
               {/* Breadcrumbs — home icon + inter-crumb chevrons, current crumb

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -269,26 +269,20 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
               ))}
             </ul>
             <div className="flex gap-2">
-              <button
-                onClick={() => onSelect(fanOut.cwd)}
-                className="text-meta px-3 py-2 border border-border text-text-muted hover:text-text rounded-xs"
-              >
+              <Button tone="default" onClick={() => onSelect(fanOut.cwd)}>
                 Just this folder
-              </button>
+              </Button>
               {onFanOut && (
-                <button
+                <Button
+                  tone="primary"
                   onClick={() => onFanOut(fanOut.cwd, fanOut.worktrees)}
-                  className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90"
                 >
                   One per worktree
-                </button>
+                </Button>
               )}
-              <button
-                onClick={() => setFanOut(null)}
-                className="text-meta px-3 py-2 text-text-faint hover:text-text"
-              >
+              <Button tone="ghost" onClick={() => setFanOut(null)}>
                 Back
-              </button>
+              </Button>
             </div>
           </div>
         ) : (
@@ -351,13 +345,9 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
                     className="relative w-full bg-transparent border-0 px-3 py-2 text-meta rounded-xs focus:outline-none font-mono"
                   />
                 </div>
-                <button
-                  onClick={goNavigate}
-                  type="button"
-                  className="shrink-0 px-4 text-meta border border-border rounded-xs bg-bg-soft text-text hover:bg-bg-soft"
-                >
+                <Button tone="default" onClick={goNavigate}>
                   Go
-                </button>
+                </Button>
               </div>
 
               {/* Breadcrumbs — home icon + inter-crumb chevrons, current crumb

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -401,7 +401,7 @@ export function InputArea({
             "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
             "disabled:cursor-default " +
             (running || input.trim()
-              ? "bg-accent text-on-accent hover:opacity-90"
+              ? "bg-accent text-on-accent hover:brightness-110"
               : "bg-fill text-text-faint")
           }
         >

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -401,7 +401,7 @@ export function InputArea({
             "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
             "disabled:cursor-default " +
             (running || input.trim()
-              ? "bg-accent text-on-accent"
+              ? "bg-accent text-on-accent hover:bg-accent/90"
               : "bg-fill text-text-faint")
           }
         >

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -401,7 +401,7 @@ export function InputArea({
             "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
             "disabled:cursor-default " +
             (running || input.trim()
-              ? "bg-accent text-on-accent hover:brightness-110"
+              ? "bg-accent text-on-accent"
               : "bg-fill text-text-faint")
           }
         >

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -612,13 +612,13 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               >
                 {sending ? "Creating…" : "Create"}
               </Button>
-              <button
+              <Button
+                tone="ghost"
                 onClick={() => setFanOutWorktrees(null)}
                 disabled={sending}
-                className="text-meta px-3 py-2 text-text-faint hover:text-text"
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </div>
         </Modal>

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -40,6 +40,7 @@ import { ModelPicker } from "./ModelPicker";
 import { MicButton } from "./ComposerParts";
 import { IconButton } from "./IconButton";
 import { Modal } from "./Modal";
+import { Button } from "./Button";
 import { Card } from "./Card";
 import { Checkbox } from "./Checkbox";
 import { FolderPickerModal } from "./FolderPickerModal";
@@ -604,13 +605,13 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               ))}
             </ul>
             <div className="flex gap-2">
-              <button
+              <Button
+                tone="primary"
                 onClick={() => void submitFanOut(draft.cwd, fanOutWorktrees ?? [])}
                 disabled={sending}
-                className="text-meta px-3 py-2 bg-accent-solid text-on-accent rounded-xs hover:opacity-90 disabled:opacity-50"
               >
                 {sending ? "Creating…" : "Create"}
-              </button>
+              </Button>
               <button
                 onClick={() => setFanOutWorktrees(null)}
                 disabled={sending}

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -55,6 +55,7 @@ import {
 import { installHttpTransport } from "./transportInstall";
 import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { ArrowRight, CheckIcon } from "./onboardingUi";
+import { Button } from "./Button";
 import { ProcessPanel } from "./ProcessPanel";
 import { Callout } from "./Callout";
 import mantaMark from "./assets/manta-mark-128.png";
@@ -408,14 +409,10 @@ function SuccessPanel({ onOpen }: { onOpen: () => void }) {
         Your box is paired and a provider is connected. Start chatting with
         your AI assistant.
       </p>
-      <button
-        onClick={onOpen}
-        className="inline-flex items-center gap-2 px-6 py-3 rounded-sm text-body font-medium text-on-accent"
-        style={{ background: ACCENT_SOLID }}
-      >
+      <Button tone="primary" block onClick={onOpen}>
         Open Manta
         <ArrowRight />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/renderer/ReconnectingBanner.tsx
+++ b/src/renderer/ReconnectingBanner.tsx
@@ -24,6 +24,7 @@
 // whenever the controller transitions.
 
 import { describe as describeConnection, type ConnectionState } from "../shared/net/state.js";
+import { BANNER_BTN } from "./Toast";
 
 export type ReconnectingBannerProps = {
   /** Live connection state from the store. */
@@ -55,7 +56,7 @@ export function ReconnectingBanner({ state, onRetryNow }: ReconnectingBannerProp
       </span>
       <button
         onClick={onRetryNow}
-        className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium"
+        className={BANNER_BTN}
         title="Reset backoff and reconnect immediately"
       >
         Retry now

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -754,7 +754,7 @@ export function Settings({
               <div className="flex-1">
                 <Field placeholder="https://example.com/skills" value={newRegistryUrl} onChange={(e) => setNewRegistryUrl(e.target.value)} onKeyDown={(e) => e.key === "Enter" && onAddRegistry()} />
               </div>
-              <button onClick={onAddRegistry} disabled={!newRegistryUrl.trim()} className="px-4 py-2 text-body bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-not-allowed">Add</button>
+              <Button onClick={onAddRegistry} disabled={!newRegistryUrl.trim()} tone="default">Add</Button>
             </div>
           </GroupCard>
           {availableLaunchers.some((l) => l.flags.length > 0) && (
@@ -885,7 +885,7 @@ export function Settings({
               <Button onClick={() => void performRestart()} disabled={restarting} tone="default">
                 {restarting ? "Restarting…" : "Restart opencode"}
               </Button>
-              <button onClick={() => setRestartNeeded(false)} disabled={restarting} className="shrink-0 px-2 py-2 text-body text-text-muted hover:text-text disabled:opacity-40">Later</button>
+              <Button onClick={() => setRestartNeeded(false)} disabled={restarting} tone="ghost">Later</Button>
             </div>
           )}
           {restartError && <div role="alert" className="mb-4 text-body text-danger">{restartError}</div>}
@@ -925,7 +925,7 @@ export function Settings({
             <h3 className="text-title font-semibold">Remove this box?</h3>
             <div className="text-body text-text-faint">The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts.</div>
             <div className="flex justify-end gap-2">
-              <button onClick={() => setConfirmRemove(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
+              <Button onClick={() => setConfirmRemove(false)} tone="ghost">Cancel</Button>
               <Button onClick={removeBox} tone="danger">Remove</Button>
             </div>
           </div>
@@ -937,7 +937,7 @@ export function Settings({
             <h3 className="text-title font-semibold">Reset all settings?</h3>
             <div className="text-body text-text-faint">Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.</div>
             <div className="flex justify-end gap-2">
-              <button onClick={() => setConfirmReset(false)} className="px-4 py-2 text-body text-text-muted hover:text-text">Cancel</button>
+              <Button onClick={() => setConfirmReset(false)} tone="ghost">Cancel</Button>
               <Button onClick={resetAll} tone="danger">Reset</Button>
             </div>
           </div>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -29,6 +29,7 @@ import { Field } from "./Field";
 import { Button } from "./Button";
 import { Eyebrow } from "./Eyebrow";
 import { useSettingsToasts, useApplySetting, ToastStack } from "./settingsApply";
+import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import {
   useLaunchers,
@@ -595,7 +596,7 @@ export function Settings({
             {store.updatePrompt && (
               <div className="rounded-md border border-accent/30 bg-accent/10 px-3 py-2 flex items-center gap-2">
                 <span className="flex-1 text-meta text-text">Update ready: <span className="font-medium">{store.updatePrompt.releaseName || store.updatePrompt.version}</span></span>
-                <button onClick={() => { void window.api.autoUpdateInstall(); }} className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium">Restart to update</button>
+                <button onClick={() => { void window.api.autoUpdateInstall(); }} className={BANNER_BTN}>Restart to update</button>
               </div>
             )}
           </GroupCard>

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1407,7 +1407,7 @@ function ConfirmDelete({
             e.stopPropagation();
             onKill();
           }}
-          className="text-meta px-2 py-px rounded-xs bg-danger-bg text-danger hover:bg-danger-bg"
+          className="text-meta px-2 py-px rounded-xs bg-transparent text-danger hover:bg-danger-bg focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
           title="kill the tmux session/window on the remote"
         >
           Kill on server
@@ -1448,7 +1448,7 @@ function ConfirmWorktreeDirty({
             e.stopPropagation();
             onRemove();
           }}
-          className="text-meta px-2 py-px rounded-xs bg-danger-bg text-danger hover:bg-danger-bg"
+          className="text-meta px-2 py-px rounded-xs bg-transparent text-danger hover:bg-danger-bg focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
           title="git worktree remove --force (discards uncommitted changes)"
         >
           Remove

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -66,6 +66,15 @@ export type ToastProps = {
   onDismiss: (id: string) => void;
 };
 
+// Shared compact banner action pill (Toast / UpdateBar / ReconnectingBanner).
+// Intentionally SMALLER than the 32px Button primitive — the three banner bars
+// render a slim text pill inside an ~24px-high strip, so they stay hand-rolled
+// (BET-727 §7). One source of truth for the three copies that used to drift
+// (ReconnectingBanner was missing the focus ring). Carries the standard
+// focus-visible ring.
+export const BANNER_BTN =
+  "shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+
 export function Toast({ toast, onDismiss }: ToastProps) {
   const ttl = toastTtl(toast);
   useEffect(() => {
@@ -86,7 +95,7 @@ export function Toast({ toast, onDismiss }: ToastProps) {
         <button
           onClick={toast.action.onClick}
           disabled={toast.action.disabled}
-          className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+          className={BANNER_BTN}
         >
           {toast.action.label}
         </button>

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -27,6 +27,7 @@ import { MantaLoader } from "./MantaLoader";
 import { CardMount } from "./components/CardMount";
 import { WORKING_TICK_MS, nowMs, useClockTick } from "./clock";
 import { QuestionCard } from "./Cards";
+import { Button } from "./Button";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import type { OpencodeMessage, QuestionRequest } from "../shared/types";
@@ -138,14 +139,14 @@ export function LoadEarlierHeader({
   if (!showLoadEarlier) return null;
   return (
     <div className="flex justify-center py-3">
-      <button
+      <Button
         type="button"
+        tone="default"
         onClick={onLoadEarlier}
         disabled={loadingEarlier}
-        className="rounded-full border border-border px-4 py-2 text-meta text-text-muted hover:bg-bg-soft disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loadingEarlier ? "Loading…" : "Load earlier messages"}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -23,6 +23,7 @@
 
 import type { ReactNode } from "react";
 import { X } from "lucide-react";
+import { BANNER_BTN } from "./Toast";
 
 export type UpdateBarProps = {
   /** Main message text. Keep it under ~80 chars so it fits the titlebar width. */
@@ -113,7 +114,7 @@ export function UpdateBar({
             onClick={() => {
               onAction();
             }}
-            className="shrink-0 rounded-xs bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+            className={BANNER_BTN}
           >
             {actionLabel}
           </button>


### PR DESCRIPTION
Adopts the Button primitive (src/renderer/Button.tsx) at every hand-rolled button straggler and kills the hover no-ops / legacy hover idiom, per issue BET-727.

**Base: origin/main @ `f174cf5c`**

## Migration list (one commit each)
1. Cards.tsx — PermissionCard/QuestionCard action rows → `tone` ladder (primary / default / danger / ghost).
2. Settings.tsx — Add → default; restart "Later" + Remove/Reset modals' Cancel → ghost. **`Settings.tsx:872` (settings-header close) stays hand-rolled — recorded decision, see Cycle-2 reply: it is an icon-only `<X>` whose accessible name comes from `aria-label`, and the `Button` primitive exposes no `aria-*` prop (and adding one is forbidden), so migrating it would drop the accessible name.**
3. App.tsx — update-confirm Cancel → ghost.
4. FolderPickerModal.tsx — fan-out trio (default/primary/ghost) + Go → default (fixed `hover:bg-bg-soft` no-op). Go keeps `shrink-0` via a wrapper container (the primitive has no className escape hatch).
5. Onboarding.tsx — success CTA → `<Button tone="primary" block>`.
6. ChatPanel Retry + Transcript "Load earlier" → default.
7. Banner pills (Toast/UpdateBar/ReconnectingBanner) → shared `BANNER_BTN` exported from Toast.tsx (added the missing focus ring to ReconnectingBanner); **the 4th surviving copy in Settings.tsx is folded into the same import.**
8. Sidebar destructive inline buttons (Kill on server, Remove) → minimal fix (real `hover:bg-danger-bg` + focus ring); compact text-meta pills left hand-rolled rather than bloated to the 32px primitive.

Cycle-2 (review) extras: NewSessionScreen fan-out row fully migrated (Create → `primary`, Cancel → `ghost`); the composer send button keeps a real, non-Button-owned hover (`hover:bg-accent/90`, the banner-pill background-step idiom — not in the BET-588 allowlist) so hover feedback is preserved on the icon-only 28px control.

## Tone mapping (§D9)
primary = primary action · default = secondary · ghost = text-only Cancel/dismiss · danger = destructive.

## Verification results
- PR branch (`multica/BET-727-button-adoption` @ `8678fef1`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, vitest `2313` pass / `7` skip / `0` fail; node:test `1608` pass / `0` fail. log sha256: `f41d49310ae421b9ccd197b01021d8f5bbcfee4a0b861baf46bcf997ab397919`
- Base (`main` @ `f174cf5c`): both suites green on the PR branch with no pre-existing failures.
- Grep deltas (all 0 outside `Button.tsx`): `hover:opacity-90` 3→0; `hover:brightness-110` 0→0; `h-8 px-[14px]` 4→0.