### PR TITLE
feat(ios): trust-mode (chatAutoAllow) toggle in chat (BET-748)

### DIFF
--- a/mobile/native/MantaUI/ChatOverflowCaptureScene.swift
+++ b/mobile/native/MantaUI/ChatOverflowCaptureScene.swift
@@ -17,6 +17,7 @@ struct ChatOverflowCaptureScene: View {
     // Present from onAppear (NOT an initial `true`): SwiftUI does not raise a
     // sheet whose binding is already true at first render.
     @State private var showOverflow = false
+    @StateObject private var settingsStore = MantaSettingsStore()
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
@@ -34,7 +35,9 @@ struct ChatOverflowCaptureScene: View {
                     onClear: {},
                     onFork: {},
                     onOpenTerminal: {},
-                    onDelete: {}
+                    onDelete: {},
+                    settingsStore: settingsStore,
+                    onToggleTrust: { _ in }
                 )
             }
     }

--- a/mobile/native/MantaUI/ChatOverflowSheet.swift
+++ b/mobile/native/MantaUI/ChatOverflowSheet.swift
@@ -43,6 +43,14 @@ struct ChatOverflowSheet: View {
     var onOpenTerminal: () -> Void
     var onDelete: () -> Void
 
+    /// Observed so the trust toggle below reflects the live `chatAutoAllow`
+    /// value (and reverts on a failed update) without the sheet holding its
+    /// own copy of the setting.
+    @ObservedObject var settingsStore: MantaSettingsStore
+    /// Flip the `chatAutoAllow` setting. Called with the requested value; the
+    /// chat screen awaits the `config:update` and reverts on failure.
+    var onToggleTrust: (Bool) -> Void
+
     /// Live count for the scheduled-tasks row (§8: "with live count").
     var scheduleCount: Int = 0
 
@@ -78,6 +86,25 @@ struct ChatOverflowSheet: View {
                     .buttonStyle(.plain)
                     row("Fork session", systemImage: "arrow.triangle.branch", action: onFork)
                     row("Open terminal", systemImage: "terminal", action: onOpenTerminal)
+                }
+                // Trust mode — the on/off autonomy switch (BET-748 gap #14). This
+                // is the ONLY trust control in chat (no permission allow-lists);
+                // it flips the `chatAutoAllow` config key over `config:update`.
+                Section {
+                    if let entry = SettingsSchema.entries.first(where: { $0.id == "chatAutoAllow" }) {
+                        Toggle(isOn: Binding(
+                            get: { settingsStore.current(entry) == .bool(true) },
+                            set: { onToggleTrust($0) }
+                        )) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Trust mode")
+                                Text("Auto-allow tool permissions")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .accessibilityIdentifier("trust-mode-toggle")
+                    }
                 }
                 Section {
                     // Clear is the consequence of something the user just chose,

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -113,6 +113,11 @@ private struct ChatScreenContent: View {
     @Binding var path: NavigationPath
     @StateObject private var store: ChatSessionStore
     @StateObject private var modelStore: ChatModelStore
+    /// Loads `chatAutoAllow` (trust mode) from the box via `config:get` and
+    /// persists it over the store's own `config:update` path (BET-748). This is
+    /// the chat surface's window into the same settings the Settings screen
+    /// renders — no second `config:get`.
+    @StateObject private var settingsStore: MantaSettingsStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
@@ -177,6 +182,7 @@ private struct ChatScreenContent: View {
             api: api
         ))
         _modelStore = StateObject(wrappedValue: ChatModelStore(sessionId: sessionId, api: api))
+        _settingsStore = StateObject(wrappedValue: MantaSettingsStore())
     }
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
@@ -205,6 +211,7 @@ private struct ChatScreenContent: View {
                 // window/branch lookup.
                 store.start()
                 modelStore.load()
+                Task { await settingsStore.load() }
                 MantaPushRouter.shared.visibleSessionID = store.sessionId
                 Task { try? await MantaAPIClient.live().reportFocus(sessionId: store.sessionId, visible: true) }
                 clearDeliveredNotifications(for: store.sessionId)
@@ -347,7 +354,8 @@ private struct ChatScreenContent: View {
                             scrollPosition.scrollTo(edge: .bottom, animated: true)
                             showScrollToBottom = false
                         },
-                        onGlassBoxHeightChange: { composerGlassHeight = $0 }
+                        onGlassBoxHeightChange: { composerGlassHeight = $0 },
+                        onToggleTrust: { flipTrustMode() }
                     )
                 }
                 // Feeds the transcript's bottom content inset its height. Safe
@@ -427,9 +435,33 @@ private struct ChatScreenContent: View {
             onFork: { Task { await forkSession() } },
             onOpenTerminal: { Task { await openTerminal() } },
             onDelete: { Task { await deleteSession() } },
+            settingsStore: settingsStore,
+            onToggleTrust: { _ in flipTrustMode() },
             scheduleCount: scheduleCount
         )
         .task { await refreshScheduleCount() }
+    }
+
+    // MARK: - Trust mode (BET-748 gap #14)
+
+    /// Flip the `chatAutoAllow` trust setting: flip to the opposite of its
+    /// current value, persist over the store's `config:update` path, and only
+    /// treat it as changed after the box confirms. A failed update never
+    /// fabricates a success — the visible toggle stays put (it reads the store,
+    /// which only mutates on success) and the composer `actionHint` bus says
+    /// why. Shared by the overflow toggle and the voice `toggleTrust` action.
+    private func flipTrustMode() {
+        guard let entry = SettingsSchema.entries.first(where: { $0.id == "chatAutoAllow" }) else { return }
+        let target = settingsStore.current(entry) != .bool(true)
+        Task { await setTrustMode(entry, target) }
+    }
+
+    private func setTrustMode(_ entry: SettingEntry, _ enabled: Bool) async {
+        do {
+            try await settingsStore.setBool(entry, enabled)
+        } catch {
+            await MainActor.run { store.actionHint = "Couldn't change trust mode — check the connection" }
+        }
     }
 
     /// The BET-627 overflow items that present their cards here.

--- a/mobile/native/MantaUI/ChatVoice.swift
+++ b/mobile/native/MantaUI/ChatVoice.swift
@@ -53,7 +53,7 @@ enum ChatVoiceHint {
         case .compact: return "Compacted to free context"
         case .fork: return "Forking isn't available in this chat yet"
         case .help: return "Try “submit…”, “abort”, or “answer…”"
-        case .toggleTrust: return "Trust mode isn't available in this chat"
+        case .toggleTrust: return "Trust mode can't be toggled right now"
         case .newSession: return "New-session isn't available in this chat"
         case .openSettings: return "Settings isn't available in this chat"
         case .switchWindow: return "Switch-window isn't available in this chat"

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -54,6 +54,9 @@ struct ComposerView: View {
     /// not at the top of the whole bottom stack (chip / cards / anchors
     /// excluded).
     var onGlassBoxHeightChange: (CGFloat) -> Void = { _ in }
+    /// Flip the `chatAutoAllow` trust setting (voice `toggleTrust`, BET-748).
+    /// The chat screen owns the flip + revert; the composer just triggers it.
+    var onToggleTrust: (() -> Void)? = nil
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var text = ""
@@ -797,6 +800,13 @@ struct ComposerView: View {
                 return nil
             }
             return "No model found for “\(query)”"
+        case .toggleTrust:
+            // Real toggle (BET-748): the chat screen flips `chatAutoAllow` and
+            // surfaces a failure through the store's `actionHint` bus. No hint
+            // is returned here — a successful flip needs no local answer, and
+            // a failure already reaches the user through that bus.
+            onToggleTrust?()
+            return nil
         case .unknown(let transcript):
             if !transcript.isEmpty { insertAtCaret(transcript) }
             return nil

--- a/mobile/native/MantaUI/MantaSettingsStore.swift
+++ b/mobile/native/MantaUI/MantaSettingsStore.swift
@@ -127,6 +127,29 @@ final class MantaSettingsStore: ObservableObject {
         }
     }
 
+    /// Set a config-driven boolean and persist it over `config:update` (the
+    /// store's own persistence path — the same one Settings uses), then flip
+    /// the in-memory value.
+    ///
+    /// Unlike `commit`, which flips the value optimistically and swallows the
+    /// box's answer, this AWAITS the update and only mutates the published
+    /// value after the box confirms. A failed `config:update` throws (so the
+    /// caller can revert / surface it) and leaves the stored value untouched —
+    /// never a fabricated success. This is the chat trust-mode toggle's path
+    /// (BET-748).
+    func setBool(_ entry: SettingEntry, _ value: Bool) async throws {
+        guard let configKey = entry.configKey else {
+            // Device-local entries persist locally; there is no box round-trip
+            // to fail, so flip directly.
+            values[entry.id] = .bool(value)
+            persistDeviceLocal(entry, value: .bool(value))
+            return
+        }
+        _ = try await configuration.update([configKey: .bool(value)])
+        values[entry.id] = .bool(value)
+        lastError = nil
+    }
+
     // MARK: - Reset (per-section + reset-all), both undoable
 
     func resetSection(_ sectionID: String) {

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -189,6 +189,16 @@ final class ComposerTests: XCTestCase {
         XCTAssertEqual(ChatVoice.parse(classify("switch-window", index: 2)), .switchWindow(index: 2))
     }
 
+    func testParseToggleTrustMapsToTupleHead() {
+        // Both wire spellings of the toggle-trust kind map to `.toggleTrust`,
+        // the action the composer now routes to the real `chatAutoAllow` toggle
+        // (BET-748) rather than the old "isn't available in this chat" answer.
+        XCTAssertEqual(ChatVoice.parse(classify("toggle-trust")), .toggleTrust)
+        XCTAssertEqual(ChatVoice.parse(classify("toggle_trust")), .toggleTrust)
+        // The fallback hint no longer describes trust mode as unavailable.
+        XCTAssertNotEqual(ChatVoiceHint.text(for: .toggleTrust), "Trust mode isn't available in this chat")
+    }
+
     func testParseUnknownDegrades() {
         XCTAssertEqual(ChatVoice.parse(classify("unknown", transcript: "do the thing")), .unknown(transcript: "do the thing"))
         // A nil/empty kind is treated as unknown.

--- a/mobile/native/MantaUITests/MantaSettingsTests.swift
+++ b/mobile/native/MantaUITests/MantaSettingsTests.swift
@@ -100,12 +100,14 @@ private final class FakeConfigStore: SettingsConfigurationStore {
     var stored: [String: JSONValue] = [:]
     var updates: [[String: JSONValue]] = []
     var failLoad = false
+    var failUpdate = false
 
     func load() async -> [String: JSONValue]? {
         failLoad ? nil : stored
     }
 
     func update(_ patch: [String: JSONValue]) async throws -> [String: JSONValue]? {
+        guard !failUpdate else { throw CancellationError() }
         updates.append(patch)
         stored.merge(patch) { _, new in new }
         return stored
@@ -205,5 +207,37 @@ final class MantaSettingsStoreTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertEqual(store.current(entry(id: "autoRenameSessions")), .bool(true))
         XCTAssertEqual(store.current(entry(id: "serverUrlMobile")), .string("https://box.example.com"))
+    }
+
+    // MARK: - Trust-mode toggle (BET-748)
+
+    func testSetBoolRoundTripsChatAutoAllowPatch() async throws {
+        await store.load()
+        let entry = entry(id: "chatAutoAllow")
+        XCTAssertEqual(store.current(entry), .bool(false))
+
+        try await store.setBool(entry, true)
+
+        // The in-memory value flips, and exactly the chatAutoAllow key is
+        // sent over the store's config:update path.
+        XCTAssertEqual(store.current(entry), .bool(true))
+        let last = try XCTUnwrap(fake.updates.last)
+        XCTAssertEqual(last["chatAutoAllow"], .bool(true))
+    }
+
+    func testSetBoolFailedUpdateThrowsAndDoesNotFlipValue() async throws {
+        await store.load()
+        let entry = entry(id: "chatAutoAllow")
+        fake.failUpdate = true
+
+        do {
+            try await store.setBool(entry, true)
+            XCTFail("Expected a thrown error for the failed config:update")
+        } catch {
+            // Expected — the update was rejected.
+        }
+
+        // No fabricated success: the persisted value must not flip.
+        XCTAssertEqual(store.current(entry), .bool(false))
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-748-trust-mode-toggle`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-748.