### PR TITLE
feat(renderer): move screenshots above composer as a pending screenshot strip (BET-762)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -743,14 +743,38 @@ function AppInner() {
 
   // Screenshot detection — subscribe ONCE at the app level. Every ChatPanel
   // used to register its own listener, so a single detection fanned out into
-  // N toasts (one per mounted chat). Now the toast lives in the store, the
-  // active ChatPanel renders it, and accept/dismiss clear it globally.
-  // Routes through the typed preload accessor so it no-ops on mobile/web.
+  // N toasts (one per mounted chat). Now the pending list lives in the store,
+  // the active ChatPanel renders the strip, and attach/discard clear it
+  // globally. Routes through the typed preload accessor so it no-ops on
+  // mobile/web.
   useEffect(() => {
     const preload = getMantaPreload();
     if (!preload) return;
     const off = preload.onScreenshotDetected((ev) => {
-      useStore.getState().setScreenshotToast(ev);
+      // Read the bytes HERE, once. Two reasons this is not just moved code:
+      // the clipboard can hold something else by the time the user clicks, and
+      // doing it here collapses the old accept path's file-vs-clipboard branch
+      // into one place. A screenshot we cannot read produces no record at all.
+      void (async () => {
+        try {
+          const bytes =
+            ev.source === "file" && ev.path
+              ? await preload.readLocalFile(ev.path)
+              : await preload.clipboardReadImage();
+          if (!bytes) return;
+          useStore.getState().addPendingScreenshot({
+            id: `shot-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+            filename: ev.path
+              ? ev.path.split("/").pop() ?? "screenshot.png"
+              : `screenshot-${Date.now()}.png`,
+            bytes,
+            previewUrl: URL.createObjectURL(new Blob([bytes], { type: "image/png" })),
+          });
+        } catch {
+          // Unreadable screenshot (file vanished, clipboard cleared) — nothing
+          // to offer, so offer nothing.
+        }
+      })();
     });
     return off;
   }, []);
@@ -1361,9 +1385,6 @@ function AppInner() {
   // is hidden so the two don't stack. Non-chat panes (terminal / AI-TUI /
   // new-session) keep the titlebar's drag region + breadcrumb + toggle.
   const isChatPaneActive = activeChatSessionId != null && mode === "chat";
-  // BET-723: the global toast host can route a screenshot "Add to chat" only
-  // when the foreground pane is a real chat session (not a draft over it).
-  const screenshotCanAddToChat = activeChatSessionId != null && !activeDraft && mode === "chat";
 
   return (
     // data-screen is the visual harness's handle on the app shell (see
@@ -1662,12 +1683,7 @@ function AppInner() {
       </main>
       {/* BET-723 §D4: ONE global toast host, rendered over every pane type
           (terminal / TUI / draft / chat) as a sibling of <main>. */}
-      {!showOnboarding && (
-        <GlobalToasts
-          activeChatSessionId={activeChatSessionId}
-          canAddToChat={screenshotCanAddToChat}
-        />
-      )}
+      {!showOnboarding && <GlobalToasts />}
       {/* BET-659: the Artifacts panel — a fixed-width sibling of <main>, so a
           chat pane is required for it to show (there's no panel to open in a
           terminal). The outer shell is already `flex` and <main> is

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -849,5 +849,3 @@ describe("ChatPanel pending screenshots", () => {
     expect(useStore.getState().pendingScreenshots.map((s) => s.id)).toEqual(["b"]);
   });
 });
-  });
-});

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -11,8 +11,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { ChatPanel } from "./ChatPanel";
-import { GlobalToasts } from "./GlobalToasts";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
+import { useStore } from "./store";
 import {
   installMockApi,
   resetStore,
@@ -762,126 +762,92 @@ describe("ChatPanel abort rejects orphaned questions", () => {
   });
 });
 
-// ===== Screenshot "Add to chat" → uploadBuffer (BET-130) =====
-//
-// Regression coverage for the HTTP-mode bug where acceptScreenshot dead-ended
-// on window.api.clipboardReadImage / window.api.uploadFiles (both server-side
-// stubs once window.api is httpApi). The fix routes bytes through
-// window.__mantaPreload (the real Electron preload, never swapped) and then
-// uploads them via window.api.uploadBuffer — the one primitive that actually
-// works in HTTP mode. These tests assert the chip reaches "ready" with a
-// remotePath, and that the preload OS bridge (not window.api) supplied bytes.
-describe("ChatPanel screenshot accept", () => {
+// The panel no longer reads any bytes itself: App.tsx reads them at detection
+// and puts them in the store. What is left to prove is that clicking a
+// thumbnail uploads THOSE bytes and clears the record, and that "Add all"
+// does it for every pending shot.
+describe("ChatPanel pending screenshots", () => {
   let h: Harness | null = null;
-
   afterEach(() => {
     h?.unmount();
     h = null;
-    (window as unknown as { __mantaPreload: unknown }).__mantaPreload = null;
   });
 
-  // Shared scaffold for the screenshot tests: mount a fresh panel (the caller
-  // has already installed the preload + window.api mock + store seed) and click
-  // the "Add to chat" toast button, which routes the buffered bytes through
-  // window.api.uploadBuffer. Returns the mounted harness for assertions; the
-  // describe-scoped `h` is also set so the shared afterEach unmounts it.
-  //
-  // Since BET-723 the toast host lives at App level (GlobalToasts), not in
-  // ChatPanel — the panel only RUNS the accept once the host's "Add to chat"
-  // action dispatches manta-accept-screenshot. So both are mounted together,
-  // with the host routing to this panel's session id.
-  async function mountScreenshotAndClickAddToChat(): Promise<Harness> {
-    h = mount(
-      <>
-        <ChatPanel {...PROPS} />
-        <GlobalToasts activeChatSessionId={PROPS.sessionId} canAddToChat />
-      </>,
-    );
-    await h.flush();
-
-    const addBtn = Array.from(h.container.querySelectorAll("button")).find(
-      (b) => b.textContent === "Add to chat",
-    ) as HTMLButtonElement;
-    expect(addBtn).toBeTruthy();
-    await act(async () => {
-      addBtn.click();
-    });
-    await h.flush();
-    return h;
+  function shot(id: string, bytes: ArrayBuffer) {
+    return { id, filename: `${id}.png`, bytes, previewUrl: `blob:${id}` };
   }
 
-  it("clipboard source: reads bytes via preload.clipboardReadImage, uploads via window.api.uploadBuffer", async () => {
-    const fakeBuf = new ArrayBuffer(4);
-    const clipboardReadImage = () => Promise.resolve(fakeBuf);
-    const readLocalFile = () => Promise.reject(new Error("should not be called"));
-    (window as unknown as {
-      __mantaPreload: { clipboardReadImage: typeof clipboardReadImage; readLocalFile: typeof readLocalFile };
-    }).__mantaPreload = { clipboardReadImage, readLocalFile };
-
-    let uploadedBuffer: ArrayBuffer | null = null;
+  it("clicking a thumbnail uploads that screenshot's bytes and clears it", async () => {
+    const bytes = new ArrayBuffer(4);
     const { api } = installMockApi({
-      uploadBuffer: (input: { buffer: ArrayBuffer }) => {
-        uploadedBuffer = input.buffer;
-        return Promise.resolve("/remote/screenshot-123.png");
-      },
+      uploadBuffer: () => Promise.resolve("/remote/shot-a.png"),
     });
-    resetStore({
-      screenshotToast: { source: "clipboard" },
-    });
+    resetStore({ pendingScreenshots: [shot("a", bytes)] });
 
-    const panel = await mountScreenshotAndClickAddToChat();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
 
-    expect(uploadedBuffer).toBe(fakeBuf);
+    const thumb = h.container.querySelector(
+      '[aria-label="Add a.png to the message"]',
+    ) as HTMLButtonElement;
+    expect(thumb).toBeTruthy();
+    await act(async () => { thumb.click(); });
+    await h.flush();
+
     expect(api.calls.uploadBuffer?.[0]?.[0]).toMatchObject({
       projectName: "proj",
-      buffer: fakeBuf,
+      filename: "a.png",
+      buffer: bytes,
     });
-    // Chip landed in the "ready" state — title attr carries the remotePath.
-    const chip = panel.container.querySelector('[title="/remote/screenshot-123.png"]');
-    expect(chip).toBeTruthy();
+    // Chip landed ready (title carries the remotePath) and the strip is empty.
+    expect(h.container.querySelector('[title="/remote/shot-a.png"]')).toBeTruthy();
+    expect(useStore.getState().pendingScreenshots).toHaveLength(0);
   });
 
-  it("file source: reads bytes via preload.readLocalFile, uploads via window.api.uploadBuffer", async () => {
-    const fakeBuf = new ArrayBuffer(8);
-    let requestedPath: string | null = null;
-    const readLocalFile = (path: string) => {
-      requestedPath = path;
-      return Promise.resolve(fakeBuf);
-    };
-    (window as unknown as {
-      __mantaPreload: { readLocalFile: typeof readLocalFile };
-    }).__mantaPreload = { readLocalFile };
-
-    let uploadedBuffer: ArrayBuffer | null = null;
-    installMockApi({
-      uploadBuffer: (input: { buffer: ArrayBuffer }) => {
-        uploadedBuffer = input.buffer;
-        return Promise.resolve("/remote/shot.png");
-      },
+  it("Add all uploads every pending screenshot", async () => {
+    const { api } = installMockApi({
+      uploadBuffer: () => Promise.resolve("/remote/x.png"),
     });
     resetStore({
-      screenshotToast: { source: "file", path: "/Users/x/Desktop/shot.png" },
+      pendingScreenshots: [
+        shot("a", new ArrayBuffer(1)),
+        shot("b", new ArrayBuffer(2)),
+      ],
     });
 
-    const panel = await mountScreenshotAndClickAddToChat();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
 
-    expect(requestedPath).toBe("/Users/x/Desktop/shot.png");
-    expect(uploadedBuffer).toBe(fakeBuf);
-    const chip = panel.container.querySelector('[title="/remote/shot.png"]');
-    expect(chip).toBeTruthy();
+    const addAll = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add all 2",
+    ) as HTMLButtonElement;
+    expect(addAll).toBeTruthy();
+    await act(async () => { addAll.click(); });
+    await h.flush();
+
+    expect(api.calls.uploadBuffer).toHaveLength(2);
+    expect(useStore.getState().pendingScreenshots).toHaveLength(0);
   });
 
-  it("no preload (mobile/web): chip goes to error state instead of silently dropping", async () => {
-    (window as unknown as { __mantaPreload: unknown }).__mantaPreload = null;
-    installMockApi();
+  it("the discard badge drops one screenshot without uploading it", async () => {
+    const { api } = installMockApi();
     resetStore({
-      screenshotToast: { source: "clipboard" },
+      pendingScreenshots: [
+        shot("a", new ArrayBuffer(1)),
+        shot("b", new ArrayBuffer(2)),
+      ],
     });
 
-    const panel = await mountScreenshotAndClickAddToChat();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
 
-    // Errored chip renders with title = errorMsg (see AttachmentStrip).
-    const chip = panel.container.querySelector('[title="Screenshot capture requires the desktop app"]');
-    expect(chip).toBeTruthy();
+    const x = h.container.querySelector('[aria-label="Discard a.png"]') as HTMLButtonElement;
+    await act(async () => { x.click(); });
+    await h.flush();
+
+    expect(api.calls.uploadBuffer).toBeUndefined();
+    expect(useStore.getState().pendingScreenshots.map((s) => s.id)).toEqual(["b"]);
+  });
+});
   });
 });

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -25,6 +25,7 @@ import type {
   QuestionRequest,
 } from "../shared/types";
 import { useStore } from "./store";
+import type { PendingScreenshot } from "./store";
 import {
   allTodosTerminal,
   selectActiveTodos,
@@ -82,8 +83,6 @@ import { useTypeahead } from "./hooks/useTypeahead";
 import { Transcript } from "./Transcript";
 import { Composer } from "./Composer";
 import { SessionHeader } from "./SessionHeader";
-import { ACCEPT_SCREENSHOT_EVENT } from "./GlobalToasts";
-import { getMantaPreload } from "./preloadAccess";
 
 // Attachment / AgentMention / TypeaheadState / TypeaheadRow are shared with
 // the extracted composer components and live in ./chatShared.
@@ -432,12 +431,6 @@ export function ChatPanel({
   // Whether the panel is currently being dragged over with files (for the
   // big "drop to attach" overlay).
   const [dragHover, setDragHover] = useState(false);
-  // Screenshot detection toast — global, lives in the store. App.tsx's global
-  // toast host owns the render + dismiss; this panel only runs the accept /
-  // upload flow ("Add to chat"), which needs the active session's own
-  // attachment state. Triggered by the ACCEPT_SCREENSHOT_EVENT below.
-  const screenshotToast = useStore((s) => s.screenshotToast);
-  const setScreenshotToast = useStore((s) => s.setScreenshotToast);
   // Ref mirror of the child-status map so `toggleTaskExpand` can read
   // current values synchronously without taking them as deps.
   const liveChildStatusRef = useRef<Map<string, "running" | "idle">>(new Map());
@@ -719,7 +712,6 @@ export function ChatPanel({
       return;
     }
     setSendError(null);
-    setScreenshotToast(null);
     setRunning(true); // optimistic — session.status will confirm
     setInput("");
     // Snap the branch indicator to current truth on every submit.
@@ -1447,78 +1439,48 @@ export function ChatPanel({
     [tmuxSession],
   );
 
-  // ===== Screenshot detection =====
-  //
-  // Subscription lives in App.tsx — single global listener writes into the
-  // store's `screenshotToast`. Only the active panel renders the toast and
-  // can accept/dismiss it; acting clears the global state for everyone.
+   // ===== Pending screenshots =====
+   //
+   // Also lives in the store (App.tsx reads the bytes + records them). Only
+   // the active panel renders + acts on them; acting clears the global
+   // records.
 
-  // Accept: upload the screenshot and create a chip.
-  const acceptScreenshot = useCallback(async () => {
-    const toast = screenshotToast;
-    setScreenshotToast(null);
-    if (!tmuxSession || !toast) return;
+   const pendingScreenshots = useStore((s) => s.pendingScreenshots);
+   const removePendingScreenshots = useStore((s) => s.removePendingScreenshots);
 
-    const mime = "image/png";
-    const filename = toast.path
-      ? toast.path.split("/").pop() ?? "screenshot.png"
-      : `screenshot-${Date.now()}.png`;
-    const id = `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+   // Attach one or more pending screenshots. The bytes were already read at
+   // detection (App.tsx), so this is now just "make a chip, upload the bytes" —
+   // the same tail every other upload path runs. Accepting one and accepting
+   // all are the same call with a different array.
+   const acceptScreenshots = useCallback(
+     (shots: PendingScreenshot[]) => {
+       removePendingScreenshots(shots.map((s) => s.id));
+       if (!tmuxSession) return;
+       for (const shot of shots) {
+         const id = `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+         setAttachments((prev) => [
+           ...prev,
+           { id, filename: shot.filename, mime: "image/png", status: "uploading", source: "paste" } as Attachment,
+         ]);
+         void (async () => {
+           try {
+             const remotePath = await window.api.uploadBuffer({
+               projectName: tmuxSession,
+               filename: shot.filename,
+               buffer: shot.bytes,
+             });
+             if (!remotePath) throw new Error("Upload failed");
+             patchAttachment(id, { status: "ready", remotePath });
+           } catch (err) {
+             patchAttachment(id, { status: "error", errorMsg: String((err as Error)?.message ?? err) });
+           }
+         })();
+       }
+     },
+     [tmuxSession, removePendingScreenshots, patchAttachment],
+   );
 
-    setAttachments((prev) => [
-      ...prev,
-      { id, filename, mime, status: "uploading", source: "paste" } as Attachment,
-    ]);
-
-    try {
-      // Only Electron main can read the Mac clipboard or a Mac file — both
-      // must come from the preload OS bridge, never window.api (which is
-      // httpApi in HTTP mode and has no OS access; the server IS the box).
-      const preload = getMantaPreload();
-      if (!preload) throw new Error("Screenshot capture requires the desktop app");
-
-      let buf: ArrayBuffer;
-      if (toast.source === "file" && toast.path) {
-        // Desktop watcher: read the local Mac file's bytes via main.
-        buf = await preload.readLocalFile(toast.path);
-      } else {
-        // Clipboard: read bytes from main.
-        const clip = await preload.clipboardReadImage();
-        if (!clip) throw new Error("Clipboard image vanished");
-        buf = clip;
-      }
-      // Upload the bytes through the same proven path as paste/drag-drop —
-      // window.api.uploadBuffer POSTs to the server's /api/upload.
-      const remotePath = await window.api.uploadBuffer({
-        projectName: tmuxSession,
-        filename,
-        buffer: buf,
-      });
-      if (!remotePath) throw new Error("Upload failed");
-      patchAttachment(id, { status: "ready", remotePath });
-    } catch (err) {
-      const msg = String((err as Error)?.message ?? err);
-      patchAttachment(id, { status: "error", errorMsg: msg });
-    }
-  }, [screenshotToast, tmuxSession]);
-
-  // The App-level toast host (BET-723) renders the screenshot toast globally
-  // and routes its "Add to chat" action here — this panel owns the active
-  // session's attachment state, so only it can accept. Gated on isActive so a
-  // hidden panel never consumes an action aimed at the visible one (the detail
-  // sessionId match is the routing backstop).
-  useEffect(() => {
-    const onAcceptScreenshot = (e: Event) => {
-      if (!isActive) return;
-      const detail = (e as CustomEvent<{ sessionId?: string }>).detail;
-      if (detail?.sessionId != null && detail.sessionId !== sessionId) return;
-      void acceptScreenshot();
-    };
-    window.addEventListener(ACCEPT_SCREENSHOT_EVENT, onAcceptScreenshot);
-    return () => window.removeEventListener(ACCEPT_SCREENSHOT_EVENT, onAcceptScreenshot);
-  }, [isActive, sessionId, acceptScreenshot]);
-
-  // Panel-level drag handlers. We listen on the chat container; the body of
+   // Panel-level drag handlers. We listen on the chat container; the body of
   // the panel paints a dotted overlay while dragHover is true. App.tsx
   // already suppresses default drag/drop on the window so the renderer
   // doesn't navigate to file:// — we only handle the panel-local case.
@@ -2252,6 +2214,9 @@ export function ChatPanel({
         attachments={attachments}
         onRemoveAttachment={removeAttachment}
         onAttachFiles={(files) => void addDroppedFiles(files)}
+        pendingScreenshots={isActive ? pendingScreenshots : []}
+        onAcceptScreenshots={acceptScreenshots}
+        onDiscardScreenshot={(id) => removePendingScreenshots([id])}
         typeahead={typeahead}
         typeaheadRows={typeaheadRows}
         onTypeaheadSelect={applyTypeahead}

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -6,9 +6,10 @@
 // and the press-and-hold mic button. InputArea.tsx composes them.
 
 import { useRef } from "react";
-import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip } from "lucide-react";
+import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip, Camera } from "lucide-react";
 import type { VoiceMode, VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
+import type { PendingScreenshot } from "./store";
 import { ALT_KEY } from "./platform";
 import { IconButton } from "./IconButton";
 // BET-726 Task 1: same scrollIntoView idiom the ⌘K / ⌘F palettes and the
@@ -165,7 +166,62 @@ export function AttachmentStrip({
             </button>
           </span>
         );
-      })}
+      }      )}
+    </div>
+  );
+}
+
+// ===== Pending screenshot strip =====
+//
+// One preview per screenshot the OS detector saw, waiting to be attached.
+// Sits ABOVE the composer box (unlike AttachmentStrip, which sits inside it):
+// these are not part of the message yet, and being outside the box is what
+// aligns the row's left edge with the model pill below — the box's own px-4
+// would inset it. Purely presentational; ChatPanel owns the attach + discard.
+export function PendingScreenshotStrip({
+  shots,
+  onAccept,
+  onDiscard,
+}: {
+  shots: PendingScreenshot[];
+  onAccept: (shots: PendingScreenshot[]) => void;
+  onDiscard: (id: string) => void;
+}) {
+  if (shots.length === 0) return null;
+  return (
+    <div className="pb-2 flex flex-wrap items-center gap-2 text-meta">
+      <span className="inline-flex items-center gap-1 text-text-faint shrink-0">
+        <Camera size={13} aria-hidden="true" />
+        {shots.length} screenshot{shots.length === 1 ? "" : "s"}
+      </span>
+      {shots.map((s) => (
+        <span key={s.id} className="relative shrink-0">
+          <button
+            onClick={() => onAccept([s])}
+            className="block w-[52px] h-[36px] rounded-sm overflow-hidden border border-border bg-fill hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+            title={`Add ${s.filename} to the message`}
+            aria-label={`Add ${s.filename} to the message`}
+          >
+            <img src={s.previewUrl} alt="" className="w-full h-full object-cover" />
+          </button>
+          <button
+            onClick={() => onDiscard(s.id)}
+            className="absolute top-px right-px w-4 h-4 rounded-full grid place-items-center bg-text/60 text-bg hover:bg-danger focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+            title="Discard"
+            aria-label={`Discard ${s.filename}`}
+          >
+            <X size={10} aria-hidden="true" />
+          </button>
+        </span>
+      ))}
+      {shots.length > 1 && (
+        <button
+          onClick={() => onAccept(shots)}
+          className="shrink-0 rounded-sm bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+        >
+          Add all {shots.length}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/renderer/GlobalToasts.tsx
+++ b/src/renderer/GlobalToasts.tsx
@@ -1,14 +1,14 @@
 // ===== Global toast host (BET-723 §D4) =====
 //
-// ONE ToastStack lives at the app root (rendered once in App.tsx) so a
-// screenshot / agent-file / error toast shows over EVERY pane type — a
+// ONE ToastStack lives at the app root (rendered once in App.tsx) so an
+// agent-file / error toast shows over EVERY pane type — a
 // terminal pane, a TUI pane, or a new-session draft — instead of only when a
 // chat pane happens to be active. ChatPanel keeps zero toast code.
 //
 // The host assembles:
 //   - `appToasts` (store): transient errors + info (the alert() replacements),
 //     each with its own id, capped at 5, dismissible via dismissAppToast.
-//   - the three legacy single-instance toasts (screenshot / agent-file /
+//   - the two legacy single-instance toasts (agent-file /
 //     system-notice), which moved up here from the active ChatPanel.
 //
 // Ordering keeps the moved behavior: newest on top, capped at MAX_TOASTS by
@@ -20,26 +20,10 @@ import { useStore } from "./store";
 import { ToastStack, type ToastItem } from "./Toast";
 import { formatBytes } from "./chatUtils";
 
-/** Window CustomEvent App dispatches when the screenshot toast's "Add to chat"
- *  is clicked, so the ACTIVE ChatPanel (which owns its attachment state) runs
- *  the accept/upload logic. Detail carries the target sessionId. */
-export const ACCEPT_SCREENSHOT_EVENT = "manta-accept-screenshot";
-
-type Props = {
-  /** Session id of the active chat-mode window, or null when the foreground
-   *  pane is a terminal / TUI pane. */
-  activeChatSessionId: string | null;
-  /** Whether the foreground pane is a chat session the screenshot "Add to
-   *  chat" action could target (active chat window + no draft on top). */
-  canAddToChat: boolean;
-};
-
-export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
-  const screenshotToast = useStore((s) => s.screenshotToast);
+export function GlobalToasts() {
   const agentFileToast = useStore((s) => s.agentFileToast);
   const systemNotice = useStore((s) => s.systemNotice);
   const appToasts = useStore((s) => s.appToasts);
-  const setScreenshotToast = useStore((s) => s.setScreenshotToast);
   const setAgentFileToast = useStore((s) => s.setAgentFileToast);
   const setSystemNotice = useStore((s) => s.setSystemNotice);
   const pushAppToast = useStore((s) => s.pushAppToast);
@@ -51,12 +35,11 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
   const [toastOrder, setToastOrder] = useState<string[]>([]);
   const activeToastIds = useMemo(() => {
     const ids: string[] = [];
-    if (screenshotToast) ids.push("screenshot");
     if (agentFileToast) ids.push("agent-file");
     if (systemNotice) ids.push("system-notice");
     for (const t of appToasts) ids.push(t.id);
     return ids;
-  }, [screenshotToast, agentFileToast, systemNotice, appToasts]);
+  }, [agentFileToast, systemNotice, appToasts]);
 
   useEffect(() => {
     setToastOrder((prev) => {
@@ -69,26 +52,12 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
 
   const dismissToast = useCallback(
     (id: string) => {
-      if (id === "screenshot") setScreenshotToast(null);
-      else if (id === "agent-file") setAgentFileToast(null);
+      if (id === "agent-file") setAgentFileToast(null);
       else if (id === "system-notice") setSystemNotice(null);
       else dismissAppToast(id);
     },
-    [setScreenshotToast, setAgentFileToast, setSystemNotice, dismissAppToast],
+    [setAgentFileToast, setSystemNotice, dismissAppToast],
   );
-
-  // Route the screenshot "Add to chat" to the ACTIVE chat session. ChatPanel
-  // listens for the event and runs its accept/upload flow (only it owns the
-  // attachment state). When the foreground pane isn't a chat, `canAddToChat`
-  // is false and the action button is hidden — the toast still shows.
-  const acceptScreenshot = useCallback(() => {
-    if (!activeChatSessionId) return;
-    window.dispatchEvent(
-      new CustomEvent(ACCEPT_SCREENSHOT_EVENT, {
-        detail: { sessionId: activeChatSessionId },
-      }),
-    );
-  }, [activeChatSessionId]);
 
   // Agent → laptop file push (moved unchanged from ChatPanel).
   const saveAgentFile = useCallback(async () => {
@@ -126,19 +95,7 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
     const items: ToastItem[] = [];
     const appMap = new Map(appToasts.map((t) => [t.id, t]));
     for (const id of toastOrder) {
-      if (id === "screenshot" && screenshotToast) {
-        items.push({
-          id: "screenshot",
-          message:
-            screenshotToast.source === "file" && screenshotToast.path
-              ? `Screenshot: ${screenshotToast.path.split("/").pop()}`
-              : "Screenshot in clipboard",
-          actions:
-            canAddToChat && activeChatSessionId
-              ? [{ label: "Add to chat", onClick: () => void acceptScreenshot() }]
-              : undefined,
-        });
-      } else if (id === "agent-file" && agentFileToast) {
+      if (id === "agent-file" && agentFileToast) {
         const size = formatBytes(agentFileToast.size);
         items.push({
           id: "agent-file",
@@ -177,14 +134,10 @@ export function GlobalToasts({ activeChatSessionId, canAddToChat }: Props) {
     return items;
   }, [
     toastOrder,
-    screenshotToast,
     agentFileToast,
     systemNotice,
     appToasts,
     agentFileSaving,
-    canAddToChat,
-    activeChatSessionId,
-    acceptScreenshot,
     revealAgentFile,
     saveAgentFile,
   ]);

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -33,7 +33,8 @@ import {
 import { baseModelId, isFastModelId, shortModelName } from "./chatUtils";
 import { ModelPicker } from "./ModelPicker";
 import { MeasureColumn } from "./MeasureColumn";
-import { AttachButton, AttachmentStrip, MicButton, SessionToolbar } from "./ComposerParts";
+import { AttachButton, AttachmentStrip, MicButton, SessionToolbar, PendingScreenshotStrip } from "./ComposerParts";
+import type { PendingScreenshot } from "./store";
 import { UsageDial } from "./UsageDial";
 // Re-exported so existing `import { TypeaheadPopup } from "./InputArea"` call
 // sites (Composer) keep working after the leaf component moved to ./ComposerParts.
@@ -126,6 +127,9 @@ export function InputArea({
   attachments,
   onRemoveAttachment,
   onAttachFiles,
+  pendingScreenshots,
+  onAcceptScreenshots,
+  onDiscardScreenshot,
   modelLabel,
   chatAutoAllow,
   setChatAutoAllow,
@@ -177,6 +181,12 @@ export function InputArea({
   // (ChatPanel's addDroppedFiles) — the button is a second door, not a second
   // upload path.
   onAttachFiles: (files: File[]) => void;
+  // Screenshots the OS detector saw, not yet attached. Rendered ABOVE the
+  // composer box (see PendingScreenshotStrip) — threaded in exactly like
+  // `attachments`, so the panel stays the single owner of what gets attached.
+  pendingScreenshots: PendingScreenshot[];
+  onAcceptScreenshots: (shots: PendingScreenshot[]) => void;
+  onDiscardScreenshot: (id: string) => void;
   modelLabel: string | null;
   chatAutoAllow: boolean;
   setChatAutoAllow: (v: boolean) => Promise<void>;
@@ -273,6 +283,14 @@ export function InputArea({
           the transcript's measure edge, per the session mockup (.comp-in). The
           reading column chrome is the MeasureColumn primitive (BET-637). */}
       <MeasureColumn>
+      {/* Pending screenshots sit above the box, inside the same measure column
+          — so the row's left edge is the model pill's, with no bespoke
+          padding. */}
+      <PendingScreenshotStrip
+        shots={pendingScreenshots}
+        onAccept={onAcceptScreenshots}
+        onDiscard={onDiscardScreenshot}
+      />
       {/* Real input shell (BET-415): a bordered card with focus-within state
           replaces the old hairline-dividers-around-a-naked-textarea. Voice
           recording is now signalled by THIS border — a fourth treatment

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -256,13 +256,20 @@ export type WindowStatusUI = {
   lastMessageAt?: number;
 };
 
-// Global screenshot detection toast. Single instance app-wide — the active
-// ChatPanel renders it and "Add to chat" / dismiss clear it for everyone.
-// Subscription lives in App.tsx so we only register one ipcRenderer listener
-// regardless of how many ChatPanels are mounted.
-export type ScreenshotToast = {
-  source: "clipboard" | "file";
-  path?: string;
+// A screenshot the OS-level detector saw, waiting for the user to attach or
+// discard it. App.tsx owns the single detection listener and READS THE BYTES
+// THERE, once, so this record is self-contained: nothing downstream has to go
+// back to the clipboard or the disk (the clipboard can have changed by then —
+// that was a real race in the old accept path).
+export type PendingScreenshot = {
+  id: string;
+  filename: string;
+  // The PNG bytes, read at detection time. Uploaded verbatim on accept.
+  bytes: ArrayBuffer;
+  // Object URL over `bytes`, for the strip's <img>. Created in App.tsx when
+  // the record is made, revoked by removePendingScreenshots when it is
+  // dropped — so creation and revocation are each in exactly one place.
+  previewUrl: string;
 };
 
 type State = {
@@ -403,8 +410,10 @@ type State = {
   // artifacts WITHOUT a second opencodeMessages fetch. Keyed by sessionId,
   // written by ChatPanel when its own transcript state changes.
   chatMessages: Record<string, OpencodeMessage[]>;
-  // Single global screenshot toast — see ScreenshotToast type comment.
-  screenshotToast: ScreenshotToast | null;
+  // Screenshots waiting to be attached — see PendingScreenshot. A LIST, not a
+  // slot: taking three screenshots in a row must show three, and it never
+  // expires on its own.
+  pendingScreenshots: PendingScreenshot[];
   // Single global agent-file toast: a file the remote AI pushed to its outbox.
   // Same single-instance pattern as screenshotToast — App.tsx owns the one
   // ipcRenderer listener, the active ChatPanel renders the toast, accept /
@@ -622,7 +631,10 @@ type State = {
   // BET-414: toggle a window's pin. Optimistic set + configUpdate + reconcile.
   // The id is `<tmuxSession>/<windowIndex>` (see windowPinId in chatUtils.ts).
   togglePin: (pinId: string) => Promise<void>;
-  setScreenshotToast: (t: ScreenshotToast | null) => void;
+  addPendingScreenshot: (s: PendingScreenshot) => void;
+  // Removes by id and revokes each removed record's previewUrl. Takes an
+  // ARRAY so "discard one", "accept one" and "accept all" are one code path.
+  removePendingScreenshots: (ids: string[]) => void;
   setAgentFileToast: (t: AgentFileReady | null) => void;
   setUpdatePrompt: (p: { version: string; releaseName?: string } | null) => void;
   setUpdateError: (p: { message: string; raw: string } | null) => void;
@@ -683,7 +695,7 @@ export const useStore = create<State>((set, get) => ({
   jobs: {},
   usage: [],
   chatMessages: {},
-  screenshotToast: null,
+  pendingScreenshots: [],
   agentFileToast: null,
   appToasts: [],
   systemNotice: null,
@@ -955,7 +967,21 @@ export const useStore = create<State>((set, get) => ({
     set({ pinnedWindows: Array.isArray(saved.pinnedWindows) ? saved.pinnedWindows : [] });
   },
 
-  setScreenshotToast: (t) => set({ screenshotToast: t }),
+  addPendingScreenshot: (s) =>
+    set((prev) => ({ pendingScreenshots: [...prev.pendingScreenshots, s] })),
+  removePendingScreenshots: (ids) =>
+    set((prev) => {
+      const drop = new Set(ids);
+      for (const s of prev.pendingScreenshots) {
+        // jsdom (the test environment) implements NEITHER createObjectURL nor
+        // revokeObjectURL, so an unguarded call makes every test that drops a
+        // pending screenshot throw. Guard rather than leak the URL.
+        if (drop.has(s.id) && typeof URL.revokeObjectURL === "function") {
+          URL.revokeObjectURL(s.previewUrl);
+        }
+      }
+      return { pendingScreenshots: prev.pendingScreenshots.filter((s) => !drop.has(s.id)) };
+    }),
   setAgentFileToast: (t) => set({ agentFileToast: t }),
   pushAppToast: (t) =>
     set((prev) => {

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -198,7 +198,7 @@ export function resetStore(
       defaultModel: null,
       cacheTtl: "1h",
       groqApiKey: "",
-      screenshotToast: null,
+      pendingScreenshots: [],
       agentFileToast: null,
       ...partial,
     } as Partial<ReturnType<typeof useStore.getState>>);


### PR DESCRIPTION
## What
Moves screenshot detection from a single global bottom-right toast to a
**pending-screenshot thumbnail strip** rendered above the composer box — one
52×36 preview per captured screenshot, wrapping to a second line when it runs
out of width, flushed with the model pill's left edge.

Net simplification: deletes the screenshot toast branch, the `Window`
CustomEvent bridge, two `GlobalToasts` props, and ChatPanel's two-branch
byte-reading path. App.tsx is now the single reader — it reads the bytes once
at detection time (killing the old accept-path clipboard race) and records a
self-contained `PendingScreenshot`.

## Behavior
- Click a thumbnail → attached to the message as a normal chip, leaves the strip.
- `✕` badge → discard that one.
- `Add all N` (only when ≥2) → attach every remaining shot.
- No expiry, no cap; desktop-only by construction (`getMantaPreload()` null elsewhere).

## Design compliance
- Strip lives ABOVE the bordered box, first child inside `MeasureColumn` (inherits the model-pill inset — inside `px-4` it would sit 16px right of the pill).
- No toast retained; no max/expiry; `PendingScreenshotStrip` is a separate component (not an `AttachmentStrip` extension); no `manta-*` hook class; no new files; `Composer.tsx` untouched (spreads props through).

**Files changed:** 8 — `store.ts`, `App.tsx`, `GlobalToasts.tsx`, `ComposerParts.tsx`, `InputArea.tsx`, `ChatPanel.tsx`, `testHarness.tsx`, `ChatPanel.harness.test.tsx`.

**Base: origin/main @ `761e5b3b`**

**Verification results:**
- PR branch (`multica/BET-762-screenshot-strip` @ `f39b6065`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1629 pass / 0 fail / 0 skip (`npm test` full suite; vitest + node:test). Failures: none. New `ChatPanel pending screenshots` block: 3/3 pass (thumbnail upload, Add all, discard).
- **Conclusion:** 0 new failures; the 3 old screenshot tests were rewritten for the new architecture, not carried forward.
