### PR TITLE
BET-728: motion scale tokens, dropdown mount animation, reduced-motion guards, UpdateBar sweep, token stragglers

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1298,8 +1298,7 @@ function AppInner() {
                 title="The box's tmux is unreachable — showing the last known session list."
               >
                 <span
-                  className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
-                  style={{ backgroundColor: "#f59e0b" }}
+                  className="inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-warn"
                   aria-hidden="true"
                 />
                 last known state

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { motion } from "framer-motion";
+import { MOTION_BASE, MOTION_EASE } from "./chatMotion";
 import {
   ArrowDown,
   ArrowUp,
@@ -242,7 +243,7 @@ function ExpiryPill({ state, label }: { state: "live" | "soon" | "expired"; labe
         : "bg-danger-bg text-danger";
   return (
     <span
-      className={`ml-1 inline-flex shrink-0 items-center gap-1 rounded-full px-[6px] py-[2px] text-[9.5px] font-semibold align-middle ${cls}`}
+      className={`ml-1 inline-flex shrink-0 items-center gap-1 rounded-full px-[6px] py-[2px] text-micro font-semibold align-middle ${cls}`}
     >
       {label}
     </span>
@@ -619,7 +620,7 @@ export function ArtifactsPanel({
         // mount rather than sliding in on app boot.
         initial={false}
         animate={{ width: open ? width : 0 }}
-        transition={{ type: "tween", duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+        transition={{ type: "tween", duration: MOTION_BASE, ease: MOTION_EASE }}
         aria-label="Artifacts"
       >
         {/* Inner content holds a FIXED width equal to the panel width so text

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -485,7 +485,7 @@ export function InputArea({
             "inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 " +
             (chatAutoAllow
               ? "text-danger hover:text-danger"
-              : "text-text-quiet hover:text-text-muted")
+              : "text-text-muted hover:text-text-muted")
           }
           title={
             chatAutoAllow

--- a/src/renderer/MenuItem.tsx
+++ b/src/renderer/MenuItem.tsx
@@ -180,6 +180,7 @@ export function Dropdown({
       role={role}
       className={
         `${hook ? `${hook} ` : ""}` +
+        `manta-menu-in ` +
         `${DROPDOWN_SURFACE} ${DROPDOWN_WIDTH[width]} ${DROPDOWN_PLACEMENT[placement]} ${DROPDOWN_ALIGN[align]}`
       }
     >

--- a/src/renderer/Modal.tsx
+++ b/src/renderer/Modal.tsx
@@ -23,6 +23,7 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useFocusTrap } from "./useFocusTrap";
+import { MOTION_BASE, MOTION_EASE, MOTION_FAST } from "./chatMotion";
 
 const SIZES = {
   sm: "w-[420px]",
@@ -30,14 +31,13 @@ const SIZES = {
   lg: "w-[560px]",
 } as const;
 
-// The modal chrome's entrance/exit ease — the same cubic-bezier as the chat
-// message entry animation (MESSAGE_IN_ENTER in chatMotion.ts) and the
-// Artifacts-panel slide, so every in-app transition reads in one motion
-// language. 0.18s for the panel scale+fade.
-const MODAL_PANEL_TRANSITION = { type: "tween", duration: 0.18, ease: [0.22, 1, 0.36, 1] } as const;
+// The modal chrome's entrance/exit ease — the shared MOTION_EASE, so every
+// in-app transition reads in one motion language. Panel uses MOTION_BASE.
+const MODAL_PANEL_TRANSITION = { type: "tween", duration: MOTION_BASE, ease: MOTION_EASE } as const;
 
-// backdrop fade is a touch faster (0.15s) than the panel (0.18s).
-const MODAL_BACKDROP_TRANSITION = { type: "tween", duration: 0.15 } as const;
+// backdrop fade is a touch faster — MOTION_FAST (the 20ms delta over the
+// old 0.15s is imperceptible; the token wins).
+const MODAL_BACKDROP_TRANSITION = { type: "tween", duration: MOTION_FAST } as const;
 
 export function Modal({
   size = "md",

--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -92,7 +92,7 @@ function ProgressRail({ current }: { current: OnboardingPosition }) {
                           background: ACCENT_SOLID,
                           color: "var(--on-accent)",
                           border: `1.5px solid ${ACCENT}`,
-                          boxShadow: `0 0 0 4px rgba(124,156,255,0.15)`,
+                          boxShadow: `0 0 0 4px var(--accent-bg)`,
                         }
                       : { background: ACCENT_SOLID, color: "var(--on-accent)", border: `1.5px solid ${ACCENT}` }
                 }
@@ -400,7 +400,7 @@ function SuccessPanel({ onOpen }: { onOpen: () => void }) {
     <div className="text-center py-5">
       <div
         className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-5"
-        style={{ background: "rgba(34,197,94,0.1)" }}
+        style={{ background: "var(--ok-bg)" }}
       >
         <CheckIcon className="w-7 h-7 text-ok" />
       </div>

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -334,7 +334,7 @@ function ContextPill({
         <div
           role="dialog"
           aria-label="Context usage"
-          className="manta-ctx-popover absolute right-0 top-full mt-1 z-30 w-[340px] p-4 rounded-lg border border-border bg-bg-soft shadow-md"
+          className="manta-ctx-popover manta-menu-in absolute right-0 top-full mt-1 z-30 w-[340px] p-4 rounded-lg border border-border bg-bg-soft shadow-md"
         >
           {/* Headline — the percentage leads, the absolute counts qualify it.
               Baseline-aligned so the 15px metric and the 12px mono counts sit

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -561,7 +561,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         >
           <button
             onClick={() => setPaletteOpen(true)}
-            className="text-text-muted hover:text-text text-base leading-none"
+            className="text-text-muted hover:text-text text-prose leading-none"
             title={`Search sessions (${MOD_KEY}K)`}
             aria-label="Search sessions"
           >
@@ -569,7 +569,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
           </button>
           <button
             onClick={onNewProject}
-            className="text-text-muted hover:text-text text-lg leading-none"
+            className="text-text-muted hover:text-text text-title leading-none"
             title={`New project (${MOD_KEY}N)`}
           >
             +
@@ -842,8 +842,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
               for blocking states only. */}
           {updateAvailable && (
             <span
-              className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
-              style={{ backgroundColor: "var(--accent)" }}
+              className="inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-accent"
               title="An update is ready to install — see Settings → General → About"
               aria-label="Update available"
             />

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -473,7 +473,7 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
         onMouseDown={() => termRef.current?.focus()}
       />
       {(dragOver || uploading) && (
-        <div className="absolute inset-2 z-10 flex items-center justify-center rounded-sm border-2 border-dashed border-accent bg-bg/70 text-text text-sm pointer-events-none">
+        <div className="absolute inset-2 z-10 flex items-center justify-center rounded-sm border-2 border-dashed border-accent bg-bg/70 text-text text-body pointer-events-none">
           {uploading ? "Uploading…" : "Drop to share with Claude"}
         </div>
       )}
@@ -499,7 +499,7 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
               }
             }}
             placeholder="Find…"
-            className="w-40 bg-transparent text-sm text-text outline-none placeholder:text-text-faint"
+            className="w-40 bg-transparent text-body text-text outline-none placeholder:text-text-faint"
           />
           <button className="px-1 text-text-muted hover:text-text" title="Previous (Shift+Enter)"
             onClick={() => findQuery && searchRef.current?.findPrevious(findQuery)}>‹</button>

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -22,6 +22,7 @@
 import { useEffect, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
+import { MOTION_BASE, MOTION_EASE } from "./chatMotion";
 
 export type ToastAction = {
   label: string;
@@ -149,7 +150,7 @@ export function ToastStack({ toasts, onDismiss }: ToastStackProps) {
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 8 }}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: MOTION_BASE, ease: MOTION_EASE }}
             className="pointer-events-auto w-full max-w-[420px]"
           >
             <Toast toast={t} onDismiss={onDismiss} />

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -24,6 +24,7 @@ import { Virtuoso, type ListProps, type VirtuosoHandle } from "react-virtuoso";
 import { TaskContext, type TaskContextValue, presentVerbFor } from "./chatShared";
 import { ActiveTodos, MessageRow } from "./MessageRow";
 import { MantaLoader } from "./MantaLoader";
+import { MOTION_FAST } from "./chatMotion";
 import { CardMount } from "./components/CardMount";
 import { WORKING_TICK_MS, nowMs, useClockTick } from "./clock";
 import { QuestionCard } from "./Cards";
@@ -193,7 +194,7 @@ export function WorkingIndicator({
     <CardMount show={running} k="working">
       <div className="manta-working-indicator flex items-center gap-2 shrink-0">
         <MantaLoader />
-        <span className="text-text-faint text-xs">
+        <span className="text-text-faint text-meta">
           {liveTurn ? (
             <>
               {presentVerbFor(liveTurn.verbSeedId)}…
@@ -428,7 +429,7 @@ export function Transcript({
             className="flex-1 min-h-0 flex flex-col"
             initial={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ type: "tween", duration: 0.15 }}
+            transition={{ type: "tween", duration: MOTION_FAST }}
           >
             {/* Empty state: full width, matching the populated flow below so
                 both states share a left edge (BET-646).

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -84,29 +84,23 @@ export function UpdateBar({
     // exactly `px-3` everywhere else.
     <div className="shrink-0 bg-accent/10 border-b border-accent/30 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2">
       <span className="flex-1 truncate">{statusLabel}</span>
-      {busy ? (
+      {busy || progress ? (
         <div
-          className="shrink-0 w-32 h-1.5 rounded-full bg-accent/20 overflow-hidden"
+          className="shrink-0 w-32 h-1.5 rounded-full bg-accent/20 overflow-hidden relative"
           role="progressbar"
           aria-label={busyLabel}
+          aria-valuenow={progress ? progress.step : undefined}
+          aria-valuemin={progress ? 1 : undefined}
+          aria-valuemax={progress ? progress.total : undefined}
         >
-          <div
-            className="h-full bg-accent animate-pulse"
-            style={{ width: progress ? `${(progress.step / progress.total) * 100}%` : "55%" }}
-          />
-        </div>
-      ) : progress ? (
-        <div
-          className="shrink-0 w-32 h-1.5 rounded-full bg-accent/20 overflow-hidden"
-          role="progressbar"
-          aria-valuenow={progress.step}
-          aria-valuemin={1}
-          aria-valuemax={progress.total}
-        >
-          <div
-            className="h-full bg-accent transition-all"
-            style={{ width: `${(progress.step / progress.total) * 100}%` }}
-          />
+          {progress ? (
+            <div
+              className="h-full bg-accent"
+              style={{ width: `${(progress.step / progress.total) * 100}%` }}
+            />
+          ) : (
+            <div className="absolute h-full w-2/5 rounded-full bg-accent manta-sweep" />
+          )}
         </div>
       ) : (
         <>

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -99,7 +99,7 @@ export function UpdateBar({
               style={{ width: `${(progress.step / progress.total) * 100}%` }}
             />
           ) : (
-            <div className="absolute h-full w-2/5 rounded-full bg-accent manta-sweep" />
+            <div className="absolute h-full manta-sweep rounded-full bg-accent" />
           )}
         </div>
       ) : (

--- a/src/renderer/chatMotion.ts
+++ b/src/renderer/chatMotion.ts
@@ -28,6 +28,13 @@ import type { MotionProps } from "framer-motion";
 
 type EntryMotionProps = Pick<MotionProps, "initial" | "animate" | "transition">;
 
+// The motion scale (audit D1): three durations, ONE easing. Every in-app
+// transition picks a token; ad-hoc durations/curves are a regression.
+export const MOTION_EASE = [0.22, 1, 0.36, 1] as const;      // the existing chat-entry ease
+export const MOTION_FAST = 0.12;   // menus, palette, backdrops
+export const MOTION_BASE = 0.2;    // modals, cards, toasts
+export const MOTION_SLOW = 0.3;    // message entry, panel slides, onboarding
+
 /**
  * The "smooth appear": a short rise (translateY 12px) with a cross-fade, on a
  * non-overshooting cubic-bezier ease. Applied identically to the user bubble,
@@ -46,7 +53,7 @@ type EntryMotionProps = Pick<MotionProps, "initial" | "animate" | "transition">;
 export const MESSAGE_IN_ENTER: EntryMotionProps = {
   initial: { opacity: 0, y: 12 },
   animate: { opacity: 1, y: 0 },
-  transition: { type: "tween", duration: 0.3, ease: [0.22, 1, 0.36, 1] },
+  transition: { type: "tween", duration: MOTION_SLOW, ease: MOTION_EASE },
 };
 
 /**

--- a/src/renderer/components/CardMount.tsx
+++ b/src/renderer/components/CardMount.tsx
@@ -20,6 +20,7 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import type { ReactNode } from "react";
+import { MOTION_BASE, MOTION_EASE } from "../chatMotion";
 
 export type CardMountProps = {
   /** Whether the card is currently visible. */
@@ -38,7 +39,7 @@ export function CardMount({ show, k, children }: CardMountProps) {
           initial={{ height: 0, opacity: 0 }}
           animate={{ height: "auto", opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
-          transition={{ duration: 0.22, ease: [0.25, 0.1, 0.25, 1] }}
+          transition={{ duration: MOTION_BASE, ease: MOTION_EASE }}
           style={{ overflow: "hidden" }}
         >
           {children}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -87,7 +87,7 @@ html, body, #root {
   to { opacity: 1; transform: translateY(0); }
 }
 .onboarding-step-enter {
-  animation: onboardingFadeSlideIn 350ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  animation: onboardingFadeSlideIn var(--motion-slow) var(--ease-out) forwards;
 }
 
 /* Recording indicator (BET-416 §A). Voice recording is signalled by the
@@ -158,7 +158,7 @@ html, body, #root {
    transcript, so a tab flip reads as the highlight gliding, not the content
    swapping. */
 .manta-artifacts-tab-indicator {
-  transition: transform 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: transform var(--motion-slow) var(--ease-out);
 }
 @media (prefers-reduced-motion: reduce) {
   .manta-artifacts-tab-indicator { transition: none; }
@@ -175,7 +175,7 @@ html, body, #root {
    a 120ms fade-in keeps a fast tab-cycle from feeling like a hard blank-frame
    swap. Fades from 0.4, not 0, so quick tab-cycling never blanks the pane.
    The class is added by PanelShell in App.tsx and removed at animationend. */
-.panel-enter { animation: panelFadeIn 120ms ease-out; }
+.panel-enter { animation: panelFadeIn var(--motion-fast) ease-out; }
 @keyframes panelFadeIn {
   from { opacity: 0.4; }
   to { opacity: 1; }
@@ -200,7 +200,7 @@ html, body, #root {
 /* PaletteShell enter/exit (⌘K switcher, ⌘F search). 140ms in / 100ms out —
    the 100ms must match CLOSE_MS in PaletteShell.tsx. */
 .manta-palette-overlay { animation: manta-palette-fade-in 140ms ease-out; }
-.manta-palette-panel { animation: manta-palette-pop-in 140ms cubic-bezier(0.16, 1, 0.3, 1); }
+.manta-palette-panel { animation: manta-palette-pop-in var(--motion-fast) var(--ease-out); }
 .manta-palette-overlay-out { animation: manta-palette-fade-out 100ms ease-in forwards; }
 .manta-palette-panel-out { animation: manta-palette-pop-out 100ms ease-in forwards; }
 @keyframes manta-palette-fade-in { from { opacity: 0; } }
@@ -213,3 +213,34 @@ html, body, #root {
   .manta-palette-overlay-out,
   .manta-palette-panel-out { animation: none; }
 }
+
+/* D2 — menus/popovers enter with a 120ms rise; exit stays instant (snappy close). */
+.manta-menu-in {
+  animation: manta-menu-in var(--motion-fast) var(--ease-out);
+  transform-origin: top left;
+}
+@keyframes manta-menu-in {
+  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .manta-menu-in { animation: none; }
+}
+
+/* Tailwind's animate-* utilities ship no reduced-motion guard; framer is
+   covered by MotionConfig and custom keyframes carry their own guards. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse, .animate-spin, .animate-bounce { animation: none; }
+}
+
+/* D8 — honest indeterminate UpdateBar sweep. */
+.manta-sweep { animation: manta-sweep 1.2s var(--ease-out) infinite; }
+@keyframes manta-sweep { from { left: -40%; } to { left: 100%; } }
+@media (prefers-reduced-motion: reduce) {
+  .manta-sweep {
+    animation: manta-pulse-fallback 1.6s ease-in-out infinite;
+    left: 0;
+    width: 100%;
+    opacity: 0.5;
+  }
+}
+@keyframes manta-pulse-fallback { 50% { opacity: 0.2; } }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -233,7 +233,7 @@ html, body, #root {
 }
 
 /* D8 — honest indeterminate UpdateBar sweep. */
-.manta-sweep { animation: manta-sweep 1.2s var(--ease-out) infinite; }
+.manta-sweep { width: 40%; animation: manta-sweep 1.2s var(--ease-out) infinite; }
 @keyframes manta-sweep { from { left: -40%; } to { left: 100%; } }
 @media (prefers-reduced-motion: reduce) {
   .manta-sweep {

--- a/src/renderer/tokens.css
+++ b/src/renderer/tokens.css
@@ -157,6 +157,16 @@
   --font-size-display: 28px;
   --font-size-confirm: 40px;
   --font-size-otp: 26px;
+
+  /* Motion scale (audit D1). Mirrors chatMotion.ts — three durations, ONE
+     easing. Every in-app transition picks a token; ad-hoc durations/curves
+     are a regression. The CSS custom properties exist so keyframe/CSS
+     consumers (dropdowns, palette, onboarding, panel swap) resolve the same
+     values the framer sites import from chatMotion.ts. */
+  --motion-fast: 120ms;   /* menus, palette, backdrops */
+  --motion-base: 200ms;   /* modals, cards, toasts */
+  --motion-slow: 300ms;   /* message entry, panel slides, onboarding */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* Density scope (BET-544). Session-row metrics live on [data-density], NOT


### PR DESCRIPTION
## Summary
Retokenizes motion across the renderer onto a single motion scale, adds a dropdown mount animation, reduced-motion guards for Tailwind keyframes, an honest indeterminate UpdateBar sweep, and migrates color/type token stragglers.

**Base: origin/main @ `6b652836`**

## Tasks
- **T1 — motion scale (D1):** `chatMotion.ts` now exports `MOTION_EASE`/`FAST`/`BASE`/`SLOW`; mirrored as CSS vars (`--motion-fast/base/slow`, `--ease-out`) in `tokens.css`. Migrated outliers: CardMount, Toast, Modal (panel→BASE, backdrop→FAST), Transcript empty-state, ArtifactsPanel, message-entry; CSS sites (onboarding, artifacts tab pill, palette, panel swap) use the vars. Grep gates pass: no `cubic-bezier(` outside tokens.css, no `ease: [` outside chatMotion.ts.
- **T2 — dropdown mount (D2):** shared `.manta-menu-in` class added to the Dropdown root (covers model/effort/session-menu) + the ctx popover. Hook classes untouched (visual-gate registry).
- **T3 — reduced-motion guards (12):** single `@media (prefers-reduced-motion: reduce)` rule killing `animate-pulse`/`animate-spin`/`animate-bounce`.
- **T4 — honest UpdateBar (D8):** indeterminate branch → sweeping track (`.manta-sweep`) with a pulse-fallback for reduced-motion. Determinate + a11y attrs preserved.
- **T5 — token stragglers (10+honourable):** App/Sidebar dots → `bg-warn`/`bg-accent`; Onboarding focus glow → `--accent-bg`, ok fill → `--ok-bg`; ArtifactsPanel badge → `text-micro`; Terminal/Transcript/Sidebar legacy sizes → type roles; InputArea trust label → `text-text-muted`.

**Deviation from issue:** the D8 snippet used `w-2/5`, which is absent from the trimmed `dimensionScale` — the `tailwindScale` guard test fails on it (silent no-op). Sweep width moved into the `.manta-sweep` class instead (reduced-motion `width:100%` still overrides in cascade). `AddPhonePanel.tsx:97 text-lg` was already migrated (`text-body`) — stale reference, no change needed.

## Verification results
- PR branch (`multica/BET-728-motion-tokens` @ `5ffdfa9a`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0. Vitest 2334 pass / 0 fail / 7 skip (126 files); node:test 1615 pass / 0 fail.
- Note: `npm install` ran once to populate a fresh node_modules (tsc was absent).