### PR TITLE
feat(ios): edit scheduled tasks & secrets from chat resource cards (BET-744)

### DIFF
--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -311,6 +311,23 @@ final class MantaAPIClient: Sendable {
         return try await call("secrets:list", args: args, as: [SecretMeta].self) ?? []
     }
 
+    /// `schedule:delete` — delete a scheduled-prompt job by its id.
+    /// `args[0]` is the job `id` (a `ScheduledJob.id`).
+    func deleteSchedule(id: String) async throws {
+        _ = try await call("schedule:delete", args: [id], as: VoidResult.self)
+    }
+
+    /// `secrets:set` — store (or upsert) a secret. The value travels to the box
+    /// and is never returned or rendered again; only the metadata comes back.
+    func setSecret(_ input: SecretInput) async throws -> SecretSetResult {
+        try await callRequired("secrets:set", args: [try jsonObject(input)], as: SecretSetResult.self)
+    }
+
+    /// `secrets:delete` — delete a secret by its store id (a `SecretMeta.id`).
+    func deleteSecret(id: String) async throws {
+        _ = try await call("secrets:delete", args: [id], as: VoidResult.self)
+    }
+
     /// `voice:transcribe` — ship recorded audio (base64 over the JSON RPC
     /// wire, as the desktop shim does) to the box's Groq transcription.
     /// Returns the transcribed text, or nil when the clip was empty.
@@ -440,6 +457,17 @@ final class MantaAPIClient: Sendable {
     private func callVoid(_ channel: String, args: [Any]) async throws -> VoidResult? {
         let data = try await transport(channel: channel, args: args)
         return try Self.decode(data, as: VoidResult.self)
+    }
+
+    /// Encode an `Encodable` payload (e.g. `SecretInput`) back into the
+    /// `[String: Any]` JSON-object shape the RPC transport serialises. Nil
+    /// optional properties are omitted, matching the box's `{...i}` merge.
+    private func jsonObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw MantaError.transport("payload is not a JSON object")
+        }
+        return object
     }
 
     private func transport(channel: String, args: [Any]) async throws -> Data {

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -335,3 +335,25 @@ struct SecretMeta: Codable, Equatable, Sendable, Identifiable {
     var createdAt: Int?
     var updatedAt: Int?
 }
+
+/// Client→box input for `secrets:set` (mirrors src/shared/types.ts SecretInput
+/// and the `{key,value,scope,sessionID,project,hint}` wire shape in
+/// src/server/rpc.mjs). The value travels device → box and is never returned or
+/// rendered again. Nil optionals are omitted by the synthesized Encodable, so a
+/// shared-scope set sends only `{key,value,scope}`.
+struct SecretInput: Encodable, Sendable {
+    var key: String
+    var value: String
+    var scope: String?
+    var sessionID: String?
+    var project: String?
+    var hint: String?
+}
+
+/// `secrets:set` reply (src/server/secrets.mjs `secretsSetStore`). `meta` is the
+/// value-stripped metadata on success; `error` is present when `ok` is false.
+struct SecretSetResult: Decodable, Equatable, Sendable {
+    var ok: Bool
+    var meta: SecretMeta?
+    var error: String?
+}

--- a/mobile/native/MantaUI/SessionResourceCards.swift
+++ b/mobile/native/MantaUI/SessionResourceCards.swift
@@ -13,13 +13,16 @@ import SwiftUI
 // picker.
 //
 // The cards talk to the box over the existing RPC wire
-// (`schedule:list` / `secrets:list`) — no new transport.
+// (`schedule:list`/`schedule:delete` / `secrets:list`/`secrets:set`/`secrets:delete`).
 // Secrets are METADATA ONLY: the box never sends a value to the device, so the
-// secrets card can list names without ever materialising a secret device-side.
+// secrets card can list names without ever materialising a secret device-side,
+// and it only ever collects an incoming value that is discarded after save.
 // ===========================================================================
 
 /// List of scheduled-prompt jobs scoped to the session. The count shown in the
 /// overflow row ("Scheduled tasks" with live count) is this list's length.
+/// Jobs are created by the AI's `schedule` tool / `POST /api/schedule` — the
+/// UI can delete but never fabricates a create RPC, so there is no create form.
 struct SchedulesCard: View {
     let sessionId: String
     let onClose: () -> Void
@@ -41,6 +44,13 @@ struct SchedulesCard: View {
                     } else {
                         List(jobs) { job in
                             row(job)
+                                .swipeActions(edge: .trailing) {
+                                    Button(role: .destructive) {
+                                        Task { await delete(job) }
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                }
                         }
                         .listStyle(.insetGrouped)
                     }
@@ -56,20 +66,28 @@ struct SchedulesCard: View {
                 }
             }
         }
-        .task {
-            guard !loaded else { return }
-            if let result = try? await api.listSchedules(sessionId: sessionId) {
-                jobs = result
-            } else {
-                failed = true
-            }
-            loaded = true
+        .task { await load() }
+    }
+
+    private func load() async {
+        if let result = try? await api.listSchedules(sessionId: sessionId) {
+            jobs = result
+            failed = false
+        } else {
+            failed = true
+        }
+        loaded = true
+    }
+
+    private func delete(_ job: ScheduledJob) async {
+        if (try? await api.deleteSchedule(id: job.id)) != nil {
+            await load()
         }
     }
 
     private var emptyState: some View {
         ContentUnavailableView("No scheduled tasks", systemImage: "clock",
-                               description: Text("Schedule a prompt from the desktop app to see it here."))
+                               description: Text("Schedule a prompt from the desktop app or the AI to see it here."))
     }
 
     private func row(_ job: ScheduledJob) -> some View {
@@ -107,7 +125,10 @@ struct SchedulesCard: View {
     }
 }
 
-/// List of secret names (metadata only — values never leave the box).
+/// List of secret names (metadata only — values never leave the box). The user
+/// can add a new secret (a `+` toolbar button → `secrets:set`) and swipe to
+/// delete an existing one (`secrets:delete`). The incoming value is discarded
+/// after save — this card never displays a value back.
 struct SecretsCard: View {
     let sessionId: String
     let onClose: () -> Void
@@ -115,6 +136,7 @@ struct SecretsCard: View {
     @State private var secrets: [SecretMeta] = []
     @State private var loaded = false
     @State private var failed = false
+    @State private var showingAdd = false
     private let api = MantaAPIClient.live()
 
     var body: some View {
@@ -129,6 +151,13 @@ struct SecretsCard: View {
                     } else {
                         List(secrets) { secret in
                             row(secret)
+                                .swipeActions(edge: .trailing) {
+                                    Button(role: .destructive) {
+                                        Task { await delete(secret) }
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                }
                         }
                         .listStyle(.insetGrouped)
                     }
@@ -139,25 +168,69 @@ struct SecretsCard: View {
             .navigationTitle("Secrets")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showingAdd = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel("Add secret")
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done", action: onClose)
                 }
             }
         }
-        .task {
-            guard !loaded else { return }
-            if let result = try? await api.listSecrets(sessionId: sessionId) {
-                secrets = result
-            } else {
-                failed = true
+        .task { await load() }
+        .sheet(isPresented: $showingAdd) {
+            SecretAddForm(sessionId: sessionId) { input in
+                await saveNewSecret(input)
+            } onCancel: {
+                showingAdd = false
             }
-            loaded = true
+        }
+    }
+
+    private func load() async {
+        if let result = try? await api.listSecrets(sessionId: sessionId) {
+            secrets = result
+            failed = false
+        } else {
+            failed = true
+        }
+        loaded = true
+    }
+
+    private func delete(_ secret: SecretMeta) async {
+        if (try? await api.deleteSecret(id: secret.id)) != nil {
+            await load()
+        }
+    }
+
+    private func saveNewSecret(_ input: SecretInput) async -> String? {
+        do {
+            let result = try await api.setSecret(input)
+            if result.ok {
+                await load()
+                return nil
+            }
+            return result.error ?? "save failed"
+        } catch {
+            return Self.message(for: error)
+        }
+    }
+
+    private static func message(for error: Error) -> String {
+        switch error {
+        case MantaError.server(let message): return message
+        case MantaError.transport(let message): return message
+        default: return error.localizedDescription
         }
     }
 
     private var emptyState: some View {
         ContentUnavailableView("No secrets", systemImage: "key",
-                               description: Text("Secrets you've stored for this session appear here."))
+                               description: Text("Tap + to add a secret for this session."))
     }
 
     private func row(_ secret: SecretMeta) -> some View {
@@ -178,5 +251,93 @@ struct SecretsCard: View {
         if let scope = secret.scope, !scope.isEmpty { parts.append(scope) }
         if let hint = secret.hint, !hint.isEmpty { parts.append(hint) }
         return parts.joined(separator: " · ")
+    }
+}
+
+/// The `+` add-secret form. Collects key/value/scope/hint, calls `secrets:set`
+/// (the value travels to the box and is never shown again), and surfaces the
+/// box's `error` when the set fails. On success the card refetches.
+private struct SecretAddForm: View {
+    let sessionId: String
+    let onSave: (SecretInput) async -> String?
+    let onCancel: () -> Void
+
+    @State private var key = ""
+    @State private var value = ""
+    @State private var scope = "session"
+    @State private var hint = ""
+    @State private var saving = false
+    @State private var errorMessage: String?
+
+    private var keyValid: Bool {
+        key.range(of: #"^[A-Za-z_][A-Za-z0-9_]{0,63}$"#, options: .regularExpression) != nil
+    }
+    private var canSave: Bool { keyValid && !value.isEmpty && !saving }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("KEY (e.g. GITHUB_PAT)", text: $key)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                        .font(.system(.body, design: .monospaced))
+                } footer: {
+                    Text("1–64 chars: a letter or underscore, then letters/digits/underscores.")
+                }
+                Section {
+                    SecureField("Value (stored on the box; never shown again)", text: $value)
+                        .font(.system(.body, design: .monospaced))
+                }
+                Section {
+                    Picker("Scope", selection: $scope) {
+                        Text("This session").tag("session")
+                        Text("This project").tag("project")
+                    }
+                    .pickerStyle(.automatic)
+                    TextField("Hint (optional)", text: $hint)
+                }
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("New secret")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task { await save() }
+                    }
+                    .disabled(!canSave)
+                }
+            }
+        }
+    }
+
+    private func save() async {
+        saving = true
+        defer {
+            saving = false
+            errorMessage = nil
+        }
+        let input = SecretInput(
+            key: key,
+            value: value,
+            scope: scope,
+            // Send the card's sessionId for BOTH session and project scope: the
+            // card is always read from within a session, and the box resolves
+            // the project name from sessionID when it is not supplied directly.
+            sessionID: sessionId,
+            hint: hint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : hint
+        )
+        if let error = await onSave(input) {
+            errorMessage = error
+        }
     }
 }

--- a/mobile/native/MantaUI/SessionResourceCards.swift
+++ b/mobile/native/MantaUI/SessionResourceCards.swift
@@ -322,10 +322,11 @@ private struct SecretAddForm: View {
 
     private func save() async {
         saving = true
-        defer {
-            saving = false
-            errorMessage = nil
-        }
+        // Clear any prior error at the START of a save attempt so a stale
+        // message doesn't linger after a subsequent successful save; a failed
+        // set then sets `errorMessage` below and it is NOT cleared on return.
+        errorMessage = nil
+        defer { saving = false }
         let input = SecretInput(
             key: key,
             value: value,

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -144,6 +144,67 @@ final class MantaActionRPCWireTests: XCTestCase {
         XCTAssertEqual(args?.count, 1)
         XCTAssertEqual(args?.first as? String, "ses_1")
     }
+    // MARK: - scheduled tasks & secrets edit (BET-744)
+
+    /// `schedule:delete` is dispatched as `fn(id)` — `args[0]` must be the job
+    /// `ScheduledJob.id` as a bare string (not an array/object).
+    func testScheduleDeleteSendsTheJobIdAsArg0() async throws {
+        let client = makeClient()
+        try await client.deleteSchedule(id: "a1b2c3d4")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/schedule:delete")
+        let args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        XCTAssertEqual(args?.count, 1)
+        XCTAssertEqual(args?.first as? String, "a1b2c3d4")
+    }
+
+    /// `secrets:delete` is dispatched as `fn(id)` — `args[0]` is the
+    /// `SecretMeta.id` store id as a bare string.
+    func testSecretDeleteSendsTheSecretIdAsArg0() async throws {
+        let client = makeClient()
+        try await client.deleteSecret(id: "ab12cd34")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/secrets:delete")
+        let args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        XCTAssertEqual(args?.count, 1)
+        XCTAssertEqual(args?.first as? String, "ab12cd34")
+    }
+
+    /// `secrets:set` serialises `{key, value, scope, sessionID, hint}` into
+    /// `args[0]` — the box's `{...i}` merge shape (src/server/rpc.mjs).
+    func testSecretSetSerializesKeyValueScopeSessionIDAndHint() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": {"ok": true, "meta": {"id": "x", "key": "GITHUB_PAT", "scope": "session", "sessionID": "ses_1", "project": null, "hint": "access", "hasValue": true}}}"#
+        _ = try await client.setSecret(SecretInput(key: "GITHUB_PAT", value: "secret", scope: "session", sessionID: "ses_1", hint: "access"))
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/secrets:set")
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertEqual(payload?["key"] as? String, "GITHUB_PAT")
+        XCTAssertEqual(payload?["value"] as? String, "secret")
+        XCTAssertEqual(payload?["scope"] as? String, "session")
+        XCTAssertEqual(payload?["sessionID"] as? String, "ses_1")
+        XCTAssertEqual(payload?["hint"] as? String, "access")
+    }
+
+    /// `secrets:set` decodes `{ok, error}` — the failure reply, surfacing the
+    /// box's error message (e.g. "value is required").
+    func testSecretSetDecodesErrorString() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": {"ok": false, "error": "value is required"}}"#
+        let result = try await client.setSecret(SecretInput(key: "K", value: ""))
+        XCTAssertFalse(result.ok)
+        XCTAssertEqual(result.error, "value is required")
+        XCTAssertNil(result.meta)
+    }
+
+    /// `secrets:set` decodes `{ok, meta}` — the success reply carries the
+    /// value-stripped metadata, never a value.
+    func testSecretSetDecodesOkAndMeta() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": {"ok": true, "meta": {"id": "x", "key": "K", "scope": "shared", "sessionID": null, "project": null, "hint": "", "hasValue": true, "createdAt": 1750000000000, "updatedAt": 1750000000000}}}"#
+        let result = try await client.setSecret(SecretInput(key: "K", value: "v", scope: "shared"))
+        XCTAssertTrue(result.ok)
+        XCTAssertEqual(result.meta?.key, "K")
+        XCTAssertEqual(result.meta?.scope, "shared")
+        XCTAssertNil(result.error)
+    }
 }
 
 // MARK: - Capturing URLProtocol


### PR DESCRIPTION
Opened automatically for `multica/BET-744-ios-edit-resource-cards`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-744.