### PR TITLE
BET-756: fix(renderer): open usage popover upward and thin ring to 2px

### DIFF
--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -129,7 +129,7 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
             <span
               aria-hidden="true"
               className="block rounded-full bg-bg"
-              style={{ width: 10, height: 10, margin: 3 }}
+              style={{ width: 12, height: 12, margin: 2 }}
             />
           )}
         </span>
@@ -139,7 +139,7 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
         <div
           role="dialog"
           aria-label="Plan usage"
-          className="manta-usage-popover absolute right-0 top-full mt-1 z-30 w-[320px] p-4 rounded-lg border border-border bg-bg-soft shadow-md"
+          className="manta-usage-popover manta-menu-in absolute right-0 bottom-full mb-1 z-30 w-[320px] p-4 rounded-lg border border-border bg-bg-soft shadow-md"
         >
           <div className="flex items-baseline justify-between gap-2 mb-3">
             <span className="text-prose font-semibold text-text">{label}</span>


### PR DESCRIPTION
## BET-756 — Usage dial: open popover upward and thin the ring

Two placement/weight fixes to `src/renderer/UsageDial.tsx` (the only file changed).

**Change 1 — open upward.** The popover panel was anchored `top-full mt-1` (below the trigger), rendering past the bottom edge of the composer row. Now `bottom-full mb-1` — the exact `DROPDOWN_PLACEMENT` "above" string — plus the shared `manta-menu-in` mount animation every other popup surface uses.

**Change 2 — thin the ring to 2px.** Inner hole disc went from `10px/10px @ margin 3` to `12px/12px @ margin 2` → ring thickness `(16-12)/2 = 2px`, matching the sibling Clock / Key / Webhook icons' `strokeWidth={2}`. Outer 16×16 box unchanged (dial stays the same size as siblings).

Out of scope (per issue): no `Dropdown` refactor, no `tone === "over"` change, no colours/thresholds/logic, no `chatUtils` edits, no code shared with `ContextPill`.

**Files changed:** `1` file — `src/renderer/UsageDial.tsx` (2 insertions, 2 deletions).

**Verification results:**
- PR branch (`multica/BET-756-usage-dial-placement` @ `18f94573`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1629 pass / 0 fail / 0 skip. Failures: none.
- Base: `origin/main @ b6e6ee1d`.
- **Conclusion:** 0 new failures. Change is two Tailwind/inline-style edits with no pure-logic surface; no base-branch re-run needed (identical outcome expected).

**Base: origin/main @ b6e6ee1d**

Note: manual visual confirmation in the running app is not possible from the Linux box (no GUI); the change is exactly the two literal class/style strings the issue specifies.
