### PR TITLE
Onboarding primary CTAs: adopt Button primitive (BET-742)

### DIFF
--- a/src/renderer/CustomProviderForm.tsx
+++ b/src/renderer/CustomProviderForm.tsx
@@ -27,8 +27,8 @@ import {
 } from "./chatUtils";
 import { Field } from "./Field";
 import { Checkbox } from "./Checkbox";
+import { Button } from "./Button";
 
-const ACCENT_SOLID = "var(--accent-solid)";
 const DANGER = "var(--danger)";
 
 type Phase = "editing" | "probing" | "ready";
@@ -261,27 +261,25 @@ export function CustomProviderForm({
       )}
       <div className="flex items-center gap-2">
         {phase !== "ready" ? (
-          <button
+          <Button
+            tone="primary"
             type="button"
             onClick={() => void probe()}
             disabled={busy || draftErr !== null}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
-            style={{ background: ACCENT_SOLID }}
           >
             {busy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
             {busy ? "Probing…" : "Probe endpoint"}
-          </button>
+          </Button>
         ) : (
-          <button
+          <Button
+            tone="primary"
             type="button"
             onClick={() => void save()}
             disabled={busy || checked.size === 0}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
-            style={{ background: ACCENT_SOLID }}
           >
             {busy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
             {busy ? "Saving…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -31,6 +31,7 @@ import {
 } from "../shared/setupLogic";
 import { detectPairClipboard } from "../shared/pairPayload";
 import { PairingCodeInput } from "./PairingCodeInput";
+import { Button } from "./Button";
 import { isValidBoxToken } from "../shared/transport.mjs";
 import { claimBox } from "./pairClaim";
 import { useStore } from "./store";
@@ -38,7 +39,6 @@ import { SshInstallStep } from "./SshInstallStep";
 import { getMantaPreload } from "./preloadAccess";
 import { channelConfig } from "../shared/channel.mjs";
 
-const ACCENT_SOLID = "var(--accent-solid)"; // filled buttons (BET-409 AA)
 const DANGER = "var(--danger)"; // inline error text
 const SERVER_URL_ERROR = "Server URL must start with http:// or https://";
 
@@ -377,14 +377,9 @@ function ManualPairForm({
           </code>{" "}
           on the box to get a code.
         </p>
-        <button
-          type="submit"
-          disabled={!connectEnabled}
-          className="inline-flex items-center gap-2 px-5 py-2 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
-          style={{ background: ACCENT_SOLID }}
-        >
+        <Button tone="primary" type="submit" disabled={!connectEnabled}>
           {submitting ? "Connecting…" : "Connect"}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/src/renderer/onboardingUi.tsx
+++ b/src/renderer/onboardingUi.tsx
@@ -6,7 +6,7 @@
 // of truth for the nav chrome. Pure step-model logic still lives in
 // onboardingUtils.ts; this module owns only the small shared JSX.
 
-const ACCENT_SOLID = "var(--accent-solid)";
+import { Button } from "./Button";
 
 // ── Brand mark ───────────────────────────────────────────────────────────────
 //
@@ -136,16 +136,10 @@ export function StepFooter({
         <ArrowLeft />
         Back
       </button>
-      <button
-        type="button"
-        onClick={onContinue}
-        disabled={continueDisabled}
-        className="inline-flex items-center gap-2 px-5 py-3 rounded-sm text-body font-medium text-on-accent transition-opacity disabled:opacity-40"
-        style={{ background: ACCENT_SOLID }}
-      >
+      <Button tone="primary" block type="button" onClick={onContinue} disabled={continueDisabled}>
         {continueLabel}
         <ArrowRight />
-      </button>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## What

BET-727 adopted the shared `Button` primitive but its migration list skipped the onboarding sub-step primary CTAs. This ticket migrates the four remaining hand-rolled `style={{ background: ACCENT_SOLID }}` primary-action buttons to `<Button tone="primary">`, deleting the inline styles and the now-unused local `ACCENT_SOLID` constants.

## Changes

- `PairStep.tsx` — "Connect" → `<Button tone="primary" type="submit">` (kept `type="submit"`, `disabled={!connectEnabled}`, label). Deleted `ACCENT_SOLID`.
- `CustomProviderForm.tsx` — "Probe endpoint" + "Save provider" → `<Button tone="primary" type="button">` (kept `type`, `onClick`, `disabled` per-branch, `Loader2` icons, busy labels). Deleted `ACCENT_SOLID`.
- `onboardingUi.tsx` — shared footer "Continue" → `<Button tone="primary" block type="button">` (the one site that gets `block` per D2; kept `onClick`, `disabled`, label, `ArrowRight`). Deleted `ACCENT_SOLID`.

Per issue D1–D4: all four become `tone="primary"`; only onboardingUi's Continue gets `block`; the inline style and hand-rolled chrome are deleted rather than moved; `type`, `disabled`, label and icon children preserved exactly. No change to `Button.tsx`.

## Verification

**Files changed:** 3. `13 insertions(+), 26 deletions(-)` — net-negative diff.

**Acceptance criteria:**
- `grep -rn "background: ACCENT_SOLID"` over the three files → nothing.
- `grep -rn "hover:brightness-110\|hover:opacity-90" src/renderer/ --include=*.tsx | grep -v Button.tsx` → still nothing (the sole hit is `Button.test.tsx`, a pre-existing test snapshot of Button's own tone on `main`, untouched by this PR).
- Net-negative diff: 13+/26−.
- `npm run typecheck` → exit 0.
- `npm test` → 1630 pass / 0 fail, including the BET-588 chrome-ownership test.

Base: origin/main @ 1de5c737
