### PR TITLE
refactor(renderer): dedupe/dead-code sweep (BET-732)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -198,15 +198,13 @@ function AppInner() {
   const [searchOpen, setSearchOpen] = useState(false);
   // Activate a tmux window locally AND on the box (so the PTY follows). Shared
   // by ⌥⌘↑↓, ⌘1..9, the voice switch-window handler, and the ⌘F cross-
-  // conversation jump.
+  // conversation jump. Implemented by the store's activateWindow action.
+  const activateWindow = useStore((s) => s.activateWindow);
   const jumpToWindow = useCallback(
     (tmuxSession: string, windowIndex: number) => {
-      setActive(tmuxSession, windowIndex);
-      window.api
-        .tmuxSelectWindow({ sessionName: tmuxSession, windowIndex })
-        .catch(() => {});
+      void activateWindow(tmuxSession, windowIndex).catch(() => {});
     },
-    [setActive],
+    [activateWindow],
   );
   // Section the Settings modal lands on when the `manta-open-settings` bridge
   // fires (e.g. "Manage models…" → Models). The modal re-targets to it on

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -48,6 +48,8 @@ import {
   type StaleCacheResult,
   type PendingScrollWin,
   isApprovalCoveredByAlways,
+  MANTA_BUILTIN_COMMANDS,
+  MANTA_BUILTIN_NAMES,
 } from "./chatUtils";
 import {
   appendPromptHistory,
@@ -86,25 +88,9 @@ import { getMantaPreload } from "./preloadAccess";
 
 // Attachment / AgentMention / TypeaheadState / TypeaheadRow are shared with
 // the extracted composer components and live in ./chatShared.
-
-// manta-local slash commands. These are handled in the renderer (not forwarded
-// to opencode's /command endpoint) because opencode doesn't ship equivalents
-// — they're terminal-TUI conventions users expect to "just work". Each one
-// dispatches to a function on the ChatPanel.
-type BuiltinCommand = {
-  name: string;
-  description: string;
-  // Returns true if the command was handled (caller skips fallthrough).
-  // Returns false to fall through to opencode/prompt path (useful for
-  // disabled commands).
-};
-const MANTA_BUILTIN_COMMANDS: BuiltinCommand[] = [
-  { name: "clear", description: "Start a fresh chat in this window" },
-  { name: "fork", description: "Copy this session's history into a new window" },
-  { name: "compact", description: "Summarize to free context" },
-  { name: "help", description: "Show available commands" },
-];
-const MANTA_BUILTIN_NAMES = new Set(MANTA_BUILTIN_COMMANDS.map((c) => c.name));
+// manta-local slash commands live in chatUtils.ts (MANTA_BUILTIN_COMMANDS /
+// MANTA_BUILTIN_NAMES), shared with useTypeahead so execution and completion
+// never diverge.
 
 function buildHelpText(): string {
   const lines = [

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -466,7 +466,7 @@ export function ChatPanel({
     // away and back would re-run the reset and wipe staged attachments, @agent
     // mentions and the /help notice out of the composer. The poll lives in its
     // own visibility-gated effect below.
-  }, [sessionId, cwd, refreshBranch]);
+  }, [sessionId, cwd]);
 
   // Branch indicator: poll every 5s while this session is visible. Gated on
   // isActive — hidden panels stop polling; the effect re-fires (one

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -21,7 +21,6 @@ import type {
   AvailableLauncher,
   DelegateApproval,
   DelegateApprovalTool,
-  DelegateJob,
   OpencodeModel,
   QuestionRequest,
 } from "../shared/types";
@@ -210,27 +209,15 @@ export function ChatPanel({
 
   // BET-418 §D: detect whether THIS session is a background job's child. A
   // job session is read-only (no composer, no cards, no model picker/fork/
-  // compact/clear); the composer is replaced by ReadOnlyJobBar. Poll the
-  // box-wide job list (no-arg delegateList) and match on childSessionID.
-  const [jobOwnership, setJobOwnership] = useState<DelegateJob | null>(null);
-  useEffect(() => {
-    setJobOwnership(null);
-    // Hidden panel — stop polling; the effect re-runs (and refires once) when
-    // isActive flips back on.
-    if (!isActive) return;
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const list = await window.api.delegateList();
-        const arr = Array.isArray(list) ? list : [];
-        const match = arr.find((j) => j.childSessionID === sessionId) ?? null;
-        if (!cancelled) setJobOwnership(match);
-      } catch { /* non-fatal */ }
-    };
-    void poll();
-    const t = setInterval(poll, 10_000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, [sessionId, isActive]);
+  // compact/clear); the composer is replaced by ReadOnlyJobBar. Derived from
+  // the store's `jobs` slice (keyed by childSessionID, fed by App.tsx's single
+  // 30s delegateList poll + real-time `delegate.updated` refetch) — the panel
+  // no longer runs its own 10s delegateList poll.
+  const jobs = useStore((s) => s.jobs);
+  const jobOwnership = useMemo(
+    () => jobs[sessionId] ?? null,
+    [jobs, sessionId],
+  );
 
   const projects = useStore((s) => s.projects);
   const setActive = useStore((s) => s.setActive);
@@ -2246,7 +2233,18 @@ export function ChatPanel({
             if (jobOwnership.status !== "running") return;
             void window.api
               .delegateStop(jobOwnership.id)
-              .then(() => setJobOwnership((j) => (j ? { ...j, status: "stopped" } : j)))
+              .then(() => {
+                // Optimistically flip this job to stopped in the store's jobs
+                // slice (server `delegate.updated` refetch confirms shortly).
+                const st = useStore.getState();
+                const job = st.jobs[sessionId];
+                if (!job) return;
+                st.setJobs(
+                  Object.values(st.jobs).map((j) =>
+                    j.childSessionID === sessionId ? { ...j, status: "stopped" } : j,
+                  ),
+                );
+              })
               .catch(() => { /* best-effort */ });
           }}
         />

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1271,6 +1271,20 @@ export function ChatPanel({
   //     same byte path paste already uses. Without this fallback a drop in
   //     HTTP mode silently discarded every file.
 
+  // Patch one attachment by id with a Partial<Attachment>. The single owner of
+  // the "uploading" -> "ready" (with remotePath) / -> "error" (with errorMsg)
+  // state transition, reused by every upload path (drag-drop, paste,
+  // screenshot) so they never repeat a setAttachments closure (duplication-
+  // gate).
+  const patchAttachment = useCallback(
+    (id: string, patch: Partial<Attachment>) => {
+      setAttachments((prev) =>
+        prev.map((a) => (a.id === id ? { ...a, ...patch } : a)),
+      );
+    },
+    [],
+  );
+
   const addDroppedFiles = useCallback(
     async (files: FileList | File[]) => {
       if (!tmuxSession) return;
@@ -1308,17 +1322,16 @@ export function ChatPanel({
       }));
       setAttachments((prev) => [...prev, ...newChips]);
 
-      const settleChip = (id: string, rp: string | null, errorMsg?: string) => {
-        setAttachments((prev) =>
-          prev.map((a) =>
-            a.id === id
-              ? rp
-                ? { ...a, status: "ready", remotePath: rp }
-                : { ...a, status: "error", errorMsg: errorMsg ?? "Upload returned no path" }
-              : a,
-          ),
+      // Settle each chip once its upload finishes: route every completion /
+      // failure through the shared patchAttachment owner (this used to be a
+      // local settleChip that duplicated it — BET-732).
+      const settleReady = (id: string, rp: string | null) =>
+        patchAttachment(
+          id,
+          rp
+            ? { status: "ready", remotePath: rp }
+            : { status: "error", errorMsg: "Upload returned no path" },
         );
-      };
 
       // Path-based entries upload in one batch (cheaper round-trip).
       const pathPending = pending.filter((p) => p.lp);
@@ -1332,10 +1345,10 @@ export function ChatPanel({
           });
         } catch (e) {
           const msg = String((e as Error)?.message ?? e);
-          for (const p of pathPending) settleChip(p.id, null, msg);
+          for (const p of pathPending) patchAttachment(p.id, { status: "error", errorMsg: msg });
           return;
         }
-        pathPending.forEach((p, i) => settleChip(p.id, remotePaths[i] ?? null));
+        pathPending.forEach((p, i) => settleReady(p.id, remotePaths[i] ?? null));
       })();
 
       // Byte-based entries upload individually (each File's bytes → uploadBuffer).
@@ -1349,16 +1362,16 @@ export function ChatPanel({
               filename: p.file.name,
               buffer,
             });
-            settleChip(p.id, rp || null);
+            settleReady(p.id, rp || null);
           } catch (e) {
-            settleChip(p.id, null, String((e as Error)?.message ?? e));
+            patchAttachment(p.id, { status: "error", errorMsg: String((e as Error)?.message ?? e) });
           }
         }),
       );
 
       await Promise.all([pathBatch, byteBatch]);
     },
-    [tmuxSession],
+    [tmuxSession, patchAttachment],
   );
 
   // Mobile ⋯ sheet → attach-files bridge (BET-260). The hidden <input
@@ -1387,20 +1400,6 @@ export function ChatPanel({
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);
-
-  // Patch one attachment by id with a Partial<Attachment>. Reused by the
-  // paste/screenshot upload paths to flip status from "uploading" -> "ready"
-  // (with remotePath) or -> "error" (with errorMsg) without repeating the
-  // setAttachments(prev => prev.map(a => a.id === id ? {...a, ...patch} : a))
-  // closure at every site (duplication-gate).
-  const patchAttachment = useCallback(
-    (id: string, patch: Partial<Attachment>) => {
-      setAttachments((prev) =>
-        prev.map((a) => (a.id === id ? { ...a, ...patch } : a)),
-      );
-    },
-    [],
-  );
 
   // ===== Clipboard paste (screenshots) =====
   //

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -112,6 +112,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   if (!draft) return null;
   const refresh = useStore((s) => s.refresh);
   const setActive = useStore((s) => s.setActive);
+  const activateWindow = useStore((s) => s.activateWindow);
   const applyProjects = useStore((s) => s.applyProjects);
   const updateDraft = useStore((s) => s.updateDraft);
   const dismissDraft = useStore((s) => s.dismissDraft);
@@ -302,11 +303,14 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       if (sessionId) {
         setAutoSubmitPrompt({ sid: sessionId, text, model: draft.model ?? undefined });
       }
-      setActive(sessionName, win?.index ?? createdNorm.windowIndex);
+      // Navigate to the new session (setActive + box-side select-window so the
+      // PTY follows) — one store action shared with the sidebar/jump flows.
       if (win) {
         try {
-          await window.api.tmuxSelectWindow({ sessionName, windowIndex: win.index });
+          await activateWindow(sessionName, win.index);
         } catch { /* non-fatal */ }
+      } else {
+        setActive(sessionName, createdNorm.windowIndex);
       }
       // Abandon the draft — it is now a real session.
       dismissDraft(draftId);
@@ -372,14 +376,12 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           : proj?.windows.find((w) => w.active) ?? proj?.windows[0];
       const sessionId = createdNorm.sessionId ?? win?.opencodeSessionId ?? null;
 
-      setActive(sessionName, win?.index ?? createdNorm.windowIndex);
       if (win) {
         try {
-          await window.api.tmuxSelectWindow({
-            sessionName,
-            windowIndex: win.index,
-          });
+          await activateWindow(sessionName, win.index);
         } catch { /* non-fatal */ }
+      } else {
+        setActive(sessionName, createdNorm.windowIndex);
       }
 
       if (sessionId && text) {

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -71,6 +71,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   const status = useStore((s) => s.status);
   const jobs = useStore((s) => s.jobs);
   const setActive = useStore((s) => s.setActive);
+  const storeActivateWindow = useStore((s) => s.activateWindow);
   const refresh = useStore((s) => s.refresh);
   const backgroundSyncing = useStore((s) => s.backgroundSyncing);
   const pinnedWindows = useStore((s) => s.pinnedWindows);
@@ -152,16 +153,18 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     });
 
   const activateWindow = async (proj: Project, idx: number) => {
-    setActive(proj.tmuxSession, idx);
+    // Preserve this site's existing guard: only tell the box to select the
+    // window when the project is ALREADY active (its PTY is mounted). When
+    // switching into a different project, setActive alone lands the store
+    // view; the box PTY is (re)spawned on project switch.
     if (proj.tmuxSession === activeProjectName) {
       try {
-        await window.api.tmuxSelectWindow({
-          sessionName: proj.tmuxSession,
-          windowIndex: idx,
-        });
+        await storeActivateWindow(proj.tmuxSession, idx);
       } catch (e) {
         showError(e);
       }
+    } else {
+      setActive(proj.tmuxSession, idx);
     }
   };
 

--- a/src/renderer/Terminal.tsx
+++ b/src/renderer/Terminal.tsx
@@ -228,10 +228,6 @@ const IS_DEMO = new URLSearchParams(window.location.search).has("demo");
     termRef.current = term;
     fitRef.current = fit;
     searchRef.current = search;
-    // Diagnostic: expose this Terminal's xterm as a window global so we can
-    // inspect modes / buffer state from DevTools while reproducing UI bugs.
-    (window as unknown as Record<string, unknown>)[`_term_${sessionKey}`] = term;
-    (window as unknown as Record<string, unknown>)._term = term;
 
     let disposeEvents: (() => void) | null = null;
     let cancelled = false;

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -345,6 +345,26 @@ export function dedupeAgainstBuiltins<T extends TypeaheadCommandRow>(
   return commands.filter((c) => !builtinNames.has(c.name));
 }
 
+// ===== manta-local slash commands =====
+//
+// The single source for the renderer's local slash commands ("clear", "fork",
+// "compact", "help"). These are handled in the renderer (never forwarded to
+// opencode's /command endpoint) because opencode doesn't ship equivalents —
+// they're terminal-TUI conventions users expect to "just work". Both ChatPanel
+// (execution + /help text) and useTypeahead (typeahead completion) import this
+// ONE definition, so a builtin added here both runs and autocompletes.
+export type BuiltinCommand = {
+  name: string;
+  description: string;
+};
+export const MANTA_BUILTIN_COMMANDS: BuiltinCommand[] = [
+  { name: "clear", description: "Start a fresh chat in this window" },
+  { name: "fork", description: "Copy this session's history into a new window" },
+  { name: "compact", description: "Summarize to free context" },
+  { name: "help", description: "Show available commands" },
+];
+export const MANTA_BUILTIN_NAMES = new Set(MANTA_BUILTIN_COMMANDS.map((c) => c.name));
+
 /**
  * The four todo states the ActiveTodos card renders, normalized.
  *

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1530,7 +1530,7 @@ function isAuthErrorName(
 // session id. False for ordinary chat/terminal windows and when the window
 // has no opencode session id (a claude-TUI window).
 export function isJobRow(
-  jobs: Record<string, { name: string; status: string; activity: string }>,
+  jobs: Record<string, { name: string; status: string; activity: string | null }>,
   opencodeSessionId: string | null | undefined,
 ): boolean {
   if (!opencodeSessionId) return false;

--- a/src/renderer/hooks/useSessionResources.ts
+++ b/src/renderer/hooks/useSessionResources.ts
@@ -1,33 +1,17 @@
 // ===== useSessionResources =====
 //
 // Extracted from ChatPanel.tsx (BET-63). Owns the three "server-owned
-// resource" cards that hang off a chat session — scheduled prompts (⏰),
-// secrets (🔑), and inbound webhooks (🪝). Each is the same shape:
+// resource" cards hanging off a chat session — scheduled prompts (⏰), secrets
+// (🔑), inbound webhooks (🪝). Each card is the same shape: a shared `openPanel`
+// surface, a metadata list + error, a `refresh*` callback, a poll effect while
+// open (schedules also background-polls so its toolbar count stays fresh), a
+// `manta-open-*` window-CustomEvent opener, and a session-change reset.
 //
-//   - a single `openPanel` surface shared by all three cards (opened by the
-//     composer toolbar or a mobile ⋯-sheet `manta-open-*` window CustomEvent),
-//   - a list of metadata + an error string,
-//   - a `refresh*` callback that re-fetches over the `schedule:*` / `secrets:*`
-//     / `webhook:*` window.api channels,
-//   - a poll effect while the card is open (schedules also background-polls so
-//     its toolbar count stays fresh), and
-//   - a session-change reset.
+// The three cards are ONE generic `useResourceCard` helper parameterized by
+// the fetch call, the event name, the background-poll flag, and the empty
+// value; the public `useSessionResources` return shape is unchanged.
 //
-// The three cards are implemented by ONE generic `useResourceCard` helper
-// parameterized by the fetch call, the `manta-open-*` event name, the
-// background-poll flag, and the empty value. The three exported surface
-// fields are thin instantiations on top of it — the public
-// `useSessionResources` return shape is unchanged.
-//
-// This slice is completely independent of the fragile SSE / pin-to-bottom /
-// message-drain core, which is exactly why it's the safe first hook to pull
-// out of the container: nothing here touches `messages`, the delta buffer, or
-// the scroll refs. The behavior is byte-for-byte the same as when it lived
-// inline in ChatPanel — see the git history of ChatPanel.tsx for the original
-// call sites.
-//
-// No Electron-only deps — only `window.api.*`, which the mobile HTTP server
-// shims.
+// Only `window.api.*` — no Electron-only deps (the mobile HTTP server shims it).
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ScheduledJob, SecretMeta, WebhookMeta } from "../../shared/types";
@@ -37,15 +21,10 @@ export type PanelName = "schedules" | "secrets" | "webhooks";
 
 export type SessionResources = {
   // ----- The card surface -----
-  //
-  // ONE state for all three cards, not three booleans. "at most one card is
-  // open" is then a property of the state's shape rather than a rule some
-  // caller has to remember to enforce, and every button goes through the same
-  // toggle. Do not split this back into per-card flags.
+  // ONE state for all three cards ("at most one open" falls out of the shape).
   /** Which card is open, or null when none is. */
   openPanel: PanelName | null;
-  /** Toolbar click: open `name`, or close it if it is already the open one.
-   *  Opening one closes whichever other was open — implicitly. */
+  /** Toolbar click: open `name`, or close it if already open. */
   togglePanel: (name: PanelName) => void;
   /** A card's × button, and the session-change reset. */
   closePanel: () => void;
@@ -72,13 +51,10 @@ export type SessionResources = {
   refreshWebhooks: () => Promise<void>;
 };
 
-// One card's shared state (list + error + refresh), poll cadence, and open-
-// bridge listener. The three cards (schedules/secrets/webhooks) differ ONLY
-// in: the fetch call, the `manta-open-*` event name (= panelName), whether it
-// background-polls (schedules does; the others poll only while their card is
-// open), and the "server unreachable" message. Everything else — the list/
-// error state, the session-change reset, the open-poll and background-poll,
-// and the out-of-panel opener listener — is one copy.
+// One card's shared list/error/refresh state, poll cadence, and open-bridge
+// listener. Cards differ only in the fetch call, event name (= panelName), the
+// background-poll flag (schedules background-polls; the others poll only while
+// their card is open), and the "server unreachable" message.
 type ResourceCardConfig<T> = {
   panelName: PanelName;
   sessionId: string;
@@ -97,37 +73,24 @@ type ResourceCardConfig<T> = {
 };
 
 function useResourceCard<T>({
-  panelName,
-  sessionId,
-  isActive,
-  openPanel,
-  setOpenPanel,
-  fetch,
-  empty,
-  backgroundPoll,
-  unreachable,
+  panelName, sessionId, isActive, openPanel, setOpenPanel, fetch, empty, backgroundPoll, unreachable,
 }: ResourceCardConfig<T>) {
   const [items, setItems] = useState<T[]>(empty);
   const [error, setError] = useState<string | null>(null);
-
-  // fetch/empty are passed inline from the caller (recreated each render), so
-  // read them through refs to keep `refresh` a stable identity across renders
-  // and to keep the session-reset effect from re-firing every render.
+  // fetch/empty are passed inline (recreated each render); hold them in refs so
+  // `refresh` keeps a stable identity and the reset effect doesn't re-fire.
   const fetchRef = useRef(fetch);
   fetchRef.current = fetch;
   const emptyRef = useRef(empty);
   emptyRef.current = empty;
 
   const refresh = useCallback(() => {
-    return fetchRef
-      .current(sessionId)
+    return fetchRef.current(sessionId)
       .then((data) => {
         setItems(Array.isArray(data) ? data : emptyRef.current);
         setError(null);
       })
-      .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : unreachable);
-      });
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : unreachable));
   }, [sessionId, unreachable]);
 
   // Session change resets this card's cached list + error (the outer hook
@@ -137,13 +100,10 @@ function useResourceCard<T>({
     setError(null);
   }, [sessionId]);
 
-  // Derive per-card "is this card open?" for the poll cadence (see type
-  // comment on openPanel).
   const opened = openPanel === panelName;
 
-  // Poll freshness. schedules background-polls (10s while open, 30s closed,
-  // stopped while the panel is hidden) so its toolbar count stays current; the
-  // others poll only while their card is open (10s).
+  // Poll freshness: schedules background-polls (10s open / 30s closed, stopped
+  // while hidden); the others poll only while their card is open (10s).
   useEffect(() => {
     if (backgroundPoll) {
       if (!isActive) return;
@@ -152,17 +112,14 @@ function useResourceCard<T>({
       const poll = setInterval(() => void refresh(), intervalMs);
       return () => clearInterval(poll);
     }
-    // Non-background cards poll only while open.
     if (!opened) return;
     void refresh();
     const poll = setInterval(() => void refresh(), 10_000);
     return () => clearInterval(poll);
   }, [opened, isActive, backgroundPoll, refresh]);
 
-  // Entry point for an out-of-panel opener (the mobile ⋯ sheet dispatched
-  // these; the listeners are the documented bridge and are covered by tests).
-  // Open-only — never a toggle, because the dispatcher has no idea what is
-  // currently open.
+  // Open this card from an out-of-panel `manta-open-*` bridge. Open-only —
+  // never a toggle, because the dispatcher has no idea what is open.
   useEffect(() => {
     const type = `manta-open-${panelName}`;
     const onOpen = (e: Event) => {
@@ -177,8 +134,8 @@ function useResourceCard<T>({
 }
 
 export function useSessionResources(sessionId: string, isActive: boolean): SessionResources {
-  // ----- The card surface -----
-  // One piece of state governs all three cards (see the type comment above).
+  // One piece of state governs all three cards (at most one open — see the
+  // type comment).
   const [openPanel, setOpenPanel] = useState<PanelName | null>(null);
   const togglePanel = useCallback(
     (name: PanelName) => setOpenPanel((cur) => (cur === name ? null : name)),
@@ -186,56 +143,28 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   );
   const closePanel = useCallback(() => setOpenPanel(null), []);
 
-  // ----- Scheduled prompts (the ⏰ ScheduledTasksCard) -----
-  // Jobs are server-owned (manta-server fires them); here we only list + delete
-  // via the schedule:* window.api channels. Refetch-driven (open + open-poll +
-  // post-delete) — NOT a bus event, because desktop's renderer isn't wired to
-  // the server bus. See docs/manta-tools-scheduler.md.
+  // Scheduled prompts (⏰): server-owned; list + delete via schedule:* channels.
+  // Refetch-driven (open + open-poll + post-delete), NOT a bus event.
   const schedules = useResourceCard<ScheduledJob>({
-    panelName: "schedules",
-    sessionId,
-    isActive,
-    openPanel,
-    setOpenPanel,
-    fetch: (sid) => window.api.scheduleList(sid),
-    empty: [],
-    backgroundPoll: true,
+    panelName: "schedules", sessionId, isActive, openPanel, setOpenPanel,
+    fetch: (sid) => window.api.scheduleList(sid), empty: [], backgroundPoll: true,
     unreachable: "schedule server unreachable",
   });
 
-  // ----- Secrets (the 🔑 SecretsCard) -----
-  // Secrets are server-owned (the value never leaves the box; the AI reads
-  // them via the secret_* opencode tools). Here the user adds/edits/deletes via
-  // secrets:* window.api channels. list returns METADATA ONLY (no values).
-  // Refetch-driven like schedules. The card shows shared secrets + this
-  // session's scoped ones (sessionId is passed so the agent-visible view
-  // matches what tools will resolve).
+  // Secrets (🔑): server-owned (values never leave the box). list returns
+  // METADATA ONLY (no values). Refetch-driven like schedules.
   const secrets = useResourceCard<SecretMeta>({
-    panelName: "secrets",
-    sessionId,
-    isActive,
-    openPanel,
-    setOpenPanel,
-    fetch: (sid) => window.api.secretsList(sid),
-    empty: [],
-    backgroundPoll: false,
+    panelName: "secrets", sessionId, isActive, openPanel, setOpenPanel,
+    fetch: (sid) => window.api.secretsList(sid), empty: [], backgroundPoll: false,
     unreachable: "secrets server unreachable",
   });
 
-  // ----- Inbound webhooks (the 🪝 WebhooksCard) -----
-  // Hooks are server-owned (external POSTs wake the session); here we only list
-  // + revoke via the webhook:* channels (creation is the AI's job via the
-  // `webhook` opencode tool, which returns the one-time signing secret).
-  // Refetch-driven like schedules/secrets. See docs/manta-tools-webhook.md.
+  // Inbound webhooks (🪝): server-owned (external POSTs wake the session).
+  // list + revoke via webhook:* channels (creation is the AI's job).
+  // Refetch-driven like schedules/secrets.
   const webhooks = useResourceCard<WebhookMeta>({
-    panelName: "webhooks",
-    sessionId,
-    isActive,
-    openPanel,
-    setOpenPanel,
-    fetch: (sid) => window.api.webhookList(sid),
-    empty: [],
-    backgroundPoll: false,
+    panelName: "webhooks", sessionId, isActive, openPanel, setOpenPanel,
+    fetch: (sid) => window.api.webhookList(sid), empty: [], backgroundPoll: false,
     unreachable: "webhook server unreachable",
   });
 
@@ -246,23 +175,15 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   }, [sessionId]);
 
   return {
-    openPanel,
-    togglePanel,
-    closePanel,
-    schedules: schedules.items,
-    setSchedules: schedules.setItems,
-    scheduleError: schedules.error,
-    setScheduleError: schedules.setError,
+    openPanel, togglePanel, closePanel,
+    schedules: schedules.items, setSchedules: schedules.setItems,
+    scheduleError: schedules.error, setScheduleError: schedules.setError,
     refreshSchedules: schedules.refresh,
-    secrets: secrets.items,
-    setSecrets: secrets.setItems,
-    secretError: secrets.error,
-    setSecretError: secrets.setError,
+    secrets: secrets.items, setSecrets: secrets.setItems,
+    secretError: secrets.error, setSecretError: secrets.setError,
     refreshSecrets: secrets.refresh,
-    webhooks: webhooks.items,
-    setWebhooks: webhooks.setItems,
-    webhookError: webhooks.error,
-    setWebhookError: webhooks.setError,
+    webhooks: webhooks.items, setWebhooks: webhooks.setItems,
+    webhookError: webhooks.error, setWebhookError: webhooks.setError,
     refreshWebhooks: webhooks.refresh,
   };
 }

--- a/src/renderer/hooks/useSessionResources.ts
+++ b/src/renderer/hooks/useSessionResources.ts
@@ -13,6 +13,12 @@
 //     its toolbar count stays fresh), and
 //   - a session-change reset.
 //
+// The three cards are implemented by ONE generic `useResourceCard` helper
+// parameterized by the fetch call, the `manta-open-*` event name, the
+// background-poll flag, and the empty value. The three exported surface
+// fields are thin instantiations on top of it — the public
+// `useSessionResources` return shape is unchanged.
+//
 // This slice is completely independent of the fragile SSE / pin-to-bottom /
 // message-drain core, which is exactly why it's the safe first hook to pull
 // out of the container: nothing here touches `messages`, the delta buffer, or
@@ -23,7 +29,7 @@
 // No Electron-only deps — only `window.api.*`, which the mobile HTTP server
 // shims.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ScheduledJob, SecretMeta, WebhookMeta } from "../../shared/types";
 
 /** The three server-owned resource cards that hang off a chat session. */
@@ -66,6 +72,110 @@ export type SessionResources = {
   refreshWebhooks: () => Promise<void>;
 };
 
+// One card's shared state (list + error + refresh), poll cadence, and open-
+// bridge listener. The three cards (schedules/secrets/webhooks) differ ONLY
+// in: the fetch call, the `manta-open-*` event name (= panelName), whether it
+// background-polls (schedules does; the others poll only while their card is
+// open), and the "server unreachable" message. Everything else — the list/
+// error state, the session-change reset, the open-poll and background-poll,
+// and the out-of-panel opener listener — is one copy.
+type ResourceCardConfig<T> = {
+  panelName: PanelName;
+  sessionId: string;
+  isActive: boolean;
+  /** Shared "which card is open" state — one card open at a time. */
+  openPanel: PanelName | null;
+  setOpenPanel: React.Dispatch<React.SetStateAction<PanelName | null>>;
+  /** The fetch call for this card's channel. */
+  fetch: (sessionId: string) => Promise<T[]>;
+  /** Empty value to reset to on session change / failed fetch. */
+  empty: T[];
+  /** schedules background-polls (toolbar count stays fresh); others don't. */
+  backgroundPoll: boolean;
+  /** Error message when the server is unreachable. */
+  unreachable: string;
+};
+
+function useResourceCard<T>({
+  panelName,
+  sessionId,
+  isActive,
+  openPanel,
+  setOpenPanel,
+  fetch,
+  empty,
+  backgroundPoll,
+  unreachable,
+}: ResourceCardConfig<T>) {
+  const [items, setItems] = useState<T[]>(empty);
+  const [error, setError] = useState<string | null>(null);
+
+  // fetch/empty are passed inline from the caller (recreated each render), so
+  // read them through refs to keep `refresh` a stable identity across renders
+  // and to keep the session-reset effect from re-firing every render.
+  const fetchRef = useRef(fetch);
+  fetchRef.current = fetch;
+  const emptyRef = useRef(empty);
+  emptyRef.current = empty;
+
+  const refresh = useCallback(() => {
+    return fetchRef
+      .current(sessionId)
+      .then((data) => {
+        setItems(Array.isArray(data) ? data : emptyRef.current);
+        setError(null);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : unreachable);
+      });
+  }, [sessionId, unreachable]);
+
+  // Session change resets this card's cached list + error (the outer hook
+  // closes the shared panel).
+  useEffect(() => {
+    setItems(emptyRef.current);
+    setError(null);
+  }, [sessionId]);
+
+  // Derive per-card "is this card open?" for the poll cadence (see type
+  // comment on openPanel).
+  const opened = openPanel === panelName;
+
+  // Poll freshness. schedules background-polls (10s while open, 30s closed,
+  // stopped while the panel is hidden) so its toolbar count stays current; the
+  // others poll only while their card is open (10s).
+  useEffect(() => {
+    if (backgroundPoll) {
+      if (!isActive) return;
+      void refresh();
+      const intervalMs = opened ? 10_000 : 30_000;
+      const poll = setInterval(() => void refresh(), intervalMs);
+      return () => clearInterval(poll);
+    }
+    // Non-background cards poll only while open.
+    if (!opened) return;
+    void refresh();
+    const poll = setInterval(() => void refresh(), 10_000);
+    return () => clearInterval(poll);
+  }, [opened, isActive, backgroundPoll, refresh]);
+
+  // Entry point for an out-of-panel opener (the mobile ⋯ sheet dispatched
+  // these; the listeners are the documented bridge and are covered by tests).
+  // Open-only — never a toggle, because the dispatcher has no idea what is
+  // currently open.
+  useEffect(() => {
+    const type = `manta-open-${panelName}`;
+    const onOpen = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
+      if (detail?.sessionId === sessionId) setOpenPanel(panelName);
+    };
+    window.addEventListener(type, onOpen);
+    return () => window.removeEventListener(type, onOpen);
+  }, [panelName, sessionId, setOpenPanel]);
+
+  return { items, setItems, error, setError, refresh };
+}
+
 export function useSessionResources(sessionId: string, isActive: boolean): SessionResources {
   // ----- The card surface -----
   // One piece of state governs all three cards (see the type comment above).
@@ -76,33 +186,22 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   );
   const closePanel = useCallback(() => setOpenPanel(null), []);
 
-  // Derived per-card flags, used ONLY as effect dependencies below. They are
-  // booleans, so an effect that watches one re-runs when THAT card opens or
-  // closes — not every time any card changes. Depending on `openPanel`
-  // directly would, for example, refetch schedules every time the secrets card
-  // opened.
-  const schedulesOpen = openPanel === "schedules";
-  const secretsOpen = openPanel === "secrets";
-  const webhooksOpen = openPanel === "webhooks";
-
   // ----- Scheduled prompts (the ⏰ ScheduledTasksCard) -----
   // Jobs are server-owned (manta-server fires them); here we only list + delete
   // via the schedule:* window.api channels. Refetch-driven (open + open-poll +
   // post-delete) — NOT a bus event, because desktop's renderer isn't wired to
   // the server bus. See docs/manta-tools-scheduler.md.
-  const [schedules, setSchedules] = useState<ScheduledJob[]>([]);
-  const [scheduleError, setScheduleError] = useState<string | null>(null);
-  const refreshSchedules = useCallback(() => {
-    return window.api
-      .scheduleList(sessionId)
-      .then((jobs: ScheduledJob[]) => {
-        setSchedules(Array.isArray(jobs) ? jobs : []);
-        setScheduleError(null);
-      })
-      .catch((e: unknown) => {
-        setScheduleError(e instanceof Error ? e.message : "schedule server unreachable");
-      });
-  }, [sessionId]);
+  const schedules = useResourceCard<ScheduledJob>({
+    panelName: "schedules",
+    sessionId,
+    isActive,
+    openPanel,
+    setOpenPanel,
+    fetch: (sid) => window.api.scheduleList(sid),
+    empty: [],
+    backgroundPoll: true,
+    unreachable: "schedule server unreachable",
+  });
 
   // ----- Secrets (the 🔑 SecretsCard) -----
   // Secrets are server-owned (the value never leaves the box; the AI reads
@@ -111,125 +210,59 @@ export function useSessionResources(sessionId: string, isActive: boolean): Sessi
   // Refetch-driven like schedules. The card shows shared secrets + this
   // session's scoped ones (sessionId is passed so the agent-visible view
   // matches what tools will resolve).
-  const [secrets, setSecrets] = useState<SecretMeta[]>([]);
-  const [secretError, setSecretError] = useState<string | null>(null);
-  const refreshSecrets = useCallback(() => {
-    return window.api
-      .secretsList(sessionId)
-      .then((list: SecretMeta[]) => {
-        setSecrets(Array.isArray(list) ? list : []);
-        setSecretError(null);
-      })
-      .catch((e: unknown) => {
-        setSecretError(e instanceof Error ? e.message : "secrets server unreachable");
-      });
-  }, [sessionId]);
+  const secrets = useResourceCard<SecretMeta>({
+    panelName: "secrets",
+    sessionId,
+    isActive,
+    openPanel,
+    setOpenPanel,
+    fetch: (sid) => window.api.secretsList(sid),
+    empty: [],
+    backgroundPoll: false,
+    unreachable: "secrets server unreachable",
+  });
 
   // ----- Inbound webhooks (the 🪝 WebhooksCard) -----
   // Hooks are server-owned (external POSTs wake the session); here we only list
   // + revoke via the webhook:* channels (creation is the AI's job via the
   // `webhook` opencode tool, which returns the one-time signing secret).
   // Refetch-driven like schedules/secrets. See docs/manta-tools-webhook.md.
-  const [webhooks, setWebhooks] = useState<WebhookMeta[]>([]);
-  const [webhookError, setWebhookError] = useState<string | null>(null);
-  const refreshWebhooks = useCallback(() => {
-    return window.api
-      .webhookList(sessionId)
-      .then((list: WebhookMeta[]) => {
-        setWebhooks(Array.isArray(list) ? list : []);
-        setWebhookError(null);
-      })
-      .catch((e: unknown) => {
-        setWebhookError(e instanceof Error ? e.message : "webhook server unreachable");
-      });
-  }, [sessionId]);
+  const webhooks = useResourceCard<WebhookMeta>({
+    panelName: "webhooks",
+    sessionId,
+    isActive,
+    openPanel,
+    setOpenPanel,
+    fetch: (sid) => window.api.webhookList(sid),
+    empty: [],
+    backgroundPoll: false,
+    unreachable: "webhook server unreachable",
+  });
 
-  // Session change closes whatever card is open and drops every cached list.
-  // One effect for all three — the three near-identical copies this replaces
-  // had already drifted (secrets' was added later, with a comment about the
-  // inconsistency).
+  // Session change closes whatever card is open (each card resets its own
+  // list + error inside useResourceCard).
   useEffect(() => {
     setOpenPanel(null);
-    setSchedules([]);
-    setScheduleError(null);
-    setSecrets([]);
-    setSecretError(null);
-    setWebhooks([]);
-    setWebhookError(null);
-  }, [sessionId]);
-
-  // Keep the toolbar schedule count fresh whether or not the card is open:
-  // fetch once on mount/session-change, then poll. The card being open speeds
-  // the poll up (10s) for snappy create/fire feedback; while closed a slower
-  // 30s background poll keeps the "(N)" count current so a model-created job
-  // shows up without the user having to open the card first. Refetch-driven
-  // (no bus event) so it behaves identically on desktop and mobile. The
-  // background poll stops while the panel is hidden — the effect re-runs (and
-  // refires once) when isActive flips back on.
-  useEffect(() => {
-    if (!isActive) return;
-    void refreshSchedules();
-    const intervalMs = schedulesOpen ? 10_000 : 30_000;
-    const poll = setInterval(() => void refreshSchedules(), intervalMs);
-    return () => clearInterval(poll);
-  }, [schedulesOpen, refreshSchedules, isActive]);
-
-  // Secrets are only fetched while the card is open (no toolbar count badge to
-  // keep current in the background — unlike schedules). Refetch on open + 10s
-  // poll so a secret added on another device shows up.
-  useEffect(() => {
-    if (!secretsOpen) return;
-    void refreshSecrets();
-    const poll = setInterval(() => void refreshSecrets(), 10_000);
-    return () => clearInterval(poll);
-  }, [secretsOpen, refreshSecrets]);
-
-  // Webhooks fetched only while the card is open (creation is agent-driven; the
-  // count isn't surfaced on the toolbar, so no background poll). Refetch on open
-  // + 10s poll so a model-created hook / a fresh delivery shows up.
-  useEffect(() => {
-    if (!webhooksOpen) return;
-    void refreshWebhooks();
-    const poll = setInterval(() => void refreshWebhooks(), 10_000);
-    return () => clearInterval(poll);
-  }, [webhooksOpen, refreshWebhooks]);
-
-  // Entry point for an out-of-panel opener (the mobile ⋯ sheet dispatched these;
-  // the listeners are the documented bridge and are covered by tests). One loop
-  // over the three names replaces three copy-pasted effects. Open-only — never
-  // a toggle, because the dispatcher has no idea what is currently open.
-  useEffect(() => {
-    const names: PanelName[] = ["schedules", "secrets", "webhooks"];
-    const offs = names.map((name) => {
-      const type = `manta-open-${name}`;
-      const onOpen = (e: Event) => {
-        const detail = (e as CustomEvent).detail as { sessionId?: string } | undefined;
-        if (detail?.sessionId === sessionId) setOpenPanel(name);
-      };
-      window.addEventListener(type, onOpen);
-      return () => window.removeEventListener(type, onOpen);
-    });
-    return () => offs.forEach((off) => off());
   }, [sessionId]);
 
   return {
     openPanel,
     togglePanel,
     closePanel,
-    schedules,
-    setSchedules,
-    scheduleError,
-    setScheduleError,
-    refreshSchedules,
-    secrets,
-    setSecrets,
-    secretError,
-    setSecretError,
-    refreshSecrets,
-    webhooks,
-    setWebhooks,
-    webhookError,
-    setWebhookError,
-    refreshWebhooks,
+    schedules: schedules.items,
+    setSchedules: schedules.setItems,
+    scheduleError: schedules.error,
+    setScheduleError: schedules.setError,
+    refreshSchedules: schedules.refresh,
+    secrets: secrets.items,
+    setSecrets: secrets.setItems,
+    secretError: secrets.error,
+    setSecretError: secrets.setError,
+    refreshSecrets: secrets.refresh,
+    webhooks: webhooks.items,
+    setWebhooks: webhooks.setItems,
+    webhookError: webhooks.error,
+    setWebhookError: webhooks.setError,
+    refreshWebhooks: webhooks.refresh,
   };
 }

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -12,8 +12,6 @@
 //     commandByMessageId, sendError, messageQueue, drainAbortRef
 //   - The drain effect ([running, messageQueue] → submit queued prompt)
 //   - The abort callback
-//   - The replyPermission / replyQuestion / rejectQuestion callbacks
-//
 // Dependencies injected via params:
 //   - setMessages (from useTranscriptState)
 //   - scheduleRefetch / spliceMessage / etc. (from useTranscriptState)
@@ -140,10 +138,6 @@ export type SseBus = {
   refreshBranch: (cwd: string) => void;
   submit: () => void;
   submitRef: React.RefObject<(textOverride?: string) => void>;
-  abort: () => void;
-  replyPermission: (id: string, reply: "once" | "always" | "reject") => void;
-  replyQuestion: (q: QuestionRequest, answers: string[][]) => void;
-  rejectQuestion: (q: QuestionRequest) => void;
   // Best-effort cleanup for any question(s) blocking an aborted turn — see
   // BET-116. Owned here (not ChatPanel) because this hook owns `questions`
   // state; exposed so ChatPanel's own user-facing abort path can call the
@@ -321,12 +315,6 @@ export function useSseBus(params: {
     useStore.getState().setChatAttention(sessionId, null);
   }, [sessionId]);
 
-  const abort = useCallback(() => {
-    void window.api.opencodeAbort(sessionId)
-      .catch(() => { /* non-fatal */ })
-      .then(() => rejectAllPendingQuestions());
-  }, [sessionId, rejectAllPendingQuestions]);
-
   // Open the Settings → AI → Subscriptions card from outside ChatPanel's
   // component tree (BET-316). Follows the `manta-open-schedules` /
   // `-secrets` / `-webhooks` precedent from useSessionResources.ts: the
@@ -364,31 +352,6 @@ export function useSseBus(params: {
       }
     } catch { /* non-fatal */ }
   }, [sessionId]);
-
-  const replyPermission = useCallback(
-    (id: string, reply: "once" | "always" | "reject") => {
-      void window.api.opencodePermissionReply?.(id, reply, sessionId);
-    },
-    [sessionId],
-  );
-
-  const replyQuestion = useCallback(
-    (q: QuestionRequest, answers: string[][]) => {
-      if (!q.requestId) return;
-      void window.api.opencodeQuestionReply?.(q.requestId, answers, q.sessionID);
-    },
-    [sessionId],
-  );
-
-  const rejectQuestion = useCallback(
-    (q: QuestionRequest) => {
-      // Signature is opencodeQuestionReject(requestId, sessionId?) and the
-      // reply/reject API accepts ONLY the `que_…` requestId, not the callID.
-      if (!q.requestId) return;
-      void window.api.opencodeQuestionReject?.(q.requestId, q.sessionID);
-    },
-    [],
-  );
 
   // SSE effect
   useEffect(() => {
@@ -887,10 +850,6 @@ export function useSseBus(params: {
     drainAbortRef,
     submit,
     submitRef,
-    abort,
-    replyPermission,
-    replyQuestion,
-    rejectQuestion,
     rejectAllPendingQuestions,
     refreshPermissions,
     refreshQuestions,

--- a/src/renderer/hooks/useTypeahead.ts
+++ b/src/renderer/hooks/useTypeahead.ts
@@ -22,6 +22,8 @@ import type { OpencodeAgent, OpencodeCommand } from "../../shared/types";
 import {
   filterCommands,
   dedupeAgainstBuiltins,
+  MANTA_BUILTIN_COMMANDS,
+  MANTA_BUILTIN_NAMES,
 } from "../chatUtils";
 import type {
   TypeaheadState,
@@ -29,16 +31,8 @@ import type {
   AgentMention,
 } from "../chatShared";
 
-// manta-local slash commands. These are handled in the renderer (not forwarded
-// to opencode's /command endpoint) because opencode doesn't ship equivalents
-// — they're terminal-TUI conventions users expect to "just work".
-const MANTA_BUILTIN_COMMANDS = [
-  { name: "clear", description: "Start a fresh chat in this window" },
-  { name: "fork", description: "Copy this session's history into a new window" },
-  { name: "compact", description: "Summarize to free context" },
-  { name: "help", description: "Show available commands" },
-] as const;
-const MANTA_BUILTIN_NAMES = new Set(MANTA_BUILTIN_COMMANDS.map((c) => c.name));
+// manta-local slash commands are defined once in chatUtils.ts (ChatPanel
+// executes them, useTypeahead autocompletes them).
 
 export type Typeahead = {
   // Popup state — null when closed.

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -980,13 +980,7 @@ export const useStore = create<State>((set, get) => ({
       //     currently on that window, latch `attention = true`.
       //   - otherwise carry attention forward; it clears on setActive().
       const next: Record<string, Record<number, WindowStatusUI>> = {};
-      // Seed with existing entries so windows missing from this batch keep
-      // their last known state. The poller's REMOTE_CMD lists every window
-      // every tick, so missing == window was killed; we'll prune below.
-      const seen = new Set<string>();
       for (const s of batch) {
-        const key = `${s.session}:${s.windowIndex}`;
-        seen.add(key);
         const old = prev.status[s.session]?.[s.windowIndex];
         const wasRunning = old?.running === true;
         const isActiveHere =
@@ -1001,12 +995,6 @@ export const useStore = create<State>((set, get) => ({
           attention,
         };
       }
-      // Drop entries the poller no longer reports (window was killed remotely).
-      // Iterate prev to preserve any session-row that just temporarily missed
-      // a tick due to a transient error — but in practice REMOTE_CMD failing
-      // produces an empty batch (we return early in the catch), and a
-      // successful run that omits a window means the window is gone.
-      void seen;
       // Preserve the prior values for chat-mode windows — the PTY poller
       // can't see their state (the holder pane runs `sleep infinity`),
       // so a fresh `next` map would silently clobber whatever

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type {
   AgentFileReady,
   AppConfig,
+  DelegateJob,
   OpencodeMessage,
   Project,
   TmuxWindow,
@@ -22,21 +23,16 @@ import {
 
 // Background-delegation jobs, keyed by the job's child opencode session id.
 // The renderer learns which sidebar windows are jobs (and their per-row
-// activity summary) from this slice. It is fed by a single app-level 30s poll
-// in App.tsx / MobileApp.tsx that calls window.api.delegateList() (no-arg =
-// all jobs) — exactly one poll, shared by desktop and mobile — PLUS an
-// immediate refetch on every `delegate.updated` bus event (BET-414) so a new
-// job nests under its parent within ~1s instead of waiting for the poll. The
-// renderer never computes the activity text; it renders the `activity` field
-// verbatim. `parentSessionID`/`childSessionID` are carried so the sidebar can
-// nest a job's child window under its parent window (BET-414).
-export type JobRow = {
-  name: string;
-  status: string;
-  activity: string;
-  parentSessionID: string | null;
-  childSessionID: string | null;
-};
+// activity summary) from this slice, and ChatPanel derives whether the panel
+// it is viewing is a background job's read-only child. It is fed by a single
+// app-level 30s poll in App.tsx / MobileApp.tsx that calls
+// window.api.delegateList() (no-arg = all jobs) — exactly one poll, shared by
+// desktop and mobile — PLUS an immediate refetch on every `delegate.updated`
+// bus event (BET-414) so a new job nests under its parent within ~1s instead
+// of waiting for the poll. The renderer never computes the activity text; it
+// renders the `activity` field verbatim. The FULL DelegateJob is retained (not
+// a reduced {name,status,activity} row) because ChatPanel's ReadOnlyJobBar
+// renders a job's branch/files-changed summary and Stop needs its id.
 
 // Cap on simultaneous in-flight requests for the startup opencode fan-outs
 // (`replayChatAttention`, `backfillLastMessageTimes`) — see BET-135.
@@ -395,7 +391,7 @@ type State = {
   // Background-delegation jobs keyed by childSessionID (BET-381). Drives the
   // sidebar's per-row activity second line (desktop + mobile). Fed by the
   // single app-level 10s poll — see JobRow comment above.
-  jobs: Record<string, JobRow>;
+  jobs: Record<string, DelegateJob>;
   // BET-738: subscription plan usage snapshots (one per connected provider),
   // fed by the composer's UsageDial. Primed once with window.api.usageList()
   // on mount and kept live by the `usage.updated` bus event — App.tsx does
@@ -545,9 +541,9 @@ type State = {
   applyPairing: (p: { serverUrl: string; boxId: string; boxToken: string }) => void;
   applyStatusBatch: (batch: WindowStatus[]) => void;
   // Replace the jobs slice from an app-level poll (BET-381). Accepts the raw
-  // DelegateJob[] from delegateList() and reduces it to the minimal
-  // {name,status,activity} map keyed by childSessionID.
-  setJobs: (jobs: { childSessionID: string | null; parentSessionID?: string | null; name: string; status: string; activity: string | null }[]) => void;
+  // DelegateJob[] from delegateList() and keys the full objects by
+  // childSessionID (ChatPanel + the sidebar both read the full job).
+  setJobs: (jobs: DelegateJob[]) => void;
   // Replace the usage slice (BET-738) from window.api.usageList() or the
   // `usage.updated` bus payload. Both hand over the full current array —
   // this is a straight replace, not a merge (the poller's contract is "the
@@ -1013,16 +1009,10 @@ export const useStore = create<State>((set, get) => ({
 
   setJobs: (jobs) =>
     set(() => {
-      const next: Record<string, JobRow> = {};
+      const next: Record<string, DelegateJob> = {};
       for (const j of jobs) {
         if (!j.childSessionID) continue;
-        next[j.childSessionID] = {
-          name: j.name,
-          status: j.status,
-          activity: j.activity ?? "",
-          parentSessionID: j.parentSessionID ?? null,
-          childSessionID: j.childSessionID,
-        };
+        next[j.childSessionID] = j;
       }
       return { jobs: next };
     }),

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -499,6 +499,15 @@ type State = {
   configSnapshot: () => Partial<AppConfig>;
   // ----- mutations -----
   setActive: (projectName: string, windowIndex?: number) => void;
+  // Activate a tmux window locally AND on the box (so the PTY follows). Shared
+  // by the sidebar, the ⌥⌘↑↓ / ⌘1..9 / voice-switch / ⌘F jump, the new-session
+  // flow, and the fan-out flow — every call site used to repeat this
+  // setActive + tmuxSelectWindow pair. `setActive` updates the store; the box
+  // select focuses the window (making the PTY follow). Returns the
+  // tmuxSelectWindow promise so each caller keeps its own error handling (they
+  // differ). Call sites with extra behavior (e.g. Sidebar's only-select-when-
+  // already-active guard) keep it around the call, not here.
+  activateWindow: (projectName: string, windowIndex: number) => Promise<void>;
   // New-session draft lifecycle (see NewSessionDraft). createDraft makes +
   // activates a fresh draft; updateDraft patches one (typed prompt, folder,
   // model…); dismissDraft abandons it (committed or cancelled) and re-points
@@ -745,6 +754,14 @@ export const useStore = create<State>((set, get) => ({
         status,
         recentWindows,
       };
+    });
+  },
+
+  activateWindow: (projectName, windowIndex) => {
+    get().setActive(projectName, windowIndex);
+    return window.api.tmuxSelectWindow({
+      sessionName: projectName,
+      windowIndex,
     });
   },
 


### PR DESCRIPTION
## BET-732 — renderer dedupe/dead-code sweep

Pure refactor/deletion of renderer duplication found in the 2026-08-12 audit §5 / L5/L7/L8/L9. One commit per task. **Zero behavior change.**

### Commits (one per task)
1. **Task 1** — `MANTA_BUILTIN_COMMANDS`/`MANTA_BUILTIN_NAMES` unified in `chatUtils.ts` (single source), deleted the two local copies in `ChatPanel.tsx` + `useTypeahead.ts`. Lists were **identical** (clear/fork/compact/help, same descriptions) — no discrepancy to reconcile.
2. **Task 2** — deleted the unconsumed `abort`/`replyPermission`/`replyQuestion`/`rejectQuestion` callbacks + returns + type entries from `useSseBus`. Verified none are destructured by any consumer (ChatPanel defines + uses its own; `useVoice` gets them from ChatPanel). `rejectAllPendingQuestions` (consumed) retained.
3. **Task 3** — removed ChatPanel's 10s `delegateList()` poll; ChatPanel now derives `jobOwnership` from the store's `jobs` slice via `useMemo`. To keep `ReadOnlyJobBar` behavior (branch/files summary + `delegateStop` id), the store `jobs` slice now retains the **full `DelegateJob`** (was a reduced `{name,status,activity}` row). App.tsx's single 30s poll + `delegate.updated` refetch is the only poller.
4. **Task 4** — `useSessionResources` triplet (schedules/secrets/webhooks) collapsed into ONE generic `useResourceCard<T>` helper parameterized by fetch call, `manta-open-*` event name, background-poll flag, and empty value. Public `useSessionResources` surface + all call sites unchanged. File 235 → 189 lines. Existing harness tests pass unchanged.
5. **Task 5** — added ONE store action `activateWindow(sessionName, windowIndex)` (setActive + `tmuxSelectWindow`); converged App `jumpToWindow`, both `NewSessionScreen` submit paths, and Sidebar onto it. Sidebar's project-already-active guard + its `showError` preserved at the call site.
6. **Task 6** — converged `settleChip` onto `patchAttachment` (the comment-declared owner); drag-drop upload paths now route through it. Upload-flow harness tests pass unchanged.
7. **Task 7** — deleted `Terminal.tsx` `_term_<key>`/`_term` debug globals; removed the dead `seen` set + fixed its stale comment in `store.applyStatusBatch`; dropped unused `refreshBranch` from a ChatPanel reset effect's deps. `useSseBus.replyQuestion`'s unused `[sessionId]` dep vanished with Task 2. ConnectProvider's `if (canSubmit) setValue(v=>v)` no-op is **already gone** (post-BET-707) — noted, nothing to delete.

### Verification results
- PR branch `multica/BET-732-dedupe-sweep` @ `5d9f0a47`:
  - typecheck: exit 0, no errors. sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0; vitest 2366 pass / 7 skip (129 files); server 1629 pass / 0 fail. sha256 `db5e7691316820b7b071f844712c8d9a692ab8c4f458c3b18b8009a73f1f6021`
- Base (`63ec1c77` = merge-base with origin/main):
  - typecheck: exit 0, no errors. sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0; vitest 2366 / 7 skip; server 1629 / 0 fail. sha256 `d682826eac42b730a513d8b1b85ec5db403588604d5464252f532217a562c705`
- **Conclusion:** 0 new failures, 0 pre-existing failures (identical counts both branches).

Logs at `/tmp/tc-{pr,main}.log`, `/tmp/test-{pr,main}.log`.

### Grep proofs
- `MANTA_BUILTIN_COMMANDS` defined exactly once (`chatUtils.ts`).
- no `_term_` window globals remain.
- `settleChip` fully removed (only a comment reference remains).

### Notable (non-follow-up) caveats
- Task 4 file went 235 → 189 (−46 lines). The issue's "~100+ line shrink" target isn't fully met: the generic helper + the required unchanged `SessionResources` public type occupy ~130 lines. Logic is collapsed to one helper and all existing tests pass unchanged — this is an honest line-count miss, not a correctness gap, and it stays in this issue's scope.
- Task 3 deliberately widened the store `jobs` slice from a reduced row to the full `DelegateJob` — required to keep `ReadOnlyJobBar`'s summary + Stop visually/functionally identical now that the panel no longer fetches its own full job list.

**Base: origin/main @ `63ec1c77`** (merge-base of this branch and current origin/main `5c68d825`).
