### PR TITLE
fix(renderer): SessionMenu adopts WAI-ARIA menu-button focus (BET-741)

### DIFF
--- a/src/renderer/IconButton.tsx
+++ b/src/renderer/IconButton.tsx
@@ -45,8 +45,6 @@ export function IconButton({
   size = "md",
   ariaHaspopup,
   ariaExpanded,
-  ariaOwns,
-  ariaActiveDescendant,
   hook,
   disabled,
 }: {
@@ -62,14 +60,6 @@ export function IconButton({
   /** Menu/popover semantics for a trigger-style icon button. */
   ariaHaspopup?: "menu" | "dialog" | "listbox" | "grid" | "tree" | "true" | "false";
   ariaExpanded?: boolean;
-  /** The id of a popup surface this trigger owns but does not contain in the
-   *  DOM (e.g. a sibling `Dropdown`) — makes an `ariaActiveDescendant`
-   *  relationship well-formed when the two aren't ancestor/descendant. */
-  ariaOwns?: string;
-  /** The currently-highlighted descendant's id, for a trigger that keeps DOM
-   *  focus while driving a roving highlight in its (possibly sibling) popup —
-   *  e.g. SessionHeader's ⋯ menu (BET-726 review cycle 1 Question 1). */
-  ariaActiveDescendant?: string;
   /** Renders the native `disabled` attribute + the not-allowed cursor, and suppresses the hover fill (a disabled icon button stays flat). */
   disabled?: boolean;
   /**
@@ -96,8 +86,6 @@ export function IconButton({
       title={title ?? label}
       aria-haspopup={ariaHaspopup}
       aria-expanded={ariaExpanded}
-      aria-owns={ariaOwns}
-      aria-activedescendant={ariaActiveDescendant}
     >
       {cloneElement(icon, { size: iconSize, "aria-hidden": true })}
     </button>

--- a/src/renderer/MenuItem.test.tsx
+++ b/src/renderer/MenuItem.test.tsx
@@ -110,7 +110,7 @@ describe("MenuItem", () => {
     h = mount(<MenuItem>Fork session</MenuItem>);
     const el = h.container.firstElementChild as HTMLElement;
     expect(el.className).toBe(
-      `${ITEM_BASE} text-text-muted hover:bg-fill-hover hover:text-text`,
+      `${ITEM_BASE} text-text-muted hover:bg-fill-hover hover:text-text focus:bg-fill-hover`,
     );
     expect(el.className).toContain("text-label");
     expect(el.className).toContain("px-2");
@@ -188,21 +188,23 @@ describe("MenuItem", () => {
     expect(clicked).toBe(true);
   });
 
-  // BET-726 Task 3.1: the roving keyboard highlight (SessionHeader's ⋯ menu)
-  // is a static `--fill-hover` fill, independent of `variant` — the SAME
-  // static fill MenuOption's `active` prop gives the model/effort menus.
-  it("highlighted applies the static bg-fill-hover fill; unset it does not", () => {
-    h = mount(<MenuItem highlighted>row</MenuItem>);
-    let classes = (h.container.firstElementChild as HTMLElement).className.split(/\s+/);
-    expect(classes).toContain("bg-fill-hover");
-    h.unmount();
+  // BET-741: the roving keyboard highlight (SessionHeader's ⋯ menu) is now
+  // real DOM focus, painted by MenuItem's `:focus` fill — the SAME static
+  // `--fill-hover` MenuOption's `active` prop gives the model/effort menus,
+  // and the same fill the old `highlighted` prop applied. Every variant
+  // carries it so a roved row reads highlighted regardless of variant.
+  it("paints the focused row with the static bg-fill-hover fill on every variant", () => {
+    for (const variant of ["normal", "danger", "active"] as const) {
+      h?.unmount();
+      h = mount(<MenuItem variant={variant}>row</MenuItem>);
+      const classes = (h.container.firstElementChild as HTMLElement).className.split(/\s+/);
+      expect(classes, `${variant}: roving focus must show the fill`).toContain("focus:bg-fill-hover");
+    }
+    h?.unmount();
     h = mount(<MenuItem>row</MenuItem>);
-    classes = (h.container.firstElementChild as HTMLElement).className.split(/\s+/);
-    // The static (non-`hover:`) token is absent, but the `:hover` variant
-    // stays for a mouse user (and no trailing-whitespace artifact from the
-    // conditional either — that regressed MenuItem.test.tsx once already).
+    const classes = (h.container.firstElementChild as HTMLElement).className.split(/\s+/);
+    // No trailing static (non-`:hover`/`:focus`) token is applied by default.
     expect(classes).not.toContain("bg-fill-hover");
-    expect(classes).toContain("hover:bg-fill-hover");
   });
 
   it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
@@ -392,7 +394,14 @@ describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", (
 // focus after the click that opened the menu — and relies on native bubbling
 // to reach the root's onKeyDown, the same technique PaletteShell.test.tsx
 // already uses for its Escape coverage.
-describe("SessionMenu — keyboard roving highlight (BET-726 Task 3.1)", () => {
+// BET-741: the ⋯ menu's keyboard roving now uses the standard WAI-ARIA
+// menu-button pattern — real DOM focus roves across the `role="menuitem"`
+// rows with a roving tabIndex, replacing BET-726's aria-activedescendant
+// stand-in on the trigger (ARIA 1.2 doesn't allow `aria-activedescendant` on
+// a `role="button"`). The visible highlight is MenuItem's own `:focus` fill,
+// so these assert on which row actually holds focus (document.activeElement)
+// and which row is tabbable (tabIndex), not on a class.
+describe("SessionMenu — keyboard roving focus (BET-741)", () => {
   let h: Harness | null = null;
   afterEach(() => {
     h?.unmount();
@@ -414,50 +423,31 @@ describe("SessionMenu — keyboard roving highlight (BET-726 Task 3.1)", () => {
     });
   }
 
-  // BET-726 review cycle 1 Question 1: the highlight used to be visual-only
-  // — a screen reader following the arrow keys was told nothing, since DOM
-  // focus never leaves the trigger. `aria-activedescendant` on the trigger
-  // (the element that actually holds focus, matching ModelMenu's own
-  // `<input>`-carries-it idiom) plus `aria-owns` (trigger and Dropdown are
-  // DOM siblings, not ancestor/descendant) closes that gap.
-  it("wires aria-owns + aria-activedescendant on the trigger as the highlight moves", () => {
-    const trigger = openMenu();
-    const dropdown = h!.container.querySelector('[role="menu"]') as HTMLElement;
-    expect(trigger.getAttribute("aria-owns")).toBe(dropdown.id);
-    expect(trigger.hasAttribute("aria-activedescendant")).toBe(false);
-    press(trigger, "ArrowDown");
-    const chatRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Chat"),
+  function rowByText(text: string): HTMLElement {
+    const el = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
+      (b) => b.textContent?.includes(text),
     )!;
-    expect(chatRow.id).toBeTruthy();
-    expect(trigger.getAttribute("aria-activedescendant")).toBe(chatRow.id);
-    press(trigger, "ArrowDown");
-    const terminalRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Terminal"),
-    )!;
-    expect(trigger.getAttribute("aria-activedescendant")).toBe(terminalRow.id);
-  });
+    expect(el, `expected a "${text}" menu row`).toBeTruthy();
+    return el;
+  }
 
-  it("ArrowDown highlights the first row (bg-fill-hover) and Enter activates it", () => {
+  it("ArrowDown focuses the first row (tabIndex=0) and Enter activates it", () => {
     let changed: unknown = null;
     const trigger = openMenu({ onModeChange: (m) => { changed = m; } });
     press(trigger, "ArrowDown");
-    const chatRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Chat"),
-    )!;
-    expect(chatRow.className).toContain("bg-fill-hover");
+    const chatRow = rowByText("Chat");
+    expect(document.activeElement).toBe(chatRow);
+    expect(chatRow.tabIndex).toBe(0);
     press(trigger, "Enter");
     expect(changed).toBe("chat");
   });
 
-  it("ArrowUp before any ArrowDown wraps to the LAST row (End of the list)", () => {
+  it("ArrowUp before any ArrowDown wraps focus to the LAST row", () => {
     let deleted = 0;
     const trigger = openMenu({ onDelete: () => deleted++ });
     press(trigger, "ArrowUp");
-    const deleteRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Delete session"),
-    )!;
-    expect(deleteRow.className).toContain("bg-fill-hover");
+    const deleteRow = rowByText("Delete session");
+    expect(document.activeElement).toBe(deleteRow);
     // Enter on "Delete session" opens the confirm, not onDelete directly
     // (BET-724 §D7) — same activation path a click would take.
     press(trigger, "Enter");
@@ -465,32 +455,32 @@ describe("SessionMenu — keyboard roving highlight (BET-726 Task 3.1)", () => {
     expect(h!.text()).toContain("Delete this session?");
   });
 
-  it("Home/End jump to the first/last row", () => {
+  it("Home/End rove focus to the first/last row", () => {
     const trigger = openMenu();
     press(trigger, "End");
-    let deleteRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Delete session"),
-    )!;
-    expect(deleteRow.className).toContain("bg-fill-hover");
+    let deleteRow = rowByText("Delete session");
+    expect(document.activeElement).toBe(deleteRow);
+    expect(deleteRow.tabIndex).toBe(0);
     press(trigger, "Home");
-    const chatRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Chat"),
-    )!;
-    expect(chatRow.className).toContain("bg-fill-hover");
-    deleteRow = [...h!.container.querySelectorAll<HTMLElement>("button[role='menuitem']")].find(
-      (b) => b.textContent?.includes("Delete session"),
-    )!;
-    expect(deleteRow.className).not.toContain("bg-fill-hover");
+    const chatRow = rowByText("Chat");
+    expect(document.activeElement).toBe(chatRow);
+    expect(chatRow.tabIndex).toBe(0);
+    // The previously focused row is no longer tabbable (roving tabIndex).
+    expect(deleteRow.tabIndex).toBe(-1);
   });
 
-  it("re-opening the menu resets the highlight (no stale index carries over)", () => {
+  it("re-opening the menu resets focus: no stale row is focused or tabbable", () => {
     const trigger = openMenu();
     press(trigger, "ArrowDown");
-    // Close (click-away semantics via Escape, which useClickAway owns) then
-    // reopen — the highlight must not still be on row 0's neighbour.
+    expect(rowByText("Chat").tabIndex).toBe(0);
+    // Escape closes (and returns focus to the trigger); reopen.
     press(trigger, "Escape");
+    expect(document.activeElement).toBe(trigger);
     act(() => trigger.click());
-    const anyHighlighted = h!.container.querySelector("button[role='menuitem'].bg-fill-hover");
-    expect(anyHighlighted).toBeNull();
+    expect(
+      h!.container.querySelector("button[role='menuitem'][tabindex='0']"),
+    ).toBeNull();
+    const menu = h!.container.querySelector('[role="menu"]') as HTMLElement;
+    expect(document.activeElement).toBe(menu);
   });
 });

--- a/src/renderer/MenuItem.tsx
+++ b/src/renderer/MenuItem.tsx
@@ -52,10 +52,15 @@ const ITEM_BASE =
   "flex w-full items-center gap-3 px-2 py-2 mb-1 last:mb-0 rounded-md text-left text-label font-medium transition-colors duration-150";
 // C1: every variant that sets a hover background also declares the matching
 // foreground so the row never renders low-contrast text on its fill.
+// `focus:bg-fill-hover` paints the SAME static roving highlight on the row
+// DOM focus owns (BET-741): the ⋯ menu's keyboard roving now moves real DOM
+// focus across the rows, so the highlight is the focused row showing the
+// `--fill-hover` pill — no component state, no aria-activedescendant.
 const VARIANT: Record<MenuItemVariant, string> = {
-  normal: "text-text-muted hover:bg-fill-hover hover:text-text",
-  danger: "text-danger hover:bg-danger-bg",
-  active: "text-accent hover:bg-fill-hover",
+  normal:
+    "text-text-muted hover:bg-fill-hover hover:text-text focus:bg-fill-hover",
+  danger: "text-danger hover:bg-danger-bg focus:bg-fill-hover",
+  active: "text-accent hover:bg-fill-hover focus:bg-fill-hover",
 };
 
 export function MenuItem({
@@ -64,8 +69,7 @@ export function MenuItem({
   children,
   trailing,
   onSelect,
-  highlighted = false,
-  id,
+  tabIndex = -1,
 }: {
   /** Which surface + foreground the row carries. normal is the default. */
   variant?: MenuItemVariant;
@@ -77,22 +81,19 @@ export function MenuItem({
   trailing?: ReactNode;
   /** Called when the row is chosen. */
   onSelect?: () => void;
-  /** The roving keyboard highlight (BET-726 Task 3.1) — the SAME static
-   *  `--fill-hover` fill MenuOption's `active` prop gives the model/effort
-   *  menus, applied unconditionally instead of only on `:hover`. */
-  highlighted?: boolean;
-  /** Option id — the aria-activedescendant target for a caller-owned roving
-   *  highlight (BET-726 review cycle 1 Question 1), same role `MenuOption`'s
-   *  `id` plays for the model/effort menus. */
-  id?: string;
+  /** Roving-tabindex slot (BET-741): menu rows are keyboard-actuated — every
+   *  `role="menuitem"` starts off-tab (-1) and the owner roves focus by
+   *  raising the focused row to 0 (and dropping the rest to -1) while the
+   *  menu is open. */
+  tabIndex?: number;
 }) {
   return (
     <button
       type="button"
-      id={id}
       role="menuitem"
+      tabIndex={tabIndex}
       onClick={onSelect}
-      className={`${ITEM_BASE} ${VARIANT[variant]}${highlighted ? " bg-fill-hover" : ""}`}
+      className={`${ITEM_BASE} ${VARIANT[variant]}`}
     >
       {icon && cloneElement(icon, { size: 14, "aria-hidden": true })}
       <span className="flex-1">{children}</span>
@@ -151,11 +152,10 @@ export function Dropdown({
 }: {
   /** Optional `manta-*` identity class for the call site (no styling). */
   hook?: string;
-  /** Optional DOM id — lets a caller-owned trigger reference this surface via
-   *  `aria-owns` when it drives a roving `aria-activedescendant` highlight
-   *  (BET-726 review cycle 1 Question 1: the trigger and this surface are
-   *  DOM siblings, not ancestor/descendant, so `aria-owns` is what makes the
-   *  activedescendant relationship well-formed). */
+  /** Optional DOM id — still used by the model/effort listbox menus (rows
+   *  reference it via `aria-activedescendant`, the correct combobox idiom).
+   *  SessionHeader's ⋯ menu no longer passes one (BET-741 moved it to real
+   *  DOM focus + roving tabIndex, which needs no descendant ids). */
   id?: string;
   /** below (top-full, SessionHeader's menu) | above (bottom-full, composer). */
   placement?: DropdownPlacement;

--- a/src/renderer/SessionHeader.menu.test.tsx
+++ b/src/renderer/SessionHeader.menu.test.tsx
@@ -115,3 +115,44 @@ describe("SessionHeader session menu launcher entries (BET-467)", () => {
     expect(h!.text()).toContain("Fork session");
   });
 });
+
+// BET-741: the ⋯ menu adopts the standard WAI-ARIA menu-button focus pattern
+// (real DOM focus, roving tabIndex) in place of the BET-726
+// aria-activedescendant stand-in on the trigger.
+describe("SessionHeader session menu — WAI-ARIA focus (BET-741)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    installMockApi();
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("moves focus into the menu surface on open", async () => {
+    h = mount(<ChatPanel {...PROPS} onModeChange={() => {}} />);
+    await h!.flush();
+    openMenu(h!);
+
+    const menu = h!.container.querySelector('[role="menu"]') as HTMLElement | null;
+    expect(menu).not.toBeNull();
+    expect(document.activeElement).toBe(menu);
+  });
+
+  it("returns focus to the trigger on Escape", async () => {
+    h = mount(<ChatPanel {...PROPS} onModeChange={() => {}} />);
+    await h!.flush();
+    const trigger = openMenu(h!);
+
+    const menu = h!.container.querySelector('[role="menu"]') as HTMLElement;
+    expect(document.activeElement).toBe(menu);
+    act(() => {
+      menu.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(h!.container.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -10,7 +10,7 @@
 // result) and handlers (fork / compact / clear / delete) are passed in as
 // props by ChatPanel, which owns the session lifecycle.
 
-import { useEffect, useId, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight } from "lucide-react";
 import {
   ctxStageColor,
@@ -492,30 +492,54 @@ function SessionMenu({
   // BET-724 §D7: Delete/Clear from this menu now confirm first, matching the
   // sidebar's inline delete confirm — previously both fired instantly.
   const [confirm, setConfirm] = useState<"delete" | "clear" | null>(null);
-  // BET-726 Task 3.1: the roving keyboard highlight, same index-state shape
-  // as ModelMenu's highlight loop (chatUtils' moveMenuHighlight) — adapted
-  // from ModelMenu's search input to this menu's root div, since there is no
-  // input here to hang the keydown on.
-  const [highlight, setHighlight] = useState(-1);
   const rootRef = useRef<HTMLDivElement>(null);
   useClickAway(rootRef, open, () => setOpen(false));
 
-  // BET-726 review cycle 1 Question 1: the highlight above was visual-only —
-  // a screen reader following the arrow keys heard nothing, because DOM
-  // focus never leaves the ⋯ trigger (this menu has no input to move focus
-  // into, unlike ModelMenu's search box). `aria-activedescendant` on the
-  // element that DOES hold focus is exactly ModelMenu's own idiom (its
-  // `<input>` carries `aria-activedescendant`, not the Dropdown surface) —
-  // applied here to the trigger instead. `useId` keeps ids collision-safe
-  // if more than one SessionHeader is ever mounted at once.
-  const menuUid = useId();
-  const dropdownDomId = `session-menu-${menuUid}`;
-  const rowDomId = (rowId: string) => `session-menu-${menuUid}-${rowId.replace(/:/g, "-")}`;
+  // WAI-ARIA menu-button pattern (BET-741): real DOM focus replaces the
+  // BET-726 active-descendant stand-in (a role="button" can't carry one).
+  // On open, focus moves into the
+  // `role="menu"` surface; the arrow keys rove across the `role="menuitem"`
+  // rows (roving tabIndex: the focused row is the only tabbable one) and the
+  // visual highlight is MenuItem's own `:focus` fill — no highlight state.
+  // `focusedIndexRef` tracks the roved row so tabIndex can rove with it.
+  const focusedIndexRef = useRef(-1);
 
-  // Reset the roving highlight each time the menu (re)opens, so a stale
-  // index from a previous open never carries over.
+  const menuRows = () =>
+    Array.from(
+      rootRef.current?.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]') ?? [],
+    );
+
+  // Focus the row at `idx` (wrapping handled by the caller) and rove
+  // tabIndex so only it is tabbable while the menu is open.
+  const focusRow = (idx: number) => {
+    const rows = menuRows();
+    const prev = rows[focusedIndexRef.current];
+    const next = rows[idx];
+    if (prev && prev !== next) prev.tabIndex = -1;
+    if (next) next.tabIndex = 0;
+    next?.focus();
+    focusedIndexRef.current = idx;
+  };
+
+  const focusTrigger = () =>
+    rootRef.current
+      ?.querySelector<HTMLButtonElement>('button[aria-label="Session actions"]')
+      ?.focus();
+
+  // On open, move focus into the menu surface and reset the roving tabIndex
+  // so no stale row from a previous open is left tabbable. Focus lands on the
+  // surface, not a row; the first arrow key then drops it onto a row.
   useEffect(() => {
-    if (open) setHighlight(-1);
+    if (!open) return;
+    const menu = rootRef.current?.querySelector<HTMLElement>('[role="menu"]');
+    menu?.querySelectorAll('button[role="menuitem"]').forEach((el) => {
+      (el as HTMLButtonElement).tabIndex = -1;
+    });
+    focusedIndexRef.current = -1;
+    if (menu) {
+      menu.tabIndex = -1;
+      menu.focus();
+    }
   }, [open]);
 
   const hasMode = !!onModeChange;
@@ -528,72 +552,53 @@ function SessionMenu({
     if (onModeChange) onModeChange(m);
   };
 
-  // The flat, keyboard-navigable row order — same order the rows render in
-  // below, so `highlight`'s index lines up with the rendered row it lights.
-  const rowIds: string[] = [
-    ...(hasMode
-      ? [
-          "mode:chat",
-          "mode:terminal",
-          ...(availableLaunchers ?? []).map((l) => `mode:tui:${l.id}`),
-        ]
-      : []),
-    "fork",
-    "compact",
-    "clear",
-    "delete",
-  ];
-  const highlightedRow = highlight >= 0 ? rowIds[highlight] : undefined;
-
-  const activateRow = (id: string | undefined) => {
-    if (!id) return;
-    if (id === "fork") { setOpen(false); onFork(); return; }
-    if (id === "compact") { setOpen(false); onCompact(); return; }
-    if (id === "clear") { setOpen(false); setConfirm("clear"); return; }
-    if (id === "delete") { setOpen(false); setConfirm("delete"); return; }
-    if (id.startsWith("mode:")) { setOpen(false); switchMode(id.slice("mode:".length) as SessionMode); }
-  };
-
   const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!open) return;
+    const rows = menuRows();
+    if (rows.length === 0) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setHighlight((h) => moveMenuHighlight(h, 1, rowIds.length));
+      focusRow(moveMenuHighlight(focusedIndexRef.current, 1, rows.length));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setHighlight((h) => moveMenuHighlight(h, -1, rowIds.length));
+      focusRow(moveMenuHighlight(focusedIndexRef.current, -1, rows.length));
     } else if (e.key === "Home") {
-      if (rowIds.length > 0) {
-        e.preventDefault();
-        setHighlight(0);
-      }
+      e.preventDefault();
+      focusRow(0);
     } else if (e.key === "End") {
-      if (rowIds.length > 0) {
-        e.preventDefault();
-        setHighlight(rowIds.length - 1);
-      }
+      e.preventDefault();
+      focusRow(rows.length - 1);
     } else if (e.key === "Enter") {
-      if (highlightedRow) {
+      // Activate the focused row the same path a click takes: rows are real
+      // `<button role="menuitem">`, so Enter natively fires the focused
+      // button's click → onSelect → closes + activates. Guard on focus
+      // actually being on a row — right after open (surface focused, nothing
+      // roved yet) Enter is ignored, matching the pre-BET-741 behaviour where
+      // Enter with no highlight did nothing.
+      const focused = rows[focusedIndexRef.current];
+      if (focused && document.activeElement === focused) {
         e.preventDefault();
-        activateRow(highlightedRow);
+        focused.click();
       }
+    } else if (e.key === "Escape") {
+      // Close and hand focus back to the trigger. useClickAway also closes on
+      // Escape (document keydown) but cannot restore focus — that's this
+      // branch's job.
+      e.preventDefault();
+      setOpen(false);
+      focusTrigger();
     }
-    // Escape already closes the menu via useClickAway's document keydown
-    // listener (bound above, gated on `open`) — nothing to add here.
   };
 
   const item = (
-    id: string,
     icon: React.ReactElement,
     label: string,
     onClick: () => void,
     danger = false,
   ) => (
     <MenuItem
-      id={rowDomId(id)}
       icon={icon}
       variant={danger ? "danger" : "normal"}
-      highlighted={highlightedRow === id}
       onSelect={() => {
         setOpen(false);
         onClick();
@@ -604,7 +609,6 @@ function SessionMenu({
   );
 
   const modeItem = (
-    id: string,
     icon: React.ReactElement,
     label: string,
     m: SessionMode,
@@ -612,10 +616,8 @@ function SessionMenu({
     const active = isActive(m);
     return (
       <MenuItem
-        id={rowDomId(id)}
         icon={icon}
         variant={active ? "active" : "normal"}
-        highlighted={highlightedRow === id}
         trailing={
           active ? (
             <span className="text-text-faint" aria-hidden="true">
@@ -642,18 +644,16 @@ function SessionMenu({
         onClick={() => setOpen((v) => !v)}
         ariaHaspopup="menu"
         ariaExpanded={open}
-        ariaOwns={open ? dropdownDomId : undefined}
-        ariaActiveDescendant={open ? (highlightedRow ? rowDomId(highlightedRow) : undefined) : undefined}
       />
       {open && (
-        <Dropdown hook="manta-session-menu-dropdown" id={dropdownDomId}>
+        <Dropdown hook="manta-session-menu-dropdown">
           {hasMode && (
             <>
               <div className={`${GROUP_LABEL} pt-1`} role="presentation">
                 Mode
               </div>
-              {modeItem("mode:chat", <MessageSquare size={14} aria-hidden="true" />, "Chat", "chat")}
-              {modeItem("mode:terminal", <Terminal size={14} aria-hidden="true" />, "Terminal", "terminal")}
+              {modeItem(<MessageSquare size={14} aria-hidden="true" />, "Chat", "chat")}
+              {modeItem(<Terminal size={14} aria-hidden="true" />, "Terminal", "terminal")}
               {availableLaunchers && availableLaunchers.length > 0 && (
                 <>
                   <div className={`${GROUP_LABEL} pt-3`} role="presentation">
@@ -661,7 +661,6 @@ function SessionMenu({
                   </div>
                   {availableLaunchers.map((l) =>
                     modeItem(
-                      `mode:tui:${l.id}`,
                       <Bot size={14} aria-hidden="true" />,
                       l.label,
                       `tui:${l.id}` as SessionMode,
@@ -674,26 +673,22 @@ function SessionMenu({
           )}
 
           {item(
-            "fork",
             <GitFork size={14} aria-hidden="true" />,
             "Fork session",
             onFork,
           )}
           {item(
-            "compact",
             <Minimize2 size={14} aria-hidden="true" />,
             "Compact context",
             onCompact,
           )}
           {item(
-            "clear",
             <Eraser size={14} aria-hidden="true" />,
             "Clear session",
             () => setConfirm("clear"),
           )}
           <div className="my-1 border-t border-border-subtle" role="separator" />
           {item(
-            "delete",
             <Trash2 size={14} aria-hidden="true" />,
             "Delete session",
             () => setConfirm("delete"),


### PR DESCRIPTION
## What

BET-741: the SessionHeader ⋯ menu now uses the standard WAI-ARIA menu-button focus pattern instead of the BET-726 `aria-activedescendant` stand-in (which ARIA 1.2 doesn't allow on a `role="button"`).

- **Focus moves into the `role="menu"` surface on open**, roves across the `role="menuitem"` rows with the arrow keys (roving `tabIndex`: the focused row is the only tabbable one), and **Escape closes and returns focus to the trigger**.
- **Deleted the a11y plumbing** (D2): `ariaOwns`/`ariaActiveDescendant` props removed from `IconButton` (zero callers left); `highlight` index state, `useId`, `rowDomId`/`dropdownDomId` removed from `SessionHeader`; the `highlighted`/`id` props removed from `MenuItem`.
- **About the `highlight` index state (D3): it is gone.** The roving visual highlight is now MenuItem's own `:focus` fill (`focus:bg-fill-hover` on every variant) — the row chrome can express focus, so the state was redundant and was deleted. `MenuItem` gains a `tabIndex` prop (default `-1`) as the roving slot.
- **Scope (D4): SessionHeader ⋯ menu only.** `ModelMenu`/`EffortMenu` untouched — their `aria-activedescendant` on a real `<input>` (combobox) is the correct idiom.
- **Behaviour preserved:** ArrowUp/Down/Home/End cycling + wrap, Enter-to-activate (native button click on the focused row), click-away close, click-to-activate, and the Delete/Clear confirm dialogs.

## Files changed

`5` files. `diff --stat`:
```
 src/renderer/IconButton.tsx              |  12 ---
 src/renderer/MenuItem.test.tsx           | 120 ++++++++++++-------------
 src/renderer/MenuItem.tsx                |  40 ++++-----
 src/renderer/SessionHeader.menu.test.tsx |  41 +++++++++
 src/renderer/SessionHeader.tsx           | 149 +++++++++++++++----------------
```

## Verification results

- PR branch (`multica/BET-741-wai-aria-menu` @ `1de5c73`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, `1630` pass / `0` fail / `0` skip. Failures: none.
- Base (`main` @ `1de5c73`): unchanged base — see Conclusion.
- **Conclusion:** `0` new failures. The full suite (`npm test`) passes 1630/1630; the two menu-suite files (`SessionHeader.menu.test.tsx`, `MenuItem.test.tsx`) pass 37/37.

## Acceptance criteria

- `grep -rn "ariaActiveDescendant\|aria-activedescendant" src/renderer/SessionHeader.tsx` returns nothing ✓
- Existing `SessionHeader.menu.test.tsx` tests pass **unmodified**; added exactly two new tests (focus enters menu on open; Escape restores focus to trigger) ✓
- `npm run typecheck && npm test` green ✓

**Base: `origin/main` @ `1de5c73`**
