### PR TITLE
feat(ios): queue a mid-turn send, drain on idle — stop the implicit abort (BET-717)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -690,6 +690,15 @@ private struct ChatScreenContent: View {
             if let trunc = store.truncation, !store.running {
                 ChatNoticeRow(text: trunc.label ?? "Response truncated", color: tokens.warn, tokens: tokens)
             }
+            if !store.queuedPrompts.isEmpty {
+                ChatNoticeRow(
+                    text: store.queuedPrompts.count == 1
+                        ? "1 message queued — sends when this turn finishes"
+                        : "\(store.queuedPrompts.count) messages queued — send when this turn finishes",
+                    color: tokens.tx2,
+                    tokens: tokens
+                )
+            }
             if let todos = store.todos, !(todos.visible?.visible ?? todos.active ?? []).isEmpty {
                 TodosCard(payload: todos, tokens: tokens)
             }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -135,6 +135,14 @@ enum ChatStreamDelta {
     }
 }
 
+/// A prompt accepted while a turn was running, held until the session goes
+/// idle. Carries everything `send()` needs so the drain replays it verbatim.
+struct QueuedPrompt: Equatable {
+    let text: String
+    let attachments: [SendPromptInput.Attachment]
+    let model: SendPromptInput.Model?
+}
+
 @MainActor
 final class ChatSessionStore: ObservableObject {
 
@@ -161,6 +169,10 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var permissions: [PermissionRequest] = []
     @Published private(set) var subagents: [StreamSubagentPayload] = []
     @Published private(set) var childStores: [String: ChatSessionStore] = [:]
+    /// Prompts accepted mid-turn, FIFO. Drained one per idle edge — never
+    /// POSTed while `running`, which is what used to implicitly abort the
+    /// in-flight turn.
+    @Published private(set) var queuedPrompts: [QueuedPrompt] = []
     @Published private(set) var loading = false
     @Published private(set) var loadFailed = false
     /// True while the box was connected and the stream dropped (mirrors
@@ -309,6 +321,8 @@ final class ChatSessionStore: ObservableObject {
         // child-store eviction — the transcript-capped half runs per rebuild.
         eventStore.unregisterSession(sessionId)
         childStores.removeAll()
+        // A queued prompt must never fire into a session the user has left.
+        queuedPrompts.removeAll()
     }
 
     func load() {
@@ -452,6 +466,12 @@ final class ChatSessionStore: ObservableObject {
         } else {
             runningSince = nil
         }
+
+        // The session just went idle (stream fold set `running = false`): any
+        // queued prompt may now be sent. Guard-based, so firing on whichever
+        // path folded running down is harmless — a second call is a no-op while
+        // running (the drain's send sets it optimistically) or an empty queue.
+        drainQueuedPromptIfIdle()
 
         // Register a store for any subagent that has a child session id, so the
         // drill-in destination can resolve it without mutating state during a
@@ -730,6 +750,12 @@ final class ChatSessionStore: ObservableObject {
     /// can restore the user's typed text.
     @discardableResult
     func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?) async -> Bool {
+        // A send while the turn runs must not reach opencode — it would abort
+        // the in-flight turn implicitly. Queue it; the idle edge drains FIFO.
+        if running {
+            queuedPrompts.append(QueuedPrompt(text: text, attachments: attachments, model: model))
+            return true
+        }
         // Echo the message straight into the transcript and assume the turn is
         // running. The box confirms both within a second (running frame, then
         // the canonical refetch replaces this block), but without the echo the
@@ -785,6 +811,23 @@ final class ChatSessionStore: ObservableObject {
                 rebuildBlocks()
             }
             return false
+        }
+    }
+
+    /// Drain ONE queued prompt now that the session is idle. One per edge: the
+    /// send() below sets `running = true` optimistically, so a second queued
+    /// item waits for the next idle. Strict FIFO.
+    private func drainQueuedPromptIfIdle() {
+        guard !running, !queuedPrompts.isEmpty else { return }
+        let next = queuedPrompts.removeFirst()
+        Task { @MainActor in
+            let ok = await send(text: next.text, attachments: next.attachments, model: next.model)
+            if !ok {
+                // The send failed after the box accepted going idle — don't lose
+                // the prompt silently. Put it back at the FRONT and tell the user.
+                queuedPrompts.insert(next, at: 0)
+                actionHint = "Queued message failed to send — will retry on next turn"
+            }
         }
     }
 

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -209,13 +209,13 @@ struct QuestionRequest: Codable, Equatable, Sendable {
 }
 
 struct SendPromptInput: Sendable {
-    struct Model: Sendable {
+    struct Model: Sendable, Equatable {
         var providerID: String
         var modelID: String
         var variant: String?
     }
 
-    struct Attachment: Sendable {
+    struct Attachment: Sendable, Equatable {
         var remotePath: String
         var mime: String
         var filename: String?

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -310,7 +310,140 @@ final class ChatStreamMergeTests: XCTestCase {
                        "start() twice must not double-fetch the transcript")
     }
 
+    // MARK: - Mid-turn send queue / drain-on-idle (BET-717)
+
+    /// A send while a turn runs must NOT reach opencode (that would implicitly
+    /// abort the in-flight turn). It is accepted and queued, and no prompt is
+    /// POSTed.
+    func testSendWhileRunningQueuesWithoutPosting() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.recordingSession())
+        )
+        await Task.yield()
+
+        // A turn is in flight.
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        XCTAssertTrue(store.running)
+
+        let ok = await store.send(text: "queued", attachments: [], model: nil)
+        XCTAssertTrue(ok, "a mid-turn send is accepted (queued), not rejected")
+        XCTAssertEqual(store.queuedPrompts.count, 1, "the send must be queued")
+        XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, [],
+                       "no prompt may be POSTed while a turn runs")
+    }
+
+    /// The stream fold (`running` flips false on the turnComplete edge) drains
+    /// exactly one queued prompt: queue empties, the prompt is POSTed once, and
+    /// the drain's own send sets running optimistically.
+    func testQueuedPromptSendsOnceOnIdleEdge() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.recordingSession())
+        )
+        await Task.yield()
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        _ = await store.send(text: "q1", attachments: [], model: nil)
+        XCTAssertEqual(store.queuedPrompts.count, 1)
+        XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, [])
+
+        // Turn finishes → idle edge drains exactly one.
+        stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
+        await waitUntil { RecordingPromptURLProtocol.sentTexts == ["q1"] }
+
+        XCTAssertEqual(store.queuedPrompts.count, 0, "the queue must empty after the idle drain")
+        XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, ["q1"],
+                       "the queued prompt must be sent exactly once on idle")
+        XCTAssertTrue(store.running, "the drained send sets running optimistically")
+    }
+
+    /// Two queued prompts drain strictly FIFO: the first idle edge sends only
+    /// the first; the second idle edge sends the second.
+    func testTwoQueuedPromptsDrainFIFOOnePerIdleEdge() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.recordingSession())
+        )
+        await Task.yield()
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        _ = await store.send(text: "q1", attachments: [], model: nil)
+        _ = await store.send(text: "q2", attachments: [], model: nil)
+        XCTAssertEqual(store.queuedPrompts.count, 2)
+
+        // First idle edge → only q1.
+        stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
+        await waitUntil { RecordingPromptURLProtocol.sentTexts == ["q1"] }
+        XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, ["q1"],
+                       "the first idle edge must send only the FIRST queued prompt")
+        XCTAssertEqual(store.queuedPrompts.count, 1)
+
+        // Drain's send is running; box confirms, then that turn finishes →
+        // second drains.
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
+        await waitUntil { RecordingPromptURLProtocol.sentTexts == ["q1", "q2"] }
+        XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, ["q1", "q2"],
+                       "the second idle edge must send the second queued prompt (FIFO)")
+        XCTAssertEqual(store.queuedPrompts.count, 0)
+    }
+
+    /// Leaving the session (stop) clears the queue so a queued prompt never
+    /// fires into a session the user has left.
+    func testStopClearsQueuedPrompts() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.recordingSession())
+        )
+        await Task.yield()
+        stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
+        await Task.yield()
+        _ = await store.send(text: "q1", attachments: [], model: nil)
+        XCTAssertEqual(store.queuedPrompts.count, 1)
+
+        store.stop()
+        XCTAssertEqual(store.queuedPrompts.count, 0,
+                       "leaving the session must clear the queue")
+    }
+
     // MARK: - Mock transport
+
+    /// Poll the main actor until `condition` holds (or ~2s elapses). The drain
+    /// send is fire-and-forget inside the store, so a test cannot await it
+    /// directly; `Task.sleep` (unlike `Task.yield`) lets the URLSession
+    /// delegate queue finish and resume the drain's continuation.
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool,
+        timeout: TimeInterval = 2.0
+    ) async {
+        let start = Date()
+        while Date().timeIntervalSince(start) < timeout {
+            if await MainActor.run(body: condition) { return }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+
+    private static func recordingSession() -> URLSession {
+        RecordingPromptURLProtocol.sentTexts = []
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RecordingPromptURLProtocol.self]
+        return URLSession(configuration: config)
+    }
 
     private static func failingSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
@@ -349,6 +482,53 @@ private final class SucceedingURLProtocol: URLProtocol {
         client?.urlProtocolDidFinishLoading(self)
     }
     override func stopLoading() {}
+}
+
+/// URLSession protocol that succeeds like `SucceedingURLProtocol` but records
+/// the `text` of every prompt body it serves, so a test can assert a send()
+/// actually reached the box — or, while running, that it did NOT. Only
+/// `opencode:prompt` carries a top-level `text` arg; transcript/misc RPCs
+/// don't, so the ledger never counts those.
+private final class RecordingPromptURLProtocol: URLProtocol {
+    // Test-only ledger. Writes happen from the URLSession delegate queue inside
+    // startLoading, reads from the @MainActor test; the awaits around each read
+    // make the append visible. `nonisolated(unsafe)` because these are a test
+    // seam, not real shared state.
+    nonisolated(unsafe) fileprivate(set) static var sentTexts: [String] = []
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        if let body = Self.bodyData(of: request),
+           let obj = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+           let args = obj["args"] as? [Any],
+           let first = args.first as? [String: Any],
+           let text = first["text"] as? String {
+            Self.sentTexts.append(text)
+        }
+        let data = Data(#"{"result":{}}"#.utf8)
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+
+    /// URLSession moves an outgoing body from `httpBody` to `httpBodyStream`
+    /// before a URLProtocol sees the request, so read whichever carries it.
+    private static func bodyData(of request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
 }
 
 /// A stream control that never connects but can inject frames into the store,


### PR DESCRIPTION
Opened automatically for `multica/BET-717-send-queue`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-717.