### PR TITLE
fix(ios): surface session-list rename/fork failures (BET-746)

### DIFF
--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -20,12 +20,39 @@ import SwiftUI
 // `SessionModels.swift`; this store is the I/O + state wiring around them.
 // ===========================================================================
 
+/// The rename/fork RPC seam for the session-list surface, so the store's
+/// "refresh only after a successful mutation" orchestration is unit-testable
+/// without a live box. The live adapter wraps `MantaAPIClient`'s existing RPCs
+/// unchanged (no semantics change — only the swallowing call sites move here).
+@MainActor
+protocol SessionListMutationAPI {
+    func renameWindow(session: String, index: Int, newName: String) async throws
+    func forkSession(sessionId: String, sessionName: String, windowName: String) async throws
+}
+
+@MainActor
+struct ServerSessionListMutations: SessionListMutationAPI {
+    let api: MantaAPIClient
+
+    func renameWindow(session: String, index: Int, newName: String) async throws {
+        try await api.renameWindow(session: session, index: index, newName: newName)
+    }
+
+    func forkSession(sessionId: String, sessionName: String, windowName: String) async throws {
+        _ = try await api.forkSession(sessionId: sessionId, sessionName: sessionName, windowName: windowName)
+    }
+}
+
 @MainActor
 final class SessionListStore: ObservableObject {
 
     @Published private(set) var projects: [MantaProject] = []
     @Published private(set) var loading = false
     @Published private(set) var loadError: String?
+    /// A transient, user-facing failure message from a mutation (rename/fork).
+    /// Set only when the RPC rejected; the view surfaces it as a brief toast
+    /// (mirrors `ChatSessionStore.actionHint`, the BET-716 composer surface).
+    @Published var actionMessage: String?
     /// True once a fetch has come back successfully. Without it an EMPTY list
     /// is ambiguous — "this box has no sessions" and "we never managed to ask"
     /// look identical — and the view rendered the inviting "No sessions yet.
@@ -41,6 +68,7 @@ final class SessionListStore: ObservableObject {
     @Published private(set) var runningSince: [String: Date] = [:]
 
     private let api: MantaAPIClient
+    private let mutations: SessionListMutationAPI
     private let eventStore: MantaEventStore
     private var undoTimers: [String: Timer] = [:]
     private var cancellables: Set<AnyCancellable> = []
@@ -52,8 +80,9 @@ final class SessionListStore: ObservableObject {
     /// vanished and the list stayed on whatever the first one returned.
     private var refreshQueued = false
 
-    init(api: MantaAPIClient = MantaAPIClient.live(), eventStore: MantaEventStore) {
+    init(api: MantaAPIClient = MantaAPIClient.live(), eventStore: MantaEventStore, mutations: SessionListMutationAPI? = nil) {
         self.api = api
+        self.mutations = mutations ?? ServerSessionListMutations(api: api)
         self.eventStore = eventStore
         self.loadConfig()
         self.eventStore.rawFrameHandler = { [weak self] frame in
@@ -288,6 +317,33 @@ final class SessionListStore: ObservableObject {
                     await refresh()
                 }
             }
+        }
+    }
+
+    // MARK: - Rename / Fork (transient-feedback mutations)
+
+    /// Rename a window. Refreshes only after a successful RPC; on a rejected
+    /// rename the in-memory list is left untouched (the pre-failure snapshot —
+    /// there is no optimistic rename to revert) and a transient message is
+    /// published for the view to surface.
+    func renameSession(project: String, index: Int, newName: String) async {
+        do {
+            try await mutations.renameWindow(session: project, index: index, newName: newName)
+            await refresh()
+        } catch {
+            actionMessage = "Couldn't rename — check the connection"
+        }
+    }
+
+    /// Fork a window. Refreshes only after a successful RPC; on a rejected fork
+    /// the list is left unchanged and a transient message is published. The
+    /// view never navigates on failure — navigation only ever follows success.
+    func forkSession(sessionId: String, project: String, newName: String) async {
+        do {
+            try await mutations.forkSession(sessionId: sessionId, sessionName: project, windowName: newName)
+            await refresh()
+        } catch {
+            actionMessage = "Couldn't fork — check the connection"
         }
     }
 

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -54,6 +54,9 @@ struct SessionListView: View {
     /// tmux's active window, which lit one row in every project and never
     /// cleared at all.)
     @State private var openRow: String?
+    /// Transient failure feedback (rename/fork) shown as a brief toast, the
+    /// same surface the 5s undo toast uses. Driven by `store.actionMessage`.
+    @State private var feedback: String?
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
@@ -121,6 +124,7 @@ struct SessionListView: View {
             }
         }
         .overlay(alignment: .bottom) { undoToast }
+        .overlay(alignment: .bottom) { feedbackToast }
         .fullScreenCover(isPresented: $showSettings) {
             SettingsScreen()
         }
@@ -145,6 +149,13 @@ struct SessionListView: View {
         // (the tap routed before the list appeared).
         .onAppear { consumePushLink() }
         .onChange(of: pushRouter.pendingSessionID) { _ in consumePushLink() }
+        // Surface a mutation failure (rename/fork) the store published. Cleared
+        // once consumed so the same message can't re-toast on a later change.
+        .onChange(of: store.actionMessage) { _, message in
+            guard let message, !message.isEmpty else { return }
+            showFeedback(message)
+            store.actionMessage = nil
+        }
     }
 
     @ViewBuilder
@@ -422,6 +433,39 @@ struct SessionListView: View {
         store.pendingDeletes.values.max(by: { $0.startedAt < $1.startedAt })
     }
 
+    // MARK: - Transient feedback toast (rename/fork failures)
+
+    /// The one shared surface for a transient rename/fork failure message.
+    /// Reuses the undo-toast presentation (ultra-thin material capsule) and
+    /// auto-dismisses after a few seconds.
+    private func showFeedback(_ text: String) {
+        feedback = text
+    }
+
+    @ViewBuilder
+    private var feedbackToast: some View {
+        if let text = feedback {
+            HStack(spacing: Metrics.spacing.sp3) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: Metrics.type.small))
+                    .foregroundColor(tokens.warn)
+                Text(text)
+                    .font(.system(size: Metrics.type.small, weight: .medium))
+                    .foregroundColor(tokens.tx1)
+                Spacer()
+            }
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.vertical, Metrics.spacing.sp2)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Metrics.type.listRowRadius))
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.bottom, Metrics.spacing.sp3)
+            .task(id: text) {
+                try? await Task.sleep(nanoseconds: UInt64(4 * 1_000_000_000))
+                withAnimation { if feedback == text { feedback = nil } }
+            }
+        }
+    }
+
     // MARK: - Floating capsule (+ search) + create
 
     // The search + create control FLOATS over the list on Liquid Glass, the
@@ -511,10 +555,7 @@ struct SessionListView: View {
                 Button("Save") {
                     let value = renameValue.trimmingCharacters(in: .whitespaces)
                     if !value.isEmpty {
-                        Task {
-                            try? await MantaAPIClient.live().renameWindow(session: targetProject, index: target.index, newName: value)
-                            await store.refresh()
-                        }
+                        Task { await store.renameSession(project: targetProject, index: target.index, newName: value) }
                     }
                     sheetRoute = nil
                 }
@@ -530,10 +571,7 @@ struct SessionListView: View {
     private func fork(window: MantaWindow, project: MantaProject) {
         let sid = window.opencodeSessionId ?? ""
         let newName = "\(window.name) fork"
-        Task {
-            try? await MantaAPIClient.live().forkSession(sessionId: sid, sessionName: project.tmuxSession, windowName: newName)
-            await store.refresh()
-        }
+        Task { await store.forkSession(sessionId: sid, project: project.tmuxSession, newName: newName) }
     }
 
     // MARK: - Empty / error

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -183,3 +183,101 @@ final class SessionModelsTests: XCTestCase {
             turnCompleteEdge: true, showScrollToBottom: true, isActive: true, hapticsEnabled: false))
     }
 }
+
+// MARK: - BET-746 rename/fork failure feedback
+
+@MainActor
+private final class SessionListMutationStub: SessionListMutationAPI {
+    var renameError: Error?
+    var forkError: Error?
+    var renameCalls = 0
+    var forkCalls = 0
+
+    func renameWindow(session: String, index: Int, newName: String) async throws {
+        renameCalls += 1
+        if let error = renameError { throw error }
+    }
+
+    func forkSession(sessionId: String, sessionName: String, windowName: String) async throws {
+        forkCalls += 1
+        if let error = forkError { throw error }
+    }
+}
+
+private enum SessionListMutationTestError: Error {
+    case rejected
+}
+
+@MainActor
+final class SessionListMutationTests: XCTestCase {
+
+    private func makeStore(_ stub: SessionListMutationStub) -> SessionListStore {
+        // Dead localhost port so any stray background config/refresh I/O fails
+        // fast and is swallowed; the mutation seam is what these tests drive.
+        SessionListStore(
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1:1")!),
+            eventStore: MantaEventStore(),
+            mutations: stub
+        )
+    }
+
+    private func project(_ name: String, _ window: String) -> MantaProject {
+        MantaProject(
+            tmuxSession: name,
+            defaultCwd: "/tmp",
+            windows: [MantaWindow(index: 0, name: window, active: false, paneCurrentPath: "", opencodeSessionId: nil, worktreePath: nil)],
+            attached: false,
+            mantaOwned: nil
+        )
+    }
+
+    func testRenameFailureLeavesListUnchangedAndPublishesMessage() async {
+        let stub = SessionListMutationStub()
+        stub.renameError = SessionListMutationTestError.rejected
+        let store = makeStore(stub)
+        let snapshot = [project("ethernal", "dev"), project("manta", "main")]
+        store.applyProjects(snapshot)
+
+        await store.renameSession(project: "ethernal", index: 0, newName: "renamed")
+
+        XCTAssertEqual(stub.renameCalls, 1)
+        XCTAssertEqual(store.actionMessage, "Couldn't rename — check the connection")
+        XCTAssertEqual(store.projects, snapshot)
+    }
+
+    func testForkFailureLeavesListUnchangedAndPublishesMessage() async {
+        let stub = SessionListMutationStub()
+        stub.forkError = SessionListMutationTestError.rejected
+        let store = makeStore(stub)
+        let snapshot = [project("ethernal", "dev")]
+        store.applyProjects(snapshot)
+
+        await store.forkSession(sessionId: "ses", project: "ethernal", newName: "dev fork")
+
+        XCTAssertEqual(stub.forkCalls, 1)
+        XCTAssertEqual(store.actionMessage, "Couldn't fork — check the connection")
+        XCTAssertEqual(store.projects, snapshot)
+    }
+
+    func testRenameSuccessPublishesNoFailure() async {
+        let stub = SessionListMutationStub()
+        let store = makeStore(stub)
+        store.applyProjects([project("ethernal", "dev")])
+
+        await store.renameSession(project: "ethernal", index: 0, newName: "renamed")
+
+        XCTAssertEqual(stub.renameCalls, 1)
+        XCTAssertNil(store.actionMessage)
+    }
+
+    func testForkSuccessPublishesNoFailure() async {
+        let stub = SessionListMutationStub()
+        let store = makeStore(stub)
+        store.applyProjects([project("ethernal", "dev")])
+
+        await store.forkSession(sessionId: "ses", project: "ethernal", newName: "dev fork")
+
+        XCTAssertEqual(stub.forkCalls, 1)
+        XCTAssertNil(store.actionMessage)
+    }
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-746-sessionlist-feedback`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-746.