### PR TITLE
feat(ios): Dynamic Type across reading surfaces + iPad/landscape support (BET-751)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		8C965541FA4ABDFB2A2A319E /* terminal in Resources */ = {isa = PBXBuildFile; fileRef = 0C1EE3F998CADE8487D2555E /* terminal */; };
 		8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471BF240012879FDED5689C1 /* ChatSessionStore.swift */; };
 		9055A7DECF435A0A430D6FAB /* MantaSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */; };
+		9068396FC592D6010419D13D /* MantaDynamicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCC705A51D162CE3E7E3B00 /* MantaDynamicType.swift */; };
 		94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
 		959894A87F301CC717772BD3 /* ChatLoadingSkeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */; };
@@ -111,6 +112,7 @@
 		0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVoice.swift; sourceTree = "<group>"; };
 		0C1EE3F998CADE8487D2555E /* terminal */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminal; path = MantaUI/Resources/terminal; sourceTree = SOURCE_ROOT; };
 		0C440016971186430E8C464B /* Scrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrim.swift; sourceTree = "<group>"; };
+		0FCC705A51D162CE3E7E3B00 /* MantaDynamicType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaDynamicType.swift; sourceTree = "<group>"; };
 		17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaRunningStateCaptureUITests.swift; sourceTree = "<group>"; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				DD646A4951E292E750890CCB /* MantaAppRoot.swift */,
 				2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */,
 				8879A94FE1BE824F438342AD /* MantaDeepLink.swift */,
+				0FCC705A51D162CE3E7E3B00 /* MantaDynamicType.swift */,
 				1E1306D325FEB295B7AB874E /* MantaEventStore.swift */,
 				872DDE9D9BAD041950DAC24A /* MantaLoader.swift */,
 				8C8240F1954861B4846E279D /* MantaModels.swift */,
@@ -578,6 +581,7 @@
 				3A14CB75D91300937752389C /* MantaAppRoot.swift in Sources */,
 				863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */,
 				F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */,
+				9068396FC592D6010419D13D /* MantaDynamicType.swift in Sources */,
 				33DC8035C0E87F9A3A7DA7DB /* MantaEventStore.swift in Sources */,
 				74D756D48A7D2A5483170A8B /* MantaLoader.swift in Sources */,
 				01871023D47544D64443194D /* MantaModels.swift in Sources */,
@@ -685,7 +689,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -697,7 +701,7 @@
 				PRODUCT_NAME = MantaUI;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -792,7 +796,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -804,7 +808,7 @@
 				PRODUCT_NAME = MantaUI;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -333,7 +333,7 @@ private struct ChatScreenContent: View {
         .overlay(alignment: .top) {
             if store.degraded {
                 Text("Connection lost — reconnecting…")
-                    .font(.system(size: Metrics.type.xs, weight: .semibold))
+                    .font(.manta(size: Metrics.type.xs, weight: .semibold))
                     .foregroundColor(tokens.danger)
                     .padding(.horizontal, Metrics.spacing.sp3)
                     .padding(.vertical, Metrics.spacing.sp1)
@@ -541,7 +541,7 @@ private struct ChatScreenContent: View {
                 // non-interactive treatment.
                 if let ctx = store.context {
                     Text("\(Int(ctx.pct.rounded()))% ctx")
-                        .font(.system(size: Metrics.type.xs, weight: .semibold))
+                        .font(.manta(size: Metrics.type.xs, weight: .semibold))
                         .foregroundColor(ctxColor(ctx.pct))
                         .padding(.horizontal, Metrics.spacing.sp2)
                         .frame(height: Metrics.type.chatHeaderBtn)
@@ -735,10 +735,10 @@ private struct ChatScreenContent: View {
                 .font(.system(size: Metrics.type.display))
                 .foregroundColor(tokens.warn)
             Text("Couldn't reach your box")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             Text("Tap to retry.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -854,7 +854,7 @@ private struct TodosCard: View {
             }
             if let overflowSummary {
                 Text(overflowSummary)
-                    .font(.system(size: Metrics.type.xs))
+                    .font(.manta(size: Metrics.type.xs))
                     .foregroundColor(tokens.tx4)
             }
         }
@@ -887,7 +887,7 @@ private struct TodosCard: View {
                 .font(.system(size: Metrics.type.xs))
                 .foregroundColor(markColor(status))
             Text(item.content ?? "")
-                .font(.system(size: Metrics.type.small, weight: status == "in_progress" ? mantaFontWeight(Metrics.type.semibold) : .regular))
+                .font(.manta(size: Metrics.type.small, weight: status == "in_progress" ? mantaFontWeight(Metrics.type.semibold) : .regular))
                 .foregroundColor(textColor(status))
                 .strikethrough(status == "cancelled")
                 // A todo's text must not be silently clipped to one line.
@@ -933,10 +933,10 @@ private struct PermissionCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
             Text("Permission needed")
-                .font(.system(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.semibold)))
+                .font(.manta(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.semibold)))
                 .foregroundColor(tokens.tx4)
             Text(summary)
-                .font(.system(size: Metrics.type.body))
+                .font(.manta(size: Metrics.type.body))
                 .foregroundColor(tokens.tx1)
                 .lineLimit(3)
             HStack(spacing: Metrics.spacing.sp2) {
@@ -947,7 +947,7 @@ private struct PermissionCard: View {
                     onReply(.reject)
                 } label: {
                     Text("Reject")
-                        .font(.system(size: Metrics.type.small, weight: .medium))
+                        .font(.manta(size: Metrics.type.small, weight: .medium))
                         .foregroundColor(tokens.danger)
                 }
             }
@@ -974,7 +974,7 @@ private struct PermissionCard: View {
             onReply(reply)
         } label: {
             Text(label)
-                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .font(.manta(size: Metrics.type.small, weight: .semibold))
                 .foregroundColor(filled ? tokens.onAccent : tokens.accentTx)
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
@@ -1005,11 +1005,11 @@ private struct QuestionCard: View {
                 VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
                     if !q.header.isEmpty {
                         Text(q.header)
-                            .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
+                            .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
                             .foregroundColor(tokens.tx1)
                     }
                     Text(q.question)
-                        .font(.system(size: Metrics.type.body))
+                        .font(.manta(size: Metrics.type.body))
                         .foregroundColor(tokens.tx1)
                     ForEach(Array(q.options.enumerated()), id: \.offset) { oi, option in
                         optionButton(questionIndex: index, optionIndex: oi, label: option.label, multi: q.multiple == true)
@@ -1022,19 +1022,19 @@ private struct QuestionCard: View {
             // only writer unreachable, so free-form questions could never be
             // answered.
             TextField("Or type your own answer…", text: $customText)
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx1)
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
                 .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
             HStack {
                 Button("Reject", action: onReject)
-                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .font(.manta(size: Metrics.type.small, weight: .medium))
                     .foregroundColor(tokens.danger)
                 Spacer()
                 Button { submit() } label: {
                     Text("Send")
-                        .font(.system(size: Metrics.type.small, weight: .semibold))
+                        .font(.manta(size: Metrics.type.small, weight: .semibold))
                         .foregroundColor(canSubmit ? tokens.onAccent : tokens.tx4)
                         .padding(.horizontal, Metrics.spacing.sp3)
                         .padding(.vertical, Metrics.spacing.sp2)
@@ -1074,7 +1074,7 @@ private struct QuestionCard: View {
                     .font(.system(size: Metrics.type.xs))
                     .foregroundColor(isOn ? tokens.accent : tokens.tx4)
                 Text(label)
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx1)
                     .multilineTextAlignment(.leading)
                 Spacer(minLength: 0)
@@ -1117,7 +1117,7 @@ private struct ChatNoticeRow: View {
                 .font(.system(size: Metrics.type.xs, weight: .semibold))
                 .foregroundColor(color)
             Text(text)
-                .font(.system(size: Metrics.type.xs))
+                .font(.manta(size: Metrics.type.xs))
                 .foregroundColor(color)
                 .lineLimit(3)
             Spacer(minLength: 0)

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -156,7 +156,7 @@ struct ComposerView: View {
     /// measured in. Taken from the font itself rather than guessed, so it
     /// tracks a type-scale change.
     private var lineHeight: CGFloat {
-        UIFont.systemFont(ofSize: Metrics.type.body).lineHeight
+        MantaDynamicType.scaled(UIFont.systemFont(ofSize: Metrics.type.body).lineHeight)
     }
 
     /// The editor's measured height for a given number of text lines.
@@ -266,14 +266,14 @@ struct ComposerView: View {
         ZStack(alignment: .topLeading) {
             if text.isEmpty {
                 Text("Message…")
-                    .font(.system(size: Metrics.type.body))
+                    .font(.manta(size: Metrics.type.body))
                     .foregroundColor(tokens.tx4)
                     .padding(.top, 8)
                     .padding(.leading, 5)
                     .allowsHitTesting(false)
             }
             TextEditor(text: $text)
-                .font(.system(size: Metrics.type.body))
+                .font(.manta(size: Metrics.type.body))
                 .foregroundColor(tokens.tx1)
                 .scrollContentBackground(.hidden)
                 .frame(minHeight: lineHeight + Metrics.spacing.sp2,
@@ -340,7 +340,7 @@ struct ComposerView: View {
             }
             if !attachments.isEmpty { chipsRow }
             TextEditor(text: $text)
-                .font(.system(size: Metrics.type.body))
+                .font(.manta(size: Metrics.type.body))
                 .foregroundColor(tokens.tx1)
                 .scrollContentBackground(.hidden)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -380,13 +380,13 @@ struct ComposerView: View {
                     .font(.system(size: Metrics.type.xs, weight: .medium))
                 if modelStore.loaded {
                     Text(ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel))
-                        .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                         .lineLimit(1)
                     if let variant = modelStore.variant, !variant.isEmpty {
                         Text("·")
-                            .font(.system(size: Metrics.type.small))
+                            .font(.manta(size: Metrics.type.small))
                         Text(variant.capitalized)
-                            .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                            .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                             .lineLimit(1)
                     }
                 } else {
@@ -587,7 +587,7 @@ struct ComposerView: View {
                                 .foregroundColor(tokens.accentTx)
                         }
                         Text(ChatVoice.chipLabel(forFilename: attachment.filename))
-                            .font(.system(size: Metrics.type.twoXS))
+                            .font(.manta(size: Metrics.type.twoXS))
                             .foregroundColor(tokens.accentTx)
                         Button {
                             attachments.removeAll { $0.id == attachment.id }
@@ -850,7 +850,7 @@ struct ComposerView: View {
             withAnimation { showHint = false }
         } label: {
             Text(text)
-                .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                 .foregroundColor(tokens.accentTx)
                 .lineLimit(1)
                 .truncationMode(.tail)

--- a/mobile/native/MantaUI/FolderPickerView.swift
+++ b/mobile/native/MantaUI/FolderPickerView.swift
@@ -64,14 +64,14 @@ struct FolderPickerView: View {
             }
             .accessibilityLabel("Close")
             Text("Choose folder")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             Spacer()
             Button {
                 selectCurrent()
             } label: {
                 Text("Select")
-                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
                     .foregroundColor(tokens.onAccent)
                     .padding(.horizontal, Metrics.spacing.sp3)
                     .padding(.vertical, Metrics.spacing.sp1)
@@ -85,7 +85,7 @@ struct FolderPickerView: View {
     private var pathField: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
             TextField("path", text: $path)
-                .font(.system(size: Metrics.type.small, design: .monospaced))
+                .font(.manta(size: Metrics.type.small, design: .monospaced))
                 .foregroundColor(tokens.tx1)
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
@@ -109,7 +109,7 @@ struct FolderPickerView: View {
                         path = crumb
                     } label: {
                         Text(FolderPath.crumbLabel(crumb))
-                            .font(.system(size: Metrics.type.twoXS, design: .monospaced))
+                            .font(.manta(size: Metrics.type.twoXS, design: .monospaced))
                             .foregroundColor(crumb == path ? tokens.tx1 : tokens.tx3)
                             .padding(.horizontal, Metrics.spacing.sp1)
                             .padding(.vertical, Metrics.spacing.spPx)
@@ -167,17 +167,17 @@ struct FolderPickerView: View {
                 VStack(spacing: Metrics.spacing.sp2) {
                     ProgressView()
                     Text("Loading…")
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.tx4)
                 }
             } else if let error {
                 Text(error)
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.danger)
                     .padding(Metrics.spacing.sp3)
             } else if rows.isEmpty {
                 Text("No subfolders")
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx4)
             }
         }
@@ -192,14 +192,14 @@ struct FolderPickerView: View {
                 .frame(width: 16)
             Text(name)
                 .font(monospaced
-                    ? .system(size: Metrics.type.body, design: .monospaced)
-                    : .system(size: Metrics.type.body))
+                    ? .manta(size: Metrics.type.body, design: .monospaced)
+                    : .manta(size: Metrics.type.body))
                 .foregroundColor(color)
                 .lineLimit(1)
             Spacer()
             if !trailing.isEmpty {
                 Text(trailing)
-                    .font(.system(size: Metrics.type.xs))
+                    .font(.manta(size: Metrics.type.xs))
                     .foregroundColor(tokens.accentTx)
             }
         }
@@ -250,7 +250,7 @@ struct FolderPickerView: View {
         if let fanOut {
             VStack(spacing: Metrics.spacing.sp2) {
                 Text("Detected \(fanOut.worktrees.count) git worktrees. Open a session for each?")
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx2)
                     .multilineTextAlignment(.center)
                 ScrollView {
@@ -258,11 +258,11 @@ struct FolderPickerView: View {
                         ForEach(fanOut.worktrees, id: \.path) { w in
                             HStack {
                                 Text(WorktreeInfoLogic.name(w))
-                                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                                    .font(.manta(size: Metrics.type.xs, design: .monospaced))
                                     .foregroundColor(tokens.tx1)
                                 Spacer()
                                 Text(w.path)
-                                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                                    .font(.manta(size: Metrics.type.xs, design: .monospaced))
                                     .foregroundColor(tokens.tx4)
                                     .lineLimit(1)
                             }
@@ -284,7 +284,7 @@ struct FolderPickerView: View {
                     self.fanOut = nil
                 } label: {
                     Text("Cancel")
-                        .font(.system(size: Metrics.type.small, weight: .medium))
+                        .font(.manta(size: Metrics.type.small, weight: .medium))
                         .foregroundColor(tokens.tx3)
                         .padding(Metrics.spacing.sp1)
                 }
@@ -299,7 +299,7 @@ struct FolderPickerView: View {
     @ViewBuilder
     private func confirmLabel(_ text: String, filled: Bool) -> some View {
         Text(text)
-            .font(.system(size: Metrics.type.small, weight: .semibold))
+            .font(.manta(size: Metrics.type.small, weight: .semibold))
             .foregroundColor(filled ? tokens.onAccent : tokens.tx2)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Metrics.spacing.sp3)

--- a/mobile/native/MantaUI/Info.plist
+++ b/mobile/native/MantaUI/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Scan the pairing code shown by the Manta desktop app.</string>
 	<key>CFBundleURLTypes</key>

--- a/mobile/native/MantaUI/MantaDynamicType.swift
+++ b/mobile/native/MantaUI/MantaDynamicType.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import UIKit
+
+// Dynamic Type support (BET-751).
+//
+// The app draws reading text at design-token sizes (`Metrics.type.*`).
+// `.font(.system(size:))` never scales, so on their own those sizes ignore the
+// user's accessibility font-size preference. Every READING surface builds its
+// font through `Font.manta(size:weight:design:)`, which keeps the design
+// system's relative sizes but scales the base by the user's current
+// content-size category (Settings → Accessibility → Display & Text Size) via
+// `UIFontMetrics`. Icon and fixed-size-button CHROME deliberately stays on
+// `.system(size:)` — scaling a glyph inside a fixed 38pt circle would clip it.
+//
+// The call sites keep reading `Metrics.type.*` as the base size, so a metric's
+// name stays meaningful; only the font constructor changes.
+extension Font {
+    static func manta(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        design: Font.Design = .default
+    ) -> Font {
+        .system(
+            size: MantaDynamicType.scaled(size),
+            weight: weight,
+            design: design
+        )
+    }
+}
+
+/// The Dynamic-Type-scaled form of a design-token base size. Reading surfaces
+/// use this for derived geometry (line spacing, editor heights) so those scale
+/// in lock-step with the text they accompany.
+enum MantaDynamicType {
+    static func scaled(_ size: CGFloat) -> CGFloat {
+        UIFontMetrics.default.scaledValue(for: size)
+    }
+}

--- a/mobile/native/MantaUI/MantaLoader.swift
+++ b/mobile/native/MantaUI/MantaLoader.swift
@@ -79,7 +79,7 @@ struct MantaLoader: View {
 
             if let caption {
                 Text(caption)
-                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                    .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx4)
                     .accessibilityLabel(caption)
             }

--- a/mobile/native/MantaUI/MantaOnboarding.swift
+++ b/mobile/native/MantaUI/MantaOnboarding.swift
@@ -278,7 +278,7 @@ private struct MantaPrimaryButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
+                .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
                 .foregroundColor(tokens.onAccent)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, Metrics.spacing.sp3)
@@ -298,7 +298,7 @@ private struct MantaTextButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                 .foregroundColor(tokens.accentTx)
         }
         .buttonStyle(.plain)
@@ -343,7 +343,7 @@ struct MantaManualEntryView: View {
                         Image(systemName: "qrcode.viewfinder")
                             .font(.system(size: Metrics.type.body))
                         Text("Scan QR code")
-                            .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                            .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                     }
                     .foregroundColor(tokens.onAccent)
                     .frame(maxWidth: .infinity)
@@ -355,7 +355,7 @@ struct MantaManualEntryView: View {
                 OTPField(value: $flow.code, placeholder: "000000", tokens: tokens)
                     .accessibilityIdentifier("onboarding-otp")
                 TextField("Box ID (32 hex)", text: $flow.boxId)
-                    .font(.system(size: Metrics.type.body, design: .monospaced))
+                    .font(.manta(size: Metrics.type.body, design: .monospaced))
                     .textFieldStyle(.plain)
                     .padding(Metrics.spacing.sp3)
                     .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
@@ -365,13 +365,13 @@ struct MantaManualEntryView: View {
                     .accessibilityIdentifier("onboarding-box-id")
                 Button(action: { withAnimation { flow.showAdvanced.toggle() } }) {
                     Text(flow.showAdvanced ? "Hide server URL" : "My box isn't reachable from the internet")
-                        .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                         .foregroundColor(tokens.accentTx)
                 }
                 .buttonStyle(.plain)
                 if flow.showAdvanced {
                     TextField("https://100.64.0.9:8787", text: $flow.serverURL)
-                        .font(.system(size: Metrics.type.small, design: .monospaced))
+                        .font(.manta(size: Metrics.type.small, design: .monospaced))
                         .textFieldStyle(.plain)
                         .padding(Metrics.spacing.sp3)
                         .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
@@ -382,7 +382,7 @@ struct MantaManualEntryView: View {
                 }
                 if let error = flow.manualError {
                     Text(error)
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.danger)
                         .accessibilityIdentifier("onboarding-error")
                 }
@@ -400,10 +400,10 @@ struct MantaManualEntryView: View {
     private func header(title: String, subtitle: String) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
             Text(title)
-                .font(.system(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
+                .font(.manta(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
                 .foregroundColor(tokens.tx1)
             Text(subtitle)
-                .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                 .foregroundColor(tokens.tx3)
                 .lineSpacing(pointsForLineHeight(Metrics.type.body))
         }
@@ -427,10 +427,10 @@ struct MantaLinkingView: View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
             VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
                 Text("Linking")
-                    .font(.system(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                 Text("A couple of seconds.")
-                    .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                    .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx3)
             }
             MantaCard(tokens: tokens) {
@@ -441,7 +441,7 @@ struct MantaLinkingView: View {
                                 .fill(index <= flow.activeLinkingStage ? tokens.accent : tokens.tx4)
                                 .frame(width: Metrics.type.stepDot, height: Metrics.type.stepDot)
                             Text(stage)
-                                .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                                .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                                 .foregroundColor(index <= flow.activeLinkingStage ? tokens.tx1 : tokens.tx4)
                         }
                         .accessibilityIdentifier("linking-stage-\(index)")
@@ -455,7 +455,7 @@ struct MantaLinkingView: View {
                 Spacer()
             }
             Text("Credentials stay on this phone and on your box.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
             Spacer(minLength: 0)
         }
@@ -476,17 +476,17 @@ struct MantaFailureView: View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
             VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
                 Text(content.heading)
-                    .font(.system(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                 Text(content.subtitle)
-                    .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                    .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx3)
                     .accessibilityIdentifier("onboarding-failure-subtitle")
             }
             if let card = content.card {
                 MantaCard(tokens: tokens) {
                     Text(card)
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.tx2)
                         .accessibilityIdentifier("onboarding-failure-card")
                 }
@@ -556,10 +556,10 @@ struct MantaNotificationsView: View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
             VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
                 Text("Know when it needs you")
-                    .font(.system(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                 Text("Agents stop for permission, ask questions, and finish while you're somewhere else. This is the point of having Manta on your phone.")
-                    .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                    .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx3)
             }
             MantaCard(tokens: tokens) {
@@ -584,7 +584,7 @@ struct MantaNotificationsView: View {
                 .foregroundColor(tint)
                 .frame(width: Metrics.spacing.sp6, height: Metrics.spacing.sp6)
             Text(text)
-                .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                 .foregroundColor(tokens.tx1)
             Spacer(minLength: 0)
         }
@@ -652,15 +652,15 @@ struct MantaOnboardingRoot: View {
                 .frame(width: Metrics.spacing.sp8, height: Metrics.spacing.sp8)
                 .overlay(
                     Text("M")
-                        .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
+                        .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
                         .foregroundColor(tokens.onAccent)
                 )
             VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
                 Text("Pair your phone")
-                    .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                 Text("Connect this device to your box.")
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx4)
             }
         }
@@ -685,10 +685,10 @@ struct MantaSwitchBoxSheet: View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
             VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
                 Text("Switch box?")
-                    .font(.system(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                 Text("A Manta pairing link arrived while you're connected to another box. Switching re-pairs this phone to the new one.")
-                    .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+                    .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx3)
             }
             MantaCard(tokens: tokens) {
@@ -715,11 +715,11 @@ struct MantaSwitchBoxSheet: View {
     private func hostRow(label: String, host: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing.sp3) {
             Text(label)
-                .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                 .foregroundColor(tokens.tx4)
             Spacer(minLength: Metrics.spacing.sp4)
             Text(host)
-                .font(.system(size: Metrics.type.small, design: .monospaced))
+                .font(.manta(size: Metrics.type.small, design: .monospaced))
                 .foregroundColor(tokens.tx1)
                 .multilineTextAlignment(.trailing)
                 .lineLimit(2)
@@ -739,7 +739,7 @@ private struct OTPField: View {
 
     var body: some View {
         TextField(placeholder, text: $value)
-            .font(.system(size: Metrics.type.otp, weight: mantaFontWeight(Metrics.type.medium), design: .monospaced))
+            .font(.manta(size: Metrics.type.otp, weight: mantaFontWeight(Metrics.type.medium), design: .monospaced))
             .keyboardType(.numberPad)
             .multilineTextAlignment(.center)
             .tracking(Metrics.spacing.sp2)

--- a/mobile/native/MantaUI/MantaQRScanner.swift
+++ b/mobile/native/MantaUI/MantaQRScanner.swift
@@ -162,7 +162,7 @@ struct MantaQRScannerSheet: View {
                 HStack {
                     Spacer()
                     Button("Cancel") { dismiss() }
-                        .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
+                        .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
                         .foregroundColor(tokens.onAccent)
                         .padding(.horizontal, Metrics.spacing.sp4)
                         .padding(.vertical, Metrics.spacing.sp2)
@@ -172,7 +172,7 @@ struct MantaQRScannerSheet: View {
                 Spacer()
                 if model.permissionDenied {
                     Text("Camera access is off — enter the code by hand instead.")
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.tx2)
                         .padding(Metrics.spacing.sp4)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -186,7 +186,7 @@ struct MantaQRScannerSheet: View {
                         .accessibilityIdentifier("scanner-permission-hint")
                 } else if model.nonMantaHint {
                     Text("Not a Manta pairing code")
-                        .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                         .foregroundColor(tokens.tx1)
                         .padding(.horizontal, Metrics.spacing.sp4)
                         .padding(.vertical, Metrics.spacing.sp3)

--- a/mobile/native/MantaUI/RunningIndicator.swift
+++ b/mobile/native/MantaUI/RunningIndicator.swift
@@ -43,10 +43,10 @@ struct RunningIndicator: View {
         HStack(spacing: Metrics.spacing.sp2) {
             MantaLoader(tokens: tokens, size: .inline)
             Text("\(verb)…")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx1)
             Text("(\(SessionTimerFormat.liveElapsed(elapsed)))")
-                .font(.system(size: Metrics.type.small, design: .monospaced))
+                .font(.manta(size: Metrics.type.small, design: .monospaced))
                 .foregroundColor(tokens.tx4)
             Spacer(minLength: 0)
         }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -237,7 +237,7 @@ struct SessionListView: View {
     @ViewBuilder
     private func groupHeader(_ name: String) -> some View {
         Text(titleCased(name))
-            .font(.system(size: Metrics.type.body, weight: .semibold))
+            .font(.manta(size: Metrics.type.body, weight: .semibold))
             .kerning(Metrics.type.headingTracking * Metrics.type.body)
             .foregroundColor(tokens.tx2)
             .padding(.top, Metrics.type.listGroupAbove)
@@ -344,10 +344,10 @@ struct SessionListView: View {
                 .font(.system(size: Metrics.type.display))
                 .foregroundColor(tokens.warn)
             Text("Delete this session?")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             Text("This will stop a turn that's been running \(deleteRunningText).")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx2)
                 .multilineTextAlignment(.center)
             Button {
@@ -365,7 +365,7 @@ struct SessionListView: View {
                 }
             } label: {
                 Text("Delete Session")
-                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
                     .foregroundColor(tokens.onAccent)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, Metrics.spacing.sp3)
@@ -375,7 +375,7 @@ struct SessionListView: View {
                 sheetRoute = nil
             } label: {
                 Text("Cancel")
-                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .font(.manta(size: Metrics.type.small, weight: .medium))
                     .foregroundColor(tokens.tx2)
                     .padding(Metrics.spacing.sp2)
             }
@@ -393,13 +393,13 @@ struct SessionListView: View {
                     .font(.system(size: Metrics.type.small))
                     .foregroundColor(tokens.tx2)
                 Text("Deleted")
-                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .font(.manta(size: Metrics.type.small, weight: .medium))
                     .foregroundColor(tokens.tx1)
                 Spacer()
                 Button("Undo") {
                     store.undoPendingDelete(pending.pinID)
                 }
-                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .font(.manta(size: Metrics.type.small, weight: .semibold))
                 .foregroundColor(tokens.accentTx)
                 .padding(.horizontal, Metrics.spacing.sp2)
                 .padding(.vertical, Metrics.spacing.sp1)
@@ -439,7 +439,7 @@ struct SessionListView: View {
                         .font(.system(size: Metrics.type.xs))
                         .foregroundColor(tokens.tx4)
                     TextField("Search sessions", text: $searchText)
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.tx1)
                 }
                 .padding(.horizontal, Metrics.spacing.sp3)
@@ -495,10 +495,10 @@ struct SessionListView: View {
     private func renameSheet(target: MantaWindow, targetProject: String) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
             Text("Rename session")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             TextField("Name", text: $renameValue)
-                .font(.system(size: Metrics.type.body))
+                .font(.manta(size: Metrics.type.body))
                 .foregroundColor(tokens.tx1)
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
@@ -541,10 +541,10 @@ struct SessionListView: View {
     private var emptyState: some View {
         VStack(spacing: Metrics.spacing.sp2) {
             Text("No sessions yet")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx3)
             Text("Tap + to create one.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
         }
         .accessibilityIdentifier("sessions-empty")
@@ -563,16 +563,16 @@ struct SessionListView: View {
                 .font(.system(size: Metrics.type.display))
                 .foregroundColor(tokens.tx4)
             Text("Can't load your sessions")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx3)
             Text(store.loadError ?? "Couldn't reach your box")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
                 .multilineTextAlignment(.center)
             Button("Try again") {
                 Task { await store.refresh() }
             }
-            .font(.system(size: Metrics.type.small, weight: .semibold))
+            .font(.manta(size: Metrics.type.small, weight: .semibold))
             .foregroundColor(tokens.accentTx)
             .padding(.top, Metrics.spacing.sp1)
             .disabled(store.loading)
@@ -584,10 +584,10 @@ struct SessionListView: View {
     private var noMatchState: some View {
         VStack(spacing: Metrics.spacing.sp2) {
             Text("No sessions match")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx3)
             Text("Nothing named “\(searchText)”.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
         }
         .accessibilityIdentifier("sessions-no-match")
@@ -599,7 +599,7 @@ struct SessionListView: View {
             HStack {
                 Image(systemName: "wifi.exclamationmark")
                 Text(error)
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                 Spacer()
             }
             .padding(.horizontal, Metrics.spacing.sp3)
@@ -644,7 +644,7 @@ private struct SessionRowContent: View {
             VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
                 HStack(spacing: Metrics.spacing.sp1) {
                     Text(window.name)
-                        .font(.system(size: Metrics.type.rowName, weight: .medium))
+                        .font(.manta(size: Metrics.type.rowName, weight: .medium))
                         .kerning(Metrics.type.rowNameTracking * Metrics.type.rowName)
                         .foregroundColor(tokens.tx1)
                         .lineLimit(1)
@@ -656,7 +656,7 @@ private struct SessionRowContent: View {
                 }
                 if let subtitle = SessionRowSubtitle.text(for: status) {
                     Text(subtitle)
-                        .font(.system(size: Metrics.type.xs, weight: .medium))
+                        .font(.manta(size: Metrics.type.xs, weight: .medium))
                         .foregroundColor(tokens.tx4)
                         .lineLimit(1)
                 }
@@ -664,7 +664,7 @@ private struct SessionRowContent: View {
             Spacer()
             if let timer {
                 Text(timer)
-                    .font(.system(size: Metrics.type.twoXS, weight: .medium, design: .monospaced))
+                    .font(.manta(size: Metrics.type.twoXS, weight: .medium, design: .monospaced))
                     .foregroundColor(tokens.tx4)
                     .monospacedDigit()
             }
@@ -762,10 +762,10 @@ private struct SessionScreenPlaceholder: View {
                 .font(.system(size: Metrics.type.display))
                 .foregroundColor(tokens.tx4)
             Text(name)
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             Text("Chat arrives in a later stage.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/mobile/native/MantaUI/SettingsScreen.swift
+++ b/mobile/native/MantaUI/SettingsScreen.swift
@@ -59,7 +59,7 @@ struct SettingsScreen: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                         .foregroundColor(tokens.accent)
-                        .font(.system(size: Metrics.type.body, weight: .semibold))
+                        .font(.manta(size: Metrics.type.body, weight: .semibold))
                 }
             }
             .overlay(alignment: .bottom) { undoToast }
@@ -73,10 +73,10 @@ struct SettingsScreen: View {
     private var searchField: some View {
         HStack(spacing: Metrics.spacing.sp2) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx3)
             TextField("Find a setting…", text: $query)
-                .font(.system(size: Metrics.type.body))
+                .font(.manta(size: Metrics.type.body))
                 .foregroundColor(tokens.tx1)
                 .autocorrectionDisabled()
             if !query.isEmpty {
@@ -84,7 +84,7 @@ struct SettingsScreen: View {
                     query = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.tx4)
                 }
             }
@@ -102,13 +102,13 @@ struct SettingsScreen: View {
         let hits = SettingsSchema.search(query)
         return VStack(alignment: .leading, spacing: 0) {
             Text(hits.count == 1 ? "1 match" : "\(hits.count) matches")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx3)
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
             if hits.isEmpty {
                 Text("No settings match. Try another term.")
-                    .font(.system(size: Metrics.type.body))
+                    .font(.manta(size: Metrics.type.body))
                     .foregroundColor(tokens.tx3)
                     .padding(.horizontal, Metrics.spacing.sp3)
                     .padding(.vertical, Metrics.spacing.sp2)
@@ -116,7 +116,7 @@ struct SettingsScreen: View {
                 ForEach(hits) { entry in
                     VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
                         Text(sectionLabel(entry.section))
-                            .font(.system(size: Metrics.type.twoXS))
+                            .font(.manta(size: Metrics.type.twoXS))
                             .foregroundColor(tokens.tx4)
                             .textCase(.uppercase)
                         field(for: entry)
@@ -148,7 +148,7 @@ struct SettingsScreen: View {
         return VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: Metrics.spacing.sp2) {
                 Text(section.label)
-                    .font(.system(size: Metrics.type.twoXS, weight: .semibold))
+                    .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
                     .foregroundColor(tokens.tx2)
                     .textCase(.uppercase)
                 if store.sectionModified(section.id) {
@@ -163,7 +163,7 @@ struct SettingsScreen: View {
                         store.resetSection(section.id)
                     } label: {
                         Label("Reset", systemImage: "arrow.counterclockwise")
-                            .font(.system(size: Metrics.type.twoXS))
+                            .font(.manta(size: Metrics.type.twoXS))
                             .labelStyle(.titleAndIcon)
                             .foregroundColor(tokens.tx3)
                     }
@@ -176,7 +176,7 @@ struct SettingsScreen: View {
 
             if entries.isEmpty {
                 Text("No settings in this section yet.")
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx3)
                     .padding(.horizontal, Metrics.spacing.sp3)
             } else {
@@ -184,7 +184,7 @@ struct SettingsScreen: View {
                     field(for: entry)
                     if entry.help.isEmpty == false, entry.control != .toggle {
                         Text(entry.help)
-                            .font(.system(size: Metrics.type.small))
+                            .font(.manta(size: Metrics.type.small))
                             .foregroundColor(tokens.tx3)
                             .padding(.horizontal, Metrics.spacing.sp3)
                     }
@@ -227,7 +227,7 @@ struct SettingsScreen: View {
         let current = store.current(entry)
         HStack {
             Text(entry.label)
-                .font(.system(size: Metrics.type.body, weight: .medium))
+                .font(.manta(size: Metrics.type.body, weight: .medium))
                 .foregroundColor(tokens.tx1)
             Spacer()
             Toggle("", isOn: Binding(
@@ -245,7 +245,7 @@ struct SettingsScreen: View {
     private func segmentedRow(_ entry: SettingEntry) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
             Text(entry.label)
-                .font(.system(size: Metrics.type.body, weight: .medium))
+                .font(.manta(size: Metrics.type.body, weight: .medium))
                 .foregroundColor(tokens.tx1)
             let current = store.current(entry)
             HStack(spacing: Metrics.spacing.sp2) {
@@ -255,7 +255,7 @@ struct SettingsScreen: View {
                         store.commit(entry, .string(option.value))
                     } label: {
                         Text(option.label)
-                            .font(.system(size: Metrics.type.small))
+                            .font(.manta(size: Metrics.type.small))
                             .foregroundColor(selected ? tokens.onAccent : tokens.tx2)
                             .padding(.horizontal, Metrics.spacing.sp3)
                             .padding(.vertical, Metrics.spacing.sp2)
@@ -308,11 +308,11 @@ struct SettingsScreen: View {
     private func labelRow(_ entry: SettingEntry) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
             Text(entry.label)
-                .font(.system(size: Metrics.type.body, weight: .medium))
+                .font(.manta(size: Metrics.type.body, weight: .medium))
                 .foregroundColor(tokens.tx1)
             if entry.help.isEmpty == false {
                 Text(entry.help)
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx3)
             }
         }
@@ -325,17 +325,17 @@ struct SettingsScreen: View {
     private var resetAllFooter: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
             Text("Reset all settings")
-                .font(.system(size: Metrics.type.twoXS, weight: .semibold))
+                .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
                 .foregroundColor(tokens.tx2)
                 .textCase(.uppercase)
             Text("Restore every setting to its default. This does not remove your box pairing or projects.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx3)
             Button {
                 confirmReset = true
             } label: {
                 Text("Reset all settings…")
-                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
                     .foregroundColor(tokens.danger)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, Metrics.spacing.sp3)
@@ -357,10 +357,10 @@ struct SettingsScreen: View {
                 .font(.system(size: Metrics.type.display))
                 .foregroundColor(tokens.warn)
             Text("Reset all settings?")
-                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             Text("Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.")
-                .font(.system(size: Metrics.type.small))
+                .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx3)
                 .multilineTextAlignment(.center)
             Button {
@@ -368,7 +368,7 @@ struct SettingsScreen: View {
                 store.resetAll()
             } label: {
                 Text("Reset")
-                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
                     .foregroundColor(tokens.onAccent)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, Metrics.spacing.sp3)
@@ -378,7 +378,7 @@ struct SettingsScreen: View {
                 confirmReset = false
             } label: {
                 Text("Cancel")
-                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .font(.manta(size: Metrics.type.small, weight: .medium))
                     .foregroundColor(tokens.tx2)
                     .padding(Metrics.spacing.sp2)
             }
@@ -392,13 +392,13 @@ struct SettingsScreen: View {
         if let message = store.undoMessage {
             HStack(spacing: Metrics.spacing.sp2) {
                 Text(message)
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx1)
                 Spacer()
                 Button("Undo") {
                     store.undoLastReset()
                 }
-                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .font(.manta(size: Metrics.type.small, weight: .semibold))
                 .foregroundColor(tokens.accent)
             }
             .padding(.horizontal, Metrics.spacing.sp3)
@@ -433,7 +433,7 @@ private struct CommitField: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
             Text(entry.label)
-                .font(.system(size: Metrics.type.body, weight: .medium))
+                .font(.manta(size: Metrics.type.body, weight: .medium))
                 .foregroundColor(tokens.tx1)
             Group {
                 if secure {
@@ -442,7 +442,7 @@ private struct CommitField: View {
                     TextField(entry.placeholder ?? "", text: $draft)
                 }
             }
-            .font(.system(size: Metrics.type.body))
+            .font(.manta(size: Metrics.type.body))
             .foregroundColor(tokens.tx1)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
@@ -464,7 +464,7 @@ private struct CommitField: View {
             }
             if let savedAt {
                 Text("Saved \(savedAt.formatted(date: .omitted, time: .standard))")
-                    .font(.system(size: Metrics.type.twoXS))
+                    .font(.manta(size: Metrics.type.twoXS))
                     .foregroundColor(tokens.ok)
             }
         }

--- a/mobile/native/MantaUI/TerminalScreen.swift
+++ b/mobile/native/MantaUI/TerminalScreen.swift
@@ -89,13 +89,13 @@ struct TerminalScreen: View {
 
             VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
                 Text(windowName)
-                    .font(.system(size: Metrics.type.chatTitle, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.chatTitle, weight: mantaFontWeight(Metrics.type.semibold)))
                     .kerning(Metrics.type.chatTitleTracking * Metrics.type.chatTitle)
                     .foregroundColor(tokens.tx1)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Text(terminal.geometryText.isEmpty ? "—" : terminal.geometryText)
-                    .font(.system(size: Metrics.type.xs, weight: .medium, design: .monospaced))
+                    .font(.manta(size: Metrics.type.xs, weight: .medium, design: .monospaced))
                     .foregroundColor(tokens.tx4)
             }
 

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -27,9 +27,9 @@ struct UserBand: View {
 
     var body: some View {
         Text(text)
-            .font(.system(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
+            .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
             .foregroundColor(tokens.tx1)
-            .lineSpacing(pointsFor(multiplier: 1.5, size: Metrics.type.body))
+            .lineSpacing(pointsFor(multiplier: 1.5, size: MantaDynamicType.scaled(Metrics.type.body)))
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Metrics.spacing.sp3)
@@ -70,21 +70,21 @@ struct MantaProse: View {
 
     var body: some View {
         MarkdownView(text)
-            .font(.system(size: Metrics.type.body), for: .body)
-            .font(.system(size: Metrics.type.body + 4, weight: .semibold), for: .h1)
-            .font(.system(size: Metrics.type.body + 2, weight: .semibold), for: .h2)
-            .font(.system(size: Metrics.type.body + 1, weight: .semibold), for: .h3)
-            .font(.system(size: Metrics.type.body, weight: .semibold), for: .h4)
-            .font(.system(size: Metrics.type.body, weight: .semibold), for: .h5)
-            .font(.system(size: Metrics.type.body, weight: .semibold), for: .h6)
-            .font(.system(size: Metrics.type.xs, design: .monospaced), for: .codeBlock)
+            .font(.manta(size: Metrics.type.body), for: .body)
+            .font(.manta(size: Metrics.type.body + 4, weight: .semibold), for: .h1)
+            .font(.manta(size: Metrics.type.body + 2, weight: .semibold), for: .h2)
+            .font(.manta(size: Metrics.type.body + 1, weight: .semibold), for: .h3)
+            .font(.manta(size: Metrics.type.body, weight: .semibold), for: .h4)
+            .font(.manta(size: Metrics.type.body, weight: .semibold), for: .h5)
+            .font(.manta(size: Metrics.type.body, weight: .semibold), for: .h6)
+            .font(.manta(size: Metrics.type.xs, design: .monospaced), for: .codeBlock)
             // Tables run at the small size, not body — on a phone column a
             // body-size table wraps every cell into a tower. Header gets the
             // semibold weight like desktop's th.
-            .font(.system(size: Metrics.type.small, weight: .semibold), for: .tableHeader)
-            .font(.system(size: Metrics.type.small), for: .tableBody)
+            .font(.manta(size: Metrics.type.small, weight: .semibold), for: .tableHeader)
+            .font(.manta(size: Metrics.type.small), for: .tableBody)
             .foregroundColor(tokens.tx1)
-            .lineSpacing(pointsFor(multiplier: Metrics.type.proseLineHeight, size: Metrics.type.body))
+            .lineSpacing(pointsFor(multiplier: Metrics.type.proseLineHeight, size: MantaDynamicType.scaled(Metrics.type.body)))
             .tint(tokens.accent, for: .link)
             // Inline code: the library renders `code` spans as tint-colored
             // text on tint@10% background (MarkdownView 3.0.0 exposes no
@@ -228,19 +228,19 @@ struct StepRowView: View {
                     // group read as ragged. It truncates rather than wraps, and
                     // never shrinks below its share of the row.
                     Text(step.verb)
-                        .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
+                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
                         .foregroundColor(tokens.tx2)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .layoutPriority(1)
                     Text(step.target)
-                        .font(.system(size: Metrics.type.xs, design: .monospaced))
+                        .font(.manta(size: Metrics.type.xs, design: .monospaced))
                         .foregroundColor(tokens.tx4)
                         .lineLimit(1)
                         .truncationMode(.tail)
                     Spacer(minLength: 0)
                     Text(step.duration)
-                        .font(.system(size: Metrics.type.twoXS))
+                        .font(.manta(size: Metrics.type.twoXS))
                         .foregroundColor(tokens.tx4)
                 }
                 .padding(.vertical, Metrics.type.stepRowY)
@@ -251,7 +251,7 @@ struct StepRowView: View {
 
             if revealed, let output = step.output {
                 Text(output)
-                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                    .font(.manta(size: Metrics.type.xs, design: .monospaced))
                     .foregroundColor(tokens.tx3)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -311,7 +311,7 @@ struct StepGroupView: View {
                         // mono — no separate glyph, no extra size literal.
                         Text(summary)
                             .lineLimit(1)
-                            .font(.system(size: Metrics.type.xs, design: .monospaced))
+                            .font(.manta(size: Metrics.type.xs, design: .monospaced))
                             .foregroundColor(tokens.tx4)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, Metrics.type.stepRowY)
@@ -513,7 +513,7 @@ struct TimestampGutterLabel: View {
 
     var body: some View {
         Text(ChatClock.time(date))
-            .font(.system(size: Metrics.type.twoXS))
+            .font(.manta(size: Metrics.type.twoXS))
             .foregroundColor(tokens.tx4)
             .monospacedDigit()
             .lineLimit(1)
@@ -558,7 +558,7 @@ struct LoadEarlierRow: View {
                     ProgressView()
                 } else {
                     Text("Load earlier messages")
-                        .font(.system(size: Metrics.type.small))
+                        .font(.manta(size: Metrics.type.small))
                         .foregroundColor(tokens.tx3)
                 }
             }
@@ -587,16 +587,16 @@ struct SubagentRowView: View {
                     .fill(tokens.accentSoft)
                     .frame(width: Metrics.spacing.sp4, height: Metrics.spacing.sp4)
                 Text(agent.taskName)
-                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text(agent.statusText)
-                    .font(.system(size: Metrics.type.twoXS))
+                    .font(.manta(size: Metrics.type.twoXS))
                     .foregroundColor(tokens.tx4)
                 Text("›")
-                    .font(.system(size: Metrics.type.small))
+                    .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx4)
             }
             .padding(.vertical, Metrics.type.stepRowY)
@@ -657,7 +657,7 @@ struct SubagentHeader: View {
         HStack(spacing: Metrics.spacing.sp2) {
             Button(action: onBack) {
                 Text("‹")
-                    .font(.system(size: Metrics.type.body))
+                    .font(.manta(size: Metrics.type.body))
                     .foregroundColor(tokens.accent)
                     .padding(Metrics.spacing.sp2)
                     .contentShape(Rectangle())
@@ -669,12 +669,12 @@ struct SubagentHeader: View {
 
             VStack(spacing: Metrics.spacing.spPx) {
                 Text(title)
-                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Text(subtitle)
-                    .font(.system(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.medium)))
+                    .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx4)
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -86,8 +86,8 @@ targets:
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait
-        TARGETED_DEVICE_FAMILY: "1"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        TARGETED_DEVICE_FAMILY: "1,2"
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Opened automatically for `multica/BET-751-dynamic-type-ipad`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-751.