### PR TITLE
BET-759: stack toast actions on their own row, drop the ⏰ emoji

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { MotionConfig } from "framer-motion";
-import { Terminal as TerminalIcon } from "lucide-react";
+import { Bell, Send, Terminal as TerminalIcon, type LucideIcon } from "lucide-react";
 import { Sidebar, type SidebarHandle } from "./Sidebar";
 import { Terminal } from "./Terminal";
 import { ChatPanel } from "./ChatPanel";
@@ -65,6 +65,19 @@ function loadArtifactsOpen(): boolean {
   } catch {
     return false;
   }
+}
+
+// A toast body with a leading glyph. The two scheduled-at-reset confirmations
+// used a ⏰ EMOJI, which is the schedules card's glyph and the only emoji in
+// the app's chrome — everything else draws from lucide. One helper so the two
+// call sites cannot drift.
+function toastLine(Icon: LucideIcon, text: string) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <Icon size={14} aria-hidden="true" className="shrink-0 text-text-faint" />
+      {text}
+    </span>
+  );
 }
 
 // PanelShell (BET-680 step 2): the always-mounted session/chat pane wrappers.
@@ -640,7 +653,7 @@ function AppInner() {
     pushAppToastStore(
       res.ok && res.job
         ? {
-            message: `⏰ “Keep going” will be sent ${formatResetClock(fireAt, true)}.`,
+            message: toastLine(Send, `“Keep going” will be sent ${formatResetClock(fireAt, true)}.`),
             actions: [
               {
                 label: "Undo",
@@ -696,7 +709,7 @@ function AppInner() {
                         if (res.ok && res.job) {
                           const jobId = res.job.id;
                           pushAppToastStore({
-                            message: `⏰ Reminder set for ${formatResetClock(fireAt, true)}.`,
+                            message: toastLine(Bell, `Reminder set for ${formatResetClock(fireAt, true)}.`),
                             actions: [
                               {
                                 label: "Undo",

--- a/src/renderer/Toast.test.tsx
+++ b/src/renderer/Toast.test.tsx
@@ -71,4 +71,27 @@ describe("Toast actions", () => {
     const buttons = Array.from(h.container.querySelectorAll("button"));
     expect(buttons.length).toBe(1);
   });
+
+  it("puts the action buttons on their own row, not beside the message", () => {
+    h = mount(
+      <Toast
+        onDismiss={() => {}}
+        toast={{
+          id: "t",
+          message: "Session (5h) limit reached on Claude",
+          actions: [
+            { label: "Remind me at reset", onClick: () => {} },
+            { label: "Keep going at reset", onClick: () => {} },
+          ],
+        }}
+      />,
+    );
+    const btn = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Remind me at reset",
+    ) as HTMLButtonElement;
+    // The row that holds the actions must not also hold the message text —
+    // that shared row is what squeezed the message to one word per line.
+    expect(btn.parentElement?.textContent).not.toContain("Session (5h)");
+    expect(btn.parentElement?.textContent).toContain("Keep going at reset");
+  });
 });

--- a/src/renderer/Toast.tsx
+++ b/src/renderer/Toast.tsx
@@ -92,21 +92,34 @@ export function Toast({ toast, onDismiss }: ToastProps) {
   return (
     <div
       role="status"
-      className={`w-full max-w-[420px] rounded-lg border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-center gap-2 shadow-md ${
+      className={`w-full max-w-[420px] rounded-lg border border-border bg-bg-soft px-3 py-2 text-meta text-text-muted flex items-start gap-2 shadow-md ${
         toast.tone === "error" ? "border-l-2 border-l-danger" : ""
       }`}
     >
-      <span className="flex-1 min-w-0 whitespace-pre-wrap break-words">{toast.message}</span>
-      {(toast.actions ?? []).slice(0, MAX_TOAST_ACTIONS).map((action) => (
-        <button
-          key={action.label}
-          onClick={action.onClick}
-          disabled={action.disabled}
-          className={BANNER_BTN}
-        >
-          {action.label}
-        </button>
-      ))}
+      {/* Message and actions stack VERTICALLY, always — one layout, no
+          conditional branch on how many actions there are. The old single-row
+          layout put `shrink-0` buttons next to a `flex-1 min-w-0` message, so
+          two actions squeezed the text to a few characters per line. The close
+          button stays on the right of the whole block, which is why the root is
+          now `items-start` (it aligns with the message's FIRST line rather than
+          the vertical middle of a two-row block). */}
+      <div className="flex-1 min-w-0 flex flex-col gap-2">
+        <span className="whitespace-pre-wrap break-words">{toast.message}</span>
+        {(toast.actions ?? []).length > 0 && (
+          <div className="flex items-center gap-2">
+            {(toast.actions ?? []).slice(0, MAX_TOAST_ACTIONS).map((action) => (
+              <button
+                key={action.label}
+                onClick={action.onClick}
+                disabled={action.disabled}
+                className={BANNER_BTN}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
       <button
         onClick={() => onDismiss(toast.id)}
         className="shrink-0 text-text-faint hover:text-text leading-none inline-flex items-center focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"


### PR DESCRIPTION
Fix the usage-limit toast (BET-739 regression) in two parts.

**Change 1 — actions get their own row (`src/renderer/Toast.tsx`)**
The old single-row layout put `shrink-0` action buttons next to a `flex-1 min-w-0`
message, so two actions squeezed the message to a few characters per line. The
message and actions now stack VERTICALLY in one always-on layout: a
`flex-1 min-w-0 flex flex-col gap-2` wrapper owns the message (first line) and a
`flex items-center gap-2` row of buttons beneath it. The close button stays
top-right, so the root flips `items-center` → `items-start`. No conditional branch
on action count — one code path (the two-action fix must not regress single-action
toasts).

**Change 2 — drop the ⏰ emoji (`src/renderer/App.tsx`)**
The two scheduled-at-reset confirmation toasts led with a ⏰ emoji (the schedules
card's own glyph, and the only emoji in an otherwise lucide-only chrome). A single
module-scope `toastLine(Icon, text)` helper (so the two call sites can't drift) now
prefixes each message with a lucide glyph: `Bell` for the "Reminder set for …"
toast (a `kind: "notify"` job, matching the schedules card's bell) and `Send` for
the "“Keep going” will be sent …" toast (a message that will be SENT into the
session, matching the composer's submit glyph). Both call sites keep their
existing text and curly quotes verbatim.

**Test** (`src/renderer/Toast.test.tsx`): added one test asserting the action
buttons sit on their own row (`parentElement`) rather than sharing the message's
row. The three pre-existing tests pass unchanged.

Files changed: `src/renderer/Toast.tsx`, `src/renderer/Toast.test.tsx`,
`src/renderer/App.tsx`.

Base: origin/main @ 0ff5bc6e

Out of scope per the issue, deliberately untouched: `ToastItem` shape,
`toastTtl`, `MAX_TOASTS`, `MAX_TOAST_ACTIONS`, `BANNER_BTN`, `ToastStack`, other
toast producers, the toast width, and the limit-message copy.
