### PR TITLE
feat(ios): @-file typeahead + / slash palette (BET-749)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -355,7 +355,10 @@ private struct ChatScreenContent: View {
                             showScrollToBottom = false
                         },
                         onGlassBoxHeightChange: { composerGlassHeight = $0 },
-                        onToggleTrust: { flipTrustMode() }
+                        onToggleTrust: { flipTrustMode() },
+                        sessionDirectory: sessionWindow?.cwd,
+                        onSlashClear: { Task { await clearSession() } },
+                        onSlashFork: { Task { await forkSession() } }
                     )
                 }
                 // Feeds the transcript's bottom content inset its height. Safe

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -141,6 +141,7 @@ struct QueuedPrompt: Equatable {
     let text: String
     let attachments: [SendPromptInput.Attachment]
     let model: SendPromptInput.Model?
+    let mentions: [SendPromptInput.Mention]?
 }
 
 @MainActor
@@ -816,11 +817,11 @@ final class ChatSessionStore: ObservableObject {
     /// the UI doesn't sit on a forever-spinner, and the caller is told so it
     /// can restore the user's typed text.
     @discardableResult
-    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?) async -> Bool {
+    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?, mentions: [SendPromptInput.Mention]? = nil) async -> Bool {
         // A send while the turn runs must not reach opencode — it would abort
         // the in-flight turn implicitly. Queue it; the idle edge drains FIFO.
         if running {
-            queuedPrompts.append(QueuedPrompt(text: text, attachments: attachments, model: model))
+            queuedPrompts.append(QueuedPrompt(text: text, attachments: attachments, model: model, mentions: mentions))
             return true
         }
         // Echo the message straight into the transcript and assume the turn is
@@ -854,7 +855,8 @@ final class ChatSessionStore: ObservableObject {
                 sessionId: sessionId,
                 text: text,
                 model: model,
-                attachments: attachments.isEmpty ? nil : attachments
+                attachments: attachments.isEmpty ? nil : attachments,
+                mentions: mentions
             ))
             return true
         } catch {
@@ -893,7 +895,7 @@ final class ChatSessionStore: ObservableObject {
         guard !running, !queuedPrompts.isEmpty else { return }
         let next = queuedPrompts.removeFirst()
         Task { @MainActor in
-            let ok = await send(text: next.text, attachments: next.attachments, model: next.model)
+            let ok = await send(text: next.text, attachments: next.attachments, model: next.model, mentions: next.mentions)
             if !ok {
                 // The send failed after the box accepted going idle — don't lose
                 // the prompt silently. Put it back at the FRONT and tell the user.

--- a/mobile/native/MantaUI/ComposerTypeahead.swift
+++ b/mobile/native/MantaUI/ComposerTypeahead.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+// ===========================================================================
+// @-file typeahead + / slash palette — pure logic (BET-749 gap #10).
+//
+// The native composer has no server-side command registry and its file
+// mentions already serialize onto sends via the `Mention` DTO, so all the
+// custom logic here is pure and unit-testable — no view, no HTTP.
+//
+//  * `detectMention` / `applyMention` — mirror the desktop's `useTypeahead`
+//    @-token detection (anchored at line start or after whitespace, caret
+//    inside the token) and substitution. Offsets are UTF-16 code units so they
+//    line up with `NSString` ranges and the `Mention.source` start/end the
+//    box expects.
+//  * `slashCommands` / `filterSlashCommands` — the compact `/` palette, listing
+//    exactly the actions the composer/store already implement (the voice
+//    `VoiceAction` set and the overflow sheet). Nothing new is invented here;
+//    a typed token that matches nothing is honestly absent from the palette.
+// ===========================================================================
+
+enum ComposerTypeahead {
+
+    // MARK: - @-file mention
+
+    /// An active `@` token in the draft: `start..<end` is the whole token in
+    /// UTF-16 code units, `query` is what was typed after the `@`.
+    struct MentionAnchor: Equatable {
+        let start: Int
+        let end: Int
+        let query: String
+    }
+
+    /// The outcome of selecting a file: the rewritten draft plus the `Mention`
+    /// that must serialize onto the next send.
+    struct MentionInsertion: Equatable {
+        let newText: String
+        let mention: SendPromptInput.Mention
+    }
+
+    /// Detect an active `@`-file token the cursor is inside. Mirrors the
+    /// desktop: `@` at the start of the line or after whitespace, with the
+    /// caret inside the token that follows it.
+    static func detectMention(in text: String, caret: Int) -> MentionAnchor? {
+        let ns = text as NSString
+        guard caret >= 0, caret <= ns.length else { return nil }
+
+        // Walk backwards from the caret to find the `@` that owns the token.
+        var atIndex: Int?
+        var i = caret - 1
+        while i >= 0 {
+            let ch = ns.character(at: i)
+            if ch == 0x40 { atIndex = i; break }                 // "@"
+            if ch == 0x20 || ch == 0x0A || ch == 0x09 { break }  // space / newline / tab
+            i -= 1
+        }
+        guard let at = atIndex else { return nil }
+
+        // The `@` must sit after whitespace (or at the very start).
+        if at > 0 {
+            let prev = ns.character(at: at - 1)
+            if !(prev == 0x20 || prev == 0x0A || prev == 0x09) { return nil }
+        }
+
+        // The token runs forward until whitespace / end of text.
+        var end = at + 1
+        while end < ns.length {
+            let ch = ns.character(at: end)
+            if ch == 0x20 || ch == 0x0A || ch == 0x09 { break }
+            end += 1
+        }
+        // The caret must still be inside the token (not past its end).
+        guard caret <= end else { return nil }
+
+        let query = ns.substring(with: NSRange(location: at + 1, length: min(end, caret) - (at + 1)))
+        return MentionAnchor(start: at, end: end, query: query)
+    }
+
+    /// Substitute a chosen file into the draft at the anchor and build the
+    /// `Mention` whose `source` references the substituted `@<file>` range.
+    static func applyMention(_ file: String, to text: String, anchor: MentionAnchor) -> MentionInsertion {
+        let token = "@" + file
+        let ns = text as NSString
+        let newText = ns.replacingCharacters(
+            in: NSRange(location: anchor.start, length: anchor.end - anchor.start),
+            with: token + " "
+        )
+        let mention = SendPromptInput.Mention(
+            name: file,
+            source: SendPromptInput.MentionSource(
+                value: token,
+                start: anchor.start,
+                end: anchor.start + (token as NSString).length
+            )
+        )
+        return MentionInsertion(newText: newText, mention: mention)
+    }
+
+    // MARK: - / slash palette
+
+    enum SlashAction: Equatable {
+        case submit
+        case compact
+        case clear
+        case fork
+        case abort
+    }
+
+    struct SlashCommand: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let subtitle: String
+        let kind: SlashAction
+    }
+
+    /// An active `/` palette anchor: only the LEADING line of the composer
+    /// triggers it (mirrors the desktop, whose command typeahead fires when
+    /// "/" is the very first character), and only while the caret is inside
+    /// that first word.
+    struct SlashAnchor: Equatable {
+        let query: String
+    }
+
+    static func detectSlash(in text: String, caret: Int) -> SlashAnchor? {
+        let ns = text as NSString
+        guard ns.length > 0, ns.character(at: 0) == 0x2F else { return nil }  // "/"
+        var end = 0
+        while end < ns.length {
+            let ch = ns.character(at: end)
+            if ch == 0x20 || ch == 0x0A || ch == 0x09 { break }
+            end += 1
+        }
+        guard caret <= end else { return nil }
+        let queryLen = min(end, caret) - 1
+        let query = queryLen > 0 ? ns.substring(with: NSRange(location: 1, length: queryLen)) : ""
+        return SlashAnchor(query: query)
+    }
+
+    /// The actions the composer/store already implement — the voice
+    /// `VoiceAction` set and the overflow sheet, nothing more. Abort appears
+    /// only while a turn is running (that is the only time it is meaningful).
+    static func slashCommands(running: Bool) -> [SlashCommand] {
+        var commands = [
+            SlashCommand(id: "submit", title: "Submit", subtitle: "Send this message", kind: .submit),
+            SlashCommand(id: "compact", title: "Compact", subtitle: "Summarise the conversation to free context", kind: .compact),
+            SlashCommand(id: "clear", title: "Clear", subtitle: "Start a fresh session in this window", kind: .clear),
+            SlashCommand(id: "fork", title: "Fork", subtitle: "Fork this session into a new window", kind: .fork),
+        ]
+        if running {
+            commands.append(SlashCommand(id: "abort", title: "Abort", subtitle: "Stop the running turn", kind: .abort))
+        }
+        return commands
+    }
+
+    /// Keep only commands whose token/title match what was typed after `/`. A
+    /// typed token that matches nothing yields an empty list — the box has no
+    /// further commands to offer honestly (nothing is fabricated here).
+    static func filterSlashCommands(_ commands: [SlashCommand], query: String) -> [SlashCommand] {
+        guard !query.isEmpty else { return commands }
+        let q = query.lowercased()
+        return commands.filter { $0.id.lowercased().contains(q) || $0.title.lowercased().contains(q) }
+    }
+}

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -57,6 +57,17 @@ struct ComposerView: View {
     /// Flip the `chatAutoAllow` trust setting (voice `toggleTrust`, BET-748).
     /// The chat screen owns the flip + revert; the composer just triggers it.
     var onToggleTrust: (() -> Void)? = nil
+    /// The session's working directory, threaded from the chat screen so the
+    /// `@`-file typeahead searches within the session (BET-749). `findFiles`
+    /// takes it directly, the same way `vcsBranch` does; nil when the session
+    /// hasn't been resolved yet.
+    var sessionDirectory: String? = nil
+    /// Performs a `/clear` (BET-749 slash palette). Optional: the chat screen
+    /// owns clearing + re-navigation; the composer just triggers it.
+    var onSlashClear: (() -> Void)? = nil
+    /// Performs a `/fork` (BET-749 slash palette). Optional: the chat screen
+    /// owns forking + navigation; the composer just triggers it.
+    var onSlashFork: (() -> Void)? = nil
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var text = ""
@@ -83,6 +94,19 @@ struct ComposerView: View {
     @State private var isTall = false
     /// The near-full-screen editing sheet, opened by the expand control.
     @State private var showExpanded = false
+    /// The active `@`-file token the cursor is inside (nil when no mention is
+    /// being composed) — BET-749 gap #10.
+    @State private var activeMention: ComposerTypeahead.MentionAnchor?
+    /// The `findFiles` matches for the active mention query, capped to bound
+    /// RPC chatter. Empty hides the typeahead.
+    @State private var fileResults: [String] = []
+    /// Mentions chosen from the `@` typeahead, pending on the draft. They
+    /// serialize onto the next send via the existing `Mention` path.
+    @State private var draftMentions: [SendPromptInput.Mention] = []
+    /// Debounced `findFiles` task (owned here so a fast typist doesn't pile up
+    /// parallel RPCs) + the sequence guard that discards stale responses.
+    @State private var fileSearchTask: Task<Void, Never>?
+    @State private var fileSearchSeq = 0
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
     var body: some View {
@@ -94,6 +118,18 @@ struct ComposerView: View {
             // exactly how attaching a file came to do nothing at all.
             pickerAnchor
             expandAnchor
+            // The `@`-file typeahead and the `/` slash palette float just above
+            // the box (BET-749). At most one is active: `@` and `/` are disjoint
+            // triggers, and each is nil unless its token is genuinely being
+            // composed.
+            if let palette = slashPalette {
+                slashPaletteView(palette)
+                    .transition(.opacity)
+            }
+            if activeMention != nil, !fileResults.isEmpty {
+                mentionTypeahead
+                    .transition(.opacity)
+            }
             // The jump-to-bottom control sits right above the composer,
             // centered — not in the control row. Shown only while scrolled up.
             if showScrollToBottom {
@@ -133,6 +169,10 @@ struct ComposerView: View {
         .onChange(of: photoItems) { _ in
             Task { await processPhotos() }
         }
+        .onChange(of: text) { _, newValue in
+            handleTextChange(newValue)
+        }
+        .animation(.smooth(duration: 0.18), value: typeaheadOpen)
         .onChange(of: store.actionHint) { _, hint in
             guard let hint else { return }
             surfaceHint(hint)
@@ -857,10 +897,11 @@ struct ComposerView: View {
             return SendPromptInput.Attachment(remotePath: remotePath, mime: attachment.mime, filename: attachment.filename)
         }
         let sentText = trimmed
+        let mentions = draftMentions.isEmpty ? nil : draftMentions
         Task { @MainActor in
             // On a failed send the store rolled its running state back; restore
             // the user's message so it is never silently lost, and surface why.
-            let ok = await store.send(text: sentText, attachments: sendAttachments, model: model)
+            let ok = await store.send(text: sentText, attachments: sendAttachments, model: model, mentions: mentions)
             if !ok {
                 text = sentText
                 surfaceHint("Send failed — message restored")
@@ -868,11 +909,177 @@ struct ComposerView: View {
         }
         text = ""
         attachments = []
+        draftMentions = []
         // Return to the compact form explicitly rather than waiting for the
         // emptied editor to re-measure. The measurement does arrive, but a beat
         // later — long enough for the box to sit stacked and empty after a
         // send, which reads as the composer being stuck.
         withAnimation(.smooth(duration: 0.22)) { isTall = false }
+        inputFocused = true
+    }
+
+    // MARK: - @-file typeahead + / slash palette (BET-749 gap #10)
+
+    /// True when either the `@` typeahead or the `/` palette is showing — the
+    /// single value the popup animation keys off.
+    private var typeaheadOpen: Bool {
+        (activeMention != nil && !fileResults.isEmpty) || slashPalette != nil
+    }
+
+    /// The live caret, in UTF-16 units — read from the focused text view the
+    /// same way dictation's insert-at-caret does. Falls back to end-of-text
+    /// when no text view is focused.
+    private var composerCaret: Int {
+        Self.activeTextView()?.selectedRange.location ?? (text as NSString).length
+    }
+
+    /// The active `/` palette's filtered command list, or nil when the slash
+    /// isn't being composed (no leading `/` / caret out of the word / no match).
+    private var slashPalette: [ComposerTypeahead.SlashCommand]? {
+        guard let anchor = ComposerTypeahead.detectSlash(in: text, caret: composerCaret) else { return nil }
+        let filtered = ComposerTypeahead.filterSlashCommands(
+            ComposerTypeahead.slashCommands(running: store.running),
+            query: anchor.query
+        )
+        return filtered.isEmpty ? nil : filtered
+    }
+
+    /// The `@`-file typeahead: a compact floating list of `findFiles` matches.
+    private var mentionTypeahead: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(fileResults, id: \.self) { file in
+                Button {
+                    selectFile(file)
+                } label: {
+                    HStack(spacing: Metrics.spacing.sp2) {
+                        Image(systemName: "doc")
+                            .font(.system(size: Metrics.type.xs, weight: .medium))
+                            .foregroundColor(tokens.accentTx)
+                        Text("@\(file)")
+                            .font(.manta(size: Metrics.type.small))
+                            .foregroundColor(tokens.tx1)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("mention-row")
+            }
+        }
+        .padding(.vertical, Metrics.spacing.sp1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.lg, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.lg, style: .continuous)
+                .stroke(tokens.borderSubtle, lineWidth: 1)
+        }
+        .accessibilityIdentifier("mention-typeahead")
+    }
+
+    /// The `/` command palette: one row per supported action. Selecting a row
+    /// performs the corresponding existing store/screen action.
+    private func slashPaletteView(_ commands: [ComposerTypeahead.SlashCommand]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(commands) { command in
+                Button {
+                    performSlash(command)
+                } label: {
+                    HStack(spacing: Metrics.spacing.sp2) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("/\(command.id)")
+                                .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                                .foregroundColor(tokens.tx1)
+                            Text(command.subtitle)
+                                .font(.manta(size: Metrics.type.twoXS))
+                                .foregroundColor(tokens.tx2)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("slash-row-\(command.id)")
+            }
+        }
+        .padding(.vertical, Metrics.spacing.sp1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.lg, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.lg, style: .continuous)
+                .stroke(tokens.borderSubtle, lineWidth: 1)
+        }
+        .accessibilityIdentifier("slash-palette")
+    }
+
+    /// Re-run the `@` detection whenever the draft changes: update the active
+    /// anchor and (debounced) fetch matches, or clear the typeahead when the
+    /// mention composition has ended.
+    private func handleTextChange(_ newText: String) {
+        let caret = Self.activeTextView()?.selectedRange.location ?? (newText as NSString).length
+        if let anchor = ComposerTypeahead.detectMention(in: newText, caret: caret) {
+            activeMention = anchor
+            searchFiles(query: anchor.query)
+        } else {
+            activeMention = nil
+            fileResults = []
+            fileSearchTask?.cancel()
+        }
+    }
+
+    /// Debounced `findFiles`, sequence-guarded so a stale response can't
+    /// clobber the latest. ~250 ms matches the desktop's fire-on-type look.
+    private func searchFiles(query: String) {
+        fileSearchTask?.cancel()
+        let seq = fileSearchSeq + 1
+        fileSearchSeq = seq
+        fileSearchTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+            let results = (try? await api.findFiles(query: query, directory: sessionDirectory)) ?? []
+            guard fileSearchSeq == seq else { return }
+            fileResults = Array(results.prefix(10))
+        }
+    }
+
+    /// Insert a chosen file into the draft at the mention anchor and record the
+    /// `Mention` so it serializes onto the next send.
+    private func selectFile(_ file: String) {
+        guard let anchor = activeMention else { return }
+        let insertion = ComposerTypeahead.applyMention(file, to: text, anchor: anchor)
+        text = insertion.newText
+        draftMentions.append(insertion.mention)
+        activeMention = nil
+        fileResults = []
+        fileSearchTask?.cancel()
+        inputFocused = true
+    }
+
+    /// Perform a `/` palette selection: route to the corresponding existing
+    /// store/screen action, then clear the composition so the palette doesn't
+    /// reopen on the same text.
+    private func performSlash(_ command: ComposerTypeahead.SlashCommand) {
+        switch command.kind {
+        case .submit:
+            submit()
+        case .compact:
+            store.compact()
+        case .clear:
+            onSlashClear?()
+        case .fork:
+            onSlashFork?()
+        case .abort:
+            store.abort()
+        }
+        if command.kind != .submit { text = "" }
+        activeMention = nil
+        fileResults = []
+        fileSearchTask?.cancel()
         inputFocused = true
     }
 

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -222,6 +222,16 @@ final class MantaAPIClient: Sendable {
         try await call("opencode:vcs-branch", args: [directory], as: String.self)
     }
 
+    /// `opencode:find-files` — ripgrep-backed file-name search under a
+    /// directory (the desktop's `@`-file lookup channel). `directory` may be
+    /// nil when the session doesn't thread one; the box then returns a
+    /// browse-style listing. Result is a bare `[String]` of matching paths.
+    func findFiles(query: String, directory: String? = nil) async throws -> [String] {
+        var input: [String: Any] = ["query": query]
+        if let directory { input["directory"] = directory }
+        return try await call("opencode:find-files", args: [input], as: [String].self) ?? []
+    }
+
     /// `tmux:rename-window` — rename a session (the row's name).
     func renameWindow(session: String, index: Int, newName: String) async throws {
         let dict: [String: Any] = [

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -221,13 +221,13 @@ struct SendPromptInput: Sendable {
         var filename: String?
     }
 
-    struct MentionSource: Sendable {
+    struct MentionSource: Sendable, Equatable {
         var value: String
         var start: Int
         var end: Int
     }
 
-    struct Mention: Sendable {
+    struct Mention: Sendable, Equatable {
         var name: String
         var source: MentionSource
     }

--- a/mobile/native/MantaUITests/ComposerTypeaheadTests.swift
+++ b/mobile/native/MantaUITests/ComposerTypeaheadTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-749 — @-file typeahead + / slash palette pure logic.
+//
+// Covers ComposerTypeahead: `@`-token detection + substitution (the Mention a
+// selection yields), and the `/` palette's action list + filtering. No view,
+// no HTTP — the same pure logic the composer drives at runtime.
+// ===========================================================================
+
+final class ComposerTypeaheadTests: XCTestCase {
+
+    // MARK: - detectMention
+
+    func testDetectMentionAtStartOfDraft() {
+        let anchor = ComposerTypeahead.detectMention(in: "@fo", caret: 3)
+        XCTAssertEqual(anchor, ComposerTypeahead.MentionAnchor(start: 0, end: 3, query: "fo"))
+    }
+
+    func testDetectMentionAfterWhitespace() {
+        let anchor = ComposerTypeahead.detectMention(in: "look at @src", caret: 12)
+        XCTAssertEqual(anchor, ComposerTypeahead.MentionAnchor(start: 8, end: 12, query: "src"))
+    }
+
+    func testDetectMentionQueryOnlyTypedPart() {
+        // The token extends past the caret, but the query is what's typed.
+        let anchor = ComposerTypeahead.detectMention(in: "a @sr", caret: 5)
+        XCTAssertEqual(anchor?.start, 2)
+        XCTAssertEqual(anchor?.end, 5)
+        XCTAssertEqual(anchor?.query, "sr")
+    }
+
+    func testDetectMentionNotTriggeredWhenAtInsideWord() {
+        // `@` embedded mid-word does NOT open the typeahead.
+        XCTAssertNil(ComposerTypeahead.detectMention(in: "foo@bar", caret: 7))
+    }
+
+    func testDetectMentionNilWhenCaretOutsideToken() {
+        // Caret is past the token's end (typing a space closes the mention).
+        XCTAssertNil(ComposerTypeahead.detectMention(in: "@foo x", caret: 5))
+    }
+
+    func testDetectMentionIgnoredWhenAtPrefixedByWordChar() {
+        XCTAssertNil(ComposerTypeahead.detectMention(in: "a@foo", caret: 5))
+    }
+
+    func testDetectMentionEmptyText() {
+        XCTAssertNil(ComposerTypeahead.detectMention(in: "", caret: 0))
+    }
+
+    // MARK: - applyMention
+
+    /// The core "composer state" behaviour: selecting a file replaces the
+    /// `@`-anchor in the draft and yields a `Mention` whose `source` references
+    /// the substituted `@<file>` range exactly.
+    func testApplyMentionReplacesAnchorAndBuildsCorrectSourceRange() {
+        let anchor = ComposerTypeahead.detectMention(in: "see @fo", caret: 7)!
+        let insertion = ComposerTypeahead.applyMention("foo.swift", to: "see @fo", anchor: anchor)
+
+        // The draft: `@fo` is replaced with `@foo.swift ` (trailing space kept
+        // so a following word doesn't glue onto the token).
+        XCTAssertEqual(insertion.newText, "see @foo.swift ")
+
+        // The mention carries the file as its `name` and the substituted
+        // `@foo.swift` as `source.value`, with start/end spanning that token.
+        XCTAssertEqual(insertion.mention.name, "foo.swift")
+        XCTAssertEqual(insertion.mention.source.value, "@foo.swift")
+        XCTAssertEqual(insertion.mention.source.start, 4)   // index of '@' of '@foo.swift'
+        XCTAssertEqual(insertion.mention.source.end, 4 + "@foo.swift".count)
+    }
+
+    /// The Mention built by a selection serializes unchanged onto a send — the
+    /// exact `name`/`source` triple the RPC emits (see the wire test too).
+    func testApplyMentionSerializesOntoSendArgs() {
+        let anchor = ComposerTypeahead.detectMention(in: "@src/", caret: 5)!
+        let insertion = ComposerTypeahead.applyMention("src/foo.swift", to: "@src/", anchor: anchor)
+        XCTAssertEqual(insertion.mention.name, "src/foo.swift")
+        XCTAssertEqual(insertion.mention.source.value, "@src/foo.swift")
+        XCTAssertEqual(insertion.mention.source.start, 0)
+        XCTAssertEqual(insertion.mention.source.end, "@src/foo.swift".count)
+    }
+
+    // MARK: - Mention equality (used by the store's queued prompt)
+
+    func testMentionEquatable() {
+        let a = SendPromptInput.Mention(name: "f", source: SendPromptInput.MentionSource(value: "@f", start: 0, end: 2))
+        let b = SendPromptInput.Mention(name: "f", source: SendPromptInput.MentionSource(value: "@f", start: 0, end: 2))
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - / slash palette
+
+    func testSlashCommandsBaseSet() {
+        let commands = ComposerTypeahead.slashCommands(running: false)
+        XCTAssertEqual(commands.map(\.id), ["submit", "compact", "clear", "fork"])
+    }
+
+    func testSlashCommandsAddsAbortOnlyWhileRunning() {
+        XCTAssertEqual(ComposerTypeahead.slashCommands(running: true).map(\.id), ["submit", "compact", "clear", "fork", "abort"])
+        XCTAssertEqual(ComposerTypeahead.slashCommands(running: false).map(\.id), ["submit", "compact", "clear", "fork"])
+    }
+
+    func testFilterSlashCommandsByTokenAndTitle() {
+        let all = ComposerTypeahead.slashCommands(running: false)
+        XCTAssertEqual(ComposerTypeahead.filterSlashCommands(all, query: "comp").map(\.id), ["compact"])
+        XCTAssertEqual(ComposerTypeahead.filterSlashCommands(all, query: "CLEAR").map(\.id), ["clear"])
+        XCTAssertEqual(ComposerTypeahead.filterSlashCommands(all, query: "fork").map(\.id), ["fork"])
+        XCTAssertEqual(ComposerTypeahead.filterSlashCommands(all, query: "sub").map(\.id), ["submit"])
+    }
+
+    func testFilterSlashCommandsEmptyQueryReturnsAll() {
+        let all = ComposerTypeahead.slashCommands(running: false)
+        XCTAssertEqual(ComposerTypeahead.filterSlashCommands(all, query: "").count, all.count)
+    }
+
+    /// A typed token that matches nothing is honestly absent — no command is
+    /// invented for it.
+    func testFilterSlashCommandsUnknownQueryIsEmpty() {
+        let all = ComposerTypeahead.slashCommands(running: false)
+        XCTAssertTrue(ComposerTypeahead.filterSlashCommands(all, query: "zzzz").isEmpty)
+    }
+
+    // MARK: - detectSlash
+
+    func testDetectSlashOnlyAtStartOfLine() {
+        XCTAssertNotNil(ComposerTypeahead.detectSlash(in: "/comp", caret: 5))
+        // Not leading → no palette (mirrors the desktop).
+        XCTAssertNil(ComposerTypeahead.detectSlash(in: "fix /comp", caret: 9))
+    }
+
+    func testDetectSlashCaretMustBeInsideFirstWord() {
+        XCTAssertNil(ComposerTypeahead.detectSlash(in: "/comp again", caret: 11))
+        XCTAssertNotNil(ComposerTypeahead.detectSlash(in: "/comp", caret: 3))
+    }
+}

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -205,6 +205,61 @@ final class MantaActionRPCWireTests: XCTestCase {
         XCTAssertEqual(result.meta?.scope, "shared")
         XCTAssertNil(result.error)
     }
+
+    // MARK: - @-file typeahead (BET-749 gap #10)
+
+    /// `opencode:find-files` is dispatched as `fn({query, directory})` — a
+    /// SINGLE payload object carrying both keys — and decodes the box's bare
+    /// `[String]` path list.
+    func testFindFilesSendsQueryAndDirectoryAndDecodesStrings() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": ["src/foo.swift", "src/bar.swift"]}"#
+        let results = try await client.findFiles(query: "foo", directory: "/home/user/project")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/opencode:find-files")
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertEqual(payload?["query"] as? String, "foo")
+        XCTAssertEqual(payload?["directory"] as? String, "/home/user/project")
+        XCTAssertEqual(results, ["src/foo.swift", "src/bar.swift"])
+    }
+
+    /// A nil directory omits the key entirely — the box then returns a
+    /// browse-style listing rather than searching a specific cwd.
+    func testFindFilesOmitsDirectoryWhenNil() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": []}"#
+        let results = try await client.findFiles(query: "foo")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/opencode:find-files")
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertEqual(payload?["query"] as? String, "foo")
+        XCTAssertNil(payload?["directory"])
+        XCTAssertEqual(results, [])
+    }
+
+    /// A `Mention` built from a file name + range serializes onto
+    /// `opencode:prompt` args UNCHANGED through the existing send path —
+    /// `name` and `source.value/start/end` all land in `args[0].mentions[i]`.
+    func testSendPromptSerializesMentionUnchanged() async throws {
+        let client = makeClient()
+        let mention = SendPromptInput.Mention(
+            name: "src/foo.swift",
+            source: SendPromptInput.MentionSource(value: "@src/foo.swift", start: 4, end: 18)
+        )
+        _ = try await client.sendPrompt(SendPromptInput(
+            sessionId: "ses_1",
+            text: "see @src/foo.swift",
+            mentions: [mention]
+        ))
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/opencode:prompt")
+        let args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        let payload = args?.first as? [String: Any]
+        let mentions = payload?["mentions"] as? [[String: Any]]
+        let m = mentions?.first
+        XCTAssertEqual(m?["name"] as? String, "src/foo.swift")
+        let source = m?["source"] as? [String: Any]
+        XCTAssertEqual(source?["value"] as? String, "@src/foo.swift")
+        XCTAssertEqual(source?["start"] as? Int, 4)
+        XCTAssertEqual(source?["end"] as? Int, 18)
+    }
 }
 
 // MARK: - Capturing URLProtocol


### PR DESCRIPTION
Opened automatically for `multica/BET-749-ios-slash-at-typeahead`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-749.