### PR TITLE
feat(renderer+server): usage escalation toasts + reset actions (BET-739)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -354,7 +354,7 @@ function AppInner() {
     fireAt: number;
     sessionID: string;
   } | null>(null);
-  const cacheTtl = useStore((s) => s.config?.cacheTtl);
+  const cacheTtl = useStore((s) => s.cacheTtl);
 
   useEffect(() => {
     // Bootstrap (BET-678). The first paint is INSTANT — read from the persisted

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -27,6 +27,7 @@ import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { Modal } from "./Modal";
 import { Button } from "./Button";
+import { Callout } from "./Callout";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
 import { parsePairPayload } from "../shared/pairPayload";
@@ -628,6 +629,9 @@ function AppInner() {
           const fireAt = fireAtFor(resetsAt);
           const sessionID = activeChatRef.current;
           const toastId = `usage-limit-${alert.key}-${Date.now()}`;
+          // Actions are hidden when the window has no resetsAt (can't compute a
+          // fireAt) OR when no chat session is active (a job needs a sessionID).
+          // The toast still shows its message either way.
           const hasActions = fireAt != null && sessionID != null;
           pushAppToastStore({
             id: toastId,
@@ -698,7 +702,8 @@ function AppInner() {
     return off;
   }, [apiGeneration, scheduleAtReset, pushAppToastStore, dismissAppToastStore]);
 
-  // Screenshot detection — subscribe ONCE at the app level. Every ChatPanel  // used to register its own listener, so a single detection fanned out into
+  // Screenshot detection — subscribe ONCE at the app level. Every ChatPanel
+  // used to register its own listener, so a single detection fanned out into
   // N toasts (one per mounted chat). Now the toast lives in the store, the
   // active ChatPanel renders it, and accept/dismiss clear it globally.
   // Routes through the typed preload accessor so it no-ops on mobile/web.
@@ -1697,21 +1702,18 @@ function AppInner() {
               session on your behalf and the agent will resume unattended. You can cancel it any
               time from ⏰ scheduled tasks.
             </div>
-            {shouldWarnStaleCache(keepGoing.fireAt, Date.now(), cacheTtl ?? "1h") && (
-              <div className="rounded-xs border border-warn/40 bg-warn/10 px-3 py-2 text-meta text-warn">
+            {shouldWarnStaleCache(keepGoing.fireAt, Date.now(), cacheTtl) && (
+              <Callout tone="warn">
                 The reset is {describeResetDistance(keepGoing.fireAt - Date.now())} away — well past
                 your {cacheTtl === "5m" ? "5 minute" : "1 hour"} prompt-cache window. The whole
                 conversation will be re-sent and re-billed as fresh input, which costs significantly
                 more than a reply now.
-              </div>
+              </Callout>
             )}
             <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setKeepGoing(null)}
-                className="px-4 py-2 text-body text-text-muted hover:text-text"
-              >
+              <Button tone="ghost" onClick={() => setKeepGoing(null)}>
                 Cancel
-              </button>
+              </Button>
               <Button tone="primary" onClick={() => void confirmKeepGoing()}>
                 Schedule it
               </Button>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -34,6 +34,18 @@ import { channelConfig } from "../shared/channel.mjs";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { MantaLoader } from "./MantaLoader";
 import type { AvailableLauncher } from "../shared/types";
+import {
+  buildLimitMessage,
+  buildUsageLevels,
+  buildWarnMessage,
+  describeResetDistance,
+  formatResetClock,
+  shouldFireUsageAlert,
+  shouldWarnStaleCache,
+  type UsageAlertLevel,
+} from "./usageEscalation";
+import { cronForInstant } from "../shared/scheduleCron.mjs";
+import { providerLabel } from "./UsageDial";
 
 // BET-373 (channel-aware wire format): the deep-link URL the OS hands this
 // app is, by construction, addressed to THIS channel's URL scheme
@@ -332,6 +344,18 @@ function AppInner() {
   const activeChatRef = useRef(activeChatSessionId);
   activeChatRef.current = activeChatSessionId;
 
+  // ---- Subscription usage escalation (BET-739) ----
+  // Fire-once level map (per `provider:window.kind`); see usageEscalation.ts.
+  const usageLevelsRef = useRef<Record<string, UsageAlertLevel>>({});
+  // "Keep going at reset" confirm-modal payload. null = closed.
+  const [keepGoing, setKeepGoing] = useState<{
+    providerLabel: string;
+    windowLabel: string;
+    fireAt: number;
+    sessionID: string;
+  } | null>(null);
+  const cacheTtl = useStore((s) => s.config?.cacheTtl);
+
   useEffect(() => {
     // Bootstrap (BET-678). The first paint is INSTANT — read from the persisted
     // local snapshot restored in main.tsx (zero round trips). This effect only
@@ -520,8 +544,157 @@ function AppInner() {
     };
   }, [apiGeneration]);
 
-  // Screenshot detection — subscribe ONCE at the app level. Every ChatPanel
-  // used to register its own listener, so a single detection fanned out into
+  // ---- Subscription usage escalation (BET-739) ----
+  // The warn (>=90%) / limit (>=100%) toasts, pushed through the existing
+  // global host via pushAppToast. Consumes the SAME `usage.updated` bus event
+  // as the store-priming effect above — this must work no matter which pane is
+  // in front, which is why it lives here at App (same BET-723 reasoning as the
+  // toast host). All transition logic is pure; the fire-once level map lives
+  // in usageLevelsRef (re-armed by writing back the new levels, so a window
+  // that resets and later crosses up again fires once more).
+  const pushAppToastStore = useStore((s) => s.pushAppToast);
+  const dismissAppToastStore = useStore((s) => s.dismissAppToast);
+
+  const fireAtFor = (resetsAt: number | undefined): number | null =>
+    resetsAt != null ? resetsAt + 60_000 : null;
+
+  // A one-shot job at `fireAt` via the existing scheduler store (window.api
+  // schedule path). Same store/poller/⏰ card as the AI `schedule` tool.
+  const scheduleAtReset = useCallback(
+    async (input: {
+      kind: "prompt" | "notify";
+      prompt: string;
+      label: string;
+      fireAt: number;
+      sessionID: string;
+    }) => {
+      return window.api.scheduleCreate({
+        cron: cronForInstant(new Date(input.fireAt)),
+        prompt: input.prompt,
+        recurring: false,
+        label: input.label,
+        sessionID: input.sessionID,
+        kind: input.kind,
+      });
+    },
+    [],
+  );
+
+  const confirmKeepGoing = useCallback(async () => {
+    if (!keepGoing) return;
+    const { fireAt, sessionID, providerLabel: pLabel, windowLabel } = keepGoing;
+    const res = await scheduleAtReset({
+      kind: "prompt",
+      prompt: "Keep going",
+      label: `Keep going: ${pLabel} ${windowLabel} reset`,
+      fireAt,
+      sessionID,
+    });
+    setKeepGoing(null);
+    pushAppToastStore(
+      res.ok && res.job
+        ? {
+            message: `⏰ “Keep going” will be sent ${formatResetClock(fireAt, true)}.`,
+            actions: [
+              {
+                label: "Undo",
+                onClick: () => {
+                  if (res.job?.id) void window.api.scheduleDelete(res.job.id);
+                },
+              },
+            ],
+          }
+        : {
+            tone: "error",
+            message: `Couldn't schedule “Keep going”: ${res.error ?? "unknown error"}`,
+          },
+    );
+  }, [keepGoing, scheduleAtReset, pushAppToastStore]);
+
+  useEffect(() => {
+    if (!window.api.onUsageUpdated) return;
+    const off = window.api.onUsageUpdated(({ snapshots }) => {
+      const next = Array.isArray(snapshots) ? snapshots : [];
+      const fired = shouldFireUsageAlert(usageLevelsRef.current, next);
+      for (const alert of fired) {
+        const label = providerLabel(alert.provider);
+        const windowLabel = alert.window.label;
+        const resetsAt = alert.window.resetsAt;
+        if (alert.level === "limit") {
+          const fireAt = fireAtFor(resetsAt);
+          const sessionID = activeChatRef.current;
+          const toastId = `usage-limit-${alert.key}-${Date.now()}`;
+          const hasActions = fireAt != null && sessionID != null;
+          pushAppToastStore({
+            id: toastId,
+            tone: "error",
+            message: buildLimitMessage(label, windowLabel, resetsAt),
+            actions: hasActions
+              ? [
+                  {
+                    label: "Remind me at reset",
+                    onClick: () => {
+                      if (fireAt == null || !sessionID) return;
+                      dismissAppToastStore(toastId);
+                      void (async () => {
+                        const res = await scheduleAtReset({
+                          kind: "notify",
+                          prompt: `${label} ${windowLabel} has reset — you can keep working.`,
+                          label: `Reminder: ${label} ${windowLabel} reset`,
+                          fireAt,
+                          sessionID,
+                        });
+                        if (res.ok && res.job) {
+                          const jobId = res.job.id;
+                          pushAppToastStore({
+                            message: `⏰ Reminder set for ${formatResetClock(fireAt, true)}.`,
+                            actions: [
+                              {
+                                label: "Undo",
+                                onClick: () => {
+                                  if (jobId) void window.api.scheduleDelete(jobId);
+                                },
+                              },
+                            ],
+                          });
+                        } else {
+                          pushAppToastStore({
+                            tone: "error",
+                            message: `Couldn't set a reminder: ${res.error ?? "unknown error"}`,
+                          });
+                        }
+                      })();
+                    },
+                  },
+                  {
+                    label: "Keep going at reset",
+                    onClick: () => {
+                      if (fireAt == null || !sessionID) return;
+                      setKeepGoing({
+                        providerLabel: label,
+                        windowLabel,
+                        fireAt,
+                        sessionID,
+                      });
+                    },
+                  },
+                ]
+              : undefined,
+          });
+        } else {
+          pushAppToastStore({
+            message: buildWarnMessage(label, windowLabel, alert.window.pct, resetsAt),
+          });
+        }
+      }
+      // Write back the CURRENT levels so a holding level doesn't re-fire and a
+      // drop (after reset) re-arms the key for the next crossing.
+      usageLevelsRef.current = buildUsageLevels(next);
+    });
+    return off;
+  }, [apiGeneration, scheduleAtReset, pushAppToastStore, dismissAppToastStore]);
+
+  // Screenshot detection — subscribe ONCE at the app level. Every ChatPanel  // used to register its own listener, so a single detection fanned out into
   // N toasts (one per mounted chat). Now the toast lives in the store, the
   // active ChatPanel renders it, and accept/dismiss clear it globally.
   // Routes through the typed preload accessor so it no-ops on mobile/web.
@@ -1503,6 +1676,45 @@ function AppInner() {
             </div>
           </div>
         </Modal>
+
+      {/* Keep going at reset — BET-739 usage escalation confirm. Rendered at
+          App level (like the toasts) so it works over any pane. */}
+      {keepGoing && (
+        <Modal
+          open
+          size="sm"
+          label="Send an automatic message at reset?"
+          onDismiss={() => setKeepGoing(null)}
+        >
+          <div className="space-y-4">
+            <h3 className="text-title font-semibold">Send an automatic message at reset?</h3>
+            <div className="text-body text-text-faint">
+              At {formatResetClock(keepGoing.fireAt, true)} MantaUI will send “Keep going” to this
+              session on your behalf and the agent will resume unattended. You can cancel it any
+              time from ⏰ scheduled tasks.
+            </div>
+            {shouldWarnStaleCache(keepGoing.fireAt, Date.now(), cacheTtl ?? "1h") && (
+              <div className="rounded-xs border border-warn/40 bg-warn/10 px-3 py-2 text-meta text-warn">
+                The reset is {describeResetDistance(keepGoing.fireAt - Date.now())} away — well past
+                your {cacheTtl === "5m" ? "5 minute" : "1 hour"} prompt-cache window. The whole
+                conversation will be re-sent and re-billed as fresh input, which costs significantly
+                more than a reply now.
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setKeepGoing(null)}
+                className="px-4 py-2 text-body text-text-muted hover:text-text"
+              >
+                Cancel
+              </button>
+              <Button tone="primary" onClick={() => void confirmKeepGoing()}>
+                Schedule it
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -568,14 +568,18 @@ function AppInner() {
       fireAt: number;
       sessionID: string;
     }) => {
-      return window.api.scheduleCreate({
-        cron: cronForInstant(new Date(input.fireAt)),
-        prompt: input.prompt,
-        recurring: false,
-        label: input.label,
-        sessionID: input.sessionID,
-        kind: input.kind,
-      });
+      try {
+        return await window.api.scheduleCreate({
+          cron: cronForInstant(new Date(input.fireAt)),
+          prompt: input.prompt,
+          recurring: false,
+          label: input.label,
+          sessionID: input.sessionID,
+          kind: input.kind,
+        });
+      } catch (err) {
+        return { ok: false as const, error: String((err as Error)?.message ?? err) };
+      }
     },
     [],
   );

--- a/src/renderer/GlobalToasts.tsx
+++ b/src/renderer/GlobalToasts.tsx
@@ -130,9 +130,9 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
             screenshotToast.source === "file" && screenshotToast.path
               ? `Screenshot: ${screenshotToast.path.split("/").pop()}`
               : "Screenshot in clipboard",
-          action:
+          actions:
             canAddToChat && activeChatSessionId
-              ? { label: "Add to chat", onClick: () => void acceptScreenshot() }
+              ? [{ label: "Add to chat", onClick: () => void acceptScreenshot() }]
               : undefined,
         });
       } else if (id === "agent-file" && agentFileToast) {
@@ -148,15 +148,17 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
               </span>
             </>
           ),
-          action: agentFileToast.autoPulled
+          actions: agentFileToast.autoPulled
             ? agentFileToast.localPath
-              ? { label: "Reveal", onClick: () => void revealAgentFile() }
+              ? [{ label: "Reveal", onClick: () => void revealAgentFile() }]
               : undefined
-            : {
-                label: agentFileSaving ? "Saving…" : "Save",
-                onClick: () => void saveAgentFile(),
-                disabled: agentFileSaving,
-              },
+            : [
+                {
+                  label: agentFileSaving ? "Saving…" : "Save",
+                  onClick: () => void saveAgentFile(),
+                  disabled: agentFileSaving,
+                },
+              ],
         });
       } else if (id === "system-notice" && systemNotice) {
         items.push({

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -11,7 +11,7 @@
 // mobile with no mobile-CSS edits.
 
 import { memo, useEffect, useState } from "react";
-import { Clock, Webhook, Key, Bot, ArrowLeft, Square, X } from "lucide-react";
+import { Clock, Bell, Webhook, Key, Bot, ArrowLeft, Square, X } from "lucide-react";
 import type {
   DelegateApproval,
   DelegateApprovalTool,
@@ -69,8 +69,11 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
             return (
               <div key={j.id} className="flex items-center gap-2">
                 <div className="min-w-0 flex-1">
-                  <div className="text-text truncate" title={j.prompt}>
-                    {j.label || j.prompt}
+                  <div className="text-text truncate flex items-center gap-1.5" title={j.prompt}>
+                    {j.kind === "notify" && (
+                      <Bell size={12} aria-hidden="true" className="shrink-0 text-text-faint" />
+                    )}
+                    <span className="truncate">{j.label || j.prompt}</span>
                   </div>
                   <div className="flex items-center gap-2 text-text-faint font-mono text-label">
                     <span className="shrink-0">

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -69,7 +69,7 @@ export const ScheduledTasksCard = memo(function ScheduledTasksCard({
             return (
               <div key={j.id} className="flex items-center gap-2">
                 <div className="min-w-0 flex-1">
-                  <div className="text-text truncate flex items-center gap-1.5" title={j.prompt}>
+                  <div className="text-text truncate flex items-center gap-2" title={j.prompt}>
                     {j.kind === "notify" && (
                       <Bell size={12} aria-hidden="true" className="shrink-0 text-text-faint" />
                     )}

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -398,11 +398,10 @@ export function Settings({
       push({
         id: `registry-${Date.now()}`,
         message: next.length > prev.length ? "Registry URL added" : "Registry URL removed",
-        action: { label: "Undo", onClick: () => { void useStore.setState({ skillRegistryUrls: prev }); window.api.configUpdate({ skillRegistryUrls: prev }).catch(() => {}); } },
+        actions: [{ label: "Undo", onClick: () => { void useStore.setState({ skillRegistryUrls: prev }); window.api.configUpdate({ skillRegistryUrls: prev }).catch(() => {}); } }],
       });
     } catch (e) {
-      useStore.setState({ skillRegistryUrls: prev });
-      push({ id: `err-registry-${Date.now()}`, message: errorDisclosure("Couldn't update skill registries.", e) });
+      useStore.setState({ skillRegistryUrls: prev });      push({ id: `err-registry-${Date.now()}`, message: errorDisclosure("Couldn't update skill registries.", e) });
     }
   };
   const onAddRegistry = () => {
@@ -448,7 +447,7 @@ export function Settings({
     if (!preload?.pluginsSetEnabled) return;
     try {
       await preload.pluginsSetEnabled(on);
-      push({ id: `plugins-${Date.now()}`, message: `Plugins ${on ? "enabled" : "disabled"} — restart Manta to apply.`, action: { label: "Undo", onClick: () => { setPluginsOn(prev); void preload.pluginsSetEnabled(prev); } } });
+      push({ id: `plugins-${Date.now()}`, message: `Plugins ${on ? "enabled" : "disabled"} — restart Manta to apply.`, actions: [{ label: "Undo", onClick: () => { setPluginsOn(prev); void preload.pluginsSetEnabled(prev); } }] });
     } catch (e) {
       setPluginsOn(prev);
       push({ id: `err-plugins-${Date.now()}`, message: errorDisclosure("Couldn't toggle plugins.", e) });
@@ -507,7 +506,7 @@ export function Settings({
       push({
         id: `reset-${Date.now()}`,
         message: "All settings reset to defaults.",
-        action: { label: "Undo", onClick: () => { void useStore.setState(prev); if (prev.theme) applyTheme(prev.theme as ThemePref); window.api.configUpdate(prev).catch(() => {}); } },
+        actions: [{ label: "Undo", onClick: () => { void useStore.setState(prev); if (prev.theme) applyTheme(prev.theme as ThemePref); window.api.configUpdate(prev).catch(() => {}); } }],
       });
     } catch (e) {
       useStore.setState(prev);

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -401,7 +401,8 @@ export function Settings({
         actions: [{ label: "Undo", onClick: () => { void useStore.setState({ skillRegistryUrls: prev }); window.api.configUpdate({ skillRegistryUrls: prev }).catch(() => {}); } }],
       });
     } catch (e) {
-      useStore.setState({ skillRegistryUrls: prev });      push({ id: `err-registry-${Date.now()}`, message: errorDisclosure("Couldn't update skill registries.", e) });
+      useStore.setState({ skillRegistryUrls: prev });
+      push({ id: `err-registry-${Date.now()}`, message: errorDisclosure("Couldn't update skill registries.", e) });
     }
   };
   const onAddRegistry = () => {

--- a/src/renderer/Toast.test.ts
+++ b/src/renderer/Toast.test.ts
@@ -1,12 +1,30 @@
 import { describe, it, expect } from "vitest";
-import { toastTtl, TOAST_DEFAULT_TTL_MS, MAX_TOASTS, type ToastItem } from "./Toast";
+import {
+  toastTtl,
+  TOAST_DEFAULT_TTL_MS,
+  MAX_TOASTS,
+  MAX_TOAST_ACTIONS,
+  type ToastItem,
+} from "./Toast";
 
 const base: ToastItem = { id: "x", message: "hi" };
 
 describe("toastTtl", () => {
-  it("never auto-dismisses when an action is present", () => {
-    expect(toastTtl({ ...base, action: { label: "Undo", onClick: () => {} } })).toBeNull();
-    expect(toastTtl({ ...base, action: { label: "Save", onClick: () => {} }, ttl: 6000 })).toBeNull();
+  it("never auto-dismisses when any action is present", () => {
+    expect(toastTtl({ ...base, actions: [{ label: "Undo", onClick: () => {} }] })).toBeNull();
+    expect(
+      toastTtl({ ...base, actions: [{ label: "Remind me", onClick: () => {} }, { label: "Keep going", onClick: () => {} }] }),
+    ).toBeNull();
+  });
+
+  it("never auto-dismisses when an action is present even with an explicit ttl", () => {
+    expect(
+      toastTtl({ ...base, actions: [{ label: "Save", onClick: () => {} }], ttl: 6000 }),
+    ).toBeNull();
+  });
+
+  it("regards an empty actions array as no action (keeps default ttl)", () => {
+    expect(toastTtl({ ...base, actions: [] })).toBe(TOAST_DEFAULT_TTL_MS);
   });
 
   it("opts out entirely with ttl: null", () => {
@@ -23,8 +41,12 @@ describe("toastTtl", () => {
   });
 });
 
-describe("MAX_TOASTS", () => {
+describe("MAX_TOASTS / MAX_TOAST_ACTIONS", () => {
   it("is three (spec: max three stacked)", () => {
     expect(MAX_TOASTS).toBe(3);
+  });
+
+  it("caps actions at two (spec, BET-739)", () => {
+    expect(MAX_TOAST_ACTIONS).toBe(2);
   });
 });

--- a/src/renderer/Toast.test.tsx
+++ b/src/renderer/Toast.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+//
+// Render tests for the Toast primitive's multiple-action support (BET-739).
+// Pure auto-dismiss logic is covered in Toast.test.ts; these cover the DOM:
+// two actions render as two buttons, and the action buttons carry their
+// onClick/disabled through.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { Toast } from "./Toast";
+
+describe("Toast actions", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders two action buttons when two are given", () => {
+    let reminded = 0;
+    let kept = 0;
+    h = mount(
+      <Toast
+        onDismiss={() => {}}
+        toast={{
+          id: "t",
+          message: "limit",
+          tone: "error",
+          actions: [
+            { label: "Remind me at reset", onClick: () => reminded++ },
+            { label: "Keep going at reset", onClick: () => kept++ },
+          ],
+        }}
+      />,
+    );
+    const buttons = Array.from(h.container.querySelectorAll("button"));
+    const labels = buttons.map((b) => b.textContent);
+    expect(labels).toContain("Remind me at reset");
+    expect(labels).toContain("Keep going at reset");
+    // Each action button fires its own handler.
+    (buttons.find((b) => b.textContent === "Remind me at reset") as HTMLButtonElement).click();
+    (buttons.find((b) => b.textContent === "Keep going at reset") as HTMLButtonElement).click();
+    expect(reminded).toBe(1);
+    expect(kept).toBe(1);
+  });
+
+  it("caps at two actions — the third is never rendered", () => {
+    h = mount(
+      <Toast
+        onDismiss={() => {}}
+        toast={{
+          id: "t",
+          message: "m",
+          actions: [
+            { label: "A", onClick: () => {} },
+            { label: "B", onClick: () => {} },
+            { label: "C", onClick: () => {} },
+          ],
+        }}
+      />,
+    );
+    const labels = Array.from(h.container.querySelectorAll("button")).map((b) => b.textContent);
+    expect(labels).toContain("A");
+    expect(labels).toContain("B");
+    expect(labels).not.toContain("C");
+  });
+
+  it("renders no action buttons when actions is omitted", () => {
+    h = mount(<Toast onDismiss={() => {}} toast={{ id: "t", message: "hi" }} />);
+    // Only the dismiss (✕) button exists.
+    const buttons = Array.from(h.container.querySelectorAll("button"));
+    expect(buttons.length).toBe(1);
+  });
+});

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -11,9 +11,11 @@
 //   - Bottom-centre, max THREE stacked, newest on top.
 //   - --card background, --border, --shadow-md, 12px radius.
 //   - 6s default auto-dismiss; NEVER auto-dismiss when it carries an action
-//     (Undo / Save / Reveal). A toast may opt out of auto-dismiss entirely
-//     with ttl: null (e.g. user-invoked reference content like /help).
-//   - One optional action slot + a close button.
+//     (Undo / Save / Reveal / Remind me / Keep going). A toast may opt out of
+//     auto-dismiss entirely with ttl: null (e.g. user-invoked reference
+//     content like /help).
+//   - Zero to TWO action slots (BET-739: the usage limit toast needs two) + a
+//     close button. More than two render the first two.
 //   - Mobile: same component, respecting the safe-area inset.
 //
 // `toastTtl` is extracted as a pure function so the auto-dismiss decision is
@@ -29,15 +31,18 @@ export type ToastAction = {
   disabled?: boolean;
 };
 
+/** A toast may carry up to this many action buttons (BET-739). */
+export const MAX_TOAST_ACTIONS = 2;
+
 export type ToastItem = {
   id: string;
   message: ReactNode;
   /** Tonal variant. `"error"` renders a danger left-edge accent (BET-723 §D5);
    *  defaults to the plain info look. */
   tone?: "info" | "error";
-  /** Optional single action (Undo / Save / Reveal). Presence disables
-   *  auto-dismiss. */
-  action?: ToastAction;
+  /** Optional action buttons (Undo / Save / Reveal / Remind me / Keep going).
+   *  Presence of any disables auto-dismiss. Capped at MAX_TOAST_ACTIONS. */
+  actions?: ToastAction[];
   /** Auto-dismiss timeout in ms. Defaults to 6000 when there is no action;
    *  `null` opts out entirely (reference content). Ignored when an action is
    *  present (never auto-dismisses). */
@@ -49,13 +54,13 @@ export const TOAST_DEFAULT_TTL_MS = 6000;
 
 /**
  * Pure: decide whether a toast auto-dismisses, and after how long.
- *  - action present  → never (null)
- *  - ttl === null    → never (null)
- *  - ttl === number  → that many ms
- *  - otherwise       → TOAST_DEFAULT_TTL_MS
+ *  - any action present  → never (null)
+ *  - ttl === null        → never (null)
+ *  - ttl === number      → that many ms
+ *  - otherwise           → TOAST_DEFAULT_TTL_MS
  */
 export function toastTtl(toast: ToastItem): number | null {
-  if (toast.action) return null;
+  if (toast.actions?.length) return null;
   if (toast.ttl === null) return null;
   if (typeof toast.ttl === "number") return toast.ttl;
   return TOAST_DEFAULT_TTL_MS;
@@ -91,15 +96,16 @@ export function Toast({ toast, onDismiss }: ToastProps) {
       }`}
     >
       <span className="flex-1 min-w-0 whitespace-pre-wrap break-words">{toast.message}</span>
-      {toast.action && (
+      {(toast.actions ?? []).slice(0, MAX_TOAST_ACTIONS).map((action) => (
         <button
-          onClick={toast.action.onClick}
-          disabled={toast.action.disabled}
+          key={action.label}
+          onClick={action.onClick}
+          disabled={action.disabled}
           className={BANNER_BTN}
         >
-          {toast.action.label}
+          {action.label}
         </button>
-      )}
+      ))}
       <button
         onClick={() => onDismiss(toast.id)}
         className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"

--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -32,14 +32,15 @@ import { mbtn } from "./ComposerParts";
 // renderer may know a provider name beyond an icon/label lookup table").
 // Falls back to Title-Casing the snapshot's own `provider` id for any
 // adapter this table doesn't know about yet, so a 4th adapter needs no
-// renderer change.
+// renderer change. Exported so the usage escalation toasts (BET-739) reuse
+// the same single lookup instead of duplicating it.
 const PROVIDER_LABELS: Record<string, string> = {
   claude: "Claude",
   codex: "Codex",
   kimi: "Kimi",
 };
 
-function providerLabel(provider: string): string {
+export function providerLabel(provider: string): string {
   return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -97,6 +97,7 @@ export const DEMO_UNIMPLEMENTED = [
   "ptyWrite",
   "pushRegisterApns",
   "revealInFolder",
+  "scheduleCreate",
   "scheduleDelete",
   "scheduleList",
   "secretsDelete",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -966,6 +966,8 @@ export const httpApi: Api = {
   // -- scheduled prompts (manta-server owned; in-process on mobile) --
   scheduleList: (sessionId) => rpc(IPC.scheduleList, sessionId),
   scheduleDelete: (id) => rpc(IPC.scheduleDelete, id),
+  // BET-739: usage reset actions create one-shot jobs through the same channel
+  scheduleCreate: (input) => rpc(IPC.scheduleCreate, input),
 
   // -- subscription plan usage (manta-server owned; in-process on mobile) --
   usageList: () => rpc(IPC.usageList),

--- a/src/renderer/settingsApply.ts
+++ b/src/renderer/settingsApply.ts
@@ -67,7 +67,7 @@ export function useApplySetting(pushToast: (t: ToastItem) => void) {
       pushToast({
         id: `apply-${key}-${Date.now()}`,
         message: `${entry.label} set to ${describeValue(entry, value)}`,
-        action: {
+        actions: [{
           label: "Undo",
           onClick: () => {
             void useStore.setState({ [key]: prevValue });
@@ -79,7 +79,7 @@ export function useApplySetting(pushToast: (t: ToastItem) => void) {
               })
               .catch(() => {});
           },
-        },
+        }],
       });
     } catch (e) {
       useStore.setState({ [key]: prevValue });

--- a/src/renderer/usageEscalation.test.ts
+++ b/src/renderer/usageEscalation.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import {
+  usageAlertLevel,
+  buildUsageLevels,
+  shouldFireUsageAlert,
+  shouldWarnStaleCache,
+  formatResetClock,
+  describeResetDistance,
+  buildWarnMessage,
+  buildLimitMessage,
+} from "./usageEscalation";
+import type { UsageSnapshot } from "../shared/types";
+
+function snap(
+  provider: string,
+  windows: Array<{ kind: string; label: string; pct: number; resetsAt?: number }>,
+): UsageSnapshot {
+  return {
+    provider,
+    providerIDs: [provider],
+    windows: windows.map((w) => ({ kind: w.kind, label: w.label, pct: w.pct, resetsAt: w.resetsAt })),
+  };
+}
+
+// Constants so the "resets" clause renders deterministically.
+const RESET = new Date(2026, 7, 18, 9, 0, 0).getTime(); // Tue 2026-08-18 09:00
+
+describe("usageAlertLevel", () => {
+  it("classifies the three levels with exact 90 and 100 boundaries", () => {
+    expect(usageAlertLevel(0)).toBe("none");
+    expect(usageAlertLevel(50)).toBe("none");
+    expect(usageAlertLevel(89.9)).toBe("none");
+    expect(usageAlertLevel(90)).toBe("warn"); // exact 90 → warn
+    expect(usageAlertLevel(93)).toBe("warn");
+    expect(usageAlertLevel(99)).toBe("warn");
+    expect(usageAlertLevel(100)).toBe("limit"); // exact 100 → limit
+    expect(usageAlertLevel(101)).toBe("limit");
+  });
+});
+
+describe("buildUsageLevels", () => {
+  it("maps each present provider:window to its current level and drops absent keys", () => {
+    const levels = buildUsageLevels([
+      snap("claude", [{ kind: "session", label: "S", pct: 95 }, { kind: "weekly", label: "W", pct: 100 }]),
+      snap("codex", [{ kind: "session", label: "S", pct: 40 }]),
+    ]);
+    expect(levels).toEqual({
+      "claude:session": "warn",
+      "claude:weekly": "limit",
+      "codex:session": "none",
+    });
+  });
+
+  it("returns an empty map for no snapshots", () => {
+    expect(buildUsageLevels(null)).toEqual({});
+    expect(buildUsageLevels(undefined)).toEqual({});
+    expect(buildUsageLevels([])).toEqual({});
+  });
+});
+
+describe("shouldFireUsageAlert — fire-once semantics", () => {
+  it("fires on the transition upward (none → warn) and NOT while the level holds", () => {
+    let prev: Record<string, ReturnType<typeof usageAlertLevel>> = {};
+    // Cross into warn.
+    const step1 = [snap("claude", [{ kind: "session", label: "Session", pct: 93, resetsAt: RESET }])];
+    let fired = shouldFireUsageAlert(prev, step1);
+    expect(fired).toHaveLength(1);
+    expect(fired[0]).toMatchObject({ key: "claude:session", level: "warn", provider: "claude" });
+    // Subscriber writes the current levels back — the hold case.
+    prev = buildUsageLevels(step1);
+    fired = shouldFireUsageAlert(prev, step1);
+    expect(fired).toHaveLength(0);
+  });
+
+  it("escalates warn → limit but does not re-fire at a held limit", () => {
+    let prev: Record<string, ReturnType<typeof usageAlertLevel>> = {};
+    const atWarn = [snap("claude", [{ kind: "session", label: "Session", pct: 93 }])];
+    prev = buildUsageLevels(atWarn);
+    const atLimit = [snap("claude", [{ kind: "session", label: "Session", pct: 100, resetsAt: RESET }])];
+    let fired = shouldFireUsageAlert(prev, atLimit);
+    expect(fired).toHaveLength(1);
+    expect(fired[0].level).toBe("limit");
+    prev = buildUsageLevels(atLimit);
+    fired = shouldFireUsageAlert(prev, atLimit);
+    expect(fired).toHaveLength(0);
+  });
+
+  it("re-arms after the level drops (the window reset)", () => {
+    // At limit, held.
+    let prev = buildUsageLevels([snap("claude", [{ kind: "weekly", label: "Weekly", pct: 100 }])]);
+    expect(shouldFireUsageAlert(prev, [snap("claude", [{ kind: "weekly", label: "Weekly", pct: 100 }])])).toHaveLength(0);
+    // Reset: provider stops reporting the window (or drops pct).
+    prev = buildUsageLevels([snap("claude", [{ kind: "weekly", label: "Weekly", pct: 10 }])]);
+    const afterReset = [snap("claude", [{ kind: "weekly", label: "Weekly", pct: 12 }])];
+    expect(shouldFireUsageAlert(prev, afterReset)).toHaveLength(0);
+    // Cross up again → fires once more.
+    prev = buildUsageLevels(afterReset);
+    const crossing = [snap("claude", [{ kind: "weekly", label: "Weekly", pct: 100, resetsAt: RESET }])];
+    const fired = shouldFireUsageAlert(prev, crossing);
+    expect(fired).toHaveLength(1);
+    expect(fired[0].key).toBe("claude:weekly");
+    expect(fired[0].level).toBe("limit");
+  });
+
+  it("also re-arms when the window disappears from the snapshot entirely", () => {
+    const present = [snap("claude", [{ kind: "weekly", label: "Weekly", pct: 100 }])];
+    let prev = buildUsageLevels(present);
+    expect(shouldFireUsageAlert(prev, present)).toHaveLength(0);
+    // Window gone → prev has no key (buildUsageLevels drops it).
+    prev = buildUsageLevels([]);
+    const fired = shouldFireUsageAlert(prev, present);
+    expect(fired).toHaveLength(1);
+  });
+
+  it("tracks two windows of the same provider independently", () => {
+    let prev: Record<string, ReturnType<typeof usageAlertLevel>> = {};
+    const both = [
+      snap("claude", [
+        { kind: "session", label: "Session (5h)", pct: 95, resetsAt: RESET },
+        { kind: "weekly", label: "Weekly", pct: 30 },
+      ]),
+    ];
+    expect(shouldFireUsageAlert(prev, both)).toHaveLength(1); // only session fires
+    prev = buildUsageLevels(both);
+    // weekly crosses up now.
+    const weeklyUp = [
+      snap("claude", [
+        { kind: "session", label: "Session (5h)", pct: 95 },
+        { kind: "weekly", label: "Weekly", pct: 100, resetsAt: RESET },
+      ]),
+    ];
+    const fired = shouldFireUsageAlert(prev, weeklyUp);
+    expect(fired).toHaveLength(1);
+    expect(fired[0].key).toBe("claude:weekly");
+  });
+
+  it("tracks two providers independently", () => {
+    let prev: Record<string, ReturnType<typeof usageAlertLevel>> = {};
+    const both = [
+      snap("claude", [{ kind: "session", label: "S", pct: 95, resetsAt: RESET }]),
+      snap("codex", [{ kind: "session", label: "S", pct: 95, resetsAt: RESET }]),
+    ];
+    expect(shouldFireUsageAlert(prev, both)).toHaveLength(2);
+    prev = buildUsageLevels(both);
+    expect(shouldFireUsageAlert(prev, both)).toHaveLength(0);
+    // Only claude holds; codex resets (drops to none) and later re-crosses.
+    prev = buildUsageLevels([
+      snap("claude", [{ kind: "session", label: "S", pct: 95 }]),
+      snap("codex", [{ kind: "session", label: "S", pct: 40 }]),
+    ]);
+    const reCross = [
+      snap("claude", [{ kind: "session", label: "S", pct: 95 }]),
+      snap("codex", [{ kind: "session", label: "S", pct: 100, resetsAt: RESET }]),
+    ];
+    const fired = shouldFireUsageAlert(prev, reCross);
+    expect(fired).toHaveLength(1);
+    expect(fired[0].provider).toBe("codex");
+  });
+});
+
+describe("shouldWarnStaleCache", () => {
+  const now = Date.now();
+  it("is true beyond the 5m TTL and false within it", () => {
+    expect(shouldWarnStaleCache(now + 6 * 60_000, now, "5m")).toBe(true);
+    expect(shouldWarnStaleCache(now + 4 * 60_000, now, "5m")).toBe(false);
+    expect(shouldWarnStaleCache(now + 90_000, now, "5m")).toBe(false);
+  });
+
+  it("is true beyond the 1h TTL and false within it", () => {
+    expect(shouldWarnStaleCache(now + 61 * 60_000, now, "1h")).toBe(true);
+    expect(shouldWarnStaleCache(now + 59 * 60_000, now, "1h")).toBe(false);
+  });
+});
+
+describe("formatResetClock", () => {
+  it("renders 12-hour time, optionally with a weekday", () => {
+    // 2026-08-18 09:00 local → "Tue 9:00 am" / "9:00 am"
+    const d = new Date(2026, 7, 18, 9, 0).getTime();
+    expect(formatResetClock(d, true)).toBe("Tue 9:00 am");
+    expect(formatResetClock(d, false)).toBe("9:00 am");
+  });
+
+  it("renders afternoon times with pm and no leading zero on the hour", () => {
+    const d = new Date(2026, 7, 18, 15, 5).getTime();
+    expect(formatResetClock(d, false)).toBe("3:05 pm");
+  });
+
+  it("returns '' for a missing or invalid timestamp", () => {
+    expect(formatResetClock(undefined, false)).toBe("");
+    expect(formatResetClock(null, true)).toBe("");
+    expect(formatResetClock(Number.NaN, false)).toBe("");
+  });
+});
+
+describe("message builders", () => {
+  it("buildWarnMessage matches the spec copy", () => {
+    expect(buildWarnMessage("Claude", "Session (5h)", 93, RESET)).toBe(
+      "Claude Session (5h) 93% used — resets " + formatResetClock(RESET, false) + ".",
+    );
+  });
+
+  it("buildLimitMessage matches the spec copy (weekday form)", () => {
+    expect(buildLimitMessage("Claude", "Weekly", RESET)).toBe(
+      "Weekly limit reached on Claude — resets " + formatResetClock(RESET, true) + ".",
+    );
+  });
+
+  it("message builders omit the resets clause when resetsAt is missing", () => {
+    expect(buildWarnMessage("Claude", "Session (5h)", 93, undefined)).toBe("Claude Session (5h) 93% used.");
+    expect(buildLimitMessage("Claude", "Weekly", undefined)).toBe("Weekly limit reached on Claude.");
+  });
+});
+
+describe("describeResetDistance", () => {
+  it("uses the coarsest whole unit", () => {
+    expect(describeResetDistance(4 * 86_400_000)).toBe("4 days");
+    expect(describeResetDistance(2 * 3_600_000)).toBe("2 hours");
+    expect(describeResetDistance(45 * 60_000)).toBe("45 minutes");
+    expect(describeResetDistance(30_000)).toBe("less than a minute");
+  });
+});

--- a/src/renderer/usageEscalation.test.ts
+++ b/src/renderer/usageEscalation.test.ts
@@ -18,6 +18,7 @@ function snap(
   return {
     provider,
     providerIDs: [provider],
+    fetchedAt: 0,
     windows: windows.map((w) => ({ kind: w.kind, label: w.label, pct: w.pct, resetsAt: w.resetsAt })),
   };
 }

--- a/src/renderer/usageEscalation.ts
+++ b/src/renderer/usageEscalation.ts
@@ -86,7 +86,7 @@ export function shouldFireUsageAlert(
 export function shouldWarnStaleCache(
   fireAt: number,
   now: number,
-  cacheTtl: "5m" | "1h" | string,
+  cacheTtl: "5m" | "1h",
 ): boolean {
   return fireAt - now > selectCacheTtlMs(cacheTtl);
 }

--- a/src/renderer/usageEscalation.ts
+++ b/src/renderer/usageEscalation.ts
@@ -1,0 +1,159 @@
+// ===== Subscription usage escalation =====
+//
+// Pure logic for surfacing plan-usage alerts (>=90% warn / >=100% limit) to
+// the global toast host (BET-739). The subscriber lives in App.tsx (the same
+// app-level place that already consumes bus events) and pushes the produced
+// toasts through the existing `pushAppToast` store action — there is no new
+// toast component and no new host.
+//
+// Fire-once semantics are the whole point: an alert fires only on a
+// TRANSITION UPWARD into a level for a given `provider:window` key. It must
+// not re-fire while the level holds, and it must re-arm when the level drops
+// (i.e. after the window resets). The previous-level map lives in a ref held
+// by the subscriber; this module is pure.
+//
+// There is deliberately no React and no provider-name branching here beyond
+// the exact strings the spec dictates.
+
+import type { UsageSnapshot, UsageWindow } from "../shared/types";
+import { selectCacheTtlMs } from "./chatUtils";
+
+/** >=90 = warn, >=100 = limit; anything below 90 is "none". */
+export type UsageAlertLevel = "none" | "warn" | "limit";
+
+const LEVEL_RANK: Record<UsageAlertLevel, number> = { none: 0, warn: 1, limit: 2 };
+
+/** Classify one window's pct into an alert level. Boundaries: exactly 90 ->
+ *  warn, exactly 100 -> limit. */
+export function usageAlertLevel(pct: number): UsageAlertLevel {
+  if (pct >= 100) return "limit";
+  if (pct >= 90) return "warn";
+  return "none";
+}
+
+/** The current alert level for every present `provider:window.kind` key.
+ *  Windows absent from the snapshots are absent from the record — the
+ *  subscriber writes this back into its prev map after each event, which is
+ *  what re-arms a key once a window resets and drops below the threshold. */
+export function buildUsageLevels(snapshots: UsageSnapshot[] | null | undefined): Record<string, UsageAlertLevel> {
+  const out: Record<string, UsageAlertLevel> = {};
+  for (const snap of snapshots ?? []) {
+    for (const win of snap.windows ?? []) {
+      out[`${snap.provider}:${win.kind}`] = usageAlertLevel(win.pct);
+    }
+  }
+  return out;
+}
+
+export type UsageAlert = {
+  key: string; // `${provider}:${window.kind}`
+  level: UsageAlertLevel;
+  provider: string;
+  window: UsageWindow;
+};
+
+/**
+ * Which alerts fire given the previous level map and the incoming snapshots.
+ * An alert fires only when the level TRANSITIONS UPWARD (none→warn, none→limit
+ * via warn, warn→limit) for a key. It does not re-fire while the level holds.
+ * Re-arming is the caller's responsibility: write the new level map (see
+ * buildUsageLevels) back into `prev` after consuming the fired alerts.
+ */
+export function shouldFireUsageAlert(
+  prev: Record<string, UsageAlertLevel>,
+  next: UsageSnapshot[] | null | undefined,
+): UsageAlert[] {
+  const fired: UsageAlert[] = [];
+  for (const snap of next ?? []) {
+    for (const win of snap.windows ?? []) {
+      const key = `${snap.provider}:${win.kind}`;
+      const newLevel = usageAlertLevel(win.pct);
+      const oldLevel = prev[key] ?? "none";
+      if (newLevel !== "none" && LEVEL_RANK[newLevel] > LEVEL_RANK[oldLevel]) {
+        fired.push({ key, level: newLevel, provider: snap.provider, window: win });
+      }
+    }
+  }
+  return fired;
+}
+
+/**
+ * "Shall the 'keep going' modal show the amber stale-cache warning?" True when
+ * the reset is beyond the configured prompt-cache window — exactly when the
+ * cached prefix will have expired and the next turn re-bills the whole
+ * conversation as fresh input. Reuses selectCacheTtlMs (do not re-derive).
+ */
+export function shouldWarnStaleCache(
+  fireAt: number,
+  now: number,
+  cacheTtl: "5m" | "1h" | string,
+): boolean {
+  return fireAt - now > selectCacheTtlMs(cacheTtl);
+}
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * 12-hour wall clock for reset times in the alert toast copy: "3:05 pm", or
+ * with a leading weekday "Tue 9:00 am". Returns "" for a missing/invalid
+ * timestamp so callers can omit the "resets …" clause rather than rendering
+ * a broken time.
+ */
+export function formatResetClock(
+  resetsAt: number | null | undefined,
+  withWeekday: boolean,
+): string {
+  if (resetsAt == null || !Number.isFinite(resetsAt) || Number.isNaN(new Date(resetsAt).getTime())) {
+    return "";
+  }
+  const d = new Date(resetsAt);
+  const h24 = d.getHours();
+  const h12 = h24 % 12 === 0 ? 12 : h24 % 12;
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ampm = h24 < 12 ? "am" : "pm";
+  const clock = `${h12}:${mm} ${ampm}`;
+  return withWeekday ? `${WEEKDAYS[d.getDay()]} ${clock}` : clock;
+}
+
+/**
+ * Human "… away" distance used by the keep-going modal's stale-cache warning:
+ * "4 days", "2 hours", "45 minutes", "less than a minute". Floors to the
+ * coarsest unit that's still >= 1.
+ */
+export function describeResetDistance(deltaMs: number): string {
+  if (!Number.isFinite(deltaMs) || deltaMs < 60_000) return "less than a minute";
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const hours = Math.floor(deltaMs / 3_600_000);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"}`;
+  const days = Math.floor(deltaMs / 86_400_000);
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+/**
+ * The warn (>=90%) toast body — plain, no actions, takes the default 6s TTL.
+ * "Claude Session (5h) 93% used — resets 3:05 pm."
+ */
+export function buildWarnMessage(
+  providerLabel: string,
+  windowLabel: string,
+  pct: number,
+  resetsAt: number | null | undefined,
+): string {
+  const pctShown = Math.round(pct);
+  const reset = formatResetClock(resetsAt, false);
+  return `${providerLabel} ${windowLabel} ${pctShown}% used${reset ? ` — resets ${reset}` : ""}.`;
+}
+
+/**
+ * The limit (>=100%) toast body — error tone, two actions, never auto-dismisses.
+ * "Weekly limit reached on Claude — resets Tue 9:00 am."
+ */
+export function buildLimitMessage(
+  providerLabel: string,
+  windowLabel: string,
+  resetsAt: number | null | undefined,
+): string {
+  const reset = formatResetClock(resetsAt, true);
+  return `${windowLabel} limit reached on ${providerLabel}${reset ? ` — resets ${reset}` : ""}.`;
+}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -232,6 +232,7 @@ const promptDelivery = createPromptDelivery({
 const { stop: stopSchedulePoller } = startSchedulePoller(
   {
     sendPrompt: (args) => promptDelivery.deliver(args),
+    fireNotify: (args) => push.fireNotify(args),
     publish: (evt) => bus.publish(evt),
   },
   { intervalMs: 30000 },

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -8,7 +8,7 @@ import { gzipSync } from "node:zlib";
 import { homedir } from "node:os";
 import { transcribeAudio, classifyVoiceCommand } from "../shared/groq.mjs";
 import { expandTilde } from "../shared/paths.mjs";
-import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob } from "./schedule.mjs";
+import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob, createJob as scheduleCreateJob } from "./schedule.mjs";
 import { listSnapshots as usageListSnapshots } from "./usage.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
 import { listPages as servePageListStore } from "./servePage.mjs";
@@ -871,6 +871,11 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.scheduleDelete, id)  → args[0] = id
     "schedule:delete": (id) =>
       scheduleDeleteJob(id, { publish: (evt) => bus.publish(evt) }),
+    // BET-739: the usage escalation actions ("remind / keep going at reset")
+    // create one-shot jobs from the renderer through this channel — same store,
+    // same poller, same ⏰ card. Returns { ok, job?, error? }.
+    "schedule:create": (input) =>
+      scheduleCreateJob(input || {}, { publish: (evt) => bus.publish(evt) }),
 
     // ---- subscription plan usage (manta-server owned; BET-737) ----
     // Read-only: returns the current UsageSnapshot[] cache maintained by the

--- a/src/server/schedule.mjs
+++ b/src/server/schedule.mjs
@@ -25,6 +25,11 @@ import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+// cronForInstant is pure (no node deps), so it lives in src/shared where the
+// RENDERER can also import it for the usage reset actions — re-exported here
+// so `src/server/schedule.test.mjs` and the server side consume it from this
+// module (single source of truth, not duplicated across the process boundary).
+export { cronForInstant } from "../shared/scheduleCron.mjs";
 
 const STORE_PATH = statePath("schedule.json");
 
@@ -184,8 +189,23 @@ function genId() {
 
 // Create + persist a job. Returns { ok, job?, error? }. Pure-ish (I/O via
 // injected load/save) so callers/tests control persistence.
+//
+// `kind` — "prompt" (default; fires sendPrompt into the session) or "notify"
+// (fires a push via fireNotify instead). The job's `prompt` field carries the
+// text in BOTH cases; there is deliberately no second text field. Defaulting
+// to "prompt" keeps every existing job and caller (the AI `schedule` tool)
+// unaffected.
 export async function createJob(
-  { cron, prompt, recurring = true, label = "", sessionID, directory = "", now = () => new Date() },
+  {
+    cron,
+    prompt,
+    recurring = true,
+    label = "",
+    sessionID,
+    directory = "",
+    kind = "prompt",
+    now = () => new Date(),
+  },
   { load = loadJobs, save = saveJobs, publish } = {},
 ) {
   const v = validateCron(cron);
@@ -194,6 +214,8 @@ export async function createJob(
     return { ok: false, error: "prompt is required" };
   if (typeof sessionID !== "string" || !sessionID)
     return { ok: false, error: "sessionID is required" };
+  if (kind !== "prompt" && kind !== "notify")
+    return { ok: false, error: `invalid kind "${kind}"` };
 
   const jobs = await load();
   const job = {
@@ -202,6 +224,7 @@ export async function createJob(
     prompt: prompt.trim(),
     recurring: !!recurring,
     label: typeof label === "string" ? label : "",
+    kind,
     sessionID,
     directory: directory || "",
     createdAt: now().getTime(),
@@ -247,6 +270,7 @@ export async function listJobs(sessionID, { load = loadJobs } = {}) {
  * @param {() => Promise<object[]>} deps.load
  * @param {(jobs: object[]) => Promise<void>} deps.save
  * @param {(args: {sessionId: string, text: string}) => Promise<any>} deps.sendPrompt
+ * @param {(args: {message: string, title?: string, urgent?: boolean, sessionID?: string}) => Promise<any>} [deps.fireNotify] — required for `kind: "notify"` jobs; injected so the tick stays testable with no push stack
  * @param {() => Date} [deps.now]
  * @param {(evt: object) => void} [deps.publish]
  * @param {(path: string) => boolean} [deps.directoryExists] — defaults to node:fs/existsSync
@@ -256,6 +280,7 @@ export function createScheduler({
   load,
   save,
   sendPrompt,
+  fireNotify,
   now = () => new Date(),
   publish,
   directoryExists = existsSync,
@@ -310,7 +335,19 @@ export function createScheduler({
         // loop or block other due jobs; lastFiredMinute is stamped regardless
         // to avoid hammering a persistently-failing send every tick.
         try {
-          await sendPrompt({ sessionId: job.sessionID, text: job.prompt });
+          if (job.kind === "notify") {
+            if (typeof fireNotify === "function") {
+              await fireNotify({
+                message: job.prompt, // the job's `prompt` carries the notify text
+                urgent: true, // draw attention on every device — that's what "remind me" means
+                sessionID: job.sessionID,
+              });
+            } else {
+              console.warn(`[schedule] fire job ${job.id}: kind "notify" but fireNotify was not injected`);
+            }
+          } else {
+            await sendPrompt({ sessionId: job.sessionID, text: job.prompt });
+          }
         } catch (e) {
           console.warn(`[schedule] fire job ${job.id} failed:`, e?.message ?? e);
         }
@@ -343,18 +380,20 @@ export function createScheduler({
  *
  * @param {object} deps
  * @param {(args: {sessionId: string, text: string}) => Promise<any>} deps.sendPrompt
+ * @param {(args: {message: string, title?: string, urgent?: boolean, sessionID?: string}) => Promise<any>} [deps.fireNotify] — for `kind: "notify"` jobs
  * @param {(evt: object) => void} [deps.publish]  - bus.publish
  * @param {object} [opts]
  * @param {number} [opts.intervalMs=30000]
  * @param {string} [opts.storePath]
  * @returns {{ stop: () => void }}
  */
-export function startSchedulePoller({ sendPrompt, publish } = {}, { intervalMs = POLL_MS, storePath } = {}) {
+export function startSchedulePoller({ sendPrompt, fireNotify, publish } = {}, { intervalMs = POLL_MS, storePath } = {}) {
   const path = storePath ?? STORE_PATH;
   const { tick } = createScheduler({
     load: () => loadJobs(path),
     save: (jobs) => saveJobs(jobs, path),
     sendPrompt,
+    fireNotify,
     publish,
   });
 

--- a/src/server/schedule.test.mjs
+++ b/src/server/schedule.test.mjs
@@ -4,7 +4,9 @@ import {
   validateCron,
   cronMatches,
   minuteKey,
+  cronForInstant,
   isJobFireable,
+  createJob,
   createScheduler,
 } from "./schedule.mjs";
 
@@ -127,6 +129,125 @@ test("cronMatches returns false for malformed expr (no throw)", () => {
 test("minuteKey is stable per-minute local key", () => {
   assert.equal(minuteKey(localDate(2026, 6, 20, 15, 5)), "2026-06-20T15:05");
   assert.equal(minuteKey(localDate(2026, 1, 2, 3, 4)), "2026-01-02T03:04");
+});
+
+// ----------------------------------------------------------------------------
+// cronForInstant — a 5-field one-shot cron for a local instant
+// ----------------------------------------------------------------------------
+
+test("cronForInstant renders M H D MO * from a local date", () => {
+  assert.equal(cronForInstant(localDate(2026, 8, 18, 9, 1)), "1 9 18 8 *");
+});
+
+test("cronForInstant handles a December date (month off-by-one)", () => {
+  // JS getMonth() is 0-11; cron months are 1-12. December = getMonth() 11 → "12".
+  assert.equal(cronForInstant(localDate(2026, 12, 31, 23, 59)), "59 23 31 12 *");
+});
+
+test("cronForInstant output matches cronMatches at that instant", () => {
+  const when = localDate(2026, 8, 18, 9, 1);
+  assert.equal(cronMatches(cronForInstant(when), when), true);
+  assert.equal(cronMatches(cronForInstant(when), localDate(2026, 8, 18, 9, 2)), false);
+});
+
+// ----------------------------------------------------------------------------
+// createJob — kind field (BET-739)
+// ----------------------------------------------------------------------------
+
+test("createJob defaults kind to prompt and stores it on the job", async () => {
+  const { ok, job } = await createJob({
+    cron: "0 9 * * *",
+    prompt: "check the deploy",
+    recurring: false,
+    sessionID: "ses_x",
+  });
+  assert.equal(ok, true);
+  assert.equal(job.kind, "prompt");
+});
+
+test("createJob accepts kind notify", async () => {
+  const { ok, job } = await createJob(
+    { cron: "1 9 * * *", prompt: "reset happened", recurring: false, sessionID: "ses_x", kind: "notify" },
+    { load: async () => [], save: async () => {} },
+  );
+  assert.equal(ok, true);
+  assert.equal(job.kind, "notify");
+});
+
+test("createJob rejects an unknown kind", async () => {
+  const res = await createJob(
+    { cron: "1 9 * * *", prompt: "x", recurring: false, sessionID: "ses_x", kind: "bogus" },
+    { load: async () => [], save: async () => {} },
+  );
+  assert.equal(res.ok, false);
+  assert.match(res.error, /kind/);
+});
+
+// ----------------------------------------------------------------------------
+// createScheduler.tick — kind branching (BET-739)
+// ----------------------------------------------------------------------------
+
+// Harness that records BOTH delivery paths so a test can assert which one ran.
+function branchHarness(initialJobs, fixedNow) {
+  let jobs = initialJobs.map((j) => ({ ...j }));
+  const promptSent = [];
+  const notifySent = [];
+  const deps = {
+    load: async () => jobs.map((j) => ({ ...j })),
+    save: async (next) => {
+      jobs = next.map((j) => ({ ...j }));
+    },
+    sendPrompt: async (args) => promptSent.push(args),
+    fireNotify: async (args) => notifySent.push(args),
+    now: () => fixedNow,
+    publish: () => {},
+  };
+  return {
+    deps,
+    promptSent,
+    notifySent,
+    get jobs() {
+      return jobs;
+    },
+  };
+}
+
+test("tick fires a kind:notify job via fireNotify and NOT sendPrompt", async () => {
+  const now = localDate(2026, 8, 18, 9, 1);
+  const notifyJob = { ...baseJob, id: "notify1", cron: "1 9 18 8 *", recurring: false, kind: "notify" };
+  const h = branchHarness([notifyJob], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.promptSent.length, 0);
+  assert.equal(h.notifySent.length, 1);
+  assert.deepEqual(h.notifySent[0], {
+    message: "check the deploy",
+    urgent: true,
+    sessionID: "ses_abc",
+  });
+  // one-shot removed after firing
+  assert.equal(h.jobs.length, 0);
+});
+
+test("tick fires a job with no kind as prompt (regression for legacy store jobs)", async () => {
+  const now = localDate(2026, 8, 18, 9, 1);
+  const legacy = { ...baseJob, id: "legacy1", cron: "1 9 18 8 *", recurring: false }; // no `kind`
+  const h = branchHarness([legacy], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.promptSent.length, 1);
+  assert.deepEqual(h.promptSent[0], { sessionId: "ses_abc", text: "check the deploy" });
+  assert.equal(h.notifySent.length, 0);
+});
+
+test("tick defaults a kind:prompt job to sendPrompt (explicit prompt kind)", async () => {
+  const now = localDate(2026, 8, 18, 9, 1);
+  const promptJob = { ...baseJob, id: "prompt1", cron: "1 9 18 8 *", recurring: false, kind: "prompt" };
+  const h = branchHarness([promptJob], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.promptSent.length, 1);
+  assert.equal(h.notifySent.length, 0);
 });
 
 // ----------------------------------------------------------------------------

--- a/src/server/schedule.test.mjs
+++ b/src/server/schedule.test.mjs
@@ -136,7 +136,7 @@ test("minuteKey is stable per-minute local key", () => {
 // ----------------------------------------------------------------------------
 
 test("cronForInstant renders M H D MO * from a local date", () => {
-  assert.equal(cronForInstant(localDate(2026, 8, 18, 9, 1)), "1 9 18 8 *");
+  assert.equal(cronForInstant(localDate(2026, 8, 18, 9, 1)), "01 09 18 8 *");
 });
 
 test("cronForInstant handles a December date (month off-by-one)", () => {

--- a/src/server/schedule.test.mjs
+++ b/src/server/schedule.test.mjs
@@ -155,12 +155,10 @@ test("cronForInstant output matches cronMatches at that instant", () => {
 // ----------------------------------------------------------------------------
 
 test("createJob defaults kind to prompt and stores it on the job", async () => {
-  const { ok, job } = await createJob({
-    cron: "0 9 * * *",
-    prompt: "check the deploy",
-    recurring: false,
-    sessionID: "ses_x",
-  });
+  const { ok, job } = await createJob(
+    { cron: "0 9 * * *", prompt: "check the deploy", recurring: false, sessionID: "ses_x" },
+    { load: async () => [], save: async () => {} }, // never touch the live store
+  );
   assert.equal(ok, true);
   assert.equal(job.kind, "prompt");
 });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -329,6 +329,17 @@ export interface Api {
   // Scheduled prompts (manta-server owned; desktop reaches it over -L 18787).
   scheduleList(sessionId?: string): Promise<ScheduledJob[]>;
   scheduleDelete(id: string): Promise<{ deleted: boolean }>;
+  // BET-739: create a one-shot job from the renderer (the usage "remind me /
+  // keep going at reset" actions). Same store/poller as the AI `schedule` tool.
+  scheduleCreate(input: {
+    cron: string;
+    prompt: string;
+    recurring?: boolean;
+    label?: string;
+    sessionID: string;
+    directory?: string;
+    kind?: "prompt" | "notify";
+  }): Promise<{ ok: boolean; job?: ScheduledJob; error?: string }>;
 
   // Subscription plan usage (manta-server owned; BET-737). Read-only —
   // snapshots are produced by the box's usage poller (src/server/usage.mjs),

--- a/src/shared/scheduleCron.d.mts
+++ b/src/shared/scheduleCron.d.mts
@@ -1,0 +1,3 @@
+// Type declaration for the pure cronForInstant helper shared across the
+// server/renderer boundary. See scheduleCron.mjs.
+export function cronForInstant(date: Date): string;

--- a/src/shared/scheduleCron.mjs
+++ b/src/shared/scheduleCron.mjs
@@ -1,0 +1,20 @@
+// Pure cron-for-instant helper shared across the server/renderer boundary.
+//
+// cronForInstant renders a 5-field cron expression ("M H D MO *") that fires
+// ONCE at a given local-time instant (only minutes resolve to a specific
+// value above cron's granularity; the DOW is "*" so the job fires on whatever
+// weekday that date falls on). Used by the usage reset actions ("remind me /
+// keep going at reset") to schedule a one-shot at `resetsAt + slack`.
+//
+// It lives here — NOT in src/server/schedule.mjs — because the RENDERER also
+// needs it (to build the cron it hands to window.api.scheduleCreate), and
+// schedule.mjs imports node builtins that must never reach the renderer
+// bundle. schedule.mjs re-exports it, keeping one source of truth.
+//
+// Pure. Watch the month off-by-one: JS getMonth() is 0-11, cron months are
+// 1-12, so a December job (getMonth() === 11) must render month "12".
+
+export function cronForInstant(date) {
+  const p = (n) => String(n).padStart(2, "0");
+  return `${p(date.getMinutes())} ${p(date.getHours())} ${p(date.getDate())} ${date.getMonth() + 1} *`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -757,6 +757,7 @@ export const IPC = {
   // mobile is in-process (src/server/rpc.mjs → schedule.mjs).
   scheduleList: "schedule:list", // (sessionId?) → ScheduledJob[]
   scheduleDelete: "schedule:delete", // (id) → { deleted: boolean }
+  scheduleCreate: "schedule:create", // (input) → { ok, job?, error? } (BET-739 usage reset actions)
 
   // ---- subscription plan usage (manta-server owned; BET-737) ----
   // Read-only: the current UsageSnapshot[] cache maintained by the usage
@@ -1055,6 +1056,9 @@ export type ScheduledJob = {
   prompt: string;
   recurring: boolean;
   label: string;
+  // BET-739: "prompt" (default; fires sendPrompt) or "notify" (fires a push).
+  // Absent on legacy jobs — treat as "prompt".
+  kind?: "prompt" | "notify";
   sessionID: string;
   directory: string;
   createdAt: number;


### PR DESCRIPTION
## BET-739 — Subscription usage: escalation toasts + reset actions (remind / keep going)

Implements the four deliverables from the issue, all "reuse over addition".

### 1. `ToastItem` gains multiple actions (`src/renderer/Toast.tsx`)
`action?: ToastAction` → `actions?: ToastAction[]`, rendered via `.map` capped at
2 (`MAX_TOAST_ACTIONS`). `toastTtl` now keys off `actions?.length`. Migrated every
toast call site: `GlobalToasts.tsx` (screenshot, agent-file), `Settings.tsx` (3
Undo pushes), `settingsApply.ts`. `Toast.test.ts` (pure) + new `Toast.test.tsx`
(render: two actions, cap at 2, zero actions → dismiss-only).

### 2. Scheduler jobs gain a `kind` (`src/server/schedule.mjs`)
`createJob` accepts `kind: "prompt" | "notify"` defaulting to `"prompt"` (validated;
legacy jobs + the AI `schedule` tool unaffected). The tick branches: `notify` →
injected `fireNotify({message, urgent:true, sessionID})` (never `sendPrompt`), else
`sendPrompt`. `fireNotify` is injected through `createScheduler` / `startSchedulePoller`
and wired in `index.mjs`. `cronForInstant` added as a pure helper; `ScheduledTasksCard`
renders `notify` jobs with a Bell glyph + label and still cancels them.

**Deviation (flagged):** `cronForInstant` is defined in a tiny new shared module
`src/shared/scheduleCron.mjs` (pure, no node deps) and re-exported from
`schedule.mjs` (which imports node builtins). The renderer needs `cronForInstant`
to build the cron it sends to `window.api.scheduleCreate`, and `schedule.mjs`'s
node:fs/crypto imports must never reach the renderer bundle — so the helper
crosses the process boundary through the shared `src/shared/` seam, matching how the
codebase already shares pure logic (`streamInterpretation.mjs` etc.). One source of
truth; `src/server/schedule.test.mjs` still imports it from `schedule.mjs`.

### 3. Escalation toasts (`src/renderer/usageEscalation.ts` + `App.tsx`)
New pure module: `usageAlertLevel` (>=90 warn / >=100 limit), `shouldFireUsageAlert`
(fire-once on upward transition), `buildUsageLevels` (write-back/re-arm helper),
`shouldWarnStaleCache` (reuses `selectCacheTtlMs`), message builders + reset-clock
formatting. The subscriber lives in `App.tsx` (same app-level place as the other
bus consumers, works over any pane) and pushes through `pushAppToast` — no new
toast component, no new host. Fire-once + re-arm-after-reset semantics; the prev
map is a ref, written back each event, so toast spam can't happen.

### 4. The two reset actions
`fireAt = resetsAt + 60s`; both create a one-shot job via the new
`window.api.scheduleCreate` (`recurring:false`, `cron: cronForInstant(fireAt)`,
current `sessionID`; actions hidden when `resetsAt` / an active chat session is
missing). "Remind me at reset" → `kind:notify` job + confirmation toast with Undo.
"Keep going at reset" → `Modal` (`size="sm"`, per `Settings.tsx` confirm pattern) with
the conditional amber stale-cache warning (`shouldWarnStaleCache`, tested) → `kind:prompt`
"Keep going" job + confirmation toast with Undo. No `window.alert`/`confirm`.

**Files changed:** 21 (now rebased onto main @ `6b652836`, incl. BET-727 button adoption).

**Verification results:**
- PR branch (`multica/BET-739-usage-escalation-toasts` @ `569e571d`, review cycle 1 fixes):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, full suite green (vitest + node:test). log sha256: `c4c9171cdad26b103f28e9290aec9051b747d9de3d1a7f20730b9ec540834975`
- Base: `origin/main @ f3a847a9` (base the branch was cut from)
- **Conclusion:** 0 failures. No base-branch re-run needed (all suites green on the PR branch).

**Acceptance mapping (issue "Done when"):** `typecheck && npm test` pass — done here.
The dev-box manual checks (forcing a snapshot >90% → one toast; 100% → two-action
error toast; "Remind me at reset" creates a visible ⏰ job; "Keep going at reset" shows
the modal with the cache warning only beyond TTL) are exercised by unit tests
(`usageEscalation.test.ts`, `schedule.test.mjs`) but the live box walk-through is the
cross-cutting step.


---

## Review cycle 1 — resolved (3 Blocks + 5 nits)

Rebased onto `origin/main @ 6b652836` (picks up BET-727 button adoption).

- **Block 1 (test wrote to live `~/.manta/schedule.json`)** — `schedule.test.mjs`
  now injects `{ load: async () => [], save: async () => {} }` into all three
  `createJob` tests (the sibling tests already did). The suite no longer pollutes
  user state on any machine it runs on.
- **Block 2 (amber warning bypassed `Callout`)** — `App.tsx` now uses
  `<Callout tone="warn">…</Callout>` for the stale-cache warning.
- **Block 3 (raw Cancel `<button>`, pre-727)** — now `<Button tone="ghost">Cancel</Button>`,
  matching every confirm-modal Cancel now on main.
- **Nits:** restored the lost newline in `Settings.tsx`; fixed the comment
  line-break artifact in `App.tsx`; dropped the dead `cacheTtl ?? "1h"` fallback
  (it's non-optional in the store, default `"1h"`); added a comment explaining the
  actions are hidden when there's no active chat session (not just missing resetsAt).

**Verification (cycle 1 head `569e571d`):** typecheck exit 0 (`75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`);
`npm test` exit 0 — vitest 2358 pass / 7 skipped, node:test 1624 pass / 0 fail
(`661c581afa6a6a5b4963a296bc8fbc7ffd9ae433bc450bf0cd66ebdd68b1c7f0`);
`npm run build` exit 0 (`dd18b30914287bac12c5cdc21c31f280505a40017ee479d0fe3c875a19b6eff8`).
