### PR TITLE
BET-733: fix(renderer): correctness nits — providerID ref, updater purity, deps, timer cleanups, honest PreloadApi, tokens field

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -229,6 +229,13 @@ export function ChatPanel({
   const childRefetchTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
   );
+  // Unmount cleanup — clear every pending child refetch timer so a 300ms timer
+  // surviving teardown can't fire fetch + setState after the panel unmounts
+  // (same pattern as useTranscriptState's own splice-timer cleanup).
+  useEffect(() => () => {
+    for (const t of childRefetchTimers.current.values()) clearTimeout(t);
+    childRefetchTimers.current.clear();
+  }, []);
   // Forward declaration: submitRef is defined later (depends on submit), but
   // useSseBus needs it now for the drain effect.
   const submitRef = useRef<(textOverride?: string) => void>(() => {});
@@ -291,6 +298,24 @@ export function ChatPanel({
     if (idx < 0) return;
     virtuosoRef.current?.scrollToIndex({ index: idx, align: "center", behavior });
   }, []);
+
+  // ===== Per-session model override =====
+  // Declared before useSseBus: the auth-banner providerID below derives from
+  // it. Initialized from the per-session localStorage override, falling back
+  // to the persisted global default (the same seed useSseBus's providerID
+  // used to recompute from readSavedModel on every render).
+  const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
+    readSavedModel(sessionId) ?? configDefaultModel ?? null,
+  );
+  // Active-model providerID for the auth-error banner (BET-316). Per-session
+  // override wins over the persisted default; null if neither is set. Memoized
+  // on `modelOverride` (the in-memory selection, itself seeded from
+  // localStorage) so the localStorage read + parse runs on model change, not
+  // on every keystroke re-render.
+  const providerID = useMemo(
+    () => modelOverride?.providerID ?? configDefaultModel?.providerID ?? null,
+    [modelOverride, configDefaultModel],
+  );
 
   // ===== SSE bus state (extracted to useSseBus) =====
   const {
@@ -357,17 +382,7 @@ export function ChatPanel({
     isActiveRef,
     refetchOwedWhileInactive,
     applyStreamFlush,
-    // Active-model providerID for the auth-error banner (BET-316).
-    // Per-session override (localStorage) wins over the persisted default;
-    // null if neither is set — the banner then falls through to the
-    // raw-message path. Computed inline rather than via useMemo: the
-    // cost is one localStorage read + one object lookup per render, and
-    // keeping it inline avoids a second memo that exists only to feed one
-    // hook argument.
-    providerID:
-      readSavedModel(sessionId)?.providerID ??
-      configDefaultModel?.providerID ??
-      null,
+    providerID,
     submit: () => {}, // placeholder — ChatPanel's submit is used below
     submitRef,
   });
@@ -417,9 +432,6 @@ export function ChatPanel({
   // the picker never flashes "Loading…" for a list that didn't change.
   // Selection, by contrast, IS per-session and persists via localStorage.
   const { models, defaultModel } = useModelCatalog();
-  const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    readSavedModel(sessionId) ?? configDefaultModel ?? null,
-  );
   // Pending attachments (chips above input) + agent @-mentions waiting to be
   // serialized into FilePart / AgentPart on next submit. Cleared on success.
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -725,7 +737,7 @@ export function ChatPanel({
     // Snap the branch indicator to current truth on every submit.
     refreshBranch(cwd);
     // If the pinned todo list is fully terminal, hide the stale checklist.
-    if (activeTodos && allTodosTerminal(activeTodos)) {
+    if (activeTodosRef.current && allTodosTerminal(activeTodosRef.current)) {
       setTodosDismissed(true);
     }
 
@@ -770,11 +782,11 @@ export function ChatPanel({
       );
       try {
         if (cmdName === "clear") {
-          await clearSession();
+          await clearSessionRef.current();
         } else if (cmdName === "fork") {
-          await forkSession();
+          await forkSessionRef.current();
         } else if (cmdName === "compact") {
-          await compactSession();
+          await compactSessionRef.current();
         } else if (cmdName === "help") {
           setSystemNotice(buildHelpText());
         }
@@ -879,7 +891,13 @@ export function ChatPanel({
         prev ? prev.filter((m) => m.info.id !== optimisticUserId) : prev,
       );
     }
-  }, [input, running, sessionId, modelOverride, attachments, agentMentions]);
+    // tmuxSession/windowIndex key the per-window prompt-history list (line
+    // 720) — if they moved to a different owning window, submit must use the
+    // NEW window's history, so they're deps. activeTodos + the session ops
+    // (clear/fork/compact) are read via their ref mirror below (declared after
+    // submit in this file — the established commandsRef pattern) so submit
+    // always sees their current value without them re-rotating this callback.
+  }, [input, running, sessionId, modelOverride, attachments, agentMentions, tmuxSession, windowIndex]);
 
   // Always-current ref to submit — lets the queued-message effect call the
   // latest version without adding submit to the effect's dependency array
@@ -1134,6 +1152,17 @@ export function ChatPanel({
       setSendError(String((e as Error)?.message ?? e));
     }
   }, [tmuxSession, windowIndex, cwd, modelOverride, refresh]);
+
+  // Current-value ref mirrors for `submit` — declared AFTER submit in this file
+  // (the established commandsRef pattern), so submit reads these instead of
+  // taking the callbacks as deps (which would hit the TDZ at submit's
+  // declaration line). Kept current each render.
+  const forkSessionRef = useRef(forkSession);
+  forkSessionRef.current = forkSession;
+  const compactSessionRef = useRef(compactSession);
+  compactSessionRef.current = compactSession;
+  const clearSessionRef = useRef(clearSession);
+  clearSessionRef.current = clearSession;
 
   // Delete session — kills the tmux window + opencode session. Reaches the
   // same IPC the mobile ⋯ sheet uses.
@@ -1602,10 +1631,9 @@ export function ChatPanel({
     for (let i = messages.length - 1; i >= 0; i--) {
       const info = messages[i].info;
       if (info.role !== "assistant") continue;
-      // OpencodeMessageInfo type doesn't surface `tokens` directly — read
-      // it off the underlying record. Shape matches AssistantMessage.tokens
-      // from the OpenAPI doc.
-      const t = (info as unknown as { tokens?: TokenUsage }).tokens;
+      // `tokens` is declared on OpencodeMessageInfo (BET-733/L10) — shape
+      // matches AssistantMessage.tokens from the OpenAPI doc.
+      const t = info.tokens;
       if (!t) continue;
       const totalInput =
         (t.input ?? 0) + (t.cache?.read ?? 0) + (t.cache?.write ?? 0);
@@ -1729,6 +1757,11 @@ export function ChatPanel({
       todosDismissed,
     );
   }, [messages, liveTodos, todosDismissed]);
+  // Current-value ref mirror for `submit` (declared after submit — commandsRef
+  // pattern) so submit's todos auto-dismiss reads the latest activeTodos even
+  // though activeTodos itself can't appear in submit's dep array.
+  const activeTodosRef = useRef(activeTodos);
+  activeTodosRef.current = activeTodos;
 
   // Turn boundary metadata: which assistant messages are the FINAL one of
   // their turn (i.e., immediately followed by a user message or end-of-list),
@@ -2307,17 +2340,23 @@ export function ChatPanel({
         onHistoryUp={() => navigateHistory(-1)}
         onHistoryDown={() => navigateHistory(1)}
         onQueuePop={() => {
+          // The setMessageQueue updater must stay pure (it's double-invoked
+          // under StrictMode). Compute the popped value inside it, then run
+          // the setInput + focus side effects AFTER — otherwise setInput and
+          // the rAF fire twice per pop.
+          let last: string | undefined;
           setMessageQueue((q) => {
             if (q.length === 0) return q;
-            const last = q[q.length - 1];
-            setInput(last);
-            requestAnimationFrame(() => {
-              const el = inputRef.current;
-              if (!el) return;
-              el.focus();
-              el.setSelectionRange(last.length, last.length);
-            });
+            last = q[q.length - 1];
             return q.slice(0, -1);
+          });
+          if (last === undefined) return;
+          setInput(last);
+          requestAnimationFrame(() => {
+            const el = inputRef.current;
+            if (!el) return;
+            el.focus();
+            el.setSelectionRange(last!.length, last!.length);
           });
         }}
         onPaste={onPaste}

--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -350,7 +350,11 @@ export function ConnectProvider({
       }
     }, CLAUDE_POLL_INTERVAL_MS);
     return () => window.clearInterval(handle);
-  }, [phase, safeSetPhase, mounted]);
+    // Narrowed to the discriminant that should restart the poll. Dependent on
+    // the whole `phase` object, every cosmetic update (`{...phase, url}` /
+    // `inputError` below) mutates the object and re-runs this effect — which
+    // resets `startedWall` above and silently defeats the 5-minute cap.
+  }, [phase.kind, phase.kind === "needsClaudeLogin" ? phase.ptySessionKey : null, safeSetPhase, mounted]);
 
   // BET-421 §E: lazy Claude CLI install poll. While `installingClaudeCli`,
   // poll opencodeClaudeCliStatus() every 2s. When the binary appears on
@@ -429,7 +433,10 @@ export function ConnectProvider({
       window.clearInterval(handle);
       dispose();
     };
-  }, [phase, safeSetPhase, mounted]);
+    // Narrowed to the discriminant (same shape as the install-elapsed effect)
+    // so cosmetic `phase` object updates can't reset `startedWall` and dodge
+    // the 5-minute install cap.
+  }, [phase.kind, phase.kind === "installingClaudeCli" ? phase.ptySessionKey : null, safeSetPhase, mounted]);
 
   // Device-code poll (waiting). Polls `{action:"status"}` every 3s; the
   // provider-id appearing in `connected[]` is the success signal (opencode

--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -695,20 +695,16 @@ export const demoPages: ServedPageMeta[] = [
 
 // Attach cumulative tokens to the in-flight assistant message so the context
 // bar (and `latestTokens` memo in ChatPanel) reads a realistic breakdown.
-// `OpencodeMessageInfo` doesn't type the `tokens` field directly — the
-// renderer reads it via `(info as unknown as { tokens?: TokenUsage }).tokens`
-// at chatPanel.tsx:1446, so the same `as unknown as` cast lets us attach
-// the live numbers without breaking the typed surface.
+// The `tokens` field is declared on OpencodeMessageInfo (BET-733/L10), so it
+// can be set on the typed surface directly.
 demoMessages[1].info = {
   ...demoMessages[1].info,
-  ...({
-    tokens: {
-      input: 1234,
-      output: 418,
-      reasoning: 67,
-      cache: { read: 68_921, write: 0 },
-    },
-  } as unknown as Record<string, unknown>),
+  tokens: {
+    input: 1234,
+    output: 418,
+    reasoning: 67,
+    cache: { read: 68_921, write: 0 },
+  },
 };
 
 // =============================================================================

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -12,6 +12,12 @@
 
 import { createContext, type ReactNode } from "react";
 import type { OpencodeMessage, OpencodeModel } from "../shared/types";
+// TokenUsage now lives in src/shared/types.ts (the single source — it also
+// types OpencodeMessageInfo.tokens, which killed the renderer's
+// `as unknown as { tokens?: TokenUsage }` casts, BET-733/L10). Re-exported here
+// so the existing renderer `import { TokenUsage } from "./chatShared"` call
+// sites are unchanged.
+export type { TokenUsage } from "../shared/types";
 
 // In-flight attachments tracked alongside the textarea content. Each chip
 // rendered above the input maps to one entry; `status` drives the chip
@@ -59,14 +65,6 @@ export type TypeaheadRow = {
   secondary?: string;         // dim caption: command description / agent description
 };
 
-// Token accounting surfaced by the running indicator / context bar.
-export type TokenUsage = {
-  total?: number;
-  input: number;
-  output: number;
-  reasoning: number;
-  cache: { read: number; write: number };
-};
 
 // One tool part's `state` shape (opencode tool-call lifecycle). Extracted so
 // the tool-rendering components share a single definition.

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ConnectionStateName } from "../shared/net/state.js";
 import type { DelegateApprovalTool, OpencodeMessage, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
-import type { SessionMode, TokenUsage } from "./chatShared";
+import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
 // shared/versionCompare.mjs so both src/server/*.mjs and the renderer share
@@ -2336,11 +2336,8 @@ export function computeTurnInfo(
         const t = messages[j].info.time;
         if (firstStart == null && t?.created != null) firstStart = t.created;
         if (t?.completed != null) lastEnd = t.completed;
-        // OpencodeMessageInfo doesn't surface `tokens` directly — read it
-        // off the underlying record the same way `latestTokens` does.
-        const tok = (
-          messages[j].info as unknown as { tokens?: TokenUsage }
-        ).tokens;
+        // `tokens` is declared on OpencodeMessageInfo (BET-733/L10) — no cast.
+        const tok = messages[j].info.tokens;
         if (tok) turnTokens += (tok.output ?? 0) + (tok.reasoning ?? 0);
         if (verbSeedId == null) verbSeedId = messages[j].info.id;
         lastAssistantId = messages[j].info.id;
@@ -2403,9 +2400,7 @@ export function computeLiveTurn(messages: OpencodeMessage[] | null): LiveTurn | 
       const c = messages[j].info.time?.created;
       if (typeof c === "number") startedAt = c;
     }
-    const tok = (
-      messages[j].info as unknown as { tokens?: TokenUsage }
-    ).tokens;
+    const tok = messages[j].info.tokens;
     if (tok) tokens += (tok.output ?? 0) + (tok.reasoning ?? 0);
   }
   if (startedAt == null) {

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -225,6 +225,12 @@ export function useSseBus(params: {
   useEffect(() => {
     questionsRef.current = questions;
   }, [questions]);
+  // Ref mirror of `providerID` so the SSE handler (whose subscription effect
+  // deps are `[sessionId]`) classifies the auth-reconnect banner against the
+  // CURRENT provider, not the one captured at mount. Without this, switching
+  // provider/model mid-session leaves the banner keyed to the old provider.
+  const providerIDRef = useRef(providerID);
+  providerIDRef.current = providerID;
   const [stepTokens, setStepTokens] = useState<(TokenUsage & { cost: number }) | null>(null);
   const [compactionState, setCompactionState] = useState<{
     reason: string;
@@ -494,7 +500,7 @@ export function useSseBus(params: {
         // running in parallel for Claude specifically — this banner is
         // additive, not a replacement. For everything else the existing
         // switch/default branch handles the message and we fall through.
-        const auth = authErrorAdvice(err?.name, raw, providerID);
+        const auth = authErrorAdvice(err?.name, raw, providerIDRef.current);
         if (auth) {
           setSendError(`${auth.label} needs to be reconnected.`);
           setAuthReconnect(auth.label);

--- a/src/renderer/hooks/useTypeahead.ts
+++ b/src/renderer/hooks/useTypeahead.ts
@@ -7,8 +7,9 @@
 // Self-contained: owns its own state (typeahead, commands, agents, fileResults)
 // and refs (fileSearchSeqRef, fileSearchTimer). Dependencies are injected via
 // params — it never reaches into the container's SSE / pin-to-bottom / drain
-// state. The hook is callback-driven (no effects) so it's trivially testable
-// with the render harness.
+// state. The hook is callback-driven (the only effect is an unmount cleanup
+// for the debounced file-search timer) so it's trivially testable with the
+// render harness.
 //
 // The textarea's onChange routes through `updateInput` which both updates
 // `input` state and detects active typeahead. Three triggers:
@@ -17,7 +18,7 @@
 // The popup tracks the [anchorStart, anchorEnd) slice and replaces it
 // verbatim on selection.
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { OpencodeAgent, OpencodeCommand } from "../../shared/types";
 import {
   filterCommands,
@@ -294,6 +295,13 @@ export function useTypeahead(params: {
     },
     [typeaheadRows.length],
   );
+
+  // Unmount cleanup — clear the debounced file-search timer so a pending
+  // 80ms timer can't fire `opencodeFindFiles` + setState after teardown
+  // (the timer was previously only cleared on keystroke, not on unmount).
+  useEffect(() => () => {
+    if (fileSearchTimer.current) clearTimeout(fileSearchTimer.current);
+  }, []);
 
   const typeaheadOpen = typeahead !== null && typeaheadRows.length > 0;
   const typeaheadExactMatch =

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -8,7 +8,7 @@ import { App } from "./App";
 import "@fontsource-variable/inter";
 import "@fontsource-variable/jetbrains-mono";
 import "./index.css";
-import type { Api } from "../shared/api";
+import type { PreloadApi } from "../shared/api";
 import { initRendererLogging } from "./log";
 import { desktopHttpClientSeed } from "../shared/transport.mjs";
 import { installHttpTransport, setWindowApi } from "./transportInstall";
@@ -41,11 +41,13 @@ import { loadPersistedSnapshot } from "./store";
 // shell that used to branch on `!preload`) is retired — a browser without a
 // preload is now only reachable through `?demo` for the visual gates and
 // marketing shots, which never run the real boot path.
-// TODO(BET-audit L10): this cast widens the ~25-method preload subset to the
-// full `Api` type; the preload shim and httpApi should eventually share one
-// typed contract rather than relying on the renderer assuming the subset
-// masks missing methods.
-const preload = (window as unknown as { __mantaPreload?: Api }).__mantaPreload;
+// BET-733 (L10): `__mantaPreload` is typed as the HONEST `PreloadApi` subset,
+// NOT the full `Api`. Casting it to `Api` was the lie that let renderer code
+// call `window.api.<method>` (typed full-`Api`) for methods the preload does
+// not implement. Post-pairing window.api is httpApi (the full contract);
+// pre-pairing it is this subset, so any `Api` method missing here is a real
+// runtime absence that must be guarded (`window.api.X?.()`).
+const preload = (window as unknown as { __mantaPreload?: PreloadApi }).__mantaPreload;
 
 // Demo mode (BET-302): parsed once at module load so the demo branch is
 // reachable from inside boot() without re-parsing the URL.
@@ -92,7 +94,7 @@ async function bootDemo(): Promise<void> {
   );
 }
 
-async function chooseDesktopTransport(realPreload: Api): Promise<void> {
+async function chooseDesktopTransport(realPreload: PreloadApi): Promise<void> {
   // Desktop always uses httpApi (BET-82: SSH main path gone).
   // The real preload already lives at window.__mantaPreload (exposed read-only by
   // the preload's contextBridge) — we NEVER write to that name. Here we only

--- a/src/server/opencode.cachewrite.test.mjs
+++ b/src/server/opencode.cachewrite.test.mjs
@@ -1,0 +1,79 @@
+// opencode.cachewrite.test.mjs — source-reading guard for the bare cache-write
+// bug class.
+//
+// AGENTS.md documents (twice) a gotcha on `src/server/opencode.mjs`:
+//
+//   "GOTCHA — every cache write MUST go through `rememberSessionDirectory`,
+//    never a bare `sessionDirectoryCache.set`."
+//
+// Only `rememberSessionDirectory` fires the `onSessionDirectoryAdded`
+// listeners that make the bus open a SCOPED `/event?directory=` stream for a
+// session directory. A bare `sessionDirectoryCache.set(...)` populates the map
+// but the bus never learns to open the scoped stream — the exact "SSE broken
+// in *existing* sessions, fine in new ones" bug: an existing/restored session
+// resolved on its first prompt, but its response events vanished because the
+// matching scoped stream never opened. The renderer shows the user message
+// optimistically then a blank assistant turn forever, with no JS error.
+//
+// This repo has no ESLint config, so the guard is a source-reading node:test
+// (the repo's established canary pattern — see stateSandbox.test.mjs): read
+// the opencode.mjs source and assert that every `sessionDirectoryCache.set(`
+// call sits inside one of the two sanctioned functions ONLY
+// (`rememberSessionDirectory`, `cacheSessionDirectoryQuiet` — the latter is
+// for the subscribe bootstrap, which intentionally does NOT open a scoped
+// stream). If a future edit adds a bare `.set` anywhere else, this fails RED
+// with a message pointing at `rememberSessionDirectory`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "opencode.mjs"), "utf8");
+
+// Find the [start, end) character range of a `function <name>(...) { ... }`
+// body: from the function declaration up to the NEXT top-level function
+// declaration. Kept deliberately simple (end at the next `\nfunction `).
+function functionRange(name) {
+  const needle = `function ${name}`;
+  const start = source.indexOf(needle);
+  assert.ok(start >= 0, `opencode.mjs is missing its sanctioned function ${name} — has it been renamed/deleted?`);
+  const nextFn = source.indexOf("\nfunction ", start + 1);
+  const end = nextFn >= 0 ? nextFn : source.length;
+  return { start, end };
+}
+
+const remember = functionRange("rememberSessionDirectory");
+const quiet = functionRange("cacheSessionDirectoryQuiet");
+
+test("every sessionDirectoryCache.set lives in a sanctioned function", () => {
+  const calls = [...source.matchAll(/sessionDirectoryCache\.set\(/g)];
+  // Exactly the two sanctioned calls, and no others, may exist.
+  assert.equal(
+    calls.length,
+    2,
+    `expected exactly 2 sessionDirectoryCache.set() calls (in ` +
+      `rememberSessionDirectory + cacheSessionDirectoryQuiet), found ${calls.length}. ` +
+      `AGENTS.md: every cache write MUST go through rememberSessionDirectory — a bare ` +
+      `.set silently breaks scoped SSE streams in *existing* sessions.`,
+  );
+
+  let inSanctioned = 0;
+  for (const m of calls) {
+    const at = m.index;
+    const inRemember = at >= remember.start && at < remember.end;
+    const inQuiet = at >= quiet.start && at < quiet.end;
+    assert.ok(
+      inRemember || inQuiet,
+      `sessionDirectoryCache.set() at char ${at} (` +
+        source.slice(Math.max(0, at - 40), at + 40).replace(/\n/g, "\\n") +
+        `) is OUTSIDE both sanctioned functions. It must go through ` +
+        `rememberSessionDirectory so the scoped-stream listeners fire ` +
+        `(AGENTS.md: bare .set = "SSE broken in existing sessions").`,
+    );
+    if (inRemember || inQuiet) inSanctioned += 1;
+  }
+  assert.equal(inSanctioned, 2);
+});

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -565,3 +565,48 @@ export interface Api {
   // can show the user why their YAML didn't load.
   pluginsRegistry(): Promise<PluginRegistryRow[]>;
 }
+
+/**
+ * The HONEST subset of `Api` that the Electron preload runtime actually
+ * implements (`src/preload/index.ts`'s `api` object literal, exposed as
+ * `window.__mantaPreload`).
+ *
+ * This is the KEY to the "Api type lie" (BET-733 / audit L10): `main.tsx`
+ * used to cast `__mantaPreload` to the FULL `Api`, letting renderer code
+ * call `window.api.<method>` for methods the preload does NOT have — a
+ * compile-legal call that is `undefined` at runtime until httpApi is
+ * installed post-pairing (the exact class of bug behind the dead-subscription
+ * P0). Typing `__mantaPreload` as `PreloadApi` makes those missing methods a
+ * compile-visible absence: anything on `PreloadApi` is guaranteed implemented;
+ * anything on `Api` but absent from `PreloadApi` must go through a guard.
+ *
+ * Enumerated from `src/preload/index.ts`'s object literal. The preload also
+ * implements methods NOT in the `Api` contract (pairing / installer / some OS
+ * bridges such as `authUnpair`, `readClipboardText`, `readLocalFile`,
+ * `onPairLink`, `dialogShowOpenFile`, the `installer*` family) — those are
+ * reached via `window.__mantaPreload` (typed `MantaPreload` in
+ * `src/renderer/preloadAccess.ts`), never through `window.api`/`Api`, so they
+ * don't belong here.
+ *
+ * Do NOT weaken `Api` — `httpApi` must still be typecheck-enforced against the
+ * FULL contract. This type only narrows what the preload bridge claims.
+ */
+export type PreloadApi = Pick<
+  Api,
+  | "configGet"
+  | "authClaim"
+  | "clipboardWriteText"
+  | "clipboardReadImage"
+  | "onScreenshotDetected"
+  | "onDesktopNotify"
+  | "getPathForFile"
+  | "peekRemoteFile"
+  | "openExternal"
+  | "revealInFolder"
+  | "onServerUpdateAvailable"
+  | "autoUpdateDownload"
+  | "autoUpdateInstall"
+  | "onAutoUpdateAvailable"
+  | "onAutoUpdateDownloaded"
+  | "onAutoUpdateError"
+>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1261,6 +1261,21 @@ export type PluginRegistryRow =
 
 export type OpencodeRole = "user" | "assistant";
 
+// Token accounting surfaced by the running indicator / context bar. Lives here
+// (shared, not renderer/chatShared) because it also types the `tokens` field
+// on OpencodeMessageInfo below — previously the renderer read tokens off an
+// explicit `as unknown as { tokens?: TokenUsage }` cast because the field
+// wasn't declared; declaring it kills those casts (BET-733 / audit L10).
+// `src/renderer/chatShared.tsx` re-exports this so existing renderer imports
+// are unchanged.
+export type TokenUsage = {
+  total?: number;
+  input: number;
+  output: number;
+  reasoning: number;
+  cache: { read: number; write: number };
+};
+
 export type OpencodeMessageInfo = {
   id: string;             // msg_...
   sessionID: string;      // ses_...
@@ -1269,6 +1284,10 @@ export type OpencodeMessageInfo = {
   // assistant-only fields surfaced here for the model/cost line in the UI:
   modelID?: string;
   providerID?: string;
+  // AssistantMessage.tokens from the OpenAPI doc — carried on the wire for
+  // assistant messages; used by the context bar / turn footers. Optional
+  // because user messages (and older/streaming snapshots) don't carry it.
+  tokens?: TokenUsage;
 };
 
 // Generic part shape. Each part carries id/messageID/type plus arbitrary


### PR DESCRIPTION
## BET-733 — Renderer/main correctness nits

Small, independent correctness fixes from audit §5 M1 + L1-L4 + L6 + L10 plus the server cache-write lint guard.

**Base: origin/main @ `f5bdc221`**

### Task 1 (M1) — stale providerID in the SSE error handler
- `useSseBus.ts`: added a `providerIDRef` mirror; the auth-error banner now classifies against the current provider, not the mount-time value (the SSE subscription effect deps are `[sessionId]`, so the plain param was captured once).
- `ChatPanel.tsx`: `providerID` is now derived from `modelOverride` via `useMemo` (moved `modelOverride` state above the `useSseBus` call), so the localStorage read + parse runs on model change, not on every keystroke.

### Task 2 (L1) — side effects inside the `onQueuePop` state updater
`ChatPanel.tsx`: the `setMessageQueue` updater is now pure — the popped value is computed inside it, and `setInput` + the `requestAnimationFrame` focus run after (StrictMode double-invoke no longer fires them twice).

### Task 3 (L2) — `submit`'s missing deps
Verified first (not already resolved by BET-709's drain rewrite). Added `tmuxSession`/`windowIndex` to the dep array (prompt history keyed to the owning window). `activeTodos` + the session ops (`clearSession`/`forkSession`/`compactSession`) are declared *after* `submit`, so they cannot be added to its dep array (TDZ ReferenceError at the declaration line). Per the codebase's established `commandsRef` pattern (comment at `ChatPanel.tsx:1059` documents the same ordering workaround), `submit` now reads current-value ref mirrors (`activeTodosRef`, `clearSessionRef`, `forkSessionRef`, `compactSessionRef`).
- Queued-drain/auto-submit paths untouched: they call `submitRef.current`, never `submit`, so no effect re-fires. `useSseBus.test.tsx` queued-drain regressions pass (44 tests across the three hook suites).

### Task 4 (L3+L6) — timer cleanup on unmount
- `ChatPanel.tsx`: `childRefetchTimers` cleared on unmount (mirrors `useTranscriptState.ts`'s cleanup).
- `useTypeahead.ts`: `fileSearchTimer` cleared on unmount (previously only on keystroke).

### Task 5 (L4) — ConnectProvider poll cap resets
Verified first (not already fixed by BET-707). The `needsClaudeLogin` and `installingClaudeCli` poll effects were keyed on the whole `phase` object; cosmetic `{...phase, url}` / `inputError` writes re-ran them and reset `startedWall`, silently defeating the 5-minute cap. Narrowed both to the discriminant (`phase.kind` + the `ptySessionKey`, same shape as the file's own install-elapsed-timer effect).

### Task 6 (L10) — kill the `Api` type lie
1. Exported `PreloadApi = Pick<Api, [16 methods]>` in `src/shared/api.ts` — the honest intersection of the preload's object literal and the `Api` contract. `main.tsx` types `__mantaPreload` and `chooseDesktopTransport` with it instead of the full `Api` cast; removed the `TODO(BET-audit L10)` comment.
2. Declared `tokens?: TokenUsage` on `OpencodeMessageInfo` (`TokenUsage` moved to `src/shared/types.ts` as the single source, re-exported from `chatShared`) and deleted the three `as unknown as { tokens?: TokenUsage }` casts (`ChatPanel.tsx`, `chatUtils.ts` ×2) plus the demoFixture wrapper cast.
- **Type-error count surfaced by the honest PreloadApi: 0.** `main.tsx`'s only direct preload use is `configGet()`, which is in the `PreloadApi` subset, and `setWindowApi` accepts untyped `unknown` — so no additional pre-pairing guard sites materialized. The lie is killed at the type level regardless; `Api` itself is unweakened, so `httpApi` is still checked against the full contract.

### Task 7 — cache-write lint guard (server)
New source-reading node:test `src/server/opencode.cachewrite.test.mjs` (canary style, matching `stateSandbox.test.mjs`): asserts every `sessionDirectoryCache.set(` in `opencode.mjs` sits inside `rememberSessionDirectory` or `cacheSessionDirectoryQuiet` only, with the AGENTS.md "SSE broken in existing sessions" gotcha cited in the failure message.

### Verification results
- PR branch (`multica/BET-733-correctness-nits` @ `7d5f33c8`):
  - typecheck: exit 0, no errors
  - test: exit 0, **1630 pass / 0 fail / 0 skip**
- Base (`origin/main` @ `f5bdc221`): rebased on top; same suite green.
- Note: verification was run against the rebased tree after bringing the branch up to date with origin/main.
