### PR TITLE
BET-758: forward session.status type on the running frame

### DIFF
--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -384,7 +384,12 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
         // pre-S1b renderer semantics) — the box is the single source of truth,
         // so it must report the same value the renderer's raw handler does.
         st.running = type === "busy" || type === "working" || type === "retry";
-        emit(sid, "running", { running: st.running });
+        // `type` is ADDITIVE, not the indicator: `running` stays the single
+        // source of truth for the running boolean, while `type` carries the
+        // raw "busy" | "working" | "retry" (or null) so a thin client (iOS)
+        // can distinguish a retry from a plain busy spinner without changing
+        // what desktop already reads. Desktop ignores the new field.
+        emit(sid, "running", { running: st.running, type });
         return;
       }
       case "session.idle": {

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -328,7 +328,7 @@ test("session.error with a MessageAbortedError name emits NOTHING", () => {
   assert.equal(events.length, 0, "an abort is not a failure — no frames emitted");
 });
 
-test("session.status retry reports running true (parity with pre-S1b renderer)", () => {
+test("session.status retry reports running true and carries type retry (parity with pre-S1b renderer)", () => {
   const { interp, events } = make();
   interp.interpret({
     type: "session.status",
@@ -337,6 +337,9 @@ test("session.status retry reports running true (parity with pre-S1b renderer)",
   const ev = events.find((e) => e.sub === "running");
   assert.ok(ev);
   assert.equal(ev.payload.running, true);
+  // BET-758: the retry-ness must reach the device so iOS can render a retry
+  // banner; `running` stays the single source of truth, `type` is additive.
+  assert.equal(ev.payload.type, "retry");
 });
 
 // ---------------------------------------------------------------------------
@@ -358,6 +361,8 @@ test("session.status reports running from the NESTED status.type the box sends",
   const ev = events.find((e) => e.sub === "running");
   assert.ok(ev);
   assert.equal(ev.payload.running, true);
+  // BET-758: the nested busy type is forwarded additively.
+  assert.equal(ev.payload.type, "busy");
 });
 
 test("message.part.delta flushes from the FLAT delta the box sends", () => {


### PR DESCRIPTION
## Summary
Follow-up to BET-747: the `session.status` retry signal never reached iOS because the interpreted `running` frame collapsed `busy`/`working`/`retry` into a single boolean. This forward the raw type additively so iOS can surface a distinct retry banner.

## Change
`src/server/streamInterp.mjs` `session.status` case now emits:

```js
emit(sid, "running", { running: st.running, type });
```

- `running` stays the SINGLE source of truth for the running indicator (unchanged, backward-compatible — desktop reads only this).
- `type` is additive: `"busy" | "working" | "retry"` (or `undefined`/`null` when no status type is present).
- `streamInterp.test.mjs` pins `type: "retry"` on the retry frame (still `running: true`), and the nested `busy` case pins `type: "busy"`.

**App contract for the iOS consumer:**
- `sub: "running"` payload adds an optional field: `{ running: Bool, type?: "busy" | "working" | "retry" | null }`.
- The iOS retry banner (filed for `macos` as the follow-up to this) renders while `type == "retry"` and clears when the session settles (`turnComplete` / `session.idle`) — both of which already emit without a retry `type`, so the banner naturally clears.

No iOS work here (per issue scope); Mac follow-up routes to `macos` once this ships.

**Base: origin/main @ 4b98e39e**

**Files changed:** 2 — `src/server/streamInterp.mjs`, `src/server/streamInterp.test.mjs`

**Verification results:**
- PR branch (`multica/BET-758-retry-type` @ `HEAD`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1629 pass / 0 fail / 0 skip (includes `src/server/streamInterp.test.mjs` 27/27). streamInterp file alone: 27 pass / 0 fail.
- Base (`main` @ `4b98e39e`): no renderer/IPC surface touched; the only files changed are the two above (server + test). The full suite already includes the unchanged renderer suite and all pre-existing server tests — 1629 pass, 0 fail.
- **Conclusion:** 0 new failures.

(E2E visual-gate verification is retired per repo policy; verification = typecheck + unit tests.)
