### PR TITLE
fix(renderer): screenshot strip fixes — drop count label, always show add button, CSP blob img, inset badge (BET-768)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -829,6 +829,28 @@ describe("ChatPanel pending screenshots", () => {
     expect(useStore.getState().pendingScreenshots).toHaveLength(0);
   });
 
+  it("Add to chat attaches a single pending screenshot", async () => {
+    const { api } = installMockApi({
+      uploadBuffer: () => Promise.resolve("/remote/x.png"),
+    });
+    resetStore({
+      pendingScreenshots: [shot("a", new ArrayBuffer(1))],
+    });
+
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const addToChat = Array.from(h.container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Add to chat",
+    ) as HTMLButtonElement;
+    expect(addToChat).toBeTruthy();
+    await act(async () => { addToChat.click(); });
+    await h.flush();
+
+    expect(api.calls.uploadBuffer).toHaveLength(1);
+    expect(useStore.getState().pendingScreenshots).toHaveLength(0);
+  });
+
   it("the discard badge drops one screenshot without uploading it", async () => {
     const { api } = installMockApi();
     resetStore({

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -6,7 +6,7 @@
 // and the press-and-hold mic button. InputArea.tsx composes them.
 
 import { useRef } from "react";
-import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip, Camera } from "lucide-react";
+import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip } from "lucide-react";
 import type { VoiceMode, VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import type { PendingScreenshot } from "./store";
@@ -190,10 +190,6 @@ export function PendingScreenshotStrip({
   if (shots.length === 0) return null;
   return (
     <div className="pb-2 flex flex-wrap items-center gap-2 text-meta">
-      <span className="inline-flex items-center gap-1 text-text-faint shrink-0">
-        <Camera size={13} aria-hidden="true" />
-        {shots.length} screenshot{shots.length === 1 ? "" : "s"}
-      </span>
       {shots.map((s) => (
         <span key={s.id} className="relative shrink-0">
           <button
@@ -206,7 +202,7 @@ export function PendingScreenshotStrip({
           </button>
           <button
             onClick={() => onDiscard(s.id)}
-            className="absolute top-px right-px w-4 h-4 rounded-full grid place-items-center bg-text/60 text-bg hover:bg-danger focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+            className="absolute top-1 right-1 w-4 h-4 rounded-full grid place-items-center bg-text/60 text-bg hover:bg-danger focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
             title="Discard"
             aria-label={`Discard ${s.filename}`}
           >
@@ -214,14 +210,12 @@ export function PendingScreenshotStrip({
           </button>
         </span>
       ))}
-      {shots.length > 1 && (
-        <button
-          onClick={() => onAccept(shots)}
-          className="shrink-0 rounded-sm bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-        >
-          Add all {shots.length}
-        </button>
-      )}
+      <button
+        onClick={() => onAccept(shots)}
+        className="shrink-0 rounded-sm bg-accent/20 px-2 py-px text-accent hover:bg-accent/30 font-medium focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+      >
+        {shots.length === 1 ? "Add to chat" : `Add all ${shots.length}`}
+      </button>
     </div>
   );
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -13,7 +13,7 @@
          that threshold, so they ship as `data:font/woff2;base64,…` inside
          the CSS and were refused under the `default-src 'self'` fallback.
          Still no remote origin — data: here is our own bundled bytes. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ws: http: https:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: http: https:;" />
     <!-- BET-559: the PWA (manifest, apple-touch-icon, install meta, home-screen
          decoration) was the web-mobile-client surface and is retired with it.
          The renderer is the desktop Electron app — none of these PWA bits apply. -->


### PR DESCRIPTION
Closes BET-768 — four fixes from the first live look at the pending screenshot strip (BET-762 follow-up).

**Base: origin/main @ `7b69984b`**

## Changes
1. **Drop the count label + camera icon** — removes the `N screenshots` span and the `Camera` import (no other use).
2. **Always show the action button** — now renders whenever the strip does; label is `Add to chat` (1 shot) or `Add all {N}` (2+). Same `onAccept(shots)` handler for both. Added a new harness test for the single-shot case; the existing `Add all 2` case is untouched.
3. **Fix the CSP-blocked thumbnail** — `img-src 'self' data:` → `img-src 'self' data: blob:` in `src/renderer/index.html`. The object-URL path retains its correct revoke lifecycle. This is the **shared** fix: `ArtifactPreview.tsx` renders image artifact previews from an object URL too, so they were blocked by the same directive and are fixed by the same one-token change. (PDF previews may embed blob URLs through a different element/directive — left untouched per scope; only images are covered here.)
4. **Inset the discard badge** — `top-px right-px` → `top-1 right-1` (4px from the corner). Size/shape/colours/hover/focus/title/aria-label unchanged; stays inside the thumbnail.

**Files changed:** 3 files. `src/renderer/ComposerParts.tsx`, `src/renderer/index.html`, `src/renderer/ChatPanel.harness.test.tsx`.

## Manual check (stated, not executed in this env — requires a live Electron + screenshot detector)
Take one screenshot → thumbnail renders as a real image (no CSP console error) and `Add to chat` attaches it; take two → `Add all 2` attaches both.

## Verification results
- **PR branch** (`multica/BET-768-screenshot-strip-fixes` @ `1574ba50`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, `1631` pass / `0` fail / `0` skip. Failures: none. log sha256: `5e21220ec3e4a368a9581ebc102b16bd18b03bb40405ae75a39c929373bb62b9`
- **Base** (`main` @ `7b69984b`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, `1631` pass / `0` fail / `0` skip. Failures: none. log sha256: `a24276f51d2ecf10a24160305a53c5eca3403cde7a0fb74c781180f1b049ea44`
- **Conclusion:** `0` test failures pre-existing, `0` failures caused by this PR, `0` resolved by this PR. The single added test ("Add to chat attaches a single pending screenshot") verified green via a targeted `vitest run -t`.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
