### PR TITLE
fix(renderer): match lucide drawn geometry in UsageDial ring (BET-769)

### DIFF
--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -25,6 +25,12 @@ import {
 } from "./chatUtils";
 import { useClickAway } from "./hooks/useClickAway";
 import { useStore } from "./store";
+
+// Lucide icons render a 24-unit viewBox scaled to size. A stroked circle
+// draws r ± strokeWidth/2 (the stroke straddles the path), so at size 16 the
+// Clock's outer disc spans (2·10 + 2)/24·16 = 22/24 of the box and its ring
+// is 2/24 of the box. The dial mirrors that drawn geometry exactly.
+const ICON_PX = 16;
 import { mbtn } from "./ComposerParts";
 
 // The ONLY provider-name-aware thing in this file — an icon/label lookup
@@ -110,12 +116,13 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
         aria-label="plan usage"
         title={title}
       >
-        {/* A 16×16 BOX holding a 13px disc. The box keeps the button's metrics
-            identical to the 16px lucide icons beside it (so the row does not
-            shift), while the disc matches what those icons actually DRAW: a
-            lucide circle is r=10 in a 24 viewBox, i.e. 20/24 of the box, which
-            is 13px at size 16. A full-bleed 16px disc read visibly heavier
-            than the Clock / Key / Webhook glyphs next to it. */}
+        {/* A 16×16 BOX holding a disc sized to a stroked lucide circle. The
+            box keeps the button's metrics identical to the 16px lucide icons
+            beside it (so the row does not shift), while the disc matches what
+            those icons actually DRAW: a lucide circle is r=10 stroked at
+            strokeWidth=2 in a 24 viewBox, and the stroke straddles the path,
+            so the drawn outer is (2·10 + 2)/24 of the box and the ring is
+            2/24 of the box, both scaled by the 16px icon size. */}
         <span
           aria-hidden="true"
           className="inline-flex items-center justify-center"
@@ -125,8 +132,8 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
             aria-hidden="true"
             className="block rounded-full"
             style={{
-              width: 13,
-              height: 13,
+              width: (22 / 24) * ICON_PX,
+              height: (22 / 24) * ICON_PX,
               background:
                 state.tone === "over"
                   ? ringColor
@@ -135,14 +142,20 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
           >
             {/* Inner disc in the surrounding surface colour turns the pie into
                 a ring — skipped for tone "over" (>=100%), which is a solid
-                disc with no hole per the design spec. Ring thickness is
-                (13 - 9) / 2 = 2px, matching the neighbours' strokeWidth={2}
+                disc with no hole per the design spec. The stroke straddles
+                the circle path, so the inner hole is (2·10 - 2)/24 of the box
+                and sits in by the ring width 2/24, both scaled by the 16px
+                icon size — matching the neighbours' strokeWidth={2}
                 (unchanged from BET-756). */}
             {state.tone !== "over" && (
               <span
                 aria-hidden="true"
                 className="block rounded-full bg-bg"
-                style={{ width: 9, height: 9, margin: 2 }}
+                style={{
+                  width: (18 / 24) * ICON_PX,
+                  height: (18 / 24) * ICON_PX,
+                  margin: (2 / 24) * ICON_PX,
+                }}
               />
             )}
           </span>


### PR DESCRIPTION
## What

BET-769: the usage dial in the composer footer was a 13px disc with a 2px ring,
reading smaller + chunkier than the lucide Clock / Key / Webhook glyphs beside it.
Per the ticket's (already-decided) arithmetic, re-derive the geometry to match the
Clock glyph's **drawn** extent — a stroked lucide circle straddles its path, so the
drawn outer is `(2·10 + 2)/24` of the 24-unit box and the stroke is `2/24`, scaled by
the 16px icon size.

## Change (one file: `src/renderer/UsageDial.tsx`)

- Outer disc: `13` → `(22 / 24) * ICON_PX` (= 14.67px)
- Inner hole: `9` → `(18 / 24) * ICON_PX` (= 12px), `margin: 2` → `(2 / 24) * ICON_PX` (= 1.33px ring)
- Hoisted a single module-level `const ICON_PX = 16;` (all three expressions read
  better with it)
- Rewrote the two geometry comments to state the corrected derivation
  (no stale `13px disc` / `(13 - 9) / 2 = 2px` claims)
- Untouched: the 16×16 wrapper span, `background` / conic-gradient / tone branching,
  `rounded-full`, `SessionToolbar`, all lucide icons, colours, popover, aria/title.

## Verification

- `grep -n "width: 13\|width: 9\|margin: 2" src/renderer/UsageDial.tsx` → nothing
- Three geometry values all present as `/ 24` expressions
- `npm run typecheck && npm test` green (below)

**Files changed:** 1. `src/renderer/UsageDial.tsx` (+24 / −11)

**Verification results:**
- PR branch (`multica/BET-769-usage-dial-geometry` @ `f79beeda`):
  - typecheck: exit 0, errors none, log sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1631 pass / 0 fail / 0 skip. log sha256 `a7fe1f284bca02571871a78560fbc000a78faf971c10dd4f89ab564e80fdfd42`
- Base (`main` @ `72c0ded8`):
  - typecheck: exit 0, errors none, log sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1631 pass / 0 fail / 0 skip. log sha256 `a904f1029189f450fed32ec3feb88d133c62454a65c25c357e3d9ec9be836c06`
- **Conclusion:** 0 new failures — this PR introduces no regressions (identical results across branches; log hash differs only by timestamps).

**Base: origin/main @ `72c0ded8`**

Manual note (visual criterion): the dial's outer disc and ring weight are now
computed from the same expression a stroked lucide circle draws, so at the same
zoom they are mathematically identical to the Clock glyph (drawn outer 22/24 of
box, ring 2/24 of box, ×16px). No screenshot gate — this criterion is satisfied by
construction per the ticket's fixed arithmetic.

Base directory for this skill: /mnt/HC_Volume_105783934/multica_workspaces/264c89bb-4659-4570-af7b-5f8daaf87985/54330b89/workdir/.opencode/skills/manta-pr-workflow
