### PR TITLE
BET-761: fix(renderer): match usage dial to composer icon row size and spacing

### DIFF
--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -452,7 +452,10 @@ export function InputArea({
             </span>
           )}
         </span>
-        <span className="shrink-0 flex items-center gap-3 flex-wrap">
+        {/* gap-2 (8px), the SAME gap SessionToolbar uses between its own three
+            icons — so the dial + clock + key + webhook read as one evenly
+            spaced run instead of a detached dial 12px off the group. */}
+        <span className="shrink-0 flex items-center gap-2 flex-wrap">
           <UsageDial providerID={activeProviderID} />
           <SessionToolbar
             scheduleCount={scheduleCount}

--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -110,28 +110,42 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
         aria-label="plan usage"
         title={title}
       >
+        {/* A 16×16 BOX holding a 13px disc. The box keeps the button's metrics
+            identical to the 16px lucide icons beside it (so the row does not
+            shift), while the disc matches what those icons actually DRAW: a
+            lucide circle is r=10 in a 24 viewBox, i.e. 20/24 of the box, which
+            is 13px at size 16. A full-bleed 16px disc read visibly heavier
+            than the Clock / Key / Webhook glyphs next to it. */}
         <span
           aria-hidden="true"
-          className="inline-block rounded-full"
-          style={{
-            width: 16,
-            height: 16,
-            background:
-              state.tone === "over"
-                ? ringColor
-                : `conic-gradient(${ringColor} 0% ${pctClamped}%, ${trackColor} ${pctClamped}% 100%)`,
-          }}
+          className="inline-flex items-center justify-center"
+          style={{ width: 16, height: 16 }}
         >
-          {/* Inner disc in the surrounding surface colour turns the pie into
-              a ring — skipped for tone "over" (>=100%), which is a solid
-              disc with no hole per the design spec. */}
-          {state.tone !== "over" && (
-            <span
-              aria-hidden="true"
-              className="block rounded-full bg-bg"
-              style={{ width: 12, height: 12, margin: 2 }}
-            />
-          )}
+          <span
+            aria-hidden="true"
+            className="block rounded-full"
+            style={{
+              width: 13,
+              height: 13,
+              background:
+                state.tone === "over"
+                  ? ringColor
+                  : `conic-gradient(${ringColor} 0% ${pctClamped}%, ${trackColor} ${pctClamped}% 100%)`,
+            }}
+          >
+            {/* Inner disc in the surrounding surface colour turns the pie into
+                a ring — skipped for tone "over" (>=100%), which is a solid
+                disc with no hole per the design spec. Ring thickness is
+                (13 - 9) / 2 = 2px, matching the neighbours' strokeWidth={2}
+                (unchanged from BET-756). */}
+            {state.tone !== "over" && (
+              <span
+                aria-hidden="true"
+                className="block rounded-full bg-bg"
+                style={{ width: 9, height: 9, margin: 2 }}
+              />
+            )}
+          </span>
         </span>
       </button>
 


### PR DESCRIPTION
Fixes **BET-761** — the composer usage dial now sits cleanly in the icon row.

## Changes
- **`src/renderer/UsageDial.tsx`** — draw the disc at **13px** inside an
  unchanged **16px box**, so it matches the 13px a 16px lucide circle
  actually renders (r=10 in a 24 viewBox = 20/24). Ring stays 2px:
  `(13 - 9) / 2 = 2`. The 16px box keeps the button's hit-area and row
  height identical to its siblings.
- **`src/renderer/InputArea.tsx`** — icon-row `gap-3` (12px) → `gap-2`
  (8px), matching SessionToolbar's internal gap, so dial + clock + key +
  webhook read as one evenly spaced run. One class token + a comment.

## Out of scope (untouched, per issue)
- Popover (`role="dialog"`) markup, placement classes, `UsageWindowRow`.
- `tone === "over"` solid-disc behaviour; ring thickness (2px, BET-756);
  colours, thresholds, chatUtils pure logic.
- No test added — four inline style numbers + one Tailwind class; UsageDial
  has no component test by design.

**Base: origin/main @ 0ff5bc6e**

## Verification results
- **PR branch** (`multica/BET-761-usage-dial-metrics` @ `f995e2e`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1629 pass / 0 fail / 0 skip. Failures: none. log sha256: `05188d20f1fc416bcc3bfab681223b03d009bd6eb523c5ebc4cab6fc62564b70`
- **Conclusion:** 0 new failures, 0 pre-existing — the PR-only typecheck+test pass clean.