### PR TITLE
fix(renderer): usage dial reports the session (5h) window, not the highest one (BET-760)

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3207,7 +3207,7 @@ describe("usageDialState", () => {
     expect(usageDialState(snap, false).visible).toBe(true);
   });
 
-  it("picks the HIGHER of two windows as the binding one", () => {
+  it("reports the FIRST window, not the highest — a 40% session beats an 85% weekly", () => {
     const snap = usageSnapshot({
       windows: [
         { kind: "session", label: "Session (5h)", pct: 40 },
@@ -3215,8 +3215,22 @@ describe("usageDialState", () => {
       ],
     });
     const state = usageDialState(snap, true);
-    expect(state.pct).toBe(85);
-    expect(state.window?.kind).toBe("weekly");
+    expect(state.pct).toBe(40);
+    expect(state.window?.kind).toBe("session");
+    expect(state.tone).toBe("under");
+  });
+
+  it("a later window over threshold still makes the dial visible at 0% primary", () => {
+    const snap = usageSnapshot({
+      windows: [
+        { kind: "session", label: "Session (5h)", pct: 0 },
+        { kind: "weekly", label: "Weekly", pct: 95 },
+      ],
+    });
+    const state = usageDialState(snap, false);
+    expect(state.visible).toBe(true); // the weekly is what surfaces it
+    expect(state.pct).toBe(0); // …but the number shown is the session's
+    expect(state.window?.kind).toBe("session");
   });
 
   it("a snapshot with a single window works", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2454,9 +2454,9 @@ export type UsageDialState = {
   visible: boolean;
   pct: number;
   tone: UsageDialTone;
-  // The window that drives the dial's colour/visibility — the HIGHEST pct
-  // among the snapshot's windows (the one that bites first in practice,
-  // independent of whether the provider set its own `binding` flag).
+  // The window the dial reports — always `windows[0]`, the snapshot's primary
+  // (shortest) window. NOT the highest-pct one: visibility uses the worst
+  // window, but the number and colour shown are the primary window's.
   window: UsageWindow | null;
 };
 
@@ -2485,13 +2485,25 @@ export function usageDialState(
   if (windows.length === 0) {
     return { visible: false, pct: 0, tone: "under", window: null };
   }
-  const binding = windows.reduce((max, w) => (w.pct > max.pct ? w : max));
-  const pct = binding.pct;
+  // The dial reports the PRIMARY window — `windows[0]`, which every adapter
+  // emits shortest-first (session before weekly; see the ordering contract on
+  // UsageSnapshot.windows in src/shared/types.ts). It used to report the
+  // highest-pct window instead, which meant a 0%-used 5h session rendered a
+  // 40%-full ring because the WEEKLY window was at 40% — read next to the send
+  // button, that says "you have burnt 40% of what you can do right now", which
+  // is the opposite of the truth. The weekly number is still one click away in
+  // the popover, which lists every window.
+  const primary = windows[0];
+  // Visibility, unlike the value, is still driven by the WORST window: a
+  // weekly at 95% must still surface the dial when the session window is
+  // empty, or the number about to block you is invisible unless the opt-in
+  // "always show" setting is on.
+  const worstPct = windows.reduce((max, w) => (w.pct > max ? w.pct : max), 0);
   return {
-    visible: pct >= 70 || alwaysShow,
-    pct,
-    tone: usageTone(pct),
-    window: binding,
+    visible: worstPct >= 70 || alwaysShow,
+    pct: primary.pct,
+    tone: usageTone(primary.pct),
+    window: primary,
   };
 }
 

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -536,6 +536,7 @@ test("kimi adapter: weekly (string counts) + session (300-minute limits entry, r
   });
   assert.equal(snap.provider, "kimi");
   assert.equal("planLabel" in snap, false); // no planLabel on this endpoint, per spec
+  assert.equal(snap.windows[0].kind, "session"); // shortest-first ordering contract
 
   const weekly = snap.windows.find((w) => w.kind === "weekly");
   assert.equal(weekly.used, 2214);

--- a/src/server/usageAdapters/kimi.mjs
+++ b/src/server/usageAdapters/kimi.mjs
@@ -79,10 +79,10 @@ export const kimiAdapter = {
     if (!res.ok) throw httpError(res, "kimi usage");
     const data = await res.json();
 
+    // Windows are emitted SHORTEST-FIRST (session before weekly) — the
+    // ordering contract on UsageSnapshot.windows: the composer dial reports
+    // windows[0] and must never show a weekly number as "right now".
     const windows = [];
-    // `usage` is the WEEKLY window.
-    const weekly = windowFromDetail(data?.usage, "weekly", "Weekly");
-    if (weekly) windows.push(weekly);
 
     // `limits[]` entries carry `window` + `detail`; the 300-minute (5h) entry
     // is the session window.
@@ -90,6 +90,10 @@ export const kimiAdapter = {
     const sessionEntry = limitsArr.find((l) => minutesOf(l?.window) === 300);
     const session = windowFromDetail(sessionEntry?.detail, "session", "Session (5h)");
     if (session) windows.push(session);
+
+    // `usage` is the WEEKLY window.
+    const weekly = windowFromDetail(data?.usage, "weekly", "Weekly");
+    if (weekly) windows.push(weekly);
 
     // No planLabel on this endpoint — it needs a cookie-auth web API, out of
     // scope per the issue spec.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1092,6 +1092,10 @@ export type UsageSnapshot = {
   // and opencode's providerID are different namespaces on purpose.
   providerIDs: string[];
   planLabel?: string; // "Max 20x", "Pro", "Allegretto"
+  // ORDERED SHORTEST-FIRST — the session (5h) window before the weekly one.
+  // The composer dial reports windows[0] as "your usage right now", so an
+  // adapter that emits weekly first makes the dial lie. Every adapter in
+  // src/server/usageAdapters/ upholds this.
   windows: UsageWindow[];
   extras?: { label: string; value: string }[]; // credits balance, model pools…
   fetchedAt: number; // epoch ms of the successful fetch


### PR DESCRIPTION
## Summary

The composer usage dial reported the **highest-percentage window** across the snapshot. A subscription has two windows — `Session (5h)` and `Weekly` — and weekly was almost always the higher one. A user at 0% in the 5h session (the window that actually gates the next message) saw a dial reading 40% (the weekly number) — the opposite of the truth.

The dial now reports the **primary (first) window** — `windows[0]`, which every adapter emits shortest-first. Visibility still uses the worst (highest-pct) window so a near-blocking weekly still surfaces the dial.

## Changes (5 files)

- `src/renderer/chatUtils.ts` — `usageDialState` reports `windows[0]` for pct/tone/window; visibility derives from the worst window. Updated the `UsageDialState.window` doc comment.
- `src/renderer/chatUtils.test.ts` — rewrote the "higher window" test into two: first-window-not-highest, and visibility-at-0%-primary.
- `src/server/usageAdapters/kimi.mjs` — pure reorder: session window emitted before weekly (shortest-first). `claude.mjs`/`codex.mjs` already did this.
- `src/server/usage.test.mjs` — added `snap.windows[0].kind === "session"` assertion to the kimi test.
- `src/shared/types.ts` — documented the shortest-first ordering contract on `UsageSnapshot.windows`.

The renderer stays ignorant of provider vocabulary (tests `windows[0]`, never `kind === "session"`). `UsageDial.tsx`, `usageTone`, thresholds, escalation toasts untouched.

## Verification results

**Files changed:** 5.

- PR branch (`multica/BET-760-usage-dial-primary-window`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1629 pass / 0 fail / 0 skip (includes server node:test).
  - test:server: exit 0, 1135 pass / 0 fail / 0 skip.
- **Conclusion:** 0 new failures.

**Base: origin/main @ `761e5b3b`**
