### PR TITLE
feat(server): live tool-output frames in the interpreted stream (BET-745)

### DIFF
--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -46,6 +46,12 @@ import {
 
 const TTL_DEFAULT = "1h";
 
+// Per-tool cap for the live tool-output tail (server half, BET-745). Once a
+// single tool has streamed this many characters to the device, further output
+// is dropped for that tool and a single "...truncated" marker is emitted so an
+// endless bash can't balloon the device stream or box memory.
+const MAX_TOOL_OUTPUT_CHARS = 20_000;
+
 /**
  * The latest index in `text` that is safe to cut at, or -1 if none is.
  *
@@ -74,6 +80,7 @@ function newSessionState() {
   return {
     parts: new Map(),          // partID -> { messageID, field, text } (delta buffers)
     finalParts: new Set(),     // partIDs that got a message.part.updated snapshot
+    tools: new Map(),          // toolIdx(partID) -> { idx, name, status, sent, truncated, ended }
     childSessionIds: new Set(),
     liveChildStatus: new Map(),
     questions: [],             // QuestionLike[]
@@ -85,6 +92,120 @@ function newSessionState() {
     msgByMsgId: new Map(),     // messageID -> minimal message for turn detection
     userTurnCount: 0,
   };
+}
+
+// design: live tool-output frames (server half, BET-745).
+//
+// opencode re-emits `message.part.updated` for a tool part (~every 20-40ms)
+// as the tool's stdout grows, with `part.type === "tool"`. The running tool's
+// live stdout streams into `part.state.metadata.output` (NOT `state.output`,
+// which only exists at completion). The canonical transcript only refreshes
+// at refetch boundaries, so a thin client never saw the running tool until the
+// turn ended. These three TEMPORARY frames publish it on the interpreted
+// stream — additive only: every existing frame (`session.run`, `running`,
+// `todos`, `truncation`, `subagent`, …) and the turnComplete/running books are
+// untouched, and the same raw event still flows through every other branch.
+//
+// App contract (the iOS rendering half, sequenced BET, must read exactly these
+// frame + field names so the two halves cannot drift):
+//   toolStarted { sessionId, idx, toolName, toolPresentationHint?, status }
+//   toolOutput  { sessionId, idx, text }
+//   toolEnded   { sessionId, idx, ok, truncated? }
+//
+// Field types:
+//   sessionId            string   — the opencode session the tool belongs to
+//   idx                  string   — the tool PART ID; stable per tool across the
+//                                   whole run (identical on started/output/ended)
+//   toolName             string   — e.g. "bash", "read", "write", "task"
+//   toolPresentationHint string?  — opencode's human title for the part (e.g.
+//                                   "Run: npm test"); null when the box gave none
+//   status               string   — "pending" | "running" | "completed" | "error"
+//   text                 string   — a single incremental stdout chunk (the delta
+//                                   since the last chunk, never the full output)
+//   ok                   boolean  — toolEnded: true when the tool completed,
+//                                   false when it errored
+//   truncated            boolean  — present true only when the per-tool output
+//                                   cap (MAX_TOOL_OUTPUT_CHARS) was hit
+//
+// Bounding: only the delta since the last chunk is ever sent (never the full
+// output again), and the per-tool cap stops a long-running bash from
+// ballooning the device stream; past the cap a single "...truncated" marker
+// rides the last toolOutput and toolEnded carries `truncated: true`. All three
+// frames are keyed by `idx`, so a duplicate/re-emitted part for the same tool
+// is a no-op for started/ended and appends only newly-arrived bytes for output.
+function updateToolFrames(st, sid, part, emit) {
+  if (!part || part.type !== "tool") return;
+  const idx = typeof part.id === "string" && part.id.length > 0 ? part.id : null;
+  if (!idx) return;
+  const state = part.state;
+  const status = typeof state?.status === "string" ? state.status : null;
+  if (!status) return;
+
+  let tool = st.tools.get(idx);
+
+  // A tool the device hasn't been told about yet -> toolStarted.
+  if (!tool) {
+    tool = { idx, name: part.tool ?? null, status, sent: 0, truncated: false, ended: false };
+    st.tools.set(idx, tool);
+    emit(sid, "toolStarted", {
+      sessionId: sid,
+      idx,
+      toolName: tool.name,
+      toolPresentationHint: typeof state?.title === "string" ? state.title : null,
+      status,
+    });
+  }
+
+  // Live incremental stdout. The running tool streams into metadata.output;
+  // send only the bytes not already delivered, bounded by the per-tool cap.
+  if (status === "running" && typeof state?.metadata?.output === "string") {
+    tool.status = status;
+    const full = state.metadata.output;
+    if (full.length > tool.sent) {
+      if (tool.truncated) {
+        // Cap already hit: advance the cursor silently so we never re-send.
+        tool.sent = full.length;
+      } else {
+        const delta = full.slice(tool.sent);
+        const room = MAX_TOOL_OUTPUT_CHARS - tool.sent;
+        if (delta.length > room) {
+          const kept = delta.slice(0, room);
+          tool.sent += kept.length;
+          tool.truncated = true;
+          emit(sid, "toolOutput", { sessionId: sid, idx, text: kept + "… [output truncated]" });
+        } else {
+          tool.sent += delta.length;
+          emit(sid, "toolOutput", { sessionId: sid, idx, text: delta });
+        }
+      }
+    }
+  }
+
+  // Terminal statuses -> deliver any final tail, then toolEnded exactly once.
+  // At completion the authoritative full output sits in state.output, which may
+  // carry a few trailing bytes the live metadata.output hadn't flushed yet.
+  if (status === "completed" || status === "error") {
+    const finalOutput =
+      typeof state?.output === "string"
+        ? state.output
+        : typeof state?.metadata?.output === "string"
+          ? state.metadata.output
+          : null;
+    if (typeof finalOutput === "string" && finalOutput.length > tool.sent && !tool.truncated) {
+      const delta = finalOutput.slice(tool.sent);
+      tool.sent = finalOutput.length;
+      emit(sid, "toolOutput", { sessionId: sid, idx, text: delta });
+    }
+    if (!tool.ended) {
+      tool.ended = true;
+      emit(sid, "toolEnded", {
+        sessionId: sid,
+        idx,
+        ok: status === "completed",
+        ...(tool.truncated ? { truncated: true } : {}),
+      });
+    }
+  }
 }
 
 /**
@@ -203,6 +324,11 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
             ),
           });
         }
+        // Live tool-output frames for any tool part (additive; the subagent
+        // branch above still runs for task tools). A task subagent is also a
+        // tool part, so it gets a toolStarted/…/toolEnded pair too — harmless
+        // alongside the richer `subagent` frame.
+        if (part?.type === "tool") updateToolFrames(st, sid, part, emit);
         return;
       }
       case "session.created": {

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -427,3 +427,113 @@ test("interpret ignores events with no session id", () => {
   interp.interpret({ type: "message.part.delta", properties: { part: { id: "x" } } });
   assert.equal(events.length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// Live tool-output frames (server half, BET-745).
+//
+// A tool part flows through `message.part.updated` with `part.type === "tool"`.
+// The running tool's stdout is in `state.metadata.output`; the authoritative
+// final output reads from `state.output` at completion.
+// ---------------------------------------------------------------------------
+
+// Build a tool `message.part.updated` payload in the shape opencode sends.
+function toolPartUpdated({ id, tool = "bash", status, title, metaOutput, output, messageID = "msg1" }) {
+  return {
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      messageID,
+      part: {
+        id,
+        type: "tool",
+        tool,
+        state: {
+          status,
+          ...(title !== undefined ? { title } : {}),
+          ...(metaOutput !== undefined ? { metadata: { output: metaOutput } } : {}),
+          ...(output !== undefined ? { output } : {}),
+        },
+      },
+    },
+  };
+}
+
+test("toolStarted is emitted once when a tool part first appears", () => {
+  const { interp, events } = make();
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", title: "Run: npm test", metaOutput: "" }));
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "" }));
+  const started = events.filter((e) => e.sub === "toolStarted");
+  assert.equal(started.length, 1, "re-emit for the same idx emits toolStarted exactly once");
+  assert.equal(started[0].payload.sessionId, SID);
+  assert.equal(started[0].payload.idx, "t1");
+  assert.equal(started[0].payload.toolName, "bash");
+  assert.equal(started[0].payload.toolPresentationHint, "Run: npm test");
+  assert.equal(started[0].payload.status, "running");
+});
+
+test("toolOutput carries only the delta since the last chunk, never the full output", () => {
+  const { interp, events } = make();
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "line1\n" }));
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "line1\nline2\n" }));
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "line1\nline2\nline3\n" }));
+  const chunks = events.filter((e) => e.sub === "toolOutput").map((e) => e.payload.text);
+  assert.deepEqual(chunks, ["line1\n", "line2\n", "line3\n"]);
+  // every chunk is keyed by the same stable tool idx
+  assert.ok(events.filter((e) => e.sub === "toolOutput").every((e) => e.payload.idx === "t1"));
+});
+
+test("re-emitting the same output does not double-append", () => {
+  const { interp, events } = make();
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "abc" }));
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "abc" }));
+  const chunks = events.filter((e) => e.sub === "toolOutput").map((e) => e.payload.text);
+  assert.deepEqual(chunks, ["abc"], "no byte is sent twice for the same tool");
+  assert.equal(events.filter((e) => e.sub === "toolStarted").length, 1);
+});
+
+test("toolEnded inverts ok on failure and flags truncation on cap", () => {
+  const { interp, events } = make();
+  // success: completed -> ok true
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "ok" }));
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "completed", output: "ok" }));
+  const ends1 = events.filter((e) => e.sub === "toolEnded" && e.payload.idx === "t1");
+  assert.equal(ends1.length, 1, "toolEnded fires exactly once");
+  assert.equal(ends1[0].payload.ok, true);
+  assert.equal(ends1[0].payload.truncated, undefined);
+
+  // failure: error -> ok false
+  interp.interpret(toolPartUpdated({ id: "t2", tool: "bash", status: "error", output: "boom" }));
+  const ends2 = events.filter((e) => e.sub === "toolEnded" && e.payload.idx === "t2");
+  assert.equal(ends2.length, 1);
+  assert.equal(ends2[0].payload.ok, false);
+
+  // cap: an over-limit bash is truncated once, then no further output
+  const { interp: i2, events: ev2 } = make();
+  const huge = "x".repeat(50_000);
+  i2.interpret(toolPartUpdated({ id: "t3", tool: "bash", status: "running", metaOutput: huge }));
+  const outs = ev2.filter((e) => e.sub === "toolOutput");
+  assert.equal(outs.length, 1);
+  assert.ok(outs[0].payload.text.endsWith("… [output truncated]"), "a truncation marker rides the last chunk");
+  i2.interpret(toolPartUpdated({ id: "t3", tool: "bash", status: "running", metaOutput: huge + "extra" }));
+  assert.equal(ev2.filter((e) => e.sub === "toolOutput").length, 1, "output is suppressed once capped");
+  i2.interpret(toolPartUpdated({ id: "t3", tool: "bash", status: "completed", output: huge + "extra" }));
+  const ends3 = ev2.filter((e) => e.sub === "toolEnded");
+  assert.equal(ends3.length, 1);
+  assert.equal(ends3[0].payload.truncated, true);
+});
+
+test("live tool frames are additive — running/truncation/sessionError still fire on their triggers", () => {
+  const { interp, events } = make();
+  // regression pins: the pre-existing frames are untouched by the new branch
+  interp.interpret({ type: "session.status", properties: { sessionID: SID, status: { type: "busy" } } });
+  assert.equal(events.filter((e) => e.sub === "running").length, 1);
+  interp.interpret({ type: "session.next.step.ended", properties: { sessionID: SID, finish: "max_tokens", lastPartIsToolUse: true } });
+  assert.equal(events.filter((e) => e.sub === "truncation").length, 1);
+  interp.interpret({ type: "session.error", properties: { sessionID: SID, error: { name: "ApiError", message: "boom" } } });
+  assert.equal(events.filter((e) => e.sub === "sessionError").length, 1);
+  assert.equal(events.filter((e) => e.sub === "turnComplete").length, 1);
+  // and a tool flow still flows through the same stream
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "hi" }));
+  assert.equal(events.filter((e) => e.sub === "toolStarted").length, 1);
+  assert.equal(events.filter((e) => e.sub === "toolOutput").length, 1);
+});


### PR DESCRIPTION
## BET-745 — Server: live tool-output frames in the interpreted stream (server half)

Server+protocol half of gap #5. Adds three temporary, additive frames to the
interpreted stream so a thin client (the sequenced iOS BET) can render a running
tool row and tail a long bash live — today tool state only reaches a device at
canonical-refetch boundaries.

No iOS work here (separate sequenced BET). No change to canonical
transcript/`opencode:messages` semantics. Not wired into push.

### Wire source (verified shapes)

A running tool streams its stdout via repeated `message.part.updated` events with
`properties.part.type === "tool"`; the live stdout is at
`part.state.metadata.output` (NOT `state.output`, which only exists at
completion). `part.state.status` transitions, `part.state.title` is the human
presentation hint, `part.id` is the stable per-tool identity. These shapes match
the repo's documented live-wire record (see the "Live tool output (bash tailing)"
and "Subagent rendering" AGENTS.md sections, both verified against `/events`).

### Design

`// design` comment block at the top of the new emitter (`updateToolFrames` in
`src/server/streamInterp.mjs`), following the existing `emit(sid, sub, payload)`
pattern and per-session state accumulation (`st.tools` map keyed by tool part id).

**App contract — iOS consumer (BET-7xx) must read exactly these frame/field names:**

```
toolStarted { sessionId, idx, toolName, toolPresentationHint?, status }
toolOutput  { sessionId, idx, text }
toolEnded   { sessionId, idx, ok, truncated? }
```

| Field | Type | Notes |
|---|---|---|
| `sessionId` | string | opencode session the tool belongs to |
| `idx` | string | tool **part id**; stable per tool across the whole run (same on started/output/ended) |
| `toolName` | string | e.g. `"bash"`, `"read"`, `"write"`, `"task"` |
| `toolPresentationHint` | string? | opencode's human title for the part (e.g. `"Run: npm test"`); `null` when none |
| `status` | string | `"pending" \| "running" \| "completed" \| "error"` |
| `text` | string | a single incremental stdout chunk (the delta since the last chunk, never the full output) |
| `ok` | boolean | `toolEnded` true on completed, false on error |
| `truncated` | boolean | present `true` only when the per-tool output cap was hit |

**Bounding:** only the delta since the last chunk is ever sent (never the full
output again); a per-tool cap (`MAX_TOOL_OUTPUT_CHARS` = 20k) drops further
output for that tool and rides a single `"… [output truncated]"` marker, with
`toolEnded.truncated = true`. All three frames key on `idx`, so a re-emitted
part for the same tool is a no-op for started/ended and appends only newly-arrived
bytes for output.

**Additive:** every existing frame (`running`, `todos`, `truncation`,
`sessionError`, `subagent`, `turnComplete`, …) is untouched and still emitted on
its existing triggers; the running/turnComplete books are never replaced.

### Tests (`src/server/streamInterp.test.mjs`, +5)

- tool-start → `toolStarted` emitted exactly once, even on re-emit
- incremental output → `toolOutput` deltas only (never the full output)
- tool-end → `toolEnded` with `ok` inversion on failure and `truncated` flag on cap
- re-emitted state for the same `idx` does not double-append
- regression pin: `running`/`truncation`/`sessionError` still fire on their triggers

### Verification

- `npm run typecheck` — ✅ passes
- `npm test` — ✅ 1620 pass / 0 fail
- `npm run test:server` — ✅ 1126 pass / 0 fail (new streamInterp cases included)

Base: origin/main @ `6b652836`
