### PR TITLE
feat(ios): live running-tool rows + bash tailing from the new tool frames (BET-753)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -701,6 +701,15 @@ private struct ChatScreenContent: View {
     @ViewBuilder
     private var bottomCards: some View {
         VStack(spacing: Metrics.spacing.sp3) {
+            // LIVE running-tool rows (BET-753): what the box is doing mid-turn,
+            // pinned above the composer. Each vanishes when its `toolEnded`
+            // frame lands and the canonical refetch renders it as a step row.
+            if !store.runningTools.isEmpty {
+                ForEach(Array(store.runningTools.enumerated()), id: \.element.idx) { _, tool in
+                    RunningToolRow(tool: tool, tokens: tokens)
+                        .transition(.opacity)
+                }
+            }
             if let err = store.sessionError {
                 ChatNoticeRow(text: err.message, color: tokens.danger, tokens: tokens)
             }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -168,6 +168,11 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var questions: [QuestionRequest] = []
     @Published private(set) var permissions: [PermissionRequest] = []
     @Published private(set) var subagents: [StreamSubagentPayload] = []
+    /// Live tools currently running on the box, in start order (BET-753). The
+    /// chat renders each as a running-tool row with its live bash tail; a tool
+    /// leaves the set the moment its `toolEnded` frame lands, and the canonical
+    /// turn-boundary refetch renders it as a step row.
+    @Published private(set) var runningTools: [LiveTool] = []
     @Published private(set) var childStores: [String: ChatSessionStore] = [:]
     /// Prompts accepted mid-turn, FIFO. Drained one per idle edge — never
     /// POSTed while `running`, which is what used to implicitly abort the
@@ -413,6 +418,7 @@ final class ChatSessionStore: ObservableObject {
         sessionError = s.sessionError
         todos = s.todos
         subagents = s.subagents
+        runningTools = s.runningTools
 
         // Which frame (if any) just changed this session's stream state. The
         // `$sessionStates` sink fires on every republish, so the stamp only

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -34,6 +34,24 @@ struct StreamTextChunk: Equatable, Sendable {
     var text: String
 }
 
+/// A tool call currently in flight (BET-753), keyed by its stable tool part id
+/// (`idx`). The device renders it as a LIVE running-tool row (with the
+/// accumulated bash tail) that converges to a canonical step row once the
+/// turn-boundary refetch lands. Mirror of the server's `st.tools` record.
+struct LiveTool: Equatable, Sendable {
+    var idx: String
+    var name: String?
+    var presentationHint: String?
+    var status: String?
+    /// Accumulated incremental stdout tail, concatenated in arrival order.
+    var tail: String = ""
+    /// True once the `toolEnded` frame lands; an ended tool no longer renders
+    /// as a running row (the record is kept so the outcome can be reflected).
+    var ended: Bool = false
+    var ok: Bool = true
+    var truncated: Bool = false
+}
+
 struct MantaSessionStreamState: Equatable, Sendable {
     var sessionId: String
     /// Accumulated flushed text, one entry per (part, field), in ARRIVAL order
@@ -53,9 +71,24 @@ struct MantaSessionStreamState: Equatable, Sendable {
     var questions: StreamQuestionsPayload?
     var permissions: StreamPermissionsPayload?
     var subagents: [StreamSubagentPayload] = []
+    /// Live tools in flight keyed by their stable tool part id (`idx`), and
+    /// the order they started in. A `toolEnded` removes the idx from the order
+    /// (so `runningTools` yields only still-running tools) but keeps the record
+    /// so the outcome can be reflected; the whole map is cleared on
+    /// `turnComplete`, when the turn's canonical refetch has taken the tools
+    /// over as step rows (BET-753).
+    var tools: [String: LiveTool] = [:]
+    var toolStartOrder: [String] = []
 
     init(sessionId: String) {
         self.sessionId = sessionId
+    }
+
+    /// The still-running tools, in start order. Ended tools are already gone
+    /// from `toolStartOrder`, so this is exactly what the running-tool rows
+    /// render (BET-753).
+    var runningTools: [LiveTool] {
+        toolStartOrder.compactMap { tools[$0] }
     }
 
     /// partID -> accumulated text, for callers that only want a lookup.
@@ -131,6 +164,37 @@ enum MantaStreamRouter {
                 // life of the session, so the working row and session-list timer
                 // never stopped.
                 s.running = p.running
+            }
+            // A finished turn has no running tools; the canonical refetch now
+            // owns them as step rows, so drop the live map to bound memory
+            // (BET-753).
+            s.tools.removeAll()
+            s.toolStartOrder.removeAll()
+        case "toolStarted":
+            if let p = try? frame.decodedPayload(StreamToolStartedPayload.self) {
+                s.tools[p.idx] = LiveTool(
+                    idx: p.idx,
+                    name: p.toolName,
+                    presentationHint: p.toolPresentationHint,
+                    status: p.status
+                )
+                if !s.toolStartOrder.contains(p.idx) { s.toolStartOrder.append(p.idx) }
+            }
+        case "toolOutput":
+            if let p = try? frame.decodedPayload(StreamToolOutputPayload.self),
+               var t = s.tools[p.idx] {
+                t.tail += p.text
+                t.status = "running"
+                s.tools[p.idx] = t
+            }
+        case "toolEnded":
+            if let p = try? frame.decodedPayload(StreamToolEndedPayload.self),
+               var t = s.tools[p.idx] {
+                t.ended = true
+                t.ok = p.ok
+                t.truncated = p.truncated ?? false
+                s.tools[p.idx] = t
+                s.toolStartOrder.removeAll { $0 == p.idx }
             }
         case "truncation":
             s.truncation = try? frame.decodedPayload(StreamTruncationPayload.self)

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -273,6 +273,46 @@ struct StreamSubagentChildPayload: Codable, Equatable, Sendable {
     var childSessionId: String
 }
 
+// MARK: - Live tool frames (server BET-745 / app BET-753)
+//
+// The server half (BET-745) publishes three temporary, additive frames so a
+// thin client can render a LIVE running-tool row with a bash tail mid-turn,
+// before the canonical turn-boundary refetch lands. The device reads exactly
+// these field names (never the raw opencode event):
+//   toolStarted { sessionId, idx, toolName, toolPresentationHint?, status }
+//   toolOutput  { sessionId, idx, text }
+//   toolEnded   { sessionId, idx, ok, truncated? }
+// `idx` is the tool PART ID — stable per tool across the whole run, identical
+// on started/output/ended — so the device keys its running-tool rows by it.
+
+/// `sub: "toolStarted"` — a live tool call began.
+struct StreamToolStartedPayload: Codable, Equatable, Sendable {
+    var sessionId: String
+    var idx: String
+    var toolName: String?
+    var toolPresentationHint: String?
+    var status: String?
+}
+
+/// `sub: "toolOutput"` — one incremental stdout chunk for a running tool. The
+/// server sends only the delta since the last chunk (never the full output),
+/// bounded by its per-tool cap.
+struct StreamToolOutputPayload: Codable, Equatable, Sendable {
+    var sessionId: String
+    var idx: String
+    var text: String
+}
+
+/// `sub: "toolEnded"` — the tool call settled. `ok` is true when the tool
+/// completed, false when it errored; `truncated` is present true only when the
+/// per-tool output cap was hit.
+struct StreamToolEndedPayload: Codable, Equatable, Sendable {
+    var sessionId: String
+    var idx: String
+    var ok: Bool
+    var truncated: Bool?
+}
+
 /// `sub: "autoRename"` — a title-summarization trigger.
 struct StreamAutoRenamePayload: Codable, Equatable, Sendable {
     var turns: Double

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -393,6 +393,85 @@ struct StepGroupView: View {
     }
 }
 
+// MARK: - Live running tool row (BET-753)
+//
+// The LIVE counterpart to a canonical step row. While a tool call is still in
+// flight the box streams `toolStarted`/`toolOutput`/`toolEnded` frames, and
+// this row renders what the box is doing mid-turn (tool name + status + the
+// accumulated bash tail) pinned above the composer, so the phone shows
+// something instead of nothing until the turn-boundary refetch lands.
+//
+// It mirrors the canonical `StepRowView` treatment (status dot + tool name +
+// mono tail on a `panel` group) so the live→canonical swap at the refetch
+// boundary doesn't pop. It is an OVERLAY — never part of the canonical
+// transcript (that remains `ChatSessionStore.swift`'s source of truth).
+struct RunningToolRow: View {
+    let tool: LiveTool
+    let tokens: Tokens
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Circle()
+                    .fill(tokens.accent)
+                    .frame(width: Metrics.type.stepDot, height: Metrics.type.stepDot)
+                Text(tool.name ?? "tool")
+                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .foregroundColor(tokens.tx2)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .layoutPriority(1)
+                // The box's human title for the part (e.g. "Run: npm test"),
+                // when it differs from the bare tool name.
+                if let hint = tool.presentationHint, !hint.isEmpty, hint != tool.name {
+                    Text(hint)
+                        .font(.system(size: Metrics.type.xs, design: .monospaced))
+                        .foregroundColor(tokens.tx4)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                Spacer(minLength: 0)
+                Text(statusText)
+                    .font(.system(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.tx4)
+            }
+            .padding(.vertical, Metrics.type.stepRowY)
+            .padding(.horizontal, Metrics.spacing.sp3)
+
+            if !tool.tail.isEmpty {
+                Text(tool.tail)
+                    .font(.system(size: Metrics.type.xs, design: .monospaced))
+                    .foregroundColor(tokens.tx3)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, Metrics.spacing.sp2)
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .background(tokens.inset)
+                    .accessibilityIdentifier("running-tool-tail")
+            }
+        }
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("running-tool-row")
+    }
+
+    /// The row's live status label. The wire `status` is one of
+    /// pending/running/completed/error; while the row renders the tool is
+    /// still in flight, so this stays truthful to the incoming value.
+    private var statusText: String {
+        switch (tool.status ?? "").lowercased() {
+        case "error": return "error"
+        case "pending": return "queued"
+        case "completed": return "done"
+        default: return "running"
+        }
+    }
+}
+
 // MARK: - Subagents (§8a) — a drill-in screen, not an inline expansion
 //
 // A subagent is a session, not a tool call: it streams, owns its own steps and

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -491,6 +491,77 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertEqual(store.turnCompletionCount, 1, "mid-turn open must count the in-flight turn's completion")
     }
 
+    // MARK: - Live tools (BET-753)
+
+    /// A `toolStarted` frame surfaces a running-tool row on the store, even
+    /// before any canonical transcript rows exist.
+    func testToolStartedPopulatesRunningTools() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        stream.inject(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","toolName":"bash","toolPresentationHint":"Run: npm test","status":"running"}}"#)
+
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+
+        XCTAssertEqual(store.runningTools.count, 1)
+        XCTAssertEqual(store.runningTools[0].idx, "toolu_1")
+        XCTAssertEqual(store.runningTools[0].name, "bash")
+        XCTAssertEqual(store.runningTools[0].presentationHint, "Run: npm test")
+    }
+
+    /// Appended `toolOutput` deltas for the same `idx` concatenate in order; a
+    /// new `idx` starts a fresh tail.
+    func testToolOutputConcatenatesByIndexInOrder() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+
+        stream.inject(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","toolName":"bash","status":"running"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","text":"one\n"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","text":"two\n"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_2","toolName":"read","status":"running"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_2","text":"file.txt"}}"#)
+        await Task.yield()
+
+        XCTAssertEqual(store.runningTools.map(\.idx), ["toolu_1", "toolu_2"])
+        XCTAssertEqual(store.runningTools[0].tail, "one\ntwo\n", "deltas for the same idx concatenate in order")
+        XCTAssertEqual(store.runningTools[1].tail, "file.txt", "a new idx starts a fresh tail")
+    }
+
+    /// `toolEnded` removes the running tool; the store surfaces the outcome
+    /// (`ok:false`/`truncated`) on the retained record until the canonical
+    /// refetch takes over.
+    func testToolEndedRemovesRunningToolAndReflectsOutcome() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.failingSession())
+        )
+        await Task.yield()
+
+        stream.inject(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","toolName":"bash","status":"running"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","text":"boom\n"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolEnded","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","ok":false,"truncated":true}}"#)
+        await Task.yield()
+
+        XCTAssertEqual(store.runningTools.count, 0, "an ended tool leaves the running set")
+        let reflected = eventStore.sessionStates["ses"]?.tools["toolu_1"]
+        XCTAssertEqual(reflected?.ended, true, "the outcome is reflected on the retained record")
+        XCTAssertEqual(reflected?.ok, false)
+        XCTAssertEqual(reflected?.truncated, true)
+    }
+
     // MARK: - Mock transport
 
     /// Poll the main actor until `condition` holds (or ~2s elapses). The drain

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -130,6 +130,32 @@ final class MantaEventStreamModelTests: XCTestCase {
         XCTAssertFalse(p.running)
     }
 
+    // MARK: - Live tool frames (BET-753)
+
+    func testParsesToolStartedPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"toolu_1","toolName":"bash","toolPresentationHint":"Run: npm test","status":"running"}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamToolStartedPayload.self))
+        XCTAssertEqual(p.idx, "toolu_1")
+        XCTAssertEqual(p.toolName, "bash")
+        XCTAssertEqual(p.toolPresentationHint, "Run: npm test")
+        XCTAssertEqual(p.status, "running")
+    }
+
+    func testParsesToolOutputPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"toolu_1","text":"line1\n"}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamToolOutputPayload.self))
+        XCTAssertEqual(p.idx, "toolu_1")
+        XCTAssertEqual(p.text, "line1\n")
+    }
+
+    func testParsesToolEndedPayload() throws {
+        let f = try frame(#"{"kind":"stream","sub":"toolEnded","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"toolu_1","ok":false,"truncated":true}}"#)
+        let p = try XCTUnwrap(f.decodedPayload(StreamToolEndedPayload.self))
+        XCTAssertEqual(p.idx, "toolu_1")
+        XCTAssertEqual(p.ok, false)
+        XCTAssertEqual(p.truncated, true)
+    }
+
     func testParsesContextPayload() throws {
         let f = try frame(#"{"kind":"stream","sub":"context","sessionId":"ses_1","payload":{"freshInput":10,"cacheRead":5,"cacheWrite":2,"totalInput":17,"pct":8,"segments":[{"kind":"fresh","pct":5},{"kind":"cacheWrite","pct":1},{"kind":"cacheRead","pct":2}]}}"#)
         let p = try XCTUnwrap(f.decodedPayload(StreamContextPayload.self))
@@ -327,6 +353,78 @@ final class MantaEventStreamRouterTests: XCTestCase {
         )
 
         XCTAssertEqual(state.subagents.count, 2)
+    }
+
+    // MARK: - Live tool frames (BET-753)
+
+    /// A `toolStarted` frame starts a running tool row, keyed by its stable
+    /// part id.
+    func testToolStartedStartsRunningTool() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"toolu_1","toolName":"bash","toolPresentationHint":"Run: npm test","status":"running"}}"#),
+            to: state
+        )
+        XCTAssertEqual(state.runningTools.count, 1)
+        XCTAssertEqual(state.runningTools[0].idx, "toolu_1")
+        XCTAssertEqual(state.runningTools[0].name, "bash")
+        XCTAssertEqual(state.runningTools[0].presentationHint, "Run: npm test")
+        XCTAssertEqual(state.tools["toolu_1"]?.status, "running")
+    }
+
+    /// Appended `toolOutput` deltas for the same `idx` concatenate in order; a
+    /// new `idx` starts a fresh tail. Running tools render in start order.
+    func testToolOutputAppendsByIDAndFreshIndexStartsFreshTail() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        func start(_ idx: String, _ name: String) throws -> MantaStreamFrame {
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"\#(idx)","toolName":"\#(name)","status":"running"}}"#)
+        }
+        func output(_ idx: String, _ text: String) throws -> MantaStreamFrame {
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"\#(idx)","text":"\#(text)"}}"#)
+        }
+        state = MantaStreamRouter.applying(try start("a", "bash"), to: state)
+        state = MantaStreamRouter.applying(try output("a", "chunk1"), to: state)
+        state = MantaStreamRouter.applying(try output("a", "chunk2"), to: state)
+        state = MantaStreamRouter.applying(try start("b", "read"), to: state)
+        state = MantaStreamRouter.applying(try output("b", "file.txt"), to: state)
+
+        XCTAssertEqual(state.tools["a"]?.tail, "chunk1chunk2", "deltas for the same idx concatenate in arrival order")
+        XCTAssertEqual(state.tools["b"]?.tail, "file.txt", "a new idx starts a fresh tail")
+        XCTAssertEqual(state.runningTools.map(\.idx), ["a", "b"], "running tools render in start order")
+    }
+
+    /// `toolEnded` removes the tool from the running set AND reflects its
+    /// outcome (`ok:false` / `truncated`) on the retained record.
+    func testToolEndedRemovesFromRunningAndReflectsOutcome() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"a","toolName":"bash","status":"running"}}"#),
+            to: state
+        )
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"toolEnded","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"a","ok":false,"truncated":true}}"#),
+            to: state
+        )
+        XCTAssertEqual(state.runningTools.count, 0, "an ended tool leaves the running set")
+        XCTAssertEqual(state.tools["a"]?.ended, true, "the outcome is reflected on the record")
+        XCTAssertEqual(state.tools["a"]?.ok, false)
+        XCTAssertEqual(state.tools["a"]?.truncated, true)
+    }
+
+    /// Once the turn completes its running-tool state is dropped — the
+    /// canonical refetch now owns the tools as step rows.
+    func testTurnCompleteClearsRunningTools() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses_1","payload":{"sessionId":"ses_1","idx":"a","toolName":"bash","status":"running"}}"#),
+            to: state
+        )
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false}}"#),
+            to: state
+        )
+        XCTAssertTrue(state.tools.isEmpty, "the live tool map clears on turnComplete")
+        XCTAssertEqual(state.runningTools.count, 0)
     }
 
     // MARK: - Retiring covered text (BET-655)


### PR DESCRIPTION
Opened automatically for `multica/BET-753-live-tool-frames`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-753.