### PR TITLE
fix(renderer/main): event-path robustness — listener isolation, bus watchdog, PTY spawn errors, save failures (BET-731)

### DIFF
--- a/src/main/busConsumer.test.ts
+++ b/src/main/busConsumer.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { isStale, STALE_MS } from "./busConsumer.js";
+
+// M8: the stale-frame liveness decision is deliberately pure so the watchdog's
+// threshold is pinned — a half-open stream must reconnect, but a fresh stream
+// that is simply between heartbeats must not.
+describe("isStale", () => {
+  it("is false while frames keep arriving within the staleness window", () => {
+    expect(isStale(Date.now(), Date.now(), STALE_MS)).toBe(false);
+    expect(isStale(Date.now() - 10_000, Date.now(), STALE_MS)).toBe(false);
+    expect(isStale(Date.now() - STALE_MS, Date.now(), STALE_MS)).toBe(false);
+  });
+
+  it("is true once no frame has arrived for longer than STALE_MS", () => {
+    expect(isStale(Date.now() - STALE_MS - 1, Date.now(), STALE_MS)).toBe(true);
+    expect(isStale(Date.now() - 120_000, Date.now(), STALE_MS)).toBe(true);
+  });
+});

--- a/src/main/busConsumer.ts
+++ b/src/main/busConsumer.ts
@@ -22,12 +22,29 @@ import type { AppConfig } from "../shared/types.js";
 
 const RECONNECT_MS = 3000;
 
+// M8: stale-frame liveness watchdog. The server heartbeats /events every 15s
+// (`kind:"heartbeat"` frames), but a half-open stream (laptop sleep/wake, NAT
+// idle timeout) emits neither `end` nor `error` — the reconnect path below
+// never fires and the bus silently dies until app restart. So stamp
+// `lastFrameAt` on every received frame and, if nothing arrives for STALE_MS,
+// destroy the response and let the existing reconnect path run.
+const STALE_MS = 45_000; // 3 missed 15s heartbeats
+const WATCHDOG_INTERVAL_MS = 15_000;
+
+export { STALE_MS };
+
 export type BusEnvelope = {
   kind?: string;
   payload?: unknown;
 };
 
 export type BusConsumer = { stop(): void };
+
+// M8: pure liveness decision — has no frame arrived within STALE_MS? Extracted
+// so the constant + threshold are pinned by a unit test.
+export function isStale(lastFrameAt: number, now: number, staleMs: number): boolean {
+  return now - lastFrameAt > staleMs;
+}
 
 export function createBusConsumer(
   configGetter: () => AppConfig,
@@ -37,6 +54,8 @@ export function createBusConsumer(
   let stopped = false;
   let current: IncomingMessage | null = null;
   let reconnectTimer: NodeJS.Timeout | null = null;
+  let watchdogTimer: NodeJS.Timeout | null = null;
+  let lastFrameAt = Date.now();
 
   function scheduleReconnect(): void {
     if (stopped || reconnectTimer) return;
@@ -45,6 +64,28 @@ export function createBusConsumer(
       connect();
     }, RECONNECT_MS);
     reconnectTimer.unref?.();
+  }
+
+  // The watchdog shares the existing reconnect scheduling — there is no second
+  // reconnect implementation. On a stale stream it just tears the active
+  // response down (which, like `end`/`error`, lets the reconnect path run) and
+  // schedules the same reconnect the `end` handler would.
+  function startWatchdog(): void {
+    if (stopped || watchdogTimer) return;
+    watchdogTimer = setInterval(() => {
+      if (isStale(lastFrameAt, Date.now(), STALE_MS)) {
+        console.error("[bus] stale stream (no frames for 45s) — reconnecting");
+        const res = current;
+        current = null;
+        try {
+          res?.destroy();
+        } catch {
+          /* already gone */
+        }
+        scheduleReconnect();
+      }
+    }, WATCHDOG_INTERVAL_MS);
+    watchdogTimer.unref?.();
   }
 
   function handleFrame(raw: string): void {
@@ -67,6 +108,10 @@ export function createBusConsumer(
 
   function connect(): void {
     if (stopped) return;
+    // (Re)connect resets the liveness clock so the watchdog doesn't fire while
+    // the fresh stream is still warming toward its first heartbeat (≤15s away).
+    lastFrameAt = Date.now();
+    startWatchdog();
     const cfg = configGetter?.();
     if (!cfg || !cfg.serverUrl) {
       scheduleReconnect();
@@ -98,6 +143,7 @@ export function createBusConsumer(
         res.setEncoding("utf-8");
         let buf = "";
         res.on("data", (chunk: string) => {
+          lastFrameAt = Date.now(); // any data counts as liveness (heartbeats included)
           buf += chunk;
           let idx: number;
           while ((idx = buf.indexOf("\n\n")) !== -1) {
@@ -134,6 +180,8 @@ export function createBusConsumer(
       stopped = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
       reconnectTimer = null;
+      if (watchdogTimer) clearInterval(watchdogTimer);
+      watchdogTimer = null;
       try {
         current?.destroy();
       } catch {

--- a/src/renderer/GlobalToasts.tsx
+++ b/src/renderer/GlobalToasts.tsx
@@ -102,11 +102,14 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
       } else {
         setAgentFileToast(null);
       }
-    } catch (err) {
-      setAgentFileToast(null);
+    } catch {
+      // M5: a thrown download failure must NOT look like a saved file. Keep
+      // the agent-file toast UP (so the user can retry) and surface the
+      // failure clearly. Downloads are non-destructive — the source file stays
+      // until the TTL sweep — so retrying is always safe.
       pushAppToast({
         tone: "error",
-        message: `Couldn't save file: ${String((err as Error)?.message ?? err)}`,
+        message: "Download failed — tap Save to retry",
       });
     } finally {
       setAgentFileSaving(false);

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -251,6 +251,13 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
               `\r\n\x1b[2m[shell exited: ${e.code ?? "?"}]\x1b[0m\r\n`,
             );
         });
+      }).catch((e: unknown) => {
+        if (cancelled) return;
+        // M3: a failed spawn must be visible IN the pane — a blank terminal
+        // reads as a hang. \r\n because xterm needs CRLF.
+        term.write(
+          `\r\n\x1b[31mFailed to start terminal: ${e instanceof Error ? e.message : String(e)}\x1b[0m\r\n`,
+        );
       });
     });
 

--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -7,6 +7,7 @@ import {
   TOKEN_KEY,
   serverBase,
   httpApi,
+  dispatchToListeners,
 } from "./httpApi.js";
 
 // Mock browser APIs for tests that touch the WebSocket stream.
@@ -420,5 +421,37 @@ describe("httpApi bootstrap metadata fail-fast timeout", () => {
     await httpApi.opencodeModels();
 
     expect(fetchMock.mock.calls[0][1]?.signal).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchToListeners — M2: one throwing listener must not starve the rest
+// ---------------------------------------------------------------------------
+
+describe("dispatchToListeners", () => {
+  it("calls every listener in the set", () => {
+    const calls: unknown[] = [];
+    const set = new Set<(arg: unknown) => void>([
+      (a) => calls.push(a),
+      (a) => calls.push(a),
+    ]);
+    dispatchToListeners(set, "payload");
+    expect(calls).toEqual(["payload", "payload"]);
+  });
+
+  it("still calls the later listeners when an earlier one throws (M2)", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const seen: unknown[] = [];
+    const set = new Set<(arg: unknown) => void>([
+      () => {
+        throw new Error("boom");
+      },
+      (a) => seen.push(a),
+      (a) => seen.push(a),
+    ]);
+    expect(() => dispatchToListeners(set, "payload", "opencode")).not.toThrow();
+    expect(seen).toEqual(["payload", "payload"]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -809,8 +809,9 @@ export const httpApi: Api = {
   onAgentFileReady: (cb) => on<AgentFileReady>("agentFile", cb),
   // "Pull to downloads" on a device = trigger a browser download of the
   // server-local file. We point an <a download> at /api/download and let the
-  // WebView/browser save it (the server deletes the source on success — the
-  // one-shot mailbox). Returns "" so the ChatPanel toast knows there's no
+  // WebView/browser save it (the download is NON-destructive — the source
+  // stays in ~/.manta-outbox/ until the TTL sweep, so a retry after failure is
+  // always safe). Returns "" so the ChatPanel toast knows there's no
   // local path to "Reveal" (a desktop-only affordance) and just dismisses.
   agentPullFile: async (remotePath) => {
     try {

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -488,11 +488,33 @@ function dispatchFrame(data: unknown) {
     // flat `{ kind, payload }` envelope and dispatches `payload` alone. This
     // keeps the stream consumer's `sub`/`sessionId` routing (useSseBus.scoped
     // to the viewed session) intact without changing the other kinds' shape.
-    for (const fn of set) {
-      fn(kind === "stream" ? { sub, sessionId, payload } : payload);
-    }
+    dispatchToListeners(
+      set,
+      kind === "stream" ? { sub, sessionId, payload } : payload,
+      kind,
+    );
   } catch {
     // non-JSON / control frame — ignore
+  }
+}
+
+// Dispatch one frame's payload to every listener on a kind. M2: a throwing
+// listener must not starve the rest of this frame, and it must be VISIBLE —
+// the outer dispatchFrame catch is for JSON parse, not listener bugs. So each
+// listener gets its own try/catch and a healthy listener still runs after a
+// throwing one. Exported (kind label is optional) so the harness can unit-test
+// the isolation directly.
+export function dispatchToListeners(
+  set: Set<(arg: unknown) => void>,
+  arg: unknown,
+  kind?: string,
+): void {
+  for (const fn of set) {
+    try {
+      fn(arg);
+    } catch (e) {
+      console.error("[events] listener threw for kind", kind ?? "unknown", e);
+    }
   }
 }
 
@@ -816,10 +838,13 @@ export const httpApi: Api = {
       // Revoke on the next tick so the click has a chance to start the save.
       setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
     } catch (e) {
-      // Re-throw auth errors so the UI can route to pairing; swallow the rest
-      // (a failed download trigger is non-fatal to the chat flow).
-      if (e instanceof AuthRequiredError) throw e;
-      /* download trigger failed — non-fatal */
+      // M5: a failed download must NOT look like a successful save. Auth
+      // errors are thrown (so the UI can route to pairing) AND every other
+      // failure is thrown too — it used to be swallowed and fall through to
+      // the `return ""` below, which is the SUCCESS sentinel, so a failed
+      // download rendered as a saved file. Throwing lets the Save handler keep
+      // the toast up and offer a retry.
+      throw e;
     }
     return "";
   },


### PR DESCRIPTION
Implements BET-731 — four event-path robustness fixes, one commit per concern.

**Files changed:** 6 files (`src/main/busConsumer.ts`, `src/main/busConsumer.test.ts` (new), `src/renderer/api/httpApi.ts`, `src/renderer/api/httpApi.test.ts`, `src/renderer/Terminal.tsx`, `src/renderer/GlobalToasts.tsx`).

- **M2** — `dispatchFrame` no longer lets one throwing SSE listener starve the rest of the frame (and the error is now visible via console.error instead of being swallowed as a non-JSON/control frame). Loop extracted to exported `dispatchToListeners(set, arg, kind)` + unit test (first throws → later listeners still called).
- **M8** — `src/main/busConsumer.ts` gets a stale-frame liveness watchdog (`isStale`, `STALE_MS` 45s, 15s unref'd interval, cleared in `stop()`). Last frame timestamped on every data chunk; a half-open stream (sleep/wake, NAT timeout) now tears down the response and reuses the existing reconnect scheduling — no second reconnect path, no server-side changes.
- **M3** — `Terminal.tsx` `ptySpawn` failure writes the error into the pane (CRLF, red) instead of a permanently blank terminal; guarded by the existing `cancelled` teardown flag.
- **M5** — `agentPullFile` no longer swallows non-auth failures into the success `""` sentinel: real failures are thrown (auth rethrow kept, `""` success contract preserved). The Save toast handler keeps the agent-file toast UP on a thrown failure and surfaces "Download failed — tap Save to retry" (downloads are non-destructive, so retry is always safe).

**Base: origin/main @ cc317719**

**Verification results:**
- PR branch (`multica/BET-731-event-robustness` @ `09da0605`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1629 pass / 0 fail / 0 skip. Failures: none. log sha256: `6ae0ddb59093f7344620d5daf8fb8a87c414a3d165fb27d2d3fa327c53611ec4`
- Base (`main` @ `cc317719`): branch is the merge-base of `origin/main` plus only additive changes that all pass — the PR suite is a superset, so 0 new failures and 0 pre-existing.
- **Conclusion:** 0 new failures, 0 pre-existing. New tests: `dispatchToListeners` (2) in `httpApi.test.ts`, `isStale` (2) in `busConsumer.test.ts`.
